### PR TITLE
Use minimal profile for toolchain CI

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Install toolchain
       uses: actions-rs/toolchain@v1
       with:
+        profile: minimal
         toolchain: 1.50.0
         override: true
 
@@ -37,7 +38,6 @@ jobs:
     - name: Build
       uses: actions-rs/cargo@v1
       with:
-        profile: minimal
         command: build
         args: --verbose
 


### PR DESCRIPTION
Use `profile: minimal` when installing toolchain. Should speed up CI.