### PR TITLE
update ssh agent for ssh cargo deps

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -19,6 +19,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    - name: Setup SSH agent
+      uses: webfactory/ssh-agent@v0.5.2
+      with:
+        ssh-private-key: |
+          ${{ secrets.PRIVATE_KEY_FUEL_ASM }}
+
     - name: Install toolchain
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -16,6 +16,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Setup SSH agent
+        uses: webfactory/ssh-agent@v0.5.2
+        with:
+          ssh-private-key: |
+            ${{ secrets.PRIVATE_KEY_FUEL_ASM }}
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Copies the SSH agent config from `fuel-tx` to allow usage of `fuel-asm` and other private repos.