### PR TITLE
Allow unit-type ASM expressions.

### DIFF
--- a/core_lang/src/parse_tree/expression/asm.rs
+++ b/core_lang/src/parse_tree/expression/asm.rs
@@ -64,14 +64,18 @@ impl<'sc> AsmExpression<'sc> {
                 a => unreachable!("{:?}", a),
             }
         }
+        let return_type = implicit_op_type.unwrap_or(if implicit_op_return.is_some() {
+            TypeInfo::UnsignedInteger(IntegerBits::SixtyFour)
+        } else {
+            TypeInfo::Unit
+        });
 
         ok(
             AsmExpression {
                 registers: asm_registers,
                 body: asm_op_buf,
                 returns: implicit_op_return,
-                return_type: implicit_op_type
-                    .unwrap_or(TypeInfo::UnsignedInteger(IntegerBits::SixtyFour)),
+                return_type,
                 whole_block_span,
             },
             warnings,


### PR DESCRIPTION
This PR allows for ASM expressions that don't return a type. Previously, it was assumed that all ASM expressions return a value, but this was an inconsistency between what the grammar allows and what the type checker enforces. 