### PR TITLE
Fix error panic if a trait is overridden with no methods 

### DIFF
--- a/core_lang/src/semantic_analysis/namespace.rs
+++ b/core_lang/src/semantic_analysis/namespace.rs
@@ -345,12 +345,7 @@ impl<'sc> Namespace<'sc> {
         {
             warnings.push(CompileWarning {
                 warning_content: Warning::OverridingTraitImplementation,
-                span: functions_buf.iter().fold(
-                    functions_buf[0].span.clone(),
-                    |acc, TypedFunctionDeclaration { span, .. }| {
-                        crate::utils::join_spans(acc, span.clone())
-                    },
-                ),
+                span: trait_name.span(),
             })
         }
         module_to_insert_into


### PR DESCRIPTION
@leviathanbeak pointed out that it is possible for this `[0]` to panic if all the methods fail or if there are none provided in an overriding trait implementation. This uses the trait name as the error message span instead of the functions themselves, which is both more intuitive (in my opinion) and doesn't have the possibility of panicking. 