### PR TITLE
Better error span on missing generic type error

### DIFF
--- a/core_lang/src/semantic_analysis/ast_node/declaration.rs
+++ b/core_lang/src/semantic_analysis/ast_node/declaration.rs
@@ -540,11 +540,9 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
             {
                 let args_span = parameters.iter().fold(
                     parameters[0].name.span.clone(),
-                    |acc,
-                     TypedFunctionParameter {
-                         name: Ident { span, .. },
-                         ..
-                     }| crate::utils::join_spans(acc, span.clone()),
+                    |acc, TypedFunctionParameter { type_span, .. }| {
+                        crate::utils::join_spans(acc, type_span.clone())
+                    },
                 );
                 if type_parameters
                     .iter()


### PR DESCRIPTION
Before:
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/12157751/125109699-8a9b0c80-e098-11eb-957d-52c7d769ca18.png">


after:

<img width="1395" alt="image" src="https://user-images.githubusercontent.com/12157751/125110287-3c3a3d80-e099-11eb-8e7d-b3d23b29f502.png">
