### PR TITLE
handle '=' before < and >

### DIFF
--- a/formatter/src/code_line.rs
+++ b/formatter/src/code_line.rs
@@ -93,10 +93,13 @@ impl CodeLine {
     pub fn append_equal_sign(&mut self) {
         let last = self.text.chars().last();
 
-        if last == Some('!') {
-            self.push_str("= ");
-        } else {
-            self.append_with_whitespace("= ");
+        match last {
+            Some(c) if c == '!' || c == '<' || c == '>' => {
+                self.push_str("= ");
+            }
+            _ => {
+                self.append_with_whitespace("= ");
+            }
         }
     }
 


### PR DESCRIPTION
this small update handles >= and <= cases, currently Sway compiler does not support this so will leave it as a draft