### PR TITLE
 better table formatting in forc parse-bytecode and small bug fix

### DIFF
--- a/forc/src/cli/commands/parse_bytecode.rs
+++ b/forc/src/cli/commands/parse_bytecode.rs
@@ -20,14 +20,14 @@ pub(crate) fn exec(command: Command) -> Result<(), String> {
     f.read(&mut buffer).expect("buffer overflow");
     let mut instructions = vec![];
 
-    for i in (0..buffer.len() - 4).step_by(4) {
+    for i in (0..buffer.len()).step_by(4) {
         let i = i as usize;
         let raw = &buffer[i..i + 4];
         let op = fuel_asm::Opcode::from_bytes_unchecked(raw.try_into().unwrap());
         instructions.push((raw, op));
     }
-    //    println!("word\tbyte\top\t\traw\tnotes");
     let mut table = term_table::Table::new();
+    table.separate_rows = false;
     table.add_row(Row::new(vec![
         TableCell::new("half-word"),
         TableCell::new("byte"),


### PR DESCRIPTION
Forc was omitting the last op in the bytecode and the table formatting was suboptimal. This tweak fixes that.

before: 
```

 half-word  byte  op                    raw                  notes

         0  0     JI(4)                 [50, 0, 0, 4]        conditionally jumps to byte 16

         1  4     NOOP                  [240, 0, 0, 0]

         2  8     Undefined             [0, 0, 0, 0]         data section offset lo (0)

         3  12    Undefined             [0, 0, 0, 84]        data section offset hi (84)

         4  16    LW(46, 12, 1)         [67, 184, 192, 1]

         5  20    ADD(46, 46, 12)       [16, 186, 227, 0]

         6  24    LW(16, 46, 0)         [67, 66, 224, 0]

         7  28    LW(17, 46, 4)         [67, 70, 224, 4]

         8  32    LW(18, 46, 5)         [67, 74, 224, 5]

         9  36    LW(19, 46, 6)         [67, 78, 224, 6]

        10  40    LW(20, 46, 7)         [67, 82, 224, 7]

        11  44    MOVE(16, 21)          [31, 65, 80, 0]

        12  48    LW(21, 46, 0)         [67, 86, 224, 0]

        13  52    MOVE(22, 5)           [31, 88, 80, 0]

        14  56    CFEI(48)              [64, 0, 0, 48]

        15  60    LW(23, 46, 8)         [67, 94, 224, 8]

        16  64    MCP(22, 21, 23)       [71, 89, 85, 192]

        17  68    SW(22, 17, 4)         [74, 89, 16, 4]

        18  72    SW(22, 18, 5)         [74, 89, 32, 5]

        19  76    CALL(22, 20, 16, 19)  [83, 89, 68, 19]

        20  80    RET(16)               [52, 64, 0, 0]

        21  84    Undefined             [0, 0, 0, 0]

        22  88    Undefined             [0, 0, 0, 0]

        23  92    Undefined             [0, 0, 0, 0]

        24  96    Undefined             [0, 0, 0, 0]

        25  100   Undefined             [0, 0, 0, 0]

        26  104   Undefined             [0, 0, 0, 0]

        27  108   Undefined             [0, 0, 0, 0]

        28  112   Undefined             [0, 0, 0, 0]

        29  116   Undefined             [0, 0, 0, 0]

        30  120   Undefined             [253, 49, 221, 178]

        31  124   Undefined             [0, 0, 0, 0]

        32  128   Undefined             [0, 0, 0, 7]

        33  132   Undefined             [0, 0, 0, 0]

        34  136   Undefined             [0, 0, 0, 5]

        35  140   Undefined             [0, 0, 0, 0]

        36  144   Undefined             [0, 0, 0, 6]

        37  148   Undefined             [0, 0, 0, 0]
```

after:

```
half-word  byte  op                    raw                  notes
         0  0     JI(4)                 [50, 0, 0, 4]        conditionally jumps to byte 16
         1  4     NOOP                  [240, 0, 0, 0]
         2  8     Undefined             [0, 0, 0, 0]         data section offset lo (0)
         3  12    Undefined             [0, 0, 0, 84]        data section offset hi (84)
         4  16    LW(46, 12, 1)         [67, 184, 192, 1]
         5  20    ADD(46, 46, 12)       [16, 186, 227, 0]
         6  24    LW(16, 46, 0)         [67, 66, 224, 0]
         7  28    LW(17, 46, 4)         [67, 70, 224, 4]
         8  32    LW(18, 46, 5)         [67, 74, 224, 5]
         9  36    LW(19, 46, 6)         [67, 78, 224, 6]
        10  40    LW(20, 46, 7)         [67, 82, 224, 7]
        11  44    MOVE(16, 21)          [31, 65, 80, 0]
        12  48    LW(21, 46, 0)         [67, 86, 224, 0]
        13  52    MOVE(22, 5)           [31, 88, 80, 0]
        14  56    CFEI(48)              [64, 0, 0, 48]
        15  60    LW(23, 46, 8)         [67, 94, 224, 8]
        16  64    MCP(22, 21, 23)       [71, 89, 85, 192]
        17  68    SW(22, 17, 4)         [74, 89, 16, 4]
        18  72    SW(22, 18, 5)         [74, 89, 32, 5]
        19  76    CALL(22, 20, 16, 19)  [83, 89, 68, 19]
        20  80    RET(16)               [52, 64, 0, 0]
        21  84    Undefined             [0, 0, 0, 0]
        22  88    Undefined             [0, 0, 0, 0]
        23  92    Undefined             [0, 0, 0, 0]
        24  96    Undefined             [0, 0, 0, 0]
        25  100   Undefined             [0, 0, 0, 0]
        26  104   Undefined             [0, 0, 0, 0]
        27  108   Undefined             [0, 0, 0, 0]
        28  112   Undefined             [0, 0, 0, 0]
        29  116   Undefined             [0, 0, 0, 0]
        30  120   Undefined             [253, 49, 221, 178]
        31  124   Undefined             [0, 0, 0, 0]
        32  128   Undefined             [0, 0, 0, 7]
        33  132   Undefined             [0, 0, 0, 0]
        34  136   Undefined             [0, 0, 0, 5]
        35  140   Undefined             [0, 0, 0, 0]
        36  144   Undefined             [0, 0, 0, 6]
        37  148   Undefined             [0, 0, 0, 0]
        38  152   Undefined             [0, 0, 0, 32]
```