### PR TITLE
Update the Cargo manifests to remove warnings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ members = [
     "sway-server",
     "test_suite"
 ]
+
+[profile.dev.package.sway-server]
+debug = 2

--- a/core_lang/Cargo.toml
+++ b/core_lang/Cargo.toml
@@ -3,7 +3,6 @@ name = "core_lang"
 version = "0.1.0"
 authors = ["Alex <alex.hansen@fuel.sh>"]
 edition = "2018"
-rust = "1.50"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -2,7 +2,6 @@
 authors = ["Alex Hansen <alex.hansen@fuel.sh>"]
 edition = "2018"
 name = "forc"
-rust = "1.50"
 version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/sway-server/Cargo.toml
+++ b/sway-server/Cargo.toml
@@ -13,6 +13,3 @@ pest = "2.0"
 ropey = "1.2"
 serde_json = "1.0.60"
 tokio = {version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"]}
-
-[profile.dev]
-debug = 2


### PR DESCRIPTION
- Remove the `rust` keys, apparently they're ignored.
- Move the debug profile customisation from sway-server to the workspace root (though I haven't tested that this actually makes a difference).