### PR TITLE
Do not add function decls to the namespace if they fail to type-check.

### DIFF
--- a/core_lang/src/semantic_analysis/ast_node/mod.rs
+++ b/core_lang/src/semantic_analysis/ast_node/mod.rs
@@ -197,11 +197,14 @@ impl<'sc> TypedAstNode<'sc> {
                                 warnings,
                                 errors
                             );
-
-                            namespace.insert(
-                                decl.name.clone(),
-                                TypedDeclaration::FunctionDeclaration(decl.clone()),
-                            );
+                            if errors.is_empty() {
+                                // Add this function declaration to the namespace only if it
+                                // fully typechecked without errors.
+                                namespace.insert(
+                                    decl.name.clone(),
+                                    TypedDeclaration::FunctionDeclaration(decl.clone()),
+                                );
+                            }
                             TypedDeclaration::FunctionDeclaration(decl)
                         }
                         Declaration::TraitDeclaration(TraitDeclaration {


### PR DESCRIPTION
OK, this is attempt 3 at fixing the bug #148 and ended up being the ~dumbest~ simplest.

My first attempt was to try to do it at the bottom of the type-checker in `TypedParseTree::type_check()`, by using a temporary namespace for each node and using it only when the check passed.

This worked for this bug, but it caused a whole lot of errors in the `test_suite`.  There were a bunch of 'module not found' or 'enum not found' type errors which seem to _need_ to update the namespace to succeed eventually.

The solution in this PR is to focus on function declarations and only let them into the namespace if they type-check successfully.  This fixes #148 without breaking the `test_suite`.

My impression is that trying too hard to fix this problem isn't worth it -- we really should replace the dodgy type-checker logic with some proper symbol dependency graph logic so that we can do the type checking in a single pass without any 'acceptable' errors.