### PR TITLE
Add more functionality to CompileResult.

### DIFF
--- a/core_lang/src/asm_generation/expression/structs.rs
+++ b/core_lang/src/asm_generation/expression/structs.rs
@@ -88,14 +88,20 @@ fn test_struct_memory_layout() {
         ],
     };
 
+    let mut warnings: Vec<CompileWarning> = Vec::new();
+    let mut errors: Vec<CompileError> = Vec::new();
     assert_eq!(numbers.total_size(), 2u64);
     assert_eq!(
-        numbers.offset_to_field_name(&first_field_name).unwrap(),
-        &0u64
+        numbers
+            .offset_to_field_name(&first_field_name)
+            .unwrap(&mut warnings, &mut errors),
+        0u64
     );
     assert_eq!(
-        numbers.offset_to_field_name(&second_field_name).unwrap(),
-        &1u64
+        numbers
+            .offset_to_field_name(&second_field_name)
+            .unwrap(&mut warnings, &mut errors),
+        1u64
     );
 }
 

--- a/core_lang/src/parse_tree/declaration/enum_declaration.rs
+++ b/core_lang/src/parse_tree/declaration/enum_declaration.rs
@@ -80,11 +80,9 @@ impl<'sc> EnumDeclaration<'sc> {
             }
         }
 
-        let mut parsed_type_parameters =
-            TypeParameter::parse_from_type_params_and_where_clause(type_params, where_clause);
-        warnings.append(&mut parsed_type_parameters.warnings);
-        errors.append(&mut parsed_type_parameters.errors);
-        let type_parameters = parsed_type_parameters.value.unwrap_or_else(|| Vec::new());
+        let type_parameters =
+            TypeParameter::parse_from_type_params_and_where_clause(type_params, where_clause)
+                .unwrap_or_else(&mut warnings, &mut errors, || Vec::new());
 
         // unwrap non-optional fields
         let enum_name = enum_name.unwrap();

--- a/core_lang/src/parse_tree/declaration/function_declaration.rs
+++ b/core_lang/src/parse_tree/declaration/function_declaration.rs
@@ -120,13 +120,11 @@ impl<'sc> FunctionDeclaration<'sc> {
             ),
             None => TypeInfo::Unit,
         };
-        let mut parsed_type_parameters = TypeParameter::parse_from_type_params_and_where_clause(
+        let type_parameters = TypeParameter::parse_from_type_params_and_where_clause(
             type_params_pair,
             where_clause_pair,
-        );
-        warnings.append(&mut parsed_type_parameters.warnings);
-        errors.append(&mut parsed_type_parameters.errors);
-        let type_parameters = parsed_type_parameters.value.unwrap_or_else(|| Vec::new());
+        )
+        .unwrap_or_else(&mut warnings, &mut errors, || Vec::new());
 
         // check that all generic types used in function parameters are a part of the type
         // parameters

--- a/core_lang/src/parse_tree/declaration/impl_trait.rs
+++ b/core_lang/src/parse_tree/declaration/impl_trait.rs
@@ -72,13 +72,11 @@ impl<'sc> ImplTrait<'sc> {
             Some(ref x) => x.as_span(),
             None => trait_name.span(),
         };
-        let mut parsed_type_arguments = TypeParameter::parse_from_type_params_and_where_clause(
+        let type_arguments = TypeParameter::parse_from_type_params_and_where_clause(
             type_params_pair,
             where_clause_pair,
-        );
-        warnings.append(&mut parsed_type_arguments.warnings);
-        errors.append(&mut parsed_type_arguments.errors);
-        let type_arguments = parsed_type_arguments.value.unwrap_or_else(|| Vec::new());
+        )
+        .unwrap_or_else(&mut warnings, &mut errors, || Vec::new());
 
         let mut fn_decls_buf = vec![];
 
@@ -142,13 +140,11 @@ impl<'sc> ImplSelf<'sc> {
             Some(ref x) => x.as_span(),
             None => type_name_span.clone(),
         };
-        let mut parsed_type_arguments = TypeParameter::parse_from_type_params_and_where_clause(
+        let type_arguments = TypeParameter::parse_from_type_params_and_where_clause(
             type_params_pair,
             where_clause_pair,
-        );
-        warnings.append(&mut parsed_type_arguments.warnings);
-        errors.append(&mut parsed_type_arguments.errors);
-        let type_arguments = parsed_type_arguments.value.unwrap_or_else(|| Vec::new());
+        )
+        .unwrap_or_else(&mut warnings, &mut errors, || Vec::new());
 
         let mut fn_decls_buf = vec![];
 

--- a/core_lang/src/parse_tree/declaration/struct_declaration.rs
+++ b/core_lang/src/parse_tree/declaration/struct_declaration.rs
@@ -57,13 +57,11 @@ impl<'sc> StructDeclaration<'sc> {
         }
         let name = name.expect("guaranteed to exist by grammar");
 
-        let mut parsed_type_parameters = TypeParameter::parse_from_type_params_and_where_clause(
+        let type_parameters = TypeParameter::parse_from_type_params_and_where_clause(
             type_params_pair,
             where_clause_pair,
-        );
-        warnings.append(&mut parsed_type_parameters.warnings);
-        errors.append(&mut parsed_type_parameters.errors);
-        let type_parameters = parsed_type_parameters.value.unwrap_or_else(|| Vec::new());
+        )
+        .unwrap_or_else(&mut warnings, &mut errors, || Vec::new());
 
         let fields = if let Some(fields) = fields_pair {
             eval!(

--- a/core_lang/src/parse_tree/declaration/trait_declaration.rs
+++ b/core_lang/src/parse_tree/declaration/trait_declaration.rs
@@ -91,14 +91,12 @@ impl<'sc> TraitDeclaration<'sc> {
                 }
             }
         }
-        let mut parsed_type_parameters =
+        let type_parameters =
             crate::parse_tree::declaration::TypeParameter::parse_from_type_params_and_where_clause(
                 type_params_pair,
                 where_clause_pair,
-            );
-        warnings.append(&mut parsed_type_parameters.warnings);
-        errors.append(&mut parsed_type_parameters.errors);
-        let type_parameters = parsed_type_parameters.value.unwrap_or_else(|| Vec::new());
+            )
+            .unwrap_or_else(&mut warnings, &mut errors, || Vec::new());
         ok(
             TraitDeclaration {
                 type_parameters,

--- a/core_lang/src/parse_tree/expression/mod.rs
+++ b/core_lang/src/parse_tree/expression/mod.rs
@@ -184,13 +184,7 @@ impl<'sc> Expression<'sc> {
             let op_str = op.as_str();
             let op_span = op.as_span();
 
-            let mut parsed_op = parse_op(op);
-            warnings.append(&mut parsed_op.warnings);
-            errors.append(&mut parsed_op.errors);
-            let op = match parsed_op.value {
-                None => return err(warnings, errors),
-                Some(value) => value,
-            };
+            let op = check!(parse_op(op), return err(warnings, errors), warnings, errors);
 
             // an op is necessarily followed by an expression
             let next_expr = match expr_iter.next() {
@@ -222,13 +216,10 @@ impl<'sc> Expression<'sc> {
         if expr_or_op_buf.len() == 1 {
             ok(first_expr, warnings, errors)
         } else {
-            let mut arranged_ops =
-                arrange_by_order_of_operations(expr_or_op_buf, expr_for_debug.as_span());
-            warnings.append(&mut arranged_ops.warnings);
-            errors.append(&mut arranged_ops.errors);
-            let expr = arranged_ops.value.unwrap_or_else(|| Expression::Unit {
-                span: expr_for_debug.as_span(),
-            });
+            let expr = arrange_by_order_of_operations(expr_or_op_buf, expr_for_debug.as_span())
+                .unwrap_or_else(&mut warnings, &mut errors, || Expression::Unit {
+                    span: expr_for_debug.as_span(),
+                });
             ok(expr, warnings, errors)
         }
     }
@@ -238,15 +229,9 @@ impl<'sc> Expression<'sc> {
         let mut warnings = Vec::new();
         let span = expr.as_span();
         let parsed = match expr.as_rule() {
-            Rule::literal_value => {
-                let mut parsed_literal = Literal::parse_from_pair(expr.clone());
-                warnings.append(&mut parsed_literal.warnings);
-                errors.append(&mut parsed_literal.errors);
-                parsed_literal
-                    .value
-                    .map(|(value, span)| Expression::Literal { value, span })
-                    .unwrap_or_else(|| Expression::Unit { span })
-            }
+            Rule::literal_value => Literal::parse_from_pair(expr.clone())
+                .map(|(value, span)| Expression::Literal { value, span })
+                .unwrap_or_else(&mut warnings, &mut errors, || Expression::Unit { span }),
             Rule::func_app => {
                 let span = expr.as_span();
                 let mut func_app_parts = expr.into_inner();

--- a/core_lang/src/semantic_analysis/ast_node/impl_trait.rs
+++ b/core_lang/src/semantic_analysis/ast_node/impl_trait.rs
@@ -31,10 +31,10 @@ pub(crate) fn implementation_of_trait<'sc>(
     namespace.insert_trait_methods(&type_arguments[..]);
     let type_implementing_for = namespace.resolve_type_without_self(&type_implementing_for);
     let self_type = type_implementing_for.clone();
-    let mut call_path = namespace.get_call_path(&trait_name);
-    warnings.append(&mut call_path.warnings);
-    errors.append(&mut call_path.errors);
-    match call_path.value {
+    match namespace
+        .get_call_path(&trait_name)
+        .ok(&mut warnings, &mut errors)
+    {
         Some(TypedDeclaration::TraitDeclaration(tr)) => {
             let tr = tr.clone();
             if type_arguments.len() != tr.type_parameters.len() {

--- a/core_lang/src/semantic_analysis/syntax_tree.rs
+++ b/core_lang/src/semantic_analysis/syntax_tree.rs
@@ -136,14 +136,11 @@ impl<'sc> TypedParseTree<'sc> {
             num_failed_nodes = next_pass_nodes.len();
         }
 
-        let mut typed_tree_nodes = Vec::new();
-        for mut res in successful_nodes {
-            warnings.append(&mut res.warnings);
-            errors.append(&mut res.errors);
-            if let Some(node) = res.value {
-                typed_tree_nodes.push(node);
-            }
-        }
+        let typed_tree_nodes = successful_nodes
+            .into_iter()
+            .filter_map(|res| res.ok(&mut warnings, &mut errors))
+            .collect::<Vec<TypedAstNode<'sc>>>();
+
         // perform validation based on the tree type
         match tree_type {
             TreeType::Predicate => {


### PR DESCRIPTION
Add and utilise some more methods for CompileResult so that it more resembles std::Result, or perhaps std::Option.

- ok() now forwards on warnings and errors.
- map() will convert the value while keeping the warnings and errors.
- unwrap_or_else() is a lot like check!() in that it forwards on
  warnings and errors and returns the fully unwrapped value or an
  alternative.
- unwrap() now forwards on warnings and errors or panics if empty/none.

check!() is still necessary for alternatives involving control flow, e.g., check!(f(), return abort_gracefully(), warnings, errors);