### PR TITLE
Run cargo test on all pushes

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -1,12 +1,6 @@
 name: Compile and Test
 
-on: 
-  push:
-    paths:
-      # Only run cargo test when relevant files are changed
-      - '**/**.rs'
-      - '**/**.sw'
-      - '**/**.toml'
+on: [push]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
I'm not sure why my change in #175 doesn't actually run on rust file changes, but this reverts that until we can spend more time optimizing our workflows.