### PR TITLE
Minor improvements to nightly deploy CI

### DIFF
--- a/.github/workflows/deploy-nightlies.yml
+++ b/.github/workflows/deploy-nightlies.yml
@@ -139,7 +139,7 @@ jobs:
         mv x86_64-unknown-linux-gnu/sway-server sway-nightly-binaries/$FOLDER_NAME/x86_64-unknown-linux-gnu/
         mv x86_64-unknown-linux-gnu/forc sway-nightly-binaries/$FOLDER_NAME/x86_64-unknown-linux-gnu/
       env: 
-        FOLDER_NAME: nightly-${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.sha_short }}
+        FOLDER_NAME: sway-nightly-${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.sha_short }}
 
     - name: Push Binaries
       run: |


### PR DESCRIPTION
- prefix sway nightlies directory with `sway-`, since the nightlies repo will serve more than just sway (despite the name)
- rename bot to more general