### PR TITLE
Fix some bugs in the if-expression ASM generation.

### DIFF
--- a/core_lang/src/asm_generation/expression/if_exp.rs
+++ b/core_lang/src/asm_generation/expression/if_exp.rs
@@ -63,7 +63,7 @@ pub(crate) fn convert_if_exp_to_asm<'sc>(
 
     let then_branch_result = register_sequencer.next();
     let mut then_branch = check!(
-        convert_expression_to_asm(then, namespace, &condition_result, register_sequencer),
+        convert_expression_to_asm(then, namespace, &then_branch_result, register_sequencer),
         return err(warnings, errors),
         warnings,
         errors
@@ -86,12 +86,13 @@ pub(crate) fn convert_if_exp_to_asm<'sc>(
             "beginning of else branch",
         ));
         let else_branch_result = register_sequencer.next();
-        let _else_branch = check!(
+        let mut else_branch = check!(
             convert_expression_to_asm(&r#else, namespace, &else_branch_result, register_sequencer),
             return err(warnings, errors),
             warnings,
             errors
         );
+        asm_buf.append(&mut else_branch);
 
         // move the result of the else branch into the return register
         asm_buf.push(Op::register_move(


### PR DESCRIPTION
These fixes show that the `if` expression generation was always broken, AFAICT.  @sezna -- why was the `else` block code ignored?  Strange.

I haven't added any tests here, because I'm not sure we can test it yet.  We do need to add a framework for validating the output of ASM generation for each basic construct, and for optimisations, by comparing the ASM output to an expected value.

Closes #184.