### PR TITLE
Make sure if main() returns Unit that it does return a 0.

### DIFF
--- a/core_lang/src/asm_generation/mod.rs
+++ b/core_lang/src/asm_generation/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     semantic_analysis::{
         TypedAstNode, TypedAstNodeContent, TypedFunctionDeclaration, TypedParseTree,
     },
-    types::ResolvedType,
+    types::{MaybeResolvedType, ResolvedType},
     BuildConfig, Ident,
 };
 use either::Either;
@@ -633,11 +633,21 @@ pub(crate) fn compile_ast_to_asm<'sc>(
                 errors
             );
             asm_buf.append(&mut body);
-            asm_buf.push(Op {
-                owning_span: None,
-                opcode: Either::Left(VirtualOp::RET(return_register)),
-                comment: "main fn return value".into(),
-            });
+            if main_function.return_type == MaybeResolvedType::Resolved(ResolvedType::Unit) {
+                asm_buf.push(Op {
+                    owning_span: None,
+                    opcode: Either::Left(VirtualOp::RET(VirtualRegister::Constant(
+                        ConstantRegister::Zero,
+                    ))),
+                    comment: "main fn returns unit value".into(),
+                });
+            } else {
+                asm_buf.push(Op {
+                    owning_span: None,
+                    opcode: Either::Left(VirtualOp::RET(return_register)),
+                    comment: "main fn return value".into(),
+                });
+            }
 
             HllAsmSet::ScriptMain {
                 program_section: AbstractInstructionSet { ops: asm_buf },

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -13,6 +13,7 @@ pub fn run() {
         ("contract_call", ProgramState::Return(0)),
         ("enum_in_fn_decl", ProgramState::Return(255)),
         ("empty_impl", ProgramState::Return(0)),
+        ("main_returns_unit", ProgramState::Return(0)),
     ];
     project_names.into_iter().for_each(|(name, res)| {
         assert_eq!(crate::e2e_vm_tests::harness::runs_in_vm(name), res);

--- a/test/src/e2e_vm_tests/test_programs/main_returns_unit/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/main_returns_unit/Forc.toml
@@ -1,0 +1,5 @@
+[project]
+author  = "Toby Hutton <toby.hutton@fuel.sh>"
+license = "MIT"
+name = "main_returns_unit"
+entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/main_returns_unit/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/main_returns_unit/src/main.sw
@@ -1,0 +1,13 @@
+script;
+
+fn ten() -> u64 {
+  10
+}
+
+fn nop() {
+  ten();
+}
+
+fn main() {
+  nop()
+}


### PR DESCRIPTION
Closes #207.

This is actually doing the bare minimum to ensure that an empty main returns zero (where beforehand it returned an uninitialised `$r0`) or more specifically, a main which has a `Unit` return type returns zero.

I've added a test which will need updating when #208 is merged, to confirm zero does get returned.

We could try harder to fix this problem, since in the test `nop()` returns `Unit` too and so it should set `$r0` to zero, but the current codebase doesn't easily support this, and I'm in favour of improving the overall codegen side of things via a 'middle end'.