### PR TITLE
Fix parser for empty `impl self` statements.

### DIFF
--- a/core_lang/src/parse_tree/declaration/impl_trait.rs
+++ b/core_lang/src/parse_tree/declaration/impl_trait.rs
@@ -131,10 +131,9 @@ impl<'sc> ImplSelf<'sc> {
             return err(warnings, errors)
         );
 
-        let where_clause_pair = if iter.peek().unwrap().as_rule() == Rule::trait_bounds {
-            iter.next()
-        } else {
-            None
+        let where_clause_pair = match iter.peek() {
+            Some(pair) if pair.as_rule() == Rule::trait_bounds => iter.next(),
+            _ => None,
         };
         let type_arguments_span = match type_params_pair {
             Some(ref x) => x.as_span(),

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -11,6 +11,7 @@ pub fn run() {
         "struct_field_reassignment",
         "contract_call",
         "enum_in_fn_decl",
+        "empty_impl",
     ];
     project_names.into_iter().for_each(|name| {
         crate::e2e_vm_tests::harness::runs_in_vm(name);

--- a/test/src/e2e_vm_tests/test_programs/empty_impl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/empty_impl/Forc.toml
@@ -1,0 +1,5 @@
+[project]
+author  = "Toby Hutton <toby.hutton@fuel.sh"
+license = "MIT"
+name = "empty_impl"
+entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/empty_impl/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/empty_impl/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+impl Coin {
+
+}
+
+fn main() {
+
+}


### PR DESCRIPTION
Closes #205.

The parser for `impl_self` is:

```
impl_self =  {impl_keyword ~ type_params? ~ type_name ~  trait_bounds? ~ ("{" ~ fn_decl* ~ "}")}
```

The trait bounds and actual function declarations can both be empty, and will be for the Sway code `impl T { }`.  The old code assumed that there would be some function declarations and was trying to peek beyond the end of the iterator.