### PR TITLE
Detect and report errors for recursive function calls.

### DIFF
--- a/core_lang/src/error.rs
+++ b/core_lang/src/error.rs
@@ -681,6 +681,16 @@ pub enum CompileError<'sc> {
         should_be: String,
         provided: String,
     },
+    #[error("Function {fn_name} is recursive, which is unsupported at this time.")]
+    RecursiveCall { fn_name: &'sc str, span: Span<'sc> },
+    #[error(
+        "Function {fn_name} is recursive via {call_chain}, which is unsupported at this time."
+    )]
+    RecursiveCallChain {
+        fn_name: &'sc str,
+        call_chain: String, // Pretty list of symbols, e.g., "a, b and c".
+        span: Span<'sc>,
+    },
 }
 
 impl<'sc> std::convert::From<TypeError<'sc>> for CompileError<'sc> {
@@ -850,6 +860,8 @@ impl<'sc> CompileError<'sc> {
             IncorrectNumberOfInterfaceSurfaceFunctionParameters { span, .. } => span,
             AbiFunctionRequiresSpecificSignature { span, .. } => span,
             ArgumentParameterTypeMismatch { span, .. } => span,
+            RecursiveCall { span, .. } => span,
+            RecursiveCallChain { span, .. } => span,
         }
     }
 

--- a/core_lang/src/semantic_analysis/syntax_tree.rs
+++ b/core_lang/src/semantic_analysis/syntax_tree.rs
@@ -78,7 +78,13 @@ impl<'sc> TypedParseTree<'sc> {
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
 
-        let ordered_nodes = node_dependencies::order_ast_nodes_by_dependency(&parsed.root_nodes);
+        let ordered_nodes = check!(
+            node_dependencies::order_ast_nodes_by_dependency(parsed.root_nodes),
+            return err(warnings, errors),
+            warnings,
+            errors
+        );
+
         let typed_nodes = check!(
             TypedParseTree::type_check_nodes(
                 ordered_nodes,

--- a/test/src/e2e_vm_tests/test_programs/recursive_calls/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/recursive_calls/Forc.toml
@@ -1,0 +1,5 @@
+[project]
+author  = "Toby Hutton <toby.hutton@fuel.sh>"
+license = "MIT"
+name = "recursive_calls"
+entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/recursive_calls/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/recursive_calls/src/main.sw
@@ -1,0 +1,39 @@
+script;
+
+// a -> a
+fn a(n: u64) -> u64 {
+    a(n)
+}
+
+// b -> c -> b
+fn b(n: u64) -> u64 {
+    c(n)
+}
+
+fn c(n: u64) -> u64 {
+    b(n)
+}
+
+// d -> e -> f -> d
+fn d(n: u64) -> u64 {
+    e(n)
+}
+
+fn e(n: u64) -> u64 {
+    f(n)
+}
+
+fn f(n: u64) -> u64 {
+    d(n)
+}
+
+// Depends on symbols 'a' and 'b' but is not recursive.
+fn g(a: u64) -> u64 {
+  let b = a;
+  a + b
+}
+
+// main
+fn main() -> u64 {
+    a(1)
+}


### PR DESCRIPTION
The dependency analysis now uses a HashMap of HashSets instead of a 2D array of &str.  Each dependency is to and from a DependentSymbol wrapper which now special cases function declarations.

With the function declarations and their dependencies gathered it's relatively easy to check whether any functions (eventually) depend on themselves.  New errors are now reported when recursion is detected.

I've added a test file but haven't added it to the test suite because it fails deliberately.  We need to update the tests to allow and capture/check errors.