### PR TITLE
Assert that a test case _should_ fail.

### DIFF
--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -84,7 +84,7 @@ pub(crate) fn runs_in_vm(file_name: &str) -> ProgramState {
 /// Panics if code _does_ compile, used for test cases where the source
 /// code should have been rejected by the compiler.
 pub(crate) fn does_not_compile(file_name: &str) {
-    if let Ok(o) = compile_to_bytes(file_name) {
+    if let Ok(_) = compile_to_bytes(file_name) {
         panic!("{} should not have compiled.", file_name);
     }
 }

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -25,5 +25,7 @@ pub fn run() {
     let project_names = vec!["recursive_calls"];
     project_names
         .into_iter()
-        .for_each(|name| does_not_compile(name));
+        .for_each(|name| crate::e2e_vm_tests::harness::does_not_compile(name));
+
+    println!("_________________________________\nTests passed.");
 }


### PR DESCRIPTION
Currently, our tests only assert successes and validate VM output. We need a way to assert that code should _not_ compile. This is a very basic stab at saying code should not compile. In an ideal world, we could specify the exact errors that it should throw, but that requires substantial rewiring and is therefore, as a task, being punted into the future.

This PR simply allows us to assert that code should _not_ compile, and I've included @otrho's recursion ban test case in it.