### PR TITLE
Only run CI tests on PRs instead of every push.

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -1,6 +1,6 @@
 name: Compile and Test
 
-on: [push]
+on: pull_request
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
To save on minutes, we only want to run our CI tests on pull requests (as per slack).