### PR TITLE
fix forc deploy as per @Voxelot's instruction

### DIFF
--- a/forc/src/ops/forc_deploy.rs
+++ b/forc/src/ops/forc_deploy.rs
@@ -1,6 +1,6 @@
 use core_lang::parse;
 use fuel_client::client::FuelClient;
-use fuel_tx::{crypto, ContractId, Output, Salt, Transaction};
+use fuel_tx::{Output, Salt, Transaction};
 use fuel_vm::prelude::*;
 
 use crate::cli::{BuildCommand, DeployCommand};


### PR DESCRIPTION
I was unable to deploy a contract to the node. @Voxelot helped diagnose and posted this fix in Slack. I think we want to take it, but @vlopes11 and @leviathanbeak should take a look and confirm.