### PR TITLE
Fix typo in error text for asm ops requiring four arguments

### DIFF
--- a/core_lang/src/asm_lang/mod.rs
+++ b/core_lang/src/asm_lang/mod.rs
@@ -979,7 +979,7 @@ fn four_regs<'sc>(
         _ => {
             errors.push(CompileError::IncorrectNumberOfAsmRegisters {
                 span: whole_op_span.clone(),
-                expected: 1,
+                expected: 4,
                 received: args.len(),
             });
             return err(warnings, errors);

--- a/core_lang/src/error.rs
+++ b/core_lang/src/error.rs
@@ -597,7 +597,7 @@ pub enum CompileError<'sc> {
     )]
     DisallowedLw { span: Span<'sc> },
     #[error(
-        "This op expects {expected} registers as arguments, but you provided {received} registers."
+        "This op expects {expected} register(s) as arguments, but you provided {received} register(s)."
     )]
     IncorrectNumberOfAsmRegisters {
         span: Span<'sc>,


### PR DESCRIPTION
I was just writing some assembly, and got this error:

<img width="632" alt="image" src="https://user-images.githubusercontent.com/12157751/133649571-d809f5c0-db18-453d-94e4-68374392c61a.png">

Clearly there's a typo in the error text for this case. This PR fixes that.