### PR TITLE
remove TODOs in docs

### DIFF
--- a/docs/src/advanced/index.md
+++ b/docs/src/advanced/index.md
@@ -1,1 +1,4 @@
 # Advanced Concepts
+
+- [Generic Types](./generic_types.md) 
+- [Traits](./generic_types.md) 

--- a/docs/src/advanced/trait_constraints.md
+++ b/docs/src/advanced/trait_constraints.md
@@ -1,1 +1,0 @@
-# Trait Constraints

--- a/docs/src/advanced/traits.md
+++ b/docs/src/advanced/traits.md
@@ -58,7 +58,6 @@ fn play_game_with_deck<T>(a: Vec<T>) where T: Card {
   }
 ```
 
-<!-- TODO: link to generic docs -->
 
 Now, if you want to use the function `play_game_with_deck` with your own personal struct, you must implement `Card` for your struct. Note that the following code example assumes a dependency _games_ has been included in the `Forc.toml` file.
 
@@ -84,14 +83,13 @@ fn main() {
     let mut deck: Vec<MyCard> = Vec::with_capacity(50);
     while i > 0 {
         i = i - 1;
-        deck.push(MyCard { suit: random_suit(), value: i % 4}
+        deck.push(MyCard { suit: generate_random_suit(), value: i % 4}
     }
     play_game_with_deck(deck);
 }
 
 fn random_suit(i: u64) -> Suit {
-    // TODO
+  [ ... ]
 }
 ```
 
-To learn more about `where` clauses and how to use trait constraints, see [Trait Constraints](./trait_constraints).

--- a/docs/src/basics/types.md
+++ b/docs/src/basics/types.md
@@ -39,7 +39,13 @@ The default numeric type is `u64`. The FuelVM's word size is 64 bits, and the ca
 
 ## Boolean Type
 
-TODO
+The boolean type (`bool`) has two potential values: `true` or `false`. Boolean values are typically used for conditional logic or validation, for example in `if` expressions. Booleans can be negated, or flipped, with the unary negation operator `!`. For example:
+```sway
+fn returns_false() -> bool {
+  let boolean_value: bool = true;
+  !true
+}
+```
 
 ## String Type
 

--- a/docs/src/style/capitalization.md
+++ b/docs/src/style/capitalization.md
@@ -1,1 +1,2 @@
 # Capitalization
+In Sway, structs, traits, and enums are `CapitalCase`. Modules, variables, and functions are `snake_case`, constants are `SCREAMING_SNAKE_CASE`. The compiler will warn you if your capitalization is ever unidiomatic.

--- a/docs/src/sway-on-chain/predicates.md
+++ b/docs/src/sway-on-chain/predicates.md
@@ -1,3 +1,11 @@
 # Predicates
 
-TODO
+From the perspective of Sway, predicates are programs which return a boolean value and which represent ownership of some resource upon execution to true. They have no access to contract storage. Here is a trivial predicate, which always evaluates to true:
+
+```sway
+predicate;
+
+fn main() -> bool {
+  true
+}
+```

--- a/docs/src/sway-on-chain/scripts.md
+++ b/docs/src/sway-on-chain/scripts.md
@@ -1,3 +1,26 @@
 # Scripts
 
-TODO
+A script is a deployed bytecode on the chain which executes to perform some task. It does not represent ownership of any resources and it cannot be called like a contract.
+
+This example script calls a contract.
+
+```sway
+script;
+
+use example_contract::MyContract;
+
+struct InputStruct { 
+  field_1: bool,
+  field_2: u64
+}
+
+fn main () {
+  let x = abi(MyContract, 0x8900c5bec4ca97d4febf9ceb4754a60d782abbf3cd815836c1872116f203f861);
+  let color = 0x7777_7777_7777_7777_7777_7777_7777_7777_7777_7777_7777_7777_7777_7777_7777_7777;
+  let input = InputStruct {
+    field_1: true,
+    field_2: 3,
+  };
+  x.foo(5000, 0, color, input);
+}
+```

--- a/docs/src/sway-on-chain/smart_contracts.md
+++ b/docs/src/sway-on-chain/smart_contracts.md
@@ -1,3 +1,4 @@
 # Smart Contracts
 
-TODO
+A smart contract is a callable entity that is deployed to the chain with some defined interface for interaction. See [this contract](../examples/wallet_smart_contract.md) for an example.
+


### PR DESCRIPTION
Removes documentation TODOs and replaces them with something, however minimal.