### PR TITLE
Replace instance of eval with check

### DIFF
--- a/core_lang/src/error.rs
+++ b/core_lang/src/error.rs
@@ -16,19 +16,6 @@ macro_rules! check {
     }};
 }
 
-/// evaluates `$fn` with argument `$arg`, and pushes any warnings to the `$warnings` buffer.
-macro_rules! eval {
-    ($fn: expr, $warnings: ident, $errors: ident, $arg: expr, $error_recovery: expr) => {{
-        let mut res = $fn($arg.clone());
-        $warnings.append(&mut res.warnings);
-        $errors.append(&mut res.errors);
-        match res.value {
-            None => $error_recovery,
-            Some(value) => value,
-        }
-    }};
-}
-
 macro_rules! assert_or_warn {
     ($bool_expr: expr, $warnings: ident, $span: expr, $warning: expr) => {
         if !$bool_expr {

--- a/core_lang/src/parse_tree/expression/asm.rs
+++ b/core_lang/src/parse_tree/expression/asm.rs
@@ -54,12 +54,11 @@ impl<'sc> AsmExpression<'sc> {
                 }
                 Rule::asm_register => {
                     implicit_op_return = Some((
-                        eval!(
-                            AsmRegister::parse_from_pair,
+                        check!(
+                            AsmRegister::parse_from_pair(pair.clone()),
+                            continue,
                             warnings,
-                            errors,
-                            pair,
-                            continue
+                            errors
                         ),
                         Span {
                             span: pair.as_span(),


### PR DESCRIPTION
Closes #220.

This PR replaces the last instance of `eval!` with `check!` and deletes the `eval!` macro entirely.