### PR TITLE
Only build and deploy Sway nightlies on release

### DIFF
--- a/.github/workflows/deploy-nightlies.yml
+++ b/.github/workflows/deploy-nightlies.yml
@@ -5,9 +5,8 @@ name: Deploy Nightly Binaries
 ## we have to break the builds apart into different jobs to run on different runners.
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
As mentioned in the Budget Meeting, we want to save on minutes and only deploy on tagged release.