### PR TITLE
Catch incorrect number of function arguments in type checking instead of code generation.

### DIFF
--- a/core_lang/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/core_lang/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -316,6 +316,35 @@ impl<'sc> TypedExpression<'sc> {
                     body,
                     ..
                 } = decl.clone();
+                if arguments.len() > parameters.len() {
+                    let arguments_span = arguments.iter().fold(
+                        arguments
+                            .get(0)
+                            .map(|x| x.span())
+                            .unwrap_or_else(|| name.span()),
+                        |acc, arg| crate::utils::join_spans(acc, arg.span()),
+                    );
+                    errors.push(CompileError::TooManyArgumentsForFunction {
+                        span: arguments_span,
+                        method_name: name.suffix.primary_name,
+                        expected: parameters.len(),
+                        received: arguments.len(),
+                    });
+                } else if arguments.len() < parameters.len() {
+                    let arguments_span = arguments.iter().fold(
+                        arguments
+                            .get(0)
+                            .map(|x| x.span())
+                            .unwrap_or_else(|| name.span()),
+                        |acc, arg| crate::utils::join_spans(acc, arg.span()),
+                    );
+                    errors.push(CompileError::TooFewArgumentsForFunction {
+                        span: arguments_span,
+                        method_name: name.suffix.primary_name,
+                        expected: parameters.len(),
+                        received: arguments.len(),
+                    });
+                }
                 // type check arguments in function application vs arguments in function
                 // declaration. Use parameter type annotations as annotations for the
                 // arguments

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -24,7 +24,11 @@ pub fn run() {
     });
 
     // source code that should _not_ compile
-    let project_names = vec!["recursive_calls"];
+    let project_names = vec![
+        "recursive_calls",
+        "missing_fn_arguments",
+        "excess_fn_arguments",
+    ];
     project_names
         .into_iter()
         .for_each(|name| crate::e2e_vm_tests::harness::does_not_compile(name));

--- a/test/src/e2e_vm_tests/test_programs/excess_fn_arguments/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/excess_fn_arguments/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+author  = "Alex Hansen <alex.hansen@fuel.sh>"
+license = "MIT"
+name = "excess_fn_arguments"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../../../../../stdlib" }

--- a/test/src/e2e_vm_tests/test_programs/excess_fn_arguments/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/excess_fn_arguments/src/main.sw
@@ -1,0 +1,13 @@
+script;
+
+fn bar(a: bool, b: u64) -> u64 {
+  if a {
+    b * 2
+  } else {
+    0
+  }
+}
+
+fn main() -> u64 {
+  bar(true, 0, true)
+}

--- a/test/src/e2e_vm_tests/test_programs/missing_fn_arguments/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/missing_fn_arguments/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+author  = "Alex Hansen <alex.hansen@fuel.sh>"
+license = "MIT"
+name = "missing_fn_arguments"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../../../../../stdlib" }

--- a/test/src/e2e_vm_tests/test_programs/missing_fn_arguments/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/missing_fn_arguments/src/main.sw
@@ -1,0 +1,13 @@
+script;
+
+fn bar(a: bool, b: u64) -> u64 {
+  if a {
+    b * 2
+  } else {
+    0
+  }
+}
+
+fn main() -> u64 {
+  bar(true)
+}


### PR DESCRIPTION

<img width="608" alt="image" src="https://user-images.githubusercontent.com/12157751/134060737-0cd0e27d-741e-4770-a08c-987df47172b7.png">


Closes #243 

Adds:
1. Tests for both too many and too few arguments
2. Fix where a missing argument would get caught by an ugly internal error in code generation instead of type checking.

See #243 for more details.