### PR TITLE
Allow an argument to the test suite for filtering cases to run.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3213,6 +3213,7 @@ dependencies = [
  "fuel-tx",
  "fuel-vm",
  "rand 0.8.4",
+ "regex",
 ]
 
 [[package]]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -12,3 +12,4 @@ fuel-tx = { git = "ssh://git@github.com/FuelLabs/fuel-tx.git" }
 fuel-vm = { git = "ssh://git@github.com/FuelLabs/fuel-vm.git" }
 fuel-asm = { git = "ssh://git@github.com/FuelLabs/fuel-asm.git" }
 rand = "0.8"
+regex = "1"

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -1,7 +1,14 @@
 mod harness;
 use fuel_vm::prelude::*;
 
-pub fn run() {
+pub fn run(filter_regex: Option<regex::Regex>) {
+    let filter = |name| {
+        filter_regex
+            .as_ref()
+            .map(|regex| regex.is_match(name))
+            .unwrap_or(true)
+    };
+
     // programs that should successfully compile and terminate
     // with some known state
     let project_names = vec![
@@ -22,7 +29,9 @@ pub fn run() {
         ("op_precedence", ProgramState::Return(0)), // 1 == false
     ];
     project_names.into_iter().for_each(|(name, res)| {
-        assert_eq!(crate::e2e_vm_tests::harness::runs_in_vm(name), res);
+        if filter(name) {
+            assert_eq!(crate::e2e_vm_tests::harness::runs_in_vm(name), res);
+        }
     });
 
     // source code that should _not_ compile
@@ -33,9 +42,11 @@ pub fn run() {
         "missing_fn_arguments",
         "excess_fn_arguments",
     ];
-    project_names
-        .into_iter()
-        .for_each(|name| crate::e2e_vm_tests::harness::does_not_compile(name));
+    project_names.into_iter().for_each(|name| {
+        if filter(name) {
+            crate::e2e_vm_tests::harness::does_not_compile(name)
+        }
+    });
 
     println!("_________________________________\nTests passed.");
 }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -1,5 +1,9 @@
 mod e2e_vm_tests;
 
 fn main() {
-    e2e_vm_tests::run();
+    let filter_regex = std::env::args().nth(1).map(|filter_str| {
+        regex::Regex::new(&filter_str).expect(&format!("Invalid filter regex: '{}'.", filter_str))
+    });
+
+    e2e_vm_tests::run(filter_regex);
 }


### PR DESCRIPTION
The optional argument may be a regex which is checked against the name of the test.

E.g., `cargo run ^contract`

... will run only the `contract_abi_impl` and `contract_call` tests (as of the time of this commit).