### PR TITLE
Allow return values from ABI functions

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/contract_abi_impl/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/contract_abi_impl/src/main.sw
@@ -3,20 +3,20 @@ contract;
 struct InputStruct { field_1: bool, field_2: u64 }
 
 abi MyContract {
-  fn foo(gas: u64, coin: u64, color: b256, input: InputStruct);
+  fn foo(gas: u64, coin: u64, color: b256, input: InputStruct) -> InputStruct;
 } {
   fn baz(gas: u64, coin: u64, color: b256, input: bool) { } 
 }
 
 
 impl MyContract for Contract {
-  fn foo(gas: u64, coin: u64, color: b256, input: InputStruct) {
+  fn foo(gas: u64, coin: u64, color: b256, input: InputStruct) -> InputStruct {
     let status_code = if input.field_1 { "okay" } else { "fail" };
-    calls_other_contract();
+    calls_other_contract()
   }
 }
 
-fn calls_other_contract() {
+fn calls_other_contract() -> InputStruct {
   let x = abi(MyContract, 0x0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000);
   // commenting this out for now since contract call asm generation is not yet implemented
   let color = 0x0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
@@ -24,5 +24,5 @@ fn calls_other_contract() {
     field_1: true,
     field_2: 3,
   };
-  x.foo(5, 5, color, input);
+  x.foo(5, 5, color, input)
 }


### PR DESCRIPTION
This also can return based on `RET` or `RETD` by the same logic as #238 

Closes #251 

This is just the code generation bit. We still want to do some type system stuff with data returned from contracts, discussed in #25. 