### PR TITLE
Add build instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ export PATH="${HOME}/.cargo/bin:${PATH}"
 
 To ensure access to all dependent repositories, [create](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) and [add](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) SSH keys to your GitHub account.
 
-## Building Sway
+### Building Sway
 
 Clone the repository and build the Sway toolchain:
 


### PR DESCRIPTION
Rendered: https://github.com/FuelLabs/sway/tree/adlerjohn/add_build_instr_to_readme