### PR TITLE
Print out contract id when deploying via `forc deploy`.

### DIFF
--- a/forc/src/ops/forc_deploy.rs
+++ b/forc/src/ops/forc_deploy.rs
@@ -44,7 +44,7 @@ pub async fn deploy(_: DeployCommand) -> Result<(), CliError> {
 
                         match client.transact(&tx).await {
                             Ok(logs) => {
-                                println!("{:?}", logs);
+                                println!("Logs:\n{:?}", logs);
                                 Ok(())
                             }
                             Err(e) => Err(e.to_string().into()),
@@ -88,7 +88,7 @@ fn create_contract_tx(compiled_contract: Vec<u8>) -> Transaction {
     let contract = Contract::from(compiled_contract);
     let root = contract.root();
     let id = contract.id(&salt, &root);
-
+    println!("Contract id: 0x{}", hex::encode(id));
     let outputs = vec![Output::ContractCreated { contract_id: id }];
 
     Transaction::create(


### PR DESCRIPTION
<img width="591" alt="image" src="https://user-images.githubusercontent.com/12157751/136104385-65f5d9c4-0e23-4ecd-bb86-1e637983bc57.png">

Also made it a bit clearer that `[]` is referring to the logs.