### PR TITLE
Fix bug referencing `const` declarations in other modules.

### DIFF
--- a/core_lang/src/asm_generation/mod.rs
+++ b/core_lang/src/asm_generation/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     error::*,
     parse_tree::Literal,
     semantic_analysis::{
-        TypedAstNode, TypedAstNodeContent, TypedDeclaration, TypedFunctionDeclaration,
+        Namespace, TypedAstNode, TypedAstNodeContent, TypedDeclaration, TypedFunctionDeclaration,
         TypedParseTree,
     },
     types::{MaybeResolvedType, ResolvedType},
@@ -626,20 +626,23 @@ pub(crate) fn compile_ast_to_asm<'sc>(
     let mut register_sequencer = RegisterSequencer::new();
     let mut warnings = vec![];
     let mut errors = vec![];
+
     let asm = match ast {
         TypedParseTree::Script {
             main_function,
+            namespace: ast_namespace,
             declarations,
             ..
         } => {
             let mut namespace: AsmNamespace = Default::default();
             let mut asm_buf = build_preamble(&mut register_sequencer).to_vec();
             check!(
-                add_global_constant_decls(
+                add_all_constant_decls(
                     &mut namespace,
                     &mut register_sequencer,
                     &mut asm_buf,
-                    &declarations
+                    &declarations,
+                    &ast_namespace,
                 ),
                 return err(warnings, errors),
                 warnings,
@@ -679,17 +682,19 @@ pub(crate) fn compile_ast_to_asm<'sc>(
         }
         TypedParseTree::Predicate {
             main_function,
+            namespace: ast_namespace,
             declarations,
             ..
         } => {
             let mut namespace: AsmNamespace = Default::default();
             let mut asm_buf = build_preamble(&mut register_sequencer).to_vec();
             check!(
-                add_global_constant_decls(
+                add_all_constant_decls(
                     &mut namespace,
                     &mut register_sequencer,
                     &mut asm_buf,
-                    &declarations
+                    &declarations,
+                    &ast_namespace,
                 ),
                 return err(warnings, errors),
                 warnings,
@@ -716,17 +721,19 @@ pub(crate) fn compile_ast_to_asm<'sc>(
         }
         TypedParseTree::Contract {
             abi_entries,
+            namespace: ast_namespace,
             declarations,
             ..
         } => {
             let mut namespace: AsmNamespace = Default::default();
             let mut asm_buf = build_preamble(&mut register_sequencer).to_vec();
             check!(
-                add_global_constant_decls(
+                add_all_constant_decls(
                     &mut namespace,
                     &mut register_sequencer,
                     &mut asm_buf,
-                    &declarations
+                    &declarations,
+                    &ast_namespace,
                 ),
                 return err(warnings, errors),
                 warnings,
@@ -1174,6 +1181,30 @@ fn build_contract_abi_switch<'sc>(
     asm_buf
 }
 
+fn add_all_constant_decls<'sc>(
+    namespace: &mut AsmNamespace<'sc>,
+    register_sequencer: &mut RegisterSequencer,
+    asm_buf: &mut Vec<Op<'sc>>,
+    declarations: &[TypedDeclaration<'sc>],
+    ast_namespace: &Namespace<'sc>,
+) -> CompileResult<'sc, ()> {
+    let mut warnings = vec![];
+    let mut errors = vec![];
+    check!(
+        add_global_constant_decls(namespace, register_sequencer, asm_buf, declarations),
+        return err(warnings, errors),
+        warnings,
+        errors
+    );
+    check!(
+        add_module_constant_decls(namespace, register_sequencer, asm_buf, ast_namespace),
+        return err(warnings, errors),
+        warnings,
+        errors
+    );
+    ok((), warnings, errors)
+}
+
 fn add_global_constant_decls<'sc>(
     namespace: &mut AsmNamespace<'sc>,
     register_sequencer: &mut RegisterSequencer,
@@ -1193,6 +1224,42 @@ fn add_global_constant_decls<'sc>(
             asm_buf.append(&mut ops);
         }
     }
+    ok((), warnings, errors)
+}
+
+fn add_module_constant_decls<'sc>(
+    namespace: &mut AsmNamespace<'sc>,
+    register_sequencer: &mut RegisterSequencer,
+    asm_buf: &mut Vec<Op<'sc>>,
+    ast_namespace: &Namespace<'sc>,
+) -> CompileResult<'sc, ()> {
+    let mut warnings = vec![];
+    let mut errors = vec![];
+
+    // NOTE: this is currently flattening out the entire namespace, which is problematic.  To fix
+    // it we need to support hierarchical names (or at least absolute normalised names) to
+    // AsmNamespace.  This can be done in the new ASM generator which translates from IR, coming
+    // soon.
+    for (_, ns) in &ast_namespace.modules {
+        for (_, decl) in &ns.symbols {
+            if let TypedDeclaration::ConstantDeclaration(decl) = decl {
+                let mut ops = check!(
+                    convert_constant_decl_to_asm(&decl, namespace, register_sequencer),
+                    return err(warnings, errors),
+                    warnings,
+                    errors
+                );
+                asm_buf.append(&mut ops);
+            }
+        }
+        check!(
+            add_module_constant_decls(namespace, register_sequencer, asm_buf, ns),
+            return err(warnings, errors),
+            warnings,
+            errors
+        );
+    }
+
     ok((), warnings, errors)
 }
 

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -52,6 +52,7 @@ pub fn run(filter_regex: Option<regex::Regex>) {
         ("eq_4_test", ProgramState::Return(1)),
         ("local_impl_for_ord", ProgramState::Return(1)), // true
         ("const_decl", ProgramState::Return(100)),
+        ("const_decl_in_library", ProgramState::Return(1)), // true
     ];
     project_names.into_iter().for_each(|(name, res)| {
         if filter(name) {

--- a/test/src/e2e_vm_tests/test_programs/const_decl_in_library/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/const_decl_in_library/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+author  = "Toby Hutton <toby.hutton@fuel.sh>"
+license = "MIT"
+name = "const_decl_in_library"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../../../../../stdlib" }

--- a/test/src/e2e_vm_tests/test_programs/const_decl_in_library/src/earth.sw
+++ b/test/src/e2e_vm_tests/test_programs/const_decl_in_library/src/earth.sw
@@ -1,0 +1,3 @@
+library earth;
+
+const MAN = 5;

--- a/test/src/e2e_vm_tests/test_programs/const_decl_in_library/src/heaven.sw
+++ b/test/src/e2e_vm_tests/test_programs/const_decl_in_library/src/heaven.sw
@@ -1,0 +1,4 @@
+library heaven;
+
+const UNKNOWN_DEITY_VALUE = 0;
+const MONKEYS_GONE_HERE = true;

--- a/test/src/e2e_vm_tests/test_programs/const_decl_in_library/src/hell.sw
+++ b/test/src/e2e_vm_tests/test_programs/const_decl_in_library/src/hell.sw
@@ -1,0 +1,3 @@
+library hell;
+
+const THE_DEVIL = 6;

--- a/test/src/e2e_vm_tests/test_programs/const_decl_in_library/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/const_decl_in_library/src/main.sw
@@ -1,0 +1,27 @@
+script;
+
+dep heaven;
+dep earth;
+dep hell;
+
+use heaven::UNKNOWN_DEITY_VALUE;
+use earth::MAN;
+use hell::THE_DEVIL;
+
+fn god() -> u64 {
+    if MAN == 5 && THE_DEVIL == 6 {
+        7
+    } else {
+        UNKNOWN_DEITY_VALUE
+    }
+}
+
+use heaven::MONKEYS_GONE_HERE;
+
+fn main() -> bool {
+    if god() == 7 {
+        MONKEYS_GONE_HERE
+    } else {
+        false
+    }
+}


### PR DESCRIPTION
Caveat, line 1239 in `mod.rs`:
```
    // NOTE: this is currently flattening out the entire namespace, which is problematic.  To fix
    // it we need to support hierarchical names (or at least absolute normalised names) to
    // AsmNamespace.  This can be done in the new ASM generator which translates from IR, coming
    // soon.
```

Closes #297.