### PR TITLE
Fix Boolean example in docs/basics/types

### DIFF
--- a/docs/src/basics/types.md
+++ b/docs/src/basics/types.md
@@ -40,10 +40,11 @@ The default numeric type is `u64`. The FuelVM's word size is 64 bits, and the ca
 ## Boolean Type
 
 The boolean type (`bool`) has two potential values: `true` or `false`. Boolean values are typically used for conditional logic or validation, for example in `if` expressions. Booleans can be negated, or flipped, with the unary negation operator `!`. For example:
+
 ```sway
 fn returns_false() -> bool {
   let boolean_value: bool = true;
-  !true
+  !boolean_value
 }
 ```
 


### PR DESCRIPTION
While reading over the sway docs I noticed this example could be improved slightly.