### PR TITLE
Remove redundant clone.

### DIFF
--- a/core_lang/src/parse_tree/declaration/impl_trait.rs
+++ b/core_lang/src/parse_tree/declaration/impl_trait.rs
@@ -162,7 +162,7 @@ impl<'sc> ImplSelf<'sc> {
         let type_arguments_span = match type_params_pair {
             Some(ref x) => Span {
                 span: x.as_span(),
-                path: path.clone(),
+                path,
             },
             None => type_name_span.clone(),
         };


### PR DESCRIPTION
# Austin's Intership Clippy

## Remove redundant clone

Removing redundant clones minimizes memory allocation. 