### PR TITLE
Fix dependency fetching in workflow.

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Install rustfmt
         run: rustup component add rustfmt
 
+      - name: Set git config
+        run: |
+          git config --global core.bigfilethreshold 100m
+
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
For some reason `git` started failing because files were too big? Weird. But this _should_ fix it.