### PR TITLE
don't build rocksdb in fuel-core

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Clone and build fuel-core
         run: |
           git clone git@github.com:FuelLabs/fuel-core
-          (cd fuel-core && cargo build -p fuel-core --no-default-features --features=axum)
+          (cd fuel-core && cargo build -p fuel-core --no-default-features)
 
       - name: Run fuel-core
         run: |


### PR DESCRIPTION
This speeds up the `build fuel-core` pipeline step by around 7 minutes.