### PR TITLE
make forc return receipts like before

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,6 +1185,7 @@ dependencies = [
  "fuel-client",
  "fuel-tx",
  "fuel-vm",
+ "futures",
  "hex",
  "line-col",
  "pest 2.1.3 (git+https://github.com/sezna/pest.git?rev=8aa58791f759daf4caee26e8560e862df5a6afb7)",

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -17,6 +17,7 @@ fuel-asm = {git = "ssh://git@github.com/FuelLabs/fuel-asm.git"}
 fuel-client = {git = "ssh://git@github.com/FuelLabs/fuel-core", default-features = false }
 fuel-tx = {git = "ssh://git@github.com/FuelLabs/fuel-tx.git"}
 fuel-vm = { git = "ssh://git@github.com/FuelLabs/fuel-vm.git" }
+futures = "0.3"
 hex = "0.4.3"
 line-col = "0.2"
 pest = {git = "https://github.com/sezna/pest.git", rev = "8aa58791f759daf4caee26e8560e862df5a6afb7"}


### PR DESCRIPTION
Forc was no longer returning receipts due to recent client api changes. This restores the original behavior so that `forc run` returns the receipts of the submitted transaction.