### PR TITLE
Fix typo in type mismatch error

### DIFF
--- a/core_lang/src/type_engine/engine.rs
+++ b/core_lang/src/type_engine/engine.rs
@@ -149,8 +149,8 @@ impl<'sc> TypeEngine<'sc> for Engine {
 
             // If no previous attempts to unify were successful, raise an error
             (a, b) => Err(TypeError::MismatchedType {
-                expected: a.friendly_type_str(),
-                received: b.friendly_type_str(),
+                expected: b.friendly_type_str(),
+                received: a.friendly_type_str(),
                 help_text: Default::default(),
                 span: span.clone(),
             }),


### PR DESCRIPTION
Noticed this this morning...

```rust
3 | fn main () {
4 |   let x: bool = 5;                                                                                               
  |                 ^ Mismatched types: Expected type u64 but found type bool. Type u64 is not castable to type bool.
  |                    help:  
```


This change fixes that so it says expected type `bool` but found `u64`. This was just a small typo that went in with the type inference engine (#286)