### PR TITLE
Recursive madness.

### DIFF
--- a/core_lang/src/type_engine/engine.rs
+++ b/core_lang/src/type_engine/engine.rs
@@ -103,6 +103,9 @@ impl<'sc> TypeEngine<'sc> for Engine {
     ) -> Result<Option<Warning<'sc>>, Self::Error> {
         use TypeInfo::*;
         match (self.vars[&a].clone(), self.vars[&b].clone()) {
+            // If the types are exactly the same, we are done.
+            (a, b) if a == b => Ok(None),
+
             // Follow any references
             (Ref(a), _) => self.unify(a, b, span),
             (_, Ref(b)) => self.unify(a, b, span),
@@ -119,8 +122,6 @@ impl<'sc> TypeEngine<'sc> for Engine {
                 Ok(None)
             }
 
-            // If the types are exactly the same, we are done.
-            (a, b) if a == b => Ok(None),
             (UnsignedInteger(x), UnsignedInteger(y)) => match numeric_cast_compat(x, y) {
                 NumericCastCompatResult::CastableWithWarning(warn) => {
                     // cast the one on the right to the one on the left

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -77,6 +77,7 @@ pub fn run(filter_regex: Option<regex::Regex>) {
         "mut_error_message",
         "reassignment_to_non_variable_message",
         "disallowed_gm",
+        "unify_identical_unknowns",
     ];
     project_names.into_iter().for_each(|name| {
         if filter(name) {

--- a/test/src/e2e_vm_tests/test_programs/unify_identical_unknowns/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/unify_identical_unknowns/Forc.toml
@@ -1,0 +1,5 @@
+[project]
+author  = "Toby Hutton <toby.hutton@fuel.sh"
+license = "MIT"
+name = "unify_identical_unknowns"
+entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/unify_identical_unknowns/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/unify_identical_unknowns/src/main.sw
@@ -1,0 +1,13 @@
+script;
+
+pub trait Foo {
+    fn bar(self, other: Self) -> bool;
+}
+
+impl Foo for NonExistant {
+    fn bar(self, other: Self) -> bool {
+        false
+    }
+}
+
+fn main() { }


### PR DESCRIPTION
Closes #378.

It was possible for the compiler to try and unify the same `Unknown` type id with itself, which would in turn create a `Ref` to itself.  Trying to unify a recursive `Ref` was itself a recursive operation before a check was added.

I also added a little mod to the test harness to make the deployed contract E2E tests honour the regex filter.