### PR TITLE
Replace the identifier checks for idiomacity with bespoke versions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,15 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "git+https://github.com/sezna/Inflector.git#76f9a169d5574c732202d27f34471e41c97b8c89"
-dependencies = [
- "lazy_static 1.4.0",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,7 +233,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b9c0aa259aa9b8e77327111ae874b8d7bf85036f00cdb4c079da62043606b"
 dependencies = [
- "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "Inflector",
  "async-graphql-parser",
  "darling",
  "proc-macro-crate",
@@ -789,7 +780,6 @@ dependencies = [
 name = "core_lang"
 version = "0.1.0"
 dependencies = [
- "Inflector 0.11.4 (git+https://github.com/sezna/Inflector.git)",
  "derivative",
  "either",
  "fuel-asm",
@@ -947,7 +937,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b58270fd2d5ced0cb1d2b4ca8b632be15840a6c99285d1062c37be40bd48ac"
 dependencies = [
- "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "Inflector",
  "darling",
  "graphql-parser",
  "lazy_static 1.4.0",
@@ -2805,7 +2795,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e953db32579999ca98c451d80801b6f6a7ecba6127196c5387ec0774c528befa"
 dependencies = [
- "Inflector 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "Inflector",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "schemafy_core",

--- a/core_lang/Cargo.toml
+++ b/core_lang/Cargo.toml
@@ -14,7 +14,6 @@ either = "1.6"
 fuel-asm = { git = "ssh://git@github.com/FuelLabs/fuel-asm.git" }
 fuel-vm = { git = "ssh://git@github.com/FuelLabs/fuel-vm.git" }
 hex = { version = "0.4", optional = true }
-Inflector = { git = "https://github.com/sezna/Inflector.git" }
 pest_derive = "2.0"
 pest = { git = "https://github.com/sezna/pest.git" , rev = "0ee8d107923f8979897efbd12e16a0eb99ea98b3" }
 petgraph = "0.5"

--- a/core_lang/src/case.rs
+++ b/core_lang/src/case.rs
@@ -1,0 +1,192 @@
+pub(crate) fn is_snake_case(ident: &str) -> bool {
+    ident.chars().all(|c| match c {
+        '_' => true,
+        c if !c.is_uppercase() => true,
+        _ => false,
+    }) && !ident.contains("__")
+}
+
+#[test]
+fn test_case_is_snake_case() {
+    assert!(is_snake_case(""));
+    assert!(is_snake_case("foo"));
+    assert!(is_snake_case("foo_bar"));
+    assert!(is_snake_case("_foo_bar"));
+    assert!(is_snake_case("foo_bar_"));
+    assert!(is_snake_case("_foo_bar_"));
+
+    assert!(is_snake_case("foo1"));
+    assert!(is_snake_case("foo1_b1ar"));
+    assert!(is_snake_case("_1foo_bar"));
+    assert!(is_snake_case("_1_")); // In Sway syntax this is a number.
+    assert!(is_snake_case("_foo_1_"));
+
+    assert!(!is_snake_case("Foo"));
+    assert!(!is_snake_case("fOo"));
+    assert!(!is_snake_case("foo_Bar"));
+    assert!(!is_snake_case("foo_baR"));
+    assert!(!is_snake_case("foo__bar"));
+    assert!(!is_snake_case("FOO_BAR_BAZ"));
+    assert!(!is_snake_case("_FOO_BAR_BAZ"));
+}
+
+pub(crate) fn is_pascal_case(ident: &str) -> bool {
+    let ident = ident.trim_start_matches('_');
+    (match ident.chars().next() {
+        None => true,
+        Some(c) => c.is_uppercase(),
+    }) && !ident.contains('_')
+}
+
+#[test]
+fn test_case_is_pascal_case() {
+    assert!(is_pascal_case(""));
+    assert!(is_pascal_case("Foo"));
+    assert!(is_pascal_case("FooB"));
+    assert!(is_pascal_case("FooBar"));
+    assert!(is_pascal_case("FooBarBaz"));
+
+    assert!(is_pascal_case("Foo1"));
+    assert!(is_pascal_case("F00B"));
+    assert!(is_pascal_case("F00b"));
+    assert!(is_pascal_case("FooB4r"));
+    assert!(is_pascal_case("FooBarBaz1"));
+
+    assert!(is_pascal_case("FooBA"));
+    assert!(is_pascal_case("FOOBA")); // Rust likes it so... so do we.
+
+    assert!(!is_pascal_case("foo"));
+    assert!(!is_pascal_case("foo_bar"));
+    assert!(!is_pascal_case("_foo_bar"));
+
+    assert!(is_pascal_case("_Foo"));
+    assert!(is_pascal_case("_FooBar"));
+    assert!(!is_pascal_case("fOOBA"));
+    assert!(!is_pascal_case("_fOOBA"));
+}
+
+pub(crate) fn to_snake_case(ident: &str) -> String {
+    // Simultaneously trim and preserve any leading underscores.
+    let mut prefix = String::new();
+    let ident = ident.trim_start_matches(|c: char| {
+        if c == '_' {
+            prefix.push(c);
+            true
+        } else {
+            false
+        }
+    });
+
+    // Split the string into any underscores separated parts and process them separately, then join
+    // them again.
+    let mut words = Vec::new();
+    for part in ident.split('_') {
+        if part.is_empty() {
+            continue;
+        }
+
+        // Loop for each character.  When we come accross a 'boundary' of lowercase followed by
+        // uppercase then save the characters to that point in a word and start a new word.
+        let (mut sub_parts, final_part, _) = part.chars().fold(
+            (Vec::new(), String::new(), false),
+            |(mut words, mut cur_word, prev_upper), c| {
+                if !prev_upper && c.is_uppercase() {
+                    // A boundary; start a new word.
+                    if !cur_word.is_empty() {
+                        words.push(cur_word);
+                    }
+                    (words, c.to_lowercase().collect(), true)
+                } else {
+                    // Prev was upper; push this char to current word.
+                    cur_word.extend(c.to_lowercase());
+                    (words, cur_word, c.is_uppercase())
+                }
+            },
+        );
+        sub_parts.push(final_part);
+        words.push(sub_parts.join("_"));
+    }
+    prefix + &words.join("_")
+}
+
+#[test]
+fn test_case_to_snake_case() {
+    assert_eq!(to_snake_case("Foo"), "foo");
+    assert_eq!(to_snake_case("FooB"), "foo_b");
+    assert_eq!(to_snake_case("FooBar"), "foo_bar");
+    assert_eq!(to_snake_case("FooBarBaz"), "foo_bar_baz");
+
+    assert_eq!(to_snake_case("Foo1"), "foo1");
+    assert_eq!(to_snake_case("F00B"), "f00_b");
+    assert_eq!(to_snake_case("F00b"), "f00b");
+    assert_eq!(to_snake_case("FooB4r"), "foo_b4r");
+    assert_eq!(to_snake_case("FooBarBaz1"), "foo_bar_baz1");
+
+    assert_eq!(to_snake_case("FooBA"), "foo_ba");
+    assert_eq!(to_snake_case("FOOBA"), "fooba");
+
+    assert_eq!(to_snake_case("foo"), "foo");
+    assert_eq!(to_snake_case("foo_bar"), "foo_bar");
+    assert_eq!(to_snake_case("_foo_bar"), "_foo_bar");
+
+    assert_eq!(to_snake_case("_Foo"), "_foo");
+    assert_eq!(to_snake_case("_FooBar"), "_foo_bar");
+    assert_eq!(to_snake_case("__FooBar"), "__foo_bar");
+    assert_eq!(to_snake_case("FooBar_FooBar"), "foo_bar_foo_bar");
+    assert_eq!(to_snake_case("fOOBA"), "f_ooba");
+    assert_eq!(to_snake_case("_fOOBA"), "_f_ooba");
+    assert_eq!(to_snake_case("__fOOBA"), "__f_ooba");
+
+    assert_eq!(to_snake_case("foo__bar"), "foo_bar");
+}
+
+pub(crate) fn to_pascal_case(ident: &str) -> String {
+    // Simultaneously trim and preserve any leading underscores.
+    let mut prefix = String::new();
+    let ident = ident.trim_start_matches(|c: char| {
+        if c == '_' {
+            prefix.push(c);
+            true
+        } else {
+            false
+        }
+    });
+
+    // Split into underscore separated parts and rejoin with capitalisation.  It's actually easier
+    // (though probably not that efficient) to convert this to snake case before recombining into
+    // pascal case.
+    let ident = to_snake_case(&ident);
+    prefix
+        + &ident
+            .split('_')
+            .map(|part| {
+                let mut iter = part.chars();
+                iter.next().unwrap().to_uppercase().chain(iter).collect()
+            })
+            .collect::<Vec<String>>()
+            .join("")
+}
+
+#[test]
+fn test_case_to_pascal_case() {
+    assert_eq!(to_pascal_case("foo"), "Foo");
+    assert_eq!(to_pascal_case("foo_bar"), "FooBar");
+    assert_eq!(to_pascal_case("_foo_bar"), "_FooBar");
+    assert_eq!(to_pascal_case("foo_bar_"), "FooBar");
+    assert_eq!(to_pascal_case("_foo_bar_"), "_FooBar");
+
+    assert_eq!(to_pascal_case("foo1"), "Foo1");
+    assert_eq!(to_pascal_case("foo1_b1ar"), "Foo1B1ar");
+    assert_eq!(to_pascal_case("_1foo_bar"), "_1fooBar"); // This is contentious.
+    assert_eq!(to_pascal_case("_foo_1_"), "_Foo1");
+
+    assert_eq!(to_pascal_case("Foo"), "Foo");
+    assert_eq!(to_pascal_case("fOo"), "FOo");
+    assert_eq!(to_pascal_case("fooBar"), "FooBar");
+    assert_eq!(to_pascal_case("fooBar_fooBar"), "FooBarFooBar");
+    assert_eq!(to_pascal_case("foo_Bar"), "FooBar");
+    assert_eq!(to_pascal_case("foo_baR"), "FooBaR");
+    assert_eq!(to_pascal_case("foo__bar"), "FooBar");
+    assert_eq!(to_pascal_case("FOO_BAR_BAZ"), "FooBarBaz");
+    assert_eq!(to_pascal_case("_FOO_BAR_BAZ"), "_FooBarBaz");
+}

--- a/core_lang/src/error.rs
+++ b/core_lang/src/error.rs
@@ -1,8 +1,9 @@
-use crate::parser::Rule;
-use crate::span::Span;
-use crate::type_engine::{IntegerBits, TypeInfo};
-use inflector::cases::classcase::to_class_case;
-use inflector::cases::snakecase::to_snake_case;
+use crate::{
+    case::{to_pascal_case, to_snake_case},
+    parser::Rule,
+    span::Span,
+    type_engine::{IntegerBits, TypeInfo},
+};
 use std::fmt;
 use thiserror::Error;
 
@@ -233,7 +234,7 @@ impl<'sc> fmt::Display for Warning<'sc> {
                 "Struct name \"{}\" is not idiomatic. Structs should have a ClassCase name, like \
                  \"{}\".",
                 struct_name,
-                to_class_case(struct_name)
+                to_pascal_case(struct_name)
             )
             }
             NonClassCaseTraitName { name } => {
@@ -241,7 +242,7 @@ impl<'sc> fmt::Display for Warning<'sc> {
                 "Trait name \"{}\" is not idiomatic. Traits should have a ClassCase name, like \
                  \"{}\".",
                 name,
-                to_class_case(name)
+                to_pascal_case(name)
             )
             }
             NonClassCaseEnumName { enum_name } => write!(
@@ -249,7 +250,7 @@ impl<'sc> fmt::Display for Warning<'sc> {
                 "Enum \"{}\"'s capitalization is not idiomatic. Enums should have a ClassCase \
                  name, like \"{}\".",
                 enum_name,
-                to_class_case(enum_name)
+                to_pascal_case(enum_name)
             ),
             NonSnakeCaseStructFieldName { field_name } => write!(
                 f,
@@ -263,7 +264,7 @@ impl<'sc> fmt::Display for Warning<'sc> {
                 "Enum variant name \"{}\" is not idiomatic. Enum variant names should be \
                  ClassCase, like \"{}\".",
                 variant_name,
-                to_class_case(variant_name)
+                to_pascal_case(variant_name)
             ),
             NonSnakeCaseFunctionName { name } => {
                 write!(f,

--- a/core_lang/src/lib.rs
+++ b/core_lang/src/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 mod asm_generation;
 mod asm_lang;
 mod build_config;
+mod case;
 pub mod constants;
 mod control_flow_analysis;
 mod ident;

--- a/core_lang/src/parse_tree/declaration/enum_declaration.rs
+++ b/core_lang/src/parse_tree/declaration/enum_declaration.rs
@@ -1,15 +1,15 @@
-use crate::build_config::BuildConfig;
-use crate::parser::Rule;
-use crate::span::Span;
-use crate::type_engine::{TypeId, TypeInfo};
-
-use crate::Ident;
-use crate::Namespace;
-use crate::{error::*, semantic_analysis::ast_node::TypedEnumDeclaration};
 use crate::{
-    parse_tree::declaration::TypeParameter, semantic_analysis::ast_node::TypedEnumVariant,
+    build_config::BuildConfig,
+    case::is_pascal_case,
+    error::*,
+    parse_tree::declaration::TypeParameter,
+    parser::Rule,
+    semantic_analysis::ast_node::{TypedEnumDeclaration, TypedEnumVariant},
+    span::Span,
+    type_engine::{TypeId, TypeInfo},
+    Ident, Namespace,
 };
-use inflector::cases::classcase::is_class_case;
+
 use pest::iterators::Pair;
 
 #[derive(Debug, Clone)]
@@ -107,7 +107,7 @@ impl<'sc> EnumDeclaration<'sc> {
             errors
         );
         assert_or_warn!(
-            is_class_case(name.primary_name),
+            is_pascal_case(name.primary_name),
             warnings,
             Span {
                 span: enum_name.as_span(),
@@ -178,7 +178,7 @@ impl<'sc> EnumVariant<'sc> {
                     errors
                 );
                 assert_or_warn!(
-                    is_class_case(name.primary_name),
+                    is_pascal_case(name.primary_name),
                     warnings,
                     name.span.clone(),
                     Warning::NonClassCaseEnumVariantName {

--- a/core_lang/src/parse_tree/declaration/function_declaration.rs
+++ b/core_lang/src/parse_tree/declaration/function_declaration.rs
@@ -1,10 +1,8 @@
-use crate::build_config::BuildConfig;
-use crate::error::*;
-use crate::parse_tree::declaration::TypeParameter;
-use crate::span::Span;
-use crate::type_engine::TypeInfo;
-use crate::{CodeBlock, Ident, Rule};
-use inflector::cases::snakecase::is_snake_case;
+use crate::{
+    build_config::BuildConfig, case::is_snake_case, error::*,
+    parse_tree::declaration::TypeParameter, span::Span, type_engine::TypeInfo, CodeBlock, Ident,
+    Rule,
+};
 use pest::iterators::Pair;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/core_lang/src/parse_tree/declaration/struct_declaration.rs
+++ b/core_lang/src/parse_tree/declaration/struct_declaration.rs
@@ -1,11 +1,13 @@
-use crate::build_config::BuildConfig;
-use crate::parse_tree::declaration::TypeParameter;
-use crate::parser::Rule;
-use crate::span::Span;
-use crate::type_engine::TypeInfo;
-use crate::{error::*, Ident};
-use inflector::cases::classcase::is_class_case;
-use inflector::cases::snakecase::is_snake_case;
+use crate::{
+    build_config::BuildConfig,
+    case::{is_pascal_case, is_snake_case},
+    error::*,
+    parse_tree::declaration::TypeParameter,
+    parser::Rule,
+    span::Span,
+    type_engine::TypeInfo,
+    Ident,
+};
 use pest::iterators::Pair;
 
 use super::Visibility;
@@ -91,7 +93,7 @@ impl<'sc> StructDeclaration<'sc> {
             errors
         );
         assert_or_warn!(
-            is_class_case(name.primary_name),
+            is_pascal_case(name.primary_name),
             warnings,
             span,
             Warning::NonClassCaseStructName {

--- a/core_lang/src/parse_tree/declaration/trait_declaration.rs
+++ b/core_lang/src/parse_tree/declaration/trait_declaration.rs
@@ -1,12 +1,14 @@
 use super::{FunctionDeclaration, FunctionParameter, Visibility};
-use crate::build_config::BuildConfig;
-use crate::parse_tree::TypeParameter;
-use crate::parser::Rule;
-use crate::span::Span;
-use crate::type_engine::TypeInfo;
-use crate::{error::*, Ident};
-use inflector::cases::classcase::is_class_case;
-use inflector::cases::snakecase::is_snake_case;
+use crate::{
+    build_config::BuildConfig,
+    case::{is_pascal_case, is_snake_case},
+    error::*,
+    parse_tree::TypeParameter,
+    parser::Rule,
+    span::Span,
+    type_engine::TypeInfo,
+    Ident,
+};
 use pest::iterators::Pair;
 
 #[derive(Debug, Clone)]
@@ -45,7 +47,7 @@ impl<'sc> TraitDeclaration<'sc> {
         );
         let span = name.span.clone();
         assert_or_warn!(
-            is_class_case(name_pair.as_str().trim()),
+            is_pascal_case(name_pair.as_str().trim()),
             warnings,
             span,
             Warning::NonClassCaseTraitName {


### PR DESCRIPTION
I became sick of those `stdlib` errors...

We used the Inflector crate which was both overkill and often wrong.

Also renamed `{is,to}_class_case()` to `{is,to}_pascal_case()` which the internet seems to think is more correct.