### PR TITLE
Fix example project by impl Ord

### DIFF
--- a/example_project/fuel_project/src/main.sw
+++ b/example_project/fuel_project/src/main.sw
@@ -1,4 +1,6 @@
 script;
+use std::ops::Ord;
+
 struct Rgb {
   red: u64,
   green: u64,
@@ -12,8 +14,20 @@ enum PrimaryColor {
    Blue : ()
 }
 
-impl std::ops::Eq for PrimaryColor {
-  fn equals(self, other: Self) -> bool {
+impl Ord for PrimaryColor {
+    fn gt(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3) {
+            gt r3 r1 r2;
+            r3: bool
+        }
+    }
+    fn lt(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3) {
+            lt r3 r1 r2;
+            r3: bool
+        }
+    }
+  fn eq(self, other: Self) -> bool {
     asm(r1: self, r2: other, r3) {
       eq r3 r1 r2;
       r3: bool


### PR DESCRIPTION
There were numerous compiler errors in the example project found by @Dentosal 
This fixes them by fully implementing the Ord trait.
~~Note: we only really need the `eq()` method here... is there a way to partially implement a trait?~~ Nope.