### PR TITLE
Store file paths in an Arc in spans and config

### DIFF
--- a/core_lang/src/build_config.rs
+++ b/core_lang/src/build_config.rs
@@ -1,11 +1,11 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 /// Configuration for the overall build and compilation process.
 #[derive(Clone)]
 pub struct BuildConfig {
-    pub(crate) file_name: PathBuf,
-    pub(crate) dir_of_code: PathBuf,
-    pub(crate) manifest_path: PathBuf,
+    pub(crate) file_name: Arc<PathBuf>,
+    pub(crate) dir_of_code: Arc<PathBuf>,
+    pub(crate) manifest_path: Arc<PathBuf>,
     pub(crate) print_intermediate_asm: bool,
     pub(crate) print_finalized_asm: bool,
 }
@@ -20,9 +20,9 @@ impl BuildConfig {
         let mut path = canonicalized_manifest_path.clone();
         path.push("src");
         Self {
-            file_name,
-            dir_of_code: path,
-            manifest_path: canonicalized_manifest_path,
+            file_name: Arc::new(file_name),
+            dir_of_code: Arc::new(path),
+            manifest_path: Arc::new(canonicalized_manifest_path),
             print_intermediate_asm: false,
             print_finalized_asm: false,
         }
@@ -42,7 +42,7 @@ impl BuildConfig {
         }
     }
 
-    pub fn path(&self) -> PathBuf {
+    pub fn path(&self) -> Arc<PathBuf> {
         self.file_name.clone()
     }
 }

--- a/core_lang/src/span.rs
+++ b/core_lang/src/span.rs
@@ -1,9 +1,9 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Span<'sc> {
     pub span: pest::Span<'sc>,
-    pub(crate) path: Option<PathBuf>,
+    pub(crate) path: Option<Arc<PathBuf>>,
 }
 
 impl<'sc> Span<'sc> {
@@ -41,8 +41,8 @@ impl<'sc> Span<'sc> {
 
     pub fn path(&self) -> String {
         self.path
-            .clone()
-            .map(|p| p.into_os_string().into_string().unwrap())
+            .as_deref()
+            .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or_else(|| "".to_string())
     }
 }


### PR DESCRIPTION
Store file paths as `Arc<PathBuf>` instead of `PathBuf` inside `Span` and `BuildConfig` to avoid repeatedly cloning paths. This makes the compiler run about twice as fast in my tests.