### PR TITLE
struct asm generation tweaks

### DIFF
--- a/core_lang/src/asm_generation/expression/structs.rs
+++ b/core_lang/src/asm_generation/expression/structs.rs
@@ -188,6 +188,11 @@ pub(crate) fn convert_struct_expression_to_asm<'sc>(
         struct_name.primary_name
     )));
 
+    if total_size == 0 {
+        asm_buf.push(Op::new_comment("fields have total size of zero."));
+        return ok(asm_buf, warnings, errors);
+    }
+
     // step 1
     asm_buf.push(Op::unowned_register_move(
         struct_beginning_pointer.clone(),


### PR DESCRIPTION
This builds off of #397. Both this and #397 are precursors to a larger PR to implement tuples.

This PR reduces the number of instructions and memory required by struct expressions for some edge-cases.