### PR TITLE
Add .gitattributes to highlight .sw syntax as rust

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Syntax highlighting of sway files as rust
+*.sw linguist-language=Rust


### PR DESCRIPTION
It's obviously not perfect syntax highlighting, but approximating as rust syntax makes Sway files more readable on github.