### PR TITLE
Allow reassignment of multiword struct fields

### DIFF
--- a/core_lang/src/constants.rs
+++ b/core_lang/src/constants.rs
@@ -1,2 +1,3 @@
 pub const DEFAULT_FILE_EXTENSION: &str = "sw";
 pub const LANGUAGE_NAME: &str = "Sway";
+pub const VM_WORD_SIZE: u64 = 8;


### PR DESCRIPTION
Closes #402 

Another special case for types larger than a word that I previously missed -- we should be using MCPI instead of `LW` to reassign struct fields larger than a word, as struct data is laid out inline and doesn't contain single-word references to b256 values like other areas would.

I tested this with @nfurfaro 's `types-B512` branch and it passed his tests.