### PR TITLE
Allow structs/enums with zero fields

### DIFF
--- a/core_lang/src/hll.pest
+++ b/core_lang/src/hll.pest
@@ -100,7 +100,7 @@ match_condition  =  {expr|"_"}
 code_block =  {"{" ~ (declaration|control_flow|expr_statement)* ~ (expr)? ~ "}"}
 
 struct_expression  =  {struct_name ~ "{" ~ struct_expr_fields ~ "}"}
-struct_expr_fields =  {struct_field_name ~ ":" ~ expr ~ ("," ~ struct_field_name ~ ":" ~ expr)* ~ ","?}
+struct_expr_fields =  {(struct_field_name ~ ":" ~ expr ~ ("," ~ struct_field_name ~ ":" ~ expr)* ~ ","?)?}
 array_exp          =  {"[" ~ array_elems?  ~ "]"}
 // Strictly speaking the [val; count] initialiser for a static array can have any constant expression
 // for the value and the count, but Sway doesn't yet have constant expression resolution, so for now
@@ -127,11 +127,11 @@ storage_decl      =  {storage_keyword ~ "{" ~ storage_fields ~ "}"}
 storage_fields    =  {storage_field ~ ("," ~ storage_field)* ~ ","?}
 storage_field     =  {ident ~ ":" ~ type_name ~ assign ~ expr}
 struct_name       =  {ident}
-struct_fields     =  {struct_field_name ~ ":" ~ type_name ~ ("," ~ struct_field_name ~ ":" ~ type_name)* ~ ","?}
+struct_fields     =  {(struct_field_name ~ ":" ~ type_name ~ ("," ~ struct_field_name ~ ":" ~ type_name)* ~ ","?)?}
 struct_field_name =  {ident}
 // // enum declaration
 enum_decl         =  {visibility ~ enum_keyword ~ enum_name ~ type_params? ~ trait_bounds? ~ "{" ~ enum_fields ~ "}"}
-enum_fields       =  {enum_field_name ~ ":" ~ type_name ~ ("," ~ enum_field_name ~ ":" ~ type_name)* ~ ","?}
+enum_fields       =  {(enum_field_name ~ ":" ~ type_name ~ ("," ~ enum_field_name ~ ":" ~ type_name)* ~ ","?)?}
 enum_name         =  {ident}
 enum_field_name   =  {ident}
 

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -61,6 +61,7 @@ pub fn run(filter_regex: Option<regex::Regex>) {
         ("import_method_from_other_file", ProgramState::Return(10)), // true
         ("address_test", ProgramState::Return(1)),             // true
         ("generic_struct", ProgramState::Return(1)),           // true
+        ("zero_field_types", ProgramState::Return(10)),        // true
         ("assert_test", ProgramState::Return(1)),              // true
         ("b512_test", ProgramState::Return(1)),                // true
         ("assert_test", ProgramState::Return(1)),              // true

--- a/test/src/e2e_vm_tests/test_programs/zero_field_types/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/zero_field_types/Forc.toml
@@ -1,0 +1,5 @@
+[project]
+author  = "Andrew Cann"
+license = "MIT"
+name = "zero_field_types"
+entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/zero_field_types/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/zero_field_types/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+struct StructWithNoFields {}
+enum EnumWithNoVariants {}
+
+fn main() -> u64 {
+    let unit_struct = StructWithNoFields {};
+    10u64
+}


### PR DESCRIPTION
Allow parsing structs/enums with zero fields. Add a test that such types can be compiled.