### PR TITLE
Formatting with forc fmt

### DIFF
--- a/stdlib/src/chain.sw
+++ b/stdlib/src/chain.sw
@@ -4,37 +4,36 @@ use ::ops::*;
 
 // When generics land, these will be generic.
 pub fn log_u64(val: u64) {
-  asm(r1: val) {
-    log r1 zero zero zero;
-  }
+    asm(r1: val) {
+        log r1 zero zero zero;
+    }
 }
 
 pub fn log_u32(val: u32) {
-  asm(r1: val) {
-    log r1 zero zero zero;
-  }
+    asm(r1: val) {
+        log r1 zero zero zero;
+    }
 }
 
 pub fn log_u16(val: u16) {
-  asm(r1: val) {
-    log r1 zero zero zero;
-  }
+    asm(r1: val) {
+        log r1 zero zero zero;
+    }
 }
 
 pub fn log_u8(val: u8) {
-  asm(r1: val) {
-    log r1 zero zero zero;
-  }
+    asm(r1: val) {
+        log r1 zero zero zero;
+    }
 }
-
 
 /// Context-dependent:
 /// will panic if used in a predicate
 /// will revert if used in a contract
 pub fn panic(code: u64) {
-  asm(r1: code) {
-    rvrt r1;
-  }
+    asm(r1: code) {
+        rvrt r1;
+    }
 }
 
 /// Assert that a value is true

--- a/stdlib/src/chain/auth.sw
+++ b/stdlib/src/chain/auth.sw
@@ -3,27 +3,27 @@ use ::ops::*;
 
 // this can be a generic option when options land
 enum Caller {
-  Some: b256,
-  None: (),
+    Some: b256,
+    None: (),
 }
 
 /// Returns `true` if the caller is external.
 pub fn caller_is_external() -> bool {
-  asm(r1) {
-    gm r1 i1;
-    r1: bool
-  }
+    asm(r1) {
+        gm r1 i1;
+        r1: bool
+    }
 }
 
 pub fn caller() -> Caller {
-  // if parent is not external
-  if not(caller_is_external()) {
-    // get the caller
-    Caller::Some(asm(r1) {
-      gm r1 i2;
-      r1: b256
-    })
-  } else {
-    Caller::None
-  }
+    // if parent is not external
+    if not(caller_is_external()) {
+        // get the caller
+        Caller::Some(asm(r1) {
+            gmr1i2;
+            r1: b256
+        })
+    } else {
+        Caller::None
+    }
 }

--- a/stdlib/src/hash.sw
+++ b/stdlib/src/hash.sw
@@ -28,31 +28,31 @@ impl HashMethod {
 }
 
 pub fn hash_u64(value: u64, method: HashMethod) -> b256 {
-  if method.eq(HashMethod::Sha256) {
-    asm(r1: value, hashed_b256_ptr, r3, value_ptr) {
-      // put the u64 on the stack
-      move value_ptr sp;
-      cfei i8;
-      sw value_ptr r1 i0;
-      move hashed_b256_ptr sp;
-      cfei i32;
-      addi r3 zero i8; // hash eight bytes since a u64 is eight bytes
-      s256 hashed_b256_ptr r1 r3;
-      hashed_b256_ptr: b256
+    if method.eq(HashMethod::Sha256) {
+        asm(r1: value, hashed_b256_ptr, r3, value_ptr) {
+            // put the u64 on the stack
+            move value_ptr sp;
+            cfei i8;
+            sw value_ptr r1 i0;
+            move hashed_b256_ptr sp;
+            cfei i32;
+            addi r3 zero i8; // hash eight bytes since a u64 is eight bytes
+            s256 hashed_b256_ptr r1 r3;
+            hashed_b256_ptr: b256
+        }
+    } else {
+        asm(r1: value, hashed_b256_ptr, r3, value_ptr) {
+            // put the u64 on the stack
+            move value_ptr sp;
+            cfei i8;
+            sw value_ptr r1 i0;
+            move hashed_b256_ptr sp;
+            cfei i32;
+            addi r3 zero i8; // hash eight bytes since a u64 is eight bytes
+            k256 hashed_b256_ptr r1 r3;
+            hashed_b256_ptr: b256
+        }
     }
-  } else {
-    asm(r1: value, hashed_b256_ptr, r3, value_ptr) {
-      // put the u64 on the stack
-      move value_ptr sp;
-      cfei i8;
-      sw value_ptr r1 i0;
-      move hashed_b256_ptr sp;
-      cfei i32;
-      addi r3 zero i8; // hash eight bytes since a u64 is eight bytes
-      k256 hashed_b256_ptr r1 r3;
-      hashed_b256_ptr: b256
-    }
-  }
 }
 
 pub fn hash_value(value: b256, method: HashMethod) -> b256 {

--- a/stdlib/src/ops.sw
+++ b/stdlib/src/ops.sw
@@ -294,7 +294,6 @@ impl b256 {
     }
 }
 
-
 impl u64 {
     fn binary_and(self, other: Self) -> Self {
         asm(r1: self, r2: other, r3) {

--- a/stdlib/src/storage.sw
+++ b/stdlib/src/storage.sw
@@ -1,82 +1,81 @@
 library storage;
-// These methods will all be replaced by generic functions when those come in. 
+// These methods will all be replaced by generic functions when those come in.
 // See https://github.com/FuelLabs/sway/issues/272 for details.
 
-
 pub fn store_u64(key: b256, value: u64) {
-  asm(r1: key, r2: value) {
-    sww r1 r2;
-  };
+    asm(r1: key, r2: value) {
+        sww r1 r2;
+    };
 }
 
 pub fn get_u64(key: b256) -> u64 {
-  asm(r1: key, r2) {
-    srw r2 r1;
-    r2: u64
-  }
+    asm(r1: key, r2) {
+        srw r2 r1;
+        r2: u64
+    }
 }
 
 pub fn store_u32(key: b256, value: u32) {
-  asm(r1: key, r2: value) {
-    sww r1 r2;
-  };
+    asm(r1: key, r2: value) {
+        sww r1 r2;
+    };
 }
 
 pub fn get_u32(key: b256) -> u32 {
-  asm(r1: key, r2) {
-    srw r2 r1;
-    r2: u32
-  }
+    asm(r1: key, r2) {
+        srw r2 r1;
+        r2: u32
+    }
 }
 
 pub fn store_u16(key: b256, value: u16) {
-  asm(r1: key, r2: value) {
-    sww r1 r2;
-  };
+    asm(r1: key, r2: value) {
+        sww r1 r2;
+    };
 }
 
 pub fn get_u16(key: b256) -> u16 {
-  asm(r1: key, r2) {
-    srw r2 r1;
-    r2: u16
-  }
+    asm(r1: key, r2) {
+        srw r2 r1;
+        r2: u16
+    }
 }
 
 pub fn store_u8(key: b256, value: u8) {
-  asm(r1: key, r2: value) {
-    sww r1 r2;
-  };
+    asm(r1: key, r2: value) {
+        sww r1 r2;
+    };
 }
 
 pub fn get_u8(key: b256) -> u8 {
-  asm(r1: key, r2) {
-    srw r2 r1;
-    r2: u8
-  }
+    asm(r1: key, r2) {
+        srw r2 r1;
+        r2: u8
+    }
 }
 
 pub fn store_bool(key: b256, value: bool) {
-  asm(r1: key, r2: value) {
-    sww r1 r2;
-  };
+    asm(r1: key, r2: value) {
+        sww r1 r2;
+    };
 }
 
 pub fn get_bool(key: b256) -> bool {
-  asm(r1: key, r2) {
-    srw r2 r1;
-    r2: bool
-  }
+    asm(r1: key, r2) {
+        srw r2 r1;
+        r2: bool
+    }
 }
 
 pub fn store_byte(key: b256, value: byte) {
-  asm(r1: key, r2: value) {
-    sww r1 r2;
-  };
+    asm(r1: key, r2: value) {
+        sww r1 r2;
+    };
 }
 
 pub fn get_byte(key: b256) -> byte {
-  asm(r1: key, r2) {
-    srw r2 r1;
-    r2: byte
-  }
+    asm(r1: key, r2) {
+        srw r2 r1;
+        r2: byte
+    }
 }


### PR DESCRIPTION
Cleans up a bunch of formatting changes that were polluting other PRs by running `forc fmt` on the stdlib.