### PR TITLE
Store source in an Arc<str>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,7 +987,6 @@ dependencies = [
  "flate2",
  "fuel-asm",
  "fuel-gql-client",
- "fuel-pest",
  "fuel-tx",
  "fuel-vm",
  "futures",
@@ -1090,15 +1089,6 @@ dependencies = [
  "lazy_static 1.4.0",
  "sha2",
  "thiserror",
-]
-
-[[package]]
-name = "fuel-pest"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad75583f2354bfc3bc533fae660e6510e8149e413382dee78e42d77236e5773c"
-dependencies = [
- "ucd-trie",
 ]
 
 [[package]]
@@ -2910,7 +2900,6 @@ name = "sway-server"
 version = "0.1.9"
 dependencies = [
  "dashmap",
- "fuel-pest",
  "lspower",
  "ropey",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -68,7 +68,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
 dependencies = [
  "cipher",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -78,7 +78,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
  "cipher",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -370,33 +370,12 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding 0.1.5",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
- "generic-array 0.14.4",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -436,12 +415,6 @@ name = "bumpalo"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -514,7 +487,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -673,7 +646,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
  "subtle",
 ]
 
@@ -860,20 +833,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -955,12 +919,6 @@ name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
@@ -1125,9 +1083,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8148b67b9ca99755b8c73fbc5bad7710590e1d7e245680ffd351289915258851"
 dependencies = [
  "bytes 1.1.0",
- "digest 0.9.0",
+ "digest",
  "fuel-storage",
- "generic-array 0.14.4",
+ "generic-array",
  "hex",
  "lazy_static 1.4.0",
  "sha2",
@@ -1306,15 +1264,6 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -1351,7 +1300,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
 dependencies = [
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "polyval",
 ]
 
@@ -1439,7 +1388,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
 dependencies = [
- "digest 0.9.0",
+ "digest",
  "hmac",
 ]
 
@@ -1450,7 +1399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac",
- "digest 0.9.0",
+ "digest",
 ]
 
 [[package]]
@@ -1957,12 +1906,6 @@ checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -2025,8 +1968,6 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 [[package]]
 name = "pest"
 version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
 ]
@@ -2034,8 +1975,6 @@ dependencies = [
 [[package]]
 name = "pest_derive"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2043,9 +1982,7 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+version = "2.1.4"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2057,8 +1994,6 @@ dependencies = [
 [[package]]
 name = "pest_meta"
 version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
  "maplit",
  "pest",
@@ -2133,7 +2068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
 dependencies = [
  "cpuid-bool",
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -2692,14 +2627,15 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.8.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -2714,11 +2650,11 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -2727,10 +2663,10 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "block-buffer",
+ "digest",
  "keccak",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -2945,11 +2881,11 @@ dependencies = [
  "derivative",
  "either",
  "fuel-asm",
- "fuel-pest",
  "fuel-vm",
  "hex",
  "lazy_static 1.4.0",
  "line-col",
+ "pest",
  "pest_derive",
  "petgraph",
  "sha2",
@@ -3401,7 +3337,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
  "subtle",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,9 +274,9 @@ version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -303,9 +303,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -551,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "constant_time_eq"
@@ -678,8 +678,8 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
- "quote 1.0.10",
- "syn 1.0.83",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -746,10 +746,10 @@ dependencies = [
  "darling",
  "graphql-parser",
  "lazy_static 1.4.0",
- "proc-macro2 1.0.34",
- "quote 1.0.10",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
  "strsim 0.10.0",
- "syn 1.0.83",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -759,7 +759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d016913e640d17de49a4ad8df09a39ea4be1554dd976b9e6ed964eedaafd563"
 dependencies = [
  "cynic-codegen",
- "syn 1.0.83",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -780,10 +780,10 @@ checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.34",
- "quote 1.0.10",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
  "strsim 0.10.0",
- "syn 1.0.83",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -793,8 +793,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
 dependencies = [
  "darling_core",
- "quote 1.0.10",
- "syn 1.0.83",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -813,9 +813,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -825,10 +825,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.34",
- "quote 1.0.10",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
  "rustc_version 0.4.0",
- "syn 1.0.83",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -1208,9 +1208,9 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -1394,13 +1394,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
- "itoa 0.4.8",
+ "itoa 1.0.1",
 ]
 
 [[package]]
@@ -1535,9 +1535,9 @@ checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "inlinable_string"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3094308123a0e9fd59659ce45e22de9f53fc1d2ac6e1feb9fef988e4f76cad77"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 dependencies = [
  "serde",
 ]
@@ -1746,9 +1746,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca1d48da0e4a6100b4afd52fae99f36d47964a209624021280ad9ffdd410e83d"
 dependencies = [
  "heck",
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -1958,6 +1958,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 [[package]]
 name = "pest"
 version = "2.1.3"
+source = "git+https://github.com/canndrew/pest?rev=51f47bbaccea15458ad6ac3cd5421d6c9f4f6279#51f47bbaccea15458ad6ac3cd5421d6c9f4f6279"
 dependencies = [
  "ucd-trie",
 ]
@@ -1965,6 +1966,7 @@ dependencies = [
 [[package]]
 name = "pest_derive"
 version = "2.1.0"
+source = "git+https://github.com/canndrew/pest?rev=51f47bbaccea15458ad6ac3cd5421d6c9f4f6279#51f47bbaccea15458ad6ac3cd5421d6c9f4f6279"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1973,17 +1975,19 @@ dependencies = [
 [[package]]
 name = "pest_generator"
 version = "2.1.4"
+source = "git+https://github.com/canndrew/pest?rev=51f47bbaccea15458ad6ac3cd5421d6c9f4f6279#51f47bbaccea15458ad6ac3cd5421d6c9f4f6279"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
 name = "pest_meta"
 version = "2.1.3"
+source = "git+https://github.com/canndrew/pest?rev=51f47bbaccea15458ad6ac3cd5421d6c9f4f6279#51f47bbaccea15458ad6ac3cd5421d6c9f4f6279"
 dependencies = [
  "maplit",
  "pest",
@@ -2002,29 +2006,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -2064,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "prettydiff"
@@ -2100,9 +2104,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
  "version_check",
 ]
 
@@ -2112,8 +2116,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.34",
- "quote 1.0.10",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
  "version_check",
 ]
 
@@ -2134,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.34"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -2152,11 +2156,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
- "proc-macro2 1.0.34",
+ "proc-macro2 1.0.36",
 ]
 
 [[package]]
@@ -2391,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "ropey"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150aff6deb25b20ed110889f070a678bcd1033e46e5e9d6fb1abeab17947f28"
+checksum = "e6b9aa65bcd9f308d37c7158b4a1afaaa32b8450213e20c9b98e7d5b3cc2fec3"
 dependencies = [
  "smallvec",
 ]
@@ -2473,13 +2477,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e953db32579999ca98c451d80801b6f6a7ecba6127196c5387ec0774c528befa"
 dependencies = [
  "Inflector",
- "proc-macro2 1.0.34",
- "quote 1.0.10",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
  "schemafy_core",
  "serde",
  "serde_derive",
  "serde_json",
- "syn 1.0.83",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2552,29 +2556,29 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -2598,9 +2602,9 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2748,11 +2752,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.34",
- "quote 1.0.10",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
  "serde",
  "serde_derive",
- "syn 1.0.83",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2762,13 +2766,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.34",
- "quote 1.0.10",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.83",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2830,9 +2834,9 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -2935,12 +2939,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.83"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a1dfb999630e338648c83e91c59a4e9fb7620f520c3194b6b89e276f2f1959"
+checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
 dependencies = [
- "proc-macro2 1.0.34",
- "quote 1.0.10",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
  "unicode-xid 0.2.2",
 ]
 
@@ -3050,9 +3054,9 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -3097,10 +3101,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.34",
- "quote 1.0.10",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
  "standback",
- "syn 1.0.83",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -3151,9 +3155,9 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -3214,9 +3218,9 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
 ]
 
 [[package]]
@@ -3256,9 +3260,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
@@ -3399,9 +3403,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"
@@ -3456,9 +3460,9 @@ dependencies = [
  "bumpalo",
  "lazy_static 1.4.0",
  "log",
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
  "wasm-bindgen-shared",
 ]
 
@@ -3480,7 +3484,7 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
- "quote 1.0.10",
+ "quote 1.0.14",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3490,9 +3494,9 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
- "proc-macro2 1.0.34",
- "quote 1.0.10",
- "syn 1.0.83",
+ "proc-macro2 1.0.36",
+ "quote 1.0.14",
+ "syn 1.0.84",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/core_lang/src/parse_tree/expression/match_condition.rs
+++ b/core_lang/src/parse_tree/expression/match_condition.rs
@@ -1,0 +1,7 @@
+use super::Expression;
+
+#[derive(Debug, Clone)]
+pub(crate) enum MatchCondition {
+    CatchAll,
+    Expression(Box<Expression>),
+}

--- a/core_lang/src/semantic_analysis/ast_node/expression/match_branch.rs
+++ b/core_lang/src/semantic_analysis/ast_node/expression/match_branch.rs
@@ -1,0 +1,10 @@
+use super::*;
+use crate::semantic_analysis::ast_node::TypedCodeBlock;
+use either::Either;
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub(crate) struct TypedMatchBranch {
+    condition: TypedMatchCondition,
+    result: Either<TypedCodeBlock, TypedExpression>,
+}

--- a/core_lang/src/semantic_analysis/ast_node/expression/match_condition.rs
+++ b/core_lang/src/semantic_analysis/ast_node/expression/match_condition.rs
@@ -1,0 +1,8 @@
+use crate::semantic_analysis::TypedExpression;
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub(crate) enum TypedMatchCondition {
+    CatchAll,
+    Expression(Box<TypedExpression>),
+}

--- a/core_lang/src/semantic_analysis/type_check_arguments.rs
+++ b/core_lang/src/semantic_analysis/type_check_arguments.rs
@@ -1,0 +1,25 @@
+use crate::build_config::BuildConfig;
+use crate::control_flow_analysis::ControlFlowGraph;
+use crate::parse_tree::declaration::Purity;
+use crate::semantic_analysis::{ast_node::Mode, Namespace};
+use crate::type_engine::*;
+
+use std::collections::{HashMap, HashSet};
+pub struct TypeCheckArguments<'a, T> {
+    pub(crate) checkee: T,
+    pub(crate) namespace: &'a mut Namespace,
+    pub(crate) crate_namespace: Option<&'a Namespace>,
+    pub(crate) return_type_annotation: TypeId,
+    pub(crate) help_text: &'static str,
+    pub(crate) self_type: TypeId,
+    pub(crate) build_config: &'a BuildConfig,
+    pub(crate) dead_code_graph: &'a mut ControlFlowGraph,
+    pub(crate) mode: Mode,
+    pub(crate) dependency_graph: &'a mut HashMap<String, HashSet<String>>,
+    pub(crate) opts: TCOpts,
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct TCOpts {
+    pub(crate) purity: Purity,
+}

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -20,7 +20,6 @@ fuel-tx = "0.1"
 fuel-vm = "0.1"
 futures = "0.3"
 hex = "0.4.3"
-pest = { version = "3.0", package = "fuel-pest" }
 prettydiff = "0.4.0"
 reqwest = { version = "0.11.4", features = ["json"] }
 semver = "1.0.3"

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -21,7 +21,7 @@ pub(crate) fn exec(command: Command) -> Result<(), String> {
     // Cargo args setup
     let mut args: Vec<String> = vec!["test".into()];
     if let Some(name) = command.test_name {
-        args.push(name)
+        args.push(name);
     };
     args.push("--color".into());
     args.push("always".into());

--- a/forc/src/ops/forc_abi_json.rs
+++ b/forc/src/ops/forc_abi_json.rs
@@ -17,6 +17,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use sway_core::{BuildConfig, CompileAstResult, Namespace, TreeType, TypedParseTree};
+use std::sync::Arc;
 
 pub fn build(command: JsonAbiCommand) -> Result<Value, String> {
     // find manifest directory, even if in subdirectory
@@ -132,7 +133,7 @@ fn compile_dependency_lib<'source, 'manifest>(
     project_file_path: &Path,
     dependency_name: &'manifest str,
     dependency_lib: &mut Dependency,
-    namespace: &mut Namespace<'source>,
+    namespace: &mut Namespace,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
     silent_mode: bool,
     offline_mode: bool,
@@ -236,13 +237,13 @@ fn compile_dependency_lib<'source, 'manifest>(
 }
 
 fn compile_library<'source>(
-    source: &'source str,
+    source: Arc<str>,
     proj_name: &str,
-    namespace: &Namespace<'source>,
+    namespace: &Namespace,
     build_config: BuildConfig,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
     silent_mode: bool,
-) -> Result<(Namespace<'source>, Vec<Function>), String> {
+) -> Result<(Namespace, Vec<Function>), String> {
     let res = sway_core::compile_to_ast(source, namespace, &build_config, dependency_graph);
     match res {
         CompileAstResult::Success {
@@ -276,9 +277,9 @@ fn compile_library<'source>(
 }
 
 fn compile<'source>(
-    source: &'source str,
+    source: Arc<str>,
     proj_name: &str,
-    namespace: &Namespace<'source>,
+    namespace: &Namespace,
     build_config: BuildConfig,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
     silent_mode: bool,

--- a/forc/src/ops/forc_abi_json.rs
+++ b/forc/src/ops/forc_abi_json.rs
@@ -16,8 +16,8 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use sway_core::{BuildConfig, CompileAstResult, Namespace, TreeType, TypedParseTree};
 use std::sync::Arc;
+use sway_core::{BuildConfig, CompileAstResult, Namespace, TreeType, TypedParseTree};
 
 pub fn build(command: JsonAbiCommand) -> Result<Value, String> {
     // find manifest directory, even if in subdirectory
@@ -254,12 +254,7 @@ fn compile_library(
             let errors = vec![];
             match tree_type {
                 TreeType::Library { name } => {
-                    print_on_success(
-                        silent_mode,
-                        proj_name,
-                        warnings,
-                        TreeType::Library { name },
-                    );
+                    print_on_success(silent_mode, proj_name, warnings, TreeType::Library { name });
                     let json_abi = generate_json_abi(&Some(*parse_tree.clone()));
                     Ok((parse_tree.into_namespace(), json_abi))
                 }

--- a/forc/src/ops/forc_abi_json.rs
+++ b/forc/src/ops/forc_abi_json.rs
@@ -129,7 +129,7 @@ pub fn build(command: JsonAbiCommand) -> Result<Value, String> {
 
 /// Takes a dependency and returns a namespace of exported things from that dependency
 /// trait implementations are included as well
-fn compile_dependency_lib<'source, 'manifest>(
+fn compile_dependency_lib<'manifest>(
     project_file_path: &Path,
     dependency_name: &'manifest str,
     dependency_lib: &mut Dependency,
@@ -236,7 +236,7 @@ fn compile_dependency_lib<'source, 'manifest>(
     Ok(json_abi)
 }
 
-fn compile_library<'source>(
+fn compile_library(
     source: Arc<str>,
     proj_name: &str,
     namespace: &Namespace,
@@ -258,7 +258,7 @@ fn compile_library<'source>(
                         silent_mode,
                         proj_name,
                         warnings,
-                        TreeType::Library { name: name.clone() },
+                        TreeType::Library { name },
                     );
                     let json_abi = generate_json_abi(&Some(*parse_tree.clone()));
                     Ok((parse_tree.into_namespace(), json_abi))
@@ -276,7 +276,7 @@ fn compile_library<'source>(
     }
 }
 
-fn compile<'source>(
+fn compile(
     source: Arc<str>,
     proj_name: &str,
     namespace: &Namespace,

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -106,7 +106,7 @@ pub fn build(command: BuildCommand) -> Result<Vec<u8>, String> {
 
 /// Takes a dependency and returns a namespace of exported things from that dependency
 /// trait implementations are included as well
-fn compile_dependency_lib<'source, 'manifest>(
+fn compile_dependency_lib<'manifest>(
     project_file_path: &Path,
     dependency_name: &'manifest str,
     dependency_lib: &mut Dependency,
@@ -233,7 +233,7 @@ fn compile_dependency_lib<'source, 'manifest>(
     Ok(())
 }
 
-fn compile_library<'source>(
+fn compile_library(
     source: Arc<str>,
     proj_name: &str,
     namespace: &Namespace,
@@ -264,7 +264,7 @@ fn compile_library<'source>(
     }
 }
 
-fn compile<'source>(
+fn compile(
     source: Arc<str>,
     proj_name: &str,
     namespace: &Namespace,
@@ -284,12 +284,12 @@ fn compile<'source>(
         }
         BytecodeCompilationResult::Failure { errors, warnings } => {
             print_on_failure(silent_mode, warnings, errors);
-            return Err(format!("Failed to compile {}", proj_name));
+            Err(format!("Failed to compile {}", proj_name))
         }
     }
 }
 
-fn compile_to_asm<'sc>(
+fn compile_to_asm(
     source: Arc<str>,
     proj_name: &str,
     namespace: &Namespace,

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -10,6 +10,7 @@ use std::fs::File;
 use std::io::Write;
 use sway_core::{FinalizedAsm, TreeType};
 use sway_utils::{constants, find_manifest_dir};
+use std::sync::Arc;
 
 use sway_core::{BuildConfig, BytecodeCompilationResult, CompilationResult, Namespace};
 
@@ -109,7 +110,7 @@ fn compile_dependency_lib<'source, 'manifest>(
     project_file_path: &Path,
     dependency_name: &'manifest str,
     dependency_lib: &mut Dependency,
-    namespace: &mut Namespace<'source>,
+    namespace: &mut Namespace,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
     silent_mode: bool,
     offline_mode: bool,
@@ -233,13 +234,13 @@ fn compile_dependency_lib<'source, 'manifest>(
 }
 
 fn compile_library<'source>(
-    source: &'source str,
+    source: Arc<str>,
     proj_name: &str,
-    namespace: &Namespace<'source>,
+    namespace: &Namespace,
     build_config: BuildConfig,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
     silent_mode: bool,
-) -> Result<Namespace<'source>, String> {
+) -> Result<Namespace, String> {
     let res = sway_core::compile_to_asm(source, namespace, build_config, dependency_graph);
     match res {
         CompilationResult::Library {
@@ -264,9 +265,9 @@ fn compile_library<'source>(
 }
 
 fn compile<'source>(
-    source: &'source str,
+    source: Arc<str>,
     proj_name: &str,
-    namespace: &Namespace<'source>,
+    namespace: &Namespace,
     build_config: BuildConfig,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
     silent_mode: bool,
@@ -289,13 +290,13 @@ fn compile<'source>(
 }
 
 fn compile_to_asm<'sc>(
-    source: &'sc str,
+    source: Arc<str>,
     proj_name: &str,
-    namespace: &Namespace<'sc>,
+    namespace: &Namespace,
     build_config: BuildConfig,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
     silent_mode: bool,
-) -> Result<FinalizedAsm<'sc>, String> {
+) -> Result<FinalizedAsm, String> {
     let res = sway_core::compile_to_asm(source, namespace, build_config, dependency_graph);
     match res {
         CompilationResult::Success { asm, warnings } => {

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -8,9 +8,9 @@ use crate::{
 };
 use std::fs::File;
 use std::io::Write;
+use std::sync::Arc;
 use sway_core::{FinalizedAsm, TreeType};
 use sway_utils::{constants, find_manifest_dir};
-use std::sync::Arc;
 
 use sway_core::{BuildConfig, BytecodeCompilationResult, CompilationResult, Namespace};
 

--- a/forc/src/ops/forc_fmt.rs
+++ b/forc/src/ops/forc_fmt.rs
@@ -2,7 +2,7 @@ use crate::cli::{BuildCommand, FormatCommand};
 use crate::ops::forc_build;
 use crate::utils::helpers::{println_green, println_red};
 use prettydiff::{basic::DiffOp, diff_lines};
-use std::{fmt, fs, io, path::Path};
+use std::{fmt, fs, io, path::Path, sync::Arc};
 use sway_fmt::get_formatted_data;
 use sway_utils::{find_manifest_dir, get_sway_files};
 
@@ -36,10 +36,11 @@ fn format_after_build(command: FormatCommand) -> Result<(), FormatError> {
             for file in files {
                 if let Ok(file_content) = fs::read_to_string(&file) {
                     // todo: get tab_size from Manifest file
-                    match get_formatted_data(&file_content, 4) {
+                    let file_content: Arc<str> = Arc::from(file_content);
+                    match get_formatted_data(file_content.clone(), 4) {
                         Ok((_, formatted_content)) => {
                             if command.check {
-                                if file_content != formatted_content {
+                                if *file_content != *formatted_content {
                                     let changeset = diff_lines(&file_content, &formatted_content);
 
                                     println!("\n{:?}\n", file);

--- a/forc/src/utils/helpers.rs
+++ b/forc/src/utils/helpers.rs
@@ -7,9 +7,9 @@ use std::ffi::OsStr;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::str;
+use std::sync::Arc;
 use sway_core::{CompileError, CompileWarning, TreeType};
 use sway_utils::constants;
-use std::sync::Arc;
 use termcolor::{self, Color as TermColor, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 pub fn is_sway_file(file: &Path) -> bool {
@@ -56,10 +56,7 @@ pub fn read_manifest(manifest_dir: &Path) -> Result<Manifest, String> {
     }
 }
 
-pub fn get_main_file(
-    manifest_of_dep: &Manifest,
-    manifest_dir: &Path,
-) -> Result<Arc<str>, String> {
+pub fn get_main_file(manifest_of_dep: &Manifest, manifest_dir: &Path) -> Result<Arc<str>, String> {
     let main_path = {
         let mut code_dir = PathBuf::from(manifest_dir);
         code_dir.push(constants::SRC_DIR);

--- a/forc/src/utils/helpers.rs
+++ b/forc/src/utils/helpers.rs
@@ -73,7 +73,7 @@ pub fn get_main_file(
     Ok(main_file)
 }
 
-pub fn print_on_success<'sc>(
+pub fn print_on_success(
     silent_mode: bool,
     proj_name: &str,
     warnings: Vec<CompileWarning>,

--- a/forc/src/utils/manifest.rs
+++ b/forc/src/utils/manifest.rs
@@ -158,14 +158,14 @@ fn default_url() -> String {
 fn try_parse() {
     println!(
         "{:#?}",
-        toml::from_str::<Manifest>(&super::defaults::default_manifest("test_proj".into())).unwrap()
+        toml::from_str::<Manifest>(&super::defaults::default_manifest("test_proj")).unwrap()
     )
 }
 
 #[test]
 fn test_print_tx_inputs() {
     let mut default_manifest: Manifest =
-        toml::from_str::<Manifest>(&super::defaults::default_manifest("test_proj".into())).unwrap();
+        toml::from_str::<Manifest>(&super::defaults::default_manifest("test_proj")).unwrap();
 
     let input1 = TxInput {
         contract_id: Some(

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -19,9 +19,8 @@ fuel-vm = "0.1"
 hex = { version = "0.4", optional = true }
 lazy_static = "1.4"
 line-col = "0.2"
-#pest = "2.0"
-pest = { path = "/home/shum/src/work/pest/pest" }
-pest_derive = { path = "/home/shum/src/work/pest/derive" }
+pest = { git = "https://github.com/canndrew/pest", rev = "51f47bbaccea15458ad6ac3cd5421d6c9f4f6279" }
+pest_derive = { git = "https://github.com/canndrew/pest", rev = "51f47bbaccea15458ad6ac3cd5421d6c9f4f6279" }
 petgraph = "0.5"
 sha2 = "0.9"
 smallvec = "1.7"

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -19,8 +19,9 @@ fuel-vm = "0.1"
 hex = { version = "0.4", optional = true }
 lazy_static = "1.4"
 line-col = "0.2"
-pest = { version = "3.0", package = "fuel-pest" }
-pest_derive = "2.0"
+#pest = "2.0"
+pest = { path = "/home/shum/src/work/pest/pest" }
+pest_derive = { path = "/home/shum/src/work/pest/derive" }
 petgraph = "0.5"
 sha2 = "0.9"
 smallvec = "1.7"

--- a/sway-core/src/asm_generation/checks.rs
+++ b/sway-core/src/asm_generation/checks.rs
@@ -9,7 +9,7 @@ use crate::error::*;
 /// Checks for disallowed opcodes in non-contract code.
 /// i.e., if this is a script or predicate, we can't use certain contract opcodes.
 /// See https://github.com/FuelLabs/sway/issues/350 for details.
-pub fn check_invalid_opcodes<'sc>(asm: &FinalizedAsm) -> CompileResult<()> {
+pub fn check_invalid_opcodes(asm: &FinalizedAsm) -> CompileResult<()> {
     match asm {
         FinalizedAsm::ContractAbi { .. } | FinalizedAsm::Library => ok((), vec![], vec![]),
         FinalizedAsm::ScriptMain {
@@ -23,7 +23,7 @@ pub fn check_invalid_opcodes<'sc>(asm: &FinalizedAsm) -> CompileResult<()> {
 
 /// Checks if an opcode is one that can only be executed from within a contract. If so, throw an
 /// error.
-fn check_for_contract_opcodes<'sc>(ops: &[AllocatedOp]) -> CompileResult<()> {
+fn check_for_contract_opcodes(ops: &[AllocatedOp]) -> CompileResult<()> {
     use AllocatedOpcode::*;
     let default_span = crate::Span {
         span: pest::Span::new("no span found for opcode".into(), 0, 1).unwrap(),

--- a/sway-core/src/asm_generation/checks.rs
+++ b/sway-core/src/asm_generation/checks.rs
@@ -9,7 +9,7 @@ use crate::error::*;
 /// Checks for disallowed opcodes in non-contract code.
 /// i.e., if this is a script or predicate, we can't use certain contract opcodes.
 /// See https://github.com/FuelLabs/sway/issues/350 for details.
-pub fn check_invalid_opcodes<'sc>(asm: &FinalizedAsm<'sc>) -> CompileResult<'sc, ()> {
+pub fn check_invalid_opcodes<'sc>(asm: &FinalizedAsm) -> CompileResult<()> {
     match asm {
         FinalizedAsm::ContractAbi { .. } | FinalizedAsm::Library => ok((), vec![], vec![]),
         FinalizedAsm::ScriptMain {
@@ -23,10 +23,10 @@ pub fn check_invalid_opcodes<'sc>(asm: &FinalizedAsm<'sc>) -> CompileResult<'sc,
 
 /// Checks if an opcode is one that can only be executed from within a contract. If so, throw an
 /// error.
-fn check_for_contract_opcodes<'sc>(ops: &[AllocatedOp<'sc>]) -> CompileResult<'sc, ()> {
+fn check_for_contract_opcodes<'sc>(ops: &[AllocatedOp]) -> CompileResult<()> {
     use AllocatedOpcode::*;
     let default_span = crate::Span {
-        span: pest::Span::new("no span found for opcode", 0, 1).unwrap(),
+        span: pest::Span::new("no span found for opcode".into(), 0, 1).unwrap(),
         path: None,
     };
     let mut errors = vec![];

--- a/sway-core/src/asm_generation/declaration/const_decl.rs
+++ b/sway-core/src/asm_generation/declaration/const_decl.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// Provisions a register to put a value in, and then adds the assembly used to initialize the
 /// value to the end of the buffer.
-pub(crate) fn convert_constant_decl_to_asm<'sc>(
+pub(crate) fn convert_constant_decl_to_asm(
     const_decl: &TypedConstantDeclaration,
     namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,

--- a/sway-core/src/asm_generation/declaration/const_decl.rs
+++ b/sway-core/src/asm_generation/declaration/const_decl.rs
@@ -8,10 +8,10 @@ use crate::{
 /// Provisions a register to put a value in, and then adds the assembly used to initialize the
 /// value to the end of the buffer.
 pub(crate) fn convert_constant_decl_to_asm<'sc>(
-    const_decl: &TypedConstantDeclaration<'sc>,
-    namespace: &mut AsmNamespace<'sc>,
+    const_decl: &TypedConstantDeclaration,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+) -> CompileResult<Vec<Op>> {
     let val_register = register_sequencer.next();
     let initialization = convert_expression_to_asm(
         &const_decl.value,

--- a/sway-core/src/asm_generation/declaration/fn_decl.rs
+++ b/sway-core/src/asm_generation/declaration/fn_decl.rs
@@ -6,10 +6,10 @@ use crate::{
 };
 
 pub(crate) fn convert_fn_decl_to_asm<'sc>(
-    _decl: &TypedFunctionDeclaration<'sc>,
+    _decl: &TypedFunctionDeclaration,
     _namespace: &mut AsmNamespace,
     _register_sequencer: &mut RegisterSequencer,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+) -> CompileResult<Vec<Op>> {
     // for now, we inline all functions as a shortcut.
     ok(vec![], vec![], vec![])
 }

--- a/sway-core/src/asm_generation/declaration/fn_decl.rs
+++ b/sway-core/src/asm_generation/declaration/fn_decl.rs
@@ -5,7 +5,7 @@ use crate::{
     TypedFunctionDeclaration,
 };
 
-pub(crate) fn convert_fn_decl_to_asm<'sc>(
+pub(crate) fn convert_fn_decl_to_asm(
     _decl: &TypedFunctionDeclaration,
     _namespace: &mut AsmNamespace,
     _register_sequencer: &mut RegisterSequencer,

--- a/sway-core/src/asm_generation/declaration/mod.rs
+++ b/sway-core/src/asm_generation/declaration/mod.rs
@@ -12,10 +12,10 @@ pub(crate) use reassignment::convert_reassignment_to_asm;
 pub(crate) use var_decl::convert_variable_decl_to_asm;
 
 pub(crate) fn convert_decl_to_asm<'sc>(
-    decl: &TypedDeclaration<'sc>,
-    namespace: &mut AsmNamespace<'sc>,
+    decl: &TypedDeclaration,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+) -> CompileResult<Vec<Op>> {
     match decl {
         // For an enum declaration, we don't generate any asm.
         TypedDeclaration::EnumDeclaration(_) => ok(vec![], vec![], vec![]),

--- a/sway-core/src/asm_generation/declaration/mod.rs
+++ b/sway-core/src/asm_generation/declaration/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn convert_decl_to_asm(
             vec![],
             vec![CompileError::Unimplemented(
                 "ASM generation has not yet been implemented for this declaration variant.",
-                decl.span()
+                decl.span(),
             )],
         ),
     }

--- a/sway-core/src/asm_generation/declaration/mod.rs
+++ b/sway-core/src/asm_generation/declaration/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use fn_decl::convert_fn_decl_to_asm;
 pub(crate) use reassignment::convert_reassignment_to_asm;
 pub(crate) use var_decl::convert_variable_decl_to_asm;
 
-pub(crate) fn convert_decl_to_asm<'sc>(
+pub(crate) fn convert_decl_to_asm(
     decl: &TypedDeclaration,
     namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
@@ -42,7 +42,7 @@ pub(crate) fn convert_decl_to_asm<'sc>(
             vec![],
             vec![CompileError::Unimplemented(
                 "ASM generation has not yet been implemented for this declaration variant.",
-                decl.span().clone(),
+                decl.span()
             )],
         ),
     }

--- a/sway-core/src/asm_generation/declaration/reassignment.rs
+++ b/sway-core/src/asm_generation/declaration/reassignment.rs
@@ -66,7 +66,7 @@ pub(crate) fn convert_reassignment_to_asm<'sc>(
                     reassignment
                         .lhs
                         .iter()
-                        .map(|x| x.name.primary_name())
+                        .map(|x| x.name.as_str())
                         .collect::<Vec<_>>()
                         .join(".")
                 ),
@@ -86,7 +86,7 @@ pub(crate) fn convert_reassignment_to_asm<'sc>(
                     match resolve_type(*r#type, name.span()) {
                         Ok(TypeInfo::Struct { ref fields, .. }) => Ok((fields.clone(), name)),
                         Ok(ref a) => Err(CompileError::NotAStruct {
-                            name: name.primary_name().to_string(),
+                            name: name.as_str().to_string(),
                             span: name.span().clone(),
                             actually: a.friendly_type_str(),
                         }),
@@ -141,7 +141,7 @@ pub(crate) fn convert_reassignment_to_asm<'sc>(
                     TypeInfo::Struct { ref fields, .. } => fields.clone(),
                     a => {
                         errors.push(CompileError::NotAStruct {
-                            name: name.primary_name().to_string(),
+                            name: name.as_str().to_string(),
                             span: name.span().clone(),
                             actually: a.friendly_type_str(),
                         });

--- a/sway-core/src/asm_generation/declaration/reassignment.rs
+++ b/sway-core/src/asm_generation/declaration/reassignment.rs
@@ -13,10 +13,10 @@ use crate::{
 use either::Either;
 
 pub(crate) fn convert_reassignment_to_asm<'sc>(
-    reassignment: &TypedReassignment<'sc>,
-    namespace: &mut AsmNamespace<'sc>,
+    reassignment: &TypedReassignment,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+) -> CompileResult<Vec<Op>> {
     // 0. evaluate the RHS of the reassignment
     // 1. Find the register that the previous var was stored in
     // 2. move the return register of the RHS into the register in the namespace
@@ -114,7 +114,7 @@ pub(crate) fn convert_reassignment_to_asm<'sc>(
                 };
                 // TODO(static span) use spans instead of strings below
                 let span = crate::Span {
-                    span: pest::Span::new("TODO(static span): use Idents instead of Strings", 0, 0)
+                    span: pest::Span::new("TODO(static span): use Idents instead of Strings".into(), 0, 0)
                         .unwrap(),
                     path: None,
                 };

--- a/sway-core/src/asm_generation/declaration/reassignment.rs
+++ b/sway-core/src/asm_generation/declaration/reassignment.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use either::Either;
 
-pub(crate) fn convert_reassignment_to_asm<'sc>(
+pub(crate) fn convert_reassignment_to_asm(
     reassignment: &TypedReassignment,
     namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,

--- a/sway-core/src/asm_generation/declaration/reassignment.rs
+++ b/sway-core/src/asm_generation/declaration/reassignment.rs
@@ -114,8 +114,12 @@ pub(crate) fn convert_reassignment_to_asm(
                 };
                 // TODO(static span) use spans instead of strings below
                 let span = crate::Span {
-                    span: pest::Span::new("TODO(static span): use Idents instead of Strings".into(), 0, 0)
-                        .unwrap(),
+                    span: pest::Span::new(
+                        "TODO(static span): use Idents instead of Strings".into(),
+                        0,
+                        0,
+                    )
+                    .unwrap(),
                     path: None,
                 };
                 let fields_for_layout = fields

--- a/sway-core/src/asm_generation/declaration/reassignment.rs
+++ b/sway-core/src/asm_generation/declaration/reassignment.rs
@@ -66,7 +66,7 @@ pub(crate) fn convert_reassignment_to_asm<'sc>(
                     reassignment
                         .lhs
                         .iter()
-                        .map(|x| x.name.primary_name)
+                        .map(|x| x.name.primary_name())
                         .collect::<Vec<_>>()
                         .join(".")
                 ),
@@ -83,11 +83,11 @@ pub(crate) fn convert_reassignment_to_asm<'sc>(
             let (mut fields, top_level_decl) = match iter
                 .next()
                 .map(|ReassignmentLhs { r#type, name }| -> Result<_, _> {
-                    match resolve_type(*r#type, &name.span) {
+                    match resolve_type(*r#type, name.span()) {
                         Ok(TypeInfo::Struct { ref fields, .. }) => Ok((fields.clone(), name)),
                         Ok(ref a) => Err(CompileError::NotAStruct {
-                            name: name.primary_name.to_string(),
-                            span: name.span.clone(),
+                            name: name.primary_name().to_string(),
+                            span: name.span().clone(),
                             actually: a.friendly_type_str(),
                         }),
                         Err(a) => Err(CompileError::TypeError(a)),
@@ -105,7 +105,7 @@ pub(crate) fn convert_reassignment_to_asm<'sc>(
             // delve into this potentially nested field access and figure out the location of this
             // subfield
             for ReassignmentLhs { r#type, name } in iter {
-                let r#type = match resolve_type(*r#type, &name.span) {
+                let r#type = match resolve_type(*r#type, name.span()) {
                     Ok(o) => o,
                     Err(e) => {
                         errors.push(CompileError::TypeError(e));
@@ -141,8 +141,8 @@ pub(crate) fn convert_reassignment_to_asm<'sc>(
                     TypeInfo::Struct { ref fields, .. } => fields.clone(),
                     a => {
                         errors.push(CompileError::NotAStruct {
-                            name: name.primary_name.to_string(),
-                            span: name.span.clone(),
+                            name: name.primary_name().to_string(),
+                            span: name.span().clone(),
                             actually: a.friendly_type_str(),
                         });
                         return err(warnings, errors);

--- a/sway-core/src/asm_generation/declaration/var_decl.rs
+++ b/sway-core/src/asm_generation/declaration/var_decl.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// Provisions a register to put a variable in, and then adds the assembly used to initialize the
 /// variable to the end of the buffer.
-pub(crate) fn convert_variable_decl_to_asm<'sc>(
+pub(crate) fn convert_variable_decl_to_asm(
     var_decl: &TypedVariableDeclaration,
     namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,

--- a/sway-core/src/asm_generation/declaration/var_decl.rs
+++ b/sway-core/src/asm_generation/declaration/var_decl.rs
@@ -8,10 +8,10 @@ use crate::{
 /// Provisions a register to put a variable in, and then adds the assembly used to initialize the
 /// variable to the end of the buffer.
 pub(crate) fn convert_variable_decl_to_asm<'sc>(
-    var_decl: &TypedVariableDeclaration<'sc>,
-    namespace: &mut AsmNamespace<'sc>,
+    var_decl: &TypedVariableDeclaration,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+) -> CompileResult<Vec<Op>> {
     let var_register = register_sequencer.next();
     let initialization =
         convert_expression_to_asm(&var_decl.body, namespace, &var_register, register_sequencer);

--- a/sway-core/src/asm_generation/expression/array.rs
+++ b/sway-core/src/asm_generation/expression/array.rs
@@ -2,11 +2,11 @@ use super::compiler_constants::{TWELVE_BITS, TWENTY_FOUR_BITS};
 use super::*;
 
 pub(super) fn convert_array_instantiation_to_asm<'sc>(
-    contents: &[TypedExpression<'sc>],
-    namespace: &mut AsmNamespace<'sc>,
+    contents: &[TypedExpression],
+    namespace: &mut AsmNamespace,
     return_register: &VirtualRegister,
     register_sequencer: &mut RegisterSequencer,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+) -> CompileResult<Vec<Op>> {
     // If the array is empty then this is a NOOP.  We don't even need to initialise
     // `return_register`, do we?  Or should we return an error about trying to create this?
     if contents.is_empty() {
@@ -78,14 +78,14 @@ pub(super) fn convert_array_instantiation_to_asm<'sc>(
 // Initialise an array with an element size in words of 1 and where all elements can be addressed
 // with twelve bits.
 fn initialize_small_array_instantiation<'sc>(
-    contents: &[TypedExpression<'sc>],
+    contents: &[TypedExpression],
     array_start_reg: &VirtualRegister,
-    mut bytecode: Vec<Op<'sc>>,
-    namespace: &mut AsmNamespace<'sc>,
+    mut bytecode: Vec<Op>,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-    mut warnings: Vec<CompileWarning<'sc>>,
-    mut errors: Vec<CompileError<'sc>>,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+    mut warnings: Vec<CompileWarning>,
+    mut errors: Vec<CompileError>,
+) -> CompileResult<Vec<Op>> {
     assert!(contents.len() as u64 - 1 <= TWELVE_BITS);
 
     let elem_init_reg = register_sequencer.next();
@@ -110,15 +110,15 @@ fn initialize_small_array_instantiation<'sc>(
 
 #[allow(clippy::too_many_arguments)]
 fn initialize_large_array_instantiation<'sc>(
-    contents: &[TypedExpression<'sc>],
+    contents: &[TypedExpression],
     elem_size_in_words: u64,
     array_offs_reg: &VirtualRegister,
-    mut bytecode: Vec<Op<'sc>>,
-    namespace: &mut AsmNamespace<'sc>,
+    mut bytecode: Vec<Op>,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-    mut warnings: Vec<CompileWarning<'sc>>,
-    mut errors: Vec<CompileError<'sc>>,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+    mut warnings: Vec<CompileWarning>,
+    mut errors: Vec<CompileError>,
+) -> CompileResult<Vec<Op>> {
     let elem_offs_reg = register_sequencer.next();
     bytecode.push(Op::unowned_register_move(
         elem_offs_reg.clone(),
@@ -206,13 +206,13 @@ fn initialize_large_array_instantiation<'sc>(
 }
 
 pub(super) fn convert_array_index_to_asm<'sc>(
-    prefix: &TypedExpression<'sc>,
-    index: &TypedExpression<'sc>,
-    span: &Span<'sc>,
-    namespace: &mut AsmNamespace<'sc>,
+    prefix: &TypedExpression,
+    index: &TypedExpression,
+    span: &Span,
+    namespace: &mut AsmNamespace,
     return_register: &VirtualRegister,
     register_sequencer: &mut RegisterSequencer,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+) -> CompileResult<Vec<Op>> {
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
     let mut bytecode = Vec::new();
@@ -347,8 +347,8 @@ pub(super) fn convert_array_index_to_asm<'sc>(
 fn set_large_register_value<'sc, 'a>(
     value: u64,
     dst_reg: &'a VirtualRegister,
-    bytecode: &mut Vec<Op<'sc>>,
-    span: &Span<'sc>,
+    bytecode: &mut Vec<Op>,
+    span: &Span,
 ) -> &'a VirtualRegister {
     if value == 0 {
         return &VirtualRegister::Constant(ConstantRegister::Zero);
@@ -382,10 +382,10 @@ fn set_large_register_value<'sc, 'a>(
 }
 
 fn compile_bounds_assertion<'sc>(
-    bytecode: &mut Vec<Op<'sc>>,
+    bytecode: &mut Vec<Op>,
     count_reg: &VirtualRegister,
     index_reg: &VirtualRegister,
-    span: &Span<'sc>,
+    span: &Span,
     register_sequencer: &mut RegisterSequencer,
 ) {
     // gt_reg = index_reg > count_reg.

--- a/sway-core/src/asm_generation/expression/array.rs
+++ b/sway-core/src/asm_generation/expression/array.rs
@@ -1,7 +1,7 @@
 use super::compiler_constants::{TWELVE_BITS, TWENTY_FOUR_BITS};
 use super::*;
 
-pub(super) fn convert_array_instantiation_to_asm<'sc>(
+pub(super) fn convert_array_instantiation_to_asm(
     contents: &[TypedExpression],
     namespace: &mut AsmNamespace,
     return_register: &VirtualRegister,
@@ -77,7 +77,7 @@ pub(super) fn convert_array_instantiation_to_asm<'sc>(
 
 // Initialise an array with an element size in words of 1 and where all elements can be addressed
 // with twelve bits.
-fn initialize_small_array_instantiation<'sc>(
+fn initialize_small_array_instantiation(
     contents: &[TypedExpression],
     array_start_reg: &VirtualRegister,
     mut bytecode: Vec<Op>,
@@ -109,7 +109,7 @@ fn initialize_small_array_instantiation<'sc>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn initialize_large_array_instantiation<'sc>(
+fn initialize_large_array_instantiation(
     contents: &[TypedExpression],
     elem_size_in_words: u64,
     array_offs_reg: &VirtualRegister,
@@ -205,7 +205,7 @@ fn initialize_large_array_instantiation<'sc>(
     ok(bytecode, warnings, errors)
 }
 
-pub(super) fn convert_array_index_to_asm<'sc>(
+pub(super) fn convert_array_index_to_asm(
     prefix: &TypedExpression,
     index: &TypedExpression,
     span: &Span,
@@ -344,7 +344,7 @@ pub(super) fn convert_array_index_to_asm<'sc>(
 // We want the first (and usually probably the only) operation to OR with Zero, so we recurse for
 // each set of 12 bits until we hit a zero value, and then return the Zero register to be used
 // next.  Thereafter we OR the destination register.
-fn set_large_register_value<'sc, 'a>(
+fn set_large_register_value<'a>(
     value: u64,
     dst_reg: &'a VirtualRegister,
     bytecode: &mut Vec<Op>,
@@ -381,7 +381,7 @@ fn set_large_register_value<'sc, 'a>(
     dst_reg
 }
 
-fn compile_bounds_assertion<'sc>(
+fn compile_bounds_assertion(
     bytecode: &mut Vec<Op>,
     count_reg: &VirtualRegister,
     index_reg: &VirtualRegister,

--- a/sway-core/src/asm_generation/expression/contract_call.rs
+++ b/sway-core/src/asm_generation/expression/contract_call.rs
@@ -3,7 +3,7 @@ use crate::semantic_analysis::ast_node::*;
 use either::Either;
 /// Converts a function application of a contract ABI function into assembly
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn convert_contract_call_to_asm<'sc>(
+pub(crate) fn convert_contract_call_to_asm(
     metadata: &ContractCallMetadata,
     cgas: &TypedExpression,
     bal: &TypedExpression,
@@ -167,7 +167,7 @@ pub(crate) fn convert_contract_call_to_asm<'sc>(
     asm_buf.push(Op::register_move(
         return_register.into(),
         VirtualRegister::Constant(ConstantRegister::ReturnValue),
-        span.clone(),
+        span,
     ));
 
     ok(asm_buf, warnings, errors)

--- a/sway-core/src/asm_generation/expression/contract_call.rs
+++ b/sway-core/src/asm_generation/expression/contract_call.rs
@@ -4,16 +4,16 @@ use either::Either;
 /// Converts a function application of a contract ABI function into assembly
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn convert_contract_call_to_asm<'sc>(
-    metadata: &ContractCallMetadata<'sc>,
-    cgas: &TypedExpression<'sc>,
-    bal: &TypedExpression<'sc>,
-    coin_color: &TypedExpression<'sc>,
-    user_argument: &TypedExpression<'sc>,
+    metadata: &ContractCallMetadata,
+    cgas: &TypedExpression,
+    bal: &TypedExpression,
+    coin_color: &TypedExpression,
+    user_argument: &TypedExpression,
     register_sequencer: &mut RegisterSequencer,
     return_register: &VirtualRegister,
-    namespace: &mut AsmNamespace<'sc>,
-    span: Span<'sc>,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+    namespace: &mut AsmNamespace,
+    span: Span,
+) -> CompileResult<Vec<Op>> {
     let mut warnings = vec![];
     let mut errors = vec![];
     let mut asm_buf = vec![];

--- a/sway-core/src/asm_generation/expression/enums.rs
+++ b/sway-core/src/asm_generation/expression/enums.rs
@@ -12,7 +12,7 @@ use crate::{
     CompileResult, Ident, Literal,
 };
 
-pub(crate) fn convert_enum_instantiation_to_asm<'sc>(
+pub(crate) fn convert_enum_instantiation_to_asm(
     decl: &TypedEnumDeclaration,
     variant_name: &Ident,
     tag: usize,
@@ -50,7 +50,7 @@ pub(crate) fn convert_enum_instantiation_to_asm<'sc>(
             return err(warnings, errors);
         }
     };
-    let size_of_enum: u64 = 1 /* tag */ + match ty.size_in_words(&variant_name.span()) {
+    let size_of_enum: u64 = 1 /* tag */ + match ty.size_in_words(variant_name.span()) {
         Ok(o) => o,
         Err(e) => {
             errors.push(e);

--- a/sway-core/src/asm_generation/expression/enums.rs
+++ b/sway-core/src/asm_generation/expression/enums.rs
@@ -13,14 +13,14 @@ use crate::{
 };
 
 pub(crate) fn convert_enum_instantiation_to_asm<'sc>(
-    decl: &TypedEnumDeclaration<'sc>,
-    variant_name: &Ident<'sc>,
+    decl: &TypedEnumDeclaration,
+    variant_name: &Ident,
     tag: usize,
-    contents: &Option<Box<TypedExpression<'sc>>>,
+    contents: &Option<Box<TypedExpression>>,
     return_register: &VirtualRegister,
-    namespace: &mut AsmNamespace<'sc>,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+) -> CompileResult<Vec<Op>> {
     let mut warnings = vec![];
     let mut errors = vec![];
     // step 0: load the tag into a register

--- a/sway-core/src/asm_generation/expression/enums.rs
+++ b/sway-core/src/asm_generation/expression/enums.rs
@@ -34,7 +34,7 @@ pub(crate) fn convert_enum_instantiation_to_asm<'sc>(
     asm_buf.push(Op::unowned_load_data_comment(
         tag_register.clone(),
         data_label,
-        format!("{} enum instantiation", decl.name.primary_name),
+        format!("{} enum instantiation", decl.name.primary_name()),
     ));
     let pointer_register = register_sequencer.next();
     // copy stack pointer into pointer register
@@ -50,7 +50,7 @@ pub(crate) fn convert_enum_instantiation_to_asm<'sc>(
             return err(warnings, errors);
         }
     };
-    let size_of_enum: u64 = 1 /* tag */ + match ty.size_in_words(&variant_name.span) {
+    let size_of_enum: u64 = 1 /* tag */ + match ty.size_in_words(&variant_name.span()) {
         Ok(o) => o,
         Err(e) => {
             errors.push(e);
@@ -116,7 +116,7 @@ pub(crate) fn convert_enum_instantiation_to_asm<'sc>(
             return_register,
             VirtualImmediate12::new_unchecked(1, "this is the constant 1; infallible"), // offset by 1 because the tag was already written
             instantiation.span.clone(),
-            format!("{} enum contents", decl.name.primary_name),
+            format!("{} enum contents", decl.name.primary_name()),
         ));
     }
 

--- a/sway-core/src/asm_generation/expression/enums.rs
+++ b/sway-core/src/asm_generation/expression/enums.rs
@@ -34,7 +34,7 @@ pub(crate) fn convert_enum_instantiation_to_asm<'sc>(
     asm_buf.push(Op::unowned_load_data_comment(
         tag_register.clone(),
         data_label,
-        format!("{} enum instantiation", decl.name.primary_name()),
+        format!("{} enum instantiation", decl.name.as_str()),
     ));
     let pointer_register = register_sequencer.next();
     // copy stack pointer into pointer register
@@ -116,7 +116,7 @@ pub(crate) fn convert_enum_instantiation_to_asm<'sc>(
             return_register,
             VirtualImmediate12::new_unchecked(1, "this is the constant 1; infallible"), // offset by 1 because the tag was already written
             instantiation.span.clone(),
-            format!("{} enum contents", decl.name.primary_name()),
+            format!("{} enum contents", decl.name.as_str()),
         ));
     }
 

--- a/sway-core/src/asm_generation/expression/if_exp.rs
+++ b/sway-core/src/asm_generation/expression/if_exp.rs
@@ -7,13 +7,13 @@ use crate::semantic_analysis::TypedExpression;
 use crate::CompileResult;
 
 pub(crate) fn convert_if_exp_to_asm<'sc>(
-    condition: &TypedExpression<'sc>,
-    then: &TypedExpression<'sc>,
-    r#else: &Option<Box<TypedExpression<'sc>>>,
+    condition: &TypedExpression,
+    then: &TypedExpression,
+    r#else: &Option<Box<TypedExpression>>,
     return_register: &VirtualRegister,
-    namespace: &mut AsmNamespace<'sc>,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+) -> CompileResult<Vec<Op>> {
     // step 0: construct 2 jump labels: to the else, and to after the else.
     // step 1: evaluate the condition
     // step 2: conditional jump -- if the condition is false, jump to the else label. If there is no

--- a/sway-core/src/asm_generation/expression/if_exp.rs
+++ b/sway-core/src/asm_generation/expression/if_exp.rs
@@ -6,7 +6,7 @@ use crate::semantic_analysis::TypedExpression;
 
 use crate::CompileResult;
 
-pub(crate) fn convert_if_exp_to_asm<'sc>(
+pub(crate) fn convert_if_exp_to_asm(
     condition: &TypedExpression,
     then: &TypedExpression,
     r#else: &Option<Box<TypedExpression>>,

--- a/sway-core/src/asm_generation/expression/lazy_op.rs
+++ b/sway-core/src/asm_generation/expression/lazy_op.rs
@@ -9,12 +9,12 @@ use crate::{
 
 pub(crate) fn convert_lazy_operator_to_asm<'sc>(
     op: &LazyOp,
-    lhs: &TypedExpression<'sc>,
-    rhs: &TypedExpression<'sc>,
+    lhs: &TypedExpression,
+    rhs: &TypedExpression,
     return_register: &VirtualRegister,
-    namespace: &mut AsmNamespace<'sc>,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+) -> CompileResult<Vec<Op>> {
     // Short circuiting operators need to evaluate the LHS first, and then only conditionally
     // evaluate the RHS.
     let mut warnings = vec![];

--- a/sway-core/src/asm_generation/expression/lazy_op.rs
+++ b/sway-core/src/asm_generation/expression/lazy_op.rs
@@ -7,7 +7,7 @@ use crate::{
     CompileResult,
 };
 
-pub(crate) fn convert_lazy_operator_to_asm<'sc>(
+pub(crate) fn convert_lazy_operator_to_asm(
     op: &LazyOp,
     lhs: &TypedExpression,
     rhs: &TypedExpression,

--- a/sway-core/src/asm_generation/expression/mod.rs
+++ b/sway-core/src/asm_generation/expression/mod.rs
@@ -125,17 +125,15 @@ pub(crate) fn convert_expression_to_asm(
             // registers from the sequencer for replacement
             let mut mapping_of_real_registers_to_declared_names: HashMap<&str, VirtualRegister> =
                 Default::default();
-            for TypedAsmRegisterDeclaration {
-                name,
-                initializer,
-            } in registers
-            {
+            for TypedAsmRegisterDeclaration { name, initializer } in registers {
                 let register = register_sequencer.next();
                 assert_or_warn!(
                     ConstantRegister::parse_register_name(name.as_str()).is_none(),
                     warnings,
                     name.span().clone(),
-                    Warning::ShadowingReservedRegister { reg_name: name.clone() }
+                    Warning::ShadowingReservedRegister {
+                        reg_name: name.clone()
+                    }
                 );
 
                 mapping_of_real_registers_to_declared_names.insert(name.as_str(), register.clone());
@@ -177,10 +175,8 @@ pub(crate) fn convert_expression_to_asm(
                 );
                 */
                 let replaced_registers = op.op_args.iter().map(|x| -> Result<_, CompileError> {
-                    match realize_register(
-                        x.as_str(),
-                        &mapping_of_real_registers_to_declared_names,
-                    ) {
+                    match realize_register(x.as_str(), &mapping_of_real_registers_to_declared_names)
+                    {
                         Some(o) => Ok(o),
                         None => Err(CompileError::UnknownRegister {
                             span: x.span().clone(),
@@ -434,10 +430,7 @@ fn convert_fn_app_to_asm(
 ) -> CompileResult<Vec<Op>> {
     let mut warnings = vec![];
     let mut errors = vec![];
-    let mut asm_buf = vec![Op::new_comment(format!(
-        "{} fn call",
-        name.suffix.as_str()
-    ))];
+    let mut asm_buf = vec![Op::new_comment(format!("{} fn call", name.suffix.as_str()))];
     // Make a local namespace so that the namespace of this function does not pollute the outer
     // scope
     let mut namespace = parent_namespace.clone();
@@ -494,10 +487,7 @@ pub(crate) fn convert_abi_fn_to_asm(
 ) -> CompileResult<Vec<Op>> {
     let mut warnings = vec![];
     let mut errors = vec![];
-    let mut asm_buf = vec![Op::new_comment(format!(
-        "{} abi fn",
-        decl.name.as_str()
-    ))];
+    let mut asm_buf = vec![Op::new_comment(format!("{} abi fn", decl.name.as_str()))];
     // Make a local namespace so that the namespace of this function does not pollute the outer
     // scope
     let mut namespace = parent_namespace.clone();

--- a/sway-core/src/asm_generation/expression/mod.rs
+++ b/sway-core/src/asm_generation/expression/mod.rs
@@ -27,7 +27,7 @@ use subfield::convert_subfield_expression_to_asm;
 
 /// Given a [TypedExpression], convert it to assembly and put its return value, if any, in the
 /// `return_register`.
-pub(crate) fn convert_expression_to_asm<'sc>(
+pub(crate) fn convert_expression_to_asm(
     exp: &TypedExpression,
     namespace: &mut AsmNamespace,
     return_register: &VirtualRegister,
@@ -370,7 +370,7 @@ fn realize_register(
     }
 }
 
-pub(crate) fn convert_code_block_to_asm<'sc>(
+pub(crate) fn convert_code_block_to_asm(
     block: &TypedCodeBlock,
     namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
@@ -406,7 +406,7 @@ pub(crate) fn convert_code_block_to_asm<'sc>(
 }
 
 /// Initializes [Literal] `lit` into [VirtualRegister] `return_register`.
-fn convert_literal_to_asm<'sc>(
+fn convert_literal_to_asm(
     lit: &Literal,
     namespace: &mut AsmNamespace,
     return_register: &VirtualRegister,
@@ -424,7 +424,7 @@ fn convert_literal_to_asm<'sc>(
 }
 
 /// For now, all functions are handled by inlining at the time of application.
-fn convert_fn_app_to_asm<'sc>(
+fn convert_fn_app_to_asm(
     name: &CallPath,
     arguments: &[(Ident, TypedExpression)],
     function_body: &TypedCodeBlock,
@@ -483,7 +483,7 @@ fn convert_fn_app_to_asm<'sc>(
 /// This is similar to `convert_fn_app_to_asm()`, except instead of function arguments, this
 /// takes four registers where the registers are expected to be pre-loaded with the desired values
 /// when this function is jumped to.
-pub(crate) fn convert_abi_fn_to_asm<'sc>(
+pub(crate) fn convert_abi_fn_to_asm(
     decl: &TypedFunctionDeclaration,
     user_argument: (Ident, VirtualRegister),
     cgas: (Ident, VirtualRegister),

--- a/sway-core/src/asm_generation/expression/mod.rs
+++ b/sway-core/src/asm_generation/expression/mod.rs
@@ -179,7 +179,7 @@ pub(crate) fn convert_expression_to_asm<'sc>(
                 */
                 let replaced_registers = op.op_args.iter().map(|x| -> Result<_, CompileError> {
                     match realize_register(
-                        x.primary_name(),
+                        x.as_str(),
                         &mapping_of_real_registers_to_declared_names,
                     ) {
                         Some(o) => Ok(o),
@@ -437,7 +437,7 @@ fn convert_fn_app_to_asm<'sc>(
     let mut errors = vec![];
     let mut asm_buf = vec![Op::new_comment(format!(
         "{} fn call",
-        name.suffix.primary_name()
+        name.suffix.as_str()
     ))];
     // Make a local namespace so that the namespace of this function does not pollute the outer
     // scope
@@ -497,7 +497,7 @@ pub(crate) fn convert_abi_fn_to_asm<'sc>(
     let mut errors = vec![];
     let mut asm_buf = vec![Op::new_comment(format!(
         "{} abi fn",
-        decl.name.primary_name()
+        decl.name.as_str()
     ))];
     // Make a local namespace so that the namespace of this function does not pollute the outer
     // scope

--- a/sway-core/src/asm_generation/expression/mod.rs
+++ b/sway-core/src/asm_generation/expression/mod.rs
@@ -179,12 +179,12 @@ pub(crate) fn convert_expression_to_asm<'sc>(
                 */
                 let replaced_registers = op.op_args.iter().map(|x| -> Result<_, CompileError> {
                     match realize_register(
-                        x.primary_name,
+                        x.primary_name(),
                         &mapping_of_real_registers_to_declared_names,
                     ) {
                         Some(o) => Ok(o),
                         None => Err(CompileError::UnknownRegister {
-                            span: x.span.clone(),
+                            span: x.span().clone(),
                             initialized_registers: mapping_of_real_registers_to_declared_names
                                 .iter()
                                 .map(|(name, _)| name.to_string())
@@ -437,7 +437,7 @@ fn convert_fn_app_to_asm<'sc>(
     let mut errors = vec![];
     let mut asm_buf = vec![Op::new_comment(format!(
         "{} fn call",
-        name.suffix.primary_name
+        name.suffix.primary_name()
     ))];
     // Make a local namespace so that the namespace of this function does not pollute the outer
     // scope
@@ -497,7 +497,7 @@ pub(crate) fn convert_abi_fn_to_asm<'sc>(
     let mut errors = vec![];
     let mut asm_buf = vec![Op::new_comment(format!(
         "{} abi fn",
-        decl.name.primary_name
+        decl.name.primary_name()
     ))];
     // Make a local namespace so that the namespace of this function does not pollute the outer
     // scope

--- a/sway-core/src/asm_generation/expression/mod.rs
+++ b/sway-core/src/asm_generation/expression/mod.rs
@@ -128,18 +128,17 @@ pub(crate) fn convert_expression_to_asm<'sc>(
             for TypedAsmRegisterDeclaration {
                 name,
                 initializer,
-                name_span,
             } in registers
             {
                 let register = register_sequencer.next();
                 assert_or_warn!(
-                    ConstantRegister::parse_register_name(name).is_none(),
+                    ConstantRegister::parse_register_name(name.as_str()).is_none(),
                     warnings,
-                    name_span.clone(),
-                    Warning::ShadowingReservedRegister { reg_name: name }
+                    name.span().clone(),
+                    Warning::ShadowingReservedRegister { reg_name: name.clone() }
                 );
 
-                mapping_of_real_registers_to_declared_names.insert(name, register.clone());
+                mapping_of_real_registers_to_declared_names.insert(name.as_str(), register.clone());
                 // evaluate each register's initializer
                 if let Some(initializer) = initializer {
                     asm_buf.append(&mut check!(

--- a/sway-core/src/asm_generation/expression/structs.rs
+++ b/sway-core/src/asm_generation/expression/structs.rs
@@ -71,14 +71,14 @@ impl<N> ContiguousMemoryLayoutDescriptor<N> {
 #[test]
 fn test_struct_memory_layout() {
     use crate::span::Span;
-    let first_field_name = Ident::new(
+    let first_field_name = Ident::new_with_override(
         "foo",
         Span {
             span: pest::Span::new(" ", 0, 0).unwrap(),
             path: None,
         },
     );
-    let second_field_name = Ident::new(
+    let second_field_name = Ident::new_with_override(
         "bar",
         Span {
             span: pest::Span::new(" ", 0, 0).unwrap(),

--- a/sway-core/src/asm_generation/expression/structs.rs
+++ b/sway-core/src/asm_generation/expression/structs.rs
@@ -33,7 +33,7 @@ impl ContiguousMemoryLayoutDescriptor<String> {
             self.fields
                 .iter()
                 .position(|FieldMemoryLayoutDescriptor { name_of_field, .. }| {
-                    name_of_field.as_str() == name.primary_name
+                    name_of_field.as_str() == name.primary_name()
                 }) {
             ix
         } else {
@@ -41,7 +41,7 @@ impl ContiguousMemoryLayoutDescriptor<String> {
                 vec![
                 CompileError::Internal(
                     "Attempted to calculate struct memory offset on field that did not exist in struct.",
-                    name.span.clone()
+                    name.span().clone()
                     )
                 ]);
         };
@@ -71,29 +71,29 @@ impl<N> ContiguousMemoryLayoutDescriptor<N> {
 #[test]
 fn test_struct_memory_layout() {
     use crate::span::Span;
-    let first_field_name = Ident {
-        span: Span {
+    let first_field_name = Ident::new(
+        "foo",
+        Span {
             span: pest::Span::new(" ", 0, 0).unwrap(),
             path: None,
         },
-        primary_name: "foo",
-    };
-    let second_field_name = Ident {
-        span: Span {
+    );
+    let second_field_name = Ident::new(
+        "bar",
+        Span {
             span: pest::Span::new(" ", 0, 0).unwrap(),
             path: None,
         },
-        primary_name: "bar",
-    };
+    );
 
     let numbers = ContiguousMemoryLayoutDescriptor {
         fields: vec![
             FieldMemoryLayoutDescriptor {
-                name_of_field: first_field_name.primary_name.to_string(),
+                name_of_field: first_field_name.primary_name().to_string(),
                 size: 1,
             },
             FieldMemoryLayoutDescriptor {
-                name_of_field: second_field_name.primary_name.to_string(),
+                name_of_field: second_field_name.primary_name().to_string(),
                 size: 1,
             },
         ],
@@ -315,15 +315,15 @@ pub(crate) fn convert_struct_expression_to_asm<'sc>(
         .map(|TypedStructExpressionField { name, value }| {
             (
                 value.clone(),
-                name.span.clone(),
-                name.primary_name.to_string(),
+                name.span().clone(),
+                name.primary_name().to_string(),
             )
         })
         .collect::<Vec<_>>();
 
     let asm_buf = vec![Op::new_comment(format!(
         "{} struct initialization",
-        struct_name.primary_name
+        struct_name.primary_name()
     ))];
 
     convert_fields_to_asm(

--- a/sway-core/src/asm_generation/expression/structs.rs
+++ b/sway-core/src/asm_generation/expression/structs.rs
@@ -33,7 +33,7 @@ impl ContiguousMemoryLayoutDescriptor<String> {
             self.fields
                 .iter()
                 .position(|FieldMemoryLayoutDescriptor { name_of_field, .. }| {
-                    name_of_field.as_str() == name.primary_name()
+                    name_of_field.as_str() == name.as_str()
                 }) {
             ix
         } else {
@@ -89,11 +89,11 @@ fn test_struct_memory_layout() {
     let numbers = ContiguousMemoryLayoutDescriptor {
         fields: vec![
             FieldMemoryLayoutDescriptor {
-                name_of_field: first_field_name.primary_name().to_string(),
+                name_of_field: first_field_name.as_str().to_string(),
                 size: 1,
             },
             FieldMemoryLayoutDescriptor {
-                name_of_field: second_field_name.primary_name().to_string(),
+                name_of_field: second_field_name.as_str().to_string(),
                 size: 1,
             },
         ],
@@ -316,14 +316,14 @@ pub(crate) fn convert_struct_expression_to_asm<'sc>(
             (
                 value.clone(),
                 name.span().clone(),
-                name.primary_name().to_string(),
+                name.as_str().to_string(),
             )
         })
         .collect::<Vec<_>>();
 
     let asm_buf = vec![Op::new_comment(format!(
         "{} struct initialization",
-        struct_name.primary_name()
+        struct_name.as_str()
     ))];
 
     convert_fields_to_asm(

--- a/sway-core/src/asm_generation/expression/structs.rs
+++ b/sway-core/src/asm_generation/expression/structs.rs
@@ -124,7 +124,7 @@ pub(crate) fn get_contiguous_memory_layout<N: Clone>(
     let mut errors = vec![];
     for (field, span, name) in fields_with_names {
         let ty = look_up_type_id(*field);
-        let stack_size = match ty.size_in_words(&span) {
+        let stack_size = match ty.size_in_words(span) {
             Ok(o) => o,
             Err(e) => {
                 errors.push(e);
@@ -230,8 +230,8 @@ pub(crate) fn convert_fields_to_asm<N: Clone + std::fmt::Display>(
     for (value, span, name) in fields {
         // evaluate the expression
         let return_register = register_sequencer.next();
-        let value_stack_size: u64 = match resolve_type(value.return_type, &span) {
-            Ok(o) => match o.size_in_words(&span) {
+        let value_stack_size: u64 = match resolve_type(value.return_type, span) {
+            Ok(o) => match o.size_in_words(span) {
                 Ok(o) => o,
                 Err(e) => {
                     errors.push(e);

--- a/sway-core/src/asm_generation/expression/subfield.rs
+++ b/sway-core/src/asm_generation/expression/subfield.rs
@@ -22,14 +22,14 @@ use crate::{
 };
 
 pub(crate) fn convert_subfield_expression_to_asm<'sc>(
-    span: &Span<'sc>,
-    parent: &TypedExpression<'sc>,
-    field_to_access: &TypedStructField<'sc>,
+    span: &Span,
+    parent: &TypedExpression,
+    field_to_access: &TypedStructField,
     resolved_type_of_parent: TypeId,
-    namespace: &mut AsmNamespace<'sc>,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
     return_register: &VirtualRegister,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+) -> CompileResult<Vec<Op>> {
     // step 0. find the type and register of the prefix
     // step 1. get the memory layout of the struct
     // step 2. calculate the offset to the spot we are accessing
@@ -60,7 +60,7 @@ pub(crate) fn convert_subfield_expression_to_asm<'sc>(
     };
     // TODO(static span): str should be ident below
     let span = crate::Span {
-        span: pest::Span::new("TODO(static span): use Idents instead of Strings", 0, 0).unwrap(),
+        span: pest::Span::new("TODO(static span): use Idents instead of Strings".into(), 0, 0).unwrap(),
         path: None,
     };
     let fields_for_layout = fields
@@ -97,7 +97,7 @@ pub(crate) fn convert_subfield_expression_to_asm<'sc>(
         );
 
     let span = crate::Span {
-        span: pest::Span::new("TODO(static span): use span_for_this_field", 0, 0).unwrap(),
+        span: pest::Span::new("TODO(static span): use span_for_this_field".into(), 0, 0).unwrap(),
         path: None,
     };
     // step 3

--- a/sway-core/src/asm_generation/expression/subfield.rs
+++ b/sway-core/src/asm_generation/expression/subfield.rs
@@ -86,7 +86,7 @@ pub(crate) fn convert_subfield_expression_to_asm<'sc>(
     let (type_of_this_field, name_for_this_field) = fields_for_layout
         .into_iter()
         .find_map(|(ty, _span, name)| {
-            if name == field_to_access.name.primary_name {
+            if name == field_to_access.name.primary_name() {
                 Some((ty, name))
             } else {
                 None

--- a/sway-core/src/asm_generation/expression/subfield.rs
+++ b/sway-core/src/asm_generation/expression/subfield.rs
@@ -86,7 +86,7 @@ pub(crate) fn convert_subfield_expression_to_asm<'sc>(
     let (type_of_this_field, name_for_this_field) = fields_for_layout
         .into_iter()
         .find_map(|(ty, _span, name)| {
-            if name == field_to_access.name.primary_name() {
+            if name == field_to_access.name.as_str() {
                 Some((ty, name))
             } else {
                 None

--- a/sway-core/src/asm_generation/expression/subfield.rs
+++ b/sway-core/src/asm_generation/expression/subfield.rs
@@ -60,7 +60,12 @@ pub(crate) fn convert_subfield_expression_to_asm(
     };
     // TODO(static span): str should be ident below
     let span = crate::Span {
-        span: pest::Span::new("TODO(static span): use Idents instead of Strings".into(), 0, 0).unwrap(),
+        span: pest::Span::new(
+            "TODO(static span): use Idents instead of Strings".into(),
+            0,
+            0,
+        )
+        .unwrap(),
         path: None,
     };
     let fields_for_layout = fields

--- a/sway-core/src/asm_generation/expression/subfield.rs
+++ b/sway-core/src/asm_generation/expression/subfield.rs
@@ -21,7 +21,7 @@ use crate::{
     },
 };
 
-pub(crate) fn convert_subfield_expression_to_asm<'sc>(
+pub(crate) fn convert_subfield_expression_to_asm(
     span: &Span,
     parent: &TypedExpression,
     field_to_access: &TypedStructField,

--- a/sway-core/src/asm_generation/finalized_asm.rs
+++ b/sway-core/src/asm_generation/finalized_asm.rs
@@ -47,7 +47,7 @@ impl<'sc> FinalizedAsm {
     }
 }
 
-fn to_bytecode_mut<'sc>(
+fn to_bytecode_mut(
     program_section: &InstructionSet,
     data_section: &mut DataSection,
 ) -> CompileResult<Vec<u8>> {

--- a/sway-core/src/asm_generation/finalized_asm.rs
+++ b/sway-core/src/asm_generation/finalized_asm.rs
@@ -9,24 +9,24 @@ use std::io::Read;
 /// Represents an ASM set which has had register allocation, jump elimination, and optimization
 /// applied to it
 #[derive(Clone)]
-pub enum FinalizedAsm<'sc> {
+pub enum FinalizedAsm {
     ContractAbi {
-        data_section: DataSection<'sc>,
-        program_section: InstructionSet<'sc>,
+        data_section: DataSection,
+        program_section: InstructionSet,
     },
     ScriptMain {
-        data_section: DataSection<'sc>,
-        program_section: InstructionSet<'sc>,
+        data_section: DataSection,
+        program_section: InstructionSet,
     },
     PredicateMain {
-        data_section: DataSection<'sc>,
-        program_section: InstructionSet<'sc>,
+        data_section: DataSection,
+        program_section: InstructionSet,
     },
     // Libraries do not generate any asm.
     Library,
 }
-impl<'sc> FinalizedAsm<'sc> {
-    pub(crate) fn to_bytecode_mut(&mut self) -> CompileResult<'sc, Vec<u8>> {
+impl<'sc> FinalizedAsm {
+    pub(crate) fn to_bytecode_mut(&mut self) -> CompileResult<Vec<u8>> {
         use FinalizedAsm::*;
         match self {
             ContractAbi {
@@ -48,16 +48,16 @@ impl<'sc> FinalizedAsm<'sc> {
 }
 
 fn to_bytecode_mut<'sc>(
-    program_section: &InstructionSet<'sc>,
-    data_section: &mut DataSection<'sc>,
-) -> CompileResult<'sc, Vec<u8>> {
+    program_section: &InstructionSet,
+    data_section: &mut DataSection,
+) -> CompileResult<Vec<u8>> {
     let mut errors = vec![];
     if program_section.ops.len() & 1 != 0 {
         println!("ops len: {}", program_section.ops.len());
         errors.push(CompileError::Internal(
             "Non-word-aligned (odd-number) ops generated. This is an invariant violation.",
             Span {
-                span: pest::Span::new(" ", 0, 0).unwrap(),
+                span: pest::Span::new(" ".into(), 0, 0).unwrap(),
                 path: None,
             },
         ));

--- a/sway-core/src/asm_generation/finalized_asm.rs
+++ b/sway-core/src/asm_generation/finalized_asm.rs
@@ -25,7 +25,7 @@ pub enum FinalizedAsm {
     // Libraries do not generate any asm.
     Library,
 }
-impl<'sc> FinalizedAsm {
+impl FinalizedAsm {
     pub(crate) fn to_bytecode_mut(&mut self) -> CompileResult<Vec<u8>> {
         use FinalizedAsm::*;
         match self {

--- a/sway-core/src/asm_generation/mod.rs
+++ b/sway-core/src/asm_generation/mod.rs
@@ -610,7 +610,7 @@ impl<'sc> AsmNamespace<'sc> {
                 vec![CompileError::Internal(
                     "Unknown variable in assembly generation. This should have been an error \
                      during type checking.",
-                    var_name.span.clone(),
+                    var_name.span().clone(),
                 )],
             ),
         }
@@ -1427,7 +1427,7 @@ fn ret_or_retd_value<'sc>(
                     ConstantRegister::Zero,
                 ))),
                 owning_span: Some(func.return_type_span.clone()),
-                comment: format!("fn {} returns unit", func.name.primary_name),
+                comment: format!("fn {} returns unit", func.name.primary_name()),
             }],
             warnings,
             errors,
@@ -1445,7 +1445,7 @@ fn ret_or_retd_value<'sc>(
         asm_buf.push(Op {
             owning_span: None,
             opcode: Either::Left(VirtualOp::RET(return_register)),
-            comment: format!("{} fn return value", func.name.primary_name),
+            comment: format!("{} fn return value", func.name.primary_name()),
         });
     } else {
         // if the type is larger than one word, then we use RETD to return data
@@ -1463,7 +1463,7 @@ fn ret_or_retd_value<'sc>(
         asm_buf.push(Op {
             owning_span: None,
             opcode: Either::Left(VirtualOp::RETD(return_register, rb_register)),
-            comment: format!("{} fn return value", func.name.primary_name),
+            comment: format!("{} fn return value", func.name.primary_name()),
         });
     }
     ok(asm_buf, warnings, errors)

--- a/sway-core/src/asm_generation/mod.rs
+++ b/sway-core/src/asm_generation/mod.rs
@@ -138,7 +138,7 @@ pub struct InstructionSet {
 }
 
 type Data = Literal;
-impl<'sc> AbstractInstructionSet {
+impl AbstractInstructionSet {
     /// Removes any jumps that jump to the subsequent line
     fn remove_sequential_jumps(&self) -> AbstractInstructionSet {
         let mut buf = vec![];
@@ -371,7 +371,7 @@ pub struct DataSection {
     pub value_pairs: Vec<Data>,
 }
 
-impl<'sc> DataSection {
+impl DataSection {
     /// Given a [DataId], calculate the offset _from the beginning of the data section_ to the data
     /// in bytes.
     pub(crate) fn offset_to_id(&self, id: &DataId) -> usize {
@@ -493,7 +493,7 @@ impl fmt::Display for JumpOptimizedAsmSet {
     }
 }
 
-impl<'sc> fmt::Display for RegisterAllocatedAsmSet {
+impl fmt::Display for RegisterAllocatedAsmSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RegisterAllocatedAsmSet::ScriptMain {
@@ -520,7 +520,7 @@ impl<'sc> fmt::Display for RegisterAllocatedAsmSet {
     }
 }
 
-impl<'sc> fmt::Display for FinalizedAsm {
+impl fmt::Display for FinalizedAsm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FinalizedAsm::ScriptMain {
@@ -555,7 +555,7 @@ impl fmt::Display for AbstractInstructionSet {
     }
 }
 
-impl<'sc> fmt::Display for InstructionSet {
+impl fmt::Display for InstructionSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -585,7 +585,7 @@ impl fmt::Display for DataId {
     }
 }
 
-impl<'sc> AsmNamespace {
+impl AsmNamespace {
     pub(crate) fn insert_variable(
         &mut self,
         var_name: Ident,
@@ -789,7 +789,7 @@ pub(crate) fn compile_ast_to_asm(
     ok(finalized_asm, warnings, errors)
 }
 
-impl<'sc> HllAsmSet {
+impl HllAsmSet {
     pub(crate) fn remove_unnecessary_jumps(self) -> JumpOptimizedAsmSet {
         match self {
             HllAsmSet::ScriptMain {
@@ -818,7 +818,7 @@ impl<'sc> HllAsmSet {
     }
 }
 
-impl<'sc> JumpOptimizedAsmSet {
+impl JumpOptimizedAsmSet {
     fn allocate_registers(self, namespace: &AsmNamespace) -> RegisterAllocatedAsmSet {
         match self {
             JumpOptimizedAsmSet::Library => RegisterAllocatedAsmSet::Library,
@@ -894,7 +894,7 @@ pub enum RegisterAllocatedAsmSet {
     Library,
 }
 
-impl<'sc> RegisterAllocatedAsmSet {
+impl RegisterAllocatedAsmSet {
     fn optimize(self) -> FinalizedAsm {
         // TODO implement this -- noop for now
         match self {
@@ -1279,16 +1279,16 @@ fn add_module_constant_decls(
 /// The function selector value and corresponding label.
 type JumpDestination = Vec<([u8; 4], Label)>;
 /// A vector of opcodes representing the body of a contract ABI function.
-type AbiFunctionOpcodeBuffer<'sc> = Vec<Op>;
+type AbiFunctionOpcodeBuffer = Vec<Op>;
 /// The function selector information and compiled body of a contract ABI function.
-type SerializedAbiFunction<'sc> = (JumpDestination, AbiFunctionOpcodeBuffer<'sc>);
+type SerializedAbiFunction = (JumpDestination, AbiFunctionOpcodeBuffer);
 
 /// Given a contract's abi entries, compile them to jump destinations and an opcode buffer.
-fn compile_contract_to_selectors<'sc>(
+fn compile_contract_to_selectors(
     abi_entries: Vec<TypedFunctionDeclaration>,
     namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-) -> CompileResult<SerializedAbiFunction<'sc>> {
+) -> CompileResult<SerializedAbiFunction> {
     let mut warnings = vec![];
     let mut errors = vec![];
     // for every ABI function, we need:

--- a/sway-core/src/asm_generation/mod.rs
+++ b/sway-core/src/asm_generation/mod.rs
@@ -1427,7 +1427,7 @@ fn ret_or_retd_value<'sc>(
                     ConstantRegister::Zero,
                 ))),
                 owning_span: Some(func.return_type_span.clone()),
-                comment: format!("fn {} returns unit", func.name.primary_name()),
+                comment: format!("fn {} returns unit", func.name.as_str()),
             }],
             warnings,
             errors,
@@ -1445,7 +1445,7 @@ fn ret_or_retd_value<'sc>(
         asm_buf.push(Op {
             owning_span: None,
             opcode: Either::Left(VirtualOp::RET(return_register)),
-            comment: format!("{} fn return value", func.name.primary_name()),
+            comment: format!("{} fn return value", func.name.as_str()),
         });
     } else {
         // if the type is larger than one word, then we use RETD to return data
@@ -1463,7 +1463,7 @@ fn ret_or_retd_value<'sc>(
         asm_buf.push(Op {
             owning_span: None,
             opcode: Either::Left(VirtualOp::RETD(return_register, rb_register)),
-            comment: format!("{} fn return value", func.name.primary_name()),
+            comment: format!("{} fn return value", func.name.as_str()),
         });
     }
     ok(asm_buf, warnings, errors)

--- a/sway-core/src/asm_generation/mod.rs
+++ b/sway-core/src/asm_generation/mod.rs
@@ -357,7 +357,7 @@ fn virtual_register_is_never_accessed_again(
 }
 
 /// helper function to check if a label is used in a given buffer of ops
-fn label_is_used<'sc>(buf: &[Op], label: &Label) -> bool {
+fn label_is_used(buf: &[Op], label: &Label) -> bool {
     buf.iter().any(|Op { ref opcode, .. }| match opcode {
         Either::Right(OrganizationalOp::Jump(ref l)) if label == l => true,
         Either::Right(OrganizationalOp::JumpIfNotEq(_reg0, _reg1, ref l)) if label == l => true,
@@ -617,7 +617,7 @@ impl<'sc> AsmNamespace {
     }
 }
 
-pub(crate) fn compile_ast_to_asm<'sc>(
+pub(crate) fn compile_ast_to_asm(
     ast: TypedParseTree,
     build_config: &BuildConfig,
 ) -> CompileResult<FinalizedAsm> {
@@ -964,7 +964,7 @@ pub(crate) enum NodeAsmResult {
 
 /// The tuple being returned here contains the opcodes of the code block and,
 /// optionally, a return register in case this node was a return statement
-fn convert_node_to_asm<'sc>(
+fn convert_node_to_asm(
     node: &TypedAstNode,
     namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
@@ -1118,7 +1118,7 @@ fn build_preamble(register_sequencer: &mut RegisterSequencer) -> [Op; 6] {
 /// Builds the contract switch statement, or function selector, which takes the selector
 /// stored in the call frame (see https://github.com/FuelLabs/sway/issues/97#issuecomment-870150684
 /// for an explanation of its location)
-fn build_contract_abi_switch<'sc>(
+fn build_contract_abi_switch(
     register_sequencer: &mut RegisterSequencer,
     namespace: &mut AsmNamespace,
     selectors_and_labels: Vec<([u8; 4], Label)>,
@@ -1194,7 +1194,7 @@ fn build_contract_abi_switch<'sc>(
     asm_buf
 }
 
-fn add_all_constant_decls<'sc>(
+fn add_all_constant_decls(
     namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
     asm_buf: &mut Vec<Op>,
@@ -1218,7 +1218,7 @@ fn add_all_constant_decls<'sc>(
     ok((), warnings, errors)
 }
 
-fn add_global_constant_decls<'sc>(
+fn add_global_constant_decls(
     namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
     asm_buf: &mut Vec<Op>,
@@ -1240,7 +1240,7 @@ fn add_global_constant_decls<'sc>(
     ok((), warnings, errors)
 }
 
-fn add_module_constant_decls<'sc>(
+fn add_module_constant_decls(
     namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
     asm_buf: &mut Vec<Op>,
@@ -1349,7 +1349,7 @@ fn compile_contract_to_selectors<'sc>(
     ok((selectors_labels_buf, asm_buf), warnings, errors)
 }
 /// Given a register, load the user-provided argument into it
-fn load_user_argument<'sc>(return_register: VirtualRegister) -> Op {
+fn load_user_argument(return_register: VirtualRegister) -> Op {
     Op {
         opcode: Either::Left(VirtualOp::LW(
             return_register,
@@ -1362,7 +1362,7 @@ fn load_user_argument<'sc>(return_register: VirtualRegister) -> Op {
     }
 }
 /// Given a register, load the current value of $cgas into it
-fn load_cgas<'sc>(return_register: VirtualRegister) -> Op {
+fn load_cgas(return_register: VirtualRegister) -> Op {
     Op {
         opcode: Either::Left(VirtualOp::LW(
             return_register,
@@ -1374,7 +1374,7 @@ fn load_cgas<'sc>(return_register: VirtualRegister) -> Op {
     }
 }
 /// Given a register, load the current value of $bal into it
-fn load_bal<'sc>(return_register: VirtualRegister) -> Op {
+fn load_bal(return_register: VirtualRegister) -> Op {
     Op {
         opcode: Either::Left(VirtualOp::LW(
             return_register,
@@ -1386,7 +1386,7 @@ fn load_bal<'sc>(return_register: VirtualRegister) -> Op {
     }
 }
 /// Given a register, load a pointer to the current coin color into it
-fn load_coin_color<'sc>(return_register: VirtualRegister) -> Op {
+fn load_coin_color(return_register: VirtualRegister) -> Op {
     Op {
         opcode: Either::Left(VirtualOp::LW(
             return_register,
@@ -1400,7 +1400,7 @@ fn load_coin_color<'sc>(return_register: VirtualRegister) -> Op {
 
 /// Given a [TypedFunctionDeclaration] and a `return_register`, return
 /// the return value of the function using either a `RET` or a `RETD` opcode.
-fn ret_or_retd_value<'sc>(
+fn ret_or_retd_value(
     func: &TypedFunctionDeclaration,
     return_register: VirtualRegister,
     register_sequencer: &mut RegisterSequencer,

--- a/sway-core/src/asm_generation/mod.rs
+++ b/sway-core/src/asm_generation/mod.rs
@@ -586,11 +586,7 @@ impl fmt::Display for DataId {
 }
 
 impl AsmNamespace {
-    pub(crate) fn insert_variable(
-        &mut self,
-        var_name: Ident,
-        register_location: VirtualRegister,
-    ) {
+    pub(crate) fn insert_variable(&mut self, var_name: Ident, register_location: VirtualRegister) {
         self.variables.insert(var_name, register_location);
     }
     pub(crate) fn insert_data_value(&mut self, data: &Data) -> DataId {
@@ -599,10 +595,7 @@ impl AsmNamespace {
     /// Finds the register which contains variable `var_name`
     /// The `get` is unwrapped, because invalid variable expressions are
     /// checked for in the type checking stage.
-    pub(crate) fn look_up_variable(
-        &self,
-        var_name: &Ident,
-    ) -> CompileResult<&VirtualRegister> {
+    pub(crate) fn look_up_variable(&self, var_name: &Ident) -> CompileResult<&VirtualRegister> {
         match self.variables.get(var_name) {
             Some(o) => ok(o, vec![], vec![]),
             None => err(

--- a/sway-core/src/asm_generation/mod.rs
+++ b/sway-core/src/asm_generation/mod.rs
@@ -67,18 +67,18 @@ use while_loop::convert_while_loop_to_asm;
 /// The [HllAsmSet] contains either a contract ABI and corresponding ASM, a script's main
 /// function's ASM, or a predicate's main function's ASM. ASM is never generated for libraries,
 /// as that happens when the library itself is imported.
-pub enum HllAsmSet<'sc> {
+pub enum HllAsmSet {
     ContractAbi {
-        data_section: DataSection<'sc>,
-        program_section: AbstractInstructionSet<'sc>,
+        data_section: DataSection,
+        program_section: AbstractInstructionSet,
     },
     ScriptMain {
-        data_section: DataSection<'sc>,
-        program_section: AbstractInstructionSet<'sc>,
+        data_section: DataSection,
+        program_section: AbstractInstructionSet,
     },
     PredicateMain {
-        data_section: DataSection<'sc>,
-        program_section: AbstractInstructionSet<'sc>,
+        data_section: DataSection,
+        program_section: AbstractInstructionSet,
     },
     // Libraries do not generate any asm.
     Library,
@@ -87,18 +87,18 @@ pub enum HllAsmSet<'sc> {
 /// An [AbstractInstructionSet] is a set of instructions that use entirely virtual registers
 /// and excessive moves, with the intention of later optimizing it.
 #[derive(Clone)]
-pub struct AbstractInstructionSet<'sc> {
-    ops: Vec<Op<'sc>>,
+pub struct AbstractInstructionSet {
+    ops: Vec<Op>,
 }
 
 /// "Realized" here refers to labels -- there are no more organizational
 /// ops or labels. In this struct, they are all "realized" to offsets.
-pub struct RealizedAbstractInstructionSet<'sc> {
-    ops: Vec<RealizedOp<'sc>>,
+pub struct RealizedAbstractInstructionSet {
+    ops: Vec<RealizedOp>,
 }
 
-impl<'sc> RealizedAbstractInstructionSet<'sc> {
-    fn allocate_registers(self) -> InstructionSet<'sc> {
+impl RealizedAbstractInstructionSet {
+    fn allocate_registers(self) -> InstructionSet {
         // Eventually, we will use a cool graph-coloring algorithm.
         // For now, just keep a pool of registers and return
         // registers when they are not read anymore
@@ -133,14 +133,14 @@ impl<'sc> RealizedAbstractInstructionSet<'sc> {
 
 /// An [InstructionSet] is produced by allocating registers on an [AbstractInstructionSet].
 #[derive(Clone)]
-pub struct InstructionSet<'sc> {
-    ops: Vec<AllocatedOp<'sc>>,
+pub struct InstructionSet {
+    ops: Vec<AllocatedOp>,
 }
 
-type Data<'sc> = Literal<'sc>;
-impl<'sc> AbstractInstructionSet<'sc> {
+type Data = Literal;
+impl<'sc> AbstractInstructionSet {
     /// Removes any jumps that jump to the subsequent line
-    fn remove_sequential_jumps(&self) -> AbstractInstructionSet<'sc> {
+    fn remove_sequential_jumps(&self) -> AbstractInstructionSet {
         let mut buf = vec![];
         for i in 0..self.ops.len() - 1 {
             if let Op {
@@ -190,9 +190,9 @@ impl<'sc> AbstractInstructionSet<'sc> {
     /// and one to replace the labels in the organizational ops
     fn realize_labels(
         self,
-        data_section: &DataSection<'sc>,
+        data_section: &DataSection,
         _namespace: &AsmNamespace,
-    ) -> RealizedAbstractInstructionSet<'sc> {
+    ) -> RealizedAbstractInstructionSet {
         let mut label_namespace: HashMap<&Label, u64> = Default::default();
         let mut counter = 0;
         for op in &self.ops {
@@ -357,7 +357,7 @@ fn virtual_register_is_never_accessed_again(
 }
 
 /// helper function to check if a label is used in a given buffer of ops
-fn label_is_used<'sc>(buf: &[Op<'sc>], label: &Label) -> bool {
+fn label_is_used<'sc>(buf: &[Op], label: &Label) -> bool {
     buf.iter().any(|Op { ref opcode, .. }| match opcode {
         Either::Right(OrganizationalOp::Jump(ref l)) if label == l => true,
         Either::Right(OrganizationalOp::JumpIfNotEq(_reg0, _reg1, ref l)) if label == l => true,
@@ -366,12 +366,12 @@ fn label_is_used<'sc>(buf: &[Op<'sc>], label: &Label) -> bool {
 }
 
 #[derive(Default, Clone, Debug)]
-pub struct DataSection<'sc> {
+pub struct DataSection {
     /// the data to be put in the data section of the asm
-    pub value_pairs: Vec<Data<'sc>>,
+    pub value_pairs: Vec<Data>,
 }
 
-impl<'sc> DataSection<'sc> {
+impl<'sc> DataSection {
     /// Given a [DataId], calculate the offset _from the beginning of the data section_ to the data
     /// in bytes.
     pub(crate) fn offset_to_id(&self, id: &DataId) -> usize {
@@ -392,7 +392,7 @@ impl<'sc> DataSection<'sc> {
     }
 
     /// Calculates the return type of the data held at a specific [DataId].
-    pub(crate) fn type_of_data(&self, id: &DataId) -> Option<ResolvedType<'sc>> {
+    pub(crate) fn type_of_data(&self, id: &DataId) -> Option<ResolvedType> {
         self.value_pairs.get(id.0 as usize).map(|x| x.as_type())
     }
 
@@ -410,7 +410,7 @@ impl<'sc> DataSection<'sc> {
     /// Given any data in the form of a [Literal] (using this type mainly because it includes type
     /// information and debug spans), insert it into the data section and return its offset as a
     /// [DataId].
-    pub(crate) fn insert_data_value(&mut self, data: &Literal<'sc>) -> DataId {
+    pub(crate) fn insert_data_value(&mut self, data: &Literal) -> DataId {
         // if there is an identical data value, use the same id
         match self.value_pairs.iter().position(|x| x == data) {
             Some(num) => DataId(num as u32),
@@ -423,7 +423,7 @@ impl<'sc> DataSection<'sc> {
     }
 }
 
-impl fmt::Display for DataSection<'_> {
+impl fmt::Display for DataSection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut data_buf = String::new();
         for (ix, data) in self.value_pairs.iter().enumerate() {
@@ -433,7 +433,7 @@ impl fmt::Display for DataSection<'_> {
                 Literal::U32(num) => format!(".u32 {:#04x}", num),
                 Literal::U64(num) => format!(".u64 {:#04x}", num),
                 Literal::Boolean(b) => format!(".bool {}", if *b { "0x01" } else { "0x00" }),
-                Literal::String(st) => format!(".str \"{}\"", st),
+                Literal::String(st) => format!(".str \"{}\"", st.as_str()),
                 Literal::Byte(b) => format!(".byte {:#08b}", b),
                 Literal::B256(b) => format!(
                     ".b256 0x{}",
@@ -451,7 +451,7 @@ impl fmt::Display for DataSection<'_> {
     }
 }
 
-impl fmt::Display for HllAsmSet<'_> {
+impl fmt::Display for HllAsmSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             HllAsmSet::ScriptMain {
@@ -472,7 +472,7 @@ impl fmt::Display for HllAsmSet<'_> {
     }
 }
 
-impl fmt::Display for JumpOptimizedAsmSet<'_> {
+impl fmt::Display for JumpOptimizedAsmSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             JumpOptimizedAsmSet::ScriptMain {
@@ -493,7 +493,7 @@ impl fmt::Display for JumpOptimizedAsmSet<'_> {
     }
 }
 
-impl<'sc> fmt::Display for RegisterAllocatedAsmSet<'sc> {
+impl<'sc> fmt::Display for RegisterAllocatedAsmSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RegisterAllocatedAsmSet::ScriptMain {
@@ -520,7 +520,7 @@ impl<'sc> fmt::Display for RegisterAllocatedAsmSet<'sc> {
     }
 }
 
-impl<'sc> fmt::Display for FinalizedAsm<'sc> {
+impl<'sc> fmt::Display for FinalizedAsm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FinalizedAsm::ScriptMain {
@@ -541,7 +541,7 @@ impl<'sc> fmt::Display for FinalizedAsm<'sc> {
     }
 }
 
-impl fmt::Display for AbstractInstructionSet<'_> {
+impl fmt::Display for AbstractInstructionSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -555,7 +555,7 @@ impl fmt::Display for AbstractInstructionSet<'_> {
     }
 }
 
-impl<'sc> fmt::Display for InstructionSet<'sc> {
+impl<'sc> fmt::Display for InstructionSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -570,9 +570,9 @@ impl<'sc> fmt::Display for InstructionSet<'sc> {
 }
 
 #[derive(Default, Clone, Debug)]
-pub(crate) struct AsmNamespace<'sc> {
-    data_section: DataSection<'sc>,
-    variables: HashMap<Ident<'sc>, VirtualRegister>,
+pub(crate) struct AsmNamespace {
+    data_section: DataSection,
+    variables: HashMap<Ident, VirtualRegister>,
 }
 
 /// An address which refers to a value in the data section of the asm.
@@ -585,15 +585,15 @@ impl fmt::Display for DataId {
     }
 }
 
-impl<'sc> AsmNamespace<'sc> {
+impl<'sc> AsmNamespace {
     pub(crate) fn insert_variable(
         &mut self,
-        var_name: Ident<'sc>,
+        var_name: Ident,
         register_location: VirtualRegister,
     ) {
         self.variables.insert(var_name, register_location);
     }
-    pub(crate) fn insert_data_value(&mut self, data: &Data<'sc>) -> DataId {
+    pub(crate) fn insert_data_value(&mut self, data: &Data) -> DataId {
         self.data_section.insert_data_value(data)
     }
     /// Finds the register which contains variable `var_name`
@@ -601,8 +601,8 @@ impl<'sc> AsmNamespace<'sc> {
     /// checked for in the type checking stage.
     pub(crate) fn look_up_variable(
         &self,
-        var_name: &Ident<'sc>,
-    ) -> CompileResult<'sc, &VirtualRegister> {
+        var_name: &Ident,
+    ) -> CompileResult<&VirtualRegister> {
         match self.variables.get(var_name) {
             Some(o) => ok(o, vec![], vec![]),
             None => err(
@@ -618,9 +618,9 @@ impl<'sc> AsmNamespace<'sc> {
 }
 
 pub(crate) fn compile_ast_to_asm<'sc>(
-    ast: TypedParseTree<'sc>,
+    ast: TypedParseTree,
     build_config: &BuildConfig,
-) -> CompileResult<'sc, FinalizedAsm<'sc>> {
+) -> CompileResult<FinalizedAsm> {
     let mut register_sequencer = RegisterSequencer::new();
     let mut warnings = vec![];
     let mut errors = vec![];
@@ -789,8 +789,8 @@ pub(crate) fn compile_ast_to_asm<'sc>(
     ok(finalized_asm, warnings, errors)
 }
 
-impl<'sc> HllAsmSet<'sc> {
-    pub(crate) fn remove_unnecessary_jumps(self) -> JumpOptimizedAsmSet<'sc> {
+impl<'sc> HllAsmSet {
+    pub(crate) fn remove_unnecessary_jumps(self) -> JumpOptimizedAsmSet {
         match self {
             HllAsmSet::ScriptMain {
                 data_section,
@@ -818,8 +818,8 @@ impl<'sc> HllAsmSet<'sc> {
     }
 }
 
-impl<'sc> JumpOptimizedAsmSet<'sc> {
-    fn allocate_registers(self, namespace: &AsmNamespace) -> RegisterAllocatedAsmSet<'sc> {
+impl<'sc> JumpOptimizedAsmSet {
+    fn allocate_registers(self, namespace: &AsmNamespace) -> RegisterAllocatedAsmSet {
         match self {
             JumpOptimizedAsmSet::Library => RegisterAllocatedAsmSet::Library,
             JumpOptimizedAsmSet::ScriptMain {
@@ -860,42 +860,42 @@ impl<'sc> JumpOptimizedAsmSet<'sc> {
 }
 
 /// Represents an ASM set which has had jump labels and jumps optimized
-pub enum JumpOptimizedAsmSet<'sc> {
+pub enum JumpOptimizedAsmSet {
     ContractAbi {
-        data_section: DataSection<'sc>,
-        program_section: AbstractInstructionSet<'sc>,
+        data_section: DataSection,
+        program_section: AbstractInstructionSet,
     },
     ScriptMain {
-        data_section: DataSection<'sc>,
-        program_section: AbstractInstructionSet<'sc>,
+        data_section: DataSection,
+        program_section: AbstractInstructionSet,
     },
     PredicateMain {
-        data_section: DataSection<'sc>,
-        program_section: AbstractInstructionSet<'sc>,
+        data_section: DataSection,
+        program_section: AbstractInstructionSet,
     },
     // Libraries do not generate any asm.
     Library,
 }
 /// Represents an ASM set which has had registers allocated
-pub enum RegisterAllocatedAsmSet<'sc> {
+pub enum RegisterAllocatedAsmSet {
     ContractAbi {
-        data_section: DataSection<'sc>,
-        program_section: InstructionSet<'sc>,
+        data_section: DataSection,
+        program_section: InstructionSet,
     },
     ScriptMain {
-        data_section: DataSection<'sc>,
-        program_section: InstructionSet<'sc>,
+        data_section: DataSection,
+        program_section: InstructionSet,
     },
     PredicateMain {
-        data_section: DataSection<'sc>,
-        program_section: InstructionSet<'sc>,
+        data_section: DataSection,
+        program_section: InstructionSet,
     },
     // Libraries do not generate any asm.
     Library,
 }
 
-impl<'sc> RegisterAllocatedAsmSet<'sc> {
-    fn optimize(self) -> FinalizedAsm<'sc> {
+impl<'sc> RegisterAllocatedAsmSet {
+    fn optimize(self) -> FinalizedAsm {
         // TODO implement this -- noop for now
         match self {
             RegisterAllocatedAsmSet::Library => FinalizedAsm::Library,
@@ -957,20 +957,20 @@ impl<'sc> RegisterAllocatedAsmSet<'sc> {
     }
 }
 
-pub(crate) enum NodeAsmResult<'sc> {
-    JustAsm(Vec<Op<'sc>>),
-    ReturnStatement { asm: Vec<Op<'sc>> },
+pub(crate) enum NodeAsmResult {
+    JustAsm(Vec<Op>),
+    ReturnStatement { asm: Vec<Op> },
 }
 
 /// The tuple being returned here contains the opcodes of the code block and,
 /// optionally, a return register in case this node was a return statement
 fn convert_node_to_asm<'sc>(
-    node: &TypedAstNode<'sc>,
-    namespace: &mut AsmNamespace<'sc>,
+    node: &TypedAstNode,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
     // Where to put the return value of this node, if it is needed.
     return_register: Option<&VirtualRegister>,
-) -> CompileResult<'sc, NodeAsmResult<'sc>> {
+) -> CompileResult<NodeAsmResult> {
     let mut warnings = vec![];
     let mut errors = vec![];
     match &node.content {
@@ -1078,7 +1078,7 @@ fn convert_node_to_asm<'sc>(
 /// 3    LW $ds $is               1 (where 1 is in words and $is is a byte address to base off of)
 /// -    ADD $ds $ds $is
 /// 4    .program_start:
-fn build_preamble(register_sequencer: &mut RegisterSequencer) -> [Op<'static>; 6] {
+fn build_preamble(register_sequencer: &mut RegisterSequencer) -> [Op; 6] {
     let label = register_sequencer.get_label();
     [
         // word 1
@@ -1120,9 +1120,9 @@ fn build_preamble(register_sequencer: &mut RegisterSequencer) -> [Op<'static>; 6
 /// for an explanation of its location)
 fn build_contract_abi_switch<'sc>(
     register_sequencer: &mut RegisterSequencer,
-    namespace: &mut AsmNamespace<'sc>,
+    namespace: &mut AsmNamespace,
     selectors_and_labels: Vec<([u8; 4], Label)>,
-) -> Vec<Op<'sc>> {
+) -> Vec<Op> {
     let input_selector_register = register_sequencer.next();
     let mut asm_buf = vec![Op {
         opcode: Either::Right(OrganizationalOp::Comment),
@@ -1195,12 +1195,12 @@ fn build_contract_abi_switch<'sc>(
 }
 
 fn add_all_constant_decls<'sc>(
-    namespace: &mut AsmNamespace<'sc>,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-    asm_buf: &mut Vec<Op<'sc>>,
-    declarations: &[TypedDeclaration<'sc>],
-    ast_namespace: &Namespace<'sc>,
-) -> CompileResult<'sc, ()> {
+    asm_buf: &mut Vec<Op>,
+    declarations: &[TypedDeclaration],
+    ast_namespace: &Namespace,
+) -> CompileResult<()> {
     let mut warnings = vec![];
     let mut errors = vec![];
     check!(
@@ -1219,11 +1219,11 @@ fn add_all_constant_decls<'sc>(
 }
 
 fn add_global_constant_decls<'sc>(
-    namespace: &mut AsmNamespace<'sc>,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-    asm_buf: &mut Vec<Op<'sc>>,
-    declarations: &[TypedDeclaration<'sc>],
-) -> CompileResult<'sc, ()> {
+    asm_buf: &mut Vec<Op>,
+    declarations: &[TypedDeclaration],
+) -> CompileResult<()> {
     let mut warnings = vec![];
     let mut errors = vec![];
     for declaration in declarations {
@@ -1241,11 +1241,11 @@ fn add_global_constant_decls<'sc>(
 }
 
 fn add_module_constant_decls<'sc>(
-    namespace: &mut AsmNamespace<'sc>,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-    asm_buf: &mut Vec<Op<'sc>>,
-    ast_namespace: &Namespace<'sc>,
-) -> CompileResult<'sc, ()> {
+    asm_buf: &mut Vec<Op>,
+    ast_namespace: &Namespace,
+) -> CompileResult<()> {
     let mut warnings = vec![];
     let mut errors = vec![];
 
@@ -1279,16 +1279,16 @@ fn add_module_constant_decls<'sc>(
 /// The function selector value and corresponding label.
 type JumpDestination = Vec<([u8; 4], Label)>;
 /// A vector of opcodes representing the body of a contract ABI function.
-type AbiFunctionOpcodeBuffer<'sc> = Vec<Op<'sc>>;
+type AbiFunctionOpcodeBuffer<'sc> = Vec<Op>;
 /// The function selector information and compiled body of a contract ABI function.
 type SerializedAbiFunction<'sc> = (JumpDestination, AbiFunctionOpcodeBuffer<'sc>);
 
 /// Given a contract's abi entries, compile them to jump destinations and an opcode buffer.
 fn compile_contract_to_selectors<'sc>(
-    abi_entries: Vec<TypedFunctionDeclaration<'sc>>,
-    namespace: &mut AsmNamespace<'sc>,
+    abi_entries: Vec<TypedFunctionDeclaration>,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-) -> CompileResult<'sc, SerializedAbiFunction<'sc>> {
+) -> CompileResult<SerializedAbiFunction<'sc>> {
     let mut warnings = vec![];
     let mut errors = vec![];
     // for every ABI function, we need:
@@ -1349,7 +1349,7 @@ fn compile_contract_to_selectors<'sc>(
     ok((selectors_labels_buf, asm_buf), warnings, errors)
 }
 /// Given a register, load the user-provided argument into it
-fn load_user_argument<'sc>(return_register: VirtualRegister) -> Op<'sc> {
+fn load_user_argument<'sc>(return_register: VirtualRegister) -> Op {
     Op {
         opcode: Either::Left(VirtualOp::LW(
             return_register,
@@ -1362,7 +1362,7 @@ fn load_user_argument<'sc>(return_register: VirtualRegister) -> Op<'sc> {
     }
 }
 /// Given a register, load the current value of $cgas into it
-fn load_cgas<'sc>(return_register: VirtualRegister) -> Op<'sc> {
+fn load_cgas<'sc>(return_register: VirtualRegister) -> Op {
     Op {
         opcode: Either::Left(VirtualOp::LW(
             return_register,
@@ -1374,7 +1374,7 @@ fn load_cgas<'sc>(return_register: VirtualRegister) -> Op<'sc> {
     }
 }
 /// Given a register, load the current value of $bal into it
-fn load_bal<'sc>(return_register: VirtualRegister) -> Op<'sc> {
+fn load_bal<'sc>(return_register: VirtualRegister) -> Op {
     Op {
         opcode: Either::Left(VirtualOp::LW(
             return_register,
@@ -1386,7 +1386,7 @@ fn load_bal<'sc>(return_register: VirtualRegister) -> Op<'sc> {
     }
 }
 /// Given a register, load a pointer to the current coin color into it
-fn load_coin_color<'sc>(return_register: VirtualRegister) -> Op<'sc> {
+fn load_coin_color<'sc>(return_register: VirtualRegister) -> Op {
     Op {
         opcode: Either::Left(VirtualOp::LW(
             return_register,
@@ -1401,11 +1401,11 @@ fn load_coin_color<'sc>(return_register: VirtualRegister) -> Op<'sc> {
 /// Given a [TypedFunctionDeclaration] and a `return_register`, return
 /// the return value of the function using either a `RET` or a `RETD` opcode.
 fn ret_or_retd_value<'sc>(
-    func: &TypedFunctionDeclaration<'sc>,
+    func: &TypedFunctionDeclaration,
     return_register: VirtualRegister,
     register_sequencer: &mut RegisterSequencer,
-    namespace: &mut AsmNamespace<'sc>,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+    namespace: &mut AsmNamespace,
+) -> CompileResult<Vec<Op>> {
     let mut errors = vec![];
     let warnings = vec![];
     let mut asm_buf = vec![];
@@ -1434,7 +1434,7 @@ fn ret_or_retd_value<'sc>(
         );
     }
     let span = crate::Span {
-        span: pest::Span::new("TODO(static span)", 0, 0).unwrap(),
+        span: pest::Span::new("TODO(static span)".into(), 0, 0).unwrap(),
         path: None,
     };
 

--- a/sway-core/src/asm_generation/while_loop.rs
+++ b/sway-core/src/asm_generation/while_loop.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::asm_lang::{ConstantRegister, VirtualRegister};
 use crate::semantic_analysis::ast_node::TypedWhileLoop;
-pub(super) fn convert_while_loop_to_asm<'sc>(
+pub(super) fn convert_while_loop_to_asm(
     r#loop: &TypedWhileLoop,
     namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
@@ -23,7 +23,7 @@ pub(super) fn convert_while_loop_to_asm<'sc>(
     let condition_span = r#loop.condition.span.clone();
     buf.push(Op::jump_label_comment(
         label.clone(),
-        condition_span.clone(),
+        condition_span,
         "begin while loop",
     ));
 

--- a/sway-core/src/asm_generation/while_loop.rs
+++ b/sway-core/src/asm_generation/while_loop.rs
@@ -2,10 +2,10 @@ use super::*;
 use crate::asm_lang::{ConstantRegister, VirtualRegister};
 use crate::semantic_analysis::ast_node::TypedWhileLoop;
 pub(super) fn convert_while_loop_to_asm<'sc>(
-    r#loop: &TypedWhileLoop<'sc>,
-    namespace: &mut AsmNamespace<'sc>,
+    r#loop: &TypedWhileLoop,
+    namespace: &mut AsmNamespace,
     register_sequencer: &mut RegisterSequencer,
-) -> CompileResult<'sc, Vec<Op<'sc>>> {
+) -> CompileResult<Vec<Op>> {
     let mut warnings = vec![];
     let mut errors = vec![];
     let mut buf: Vec<Op> = vec![];

--- a/sway-core/src/asm_lang/allocated_ops.rs
+++ b/sway-core/src/asm_lang/allocated_ops.rs
@@ -161,14 +161,14 @@ pub(crate) enum AllocatedOpcode {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct AllocatedOp<'sc> {
+pub(crate) struct AllocatedOp {
     pub(crate) opcode: AllocatedOpcode,
     /// A descriptive comment for ASM readability
     pub(crate) comment: String,
-    pub(crate) owning_span: Option<Span<'sc>>,
+    pub(crate) owning_span: Option<Span>,
 }
 
-impl<'sc> fmt::Display for AllocatedOp<'sc> {
+impl<'sc> fmt::Display for AllocatedOp {
     fn fmt(&self, fmtr: &mut fmt::Formatter<'_>) -> fmt::Result {
         use AllocatedOpcode::*;
         #[rustfmt::skip]
@@ -268,7 +268,7 @@ impl<'sc> fmt::Display for AllocatedOp<'sc> {
 
 type DoubleWideData = [u8; 8];
 
-impl<'sc> AllocatedOp<'sc> {
+impl<'sc> AllocatedOp {
     pub(crate) fn to_fuel_asm(
         &self,
         offset_to_data_section: u64,
@@ -374,7 +374,7 @@ fn realize_lw(
     let offset_bytes = data_section.offset_to_id(data_id) as u64;
     let offset_words = offset_bytes / 8;
     let offset = match VirtualImmediate12::new(offset_words, Span {
-        span: pest::Span::new(" ", 0, 0).unwrap(),
+        span: pest::Span::new(" ".into(), 0, 0).unwrap(),
         path: None
     }) {
         Ok(value) => value,

--- a/sway-core/src/asm_lang/allocated_ops.rs
+++ b/sway-core/src/asm_lang/allocated_ops.rs
@@ -168,7 +168,7 @@ pub(crate) struct AllocatedOp {
     pub(crate) owning_span: Option<Span>,
 }
 
-impl<'sc> fmt::Display for AllocatedOp {
+impl fmt::Display for AllocatedOp {
     fn fmt(&self, fmtr: &mut fmt::Formatter<'_>) -> fmt::Result {
         use AllocatedOpcode::*;
         #[rustfmt::skip]
@@ -268,7 +268,7 @@ impl<'sc> fmt::Display for AllocatedOp {
 
 type DoubleWideData = [u8; 8];
 
-impl<'sc> AllocatedOp {
+impl AllocatedOp {
     pub(crate) fn to_fuel_asm(
         &self,
         offset_to_data_section: u64,

--- a/sway-core/src/asm_lang/mod.rs
+++ b/sway-core/src/asm_lang/mod.rs
@@ -1009,14 +1009,12 @@ fn four_regs(
     args: &[VirtualRegister],
     immediate: &Option<Ident>,
     whole_op_span: Span,
-) -> CompileResult<
-    (
-        VirtualRegister,
-        VirtualRegister,
-        VirtualRegister,
-        VirtualRegister,
-    ),
-> {
+) -> CompileResult<(
+    VirtualRegister,
+    VirtualRegister,
+    VirtualRegister,
+    VirtualRegister,
+)> {
     let warnings = vec![];
     let mut errors = vec![];
     if args.len() > 4 {

--- a/sway-core/src/asm_lang/mod.rs
+++ b/sway-core/src/asm_lang/mod.rs
@@ -258,7 +258,7 @@ impl<'sc> Op<'sc> {
         let mut warnings = vec![];
         let mut errors = vec![];
         ok(
-            match name.primary_name() {
+            match name.as_str() {
                 "add" => {
                     let (r1, r2, r3) = check!(
                         three_regs(args, immediate, whole_op_span),
@@ -1143,7 +1143,7 @@ fn single_imm_24<'sc>(
             });
             return err(warnings, errors);
         }
-        Some(i) => match i.primary_name()[1..].parse() {
+        Some(i) => match i.as_str()[1..].parse() {
             Ok(o) => (o, i.span().clone()),
             Err(_) => {
                 errors.push(CompileError::InvalidImmediateValue {
@@ -1196,7 +1196,7 @@ fn single_reg_imm_18<'sc>(
             });
             return err(warnings, errors);
         }
-        Some(i) => match i.primary_name()[1..].parse() {
+        Some(i) => match i.as_str()[1..].parse() {
             Ok(o) => (o, i.span().clone()),
             Err(_) => {
                 errors.push(CompileError::InvalidImmediateValue {
@@ -1249,7 +1249,7 @@ fn two_regs_imm_12<'sc>(
             });
             return err(warnings, errors);
         }
-        Some(i) => match i.primary_name()[1..].parse() {
+        Some(i) => match i.as_str()[1..].parse() {
             Ok(o) => (o, i.span().clone()),
             Err(_) => {
                 errors.push(CompileError::InvalidImmediateValue {

--- a/sway-core/src/asm_lang/mod.rs
+++ b/sway-core/src/asm_lang/mod.rs
@@ -931,7 +931,7 @@ impl Op {
     }
 }
 
-fn single_reg<'sc>(
+fn single_reg(
     args: &[VirtualRegister],
     immediate: &Option<Ident>,
     whole_op_span: Span,
@@ -950,7 +950,7 @@ fn single_reg<'sc>(
         Some(reg) => reg,
         _ => {
             errors.push(CompileError::IncorrectNumberOfAsmRegisters {
-                span: whole_op_span.clone(),
+                span: whole_op_span,
                 expected: 1,
                 received: args.len(),
             });
@@ -969,7 +969,7 @@ fn single_reg<'sc>(
     ok(reg.clone(), warnings, errors)
 }
 
-fn two_regs<'sc>(
+fn two_regs(
     args: &[VirtualRegister],
     immediate: &Option<Ident>,
     whole_op_span: Span,
@@ -988,7 +988,7 @@ fn two_regs<'sc>(
         (Some(reg), Some(reg2)) => (reg, reg2),
         _ => {
             errors.push(CompileError::IncorrectNumberOfAsmRegisters {
-                span: whole_op_span.clone(),
+                span: whole_op_span,
                 expected: 2,
                 received: args.len(),
             });
@@ -1005,7 +1005,7 @@ fn two_regs<'sc>(
     ok((reg.clone(), reg2.clone()), warnings, errors)
 }
 
-fn four_regs<'sc>(
+fn four_regs(
     args: &[VirtualRegister],
     immediate: &Option<Ident>,
     whole_op_span: Span,
@@ -1031,7 +1031,7 @@ fn four_regs<'sc>(
         (Some(reg), Some(reg2), Some(reg3), Some(reg4)) => (reg, reg2, reg3, reg4),
         _ => {
             errors.push(CompileError::IncorrectNumberOfAsmRegisters {
-                span: whole_op_span.clone(),
+                span: whole_op_span,
                 expected: 4,
                 received: args.len(),
             });
@@ -1083,7 +1083,7 @@ fn four_regs<'sc>(
     )
 }
 
-fn three_regs<'sc>(
+fn three_regs(
     args: &[VirtualRegister],
     immediate: &Option<Ident>,
     whole_op_span: Span,
@@ -1102,7 +1102,7 @@ fn three_regs<'sc>(
         (Some(reg), Some(reg2), Some(reg3)) => (reg, reg2, reg3),
         _ => {
             errors.push(CompileError::IncorrectNumberOfAsmRegisters {
-                span: whole_op_span.clone(),
+                span: whole_op_span,
                 expected: 3,
                 received: args.len(),
             });
@@ -1120,7 +1120,7 @@ fn three_regs<'sc>(
 
     ok((reg.clone(), reg2.clone(), reg3.clone()), warnings, errors)
 }
-fn single_imm_24<'sc>(
+fn single_imm_24(
     args: &[VirtualRegister],
     immediate: &Option<Ident>,
     whole_op_span: Span,
@@ -1137,7 +1137,7 @@ fn single_imm_24<'sc>(
     let (imm, imm_span): (u64, _) = match immediate {
         None => {
             errors.push(CompileError::MissingImmediate {
-                span: whole_op_span.clone(),
+                span: whole_op_span,
             });
             return err(warnings, errors);
         }
@@ -1162,7 +1162,7 @@ fn single_imm_24<'sc>(
 
     ok(imm, warnings, errors)
 }
-fn single_reg_imm_18<'sc>(
+fn single_reg_imm_18(
     args: &[VirtualRegister],
     immediate: &Option<Ident>,
     whole_op_span: Span,
@@ -1180,7 +1180,7 @@ fn single_reg_imm_18<'sc>(
         Some(reg) => reg,
         _ => {
             errors.push(CompileError::IncorrectNumberOfAsmRegisters {
-                span: whole_op_span.clone(),
+                span: whole_op_span,
                 expected: 1,
                 received: args.len(),
             });
@@ -1190,7 +1190,7 @@ fn single_reg_imm_18<'sc>(
     let (imm, imm_span): (u64, _) = match immediate {
         None => {
             errors.push(CompileError::MissingImmediate {
-                span: whole_op_span.clone(),
+                span: whole_op_span,
             });
             return err(warnings, errors);
         }
@@ -1215,7 +1215,7 @@ fn single_reg_imm_18<'sc>(
 
     ok((reg.clone(), imm), warnings, errors)
 }
-fn two_regs_imm_12<'sc>(
+fn two_regs_imm_12(
     args: &[VirtualRegister],
     immediate: &Option<Ident>,
     whole_op_span: Span,
@@ -1233,7 +1233,7 @@ fn two_regs_imm_12<'sc>(
         (Some(reg), Some(reg2)) => (reg, reg2),
         _ => {
             errors.push(CompileError::IncorrectNumberOfAsmRegisters {
-                span: whole_op_span.clone(),
+                span: whole_op_span,
                 expected: 2,
                 received: args.len(),
             });
@@ -1243,7 +1243,7 @@ fn two_regs_imm_12<'sc>(
     let (imm, imm_span): (u64, _) = match immediate {
         None => {
             errors.push(CompileError::MissingImmediate {
-                span: whole_op_span.clone(),
+                span: whole_op_span,
             });
             return err(warnings, errors);
         }

--- a/sway-core/src/asm_lang/mod.rs
+++ b/sway-core/src/asm_lang/mod.rs
@@ -917,10 +917,9 @@ impl<'sc> Op<'sc> {
                     );
                     VirtualOp::GM(r1, imm)
                 }
-
-                other => {
+                _ => {
                     errors.push(CompileError::UnrecognizedOp {
-                        op_name: other,
+                        op_name: name.clone(),
                         span: name.span().clone(),
                     });
                     return err(warnings, errors);

--- a/sway-core/src/asm_lang/mod.rs
+++ b/sway-core/src/asm_lang/mod.rs
@@ -28,29 +28,29 @@ impl From<&AsmRegister> for VirtualRegister {
 }
 
 #[derive(Clone)]
-pub(crate) struct Op<'sc> {
+pub(crate) struct Op {
     pub(crate) opcode: Either<VirtualOp, OrganizationalOp>,
     /// A descriptive comment for ASM readability
     pub(crate) comment: String,
-    pub(crate) owning_span: Option<Span<'sc>>,
+    pub(crate) owning_span: Option<Span>,
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct RealizedOp<'sc> {
+pub(crate) struct RealizedOp {
     pub(crate) opcode: VirtualOp,
     /// A descriptive comment for ASM readability
     pub(crate) comment: String,
-    pub(crate) owning_span: Option<Span<'sc>>,
+    pub(crate) owning_span: Option<Span>,
 }
 
-impl<'sc> Op<'sc> {
+impl Op {
     /// Write value in given [VirtualRegister] `value_to_write` to given memory address that is held within the
     /// [VirtualRegister] `destination_address`
     pub(crate) fn write_register_to_memory(
         destination_address: VirtualRegister,
         value_to_write: VirtualRegister,
         offset: VirtualImmediate12,
-        span: Span<'sc>,
+        span: Span,
     ) -> Self {
         Op {
             opcode: Either::Left(VirtualOp::SW(destination_address, value_to_write, offset)),
@@ -64,7 +64,7 @@ impl<'sc> Op<'sc> {
         destination_address: VirtualRegister,
         value_to_write: VirtualRegister,
         offset: VirtualImmediate12,
-        span: Span<'sc>,
+        span: Span,
         comment: impl Into<String>,
     ) -> Self {
         Op {
@@ -90,7 +90,7 @@ impl<'sc> Op<'sc> {
             owning_span: None,
         }
     }
-    pub(crate) fn new(opcode: VirtualOp, owning_span: Span<'sc>) -> Self {
+    pub(crate) fn new(opcode: VirtualOp, owning_span: Span) -> Self {
         Op {
             opcode: Either::Left(opcode),
             comment: String::new(),
@@ -99,7 +99,7 @@ impl<'sc> Op<'sc> {
     }
     pub(crate) fn new_with_comment(
         opcode: VirtualOp,
-        owning_span: Span<'sc>,
+        owning_span: Span,
         comment: impl Into<String>,
     ) -> Self {
         let comment = comment.into();
@@ -111,7 +111,7 @@ impl<'sc> Op<'sc> {
     }
 
     /// Given a label, creates the actual asm line to put in the ASM which represents a label
-    pub(crate) fn jump_label(label: Label, owning_span: Span<'sc>) -> Self {
+    pub(crate) fn jump_label(label: Label, owning_span: Span) -> Self {
         Op {
             opcode: Either::Right(OrganizationalOp::Label(label)),
             comment: String::new(),
@@ -145,7 +145,7 @@ impl<'sc> Op<'sc> {
     /// Also attaches a comment to it.
     pub(crate) fn jump_label_comment(
         label: Label,
-        owning_span: Span<'sc>,
+        owning_span: Span,
         comment: impl Into<String>,
     ) -> Self {
         Op {
@@ -168,7 +168,7 @@ impl<'sc> Op<'sc> {
     pub(crate) fn register_move(
         r1: VirtualRegister,
         r2: VirtualRegister,
-        owning_span: Span<'sc>,
+        owning_span: Span,
     ) -> Self {
         Op {
             opcode: Either::Left(VirtualOp::MOVE(r1, r2)),
@@ -189,7 +189,7 @@ impl<'sc> Op<'sc> {
     pub(crate) fn register_move_comment(
         r1: VirtualRegister,
         r2: VirtualRegister,
-        owning_span: Span<'sc>,
+        owning_span: Span,
         comment: impl Into<String>,
     ) -> Self {
         Op {
@@ -250,11 +250,11 @@ impl<'sc> Op<'sc> {
     }
 
     pub(crate) fn parse_opcode(
-        name: &Ident<'sc>,
+        name: &Ident,
         args: &[VirtualRegister],
-        immediate: &Option<Ident<'sc>>,
-        whole_op_span: Span<'sc>,
-    ) -> CompileResult<'sc, VirtualOp> {
+        immediate: &Option<Ident>,
+        whole_op_span: Span,
+    ) -> CompileResult<VirtualOp> {
         let mut warnings = vec![];
         let mut errors = vec![];
         ok(
@@ -933,9 +933,9 @@ impl<'sc> Op<'sc> {
 
 fn single_reg<'sc>(
     args: &[VirtualRegister],
-    immediate: &Option<Ident<'sc>>,
-    whole_op_span: Span<'sc>,
-) -> CompileResult<'sc, VirtualRegister> {
+    immediate: &Option<Ident>,
+    whole_op_span: Span,
+) -> CompileResult<VirtualRegister> {
     let warnings = vec![];
     let mut errors = vec![];
     if args.len() > 1 {
@@ -971,9 +971,9 @@ fn single_reg<'sc>(
 
 fn two_regs<'sc>(
     args: &[VirtualRegister],
-    immediate: &Option<Ident<'sc>>,
-    whole_op_span: Span<'sc>,
-) -> CompileResult<'sc, (VirtualRegister, VirtualRegister)> {
+    immediate: &Option<Ident>,
+    whole_op_span: Span,
+) -> CompileResult<(VirtualRegister, VirtualRegister)> {
     let warnings = vec![];
     let mut errors = vec![];
     if args.len() > 2 {
@@ -1007,10 +1007,9 @@ fn two_regs<'sc>(
 
 fn four_regs<'sc>(
     args: &[VirtualRegister],
-    immediate: &Option<Ident<'sc>>,
-    whole_op_span: Span<'sc>,
+    immediate: &Option<Ident>,
+    whole_op_span: Span,
 ) -> CompileResult<
-    'sc,
     (
         VirtualRegister,
         VirtualRegister,
@@ -1086,9 +1085,9 @@ fn four_regs<'sc>(
 
 fn three_regs<'sc>(
     args: &[VirtualRegister],
-    immediate: &Option<Ident<'sc>>,
-    whole_op_span: Span<'sc>,
-) -> CompileResult<'sc, (VirtualRegister, VirtualRegister, VirtualRegister)> {
+    immediate: &Option<Ident>,
+    whole_op_span: Span,
+) -> CompileResult<(VirtualRegister, VirtualRegister, VirtualRegister)> {
     let warnings = vec![];
     let mut errors = vec![];
     if args.len() > 3 {
@@ -1123,9 +1122,9 @@ fn three_regs<'sc>(
 }
 fn single_imm_24<'sc>(
     args: &[VirtualRegister],
-    immediate: &Option<Ident<'sc>>,
-    whole_op_span: Span<'sc>,
-) -> CompileResult<'sc, VirtualImmediate24> {
+    immediate: &Option<Ident>,
+    whole_op_span: Span,
+) -> CompileResult<VirtualImmediate24> {
     let warnings = vec![];
     let mut errors = vec![];
     if !args.is_empty() {
@@ -1165,9 +1164,9 @@ fn single_imm_24<'sc>(
 }
 fn single_reg_imm_18<'sc>(
     args: &[VirtualRegister],
-    immediate: &Option<Ident<'sc>>,
-    whole_op_span: Span<'sc>,
-) -> CompileResult<'sc, (VirtualRegister, VirtualImmediate18)> {
+    immediate: &Option<Ident>,
+    whole_op_span: Span,
+) -> CompileResult<(VirtualRegister, VirtualImmediate18)> {
     let warnings = vec![];
     let mut errors = vec![];
     if args.len() > 1 {
@@ -1218,9 +1217,9 @@ fn single_reg_imm_18<'sc>(
 }
 fn two_regs_imm_12<'sc>(
     args: &[VirtualRegister],
-    immediate: &Option<Ident<'sc>>,
-    whole_op_span: Span<'sc>,
-) -> CompileResult<'sc, (VirtualRegister, VirtualRegister, VirtualImmediate12)> {
+    immediate: &Option<Ident>,
+    whole_op_span: Span,
+) -> CompileResult<(VirtualRegister, VirtualRegister, VirtualImmediate12)> {
     let warnings = vec![];
     let mut errors = vec![];
     if args.len() > 2 {
@@ -1270,7 +1269,7 @@ fn two_regs_imm_12<'sc>(
     ok((reg.clone(), reg2.clone(), imm), warnings, errors)
 }
 
-impl fmt::Display for Op<'_> {
+impl fmt::Display for Op {
     fn fmt(&self, fmtr: &mut fmt::Formatter<'_>) -> fmt::Result {
         use OrganizationalOp::*;
         use VirtualOp::*;

--- a/sway-core/src/asm_lang/mod.rs
+++ b/sway-core/src/asm_lang/mod.rs
@@ -258,7 +258,7 @@ impl<'sc> Op<'sc> {
         let mut warnings = vec![];
         let mut errors = vec![];
         ok(
-            match name.primary_name {
+            match name.primary_name() {
                 "add" => {
                     let (r1, r2, r3) = check!(
                         three_regs(args, immediate, whole_op_span),
@@ -921,7 +921,7 @@ impl<'sc> Op<'sc> {
                 other => {
                     errors.push(CompileError::UnrecognizedOp {
                         op_name: other,
-                        span: name.span.clone(),
+                        span: name.span().clone(),
                     });
                     return err(warnings, errors);
                 }
@@ -962,7 +962,7 @@ fn single_reg<'sc>(
         None => (),
         Some(i) => {
             errors.push(CompileError::UnnecessaryImmediate {
-                span: i.span.clone(),
+                span: i.span().clone(),
             });
         }
     };
@@ -999,7 +999,7 @@ fn two_regs<'sc>(
     match immediate {
         None => (),
         Some(i) => errors.push(CompileError::UnnecessaryImmediate {
-            span: i.span.clone(),
+            span: i.span().clone(),
         }),
     };
 
@@ -1044,7 +1044,7 @@ fn four_regs<'sc>(
         None => (),
         Some(i) => {
             errors.push(CompileError::MissingImmediate {
-                span: i.span.clone(),
+                span: i.span().clone(),
             });
         }
     };
@@ -1115,7 +1115,7 @@ fn three_regs<'sc>(
         None => (),
         Some(i) => {
             errors.push(CompileError::UnnecessaryImmediate {
-                span: i.span.clone(),
+                span: i.span().clone(),
             });
         }
     };
@@ -1143,11 +1143,11 @@ fn single_imm_24<'sc>(
             });
             return err(warnings, errors);
         }
-        Some(i) => match i.primary_name[1..].parse() {
-            Ok(o) => (o, i.span.clone()),
+        Some(i) => match i.primary_name()[1..].parse() {
+            Ok(o) => (o, i.span().clone()),
             Err(_) => {
                 errors.push(CompileError::InvalidImmediateValue {
-                    span: i.span.clone(),
+                    span: i.span().clone(),
                 });
                 return err(warnings, errors);
             }
@@ -1196,11 +1196,11 @@ fn single_reg_imm_18<'sc>(
             });
             return err(warnings, errors);
         }
-        Some(i) => match i.primary_name[1..].parse() {
-            Ok(o) => (o, i.span.clone()),
+        Some(i) => match i.primary_name()[1..].parse() {
+            Ok(o) => (o, i.span().clone()),
             Err(_) => {
                 errors.push(CompileError::InvalidImmediateValue {
-                    span: i.span.clone(),
+                    span: i.span().clone(),
                 });
                 return err(warnings, errors);
             }
@@ -1249,11 +1249,11 @@ fn two_regs_imm_12<'sc>(
             });
             return err(warnings, errors);
         }
-        Some(i) => match i.primary_name[1..].parse() {
-            Ok(o) => (o, i.span.clone()),
+        Some(i) => match i.primary_name()[1..].parse() {
+            Ok(o) => (o, i.span().clone()),
             Err(_) => {
                 errors.push(CompileError::InvalidImmediateValue {
-                    span: i.span.clone(),
+                    span: i.span().clone(),
                 });
                 return err(warnings, errors);
             }

--- a/sway-core/src/asm_lang/virtual_immediate.rs
+++ b/sway-core/src/asm_lang/virtual_immediate.rs
@@ -11,7 +11,7 @@ pub struct VirtualImmediate06 {
 }
 
 impl VirtualImmediate06 {
-    pub(crate) fn new(raw: u64, err_msg_span: Span<'_>) -> Result<Self, CompileError<'_>> {
+    pub(crate) fn new(raw: u64, err_msg_span: Span) -> Result<Self, CompileError> {
         if raw > crate::asm_generation::compiler_constants::SIX_BITS {
             Err(CompileError::Immediate06TooLarge {
                 val: raw,
@@ -37,7 +37,7 @@ pub struct VirtualImmediate12 {
 }
 
 impl VirtualImmediate12 {
-    pub(crate) fn new(raw: u64, err_msg_span: Span<'_>) -> Result<Self, CompileError<'_>> {
+    pub(crate) fn new(raw: u64, err_msg_span: Span) -> Result<Self, CompileError> {
         if raw > crate::asm_generation::compiler_constants::TWELVE_BITS {
             Err(CompileError::Immediate12TooLarge {
                 val: raw,
@@ -72,7 +72,7 @@ pub struct VirtualImmediate18 {
     pub(crate) value: u32,
 }
 impl VirtualImmediate18 {
-    pub(crate) fn new(raw: u64, err_msg_span: Span<'_>) -> Result<Self, CompileError<'_>> {
+    pub(crate) fn new(raw: u64, err_msg_span: Span) -> Result<Self, CompileError> {
         if raw > crate::asm_generation::compiler_constants::EIGHTEEN_BITS {
             Err(CompileError::Immediate18TooLarge {
                 val: raw,
@@ -107,7 +107,7 @@ pub struct VirtualImmediate24 {
     pub(crate) value: u32,
 }
 impl VirtualImmediate24 {
-    pub(crate) fn new(raw: u64, err_msg_span: Span<'_>) -> Result<Self, CompileError<'_>> {
+    pub(crate) fn new(raw: u64, err_msg_span: Span) -> Result<Self, CompileError> {
         if raw > crate::asm_generation::compiler_constants::TWENTY_FOUR_BITS {
             Err(CompileError::Immediate24TooLarge {
                 val: raw,

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -18,7 +18,7 @@ use crate::type_engine::{resolve_type, TypeInfo};
 use crate::{error::*, semantic_analysis::TypedParseTree};
 use petgraph::prelude::NodeIndex;
 
-impl<'sc> ControlFlowGraph {
+impl ControlFlowGraph {
     pub(crate) fn construct_return_path_graph(ast: &TypedParseTree) -> Self {
         let mut graph = ControlFlowGraph {
             graph: Graph::new(),

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use super::{ControlFlowGraph, EntryPoint, ExitPoint, Graph};
+use crate::ident::Ident;
 use crate::parse_tree::CallPath;
 use crate::semantic_analysis::{
     ast_node::{
@@ -56,7 +57,7 @@ impl<'sc> ControlFlowGraph<'sc> {
             errors.append(&mut self.ensure_all_paths_reach_exit(
                 *entry_point,
                 *exit_point,
-                name.as_str(),
+                name,
                 return_type,
             ));
         }
@@ -66,7 +67,7 @@ impl<'sc> ControlFlowGraph<'sc> {
         &self,
         entry_point: EntryPoint,
         exit_point: ExitPoint,
-        function_name: &'sc str,
+        function_name: &Ident<'sc>,
         return_ty: &TypeInfo,
     ) -> Vec<CompileError<'sc>> {
         let mut rovers = vec![entry_point];
@@ -104,7 +105,7 @@ impl<'sc> ControlFlowGraph<'sc> {
                         // TODO: unwrap_to_node is a shortcut. In reality, the graph type should be
                         // different. To save some code duplication,
                         span,
-                        function_name,
+                        function_name: function_name.clone(),
                         ty: return_ty.friendly_type_str(),
                     });
                 }

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -268,8 +268,7 @@ fn connect_typed_fn_decl(
     entry_node: NodeIndex,
     _span: Span,
 ) {
-    let fn_exit_node =
-        graph.add_node(format!("\"{}\" fn exit", fn_decl.name.as_str()).into());
+    let fn_exit_node = graph.add_node(format!("\"{}\" fn exit", fn_decl.name.as_str()).into());
     let return_nodes = depth_first_insertion_code_block(&fn_decl.body, graph, &[entry_node]);
     for node in return_nodes {
         graph.add_edge(node, fn_exit_node, "return".into());

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -126,7 +126,7 @@ enum NodeConnection {
     Return(NodeIndex),
 }
 
-fn connect_node<'sc>(
+fn connect_node(
     node: &TypedAstNode,
     graph: &mut ControlFlowGraph,
     leaves: &[NodeIndex],
@@ -167,7 +167,7 @@ fn connect_node<'sc>(
     }
 }
 
-fn connect_declaration<'sc>(
+fn connect_declaration(
     node: &TypedAstNode,
     decl: &TypedDeclaration,
     graph: &mut ControlFlowGraph,
@@ -224,7 +224,7 @@ fn connect_declaration<'sc>(
 /// that the declaration was indeed at some point implemented.
 /// Additionally, we insert the trait's methods into the method namespace in order to
 /// track which exact methods are dead code.
-fn connect_impl_trait<'sc>(
+fn connect_impl_trait(
     trait_name: &CallPath,
     graph: &mut ControlFlowGraph,
     methods: &[TypedFunctionDeclaration],
@@ -262,7 +262,7 @@ fn connect_impl_trait<'sc>(
 /// When connecting a function declaration, we are inserting a new root node into the graph that
 /// has no entry points, since it is just a declaration.
 /// When something eventually calls it, it gets connected to the declaration.
-fn connect_typed_fn_decl<'sc>(
+fn connect_typed_fn_decl(
     fn_decl: &TypedFunctionDeclaration,
     graph: &mut ControlFlowGraph,
     entry_node: NodeIndex,
@@ -279,7 +279,7 @@ fn connect_typed_fn_decl<'sc>(
         entry_point: entry_node,
         exit_point: fn_exit_node,
         return_type: resolve_type(fn_decl.return_type, &fn_decl.return_type_span)
-            .unwrap_or(TypeInfo::Tuple(Vec::new())),
+            .unwrap_or_else(|_| TypeInfo::Tuple(Vec::new())),
     };
     graph
         .namespace
@@ -288,7 +288,7 @@ fn connect_typed_fn_decl<'sc>(
 
 type ReturnStatementNodes = Vec<NodeIndex>;
 
-fn depth_first_insertion_code_block<'sc>(
+fn depth_first_insertion_code_block(
     node_content: &TypedCodeBlock,
     graph: &mut ControlFlowGraph,
     leaves: &[NodeIndex],

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -56,7 +56,7 @@ impl<'sc> ControlFlowGraph<'sc> {
             errors.append(&mut self.ensure_all_paths_reach_exit(
                 *entry_point,
                 *exit_point,
-                name.primary_name,
+                name.primary_name(),
                 return_type,
             ));
         }
@@ -267,7 +267,8 @@ fn connect_typed_fn_decl<'sc>(
     entry_node: NodeIndex,
     _span: Span<'sc>,
 ) {
-    let fn_exit_node = graph.add_node(format!("\"{}\" fn exit", fn_decl.name.primary_name).into());
+    let fn_exit_node =
+        graph.add_node(format!("\"{}\" fn exit", fn_decl.name.primary_name()).into());
     let return_nodes = depth_first_insertion_code_block(&fn_decl.body, graph, &[entry_node]);
     for node in return_nodes {
         graph.add_edge(node, fn_exit_node, "return".into());

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -18,8 +18,8 @@ use crate::type_engine::{resolve_type, TypeInfo};
 use crate::{error::*, semantic_analysis::TypedParseTree};
 use petgraph::prelude::NodeIndex;
 
-impl<'sc> ControlFlowGraph<'sc> {
-    pub(crate) fn construct_return_path_graph(ast: &TypedParseTree<'sc>) -> Self {
+impl<'sc> ControlFlowGraph {
+    pub(crate) fn construct_return_path_graph(ast: &TypedParseTree) -> Self {
         let mut graph = ControlFlowGraph {
             graph: Graph::new(),
             entry_points: vec![],
@@ -42,7 +42,7 @@ impl<'sc> ControlFlowGraph<'sc> {
     /// and the functions namespace and validating that all paths leading to the function exit node
     /// return the same type. Additionally, if a function has a return type, all paths must indeed
     /// lead to the function exit node.
-    pub(crate) fn analyze_return_paths(&self) -> Vec<CompileError<'sc>> {
+    pub(crate) fn analyze_return_paths(&self) -> Vec<CompileError> {
         let mut errors = vec![];
         for (
             name,
@@ -67,9 +67,9 @@ impl<'sc> ControlFlowGraph<'sc> {
         &self,
         entry_point: EntryPoint,
         exit_point: ExitPoint,
-        function_name: &Ident<'sc>,
+        function_name: &Ident,
         return_ty: &TypeInfo,
-    ) -> Vec<CompileError<'sc>> {
+    ) -> Vec<CompileError> {
         let mut rovers = vec![entry_point];
         let mut errors = vec![];
         let mut max_iterations = 50;
@@ -95,7 +95,7 @@ impl<'sc> ControlFlowGraph<'sc> {
                         Some(ref o) => o.clone(),
                         None => {
                             errors.push(CompileError::Internal("Attempted to construct return path error but no source span was found.", Span {
-                                span: pest::Span::new(" ", 0, 0).unwrap(),
+                                span: pest::Span::new(" ".into(), 0, 0).unwrap(),
                                 path: None
                             }));
                             return errors;
@@ -127,8 +127,8 @@ enum NodeConnection {
 }
 
 fn connect_node<'sc>(
-    node: &TypedAstNode<'sc>,
-    graph: &mut ControlFlowGraph<'sc>,
+    node: &TypedAstNode,
+    graph: &mut ControlFlowGraph,
     leaves: &[NodeIndex],
 ) -> NodeConnection {
     let span = node.span.clone();
@@ -168,10 +168,10 @@ fn connect_node<'sc>(
 }
 
 fn connect_declaration<'sc>(
-    node: &TypedAstNode<'sc>,
-    decl: &TypedDeclaration<'sc>,
-    graph: &mut ControlFlowGraph<'sc>,
-    span: Span<'sc>,
+    node: &TypedAstNode,
+    decl: &TypedDeclaration,
+    graph: &mut ControlFlowGraph,
+    span: Span,
     leaves: &[NodeIndex],
 ) -> Vec<NodeIndex> {
     use TypedDeclaration::*;
@@ -225,9 +225,9 @@ fn connect_declaration<'sc>(
 /// Additionally, we insert the trait's methods into the method namespace in order to
 /// track which exact methods are dead code.
 fn connect_impl_trait<'sc>(
-    trait_name: &CallPath<'sc>,
-    graph: &mut ControlFlowGraph<'sc>,
-    methods: &[TypedFunctionDeclaration<'sc>],
+    trait_name: &CallPath,
+    graph: &mut ControlFlowGraph,
+    methods: &[TypedFunctionDeclaration],
     entry_node: NodeIndex,
 ) {
     let mut methods_and_indexes = vec![];
@@ -263,10 +263,10 @@ fn connect_impl_trait<'sc>(
 /// has no entry points, since it is just a declaration.
 /// When something eventually calls it, it gets connected to the declaration.
 fn connect_typed_fn_decl<'sc>(
-    fn_decl: &TypedFunctionDeclaration<'sc>,
-    graph: &mut ControlFlowGraph<'sc>,
+    fn_decl: &TypedFunctionDeclaration,
+    graph: &mut ControlFlowGraph,
     entry_node: NodeIndex,
-    _span: Span<'sc>,
+    _span: Span,
 ) {
     let fn_exit_node =
         graph.add_node(format!("\"{}\" fn exit", fn_decl.name.as_str()).into());
@@ -289,8 +289,8 @@ fn connect_typed_fn_decl<'sc>(
 type ReturnStatementNodes = Vec<NodeIndex>;
 
 fn depth_first_insertion_code_block<'sc>(
-    node_content: &TypedCodeBlock<'sc>,
-    graph: &mut ControlFlowGraph<'sc>,
+    node_content: &TypedCodeBlock,
+    graph: &mut ControlFlowGraph,
     leaves: &[NodeIndex],
 ) -> ReturnStatementNodes {
     let mut leaves = leaves.to_vec();

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -56,7 +56,7 @@ impl<'sc> ControlFlowGraph<'sc> {
             errors.append(&mut self.ensure_all_paths_reach_exit(
                 *entry_point,
                 *exit_point,
-                name.primary_name(),
+                name.as_str(),
                 return_type,
             ));
         }
@@ -268,7 +268,7 @@ fn connect_typed_fn_decl<'sc>(
     _span: Span<'sc>,
 ) {
     let fn_exit_node =
-        graph.add_node(format!("\"{}\" fn exit", fn_decl.name.primary_name()).into());
+        graph.add_node(format!("\"{}\" fn exit", fn_decl.name.as_str()).into());
     let return_nodes = depth_first_insertion_code_block(&fn_decl.body, graph, &[entry_node]);
     for node in return_nodes {
         graph.add_edge(node, fn_exit_node, "return".into());

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -126,7 +126,7 @@ impl<'sc> ControlFlowGraph<'sc> {
                                         ),
                                     ),
                                 ..
-                            }) => name.primary_name() == "main",
+                            }) => name.as_str() == "main",
                             _ => false,
                         })
                         .unwrap(),
@@ -413,7 +413,7 @@ fn connect_struct_declaration<'sc>(
     // of the field names
     graph
         .namespace
-        .insert_struct(name.primary_name().to_string(), entry_node, field_nodes);
+        .insert_struct(name.as_str().to_string(), entry_node, field_nodes);
 }
 
 /// Implementations of traits are top-level things that are not conditional, so
@@ -545,7 +545,7 @@ fn connect_typed_fn_decl<'sc>(
     tree_type: &TreeType<'sc>,
 ) -> Result<(), CompileError<'sc>> {
     let fn_exit_node =
-        graph.add_node(format!("\"{}\" fn exit", fn_decl.name.primary_name()).into());
+        graph.add_node(format!("\"{}\" fn exit", fn_decl.name.as_str()).into());
     let (_exit_nodes, _exit_node) = depth_first_insertion_code_block(
         &fn_decl.body,
         graph,
@@ -621,12 +621,12 @@ fn connect_expression<'sc>(
                 )
                 .unwrap_or_else(|| {
                     let node_idx = graph
-                        .add_node(format!("extern fn {}()", name.suffix.primary_name()).into());
+                        .add_node(format!("extern fn {}()", name.suffix.as_str()).into());
                     is_external = true;
                     (
                         node_idx,
                         graph.add_node(
-                            format!("extern fn {} exit", name.suffix.primary_name()).into(),
+                            format!("extern fn {} exit", name.suffix.as_str()).into(),
                         ),
                     )
                 });
@@ -777,10 +777,10 @@ fn connect_expression<'sc>(
             struct_name,
             fields,
         } => {
-            let decl = match graph.namespace.find_struct_decl(struct_name.primary_name()) {
+            let decl = match graph.namespace.find_struct_decl(struct_name.as_str()) {
                 Some(ix) => *ix,
                 None => graph
-                    .add_node(format!("External struct  {}", struct_name.primary_name()).into()),
+                    .add_node(format!("External struct  {}", struct_name.as_str()).into()),
             };
             let entry = graph.add_node("Struct declaration entry".into());
             let exit = graph.add_node("Struct declaration exit".into());
@@ -967,8 +967,8 @@ fn connect_enum_instantiation<'sc>(
             let node_idx = graph.add_node(
                 format!(
                     "extern enum {}::{}",
-                    enum_name.primary_name(),
-                    variant_name.primary_name()
+                    enum_name.as_str(),
+                    variant_name.as_str()
                 )
                 .into(),
             );

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -19,7 +19,7 @@ use crate::{
 use petgraph::algo::has_path_connecting;
 use petgraph::prelude::NodeIndex;
 
-impl<'sc> ControlFlowGraph {
+impl ControlFlowGraph {
     pub(crate) fn find_dead_code(&self) -> Vec<CompileWarning> {
         // dead code is code that has no path to the entry point
         let mut dead_nodes = vec![];

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -544,8 +544,7 @@ fn connect_typed_fn_decl(
     exit_node: Option<NodeIndex>,
     tree_type: &TreeType,
 ) -> Result<(), CompileError> {
-    let fn_exit_node =
-        graph.add_node(format!("\"{}\" fn exit", fn_decl.name.as_str()).into());
+    let fn_exit_node = graph.add_node(format!("\"{}\" fn exit", fn_decl.name.as_str()).into());
     let (_exit_nodes, _exit_node) = depth_first_insertion_code_block(
         &fn_decl.body,
         graph,
@@ -559,7 +558,8 @@ fn connect_typed_fn_decl(
 
     // not sure how correct it is to default to Unit here...
     // I think types should all be resolved by now.
-    let ty = resolve_type(fn_decl.return_type, &span).unwrap_or_else(|_| TypeInfo::Tuple(Vec::new()));
+    let ty =
+        resolve_type(fn_decl.return_type, &span).unwrap_or_else(|_| TypeInfo::Tuple(Vec::new()));
 
     let namespace_entry = FunctionNamespaceEntry {
         entry_point: entry_node,
@@ -620,14 +620,12 @@ fn connect_expression(
                      }| (entry_point, exit_point),
                 )
                 .unwrap_or_else(|| {
-                    let node_idx = graph
-                        .add_node(format!("extern fn {}()", name.suffix.as_str()).into());
+                    let node_idx =
+                        graph.add_node(format!("extern fn {}()", name.suffix.as_str()).into());
                     is_external = true;
                     (
                         node_idx,
-                        graph.add_node(
-                            format!("extern fn {} exit", name.suffix.as_str()).into(),
-                        ),
+                        graph.add_node(format!("extern fn {} exit", name.suffix.as_str()).into()),
                     )
                 });
             for leaf in leaves {
@@ -779,8 +777,7 @@ fn connect_expression(
         } => {
             let decl = match graph.namespace.find_struct_decl(struct_name.as_str()) {
                 Some(ix) => *ix,
-                None => graph
-                    .add_node(format!("External struct  {}", struct_name.as_str()).into()),
+                None => graph.add_node(format!("External struct  {}", struct_name.as_str()).into()),
             };
             let entry = graph.add_node("Struct declaration entry".into());
             let exit = graph.add_node("Struct declaration exit".into());
@@ -995,9 +992,7 @@ fn connect_enum_instantiation(
 /// representing its unreached status. For example, we want to say "this function is never called"
 /// if the node is a function declaration, but "this trait is never used" if it is a trait
 /// declaration.
-fn construct_dead_code_warning_from_node(
-    node: &TypedAstNode,
-) -> Option<CompileWarning> {
+fn construct_dead_code_warning_from_node(node: &TypedAstNode) -> Option<CompileWarning> {
     Some(match node {
         // if this is a function, struct, or trait declaration that is never called, then it is dead
         // code.

--- a/sway-core/src/control_flow_analysis/flow_graph/mod.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/mod.rs
@@ -70,14 +70,14 @@ impl<'sc> std::fmt::Debug for ControlFlowGraphNode<'sc> {
                 format!("Enum variant {}", variant_name.to_string())
             }
             ControlFlowGraphNode::MethodDeclaration { method_name, .. } => {
-                format!("Method {}", method_name.primary_name.to_string())
+                format!("Method {}", method_name.primary_name().to_string())
             }
             ControlFlowGraphNode::StructField {
                 struct_field_name, ..
             } => {
                 format!(
                     "Struct field {}",
-                    struct_field_name.primary_name.to_string()
+                    struct_field_name.primary_name().to_string()
                 )
             }
         };
@@ -94,7 +94,7 @@ impl<'sc> std::convert::From<&TypedAstNode<'sc>> for ControlFlowGraphNode<'sc> {
 impl<'sc> std::convert::From<&TypedEnumVariant<'sc>> for ControlFlowGraphNode<'sc> {
     fn from(other: &TypedEnumVariant<'sc>) -> Self {
         ControlFlowGraphNode::EnumVariant {
-            variant_name: other.name.primary_name.to_string(),
+            variant_name: other.name.primary_name().to_string(),
             span: other.span.clone(),
         }
     }

--- a/sway-core/src/control_flow_analysis/flow_graph/mod.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/mod.rs
@@ -70,14 +70,14 @@ impl<'sc> std::fmt::Debug for ControlFlowGraphNode<'sc> {
                 format!("Enum variant {}", variant_name.to_string())
             }
             ControlFlowGraphNode::MethodDeclaration { method_name, .. } => {
-                format!("Method {}", method_name.primary_name().to_string())
+                format!("Method {}", method_name.as_str().to_string())
             }
             ControlFlowGraphNode::StructField {
                 struct_field_name, ..
             } => {
                 format!(
                     "Struct field {}",
-                    struct_field_name.primary_name().to_string()
+                    struct_field_name.as_str().to_string()
                 )
             }
         };
@@ -94,7 +94,7 @@ impl<'sc> std::convert::From<&TypedAstNode<'sc>> for ControlFlowGraphNode<'sc> {
 impl<'sc> std::convert::From<&TypedEnumVariant<'sc>> for ControlFlowGraphNode<'sc> {
     fn from(other: &TypedEnumVariant<'sc>) -> Self {
         ControlFlowGraphNode::EnumVariant {
-            variant_name: other.name.primary_name().to_string(),
+            variant_name: other.name.as_str().to_string(),
             span: other.span.clone(),
         }
     }

--- a/sway-core/src/control_flow_analysis/flow_graph/mod.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/mod.rs
@@ -75,10 +75,7 @@ impl std::fmt::Debug for ControlFlowGraphNode {
             ControlFlowGraphNode::StructField {
                 struct_field_name, ..
             } => {
-                format!(
-                    "Struct field {}",
-                    struct_field_name.as_str().to_string()
-                )
+                format!("Struct field {}", struct_field_name.as_str().to_string())
             }
         };
         f.write_str(&text)

--- a/sway-core/src/control_flow_analysis/flow_graph/mod.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/mod.rs
@@ -61,7 +61,7 @@ pub enum ControlFlowGraphNode {
     },
 }
 
-impl<'sc> std::fmt::Debug for ControlFlowGraphNode {
+impl std::fmt::Debug for ControlFlowGraphNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let text = match self {
             ControlFlowGraphNode::OrganizationalDominator(s) => s.to_string(),
@@ -85,13 +85,13 @@ impl<'sc> std::fmt::Debug for ControlFlowGraphNode {
     }
 }
 
-impl<'sc> std::convert::From<&TypedAstNode> for ControlFlowGraphNode {
+impl std::convert::From<&TypedAstNode> for ControlFlowGraphNode {
     fn from(other: &TypedAstNode) -> Self {
         ControlFlowGraphNode::ProgramNode(other.clone())
     }
 }
 
-impl<'sc> std::convert::From<&TypedEnumVariant> for ControlFlowGraphNode {
+impl std::convert::From<&TypedEnumVariant> for ControlFlowGraphNode {
     fn from(other: &TypedEnumVariant) -> Self {
         ControlFlowGraphNode::EnumVariant {
             variant_name: other.name.as_str().to_string(),
@@ -100,7 +100,7 @@ impl<'sc> std::convert::From<&TypedEnumVariant> for ControlFlowGraphNode {
     }
 }
 
-impl<'sc> std::convert::From<&TypedStructField> for ControlFlowGraphNode {
+impl std::convert::From<&TypedStructField> for ControlFlowGraphNode {
     fn from(other: &TypedStructField) -> Self {
         ControlFlowGraphNode::StructField {
             struct_field_name: other.name.clone(),
@@ -120,7 +120,7 @@ impl std::convert::From<&str> for ControlFlowGraphNode {
     }
 }
 
-impl<'sc> ControlFlowGraph {
+impl ControlFlowGraph {
     pub(crate) fn add_edge_from_entry(&mut self, to: NodeIndex, label: ControlFlowGraphEdge) {
         for entry in &self.entry_points {
             self.graph.add_edge(*entry, to, label.clone());

--- a/sway-core/src/control_flow_analysis/flow_graph/mod.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/mod.rs
@@ -18,13 +18,13 @@ pub type ExitPoint = NodeIndex;
 /// A graph that can be used to model the control flow of a fuel HLL program.
 /// This graph is used as the basis for all of the algorithms in the control flow analysis portion
 /// of the compiler.
-pub struct ControlFlowGraph<'sc> {
-    pub(crate) graph: Graph<'sc>,
+pub struct ControlFlowGraph {
+    pub(crate) graph: Graph,
     pub(crate) entry_points: Vec<NodeIndex>,
-    pub(crate) namespace: ControlFlowNamespace<'sc>,
+    pub(crate) namespace: ControlFlowNamespace,
 }
 
-pub type Graph<'sc> = petgraph::Graph<ControlFlowGraphNode<'sc>, ControlFlowGraphEdge>;
+pub type Graph = petgraph::Graph<ControlFlowGraphNode, ControlFlowGraphEdge>;
 
 #[derive(Clone)]
 pub struct ControlFlowGraphEdge(String);
@@ -43,25 +43,25 @@ impl std::convert::From<&str> for ControlFlowGraphEdge {
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
-pub enum ControlFlowGraphNode<'sc> {
+pub enum ControlFlowGraphNode {
     OrganizationalDominator(String),
     #[allow(clippy::large_enum_variant)]
-    ProgramNode(TypedAstNode<'sc>),
+    ProgramNode(TypedAstNode),
     EnumVariant {
-        span: Span<'sc>,
+        span: Span,
         variant_name: String,
     },
     MethodDeclaration {
-        span: Span<'sc>,
-        method_name: Ident<'sc>,
+        span: Span,
+        method_name: Ident,
     },
     StructField {
-        struct_field_name: Ident<'sc>,
-        span: Span<'sc>,
+        struct_field_name: Ident,
+        span: Span,
     },
 }
 
-impl<'sc> std::fmt::Debug for ControlFlowGraphNode<'sc> {
+impl<'sc> std::fmt::Debug for ControlFlowGraphNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let text = match self {
             ControlFlowGraphNode::OrganizationalDominator(s) => s.to_string(),
@@ -85,14 +85,14 @@ impl<'sc> std::fmt::Debug for ControlFlowGraphNode<'sc> {
     }
 }
 
-impl<'sc> std::convert::From<&TypedAstNode<'sc>> for ControlFlowGraphNode<'sc> {
-    fn from(other: &TypedAstNode<'sc>) -> Self {
+impl<'sc> std::convert::From<&TypedAstNode> for ControlFlowGraphNode {
+    fn from(other: &TypedAstNode) -> Self {
         ControlFlowGraphNode::ProgramNode(other.clone())
     }
 }
 
-impl<'sc> std::convert::From<&TypedEnumVariant<'sc>> for ControlFlowGraphNode<'sc> {
-    fn from(other: &TypedEnumVariant<'sc>) -> Self {
+impl<'sc> std::convert::From<&TypedEnumVariant> for ControlFlowGraphNode {
+    fn from(other: &TypedEnumVariant) -> Self {
         ControlFlowGraphNode::EnumVariant {
             variant_name: other.name.as_str().to_string(),
             span: other.span.clone(),
@@ -100,33 +100,33 @@ impl<'sc> std::convert::From<&TypedEnumVariant<'sc>> for ControlFlowGraphNode<'s
     }
 }
 
-impl<'sc> std::convert::From<&TypedStructField<'sc>> for ControlFlowGraphNode<'sc> {
-    fn from(other: &TypedStructField<'sc>) -> Self {
+impl<'sc> std::convert::From<&TypedStructField> for ControlFlowGraphNode {
+    fn from(other: &TypedStructField) -> Self {
         ControlFlowGraphNode::StructField {
             struct_field_name: other.name.clone(),
             span: other.span.clone(),
         }
     }
 }
-impl std::convert::From<String> for ControlFlowGraphNode<'_> {
+impl std::convert::From<String> for ControlFlowGraphNode {
     fn from(other: String) -> Self {
         ControlFlowGraphNode::OrganizationalDominator(other)
     }
 }
 
-impl std::convert::From<&str> for ControlFlowGraphNode<'_> {
+impl std::convert::From<&str> for ControlFlowGraphNode {
     fn from(other: &str) -> Self {
         ControlFlowGraphNode::OrganizationalDominator(other.to_string())
     }
 }
 
-impl<'sc> ControlFlowGraph<'sc> {
+impl<'sc> ControlFlowGraph {
     pub(crate) fn add_edge_from_entry(&mut self, to: NodeIndex, label: ControlFlowGraphEdge) {
         for entry in &self.entry_points {
             self.graph.add_edge(*entry, to, label.clone());
         }
     }
-    pub(crate) fn add_node(&mut self, node: ControlFlowGraphNode<'sc>) -> NodeIndex {
+    pub(crate) fn add_node(&mut self, node: ControlFlowGraphNode) -> NodeIndex {
         self.graph.add_node(node)
     }
     pub(crate) fn add_edge(

--- a/sway-core/src/control_flow_analysis/flow_graph/namespace.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/namespace.rs
@@ -123,7 +123,7 @@ impl<'sc> ControlFlowNamespace<'sc> {
             struct_decl_ix: declaration_node,
             fields: field_nodes
                 .into_iter()
-                .map(|(Ident { primary_name, .. }, ix)| (primary_name.to_string(), ix))
+                .map(|(ident, ix)| (ident.primary_name().to_string(), ix))
                 .collect(),
         };
         self.struct_namespace.insert(struct_name, entry);

--- a/sway-core/src/control_flow_analysis/flow_graph/namespace.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/namespace.rs
@@ -123,7 +123,7 @@ impl<'sc> ControlFlowNamespace<'sc> {
             struct_decl_ix: declaration_node,
             fields: field_nodes
                 .into_iter()
-                .map(|(ident, ix)| (ident.primary_name().to_string(), ix))
+                .map(|(ident, ix)| (ident.as_str().to_string(), ix))
                 .collect(),
         };
         self.struct_namespace.insert(struct_name, entry);

--- a/sway-core/src/control_flow_analysis/flow_graph/namespace.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/namespace.rs
@@ -40,7 +40,7 @@ pub struct ControlFlowNamespace {
     pub(crate) const_namespace: HashMap<Ident, NodeIndex>,
 }
 
-impl<'sc> ControlFlowNamespace {
+impl ControlFlowNamespace {
     pub(crate) fn get_function(&self, ident: &Ident) -> Option<&FunctionNamespaceEntry> {
         self.function_namespace.get(ident)
     }

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -1,5 +1,6 @@
 //! Tools related to handling/recovering from Sway compile errors and reporting them to the user.
 
+use crate::ident::Ident;
 use crate::parser::Rule;
 use crate::span::Span;
 use crate::style::{to_screaming_snake_case, to_snake_case, to_upper_camel_case};
@@ -223,25 +224,25 @@ impl<'sc> CompileWarning<'sc> {
 #[derive(Debug, Clone, PartialEq, Hash)]
 pub enum Warning<'sc> {
     NonClassCaseStructName {
-        struct_name: &'sc str,
+        struct_name: Ident<'sc>,
     },
     NonClassCaseTraitName {
-        name: &'sc str,
+        name: Ident<'sc>,
     },
     NonClassCaseEnumName {
-        enum_name: &'sc str,
+        enum_name: Ident<'sc>,
     },
     NonClassCaseEnumVariantName {
-        variant_name: &'sc str,
+        variant_name: Ident<'sc>,
     },
     NonSnakeCaseStructFieldName {
-        field_name: &'sc str,
+        field_name: Ident<'sc>,
     },
     NonSnakeCaseFunctionName {
-        name: &'sc str,
+        name: Ident<'sc>,
     },
     NonScreamingSnakeCaseConstName {
-        name: &'sc str,
+        name: Ident<'sc>,
     },
     LossOfPrecision {
         initial_type: IntegerBits,
@@ -251,9 +252,9 @@ pub enum Warning<'sc> {
         r#type: TypeInfo,
     },
     SimilarMethodFound {
-        lib: &'sc str,
-        module: &'sc str,
-        name: &'sc str,
+        lib: Ident<'sc>,
+        module: Ident<'sc>,
+        name: Ident<'sc>,
     },
     OverridesOtherSymbol {
         name: String,
@@ -270,7 +271,7 @@ pub enum Warning<'sc> {
     DeadMethod,
     StructFieldNeverRead,
     ShadowingReservedRegister {
-        reg_name: &'sc str,
+        reg_name: Ident<'sc>,
     },
 }
 
@@ -284,7 +285,7 @@ impl<'sc> fmt::Display for Warning<'sc> {
                 "Struct name \"{}\" is not idiomatic. Structs should have a ClassCase name, like \
                  \"{}\".",
                 struct_name,
-                to_upper_camel_case(struct_name)
+                to_upper_camel_case(struct_name.as_str())
             )
             }
             NonClassCaseTraitName { name } => {
@@ -292,7 +293,7 @@ impl<'sc> fmt::Display for Warning<'sc> {
                 "Trait name \"{}\" is not idiomatic. Traits should have a ClassCase name, like \
                  \"{}\".",
                 name,
-                to_upper_camel_case(name)
+                to_upper_camel_case(name.as_str())
             )
             }
             NonClassCaseEnumName { enum_name } => write!(
@@ -300,28 +301,28 @@ impl<'sc> fmt::Display for Warning<'sc> {
                 "Enum \"{}\"'s capitalization is not idiomatic. Enums should have a ClassCase \
                  name, like \"{}\".",
                 enum_name,
-                to_upper_camel_case(enum_name)
+                to_upper_camel_case(enum_name.as_str())
             ),
             NonSnakeCaseStructFieldName { field_name } => write!(
                 f,
                 "Struct field name \"{}\" is not idiomatic. Struct field names should have a \
                  snake_case name, like \"{}\".",
                 field_name,
-                to_snake_case(field_name)
+                to_snake_case(field_name.as_str())
             ),
             NonClassCaseEnumVariantName { variant_name } => write!(
                 f,
                 "Enum variant name \"{}\" is not idiomatic. Enum variant names should be \
                  ClassCase, like \"{}\".",
                 variant_name,
-                to_upper_camel_case(variant_name)
+                to_upper_camel_case(variant_name.as_str())
             ),
             NonSnakeCaseFunctionName { name } => {
                 write!(f,
                 "Function name \"{}\" is not idiomatic. Function names should be snake_case, like \
                  \"{}\".",
                 name,
-                to_snake_case(name)
+                to_snake_case(name.as_str())
             )
             }
             NonScreamingSnakeCaseConstName { name } => {
@@ -330,7 +331,7 @@ impl<'sc> fmt::Display for Warning<'sc> {
                     "Constant name \"{}\" is not idiomatic. Constant names should be SCREAMING_SNAKE_CASE, like \
                     \"{}\".",
                     name,
-                    to_screaming_snake_case(name),
+                    to_screaming_snake_case(name.as_str()),
                 )
             },
             LossOfPrecision {

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -52,7 +52,7 @@ macro_rules! assert_or_warn {
 }
 
 /// Denotes a non-recoverable state
-pub(crate) fn err<'sc, T>(
+pub(crate) fn err<T>(
     warnings: Vec<CompileWarning>,
     errors: Vec<CompileError>,
 ) -> CompileResult<T> {
@@ -64,7 +64,7 @@ pub(crate) fn err<'sc, T>(
 }
 
 /// Denotes a recovered or non-error state
-pub(crate) fn ok<'sc, T>(
+pub(crate) fn ok<T>(
     value: T,
     warnings: Vec<CompileWarning>,
     errors: Vec<CompileError>,

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -52,10 +52,7 @@ macro_rules! assert_or_warn {
 }
 
 /// Denotes a non-recoverable state
-pub(crate) fn err<T>(
-    warnings: Vec<CompileWarning>,
-    errors: Vec<CompileError>,
-) -> CompileResult<T> {
+pub(crate) fn err<T>(warnings: Vec<CompileWarning>, errors: Vec<CompileError>) -> CompileResult<T> {
     CompileResult {
         value: None,
         warnings,
@@ -132,11 +129,7 @@ impl<T> CompileResult<T> {
         }
     }
 
-    pub fn unwrap(
-        self,
-        warnings: &mut Vec<CompileWarning>,
-        errors: &mut Vec<CompileError>,
-    ) -> T {
+    pub fn unwrap(self, warnings: &mut Vec<CompileWarning>, errors: &mut Vec<CompileError>) -> T {
         let panic_msg = format!("Unwrapped an err {:?}", self.errors);
         self.unwrap_or_else(warnings, errors, || panic!("{}", panic_msg))
     }
@@ -451,10 +444,7 @@ pub enum CompileError {
         "Specified generic type in where clause \"{type_name}\" not found in generic type \
          arguments of function."
     )]
-    UndeclaredGenericTypeInWhereClause {
-        type_name: Ident,
-        span: Span,
-    },
+    UndeclaredGenericTypeInWhereClause { type_name: Ident, span: Span },
     #[error(
         "Program contains multiple contracts. A valid program should only contain at most one \
          contract."
@@ -821,11 +811,7 @@ pub enum CompileError {
     #[error("Contract storage cannot be used in an external context.")]
     ContractStorageFromExternalContext { span: Span },
     #[error("Array index out of bounds; the length is {count} but the index is {index}.")]
-    ArrayOutOfBounds {
-        index: u64,
-        count: u64,
-        span: Span,
-    },
+    ArrayOutOfBounds { index: u64, count: u64, span: Span },
     #[error(
         "Match expression arm has mismatched types.\n\
          expected: {expected}\n\

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -53,9 +53,9 @@ macro_rules! assert_or_warn {
 
 /// Denotes a non-recoverable state
 pub(crate) fn err<'sc, T>(
-    warnings: Vec<CompileWarning<'sc>>,
-    errors: Vec<CompileError<'sc>>,
-) -> CompileResult<'sc, T> {
+    warnings: Vec<CompileWarning>,
+    errors: Vec<CompileError>,
+) -> CompileResult<T> {
     CompileResult {
         value: None,
         warnings,
@@ -66,9 +66,9 @@ pub(crate) fn err<'sc, T>(
 /// Denotes a recovered or non-error state
 pub(crate) fn ok<'sc, T>(
     value: T,
-    warnings: Vec<CompileWarning<'sc>>,
-    errors: Vec<CompileError<'sc>>,
-) -> CompileResult<'sc, T> {
+    warnings: Vec<CompileWarning>,
+    errors: Vec<CompileError>,
+) -> CompileResult<T> {
     CompileResult {
         value: Some(value),
         warnings,
@@ -77,14 +77,14 @@ pub(crate) fn ok<'sc, T>(
 }
 
 #[derive(Debug, Clone)]
-pub struct CompileResult<'sc, T> {
+pub struct CompileResult<T> {
     pub value: Option<T>,
-    pub warnings: Vec<CompileWarning<'sc>>,
-    pub errors: Vec<CompileError<'sc>>,
+    pub warnings: Vec<CompileWarning>,
+    pub errors: Vec<CompileError>,
 }
 
-impl<'sc, T> From<Result<T, TypeError<'sc>>> for CompileResult<'sc, T> {
-    fn from(o: Result<T, TypeError<'sc>>) -> Self {
+impl<'sc, T> From<Result<T, TypeError>> for CompileResult<T> {
+    fn from(o: Result<T, TypeError>) -> Self {
         match o {
             Ok(o) => CompileResult {
                 value: Some(o),
@@ -100,25 +100,25 @@ impl<'sc, T> From<Result<T, TypeError<'sc>>> for CompileResult<'sc, T> {
     }
 }
 
-impl<'sc, T> CompileResult<'sc, T> {
+impl<'sc, T> CompileResult<T> {
     pub fn ok(
         mut self,
-        warnings: &mut Vec<CompileWarning<'sc>>,
-        errors: &mut Vec<CompileError<'sc>>,
+        warnings: &mut Vec<CompileWarning>,
+        errors: &mut Vec<CompileError>,
     ) -> Option<T> {
         warnings.append(&mut self.warnings);
         errors.append(&mut self.errors);
         self.value
     }
 
-    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> CompileResult<'sc, U> {
+    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> CompileResult<U> {
         match self.value {
             None => err(self.warnings, self.errors),
             Some(value) => ok(f(value), self.warnings, self.errors),
         }
     }
 
-    pub fn flat_map<U, F: FnOnce(T) -> CompileResult<'sc, U>>(self, f: F) -> CompileResult<'sc, U> {
+    pub fn flat_map<U, F: FnOnce(T) -> CompileResult<U>>(self, f: F) -> CompileResult<U> {
         match self.value {
             None => err(self.warnings, self.errors),
             Some(value) => {
@@ -134,8 +134,8 @@ impl<'sc, T> CompileResult<'sc, T> {
 
     pub fn unwrap(
         self,
-        warnings: &mut Vec<CompileWarning<'sc>>,
-        errors: &mut Vec<CompileError<'sc>>,
+        warnings: &mut Vec<CompileWarning>,
+        errors: &mut Vec<CompileError>,
     ) -> T {
         let panic_msg = format!("Unwrapped an err {:?}", self.errors);
         self.unwrap_or_else(warnings, errors, || panic!("{}", panic_msg))
@@ -143,8 +143,8 @@ impl<'sc, T> CompileResult<'sc, T> {
 
     pub fn unwrap_or_else<F: FnOnce() -> T>(
         self,
-        warnings: &mut Vec<CompileWarning<'sc>>,
-        errors: &mut Vec<CompileError<'sc>>,
+        warnings: &mut Vec<CompileWarning>,
+        errors: &mut Vec<CompileError>,
         or_else: F,
     ) -> T {
         self.ok(warnings, errors).unwrap_or_else(or_else)
@@ -154,9 +154,9 @@ impl<'sc, T> CompileResult<'sc, T> {
 // TODO: since moving to using Idents instead of strings the warning_content will usually contain a
 // duplicate of the span.
 #[derive(Debug, Clone, PartialEq, Hash)]
-pub struct CompileWarning<'sc> {
-    pub span: Span<'sc>,
-    pub warning_content: Warning<'sc>,
+pub struct CompileWarning {
+    pub span: Span,
+    pub warning_content: Warning,
 }
 
 pub struct LineCol {
@@ -173,7 +173,7 @@ impl From<(usize, usize)> for LineCol {
     }
 }
 
-impl<'sc> CompileWarning<'sc> {
+impl<'sc> CompileWarning {
     pub fn to_friendly_warning_string(&self) -> String {
         self.warning_content.to_string()
     }
@@ -224,27 +224,27 @@ impl<'sc> CompileWarning<'sc> {
 }
 
 #[derive(Debug, Clone, PartialEq, Hash)]
-pub enum Warning<'sc> {
+pub enum Warning {
     NonClassCaseStructName {
-        struct_name: Ident<'sc>,
+        struct_name: Ident,
     },
     NonClassCaseTraitName {
-        name: Ident<'sc>,
+        name: Ident,
     },
     NonClassCaseEnumName {
-        enum_name: Ident<'sc>,
+        enum_name: Ident,
     },
     NonClassCaseEnumVariantName {
-        variant_name: Ident<'sc>,
+        variant_name: Ident,
     },
     NonSnakeCaseStructFieldName {
-        field_name: Ident<'sc>,
+        field_name: Ident,
     },
     NonSnakeCaseFunctionName {
-        name: Ident<'sc>,
+        name: Ident,
     },
     NonScreamingSnakeCaseConstName {
-        name: Ident<'sc>,
+        name: Ident,
     },
     LossOfPrecision {
         initial_type: IntegerBits,
@@ -254,9 +254,9 @@ pub enum Warning<'sc> {
         r#type: TypeInfo,
     },
     SimilarMethodFound {
-        lib: Ident<'sc>,
-        module: Ident<'sc>,
-        name: Ident<'sc>,
+        lib: Ident,
+        module: Ident,
+        name: Ident,
     },
     OverridesOtherSymbol {
         name: String,
@@ -273,11 +273,11 @@ pub enum Warning<'sc> {
     DeadMethod,
     StructFieldNeverRead,
     ShadowingReservedRegister {
-        reg_name: Ident<'sc>,
+        reg_name: Ident,
     },
 }
 
-impl<'sc> fmt::Display for Warning<'sc> {
+impl<'sc> fmt::Display for Warning {
     // This trait requires `fmt` with this exact signature.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Warning::*;
@@ -388,17 +388,17 @@ impl<'sc> fmt::Display for Warning<'sc> {
 // TODO: since moving to using Idents instead of strings, there are a lot of redundant spans in
 // this type.
 #[derive(Error, Debug, Clone, PartialEq, Hash)]
-pub enum CompileError<'sc> {
+pub enum CompileError {
     #[error("Variable \"{var_name}\" does not exist in this scope.")]
-    UnknownVariable { var_name: String, span: Span<'sc> },
+    UnknownVariable { var_name: String, span: Span },
     #[error("Variable \"{var_name}\" does not exist in this scope.")]
-    UnknownVariablePath { var_name: Ident<'sc>, span: Span<'sc> },
+    UnknownVariablePath { var_name: Ident, span: Span },
     #[error("Function \"{name}\" does not exist in this scope.")]
-    UnknownFunction { name: Ident<'sc>, span: Span<'sc> },
+    UnknownFunction { name: Ident, span: Span },
     #[error("Identifier \"{name}\" was used as a variable, but it is actually a {what_it_is}.")]
     NotAVariable {
         name: String,
-        span: Span<'sc>,
+        span: Span,
         what_it_is: &'static str,
     },
     #[error(
@@ -407,108 +407,108 @@ pub enum CompileError<'sc> {
     )]
     NotAFunction {
         name: String,
-        span: Span<'sc>,
+        span: Span,
         what_it_is: &'static str,
     },
     #[error("Unimplemented feature: {0}")]
-    Unimplemented(&'static str, Span<'sc>),
+    Unimplemented(&'static str, Span),
     #[error("pattern matching algorithm failure on: {0}")]
-    PatternMatchingAlgorithmFailure(&'static str, Span<'sc>),
+    PatternMatchingAlgorithmFailure(&'static str, Span),
     #[error("{0}")]
-    TypeError(TypeError<'sc>),
+    TypeError(TypeError),
     #[error("Error parsing input: expected {err:?}")]
     ParseFailure {
-        span: Span<'sc>,
+        span: Span,
         err: pest::error::Error<Rule>,
     },
     #[error(
         "Invalid top-level item: {0:?}. A program should consist of a contract, script, or \
          predicate at the top level."
     )]
-    InvalidTopLevelItem(Rule, Span<'sc>),
+    InvalidTopLevelItem(Rule, Span),
     #[error(
         "Internal compiler error: {0}\nPlease file an issue on the repository and include the \
          code that triggered this error."
     )]
-    Internal(&'static str, Span<'sc>),
+    Internal(&'static str, Span),
     #[error("Unimplemented feature: {0:?}")]
-    UnimplementedRule(Rule, Span<'sc>),
+    UnimplementedRule(Rule, Span),
     #[error(
         "Byte literal had length of {byte_length}. Byte literals must be either one byte long (8 \
          binary digits or 2 hex digits) or 32 bytes long (256 binary digits or 64 hex digits)"
     )]
-    InvalidByteLiteralLength { byte_length: usize, span: Span<'sc> },
+    InvalidByteLiteralLength { byte_length: usize, span: Span },
     #[error("Expected an expression to follow operator \"{op}\"")]
-    ExpectedExprAfterOp { op: String, span: Span<'sc> },
+    ExpectedExprAfterOp { op: String, span: Span },
     #[error("Expected an operator, but \"{op}\" is not a recognized operator. ")]
-    ExpectedOp { op: String, span: Span<'sc> },
+    ExpectedOp { op: String, span: Span },
     #[error(
         "Where clause was specified but there are no generic type parameters. Where clauses can \
          only be applied to generic type parameters."
     )]
-    UnexpectedWhereClause(Span<'sc>),
+    UnexpectedWhereClause(Span),
     #[error(
         "Specified generic type in where clause \"{type_name}\" not found in generic type \
          arguments of function."
     )]
     UndeclaredGenericTypeInWhereClause {
-        type_name: Ident<'sc>,
-        span: Span<'sc>,
+        type_name: Ident,
+        span: Span,
     },
     #[error(
         "Program contains multiple contracts. A valid program should only contain at most one \
          contract."
     )]
-    MultipleContracts(Span<'sc>),
+    MultipleContracts(Span),
     #[error(
         "Program contains multiple scripts. A valid program should only contain at most one \
          script."
     )]
-    MultipleScripts(Span<'sc>),
+    MultipleScripts(Span),
     #[error(
         "Program contains multiple predicates. A valid program should only contain at most one \
          predicate."
     )]
-    MultiplePredicates(Span<'sc>),
+    MultiplePredicates(Span),
     #[error(
         "Trait constraint was applied to generic type that is not in scope. Trait \
          \"{trait_name}\" cannot constrain type \"{type_name}\" because that type does not exist \
          in this scope."
     )]
     ConstrainedNonExistentType {
-        trait_name: Ident<'sc>,
-        type_name: Ident<'sc>,
-        span: Span<'sc>,
+        trait_name: Ident,
+        type_name: Ident,
+        span: Span,
     },
     #[error(
         "Predicate definition contains multiple main functions. Multiple functions in the same \
          scope cannot have the same name."
     )]
-    MultiplePredicateMainFunctions(Span<'sc>),
+    MultiplePredicateMainFunctions(Span),
     #[error(
         "Predicate declaration contains no main function. Predicates require a main function."
     )]
-    NoPredicateMainFunction(Span<'sc>),
+    NoPredicateMainFunction(Span),
     #[error("A predicate's main function must return a boolean.")]
-    PredicateMainDoesNotReturnBool(Span<'sc>),
+    PredicateMainDoesNotReturnBool(Span),
     #[error("Script declaration contains no main function. Scripts require a main function.")]
-    NoScriptMainFunction(Span<'sc>),
+    NoScriptMainFunction(Span),
     #[error(
         "Script definition contains multiple main functions. Multiple functions in the same scope \
          cannot have the same name."
     )]
-    MultipleScriptMainFunctions(Span<'sc>),
+    MultipleScriptMainFunctions(Span),
     #[error(
         "Attempted to reassign to a symbol that is not a variable. Symbol {name} is not a mutable \
          variable, it is a {kind}."
     )]
     ReassignmentToNonVariable {
-        name: Ident<'sc>,
+        name: Ident,
         kind: &'static str,
-        span: Span<'sc>,
+        span: Span,
     },
     #[error("Assignment to immutable variable. Variable {0} is not declared as mutable.")]
-    AssignmentToNonMutable(String, Span<'sc>),
+    AssignmentToNonMutable(String, Span),
     #[error(
         "Generic type \"{name}\" is not in scope. Perhaps you meant to specify type parameters in \
          the function signature? For example: \n`fn \
@@ -516,106 +516,106 @@ pub enum CompileError<'sc> {
     )]
     TypeParameterNotInTypeScope {
         name: String,
-        span: Span<'sc>,
+        span: Span,
         comma_separated_generic_params: String,
-        fn_name: Ident<'sc>,
+        fn_name: Ident,
         args: String,
     },
     #[error(
         "Asm opcode has multiple immediates specified, when any opcode has at most one immediate."
     )]
-    MultipleImmediates(Span<'sc>),
+    MultipleImmediates(Span),
     #[error(
         "Expected: {expected} \n\
          found:    {given}. The definition of this function must \
          match the one in the trait declaration."
     )]
     MismatchedTypeInTrait {
-        span: Span<'sc>,
+        span: Span,
         given: String,
         expected: String,
     },
     #[error("\"{name}\" is not a trait, so it cannot be \"impl'd\". ")]
-    NotATrait { span: Span<'sc>, name: Ident<'sc> },
+    NotATrait { span: Span, name: Ident },
     #[error("Trait \"{name}\" cannot be found in the current scope.")]
-    UnknownTrait { span: Span<'sc>, name: Ident<'sc> },
+    UnknownTrait { span: Span, name: Ident },
     #[error("Function \"{name}\" is not a part of trait \"{trait_name}\"'s interface surface.")]
     FunctionNotAPartOfInterfaceSurface {
-        name: Ident<'sc>,
-        trait_name: Ident<'sc>,
-        span: Span<'sc>,
+        name: Ident,
+        trait_name: Ident,
+        span: Span,
     },
     #[error("Functions are missing from this trait implementation: {missing_functions}")]
     MissingInterfaceSurfaceMethods {
         missing_functions: String,
-        span: Span<'sc>,
+        span: Span,
     },
     #[error("Expected {expected} type arguments, but instead found {given}.")]
     IncorrectNumberOfTypeArguments {
         given: usize,
         expected: usize,
-        span: Span<'sc>,
+        span: Span,
     },
     #[error(
         "Struct with name \"{name}\" could not be found in this scope. Perhaps you need to import \
          it?"
     )]
-    StructNotFound { name: Ident<'sc>, span: Span<'sc> },
+    StructNotFound { name: Ident, span: Span },
     #[error(
         "The name \"{name}\" does not refer to a struct, but this is an attempted struct \
          declaration."
     )]
-    DeclaredNonStructAsStruct { name: Ident<'sc>, span: Span<'sc> },
+    DeclaredNonStructAsStruct { name: Ident, span: Span },
     #[error(
         "Attempted to access field \"{field_name}\" of non-struct \"{name}\". Field accesses are \
          only valid on structs."
     )]
     AccessedFieldOfNonStruct {
-        field_name: Ident<'sc>,
-        name: Ident<'sc>,
-        span: Span<'sc>,
+        field_name: Ident,
+        name: Ident,
+        span: Span,
     },
     #[error(
         "Attempted to access a method on something that has no methods. \"{name}\" is a {thing}, \
          not a type with methods."
     )]
     MethodOnNonValue {
-        name: Ident<'sc>,
-        thing: Ident<'sc>,
-        span: Span<'sc>,
+        name: Ident,
+        thing: Ident,
+        span: Span,
     },
     #[error("Initialization of struct \"{struct_name}\" is missing field \"{field_name}\".")]
     StructMissingField {
-        field_name: Ident<'sc>,
-        struct_name: Ident<'sc>,
-        span: Span<'sc>,
+        field_name: Ident,
+        struct_name: Ident,
+        span: Span,
     },
     #[error("Struct \"{struct_name}\" does not have field \"{field_name}\".")]
     StructDoesNotHaveField {
-        field_name: Ident<'sc>,
-        struct_name: Ident<'sc>,
-        span: Span<'sc>,
+        field_name: Ident,
+        struct_name: Ident,
+        span: Span,
     },
     #[error("No method named \"{method_name}\" found for type \"{type_name}\".")]
     MethodNotFound {
-        span: Span<'sc>,
+        span: Span,
         method_name: String,
         type_name: String,
     },
     #[error("The asterisk, if present, must be the last part of a path. E.g., `use foo::bar::*`.")]
-    NonFinalAsteriskInPath { span: Span<'sc> },
+    NonFinalAsteriskInPath { span: Span },
     #[error("Module \"{name}\" could not be found.")]
-    ModuleNotFound { span: Span<'sc>, name: String },
+    ModuleNotFound { span: Span, name: String },
     #[error("\"{name}\" is a {actually}, not a struct. Fields can only be accessed on structs.")]
     NotAStruct {
         name: String,
-        span: Span<'sc>,
+        span: Span,
         actually: String,
     },
     #[error("\"{name}\" is a {actually}, not an enum.")]
     NotAnEnum {
         name: String,
-        span: Span<'sc>,
+        span: Span,
         actually: String,
     },
     #[error(
@@ -623,28 +623,28 @@ pub enum CompileError<'sc> {
          {available_fields}"
     )]
     FieldNotFound {
-        field_name: Ident<'sc>,
+        field_name: Ident,
         available_fields: String,
         struct_name: String,
-        span: Span<'sc>,
+        span: Span,
     },
     #[error("Could not find symbol \"{name}\" in this scope.")]
-    SymbolNotFound { span: Span<'sc>, name: String },
+    SymbolNotFound { span: Span, name: String },
     #[error("Symbol \"{name}\" is private.")]
-    ImportPrivateSymbol { span: Span<'sc>, name: String },
+    ImportPrivateSymbol { span: Span, name: String },
     #[error(
         "Because this if expression's value is used, an \"else\" branch is required and it must \
          return type \"{r#type}\""
     )]
-    NoElseBranch { span: Span<'sc>, r#type: String },
+    NoElseBranch { span: Span, r#type: String },
     #[error("Use of type `Self` outside of a context in which `Self` refers to a type.")]
-    UnqualifiedSelfType { span: Span<'sc> },
+    UnqualifiedSelfType { span: Span },
     #[error(
         "Symbol \"{name}\" does not refer to a type, it refers to a {actually_is}. It cannot be \
          used in this position."
     )]
     NotAType {
-        span: Span<'sc>,
+        span: Span,
         name: String,
         actually_is: &'static str,
     },
@@ -652,111 +652,111 @@ pub enum CompileError<'sc> {
         "This enum variant requires an instantiation expression. Try initializing it with \
          arguments in parentheses."
     )]
-    MissingEnumInstantiator { span: Span<'sc> },
+    MissingEnumInstantiator { span: Span },
     #[error(
         "This path must return a value of type \"{ty}\" from function \"{function_name}\", but it \
          does not."
     )]
     PathDoesNotReturn {
-        span: Span<'sc>,
+        span: Span,
         ty: String,
-        function_name: Ident<'sc>,
+        function_name: Ident,
     },
     #[error("Expected block to implicitly return a value of type \"{ty}\".")]
-    ExpectedImplicitReturnFromBlockWithType { span: Span<'sc>, ty: String },
+    ExpectedImplicitReturnFromBlockWithType { span: Span, ty: String },
     #[error("Expected block to implicitly return a value.")]
-    ExpectedImplicitReturnFromBlock { span: Span<'sc> },
+    ExpectedImplicitReturnFromBlock { span: Span },
     #[error(
         "This register was not initialized in the initialization section of the ASM expression. \
          Initialized registers are: {initialized_registers}"
     )]
     UnknownRegister {
-        span: Span<'sc>,
+        span: Span,
         initialized_registers: String,
     },
     #[error("This opcode takes an immediate value but none was provided.")]
-    MissingImmediate { span: Span<'sc> },
+    MissingImmediate { span: Span },
     #[error("This immediate value is invalid.")]
-    InvalidImmediateValue { span: Span<'sc> },
+    InvalidImmediateValue { span: Span },
     #[error(
         "This expression was expected to return a value but no return register was specified. \
          Provide a register in the implicit return position of this asm expression to return it."
     )]
-    InvalidAssemblyMismatchedReturn { span: Span<'sc> },
+    InvalidAssemblyMismatchedReturn { span: Span },
     #[error("Variant \"{variant_name}\" does not exist on enum \"{enum_name}\"")]
     UnknownEnumVariant {
-        enum_name: Ident<'sc>,
-        variant_name: Ident<'sc>,
-        span: Span<'sc>,
+        enum_name: Ident,
+        variant_name: Ident,
+        span: Span,
     },
     #[error("Unknown opcode: \"{op_name}\".")]
-    UnrecognizedOp { op_name: Ident<'sc>, span: Span<'sc> },
+    UnrecognizedOp { op_name: Ident, span: Span },
     #[error("Unknown type \"{ty}\".")]
-    TypeMustBeKnown { ty: String, span: Span<'sc> },
+    TypeMustBeKnown { ty: String, span: Span },
     #[error("The value \"{val}\" is too large to fit in this 6-bit immediate spot.")]
-    Immediate06TooLarge { val: u64, span: Span<'sc> },
+    Immediate06TooLarge { val: u64, span: Span },
     #[error("The value \"{val}\" is too large to fit in this 12-bit immediate spot.")]
-    Immediate12TooLarge { val: u64, span: Span<'sc> },
+    Immediate12TooLarge { val: u64, span: Span },
     #[error("The value \"{val}\" is too large to fit in this 18-bit immediate spot.")]
-    Immediate18TooLarge { val: u64, span: Span<'sc> },
+    Immediate18TooLarge { val: u64, span: Span },
     #[error("The value \"{val}\" is too large to fit in this 24-bit immediate spot.")]
-    Immediate24TooLarge { val: u64, span: Span<'sc> },
+    Immediate24TooLarge { val: u64, span: Span },
     #[error("The opcode \"jnei\" is not valid in inline assembly. Use an enclosing if expression instead.")]
-    DisallowedJnei { span: Span<'sc> },
+    DisallowedJnei { span: Span },
     #[error(
         "The opcode \"ji\" is not valid in inline assembly. Try using function calls instead."
     )]
-    DisallowedJi { span: Span<'sc> },
+    DisallowedJi { span: Span },
     #[error(
         "The opcode \"lw\" is not valid in inline assembly. Try assigning a static value to a variable instead."
     )]
-    DisallowedLw { span: Span<'sc> },
+    DisallowedLw { span: Span },
     #[error(
         "This op expects {expected} register(s) as arguments, but you provided {received} register(s)."
     )]
     IncorrectNumberOfAsmRegisters {
-        span: Span<'sc>,
+        span: Span,
         expected: usize,
         received: usize,
     },
     #[error("This op does not take an immediate value.")]
-    UnnecessaryImmediate { span: Span<'sc> },
+    UnnecessaryImmediate { span: Span },
     #[error("This reference is ambiguous, and could refer to either a module or an enum of the same name. Try qualifying the name with a path.")]
-    AmbiguousPath { span: Span<'sc> },
+    AmbiguousPath { span: Span },
     #[error("This value is not valid within a \"str\" type.")]
-    InvalidStrType { raw: String, span: Span<'sc> },
+    InvalidStrType { raw: String, span: Span },
     #[error("Unknown type name.")]
-    UnknownType { span: Span<'sc> },
+    UnknownType { span: Span },
     #[error("Bytecode can only support programs with up to 2^12 words worth of opcodes. Try refactoring into contract calls? This is a temporary error and will be implemented in the future.")]
-    TooManyInstructions { span: Span<'sc> },
+    TooManyInstructions { span: Span },
     #[error(
         "No valid {} file (.{}) was found at {file_path}",
         crate::constants::LANGUAGE_NAME,
         crate::constants::DEFAULT_FILE_EXTENSION
     )]
-    FileNotFound { span: Span<'sc>, file_path: String },
+    FileNotFound { span: Span, file_path: String },
     #[error("The file {file_path} could not be read: {stringified_error}")]
     FileCouldNotBeRead {
-        span: Span<'sc>,
+        span: Span,
         file_path: String,
         stringified_error: String,
     },
     #[error("This imported file must be a library. It must start with \"library <name>\", where \"name\" is the name of the library this file contains.")]
-    ImportMustBeLibrary { span: Span<'sc> },
+    ImportMustBeLibrary { span: Span },
     #[error("An enum instantiaton cannot contain more than one value. This should be a single value of type {ty}.")]
-    MoreThanOneEnumInstantiator { span: Span<'sc>, ty: String },
+    MoreThanOneEnumInstantiator { span: Span, ty: String },
     #[error("This enum variant represents the unit type, so it should not be instantiated with any value.")]
-    UnnecessaryEnumInstantiator { span: Span<'sc> },
+    UnnecessaryEnumInstantiator { span: Span },
     #[error("Trait \"{name}\" does not exist in this scope.")]
-    TraitNotFound { name: Ident<'sc>, span: Span<'sc> },
+    TraitNotFound { name: Ident, span: Span },
     #[error("This expression is not valid on the left hand side of a reassignment.")]
-    InvalidExpressionOnLhs { span: Span<'sc> },
+    InvalidExpressionOnLhs { span: Span },
     #[error(
         "Function \"{method_name}\" expects {expected} arguments but you provided {received}."
     )]
     TooManyArgumentsForFunction {
-        span: Span<'sc>,
-        method_name: Ident<'sc>,
+        span: Span,
+        method_name: Ident,
         expected: usize,
         received: usize,
     },
@@ -764,94 +764,94 @@ pub enum CompileError<'sc> {
         "Function \"{method_name}\" expects {expected} arguments but you provided {received}."
     )]
     TooFewArgumentsForFunction {
-        span: Span<'sc>,
-        method_name: Ident<'sc>,
+        span: Span,
+        method_name: Ident,
         expected: usize,
         received: usize,
     },
     #[error("This type is invalid in a function selector. A contract ABI function selector must be a known sized type, not generic.")]
-    InvalidAbiType { span: Span<'sc> },
+    InvalidAbiType { span: Span },
     #[error("An ABI function must accept exactly four arguments.")]
-    InvalidNumberOfAbiParams { span: Span<'sc> },
+    InvalidNumberOfAbiParams { span: Span },
     #[error("This is a {actually_is}, not an ABI. An ABI cast requires a valid ABI to cast the address to.")]
     NotAnAbi {
-        span: Span<'sc>,
+        span: Span,
         actually_is: &'static str,
     },
     #[error("An ABI can only be implemented for the `Contract` type, so this implementation of an ABI for type \"{ty}\" is invalid.")]
-    ImplAbiForNonContract { span: Span<'sc>, ty: String },
+    ImplAbiForNonContract { span: Span, ty: String },
     #[error("The trait function \"{fn_name}\" in trait \"{trait_name}\" expects {num_args} arguments, but the provided implementation only takes {provided_args} arguments.")]
     IncorrectNumberOfInterfaceSurfaceFunctionParameters {
-        fn_name: Ident<'sc>,
-        trait_name: Ident<'sc>,
+        fn_name: Ident,
+        trait_name: Ident,
         num_args: usize,
         provided_args: usize,
-        span: Span<'sc>,
+        span: Span,
     },
     #[error("For now, ABI functions must take exactly four parameters, in this order: gas_to_forward: u64, coins_to_forward: u64, color_of_coins: b256, <your_function_parameter>: ?")]
-    AbiFunctionRequiresSpecificSignature { span: Span<'sc> },
+    AbiFunctionRequiresSpecificSignature { span: Span },
     #[error("This parameter was declared as type {should_be}, but argument of type {provided} was provided.")]
     ArgumentParameterTypeMismatch {
-        span: Span<'sc>,
+        span: Span,
         should_be: String,
         provided: String,
     },
     #[error("Function {fn_name} is recursive, which is unsupported at this time.")]
-    RecursiveCall { fn_name: Ident<'sc>, span: Span<'sc> },
+    RecursiveCall { fn_name: Ident, span: Span },
     #[error(
         "Function {fn_name} is recursive via {call_chain}, which is unsupported at this time."
     )]
     RecursiveCallChain {
-        fn_name: Ident<'sc>,
+        fn_name: Ident,
         call_chain: String, // Pretty list of symbols, e.g., "a, b and c".
-        span: Span<'sc>,
+        span: Span,
     },
     #[error(
         "The size of this type is not known. Try putting it on the heap or changing the type."
     )]
-    TypeWithUnknownSize { span: Span<'sc> },
+    TypeWithUnknownSize { span: Span },
     #[error("File {file_path} generates an infinite dependency cycle.")]
-    InfiniteDependencies { file_path: String, span: Span<'sc> },
+    InfiniteDependencies { file_path: String, span: Span },
     #[error("The GM (get-metadata) opcode, when called from an external context, will cause the VM to panic.")]
-    GMFromExternalContract { span: Span<'sc> },
+    GMFromExternalContract { span: Span },
     #[error("The MINT opcode cannot be used in an external context.")]
-    MintFromExternalContext { span: Span<'sc> },
+    MintFromExternalContext { span: Span },
     #[error("The BURN opcode cannot be used in an external context.")]
-    BurnFromExternalContext { span: Span<'sc> },
+    BurnFromExternalContext { span: Span },
     #[error("Contract storage cannot be used in an external context.")]
-    ContractStorageFromExternalContext { span: Span<'sc> },
+    ContractStorageFromExternalContext { span: Span },
     #[error("Array index out of bounds; the length is {count} but the index is {index}.")]
     ArrayOutOfBounds {
         index: u64,
         count: u64,
-        span: Span<'sc>,
+        span: Span,
     },
     #[error(
         "Match expression arm has mismatched types.\n\
          expected: {expected}\n\
          "
     )]
-    MatchWrongType { expected: TypeId, span: Span<'sc> },
+    MatchWrongType { expected: TypeId, span: Span },
     #[error("Impure function called inside of pure function. Pure functions can only call other pure functions. Try making the surrounding function impure by prepending \"impure\" to the function declaration.")]
-    PureCalledImpure { span: Span<'sc> },
+    PureCalledImpure { span: Span },
     #[error("Impure function inside of non-contract. Contract storage is only accessible from contracts.")]
-    ImpureInNonContract { span: Span<'sc> },
+    ImpureInNonContract { span: Span },
     #[error("Literal value is too large for type {ty}.")]
-    IntegerTooLarge { span: Span<'sc>, ty: String },
+    IntegerTooLarge { span: Span, ty: String },
     #[error("Literal value underflows type {ty}.")]
-    IntegerTooSmall { span: Span<'sc>, ty: String },
+    IntegerTooSmall { span: Span, ty: String },
     #[error("Literal value contains digits which are not valid for type {ty}.")]
-    IntegerContainsInvalidDigit { span: Span<'sc>, ty: String },
+    IntegerContainsInvalidDigit { span: Span, ty: String },
 }
 
-impl<'sc> std::convert::From<TypeError<'sc>> for CompileError<'sc> {
-    fn from(other: TypeError<'sc>) -> CompileError<'sc> {
+impl<'sc> std::convert::From<TypeError> for CompileError {
+    fn from(other: TypeError) -> CompileError {
         CompileError::TypeError(other)
     }
 }
 
 #[derive(Error, Debug, Clone, PartialEq, Hash)]
-pub enum TypeError<'sc> {
+pub enum TypeError {
     #[error(
         "Mismatched types.\n\
          expected: {expected}\n\
@@ -862,14 +862,14 @@ pub enum TypeError<'sc> {
         expected: TypeId,
         received: TypeId,
         help_text: String,
-        span: Span<'sc>,
+        span: Span,
     },
     #[error("This type is not known. Try annotating it with a type annotation.")]
-    UnknownType { span: Span<'sc> },
+    UnknownType { span: Span },
 }
 
-impl<'sc> TypeError<'sc> {
-    pub(crate) fn internal_span(&self) -> &Span<'sc> {
+impl<'sc> TypeError {
+    pub(crate) fn internal_span(&self) -> &Span {
         use TypeError::*;
         match self {
             MismatchedType { span, .. } => span,
@@ -878,7 +878,7 @@ impl<'sc> TypeError<'sc> {
     }
 }
 
-impl<'sc> CompileError<'sc> {
+impl<'sc> CompileError {
     pub fn to_friendly_error_string(&self) -> String {
         match self {
             CompileError::ParseFailure { err, .. } => format!(
@@ -927,7 +927,7 @@ impl<'sc> CompileError<'sc> {
         self.internal_span().path()
     }
 
-    pub fn internal_span(&self) -> &Span<'sc> {
+    pub fn internal_span(&self) -> &Span {
         use CompileError::*;
         match self {
             UnknownVariable { span, .. } => span,

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -83,7 +83,7 @@ pub struct CompileResult<T> {
     pub errors: Vec<CompileError>,
 }
 
-impl<'sc, T> From<Result<T, TypeError>> for CompileResult<T> {
+impl<T> From<Result<T, TypeError>> for CompileResult<T> {
     fn from(o: Result<T, TypeError>) -> Self {
         match o {
             Ok(o) => CompileResult {
@@ -100,7 +100,7 @@ impl<'sc, T> From<Result<T, TypeError>> for CompileResult<T> {
     }
 }
 
-impl<'sc, T> CompileResult<T> {
+impl<T> CompileResult<T> {
     pub fn ok(
         mut self,
         warnings: &mut Vec<CompileWarning>,
@@ -173,7 +173,7 @@ impl From<(usize, usize)> for LineCol {
     }
 }
 
-impl<'sc> CompileWarning {
+impl CompileWarning {
     pub fn to_friendly_warning_string(&self) -> String {
         self.warning_content.to_string()
     }
@@ -277,7 +277,7 @@ pub enum Warning {
     },
 }
 
-impl<'sc> fmt::Display for Warning {
+impl fmt::Display for Warning {
     // This trait requires `fmt` with this exact signature.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Warning::*;
@@ -844,7 +844,7 @@ pub enum CompileError {
     IntegerContainsInvalidDigit { span: Span, ty: String },
 }
 
-impl<'sc> std::convert::From<TypeError> for CompileError {
+impl std::convert::From<TypeError> for CompileError {
     fn from(other: TypeError) -> CompileError {
         CompileError::TypeError(other)
     }
@@ -868,7 +868,7 @@ pub enum TypeError {
     UnknownType { span: Span },
 }
 
-impl<'sc> TypeError {
+impl TypeError {
     pub(crate) fn internal_span(&self) -> &Span {
         use TypeError::*;
         match self {
@@ -878,7 +878,7 @@ impl<'sc> TypeError {
     }
 }
 
-impl<'sc> CompileError {
+impl CompileError {
     pub fn to_friendly_error_string(&self) -> String {
         match self {
             CompileError::ParseFailure { err, .. } => format!(

--- a/sway-core/src/ident.rs
+++ b/sway-core/src/ident.rs
@@ -77,7 +77,6 @@ impl Ident {
     ) -> CompileResult<Ident> {
         let path = config.map(|config| config.path());
         let span = {
-            let pair = pair.clone();
             if pair.as_rule() != Rule::ident {
                 Span {
                     span: pair.into_inner().next().unwrap().as_span(),

--- a/sway-core/src/ident.rs
+++ b/sway-core/src/ident.rs
@@ -4,8 +4,8 @@ use crate::parser::Rule;
 use crate::Span;
 use pest::iterators::Pair;
 use std::cmp::{Ord, Ordering};
-use std::hash::{Hash, Hasher};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 
 /// An [Ident] is an _identifier_ with a corresponding `span` from which it was derived.
 #[derive(Debug, Clone)]

--- a/sway-core/src/ident.rs
+++ b/sway-core/src/ident.rs
@@ -21,17 +21,17 @@ pub struct Ident<'sc> {
 // often be different.
 impl Hash for Ident<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.primary_name().hash(state);
+        self.as_str().hash(state);
     }
 }
 impl PartialEq for Ident<'_> {
     fn eq(&self, other: &Self) -> bool {
-        self.primary_name() == other.primary_name()
+        self.as_str() == other.as_str()
     }
 }
 impl Ord for Ident<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.primary_name().cmp(other.primary_name())
+        self.as_str().cmp(other.as_str())
     }
 }
 
@@ -44,7 +44,7 @@ impl PartialOrd for Ident<'_> {
 impl Eq for Ident<'_> {}
 
 impl<'sc> Ident<'sc> {
-    pub fn primary_name(&self) -> &'sc str {
+    pub fn as_str(&self) -> &'sc str {
         match self.name_override_opt {
             Some(name_override) => name_override,
             None => self.span.as_str(),

--- a/sway-core/src/ident.rs
+++ b/sway-core/src/ident.rs
@@ -9,54 +9,54 @@ use std::fmt;
 
 /// An [Ident] is an _identifier_ with a corresponding `span` from which it was derived.
 #[derive(Debug, Clone)]
-pub struct Ident<'sc> {
+pub struct Ident {
     name_override_opt: Option<&'static str>,
     // sub-names are the stuff after periods
     // like x.test.thing.method()
     // `test`, `thing`, and `method` are sub-names
     // the primary name is `x`
-    span: Span<'sc>,
+    span: Span,
 }
 
 // custom implementation of Hash so that namespacing isn't reliant on the span itself, which will
 // often be different.
-impl Hash for Ident<'_> {
+impl Hash for Ident {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.as_str().hash(state);
     }
 }
-impl PartialEq for Ident<'_> {
+impl PartialEq for Ident {
     fn eq(&self, other: &Self) -> bool {
         self.as_str() == other.as_str()
     }
 }
-impl Ord for Ident<'_> {
+impl Ord for Ident {
     fn cmp(&self, other: &Self) -> Ordering {
         self.as_str().cmp(other.as_str())
     }
 }
 
-impl PartialOrd for Ident<'_> {
+impl PartialOrd for Ident {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Eq for Ident<'_> {}
+impl Eq for Ident {}
 
-impl<'sc> Ident<'sc> {
-    pub fn as_str(&self) -> &'sc str {
+impl Ident {
+    pub fn as_str(&self) -> &str {
         match self.name_override_opt {
             Some(name_override) => name_override,
             None => self.span.as_str(),
         }
     }
 
-    pub fn span(&self) -> &Span<'sc> {
+    pub fn span(&self) -> &Span {
         &self.span
     }
 
-    pub fn new(span: Span<'sc>) -> Ident<'sc> {
+    pub fn new(span: Span) -> Ident {
         let span = span.trim();
         Ident {
             name_override_opt: None,
@@ -64,7 +64,7 @@ impl<'sc> Ident<'sc> {
         }
     }
 
-    pub fn new_with_override(name_override: &'static str, span: Span<'sc>) -> Ident<'sc> {
+    pub fn new_with_override(name_override: &'static str, span: Span) -> Ident {
         Ident {
             name_override_opt: Some(name_override),
             span,
@@ -72,9 +72,9 @@ impl<'sc> Ident<'sc> {
     }
 
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Ident<'sc>> {
+    ) -> CompileResult<Ident> {
         let path = config.map(|config| config.path());
         let span = {
             let pair = pair.clone();
@@ -94,7 +94,7 @@ impl<'sc> Ident<'sc> {
     }
 }
 
-impl fmt::Display for Ident<'_> {
+impl fmt::Display for Ident {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "{}", self.as_str())
     }

--- a/sway-core/src/ident.rs
+++ b/sway-core/src/ident.rs
@@ -5,6 +5,7 @@ use crate::Span;
 use pest::iterators::Pair;
 use std::cmp::{Ord, Ordering};
 use std::hash::{Hash, Hasher};
+use std::fmt;
 
 /// An [Ident] is an _identifier_ with a corresponding `span` from which it was derived.
 #[derive(Debug, Clone)]
@@ -90,5 +91,11 @@ impl<'sc> Ident<'sc> {
             }
         };
         ok(Ident::new(span), Vec::new(), Vec::new())
+    }
+}
+
+impl fmt::Display for Ident<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "{}", self.as_str())
     }
 }

--- a/sway-core/src/ident.rs
+++ b/sway-core/src/ident.rs
@@ -1,7 +1,7 @@
 use crate::build_config::BuildConfig;
 use crate::error::*;
 use crate::parser::Rule;
-use crate::span::Span;
+use crate::Span;
 use pest::iterators::Pair;
 use std::cmp::{Ord, Ordering};
 use std::hash::{Hash, Hasher};
@@ -9,12 +9,12 @@ use std::hash::{Hash, Hasher};
 /// An [Ident] is an _identifier_ with a corresponding `span` from which it was derived.
 #[derive(Debug, Clone)]
 pub struct Ident<'sc> {
-    pub primary_name: &'sc str,
+    primary_name: &'sc str,
     // sub-names are the stuff after periods
     // like x.test.thing.method()
     // `test`, `thing`, and `method` are sub-names
     // the primary name is `x`
-    pub span: Span<'sc>,
+    span: Span<'sc>,
 }
 
 // custom implementation of Hash so that namespacing isn't reliant on the span itself, which will
@@ -44,6 +44,18 @@ impl PartialOrd for Ident<'_> {
 impl Eq for Ident<'_> {}
 
 impl<'sc> Ident<'sc> {
+    pub fn primary_name(&self) -> &'sc str {
+        self.primary_name
+    }
+
+    pub fn span(&self) -> &Span<'sc> {
+        &self.span
+    }
+
+    pub fn new(primary_name: &'sc str, span: Span<'sc>) -> Ident<'sc> {
+        Ident { primary_name, span }
+    }
+
     pub(crate) fn parse_from_pair(
         pair: Pair<'sc, Rule>,
         config: Option<&BuildConfig>,
@@ -64,13 +76,6 @@ impl<'sc> Ident<'sc> {
             }
         };
         let name = pair.as_str().trim();
-        ok(
-            Ident {
-                primary_name: name,
-                span,
-            },
-            Vec::new(),
-            Vec::new(),
-        )
+        ok(Ident::new(name, span), Vec::new(), Vec::new())
     }
 }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -245,7 +245,7 @@ pub(crate) struct InnerDependencyCompileResult {
 /// TODO -- there is _so_ much duplicated code and messiness in this file around the
 /// different types of compilation and stuff. After we get to a good state with the MVP,
 /// clean up the types here with the power of hindsight
-pub(crate) fn compile_inner_dependency<'sc>(
+pub(crate) fn compile_inner_dependency(
     input: Arc<str>,
     initial_namespace: &Namespace,
     build_config: BuildConfig,
@@ -266,7 +266,7 @@ pub(crate) fn compile_inner_dependency<'sc>(
             errors.push(CompileError::ImportMustBeLibrary {
                 span: span::Span {
                     span: pest::Span::new(input, 0, 0).unwrap(),
-                    path: Some(build_config.clone().path()),
+                    path: Some(build_config.path()),
                 },
             });
             return err(warnings, errors);
@@ -277,7 +277,7 @@ pub(crate) fn compile_inner_dependency<'sc>(
             parse_tree.tree,
             initial_namespace.clone(),
             &parse_tree.tree_type,
-            &build_config.clone(),
+            &build_config,
             dead_code_graph,
             dependency_graph,
         ),
@@ -310,7 +310,7 @@ pub(crate) fn compile_inner_dependency<'sc>(
     )
 }
 
-pub fn compile_to_ast<'sc>(
+pub fn compile_to_ast(
     input: Arc<str>,
     initial_namespace: &Namespace,
     build_config: &BuildConfig,
@@ -368,7 +368,7 @@ pub fn compile_to_ast<'sc>(
 
 /// Given input Sway source code, compile to a [CompilationResult] which contains the asm in opcode
 /// form (not raw bytes/bytecode).
-pub fn compile_to_asm<'sc>(
+pub fn compile_to_asm(
     input: Arc<str>,
     initial_namespace: &Namespace,
     build_config: BuildConfig,
@@ -409,7 +409,7 @@ pub fn compile_to_asm<'sc>(
 
 /// Given input Sway source code, compile to a [BytecodeCompilationResult] which contains the asm in
 /// bytecode form.
-pub fn compile_to_bytecode<'sc>(
+pub fn compile_to_bytecode(
     input: Arc<str>,
     initial_namespace: &Namespace,
     build_config: BuildConfig,
@@ -446,7 +446,7 @@ pub fn compile_to_bytecode<'sc>(
 
 /// Given a [TypedParseTree], which is type-checked Sway source, construct a graph to analyze
 /// control flow and determine if it is valid.
-fn perform_control_flow_analysis<'sc>(
+fn perform_control_flow_analysis(
     tree: &TypedParseTree,
     tree_type: &TreeType,
     dead_code_graph: &mut ControlFlowGraph,
@@ -465,7 +465,7 @@ fn perform_control_flow_analysis<'sc>(
 
 /// The basic recursive parser which handles the top-level parsing given the output of the
 /// pest-generated parser.
-fn parse_root_from_pairs<'sc>(
+fn parse_root_from_pairs(
     input: impl Iterator<Item = Pair<Rule>>,
     config: Option<&BuildConfig>,
 ) -> CompileResult<HllParseTree> {

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -97,7 +97,7 @@ pub enum AstNodeContent {
     IncludeStatement(IncludeStatement),
 }
 
-impl<'sc> ParseTree {
+impl ParseTree {
     /// Create a new, empty, [ParseTree] from a span which represents the source code that it will
     /// cover.
     pub(crate) fn new(span: span::Span) -> Self {
@@ -113,11 +113,7 @@ impl<'sc> ParseTree {
     }
 }
 
-/// Given an input `str` and an optional [BuildConfig], parse the input into a [HllParseTree].
-///
-/// Here, the `'sc` lifetime is introduced to the compilation process. It stands for _source code_,
-/// and all references to `'sc` in the compiler refer to the lifetime of the original source input
-/// `str`.
+/// Given an input `Arc<str>` and an optional [BuildConfig], parse the input into a [HllParseTree].
 ///
 /// # Example
 /// ```

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -26,6 +26,7 @@ pub use build_config::BuildConfig;
 use control_flow_analysis::{ControlFlowGraph, Graph};
 use pest::iterators::Pair;
 use pest::Parser;
+use std::sync::Arc;
 use std::collections::{HashMap, HashSet};
 
 pub use semantic_analysis::TreeType;
@@ -45,61 +46,61 @@ pub use type_engine::TypeInfo;
 /// it can be a library to be imported into one of the aforementioned
 /// program types.
 #[derive(Debug)]
-pub struct HllParseTree<'sc> {
-    pub tree_type: TreeType<'sc>,
-    pub tree: ParseTree<'sc>,
+pub struct HllParseTree {
+    pub tree_type: TreeType,
+    pub tree: ParseTree,
 }
 
 /// Represents some exportable information that results from compiling some
 /// Sway source code.
 #[derive(Debug)]
-pub struct ParseTree<'sc> {
+pub struct ParseTree {
     /// The untyped AST nodes that constitute this tree's root nodes.
-    pub root_nodes: Vec<AstNode<'sc>>,
+    pub root_nodes: Vec<AstNode>,
     /// The [span::Span] of the entire tree.
-    pub span: span::Span<'sc>,
+    pub span: span::Span,
 }
 
 /// A single [AstNode] represents a node in the parse tree. Note that [AstNode]
 /// is a recursive type and can contain other [AstNode], thus populating the tree.
 #[derive(Debug, Clone)]
-pub struct AstNode<'sc> {
+pub struct AstNode {
     /// The content of this ast node, which could be any control flow structure or other
     /// basic organizational component.
-    pub content: AstNodeContent<'sc>,
+    pub content: AstNodeContent,
     /// The [span::Span] representing this entire [AstNode].
-    pub span: span::Span<'sc>,
+    pub span: span::Span,
 }
 
 /// Represents the various structures that constitute a Sway program.
 #[derive(Debug, Clone)]
-pub enum AstNodeContent<'sc> {
+pub enum AstNodeContent {
     /// A statement of the form `use foo::bar;` or `use ::foo::bar;`
-    UseStatement(UseStatement<'sc>),
+    UseStatement(UseStatement),
     /// A statement of the form `return foo;`
-    ReturnStatement(ReturnStatement<'sc>),
+    ReturnStatement(ReturnStatement),
     /// Any type of declaration, of which there are quite a few. See [Declaration] for more details
     /// on the possible variants.
-    Declaration(Declaration<'sc>),
+    Declaration(Declaration),
     /// Any type of expression, of which there are quite a few. See [Expression] for more details.
-    Expression(Expression<'sc>),
+    Expression(Expression),
     /// An implicit return expression is different from a [AstNodeContent::ReturnStatement] because
     /// it is not a control flow item. Therefore it is a different variant.
     ///
     /// An implicit return expression is an [Expression] at the end of a code block which has no
     /// semicolon, denoting that it is the [Expression] to be returned from that block.
-    ImplicitReturnExpression(Expression<'sc>),
+    ImplicitReturnExpression(Expression),
     /// A control flow element which loops continually until some boolean expression evaluates as
     /// `false`.
-    WhileLoop(WhileLoop<'sc>),
+    WhileLoop(WhileLoop),
     /// A statement of the form `dep foo::bar;` which imports/includes another source file.
-    IncludeStatement(IncludeStatement<'sc>),
+    IncludeStatement(IncludeStatement),
 }
 
-impl<'sc> ParseTree<'sc> {
+impl<'sc> ParseTree {
     /// Create a new, empty, [ParseTree] from a span which represents the source code that it will
     /// cover.
-    pub(crate) fn new(span: span::Span<'sc>) -> Self {
+    pub(crate) fn new(span: span::Span) -> Self {
         ParseTree {
             root_nodes: Vec::new(),
             span,
@@ -107,7 +108,7 @@ impl<'sc> ParseTree<'sc> {
     }
 
     /// Push a new [AstNode] on to the end of a [ParseTree]'s root nodes.
-    pub(crate) fn push(&mut self, new_node: AstNode<'sc>) {
+    pub(crate) fn push(&mut self, new_node: AstNode) {
         self.root_nodes.push(new_node);
     }
 }
@@ -123,19 +124,19 @@ impl<'sc> ParseTree<'sc> {
 /// # use sway_core::parse;
 /// # fn main() {
 ///     let input = "script; fn main() -> bool { true }";
-///     let result = parse(input, Default::default());
+///     let result = parse(input.into(), Default::default());
 /// # }
 /// ```
 ///
 /// # Panics
 /// Panics if the generated parser from Pest panics.
-pub fn parse<'sc>(
-    input: &'sc str,
+pub fn parse(
+    input: Arc<str>,
     config: Option<&BuildConfig>,
-) -> CompileResult<'sc, HllParseTree<'sc>> {
+) -> CompileResult<HllParseTree> {
     let mut warnings: Vec<CompileWarning> = Vec::new();
     let mut errors: Vec<CompileError> = Vec::new();
-    let mut parsed = match HllParser::parse(Rule::program, input) {
+    let mut parsed = match HllParser::parse(Rule::program, input.clone()) {
         Ok(o) => o,
         Err(e) => {
             return err(
@@ -161,55 +162,55 @@ pub fn parse<'sc>(
 
 /// Represents the result of compiling Sway code via [compile_to_asm].
 /// Contains the compiled assets or resulting errors, and any warnings generated.
-pub enum CompilationResult<'sc> {
+pub enum CompilationResult {
     Success {
-        asm: FinalizedAsm<'sc>,
-        warnings: Vec<CompileWarning<'sc>>,
+        asm: FinalizedAsm,
+        warnings: Vec<CompileWarning>,
     },
     Library {
-        name: Ident<'sc>,
-        namespace: Box<Namespace<'sc>>,
-        warnings: Vec<CompileWarning<'sc>>,
+        name: Ident,
+        namespace: Box<Namespace>,
+        warnings: Vec<CompileWarning>,
     },
     Failure {
-        warnings: Vec<CompileWarning<'sc>>,
-        errors: Vec<CompileError<'sc>>,
+        warnings: Vec<CompileWarning>,
+        errors: Vec<CompileError>,
     },
 }
 
-pub enum CompileAstResult<'sc> {
+pub enum CompileAstResult {
     Success {
-        parse_tree: Box<TypedParseTree<'sc>>,
-        tree_type: TreeType<'sc>,
-        warnings: Vec<CompileWarning<'sc>>,
+        parse_tree: Box<TypedParseTree>,
+        tree_type: TreeType,
+        warnings: Vec<CompileWarning>,
     },
     Failure {
-        warnings: Vec<CompileWarning<'sc>>,
-        errors: Vec<CompileError<'sc>>,
+        warnings: Vec<CompileWarning>,
+        errors: Vec<CompileError>,
     },
 }
 
 /// Represents the result of compiling Sway code via [compile_to_bytecode].
 /// Contains the compiled bytecode in byte form, or resulting errors, and any warnings generated.
-pub enum BytecodeCompilationResult<'sc> {
+pub enum BytecodeCompilationResult {
     Success {
         bytes: Vec<u8>,
-        warnings: Vec<CompileWarning<'sc>>,
+        warnings: Vec<CompileWarning>,
     },
     Library {
-        warnings: Vec<CompileWarning<'sc>>,
+        warnings: Vec<CompileWarning>,
     },
     Failure {
-        warnings: Vec<CompileWarning<'sc>>,
-        errors: Vec<CompileError<'sc>>,
+        warnings: Vec<CompileWarning>,
+        errors: Vec<CompileError>,
     },
 }
 
 /// If a given [Rule] exists in the input text, return
 /// that string trimmed. Otherwise, return `None`. This is typically used to find keywords.
-pub fn extract_keyword(line: &str, rule: Rule) -> Option<&str> {
-    if let Ok(pair) = HllParser::parse(rule, line) {
-        Some(pair.as_str().trim())
+pub fn extract_keyword(line: &str, rule: Rule) -> Option<String> {
+    if let Ok(pair) = HllParser::parse(rule, Arc::from(line)) {
+        Some(pair.as_str().trim().to_string())
     } else {
         None
     }
@@ -233,9 +234,9 @@ fn get_end(err: &pest::error::Error<Rule>) -> usize {
 
 /// This struct represents the compilation of an internal dependency
 /// defined through an include statement (the `dep` keyword).
-pub(crate) struct InnerDependencyCompileResult<'sc> {
-    name: Ident<'sc>,
-    namespace: Namespace<'sc>,
+pub(crate) struct InnerDependencyCompileResult {
+    name: Ident,
+    namespace: Namespace,
 }
 /// For internal compiler use.
 /// Compiles an included file and returns its control flow and dead code graphs.
@@ -245,16 +246,16 @@ pub(crate) struct InnerDependencyCompileResult<'sc> {
 /// different types of compilation and stuff. After we get to a good state with the MVP,
 /// clean up the types here with the power of hindsight
 pub(crate) fn compile_inner_dependency<'sc>(
-    input: &'sc str,
-    initial_namespace: &Namespace<'sc>,
+    input: Arc<str>,
+    initial_namespace: &Namespace,
     build_config: BuildConfig,
-    dead_code_graph: &mut ControlFlowGraph<'sc>,
+    dead_code_graph: &mut ControlFlowGraph,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
-) -> CompileResult<'sc, InnerDependencyCompileResult<'sc>> {
+) -> CompileResult<InnerDependencyCompileResult> {
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
     let parse_tree = check!(
-        parse(input, Some(&build_config)),
+        parse(input.clone(), Some(&build_config)),
         return err(warnings, errors),
         warnings,
         errors
@@ -310,11 +311,11 @@ pub(crate) fn compile_inner_dependency<'sc>(
 }
 
 pub fn compile_to_ast<'sc>(
-    input: &'sc str,
-    initial_namespace: &Namespace<'sc>,
+    input: Arc<str>,
+    initial_namespace: &Namespace,
     build_config: &BuildConfig,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
-) -> CompileAstResult<'sc> {
+) -> CompileAstResult {
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
     let parse_tree = check!(
@@ -368,11 +369,11 @@ pub fn compile_to_ast<'sc>(
 /// Given input Sway source code, compile to a [CompilationResult] which contains the asm in opcode
 /// form (not raw bytes/bytecode).
 pub fn compile_to_asm<'sc>(
-    input: &'sc str,
-    initial_namespace: &Namespace<'sc>,
+    input: Arc<str>,
+    initial_namespace: &Namespace,
     build_config: BuildConfig,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
-) -> CompilationResult<'sc> {
+) -> CompilationResult {
     match compile_to_ast(input, initial_namespace, &build_config, dependency_graph) {
         CompileAstResult::Failure { warnings, errors } => {
             CompilationResult::Failure { warnings, errors }
@@ -409,11 +410,11 @@ pub fn compile_to_asm<'sc>(
 /// Given input Sway source code, compile to a [BytecodeCompilationResult] which contains the asm in
 /// bytecode form.
 pub fn compile_to_bytecode<'sc>(
-    input: &'sc str,
-    initial_namespace: &Namespace<'sc>,
+    input: Arc<str>,
+    initial_namespace: &Namespace,
     build_config: BuildConfig,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
-) -> BytecodeCompilationResult<'sc> {
+) -> BytecodeCompilationResult {
     match compile_to_asm(input, initial_namespace, build_config, dependency_graph) {
         CompilationResult::Success {
             mut asm,
@@ -446,10 +447,10 @@ pub fn compile_to_bytecode<'sc>(
 /// Given a [TypedParseTree], which is type-checked Sway source, construct a graph to analyze
 /// control flow and determine if it is valid.
 fn perform_control_flow_analysis<'sc>(
-    tree: &TypedParseTree<'sc>,
-    tree_type: &TreeType<'sc>,
-    dead_code_graph: &mut ControlFlowGraph<'sc>,
-) -> (Vec<CompileWarning<'sc>>, Vec<CompileError<'sc>>) {
+    tree: &TypedParseTree,
+    tree_type: &TreeType,
+    dead_code_graph: &mut ControlFlowGraph,
+) -> (Vec<CompileWarning>, Vec<CompileError>) {
     match ControlFlowGraph::append_to_dead_code_graph(tree, tree_type, dead_code_graph) {
         Ok(_) => (),
         Err(e) => return (vec![], vec![e]),
@@ -465,9 +466,9 @@ fn perform_control_flow_analysis<'sc>(
 /// The basic recursive parser which handles the top-level parsing given the output of the
 /// pest-generated parser.
 fn parse_root_from_pairs<'sc>(
-    input: impl Iterator<Item = Pair<'sc, Rule>>,
+    input: impl Iterator<Item = Pair<Rule>>,
     config: Option<&BuildConfig>,
-) -> CompileResult<'sc, HllParseTree<'sc>> {
+) -> CompileResult<HllParseTree> {
     let path = config.map(|config| config.dir_of_code.clone());
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
@@ -668,7 +669,7 @@ fn test_basic_prog() {
          func_app(my_args, (so_many_args))];
         return 5;
     }
-    "#,
+    "#.into(),
         None,
     );
     let mut warnings: Vec<CompileWarning> = Vec::new();
@@ -684,7 +685,7 @@ fn test_parenthesized() {
             let x = (5 + 6 / (1 + (2 / 1) + 4));
             return;
         }
-    "#,
+    "#.into(),
         None,
     );
     let mut warnings: Vec<CompileWarning> = Vec::new();
@@ -702,7 +703,7 @@ fn test_unary_ordering() {
         let a = true;
         let b = true;
         !a && b;
-    }"#,
+    }"#.into(),
         None,
     );
     let mut warnings: Vec<CompileWarning> = Vec::new();

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -26,8 +26,8 @@ pub use build_config::BuildConfig;
 use control_flow_analysis::{ControlFlowGraph, Graph};
 use pest::iterators::Pair;
 use pest::Parser;
-use std::sync::Arc;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 pub use semantic_analysis::TreeType;
 pub use semantic_analysis::TypedParseTree;
@@ -126,10 +126,7 @@ impl ParseTree {
 ///
 /// # Panics
 /// Panics if the generated parser from Pest panics.
-pub fn parse(
-    input: Arc<str>,
-    config: Option<&BuildConfig>,
-) -> CompileResult<HllParseTree> {
+pub fn parse(input: Arc<str>, config: Option<&BuildConfig>) -> CompileResult<HllParseTree> {
     let mut warnings: Vec<CompileWarning> = Vec::new();
     let mut errors: Vec<CompileError> = Vec::new();
     let mut parsed = match HllParser::parse(Rule::program, input.clone()) {
@@ -665,7 +662,8 @@ fn test_basic_prog() {
          func_app(my_args, (so_many_args))];
         return 5;
     }
-    "#.into(),
+    "#
+        .into(),
         None,
     );
     let mut warnings: Vec<CompileWarning> = Vec::new();
@@ -681,7 +679,8 @@ fn test_parenthesized() {
             let x = (5 + 6 / (1 + (2 / 1) + 4));
             return;
         }
-    "#.into(),
+    "#
+        .into(),
         None,
     );
     let mut warnings: Vec<CompileWarning> = Vec::new();
@@ -699,7 +698,8 @@ fn test_unary_ordering() {
         let a = true;
         let b = true;
         !a && b;
-    }"#.into(),
+    }"#
+        .into(),
         None,
     );
     let mut warnings: Vec<CompileWarning> = Vec::new();

--- a/sway-core/src/parse_tree/call_path.rs
+++ b/sway-core/src/parse_tree/call_path.rs
@@ -33,24 +33,24 @@ impl CallPath<'_> {
             prefixes: self
                 .prefixes
                 .iter()
-                .map(|x| x.primary_name.to_string())
+                .map(|x| x.primary_name().to_string())
                 .collect(),
-            suffix: self.suffix.primary_name.to_string(),
+            suffix: self.suffix.primary_name().to_string(),
         }
     }
 }
 impl<'sc> CallPath<'sc> {
     pub(crate) fn span(&self) -> Span<'sc> {
         if self.prefixes.is_empty() {
-            self.suffix.span.clone()
+            self.suffix.span().clone()
         } else {
             let prefixes_span = self
                 .prefixes
                 .iter()
-                .fold(self.prefixes[0].span.clone(), |acc, sp| {
-                    crate::utils::join_spans(acc, sp.span.clone())
+                .fold(self.prefixes[0].span().clone(), |acc, sp| {
+                    crate::utils::join_spans(acc, sp.span().clone())
                 });
-            crate::utils::join_spans(prefixes_span, self.suffix.span.clone())
+            crate::utils::join_spans(prefixes_span, self.suffix.span().clone())
         }
     }
     pub(crate) fn parse_from_pair(

--- a/sway-core/src/parse_tree/call_path.rs
+++ b/sway-core/src/parse_tree/call_path.rs
@@ -60,7 +60,7 @@ impl<'sc> CallPath {
         let mut warnings = vec![];
         let mut errors = vec![];
         let mut pairs_buf = vec![];
-        for pair in pair.clone().into_inner() {
+        for pair in pair.into_inner() {
             if pair.as_rule() != Rule::path_separator {
                 pairs_buf.push(check!(
                     Ident::parse_from_pair(pair, config),

--- a/sway-core/src/parse_tree/call_path.rs
+++ b/sway-core/src/parse_tree/call_path.rs
@@ -7,13 +7,13 @@ use pest::iterators::Pair;
 
 /// in the expression `a::b::c()`, `a` and `b` are the prefixes and `c` is the suffix.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct CallPath<'sc> {
-    pub prefixes: Vec<Ident<'sc>>,
-    pub suffix: Ident<'sc>,
+pub struct CallPath {
+    pub prefixes: Vec<Ident>,
+    pub suffix: Ident,
 }
 
-impl<'sc> std::convert::From<Ident<'sc>> for CallPath<'sc> {
-    fn from(other: Ident<'sc>) -> Self {
+impl<'sc> std::convert::From<Ident> for CallPath {
+    fn from(other: Ident) -> Self {
         CallPath {
             prefixes: vec![],
             suffix: other,
@@ -27,7 +27,7 @@ pub struct OwnedCallPath {
     pub suffix: String,
 }
 
-impl CallPath<'_> {
+impl CallPath {
     pub(crate) fn to_owned_call_path(&self) -> OwnedCallPath {
         OwnedCallPath {
             prefixes: self
@@ -39,8 +39,8 @@ impl CallPath<'_> {
         }
     }
 }
-impl<'sc> CallPath<'sc> {
-    pub(crate) fn span(&self) -> Span<'sc> {
+impl<'sc> CallPath {
+    pub(crate) fn span(&self) -> Span {
         if self.prefixes.is_empty() {
             self.suffix.span().clone()
         } else {
@@ -54,9 +54,9 @@ impl<'sc> CallPath<'sc> {
         }
     }
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, CallPath<'sc>> {
+    ) -> CompileResult<CallPath> {
         let mut warnings = vec![];
         let mut errors = vec![];
         let mut pairs_buf = vec![];

--- a/sway-core/src/parse_tree/call_path.rs
+++ b/sway-core/src/parse_tree/call_path.rs
@@ -33,9 +33,9 @@ impl CallPath<'_> {
             prefixes: self
                 .prefixes
                 .iter()
-                .map(|x| x.primary_name().to_string())
+                .map(|x| x.as_str().to_string())
                 .collect(),
-            suffix: self.suffix.primary_name().to_string(),
+            suffix: self.suffix.as_str().to_string(),
         }
     }
 }

--- a/sway-core/src/parse_tree/call_path.rs
+++ b/sway-core/src/parse_tree/call_path.rs
@@ -12,7 +12,7 @@ pub struct CallPath {
     pub suffix: Ident,
 }
 
-impl<'sc> std::convert::From<Ident> for CallPath {
+impl std::convert::From<Ident> for CallPath {
     fn from(other: Ident) -> Self {
         CallPath {
             prefixes: vec![],
@@ -39,7 +39,7 @@ impl CallPath {
         }
     }
 }
-impl<'sc> CallPath {
+impl CallPath {
     pub(crate) fn span(&self) -> Span {
         if self.prefixes.is_empty() {
             self.suffix.span().clone()

--- a/sway-core/src/parse_tree/code_block.rs
+++ b/sway-core/src/parse_tree/code_block.rs
@@ -10,16 +10,16 @@ use crate::{
 use pest::iterators::Pair;
 
 #[derive(Debug, Clone)]
-pub struct CodeBlock<'sc> {
-    pub contents: Vec<AstNode<'sc>>,
-    pub(crate) whole_block_span: Span<'sc>,
+pub struct CodeBlock {
+    pub contents: Vec<AstNode>,
+    pub(crate) whole_block_span: Span,
 }
 
-impl<'sc> CodeBlock<'sc> {
+impl<'sc> CodeBlock {
     pub(crate) fn parse_from_pair(
-        block: Pair<'sc, Rule>,
+        block: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();

--- a/sway-core/src/parse_tree/code_block.rs
+++ b/sway-core/src/parse_tree/code_block.rs
@@ -15,7 +15,7 @@ pub struct CodeBlock {
     pub(crate) whole_block_span: Span,
 }
 
-impl<'sc> CodeBlock {
+impl CodeBlock {
     pub(crate) fn parse_from_pair(
         block: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/declaration.rs
+++ b/sway-core/src/parse_tree/declaration.rs
@@ -42,7 +42,7 @@ pub enum Declaration {
     ConstantDeclaration(ConstantDeclaration),
     StorageDeclaration(StorageDeclaration),
 }
-impl<'sc> Declaration {
+impl Declaration {
     pub(crate) fn parse_non_var_from_pair(
         decl: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/declaration.rs
+++ b/sway-core/src/parse_tree/declaration.rs
@@ -29,24 +29,24 @@ use crate::*;
 use pest::iterators::Pair;
 
 #[derive(Debug, Clone)]
-pub enum Declaration<'sc> {
-    VariableDeclaration(VariableDeclaration<'sc>),
-    FunctionDeclaration(FunctionDeclaration<'sc>),
-    TraitDeclaration(TraitDeclaration<'sc>),
-    StructDeclaration(StructDeclaration<'sc>),
-    EnumDeclaration(EnumDeclaration<'sc>),
-    Reassignment(Reassignment<'sc>),
-    ImplTrait(ImplTrait<'sc>),
-    ImplSelf(ImplSelf<'sc>),
-    AbiDeclaration(AbiDeclaration<'sc>),
-    ConstantDeclaration(ConstantDeclaration<'sc>),
-    StorageDeclaration(StorageDeclaration<'sc>),
+pub enum Declaration {
+    VariableDeclaration(VariableDeclaration),
+    FunctionDeclaration(FunctionDeclaration),
+    TraitDeclaration(TraitDeclaration),
+    StructDeclaration(StructDeclaration),
+    EnumDeclaration(EnumDeclaration),
+    Reassignment(Reassignment),
+    ImplTrait(ImplTrait),
+    ImplSelf(ImplSelf),
+    AbiDeclaration(AbiDeclaration),
+    ConstantDeclaration(ConstantDeclaration),
+    StorageDeclaration(StorageDeclaration),
 }
-impl<'sc> Declaration<'sc> {
+impl<'sc> Declaration {
     pub(crate) fn parse_non_var_from_pair(
-        decl: Pair<'sc, Rule>,
+        decl: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
         let mut pair = decl.clone().into_inner();
@@ -129,9 +129,9 @@ impl<'sc> Declaration<'sc> {
         ok(parsed_declaration, warnings, errors)
     }
     pub(crate) fn parse_from_pair(
-        decl: Pair<'sc, Rule>,
+        decl: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
         let mut pair = decl.clone().into_inner();

--- a/sway-core/src/parse_tree/declaration.rs
+++ b/sway-core/src/parse_tree/declaration.rs
@@ -49,7 +49,7 @@ impl<'sc> Declaration {
     ) -> CompileResult<Self> {
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
-        let mut pair = decl.clone().into_inner();
+        let mut pair = decl.into_inner();
         let decl_inner = pair.next().unwrap();
         let parsed_declaration = match decl_inner.as_rule() {
             Rule::non_var_decl => check!(
@@ -134,7 +134,7 @@ impl<'sc> Declaration {
     ) -> CompileResult<Self> {
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
-        let mut pair = decl.clone().into_inner();
+        let mut pair = decl.into_inner();
         let decl_inner = pair.next().unwrap();
         let parsed_declaration = match decl_inner.as_rule() {
             Rule::fn_decl => Declaration::FunctionDeclaration(check!(

--- a/sway-core/src/parse_tree/declaration/abi.rs
+++ b/sway-core/src/parse_tree/declaration/abi.rs
@@ -9,21 +9,21 @@ use pest::iterators::Pair;
 /// An `abi` declaration, which declares an interface for a contract
 /// to implement or for a caller to use to call a contract.
 #[derive(Debug, Clone)]
-pub struct AbiDeclaration<'sc> {
+pub struct AbiDeclaration {
     /// The name of the abi trait (also known as a "contract trait")
-    pub(crate) name: Ident<'sc>,
+    pub(crate) name: Ident,
     /// The methods a contract is required to implement in order opt in to this interface
-    pub(crate) interface_surface: Vec<TraitFn<'sc>>,
+    pub(crate) interface_surface: Vec<TraitFn>,
     /// The methods provided to a contract "for free" upon opting in to this interface
-    pub(crate) methods: Vec<FunctionDeclaration<'sc>>,
-    pub(crate) span: Span<'sc>,
+    pub(crate) methods: Vec<FunctionDeclaration>,
+    pub(crate) span: Span,
 }
 
-impl<'sc> AbiDeclaration<'sc> {
+impl<'sc> AbiDeclaration {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let span = Span {
             span: pair.as_span(),
             path: config.map(|c| c.path()),

--- a/sway-core/src/parse_tree/declaration/abi.rs
+++ b/sway-core/src/parse_tree/declaration/abi.rs
@@ -19,7 +19,7 @@ pub struct AbiDeclaration {
     pub(crate) span: Span,
 }
 
-impl<'sc> AbiDeclaration {
+impl AbiDeclaration {
     pub(crate) fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/declaration/constant.rs
+++ b/sway-core/src/parse_tree/declaration/constant.rs
@@ -73,9 +73,7 @@ impl ConstantDeclaration {
                 span: name_pair.as_span(),
                 path,
             },
-            Warning::NonScreamingSnakeCaseConstName {
-                name: name.clone(),
-            }
+            Warning::NonScreamingSnakeCaseConstName { name: name.clone() }
         );
         ok(
             ConstantDeclaration {

--- a/sway-core/src/parse_tree/declaration/constant.rs
+++ b/sway-core/src/parse_tree/declaration/constant.rs
@@ -74,7 +74,7 @@ impl<'sc> ConstantDeclaration<'sc> {
                 path,
             },
             Warning::NonScreamingSnakeCaseConstName {
-                name: name.as_str(),
+                name: name.clone(),
             }
         );
         ok(

--- a/sway-core/src/parse_tree/declaration/constant.rs
+++ b/sway-core/src/parse_tree/declaration/constant.rs
@@ -67,14 +67,14 @@ impl<'sc> ConstantDeclaration<'sc> {
             errors
         );
         assert_or_warn!(
-            is_screaming_snake_case(name.primary_name()),
+            is_screaming_snake_case(name.as_str()),
             warnings,
             Span {
                 span: name_pair.as_span(),
                 path,
             },
             Warning::NonScreamingSnakeCaseConstName {
-                name: name.primary_name(),
+                name: name.as_str(),
             }
         );
         ok(

--- a/sway-core/src/parse_tree/declaration/constant.rs
+++ b/sway-core/src/parse_tree/declaration/constant.rs
@@ -16,7 +16,7 @@ pub struct ConstantDeclaration {
     pub visibility: Visibility,
 }
 
-impl<'sc> ConstantDeclaration {
+impl ConstantDeclaration {
     pub(crate) fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/declaration/constant.rs
+++ b/sway-core/src/parse_tree/declaration/constant.rs
@@ -9,18 +9,18 @@ use crate::style::is_screaming_snake_case;
 use pest::iterators::Pair;
 
 #[derive(Debug, Clone)]
-pub struct ConstantDeclaration<'sc> {
-    pub name: Ident<'sc>,
+pub struct ConstantDeclaration {
+    pub name: Ident,
     pub type_ascription: TypeInfo,
-    pub value: Expression<'sc>,
+    pub value: Expression,
     pub visibility: Visibility,
 }
 
-impl<'sc> ConstantDeclaration<'sc> {
+impl<'sc> ConstantDeclaration {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, ConstantDeclaration<'sc>> {
+    ) -> CompileResult<ConstantDeclaration> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();

--- a/sway-core/src/parse_tree/declaration/constant.rs
+++ b/sway-core/src/parse_tree/declaration/constant.rs
@@ -67,14 +67,14 @@ impl<'sc> ConstantDeclaration<'sc> {
             errors
         );
         assert_or_warn!(
-            is_screaming_snake_case(name.primary_name),
+            is_screaming_snake_case(name.primary_name()),
             warnings,
             Span {
                 span: name_pair.as_span(),
                 path,
             },
             Warning::NonScreamingSnakeCaseConstName {
-                name: name.primary_name,
+                name: name.primary_name(),
             }
         );
         ok(

--- a/sway-core/src/parse_tree/declaration/enum.rs
+++ b/sway-core/src/parse_tree/declaration/enum.rs
@@ -118,14 +118,14 @@ impl<'sc> EnumDeclaration<'sc> {
             errors
         );
         assert_or_warn!(
-            is_upper_camel_case(name.primary_name),
+            is_upper_camel_case(name.primary_name()),
             warnings,
             Span {
                 span: enum_name.as_span(),
                 path,
             },
             Warning::NonClassCaseEnumName {
-                enum_name: name.primary_name
+                enum_name: name.primary_name()
             }
         );
 
@@ -203,11 +203,11 @@ impl<'sc> EnumVariant<'sc> {
                     errors
                 );
                 assert_or_warn!(
-                    is_upper_camel_case(name.primary_name),
+                    is_upper_camel_case(name.primary_name()),
                     warnings,
-                    name.span.clone(),
+                    name.span().clone(),
                     Warning::NonClassCaseEnumVariantName {
-                        variant_name: name.primary_name
+                        variant_name: name.primary_name()
                     }
                 );
                 let r#type = check!(

--- a/sway-core/src/parse_tree/declaration/enum.rs
+++ b/sway-core/src/parse_tree/declaration/enum.rs
@@ -118,14 +118,14 @@ impl<'sc> EnumDeclaration<'sc> {
             errors
         );
         assert_or_warn!(
-            is_upper_camel_case(name.primary_name()),
+            is_upper_camel_case(name.as_str()),
             warnings,
             Span {
                 span: enum_name.as_span(),
                 path,
             },
             Warning::NonClassCaseEnumName {
-                enum_name: name.primary_name()
+                enum_name: name.as_str()
             }
         );
 
@@ -203,11 +203,11 @@ impl<'sc> EnumVariant<'sc> {
                     errors
                 );
                 assert_or_warn!(
-                    is_upper_camel_case(name.primary_name()),
+                    is_upper_camel_case(name.as_str()),
                     warnings,
                     name.span().clone(),
                     Warning::NonClassCaseEnumVariantName {
-                        variant_name: name.primary_name()
+                        variant_name: name.as_str()
                     }
                 );
                 let r#type = check!(

--- a/sway-core/src/parse_tree/declaration/enum.rs
+++ b/sway-core/src/parse_tree/declaration/enum.rs
@@ -33,7 +33,7 @@ pub(crate) struct EnumVariant {
     pub(crate) span: Span,
 }
 
-impl<'sc> EnumDeclaration {
+impl EnumDeclaration {
     /// Looks up the various TypeInfos in the [Namespace] to see if they are generic or refer to
     /// something.
     pub(crate) fn to_typed_decl(
@@ -150,7 +150,7 @@ impl<'sc> EnumDeclaration {
     }
 }
 
-impl<'sc> EnumVariant {
+impl EnumVariant {
     pub(crate) fn to_typed_decl(
         &self,
         namespace: &mut Namespace,

--- a/sway-core/src/parse_tree/declaration/enum.rs
+++ b/sway-core/src/parse_tree/declaration/enum.rs
@@ -17,30 +17,30 @@ use crate::{
 use pest::iterators::Pair;
 
 #[derive(Debug, Clone)]
-pub struct EnumDeclaration<'sc> {
-    pub name: Ident<'sc>,
-    pub(crate) type_parameters: Vec<TypeParameter<'sc>>,
-    pub(crate) variants: Vec<EnumVariant<'sc>>,
-    pub(crate) span: Span<'sc>,
+pub struct EnumDeclaration {
+    pub name: Ident,
+    pub(crate) type_parameters: Vec<TypeParameter>,
+    pub(crate) variants: Vec<EnumVariant>,
+    pub(crate) span: Span,
     pub visibility: Visibility,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct EnumVariant<'sc> {
-    pub(crate) name: Ident<'sc>,
+pub(crate) struct EnumVariant {
+    pub(crate) name: Ident,
     pub(crate) r#type: TypeInfo,
     pub(crate) tag: usize,
-    pub(crate) span: Span<'sc>,
+    pub(crate) span: Span,
 }
 
-impl<'sc> EnumDeclaration<'sc> {
+impl<'sc> EnumDeclaration {
     /// Looks up the various TypeInfos in the [Namespace] to see if they are generic or refer to
     /// something.
     pub(crate) fn to_typed_decl(
         &self,
-        namespace: &mut Namespace<'sc>,
+        namespace: &mut Namespace,
         self_type: TypeId,
-    ) -> TypedEnumDeclaration<'sc> {
+    ) -> TypedEnumDeclaration {
         let mut variants_buf = vec![];
         let mut errors = vec![];
         let mut warnings = vec![];
@@ -64,9 +64,9 @@ impl<'sc> EnumDeclaration<'sc> {
     }
 
     pub(crate) fn parse_from_pair(
-        decl_inner: Pair<'sc, Rule>,
+        decl_inner: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let whole_enum_span = Span {
             span: decl_inner.as_span(),
@@ -150,14 +150,14 @@ impl<'sc> EnumDeclaration<'sc> {
     }
 }
 
-impl<'sc> EnumVariant<'sc> {
+impl<'sc> EnumVariant {
     pub(crate) fn to_typed_decl(
         &self,
-        namespace: &mut Namespace<'sc>,
+        namespace: &mut Namespace,
         self_type: TypeId,
-        span: Span<'sc>,
+        span: Span,
         type_mapping: &[(TypeParameter, TypeId)],
-    ) -> CompileResult<'sc, TypedEnumVariant<'sc>> {
+    ) -> CompileResult<TypedEnumVariant> {
         let mut errors = vec![];
         let enum_variant_type =
             if let Some(matching_id) = self.r#type.matches_type_parameter(type_mapping) {
@@ -182,9 +182,9 @@ impl<'sc> EnumVariant<'sc> {
         )
     }
     pub(crate) fn parse_from_pairs(
-        decl_inner: Option<Pair<'sc, Rule>>,
+        decl_inner: Option<Pair<Rule>>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Vec<Self>> {
+    ) -> CompileResult<Vec<Self>> {
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
         let mut fields_buf = Vec::new();

--- a/sway-core/src/parse_tree/declaration/enum.rs
+++ b/sway-core/src/parse_tree/declaration/enum.rs
@@ -125,7 +125,7 @@ impl<'sc> EnumDeclaration<'sc> {
                 path,
             },
             Warning::NonClassCaseEnumName {
-                enum_name: name.as_str()
+                enum_name: name.clone()
             }
         );
 
@@ -207,7 +207,7 @@ impl<'sc> EnumVariant<'sc> {
                     warnings,
                     name.span().clone(),
                     Warning::NonClassCaseEnumVariantName {
-                        variant_name: name.as_str()
+                        variant_name: name.clone()
                     }
                 );
                 let r#type = check!(

--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -66,11 +66,11 @@ impl<'sc> FunctionDeclaration<'sc> {
             errors
         );
         assert_or_warn!(
-            is_snake_case(name.primary_name()),
+            is_snake_case(name.as_str()),
             warnings,
             name_span,
             Warning::NonSnakeCaseFunctionName {
-                name: name.primary_name()
+                name: name.as_str()
             }
         );
         let mut type_params_pair = None;
@@ -207,13 +207,13 @@ impl<'sc> FunctionDeclaration<'sc> {
 
     pub fn parse_json_abi(&self) -> Function {
         Function {
-            name: self.name.primary_name().to_string(),
+            name: self.name.as_str().to_string(),
             type_field: "function".to_string(),
             inputs: self
                 .parameters
                 .iter()
                 .map(|x| Property {
-                    name: x.name.primary_name().to_string(),
+                    name: x.name.as_str().to_string(),
                     type_field: x.r#type.friendly_type_str(),
                     components: None,
                 })

--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -109,7 +109,7 @@ impl<'sc> FunctionDeclaration {
         let parameters_span = parameters_pair.as_span();
 
         let parameters = check!(
-            FunctionParameter::list_from_pairs(parameters_pair.clone().into_inner(), config),
+            FunctionParameter::list_from_pairs(parameters_pair.into_inner(), config),
             Vec::new(),
             warnings,
             errors

--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -25,10 +25,7 @@ pub struct FunctionDeclaration {
 }
 
 impl FunctionDeclaration {
-    pub fn parse_from_pair(
-        pair: Pair<Rule>,
-        config: Option<&BuildConfig>,
-    ) -> CompileResult<Self> {
+    pub fn parse_from_pair(pair: Pair<Rule>, config: Option<&BuildConfig>) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut parts = pair.clone().into_inner();
         let mut warnings = Vec::new();
@@ -69,9 +66,7 @@ impl FunctionDeclaration {
             is_snake_case(name.as_str()),
             warnings,
             name_span,
-            Warning::NonSnakeCaseFunctionName {
-                name: name.clone()
-            }
+            Warning::NonSnakeCaseFunctionName { name: name.clone() }
         );
         let mut type_params_pair = None;
         let mut where_clause_pair = None;

--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -70,7 +70,7 @@ impl<'sc> FunctionDeclaration<'sc> {
             warnings,
             name_span,
             Warning::NonSnakeCaseFunctionName {
-                name: name.as_str()
+                name: name.clone()
             }
         );
         let mut type_params_pair = None;

--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -12,23 +12,23 @@ mod purity;
 pub use purity::Purity;
 
 #[derive(Debug, Clone)]
-pub struct FunctionDeclaration<'sc> {
+pub struct FunctionDeclaration {
     pub purity: Purity,
-    pub name: Ident<'sc>,
+    pub name: Ident,
     pub visibility: Visibility,
-    pub body: CodeBlock<'sc>,
-    pub(crate) parameters: Vec<FunctionParameter<'sc>>,
-    pub span: Span<'sc>,
+    pub body: CodeBlock,
+    pub(crate) parameters: Vec<FunctionParameter>,
+    pub span: Span,
     pub(crate) return_type: TypeInfo,
-    pub(crate) type_parameters: Vec<TypeParameter<'sc>>,
-    pub(crate) return_type_span: Span<'sc>,
+    pub(crate) type_parameters: Vec<TypeParameter>,
+    pub(crate) return_type_span: Span,
 }
 
-impl<'sc> FunctionDeclaration<'sc> {
+impl<'sc> FunctionDeclaration {
     pub fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut parts = pair.clone().into_inner();
         let mut warnings = Vec::new();
@@ -228,17 +228,17 @@ impl<'sc> FunctionDeclaration<'sc> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct FunctionParameter<'sc> {
-    pub(crate) name: Ident<'sc>,
+pub(crate) struct FunctionParameter {
+    pub(crate) name: Ident,
     pub(crate) r#type: TypeInfo,
-    pub(crate) type_span: Span<'sc>,
+    pub(crate) type_span: Span,
 }
 
-impl<'sc> FunctionParameter<'sc> {
+impl<'sc> FunctionParameter {
     pub(crate) fn list_from_pairs(
-        pairs: impl Iterator<Item = Pair<'sc, Rule>>,
+        pairs: impl Iterator<Item = Pair<Rule>>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Vec<FunctionParameter<'sc>>> {
+    ) -> CompileResult<Vec<FunctionParameter>> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();

--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -24,7 +24,7 @@ pub struct FunctionDeclaration {
     pub(crate) return_type_span: Span,
 }
 
-impl<'sc> FunctionDeclaration {
+impl FunctionDeclaration {
     pub fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,
@@ -234,7 +234,7 @@ pub(crate) struct FunctionParameter {
     pub(crate) type_span: Span,
 }
 
-impl<'sc> FunctionParameter {
+impl FunctionParameter {
     pub(crate) fn list_from_pairs(
         pairs: impl Iterator<Item = Pair<Rule>>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -250,7 +250,7 @@ impl<'sc> FunctionParameter<'sc> {
                     path: path.clone(),
                 };
                 let r#type = TypeInfo::SelfType;
-                let name = Ident::new(
+                let name = Ident::new_with_override(
                     "self",
                     Span {
                         span: pair.as_span(),

--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -66,11 +66,11 @@ impl<'sc> FunctionDeclaration<'sc> {
             errors
         );
         assert_or_warn!(
-            is_snake_case(name.primary_name),
+            is_snake_case(name.primary_name()),
             warnings,
             name_span,
             Warning::NonSnakeCaseFunctionName {
-                name: name.primary_name
+                name: name.primary_name()
             }
         );
         let mut type_params_pair = None;
@@ -207,13 +207,13 @@ impl<'sc> FunctionDeclaration<'sc> {
 
     pub fn parse_json_abi(&self) -> Function {
         Function {
-            name: self.name.primary_name.to_string(),
+            name: self.name.primary_name().to_string(),
             type_field: "function".to_string(),
             inputs: self
                 .parameters
                 .iter()
                 .map(|x| Property {
-                    name: x.name.primary_name.to_string(),
+                    name: x.name.primary_name().to_string(),
                     type_field: x.r#type.friendly_type_str(),
                     components: None,
                 })
@@ -250,13 +250,13 @@ impl<'sc> FunctionParameter<'sc> {
                     path: path.clone(),
                 };
                 let r#type = TypeInfo::SelfType;
-                let name = Ident {
-                    span: Span {
+                let name = Ident::new(
+                    "self",
+                    Span {
                         span: pair.as_span(),
                         path: path.clone(),
                     },
-                    primary_name: "self",
-                };
+                );
                 pairs_buf.push(FunctionParameter {
                     name,
                     r#type,

--- a/sway-core/src/parse_tree/declaration/impl_trait.rs
+++ b/sway-core/src/parse_tree/declaration/impl_trait.rs
@@ -6,38 +6,38 @@ use crate::{error::*, parser::Rule, type_engine::TypeInfo};
 use pest::iterators::Pair;
 
 #[derive(Debug, Clone)]
-pub struct ImplTrait<'sc> {
-    pub(crate) trait_name: CallPath<'sc>,
+pub struct ImplTrait {
+    pub(crate) trait_name: CallPath,
     pub(crate) type_implementing_for: TypeInfo,
-    pub(crate) type_implementing_for_span: Span<'sc>,
-    pub(crate) type_arguments: Vec<TypeParameter<'sc>>,
-    pub functions: Vec<FunctionDeclaration<'sc>>,
+    pub(crate) type_implementing_for_span: Span,
+    pub(crate) type_arguments: Vec<TypeParameter>,
+    pub functions: Vec<FunctionDeclaration>,
     // the span of the whole impl trait and block
-    pub(crate) block_span: Span<'sc>,
-    pub(crate) type_arguments_span: Span<'sc>,
+    pub(crate) block_span: Span,
+    pub(crate) type_arguments_span: Span,
 }
 
 /// An impl of methods without a trait
 /// like `impl MyType { fn foo { .. } }`
 #[derive(Debug, Clone)]
-pub struct ImplSelf<'sc> {
+pub struct ImplSelf {
     pub(crate) type_implementing_for: TypeInfo,
-    pub(crate) type_arguments: Vec<TypeParameter<'sc>>,
-    pub functions: Vec<FunctionDeclaration<'sc>>,
+    pub(crate) type_arguments: Vec<TypeParameter>,
+    pub functions: Vec<FunctionDeclaration>,
     // the span of the whole impl trait and block
-    pub(crate) block_span: Span<'sc>,
+    pub(crate) block_span: Span,
     #[allow(dead_code)]
     // these spans may be used for errors in the future, although it is not right now.
-    pub(crate) type_arguments_span: Span<'sc>,
+    pub(crate) type_arguments_span: Span,
     #[allow(dead_code)]
-    pub(crate) type_name_span: Span<'sc>,
+    pub(crate) type_name_span: Span,
 }
 
-impl<'sc> ImplTrait<'sc> {
+impl<'sc> ImplTrait {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
@@ -121,11 +121,11 @@ impl<'sc> ImplTrait<'sc> {
     }
 }
 
-impl<'sc> ImplSelf<'sc> {
+impl<'sc> ImplSelf {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();

--- a/sway-core/src/parse_tree/declaration/impl_trait.rs
+++ b/sway-core/src/parse_tree/declaration/impl_trait.rs
@@ -33,7 +33,7 @@ pub struct ImplSelf {
     pub(crate) type_name_span: Span,
 }
 
-impl<'sc> ImplTrait {
+impl ImplTrait {
     pub(crate) fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,
@@ -121,7 +121,7 @@ impl<'sc> ImplTrait {
     }
 }
 
-impl<'sc> ImplSelf {
+impl ImplSelf {
     pub(crate) fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/declaration/reassignment.rs
+++ b/sway-core/src/parse_tree/declaration/reassignment.rs
@@ -7,19 +7,19 @@ use crate::{parse_array_index, Ident};
 use pest::iterators::Pair;
 
 #[derive(Debug, Clone)]
-pub struct Reassignment<'sc> {
+pub struct Reassignment {
     // the thing being reassigned
-    pub lhs: Box<Expression<'sc>>,
+    pub lhs: Box<Expression>,
     // the expression that is being assigned to the lhs
-    pub rhs: Expression<'sc>,
-    pub(crate) span: Span<'sc>,
+    pub rhs: Expression,
+    pub(crate) span: Span,
 }
 
-impl<'sc> Reassignment<'sc> {
+impl<'sc> Reassignment {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Reassignment<'sc>> {
+    ) -> CompileResult<Reassignment> {
         let path = config.map(|c| c.path());
         let span = Span {
             span: pair.as_span(),
@@ -131,10 +131,10 @@ impl<'sc> Reassignment<'sc> {
     }
 }
 
-fn parse_subfield_path_ensure_only_var<'sc>(
-    item: Pair<'sc, Rule>,
+fn parse_subfield_path_ensure_only_var(
+    item: Pair<Rule>,
     config: Option<&BuildConfig>,
-) -> CompileResult<'sc, Expression<'sc>> {
+) -> CompileResult<Expression> {
     let warnings = vec![];
     let mut errors = vec![];
     let path = config.map(|c| c.path());
@@ -181,9 +181,9 @@ fn parse_subfield_path_ensure_only_var<'sc>(
 /// (foo()).x = 5;
 /// ```
 fn parse_call_item_ensure_only_var<'sc>(
-    item: Pair<'sc, Rule>,
+    item: Pair<Rule>,
     config: Option<&BuildConfig>,
-) -> CompileResult<'sc, Expression<'sc>> {
+) -> CompileResult<Expression> {
     let path = config.map(|c| c.path());
     let mut warnings = vec![];
     let mut errors = vec![];

--- a/sway-core/src/parse_tree/declaration/reassignment.rs
+++ b/sway-core/src/parse_tree/declaration/reassignment.rs
@@ -180,7 +180,7 @@ fn parse_subfield_path_ensure_only_var(
 /// ```ignore
 /// (foo()).x = 5;
 /// ```
-fn parse_call_item_ensure_only_var<'sc>(
+fn parse_call_item_ensure_only_var(
     item: Pair<Rule>,
     config: Option<&BuildConfig>,
 ) -> CompileResult<Expression> {

--- a/sway-core/src/parse_tree/declaration/reassignment.rs
+++ b/sway-core/src/parse_tree/declaration/reassignment.rs
@@ -15,7 +15,7 @@ pub struct Reassignment {
     pub(crate) span: Span,
 }
 
-impl<'sc> Reassignment {
+impl Reassignment {
     pub(crate) fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/declaration/storage.rs
+++ b/sway-core/src/parse_tree/declaration/storage.rs
@@ -22,7 +22,7 @@ pub struct StorageField {
     pub initializer: Expression,
 }
 
-impl<'sc> StorageField {
+impl StorageField {
     pub(crate) fn parse_from_pair(
         pair: Pair<Rule>,
         conf: Option<&BuildConfig>,
@@ -64,7 +64,7 @@ impl<'sc> StorageField {
     }
 }
 
-impl<'sc> StorageDeclaration {
+impl StorageDeclaration {
     pub(crate) fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/declaration/storage.rs
+++ b/sway-core/src/parse_tree/declaration/storage.rs
@@ -6,9 +6,9 @@ use pest::iterators::Pair;
 #[derive(Debug, Clone)]
 /// A declaration of contract storage. Only valid within contract contexts.
 /// All values in this struct are mutable and persistent among executions of the same contract deployment.
-pub struct StorageDeclaration<'sc> {
-    pub fields: Vec<StorageField<'sc>>,
-    pub span: Span<'sc>,
+pub struct StorageDeclaration {
+    pub fields: Vec<StorageField>,
+    pub span: Span,
 }
 
 /// An individual field in a storage declaration.
@@ -16,17 +16,17 @@ pub struct StorageDeclaration<'sc> {
 /// constant expression. For now, that basically means just a literal, but as constant folding
 /// improves, we can update that.
 #[derive(Debug, Clone)]
-pub struct StorageField<'sc> {
-    pub name: Ident<'sc>,
+pub struct StorageField {
+    pub name: Ident,
     pub r#type: TypeInfo,
-    pub initializer: Expression<'sc>,
+    pub initializer: Expression,
 }
 
-impl<'sc> StorageField<'sc> {
+impl<'sc> StorageField {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         conf: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let mut errors = vec![];
         let mut warnings = vec![];
         let mut iter = pair.into_inner();
@@ -64,11 +64,11 @@ impl<'sc> StorageField<'sc> {
     }
 }
 
-impl<'sc> StorageDeclaration<'sc> {
+impl<'sc> StorageDeclaration {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         debug_assert_eq!(pair.as_rule(), Rule::storage_decl);
         let path = config.map(|c| c.path());
         let mut errors = vec![];
@@ -83,7 +83,7 @@ impl<'sc> StorageDeclaration<'sc> {
             storage_keyword.map(|x| x.as_rule()),
             Some(Rule::storage_keyword)
         );
-        let fields_results: Vec<CompileResult<'sc, StorageField>> = iter
+        let fields_results: Vec<CompileResult<StorageField>> = iter
             .next()
             .unwrap()
             .into_inner()

--- a/sway-core/src/parse_tree/declaration/struct.rs
+++ b/sway-core/src/parse_tree/declaration/struct.rs
@@ -23,7 +23,7 @@ pub(crate) struct StructField {
     pub(crate) type_span: Span,
 }
 
-impl<'sc> StructDeclaration {
+impl StructDeclaration {
     pub(crate) fn parse_from_pair(
         decl: Pair<Rule>,
         config: Option<&BuildConfig>,
@@ -109,7 +109,7 @@ impl<'sc> StructDeclaration {
     }
 }
 
-impl<'sc> StructField {
+impl StructField {
     pub(crate) fn parse_from_pairs(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/declaration/struct.rs
+++ b/sway-core/src/parse_tree/declaration/struct.rs
@@ -93,7 +93,7 @@ impl<'sc> StructDeclaration<'sc> {
             warnings,
             span,
             Warning::NonClassCaseStructName {
-                struct_name: name.as_str()
+                struct_name: name.clone()
             }
         );
         ok(
@@ -135,7 +135,7 @@ impl<'sc> StructField<'sc> {
                 warnings,
                 span.clone(),
                 Warning::NonSnakeCaseStructFieldName {
-                    field_name: name.as_str(),
+                    field_name: name.clone(),
                 }
             );
             let type_pair = fields[i + 1].clone();

--- a/sway-core/src/parse_tree/declaration/struct.rs
+++ b/sway-core/src/parse_tree/declaration/struct.rs
@@ -89,11 +89,11 @@ impl<'sc> StructDeclaration<'sc> {
             errors
         );
         assert_or_warn!(
-            is_upper_camel_case(name.primary_name),
+            is_upper_camel_case(name.primary_name()),
             warnings,
             span,
             Warning::NonClassCaseStructName {
-                struct_name: name.primary_name
+                struct_name: name.primary_name()
             }
         );
         ok(
@@ -131,11 +131,11 @@ impl<'sc> StructField<'sc> {
                 errors
             );
             assert_or_warn!(
-                is_snake_case(name.primary_name),
+                is_snake_case(name.primary_name()),
                 warnings,
                 span.clone(),
                 Warning::NonSnakeCaseStructFieldName {
-                    field_name: name.primary_name,
+                    field_name: name.primary_name(),
                 }
             );
             let type_pair = fields[i + 1].clone();

--- a/sway-core/src/parse_tree/declaration/struct.rs
+++ b/sway-core/src/parse_tree/declaration/struct.rs
@@ -8,26 +8,26 @@ use crate::{error::*, Ident};
 use pest::iterators::Pair;
 
 #[derive(Debug, Clone)]
-pub struct StructDeclaration<'sc> {
-    pub name: Ident<'sc>,
-    pub(crate) fields: Vec<StructField<'sc>>,
-    pub(crate) type_parameters: Vec<TypeParameter<'sc>>,
+pub struct StructDeclaration {
+    pub name: Ident,
+    pub(crate) fields: Vec<StructField>,
+    pub(crate) type_parameters: Vec<TypeParameter>,
     pub visibility: Visibility,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct StructField<'sc> {
-    pub(crate) name: Ident<'sc>,
+pub(crate) struct StructField {
+    pub(crate) name: Ident,
     pub(crate) r#type: TypeInfo,
-    pub(crate) span: Span<'sc>,
-    pub(crate) type_span: Span<'sc>,
+    pub(crate) span: Span,
+    pub(crate) type_span: Span,
 }
 
-impl<'sc> StructDeclaration<'sc> {
+impl<'sc> StructDeclaration {
     pub(crate) fn parse_from_pair(
-        decl: Pair<'sc, Rule>,
+        decl: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
@@ -109,11 +109,11 @@ impl<'sc> StructDeclaration<'sc> {
     }
 }
 
-impl<'sc> StructField<'sc> {
+impl<'sc> StructField {
     pub(crate) fn parse_from_pairs(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Vec<Self>> {
+    ) -> CompileResult<Vec<Self>> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();

--- a/sway-core/src/parse_tree/declaration/struct.rs
+++ b/sway-core/src/parse_tree/declaration/struct.rs
@@ -89,11 +89,11 @@ impl<'sc> StructDeclaration<'sc> {
             errors
         );
         assert_or_warn!(
-            is_upper_camel_case(name.primary_name()),
+            is_upper_camel_case(name.as_str()),
             warnings,
             span,
             Warning::NonClassCaseStructName {
-                struct_name: name.primary_name()
+                struct_name: name.as_str()
             }
         );
         ok(
@@ -131,11 +131,11 @@ impl<'sc> StructField<'sc> {
                 errors
             );
             assert_or_warn!(
-                is_snake_case(name.primary_name()),
+                is_snake_case(name.as_str()),
                 warnings,
                 span.clone(),
                 Warning::NonSnakeCaseStructFieldName {
-                    field_name: name.primary_name(),
+                    field_name: name.as_str(),
                 }
             );
             let type_pair = fields[i + 1].clone();

--- a/sway-core/src/parse_tree/declaration/trait.rs
+++ b/sway-core/src/parse_tree/declaration/trait.rs
@@ -47,9 +47,7 @@ impl TraitDeclaration {
             is_upper_camel_case(name_pair.as_str().trim()),
             warnings,
             span,
-            Warning::NonClassCaseTraitName {
-                name: name.clone(),
-            }
+            Warning::NonClassCaseTraitName { name: name.clone() }
         );
         let mut type_params_pair = None;
         let mut where_clause_pair = None;
@@ -149,9 +147,7 @@ impl TraitFn {
             is_snake_case(name.as_str()),
             warnings,
             name_span,
-            Warning::NonSnakeCaseFunctionName {
-                name: name.clone()
-            }
+            Warning::NonSnakeCaseFunctionName { name: name.clone() }
         );
         let parameters = signature.next().unwrap();
         let parameters = check!(

--- a/sway-core/src/parse_tree/declaration/trait.rs
+++ b/sway-core/src/parse_tree/declaration/trait.rs
@@ -9,19 +9,19 @@ use crate::{error::*, Ident};
 use pest::iterators::Pair;
 
 #[derive(Debug, Clone)]
-pub struct TraitDeclaration<'sc> {
-    pub name: Ident<'sc>,
-    pub(crate) interface_surface: Vec<TraitFn<'sc>>,
-    pub(crate) methods: Vec<FunctionDeclaration<'sc>>,
-    pub(crate) type_parameters: Vec<TypeParameter<'sc>>,
+pub struct TraitDeclaration {
+    pub name: Ident,
+    pub(crate) interface_surface: Vec<TraitFn>,
+    pub(crate) methods: Vec<FunctionDeclaration>,
+    pub(crate) type_parameters: Vec<TypeParameter>,
     pub visibility: Visibility,
 }
 
-impl<'sc> TraitDeclaration<'sc> {
+impl<'sc> TraitDeclaration {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
         let mut trait_parts = pair.into_inner().peekable();
@@ -113,18 +113,18 @@ impl<'sc> TraitDeclaration<'sc> {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub(crate) struct TraitFn<'sc> {
-    pub(crate) name: Ident<'sc>,
-    pub(crate) parameters: Vec<FunctionParameter<'sc>>,
+pub(crate) struct TraitFn {
+    pub(crate) name: Ident,
+    pub(crate) parameters: Vec<FunctionParameter>,
     pub(crate) return_type: TypeInfo,
-    pub(crate) return_type_span: Span<'sc>,
+    pub(crate) return_type_span: Span,
 }
 
-impl<'sc> TraitFn<'sc> {
+impl<'sc> TraitFn {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();

--- a/sway-core/src/parse_tree/declaration/trait.rs
+++ b/sway-core/src/parse_tree/declaration/trait.rs
@@ -48,7 +48,7 @@ impl<'sc> TraitDeclaration<'sc> {
             warnings,
             span,
             Warning::NonClassCaseTraitName {
-                name: name_pair.as_str().trim()
+                name: name.clone(),
             }
         );
         let mut type_params_pair = None;
@@ -150,7 +150,7 @@ impl<'sc> TraitFn<'sc> {
             warnings,
             name_span,
             Warning::NonSnakeCaseFunctionName {
-                name: name.as_str()
+                name: name.clone()
             }
         );
         let parameters = signature.next().unwrap();

--- a/sway-core/src/parse_tree/declaration/trait.rs
+++ b/sway-core/src/parse_tree/declaration/trait.rs
@@ -146,11 +146,11 @@ impl<'sc> TraitFn<'sc> {
             errors
         );
         assert_or_warn!(
-            is_snake_case(name.primary_name()),
+            is_snake_case(name.as_str()),
             warnings,
             name_span,
             Warning::NonSnakeCaseFunctionName {
-                name: name.primary_name()
+                name: name.as_str()
             }
         );
         let parameters = signature.next().unwrap();

--- a/sway-core/src/parse_tree/declaration/trait.rs
+++ b/sway-core/src/parse_tree/declaration/trait.rs
@@ -17,7 +17,7 @@ pub struct TraitDeclaration {
     pub visibility: Visibility,
 }
 
-impl<'sc> TraitDeclaration {
+impl TraitDeclaration {
     pub(crate) fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,
@@ -120,7 +120,7 @@ pub(crate) struct TraitFn {
     pub(crate) return_type_span: Span,
 }
 
-impl<'sc> TraitFn {
+impl TraitFn {
     pub(crate) fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/declaration/trait.rs
+++ b/sway-core/src/parse_tree/declaration/trait.rs
@@ -42,7 +42,7 @@ impl<'sc> TraitDeclaration<'sc> {
             warnings,
             errors
         );
-        let span = name.span.clone();
+        let span = name.span().clone();
         assert_or_warn!(
             is_upper_camel_case(name_pair.as_str().trim()),
             warnings,
@@ -146,11 +146,11 @@ impl<'sc> TraitFn<'sc> {
             errors
         );
         assert_or_warn!(
-            is_snake_case(name.primary_name),
+            is_snake_case(name.primary_name()),
             warnings,
             name_span,
             Warning::NonSnakeCaseFunctionName {
-                name: name.primary_name
+                name: name.primary_name()
             }
         );
         let parameters = signature.next().unwrap();

--- a/sway-core/src/parse_tree/declaration/type_parameter.rs
+++ b/sway-core/src/parse_tree/declaration/type_parameter.rs
@@ -75,7 +75,7 @@ impl<'sc> TypeParameter<'sc> {
                 // find associated type name
                 let param_to_edit =
                     match params.iter_mut().find(|TypeParameter { name_ident, .. }| {
-                        name_ident.primary_name == type_param.as_str()
+                        name_ident.primary_name() == type_param.as_str()
                     }) {
                         Some(o) => o,
                         None => {

--- a/sway-core/src/parse_tree/declaration/type_parameter.rs
+++ b/sway-core/src/parse_tree/declaration/type_parameter.rs
@@ -11,7 +11,7 @@ pub(crate) struct TypeParameter {
     pub(crate) trait_constraints: Vec<TraitConstraint>,
 }
 
-impl<'sc> From<&TypeParameter> for TypedDeclaration {
+impl From<&TypeParameter> for TypedDeclaration {
     fn from(n: &TypeParameter) -> Self {
         TypedDeclaration::GenericTypeForFunctionScope {
             name: n.name_ident.clone(),
@@ -19,7 +19,7 @@ impl<'sc> From<&TypeParameter> for TypedDeclaration {
     }
 }
 
-impl<'sc> TypeParameter {
+impl TypeParameter {
     pub(crate) fn parse_from_type_params_and_where_clause(
         type_params_pair: Option<Pair<Rule>>,
         where_clause_pair: Option<Pair<Rule>>,

--- a/sway-core/src/parse_tree/declaration/type_parameter.rs
+++ b/sway-core/src/parse_tree/declaration/type_parameter.rs
@@ -67,8 +67,12 @@ impl TypeParameter {
         if let Some(where_clause_pair) = where_clause_pair {
             let mut pair = where_clause_pair.into_inner().peekable();
             while pair.peek().is_some() {
-                let type_param = Ident::parse_from_pair(pair.next().unwrap(), config).value.unwrap();
-                let trait_constraint = Ident::parse_from_pair(pair.next().unwrap(), config).value.unwrap();
+                let type_param = Ident::parse_from_pair(pair.next().unwrap(), config)
+                    .value
+                    .unwrap();
+                let trait_constraint = Ident::parse_from_pair(pair.next().unwrap(), config)
+                    .value
+                    .unwrap();
                 // assign trait constraints to above parsed type params
                 // find associated type name
                 let param_to_edit =

--- a/sway-core/src/parse_tree/declaration/type_parameter.rs
+++ b/sway-core/src/parse_tree/declaration/type_parameter.rs
@@ -75,7 +75,7 @@ impl<'sc> TypeParameter<'sc> {
                 // find associated type name
                 let param_to_edit =
                     match params.iter_mut().find(|TypeParameter { name_ident, .. }| {
-                        name_ident.primary_name() == type_param.as_str()
+                        name_ident.as_str() == type_param.as_str()
                     }) {
                         Some(o) => o,
                         None => {

--- a/sway-core/src/parse_tree/declaration/type_parameter.rs
+++ b/sway-core/src/parse_tree/declaration/type_parameter.rs
@@ -5,26 +5,26 @@ use pest::iterators::Pair;
 use std::convert::From;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct TypeParameter<'sc> {
+pub(crate) struct TypeParameter {
     pub(crate) name: TypeInfo,
-    pub(crate) name_ident: Ident<'sc>,
-    pub(crate) trait_constraints: Vec<TraitConstraint<'sc>>,
+    pub(crate) name_ident: Ident,
+    pub(crate) trait_constraints: Vec<TraitConstraint>,
 }
 
-impl<'sc> From<&TypeParameter<'sc>> for TypedDeclaration<'sc> {
-    fn from(n: &TypeParameter<'sc>) -> Self {
+impl<'sc> From<&TypeParameter> for TypedDeclaration {
+    fn from(n: &TypeParameter) -> Self {
         TypedDeclaration::GenericTypeForFunctionScope {
             name: n.name_ident.clone(),
         }
     }
 }
 
-impl<'sc> TypeParameter<'sc> {
+impl<'sc> TypeParameter {
     pub(crate) fn parse_from_type_params_and_where_clause(
-        type_params_pair: Option<Pair<'sc, Rule>>,
-        where_clause_pair: Option<Pair<'sc, Rule>>,
+        type_params_pair: Option<Pair<Rule>>,
+        where_clause_pair: Option<Pair<Rule>>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Vec<TypeParameter<'sc>>> {
+    ) -> CompileResult<Vec<TypeParameter>> {
         let path = config.map(|c| c.path());
         let mut errors = Vec::new();
         let mut warnings = vec![];
@@ -96,6 +96,6 @@ impl<'sc> TypeParameter<'sc> {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub(crate) struct TraitConstraint<'sc> {
-    pub(crate) name: Ident<'sc>,
+pub(crate) struct TraitConstraint {
+    pub(crate) name: Ident,
 }

--- a/sway-core/src/parse_tree/declaration/variable.rs
+++ b/sway-core/src/parse_tree/declaration/variable.rs
@@ -3,10 +3,10 @@ use crate::Span;
 use crate::{type_engine::TypeInfo, Ident};
 
 #[derive(Debug, Clone)]
-pub struct VariableDeclaration<'sc> {
-    pub name: Ident<'sc>,
+pub struct VariableDeclaration {
+    pub name: Ident,
     pub type_ascription: TypeInfo,
-    pub type_ascription_span: Option<Span<'sc>>,
-    pub body: Expression<'sc>, // will be codeblock variant
+    pub type_ascription_span: Option<Span>,
+    pub body: Expression, // will be codeblock variant
     pub is_mutable: bool,
 }

--- a/sway-core/src/parse_tree/expression/asm.rs
+++ b/sway-core/src/parse_tree/expression/asm.rs
@@ -17,7 +17,7 @@ pub struct AsmExpression {
     pub(crate) whole_block_span: Span,
 }
 
-impl<'sc> AsmExpression {
+impl AsmExpression {
     pub(crate) fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,
@@ -110,7 +110,7 @@ pub(crate) struct AsmRegister {
     pub(crate) name: String,
 }
 
-impl<'sc> AsmRegister {
+impl AsmRegister {
     fn parse_from_pair(pair: Pair<Rule>) -> CompileResult<Self> {
         ok(
             AsmRegister {
@@ -128,7 +128,7 @@ impl From<AsmRegister> for String {
     }
 }
 
-impl<'sc> AsmOp {
+impl AsmOp {
     fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,
@@ -190,7 +190,7 @@ pub(crate) struct AsmRegisterDeclaration {
     pub(crate) initializer: Option<Expression>,
 }
 
-impl<'sc> AsmRegisterDeclaration {
+impl AsmRegisterDeclaration {
     fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/expression/asm.rs
+++ b/sway-core/src/parse_tree/expression/asm.rs
@@ -153,22 +153,22 @@ impl<'sc> AsmOp<'sc> {
         for pair in iter {
             match pair.as_rule() {
                 Rule::asm_register => {
-                    args.push(Ident {
-                        primary_name: pair.as_str(),
-                        span: Span {
+                    args.push(Ident::new(
+                        pair.as_str(),
+                        Span {
                             span: pair.as_span(),
                             path: path.clone(),
                         },
-                    });
+                    ));
                 }
                 Rule::asm_immediate => {
-                    immediate_value = Some(Ident {
-                        primary_name: pair.as_str().trim(),
-                        span: Span {
+                    immediate_value = Some(Ident::new(
+                        pair.as_str().trim(),
+                        Span {
                             span: pair.as_span(),
                             path: path.clone(),
                         },
-                    });
+                    ));
                 }
                 _ => unreachable!(),
             }
@@ -235,15 +235,15 @@ impl<'sc> AsmRegisterDeclaration<'sc> {
 fn disallow_opcode<'sc>(op: &Ident<'sc>) -> Vec<CompileError<'sc>> {
     let mut errors = vec![];
 
-    match op.primary_name.to_lowercase().as_str() {
+    match op.primary_name().to_lowercase().as_str() {
         "jnei" => {
             errors.push(CompileError::DisallowedJnei {
-                span: op.span.clone(),
+                span: op.span().clone(),
             });
         }
         "ji" => {
             errors.push(CompileError::DisallowedJi {
-                span: op.span.clone(),
+                span: op.span().clone(),
             });
         }
         _ => (),

--- a/sway-core/src/parse_tree/expression/asm.rs
+++ b/sway-core/src/parse_tree/expression/asm.rs
@@ -233,7 +233,7 @@ impl<'sc> AsmRegisterDeclaration<'sc> {
 fn disallow_opcode<'sc>(op: &Ident<'sc>) -> Vec<CompileError<'sc>> {
     let mut errors = vec![];
 
-    match op.primary_name().to_lowercase().as_str() {
+    match op.as_str().to_lowercase().as_str() {
         "jnei" => {
             errors.push(CompileError::DisallowedJnei {
                 span: op.span().clone(),

--- a/sway-core/src/parse_tree/expression/asm.rs
+++ b/sway-core/src/parse_tree/expression/asm.rs
@@ -9,19 +9,19 @@ use super::Expression;
 use crate::type_engine::IntegerBits;
 
 #[derive(Debug, Clone)]
-pub struct AsmExpression<'sc> {
-    pub(crate) registers: Vec<AsmRegisterDeclaration<'sc>>,
-    pub(crate) body: Vec<AsmOp<'sc>>,
-    pub(crate) returns: Option<(AsmRegister, Span<'sc>)>,
+pub struct AsmExpression {
+    pub(crate) registers: Vec<AsmRegisterDeclaration>,
+    pub(crate) body: Vec<AsmOp>,
+    pub(crate) returns: Option<(AsmRegister, Span)>,
     pub(crate) return_type: TypeInfo,
-    pub(crate) whole_block_span: Span<'sc>,
+    pub(crate) whole_block_span: Span,
 }
 
-impl<'sc> AsmExpression<'sc> {
+impl<'sc> AsmExpression {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let whole_block_span = Span {
             span: pair.as_span(),
@@ -98,11 +98,11 @@ impl<'sc> AsmExpression<'sc> {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct AsmOp<'sc> {
-    pub(crate) op_name: Ident<'sc>,
-    pub(crate) op_args: Vec<Ident<'sc>>,
-    pub(crate) span: Span<'sc>,
-    pub(crate) immediate: Option<Ident<'sc>>,
+pub(crate) struct AsmOp {
+    pub(crate) op_name: Ident,
+    pub(crate) op_args: Vec<Ident>,
+    pub(crate) span: Span,
+    pub(crate) immediate: Option<Ident>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -111,7 +111,7 @@ pub(crate) struct AsmRegister {
 }
 
 impl<'sc> AsmRegister {
-    fn parse_from_pair(pair: Pair<'sc, Rule>) -> CompileResult<'sc, Self> {
+    fn parse_from_pair(pair: Pair<Rule>) -> CompileResult<Self> {
         ok(
             AsmRegister {
                 name: pair.as_str().to_string(),
@@ -128,11 +128,11 @@ impl From<AsmRegister> for String {
     }
 }
 
-impl<'sc> AsmOp<'sc> {
+impl<'sc> AsmOp {
     fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
@@ -185,16 +185,16 @@ impl<'sc> AsmOp<'sc> {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct AsmRegisterDeclaration<'sc> {
-    pub(crate) name: Ident<'sc>,
-    pub(crate) initializer: Option<Expression<'sc>>,
+pub(crate) struct AsmRegisterDeclaration {
+    pub(crate) name: Ident,
+    pub(crate) initializer: Option<Expression>,
 }
 
-impl<'sc> AsmRegisterDeclaration<'sc> {
+impl<'sc> AsmRegisterDeclaration {
     fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Vec<Self>> {
+    ) -> CompileResult<Vec<Self>> {
         let iter = pair.into_inner();
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
@@ -230,7 +230,7 @@ impl<'sc> AsmRegisterDeclaration<'sc> {
     }
 }
 
-fn disallow_opcode<'sc>(op: &Ident<'sc>) -> Vec<CompileError<'sc>> {
+fn disallow_opcode(op: &Ident) -> Vec<CompileError> {
     let mut errors = vec![];
 
     match op.as_str().to_lowercase().as_str() {

--- a/sway-core/src/parse_tree/expression/asm.rs
+++ b/sway-core/src/parse_tree/expression/asm.rs
@@ -129,10 +129,7 @@ impl From<AsmRegister> for String {
 }
 
 impl AsmOp {
-    fn parse_from_pair(
-        pair: Pair<Rule>,
-        config: Option<&BuildConfig>,
-    ) -> CompileResult<Self> {
+    fn parse_from_pair(pair: Pair<Rule>, config: Option<&BuildConfig>) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
@@ -153,20 +150,16 @@ impl AsmOp {
         for pair in iter {
             match pair.as_rule() {
                 Rule::asm_register => {
-                    args.push(Ident::new(
-                        Span {
-                            span: pair.as_span(),
-                            path: path.clone(),
-                        },
-                    ));
+                    args.push(Ident::new(Span {
+                        span: pair.as_span(),
+                        path: path.clone(),
+                    }));
                 }
                 Rule::asm_immediate => {
-                    immediate_value = Some(Ident::new(
-                        Span {
-                            span: pair.as_span(),
-                            path: path.clone(),
-                        },
-                    ));
+                    immediate_value = Some(Ident::new(Span {
+                        span: pair.as_span(),
+                        path: path.clone(),
+                    }));
                 }
                 _ => unreachable!(),
             }
@@ -191,10 +184,7 @@ pub(crate) struct AsmRegisterDeclaration {
 }
 
 impl AsmRegisterDeclaration {
-    fn parse_from_pair(
-        pair: Pair<Rule>,
-        config: Option<&BuildConfig>,
-    ) -> CompileResult<Vec<Self>> {
+    fn parse_from_pair(pair: Pair<Rule>, config: Option<&BuildConfig>) -> CompileResult<Vec<Self>> {
         let iter = pair.into_inner();
         let mut warnings = Vec::new();
         let mut errors = Vec::new();

--- a/sway-core/src/parse_tree/expression/asm.rs
+++ b/sway-core/src/parse_tree/expression/asm.rs
@@ -154,7 +154,6 @@ impl<'sc> AsmOp<'sc> {
             match pair.as_rule() {
                 Rule::asm_register => {
                     args.push(Ident::new(
-                        pair.as_str(),
                         Span {
                             span: pair.as_span(),
                             path: path.clone(),
@@ -163,7 +162,6 @@ impl<'sc> AsmOp<'sc> {
                 }
                 Rule::asm_immediate => {
                     immediate_value = Some(Ident::new(
-                        pair.as_str().trim(),
                         Span {
                             span: pair.as_span(),
                             path: path.clone(),

--- a/sway-core/src/parse_tree/expression/match_branch.rs
+++ b/sway-core/src/parse_tree/expression/match_branch.rs
@@ -16,7 +16,7 @@ pub struct MatchBranch {
     pub(crate) span: span::Span,
 }
 
-impl<'sc> MatchBranch {
+impl MatchBranch {
     pub fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/expression/match_branch.rs
+++ b/sway-core/src/parse_tree/expression/match_branch.rs
@@ -10,17 +10,17 @@ use super::scrutinee::Scrutinee;
 use super::{Expression, MatchCondition};
 
 #[derive(Debug, Clone)]
-pub struct MatchBranch<'sc> {
-    pub(crate) condition: MatchCondition<'sc>,
-    pub(crate) result: Expression<'sc>,
-    pub(crate) span: span::Span<'sc>,
+pub struct MatchBranch {
+    pub(crate) condition: MatchCondition,
+    pub(crate) result: Expression,
+    pub(crate) span: span::Span,
 }
 
-impl<'sc> MatchBranch<'sc> {
+impl<'sc> MatchBranch {
     pub fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();

--- a/sway-core/src/parse_tree/expression/match_branch.rs
+++ b/sway-core/src/parse_tree/expression/match_branch.rs
@@ -53,7 +53,7 @@ impl<'sc> MatchBranch {
                     }),
                     Rule::scrutinee => {
                         let scrutinee = check!(
-                            Scrutinee::parse_from_pair(e.clone(), config),
+                            Scrutinee::parse_from_pair(e, config),
                             return err(warnings, errors),
                             warnings,
                             errors

--- a/sway-core/src/parse_tree/expression/match_branch.rs
+++ b/sway-core/src/parse_tree/expression/match_branch.rs
@@ -17,10 +17,7 @@ pub struct MatchBranch {
 }
 
 impl MatchBranch {
-    pub fn parse_from_pair(
-        pair: Pair<Rule>,
-        config: Option<&BuildConfig>,
-    ) -> CompileResult<Self> {
+    pub fn parse_from_pair(pair: Pair<Rule>, config: Option<&BuildConfig>) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();

--- a/sway-core/src/parse_tree/expression/match_condition.rs
+++ b/sway-core/src/parse_tree/expression/match_condition.rs
@@ -3,12 +3,12 @@ use crate::Span;
 use super::scrutinee::Scrutinee;
 
 #[derive(Debug, Clone)]
-pub(crate) enum MatchCondition<'sc> {
-    CatchAll(CatchAll<'sc>),
-    Scrutinee(Scrutinee<'sc>),
+pub(crate) enum MatchCondition {
+    CatchAll(CatchAll),
+    Scrutinee(Scrutinee),
 }
 
 #[derive(Debug, Clone)]
-pub struct CatchAll<'sc> {
-    pub span: Span<'sc>,
+pub struct CatchAll {
+    pub span: Span,
 }

--- a/sway-core/src/parse_tree/expression/matcher.rs
+++ b/sway-core/src/parse_tree/expression/matcher.rs
@@ -52,10 +52,7 @@ pub type MatcherResult = Option<(MatchReqMap, MatchImplMap)>;
 ///     (x, 42) // add `let x = 42 in the body of the desugared if expression
 /// ]
 /// ```
-pub fn matcher(
-    exp: &Expression,
-    scrutinee: &Scrutinee,
-) -> CompileResult<MatcherResult> {
+pub fn matcher(exp: &Expression, scrutinee: &Scrutinee) -> CompileResult<MatcherResult> {
     let mut errors = vec![];
     let warnings = vec![];
     match scrutinee {

--- a/sway-core/src/parse_tree/expression/matcher.rs
+++ b/sway-core/src/parse_tree/expression/matcher.rs
@@ -6,11 +6,11 @@ use crate::{
 };
 
 /// List of requirements that a desugared if expression must include in the conditional.
-pub type MatchReqMap<'sc> = Vec<(Expression<'sc>, Expression<'sc>)>;
+pub type MatchReqMap = Vec<(Expression, Expression)>;
 /// List of variable declarations that must be placed inside of the body of the if expression.
-pub type MatchImplMap<'sc> = Vec<(Ident<'sc>, Expression<'sc>)>;
+pub type MatchImplMap = Vec<(Ident, Expression)>;
 /// This is the result type given back by the matcher.
-pub type MatcherResult<'sc> = Option<(MatchReqMap<'sc>, MatchImplMap<'sc>)>;
+pub type MatcherResult = Option<(MatchReqMap, MatchImplMap)>;
 
 /// This algorithm desugars pattern matching into a [MatcherResult], by creating two lists,
 /// the [MatchReqMap] which is a list of requirements that a desugared if expression
@@ -52,10 +52,10 @@ pub type MatcherResult<'sc> = Option<(MatchReqMap<'sc>, MatchImplMap<'sc>)>;
 ///     (x, 42) // add `let x = 42 in the body of the desugared if expression
 /// ]
 /// ```
-pub fn matcher<'sc>(
-    exp: &Expression<'sc>,
-    scrutinee: &Scrutinee<'sc>,
-) -> CompileResult<'sc, MatcherResult<'sc>> {
+pub fn matcher(
+    exp: &Expression,
+    scrutinee: &Scrutinee,
+) -> CompileResult<MatcherResult> {
     let mut errors = vec![];
     let warnings = vec![];
     match scrutinee {
@@ -82,11 +82,11 @@ pub fn matcher<'sc>(
     }
 }
 
-fn match_literal<'sc>(
-    exp: &Expression<'sc>,
-    scrutinee: &Literal<'sc>,
-    scrutinee_span: &Span<'sc>,
-) -> CompileResult<'sc, MatcherResult<'sc>> {
+fn match_literal(
+    exp: &Expression,
+    scrutinee: &Literal,
+    scrutinee_span: &Span,
+) -> CompileResult<MatcherResult> {
     let match_req_map = vec![(
         exp.to_owned(),
         Expression::Literal {
@@ -98,22 +98,22 @@ fn match_literal<'sc>(
     ok(Some((match_req_map, match_impl_map)), vec![], vec![])
 }
 
-fn match_variable<'sc>(
-    exp: &Expression<'sc>,
-    scrutinee_name: &Ident<'sc>,
-    _span: &Span<'sc>,
-) -> CompileResult<'sc, MatcherResult<'sc>> {
+fn match_variable(
+    exp: &Expression,
+    scrutinee_name: &Ident,
+    _span: &Span,
+) -> CompileResult<MatcherResult> {
     let match_req_map = vec![];
     let match_impl_map = vec![(scrutinee_name.to_owned(), exp.to_owned())];
     ok(Some((match_req_map, match_impl_map)), vec![], vec![])
 }
 
-fn match_struct<'sc>(
-    exp: &Expression<'sc>,
-    struct_name: &Ident<'sc>,
-    fields: &[StructScrutineeField<'sc>],
-    span: &Span<'sc>,
-) -> CompileResult<'sc, MatcherResult<'sc>> {
+fn match_struct(
+    exp: &Expression,
+    struct_name: &Ident,
+    fields: &[StructScrutineeField],
+    span: &Span,
+) -> CompileResult<MatcherResult> {
     let mut warnings = vec![];
     let mut errors = vec![];
     let mut match_req_map = vec![];
@@ -156,12 +156,12 @@ fn match_struct<'sc>(
     ok(Some((match_req_map, match_impl_map)), warnings, errors)
 }
 
-fn match_enum<'sc>(
-    exp: &Expression<'sc>,
-    call_path: &CallPath<'sc>,
-    args: &[Scrutinee<'sc>],
-    span: &Span<'sc>,
-) -> CompileResult<'sc, MatcherResult<'sc>> {
+fn match_enum(
+    exp: &Expression,
+    call_path: &CallPath,
+    args: &[Scrutinee],
+    span: &Span,
+) -> CompileResult<MatcherResult> {
     let mut warnings = vec![];
     let mut errors = vec![];
     let mut match_req_map = vec![];

--- a/sway-core/src/parse_tree/expression/method_name.rs
+++ b/sway-core/src/parse_tree/expression/method_name.rs
@@ -3,21 +3,21 @@ use crate::type_engine::TypeInfo;
 use crate::Ident;
 
 #[derive(Debug, Clone)]
-pub enum MethodName<'sc> {
+pub enum MethodName {
     /// Represents a method lookup with a type somewhere in the path
     FromType {
-        call_path: CallPath<'sc>,
+        call_path: CallPath,
         // if this is `None`, then use the first argument to determine the type
         type_name: Option<TypeInfo>,
         is_absolute: bool,
     },
     /// Represents a method lookup that does not contain any types in the path
-    FromModule { method_name: Ident<'sc> },
+    FromModule { method_name: Ident },
 }
 
-impl<'sc> MethodName<'sc> {
+impl<'sc> MethodName {
     /// To be used for error messages and debug strings
-    pub(crate) fn easy_name(&self) -> Ident<'sc> {
+    pub(crate) fn easy_name(&self) -> Ident {
         match self {
             MethodName::FromType { call_path, .. } => call_path.suffix.clone(),
             MethodName::FromModule { method_name, .. } => method_name.clone(),

--- a/sway-core/src/parse_tree/expression/method_name.rs
+++ b/sway-core/src/parse_tree/expression/method_name.rs
@@ -15,7 +15,7 @@ pub enum MethodName {
     FromModule { method_name: Ident },
 }
 
-impl<'sc> MethodName {
+impl MethodName {
     /// To be used for error messages and debug strings
     pub(crate) fn easy_name(&self) -> Ident {
         match self {

--- a/sway-core/src/parse_tree/expression/method_name.rs
+++ b/sway-core/src/parse_tree/expression/method_name.rs
@@ -19,8 +19,8 @@ impl<'sc> MethodName<'sc> {
     /// To be used for error messages and debug strings
     pub(crate) fn easy_name(&self) -> &'sc str {
         match self {
-            MethodName::FromType { call_path, .. } => call_path.suffix.primary_name(),
-            MethodName::FromModule { method_name, .. } => method_name.primary_name(),
+            MethodName::FromType { call_path, .. } => call_path.suffix.as_str(),
+            MethodName::FromModule { method_name, .. } => method_name.as_str(),
         }
     }
 }

--- a/sway-core/src/parse_tree/expression/method_name.rs
+++ b/sway-core/src/parse_tree/expression/method_name.rs
@@ -19,8 +19,8 @@ impl<'sc> MethodName<'sc> {
     /// To be used for error messages and debug strings
     pub(crate) fn easy_name(&self) -> &'sc str {
         match self {
-            MethodName::FromType { call_path, .. } => call_path.suffix.primary_name,
-            MethodName::FromModule { method_name, .. } => method_name.primary_name,
+            MethodName::FromType { call_path, .. } => call_path.suffix.primary_name(),
+            MethodName::FromModule { method_name, .. } => method_name.primary_name(),
         }
     }
 }

--- a/sway-core/src/parse_tree/expression/method_name.rs
+++ b/sway-core/src/parse_tree/expression/method_name.rs
@@ -17,10 +17,10 @@ pub enum MethodName<'sc> {
 
 impl<'sc> MethodName<'sc> {
     /// To be used for error messages and debug strings
-    pub(crate) fn easy_name(&self) -> &'sc str {
+    pub(crate) fn easy_name(&self) -> Ident<'sc> {
         match self {
-            MethodName::FromType { call_path, .. } => call_path.suffix.as_str(),
-            MethodName::FromModule { method_name, .. } => method_name.as_str(),
+            MethodName::FromType { call_path, .. } => call_path.suffix.clone(),
+            MethodName::FromModule { method_name, .. } => method_name.clone(),
         }
     }
 }

--- a/sway-core/src/parse_tree/expression/mod.rs
+++ b/sway-core/src/parse_tree/expression/mod.rs
@@ -199,14 +199,8 @@ impl<'sc> Expression<'sc> {
             method_name: MethodName::FromType {
                 call_path: CallPath {
                     prefixes: vec![
-                        Ident {
-                            primary_name: "core",
-                            span: span.clone(),
-                        },
-                        Ident {
-                            primary_name: "ops",
-                            span: span.clone(),
-                        },
+                        Ident::new("core", span.clone()),
+                        Ident::new("ops", span.clone()),
                     ],
                     suffix: Op {
                         op_variant: OpVariant::Equals,
@@ -231,14 +225,8 @@ impl<'sc> Expression<'sc> {
             method_name: MethodName::FromType {
                 call_path: CallPath {
                     prefixes: vec![
-                        Ident {
-                            primary_name: "core",
-                            span: span.clone(),
-                        },
-                        Ident {
-                            primary_name: "ops",
-                            span: span.clone(),
-                        },
+                        Ident::new("core", span.clone()),
+                        Ident::new("ops", span.clone()),
                     ],
                     suffix: op.to_var_name(),
                 },
@@ -464,10 +452,7 @@ impl<'sc> Expression<'sc> {
                         Rule::var_name_ident => {
                             name = Some(check!(
                                 Ident::parse_from_pair(pair, config),
-                                Ident {
-                                    primary_name: "error parsing var name",
-                                    span: span.clone()
-                                },
+                                Ident::new("error parsing var name", span.clone()),
                                 warnings,
                                 errors
                             ));
@@ -1290,11 +1275,7 @@ pub(crate) struct Op<'sc> {
 
 impl<'sc> Op<'sc> {
     pub fn to_var_name(&self) -> Ident<'sc> {
-        Ident {
-            primary_name: self.op_variant.as_str(),
-            span: self.span.clone(),
-            // TODO this should be a method exp not a var name
-        }
+        Ident::new(self.op_variant.as_str(), self.span.clone())
     }
 }
 #[derive(Debug)]
@@ -1613,7 +1594,7 @@ pub fn desugar_match_expression<'sc>(
                 type_ascription: TypeInfo::Unknown,
                 type_ascription_span: None,
             });
-            let new_span = join_spans(left_impl.span.clone(), right_impl.span());
+            let new_span = join_spans(left_impl.span().clone(), right_impl.span());
             code_block_stmts.push(AstNode {
                 content: AstNodeContent::Declaration(decl),
                 span: new_span.clone(),

--- a/sway-core/src/parse_tree/expression/mod.rs
+++ b/sway-core/src/parse_tree/expression/mod.rs
@@ -193,7 +193,7 @@ pub struct StructExpressionField {
     pub(crate) span: Span,
 }
 
-impl<'sc> Expression {
+impl Expression {
     pub(crate) fn core_ops_eq(arguments: Vec<Expression>, span: Span) -> Expression {
         Expression::MethodApplication {
             method_name: MethodName::FromType {
@@ -1276,6 +1276,7 @@ impl Op {
         Ident::new_with_override(self.op_variant.as_str(), self.span.clone())
     }
 }
+
 #[derive(Debug)]
 pub enum OpVariant {
     Add,

--- a/sway-core/src/parse_tree/expression/mod.rs
+++ b/sway-core/src/parse_tree/expression/mod.rs
@@ -216,11 +216,7 @@ impl Expression {
         }
     }
 
-    pub(crate) fn core_ops(
-        op: Op,
-        arguments: Vec<Expression>,
-        span: Span,
-    ) -> Expression {
+    pub(crate) fn core_ops(op: Op, arguments: Vec<Expression>, span: Span) -> Expression {
         Expression::MethodApplication {
             method_name: MethodName::FromType {
                 call_path: CallPath {
@@ -1111,10 +1107,7 @@ fn parse_subfield_path(
 // A call item is parsed as either an `ident` or a parenthesized `expr`. This method's job is to
 // figure out which variant of `call_item` this is and turn it into either a variable expression
 // or parse it as an expression otherwise.
-fn parse_call_item(
-    item: Pair<Rule>,
-    config: Option<&BuildConfig>,
-) -> CompileResult<Expression> {
+fn parse_call_item(item: Pair<Rule>, config: Option<&BuildConfig>) -> CompileResult<Expression> {
     let mut warnings = vec![];
     let mut errors = vec![];
     assert_eq!(item.as_rule(), Rule::call_item);
@@ -1143,10 +1136,7 @@ fn parse_call_item(
     ok(exp, warnings, errors)
 }
 
-fn parse_array_elems(
-    elems: Pair<Rule>,
-    config: Option<&BuildConfig>,
-) -> CompileResult<Expression> {
+fn parse_array_elems(elems: Pair<Rule>, config: Option<&BuildConfig>) -> CompileResult<Expression> {
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
 

--- a/sway-core/src/parse_tree/expression/mod.rs
+++ b/sway-core/src/parse_tree/expression/mod.rs
@@ -29,64 +29,64 @@ pub(crate) use unary_op::UnaryOp;
 
 /// Represents a parsed, but not yet type checked, [Expression](https://en.wikipedia.org/wiki/Expression_(computer_science)).
 #[derive(Debug, Clone)]
-pub enum Expression<'sc> {
+pub enum Expression {
     Literal {
-        value: Literal<'sc>,
-        span: Span<'sc>,
+        value: Literal,
+        span: Span,
     },
     FunctionApplication {
-        name: CallPath<'sc>,
-        arguments: Vec<Expression<'sc>>,
-        type_arguments: Vec<(TypeInfo, Span<'sc>)>,
-        span: Span<'sc>,
+        name: CallPath,
+        arguments: Vec<Expression>,
+        type_arguments: Vec<(TypeInfo, Span)>,
+        span: Span,
     },
     LazyOperator {
         op: LazyOp,
-        lhs: Box<Expression<'sc>>,
-        rhs: Box<Expression<'sc>>,
-        span: Span<'sc>,
+        lhs: Box<Expression>,
+        rhs: Box<Expression>,
+        span: Span,
     },
     VariableExpression {
-        name: Ident<'sc>,
-        span: Span<'sc>,
+        name: Ident,
+        span: Span,
     },
     Tuple {
-        fields: Vec<Expression<'sc>>,
-        span: Span<'sc>,
+        fields: Vec<Expression>,
+        span: Span,
     },
     Array {
-        contents: Vec<Expression<'sc>>,
-        span: Span<'sc>,
+        contents: Vec<Expression>,
+        span: Span,
     },
     MatchExpression {
-        primary_expression: Box<Expression<'sc>>,
-        branches: Vec<MatchBranch<'sc>>,
-        span: Span<'sc>,
+        primary_expression: Box<Expression>,
+        branches: Vec<MatchBranch>,
+        span: Span,
     },
     StructExpression {
-        struct_name: Ident<'sc>,
-        fields: Vec<StructExpressionField<'sc>>,
-        span: Span<'sc>,
+        struct_name: Ident,
+        fields: Vec<StructExpressionField>,
+        span: Span,
     },
     CodeBlock {
-        contents: CodeBlock<'sc>,
-        span: Span<'sc>,
+        contents: CodeBlock,
+        span: Span,
     },
     IfExp {
-        condition: Box<Expression<'sc>>,
-        then: Box<Expression<'sc>>,
-        r#else: Option<Box<Expression<'sc>>>,
-        span: Span<'sc>,
+        condition: Box<Expression>,
+        then: Box<Expression>,
+        r#else: Option<Box<Expression>>,
+        span: Span,
     },
     // separated into other struct for parsing reasons
     AsmExpression {
-        span: Span<'sc>,
-        asm: AsmExpression<'sc>,
+        span: Span,
+        asm: AsmExpression,
     },
     MethodApplication {
-        method_name: MethodName<'sc>,
-        arguments: Vec<Expression<'sc>>,
-        span: Span<'sc>,
+        method_name: MethodName,
+        arguments: Vec<Expression>,
+        span: Span,
     },
     /// A _subfield expression_ is anything of the form:
     /// ```ignore
@@ -94,9 +94,9 @@ pub enum Expression<'sc> {
     /// ```
     ///
     SubfieldExpression {
-        prefix: Box<Expression<'sc>>,
-        span: Span<'sc>,
-        field_to_access: Ident<'sc>,
+        prefix: Box<Expression>,
+        span: Span,
+        field_to_access: Ident,
     },
     /// A _delineated path_ is anything of the form:
     /// ```ignore
@@ -120,21 +120,21 @@ pub enum Expression<'sc> {
     /// MyEnum::Variant1
     /// ```
     DelineatedPath {
-        call_path: CallPath<'sc>,
-        args: Vec<Expression<'sc>>,
-        span: Span<'sc>,
+        call_path: CallPath,
+        args: Vec<Expression>,
+        span: Span,
         type_arguments: Vec<TypeInfo>,
     },
     /// A cast of a hash to an ABI for calling a contract.
     AbiCast {
-        abi_name: CallPath<'sc>,
-        address: Box<Expression<'sc>>,
-        span: Span<'sc>,
+        abi_name: CallPath,
+        address: Box<Expression>,
+        span: Span,
     },
     ArrayIndex {
-        prefix: Box<Expression<'sc>>,
-        index: Box<Expression<'sc>>,
-        span: Span<'sc>,
+        prefix: Box<Expression>,
+        index: Box<Expression>,
+        span: Span,
     },
     /// This variant serves as a stand-in for parsing-level match expression desugaring.
     /// Because types cannot be known at parsing-time, a desugared struct or enum gets
@@ -143,30 +143,30 @@ pub enum Expression<'sc> {
     /// expression inside of the delayed resolution has the appropriate struct or enum
     /// type)
     DelayedMatchTypeResolution {
-        variant: DelayedResolutionVariant<'sc>,
-        span: Span<'sc>,
+        variant: DelayedResolutionVariant,
+        span: Span,
     },
 }
 
 #[derive(Debug, Clone)]
-pub enum DelayedResolutionVariant<'sc> {
-    StructField(DelayedStructFieldResolution<'sc>),
-    EnumVariant(DelayedEnumVariantResolution<'sc>),
+pub enum DelayedResolutionVariant {
+    StructField(DelayedStructFieldResolution),
+    EnumVariant(DelayedEnumVariantResolution),
 }
 
 /// During type checking, this gets replaced with struct field access.
 #[derive(Debug, Clone)]
-pub struct DelayedStructFieldResolution<'sc> {
-    pub exp: Box<Expression<'sc>>,
-    pub struct_name: Ident<'sc>,
-    pub field: Ident<'sc>,
+pub struct DelayedStructFieldResolution {
+    pub exp: Box<Expression>,
+    pub struct_name: Ident,
+    pub field: Ident,
 }
 
 /// During type checking, this gets replaced with enum arg access.
 #[derive(Debug, Clone)]
-pub struct DelayedEnumVariantResolution<'sc> {
-    pub exp: Box<Expression<'sc>>,
-    pub call_path: CallPath<'sc>,
+pub struct DelayedEnumVariantResolution {
+    pub exp: Box<Expression>,
+    pub call_path: CallPath,
     pub arg_num: usize,
 }
 
@@ -187,14 +187,14 @@ impl LazyOp {
 }
 
 #[derive(Debug, Clone)]
-pub struct StructExpressionField<'sc> {
-    pub(crate) name: Ident<'sc>,
-    pub(crate) value: Expression<'sc>,
-    pub(crate) span: Span<'sc>,
+pub struct StructExpressionField {
+    pub(crate) name: Ident,
+    pub(crate) value: Expression,
+    pub(crate) span: Span,
 }
 
-impl<'sc> Expression<'sc> {
-    pub(crate) fn core_ops_eq(arguments: Vec<Expression<'sc>>, span: Span<'sc>) -> Expression<'sc> {
+impl<'sc> Expression {
+    pub(crate) fn core_ops_eq(arguments: Vec<Expression>, span: Span) -> Expression {
         Expression::MethodApplication {
             method_name: MethodName::FromType {
                 call_path: CallPath {
@@ -217,10 +217,10 @@ impl<'sc> Expression<'sc> {
     }
 
     pub(crate) fn core_ops(
-        op: Op<'sc>,
-        arguments: Vec<Expression<'sc>>,
-        span: Span<'sc>,
-    ) -> Expression<'sc> {
+        op: Op,
+        arguments: Vec<Expression>,
+        span: Span,
+    ) -> Expression {
         Expression::MethodApplication {
             method_name: MethodName::FromType {
                 call_path: CallPath {
@@ -238,7 +238,7 @@ impl<'sc> Expression<'sc> {
         }
     }
 
-    pub(crate) fn span(&self) -> Span<'sc> {
+    pub(crate) fn span(&self) -> Span {
         use Expression::*;
         (match self {
             Literal { span, .. } => span,
@@ -262,9 +262,9 @@ impl<'sc> Expression<'sc> {
         .clone()
     }
     pub(crate) fn parse_from_pair(
-        expr: Pair<'sc, Rule>,
+        expr: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
@@ -288,7 +288,7 @@ impl<'sc> Expression<'sc> {
             vec![Either::Right(first_expr.clone())];
         // sometimes exprs are followed by ops in the same expr
         while let Some(op) = expr_iter.next() {
-            let op_str = op.as_str();
+            let op_str = op.as_str().to_string();
             let op_span = Span {
                 span: op.as_span(),
                 path: path.clone(),
@@ -317,7 +317,7 @@ impl<'sc> Expression<'sc> {
                 ),
                 None => {
                     errors.push(CompileError::ExpectedExprAfterOp {
-                        op: op_str.to_string(),
+                        op: op_str,
                         span: Span {
                             span: expr_for_debug.as_span(),
                             path: path.clone(),
@@ -361,9 +361,9 @@ impl<'sc> Expression<'sc> {
     }
 
     pub(crate) fn parse_from_pair_inner(
-        expr: Pair<'sc, Rule>,
+        expr: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut errors = Vec::new();
         let mut warnings = Vec::new();
@@ -981,9 +981,9 @@ impl<'sc> Expression<'sc> {
 }
 
 fn convert_unary_to_fn_calls<'sc>(
-    item: Pair<'sc, Rule>,
+    item: Pair<Rule>,
     config: Option<&BuildConfig>,
-) -> CompileResult<'sc, Expression<'sc>> {
+) -> CompileResult<Expression> {
     let iter = item.into_inner();
     let mut unary_stack = vec![];
     let mut warnings = vec![];
@@ -1026,10 +1026,10 @@ fn convert_unary_to_fn_calls<'sc>(
     ok(expr, warnings, errors)
 }
 
-pub(crate) fn parse_array_index<'sc>(
-    item: Pair<'sc, Rule>,
+pub(crate) fn parse_array_index(
+    item: Pair<Rule>,
     config: Option<&BuildConfig>,
-) -> CompileResult<'sc, Expression<'sc>> {
+) -> CompileResult<Expression> {
     let mut warnings = vec![];
     let mut errors = vec![];
     let path = config.map(|c| c.path());
@@ -1055,7 +1055,7 @@ pub(crate) fn parse_array_index<'sc>(
         prefix: Box::new(prefix),
         index: Box::new(first_index.to_owned()),
         span: Span {
-            span,
+            span: span.clone(),
             path: path.clone(),
         },
     };
@@ -1064,7 +1064,7 @@ pub(crate) fn parse_array_index<'sc>(
             prefix: Box::new(exp),
             index: Box::new(index),
             span: Span {
-                span,
+                span: span.clone(),
                 path: path.clone(),
             },
         };
@@ -1072,10 +1072,10 @@ pub(crate) fn parse_array_index<'sc>(
     ok(exp, warnings, errors)
 }
 
-fn parse_subfield_path<'sc>(
-    item: Pair<'sc, Rule>,
+fn parse_subfield_path(
+    item: Pair<Rule>,
     config: Option<&BuildConfig>,
-) -> CompileResult<'sc, Expression<'sc>> {
+) -> CompileResult<Expression> {
     let warnings = vec![];
     let mut errors = vec![];
     let path = config.map(|c| c.path());
@@ -1114,9 +1114,9 @@ fn parse_subfield_path<'sc>(
 // figure out which variant of `call_item` this is and turn it into either a variable expression
 // or parse it as an expression otherwise.
 fn parse_call_item<'sc>(
-    item: Pair<'sc, Rule>,
+    item: Pair<Rule>,
     config: Option<&BuildConfig>,
-) -> CompileResult<'sc, Expression<'sc>> {
+) -> CompileResult<Expression> {
     let mut warnings = vec![];
     let mut errors = vec![];
     assert_eq!(item.as_rule(), Rule::call_item);
@@ -1146,9 +1146,9 @@ fn parse_call_item<'sc>(
 }
 
 fn parse_array_elems<'sc>(
-    elems: Pair<'sc, Rule>,
+    elems: Pair<Rule>,
     config: Option<&BuildConfig>,
-) -> CompileResult<'sc, Expression<'sc>> {
+) -> CompileResult<Expression> {
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
 
@@ -1222,7 +1222,7 @@ fn parse_array_elems<'sc>(
     ok(Expression::Array { contents, span }, warnings, errors)
 }
 
-fn parse_op<'sc>(op: Pair<'sc, Rule>, config: Option<&BuildConfig>) -> CompileResult<'sc, Op<'sc>> {
+fn parse_op<'sc>(op: Pair<Rule>, config: Option<&BuildConfig>) -> CompileResult<Op> {
     let path = config.map(|c| c.path());
     use OpVariant::*;
     let mut errors = Vec::new();
@@ -1268,13 +1268,13 @@ fn parse_op<'sc>(op: Pair<'sc, Rule>, config: Option<&BuildConfig>) -> CompileRe
 }
 
 #[derive(Debug)]
-pub(crate) struct Op<'sc> {
-    pub span: Span<'sc>,
+pub(crate) struct Op {
+    pub span: Span,
     pub op_variant: OpVariant,
 }
 
-impl<'sc> Op<'sc> {
-    pub fn to_var_name(&self) -> Ident<'sc> {
+impl Op {
+    pub fn to_var_name(&self) -> Ident {
         Ident::new_with_override(self.op_variant.as_str(), self.span.clone())
     }
 }
@@ -1350,9 +1350,9 @@ impl OpVariant {
 }
 
 fn arrange_by_order_of_operations<'sc>(
-    expressions: Vec<Either<Op<'sc>, Expression<'sc>>>,
-    debug_span: Span<'sc>,
-) -> CompileResult<'sc, Expression<'sc>> {
+    expressions: Vec<Either<Op, Expression>>,
+    debug_span: Span,
+) -> CompileResult<Expression> {
     let mut errors = Vec::new();
     let warnings = Vec::new();
     let mut expression_stack = Vec::new();
@@ -1452,11 +1452,11 @@ fn arrange_by_order_of_operations<'sc>(
     ok(expression_stack[0].clone(), warnings, errors)
 }
 
-struct MatchedBranch<'sc> {
-    result: Expression<'sc>,
-    match_req_map: Vec<(Expression<'sc>, Expression<'sc>)>,
-    match_impl_map: Vec<(Ident<'sc>, Expression<'sc>)>,
-    branch_span: Span<'sc>,
+struct MatchedBranch {
+    result: Expression,
+    match_req_map: Vec<(Expression, Expression)>,
+    match_impl_map: Vec<(Ident, Expression)>,
+    branch_span: Span,
 }
 
 /// This algorithm desugars match expressions to if statements.
@@ -1503,11 +1503,11 @@ struct MatchedBranch<'sc> {
 ///     2b. Assemble the statements that go inside of the body of the if expression
 ///     2c. Assemble the giant if statement.
 /// 3. Return!
-pub fn desugar_match_expression<'sc>(
-    primary_expression: Expression<'sc>,
-    branches: Vec<MatchBranch<'sc>>,
-    _span: Span<'sc>,
-) -> CompileResult<'sc, Expression<'sc>> {
+pub fn desugar_match_expression(
+    primary_expression: Expression,
+    branches: Vec<MatchBranch>,
+    _span: Span,
+) -> CompileResult<Expression> {
     let mut errors = vec![];
     let mut warnings = vec![];
 

--- a/sway-core/src/parse_tree/expression/mod.rs
+++ b/sway-core/src/parse_tree/expression/mod.rs
@@ -317,7 +317,7 @@ impl<'sc> Expression<'sc> {
                 ),
                 None => {
                     errors.push(CompileError::ExpectedExprAfterOp {
-                        op: op_str,
+                        op: op_str.to_string(),
                         span: Span {
                             span: expr_for_debug.as_span(),
                             path: path.clone(),
@@ -1245,7 +1245,7 @@ fn parse_op<'sc>(op: Pair<'sc, Rule>, config: Option<&BuildConfig>) -> CompileRe
         "<=" => LessThanOrEqualTo,
         a => {
             errors.push(CompileError::ExpectedOp {
-                op: a,
+                op: a.to_string(),
                 span: Span {
                     span: op.as_span(),
                     path,

--- a/sway-core/src/parse_tree/expression/mod.rs
+++ b/sway-core/src/parse_tree/expression/mod.rs
@@ -199,8 +199,8 @@ impl<'sc> Expression<'sc> {
             method_name: MethodName::FromType {
                 call_path: CallPath {
                     prefixes: vec![
-                        Ident::new("core", span.clone()),
-                        Ident::new("ops", span.clone()),
+                        Ident::new_with_override("core", span.clone()),
+                        Ident::new_with_override("ops", span.clone()),
                     ],
                     suffix: Op {
                         op_variant: OpVariant::Equals,
@@ -225,8 +225,8 @@ impl<'sc> Expression<'sc> {
             method_name: MethodName::FromType {
                 call_path: CallPath {
                     prefixes: vec![
-                        Ident::new("core", span.clone()),
-                        Ident::new("ops", span.clone()),
+                        Ident::new_with_override("core", span.clone()),
+                        Ident::new_with_override("ops", span.clone()),
                     ],
                     suffix: op.to_var_name(),
                 },
@@ -452,7 +452,7 @@ impl<'sc> Expression<'sc> {
                         Rule::var_name_ident => {
                             name = Some(check!(
                                 Ident::parse_from_pair(pair, config),
-                                Ident::new("error parsing var name", span.clone()),
+                                Ident::new_with_override("error parsing var name", span.clone()),
                                 warnings,
                                 errors
                             ));
@@ -1275,7 +1275,7 @@ pub(crate) struct Op<'sc> {
 
 impl<'sc> Op<'sc> {
     pub fn to_var_name(&self) -> Ident<'sc> {
-        Ident::new(self.op_variant.as_str(), self.span.clone())
+        Ident::new_with_override(self.op_variant.as_str(), self.span.clone())
     }
 }
 #[derive(Debug)]

--- a/sway-core/src/parse_tree/expression/scrutinee.rs
+++ b/sway-core/src/parse_tree/expression/scrutinee.rs
@@ -12,39 +12,39 @@ use pest::iterators::Pair;
 /// need to be implemented in a desugared if expression.
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
-pub enum Scrutinee<'sc> {
+pub enum Scrutinee {
     Unit {
-        span: Span<'sc>,
+        span: Span,
     },
     Literal {
-        value: Literal<'sc>,
-        span: Span<'sc>,
+        value: Literal,
+        span: Span,
     },
     Variable {
-        name: Ident<'sc>,
-        span: Span<'sc>,
+        name: Ident,
+        span: Span,
     },
     StructScrutinee {
-        struct_name: Ident<'sc>,
-        fields: Vec<StructScrutineeField<'sc>>,
-        span: Span<'sc>,
+        struct_name: Ident,
+        fields: Vec<StructScrutineeField>,
+        span: Span,
     },
     EnumScrutinee {
-        call_path: CallPath<'sc>,
-        args: Vec<Scrutinee<'sc>>,
-        span: Span<'sc>,
+        call_path: CallPath,
+        args: Vec<Scrutinee>,
+        span: Span,
     },
 }
 
 #[derive(Debug, Clone)]
-pub struct StructScrutineeField<'sc> {
-    pub field: Ident<'sc>,
-    pub scrutinee: Option<Scrutinee<'sc>>,
-    pub span: Span<'sc>,
+pub struct StructScrutineeField {
+    pub field: Ident,
+    pub scrutinee: Option<Scrutinee>,
+    pub span: Span,
 }
 
-impl<'sc> Scrutinee<'sc> {
-    pub fn span(&self) -> Span<'sc> {
+impl Scrutinee {
+    pub fn span(&self) -> Span {
         match self {
             Scrutinee::Literal { span, .. } => span.clone(),
             Scrutinee::Unit { span } => span.clone(),
@@ -55,9 +55,9 @@ impl<'sc> Scrutinee<'sc> {
     }
 
     pub fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
         let mut scrutinees = pair.into_inner();
@@ -72,9 +72,9 @@ impl<'sc> Scrutinee<'sc> {
     }
 
     pub fn parse_from_pair_inner(
-        scrutinee: Pair<'sc, Rule>,
+        scrutinee: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut errors = Vec::new();
         let mut warnings = Vec::new();
@@ -134,10 +134,10 @@ impl<'sc> Scrutinee<'sc> {
     }
 
     fn parse_from_pair_literal(
-        scrutinee: Pair<'sc, Rule>,
+        scrutinee: Pair<Rule>,
         config: Option<&BuildConfig>,
-        span: Span<'sc>,
-    ) -> CompileResult<'sc, Self> {
+        span: Span,
+    ) -> CompileResult<Self> {
         let mut warnings = vec![];
         let mut errors = vec![];
         let scrutinee = Literal::parse_from_pair(scrutinee.clone(), config)
@@ -149,10 +149,10 @@ impl<'sc> Scrutinee<'sc> {
     }
 
     fn parse_from_pair_ident(
-        scrutinee: Pair<'sc, Rule>,
+        scrutinee: Pair<Rule>,
         config: Option<&BuildConfig>,
-        span: Span<'sc>,
-    ) -> CompileResult<'sc, Self> {
+        span: Span,
+    ) -> CompileResult<Self> {
         let mut warnings = vec![];
         let mut errors = vec![];
         let scrutinee = Ident::parse_from_pair(scrutinee.clone(), config)
@@ -167,11 +167,11 @@ impl<'sc> Scrutinee<'sc> {
     }
 
     fn parse_from_pair_struct(
-        scrutinee: Pair<'sc, Rule>,
+        scrutinee: Pair<Rule>,
         config: Option<&BuildConfig>,
-        span: Span<'sc>,
+        span: Span,
         path: Option<Arc<PathBuf>>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let mut warnings = vec![];
         let mut errors = vec![];
         let mut it = scrutinee.into_inner();
@@ -230,10 +230,10 @@ impl<'sc> Scrutinee<'sc> {
     }
 
     fn parse_from_pair_enum(
-        scrutinee: Pair<'sc, Rule>,
+        scrutinee: Pair<Rule>,
         config: Option<&BuildConfig>,
-        span: Span<'sc>,
-    ) -> CompileResult<'sc, Self> {
+        span: Span,
+    ) -> CompileResult<Self> {
         let mut warnings = vec![];
         let mut errors = vec![];
         let mut parts = scrutinee.into_inner();

--- a/sway-core/src/parse_tree/expression/scrutinee.rs
+++ b/sway-core/src/parse_tree/expression/scrutinee.rs
@@ -54,10 +54,7 @@ impl Scrutinee {
         }
     }
 
-    pub fn parse_from_pair(
-        pair: Pair<Rule>,
-        config: Option<&BuildConfig>,
-    ) -> CompileResult<Self> {
+    pub fn parse_from_pair(pair: Pair<Rule>, config: Option<&BuildConfig>) -> CompileResult<Self> {
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
         let mut scrutinees = pair.into_inner();

--- a/sway-core/src/parse_tree/expression/scrutinee.rs
+++ b/sway-core/src/parse_tree/expression/scrutinee.rs
@@ -63,7 +63,7 @@ impl Scrutinee {
         let mut scrutinees = pair.into_inner();
         let scrutinee = scrutinees.next().unwrap();
         let scrutinee = check!(
-            Scrutinee::parse_from_pair_inner(scrutinee.clone(), config),
+            Scrutinee::parse_from_pair_inner(scrutinee, config),
             return err(warnings, errors),
             warnings,
             errors
@@ -140,7 +140,7 @@ impl Scrutinee {
     ) -> CompileResult<Self> {
         let mut warnings = vec![];
         let mut errors = vec![];
-        let scrutinee = Literal::parse_from_pair(scrutinee.clone(), config)
+        let scrutinee = Literal::parse_from_pair(scrutinee, config)
             .map(|(value, span)| Scrutinee::Literal { value, span })
             .unwrap_or_else(&mut warnings, &mut errors, || Scrutinee::Unit {
                 span: span.clone(),
@@ -155,7 +155,7 @@ impl Scrutinee {
     ) -> CompileResult<Self> {
         let mut warnings = vec![];
         let mut errors = vec![];
-        let scrutinee = Ident::parse_from_pair(scrutinee.clone(), config)
+        let scrutinee = Ident::parse_from_pair(scrutinee, config)
             .map(|name| Scrutinee::Variable {
                 name,
                 span: span.clone(),

--- a/sway-core/src/parse_tree/expression/unary_op.rs
+++ b/sway-core/src/parse_tree/expression/unary_op.rs
@@ -55,19 +55,10 @@ impl UnaryOp {
             type_arguments: Default::default(),
             name: CallPath {
                 prefixes: vec![
-                    Ident {
-                        primary_name: "core",
-                        span: op_span.clone(),
-                    },
-                    Ident {
-                        primary_name: "ops",
-                        span: op_span.clone(),
-                    },
+                    Ident::new("core", op_span.clone()),
+                    Ident::new("ops", op_span.clone()),
                 ],
-                suffix: Ident {
-                    primary_name: self.to_var_name(),
-                    span: op_span,
-                },
+                suffix: Ident::new(self.to_var_name(), op_span),
             },
             arguments: vec![arg],
             span,

--- a/sway-core/src/parse_tree/expression/unary_op.rs
+++ b/sway-core/src/parse_tree/expression/unary_op.rs
@@ -15,9 +15,9 @@ pub enum UnaryOp {
 
 impl UnaryOp {
     pub fn parse_from_pair<'sc>(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         use UnaryOp::*;
         match pair.as_str() {
             "!" => ok(Not, Vec::new(), Vec::new()),
@@ -47,10 +47,10 @@ impl UnaryOp {
 
     pub fn to_fn_application<'sc>(
         &self,
-        arg: Expression<'sc>,
-        span: Span<'sc>,
-        op_span: Span<'sc>,
-    ) -> Expression<'sc> {
+        arg: Expression,
+        span: Span,
+        op_span: Span,
+    ) -> Expression {
         Expression::FunctionApplication {
             type_arguments: Default::default(),
             name: CallPath {

--- a/sway-core/src/parse_tree/expression/unary_op.rs
+++ b/sway-core/src/parse_tree/expression/unary_op.rs
@@ -14,7 +14,7 @@ pub enum UnaryOp {
 }
 
 impl UnaryOp {
-    pub fn parse_from_pair<'sc>(
+    pub fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,
     ) -> CompileResult<Self> {
@@ -45,7 +45,7 @@ impl UnaryOp {
         }
     }
 
-    pub fn to_fn_application<'sc>(
+    pub fn to_fn_application(
         &self,
         arg: Expression,
         span: Span,

--- a/sway-core/src/parse_tree/expression/unary_op.rs
+++ b/sway-core/src/parse_tree/expression/unary_op.rs
@@ -55,10 +55,10 @@ impl UnaryOp {
             type_arguments: Default::default(),
             name: CallPath {
                 prefixes: vec![
-                    Ident::new("core", op_span.clone()),
-                    Ident::new("ops", op_span.clone()),
+                    Ident::new_with_override("core", op_span.clone()),
+                    Ident::new_with_override("ops", op_span.clone()),
                 ],
-                suffix: Ident::new(self.to_var_name(), op_span),
+                suffix: Ident::new_with_override(self.to_var_name(), op_span),
             },
             arguments: vec![arg],
             span,

--- a/sway-core/src/parse_tree/expression/unary_op.rs
+++ b/sway-core/src/parse_tree/expression/unary_op.rs
@@ -14,10 +14,7 @@ pub enum UnaryOp {
 }
 
 impl UnaryOp {
-    pub fn parse_from_pair(
-        pair: Pair<Rule>,
-        config: Option<&BuildConfig>,
-    ) -> CompileResult<Self> {
+    pub fn parse_from_pair(pair: Pair<Rule>, config: Option<&BuildConfig>) -> CompileResult<Self> {
         use UnaryOp::*;
         match pair.as_str() {
             "!" => ok(Not, Vec::new(), Vec::new()),
@@ -45,12 +42,7 @@ impl UnaryOp {
         }
     }
 
-    pub fn to_fn_application(
-        &self,
-        arg: Expression,
-        span: Span,
-        op_span: Span,
-    ) -> Expression {
+    pub fn to_fn_application(&self, arg: Expression, span: Span, op_span: Span) -> Expression {
         Expression::FunctionApplication {
             type_arguments: Default::default(),
             name: CallPath {

--- a/sway-core/src/parse_tree/include_statement.rs
+++ b/sway-core/src/parse_tree/include_statement.rs
@@ -6,20 +6,19 @@ use crate::Ident;
 use pest::iterators::Pair;
 
 #[derive(Clone, Debug)]
-pub struct IncludeStatement<'sc> {
-    pub(crate) file_path: &'sc str,
-    pub(crate) alias: Option<Ident<'sc>>,
+pub struct IncludeStatement {
+    pub(crate) alias: Option<Ident>,
     #[allow(dead_code)]
     // this span may be used for errors in the future, although it is not right now.
-    span: Span<'sc>,
-    pub(crate) path_span: Span<'sc>,
+    span: Span,
+    pub(crate) path_span: Span,
 }
 
-impl<'sc> IncludeStatement<'sc> {
+impl IncludeStatement {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut warnings = vec![];
         let mut errors = vec![];
@@ -31,16 +30,14 @@ impl<'sc> IncludeStatement<'sc> {
         let _include_keyword = iter.next();
         let path_to_file_raw = iter.collect::<Vec<_>>();
         let mut alias = None;
-        let mut file_path = None;
         let mut path_span = None;
 
         for item in path_to_file_raw {
             if item.as_rule() == Rule::file_path {
-                file_path = Some(item.as_str().trim());
                 path_span = Some(Span {
                     span: item.as_span(),
                     path: path.clone(),
-                });
+                }.trim());
             } else if item.as_rule() == Rule::alias {
                 let alias_parsed = check!(
                     Ident::parse_from_pair(item.into_inner().next().unwrap(), config),
@@ -52,12 +49,10 @@ impl<'sc> IncludeStatement<'sc> {
             }
         }
 
-        let file_path = file_path.expect("guaranteed to exist by grammar");
         let path_span = path_span.expect("guaranteed to exist by grammar");
         ok(
             IncludeStatement {
                 span,
-                file_path,
                 alias,
                 path_span,
             },

--- a/sway-core/src/parse_tree/include_statement.rs
+++ b/sway-core/src/parse_tree/include_statement.rs
@@ -34,10 +34,13 @@ impl IncludeStatement {
 
         for item in path_to_file_raw {
             if item.as_rule() == Rule::file_path {
-                path_span = Some(Span {
-                    span: item.as_span(),
-                    path: path.clone(),
-                }.trim());
+                path_span = Some(
+                    Span {
+                        span: item.as_span(),
+                        path: path.clone(),
+                    }
+                    .trim(),
+                );
             } else if item.as_rule() == Rule::alias {
                 let alias_parsed = check!(
                     Ident::parse_from_pair(item.into_inner().next().unwrap(), config),

--- a/sway-core/src/parse_tree/literal.rs
+++ b/sway-core/src/parse_tree/literal.rs
@@ -124,7 +124,12 @@ impl Literal {
                 // remove opening and closing quotes
                 let lit_span = lit_inner.as_span();
                 let lit = span::Span {
-                    span: pest::Span::new(lit_span.input().clone(), lit_span.start() + 1, lit_span.end() - 1).unwrap(),
+                    span: pest::Span::new(
+                        lit_span.input().clone(),
+                        lit_span.start() + 1,
+                        lit_span.end() - 1,
+                    )
+                    .unwrap(),
                     path: path.clone(),
                 };
                 let span = span::Span {

--- a/sway-core/src/parse_tree/literal.rs
+++ b/sway-core/src/parse_tree/literal.rs
@@ -25,7 +25,7 @@ pub enum Literal {
     B256([u8; 32]),
 }
 
-impl<'sc> Literal {
+impl Literal {
     #[allow(dead_code)]
     pub(crate) fn as_type(&self) -> ResolvedType {
         use Literal::*;

--- a/sway-core/src/parse_tree/literal.rs
+++ b/sway-core/src/parse_tree/literal.rs
@@ -129,7 +129,7 @@ impl<'sc> Literal {
                 };
                 let span = span::Span {
                     span: lit_span,
-                    path: path.clone(),
+                    path,
                 };
                 (Ok(Literal::String(lit)), span)
             }
@@ -137,7 +137,7 @@ impl<'sc> Literal {
                 let inner_byte = lit_inner.into_inner().next().unwrap();
                 let span = span::Span {
                     span: inner_byte.as_span(),
-                    path: path.clone(),
+                    path,
                 };
                 (
                     match inner_byte.as_rule() {
@@ -151,7 +151,7 @@ impl<'sc> Literal {
             Rule::boolean => {
                 let span = span::Span {
                     span: lit_inner.as_span(),
-                    path: path.clone(),
+                    path,
                 };
                 (
                     Ok(match lit_inner.as_str() {
@@ -178,7 +178,7 @@ impl<'sc> Literal {
                     )),
                     span::Span {
                         span: lit_inner.as_span(),
-                        path: path.clone(),
+                        path,
                     },
                 )
             }
@@ -236,7 +236,7 @@ impl<'sc> Literal {
     }
 }
 
-fn parse_hex_from_pair<'sc>(
+fn parse_hex_from_pair(
     pair: Pair<Rule>,
     config: Option<&BuildConfig>,
 ) -> Result<Literal, CompileError> {
@@ -298,7 +298,7 @@ fn parse_hex_from_pair<'sc>(
     })
 }
 
-fn parse_binary_from_pair<'sc>(
+fn parse_binary_from_pair(
     pair: Pair<Rule>,
     config: Option<&BuildConfig>,
 ) -> Result<Literal, CompileError> {

--- a/sway-core/src/parse_tree/return_statement.rs
+++ b/sway-core/src/parse_tree/return_statement.rs
@@ -10,7 +10,7 @@ pub struct ReturnStatement {
     pub expr: Expression,
 }
 
-impl<'sc> ReturnStatement {
+impl ReturnStatement {
     pub(crate) fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/return_statement.rs
+++ b/sway-core/src/parse_tree/return_statement.rs
@@ -6,15 +6,15 @@ use crate::{CompileResult, Expression};
 use pest::iterators::Pair;
 
 #[derive(Debug, Clone)]
-pub struct ReturnStatement<'sc> {
-    pub expr: Expression<'sc>,
+pub struct ReturnStatement {
+    pub expr: Expression,
 }
 
-impl<'sc> ReturnStatement<'sc> {
+impl<'sc> ReturnStatement {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let span = span::Span {
             span: pair.as_span(),
             path: config.map(|c| c.path()),

--- a/sway-core/src/parse_tree/use_statement.rs
+++ b/sway-core/src/parse_tree/use_statement.rs
@@ -6,27 +6,27 @@ use crate::Rule;
 use pest::iterators::Pair;
 
 #[derive(Debug, Clone)]
-pub enum ImportType<'sc> {
+pub enum ImportType {
     Star,
-    Item(Ident<'sc>),
+    Item(Ident),
 }
 
 /// A [UseStatement] is a statement that imports something from a module into the local namespace.
 #[derive(Debug, Clone)]
-pub struct UseStatement<'sc> {
-    pub(crate) call_path: Vec<Ident<'sc>>,
-    pub(crate) import_type: ImportType<'sc>,
+pub struct UseStatement {
+    pub(crate) call_path: Vec<Ident>,
+    pub(crate) import_type: ImportType,
     // If `is_absolute` is true, then this use statement is an absolute path from
     // the project root namespace. If not, then it is relative to the current namespace.
     pub(crate) is_absolute: bool,
-    pub(crate) alias: Option<Ident<'sc>>,
+    pub(crate) alias: Option<Ident>,
 }
 
-impl<'sc> UseStatement<'sc> {
+impl<'sc> UseStatement {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let mut errors = vec![];
         let mut warnings = vec![];
         let stmt = pair.into_inner().next().unwrap();

--- a/sway-core/src/parse_tree/use_statement.rs
+++ b/sway-core/src/parse_tree/use_statement.rs
@@ -22,7 +22,7 @@ pub struct UseStatement {
     pub(crate) alias: Option<Ident>,
 }
 
-impl<'sc> UseStatement {
+impl UseStatement {
     pub(crate) fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parse_tree/visibility.rs
+++ b/sway-core/src/parse_tree/visibility.rs
@@ -8,7 +8,7 @@ pub enum Visibility {
 }
 
 impl Visibility {
-    pub(crate) fn parse_from_pair(input: Pair<'_, Rule>) -> Self {
+    pub(crate) fn parse_from_pair(input: Pair<Rule>) -> Self {
         match input.as_str().trim() {
             "pub" => Visibility::Public,
             _ => Visibility::Private,

--- a/sway-core/src/parse_tree/while_loop.rs
+++ b/sway-core/src/parse_tree/while_loop.rs
@@ -9,16 +9,16 @@ use pest::iterators::Pair;
 
 /// A parsed while loop. Contains the `condition`, which is defined from an [Expression], and the `body` from a [CodeBlock].
 #[derive(Debug, Clone)]
-pub struct WhileLoop<'sc> {
-    pub(crate) condition: Expression<'sc>,
-    pub(crate) body: CodeBlock<'sc>,
+pub struct WhileLoop {
+    pub(crate) condition: Expression,
+    pub(crate) body: CodeBlock,
 }
 
-impl<'sc> WhileLoop<'sc> {
+impl<'sc> WhileLoop {
     pub(crate) fn parse_from_pair(
-        pair: Pair<'sc, Rule>,
+        pair: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();

--- a/sway-core/src/parse_tree/while_loop.rs
+++ b/sway-core/src/parse_tree/while_loop.rs
@@ -14,7 +14,7 @@ pub struct WhileLoop {
     pub(crate) body: CodeBlock,
 }
 
-impl<'sc> WhileLoop {
+impl WhileLoop {
     pub(crate) fn parse_from_pair(
         pair: Pair<Rule>,
         config: Option<&BuildConfig>,

--- a/sway-core/src/parser.rs
+++ b/sway-core/src/parser.rs
@@ -11,7 +11,7 @@ mod test {
     // basic sway-core tests
     #[test]
     fn test_var_decl() {
-        let parsed = HllParser::parse(Rule::var_decl, r#"let x = 2;"#);
+        let parsed = HllParser::parse(Rule::var_decl, r#"let x = 2;"#.into());
         if let Err(e) = parsed {
             panic!("{:#?}", e);
         }
@@ -24,7 +24,7 @@ mod test {
             r#"let x = 2; // and a comment
 
         /* and a multiline comment
-         * second line */"#,
+         * second line */"#.into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -40,7 +40,7 @@ mod test {
             let x = 5;
             let y = 10;
             return 10;
-        }"#,
+        }"#.into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -59,7 +59,7 @@ mod test {
                 else { 6 };
             let y = 10;
             return 10;
-        }"#,
+        }"#.into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -74,7 +74,7 @@ mod test {
             // a function body
             if true { /* comment */ 5 /*comment test*/ };
             /* some comments */
-        }"#,
+        }"#.into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -89,7 +89,7 @@ mod test {
             // a function body
             if ((true)) { /* comment */ (((5))) /*comment test*/ };
             /* some comments */
-        }"#,
+        }"#.into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -102,7 +102,7 @@ mod test {
             r#"fn myfunc(x: i32, y: i32) -> i32 {
             // a function body
             if ((true)) { /* comment */ (((5)) };
-        }"#,
+        }"#.into(),
         );
         // this parse should fail since parens are wrong
         match parsed {
@@ -119,7 +119,7 @@ mod test {
             Rule::fn_decl,
             r#"fn myfunc(x: i32, y: i32) -> i32 {
         let x = 5 + 10;
-        }"#,
+        }"#.into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -135,7 +135,7 @@ mod test {
         let foo = 20;
         let y = (x + foo) - x ;
         return y;
-        }"#,
+        }"#.into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -150,7 +150,7 @@ mod test {
         let foo = 20;
         let y = (x + foo + 3) - x ;
         return y;
-        }"#,
+        }"#.into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -163,7 +163,7 @@ mod test {
             r#"script;
                 trait MyTrait {
                     fn some_method_you_need_to_implement(x: i32) -> i32;
-            }"#,
+            }"#.into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -184,7 +184,7 @@ mod test {
                 }
                 }
 
-            "#,
+            "#.into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -195,7 +195,7 @@ mod test {
         let parsed = HllParser::parse(
             Rule::use_statement,
             r#"use otherlibrary::packagename;
-            "#,
+            "#.into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -213,7 +213,7 @@ mod test {
                 return x;
                 
             }
-            "#,
+            "#.into(),
         );
         // this parse should fail since parens are wrong
         if let Err(e) = parsed {
@@ -230,7 +230,7 @@ mod test {
                     let x = 0b01011010;
                     let y = 0xAF;
                     return 0;
-            }"#,
+            }"#.into(),
         );
         // this parse should fail since parens are wrong
         match parsed {
@@ -252,7 +252,7 @@ mod test {
                     let y = 0xAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAF;
                     return x;
                 }
-            "#,
+            "#.into(),
         );
         // this parse should fail since parens are wrong
         match parsed {
@@ -283,7 +283,7 @@ mod test {
                     let y = 0xAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAF;
                     return x;
                 }
-            "#,
+            "#.into(),
         );
         match parsed {
             Err(_) => {
@@ -302,7 +302,7 @@ mod test {
             let x = 5;
             let y = 10;
             return 10;
-        }"#,
+        }"#.into(),
         );
         match parsed {
             Err(e) => {

--- a/sway-core/src/parser.rs
+++ b/sway-core/src/parser.rs
@@ -233,12 +233,7 @@ mod test {
             }"#.into(),
         );
         // this parse should fail since parens are wrong
-        match parsed {
-            Err(e) => {
-                panic!("{:#?}", e);
-            }
-            Ok(_) => (),
-        }
+        parsed.unwrap();
     }
     #[test]
     fn bytes_literals() {
@@ -255,12 +250,7 @@ mod test {
             "#.into(),
         );
         // this parse should fail since parens are wrong
-        match parsed {
-            Err(e) => {
-                panic!("{:#?}", e);
-            }
-            Ok(_) => (),
-        }
+        parsed.unwrap();
     }
 
     #[test]
@@ -285,12 +275,7 @@ mod test {
                 }
             "#.into(),
         );
-        match parsed {
-            Err(_) => {
-                panic!()
-            }
-            Ok(_) => (),
-        }
+        parsed.unwrap();
     }
 
     #[test]
@@ -304,11 +289,6 @@ mod test {
             return 10;
         }"#.into(),
         );
-        match parsed {
-            Err(e) => {
-                panic!("{:#?}", e);
-            }
-            Ok(_) => {}
-        }
+        parsed.unwrap();
     }
 }

--- a/sway-core/src/parser.rs
+++ b/sway-core/src/parser.rs
@@ -24,7 +24,8 @@ mod test {
             r#"let x = 2; // and a comment
 
         /* and a multiline comment
-         * second line */"#.into(),
+         * second line */"#
+                .into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -40,7 +41,8 @@ mod test {
             let x = 5;
             let y = 10;
             return 10;
-        }"#.into(),
+        }"#
+            .into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -59,7 +61,8 @@ mod test {
                 else { 6 };
             let y = 10;
             return 10;
-        }"#.into(),
+        }"#
+            .into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -74,7 +77,8 @@ mod test {
             // a function body
             if true { /* comment */ 5 /*comment test*/ };
             /* some comments */
-        }"#.into(),
+        }"#
+            .into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -89,7 +93,8 @@ mod test {
             // a function body
             if ((true)) { /* comment */ (((5))) /*comment test*/ };
             /* some comments */
-        }"#.into(),
+        }"#
+            .into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -102,7 +107,8 @@ mod test {
             r#"fn myfunc(x: i32, y: i32) -> i32 {
             // a function body
             if ((true)) { /* comment */ (((5)) };
-        }"#.into(),
+        }"#
+            .into(),
         );
         // this parse should fail since parens are wrong
         match parsed {
@@ -119,7 +125,8 @@ mod test {
             Rule::fn_decl,
             r#"fn myfunc(x: i32, y: i32) -> i32 {
         let x = 5 + 10;
-        }"#.into(),
+        }"#
+            .into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -135,7 +142,8 @@ mod test {
         let foo = 20;
         let y = (x + foo) - x ;
         return y;
-        }"#.into(),
+        }"#
+            .into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -150,7 +158,8 @@ mod test {
         let foo = 20;
         let y = (x + foo + 3) - x ;
         return y;
-        }"#.into(),
+        }"#
+            .into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -163,7 +172,8 @@ mod test {
             r#"script;
                 trait MyTrait {
                     fn some_method_you_need_to_implement(x: i32) -> i32;
-            }"#.into(),
+            }"#
+            .into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -184,7 +194,8 @@ mod test {
                 }
                 }
 
-            "#.into(),
+            "#
+            .into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -195,7 +206,8 @@ mod test {
         let parsed = HllParser::parse(
             Rule::use_statement,
             r#"use otherlibrary::packagename;
-            "#.into(),
+            "#
+            .into(),
         );
         if let Err(e) = parsed {
             panic!("{:#?}", e);
@@ -213,7 +225,8 @@ mod test {
                 return x;
                 
             }
-            "#.into(),
+            "#
+            .into(),
         );
         // this parse should fail since parens are wrong
         if let Err(e) = parsed {
@@ -230,7 +243,8 @@ mod test {
                     let x = 0b01011010;
                     let y = 0xAF;
                     return 0;
-            }"#.into(),
+            }"#
+            .into(),
         );
         // this parse should fail since parens are wrong
         parsed.unwrap();
@@ -247,7 +261,8 @@ mod test {
                     let y = 0xAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAF;
                     return x;
                 }
-            "#.into(),
+            "#
+            .into(),
         );
         // this parse should fail since parens are wrong
         parsed.unwrap();
@@ -273,7 +288,8 @@ mod test {
                     let y = 0xAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAF;
                     return x;
                 }
-            "#.into(),
+            "#
+            .into(),
         );
         parsed.unwrap();
     }
@@ -287,7 +303,8 @@ mod test {
             let x = 5;
             let y = 10;
             return 10;
-        }"#.into(),
+        }"#
+            .into(),
         );
         parsed.unwrap();
     }

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -9,7 +9,7 @@ pub(crate) struct TypedCodeBlock {
 }
 
 #[allow(clippy::too_many_arguments)]
-impl<'sc> TypedCodeBlock {
+impl TypedCodeBlock {
     pub(crate) fn type_check(
         arguments: TypeCheckArguments<'_, CodeBlock>,
     ) -> CompileResult<(Self, TypeId)> {

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -82,8 +82,7 @@ impl TypedCodeBlock {
                 return_type,
                 type_annotation,
                 self_type,
-                &implicit_return_span
-                    .unwrap_or_else(|| other.whole_block_span.clone()),
+                &implicit_return_span.unwrap_or_else(|| other.whole_block_span.clone()),
             ) {
                 Ok(mut ws) => {
                     warnings.append(&mut ws);

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -10,8 +10,8 @@ pub(crate) struct TypedCodeBlock {
 
 #[allow(clippy::too_many_arguments)]
 impl<'sc> TypedCodeBlock {
-    pub(crate) fn type_check<'n>(
-        arguments: TypeCheckArguments<'n, CodeBlock>,
+    pub(crate) fn type_check(
+        arguments: TypeCheckArguments<'_, CodeBlock>,
     ) -> CompileResult<(Self, TypeId)> {
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
@@ -83,7 +83,6 @@ impl<'sc> TypedCodeBlock {
                 type_annotation,
                 self_type,
                 &implicit_return_span
-                    .clone()
                     .unwrap_or_else(|| other.whole_block_span.clone()),
             ) {
                 Ok(mut ws) => {

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -3,16 +3,16 @@ use crate::semantic_analysis::{ast_node::Mode, TypeCheckArguments};
 use crate::CodeBlock;
 
 #[derive(Clone, Debug)]
-pub(crate) struct TypedCodeBlock<'sc> {
-    pub(crate) contents: Vec<TypedAstNode<'sc>>,
-    pub(crate) whole_block_span: Span<'sc>,
+pub(crate) struct TypedCodeBlock {
+    pub(crate) contents: Vec<TypedAstNode>,
+    pub(crate) whole_block_span: Span,
 }
 
 #[allow(clippy::too_many_arguments)]
-impl<'sc> TypedCodeBlock<'sc> {
+impl<'sc> TypedCodeBlock {
     pub(crate) fn type_check<'n>(
-        arguments: TypeCheckArguments<'n, 'sc, CodeBlock<'sc>>,
-    ) -> CompileResult<'sc, (Self, TypeId)> {
+        arguments: TypeCheckArguments<'n, CodeBlock>,
+    ) -> CompileResult<(Self, TypeId)> {
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
 
@@ -52,7 +52,7 @@ impl<'sc> TypedCodeBlock<'sc> {
                 })
                 .ok(&mut warnings, &mut errors)
             })
-            .collect::<Vec<TypedAstNode<'sc>>>();
+            .collect::<Vec<TypedAstNode>>();
 
         let implicit_return_span = other
             .contents

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -157,11 +157,7 @@ impl TypedDeclaration {
                     is_mutable,
                     name,
                     ..
-                }) => format!(
-                    "{} {}",
-                    if *is_mutable { "mut" } else { "" },
-                    name.as_str()
-                ),
+                }) => format!("{} {}", if *is_mutable { "mut" } else { "" }, name.as_str()),
                 TypedDeclaration::FunctionDeclaration(TypedFunctionDeclaration {
                     name, ..
                 }) => {
@@ -263,9 +259,7 @@ impl OwnedTypedStructField {
 
     pub(crate) fn as_typed_struct_field(&self, span: &Span) -> TypedStructField {
         TypedStructField {
-            name: Ident::new(
-                span.clone(),
-            ),
+            name: Ident::new(span.clone()),
             r#type: self.r#type,
             span: span.clone(),
         }

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -264,7 +264,6 @@ impl OwnedTypedStructField {
     pub(crate) fn as_typed_struct_field<'sc>(&self, span: &Span<'sc>) -> TypedStructField<'sc> {
         TypedStructField {
             name: Ident::new(
-                Box::leak(span.clone().as_str().to_string().into_boxed_str()),
                 span.clone(),
             ),
             r#type: self.r#type,

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -98,7 +98,7 @@ impl<'sc> TypedDeclaration<'sc> {
                     fields,
                     ..
                 }) => crate::type_engine::insert_type(TypeInfo::Struct {
-                    name: name.primary_name().to_string(),
+                    name: name.as_str().to_string(),
                     fields: fields
                         .iter()
                         .map(TypedStructField::as_owned_typed_struct_field)
@@ -107,7 +107,7 @@ impl<'sc> TypedDeclaration<'sc> {
                 TypedDeclaration::Reassignment(TypedReassignment { rhs, .. }) => rhs.return_type,
                 TypedDeclaration::GenericTypeForFunctionScope { name } => {
                     insert_type(TypeInfo::UnknownGeneric {
-                        name: name.primary_name().to_string(),
+                        name: name.as_str().to_string(),
                     })
                 }
                 decl => {
@@ -160,22 +160,22 @@ impl<'sc> TypedDeclaration<'sc> {
                 }) => format!(
                     "{} {}",
                     if *is_mutable { "mut" } else { "" },
-                    name.primary_name()
+                    name.as_str()
                 ),
                 TypedDeclaration::FunctionDeclaration(TypedFunctionDeclaration {
                     name, ..
                 }) => {
-                    name.primary_name().into()
+                    name.as_str().into()
                 }
                 TypedDeclaration::TraitDeclaration(TypedTraitDeclaration { name, .. }) =>
-                    name.primary_name().into(),
+                    name.as_str().into(),
                 TypedDeclaration::StructDeclaration(TypedStructDeclaration { name, .. }) =>
-                    name.primary_name().into(),
+                    name.as_str().into(),
                 TypedDeclaration::EnumDeclaration(TypedEnumDeclaration { name, .. }) =>
-                    name.primary_name().into(),
+                    name.as_str().into(),
                 TypedDeclaration::Reassignment(TypedReassignment { lhs, .. }) => lhs
                     .iter()
-                    .map(|x| x.name.primary_name())
+                    .map(|x| x.name.as_str())
                     .collect::<Vec<_>>()
                     .join("."),
                 _ => String::new(),
@@ -292,7 +292,7 @@ impl TypedStructField<'_> {
     }
     pub(crate) fn as_owned_typed_struct_field(&self) -> OwnedTypedStructField {
         OwnedTypedStructField {
-            name: self.name.primary_name().to_string(),
+            name: self.name.as_str().to_string(),
             r#type: self.r#type,
         }
     }
@@ -321,7 +321,7 @@ impl TypedEnumDeclaration<'_> {
     /// Returns the [ResolvedType] corresponding to this enum's type.
     pub(crate) fn as_type(&self) -> TypeId {
         crate::type_engine::insert_type(TypeInfo::Enum {
-            name: self.name.primary_name().to_string(),
+            name: self.name.as_str().to_string(),
             variant_types: self
                 .variants
                 .iter()
@@ -350,7 +350,7 @@ impl TypedEnumVariant<'_> {
     }
     pub(crate) fn as_owned_typed_enum_variant(&self) -> OwnedTypedEnumVariant {
         OwnedTypedEnumVariant {
-            name: self.name.primary_name().to_string(),
+            name: self.name.as_str().to_string(),
             r#type: self.r#type,
             tag: self.tag,
         }

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -261,7 +261,7 @@ impl OwnedTypedStructField {
         };
     }
 
-    pub(crate) fn as_typed_struct_field<'sc>(&self, span: &Span) -> TypedStructField {
+    pub(crate) fn as_typed_struct_field(&self, span: &Span) -> TypedStructField {
         TypedStructField {
             name: Ident::new(
                 span.clone(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -60,7 +60,7 @@ impl TypedDeclaration {
     }
 }
 
-impl<'sc> TypedDeclaration {
+impl TypedDeclaration {
     /// friendly name string used for error reporting.
     pub(crate) fn friendly_name(&self) -> &'static str {
         use TypedDeclaration::*;
@@ -221,7 +221,7 @@ pub struct TypedStructDeclaration {
     pub(crate) visibility: Visibility,
 }
 
-impl<'sc> TypedStructDeclaration {
+impl TypedStructDeclaration {
     pub(crate) fn monomorphize(&self) -> Self {
         let mut new_decl = self.clone();
         let type_mapping = insert_type_parameters(&self.type_parameters);
@@ -423,7 +423,7 @@ pub struct ReassignmentLhs {
     pub(crate) r#type: TypeId,
 }
 
-impl<'sc> ReassignmentLhs {
+impl ReassignmentLhs {
     pub(crate) fn span(&self) -> Span {
         self.name.span().clone()
     }
@@ -454,7 +454,7 @@ impl TypedReassignment {
     }
 }
 
-impl<'sc> TypedTraitFn {
+impl TypedTraitFn {
     pub(crate) fn copy_types(&mut self, type_mapping: &[(TypeParameter, TypeId)]) {
         self.return_type = if let Some(matching_id) =
             look_up_type_id(self.return_type).matches_type_parameter(type_mapping)

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -33,7 +33,7 @@ pub struct TypedFunctionDeclaration {
     pub(crate) purity: Purity,
 }
 
-impl<'sc> TypedFunctionDeclaration {
+impl TypedFunctionDeclaration {
     pub fn type_check(
         arguments: TypeCheckArguments<'_, FunctionDeclaration>,
     ) -> CompileResult<TypedFunctionDeclaration> {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -111,7 +111,7 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
                         expression: TypedExpressionVariant::FunctionParameter,
                         return_type: r#type,
                         is_constant: IsConstant::No,
-                        span: name.span.clone(),
+                        span: name.span().clone(),
                     },
                     is_mutable: false, // TODO allow mutable function params?
                     type_ascription: r#type,
@@ -244,7 +244,7 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
                     span: parameters
                         .get(0)
                         .map(|x| x.type_span.clone())
-                        .unwrap_or_else(|| fn_decl.name.span.clone()),
+                        .unwrap_or_else(|| fn_decl.name.span().clone()),
                 });
             }
         }
@@ -353,13 +353,13 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
     pub(crate) fn parameters_span(&self) -> Span<'sc> {
         if !self.parameters.is_empty() {
             self.parameters.iter().fold(
-                self.parameters[0].name.span.clone(),
+                self.parameters[0].name.span().clone(),
                 |acc, TypedFunctionParameter { type_span, .. }| {
                     crate::utils::join_spans(acc, type_span.clone())
                 },
             )
         } else {
-            self.name.span.clone()
+            self.name.span().clone()
         }
     }
     pub(crate) fn replace_self_types(self, self_type: TypeId) -> Self {
@@ -437,7 +437,7 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
             .collect::<Vec<String>>();
 
         ok(
-            format!("{}({})", self.name.primary_name, named_params.join(","),),
+            format!("{}({})", self.name.primary_name(), named_params.join(","),),
             warnings,
             errors,
         )
@@ -445,13 +445,13 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
 
     pub fn generate_json_abi(&self) -> Function {
         Function {
-            name: self.name.primary_name.to_string(),
+            name: self.name.primary_name().to_string(),
             type_field: "function".to_string(),
             inputs: self
                 .parameters
                 .iter()
                 .map(|x| Property {
-                    name: x.name.primary_name.to_string(),
+                    name: x.name.primary_name().to_string(),
                     type_field: x.r#type.json_abi_str(),
                     components: x.r#type.generate_json_abi(),
                 })
@@ -470,13 +470,13 @@ fn test_function_selector_behavior() {
     use crate::type_engine::IntegerBits;
     let decl = TypedFunctionDeclaration {
         purity: Default::default(),
-        name: Ident {
-            primary_name: "foo",
-            span: Span {
+        name: Ident::new(
+            "foo",
+            Span {
                 span: pest::Span::new(" ", 0, 0).unwrap(),
                 path: None,
             },
-        },
+        ),
         body: TypedCodeBlock {
             contents: vec![],
             whole_block_span: Span {
@@ -508,13 +508,13 @@ fn test_function_selector_behavior() {
 
     let decl = TypedFunctionDeclaration {
         purity: Default::default(),
-        name: Ident {
-            primary_name: "bar",
-            span: Span {
+        name: Ident::new(
+            "bar",
+            Span {
                 span: pest::Span::new(" ", 0, 0).unwrap(),
                 path: None,
             },
-        },
+        ),
         body: TypedCodeBlock {
             contents: vec![],
             whole_block_span: Span {
@@ -524,13 +524,13 @@ fn test_function_selector_behavior() {
         },
         parameters: vec![
             TypedFunctionParameter {
-                name: Ident {
-                    primary_name: "foo",
-                    span: Span {
+                name: Ident::new(
+                    "foo",
+                    Span {
                         span: pest::Span::new(" ", 0, 0).unwrap(),
                         path: None,
                     },
-                },
+                ),
                 r#type: crate::type_engine::insert_type(TypeInfo::Str(5)),
                 type_span: Span {
                     span: pest::Span::new(" ", 0, 0).unwrap(),
@@ -538,13 +538,13 @@ fn test_function_selector_behavior() {
                 },
             },
             TypedFunctionParameter {
-                name: Ident {
-                    primary_name: "baz",
-                    span: Span {
+                name: Ident::new(
+                    "baz",
+                    Span {
                         span: pest::Span::new(" ", 0, 0).unwrap(),
                         path: None,
                     },
-                },
+                ),
                 r#type: insert_type(TypeInfo::UnsignedInteger(IntegerBits::ThirtyTwo)),
                 type_span: Span {
                     span: pest::Span::new(" ", 0, 0).unwrap(),
@@ -584,7 +584,7 @@ pub(crate) fn insert_type_parameters<'sc>(
             (
                 x.clone(),
                 insert_type(TypeInfo::UnknownGeneric {
-                    name: x.name_ident.primary_name.to_string(),
+                    name: x.name_ident.primary_name().to_string(),
                 }),
             )
         })

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -470,7 +470,7 @@ fn test_function_selector_behavior() {
     use crate::type_engine::IntegerBits;
     let decl = TypedFunctionDeclaration {
         purity: Default::default(),
-        name: Ident::new(
+        name: Ident::new_with_override(
             "foo",
             Span {
                 span: pest::Span::new(" ", 0, 0).unwrap(),
@@ -508,7 +508,7 @@ fn test_function_selector_behavior() {
 
     let decl = TypedFunctionDeclaration {
         purity: Default::default(),
-        name: Ident::new(
+        name: Ident::new_with_override(
             "bar",
             Span {
                 span: pest::Span::new(" ", 0, 0).unwrap(),
@@ -524,7 +524,7 @@ fn test_function_selector_behavior() {
         },
         parameters: vec![
             TypedFunctionParameter {
-                name: Ident::new(
+                name: Ident::new_with_override(
                     "foo",
                     Span {
                         span: pest::Span::new(" ", 0, 0).unwrap(),
@@ -538,7 +538,7 @@ fn test_function_selector_behavior() {
                 },
             },
             TypedFunctionParameter {
-                name: Ident::new(
+                name: Ident::new_with_override(
                     "baz",
                     Span {
                         span: pest::Span::new(" ", 0, 0).unwrap(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -437,7 +437,7 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
             .collect::<Vec<String>>();
 
         ok(
-            format!("{}({})", self.name.primary_name(), named_params.join(","),),
+            format!("{}({})", self.name.as_str(), named_params.join(","),),
             warnings,
             errors,
         )
@@ -445,13 +445,13 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
 
     pub fn generate_json_abi(&self) -> Function {
         Function {
-            name: self.name.primary_name().to_string(),
+            name: self.name.as_str().to_string(),
             type_field: "function".to_string(),
             inputs: self
                 .parameters
                 .iter()
                 .map(|x| Property {
-                    name: x.name.primary_name().to_string(),
+                    name: x.name.as_str().to_string(),
                     type_field: x.r#type.json_abi_str(),
                     components: x.r#type.generate_json_abi(),
                 })
@@ -584,7 +584,7 @@ pub(crate) fn insert_type_parameters<'sc>(
             (
                 x.clone(),
                 insert_type(TypeInfo::UnknownGeneric {
-                    name: x.name_ident.primary_name().to_string(),
+                    name: x.name_ident.as_str().to_string(),
                 }),
             )
         })

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -17,26 +17,26 @@ mod function_parameter;
 pub use function_parameter::*;
 
 #[derive(Clone, Debug)]
-pub struct TypedFunctionDeclaration<'sc> {
-    pub(crate) name: Ident<'sc>,
-    pub(crate) body: TypedCodeBlock<'sc>,
-    pub(crate) parameters: Vec<TypedFunctionParameter<'sc>>,
-    pub(crate) span: Span<'sc>,
+pub struct TypedFunctionDeclaration {
+    pub(crate) name: Ident,
+    pub(crate) body: TypedCodeBlock,
+    pub(crate) parameters: Vec<TypedFunctionParameter>,
+    pub(crate) span: Span,
     pub(crate) return_type: TypeId,
-    pub(crate) type_parameters: Vec<TypeParameter<'sc>>,
+    pub(crate) type_parameters: Vec<TypeParameter>,
     /// Used for error messages -- the span pointing to the return type
     /// annotation of the function
-    pub(crate) return_type_span: Span<'sc>,
+    pub(crate) return_type_span: Span,
     pub(crate) visibility: Visibility,
     /// whether this function exists in another contract and requires a call to it or not
     pub(crate) is_contract_call: bool,
     pub(crate) purity: Purity,
 }
 
-impl<'sc> TypedFunctionDeclaration<'sc> {
+impl<'sc> TypedFunctionDeclaration {
     pub fn type_check<'n>(
-        arguments: TypeCheckArguments<'n, 'sc, FunctionDeclaration<'sc>>,
-    ) -> CompileResult<'sc, TypedFunctionDeclaration<'sc>> {
+        arguments: TypeCheckArguments<'n, FunctionDeclaration>,
+    ) -> CompileResult<TypedFunctionDeclaration> {
         let TypeCheckArguments {
             checkee: fn_decl,
             namespace,
@@ -174,7 +174,7 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
             )
             .collect::<Vec<_>>();
         // handle the return statement(s)
-        let return_statements: Vec<(&TypedExpression, &Span<'sc>)> = body
+        let return_statements: Vec<(&TypedExpression, &Span)> = body
             .contents
             .iter()
             .filter_map(|x| {
@@ -287,9 +287,9 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
     /// generic type info.
     pub(crate) fn monomorphize(
         &self,
-        type_arguments: Vec<(TypeInfo, Span<'sc>)>,
+        type_arguments: Vec<(TypeInfo, Span)>,
         self_type: TypeId,
-    ) -> CompileResult<'sc, TypedFunctionDeclaration<'sc>> {
+    ) -> CompileResult<TypedFunctionDeclaration> {
         let mut warnings: Vec<CompileWarning> = vec![];
         let mut errors: Vec<CompileError> = vec![];
         debug_assert!(
@@ -350,7 +350,7 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
         ok(new_decl, warnings, errors)
     }
     /// If there are parameters, join their spans. Otherwise, use the fn name span.
-    pub(crate) fn parameters_span(&self) -> Span<'sc> {
+    pub(crate) fn parameters_span(&self) -> Span {
         if !self.parameters.is_empty() {
             self.parameters.iter().fold(
                 self.parameters[0].name.span().clone(),
@@ -386,7 +386,7 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
             ..self
         }
     }
-    pub fn to_fn_selector_value_untruncated(&self) -> CompileResult<'sc, Vec<u8>> {
+    pub fn to_fn_selector_value_untruncated(&self) -> CompileResult<Vec<u8>> {
         let mut errors = vec![];
         let mut warnings = vec![];
         let mut hasher = Sha256::new();
@@ -403,7 +403,7 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
     /// Converts a [TypedFunctionDeclaration] into a value that is to be used in contract function
     /// selectors.
     /// Hashes the name and parameters using SHA256, and then truncates to four bytes.
-    pub fn to_fn_selector_value(&self) -> CompileResult<'sc, [u8; 4]> {
+    pub fn to_fn_selector_value(&self) -> CompileResult<[u8; 4]> {
         let mut errors = vec![];
         let mut warnings = vec![];
         let hash = check!(
@@ -418,7 +418,7 @@ impl<'sc> TypedFunctionDeclaration<'sc> {
         ok(buf, warnings, errors)
     }
 
-    pub fn to_selector_name(&self) -> CompileResult<'sc, String> {
+    pub fn to_selector_name(&self) -> CompileResult<String> {
         let mut errors = vec![];
         let mut warnings = vec![];
         let named_params = self
@@ -473,26 +473,26 @@ fn test_function_selector_behavior() {
         name: Ident::new_with_override(
             "foo",
             Span {
-                span: pest::Span::new(" ", 0, 0).unwrap(),
+                span: pest::Span::new(" ".into(), 0, 0).unwrap(),
                 path: None,
             },
         ),
         body: TypedCodeBlock {
             contents: vec![],
             whole_block_span: Span {
-                span: pest::Span::new(" ", 0, 0).unwrap(),
+                span: pest::Span::new(" ".into(), 0, 0).unwrap(),
                 path: None,
             },
         },
         parameters: vec![],
         span: Span {
-            span: pest::Span::new(" ", 0, 0).unwrap(),
+            span: pest::Span::new(" ".into(), 0, 0).unwrap(),
             path: None,
         },
         return_type: 0,
         type_parameters: vec![],
         return_type_span: Span {
-            span: pest::Span::new(" ", 0, 0).unwrap(),
+            span: pest::Span::new(" ".into(), 0, 0).unwrap(),
             path: None,
         },
         visibility: Visibility::Public,
@@ -511,14 +511,14 @@ fn test_function_selector_behavior() {
         name: Ident::new_with_override(
             "bar",
             Span {
-                span: pest::Span::new(" ", 0, 0).unwrap(),
+                span: pest::Span::new(" ".into(), 0, 0).unwrap(),
                 path: None,
             },
         ),
         body: TypedCodeBlock {
             contents: vec![],
             whole_block_span: Span {
-                span: pest::Span::new(" ", 0, 0).unwrap(),
+                span: pest::Span::new(" ".into(), 0, 0).unwrap(),
                 path: None,
             },
         },
@@ -527,13 +527,13 @@ fn test_function_selector_behavior() {
                 name: Ident::new_with_override(
                     "foo",
                     Span {
-                        span: pest::Span::new(" ", 0, 0).unwrap(),
+                        span: pest::Span::new(" ".into(), 0, 0).unwrap(),
                         path: None,
                     },
                 ),
                 r#type: crate::type_engine::insert_type(TypeInfo::Str(5)),
                 type_span: Span {
-                    span: pest::Span::new(" ", 0, 0).unwrap(),
+                    span: pest::Span::new(" ".into(), 0, 0).unwrap(),
                     path: None,
                 },
             },
@@ -541,25 +541,25 @@ fn test_function_selector_behavior() {
                 name: Ident::new_with_override(
                     "baz",
                     Span {
-                        span: pest::Span::new(" ", 0, 0).unwrap(),
+                        span: pest::Span::new(" ".into(), 0, 0).unwrap(),
                         path: None,
                     },
                 ),
                 r#type: insert_type(TypeInfo::UnsignedInteger(IntegerBits::ThirtyTwo)),
                 type_span: Span {
-                    span: pest::Span::new(" ", 0, 0).unwrap(),
+                    span: pest::Span::new(" ".into(), 0, 0).unwrap(),
                     path: None,
                 },
             },
         ],
         span: Span {
-            span: pest::Span::new(" ", 0, 0).unwrap(),
+            span: pest::Span::new(" ".into(), 0, 0).unwrap(),
             path: None,
         },
         return_type: 0,
         type_parameters: vec![],
         return_type_span: Span {
-            span: pest::Span::new(" ", 0, 0).unwrap(),
+            span: pest::Span::new(" ".into(), 0, 0).unwrap(),
             path: None,
         },
         visibility: Visibility::Public,
@@ -576,8 +576,8 @@ fn test_function_selector_behavior() {
 /// Insert all type parameters as unknown types. Return a mapping of type parameter to
 /// [TypeId]
 pub(crate) fn insert_type_parameters<'sc>(
-    params: &[TypeParameter<'sc>],
-) -> Vec<(TypeParameter<'sc>, TypeId)> {
+    params: &[TypeParameter],
+) -> Vec<(TypeParameter, TypeId)> {
     params
         .iter()
         .map(|x| {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -575,9 +575,7 @@ fn test_function_selector_behavior() {
 }
 /// Insert all type parameters as unknown types. Return a mapping of type parameter to
 /// [TypeId]
-pub(crate) fn insert_type_parameters(
-    params: &[TypeParameter],
-) -> Vec<(TypeParameter, TypeId)> {
+pub(crate) fn insert_type_parameters(params: &[TypeParameter]) -> Vec<(TypeParameter, TypeId)> {
     params
         .iter()
         .map(|x| {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -34,8 +34,8 @@ pub struct TypedFunctionDeclaration {
 }
 
 impl<'sc> TypedFunctionDeclaration {
-    pub fn type_check<'n>(
-        arguments: TypeCheckArguments<'n, FunctionDeclaration>,
+    pub fn type_check(
+        arguments: TypeCheckArguments<'_, FunctionDeclaration>,
     ) -> CompileResult<TypedFunctionDeclaration> {
         let TypeCheckArguments {
             checkee: fn_decl,
@@ -139,7 +139,7 @@ impl<'sc> TypedFunctionDeclaration {
             (
                 TypedCodeBlock {
                     contents: vec![],
-                    whole_block_span: body.whole_block_span.clone()
+                    whole_block_span: body.whole_block_span,
                 },
                 crate::type_engine::insert_type(TypeInfo::ErrorRecovery)
             ),
@@ -254,7 +254,7 @@ impl<'sc> TypedFunctionDeclaration {
                 name,
                 body,
                 parameters,
-                span: span.clone(),
+                span,
                 return_type,
                 type_parameters,
                 return_type_span,
@@ -575,7 +575,7 @@ fn test_function_selector_behavior() {
 }
 /// Insert all type parameters as unknown types. Return a mapping of type parameter to
 /// [TypeId]
-pub(crate) fn insert_type_parameters<'sc>(
+pub(crate) fn insert_type_parameters(
     params: &[TypeParameter],
 ) -> Vec<(TypeParameter, TypeId)> {
     params

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
@@ -5,13 +5,13 @@ use crate::Ident;
 use crate::TypeParameter;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TypedFunctionParameter<'sc> {
-    pub(crate) name: Ident<'sc>,
+pub struct TypedFunctionParameter {
+    pub(crate) name: Ident,
     pub(crate) r#type: TypeId,
-    pub(crate) type_span: Span<'sc>,
+    pub(crate) type_span: Span,
 }
 
-impl TypedFunctionParameter<'_> {
+impl TypedFunctionParameter {
     pub(crate) fn copy_types(&mut self, type_mapping: &[(TypeParameter, TypeId)]) {
         self.r#type = if let Some(matching_id) =
             look_up_type_id(self.r#type).matches_type_parameter(type_mapping)

--- a/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
@@ -4,14 +4,14 @@ use crate::Ident;
 use crate::{type_engine::TypeId, TypeParameter};
 
 #[derive(Clone, Debug)]
-pub struct TypedVariableDeclaration<'sc> {
-    pub(crate) name: Ident<'sc>,
-    pub(crate) body: TypedExpression<'sc>, // will be codeblock variant
+pub struct TypedVariableDeclaration {
+    pub(crate) name: Ident,
+    pub(crate) body: TypedExpression, // will be codeblock variant
     pub(crate) is_mutable: bool,
     pub(crate) type_ascription: TypeId,
 }
 
-impl<'sc> TypedVariableDeclaration<'sc> {
+impl TypedVariableDeclaration {
     pub(crate) fn copy_types(&mut self, type_mapping: &[(TypeParameter, TypeId)]) {
         if let Some(matching_id) =
             look_up_type_id(self.type_ascription).matches_type_parameter(type_mapping)

--- a/sway-core/src/semantic_analysis/ast_node/expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/enum_instantiation.rs
@@ -37,8 +37,8 @@ pub(crate) fn instantiate_enum<'n, 'sc>(
         Some(o) => (o.r#type, o.tag, o.name.clone()),
         None => {
             errors.push(CompileError::UnknownEnumVariant {
-                enum_name: enum_decl.name.as_str(),
-                variant_name: enum_field_name.as_str(),
+                enum_name: enum_decl.name.clone(),
+                variant_name: enum_field_name.clone(),
                 span: enum_field_name.span().clone(),
             });
             return err(warnings, errors);

--- a/sway-core/src/semantic_analysis/ast_node/expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/enum_instantiation.rs
@@ -32,13 +32,13 @@ pub(crate) fn instantiate_enum<'n, 'sc>(
     let (enum_field_type, tag, variant_name) = match enum_decl
         .variants
         .iter()
-        .find(|x| x.name.primary_name() == enum_field_name.primary_name())
+        .find(|x| x.name.as_str() == enum_field_name.as_str())
     {
         Some(o) => (o.r#type, o.tag, o.name.clone()),
         None => {
             errors.push(CompileError::UnknownEnumVariant {
-                enum_name: enum_decl.name.primary_name(),
-                variant_name: enum_field_name.primary_name(),
+                enum_name: enum_decl.name.as_str(),
+                variant_name: enum_field_name.as_str(),
                 span: enum_field_name.span().clone(),
             });
             return err(warnings, errors);

--- a/sway-core/src/semantic_analysis/ast_node/expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/enum_instantiation.rs
@@ -8,17 +8,17 @@ use crate::type_engine::{look_up_type_id, TypeId};
 /// [TypedExpression].
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn instantiate_enum<'n, 'sc>(
-    enum_decl: TypedEnumDeclaration<'sc>,
-    enum_field_name: Ident<'sc>,
-    args: Vec<Expression<'sc>>,
-    namespace: &mut Namespace<'sc>,
-    crate_namespace: Option<&'n Namespace<'sc>>,
+    enum_decl: TypedEnumDeclaration,
+    enum_field_name: Ident,
+    args: Vec<Expression>,
+    namespace: &mut Namespace,
+    crate_namespace: Option<&'n Namespace>,
     self_type: TypeId,
     build_config: &BuildConfig,
-    dead_code_graph: &mut ControlFlowGraph<'sc>,
+    dead_code_graph: &mut ControlFlowGraph,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
     opts: TCOpts,
-) -> CompileResult<'sc, TypedExpression<'sc>> {
+) -> CompileResult<TypedExpression> {
     let mut warnings = vec![];
     let mut errors = vec![];
     // if this is a generic enum, i.e. it has some type

--- a/sway-core/src/semantic_analysis/ast_node/expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/enum_instantiation.rs
@@ -7,7 +7,7 @@ use crate::type_engine::{look_up_type_id, TypeId};
 /// Given an enum declaration and the instantiation expression/type arguments, construct a valid
 /// [TypedExpression].
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn instantiate_enum<'n, 'sc>(
+pub(crate) fn instantiate_enum<'n>(
     enum_decl: TypedEnumDeclaration,
     enum_field_name: Ident,
     args: Vec<Expression>,

--- a/sway-core/src/semantic_analysis/ast_node/expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/enum_instantiation.rs
@@ -32,14 +32,14 @@ pub(crate) fn instantiate_enum<'n, 'sc>(
     let (enum_field_type, tag, variant_name) = match enum_decl
         .variants
         .iter()
-        .find(|x| x.name.primary_name == enum_field_name.primary_name)
+        .find(|x| x.name.primary_name() == enum_field_name.primary_name())
     {
         Some(o) => (o.r#type, o.tag, o.name.clone()),
         None => {
             errors.push(CompileError::UnknownEnumVariant {
-                enum_name: enum_decl.name.primary_name,
-                variant_name: enum_field_name.primary_name,
-                span: enum_field_name.clone().span,
+                enum_name: enum_decl.name.primary_name(),
+                variant_name: enum_field_name.primary_name(),
+                span: enum_field_name.span().clone(),
             });
             return err(warnings, errors);
         }
@@ -59,7 +59,7 @@ pub(crate) fn instantiate_enum<'n, 'sc>(
                     variant_name,
                 },
                 is_constant: IsConstant::No,
-                span: enum_field_name.span.clone(),
+                span: enum_field_name.span().clone(),
             },
             warnings,
             errors,
@@ -97,7 +97,7 @@ pub(crate) fn instantiate_enum<'n, 'sc>(
                         variant_name,
                     },
                     is_constant: IsConstant::No,
-                    span: enum_field_name.span.clone(),
+                    span: enum_field_name.span().clone(),
                 },
                 warnings,
                 errors,
@@ -105,19 +105,19 @@ pub(crate) fn instantiate_enum<'n, 'sc>(
         }
         ([], _) => {
             errors.push(CompileError::MissingEnumInstantiator {
-                span: enum_field_name.span.clone(),
+                span: enum_field_name.span().clone(),
             });
             err(warnings, errors)
         }
         (_too_many_expressions, ty) if ty.is_unit() => {
             errors.push(CompileError::UnnecessaryEnumInstantiator {
-                span: enum_field_name.span.clone(),
+                span: enum_field_name.span().clone(),
             });
             err(warnings, errors)
         }
         (_too_many_expressions, ty) => {
             errors.push(CompileError::MoreThanOneEnumInstantiator {
-                span: enum_field_name.span.clone(),
+                span: enum_field_name.span().clone(),
                 ty: ty.friendly_type_str(),
             });
             err(warnings, errors)

--- a/sway-core/src/semantic_analysis/ast_node/expression/struct_expr_field.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/struct_expr_field.rs
@@ -3,12 +3,12 @@ use crate::Ident;
 use crate::{type_engine::TypeId, TypeParameter};
 
 #[derive(Clone, Debug)]
-pub(crate) struct TypedStructExpressionField<'sc> {
-    pub(crate) name: Ident<'sc>,
-    pub(crate) value: TypedExpression<'sc>,
+pub(crate) struct TypedStructExpressionField {
+    pub(crate) name: Ident,
+    pub(crate) value: TypedExpression,
 }
 
-impl TypedStructExpressionField<'_> {
+impl TypedStructExpressionField {
     pub(crate) fn copy_types(&mut self, type_mapping: &[(TypeParameter, TypeId)]) {
         self.value.copy_types(type_mapping);
     }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -844,10 +844,8 @@ impl<'sc> TypedExpression<'sc> {
                 |AsmRegisterDeclaration {
                      name,
                      initializer,
-                     name_span,
                  }| {
                     TypedAsmRegisterDeclaration {
-                        name_span: name_span.clone(),
                         name,
                         initializer: initializer.map(|initializer| {
                             check!(

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -479,7 +479,7 @@ impl<'sc> TypedExpression<'sc> {
                 );
                 errors.push(CompileError::TooManyArgumentsForFunction {
                     span: arguments_span,
-                    method_name: name.suffix.as_str(),
+                    method_name: name.suffix.clone(),
                     expected: parameters.len(),
                     received: arguments.len(),
                 });
@@ -494,7 +494,7 @@ impl<'sc> TypedExpression<'sc> {
                 );
                 errors.push(CompileError::TooFewArgumentsForFunction {
                     span: arguments_span,
-                    method_name: name.suffix.as_str(),
+                    method_name: name.suffix.clone(),
                     expected: parameters.len(),
                     received: arguments.len(),
                 });
@@ -907,14 +907,14 @@ impl<'sc> TypedExpression<'sc> {
                 Some(TypedDeclaration::StructDeclaration(st)) => st.clone(),
                 Some(_) => {
                     errors.push(CompileError::DeclaredNonStructAsStruct {
-                        name: struct_name.as_str(),
+                        name: struct_name.clone(),
                         span: span.clone(),
                     });
                     return err(warnings, errors);
                 }
                 None => {
                     errors.push(CompileError::StructNotFound {
-                        name: struct_name.as_str(),
+                        name: struct_name.clone(),
                         span: span.clone(),
                     });
                     return err(warnings, errors);
@@ -936,8 +936,8 @@ impl<'sc> TypedExpression<'sc> {
                     Some(val) => val.clone(),
                     None => {
                         errors.push(CompileError::StructMissingField {
-                            field_name: def_field.name.as_str(),
-                            struct_name: definition.name.as_str(),
+                            field_name: def_field.name.clone(),
+                            struct_name: definition.name.clone(),
                             span: span.clone(),
                         });
                         typed_fields_buf.push(TypedStructExpressionField {
@@ -983,8 +983,8 @@ impl<'sc> TypedExpression<'sc> {
         for field in fields {
             if !definition.fields.iter().any(|x| x.name == field.name) {
                 errors.push(CompileError::StructDoesNotHaveField {
-                    field_name: &(*field.name.as_str()),
-                    struct_name: definition.name.as_str(),
+                    field_name: field.name.clone(),
+                    struct_name: definition.name.clone(),
                     span: field.span,
                 });
             }
@@ -1065,7 +1065,7 @@ impl<'sc> TypedExpression<'sc> {
                     .map(|OwnedTypedStructField { name, .. }| name.to_string())
                     .collect::<Vec<_>>()
                     .join("\n"),
-                field_name: field_to_access.as_str(),
+                field_name: field_to_access.clone(),
                 struct_name,
             });
             return err(warnings, errors);

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -479,7 +479,7 @@ impl<'sc> TypedExpression<'sc> {
                 );
                 errors.push(CompileError::TooManyArgumentsForFunction {
                     span: arguments_span,
-                    method_name: name.suffix.primary_name(),
+                    method_name: name.suffix.as_str(),
                     expected: parameters.len(),
                     received: arguments.len(),
                 });
@@ -494,7 +494,7 @@ impl<'sc> TypedExpression<'sc> {
                 );
                 errors.push(CompileError::TooFewArgumentsForFunction {
                     span: arguments_span,
-                    method_name: name.suffix.primary_name(),
+                    method_name: name.suffix.as_str(),
                     expected: parameters.len(),
                     received: arguments.len(),
                 });
@@ -909,14 +909,14 @@ impl<'sc> TypedExpression<'sc> {
                 Some(TypedDeclaration::StructDeclaration(st)) => st.clone(),
                 Some(_) => {
                     errors.push(CompileError::DeclaredNonStructAsStruct {
-                        name: struct_name.primary_name(),
+                        name: struct_name.as_str(),
                         span: span.clone(),
                     });
                     return err(warnings, errors);
                 }
                 None => {
                     errors.push(CompileError::StructNotFound {
-                        name: struct_name.primary_name(),
+                        name: struct_name.as_str(),
                         span: span.clone(),
                     });
                     return err(warnings, errors);
@@ -938,8 +938,8 @@ impl<'sc> TypedExpression<'sc> {
                     Some(val) => val.clone(),
                     None => {
                         errors.push(CompileError::StructMissingField {
-                            field_name: def_field.name.primary_name(),
-                            struct_name: definition.name.primary_name(),
+                            field_name: def_field.name.as_str(),
+                            struct_name: definition.name.as_str(),
                             span: span.clone(),
                         });
                         typed_fields_buf.push(TypedStructExpressionField {
@@ -985,14 +985,14 @@ impl<'sc> TypedExpression<'sc> {
         for field in fields {
             if !definition.fields.iter().any(|x| x.name == field.name) {
                 errors.push(CompileError::StructDoesNotHaveField {
-                    field_name: &(*field.name.primary_name()),
-                    struct_name: definition.name.primary_name(),
+                    field_name: &(*field.name.as_str()),
+                    struct_name: definition.name.as_str(),
                     span: field.span,
                 });
             }
         }
         let struct_type_id = crate::type_engine::insert_type(TypeInfo::Struct {
-            name: definition.name.primary_name().to_string(),
+            name: definition.name.as_str().to_string(),
             fields: definition
                 .fields
                 .iter()
@@ -1056,7 +1056,7 @@ impl<'sc> TypedExpression<'sc> {
         );
         let field = if let Some(field) =
             fields.iter().find(|OwnedTypedStructField { name, .. }| {
-                name.as_str() == field_to_access.primary_name()
+                name.as_str() == field_to_access.as_str()
             }) {
             field
         } else {
@@ -1067,7 +1067,7 @@ impl<'sc> TypedExpression<'sc> {
                     .map(|OwnedTypedStructField { name, .. }| name.to_string())
                     .collect::<Vec<_>>()
                     .join("\n"),
-                field_name: field_to_access.primary_name(),
+                field_name: field_to_access.as_str(),
                 struct_name,
             });
             return err(warnings, errors);
@@ -1201,7 +1201,7 @@ impl<'sc> TypedExpression<'sc> {
                     Some(decl) => Either::Left(decl),
                     None => {
                         errors.push(CompileError::SymbolNotFound {
-                            name: call_path.suffix.primary_name().to_string(),
+                            name: call_path.suffix.as_str().to_string(),
                             span: call_path.suffix.span().clone(),
                         });
                         return err(warnings, errors);
@@ -1227,7 +1227,7 @@ impl<'sc> TypedExpression<'sc> {
                 (None, None) => {
                     errors.push(CompileError::SymbolNotFound {
                         span,
-                        name: call_path.suffix.primary_name().to_string(),
+                        name: call_path.suffix.as_str().to_string(),
                     });
                     return err(warnings, errors);
                 }
@@ -1704,7 +1704,7 @@ impl<'sc> TypedExpression<'sc> {
                     warnings,
                     errors
                 );
-                if struct_name.primary_name() != other_struct_name {
+                if struct_name.as_str() != other_struct_name {
                     errors.push(CompileError::MatchWrongType {
                         expected: parent.return_type,
                         span: struct_name.span().clone(),
@@ -1714,7 +1714,7 @@ impl<'sc> TypedExpression<'sc> {
                 }
                 let mut field_to_access = None;
                 for struct_field in struct_fields.iter() {
-                    if struct_field.name == *field.primary_name() {
+                    if struct_field.name == *field.as_str() {
                         field_to_access = Some(struct_field.clone())
                     }
                 }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -32,7 +32,7 @@ pub(crate) fn error_recovery_expr(span: Span) -> TypedExpression {
 }
 
 #[allow(clippy::too_many_arguments)]
-impl<'sc> TypedExpression {
+impl TypedExpression {
     pub(crate) fn type_check(
         arguments: TypeCheckArguments<'_, Expression>,
     ) -> CompileResult<Self> {
@@ -1750,7 +1750,7 @@ impl<'sc> TypedExpression {
 mod tests {
     use super::*;
 
-    fn do_type_check<'sc>(
+    fn do_type_check(
         expr: Expression,
         type_annotation: TypeId,
     ) -> CompileResult<TypedExpression> {
@@ -1781,7 +1781,7 @@ mod tests {
         })
     }
 
-    fn do_type_check_for_boolx2<'sc>(expr: Expression) -> CompileResult<TypedExpression> {
+    fn do_type_check_for_boolx2(expr: Expression) -> CompileResult<TypedExpression> {
         do_type_check(
             expr,
             insert_type(TypeInfo::Array(insert_type(TypeInfo::Boolean), 2)),
@@ -1789,7 +1789,7 @@ mod tests {
     }
 
     #[test]
-    fn test_array_type_check_non_homogeneous_0<'sc>() {
+    fn test_array_type_check_non_homogeneous_0() {
         let empty_span = Span {
             span: pest::Span::new(" ".into(), 0, 0).unwrap(),
             path: None,
@@ -1822,7 +1822,7 @@ mod tests {
     }
 
     #[test]
-    fn test_array_type_check_non_homogeneous_1<'sc>() {
+    fn test_array_type_check_non_homogeneous_1() {
         let empty_span = Span {
             span: pest::Span::new(" ".into(), 0, 0).unwrap(),
             path: None,
@@ -1862,7 +1862,7 @@ mod tests {
     }
 
     #[test]
-    fn test_array_type_check_bad_count<'sc>() {
+    fn test_array_type_check_bad_count() {
         let empty_span = Span {
             span: pest::Span::new(" ".into(), 0, 0).unwrap(),
             path: None,
@@ -1899,7 +1899,7 @@ mod tests {
     }
 
     #[test]
-    fn test_array_type_check_empty<'sc>() {
+    fn test_array_type_check_empty() {
         let empty_span = Span {
             span: pest::Span::new(" ".into(), 0, 0).unwrap(),
             path: None,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1528,10 +1528,10 @@ impl<'sc> TypedExpression<'sc> {
             let method_name = MethodName::FromType {
                 call_path: CallPath {
                     prefixes: vec![
-                        Ident::new("core", span.clone()),
-                        Ident::new("ops", span.clone()),
+                        Ident::new_with_override("core", span.clone()),
+                        Ident::new_with_override("ops", span.clone()),
                     ],
-                    suffix: Ident::new("index", span.clone()),
+                    suffix: Ident::new_with_override("index", span.clone()),
                 },
                 type_name: None,
                 is_absolute: true,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -125,7 +125,7 @@ pub(crate) fn type_check_method_application<'n, 'sc>(
             if args_buf.len() > method.parameters.len() {
                 errors.push(CompileError::TooManyArgumentsForFunction {
                     span: span.clone(),
-                    method_name: method_name.primary_name,
+                    method_name: method_name.primary_name(),
                     expected: method.parameters.len(),
                     received: args_buf.len(),
                 });
@@ -134,7 +134,7 @@ pub(crate) fn type_check_method_application<'n, 'sc>(
             if args_buf.len() < method.parameters.len() {
                 errors.push(CompileError::TooFewArgumentsForFunction {
                     span: span.clone(),
-                    method_name: method_name.primary_name,
+                    method_name: method_name.primary_name(),
                     expected: method.parameters.len(),
                     received: args_buf.len(),
                 });

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -125,7 +125,7 @@ pub(crate) fn type_check_method_application<'n, 'sc>(
             if args_buf.len() > method.parameters.len() {
                 errors.push(CompileError::TooManyArgumentsForFunction {
                     span: span.clone(),
-                    method_name: method_name.primary_name(),
+                    method_name: method_name.as_str(),
                     expected: method.parameters.len(),
                     received: args_buf.len(),
                 });
@@ -134,7 +134,7 @@ pub(crate) fn type_check_method_application<'n, 'sc>(
             if args_buf.len() < method.parameters.len() {
                 errors.push(CompileError::TooFewArgumentsForFunction {
                     span: span.clone(),
-                    method_name: method_name.primary_name(),
+                    method_name: method_name.as_str(),
                     expected: method.parameters.len(),
                     received: args_buf.len(),
                 });

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -295,7 +295,12 @@ fn re_parse_expression<'n>(
     let mut warnings = vec![];
     let mut errors = vec![];
     let span = crate::Span {
-        span: pest::Span::new("TODO(static span): use Idents instead of Strings".into(), 0, 0).unwrap(),
+        span: pest::Span::new(
+            "TODO(static span): use Idents instead of Strings".into(),
+            0,
+            0,
+        )
+        .unwrap(),
         path: None,
     };
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -8,7 +8,7 @@ use pest::Parser;
 use std::collections::{HashMap, VecDeque};
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn type_check_method_application<'n, 'sc>(
+pub(crate) fn type_check_method_application<'n>(
     method_name: MethodName,
     arguments: Vec<Expression>,
     span: Span,
@@ -282,7 +282,7 @@ pub(crate) fn type_check_method_application<'n, 'sc>(
 // TODO(static span): this whole method can go away and the address can go back in the contract
 // caller type.
 #[allow(clippy::too_many_arguments)]
-fn re_parse_expression<'n, 'a>(
+fn re_parse_expression<'n>(
     contract_string: Arc<str>,
     build_config: &BuildConfig,
     namespace: &mut Namespace,
@@ -304,7 +304,7 @@ fn re_parse_expression<'n, 'a>(
         Err(_e) => {
             errors.push(CompileError::Internal(
                 "Internal error handling contract call address parsing.",
-                span.clone(),
+                span,
             ));
             return err(warnings, errors);
         }
@@ -314,7 +314,7 @@ fn re_parse_expression<'n, 'a>(
         None => {
             errors.push(CompileError::Internal(
                 "Internal error handling contract call address parsing. No address.",
-                span.clone(),
+                span,
             ));
             return err(warnings, errors);
         }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -125,7 +125,7 @@ pub(crate) fn type_check_method_application<'n, 'sc>(
             if args_buf.len() > method.parameters.len() {
                 errors.push(CompileError::TooManyArgumentsForFunction {
                     span: span.clone(),
-                    method_name: method_name.as_str(),
+                    method_name: method_name.clone(),
                     expected: method.parameters.len(),
                     received: args_buf.len(),
                 });
@@ -134,7 +134,7 @@ pub(crate) fn type_check_method_application<'n, 'sc>(
             if args_buf.len() < method.parameters.len() {
                 errors.push(CompileError::TooFewArgumentsForFunction {
                     span: span.clone(),
-                    method_name: method_name.as_str(),
+                    method_name: method_name.clone(),
                     expected: method.parameters.len(),
                     received: args_buf.len(),
                 });

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -9,17 +9,17 @@ use std::collections::{HashMap, VecDeque};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn type_check_method_application<'n, 'sc>(
-    method_name: MethodName<'sc>,
-    arguments: Vec<Expression<'sc>>,
-    span: Span<'sc>,
-    namespace: &mut Namespace<'sc>,
-    crate_namespace: Option<&'n Namespace<'sc>>,
+    method_name: MethodName,
+    arguments: Vec<Expression>,
+    span: Span,
+    namespace: &mut Namespace,
+    crate_namespace: Option<&'n Namespace>,
     self_type: TypeId,
     build_config: &BuildConfig,
-    dead_code_graph: &mut ControlFlowGraph<'sc>,
+    dead_code_graph: &mut ControlFlowGraph,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
     opts: TCOpts,
-) -> CompileResult<'sc, TypedExpression<'sc>> {
+) -> CompileResult<TypedExpression> {
     let mut warnings = vec![];
     let mut errors = vec![];
     let mut args_buf = VecDeque::new();
@@ -172,7 +172,7 @@ pub(crate) fn type_check_method_application<'n, 'sc>(
                         // so we don't need to re-parse and re-compile
                         let contract_address = check!(
                             re_parse_expression(
-                                contract_address,
+                                contract_address.into(),
                                 build_config,
                                 namespace,
                                 crate_namespace,
@@ -247,7 +247,7 @@ pub(crate) fn type_check_method_application<'n, 'sc>(
                         };
                         let contract_address = check!(
                             re_parse_expression(
-                                contract_address,
+                                contract_address.into(),
                                 build_config,
                                 namespace,
                                 crate_namespace,
@@ -283,24 +283,23 @@ pub(crate) fn type_check_method_application<'n, 'sc>(
 // caller type.
 #[allow(clippy::too_many_arguments)]
 fn re_parse_expression<'n, 'a>(
-    contract_string: String,
+    contract_string: Arc<str>,
     build_config: &BuildConfig,
-    namespace: &mut Namespace<'a>,
-    crate_namespace: Option<&'n Namespace<'a>>,
+    namespace: &mut Namespace,
+    crate_namespace: Option<&'n Namespace>,
     self_type: TypeId,
-    dead_code_graph: &mut ControlFlowGraph<'a>,
+    dead_code_graph: &mut ControlFlowGraph,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
     opts: TCOpts,
-) -> CompileResult<'a, TypedExpression<'a>> {
+) -> CompileResult<TypedExpression> {
     let mut warnings = vec![];
     let mut errors = vec![];
     let span = crate::Span {
-        span: pest::Span::new("TODO(static span): use Idents instead of Strings", 0, 0).unwrap(),
+        span: pest::Span::new("TODO(static span): use Idents instead of Strings".into(), 0, 0).unwrap(),
         path: None,
     };
 
-    let leaked_contract_string = Box::leak(contract_string.into_boxed_str());
-    let mut contract_pairs = match HllParser::parse(Rule::expr, leaked_contract_string) {
+    let mut contract_pairs = match HllParser::parse(Rule::expr, contract_string) {
         Ok(o) => o,
         Err(_e) => {
             errors.push(CompileError::Internal(

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -102,7 +102,7 @@ impl TypedAsmRegisterDeclaration {
     }
 }
 
-impl<'sc> TypedExpressionVariant {
+impl TypedExpressionVariant {
     pub(crate) fn pretty_print(&self) -> String {
         match self {
             TypedExpressionVariant::Literal(lit) => format!(

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -124,7 +124,7 @@ impl<'sc> TypedExpressionVariant<'sc> {
                 }
             ),
             TypedExpressionVariant::FunctionApplication { name, .. } => {
-                format!("\"{}\" fn entry", name.suffix.primary_name)
+                format!("\"{}\" fn entry", name.suffix.primary_name())
             }
             TypedExpressionVariant::LazyOperator { op, .. } => match op {
                 LazyOp::And => "&&".into(),
@@ -141,14 +141,14 @@ impl<'sc> TypedExpressionVariant<'sc> {
             TypedExpressionVariant::Array { .. } => "array".into(),
             TypedExpressionVariant::ArrayIndex { .. } => "[..]".into(),
             TypedExpressionVariant::StructExpression { struct_name, .. } => {
-                format!("\"{}\" struct init", struct_name.primary_name)
+                format!("\"{}\" struct init", struct_name.primary_name())
             }
             TypedExpressionVariant::CodeBlock(_) => "code block entry".into(),
             TypedExpressionVariant::FunctionParameter => "fn param access".into(),
             TypedExpressionVariant::IfExp { .. } => "if exp".into(),
             TypedExpressionVariant::AsmExpression { .. } => "inline asm".into(),
             TypedExpressionVariant::AbiCast { abi_name, .. } => {
-                format!("abi cast {}", abi_name.suffix.primary_name)
+                format!("abi cast {}", abi_name.suffix.primary_name())
             }
             TypedExpressionVariant::StructFieldAccess {
                 resolved_type_of_parent,
@@ -173,7 +173,7 @@ impl<'sc> TypedExpressionVariant<'sc> {
                 )
             }
             TypedExpressionVariant::VariableExpression { name, .. } => {
-                format!("\"{}\" variable exp", name.primary_name)
+                format!("\"{}\" variable exp", name.primary_name())
             }
             TypedExpressionVariant::EnumInstantiation {
                 tag,
@@ -183,7 +183,9 @@ impl<'sc> TypedExpressionVariant<'sc> {
             } => {
                 format!(
                     "{}::{} enum instantiation (tag: {})",
-                    enum_decl.name.primary_name, variant_name.primary_name, tag
+                    enum_decl.name.primary_name(),
+                    variant_name.primary_name(),
+                    tag
                 )
             }
         }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -91,8 +91,7 @@ pub(crate) enum TypedExpressionVariant<'sc> {
 #[derive(Clone, Debug)]
 pub(crate) struct TypedAsmRegisterDeclaration<'sc> {
     pub(crate) initializer: Option<TypedExpression<'sc>>,
-    pub(crate) name: &'sc str,
-    pub(crate) name_span: Span<'sc>,
+    pub(crate) name: Ident<'sc>,
 }
 
 impl TypedAsmRegisterDeclaration<'_> {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -124,7 +124,7 @@ impl<'sc> TypedExpressionVariant<'sc> {
                 }
             ),
             TypedExpressionVariant::FunctionApplication { name, .. } => {
-                format!("\"{}\" fn entry", name.suffix.primary_name())
+                format!("\"{}\" fn entry", name.suffix.as_str())
             }
             TypedExpressionVariant::LazyOperator { op, .. } => match op {
                 LazyOp::And => "&&".into(),
@@ -141,14 +141,14 @@ impl<'sc> TypedExpressionVariant<'sc> {
             TypedExpressionVariant::Array { .. } => "array".into(),
             TypedExpressionVariant::ArrayIndex { .. } => "[..]".into(),
             TypedExpressionVariant::StructExpression { struct_name, .. } => {
-                format!("\"{}\" struct init", struct_name.primary_name())
+                format!("\"{}\" struct init", struct_name.as_str())
             }
             TypedExpressionVariant::CodeBlock(_) => "code block entry".into(),
             TypedExpressionVariant::FunctionParameter => "fn param access".into(),
             TypedExpressionVariant::IfExp { .. } => "if exp".into(),
             TypedExpressionVariant::AsmExpression { .. } => "inline asm".into(),
             TypedExpressionVariant::AbiCast { abi_name, .. } => {
-                format!("abi cast {}", abi_name.suffix.primary_name())
+                format!("abi cast {}", abi_name.suffix.as_str())
             }
             TypedExpressionVariant::StructFieldAccess {
                 resolved_type_of_parent,
@@ -173,7 +173,7 @@ impl<'sc> TypedExpressionVariant<'sc> {
                 )
             }
             TypedExpressionVariant::VariableExpression { name, .. } => {
-                format!("\"{}\" variable exp", name.primary_name())
+                format!("\"{}\" variable exp", name.as_str())
             }
             TypedExpressionVariant::EnumInstantiation {
                 tag,
@@ -183,8 +183,8 @@ impl<'sc> TypedExpressionVariant<'sc> {
             } => {
                 format!(
                     "{}::{} enum instantiation (tag: {})",
-                    enum_decl.name.primary_name(),
-                    variant_name.primary_name(),
+                    enum_decl.name.as_str(),
+                    variant_name.as_str(),
                     tag
                 )
             }

--- a/sway-core/src/semantic_analysis/ast_node/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/impl_trait.rs
@@ -161,7 +161,7 @@ pub(crate) fn implementation_of_trait<'sc>(
         }
         Some(_) | None => {
             errors.push(CompileError::UnknownTrait {
-                name: trait_name.suffix.primary_name(),
+                name: trait_name.suffix.as_str(),
                 span: trait_name.span(),
             });
             ok(ERROR_RECOVERY_DECLARATION.clone(), warnings, errors)
@@ -243,7 +243,7 @@ fn type_check_trait_implementation<'sc>(
             Some(ix) => ix,
             None => {
                 errors.push(CompileError::FunctionNotAPartOfInterfaceSurface {
-                    name: &(*fn_decl.name.primary_name()),
+                    name: &(*fn_decl.name.as_str()),
                     trait_name: trait_name.span().as_str().to_string(),
                     span: fn_decl.name.span().clone(),
                 });
@@ -270,8 +270,8 @@ fn type_check_trait_implementation<'sc>(
                         errors.push(
                             CompileError::IncorrectNumberOfInterfaceSurfaceFunctionParameters {
                                 span: fn_decl.parameters_span(),
-                                fn_name: fn_decl.name.primary_name(),
-                                trait_name: trait_name.primary_name(),
+                                fn_name: fn_decl.name.as_str(),
+                                trait_name: trait_name.as_str(),
                                 num_args: parameters.len(),
                                 provided_args: fn_decl.parameters.len(),
                             },
@@ -400,7 +400,7 @@ fn type_check_trait_implementation<'sc>(
             span: block_span.clone(),
             missing_functions: function_checklist
                 .into_iter()
-                .map(|ident| ident.primary_name().to_string())
+                .map(|ident| ident.as_str().to_string())
                 .collect::<Vec<_>>()
                 .join("\n"),
         });

--- a/sway-core/src/semantic_analysis/ast_node/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/impl_trait.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use std::collections::{HashMap, HashSet};
 
-pub(crate) fn implementation_of_trait<'sc>(
+pub(crate) fn implementation_of_trait(
     impl_trait: ImplTrait,
     namespace: &mut Namespace,
     crate_namespace: Option<&Namespace>,
@@ -47,7 +47,6 @@ pub(crate) fn implementation_of_trait<'sc>(
         .ok(&mut warnings, &mut errors)
     {
         Some(TypedDeclaration::TraitDeclaration(tr)) => {
-            let tr = tr.clone();
             if type_arguments.len() != tr.type_parameters.len() {
                 errors.push(CompileError::IncorrectNumberOfTypeArguments {
                     given: type_arguments.len(),
@@ -182,7 +181,7 @@ impl Default for Mode {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn type_check_trait_implementation<'sc>(
+fn type_check_trait_implementation(
     interface_surface: &[TypedTraitFn],
     functions: &[FunctionDeclaration],
     methods: &[FunctionDeclaration],

--- a/sway-core/src/semantic_analysis/ast_node/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/impl_trait.rs
@@ -161,7 +161,7 @@ pub(crate) fn implementation_of_trait<'sc>(
         }
         Some(_) | None => {
             errors.push(CompileError::UnknownTrait {
-                name: trait_name.suffix.as_str(),
+                name: trait_name.suffix.clone(),
                 span: trait_name.span(),
             });
             ok(ERROR_RECOVERY_DECLARATION.clone(), warnings, errors)
@@ -243,8 +243,8 @@ fn type_check_trait_implementation<'sc>(
             Some(ix) => ix,
             None => {
                 errors.push(CompileError::FunctionNotAPartOfInterfaceSurface {
-                    name: &(*fn_decl.name.as_str()),
-                    trait_name: trait_name.span().as_str().to_string(),
+                    name: fn_decl.name.clone(),
+                    trait_name: trait_name.clone(),
                     span: fn_decl.name.span().clone(),
                 });
                 return err(warnings, errors);
@@ -270,8 +270,8 @@ fn type_check_trait_implementation<'sc>(
                         errors.push(
                             CompileError::IncorrectNumberOfInterfaceSurfaceFunctionParameters {
                                 span: fn_decl.parameters_span(),
-                                fn_name: fn_decl.name.as_str(),
-                                trait_name: trait_name.as_str(),
+                                fn_name: fn_decl.name.clone(),
+                                trait_name: trait_name.clone(),
                                 num_args: parameters.len(),
                                 provided_args: fn_decl.parameters.len(),
                             },

--- a/sway-core/src/semantic_analysis/ast_node/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/impl_trait.rs
@@ -39,7 +39,7 @@ pub(crate) fn implementation_of_trait<'sc>(
     if !type_arguments.is_empty() {
         errors.push(CompileError::Internal(
             "Where clauses are not supported yet.",
-            type_arguments[0].clone().name_ident.span,
+            type_arguments[0].clone().name_ident.span().clone(),
         ));
     }
     match namespace
@@ -161,7 +161,7 @@ pub(crate) fn implementation_of_trait<'sc>(
         }
         Some(_) | None => {
             errors.push(CompileError::UnknownTrait {
-                name: trait_name.suffix.primary_name,
+                name: trait_name.suffix.primary_name(),
                 span: trait_name.span(),
             });
             ok(ERROR_RECOVERY_DECLARATION.clone(), warnings, errors)
@@ -243,9 +243,9 @@ fn type_check_trait_implementation<'sc>(
             Some(ix) => ix,
             None => {
                 errors.push(CompileError::FunctionNotAPartOfInterfaceSurface {
-                    name: &(*fn_decl.name.primary_name),
-                    trait_name: trait_name.span.as_str().to_string(),
-                    span: fn_decl.name.span.clone(),
+                    name: &(*fn_decl.name.primary_name()),
+                    trait_name: trait_name.span().as_str().to_string(),
+                    span: fn_decl.name.span().clone(),
                 });
                 return err(warnings, errors);
             }
@@ -270,8 +270,8 @@ fn type_check_trait_implementation<'sc>(
                         errors.push(
                             CompileError::IncorrectNumberOfInterfaceSurfaceFunctionParameters {
                                 span: fn_decl.parameters_span(),
-                                fn_name: fn_decl.name.primary_name,
-                                trait_name: trait_name.primary_name,
+                                fn_name: fn_decl.name.primary_name(),
+                                trait_name: trait_name.primary_name(),
                                 num_args: parameters.len(),
                                 provided_args: fn_decl.parameters.len(),
                             },
@@ -400,7 +400,7 @@ fn type_check_trait_implementation<'sc>(
             span: block_span.clone(),
             missing_functions: function_checklist
                 .into_iter()
-                .map(|Ident { primary_name, .. }| primary_name.to_string())
+                .map(|ident| ident.primary_name().to_string())
                 .collect::<Vec<_>>()
                 .join("\n"),
         });

--- a/sway-core/src/semantic_analysis/ast_node/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/impl_trait.rs
@@ -14,14 +14,14 @@ use crate::{
 use std::collections::{HashMap, HashSet};
 
 pub(crate) fn implementation_of_trait<'sc>(
-    impl_trait: ImplTrait<'sc>,
-    namespace: &mut Namespace<'sc>,
-    crate_namespace: Option<&Namespace<'sc>>,
+    impl_trait: ImplTrait,
+    namespace: &mut Namespace,
+    crate_namespace: Option<&Namespace>,
     build_config: &BuildConfig,
-    dead_code_graph: &mut ControlFlowGraph<'sc>,
+    dead_code_graph: &mut ControlFlowGraph,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
     opts: TCOpts,
-) -> CompileResult<'sc, TypedDeclaration<'sc>> {
+) -> CompileResult<TypedDeclaration> {
     let mut errors = vec![];
     let mut warnings = vec![];
     let ImplTrait {
@@ -183,23 +183,23 @@ impl Default for Mode {
 
 #[allow(clippy::too_many_arguments)]
 fn type_check_trait_implementation<'sc>(
-    interface_surface: &[TypedTraitFn<'sc>],
-    functions: &[FunctionDeclaration<'sc>],
-    methods: &[FunctionDeclaration<'sc>],
-    trait_name: &Ident<'sc>,
-    type_arguments: &[TypeParameter<'sc>],
-    namespace: &mut Namespace<'sc>,
-    crate_namespace: Option<&Namespace<'sc>>,
+    interface_surface: &[TypedTraitFn],
+    functions: &[FunctionDeclaration],
+    methods: &[FunctionDeclaration],
+    trait_name: &Ident,
+    type_arguments: &[TypeParameter],
+    namespace: &mut Namespace,
+    crate_namespace: Option<&Namespace>,
     _self_type: TypeId,
     build_config: &BuildConfig,
-    dead_code_graph: &mut ControlFlowGraph<'sc>,
-    block_span: &Span<'sc>,
+    dead_code_graph: &mut ControlFlowGraph,
+    block_span: &Span,
     type_implementing_for: TypeId,
-    type_implementing_for_span: &Span<'sc>,
+    type_implementing_for_span: &Span,
     mode: Mode,
     dependency_graph: &mut HashMap<String, HashSet<String>>,
     opts: TCOpts,
-) -> CompileResult<'sc, Vec<TypedFunctionDeclaration<'sc>>> {
+) -> CompileResult<Vec<TypedFunctionDeclaration>> {
     let mut functions_buf: Vec<TypedFunctionDeclaration> = vec![];
     let mut errors = vec![];
     let mut warnings = vec![];

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -269,13 +269,11 @@ impl<'sc> TypedAstNode<'sc> {
                             typed_const_decl
                         }
                         Declaration::EnumDeclaration(e) => {
-                            let span = e.span.clone();
-                            let primary_name = e.name.primary_name();
                             let decl = TypedDeclaration::EnumDeclaration(
                                 e.to_typed_decl(namespace, self_type),
                             );
 
-                            namespace.insert(Ident::new(primary_name, span), decl.clone());
+                            namespace.insert(e.name.clone(), decl.clone());
                             decl
                         }
                         Declaration::FunctionDeclaration(fn_decl) => {
@@ -455,7 +453,7 @@ impl<'sc> TypedAstNode<'sc> {
                             }
                             let trait_name = CallPath {
                                 prefixes: vec![],
-                                suffix: Ident::new("r#Self", block_span.clone()),
+                                suffix: Ident::new_with_override("r#Self", block_span.clone()),
                             };
                             namespace.insert_trait_implementation(
                                 trait_name.clone(),

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -832,7 +832,7 @@ fn reassignment<'n, 'sc>(
                 }
                 Some(o) => {
                     errors.push(CompileError::ReassignmentToNonVariable {
-                        name: name.as_str(),
+                        name: name.clone(),
                         kind: o.friendly_name(),
                         span,
                     });
@@ -1140,7 +1140,7 @@ fn type_check_trait_methods<'sc>(
                         name: name.to_string(),
                         span: span.clone(),
                         comma_separated_generic_params: comma_separated_generic_params.clone(),
-                        fn_name: fn_name.as_str(),
+                        fn_name: fn_name.clone(),
                         args: args_span.as_str().to_string(),
                     });
                 }

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -61,7 +61,7 @@ pub struct TypedAstNode {
     pub(crate) span: Span,
 }
 
-impl<'sc> std::fmt::Debug for TypedAstNode {
+impl std::fmt::Debug for TypedAstNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use TypedAstNodeContent::*;
         let text = match &self.content {
@@ -78,7 +78,7 @@ impl<'sc> std::fmt::Debug for TypedAstNode {
     }
 }
 
-impl<'sc> TypedAstNode {
+impl TypedAstNode {
     pub(crate) fn copy_types(&mut self, type_mapping: &[(TypeParameter, TypeId)]) {
         match self.content {
             TypedAstNodeContent::ReturnStatement(ref mut ret_stmt) => {

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -784,7 +784,7 @@ fn import_new_file<'sc>(
         Some(ref alias) => alias,
         None => &name,
     };
-    let name = name.primary_name().to_string();
+    let name = name.as_str().to_string();
     namespace.insert_module(name, module);
     ok((), warnings, errors)
 }
@@ -823,7 +823,7 @@ fn reassignment<'n, 'sc>(
                     // early-returning, for the sake of better error reporting
                     if !is_mutable {
                         errors.push(CompileError::AssignmentToNonMutable(
-                            name.primary_name().to_string(),
+                            name.as_str().to_string(),
                             span.clone(),
                         ));
                     }
@@ -832,7 +832,7 @@ fn reassignment<'n, 'sc>(
                 }
                 Some(o) => {
                     errors.push(CompileError::ReassignmentToNonVariable {
-                        name: name.primary_name(),
+                        name: name.as_str(),
                         kind: o.friendly_name(),
                         span,
                     });
@@ -840,7 +840,7 @@ fn reassignment<'n, 'sc>(
                 }
                 None => {
                     errors.push(CompileError::UnknownVariable {
-                        var_name: name.primary_name().to_string(),
+                        var_name: name.as_str().to_string(),
                         span: name.span().clone(),
                     });
                     return err(warnings, errors);
@@ -1140,7 +1140,7 @@ fn type_check_trait_methods<'sc>(
                         name: name.to_string(),
                         span: span.clone(),
                         comma_separated_generic_params: comma_separated_generic_params.clone(),
-                        fn_name: fn_name.primary_name(),
+                        fn_name: fn_name.as_str(),
                         args: args_span.as_str().to_string(),
                     });
                 }

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -113,8 +113,8 @@ impl<'sc> TypedAstNode {
             WhileLoop(_) | SideEffect => TypeInfo::Tuple(Vec::new()),
         }
     }
-    pub(crate) fn type_check<'n>(
-        arguments: TypeCheckArguments<'n, AstNode>,
+    pub(crate) fn type_check(
+        arguments: TypeCheckArguments<'_, AstNode>,
     ) -> CompileResult<TypedAstNode> {
         let TypeCheckArguments {
             checkee: node,
@@ -204,7 +204,7 @@ impl<'sc> TypedAstNode {
                                 .resolve_type_with_self(type_ascription, self_type)
                                 .unwrap_or_else(|_| {
                                     errors.push(CompileError::UnknownType {
-                                        span: type_ascription_span.expect("Invariant violated: type checked an annotation that did not exist in the source").clone(),
+                                        span: type_ascription_span.expect("Invariant violated: type checked an annotation that did not exist in the source"),
                                     });
                                     insert_type(TypeInfo::ErrorRecovery)
                                 });
@@ -561,7 +561,7 @@ impl<'sc> TypedAstNode {
                         Declaration::StorageDeclaration(StorageDeclaration { span, .. }) => {
                             errors.push(CompileError::Unimplemented(
                                 "Storage declarations are not supported yet. Coming soon!",
-                                span.clone(),
+                                span,
                             ));
                             return err(warnings, errors);
                         }
@@ -673,7 +673,7 @@ impl<'sc> TypedAstNode {
                         (
                             TypedCodeBlock {
                                 contents: vec![],
-                                whole_block_span: body.whole_block_span.clone(),
+                                whole_block_span: body.whole_block_span,
                             },
                             crate::type_engine::insert_type(TypeInfo::Tuple(Vec::new()))
                         ),
@@ -711,7 +711,7 @@ impl<'sc> TypedAstNode {
 
 /// Imports a new file, populates the given [Namespace] with its content,
 /// and appends the module's content to the control flow graph for later analysis.
-fn import_new_file<'sc>(
+fn import_new_file(
     statement: &IncludeStatement,
     namespace: &mut Namespace,
     build_config: &BuildConfig,
@@ -787,8 +787,8 @@ fn import_new_file<'sc>(
     ok((), warnings, errors)
 }
 
-fn reassignment<'n, 'sc>(
-    arguments: TypeCheckArguments<'n, (Box<Expression>, Expression)>,
+fn reassignment(
+    arguments: TypeCheckArguments<'_, (Box<Expression>, Expression)>,
     span: Span,
 ) -> CompileResult<TypedDeclaration> {
     let TypeCheckArguments {
@@ -985,7 +985,7 @@ fn reassignment<'n, 'sc>(
     }
 }
 
-fn type_check_interface_surface<'sc>(
+fn type_check_interface_surface(
     interface_surface: Vec<TraitFn>,
     namespace: &Namespace,
 ) -> CompileResult<Vec<TypedTraitFn>> {
@@ -1045,7 +1045,7 @@ fn type_check_interface_surface<'sc>(
     )
 }
 
-fn type_check_trait_methods<'sc>(
+fn type_check_trait_methods(
     methods: Vec<FunctionDeclaration>,
     namespace: &mut Namespace,
     crate_namespace: Option<&Namespace>,

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -1220,9 +1220,7 @@ fn type_check_trait_methods(
 
 /// Used to create a stubbed out function when the function fails to compile, preventing cascading
 /// namespace errors
-fn error_recovery_function_declaration(
-    decl: FunctionDeclaration,
-) -> TypedFunctionDeclaration {
+fn error_recovery_function_declaration(decl: FunctionDeclaration) -> TypedFunctionDeclaration {
     let FunctionDeclaration {
         name,
         return_type,

--- a/sway-core/src/semantic_analysis/ast_node/return_statement.rs
+++ b/sway-core/src/semantic_analysis/ast_node/return_statement.rs
@@ -2,11 +2,11 @@ use super::TypedExpression;
 use crate::{type_engine::TypeId, TypeParameter};
 
 #[derive(Clone, Debug)]
-pub(crate) struct TypedReturnStatement<'sc> {
-    pub(crate) expr: TypedExpression<'sc>,
+pub(crate) struct TypedReturnStatement {
+    pub(crate) expr: TypedExpression,
 }
 
-impl TypedReturnStatement<'_> {
+impl TypedReturnStatement {
     /// Makes a fresh copy of all types contained in this statement.
     pub(crate) fn copy_types(&mut self, type_mapping: &[(TypeParameter, TypeId)]) {
         self.expr.copy_types(type_mapping);

--- a/sway-core/src/semantic_analysis/ast_node/while_loop.rs
+++ b/sway-core/src/semantic_analysis/ast_node/while_loop.rs
@@ -6,7 +6,7 @@ pub(crate) struct TypedWhileLoop {
     pub(crate) body: TypedCodeBlock,
 }
 
-impl<'sc> TypedWhileLoop {
+impl TypedWhileLoop {
     pub(crate) fn pretty_print(&self) -> String {
         format!("while loop on {}", self.condition.pretty_print())
     }

--- a/sway-core/src/semantic_analysis/ast_node/while_loop.rs
+++ b/sway-core/src/semantic_analysis/ast_node/while_loop.rs
@@ -1,12 +1,12 @@
 use super::{TypedCodeBlock, TypedExpression};
 
 #[derive(Clone, Debug)]
-pub(crate) struct TypedWhileLoop<'sc> {
-    pub(crate) condition: TypedExpression<'sc>,
-    pub(crate) body: TypedCodeBlock<'sc>,
+pub(crate) struct TypedWhileLoop {
+    pub(crate) condition: TypedExpression,
+    pub(crate) body: TypedCodeBlock,
 }
 
-impl<'sc> TypedWhileLoop<'sc> {
+impl<'sc> TypedWhileLoop {
     pub(crate) fn pretty_print(&self) -> String {
         format!("while loop on {}", self.condition.pretty_print())
     }

--- a/sway-core/src/semantic_analysis/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace.rs
@@ -141,7 +141,7 @@ impl<'sc> Namespace {
                 },
             });
         }
-        self.symbols.insert(name.clone(), item.clone());
+        self.symbols.insert(name, item);
         ok((), warnings, vec![])
     }
 
@@ -383,7 +383,7 @@ impl<'sc> Namespace {
             errors
         );
         let mut type_fields =
-            self.get_struct_type_fields(symbol, first_ident.as_str(), &first_ident.span());
+            self.get_struct_type_fields(symbol, first_ident.as_str(), first_ident.span());
         warnings.append(&mut type_fields.warnings);
         errors.append(&mut type_fields.errors);
         let (mut fields, struct_name) = match type_fields.value {

--- a/sway-core/src/semantic_analysis/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace.rs
@@ -36,7 +36,7 @@ pub struct Namespace {
     use_aliases: HashMap<String, Ident>,
 }
 
-impl<'sc> Namespace {
+impl Namespace {
     pub fn get_all_declared_symbols(&self) -> impl Iterator<Item = &TypedDeclaration> {
         self.symbols.values()
     }

--- a/sway-core/src/semantic_analysis/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace.rs
@@ -402,12 +402,11 @@ impl<'sc> Namespace<'sc> {
                     Some(field) => field.clone(),
                     None => {
                         // gather available fields for the error message
-                        let field_name = &(*ident.as_str());
                         let available_fields =
                             fields.iter().map(|x| x.name.as_str()).collect::<Vec<_>>();
 
                         errors.push(CompileError::FieldNotFound {
-                            field_name,
+                            field_name: ident.clone(),
                             struct_name,
                             available_fields: available_fields.join(", "),
                             span: ident.span().clone(),

--- a/sway-core/src/semantic_analysis/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace.rs
@@ -127,11 +127,7 @@ impl Namespace {
         }
     }
 
-    pub(crate) fn insert(
-        &mut self,
-        name: Ident,
-        item: TypedDeclaration,
-    ) -> CompileResult<()> {
+    pub(crate) fn insert(&mut self, name: Ident, item: TypedDeclaration) -> CompileResult<()> {
         let mut warnings = vec![];
         if self.symbols.get(&name).is_some() {
             warnings.push(CompileWarning {
@@ -162,10 +158,7 @@ impl Namespace {
         self.get_name_from_path_str(path, symbol).value
     }
 
-    pub(crate) fn get_symbol(
-        &self,
-        symbol: &Ident,
-    ) -> CompileResult<&TypedDeclaration> {
+    pub(crate) fn get_symbol(&self, symbol: &Ident) -> CompileResult<&TypedDeclaration> {
         let empty = vec![];
         let path = self.use_synonyms.get(symbol).unwrap_or(&empty);
         let true_symbol = self
@@ -179,10 +172,7 @@ impl Namespace {
     /// `foo::bar::function`
     /// where `foo` and `bar` are the prefixes
     /// and `function` is the suffix
-    pub(crate) fn get_call_path(
-        &self,
-        symbol: &CallPath,
-    ) -> CompileResult<TypedDeclaration> {
+    pub(crate) fn get_call_path(&self, symbol: &CallPath) -> CompileResult<TypedDeclaration> {
         let path = if symbol.prefixes.is_empty() {
             self.use_synonyms
                 .get(&symbol.suffix)
@@ -194,11 +184,7 @@ impl Namespace {
             .map(|decl| decl.clone())
     }
 
-    fn get_name_from_path(
-        &self,
-        path: &[Ident],
-        name: &Ident,
-    ) -> CompileResult<&TypedDeclaration> {
+    fn get_name_from_path(&self, path: &[Ident], name: &Ident) -> CompileResult<&TypedDeclaration> {
         let mut warnings = vec![];
         let mut errors = vec![];
         let module = check!(
@@ -265,10 +251,7 @@ impl Namespace {
         }
     }
 
-    pub(crate) fn find_module_relative(
-        &self,
-        path: &[Ident],
-    ) -> CompileResult<&Namespace> {
+    pub(crate) fn find_module_relative(&self, path: &[Ident]) -> CompileResult<&Namespace> {
         let mut namespace = self;
         let mut errors = vec![];
         let warnings = vec![];
@@ -330,11 +313,7 @@ impl Namespace {
         self.modules.insert(module_name, module_contents);
     }
 
-    pub fn insert_dependency_module(
-        &mut self,
-        module_name: String,
-        module_contents: Namespace,
-    ) {
+    pub fn insert_dependency_module(&mut self, module_name: String, module_contents: Namespace) {
         self.modules.insert(module_name, module_contents);
     }
 
@@ -434,10 +413,7 @@ impl Namespace {
         ok((symbol, parent_rover), warnings, errors)
     }
 
-    pub(crate) fn get_methods_for_type(
-        &self,
-        r#type: TypeId,
-    ) -> Vec<TypedFunctionDeclaration> {
+    pub(crate) fn get_methods_for_type(&self, r#type: TypeId) -> Vec<TypedFunctionDeclaration> {
         let mut methods = vec![];
         let r#type = crate::type_engine::look_up_type_id(r#type);
         for ((_trait_name, type_info), l_methods) in &self.implemented_traits {

--- a/sway-core/src/semantic_analysis/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace.rs
@@ -62,7 +62,7 @@ impl<'sc> Namespace<'sc> {
                     fields,
                     ..
                 })) => crate::type_engine::insert_type(TypeInfo::Struct {
-                    name: name.primary_name().to_string(),
+                    name: name.as_str().to_string(),
                     fields: fields
                         .iter()
                         .map(TypedStructField::as_owned_typed_struct_field)
@@ -73,7 +73,7 @@ impl<'sc> Namespace<'sc> {
                     variants,
                     ..
                 })) => crate::type_engine::insert_type(TypeInfo::Enum {
-                    name: name.primary_name().to_string(),
+                    name: name.as_str().to_string(),
                     variant_types: variants
                         .iter()
                         .map(TypedEnumVariant::as_owned_typed_enum_variant)
@@ -81,7 +81,7 @@ impl<'sc> Namespace<'sc> {
                 }),
                 Some(TypedDeclaration::GenericTypeForFunctionScope { name, .. }) => {
                     crate::type_engine::insert_type(TypeInfo::UnknownGeneric {
-                        name: name.primary_name().to_string(),
+                        name: name.as_str().to_string(),
                     })
                 }
                 _ => return Err(()),
@@ -103,7 +103,7 @@ impl<'sc> Namespace<'sc> {
                     fields,
                     ..
                 })) => crate::type_engine::insert_type(TypeInfo::Struct {
-                    name: name.primary_name().to_string(),
+                    name: name.as_str().to_string(),
                     fields: fields
                         .iter()
                         .map(TypedStructField::as_owned_typed_struct_field)
@@ -114,7 +114,7 @@ impl<'sc> Namespace<'sc> {
                     variants,
                     ..
                 })) => crate::type_engine::insert_type(TypeInfo::Enum {
-                    name: name.primary_name().to_string(),
+                    name: name.as_str().to_string(),
                     variant_types: variants
                         .iter()
                         .map(TypedEnumVariant::as_owned_typed_enum_variant)
@@ -152,7 +152,7 @@ impl<'sc> Namespace<'sc> {
             .use_synonyms
             .iter()
             .find_map(|(name, value)| {
-                if name.primary_name() == symbol {
+                if name.as_str() == symbol {
                     Some(value)
                 } else {
                     None
@@ -170,7 +170,7 @@ impl<'sc> Namespace<'sc> {
         let path = self.use_synonyms.get(symbol).unwrap_or(&empty);
         let true_symbol = self
             .use_aliases
-            .get(&symbol.primary_name().to_string())
+            .get(&symbol.as_str().to_string())
             .unwrap_or(symbol);
         self.get_name_from_path(path, true_symbol)
     }
@@ -212,7 +212,7 @@ impl<'sc> Namespace<'sc> {
             Some(decl) => ok(decl, warnings, errors),
             None => {
                 errors.push(CompileError::SymbolNotFound {
-                    name: name.primary_name().to_string(),
+                    name: name.as_str().to_string(),
                     span: name.span().clone(),
                 });
                 err(warnings, errors)
@@ -236,7 +236,7 @@ impl<'sc> Namespace<'sc> {
         );
 
         match module.symbols.iter().find_map(|(item, other)| {
-            if item.primary_name() == name {
+            if item.as_str() == name {
                 Some(other)
             } else {
                 None
@@ -273,7 +273,7 @@ impl<'sc> Namespace<'sc> {
         let mut errors = vec![];
         let warnings = vec![];
         for ident in path {
-            match namespace.modules.get(ident.primary_name()) {
+            match namespace.modules.get(ident.as_str()) {
                 Some(o) => namespace = o,
                 None => {
                     errors.push(CompileError::ModuleNotFound {
@@ -282,7 +282,7 @@ impl<'sc> Namespace<'sc> {
                         }),
                         name: path
                             .iter()
-                            .map(|x| x.primary_name())
+                            .map(|x| x.as_str())
                             .collect::<Vec<_>>()
                             .join("::"),
                     });
@@ -361,7 +361,7 @@ impl<'sc> Namespace<'sc> {
             Some(s) => s,
             None => {
                 errors.push(CompileError::UnknownVariable {
-                    var_name: first_ident.primary_name().to_string(),
+                    var_name: first_ident.as_str().to_string(),
                     span: first_ident.span().clone(),
                 });
                 return err(warnings, errors);
@@ -383,7 +383,7 @@ impl<'sc> Namespace<'sc> {
             errors
         );
         let mut type_fields =
-            self.get_struct_type_fields(symbol, first_ident.primary_name(), &first_ident.span());
+            self.get_struct_type_fields(symbol, first_ident.as_str(), &first_ident.span());
         warnings.append(&mut type_fields.warnings);
         errors.append(&mut type_fields.errors);
         let (mut fields, struct_name) = match type_fields.value {
@@ -398,11 +398,11 @@ impl<'sc> Namespace<'sc> {
         for ident in ident_iter {
             // find the ident in the currently available fields
             let OwnedTypedStructField { r#type, .. } =
-                match fields.iter().find(|x| x.name == ident.primary_name()) {
+                match fields.iter().find(|x| x.name == ident.as_str()) {
                     Some(field) => field.clone(),
                     None => {
                         // gather available fields for the error message
-                        let field_name = &(*ident.primary_name());
+                        let field_name = &(*ident.as_str());
                         let available_fields =
                             fields.iter().map(|x| x.name.as_str()).collect::<Vec<_>>();
 
@@ -540,7 +540,7 @@ impl<'sc> Namespace<'sc> {
                 //  if this is an enum or struct, import its implementations
                 if decl.visibility() != Visibility::Public {
                     errors.push(CompileError::ImportPrivateSymbol {
-                        name: item.primary_name().to_string(),
+                        name: item.as_str().to_string(),
                         span: item.span().clone(),
                     });
                 }
@@ -559,7 +559,7 @@ impl<'sc> Namespace<'sc> {
                     Some(alias) => {
                         self.use_synonyms.insert(alias.clone(), path);
                         self.use_aliases
-                            .insert(alias.primary_name().to_string(), item.clone());
+                            .insert(alias.as_str().to_string(), item.clone());
                     }
                     None => {
                         self.use_synonyms.insert(item.clone(), path);
@@ -568,7 +568,7 @@ impl<'sc> Namespace<'sc> {
             }
             None => {
                 errors.push(CompileError::SymbolNotFound {
-                    name: item.primary_name().to_string(),
+                    name: item.as_str().to_string(),
                     span: item.span().clone(),
                 });
                 return err(warnings, errors);
@@ -635,7 +635,7 @@ impl<'sc> Namespace<'sc> {
                     != Some(TypeInfo::ErrorRecovery)
                 {
                     errors.push(CompileError::MethodNotFound {
-                        method_name: method_name.primary_name().to_string(),
+                        method_name: method_name.as_str().to_string(),
                         type_name: r#type.friendly_type_str(),
                         span: method_name.span().clone(),
                     });

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -2,18 +2,16 @@ use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 
 use crate::{
-    ident::Ident,
-    error::*, parse_tree::Scrutinee, parse_tree::*, span::Span, type_engine::IntegerBits, AstNode,
-    AstNodeContent, CodeBlock, Declaration, Expression, ReturnStatement, TypeInfo, WhileLoop,
+    error::*, ident::Ident, parse_tree::Scrutinee, parse_tree::*, span::Span,
+    type_engine::IntegerBits, AstNode, AstNodeContent, CodeBlock, Declaration, Expression,
+    ReturnStatement, TypeInfo, WhileLoop,
 };
 
 // -------------------------------------------------------------------------------------------------
 /// Take a list of nodes and reorder them so that they may be semantically analysed without any
 /// dependencies breaking.
 
-pub(crate) fn order_ast_nodes_by_dependency(
-    nodes: Vec<AstNode>,
-) -> CompileResult<Vec<AstNode>> {
+pub(crate) fn order_ast_nodes_by_dependency(nodes: Vec<AstNode>) -> CompileResult<Vec<AstNode>> {
     let decl_dependencies =
         DependencyMap::from_iter(nodes.iter().filter_map(Dependencies::gather_from_decl_node));
 
@@ -99,11 +97,7 @@ fn find_recursive_call_chain(
     }
 }
 
-fn build_recursion_error(
-    fn_sym: Ident,
-    span: Span,
-    chain: &[Ident],
-) -> CompileError {
+fn build_recursion_error(fn_sym: Ident, span: Span, chain: &[Ident]) -> CompileError {
     match chain.len() {
         // An empty chain indicates immediate recursion.
         0 => CompileError::RecursiveCall {
@@ -204,9 +198,7 @@ struct Dependencies {
 }
 
 impl Dependencies {
-    fn gather_from_decl_node(
-        node: &AstNode,
-    ) -> Option<(DependentSymbol, Dependencies)> {
+    fn gather_from_decl_node(node: &AstNode) -> Option<(DependentSymbol, Dependencies)> {
         match &node.content {
             AstNodeContent::Declaration(decl) => decl_name(decl).map(|name| {
                 (
@@ -378,9 +370,8 @@ impl Dependencies {
                 fields,
                 ..
             } => {
-                self.deps.insert(DependentSymbol::Symbol(
-                    struct_name.as_str().to_string(),
-                ));
+                self.deps
+                    .insert(DependentSymbol::Symbol(struct_name.as_str().to_string()));
                 self.gather_from_iter(fields.iter(), |deps, field| {
                     deps.gather_from_expr(&field.value)
                 })
@@ -582,13 +573,10 @@ fn decl_name(decl: &Declaration) -> Option<DependentSymbol> {
         Declaration::ImplSelf(decl) => {
             let trait_name = Ident::new_with_override("self", decl.type_name_span.clone());
             impl_sym(trait_name, &decl.type_implementing_for)
-        },
+        }
         Declaration::ImplTrait(decl) => {
             if decl.trait_name.prefixes.is_empty() {
-                impl_sym(
-                    decl.trait_name.suffix.clone(),
-                    &decl.type_implementing_for,
-                )
+                impl_sym(decl.trait_name.suffix.clone(), &decl.type_implementing_for)
             } else {
                 None
             }

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -372,7 +372,7 @@ impl<'sc> Dependencies<'sc> {
                 ..
             } => {
                 self.deps.insert(DependentSymbol::Symbol(
-                    struct_name.primary_name().to_string(),
+                    struct_name.as_str().to_string(),
                 ));
                 self.gather_from_iter(fields.iter(), |deps, field| {
                     deps.gather_from_expr(&field.value)
@@ -470,15 +470,15 @@ impl<'sc> Dependencies<'sc> {
         if call_path.prefixes.is_empty() {
             // We can just use the suffix.
             self.deps.insert(if is_fn_app {
-                DependentSymbol::Fn(call_path.suffix.primary_name(), None)
+                DependentSymbol::Fn(call_path.suffix.as_str(), None)
             } else {
-                DependentSymbol::Symbol(call_path.suffix.primary_name().to_string())
+                DependentSymbol::Symbol(call_path.suffix.as_str().to_string())
             });
         } else if use_prefix && call_path.prefixes.len() == 1 {
             // Here we can use the prefix (e.g., for 'Enum::Variant' -> 'Enum') as long is it's
             // only a single element.
             self.deps.insert(DependentSymbol::Symbol(
-                call_path.prefixes[0].primary_name().to_string(),
+                call_path.prefixes[0].as_str().to_string(),
             ));
         }
         self
@@ -488,7 +488,7 @@ impl<'sc> Dependencies<'sc> {
         for type_param in type_parameters {
             for constraint in &type_param.trait_constraints {
                 self.deps.insert(DependentSymbol::Symbol(
-                    constraint.name.primary_name().to_string(),
+                    constraint.name.as_str().to_string(),
                 ));
             }
         }
@@ -562,21 +562,21 @@ fn decl_name<'sc>(decl: &Declaration<'sc>) -> Option<DependentSymbol<'sc>> {
     match decl {
         // These declarations can depend upon other declarations.
         Declaration::FunctionDeclaration(decl) => Some(DependentSymbol::Fn(
-            decl.name.primary_name(),
+            decl.name.as_str(),
             Some(decl.span.clone()),
         )),
-        Declaration::ConstantDeclaration(decl) => dep_sym(decl.name.primary_name().to_string()),
-        Declaration::StructDeclaration(decl) => dep_sym(decl.name.primary_name().to_string()),
-        Declaration::EnumDeclaration(decl) => dep_sym(decl.name.primary_name().to_string()),
-        Declaration::TraitDeclaration(decl) => dep_sym(decl.name.primary_name().to_string()),
-        Declaration::AbiDeclaration(decl) => dep_sym(decl.name.primary_name().to_string()),
+        Declaration::ConstantDeclaration(decl) => dep_sym(decl.name.as_str().to_string()),
+        Declaration::StructDeclaration(decl) => dep_sym(decl.name.as_str().to_string()),
+        Declaration::EnumDeclaration(decl) => dep_sym(decl.name.as_str().to_string()),
+        Declaration::TraitDeclaration(decl) => dep_sym(decl.name.as_str().to_string()),
+        Declaration::AbiDeclaration(decl) => dep_sym(decl.name.as_str().to_string()),
 
         // These have the added complexity of converting CallPath and/or TypeInfo into a name.
         Declaration::ImplSelf(decl) => impl_sym("self", &decl.type_implementing_for),
         Declaration::ImplTrait(decl) => {
             if decl.trait_name.prefixes.is_empty() {
                 impl_sym(
-                    decl.trait_name.suffix.primary_name(),
+                    decl.trait_name.suffix.as_str(),
                     &decl.type_implementing_for,
                 )
             } else {

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -372,7 +372,7 @@ impl<'sc> Dependencies<'sc> {
                 ..
             } => {
                 self.deps.insert(DependentSymbol::Symbol(
-                    struct_name.primary_name.to_string(),
+                    struct_name.primary_name().to_string(),
                 ));
                 self.gather_from_iter(fields.iter(), |deps, field| {
                     deps.gather_from_expr(&field.value)
@@ -470,15 +470,15 @@ impl<'sc> Dependencies<'sc> {
         if call_path.prefixes.is_empty() {
             // We can just use the suffix.
             self.deps.insert(if is_fn_app {
-                DependentSymbol::Fn(call_path.suffix.primary_name, None)
+                DependentSymbol::Fn(call_path.suffix.primary_name(), None)
             } else {
-                DependentSymbol::Symbol(call_path.suffix.primary_name.to_string())
+                DependentSymbol::Symbol(call_path.suffix.primary_name().to_string())
             });
         } else if use_prefix && call_path.prefixes.len() == 1 {
             // Here we can use the prefix (e.g., for 'Enum::Variant' -> 'Enum') as long is it's
             // only a single element.
             self.deps.insert(DependentSymbol::Symbol(
-                call_path.prefixes[0].primary_name.to_string(),
+                call_path.prefixes[0].primary_name().to_string(),
             ));
         }
         self
@@ -488,7 +488,7 @@ impl<'sc> Dependencies<'sc> {
         for type_param in type_parameters {
             for constraint in &type_param.trait_constraints {
                 self.deps.insert(DependentSymbol::Symbol(
-                    constraint.name.primary_name.to_string(),
+                    constraint.name.primary_name().to_string(),
                 ));
             }
         }
@@ -562,21 +562,21 @@ fn decl_name<'sc>(decl: &Declaration<'sc>) -> Option<DependentSymbol<'sc>> {
     match decl {
         // These declarations can depend upon other declarations.
         Declaration::FunctionDeclaration(decl) => Some(DependentSymbol::Fn(
-            decl.name.primary_name,
+            decl.name.primary_name(),
             Some(decl.span.clone()),
         )),
-        Declaration::ConstantDeclaration(decl) => dep_sym(decl.name.primary_name.to_string()),
-        Declaration::StructDeclaration(decl) => dep_sym(decl.name.primary_name.to_string()),
-        Declaration::EnumDeclaration(decl) => dep_sym(decl.name.primary_name.to_string()),
-        Declaration::TraitDeclaration(decl) => dep_sym(decl.name.primary_name.to_string()),
-        Declaration::AbiDeclaration(decl) => dep_sym(decl.name.primary_name.to_string()),
+        Declaration::ConstantDeclaration(decl) => dep_sym(decl.name.primary_name().to_string()),
+        Declaration::StructDeclaration(decl) => dep_sym(decl.name.primary_name().to_string()),
+        Declaration::EnumDeclaration(decl) => dep_sym(decl.name.primary_name().to_string()),
+        Declaration::TraitDeclaration(decl) => dep_sym(decl.name.primary_name().to_string()),
+        Declaration::AbiDeclaration(decl) => dep_sym(decl.name.primary_name().to_string()),
 
         // These have the added complexity of converting CallPath and/or TypeInfo into a name.
         Declaration::ImplSelf(decl) => impl_sym("self", &decl.type_implementing_for),
         Declaration::ImplTrait(decl) => {
             if decl.trait_name.prefixes.is_empty() {
                 impl_sym(
-                    decl.trait_name.suffix.primary_name,
+                    decl.trait_name.suffix.primary_name(),
                     &decl.type_implementing_for,
                 )
             } else {

--- a/sway-core/src/semantic_analysis/syntax_tree.rs
+++ b/sway-core/src/semantic_analysis/syntax_tree.rs
@@ -46,7 +46,7 @@ pub enum TypedParseTree {
     },
 }
 
-impl<'sc> TypedParseTree {
+impl TypedParseTree {
     /// The `all_nodes` field in the AST variants is used to perform control flow and return flow
     /// analysis, while the direct copies of the declarations and main functions are used to create
     /// the ASM.

--- a/sway-core/src/semantic_analysis/syntax_tree.rs
+++ b/sway-core/src/semantic_analysis/syntax_tree.rs
@@ -165,7 +165,7 @@ impl<'sc> TypedParseTree<'sc> {
         for node in typed_tree_nodes {
             match node.content {
                 TypedAstNodeContent::Declaration(TypedDeclaration::FunctionDeclaration(func))
-                    if func.name.primary_name == "main" =>
+                    if func.name.primary_name() == "main" =>
                 {
                     mains.push(func)
                 }
@@ -263,7 +263,7 @@ fn disallow_impure_functions<'sc>(
         .filter_map(|TypedFunctionDeclaration { purity, name, .. }| {
             if *purity == Purity::Impure {
                 Some(CompileError::ImpureInNonContract {
-                    span: name.span.clone(),
+                    span: name.span().clone(),
                 })
             } else {
                 None

--- a/sway-core/src/semantic_analysis/syntax_tree.rs
+++ b/sway-core/src/semantic_analysis/syntax_tree.rs
@@ -72,13 +72,12 @@ impl<'sc> TypedParseTree {
 
     pub(crate) fn type_check(
         parsed: ParseTree,
-        initial_namespace: Namespace,
+        mut new_namespace: Namespace,
         tree_type: &TreeType,
         build_config: &BuildConfig,
         dead_code_graph: &mut ControlFlowGraph,
         dependency_graph: &mut HashMap<String, HashSet<String>>,
     ) -> CompileResult<Self> {
-        let mut new_namespace = initial_namespace.clone();
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
 
@@ -124,7 +123,7 @@ impl<'sc> TypedParseTree {
             .into_iter()
             .map(|node| {
                 TypedAstNode::type_check(TypeCheckArguments {
-                    checkee: node.clone(),
+                    checkee: node,
                     namespace,
                     crate_namespace: None,
                     return_type_annotation: insert_type(TypeInfo::Unknown),
@@ -248,7 +247,7 @@ impl<'sc> TypedParseTree {
     }
 }
 
-fn disallow_impure_functions<'sc>(
+fn disallow_impure_functions(
     declarations: &[TypedDeclaration],
     mains: &[TypedFunctionDeclaration],
 ) -> Vec<CompileError> {

--- a/sway-core/src/semantic_analysis/syntax_tree.rs
+++ b/sway-core/src/semantic_analysis/syntax_tree.rs
@@ -13,44 +13,44 @@ use std::collections::{HashMap, HashSet};
 
 /// Represents the different variants of the AST.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum TreeType<'sc> {
+pub enum TreeType {
     Predicate,
     Script,
     Contract,
-    Library { name: Ident<'sc> },
+    Library { name: Ident },
 }
 
 #[derive(Debug, Clone)]
-pub enum TypedParseTree<'sc> {
+pub enum TypedParseTree {
     Script {
-        main_function: TypedFunctionDeclaration<'sc>,
-        namespace: Namespace<'sc>,
-        declarations: Vec<TypedDeclaration<'sc>>,
-        all_nodes: Vec<TypedAstNode<'sc>>,
+        main_function: TypedFunctionDeclaration,
+        namespace: Namespace,
+        declarations: Vec<TypedDeclaration>,
+        all_nodes: Vec<TypedAstNode>,
     },
     Predicate {
-        main_function: TypedFunctionDeclaration<'sc>,
-        namespace: Namespace<'sc>,
-        declarations: Vec<TypedDeclaration<'sc>>,
-        all_nodes: Vec<TypedAstNode<'sc>>,
+        main_function: TypedFunctionDeclaration,
+        namespace: Namespace,
+        declarations: Vec<TypedDeclaration>,
+        all_nodes: Vec<TypedAstNode>,
     },
     Contract {
-        abi_entries: Vec<TypedFunctionDeclaration<'sc>>,
-        namespace: Namespace<'sc>,
-        declarations: Vec<TypedDeclaration<'sc>>,
-        all_nodes: Vec<TypedAstNode<'sc>>,
+        abi_entries: Vec<TypedFunctionDeclaration>,
+        namespace: Namespace,
+        declarations: Vec<TypedDeclaration>,
+        all_nodes: Vec<TypedAstNode>,
     },
     Library {
-        namespace: Namespace<'sc>,
-        all_nodes: Vec<TypedAstNode<'sc>>,
+        namespace: Namespace,
+        all_nodes: Vec<TypedAstNode>,
     },
 }
 
-impl<'sc> TypedParseTree<'sc> {
+impl<'sc> TypedParseTree {
     /// The `all_nodes` field in the AST variants is used to perform control flow and return flow
     /// analysis, while the direct copies of the declarations and main functions are used to create
     /// the ASM.
-    pub(crate) fn all_nodes(&self) -> &[TypedAstNode<'sc>] {
+    pub(crate) fn all_nodes(&self) -> &[TypedAstNode] {
         use TypedParseTree::*;
         match self {
             Library { all_nodes, .. } => all_nodes,
@@ -60,7 +60,7 @@ impl<'sc> TypedParseTree<'sc> {
         }
     }
 
-    pub fn into_namespace(self) -> Namespace<'sc> {
+    pub fn into_namespace(self) -> Namespace {
         use TypedParseTree::*;
         match self {
             Library { namespace, .. } => namespace,
@@ -71,13 +71,13 @@ impl<'sc> TypedParseTree<'sc> {
     }
 
     pub(crate) fn type_check(
-        parsed: ParseTree<'sc>,
-        initial_namespace: Namespace<'sc>,
-        tree_type: &TreeType<'sc>,
+        parsed: ParseTree,
+        initial_namespace: Namespace,
+        tree_type: &TreeType,
         build_config: &BuildConfig,
-        dead_code_graph: &mut ControlFlowGraph<'sc>,
+        dead_code_graph: &mut ControlFlowGraph,
         dependency_graph: &mut HashMap<String, HashSet<String>>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let mut new_namespace = initial_namespace.clone();
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
@@ -112,12 +112,12 @@ impl<'sc> TypedParseTree<'sc> {
     }
 
     fn type_check_nodes(
-        nodes: Vec<AstNode<'sc>>,
-        namespace: &mut Namespace<'sc>,
+        nodes: Vec<AstNode>,
+        namespace: &mut Namespace,
         build_config: &BuildConfig,
-        dead_code_graph: &mut ControlFlowGraph<'sc>,
+        dead_code_graph: &mut ControlFlowGraph,
         dependency_graph: &mut HashMap<String, HashSet<String>>,
-    ) -> CompileResult<'sc, Vec<TypedAstNode<'sc>>> {
+    ) -> CompileResult<Vec<TypedAstNode>> {
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
         let typed_nodes = nodes
@@ -148,13 +148,13 @@ impl<'sc> TypedParseTree<'sc> {
     }
 
     fn validate_typed_nodes(
-        typed_tree_nodes: Vec<TypedAstNode<'sc>>,
-        span: Span<'sc>,
-        namespace: Namespace<'sc>,
-        tree_type: &TreeType<'sc>,
-        warnings: Vec<CompileWarning<'sc>>,
-        mut errors: Vec<CompileError<'sc>>,
-    ) -> CompileResult<'sc, Self> {
+        typed_tree_nodes: Vec<TypedAstNode>,
+        span: Span,
+        namespace: Namespace,
+        tree_type: &TreeType,
+        warnings: Vec<CompileWarning>,
+        mut errors: Vec<CompileError>,
+    ) -> CompileResult<Self> {
         // Keep a copy of the nodes as they are.
         let all_nodes = typed_tree_nodes.clone();
 
@@ -249,9 +249,9 @@ impl<'sc> TypedParseTree<'sc> {
 }
 
 fn disallow_impure_functions<'sc>(
-    declarations: &[TypedDeclaration<'sc>],
-    mains: &[TypedFunctionDeclaration<'sc>],
-) -> Vec<CompileError<'sc>> {
+    declarations: &[TypedDeclaration],
+    mains: &[TypedFunctionDeclaration],
+) -> Vec<CompileError> {
     let fn_decls = declarations
         .iter()
         .filter_map(|decl| match decl {

--- a/sway-core/src/semantic_analysis/syntax_tree.rs
+++ b/sway-core/src/semantic_analysis/syntax_tree.rs
@@ -165,7 +165,7 @@ impl<'sc> TypedParseTree<'sc> {
         for node in typed_tree_nodes {
             match node.content {
                 TypedAstNodeContent::Declaration(TypedDeclaration::FunctionDeclaration(func))
-                    if func.name.primary_name() == "main" =>
+                    if func.name.as_str() == "main" =>
                 {
                     mains.push(func)
                 }

--- a/sway-core/src/semantic_analysis/type_check_arguments.rs
+++ b/sway-core/src/semantic_analysis/type_check_arguments.rs
@@ -5,15 +5,15 @@ use crate::semantic_analysis::{ast_node::Mode, Namespace};
 use crate::type_engine::*;
 
 use std::collections::{HashMap, HashSet};
-pub struct TypeCheckArguments<'a, 'sc, T> {
+pub struct TypeCheckArguments<'a, T> {
     pub checkee: T,
-    pub namespace: &'a mut Namespace<'sc>,
-    pub crate_namespace: Option<&'a Namespace<'sc>>,
+    pub namespace: &'a mut Namespace,
+    pub crate_namespace: Option<&'a Namespace>,
     pub return_type_annotation: TypeId,
     pub help_text: &'static str,
     pub self_type: TypeId,
     pub build_config: &'a BuildConfig,
-    pub dead_code_graph: &'a mut ControlFlowGraph<'sc>,
+    pub dead_code_graph: &'a mut ControlFlowGraph,
     pub mode: Mode,
     pub dependency_graph: &'a mut HashMap<String, HashSet<String>>,
     pub opts: TCOpts,

--- a/sway-core/src/span.rs
+++ b/sway-core/src/span.rs
@@ -56,7 +56,8 @@ impl Span {
             self.span.input().clone(),
             self.span.start() + start_delta,
             self.span.end() - end_delta,
-        ).unwrap();
+        )
+        .unwrap();
         Span {
             span,
             path: self.path,

--- a/sway-core/src/span.rs
+++ b/sway-core/src/span.rs
@@ -34,7 +34,7 @@ impl<'sc> Span<'sc> {
         self.span.as_str().to_string()
     }
 
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'sc str {
         self.span.as_str()
     }
 
@@ -47,5 +47,19 @@ impl<'sc> Span<'sc> {
             .as_deref()
             .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or_else(|| "".to_string())
+    }
+
+    pub fn trim(self) -> Span<'sc> {
+        let start_delta = self.as_str().len() - self.as_str().trim_start().len();
+        let end_delta = self.as_str().len() - self.as_str().trim_end().len();
+        let span = pest::Span::new(
+            self.span.input().clone(),
+            self.span.start() + start_delta,
+            self.span.end() - end_delta,
+        ).unwrap();
+        Span {
+            span,
+            path: self.path,
+        }
     }
 }

--- a/sway-core/src/span.rs
+++ b/sway-core/src/span.rs
@@ -2,14 +2,14 @@ use std::{path::PathBuf, sync::Arc};
 
 /// Represents a span of the source code in a specific file.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct Span<'sc> {
+pub struct Span {
     ///  A [pest::Span] returned directly from the generated parser.
-    pub span: pest::Span<'sc>,
+    pub span: pest::Span,
     // A reference counted pointer to the file from which this span originated.
     pub(crate) path: Option<Arc<PathBuf>>,
 }
 
-impl<'sc> Span<'sc> {
+impl Span {
     pub fn start(&self) -> usize {
         self.span.start()
     }
@@ -26,15 +26,15 @@ impl<'sc> Span<'sc> {
         self.span.end_pos()
     }
 
-    pub fn split(&self) -> (pest::Position<'sc>, pest::Position<'sc>) {
-        self.span.split()
+    pub fn split(&self) -> (pest::Position, pest::Position) {
+        self.span.clone().split()
     }
 
     pub fn str(self) -> String {
         self.span.as_str().to_string()
     }
 
-    pub fn as_str(&self) -> &'sc str {
+    pub fn as_str(&self) -> &str {
         self.span.as_str()
     }
 
@@ -49,7 +49,7 @@ impl<'sc> Span<'sc> {
             .unwrap_or_else(|| "".to_string())
     }
 
-    pub fn trim(self) -> Span<'sc> {
+    pub fn trim(self) -> Span {
         let start_delta = self.as_str().len() - self.as_str().trim_start().len();
         let end_delta = self.as_str().len() - self.as_str().trim_end().len();
         let span = pest::Span::new(

--- a/sway-core/src/type_engine.rs
+++ b/sway-core/src/type_engine.rs
@@ -59,7 +59,7 @@ fn basic_numeric_unknown() {
     let engine = Engine::default();
 
     let sp = Span {
-        span: pest::Span::new(" ", 0, 0).unwrap(),
+        span: pest::Span::new(" ".into(), 0, 0).unwrap(),
         path: None,
     };
     // numerics
@@ -78,7 +78,7 @@ fn basic_numeric_unknown() {
 fn chain_of_refs() {
     let engine = Engine::default();
     let sp = Span {
-        span: pest::Span::new(" ", 0, 0).unwrap(),
+        span: pest::Span::new(" ".into(), 0, 0).unwrap(),
         path: None,
     };
     // numerics
@@ -99,7 +99,7 @@ fn chain_of_refs() {
 fn chain_of_refs_2() {
     let engine = Engine::default();
     let sp = Span {
-        span: pest::Span::new(" ", 0, 0).unwrap(),
+        span: pest::Span::new(" ".into(), 0, 0).unwrap(),
         path: None,
     };
     // numerics
@@ -117,7 +117,7 @@ fn chain_of_refs_2() {
     );
 }
 
-fn parse_str_type<'sc>(raw: &'sc str, span: Span<'sc>) -> CompileResult<'sc, TypeInfo> {
+fn parse_str_type<'sc>(raw: &'sc str, span: Span) -> CompileResult<TypeInfo> {
     if raw.starts_with("str[") {
         let mut rest = raw.split_at("str[".len()).1.chars().collect::<Vec<_>>();
         if let Some(']') = rest.pop() {
@@ -141,7 +141,7 @@ fn test_str_parse() {
     match parse_str_type(
         "str[20]",
         Span {
-            span: pest::Span::new("", 0, 0).unwrap(),
+            span: pest::Span::new("".into(), 0, 0).unwrap(),
             path: None,
         },
     )
@@ -153,7 +153,7 @@ fn test_str_parse() {
     match parse_str_type(
         "str[]",
         Span {
-            span: pest::Span::new("", 0, 0).unwrap(),
+            span: pest::Span::new("".into(), 0, 0).unwrap(),
             path: None,
         },
     )
@@ -165,7 +165,7 @@ fn test_str_parse() {
     match parse_str_type(
         "str[ab]",
         Span {
-            span: pest::Span::new("", 0, 0).unwrap(),
+            span: pest::Span::new("".into(), 0, 0).unwrap(),
             path: None,
         },
     )
@@ -177,7 +177,7 @@ fn test_str_parse() {
     match parse_str_type(
         "str [ab]",
         Span {
-            span: pest::Span::new("", 0, 0).unwrap(),
+            span: pest::Span::new("".into(), 0, 0).unwrap(),
             path: None,
         },
     )
@@ -190,7 +190,7 @@ fn test_str_parse() {
     match parse_str_type(
         "not even a str[ type",
         Span {
-            span: pest::Span::new("", 0, 0).unwrap(),
+            span: pest::Span::new("".into(), 0, 0).unwrap(),
             path: None,
         },
     )
@@ -202,7 +202,7 @@ fn test_str_parse() {
     match parse_str_type(
         "",
         Span {
-            span: pest::Span::new("", 0, 0).unwrap(),
+            span: pest::Span::new("".into(), 0, 0).unwrap(),
             path: None,
         },
     )
@@ -214,7 +214,7 @@ fn test_str_parse() {
     match parse_str_type(
         "20",
         Span {
-            span: pest::Span::new("", 0, 0).unwrap(),
+            span: pest::Span::new("".into(), 0, 0).unwrap(),
             path: None,
         },
     )
@@ -226,7 +226,7 @@ fn test_str_parse() {
     match parse_str_type(
         "[20]",
         Span {
-            span: pest::Span::new("", 0, 0).unwrap(),
+            span: pest::Span::new("".into(), 0, 0).unwrap(),
             path: None,
         },
     )

--- a/sway-core/src/type_engine.rs
+++ b/sway-core/src/type_engine.rs
@@ -117,7 +117,7 @@ fn chain_of_refs_2() {
     );
 }
 
-fn parse_str_type<'sc>(raw: &'sc str, span: Span) -> CompileResult<TypeInfo> {
+fn parse_str_type(raw: &str, span: Span) -> CompileResult<TypeInfo> {
     if raw.starts_with("str[") {
         let mut rest = raw.split_at("str[".len()).1.chars().collect::<Vec<_>>();
         if let Some(']') = rest.pop() {

--- a/sway-core/src/type_engine/engine.rs
+++ b/sway-core/src/type_engine/engine.rs
@@ -32,7 +32,7 @@ impl Engine {
     /// there is a conflict between them).
     //
     // When reporting type errors we will report 'received' and 'expected' as such.
-    pub(crate) fn unify<'sc>(
+    pub(crate) fn unify(
         &self,
         received: TypeId,
         expected: TypeId,
@@ -190,7 +190,7 @@ impl Engine {
         }
     }
 
-    pub fn unify_with_self<'sc>(
+    pub fn unify_with_self(
         &self,
         received: TypeId,
         expected: TypeId,
@@ -211,7 +211,7 @@ impl Engine {
         self.unify(received, expected, span)
     }
 
-    pub fn resolve_type<'sc>(
+    pub fn resolve_type(
         &self,
         id: TypeId,
         error_span: &Span,
@@ -237,7 +237,7 @@ pub(crate) fn look_up_type_id_raw(id: TypeId) -> TypeInfo {
     TYPE_ENGINE.look_up_type_id_raw(id)
 }
 
-pub fn unify_with_self<'sc>(
+pub fn unify_with_self(
     a: TypeId,
     b: TypeId,
     self_type: TypeId,
@@ -246,11 +246,11 @@ pub fn unify_with_self<'sc>(
     TYPE_ENGINE.unify_with_self(a, b, self_type, span)
 }
 
-pub fn resolve_type<'sc>(id: TypeId, error_span: &Span) -> Result<TypeInfo, TypeError> {
+pub fn resolve_type(id: TypeId, error_span: &Span) -> Result<TypeInfo, TypeError> {
     TYPE_ENGINE.resolve_type(id, error_span)
 }
 
-fn numeric_cast_compat<'sc>(
+fn numeric_cast_compat(
     new_size: IntegerBits,
     old_size: IntegerBits,
 ) -> NumericCastCompatResult {

--- a/sway-core/src/type_engine/engine.rs
+++ b/sway-core/src/type_engine/engine.rs
@@ -36,8 +36,8 @@ impl Engine {
         &self,
         received: TypeId,
         expected: TypeId,
-        span: &Span<'sc>,
-    ) -> Result<Vec<CompileWarning<'sc>>, TypeError<'sc>> {
+        span: &Span,
+    ) -> Result<Vec<CompileWarning>, TypeError> {
         use TypeInfo::*;
         match (self.slab.get(received), self.slab.get(expected)) {
             // If the types are exactly the same, we are done.
@@ -195,8 +195,8 @@ impl Engine {
         received: TypeId,
         expected: TypeId,
         self_type: TypeId,
-        span: &Span<'sc>,
-    ) -> Result<Vec<CompileWarning<'sc>>, TypeError<'sc>> {
+        span: &Span,
+    ) -> Result<Vec<CompileWarning>, TypeError> {
         let received = if self.look_up_type_id(received) == TypeInfo::SelfType {
             self_type
         } else {
@@ -214,8 +214,8 @@ impl Engine {
     pub fn resolve_type<'sc>(
         &self,
         id: TypeId,
-        error_span: &Span<'sc>,
-    ) -> Result<TypeInfo, TypeError<'sc>> {
+        error_span: &Span,
+    ) -> Result<TypeInfo, TypeError> {
         match self.look_up_type_id(id) {
             TypeInfo::Unknown => Err(TypeError::UnknownType {
                 span: error_span.clone(),
@@ -241,19 +241,19 @@ pub fn unify_with_self<'sc>(
     a: TypeId,
     b: TypeId,
     self_type: TypeId,
-    span: &Span<'sc>,
-) -> Result<Vec<CompileWarning<'sc>>, TypeError<'sc>> {
+    span: &Span,
+) -> Result<Vec<CompileWarning>, TypeError> {
     TYPE_ENGINE.unify_with_self(a, b, self_type, span)
 }
 
-pub fn resolve_type<'sc>(id: TypeId, error_span: &Span<'sc>) -> Result<TypeInfo, TypeError<'sc>> {
+pub fn resolve_type<'sc>(id: TypeId, error_span: &Span) -> Result<TypeInfo, TypeError> {
     TYPE_ENGINE.resolve_type(id, error_span)
 }
 
 fn numeric_cast_compat<'sc>(
     new_size: IntegerBits,
     old_size: IntegerBits,
-) -> NumericCastCompatResult<'sc> {
+) -> NumericCastCompatResult {
     // If this is a downcast, warn for loss of precision. If upcast, then no warning.
     use IntegerBits::*;
     match (new_size, old_size) {
@@ -273,7 +273,7 @@ fn numeric_cast_compat<'sc>(
         _ => NumericCastCompatResult::Compatible,
     }
 }
-enum NumericCastCompatResult<'sc> {
+enum NumericCastCompatResult {
     Compatible,
-    CastableWithWarning(Warning<'sc>),
+    CastableWithWarning(Warning),
 }

--- a/sway-core/src/type_engine/engine.rs
+++ b/sway-core/src/type_engine/engine.rs
@@ -211,11 +211,7 @@ impl Engine {
         self.unify(received, expected, span)
     }
 
-    pub fn resolve_type(
-        &self,
-        id: TypeId,
-        error_span: &Span,
-    ) -> Result<TypeInfo, TypeError> {
+    pub fn resolve_type(&self, id: TypeId, error_span: &Span) -> Result<TypeInfo, TypeError> {
         match self.look_up_type_id(id) {
             TypeInfo::Unknown => Err(TypeError::UnknownType {
                 span: error_span.clone(),
@@ -250,10 +246,7 @@ pub fn resolve_type(id: TypeId, error_span: &Span) -> Result<TypeInfo, TypeError
     TYPE_ENGINE.resolve_type(id, error_span)
 }
 
-fn numeric_cast_compat(
-    new_size: IntegerBits,
-    old_size: IntegerBits,
-) -> NumericCastCompatResult {
+fn numeric_cast_compat(new_size: IntegerBits, old_size: IntegerBits) -> NumericCastCompatResult {
     // If this is a downcast, warn for loss of precision. If upcast, then no warning.
     use IntegerBits::*;
     match (new_size, old_size) {

--- a/sway-core/src/type_engine/type_info.rs
+++ b/sway-core/src/type_engine/type_info.rs
@@ -40,7 +40,7 @@ pub enum TypeInfo {
         address: String,
         // TODO(static span): the above String should be a TypedExpression
         //        #[derivative(PartialEq = "ignore", Hash = "ignore")]
-        //        address: Box<TypedExpression<'sc>>,
+        //        address: Box<TypedExpression>,
     },
     /// A custom type could be a struct or similar if the name is in scope,
     /// or just a generic parameter if it is not.
@@ -70,9 +70,9 @@ impl Default for TypeInfo {
 
 impl TypeInfo {
     pub(crate) fn parse_from_pair<'sc>(
-        input: Pair<'sc, Rule>,
+        input: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         match input.as_rule() {
             Rule::type_name | Rule::generic_type_param => (),
             _ => {
@@ -91,9 +91,9 @@ impl TypeInfo {
     }
 
     fn parse_from_pair_inner<'sc>(
-        input: Pair<'sc, Rule>,
+        input: Pair<Rule>,
         config: Option<&BuildConfig>,
-    ) -> CompileResult<'sc, Self> {
+    ) -> CompileResult<Self> {
         let mut warnings = vec![];
         let mut errors = vec![];
         let span = Span {
@@ -309,8 +309,8 @@ impl TypeInfo {
     /// maps a type to a name that is used when constructing function selectors
     pub(crate) fn to_selector_name<'sc>(
         &self,
-        error_msg_span: &Span<'sc>,
-    ) -> CompileResult<'sc, String> {
+        error_msg_span: &Span,
+    ) -> CompileResult<String> {
         use TypeInfo::*;
         let name = match self {
             Str(len) => format!("str[{}]", len),
@@ -410,8 +410,8 @@ impl TypeInfo {
     /// Calculates the stack size of this type, to be used when allocating stack memory for it.
     pub(crate) fn size_in_words<'sc>(
         &self,
-        err_span: &Span<'sc>,
-    ) -> Result<u64, CompileError<'sc>> {
+        err_span: &Span,
+    ) -> Result<u64, CompileError> {
         match self {
             // Each char is a byte, so the size is the num of characters / 8
             // rounded up to the nearest word
@@ -551,7 +551,7 @@ impl TypeInfo {
 
     pub(crate) fn matches_type_parameter<'sc>(
         &self,
-        mapping: &[(TypeParameter<'sc>, TypeId)],
+        mapping: &[(TypeParameter, TypeId)],
     ) -> Option<TypeId> {
         use TypeInfo::*;
         match self {

--- a/sway-core/src/type_engine/type_info.rs
+++ b/sway-core/src/type_engine/type_info.rs
@@ -69,7 +69,7 @@ impl Default for TypeInfo {
 }
 
 impl TypeInfo {
-    pub(crate) fn parse_from_pair<'sc>(
+    pub(crate) fn parse_from_pair(
         input: Pair<Rule>,
         config: Option<&BuildConfig>,
     ) -> CompileResult<Self> {
@@ -90,7 +90,7 @@ impl TypeInfo {
         Self::parse_from_pair_inner(input.into_inner().next().unwrap(), config)
     }
 
-    fn parse_from_pair_inner<'sc>(
+    fn parse_from_pair_inner(
         input: Pair<Rule>,
         config: Option<&BuildConfig>,
     ) -> CompileResult<Self> {
@@ -307,7 +307,7 @@ impl TypeInfo {
     }
 
     /// maps a type to a name that is used when constructing function selectors
-    pub(crate) fn to_selector_name<'sc>(
+    pub(crate) fn to_selector_name(
         &self,
         error_msg_span: &Span,
     ) -> CompileResult<String> {
@@ -408,7 +408,7 @@ impl TypeInfo {
         ok(name, vec![], vec![])
     }
     /// Calculates the stack size of this type, to be used when allocating stack memory for it.
-    pub(crate) fn size_in_words<'sc>(
+    pub(crate) fn size_in_words(
         &self,
         err_span: &Span,
     ) -> Result<u64, CompileError> {
@@ -549,7 +549,7 @@ impl TypeInfo {
         }
     }
 
-    pub(crate) fn matches_type_parameter<'sc>(
+    pub(crate) fn matches_type_parameter(
         &self,
         mapping: &[(TypeParameter, TypeId)],
     ) -> Option<TypeId> {
@@ -628,7 +628,7 @@ impl TypeInfo {
                     let new_field =
                         match look_up_type_id(fields[index]).matches_type_parameter(mapping) {
                             Some(new_field_id) => insert_type(TypeInfo::Ref(new_field_id)),
-                            None => fields[index].clone(),
+                            None => fields[index],
                         };
                     new_fields.push(new_field);
                     index += 1;

--- a/sway-core/src/type_engine/type_info.rs
+++ b/sway-core/src/type_engine/type_info.rs
@@ -307,10 +307,7 @@ impl TypeInfo {
     }
 
     /// maps a type to a name that is used when constructing function selectors
-    pub(crate) fn to_selector_name(
-        &self,
-        error_msg_span: &Span,
-    ) -> CompileResult<String> {
+    pub(crate) fn to_selector_name(&self, error_msg_span: &Span) -> CompileResult<String> {
         use TypeInfo::*;
         let name = match self {
             Str(len) => format!("str[{}]", len),
@@ -408,10 +405,7 @@ impl TypeInfo {
         ok(name, vec![], vec![])
     }
     /// Calculates the stack size of this type, to be used when allocating stack memory for it.
-    pub(crate) fn size_in_words(
-        &self,
-        err_span: &Span,
-    ) -> Result<u64, CompileError> {
+    pub(crate) fn size_in_words(&self, err_span: &Span) -> Result<u64, CompileError> {
         match self {
             // Each char is a byte, so the size is the num of characters / 8
             // rounded up to the nearest word

--- a/sway-core/src/types/resolved_type.rs
+++ b/sway-core/src/types/resolved_type.rs
@@ -47,7 +47,7 @@ impl Default for ResolvedType {
     }
 }
 
-impl<'sc> ResolvedType {
+impl ResolvedType {
     /// Calculates the stack size of this type, to be used when allocating stack memory for it.
     /// This is _in words_!
     pub(crate) fn stack_size_of(&self) -> u64 {

--- a/sway-core/src/types/resolved_type.rs
+++ b/sway-core/src/types/resolved_type.rs
@@ -5,7 +5,7 @@ use derivative::Derivative;
 
 #[derive(Derivative)]
 #[derivative(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum ResolvedType<'sc> {
+pub enum ResolvedType {
     /// The number in a `Str` represents its size, which must be known at compile time
     Str(u64),
     UnsignedInteger(IntegerBits),
@@ -14,12 +14,12 @@ pub enum ResolvedType<'sc> {
     Byte,
     B256,
     Struct {
-        name: Ident<'sc>,
-        fields: Vec<TypedStructField<'sc>>,
+        name: Ident,
+        fields: Vec<TypedStructField>,
     },
     Enum {
-        name: Ident<'sc>,
-        variant_types: Vec<ResolvedType<'sc>>,
+        name: Ident,
+        variant_types: Vec<ResolvedType>,
     },
     /// Represents the contract's type as a whole. Used for implementing
     /// traits on the contract itself, to enforce a specific type of ABI.
@@ -27,32 +27,32 @@ pub enum ResolvedType<'sc> {
     /// Represents a type which contains methods to issue a contract call.
     /// The specific contract is identified via the `Ident` within.
     ContractCaller {
-        abi_name: CallPath<'sc>,
+        abi_name: CallPath,
         #[derivative(PartialEq = "ignore", Hash = "ignore")]
-        address: Box<TypedExpression<'sc>>,
+        address: Box<TypedExpression>,
     },
     Function {
-        from: Box<ResolvedType<'sc>>,
-        to: Box<ResolvedType<'sc>>,
+        from: Box<ResolvedType>,
+        to: Box<ResolvedType>,
     },
     // used for recovering from errors in the ast
     ErrorRecovery,
 }
 
-impl ResolvedType<'_> {}
+impl ResolvedType {}
 
-impl Default for ResolvedType<'_> {
+impl Default for ResolvedType {
     fn default() -> Self {
         ResolvedType::Unit
     }
 }
 
-impl<'sc> ResolvedType<'sc> {
+impl<'sc> ResolvedType {
     /// Calculates the stack size of this type, to be used when allocating stack memory for it.
     /// This is _in words_!
     pub(crate) fn stack_size_of(&self) -> u64 {
         let span = crate::Span {
-            span: pest::Span::new("TODO(static span)", 0, 0).unwrap(),
+            span: pest::Span::new("TODO(static span)".into(), 0, 0).unwrap(),
             path: None,
         };
 

--- a/sway-core/src/utils.rs
+++ b/sway-core/src/utils.rs
@@ -2,7 +2,7 @@ use crate::span::Span;
 
 /// This panics if the spans are not from the same file. This should
 /// only be used on spans that are actually next to each other.
-pub fn join_spans<'sc>(s1: Span<'sc>, s2: Span<'sc>) -> Span<'sc> {
+pub fn join_spans<'sc>(s1: Span, s2: Span) -> Span {
     assert!(
         s1.input() == s2.input() && s1.path == s2.path,
         "Spans from different files cannot be joined.",

--- a/sway-core/src/utils.rs
+++ b/sway-core/src/utils.rs
@@ -2,7 +2,7 @@ use crate::span::Span;
 
 /// This panics if the spans are not from the same file. This should
 /// only be used on spans that are actually next to each other.
-pub fn join_spans<'sc>(s1: Span, s2: Span) -> Span {
+pub fn join_spans(s1: Span, s2: Span) -> Span {
     assert!(
         s1.input() == s2.input() && s1.path == s2.path,
         "Spans from different files cannot be joined.",

--- a/sway-core/utils/selector_debug.rs
+++ b/sway-core/utils/selector_debug.rs
@@ -2,7 +2,7 @@
 //! Given an input function declaration, return the selector for it in hexidecimal.
 use pest::Parser;
 use structopt::StructOpt;
-
+use std::sync::Arc;
 use sway_core::{
     parse_tree::declaration::FunctionDeclaration,
     semantic_analysis::{
@@ -25,7 +25,7 @@ fn main() {
     let mut warnings = vec![];
     let mut errors = vec![];
 
-    let parsed_fn_decl = HllParser::parse(Rule::fn_decl, &fn_decl);
+    let parsed_fn_decl = HllParser::parse(Rule::fn_decl, Arc::from(fn_decl));
     let mut parsed_fn_decl = match parsed_fn_decl {
         Ok(o) => o,
         Err(e) => panic!("Failed to parse: {:?}", e),

--- a/sway-core/utils/selector_debug.rs
+++ b/sway-core/utils/selector_debug.rs
@@ -1,8 +1,8 @@
 //! Used to debug function selectors
 //! Given an input function declaration, return the selector for it in hexidecimal.
 use pest::Parser;
-use structopt::StructOpt;
 use std::sync::Arc;
+use structopt::StructOpt;
 use sway_core::{
     parse_tree::declaration::FunctionDeclaration,
     semantic_analysis::{

--- a/sway-fmt/src/fmt.rs
+++ b/sway-fmt/src/fmt.rs
@@ -1,14 +1,15 @@
+use std::sync::Arc;
 use super::code_builder::CodeBuilder;
 use crate::traversal::{traverse_for_changes, Change};
 use ropey::Rope;
 
 /// returns number of lines and formatted text
-pub fn get_formatted_data(file: &str, tab_size: u32) -> Result<(usize, String), Vec<String>> {
-    let parsed_res = sway_core::parse(file, None);
+pub fn get_formatted_data(file: Arc<str>, tab_size: u32) -> Result<(usize, String), Vec<String>> {
+    let parsed_res = sway_core::parse(file.clone(), None);
     match parsed_res.value {
         Some(parse_tree) => {
             let changes = traverse_for_changes(&parse_tree);
-            let mut rope_file = Rope::from_str(file);
+            let mut rope_file = Rope::from_str(&file);
 
             let mut offset: i32 = 0;
             for change in changes {
@@ -80,7 +81,7 @@ pub fn add(a: u32, b: u32) -> u32 {
     a + b
 }
 "#;
-        let result = get_formatted_data(correct_sway_code, 4);
+        let result = get_formatted_data(correct_sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
@@ -129,7 +130,7 @@ add
 
 "#;
 
-        let result = get_formatted_data(sway_code, 4);
+        let result = get_formatted_data(sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
@@ -149,7 +150,7 @@ fn main() {
 }
 "#;
 
-        let result = get_formatted_data(correct_sway_code, 4);
+        let result = get_formatted_data(correct_sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
@@ -167,7 +168,7 @@ fn main(){
 }
 "#;
 
-        let result = get_formatted_data(sway_code, 4);
+        let result = get_formatted_data(sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
@@ -188,7 +189,7 @@ fn main() {
 }
 "#;
 
-        let result = get_formatted_data(correct_sway_code, 4);
+        let result = get_formatted_data(correct_sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
@@ -209,7 +210,7 @@ fn main() {
 }
 "#;
 
-        let result = get_formatted_data(sway_code, 4);
+        let result = get_formatted_data(sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
@@ -243,7 +244,7 @@ struct Example { // first comment
 } // comment as well
 "#;
 
-        let result = get_formatted_data(correct_sway_code, 4);
+        let result = get_formatted_data(correct_sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
@@ -274,7 +275,7 @@ struct Example {    // first comment
 }   // comment as well
 "#;
 
-        let result = get_formatted_data(sway_code, 4);
+        let result = get_formatted_data(sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
@@ -384,7 +385,7 @@ fn get_gas() -> A {
 }
 "#;
 
-        let result = get_formatted_data(correct_sway_code, 4);
+        let result = get_formatted_data(correct_sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
@@ -484,7 +485,7 @@ cgas
 }
 "#;
 
-        let result = get_formatted_data(sway_code, 4);
+        let result = get_formatted_data(sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
@@ -513,7 +514,7 @@ pub fn tell_a_story() -> Story {
 }
 "#;
 
-        let result = get_formatted_data(correct_sway_code, 4);
+        let result = get_formatted_data(correct_sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
@@ -541,7 +542,7 @@ pub fn tell_a_story() -> Story {
         }
 "#;
 
-        let result = get_formatted_data(sway_code, 4);
+        let result = get_formatted_data(sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
@@ -571,7 +572,7 @@ fn one_liner() -> bool {
 }
 "#;
 
-        let result = get_formatted_data(correct_sway_code, 4);
+        let result = get_formatted_data(correct_sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
@@ -601,7 +602,7 @@ fn one_liner() -> bool {
         }
 "#;
 
-        let result = get_formatted_data(sway_code, 4);
+        let result = get_formatted_data(sway_code.into(), 4);
         assert!(result.is_ok());
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);

--- a/sway-fmt/src/fmt.rs
+++ b/sway-fmt/src/fmt.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
 use super::code_builder::CodeBuilder;
 use crate::traversal::{traverse_for_changes, Change};
 use ropey::Rope;
+use std::sync::Arc;
 
 /// returns number of lines and formatted text
 pub fn get_formatted_data(file: Arc<str>, tab_size: u32) -> Result<(usize, String), Vec<String>> {

--- a/sway-fmt/src/traversal_helper.rs
+++ b/sway-fmt/src/traversal_helper.rs
@@ -74,7 +74,7 @@ pub fn format_delineated_path(line: &str) -> String {
 
 pub fn format_use_statement(line: &str) -> String {
     let use_keyword = extract_keyword(line, Rule::use_keyword).unwrap();
-    let (_, right) = line.split_once(use_keyword).unwrap();
+    let (_, right) = line.split_once(&use_keyword).unwrap();
     let right: String = right.chars().filter(|c| !c.is_whitespace()).collect();
     format!(
         "{}{} {}",
@@ -84,7 +84,7 @@ pub fn format_use_statement(line: &str) -> String {
 
 pub fn format_include_statement(line: &str) -> String {
     let include_keyword = extract_keyword(line, Rule::include_keyword).unwrap();
-    let (_, right) = line.split_once(include_keyword).unwrap();
+    let (_, right) = line.split_once(&include_keyword).unwrap();
     let right: String = right.chars().filter(|c| !c.is_whitespace()).collect();
     format!(
         "{}{} {}",

--- a/sway-server/Cargo.toml
+++ b/sway-server/Cargo.toml
@@ -11,7 +11,6 @@ description = "LSP server for Sway."
 [dependencies]
 dashmap = "4.0.2"
 lspower = "1.0.0"
-pest = { version = "3.0", package = "fuel-pest" }
 ropey = "1.2"
 serde_json = "1.0.60"
 sway-core = { version = "0.1.9", path = "../sway-core" }

--- a/sway-server/src/capabilities/diagnostic.rs
+++ b/sway-server/src/capabilities/diagnostic.rs
@@ -55,6 +55,6 @@ fn get_range(warning_or_error: &WarningOrError<'_>) -> Range {
 }
 
 enum WarningOrError<'s> {
-    Warning(&'s CompileWarning<'s>),
-    Error(&'s CompileError<'s>),
+    Warning(&'s CompileWarning),
+    Error(&'s CompileError),
 }

--- a/sway-server/src/capabilities/formatting.rs
+++ b/sway-server/src/capabilities/formatting.rs
@@ -17,9 +17,9 @@ pub fn format_document(
     session.format_text(&url, options)
 }
 
-pub fn get_format_text_edits(text: &str, options: FormattingOptions) -> Option<Vec<TextEdit>> {
+pub fn get_format_text_edits(text: Arc<str>, options: FormattingOptions) -> Option<Vec<TextEdit>> {
     // we only format if code is correct
-    match get_formatted_data(text, options.tab_size) {
+    match get_formatted_data(text.clone(), options.tab_size) {
         Ok((num_of_lines, formatted_text)) => {
             let text_lines_count = text.split('\n').count();
             let line_end = std::cmp::max(num_of_lines, text_lines_count) as u32;

--- a/sway-server/src/core/document.rs
+++ b/sway-server/src/core/document.rs
@@ -5,6 +5,7 @@ use lspower::lsp::{Diagnostic, Position, Range, TextDocumentContentChangeEvent};
 use ropey::Rope;
 use std::collections::HashMap;
 use sway_core::{parse, TreeType};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct TextDocument {
@@ -107,7 +108,7 @@ impl TextDocument {
 // private methods
 impl TextDocument {
     fn parse_tokens_from_text(&self) -> Result<(Vec<Token>, Vec<Diagnostic>), Vec<Diagnostic>> {
-        let text = &self.get_text();
+        let text = Arc::from(self.get_text());
         let parsed_result = parse(text, None);
         match parsed_result.value {
             None => Err(capabilities::diagnostic::get_diagnostics(

--- a/sway-server/src/core/document.rs
+++ b/sway-server/src/core/document.rs
@@ -4,8 +4,8 @@ use crate::{capabilities, core::token::traverse_node};
 use lspower::lsp::{Diagnostic, Position, Range, TextDocumentContentChangeEvent};
 use ropey::Rope;
 use std::collections::HashMap;
-use sway_core::{parse, TreeType};
 use std::sync::Arc;
+use sway_core::{parse, TreeType};
 
 #[derive(Debug)]
 pub struct TextDocument {

--- a/sway-server/src/core/session.rs
+++ b/sway-server/src/core/session.rs
@@ -5,6 +5,7 @@ use lspower::lsp::{
     CompletionItem, Diagnostic, FormattingOptions, GotoDefinitionResponse, Position, Range,
     SemanticToken, SymbolInformation, TextDocumentContentChangeEvent, TextEdit, Url,
 };
+use std::sync::Arc;
 
 pub type Documents = DashMap<String, TextDocument>;
 
@@ -146,7 +147,7 @@ impl Session {
 
     pub fn format_text(&self, url: &Url, options: FormattingOptions) -> Option<Vec<TextEdit>> {
         if let Some(document) = self.documents.get(url.path()) {
-            get_format_text_edits(&document.get_text(), options)
+            get_format_text_edits(Arc::from(document.get_text()), options)
         } else {
             None
         }

--- a/sway-server/src/core/token.rs
+++ b/sway-server/src/core/token.rs
@@ -58,7 +58,7 @@ impl Token {
 
     pub fn from_variable(var_dec: &VariableDeclaration) -> Self {
         let ident = &var_dec.name;
-        let name = ident.primary_name();
+        let name = ident.as_str();
         let var_body = extract_var_body(var_dec);
 
         Token::new(
@@ -72,7 +72,7 @@ impl Token {
     }
 
     pub fn from_ident(ident: &Ident, token_type: TokenType) -> Self {
-        Token::new(&ident.span(), ident.primary_name().into(), token_type)
+        Token::new(&ident.span(), ident.as_str().into(), token_type)
     }
 
     pub fn from_span(span: Span, token_type: TokenType) -> Self {

--- a/sway-server/src/core/token.rs
+++ b/sway-server/src/core/token.rs
@@ -58,11 +58,11 @@ impl Token {
 
     pub fn from_variable(var_dec: &VariableDeclaration) -> Self {
         let ident = &var_dec.name;
-        let name = ident.primary_name;
+        let name = ident.primary_name();
         let var_body = extract_var_body(var_dec);
 
         Token::new(
-            &ident.span,
+            &ident.span(),
             name.into(),
             TokenType::Variable(VariableDetails {
                 is_mutable: var_dec.is_mutable,
@@ -72,7 +72,7 @@ impl Token {
     }
 
     pub fn from_ident(ident: &Ident, token_type: TokenType) -> Self {
-        Token::new(&ident.span, ident.primary_name.into(), token_type)
+        Token::new(&ident.span(), ident.primary_name().into(), token_type)
     }
 
     pub fn from_span(span: Span, token_type: TokenType) -> Self {

--- a/sway-server/src/core/token.rs
+++ b/sway-server/src/core/token.rs
@@ -62,7 +62,7 @@ impl Token {
         let var_body = extract_var_body(var_dec);
 
         Token::new(
-            &ident.span(),
+            ident.span(),
             name.into(),
             TokenType::Variable(VariableDetails {
                 is_mutable: var_dec.is_mutable,
@@ -72,7 +72,7 @@ impl Token {
     }
 
     pub fn from_ident(ident: &Ident, token_type: TokenType) -> Self {
-        Token::new(&ident.span(), ident.as_str().into(), token_type)
+        Token::new(ident.span(), ident.as_str().into(), token_type)
     }
 
     pub fn from_span(span: Span, token_type: TokenType) -> Self {

--- a/sway-server/src/utils/common.rs
+++ b/sway-server/src/utils/common.rs
@@ -13,10 +13,10 @@ pub(crate) fn extract_visibility(visibility: &Visibility) -> String {
 pub(crate) fn extract_var_body(var_dec: &VariableDeclaration) -> VarBody {
     match &var_dec.body {
         Expression::FunctionApplication { name, .. } => {
-            VarBody::FunctionCall(name.suffix.primary_name.into())
+            VarBody::FunctionCall(name.suffix.primary_name().into())
         }
         Expression::StructExpression { struct_name, .. } => {
-            VarBody::Type(struct_name.primary_name.into())
+            VarBody::Type(struct_name.primary_name().into())
         }
         _ => VarBody::Other,
     }

--- a/sway-server/src/utils/common.rs
+++ b/sway-server/src/utils/common.rs
@@ -13,10 +13,10 @@ pub(crate) fn extract_visibility(visibility: &Visibility) -> String {
 pub(crate) fn extract_var_body(var_dec: &VariableDeclaration) -> VarBody {
     match &var_dec.body {
         Expression::FunctionApplication { name, .. } => {
-            VarBody::FunctionCall(name.suffix.primary_name().into())
+            VarBody::FunctionCall(name.suffix.as_str().into())
         }
         Expression::StructExpression { struct_name, .. } => {
-            VarBody::Type(struct_name.primary_name().into())
+            VarBody::Type(struct_name.as_str().into())
         }
         _ => VarBody::Other,
     }


### PR DESCRIPTION
This PR removes the `<'sc>` lifetime which was on just about every type and function in the codebase. Source code is now stored in an `Arc<str>` and `Span` is used to represent a sub-slice of the string.