### PR TITLE
Use exact version for local deps.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "docstrings"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "thiserror",
 ]
@@ -1020,7 +1020,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -2007,7 +2007,7 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parser"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ariadne",
  "chumsky",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "sway-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "derivative",
  "either",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "sway-fmt"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ropey",
  "sway-core",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "sway-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dashmap",
  "fuel-pest",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "sway-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fuel-asm",
  "fuel-tx",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "sway-utils"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "syn"
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "test"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "forc",
  "fuel-asm",

--- a/docstrings/Cargo.toml
+++ b/docstrings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docstrings"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 homepage = "https://fuel.network/"
@@ -20,7 +20,7 @@ fuel-tx = "0.1"
 fuel-vm = "0.1"
 futures = "0.3"
 hex = "0.4.3"
-pest = {version = "3.0", package = "fuel-pest" }
+pest = { version = "3.0", package = "fuel-pest" }
 prettydiff = "0.4.0"
 reqwest = { version = "0.11.4", features = ["json"] }
 semver = "1.0.3"
@@ -28,11 +28,11 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = "*"
 source-span = "2.4"
 structopt = "0.3"
-sway-core = { version = "0.1", path = "../sway-core" }
-sway-fmt = { version = "0.1", path = "../sway-fmt" }
-sway-server = { version = "0.1", path = "../sway-server" }
-sway-utils = { version = "0.1", path = "../sway-utils" }
-sway-types = { version = "0.1", path = "../sway-types" }
+sway-core = { version = "0.1.1", path = "../sway-core" }
+sway-fmt = { version = "0.1.1", path = "../sway-fmt" }
+sway-server = { version = "0.1.1", path = "../sway-server" }
+sway-utils = { version = "0.1.1", path = "../sway-utils" }
+sway-types = { version = "0.1.1", path = "../sway-types" }
 tar = "0.4.35"
 term-table = "1.3"
 termcolor = "1.1"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parser"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-core"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 homepage = "https://fuel.network/"
@@ -19,14 +19,14 @@ fuel-vm = "0.1"
 hex = { version = "0.4", optional = true }
 lazy_static = "1.4"
 line-col = "0.2"
-pest = {version = "3.0", package = "fuel-pest" }
+pest = { version = "3.0", package = "fuel-pest" }
 pest_derive = "2.0"
 petgraph = "0.5"
 sha2 = "0.9"
 smallvec = "1.7"
 source-span = "2.4"
 structopt = { version = "0.3", default-features = false, optional = true }
-sway-types = { version = "0.1", path = "../sway-types" }
+sway-types = { version = "0.1.1", path = "../sway-types" }
 thiserror = "1.0"
 uuid-b64 = "0.1"
 

--- a/sway-fmt/Cargo.toml
+++ b/sway-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-fmt"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 homepage = "https://fuel.network/"
@@ -10,4 +10,4 @@ description = "Sway sway-fmt."
 
 [dependencies]
 ropey = "1.2"
-sway-core = { version = "0.1", path = "../sway-core" }
+sway-core = { version = "0.1.1", path = "../sway-core" }

--- a/sway-server/Cargo.toml
+++ b/sway-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-server"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 homepage = "https://fuel.network/"
@@ -11,10 +11,10 @@ description = "LSP server for Sway."
 [dependencies]
 dashmap = "4.0.2"
 lspower = "1.0.0"
-pest = {version = "3.0", package = "fuel-pest" }
+pest = { version = "3.0", package = "fuel-pest" }
 ropey = "1.2"
 serde_json = "1.0.60"
-sway-core = { version = "0.1", path = "../sway-core" }
-sway-fmt = { version = "0.1", path = "../sway-fmt" }
-sway-utils = { version = "0.1", path = "../sway-utils" }
+sway-core = { version = "0.1.1", path = "../sway-core" }
+sway-fmt = { version = "0.1.1", path = "../sway-fmt" }
+sway-utils = { version = "0.1.1", path = "../sway-utils" }
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }

--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-types"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 homepage = "https://fuel.network/"

--- a/sway-utils/Cargo.toml
+++ b/sway-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-utils"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "test"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 publish = false
 
 [dependencies]
-forc = { path = "../forc", features = ["test"], default-features = false }
+forc = { version = "0.1.1", path = "../forc", features = ["test"], default-features = false }
 fuel-asm = "0.1"
 fuel-tx = "0.1"
 fuel-vm = { version = "0.1", features = ["random"] }


### PR DESCRIPTION
The cargo publish action [seems to want an exact match](https://github.com/katyo/publish-crates/blob/b9f892948cc44179a7d686293d2277fa2e958f15/src/package.ts#L191), so use the exact version for local deps. Also bump version to v0.1.1.