### PR TITLE
Fix default manifest file

### DIFF
--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -25,7 +25,7 @@ pub(crate) fn default_tests_manifest(project_name: &str) -> String {
         r#"[package]
 name = "{}"
 version = "0.1.0"
-authors = "[{}]"
+authors = ["{}"]
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
1. Fix order of parameters to properly fill in package name and author(s).
2. Use `[]` for Cargo `authors`.
3. Use crates.io instead of git dependencies.