### PR TITLE
fix: flip project_name and real_name

### DIFF
--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -10,7 +10,7 @@ author = "{}"
 entry = "main.sw"
 license = "Apache-2.0"
 "#,
-        real_name, project_name,
+        project_name, real_name,
     )
 }
 
@@ -42,7 +42,7 @@ name = "integration_tests"
 path = "tests/harness.rs"
 harness = true
 "#,
-        real_name, project_name,
+        project_name, real_name,
     )
 }
 


### PR DESCRIPTION
the current impl leads to a Forc.toml that looks like this

<img width="294" alt="Screen Shot 2021-12-27 at 3 08 04 PM" src="https://user-images.githubusercontent.com/26209401/147512734-e00d003a-507a-46e4-a213-43852c90b1fc.png">
