### PR TITLE
Add fuels-core to default Cargo manifest file.

### DIFF
--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -32,6 +32,7 @@ license = "Apache-2.0"
 [dependencies]
 tokio = {{ version = "1.12", features = ["rt", "macros"] }}
 fuels-abigen-macro = "0.1"
+fuels-core = "0.1"
 fuels-rs = "0.1"
 fuel-gql-client = {{ version = "0.1", default-features = false }}
 fuel-tx = "0.1"


### PR DESCRIPTION
I'm not actually sure why this is necessary, shouldn't `fuels-core` be a dependency of `fuels-rs`? Regardless, here it is. cc @digorithm