### PR TITLE
Fix basic types.

### DIFF
--- a/docs/src/basics/built_in_types.md
+++ b/docs/src/basics/built_in_types.md
@@ -12,11 +12,9 @@ Sway has the following primitive types:
 1. `u16` (16-bit unsigned integer)
 1. `u32` (32-bit unsigned integer)
 1. `u64` (64-bit unsigned integer)
-1. `String`
-1. `Boolean`
-1. `Byte`
-1. `b256` (256 bits(32 bytes) -- i.e. a hash)
-1. Static-length arrays (as of now, not yet implemented)
+1. `str[]` (fixed-length string)
+1. `bool` (Boolean `true` or `false`)
+1. `b256` (256 bits (32 bytes), i.e. a hash)
 
 All other types in Sway are built up of these primitive types, or references to these primitive types. You may notice that there are no signed integers -- this is by design. In the blockchain domain that Sway occupies, floating point values and negative numbers have smaller utility, so their implementation has been left up to libraries for specific use cases.
 


### PR DESCRIPTION
1. Change `String` to `str[]`.
2. Change `Boolean` to `bool`.
3. Remove `Byte`.
4. Remove arrays from list of primitive types (it's in a section further down).