### PR TITLE
Remove lines to install forc in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,3 @@ Confirm the Sway toolchain built successfully:
 ```sh
 cargo run --bin forc -- --help
 ```
-
-To run `forc` from any directory, install `forc` to your local Cargo bin directory:
-
-```sh
-cargo install --locked --path forc
-```


### PR DESCRIPTION
No longer work ever since `forc` is on crates.io.