### PR TITLE
fix: fix hover and add variable types on hover

### DIFF
--- a/sway-server/src/core/token.rs
+++ b/sway-server/src/core/token.rs
@@ -80,7 +80,7 @@ impl Token {
     }
 
     pub fn is_initial_declaration(&self) -> bool {
-        matches!(
+        !matches!(
             self.token_type,
             TokenType::Reassignment | TokenType::FunctionApplication
         )

--- a/sway-server/src/utils/common.rs
+++ b/sway-server/src/utils/common.rs
@@ -27,7 +27,6 @@ pub(crate) fn extract_var_body(var_dec: &VariableDeclaration) -> VarBody {
             Literal::Boolean(_) => VarBody::Type("bool".into()),
             Literal::Byte(_) => VarBody::Type("u8".into()),
             Literal::B256(_) => VarBody::Type("b256".into()),
-            _ => VarBody::Type("unknown".into()),
         },
         _ => VarBody::Other,
     }

--- a/sway-server/src/utils/common.rs
+++ b/sway-server/src/utils/common.rs
@@ -1,4 +1,4 @@
-use sway_core::{VariableDeclaration, Visibility, Literal};
+use sway_core::{Literal, VariableDeclaration, Visibility};
 
 use crate::core::token_type::VarBody;
 use sway_core::Expression;
@@ -18,19 +18,17 @@ pub(crate) fn extract_var_body(var_dec: &VariableDeclaration) -> VarBody {
         Expression::StructExpression { struct_name, .. } => {
             VarBody::Type(struct_name.primary_name.into())
         }
-        Expression::Literal { value, .. } => {
-            match value {
-                Literal::U8(_) => VarBody::Type("u8".into()),
-                Literal::U16(_) => VarBody::Type("u16".into()),
-                Literal::U32(_) => VarBody::Type("u32".into()),
-                Literal::U64(_) => VarBody::Type("u64".into()),
-                Literal::String(_) => VarBody::Type("string".into()),
-                Literal::Boolean(_) => VarBody::Type("bool".into()),
-                Literal::Byte(_) => VarBody::Type("u8".into()),
-                Literal::B256(_) => VarBody::Type("b256".into()),
-                _ => VarBody::Type("unknown".into())
-            }
-        }
+        Expression::Literal { value, .. } => match value {
+            Literal::U8(_) => VarBody::Type("u8".into()),
+            Literal::U16(_) => VarBody::Type("u16".into()),
+            Literal::U32(_) => VarBody::Type("u32".into()),
+            Literal::U64(_) => VarBody::Type("u64".into()),
+            Literal::String(_) => VarBody::Type("string".into()),
+            Literal::Boolean(_) => VarBody::Type("bool".into()),
+            Literal::Byte(_) => VarBody::Type("u8".into()),
+            Literal::B256(_) => VarBody::Type("b256".into()),
+            _ => VarBody::Type("unknown".into()),
+        },
         _ => VarBody::Other,
     }
 }

--- a/sway-server/src/utils/common.rs
+++ b/sway-server/src/utils/common.rs
@@ -23,7 +23,7 @@ pub(crate) fn extract_var_body(var_dec: &VariableDeclaration) -> VarBody {
             Literal::U16(_) => VarBody::Type("u16".into()),
             Literal::U32(_) => VarBody::Type("u32".into()),
             Literal::U64(_) => VarBody::Type("u64".into()),
-            Literal::String(_) => VarBody::Type("string".into()),
+            Literal::String(len) => VarBody::Type(format!("str[{}]", len)),
             Literal::Boolean(_) => VarBody::Type("bool".into()),
             Literal::Byte(_) => VarBody::Type("u8".into()),
             Literal::B256(_) => VarBody::Type("b256".into()),

--- a/sway-server/src/utils/common.rs
+++ b/sway-server/src/utils/common.rs
@@ -1,4 +1,4 @@
-use sway_core::{VariableDeclaration, Visibility};
+use sway_core::{VariableDeclaration, Visibility, Literal};
 
 use crate::core::token_type::VarBody;
 use sway_core::Expression;
@@ -17,6 +17,19 @@ pub(crate) fn extract_var_body(var_dec: &VariableDeclaration) -> VarBody {
         }
         Expression::StructExpression { struct_name, .. } => {
             VarBody::Type(struct_name.primary_name.into())
+        }
+        Expression::Literal { value, .. } => {
+            match value {
+                Literal::U8(_) => VarBody::Type("u8".into()),
+                Literal::U16(_) => VarBody::Type("u16".into()),
+                Literal::U32(_) => VarBody::Type("u32".into()),
+                Literal::U64(_) => VarBody::Type("u64".into()),
+                Literal::String(_) => VarBody::Type("string".into()),
+                Literal::Boolean(_) => VarBody::Type("bool".into()),
+                Literal::Byte(_) => VarBody::Type("u8".into()),
+                Literal::B256(_) => VarBody::Type("b256".into()),
+                _ => VarBody::Type("unknown".into())
+            }
         }
         _ => VarBody::Other,
     }


### PR DESCRIPTION
Hover functionality was broken in the language server. Fixed it and also added types when hovering on variables in VS Code