### PR TITLE
fix incorrect enum method syntax

### DIFF
--- a/docs/src/basics/custom_types.md
+++ b/docs/src/basics/custom_types.md
@@ -109,7 +109,7 @@ struct Claim {
 }
 
 let event = InventoryEvent::ItemLoss(Claim {
-    insurance_company: Insurer::default(),
+    insurance_company: ~Insurer::default(),
     item_number: 42,
     item_cost: 1_000,
 });


### PR DESCRIPTION
Just noticed this was off in the docs...