### PR TITLE
Rename the arg to unowned_stack_allocate_memory().

### DIFF
--- a/sway-core/src/asm_lang/mod.rs
+++ b/sway-core/src/asm_lang/mod.rs
@@ -75,10 +75,10 @@ impl Op {
     }
     /// Moves the stack pointer by the given amount (i.e. allocates stack memory)
     pub(crate) fn unowned_stack_allocate_memory(
-        size_to_allocate_in_words: VirtualImmediate24,
+        size_to_allocate_in_bytes: VirtualImmediate24,
     ) -> Self {
         Op {
-            opcode: Either::Left(VirtualOp::CFEI(size_to_allocate_in_words)),
+            opcode: Either::Left(VirtualOp::CFEI(size_to_allocate_in_bytes)),
             comment: String::new(),
             owning_span: None,
         }


### PR DESCRIPTION
It was `size_to_allocate_in_words` which is misleading.  Changed to `size_to_allocate_in_bytes`.

This is a commit I've had floating around in my IR branch for a couple of months, I want to just commit it to get it out of the way.