### PR TITLE
Update to the dependency name to avoid download collisions in `forc_build`.

### DIFF
--- a/forc/src/ops/forc_abi_json.rs
+++ b/forc/src/ops/forc_abi_json.rs
@@ -71,8 +71,9 @@ pub fn build(command: JsonAbiCommand) -> Result<Value, String> {
 
             // Download a non-local dependency if the `git` property is set in this dependency.
             if let Some(git) = &dep.git {
+                let fully_qualified_dep_name = format!("{}-{}", dependency_name, git);
                 let downloaded_dep_path = match dependency::download_github_dep(
-                    dependency_name,
+                    &fully_qualified_dep_name,
                     git,
                     &dep.branch,
                     &dep.version,
@@ -148,8 +149,9 @@ fn compile_dependency_lib<'manifest>(
     };
     // Download a non-local dependency if the `git` property is set in this dependency.
     if let Some(ref git) = details.git {
+        let fully_qualified_dep_name = format!("{}-{}", dependency_name, git);
         let downloaded_dep_path = match dependency::download_github_dep(
-            dependency_name,
+            &fully_qualified_dep_name,
             git,
             &details.branch,
             &details.version,

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -125,8 +125,11 @@ fn compile_dependency_lib<'manifest>(
     };
     // Download a non-local dependency if the `git` property is set in this dependency.
     if let Some(ref git) = details.git {
+        // the qualified name of the dependency includes its source and some metadata to prevent
+        // conflating dependencies from different sources
+        let fully_qualified_dep_name = format!("{}-{}", dependency_name, git);
         let downloaded_dep_path = match dependency::download_github_dep(
-            dependency_name,
+            &fully_qualified_dep_name,
             git,
             &details.branch,
             &details.version,


### PR DESCRIPTION
Updated the file that a git dependency is downloaded to to avoid collisions where dependencies have the same name, but different URLs.