### PR TITLE
Display unimplemented error instead of panicking on generic traits

### DIFF
--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -134,38 +134,6 @@ impl FunctionDeclaration {
         )
         .unwrap_or_else(&mut warnings, &mut errors, Vec::new);
 
-        // check that all generic types used in function parameters are a part of the type
-        // parameters
-        /*
-        let mut generic_params_buf_for_error_message = Vec::new();
-        for param in parameters.iter() {
-            if let TypeInfo::Generic { name } = param.r#type {
-                generic_params_buf_for_error_message.push(name);
-            }
-        }
-        let comma_separated_generic_params = generic_params_buf_for_error_message.join(", ");
-        for param in parameters.iter() {
-            if let TypeInfo::Generic { name: st } = param.r#type {
-                if type_parameters
-                    .iter()
-                    .find(|TypeParameter { name, .. }| *name == st)
-                    .is_none()
-                {
-                    errors.push(CompileError::TypeParameterNotInTypeScope {
-                        name: st,
-                        span: param.name.span.clone(),
-                        comma_separated_generic_params: comma_separated_generic_params.clone(),
-                        fn_name: name,
-                        args: parameters_pair.clone().as_str(),
-                        return_type: return_type_pair
-                            .clone()
-                            .map(|x| x.as_str().to_string())
-                            .unwrap_or(TypeInfo::Unit.friendly_type_str()),
-                    });
-                }
-            }
-        }
-        */
         let body = parts.next().unwrap();
         let whole_block_span = Span {
             span: body.as_span(),

--- a/sway-core/src/parse_tree/declaration/trait.rs
+++ b/sway-core/src/parse_tree/declaration/trait.rs
@@ -126,7 +126,7 @@ impl TraitFn {
         let path = config.map(|c| c.path());
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
-        let mut signature = pair.clone().into_inner();
+        let mut signature = pair.into_inner();
         let _fn_keyword = signature.next().unwrap();
         let name = signature.next().unwrap();
         let name_span = Span {
@@ -208,7 +208,7 @@ impl TraitFn {
                 "Generic traits have not yet been implemented.",
                 Span {
                     span: type_params.as_span(),
-                    path: path.clone(),
+                    path,
                 },
             ));
         }

--- a/sway-core/src/parse_tree/declaration/trait.rs
+++ b/sway-core/src/parse_tree/declaration/trait.rs
@@ -127,10 +127,6 @@ impl TraitFn {
         let mut warnings = Vec::new();
         let mut errors = Vec::new();
         let mut signature = pair.clone().into_inner();
-        let whole_fn_sig_span = Span {
-            span: pair.as_span(),
-            path: path.clone(),
-        };
         let _fn_keyword = signature.next().unwrap();
         let name = signature.next().unwrap();
         let name_span = Span {
@@ -143,39 +139,89 @@ impl TraitFn {
             warnings,
             errors
         );
+        let mut type_params_pair = None;
+        let mut _where_clause_pair = None;
+        let mut parameters_pair = None;
+        let mut return_type_pair = None;
+        for pair in signature {
+            match pair.as_rule() {
+                Rule::type_params => {
+                    type_params_pair = Some(pair);
+                }
+                Rule::type_name => {
+                    return_type_pair = Some(pair);
+                }
+                Rule::fn_decl_params => {
+                    parameters_pair = Some(pair);
+                }
+                Rule::trait_bounds => {
+                    _where_clause_pair = Some(pair);
+                }
+                Rule::fn_returns => (),
+                _ => {
+                    errors.push(CompileError::Internal(
+                        "Unexpected token while parsing function signature.",
+                        Span {
+                            span: pair.as_span(),
+                            path: path.clone(),
+                        },
+                    ));
+                }
+            }
+        }
         assert_or_warn!(
             is_snake_case(name.as_str()),
             warnings,
             name_span,
             Warning::NonSnakeCaseFunctionName { name: name.clone() }
         );
-        let parameters = signature.next().unwrap();
+        // these are non-optional in a func decl
+        let parameters_pair = parameters_pair.unwrap();
+        let parameters_span = parameters_pair.as_span();
+
         let parameters = check!(
-            FunctionParameter::list_from_pairs(parameters.into_inner(), config),
+            FunctionParameter::list_from_pairs(parameters_pair.into_inner(), config),
             Vec::new(),
             warnings,
             errors
         );
-        let return_type_signal = signature.next();
-        let (return_type, return_type_span) = match return_type_signal {
-            Some(_) => {
-                let pair = signature.next().unwrap();
-                let span = Span {
-                    span: pair.as_span(),
-                    path,
-                };
-                (
-                    check!(
-                        TypeInfo::parse_from_pair(pair, config),
-                        TypeInfo::ErrorRecovery,
-                        warnings,
-                        errors
-                    ),
-                    span,
-                )
-            }
-            None => (TypeInfo::Tuple(Vec::new()), whole_fn_sig_span),
+        let return_type_span = Span {
+            span: if let Some(ref pair) = return_type_pair {
+                pair.as_span()
+            } else {
+                /* if this has no return type, just use the fn params as the span. */
+                parameters_span
+            },
+            path: path.clone(),
         };
+        let return_type = match return_type_pair {
+            Some(ref pair) => check!(
+                TypeInfo::parse_from_pair(pair.clone(), config),
+                TypeInfo::Tuple(Vec::new()),
+                warnings,
+                errors
+            ),
+            None => TypeInfo::Tuple(Vec::new()),
+        };
+        if let Some(type_params) = type_params_pair {
+            errors.push(CompileError::Unimplemented(
+                "Generic traits have not yet been implemented.",
+                Span {
+                    span: type_params.as_span(),
+                    path: path.clone(),
+                },
+            ));
+        }
+
+        /* when we implement generic traits, uncomment this to get the type params and where
+                 * clause
+                let type_parameters = TypeParameter::parse_from_type_params_and_where_clause(
+                    type_params_pair,
+                    where_clause_pair,
+                    config,
+                )
+                .unwrap_or_else(&mut warnings, &mut errors, Vec::new);
+        */
 
         ok(
             TraitFn {


### PR DESCRIPTION
In Discord, @ControlCplusControlV found that we panic on generic traits. We don't actually have them implemented yet, so this PR changes that behavior from a compiler panic to a proper unimplemented compiler error.