### PR TITLE
Remove unused dependency which is preventing builds on Windows.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,6 @@ dependencies = [
  "semver 1.0.4",
  "serde",
  "serde_json",
- "source-span",
  "structopt 0.3.25",
  "sway-core",
  "sway-fmt",
@@ -1917,12 +1916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "numtoa"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
-
-[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,15 +2291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "redox_termios"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
-dependencies = [
- "redox_syscall 0.2.10",
 ]
 
 [[package]]
@@ -2710,15 +2694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "source-span"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3afeb8b7a1ae2e8721f2193cc2291c9e00dd68511907fd8b807e2c8d42caa3c"
-dependencies = [
- "termion",
-]
-
-[[package]]
 name = "spinning_top"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,7 +2863,6 @@ dependencies = [
  "petgraph",
  "sha2",
  "smallvec",
- "source-span",
  "structopt 0.3.25",
  "sway-types",
  "thiserror",
@@ -3006,18 +2980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "termion"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
-dependencies = [
- "libc",
- "numtoa",
- "redox_syscall 0.2.10",
- "redox_termios",
 ]
 
 [[package]]

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -25,7 +25,6 @@ reqwest = { version = "0.11.4", features = ["json"] }
 semver = "1.0.3"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0.73"
-source-span = "2.4"
 structopt = "0.3"
 sway-core = { version = "0.2.1", path = "../sway-core" }
 sway-fmt = { version = "0.2.1", path = "../sway-fmt" }

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -18,17 +18,14 @@ fuel-asm = "0.1"
 fuel-vm = "0.1"
 hex = { version = "0.4", optional = true }
 lazy_static = "1.4"
-line-col = "0.2"
 pest = { version = "3.0.4", package = "fuel-pest" }
 pest_derive = { version = "3.0.4", package = "fuel-pest_derive" }
 petgraph = "0.5"
 sha2 = "0.9"
 smallvec = "1.7"
-source-span = "2.4"
 structopt = { version = "0.3", default-features = false, optional = true }
 sway-types = { version = "0.2.1", path = "../sway-types" }
 thiserror = "1.0"
-uuid-b64 = "0.1"
 
 [[bin]]
 name = "selector-debug"

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -6,11 +6,6 @@ use crate::span::Span;
 use crate::style::{to_screaming_snake_case, to_snake_case, to_upper_camel_case};
 use crate::type_engine::*;
 use crate::type_engine::{IntegerBits, TypeInfo};
-use line_col::LineColLookup;
-use source_span::{
-    fmt::{Formatter, Style},
-    Position,
-};
 use std::fmt;
 use thiserror::Error;
 
@@ -185,34 +180,6 @@ impl CompileWarning {
             self.span.start_pos().line_col().into(),
             self.span.end_pos().line_col().into(),
         )
-    }
-
-    pub fn format(&self, fmt: &mut Formatter) -> source_span::fmt::Formatted {
-        let input = self.span.input();
-        let chars = input.chars().map(|x| -> Result<_, ()> { Ok(x) });
-
-        let metrics = source_span::DEFAULT_METRICS;
-        let buffer = source_span::SourceBuffer::new(chars, Position::default(), metrics);
-
-        for c in buffer.iter() {
-            let _ = c.unwrap(); // report eventual errors.
-        }
-
-        let (start_pos, end_pos) = self.span();
-        let lookup = LineColLookup::new(input);
-        let (start_line, start_col) = lookup.get(start_pos);
-        let (end_line, end_col) = lookup.get(end_pos - 1);
-
-        let err_start = Position::new(start_line - 1, start_col - 1);
-        let err_end = Position::new(end_line - 1, end_col - 1);
-        let err_span = source_span::Span::new(err_start, err_end, err_end.next_column());
-        fmt.add(
-            err_span,
-            Some(self.to_friendly_warning_string()),
-            Style::Warning,
-        );
-
-        fmt.render(buffer.iter(), buffer.span(), &metrics).unwrap()
     }
 }
 
@@ -1039,33 +1006,5 @@ impl CompileError {
             self.internal_span().start_pos().line_col().into(),
             self.internal_span().end_pos().line_col().into(),
         )
-    }
-
-    pub fn format(&self, fmt: &mut Formatter) -> source_span::fmt::Formatted {
-        let input = self.internal_span().input();
-        let chars = input.chars().map(Result::<_, String>::Ok);
-
-        let metrics = source_span::DEFAULT_METRICS;
-        let buffer = source_span::SourceBuffer::new(chars, Position::default(), metrics);
-
-        for c in buffer.iter() {
-            let _ = c.unwrap(); // report eventual errors.
-        }
-
-        let (start_pos, end_pos) = self.span();
-        let lookup = LineColLookup::new(input);
-        let (start_line, start_col) = lookup.get(start_pos);
-        let (end_line, end_col) = lookup.get(if end_pos == 0 { 0 } else { end_pos - 1 });
-
-        let err_start = Position::new(start_line - 1, start_col - 1);
-        let err_end = Position::new(end_line - 1, end_col - 1);
-        let err_span = source_span::Span::new(err_start, err_end, err_end.next_column());
-        fmt.add(
-            err_span,
-            Some(self.to_friendly_error_string()),
-            Style::Error,
-        );
-
-        fmt.render(buffer.iter(), buffer.span(), &metrics).unwrap()
     }
 }


### PR DESCRIPTION
This PR does two things:
1. Removes some dead code in `sway-core` that formatted errors using a Linux/OSX-only library
2. Removes that dependency from the workspace, thus restoring Windows compatibility. 