### PR TITLE
fix OOG in tests

### DIFF
--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -62,7 +62,7 @@ pub(crate) fn runs_in_vm(file_name: &str) -> ProgramState {
 
     let script = compile_to_bytes(file_name).unwrap();
     let gas_price = 10;
-    let gas_limit = 100000;
+    let gas_limit = 10000000;
     let maturity = 0;
     let script_data = vec![];
     let inputs = vec![];


### PR DESCRIPTION
The test harness was using less gas than forc run.