### PR TITLE
sway-fmt refactor

### DIFF
--- a/sway-fmt/src/constants.rs
+++ b/sway-fmt/src/constants.rs
@@ -1,3 +1,5 @@
 // patterns should be invalid Sway code
+// they inform CodeBuilder (`second` pass) of the formatter what should it do
+// if it comes across a known pattern
 pub const NEW_LINE_PATTERN: &str = "+/+";
 pub const ALREADY_FORMATTED_LINE_PATTERN: &str = "---";

--- a/sway-fmt/src/traversal.rs
+++ b/sway-fmt/src/traversal.rs
@@ -3,9 +3,12 @@ use sway_core::{
 };
 
 use crate::traversal_helper::{
-    format_custom_types, format_delineated_path, format_include_statement, format_use_statement,
+    format_data_types, format_delineated_path, format_include_statement, format_use_statement,
 };
 
+/// Change contains the formatted change itself.
+/// `start` and `end` denote the start and end of that change,
+/// which are used to caluclate the position for inserting this change in the existing file.
 #[derive(Debug)]
 pub struct Change {
     pub text: String,
@@ -16,8 +19,8 @@ pub struct Change {
 impl Change {
     fn new(span: &Span, change_type: ChangeType) -> Self {
         let text = match change_type {
-            ChangeType::Struct => format_custom_types(span.as_str()),
-            ChangeType::Enum => format_custom_types(span.as_str()),
+            ChangeType::Struct => format_data_types(span.as_str()),
+            ChangeType::Enum => format_data_types(span.as_str()),
             ChangeType::IncludeStatement => format_include_statement(span.as_str()),
             ChangeType::UseStatement => format_use_statement(span.as_str()),
             ChangeType::DelineatedPath => format_delineated_path(span.as_str()),
@@ -40,6 +43,7 @@ enum ChangeType {
     DelineatedPath,
 }
 
+/// traverses the Sway ParseTree and returns list of formatted changes
 pub fn traverse_for_changes(parse_tree: &HllParseTree) -> Vec<Change> {
     let mut changes = vec![];
 

--- a/sway-fmt/src/traversal_helper.rs
+++ b/sway-fmt/src/traversal_helper.rs
@@ -1,28 +1,30 @@
-use std::iter::{Enumerate, Peekable};
-use std::str::Chars;
-
-use sway_core::{extract_keyword, Rule};
-
 use super::code_builder_helpers::{is_comment, is_multiline_comment, is_newline_incoming};
 use crate::code_builder_helpers::clean_all_whitespace;
 use crate::constants::{ALREADY_FORMATTED_LINE_PATTERN, NEW_LINE_PATTERN};
+use std::iter::{Enumerate, Peekable};
+use std::str::Chars;
+use sway_core::{extract_keyword, Rule};
 
-/// formats custom Enums and Structs
-pub fn format_custom_types(text: &str) -> String {
+/// Performs the formatting of the `comments` section in your code.
+/// Takes in a function that provides the logic to handle the rest of the code.
+fn custom_format_with_comments<F>(text: &str, custom_format_fn: &mut F) -> String
+where
+    F: FnMut(&str, &mut String, char, &mut Peekable<Enumerate<Chars>>),
+{
     let mut iter = text.chars().enumerate().peekable();
 
     let mut is_curr_comment = false;
     let mut is_curr_multi_comment = false;
-
     let mut result = String::default();
 
     while let Some((_, current_char)) = iter.next() {
-        result.push(current_char);
         if is_curr_comment {
+            result.push(current_char);
             if current_char == '\n' {
                 is_curr_comment = false;
             }
         } else if is_curr_multi_comment {
+            result.push(current_char);
             if current_char == '*' {
                 if let Some((_, c)) = iter.peek() {
                     if *c == '/' {
@@ -36,35 +38,45 @@ pub fn format_custom_types(text: &str) -> String {
             match current_char {
                 '/' => match iter.peek() {
                     Some((_, '/')) => {
-                        result.push('/');
+                        result.push_str("//");
                         iter.next();
                         is_curr_comment = true;
                     }
                     Some((_, '*')) => {
-                        result.push('*');
+                        result.push_str("/*");
                         iter.next();
                         is_curr_multi_comment = true;
                     }
-                    _ => {}
+                    _ => custom_format_fn(text, &mut result, current_char, &mut iter),
                 },
-                '}' => {
-                    clean_all_whitespace(&mut iter);
-                    if let Some((_, next_char)) = iter.peek() {
-                        if *next_char != ',' {
-                            result.push(',');
-                        }
-                    }
-                }
-                ':' => {
-                    let struct_field_type = get_struct_field_type(text, &mut iter);
-                    result.push_str(&struct_field_type);
-                }
-                _ => {}
+                _ => custom_format_fn(text, &mut result, current_char, &mut iter),
             }
         }
     }
 
     result
+}
+
+/// Formats Sway data types: Enums and Structs.
+pub fn format_data_types(text: &str) -> String {
+    custom_format_with_comments(text, &mut move |text, result, current_char, iter| {
+        result.push(current_char);
+        match current_char {
+            '}' => {
+                clean_all_whitespace(iter);
+                if let Some((_, next_char)) = iter.peek() {
+                    if *next_char != ',' {
+                        result.push(',');
+                    }
+                }
+            }
+            ':' => {
+                let field_type = get_data_field_type(text, iter);
+                result.push_str(&field_type);
+            }
+            _ => {}
+        }
+    })
 }
 
 pub fn format_delineated_path(line: &str) -> String {
@@ -92,7 +104,7 @@ pub fn format_include_statement(line: &str) -> String {
     )
 }
 
-fn get_struct_field_type(line: &str, iter: &mut Peekable<Enumerate<Chars>>) -> String {
+fn get_data_field_type(line: &str, iter: &mut Peekable<Enumerate<Chars>>) -> String {
     let mut result = String::default();
 
     loop {


### PR DESCRIPTION
I have refactored the formatter a bit, the changes could be separated into 2 parts:

1. Just added few comments to make it easier for newcomers to go through the code, and better naming of certain functions (now that they serve slightly different purpose)

2. Since we might have a case where we would like to perform different formatting on different types, I have extracted the formatting of comments into a generic function, that also takes a closure which will do the rest of the formatting.

one example of this is: https://github.com/FuelLabs/sway/issues/578 
The implementer of that issue should only worry about the `enum` parts and not about the `comments` possibly contained within it.

so he can solve it like this
```
custom_format_with_comments(text, &mut move |text, result, current_char, iter| {
    // your formatting logic here
}
```