### PR TITLE
Adds the missing `ec_recover` tests.

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/ec_recover_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/ec_recover_test/src/main.sw
@@ -3,6 +3,7 @@ script;
 use std::b512::B512;
 use std::address::Address;
 use std::ecr::ec_recover_address;
+use std::ecr::ec_recover;
 use std::chain::assert;
 
 fn main() -> bool {
@@ -34,6 +35,11 @@ fn main() -> bool {
     // recover the address:
     let mut recovered_address: Address = ec_recover_address(signature, msg_hash);
     assert(recovered_address.value == address.value);
+
+    // recover the public key:
+    let mut recovered_pubkey: B512 = ec_recover(signature, msg_hash);
+    assert(recovered_pubkey.hi == pubkey.hi);
+    assert(recovered_pubkey.lo == pubkey.lo);
 
     true
 }

--- a/test/src/e2e_vm_tests/test_programs/ec_recover_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/ec_recover_test/src/main.sw
@@ -33,11 +33,11 @@ fn main() -> bool {
     let signature: B512 = ~B512::from(sig_hi, sig_lo);
 
     // recover the address:
-    let mut recovered_address: Address = ec_recover_address(signature, msg_hash);
+    let recovered_address: Address = ec_recover_address(signature, msg_hash);
     assert(recovered_address.value == address.value);
 
     // recover the public key:
-    let mut recovered_pubkey: B512 = ec_recover(signature, msg_hash);
+    let recovered_pubkey: B512 = ec_recover(signature, msg_hash);
     assert(recovered_pubkey.hi == pubkey.hi);
     assert(recovered_pubkey.lo == pubkey.lo);
 


### PR DESCRIPTION
Formerly, only `ec_recover_address` tests were implemented.
This fixes that.
The code being tested is here: https://github.com/FuelLabs/sway-lib-std/pull/18
