### PR TITLE
Hash the dependency name and source before writing to avoid bad characters

### DIFF
--- a/forc/src/utils/dependency.rs
+++ b/forc/src/utils/dependency.rs
@@ -4,6 +4,8 @@ use curl::easy::Easy;
 use dirs::home_dir;
 use flate2::read::GzDecoder;
 use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::{
     collections::HashMap,
     fs,
@@ -102,13 +104,18 @@ pub fn download_github_dep(
         Some(p) => p.to_str().unwrap().to_owned(),
     };
 
+    // hash the dep name into a number to avoid bad characters
+    let mut s = DefaultHasher::new();
+    dep_name.hash(&mut s);
+    let hashed_dep_name = s.finish().to_string();
+
     // Version tag takes precedence over branch reference.
     let out_dir = match &version {
         Some(v) => PathBuf::from(format!(
             "{}/{}/{}/{}",
             home_dir,
             constants::FORC_DEPENDENCIES_DIRECTORY,
-            dep_name,
+            hashed_dep_name,
             v
         )),
         // If no version specified, check if a branch was specified
@@ -117,7 +124,7 @@ pub fn download_github_dep(
                 "{}/{}/{}/{}",
                 home_dir,
                 constants::FORC_DEPENDENCIES_DIRECTORY,
-                dep_name,
+                hashed_dep_name,
                 b
             )),
             // If no version and no branch, use default
@@ -125,7 +132,7 @@ pub fn download_github_dep(
                 "{}/{}/{}/default",
                 home_dir,
                 constants::FORC_DEPENDENCIES_DIRECTORY,
-                dep_name
+                hashed_dep_name
             )),
         },
     };


### PR DESCRIPTION
This is kind of a funny one. To solve #521, we saved the download to a folder named after its github repo. Well, humorously, that led to tree structures like this (which still worked fine!)
```
├── core-http:
│   └── github.com
│       └── FuelLabs
│           └── sway-lib-core
│               └── default
│                   └── FuelLabs-sway-lib-core-87138fb
│                       ├── Forc.toml
│                       ├── LICENSE
│                       ├── README.md
│                       └── src
│                           ├── lib.sw
│                           └── ops.sw
```

This PR changes that to just use a hash, so we know the character set:
```
├── 7786363458449203048
│   └── default
│       └── FuelLabs-sway-lib-core-87138fb
│           ├── Forc.toml
│           ├── LICENSE
│           ├── README.md
│           └── src
│               ├── lib.sw
│               └── ops.sw
```
