### PR TITLE
lsp: fix exhaustive symbol check

### DIFF
--- a/sway-server/src/capabilities/document_symbol.rs
+++ b/sway-server/src/capabilities/document_symbol.rs
@@ -40,6 +40,6 @@ fn get_kind(token_type: &TokenType) -> SymbolKind {
         TokenType::Struct(_) => SymbolKind::STRUCT,
         TokenType::Variable(_) => SymbolKind::VARIABLE,
         TokenType::Trait(_) => SymbolKind::INTERFACE,
-        _ => SymbolKind::NULL, // TODO SymbolKind::UNKNOWN was removed in https://github.com/gluon-lang/lsp-types/pull/219
+        TokenType::Reassignment => SymbolKind::OPERATOR,
     }
 }


### PR DESCRIPTION
Fix todo introduced in #493.

I'm not sure if this is the correct fix, but it seems like (re)-assignment is an operator? cc @leviathanbeak