### PR TITLE
sway-fmt with FormattingOptions

### DIFF
--- a/forc/src/cli/commands/format.rs
+++ b/forc/src/cli/commands/format.rs
@@ -11,6 +11,7 @@ pub struct Command {
     pub check: bool,
 }
 
+// todo: add formatting options in the command line
 pub(crate) fn exec(command: Command) -> Result<(), String> {
     match forc_fmt::format(command) {
         Err(e) => Err(e.message),

--- a/forc/src/ops/forc_fmt.rs
+++ b/forc/src/ops/forc_fmt.rs
@@ -4,7 +4,7 @@ use crate::utils::helpers::{println_green, println_red};
 use prettydiff::{basic::DiffOp, diff_lines};
 use std::default::Default;
 use std::{fmt, fs, io, path::Path, sync::Arc};
-use sway_fmt::get_formatted_data;
+use sway_fmt::{get_formatted_data, FormattingOptions};
 use sway_utils::{constants, find_manifest_dir, get_sway_files};
 use taplo::formatter as taplo_fmt;
 
@@ -41,9 +41,10 @@ fn format_after_build(command: FormatCommand) -> Result<(), FormatError> {
 
             for file in files {
                 if let Ok(file_content) = fs::read_to_string(&file) {
-                    // todo: get tab_size from Manifest file
+                    // todo read options from manifest file
+                    let formatting_options = FormattingOptions::default();
                     let file_content: Arc<str> = Arc::from(file_content);
-                    match get_formatted_data(file_content.clone(), 4) {
+                    match get_formatted_data(file_content.clone(), formatting_options) {
                         Ok((_, formatted_content)) => {
                             if command.check {
                                 if *file_content != *formatted_content {

--- a/sway-fmt/src/lib.rs
+++ b/sway-fmt/src/lib.rs
@@ -6,4 +6,4 @@ mod fmt;
 mod traversal;
 mod traversal_helper;
 
-pub use crate::fmt::get_formatted_data;
+pub use crate::fmt::{get_formatted_data, FormattingOptions};

--- a/sway-server/src/capabilities/formatting.rs
+++ b/sway-server/src/capabilities/formatting.rs
@@ -1,25 +1,22 @@
-use std::sync::Arc;
-
 use crate::core::session::Session;
-use lspower::lsp::{
-    DocumentFormattingParams, FormattingOptions, Position, Range, TextDocumentIdentifier, TextEdit,
-};
-use sway_fmt::get_formatted_data;
+use lspower::lsp::{DocumentFormattingParams, Position, Range, TextDocumentIdentifier, TextEdit};
+use std::sync::Arc;
+use sway_fmt::{get_formatted_data, FormattingOptions};
 
 pub fn format_document(
     session: Arc<Session>,
     params: DocumentFormattingParams,
 ) -> Option<Vec<TextEdit>> {
-    let options: FormattingOptions = params.options;
     let text_document: TextDocumentIdentifier = params.text_document;
     let url = text_document.uri;
 
-    session.format_text(&url, options)
+    session.format_text(&url)
 }
 
 pub fn get_format_text_edits(text: Arc<str>, options: FormattingOptions) -> Option<Vec<TextEdit>> {
     // we only format if code is correct
-    match get_formatted_data(text.clone(), options.tab_size) {
+
+    match get_formatted_data(text.clone(), options) {
         Ok((num_of_lines, formatted_text)) => {
             let text_lines_count = text.split('\n').count();
             let line_end = std::cmp::max(num_of_lines, text_lines_count) as u32;

--- a/sway-server/src/core/session.rs
+++ b/sway-server/src/core/session.rs
@@ -1,23 +1,39 @@
 use super::document::{DocumentError, TextDocument};
-use crate::capabilities::{self, formatting::get_format_text_edits};
+use crate::{
+    capabilities::{self, formatting::get_format_text_edits},
+    sway_config::SwayConfig,
+};
 use dashmap::DashMap;
 use lspower::lsp::{
-    CompletionItem, Diagnostic, FormattingOptions, GotoDefinitionResponse, Position, Range,
-    SemanticToken, SymbolInformation, TextDocumentContentChangeEvent, TextEdit, Url,
+    CompletionItem, Diagnostic, GotoDefinitionResponse, Position, Range, SemanticToken,
+    SymbolInformation, TextDocumentContentChangeEvent, TextEdit, Url,
 };
-use std::sync::Arc;
+use serde_json::Value;
+use std::sync::{Arc, LockResult, RwLock};
 
 pub type Documents = DashMap<String, TextDocument>;
 
 #[derive(Debug)]
 pub struct Session {
     pub documents: Documents,
+    pub config: RwLock<SwayConfig>,
 }
 
 impl Session {
     pub fn new() -> Self {
         Session {
             documents: DashMap::new(),
+            config: RwLock::new(SwayConfig::default()),
+        }
+    }
+
+    // update sway config
+    pub fn update_config(&self, options: Value) {
+        match self.config.write() {
+            LockResult::Ok(mut config) => {
+                *config = SwayConfig::with_options(options);
+            }
+            _ => {}
         }
     }
 
@@ -145,9 +161,15 @@ impl Session {
         None
     }
 
-    pub fn format_text(&self, url: &Url, options: FormattingOptions) -> Option<Vec<TextEdit>> {
+    pub fn format_text(&self, url: &Url) -> Option<Vec<TextEdit>> {
         if let Some(document) = self.documents.get(url.path()) {
-            get_format_text_edits(Arc::from(document.get_text()), options)
+            match self.config.read() {
+                std::sync::LockResult::Ok(config) => {
+                    let config: SwayConfig = *config;
+                    get_format_text_edits(Arc::from(document.get_text()), config.into())
+                }
+                _ => None,
+            }
         } else {
             None
         }

--- a/sway-server/src/core/session.rs
+++ b/sway-server/src/core/session.rs
@@ -29,11 +29,8 @@ impl Session {
 
     // update sway config
     pub fn update_config(&self, options: Value) {
-        match self.config.write() {
-            LockResult::Ok(mut config) => {
-                *config = SwayConfig::with_options(options);
-            }
-            _ => {}
+        if let LockResult::Ok(mut config) = self.config.write() {
+            *config = SwayConfig::with_options(options);
         }
     }
 

--- a/sway-server/src/lib.rs
+++ b/sway-server/src/lib.rs
@@ -3,6 +3,7 @@ use lspower::{LspService, Server};
 mod capabilities;
 mod core;
 mod server;
+mod sway_config;
 mod utils;
 use server::Backend;
 

--- a/sway-server/src/server.rs
+++ b/sway-server/src/server.rs
@@ -10,7 +10,6 @@ use lsp::{
 use lspower::{jsonrpc, lsp, Client, LanguageServer};
 use std::sync::Arc;
 use sway_utils::helpers::{find_manifest_dir, get_sway_files};
-
 #[derive(Debug)]
 pub struct Backend {
     pub client: Client,
@@ -50,7 +49,11 @@ impl Backend {
 
 #[lspower::async_trait]
 impl LanguageServer for Backend {
-    async fn initialize(&self, _params: InitializeParams) -> jsonrpc::Result<InitializeResult> {
+    async fn initialize(&self, params: InitializeParams) -> jsonrpc::Result<InitializeResult> {
+        if let Some(options) = params.initialization_options {
+            self.session.update_config(options);
+        }
+
         self.client
             .log_message(MessageType::INFO, "Initializing the Server")
             .await;

--- a/sway-server/src/sway_config.rs
+++ b/sway-server/src/sway_config.rs
@@ -1,0 +1,76 @@
+use serde_json::Value;
+use sway_fmt::FormattingOptions;
+
+const ALIGN_FIELDS_FIELD: &str = "alignFields";
+const TAB_SIZE_FIELD: &str = "tabSize";
+const TAB_SIZE: u64 = 4;
+const ALIGN_FIELDS: bool = true;
+
+#[derive(Debug, Clone, Copy)]
+pub struct SwayConfig {
+    tab_size: u64,
+    align_fields: bool,
+}
+
+impl SwayConfig {
+    pub fn default() -> Self {
+        Self {
+            align_fields: ALIGN_FIELDS,
+            tab_size: TAB_SIZE,
+        }
+    }
+
+    pub fn with_options(options: Value) -> Self {
+        let align_fields = extract_align_fields(&options);
+        let tab_size = extract_tab_size(&options);
+
+        Self {
+            align_fields,
+            tab_size,
+        }
+    }
+}
+
+// note `FormattingOptions` and `SwayConfig` may be similar at this moment,
+// but they are not the same thing, `SwayConfig` contains all the data related to the LanguageServer
+// while `FormattingOptions` is only the part that is necessary for 'formating'
+impl From<SwayConfig> for FormattingOptions {
+    fn from(config: SwayConfig) -> Self {
+        FormattingOptions {
+            align_fields: config.align_fields,
+            tab_size: config.tab_size as u32,
+        }
+    }
+}
+
+fn extract_align_fields(options: &Value) -> bool {
+    if let Value::Object(options_object) = options {
+        if options_object.contains_key(ALIGN_FIELDS_FIELD) {
+            if let Value::Bool(value) = options_object.get(ALIGN_FIELDS_FIELD).unwrap() {
+                *value
+            } else {
+                ALIGN_FIELDS
+            }
+        } else {
+            ALIGN_FIELDS
+        }
+    } else {
+        ALIGN_FIELDS
+    }
+}
+
+fn extract_tab_size(options: &Value) -> u64 {
+    if let Value::Object(options_object) = options {
+        if options_object.contains_key(TAB_SIZE_FIELD) {
+            if let Value::Number(value) = options_object.get(TAB_SIZE_FIELD).unwrap() {
+                value.as_u64().unwrap_or(TAB_SIZE)
+            } else {
+                TAB_SIZE
+            }
+        } else {
+            TAB_SIZE
+        }
+    } else {
+        TAB_SIZE
+    }
+}


### PR DESCRIPTION
I have added a config struct for formatting to `sway-fmt`, currently only 2 fields: `align_fields` & `tab_size`.

I have updated Language Server to get that info (and any other in the future) from the Client during server initialization and pass it to the formatter.

I have updated `forc` to also currently use default formatting options.

Future TODOs:
- add options to `forc fmt` command
- for `forc fmt` read the manifest file for formatting options
- actually start using `align_fields` -> should be introduced with #578 
- implement [onConfigChanged](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#workspace_didChangeConfiguration) so that the SwayConfig within Language Server can get updated as well
