### PR TITLE
Add details in "A Forc Project"

### DIFF
--- a/docs/src/getting-started/forc_project.md
+++ b/docs/src/getting-started/forc_project.md
@@ -71,7 +71,7 @@ Bytecode size is 28 bytes.
 [Return { id: ContractId([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), val: 0, pc: 488, is: 464 }]
 ```
 
-Use `forc abi-json` to output the abi of the contract. To write this to a `json` (which is necessary for running tests below), simple pipe it using something like `forc abi-json > my_contract.json`. There is currently not a convention for where abi files should be placed, one common choice is loose in the root directory.
+Use `forc json-abi` to output the ABI of the contract. To write this to a `.json` file (which is necessary for running tests below), pipe it using something like `forc json-abi > my_contract.json`. There is currently not a convention for where ABI files should be placed; one common choice is loose in the root directory.
 
 ## Testing a Sway Project with Forc
 

--- a/docs/src/getting-started/forc_project.md
+++ b/docs/src/getting-started/forc_project.md
@@ -71,6 +71,8 @@ Bytecode size is 28 bytes.
 [Return { id: ContractId([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), val: 0, pc: 488, is: 464 }]
 ```
 
+Use `forc abi-json` to output the abi of the contract. To write this to a `json` (which is necessary for running tests below), simple pipe it using something like `forc abi-json > my_contract.json`. There is currently not a convention for where abi files should be placed, one common choice is loose in the root directory.
+
 ## Testing a Sway Project with Forc
 
 If you look again at the project structure when you create a new Forc project, you can see a directory called `tests/`:
@@ -91,7 +93,7 @@ Note that this is a Rust package, hence the existence of a `Cargo.toml` (Rust ma
 
 These tests can be run using either `carg test`, or `forc test` which will look for Rust tests under the `tests/` directory (created automatically with `forc init`).
 
-For example, let's write tests against this contract, written in Sway:
+For example, let's write tests against the following contract, written in Sway. This can be done in the pregenerated `src/main.sw` or in a new file in `src`. In the case of the latter, update the `entry` field in `Forc.toml` to point at the new contract.
 
 ```sway
 contract;


### PR DESCRIPTION
adds `forc abi-json` and details about `entry` in Forc.toml` to the "A Forc Project" page, fixing #658 and #659