### PR TITLE
Rename signature gen util for added clarity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2608,17 +2608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signatures"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "fuel-tx",
- "fuel-vm",
- "hex",
- "secp256k1",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2976,6 +2965,17 @@ dependencies = [
  "regex",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "test-sig-gen-util"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "fuel-tx",
+ "fuel-vm",
+ "hex",
+ "secp256k1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "test-sig-gen-util"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "fuel-tx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     "docstrings",
     "forc",
     "parser",
-    "sig-gen-util",
+    "test-sig-gen-util",
     "sway-core",
     "sway-fmt",
     "sway-ir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ members = [
     "docstrings",
     "forc",
     "parser",
-    "test-sig-gen-util",
     "sway-core",
     "sway-fmt",
     "sway-ir",
     "sway-server",
     "sway-types",
     "sway-utils",
-    "test"
+    "test",
+    "test-sig-gen-util"
 ]
 
 [profile.dev.package.sway-server]

--- a/test-sig-gen-util/Cargo.toml
+++ b/test-sig-gen-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-sig-gen-util"
-version = "0.0.1"
+version = "0.0.0"
 edition = "2021"
 publish = false
 

--- a/test-sig-gen-util/Cargo.toml
+++ b/test-sig-gen-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "signatures"
-version = "0.0.0"
+name = "test-sig-gen-util"
+version = "0.0.1"
 edition = "2021"
 publish = false
 

--- a/test-sig-gen-util/src/main.rs
+++ b/test-sig-gen-util/src/main.rs
@@ -17,6 +17,7 @@ fn main() -> Result<()> {
             .unwrap();
     let public = PublicKey::from_secret_key(&secp, &secret).serialize_uncompressed();
     let public = Bytes64::try_from(&public[1..]).expect("Failed to parse public key!");
+    // 64 byte fuel address is the sha-256 hash of the public key.
     let address = Hasher::hash(&public[..]);
 
     let message = b"The gift of words is the gift of deception and illusion.";
@@ -26,7 +27,7 @@ fn main() -> Result<()> {
 
     println!("Secret Key: {:?}", secret);
     println!("Public Key: {:?}", public);
-    println!("Address: {:?}", address);
+    println!("Fuel Address: {:?}", address);
     println!("Message Hash: {:?}", e);
     println!("Signature: {:?}", sig);
 


### PR DESCRIPTION
Changed the name to `test-sig-gen-utility` for additional clarity on the use of this util.
Added an additional comment on how the fuel address is derived.