### PR TITLE
Pin our std and core deps in the test suite

### DIFF
--- a/docs/src/getting-started/forc_project.md
+++ b/docs/src/getting-started/forc_project.md
@@ -29,8 +29,8 @@ entry = "main.sw"
 license = "Apache-2.0"
 
 [dependencies]
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
 ```
 
 Here are the contents of the only Sway file in the project, and the main entry point, `src/main.sw`:

--- a/docs/src/getting-started/temporary_workarounds.md
+++ b/docs/src/getting-started/temporary_workarounds.md
@@ -6,8 +6,8 @@ The standard library is currently not distributed with `forc` if [installed via 
 
 ```toml
 [dependencies]
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
 ```
 
 Note that the default `Forc.toml` generated with `forc init` already includes these lines, so no further action is necessary.

--- a/forc/src/ops/forc_fmt.rs
+++ b/forc/src/ops/forc_fmt.rs
@@ -196,8 +196,8 @@ name = "Fuel example project"
 
 
 [dependencies]
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
 "#;
         let taplo_alphabetize = taplo_fmt::Options {
             reorder_keys: true,
@@ -213,8 +213,8 @@ std = { git = "http://github.com/FuelLabs/sway-lib-std" }
 
 
     [dependencies]
-        core = { git = "http://github.com/FuelLabs/sway-lib-core" }
-                    std = { git = "http://github.com/FuelLabs/sway-lib-std" }
+        core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
+                    std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
 "#;
         let formatted_content =
             taplo_fmt::format(indented_forc_manifest, taplo_alphabetize.clone());
@@ -244,8 +244,8 @@ name = "Fuel example project"
 
 
 [dependencies]
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
 "#;
         let taplo_alphabetize = taplo_fmt::Options {
             reorder_keys: true,
@@ -261,8 +261,8 @@ author = "Fuel Labs <contact@fuel.sh>"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
     "#;
         let formatted_content = taplo_fmt::format(disordered_forc_manifest, taplo_alphabetize);
         assert_eq!(formatted_content, correct_forc_manifest);

--- a/test/src/e2e_vm_tests/test_programs/address_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/address_test/Forc.toml
@@ -5,5 +5,5 @@ name = "address_test"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/aliased_imports/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/aliased_imports/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 

--- a/test/src/e2e_vm_tests/test_programs/array_basics/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/array_basics/Forc.toml
@@ -5,5 +5,5 @@ name = "array_basics"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/assert_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/assert_test/Forc.toml
@@ -5,5 +5,5 @@ name = "assert_test"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/auth_testing_contract/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/auth_testing_contract/Forc.toml
@@ -5,6 +5,6 @@ name = "auth_testing_contract"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 auth_testing_abi = { path = "../auth_testing_abi" }

--- a/test/src/e2e_vm_tests/test_programs/b256_bad_jumps/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/b256_bad_jumps/Forc.toml
@@ -5,5 +5,5 @@ name = "b256_bad_jumps"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/b256_ops/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/b256_ops/Forc.toml
@@ -5,5 +5,5 @@ name = "b256_ops"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/b512_struct_alignment/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/b512_struct_alignment/Forc.toml
@@ -5,6 +5,6 @@ name = "b512_panic_test"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 

--- a/test/src/e2e_vm_tests/test_programs/b512_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/b512_test/Forc.toml
@@ -5,5 +5,5 @@ name = "b512_test"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/bal_opcode/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/bal_opcode/Forc.toml
@@ -5,8 +5,8 @@ name = "bal_opcode"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 balance_test_abi = { path = "../balance_test_abi"}
 
 [[tx-input]]

--- a/test/src/e2e_vm_tests/test_programs/balance_test_contract/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/balance_test_contract/Forc.toml
@@ -5,5 +5,5 @@ name = "balance_test_contract"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
 balance_test_abi = { path = "../balance_test_abi"}

--- a/test/src/e2e_vm_tests/test_programs/basic_func_decl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/basic_func_decl/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 

--- a/test/src/e2e_vm_tests/test_programs/basic_storage/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/basic_storage/Forc.toml
@@ -5,6 +5,6 @@ name = "basic_storage"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 basic_storage_abi = { path = "../basic_storage_abi" }

--- a/test/src/e2e_vm_tests/test_programs/block_height/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/block_height/Forc.toml
@@ -5,5 +5,5 @@ name = "block_height"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/call_increment_contract/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/call_increment_contract/Forc.toml
@@ -5,8 +5,8 @@ name = "call_increment_contract"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 increment_abi = { path = "../increment_abi" }
 
 [[tx-input]]

--- a/test/src/e2e_vm_tests/test_programs/caller_auth_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/caller_auth_test/Forc.toml
@@ -5,8 +5,8 @@ name = "caller_auth_test"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 auth_testing_abi = { path = "../auth_testing_abi" }
 
 [[tx-input]]

--- a/test/src/e2e_vm_tests/test_programs/caller_context_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/caller_context_test/Forc.toml
@@ -5,8 +5,8 @@ name = "caller_context_test"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 context_testing_abi = { path = "../context_testing_abi" }
 
 [[tx-input]]

--- a/test/src/e2e_vm_tests/test_programs/const_decl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/const_decl/Forc.toml
@@ -5,5 +5,5 @@ name = "const_decl"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/const_decl_in_library/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/const_decl_in_library/Forc.toml
@@ -5,5 +5,5 @@ name = "const_decl_in_library"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/context_testing_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/context_testing_abi/Forc.toml
@@ -5,4 +5,4 @@ name = "context_testing_abi"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/context_testing_contract/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/context_testing_contract/Forc.toml
@@ -5,5 +5,5 @@ name = "context_testing_contract"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
 context_testing_abi = { path = "../context_testing_abi"}

--- a/test/src/e2e_vm_tests/test_programs/contract_abi_impl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/contract_abi_impl/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 

--- a/test/src/e2e_vm_tests/test_programs/contract_call/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/contract_call/Forc.toml
@@ -6,8 +6,8 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 [[tx-input]]
 type = "Contract"

--- a/test/src/e2e_vm_tests/test_programs/contract_id_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/contract_id_test/Forc.toml
@@ -5,5 +5,5 @@ name = "contract_id_test"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/dependencies/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/dependencies/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 

--- a/test/src/e2e_vm_tests/test_programs/dependencies_parsing_error/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/dependencies_parsing_error/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 

--- a/test/src/e2e_vm_tests/test_programs/ec_recover_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/ec_recover_test/Forc.toml
@@ -5,5 +5,5 @@ name = "ec_recover_test"
 entry = "main.sw"
 
 [dependencies]
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/empty_method_initializer/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/empty_method_initializer/Forc.toml
@@ -5,5 +5,5 @@ name = "empty_method_initializer"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/enum_in_fn_decl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/enum_in_fn_decl/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 

--- a/test/src/e2e_vm_tests/test_programs/eq_4_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/eq_4_test/Forc.toml
@@ -5,5 +5,5 @@ name = "eq_4_test"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/excess_fn_arguments/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/excess_fn_arguments/Forc.toml
@@ -5,5 +5,5 @@ name = "excess_fn_arguments"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/fix_opcode_bug/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/fix_opcode_bug/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 

--- a/test/src/e2e_vm_tests/test_programs/generic_enum/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/generic_enum/Forc.toml
@@ -5,5 +5,5 @@ name = "generic_enum"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/if_elseif_enum/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/if_elseif_enum/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 

--- a/test/src/e2e_vm_tests/test_programs/increment_contract/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/increment_contract/Forc.toml
@@ -6,5 +6,5 @@ entry = "main.sw"
 
 [dependencies]
 increment_abi = { path = "../increment_abi" }
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/infinite_dependencies/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/infinite_dependencies/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 

--- a/test/src/e2e_vm_tests/test_programs/local_impl_for_ord/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/local_impl_for_ord/Forc.toml
@@ -5,5 +5,5 @@ name = "local_impl_for_ord"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/match_expressions/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/match_expressions/Forc.toml
@@ -5,5 +5,5 @@ name = "match_expressions"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/match_expressions_enums/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/match_expressions_enums/Forc.toml
@@ -5,5 +5,5 @@ name = "match_expressions_enums"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/match_expressions_structs/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/match_expressions_structs/Forc.toml
@@ -5,5 +5,5 @@ name = "match_expressions_structs"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/match_expressions_wrong_struct/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/match_expressions_wrong_struct/Forc.toml
@@ -5,5 +5,5 @@ name = "match_expressions_wrong_struct"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/missing_fn_arguments/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/missing_fn_arguments/Forc.toml
@@ -5,5 +5,5 @@ name = "missing_fn_arguments"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/modulo_uint_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/modulo_uint_test/Forc.toml
@@ -5,5 +5,5 @@ name = "modulo_uint_test"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/multi_item_import/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/multi_item_import/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 

--- a/test/src/e2e_vm_tests/test_programs/neq_4_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/neq_4_test/Forc.toml
@@ -5,5 +5,5 @@ name = "neq_4_test"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/op_precedence/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/op_precedence/Forc.toml
@@ -5,5 +5,5 @@ name = "unary_not_basic"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/out_of_order_decl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/out_of_order_decl/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 

--- a/test/src/e2e_vm_tests/test_programs/struct_field_access/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/struct_field_access/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 

--- a/test/src/e2e_vm_tests/test_programs/struct_field_reassignment/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/struct_field_reassignment/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 

--- a/test/src/e2e_vm_tests/test_programs/trait_override_bug/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/trait_override_bug/Forc.toml
@@ -6,4 +6,4 @@ license = "Apache-2.0"
 
 [dependencies]
 std  = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/tuple_desugaring/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/tuple_desugaring/Forc.toml
@@ -5,6 +5,6 @@ name = "tuple_desugaring"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 

--- a/test/src/e2e_vm_tests/test_programs/tuple_types/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/tuple_types/Forc.toml
@@ -5,6 +5,6 @@ name = "tuple_types"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 

--- a/test/src/e2e_vm_tests/test_programs/unary_not_basic/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/unary_not_basic/Forc.toml
@@ -5,5 +5,5 @@ name = "unary_not_basic"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/unary_not_basic_2/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/unary_not_basic_2/Forc.toml
@@ -5,5 +5,5 @@ name = "unary_not_basic_2"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/xos_opcode/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/xos_opcode/Forc.toml
@@ -5,5 +5,5 @@ name = "xos_opcode"
 entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }


### PR DESCRIPTION
Now that we have a `v0.0.1` of `lib-core` and `lib-std`, we can pin them in our test suite to avoid having to synchronize PRs.