### PR TITLE
Bump to version v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,7 +937,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -1887,7 +1887,7 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parser"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ariadne",
  "chumsky",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "sway-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "derivative",
  "either",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "sway-fmt"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ropey",
  "sway-core",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "fuel-pest",
  "generational-arena",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "sway-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dashmap",
  "lspower",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "sway-types"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "fuel-asm",
  "fuel-pest",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "sway-utils"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "syn"

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 homepage = "https://fuel.network/"
@@ -25,11 +25,11 @@ semver = "1.0.3"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0.73"
 structopt = "0.3"
-sway-core = { version = "0.3.0", path = "../sway-core" }
-sway-fmt = { version = "0.3.0", path = "../sway-fmt" }
-sway-server = { version = "0.3.0", path = "../sway-server" }
-sway-utils = { version = "0.3.0", path = "../sway-utils" }
-sway-types = { version = "0.3.0", path = "../sway-types" }
+sway-core = { version = "0.3.1", path = "../sway-core" }
+sway-fmt = { version = "0.3.1", path = "../sway-fmt" }
+sway-server = { version = "0.3.1", path = "../sway-server" }
+sway-utils = { version = "0.3.1", path = "../sway-utils" }
+sway-types = { version = "0.3.1", path = "../sway-types" }
 taplo = "0.7"
 tar = "0.4.35"
 term-table = "1.3"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parser"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-core"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 homepage = "https://fuel.network/"
@@ -25,8 +25,8 @@ prettydiff = "0.5"
 sha2 = "0.9"
 smallvec = "1.7"
 structopt = { version = "0.3", default-features = false, optional = true }
-sway-ir = { version = "0.3.0", path = "../sway-ir" }
-sway-types = { version = "0.3.0", path = "../sway-types" }
+sway-ir = { version = "0.3.1", path = "../sway-ir" }
+sway-types = { version = "0.3.1", path = "../sway-types" }
 generational-arena = "0.2"
 thiserror = "1.0"
 

--- a/sway-fmt/Cargo.toml
+++ b/sway-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-fmt"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 homepage = "https://fuel.network/"
@@ -10,6 +10,6 @@ description = "Sway sway-fmt."
 
 [dependencies]
 ropey = "1.2"
-sway-core = { version = "0.3.0", path = "../sway-core" }
-sway-types = { version = "0.3.0", path = "../sway-types" }
+sway-core = { version = "0.3.1", path = "../sway-core" }
+sway-types = { version = "0.3.1", path = "../sway-types" }
 

--- a/sway-ir/Cargo.toml
+++ b/sway-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ir"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -16,4 +16,4 @@ generational-arena = "0.2"
 peg = "0.7"
 pest = { version = "3.0.4", package = "fuel-pest" }
 prettydiff = "0.5"
-sway-types = { version = "0.3.0", path = "../sway-types" }
+sway-types = { version = "0.3.1", path = "../sway-types" }

--- a/sway-server/Cargo.toml
+++ b/sway-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-server"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 homepage = "https://fuel.network/"
@@ -13,8 +13,8 @@ dashmap = "4.0.2"
 lspower = "1.0.0"
 ropey = "1.2"
 serde_json = "1.0.60"
-sway-core = { version = "0.3.0", path = "../sway-core" }
-sway-fmt = { version = "0.3.0", path = "../sway-fmt" }
-sway-types = { version = "0.3.0", path = "../sway-types" }
-sway-utils = { version = "0.3.0", path = "../sway-utils" }
+sway-core = { version = "0.3.1", path = "../sway-core" }
+sway-fmt = { version = "0.3.1", path = "../sway-fmt" }
+sway-types = { version = "0.3.1", path = "../sway-types" }
+sway-utils = { version = "0.3.1", path = "../sway-utils" }
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }

--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-types"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2018"
 homepage = "https://fuel.network/"

--- a/sway-utils/Cargo.toml
+++ b/sway-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-utils"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-forc = { version = "0.3.0", path = "../forc", features = ["test"], default-features = false }
+forc = { version = "0.3.1", path = "../forc", features = ["test"], default-features = false }
 fuel-asm = "0.1"
 fuel-tx = "0.2"
 fuel-vm = { version = "0.2", features = ["random"] }


### PR DESCRIPTION
While we could say that technically the removal of `[[tx-input]]` in #675 was breaking, it was 1) undocumented and 2) only used in this repo, since everyone else used the SDK. So, bump the patch version.