### PR TITLE
Pin lib version

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/use_full_path_names/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/use_full_path_names/Forc.toml
@@ -6,7 +6,7 @@ entry = "main.sw"
 
 
 [dependencies]
-std  = { git = "http://github.com/FuelLabs/sway-lib-std" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std  = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
 
 


### PR DESCRIPTION
Depends on #683. If that goes in before, then merge this into #472, otherwise rebase against `master`.