### PR TITLE
Fix unhelpful error found when there is an unimplemented feature.

### DIFF
--- a/sway-core/src/type_engine/engine.rs
+++ b/sway-core/src/type_engine/engine.rs
@@ -181,12 +181,16 @@ impl Engine {
             // }
 
             // If no previous attempts to unify were successful, raise an error
-            (_, _) => Err(TypeError::MismatchedType {
-                expected,
-                received,
-                help_text: Default::default(),
-                span: span.clone(),
-            }),
+            (the_received, the_expected) => match (the_received, the_expected) {
+                (TypeInfo::ErrorRecovery, _) => Ok(vec![]),
+                (_, TypeInfo::ErrorRecovery) => Ok(vec![]),
+                _ => Err(TypeError::MismatchedType {
+                    expected,
+                    received,
+                    help_text: Default::default(),
+                    span: span.clone(),
+                }),
+            },
         }
     }
 

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -122,7 +122,7 @@ pub(crate) fn compile_to_bytes(file_name: &str) -> Result<Vec<u8>, String> {
         print_ir: false,
         binary_outfile: None,
         offline_mode: false,
-        silent_mode: false,
+        silent_mode: true,
     })
 }
 

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -122,7 +122,7 @@ pub(crate) fn compile_to_bytes(file_name: &str) -> Result<Vec<u8>, String> {
         print_ir: false,
         binary_outfile: None,
         offline_mode: false,
-        silent_mode: true,
+        silent_mode: false,
     })
 }
 


### PR DESCRIPTION
Closes #415. Removes the onslaught of `expected: unknown due to error` messages when you have an unimplemented feature.