### PR TITLE
Version Bump Default Cargo.toml

### DIFF
--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -35,9 +35,9 @@ license = "Apache-2.0"
 
 [dependencies]
 fuels-abigen-macro = "0.1"
-fuels-core = "0.1"
-fuels-rs = "0.1"
-fuel-gql-client = {{ version = "0.1", default-features = false }}
+fuels-core = "0.2"
+fuels-rs = "0.2"
+fuel-gql-client = {{ version = "0.2", default-features = false }}
 fuel-tx = "0.2"
 rand = "0.8"
 tokio = {{ version = "1.12", features = ["rt", "macros"] }}

--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -34,7 +34,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels-abigen-macro = "0.1"
+fuels-abigen-macro = "0.2"
 fuels-core = "0.2"
 fuels-rs = "0.2"
 fuel-gql-client = {{ version = "0.2", default-features = false }}

--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -38,7 +38,7 @@ fuels-abigen-macro = "0.1"
 fuels-core = "0.2"
 fuels-rs = "0.2"
 fuel-gql-client = {{ version = "0.2", default-features = false }}
-fuel-tx = "0.2"
+fuel-tx = "0.3"
 rand = "0.8"
 tokio = {{ version = "1.12", features = ["rt", "macros"] }}
 


### PR DESCRIPTION
Default Cargo.toml for a new Rust project utilizes old dependencies which have some pretty significant bugs, move the version up to most recent versions of Fuel packages.