### PR TITLE
Add environment variable knobs to customise the E2E test runs.

### DIFF
--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -14,6 +14,8 @@ pub(crate) fn deploy_contract(file_name: &str) -> ContractId {
     println!(" Deploying {}", file_name);
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
 
+    let (verbose, use_ir) = get_test_config_from_env();
+
     tokio::runtime::Runtime::new()
         .unwrap()
         .block_on(forc_deploy::deploy(DeployCommand {
@@ -21,13 +23,13 @@ pub(crate) fn deploy_contract(file_name: &str) -> ContractId {
                 "{}/src/e2e_vm_tests/test_programs/{}",
                 manifest_dir, file_name
             )),
-            use_ir: false,
+            use_ir,
             print_finalized_asm: false,
             print_intermediate_asm: false,
             print_ir: false,
             binary_outfile: None,
             offline_mode: false,
-            silent_mode: true,
+            silent_mode: !verbose,
         }))
         .unwrap()
 }
@@ -43,6 +45,8 @@ pub(crate) fn runs_on_node(file_name: &str, contract_ids: &[fuel_tx::ContractId]
         contracts.push(contract);
     }
 
+    let (verbose, use_ir) = get_test_config_from_env();
+
     let command = RunCommand {
         data: None,
         path: Some(format!(
@@ -52,12 +56,12 @@ pub(crate) fn runs_on_node(file_name: &str, contract_ids: &[fuel_tx::ContractId]
         dry_run: false,
         node_url: "127.0.0.1:4000".into(),
         kill_node: false,
-        use_ir: false,
+        use_ir,
         binary_outfile: None,
         print_finalized_asm: false,
         print_intermediate_asm: false,
         print_ir: false,
-        silent_mode: true,
+        silent_mode: !verbose,
         pretty_print: false,
         contract: Some(contracts),
     };
@@ -111,18 +115,19 @@ pub(crate) fn does_not_compile(file_name: &str) {
 pub(crate) fn compile_to_bytes(file_name: &str) -> Result<Vec<u8>, String> {
     println!(" Compiling {}", file_name);
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let (verbose, use_ir) = get_test_config_from_env();
     forc_build::build(BuildCommand {
         path: Some(format!(
             "{}/src/e2e_vm_tests/test_programs/{}",
             manifest_dir, file_name
         )),
-        use_ir: false,
+        use_ir,
         print_finalized_asm: false,
         print_intermediate_asm: false,
         print_ir: false,
         binary_outfile: None,
         offline_mode: false,
-        silent_mode: true,
+        silent_mode: !verbose,
     })
 }
 
@@ -168,4 +173,13 @@ fn compile_to_json_abi(file_name: &str) -> Result<Value, String> {
         offline_mode: false,
         silent_mode: true,
     })
+}
+
+fn get_test_config_from_env() -> (bool, bool) {
+    let var_exists = |key| std::env::var(key).map(|_| true).unwrap_or(false);
+
+    (
+        var_exists("SWAY_TEST_VERBOSE"),
+        var_exists("SWAY_TEST_USE_IR"),
+    )
 }


### PR DESCRIPTION
The harness will now check for the existence (but not care about the
value) of two environment variables while running tests:
- SWAY_TEST_VERBOSE - this disables `silent_mode` and prints warnings
  and errors to stdout.
- SWAY_TEST_USE_IR - this turns on the `use_ir` flag to run the tests
  using the IR pipeline (useful presently until IR becomes the default).

E.g.,
```
$ cd sway/test
$ SWAY_TEST_VERBOSE=yes cargo r neq
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `sway/target/debug/test neq`
 Compiling neq_4_test
  Compiled library "core".
  Compiled library "core".
warning
 --> FuelLabs-sway-lib-std-5a0938f/src/result.sw:0:5
  |
...
3 |     Ok: T,
  |     -- Enum variant Ok is never constructed.
  |
warning
 --> FuelLabs-sway-lib-std-5a0938f/src/result.sw:0:5
  |
...
4 |     Err: E,
  |     --- Enum variant Err is never constructed.
  |
  Compiled library "lib-std" with 2 warnings.
  Compiled script "neq_4_test".
  Bytecode size is 108 bytes.
   ABI gen neq_4_test
  Compiled library "core".
  Compiled library "core".
  Compiled library "lib-std" with 2 warnings.
  Compiled script "neq_4_test".
_________________________________
Tests passed.
1 tests run (81 skipped)
```
