### PR TITLE
Fix starting line of warning spans

### DIFF
--- a/forc/src/utils/helpers.rs
+++ b/forc/src/utils/helpers.rs
@@ -307,9 +307,8 @@ fn construct_window<'a>(
     let mut calculated_start_ix = None;
     let mut calculated_end_ix = None;
     for (ix, character) in input.chars().enumerate() {
-        match character {
-            '\n' => current_line += 1,
-            _ => (),
+        if character == '\n' {
+            current_line += 1
         }
 
         if current_line >= start.line - NUM_LINES_BUFFER && calculated_start_ix.is_none() {

--- a/forc/src/utils/helpers.rs
+++ b/forc/src/utils/helpers.rs
@@ -215,6 +215,7 @@ fn format_err(err: &sway_core::CompileError) {
         end_pos += 1;
     }
     let friendly_str = err.to_friendly_error_string();
+    let (start, _end) = err.line_col();
     let snippet = Snippet {
         title: Some(Annotation {
             label: None,
@@ -224,7 +225,7 @@ fn format_err(err: &sway_core::CompileError) {
         footer: vec![],
         slices: vec![Slice {
             source: input,
-            line_start: 0,
+            line_start: start.line,
             origin: Some(&path),
             fold: true,
             annotations: vec![SourceAnnotation {
@@ -251,6 +252,7 @@ fn format_warning(err: &sway_core::CompileWarning) {
         // if start/pos are same we will not get that arrow pointing to code, so we add +1.
         end_pos += 1;
     }
+    let (start, _end) = err.line_col();
     let snippet = Snippet {
         title: Some(Annotation {
             label: None,
@@ -260,7 +262,7 @@ fn format_warning(err: &sway_core::CompileWarning) {
         footer: vec![],
         slices: vec![Slice {
             source: input,
-            line_start: 0,
+            line_start: start.line,
             origin: Some(&path),
             fold: true,
             annotations: vec![SourceAnnotation {

--- a/forc/src/utils/helpers.rs
+++ b/forc/src/utils/helpers.rs
@@ -8,7 +8,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::str;
 use std::sync::Arc;
-use sway_core::{CompileError, CompileWarning, TreeType};
+use sway_core::{error::LineCol, CompileError, CompileWarning, TreeType};
 use sway_utils::constants;
 use termcolor::{self, Color as TermColor, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
@@ -209,13 +209,14 @@ fn format_err(err: &sway_core::CompileError) {
     let input = err.internal_span().input();
     let path = err.path();
 
-    let (start_pos, mut end_pos) = err.span();
+    let (mut start_pos, mut end_pos) = err.span();
     if start_pos == end_pos {
         // if start/pos are same we will not get that arrow pointing to code, so we add +1.
         end_pos += 1;
     }
     let friendly_str = err.to_friendly_error_string();
-    let (start, _end) = err.line_col();
+    let (mut start, mut end) = err.line_col();
+    let input = construct_window(&mut start, end, &mut start_pos, &mut end_pos, input);
     let snippet = Snippet {
         title: Some(Annotation {
             label: None,
@@ -227,7 +228,7 @@ fn format_err(err: &sway_core::CompileError) {
             source: input,
             line_start: start.line,
             origin: Some(&path),
-            fold: true,
+            fold: false,
             annotations: vec![SourceAnnotation {
                 label: &friendly_str,
                 annotation_type: AnnotationType::Error,
@@ -246,13 +247,15 @@ fn format_warning(err: &sway_core::CompileWarning) {
     let input = err.span.input();
     let path = err.path();
 
-    let (start_pos, mut end_pos) = err.span();
+    let (mut start_pos, mut end_pos) = err.span();
     let friendly_str = err.to_friendly_warning_string();
     if start_pos == end_pos {
         // if start/pos are same we will not get that arrow pointing to code, so we add +1.
         end_pos += 1;
     }
-    let (start, _end) = err.line_col();
+
+    let (mut start, mut end) = err.line_col();
+    let input = construct_window(&mut start, end, &mut start_pos, &mut end_pos, input);
     let snippet = Snippet {
         title: Some(Annotation {
             label: None,
@@ -264,7 +267,7 @@ fn format_warning(err: &sway_core::CompileWarning) {
             source: input,
             line_start: start.line,
             origin: Some(&path),
-            fold: true,
+            fold: false,
             annotations: vec![SourceAnnotation {
                 label: &friendly_str,
                 annotation_type: AnnotationType::Warning,
@@ -277,4 +280,56 @@ fn format_warning(err: &sway_core::CompileWarning) {
         },
     };
     eprintln!("{}", DisplayList::from(snippet))
+}
+
+/// Given a start and an end position and an input, determine how much of a window to show in the
+/// error.
+/// Mutates the start and end indexes to be in line with the new slice length.
+///
+/// The library we use doesn't handle auto-windowing and line numbers, so we must manually
+/// calculate the line numbers and match them up with the input window. It is a bit fiddly.t
+fn construct_window<'a>(
+    start: &mut LineCol,
+    end: LineCol,
+    start_ix: &mut usize,
+    end_ix: &mut usize,
+    input: &'a str,
+) -> &'a str {
+    // how many lines to prepend or append to the highlighted region in the window
+    const NUM_LINES_BUFFER: usize = 2;
+
+    let total_lines_in_input = input.chars().filter(|x| *x == '\n').count();
+    let total_lines_of_highlight = end.line - start.line;
+    debug_assert!(total_lines_in_input > total_lines_of_highlight);
+
+    let mut current_line = 0;
+    let mut lines_to_start_of_snippet = 0;
+    let mut calculated_start_ix = None;
+    let mut calculated_end_ix = None;
+    for (ix, character) in input.chars().enumerate() {
+        match character {
+            '\n' => current_line += 1,
+            _ => (),
+        }
+
+        if current_line >= start.line - NUM_LINES_BUFFER && calculated_start_ix.is_none() {
+            calculated_start_ix = Some(ix);
+            lines_to_start_of_snippet = current_line;
+        }
+
+        if current_line >= end.line + NUM_LINES_BUFFER && calculated_end_ix.is_none() {
+            calculated_end_ix = Some(ix);
+        }
+
+        if calculated_start_ix.is_some() && calculated_end_ix.is_some() {
+            break;
+        }
+    }
+    let calculated_start_ix = calculated_start_ix.unwrap_or(0);
+    let calculated_end_ix = calculated_end_ix.unwrap_or(input.len());
+
+    *start_ix -= calculated_start_ix;
+    *end_ix -= calculated_start_ix;
+    start.line = lines_to_start_of_snippet;
+    &input[calculated_start_ix..calculated_end_ix]
 }

--- a/forc/src/utils/helpers.rs
+++ b/forc/src/utils/helpers.rs
@@ -215,7 +215,7 @@ fn format_err(err: &sway_core::CompileError) {
         end_pos += 1;
     }
     let friendly_str = maybe_uwuify(&err.to_friendly_error_string());
-    let (mut start, mut end) = err.line_col();
+    let (mut start, end) = err.line_col();
     let input = construct_window(&mut start, end, &mut start_pos, &mut end_pos, input);
     let snippet = Snippet {
         title: Some(Annotation {
@@ -254,7 +254,7 @@ fn format_warning(err: &sway_core::CompileWarning) {
         end_pos += 1;
     }
 
-    let (mut start, mut end) = err.line_col();
+    let (mut start, end) = err.line_col();
     let input = construct_window(&mut start, end, &mut start_pos, &mut end_pos, input);
     let snippet = Snippet {
         title: Some(Annotation {

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -148,6 +148,7 @@ pub struct CompileWarning {
     pub warning_content: Warning,
 }
 
+#[derive(Clone, Copy)]
 pub struct LineCol {
     pub line: usize,
     pub col: usize,


### PR DESCRIPTION
It appears there was a regression in warning/error formatting where all spans would start from line 0:
<img width="306" alt="image" src="https://user-images.githubusercontent.com/12157751/151431919-a5dea5c4-0e06-4435-bca0-06f092527b0b.png">


This PR fixes that:
<img width="406" alt="image" src="https://user-images.githubusercontent.com/12157751/151462582-af9015a8-05bd-44c5-95db-38254b63bb61.png">

I've also removed folding (omission of lines within the annotation) for better readability. The window size is currently two lines before the annotation and two lines after, which I feel is reasonable.
