### PR TITLE
Initial auth module tests

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/auth_testing_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/auth_testing_abi/Forc.toml
@@ -1,5 +1,5 @@
 [project]
 author = "Fuel Labs <contact@fuel.sh>"
+entry = "main.sw"
 license = "Apache-2.0"
 name = "auth_testing_abi"
-entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/auth_testing_abi/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/auth_testing_abi/src/main.sw
@@ -1,5 +1,7 @@
 library auth_testing_abi;
+use std::result::Result;
 
 abi AuthTesting {
   fn returns_gm_one(gas: u64, coins: u64, asset_id: b256, input: ()) -> bool;
+  fn returns_msg_sender(gas: u64, coins: u64, asset_id: b256, input: ()) -> Result;
 }

--- a/test/src/e2e_vm_tests/test_programs/auth_testing_contract/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/auth_testing_contract/Forc.toml
@@ -1,10 +1,10 @@
 [project]
 author = "Fuel Labs <contact@fuel.sh>"
+entry = "main.sw"
 license = "Apache-2.0"
 name = "auth_testing_contract"
-entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std" }
+core = { git = "http://github.com/FuelLabs/sway-lib-core"}
 auth_testing_abi = { path = "../auth_testing_abi" }

--- a/test/src/e2e_vm_tests/test_programs/auth_testing_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/auth_testing_contract/src/main.sw
@@ -1,5 +1,5 @@
 contract;
---use std::chain::auth::{caller_is_external,msg_sender};
+use std::chain::auth::{caller_is_external,msg_sender};
 use std::result::Result;
 use auth_testing_abi::AuthTesting;
 

--- a/test/src/e2e_vm_tests/test_programs/auth_testing_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/auth_testing_contract/src/main.sw
@@ -1,9 +1,14 @@
 contract;
-use std::chain::auth::caller_is_external;
+--use std::chain::auth::{caller_is_external,msg_sender};
+use std::result::Result;
 use auth_testing_abi::AuthTesting;
 
 impl AuthTesting for Contract {
-  fn returns_gm_one(gas: u64, coins: u64, asset_id: b256, input: ()) -> bool {
-     caller_is_external()
-  }
+    fn returns_gm_one(gas: u64, coins: u64, asset_id: b256, input: ()) -> bool {
+        caller_is_external()
+    }
+
+    fn returns_msg_sender(gas: u64, coins: u64, asset_id: b256, input: ()) -> Result {
+        msg_sender()
+    }
 }

--- a/test/src/e2e_vm_tests/test_programs/caller_auth_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/caller_auth_test/Forc.toml
@@ -1,10 +1,10 @@
 [project]
 author = "Fuel Labs <contact@fuel.sh>"
+entry = "main.sw"
 license = "Apache-2.0"
 name = "caller_auth_test"
-entry = "main.sw"
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
-core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std"}
+core = { git = "http://github.com/FuelLabs/sway-lib-core"}
 auth_testing_abi = { path = "../auth_testing_abi" }

--- a/test/src/e2e_vm_tests/test_programs/caller_auth_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/caller_auth_test/src/main.sw
@@ -1,10 +1,16 @@
 script;
-use std::{chain::auth::caller_is_external, constants::ETH_ID};
+use std::{chain::{assert, auth::{caller_is_external, AuthError}}, constants::ETH_ID, result::*};
 use auth_testing_abi::AuthTesting;
 
 // should be false in the case of a script
 fn main() -> bool {
-  let caller = abi(AuthTesting, 0x27829e78404b18c037b15bfba5110c613a83ea22c718c8b51596e17c9cb1cd6f);
+  let caller = abi(AuthTesting, 0x46bd0d4a848314a56f156e4a1f6c118abfd425a877fe5b4212660ba3a6793ff8);
 
-  caller.returns_gm_one(1000, 0, ETH_ID, ())
+  assert(caller.returns_gm_one(1000, 0, ETH_ID, ()));
+  let res: Result = caller.returns_msg_sender(1000, 0, ETH_ID, ());
+  assert(~Result::is_err(res));
+  // TODO: impl Eq for Result so we can test more precisely:
+  // assert(res == Result::Err(AuthError::ContextError));
+
+  true
 }


### PR DESCRIPTION
Additional tests for the `msg_sender()` function added in : https://github.com/FuelLabs/sway-lib-std/pull/30

Note: Not currently working, I'm pretty sure this is blocked by https://github.com/FuelLabs/sway/issues/579