### PR TITLE
feature to uwu-ify compile errors and warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,6 +967,7 @@ dependencies = [
  "tokio",
  "toml",
  "ureq",
+ "uwuify",
  "whoami",
 ]
 
@@ -1880,10 +1881,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.10",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "parser"
@@ -3340,6 +3372,18 @@ name = "utf8-ranges"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
+
+[[package]]
+name = "uwuify"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db6840b7adcfd2e866c79157cc890ecdbbc1f739607134039ae64eaa6c07e24"
+dependencies = [
+ "clap",
+ "owo-colors",
+ "parking_lot",
+ "thiserror",
+]
 
 [[package]]
 name = "value-bag"

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -38,8 +38,10 @@ tokio = { version = "1.8.0", features = ["macros", "rt-multi-thread", "process"]
 toml = "0.5"
 ureq = "2.4"
 whoami = "1.1"
+uwuify = { version = "^0.2", optional = true }
 
 [features]
 default = []
 test = []
 util = []
+uwu = ["uwuify"]

--- a/forc/src/utils/helpers.rs
+++ b/forc/src/utils/helpers.rs
@@ -280,7 +280,6 @@ fn format_warning(err: &sway_core::CompileWarning) {
 #[cfg(all(feature = "uwu", any(target_arch = "x86", target_arch = "x86_64")))]
 fn maybe_uwuify(raw: &str) -> String {
     use uwuifier::uwuify_str_sse;
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     uwuify_str_sse(raw)
 }
 #[cfg(all(feature = "uwu", not(any(target_arch = "x86", target_arch = "x86_64"))))]

--- a/forc/src/utils/helpers.rs
+++ b/forc/src/utils/helpers.rs
@@ -214,7 +214,7 @@ fn format_err(err: &sway_core::CompileError) {
         // if start/pos are same we will not get that arrow pointing to code, so we add +1.
         end_pos += 1;
     }
-    let friendly_str = err.to_friendly_error_string();
+    let friendly_str = maybe_uwuify(&err.to_friendly_error_string());
     let snippet = Snippet {
         title: Some(Annotation {
             label: None,
@@ -246,7 +246,7 @@ fn format_warning(err: &sway_core::CompileWarning) {
     let path = err.path();
 
     let (start_pos, mut end_pos) = err.span();
-    let friendly_str = err.to_friendly_warning_string();
+    let friendly_str = maybe_uwuify(&err.to_friendly_warning_string());
     if start_pos == end_pos {
         // if start/pos are same we will not get that arrow pointing to code, so we add +1.
         end_pos += 1;
@@ -275,4 +275,21 @@ fn format_warning(err: &sway_core::CompileWarning) {
         },
     };
     eprintln!("{}", DisplayList::from(snippet))
+}
+
+#[cfg(all(feature = "uwu", any(target_arch = "x86", target_arch = "x86_64")))]
+fn maybe_uwuify(raw: &str) -> String {
+    use uwuifier::uwuify_str_sse;
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    uwuify_str_sse(raw)
+}
+#[cfg(all(feature = "uwu", not(any(target_arch = "x86", target_arch = "x86_64"))))]
+fn maybe_uwuify(raw: &str) -> String {
+    compile_error!("The `uwu` feature only works on x86 or x86_64 processors.");
+    Default::default()
+}
+
+#[cfg(not(feature = "uwu"))]
+fn maybe_uwuify(raw: &str) -> String {
+    raw.to_string()
 }

--- a/test/src/e2e_vm_tests/test_programs/if_elseif_enum/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/if_elseif_enum/Forc.toml
@@ -1,12 +1,10 @@
 [project]
 author = "Fuel Labs <contact@fuel.sh>"
+entry = "main.sw"
 license = "Apache-2.0"
 name = "if_elseif_enum"
-entry = "main.sw"
 
 
 [dependencies]
-std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
 core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
-
-
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }


### PR DESCRIPTION
Not sure if we should include this easter egg...feel free to shoot this down. Putting up the PR for posterity.

only works on x86. if we release this and you install via `cargo install forc --features=uwu`, you'll get uwu-ified error messages.

What is uwufying?

before:
> impure function called inside of pure function. Pure functions can only call other pure functions. Try making the surrounding function impure by prepending "impure" to the function declaration.

after (uwufied)
> impuwe function cawwed *looks at you* inside of puwe function. Puwe functions c-can onwy caww othew puwe functions. Twy making the x3 suwwounding function impuwe by pwepending "impuwe" t-to the x3 function d-decwawation.


# Why is this `x86` only?

[The code is insanely optimized and vectorized.](https://github.com/Daniel-Liu-c0deb0t/uwu/blob/uwu/src/lib.rs)