### PR TITLE
Update ec_recover test to use updated B512 data structure.

### DIFF
--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -130,7 +130,7 @@ pub(crate) fn compile_to_bytes(file_name: &str) -> Result<Vec<u8>, String> {
         binary_outfile: None,
         debug_outfile: None,
         offline_mode: false,
-        silent_mode: verbose,
+        silent_mode: !verbose,
     })
 }
 

--- a/test/src/e2e_vm_tests/test_programs/ec_recover_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/ec_recover_test/Forc.toml
@@ -6,4 +6,4 @@ entry = "main.sw"
 
 [dependencies]
 core = { git = "http://github.com/FuelLabs/sway-lib-core", version = "v0.0.1" }
-std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.1.0" }

--- a/test/src/e2e_vm_tests/test_programs/ec_recover_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/ec_recover_test/src/main.sw
@@ -38,8 +38,8 @@ fn main() -> bool {
 
     // recover the public key:
     let recovered_pubkey: B512 = ec_recover(signature, msg_hash);
-    assert(recovered_pubkey.hi == pubkey.hi);
-    assert(recovered_pubkey.lo == pubkey.lo);
+    assert((recovered_pubkey.bytes)[0] == (pubkey.bytes)[0]);
+    assert((recovered_pubkey.bytes)[1] == (pubkey.bytes)[1]);
 
     true
 }


### PR DESCRIPTION
This is a small change to accommodate the (proposed) changes to `B512` and `ec_recover()` in `sway-lib-std`.