### PR TITLE
Fix E2E tests for IR.

### DIFF
--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -286,14 +286,16 @@ impl<'ir> AsmBuilder<'ir> {
         // Reserve space on the stack for ALL our locals which require it.
         if stack_base > 0 {
             let base_reg = self.reg_seqr.next();
-            self.bytecode.push(Op::register_move(
+            self.bytecode.push(Op::unowned_register_move_comment(
                 base_reg.clone(),
                 VirtualRegister::Constant(ConstantRegister::StackPointer),
-                Self::empty_span(),
+                "save locals base register",
             ));
-            self.bytecode.push(Op::unowned_stack_allocate_memory(
+            let mut alloc_op = Op::unowned_stack_allocate_memory(
                 VirtualImmediate24::new(stack_base * 8, Self::empty_span()).unwrap(),
-            ));
+            );
+            alloc_op.comment = format!("allocate {} bytes for all locals", stack_base * 8);
+            self.bytecode.push(alloc_op);
             self.stack_base_reg = Some(base_reg);
         }
     }
@@ -482,7 +484,7 @@ impl<'ir> AsmBuilder<'ir> {
 
             inline_ops.push(Op {
                 opcode: either::Either::Left(opcode),
-                comment: String::new(),
+                comment: "asm block".into(),
                 owning_span: None,
             });
         }
@@ -796,6 +798,11 @@ impl<'ir> AsmBuilder<'ir> {
         let insert_reg = self.value_to_register(value);
         let (insert_offs, value_size) = self.aggregate_idcs_to_field_layout(ty, indices);
 
+        let indices_str = indices
+            .iter()
+            .map(|idx| format!("{}", idx))
+            .collect::<Vec<String>>()
+            .join(",");
         if value_size <= 8 {
             self.bytecode.push(Op {
                 opcode: Either::Left(VirtualOp::SW(
@@ -803,14 +810,7 @@ impl<'ir> AsmBuilder<'ir> {
                     insert_reg,
                     VirtualImmediate12::new(insert_offs, Self::empty_span()).unwrap(),
                 )),
-                comment: format!(
-                    "insert_value @ {}",
-                    indices
-                        .iter()
-                        .map(|idx| format!("{}", idx))
-                        .collect::<Vec<String>>()
-                        .join(",")
-                ),
+                comment: format!("insert_value @ {}", indices_str),
                 owning_span: None,
             });
         } else {
@@ -821,7 +821,7 @@ impl<'ir> AsmBuilder<'ir> {
                     base_reg.clone(),
                     VirtualImmediate12::new(insert_offs * 8, Self::empty_span()).unwrap(),
                 )),
-                comment: "insert_value get offset".into(),
+                comment: format!("get struct field(s) {} offset", indices_str),
                 owning_span: None,
             });
             self.bytecode.push(Op {
@@ -830,7 +830,7 @@ impl<'ir> AsmBuilder<'ir> {
                     insert_reg,
                     VirtualImmediate12::new(value_size, Self::empty_span()).unwrap(),
                 )),
-                comment: "insert_value store value".into(),
+                comment: "store struct field value".into(),
                 owning_span: None,
             });
         }
@@ -1000,7 +1000,7 @@ impl<'ir> AsmBuilder<'ir> {
                                     VirtualImmediate12::new(word_offs * 8, Self::empty_span())
                                         .unwrap(),
                                 )),
-                                comment: "store get offset".into(),
+                                comment: "get store offset".into(),
                                 owning_span: None,
                             });
 
@@ -1047,16 +1047,26 @@ impl<'ir> AsmBuilder<'ir> {
                                 // We can have zero sized structs and maybe arrays?
                                 if total_size > 0 {
                                     // Save the stack pointer.
-                                    self.bytecode.push(Op::register_move(
+                                    self.bytecode.push(Op::unowned_register_move_comment(
                                         start_reg.clone(),
                                         VirtualRegister::Constant(ConstantRegister::StackPointer),
-                                        Self::empty_span(),
+                                        "save register for temporary stack value",
                                     ));
 
-                                    self.bytecode.push(Op::unowned_stack_allocate_memory(
+                                    let mut alloc_op = Op::unowned_stack_allocate_memory(
                                         VirtualImmediate24::new(total_size, Self::empty_span())
                                             .unwrap(),
-                                    ));
+                                    );
+                                    alloc_op.comment = format!(
+                                        "allocate {} bytes for temporary {}",
+                                        total_size,
+                                        if matches!(&constant.value, ConstantValue::Struct(_)) {
+                                            "struct"
+                                        } else {
+                                            "array"
+                                        },
+                                    );
+                                    self.bytecode.push(alloc_op);
 
                                     // Fill in the fields.
                                     self.initialise_constant_memory(constant, &start_reg, 0);

--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -31,10 +31,10 @@ pub(crate) fn compile_ast(ast: TypedParseTree) -> Result<Context, String> {
         } => unimplemented!("compile predicate to ir"),
         TypedParseTree::Contract {
             abi_entries,
-            namespace: _,
+            namespace,
             declarations,
             all_nodes: _,
-        } => compile_contract(&mut ctx, abi_entries, declarations),
+        } => compile_contract(&mut ctx, abi_entries, namespace, declarations),
         TypedParseTree::Library {
             namespace: _,
             all_nodes: _,
@@ -64,10 +64,12 @@ fn compile_script(
 fn compile_contract(
     context: &mut Context,
     abi_entries: Vec<TypedFunctionDeclaration>,
+    namespace: NamespaceRef,
     declarations: Vec<TypedDeclaration>,
 ) -> Result<Module, String> {
     let module = Module::new(context, Kind::Contract, "contract");
 
+    compile_constants(context, module, namespace, false)?;
     compile_declarations(context, module, declarations)?;
     for decl in abi_entries {
         compile_abi_method(context, module, decl)?;
@@ -87,16 +89,33 @@ fn compile_constants(
     read_module(
         |ns| -> Result<(), String> {
             for decl in ns.get_all_declared_symbols() {
-                if let TypedDeclaration::ConstantDeclaration(TypedConstantDeclaration {
-                    name,
-                    value,
-                    visibility,
-                }) = decl
-                {
-                    if !public_only || matches!(visibility, Visibility::Public) {
-                        let const_val = compile_constant_expression(context, value)?;
-                        module.add_global_constant(context, name.as_str().to_owned(), const_val);
+                let decl_name_value = match decl {
+                    TypedDeclaration::ConstantDeclaration(TypedConstantDeclaration {
+                        name,
+                        value,
+                        visibility,
+                    }) => {
+                        // XXX Do we really only add public constants?
+                        if !public_only || matches!(visibility, Visibility::Public) {
+                            Some((name, value))
+                        } else {
+                            None
+                        }
                     }
+
+                    TypedDeclaration::VariableDeclaration(TypedVariableDeclaration {
+                        name,
+                        body,
+                        const_decl_origin,
+                        ..
+                    }) if *const_decl_origin => Some((name, body)),
+
+                    _otherwise => None,
+                };
+
+                if let Some((name, value)) = decl_name_value {
+                    let const_val = compile_constant_expression(context, value)?;
+                    module.add_global_constant(context, name.as_str().to_owned(), const_val);
                 }
             }
 
@@ -118,7 +137,7 @@ fn compile_constant_expression(
     if let TypedExpressionVariant::Literal(literal) = &const_expr.expression {
         Ok(convert_literal_to_value(context, literal))
     } else {
-        Err("Unsupported constant declaration type.".into())
+        Err("Unsupported constant expression type.".into())
     }
 }
 

--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -1420,6 +1420,7 @@ fn convert_resolved_type(context: &mut Context, ast_type: &TypeInfo) -> Result<T
             };
             Type::Uint(nbits)
         }
+        TypeInfo::Numeric => Type::Uint(64),
         TypeInfo::Boolean => Type::Bool,
         TypeInfo::Byte => Type::Uint(8), // XXX?
         TypeInfo::B256 => Type::B256,
@@ -1469,7 +1470,6 @@ fn convert_resolved_type(context: &mut Context, ast_type: &TypeInfo) -> Result<T
         )),
         TypeInfo::Unknown => return Err("unknown type found in AST..?".into()),
         TypeInfo::UnknownGeneric { .. } => return Err("unknowngeneric type found in AST..?".into()),
-        TypeInfo::Numeric => return Err("'numeric' type found in AST..?".into()),
         TypeInfo::Ref(_) => return Err("ref type found in AST..?".into()),
         TypeInfo::ErrorRecovery => return Err("error recovery type found in AST..?".into()),
     })

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -118,6 +118,7 @@ impl TypedFunctionDeclaration {
                         span: name.span().clone(),
                     },
                     is_mutable: VariableMutability::Immutable,
+                    const_decl_origin: false,
                     type_ascription: r#type,
                 }),
             );

--- a/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
@@ -56,6 +56,7 @@ pub struct TypedVariableDeclaration {
     pub(crate) body: TypedExpression,
     pub(crate) is_mutable: VariableMutability,
     pub(crate) type_ascription: TypeId,
+    pub(crate) const_decl_origin: bool,
 }
 
 impl TypedVariableDeclaration {

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -251,6 +251,7 @@ impl TypedAstNode {
                                     name: name.clone(),
                                     body,
                                     is_mutable: is_mutable.into(),
+                                    const_decl_origin: false,
                                     type_ascription,
                                 });
                             namespace.insert(name, typed_var_decl.clone());
@@ -283,6 +284,7 @@ impl TypedAstNode {
                                     } else {
                                         VariableMutability::Immutable
                                     },
+                                    const_decl_origin: true,
                                     type_ascription: insert_type(type_ascription),
                                 });
                             namespace.insert(name, typed_const_decl.clone());
@@ -1122,6 +1124,7 @@ fn type_check_trait_methods(
                         },
                         // TODO allow mutable function params?
                         is_mutable: VariableMutability::Immutable,
+                        const_decl_origin: false,
                         type_ascription: r#type,
                     }),
                 );

--- a/sway-core/tests/ir_to_asm/bigger_asm_block.asm
+++ b/sway-core/tests/ir_to_asm/bigger_asm_block.asm
@@ -5,15 +5,15 @@ DATA_SECTION_OFFSET[0..32]
 DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
-move $r0 $sp
-cfei i32
+move $r0 $sp                  ; save locals base register
+cfei i32                      ; allocate 32 bytes for all locals
 lw   $r1 data_0               ; literal instantiation
-addi $r2 $r0 i0               ; store get offset
+addi $r2 $r0 i0               ; get store offset
 mcpi $r2 $r1 i32              ; store value
 addi $r1 $r0 i0               ; load address
 lw   $r0 data_1               ; literal instantiation
-addi $r2 $zero i32
-meq  $r3 $r1 $r0 $r2
+addi $r2 $zero i32            ; asm block
+meq  $r3 $r1 $r0 $r2          ; asm block
 move $r0 $r3                  ; return value from inline asm
 move $r1 $r0
 ret  $r1

--- a/sway-core/tests/ir_to_asm/mutable_struct.asm
+++ b/sway-core/tests/ir_to_asm/mutable_struct.asm
@@ -5,15 +5,15 @@ DATA_SECTION_OFFSET[0..32]
 DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
-move $r0 $sp
-cfei i16
-move $r1 $sp
-cfei i16
+move $r0 $sp                  ; save locals base register
+cfei i16                      ; allocate 16 bytes for all locals
+move $r1 $sp                  ; save register for temporary stack value
+cfei i16                      ; allocate 16 bytes for temporary struct
 lw   $r2 data_0               ; literal instantiation
 sw   $r1 $r2 i0               ; insert_value @ 0
 lw   $r2 data_1               ; literal instantiation
 sw   $r1 $r2 i1               ; insert_value @ 1
-addi $r2 $r0 i0               ; store get offset
+addi $r2 $r0 i0               ; get store offset
 mcpi $r2 $r1 i16              ; store value
 addi $r1 $r0 i0               ; get_ptr
 lw   $r2 data_2               ; literal instantiation

--- a/sway-core/tests/ir_to_asm/simple_array.asm
+++ b/sway-core/tests/ir_to_asm/simple_array.asm
@@ -5,10 +5,10 @@ DATA_SECTION_OFFSET[0..32]
 DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
-move $r0 $sp
-cfei i24
-move $r1 $sp
-cfei i24
+move $r0 $sp                  ; save locals base register
+cfei i24                      ; allocate 24 bytes for all locals
+move $r1 $sp                  ; save register for temporary stack value
+cfei i24                      ; allocate 24 bytes for temporary array
 lw   $r2 data_0               ; literal instantiation
 lw   $r3 data_1               ; literal instantiation
 muli $r3 $r3 i8               ; insert_element relative offset
@@ -24,7 +24,7 @@ lw   $r3 data_4               ; literal instantiation
 muli $r3 $r3 i8               ; insert_element relative offset
 add  $r4 $r1 $r3              ; insert_element absolute offset
 sw   $r4 $r2 i0               ; insert_element
-addi $r2 $r0 i0               ; store get offset
+addi $r2 $r0 i0               ; get store offset
 mcpi $r2 $r1 i24              ; store value
 addi $r1 $r0 i0               ; load address
 lw   $r0 data_3               ; literal instantiation

--- a/sway-core/tests/ir_to_asm/simple_enum.asm
+++ b/sway-core/tests/ir_to_asm/simple_enum.asm
@@ -5,19 +5,19 @@ DATA_SECTION_OFFSET[0..32]
 DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
-move $r0 $sp
-cfei i16
-move $r1 $sp
-cfei i16
+move $r0 $sp                  ; save locals base register
+cfei i16                      ; allocate 16 bytes for all locals
+move $r1 $sp                  ; save register for temporary stack value
+cfei i16                      ; allocate 16 bytes for temporary struct
 lw   $r2 data_0               ; literal instantiation
 sw   $r1 $r2 i0               ; insert_value @ 0
-addi $r2 $r0 i0               ; store get offset
+addi $r2 $r0 i0               ; get store offset
 mcpi $r2 $r1 i16              ; store value
 addi $r1 $r0 i0               ; get_ptr
 lw   $r0 data_1               ; literal instantiation
 move $r1 $r0
-move $r0 $sp
-cfei i16
+move $r0 $sp                  ; save register for temporary stack value
+cfei i16                      ; allocate 16 bytes for temporary struct
 lw   $r1 data_2               ; literal instantiation
 sw   $r0 $r1 i0               ; insert_value @ 0
 lw   $r1 data_3               ; literal instantiation

--- a/sway-core/tests/ir_to_asm/simple_struct.asm
+++ b/sway-core/tests/ir_to_asm/simple_struct.asm
@@ -5,15 +5,15 @@ DATA_SECTION_OFFSET[0..32]
 DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
-move $r0 $sp
-cfei i16
-move $r1 $sp
-cfei i16
+move $r0 $sp                  ; save locals base register
+cfei i16                      ; allocate 16 bytes for all locals
+move $r1 $sp                  ; save register for temporary stack value
+cfei i16                      ; allocate 16 bytes for temporary struct
 lw   $r2 data_0               ; literal instantiation
 sw   $r1 $r2 i0               ; insert_value @ 0
 lw   $r2 data_1               ; literal instantiation
 sw   $r1 $r2 i1               ; insert_value @ 1
-addi $r2 $r0 i0               ; store get offset
+addi $r2 $r0 i0               ; get store offset
 mcpi $r2 $r1 i16              ; store value
 addi $r1 $r0 i0               ; get_ptr
 lw   $r0 $r1 i0               ; extract_value @ 0

--- a/sway-core/tests/ir_to_asm/tiny_asm_block.asm
+++ b/sway-core/tests/ir_to_asm/tiny_asm_block.asm
@@ -5,7 +5,7 @@ DATA_SECTION_OFFSET[0..32]
 DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
-bhei $r0
+bhei $r0                      ; asm block
 move $r1 $r0                  ; return value from inline asm
 ret  $r1
 .data:

--- a/sway-ir/src/block.rs
+++ b/sway-ir/src/block.rs
@@ -151,8 +151,9 @@ impl Block {
     /// Remove an instruction from this block.
     ///
     /// **NOTE:** We must be very careful!  We mustn't remove the phi or the terminator.  Some
-    /// extra checks should probably be performed here to avoid corruption! Using `Vec::remove()`
-    /// is also O(n) which we may want to avoid someday.
+    /// extra checks should probably be performed here to avoid corruption! Ideally we use get a
+    /// user/uses system implemented.  Using `Vec::remove()` is also O(n) which we may want to
+    /// avoid someday.
     pub fn remove_instruction(&self, context: &mut Context, instr_val: Value) {
         let ins = &mut context.blocks[self.0].instructions;
         if let Some(pos) = ins.iter().position(|iv| *iv == instr_val) {

--- a/sway-ir/src/optimize/constants.rs
+++ b/sway-ir/src/optimize/constants.rs
@@ -109,7 +109,12 @@ fn combine_const_aggregate_field(
     function.replace_value(context, aggregate, new_aggregate_value, None);
 
     // Remove the old aggregate from the context.
-    context.values.remove(aggregate.0);
+    //
+    // OR NOT!  This is too dangerous unless we can
+    // guarantee it has no uses, which is something we should implement eventually.  For now, in
+    // this case it shouldn't matter if we leave it, even if it's not used.
+    //
+    // TODO: context.values.remove(aggregate.0);
 
     new_aggregate_value
 }

--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -182,7 +182,6 @@ fn inline_instruction(
     // Util to translate old values to new.  If an old value isn't in the map then it (should be)
     // a const, which we can just keep using.
     let map_value = |old_val: Value| value_map.get(&old_val).copied().unwrap_or(old_val);
-    let map_value_ref = |old_val: &Value| map_value(*old_val);
     let map_ptr = |old_ptr| ptr_map.get(&old_ptr).copied().unwrap();
 
     // The instruction needs to be cloned into the new block, with each value and/or block
@@ -212,7 +211,7 @@ fn inline_instruction(
             Instruction::Call(f, args) => new_block.ins(context).call(
                 f,
                 args.iter()
-                    .map(&map_value_ref)
+                    .map(|old_val: &Value| map_value(*old_val))
                     .collect::<Vec<Value>>()
                     .as_slice(),
             ),

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -44,7 +44,6 @@ pub fn run(filter_regex: Option<regex::Regex>) {
         ),
         ("op_precedence", ProgramState::Return(0)),
         ("asm_without_return", ProgramState::Return(0)),
-        ("op_precedence", ProgramState::Return(0)), // false
         ("b256_bad_jumps", ProgramState::Return(1)),
         ("b256_ops", ProgramState::Return(100)),
         ("struct_field_access", ProgramState::Return(43)),
@@ -53,7 +52,7 @@ pub fn run(filter_regex: Option<regex::Regex>) {
         ("eq_4_test", ProgramState::Return(1)),
         ("local_impl_for_ord", ProgramState::Return(1)), // true
         ("const_decl", ProgramState::Return(100)),
-        // TEMPORARILY DISABLED DUE TO OOM ("const_decl_in_library", ProgramState::Return(1)), // true
+        ("const_decl_in_library", ProgramState::Return(1)), // true
         ("aliased_imports", ProgramState::Return(42)),
         ("empty_method_initializer", ProgramState::Return(1)), // true
         ("b512_struct_alignment", ProgramState::Return(1)),    // true
@@ -61,19 +60,16 @@ pub fn run(filter_regex: Option<regex::Regex>) {
         ("generic_functions", ProgramState::Return(1)),        // true
         ("generic_enum", ProgramState::Return(1)),             // true
         ("import_method_from_other_file", ProgramState::Return(10)), // true
-        ("b512_test", ProgramState::Return(1)),                // true
         ("ec_recover_test", ProgramState::Return(1)),          // true
         ("address_test", ProgramState::Return(1)),             // true
         ("generic_struct", ProgramState::Return(1)),           // true
         ("zero_field_types", ProgramState::Return(10)),        // true
         ("assert_test", ProgramState::Return(1)),              // true
         ("match_expressions", ProgramState::Return(42)),
-        ("assert_test", ProgramState::Return(1)),  // true
         ("array_basics", ProgramState::Return(1)), // true
         // Disabled, pending decision on runtime OOB checks. ("array_dynamic_oob", ProgramState::Revert(1)),
         ("array_generics", ProgramState::Return(1)), // true
         ("match_expressions_structs", ProgramState::Return(4)),
-        ("block_height", ProgramState::Return(1)),   // true
         ("b512_test", ProgramState::Return(1)),      // true
         ("block_height", ProgramState::Return(1)),   // true
         ("valid_impurity", ProgramState::Revert(0)), // false


### PR DESCRIPTION
These are some relatively minor fixes for bugs which accrued while I was away.  The E2E tests were failing sometimes when using IR, these changes fix that.

The `ec_recover_test` still fails with IR but will be resolved when the new `B512` code in `sway-lib-std` is released.

Closes #709