### PR TITLE
Rename fuels-rs to fuels-contract

### DIFF
--- a/docs/src/getting-started/forc_project.md
+++ b/docs/src/getting-started/forc_project.md
@@ -128,7 +128,7 @@ Our `tests/harness.rs` file could look like:
 ```rust
 use fuel_tx::Salt;
 use fuels_abigen_macro::abigen;
-use fuels_rs::contract::Contract;
+use fuels_contract::contract::Contract;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 

--- a/forc/README.md
+++ b/forc/README.md
@@ -72,7 +72,7 @@ Our `tests/harness.rs` file could look like:
 ```rust
 use fuel_tx::Salt;
 use fuels_abigen_macro::abigen;
-use fuels_rs::contract::Contract;
+use fuels_contract::contract::Contract;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 

--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -34,9 +34,9 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels-abigen-macro = "0.2"
-fuels-core = "0.2"
-fuels-rs = "0.2"
+fuels-abigen-macro = "0.3"
+fuels-core = "0.3"
+fuels-contract = "0.3"
 fuel-gql-client = {{ version = "0.2", default-features = false }}
 fuel-tx = "0.3"
 rand = "0.8"

--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -34,11 +34,11 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels-abigen-macro = "0.3"
-fuels-core = "0.3"
-fuels-contract = "0.3"
 fuel-gql-client = {{ version = "0.2", default-features = false }}
 fuel-tx = "0.3"
+fuels-abigen-macro = "0.3"
+fuels-contract = "0.3"
+fuels-core = "0.3"
 rand = "0.8"
 tokio = {{ version = "1.12", features = ["rt", "macros"] }}
 


### PR DESCRIPTION
Recently, `fuels-rs`, the sub-crate inside `fuels-rs` the repo was renamed to `fuels-contract`. This PR makes the necessary renaming so that `forc init` will generate the right `Cargo.toml` for the SDK-based tests.

More context on the renaming here: https://github.com/FuelLabs/fuels-rs/pull/66. 