### PR TITLE
Turning an instance of HashSet into BTreeSet in `asm_generation`

### DIFF
--- a/sway-core/src/asm_generation/mod.rs
+++ b/sway-core/src/asm_generation/mod.rs
@@ -308,7 +308,7 @@ impl RegisterPool {
     pub(crate) fn get_register(
         &mut self,
         virtual_register: &VirtualRegister,
-        op_register_mapping: &[(RealizedOp, std::collections::HashSet<VirtualRegister>)],
+        op_register_mapping: &[(RealizedOp, std::collections::BTreeSet<VirtualRegister>)],
     ) -> Option<AllocatedRegister> {
         // check if this register has already been allocated for
         if let a @ Some(_) = self.registers.iter().find_map(
@@ -349,7 +349,7 @@ impl RegisterPool {
 
 fn virtual_register_is_never_accessed_again(
     reg: &VirtualRegister,
-    ops: &[(RealizedOp, std::collections::HashSet<VirtualRegister>)],
+    ops: &[(RealizedOp, std::collections::BTreeSet<VirtualRegister>)],
 ) -> bool {
     !ops.iter().any(|(_, regs)| regs.contains(reg))
 }

--- a/sway-core/src/asm_lang/virtual_ops.rs
+++ b/sway-core/src/asm_lang/virtual_ops.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use crate::asm_generation::RegisterPool;
 
-use std::collections::{HashMap, BTreeSet};
+use std::collections::{BTreeSet, HashMap};
 
 use std::fmt;
 

--- a/sway-core/src/asm_lang/virtual_ops.rs
+++ b/sway-core/src/asm_lang/virtual_ops.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use crate::asm_generation::RegisterPool;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, BTreeSet};
 
 use std::fmt;
 
@@ -135,7 +135,7 @@ pub(crate) enum VirtualOp {
 }
 
 impl VirtualOp {
-    pub(crate) fn registers(&self) -> HashSet<&VirtualRegister> {
+    pub(crate) fn registers(&self) -> BTreeSet<&VirtualRegister> {
         use VirtualOp::*;
         (match self {
             ADD(r1, r2, r3) => vec![r1, r2, r3],
@@ -226,7 +226,7 @@ impl VirtualOp {
     pub(crate) fn allocate_registers(
         &self,
         pool: &mut RegisterPool,
-        op_register_mapping: &[(RealizedOp, HashSet<VirtualRegister>)],
+        op_register_mapping: &[(RealizedOp, BTreeSet<VirtualRegister>)],
         ix: usize,
     ) -> AllocatedOpcode {
         let virtual_registers = self.registers();

--- a/sway-core/src/asm_lang/virtual_register.rs
+++ b/sway-core/src/asm_lang/virtual_register.rs
@@ -3,7 +3,7 @@ use std::fmt;
 /// Represents virtual registers that have yet to be allocated.
 /// Note that only the Virtual variant will be allocated, and the Constant variant refers to
 /// reserved registers.
-#[derive(Hash, PartialEq, Eq, Debug, Clone)]
+#[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Debug, Clone)]
 pub enum VirtualRegister {
     Virtual(String),
     Constant(ConstantRegister),
@@ -26,7 +26,7 @@ impl fmt::Display for VirtualRegister {
     }
 }
 
-#[derive(Hash, PartialEq, Eq, Debug, Clone)]
+#[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Debug, Clone)]
 /// These are the special registers defined in the spec
 pub enum ConstantRegister {
     // Below are VM-reserved registers


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway/issues/619

At the very least, John's minimum repro doesn't have indeterminsm anymore, so this change should go in anyways. I'm checking if it fixes the main issue next.

Edit: Confirmed that @nfurfaro's original issue is resolved with this. 