### PR TITLE
Make missing manifest file error the same as Rust's.

### DIFF
--- a/forc/src/ops/forc_abi_json.rs
+++ b/forc/src/ops/forc_abi_json.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use sway_types::{Function, JsonABI};
-use sway_utils::find_manifest_dir;
+use sway_utils::{find_manifest_dir, MANIFEST_FILE_NAME};
 
 use anyhow::Result;
 use serde_json::{json, Value};
@@ -41,8 +41,9 @@ pub fn build(command: JsonAbiCommand) -> Result<Value, String> {
         Some(dir) => dir,
         None => {
             return Err(format!(
-                "No manifest file found in this directory or any parent directories of it: {:?}",
-                this_dir
+                "could not find `{}` in `{}` or any parent directory",
+                MANIFEST_FILE_NAME,
+                this_dir.display()
             ))
         }
     };

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -11,7 +11,7 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::sync::Arc;
 use sway_core::{FinalizedAsm, TreeType};
-use sway_utils::{constants, find_manifest_dir};
+use sway_utils::{constants, find_manifest_dir, MANIFEST_FILE_NAME};
 
 use sway_core::{
     create_module, source_map::SourceMap, BuildConfig, BytecodeCompilationResult,
@@ -45,8 +45,9 @@ pub fn build(command: BuildCommand) -> Result<Vec<u8>, String> {
         Some(dir) => dir,
         None => {
             return Err(format!(
-                "No manifest file found in this directory or any parent directories of it: {:?}",
-                this_dir
+                "could not find `{}` in `{}` or any parent directory",
+                MANIFEST_FILE_NAME,
+                this_dir.display(),
             ))
         }
     };

--- a/forc/src/utils/cli_error.rs
+++ b/forc/src/utils/cli_error.rs
@@ -13,8 +13,9 @@ pub struct CliError {
 impl CliError {
     pub fn manifest_file_missing(curr_dir: PathBuf) -> Self {
         let message = format!(
-            "Manifest file not found at {:?}. Project root should contain '{}'",
-            curr_dir, MANIFEST_FILE_NAME
+            "could not find `{}` in `{}` or any parent directory",
+            MANIFEST_FILE_NAME,
+            curr_dir.display()
         );
         Self { message }
     }


### PR DESCRIPTION
Also make error consistent across subcommands.