### PR TITLE
Clean up forc run no node error string.

### DIFF
--- a/forc/src/utils/cli_error.rs
+++ b/forc/src/utils/cli_error.rs
@@ -41,7 +41,7 @@ impl CliError {
     }
 
     pub fn fuel_core_not_running(node_url: &str) -> Self {
-        let message = format!("could not get a response from node at the URL {}. Start a node with `fuel-core`. See <https://github.com/FuelLabs/fuel-core#running> for more information", node_url);
+        let message = format!("could not get a response from node at the URL {}. Start a node with `fuel-core`. See https://github.com/FuelLabs/fuel-core#running for more information", node_url);
         Self { message }
     }
 }


### PR DESCRIPTION
Remove the `<` and `>` from link, since it works without those.