### PR TITLE
Fix forc explorer error string

### DIFF
--- a/forc/src/ops/forc_explorer.rs
+++ b/forc/src/ops/forc_explorer.rs
@@ -184,9 +184,9 @@ async fn start_server(port: &str, version: &str) {
 
     let port_number = match port.parse::<u16>() {
         Ok(n) => n,
-        Err(error) => panic!(
+        Err(_) => panic!(
             "Invalid port number {:?}. Expected integer value in the range [0, 65353].",
-            error
+            port
         ),
     };
     println!("Started server on 127.0.0.1:{}", port_number);

--- a/forc/src/ops/forc_explorer.rs
+++ b/forc/src/ops/forc_explorer.rs
@@ -184,7 +184,10 @@ async fn start_server(port: &str, version: &str) {
 
     let port_number = match port.parse::<u16>() {
         Ok(n) => n,
-        Err(error) => panic!("Invalid port number {:?}", error),
+        Err(error) => panic!(
+            "Invalid port number {:?}. Expected integer value in the range [0, 65353].",
+            error
+        ),
     };
     println!("Started server on 127.0.0.1:{}", port_number);
     warp::serve(routes).run(([127, 0, 0, 1], port_number)).await

--- a/forc/src/ops/forc_explorer.rs
+++ b/forc/src/ops/forc_explorer.rs
@@ -185,7 +185,7 @@ async fn start_server(port: &str, version: &str) {
     let port_number = match port.parse::<u16>() {
         Ok(n) => n,
         Err(_) => panic!(
-            "Invalid port number {:?}. Expected integer value in the range [0, 65353].",
+            "Invalid port number {:?}. Expected integer value in the range [0, 65535].",
             port
         ),
     };


### PR DESCRIPTION
Improve the error message and also print out the actual value instead of `ParseIntError { kind: InvalidDigit }`.