### PR TITLE
Allow trailing comma for function parameters.

### DIFF
--- a/sway-core/src/parser.rs
+++ b/sway-core/src/parser.rs
@@ -308,4 +308,34 @@ mod test {
         );
         parsed.unwrap();
     }
+
+    #[test]
+    fn test_trailing_fn_param_comma_pass() {
+        let parsed = SwayParser::parse(
+            Rule::fn_decl,
+            r#"fn myfunc(x: u64, y: u64,) -> u64 {
+            69
+        }"#
+            .into(),
+        );
+        parsed.unwrap();
+    }
+
+    #[test]
+    fn test_trailing_fn_param_comma_fail() {
+        let parsed = SwayParser::parse(
+            Rule::fn_decl,
+            r#"fn myfunc(x: u64, y: u64,,) -> u64 {
+            69
+        }"#
+            .into(),
+        );
+        // this parse should fail since double comma
+        match parsed {
+            Err(_) => (),
+            Ok(o) => {
+                panic!("{:?}", o)
+            }
+        }
+    }
 }

--- a/sway-core/src/sway.pest
+++ b/sway-core/src/sway.pest
@@ -148,7 +148,7 @@ enum_field_name   =  {ident}
 impl_self =  {impl_keyword ~ type_params? ~ type_name ~  trait_bounds? ~ ("{" ~ fn_decl* ~ "}")}
 
 // // fn declaration
-fn_decl_params     =  {"(" ~ (fn_decl_param ~ ("," ~ fn_decl_param)*)? ~ ")"}
+fn_decl_params     =  {"(" ~ (fn_decl_param ~ ("," ~ fn_decl_param)*)? ~ ","? ~ ")"}
 type_params        =  {"<" ~ generic_type_param ~ (", " ~ generic_type_param)* ~ ">"}
 fn_decl_param      =  {("self")|(fn_decl_param_name ~ ":" ~ type_name)}
 fn_decl_param_name =  {ident}


### PR DESCRIPTION
Fixes #780