### PR TITLE
Warn if the CEI pattern is violated at the assembly level

### DIFF
--- a/sway-core/src/asm_generation/checks.rs
+++ b/sway-core/src/asm_generation/checks.rs
@@ -87,7 +87,7 @@ fn check_for_contract_opcodes(ops: &[AllocatedOp]) -> CompileResult<()> {
 ///For every opcode:
 ///  if this is a `SWW`/`SWWQ`:
 ///     if seen_call:
-///	      throw CEI violation
+///       throw CEI violation
 ///
 ///  if this is a jump (non-conditional):
 ///     seen_call = false;

--- a/sway-core/src/asm_generation/checks.rs
+++ b/sway-core/src/asm_generation/checks.rs
@@ -94,6 +94,8 @@ fn check_for_contract_opcodes(ops: &[AllocatedOp]) -> CompileResult<()> {
 ///  if this is a CALL:
 ///     seen_call = true;
 ///
+/// TODO: We need to do this at the storage API level, or improve the span here. The span often
+/// just points to the standard library that is doing the storing.
 fn check_for_cei_violation(ops: &[AllocatedOp]) -> CompileResult<()> {
     let mut warnings = vec![];
     let mut seen_call = false;

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -343,8 +343,11 @@ impl fmt::Display for Warning {
                 "This register declaration shadows the reserved register, \"{}\".",
                 reg_name
             ),
-            CEIViolation => write!(f, 
-                "This effect (storage write) violates the CEI pattern. Try to write to storage/contract state before calling another contract.")
+            CEIViolation => write!(f,
+                "This effect (storage write) violates the CEI pattern. \
+                Try to write to storage/contract state before calling \
+                another contract."
+            )
         }
     }
 }

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -237,6 +237,7 @@ pub enum Warning {
     ShadowingReservedRegister {
         reg_name: Ident,
     },
+    CEIViolation,
 }
 
 impl fmt::Display for Warning {
@@ -342,6 +343,8 @@ impl fmt::Display for Warning {
                 "This register declaration shadows the reserved register, \"{}\".",
                 reg_name
             ),
+            CEIViolation => write!(f, 
+                "This effect (storage write) violates the CEI pattern. Try to write to storage/contract state before calling another contract.")
         }
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/cei_warn/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/cei_warn/Forc.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cei_warn"
-author = "Alexander Hansen"
+author = "Fuel Labs <contact@fuel.sh>"
 entry = "main.sw"
 license = "Apache-2.0"
 

--- a/test/src/e2e_vm_tests/test_programs/cei_warn/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/cei_warn/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+name = "cei_warn"
+author = "Alexander Hansen"
+entry = "main.sw"
+license = "Apache-2.0"
+
+[dependencies]
+core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/cei_warn/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/cei_warn/src/main.sw
@@ -1,0 +1,21 @@
+contract;
+
+use std::storage::store;
+
+// TODO when the test harness can expect warnings, _this should warn about CEI_!
+
+abi TestAbi {
+  fn deposit(gas: u64, amount: u64, color: b256,  unused: ());
+}
+
+impl TestAbi for Contract {
+  fn deposit(gas: u64,  amount: u64, color: b256, unused: ()) {
+    let other_contract = abi(TestAbi, 0x3dba0a4455b598b7655a7fb430883d96c9527ef275b49739e7b0ad12f8280eae);
+
+    // interaction
+    other_contract.deposit(gas, amount, color, unused);
+    // effect -- therefore violation of CEI where effect should go before interaction
+    let storage_key = 0x3dba0a4455b598b7655a7fb430883d96c9527ef275b49739e7b0ad12f8280eae;
+    store(storage_key, ());
+  }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12157751/154387401-b3954db4-9f19-4ec1-8d1d-c32c151075c8.png)


This checks if there is an unconditional storage write after a call and warns if so. Unfortunately, as this is an opcode-level check, we only have opcode spans (which are typically in the standard library). Ideally, this will be done at the purity/impurity level in the AST when the new storage API goes in. That will be V2 of this feature. For that reason, I'm not going to close the issue #10 yet. 