### PR TITLE
change Forc.toml to take an array of authors

### DIFF
--- a/docs/src/sway-on-chain/libraries.md
+++ b/docs/src/sway-on-chain/libraries.md
@@ -40,7 +40,7 @@ Libraries are composed of just a `Forc.toml` file and a `src` folder, unlike usu
 
 ```toml=
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "lib.sw"
 license = "Apache-2.0"
 name = "lib-std"

--- a/examples/fizzbuzz/Forc.toml
+++ b/examples/fizzbuzz/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "fizzbuzz"

--- a/examples/hello_world/Forc.toml
+++ b/examples/hello_world/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "hello_world"

--- a/examples/subcurrency/Forc.toml
+++ b/examples/subcurrency/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "subcurrency"

--- a/examples/wallet_smart_contract/Forc.toml
+++ b/examples/wallet_smart_contract/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "wallet_smart_contract"

--- a/forc/src/ops/forc_fmt.rs
+++ b/forc/src/ops/forc_fmt.rs
@@ -176,7 +176,7 @@ mod tests {
     fn test_forc_indentation() {
         let correct_forc_manifest = r#"
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "Fuel example project"
 
@@ -193,7 +193,7 @@ std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
         assert_eq!(formatted_content, correct_forc_manifest);
         let indented_forc_manifest = r#"
         [project]
-    author = "Fuel Labs <contact@fuel.sh>"
+    authors = ["Fuel Labs <contact@fuel.sh>"]
                     license = "Apache-2.0"
     name = "Fuel example project"
 
@@ -207,7 +207,7 @@ std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
         assert_eq!(formatted_content, correct_forc_manifest);
         let whitespace_forc_manifest = r#"
 [project]
- author="Fuel Labs <contact@fuel.sh>"
+ authors=["Fuel Labs <contact@fuel.sh>"]
 license   =                                   "Apache-2.0"
 name = "Fuel example project"
 
@@ -224,7 +224,7 @@ std         =     {   git     =  "http://github.com/FuelLabs/sway-lib-std"  , ve
     fn test_forc_alphabetization() {
         let correct_forc_manifest = r#"
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "Fuel example project"
 
@@ -243,7 +243,7 @@ std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }
 [project]
 name = "Fuel example project"
 license = "Apache-2.0"
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 
 
 [dependencies]

--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -5,7 +5,7 @@ pub(crate) fn default_manifest(project_name: &str) -> String {
 
     format!(
         r#"[project]
-author = "{real_name}"
+authors = ["{real_name}"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "{project_name}"

--- a/forc/src/utils/manifest.rs
+++ b/forc/src/utils/manifest.rs
@@ -20,7 +20,9 @@ impl Manifest {}
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Project {
-    pub authors: Vec<String>,
+    #[deprecated = "use the authors field instead, the author field will be removed soon."]
+    pub author: Option<String>,
+    pub authors: Option<Vec<String>>,
     pub name: String,
     pub organization: Option<String>,
     pub license: String,

--- a/forc/src/utils/manifest.rs
+++ b/forc/src/utils/manifest.rs
@@ -20,7 +20,7 @@ impl Manifest {}
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Project {
-    pub author: String,
+    pub authors: Vec<String>,
     pub name: String,
     pub organization: Option<String>,
     pub license: String,

--- a/test/src/e2e_vm_tests/test_programs/address_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/address_test/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "address_test"

--- a/test/src/e2e_vm_tests/test_programs/aliased_imports/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/aliased_imports/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "aliased_imports"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/array_bad_index/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/array_bad_index/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "array_bad_index"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/array_basics/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/array_basics/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "array_basics"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/array_dynamic_oob/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/array_dynamic_oob/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "array_dynamic_oob"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/array_generics/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/array_generics/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "array_generics"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/array_oob/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/array_oob/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "array_oob"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/asm_expr_basic/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/asm_expr_basic/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "asm_expr_basic"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/asm_missing_return/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/asm_missing_return/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "asm_missing_return"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/asm_should_not_have_return/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/asm_should_not_have_return/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "asm_should_not_have_return"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/asm_without_return/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/asm_without_return/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "asm_without_return"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/assert_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/assert_test/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "assert_test"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/auth_testing_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/auth_testing_abi/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "auth_testing_abi"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/auth_testing_contract/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/auth_testing_contract/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "auth_testing_contract"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/b256_bad_jumps/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/b256_bad_jumps/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "b256_bad_jumps"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/b256_ops/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/b256_ops/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "b256_ops"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/b512_struct_alignment/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/b512_struct_alignment/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "b512_panic_test"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/b512_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/b512_test/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "b512_test"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/bad_generic_annotation/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/bad_generic_annotation/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "bad_generic_annotation"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/bad_generic_var_annotation/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/bad_generic_var_annotation/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "bad_generic_var_annotation"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/bal_opcode/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/bal_opcode/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "bal_opcode"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/balance_test_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/balance_test_abi/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "balance_test_abi"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/balance_test_contract/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/balance_test_contract/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "balance_test_contract"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/basic_func_decl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/basic_func_decl/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "basic_func_decl"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/basic_storage/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/basic_storage/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "basic_storage"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/basic_storage_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/basic_storage_abi/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "basic_storage_abi"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/block_height/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/block_height/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "block_height"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/bool_and_or/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/bool_and_or/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "bool_and_or"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/call_basic_storage/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/call_basic_storage/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "call_basic_storage"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/call_increment_contract/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/call_increment_contract/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "call_increment_contract"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/caller_auth_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/caller_auth_test/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "caller_auth_test"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/caller_context_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/caller_context_test/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "caller_context_test"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/const_decl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/const_decl/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "const_decl"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/const_decl_in_library/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/const_decl_in_library/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "const_decl_in_library"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/context_testing_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/context_testing_abi/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "context_testing_abi"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/context_testing_contract/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/context_testing_contract/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "context_testing_contract"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/contract_abi_impl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/contract_abi_impl/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "contract_abi_impl"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/contract_call/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/contract_call/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "contract_call"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/contract_id_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/contract_id_test/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "contract_id_test"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/contract_pure_calls_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/contract_pure_calls_impure/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "valid_impurity"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/dependencies/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/dependencies/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "dependencies"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/dependency_parsing_error/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/dependency_parsing_error/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "dependencies_parsing_error"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/disallowed_gm/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/disallowed_gm/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "disallowed_opcodes"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/ec_recover_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/ec_recover_test/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "ec_recover_test"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/empty_impl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/empty_impl/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "empty_impl"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/empty_method_initializer/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/empty_method_initializer/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "empty_method_initializer"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/enum_in_fn_decl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/enum_in_fn_decl/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "enum_in_fn_decl"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/eq_4_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/eq_4_test/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "eq_4_test"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/excess_fn_arguments/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/excess_fn_arguments/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "excess_fn_arguments"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/fix_opcode_bug/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/fix_opcode_bug/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "asm_expr_basic"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/funcs_with_generic_types/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/funcs_with_generic_types/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "funcs_with_generic_types"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/generic_enum/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/generic_enum/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "generic_enum"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/generic_functions/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/generic_functions/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "generic_functions"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/generic_struct/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/generic_struct/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "generic_struct"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/generic_structs/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/generic_structs/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "generic_structs"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/if_elseif_enum/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/if_elseif_enum/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "if_elseif_enum"

--- a/test/src/e2e_vm_tests/test_programs/if_implicit_unit/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/if_implicit_unit/Forc.toml
@@ -1,5 +1,5 @@
 [project]
 name = "if_implicit_unit"
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"

--- a/test/src/e2e_vm_tests/test_programs/import_method_from_other_file/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/import_method_from_other_file/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "import_method_from_other_file"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/increment_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/increment_abi/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "increment_abi"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/increment_contract/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/increment_contract/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "increment_contract"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/infinite_dependencies/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/infinite_dependencies/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "infinite_dependencies"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/item_used_without_import/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/item_used_without_import/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "item_used_without_import"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/literal_too_large_for_type/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/literal_too_large_for_type/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "literal_too_large_for_type"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/local_impl_for_ord/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/local_impl_for_ord/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "local_impl_for_ord"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/main_returns_unit/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/main_returns_unit/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "main_returns_unit"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/match_expressions/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/match_expressions/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Emily Herbert <emily.herbert@fuel.sh>"
+authors = ["Emily Herbert <emily.herbert@fuel.sh>"]
 license = "MIT"
 name = "match_expressions"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/match_expressions_enums/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/match_expressions_enums/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Emily Herbert <emily.herbert@fuel.sh>"
+authors = ["Emily Herbert <emily.herbert@fuel.sh>"]
 license = "MIT"
 name = "match_expressions_enums"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/match_expressions_structs/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/match_expressions_structs/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Emily Herbert <emily.herbert@fuel.sh>"
+authors = ["Emily Herbert <emily.herbert@fuel.sh>"]
 license = "MIT"
 name = "match_expressions_structs"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/match_expressions_wrong_struct/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/match_expressions_wrong_struct/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Emily Herbert <emily.herbert@fuel.sh>"
+authors = ["Emily Herbert <emily.herbert@fuel.sh>"]
 license = "MIT"
 name = "match_expressions_wrong_struct"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/missing_fn_arguments/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/missing_fn_arguments/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "missing_fn_arguments"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/missing_func_from_supertrait_impl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/missing_func_from_supertrait_impl/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "missing_func_from_supertrait_impl"

--- a/test/src/e2e_vm_tests/test_programs/missing_supertrait_impl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/missing_supertrait_impl/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "missing_supertrait_impl"

--- a/test/src/e2e_vm_tests/test_programs/missing_type_parameters/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/missing_type_parameters/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "missing_type_parameters"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/modulo_uint_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/modulo_uint_test/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "ControlCplusControlV"
+authors = ["ControlCplusControlV"]
 license = "Apache-2.0"
 name = "modulo_uint_test"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/multi_item_import/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/multi_item_import/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "multi_item_import"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/name_shadowing/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/name_shadowing/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "name_shadowing"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/neq_4_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/neq_4_test/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "neq_4_test"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/nested_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/nested_impure/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "nested_impure"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/new_allocator_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/new_allocator_test/Forc.toml
@@ -1,5 +1,6 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
 license = "Apache-2.0"
 name = "new_alloc"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/new_allocator_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/new_allocator_test/Forc.toml
@@ -3,7 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "new_alloc"
-entry = "main.sw"
 
 [dependencies]
 std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/op_precedence/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/op_precedence/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "unary_not_basic"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/out_of_order_decl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/out_of_order_decl/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "out_of_order_decl"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/predicate_calls_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/predicate_calls_impure/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "script_calls_impure"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/pure_calls_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/pure_calls_impure/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "pure_calls_impure"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/recursive_calls/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/recursive_calls/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "recursive_calls"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/retd_b256/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/retd_b256/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "retd_b256"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/retd_struct/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/retd_struct/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "retd_struct"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/script_calls_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/script_calls_impure/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "script_calls_impure"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/shadow_import/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/shadow_import/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "shadow_import"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/size_of/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/size_of/Forc.toml
@@ -3,7 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "size_of"
-entry = "main.sw"
 
 [dependencies]
 std = { git = "http://github.com/FuelLabs/sway-lib-std", version = "v0.0.1" }

--- a/test/src/e2e_vm_tests/test_programs/size_of/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/size_of/Forc.toml
@@ -1,5 +1,6 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
 license = "Apache-2.0"
 name = "size_of"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/star_import_alias/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/star_import_alias/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "star_import_alias"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/storage_declaration/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/storage_declaration/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "storage_declaration"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/struct_field_access/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/struct_field_access/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "struct_field_access"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/struct_field_reassignment/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/struct_field_reassignment/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "struct_field_reassignment"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/supertrait_does_not_exist/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/supertrait_does_not_exist/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "supertrait_does_not_exist"

--- a/test/src/e2e_vm_tests/test_programs/test_fuel_coin_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/test_fuel_coin_abi/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "test_fuel_coin_abi"

--- a/test/src/e2e_vm_tests/test_programs/test_fuel_coin_contract/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/test_fuel_coin_contract/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "test_fuel_coin_contract"

--- a/test/src/e2e_vm_tests/test_programs/token_ops_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/token_ops_test/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "token_ops_test"

--- a/test/src/e2e_vm_tests/test_programs/top_level_vars/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/top_level_vars/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "top_level_vars"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/trait_import_with_star/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/trait_import_with_star/Forc.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trait_impl_import"
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 

--- a/test/src/e2e_vm_tests/test_programs/trait_override_bug/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/trait_override_bug/Forc.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trait_override_bug"
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 

--- a/test/src/e2e_vm_tests/test_programs/tuple_access/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/tuple_access/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "tuple_access"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/tuple_desugaring/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/tuple_desugaring/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "tuple_desugaring"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/tuple_indexing/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/tuple_indexing/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "tuple_indexing"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/tuple_types/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/tuple_types/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "tuple_types"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/unary_not_basic/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/unary_not_basic/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "unary_not_basic"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/unary_not_basic_2/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/unary_not_basic_2/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "unary_not_basic_2"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/unify_identical_unknowns/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/unify_identical_unknowns/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "unify_identical_unknowns"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/use_full_path_names/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/use_full_path_names/Forc.toml
@@ -1,5 +1,6 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
 license = "Apache-2.0"
 name = "use_full_path_names"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/use_full_path_names/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/use_full_path_names/Forc.toml
@@ -3,4 +3,3 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "use_full_path_names"
-entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/valid_impurity/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/valid_impurity/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "valid_impurity"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/xos_opcode/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/xos_opcode/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "xos_opcode"
 entry = "main.sw"

--- a/test/src/e2e_vm_tests/test_programs/zero_field_types/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/zero_field_types/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Fuel Labs <contact@fuel.sh>"
+authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "zero_field_types"
 entry = "main.sw"


### PR DESCRIPTION
Currently in the `Forc.toml` we only specify a single `author` as opposed to the `Cargo.toml` that allows for an array of `authors`. 

This PR changes `Forc.toml` to take an array of `authors` so it's structured the same as `Cargo.toml` files. 