### PR TITLE
Smaller IR changes.

### DIFF
--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -498,9 +498,9 @@ impl<'ir> AsmBuilder<'ir> {
                 }
                 Some(span_md_idx) => match span_md_idx.to_span(self.context) {
                     Ok(span) => span,
-                    Err(msg) => {
+                    Err(ir_error) => {
                         errors.push(CompileError::InternalOwned(
-                            msg,
+                            ir_error.to_string(),
                             instr_val
                                 .get_span(self.context)
                                 .unwrap_or_else(Self::empty_span),

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -469,11 +469,11 @@ pub(crate) fn compile_ast_to_ir_to_asm(
 
 fn inline_function_calls(ir: &mut Context, functions: &[Function]) -> CompileResult<()> {
     for function in functions {
-        if let Err(msg) = sway_ir::optimize::inline_all_function_calls(ir, function) {
+        if let Err(ir_error) = sway_ir::optimize::inline_all_function_calls(ir, function) {
             return err(
                 Vec::new(),
                 vec![CompileError::InternalOwned(
-                    msg,
+                    ir_error.to_string(),
                     span::Span {
                         span: pest::Span::new("".into(), 0, 0).unwrap(),
                         path: None,
@@ -487,11 +487,11 @@ fn inline_function_calls(ir: &mut Context, functions: &[Function]) -> CompileRes
 
 fn combine_constants(ir: &mut Context, functions: &[Function]) -> CompileResult<()> {
     for function in functions {
-        if let Err(msg) = sway_ir::optimize::combine_constants(ir, function) {
+        if let Err(ir_error) = sway_ir::optimize::combine_constants(ir, function) {
             return err(
                 Vec::new(),
                 vec![CompileError::InternalOwned(
-                    msg,
+                    ir_error.to_string(),
                     span::Span {
                         span: pest::Span::new("".into(), 0, 0).unwrap(),
                         path: None,

--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -52,7 +52,7 @@ fn compile_script(
     namespace: NamespaceRef,
     declarations: Vec<TypedDeclaration>,
 ) -> Result<Module, String> {
-    let module = Module::new(context, Kind::Script, "script");
+    let module = Module::new(context, Kind::Script);
 
     compile_constants(context, module, namespace, false)?;
     compile_declarations(context, module, declarations)?;
@@ -67,7 +67,7 @@ fn compile_contract(
     namespace: NamespaceRef,
     declarations: Vec<TypedDeclaration>,
 ) -> Result<Module, String> {
-    let module = Module::new(context, Kind::Contract, "contract");
+    let module = Module::new(context, Kind::Contract);
 
     compile_constants(context, module, namespace, false)?;
     compile_declarations(context, module, declarations)?;

--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -12,7 +12,9 @@ use sway_types::{ident::Ident, span::Span};
 use sway_ir::*;
 
 // -------------------------------------------------------------------------------------------------
-// XXX This needs to return a CompileResult.
+// XXX This needs to return a CompileResult.  OTOH, retrofitting a CompileResult here would add
+// very little value and require a lot of work.  An alternative might be returning
+// Result<T, CompileError>.
 
 pub(crate) fn compile_ast(ast: TypedParseTree) -> Result<Context, String> {
     let mut ctx = Context::default();
@@ -54,9 +56,11 @@ fn compile_script(
 ) -> Result<Module, String> {
     let module = Module::new(context, Kind::Script);
 
+    let mut struct_names = StructSymbolMap::default();
+
     compile_constants(context, module, namespace, false)?;
-    compile_declarations(context, module, declarations)?;
-    compile_function(context, module, main_function)?;
+    compile_declarations(context, module, &mut struct_names, declarations)?;
+    compile_function(context, module, &mut struct_names, main_function)?;
 
     Ok(module)
 }
@@ -69,10 +73,12 @@ fn compile_contract(
 ) -> Result<Module, String> {
     let module = Module::new(context, Kind::Contract);
 
+    let mut struct_names = StructSymbolMap::default();
+
     compile_constants(context, module, namespace, false)?;
-    compile_declarations(context, module, declarations)?;
+    compile_declarations(context, module, &mut struct_names, declarations)?;
     for decl in abi_entries {
-        compile_abi_method(context, module, decl)?;
+        compile_abi_method(context, module, &mut struct_names, decl)?;
     }
 
     Ok(module)
@@ -156,6 +162,7 @@ fn compile_constant_expression(
 fn compile_declarations(
     context: &mut Context,
     module: Module,
+    struct_names: &mut StructSymbolMap,
     declarations: Vec<TypedDeclaration>,
 ) -> Result<(), String> {
     for declaration in declarations {
@@ -166,12 +173,20 @@ fn compile_declarations(
                 module.add_global_constant(context, decl.name.as_str().to_owned(), const_val);
             }
 
-            TypedDeclaration::FunctionDeclaration(decl) => compile_function(context, module, decl)?,
+            TypedDeclaration::FunctionDeclaration(decl) => {
+                compile_function(context, module, struct_names, decl)?
+            }
             TypedDeclaration::ImplTrait {
                 methods,
                 type_implementing_for,
                 ..
-            } => compile_impl(context, module, type_implementing_for, methods)?,
+            } => compile_impl(
+                context,
+                module,
+                struct_names,
+                type_implementing_for,
+                methods,
+            )?,
 
             TypedDeclaration::StructDeclaration(_)
             | TypedDeclaration::TraitDeclaration(_)
@@ -188,8 +203,49 @@ fn compile_declarations(
 
 // -------------------------------------------------------------------------------------------------
 
+#[derive(Clone, Default)]
+struct StructSymbolMap {
+    aggregate_names: HashMap<String, Aggregate>,
+    aggregate_symbols: HashMap<Aggregate, HashMap<String, u64>>,
+}
+
+impl StructSymbolMap {
+    pub fn add_aggregate_symbols(
+        &mut self,
+        name: String,
+        aggregate: Aggregate,
+        symbols: Option<HashMap<String, u64>>,
+    ) -> Result<(), String> {
+        match self.aggregate_names.insert(dbg!(name), aggregate) {
+            None => Ok(()),
+            Some(_) => Err("Aggregate symbols were overwritten/shadowed.".to_owned()),
+        }?;
+        symbols
+            .map(
+                |symbols| match self.aggregate_symbols.insert(aggregate, symbols) {
+                    None => Ok(()),
+                    Some(_) => Err("Aggregate symbols were overwritten/shadowed.".to_owned()),
+                },
+            )
+            .unwrap_or(Ok(()))
+    }
+
+    pub fn get_aggregate_by_name(&self, name: &str) -> Option<Aggregate> {
+        self.aggregate_names.get(name).copied()
+    }
+
+    pub fn get_aggregate_index(&self, aggregate: &Aggregate, field_name: &str) -> Option<u64> {
+        self.aggregate_symbols
+            .get(aggregate)
+            .and_then(|idx_map| idx_map.get(field_name).copied())
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
 fn create_struct_aggregate(
     context: &mut Context,
+    struct_names: &mut StructSymbolMap,
     name: String,
     fields: Vec<OwnedTypedStructField>,
 ) -> Result<Aggregate, String> {
@@ -197,7 +253,7 @@ fn create_struct_aggregate(
         .into_iter()
         .map(|tsf| {
             (
-                convert_resolved_typeid_no_span(context, &tsf.r#type),
+                convert_resolved_typeid_no_span(context, struct_names, &tsf.r#type),
                 tsf.name,
             )
         })
@@ -207,13 +263,14 @@ fn create_struct_aggregate(
         .into_iter()
         .collect::<Result<Vec<_>, String>>()?;
 
-    let aggregate = Aggregate::new_struct(context, Some(name), field_types);
-    context
-        .add_aggregate_symbols(
-            aggregate,
-            HashMap::from_iter(syms.into_iter().enumerate().map(|(n, sym)| (sym, n as u64))),
-        )
-        .map_err(|ir_error| ir_error.to_string())?;
+    let aggregate = Aggregate::new_struct(context, field_types);
+    struct_names.add_aggregate_symbols(
+        name,
+        aggregate,
+        Some(HashMap::from_iter(
+            syms.into_iter().enumerate().map(|(n, sym)| (sym, n as u64)),
+        )),
+    )?;
 
     Ok(aggregate)
 }
@@ -222,13 +279,14 @@ fn create_struct_aggregate(
 
 fn compile_enum_decl(
     context: &mut Context,
+    struct_names: &mut StructSymbolMap,
     enum_decl: TypedEnumDeclaration,
 ) -> Result<Aggregate, String> {
     let TypedEnumDeclaration {
         name,
         type_parameters,
         variants,
-        .. //span,
+        ..
     } = enum_decl;
 
     if !type_parameters.is_empty() {
@@ -237,6 +295,7 @@ fn compile_enum_decl(
 
     create_enum_aggregate(
         context,
+        struct_names,
         name.as_str().to_owned(),
         variants
             .into_iter()
@@ -247,53 +306,39 @@ fn compile_enum_decl(
 
 fn create_enum_aggregate(
     context: &mut Context,
+    struct_names: &mut StructSymbolMap,
     name: String,
     variants: Vec<OwnedTypedEnumVariant>,
 ) -> Result<Aggregate, String> {
-    // Create the enum aggregate first.
-    let (field_types, syms): (Vec<_>, Vec<_>) = variants
+    // Create the enum aggregate first.  NOTE: single variant enums don't need an aggregate but are
+    // getting one here anyway.  They don't need to be a tagged union either.
+    let field_types: Vec<_> = variants
         .into_iter()
-        .map(|tev| {
-            (
-                convert_resolved_typeid_no_span(context, &tev.r#type),
-                tev.name,
-            )
-        })
-        .unzip();
-
-    let field_types = field_types
-        .into_iter()
+        .map(|tev| convert_resolved_typeid_no_span(context, struct_names, &tev.r#type))
         .collect::<Result<Vec<_>, String>>()?;
+    let enum_aggregate = Aggregate::new_struct(context, field_types);
+    struct_names.add_aggregate_symbols(name.clone() + "_union", enum_aggregate, None)?;
 
-    let enum_aggregate = Aggregate::new_struct(context, Some(name.clone() + "_union"), field_types);
-    // Not sure if we should do this..?  The 'field' names aren't used for enums?
-    context
-        .add_aggregate_symbols(
-            enum_aggregate,
-            HashMap::from_iter(syms.into_iter().enumerate().map(|(n, sym)| (sym, n as u64))),
-        )
-        .map_err(|ir_error| ir_error.to_string())?;
-
-    // Create the tagged union struct next.  Just by creating it here with the name it'll be added
-    // to the context and can be looked up.  It isn't obvious from the name, maybe it should
-    // change... to create()?  insert()?  Anonymous aggregates aren't added though, so... maybe it
-    // should be separate calls to create it and then insert it by name.
-    Ok(Aggregate::new_struct(
-        context,
-        Some(name),
-        vec![Type::Uint(64), Type::Union(enum_aggregate)],
-    ))
+    // Create the tagged union struct next.
+    let tagged_union =
+        Aggregate::new_struct(context, vec![Type::Uint(64), Type::Union(enum_aggregate)]);
+    struct_names.add_aggregate_symbols(name, tagged_union, None)?;
+    Ok(tagged_union)
 }
 
 // -------------------------------------------------------------------------------------------------
 
-fn create_tuple_aggregate(context: &mut Context, fields: Vec<TypeId>) -> Result<Aggregate, String> {
+fn create_tuple_aggregate(
+    context: &mut Context,
+    struct_names: &mut StructSymbolMap,
+    fields: Vec<TypeId>,
+) -> Result<Aggregate, String> {
     let field_types = fields
         .into_iter()
-        .map(|ty_id| convert_resolved_typeid_no_span(context, &ty_id))
+        .map(|ty_id| convert_resolved_typeid_no_span(context, struct_names, &ty_id))
         .collect::<Result<Vec<_>, String>>()?;
 
-    Ok(Aggregate::new_struct(context, None, field_types))
+    Ok(Aggregate::new_struct(context, field_types))
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -301,6 +346,7 @@ fn create_tuple_aggregate(context: &mut Context, fields: Vec<TypeId>) -> Result<
 fn compile_function(
     context: &mut Context,
     module: Module,
+    struct_names: &mut StructSymbolMap,
     ast_fn_decl: TypedFunctionDeclaration,
 ) -> Result<(), String> {
     // Currently monomorphisation of generics is inlined into main() and the functions with generic
@@ -312,12 +358,12 @@ fn compile_function(
             .parameters
             .iter()
             .map(|param| {
-                convert_resolved_typeid(context, &param.r#type, &param.type_span)
+                convert_resolved_typeid(context, struct_names, &param.r#type, &param.type_span)
                     .map(|ty| (param.name.as_str().into(), ty, param.name.span().clone()))
             })
             .collect::<Result<Vec<(String, Type, Span)>, String>>()?;
 
-        compile_fn_with_args(context, module, ast_fn_decl, args, None)
+        compile_fn_with_args(context, module, struct_names, ast_fn_decl, args, None)
     }
 }
 
@@ -326,6 +372,7 @@ fn compile_function(
 fn compile_fn_with_args(
     context: &mut Context,
     module: Module,
+    struct_names: &mut StructSymbolMap,
     ast_fn_decl: TypedFunctionDeclaration,
     args: Vec<(String, Type, Span)>,
     selector: Option<[u8; 4]>,
@@ -343,7 +390,7 @@ fn compile_fn_with_args(
         .into_iter()
         .map(|(name, ty, span)| (name, ty, MetadataIndex::from_span(context, &span)))
         .collect();
-    let ret_type = convert_resolved_typeid(context, &return_type, &return_type_span)?;
+    let ret_type = convert_resolved_typeid(context, struct_names, &return_type, &return_type_span)?;
     let func = Function::new(
         context,
         module,
@@ -354,7 +401,9 @@ fn compile_fn_with_args(
         visibility == Visibility::Public,
     );
 
-    let mut compiler = FnCompiler::new(context, module, func);
+    // We clone the struct symbols here, as they contain the globals; any new local declarations
+    // may remain within the function scope.
+    let mut compiler = FnCompiler::new(context, module, func, struct_names.clone());
 
     let ret_val = compiler.compile_code_block(context, body)?;
     compiler
@@ -369,6 +418,7 @@ fn compile_fn_with_args(
 fn compile_impl(
     context: &mut Context,
     module: Module,
+    struct_names: &mut StructSymbolMap,
     self_type: TypeInfo,
     ast_methods: Vec<TypedFunctionDeclaration>,
 ) -> Result<(), String> {
@@ -378,15 +428,15 @@ fn compile_impl(
             .iter()
             .map(|param| {
                 if param.name.as_str() == "self" {
-                    convert_resolved_type(context, &self_type)
+                    convert_resolved_type(context, struct_names, &self_type)
                 } else {
-                    convert_resolved_typeid(context, &param.r#type, &param.type_span)
+                    convert_resolved_typeid(context, struct_names, &param.r#type, &param.type_span)
                 }
                 .map(|ty| (param.name.as_str().into(), ty, param.name.span().clone()))
             })
             .collect::<Result<Vec<(String, Type, Span)>, String>>()?;
 
-        compile_fn_with_args(context, module, method, args, None)?;
+        compile_fn_with_args(context, module, struct_names, method, args, None)?;
     }
     Ok(())
 }
@@ -396,6 +446,7 @@ fn compile_impl(
 fn compile_abi_method(
     context: &mut Context,
     module: Module,
+    struct_names: &mut StructSymbolMap,
     ast_fn_decl: TypedFunctionDeclaration,
 ) -> Result<(), String> {
     let selector = ast_fn_decl.to_fn_selector_value().value.ok_or(format!(
@@ -407,12 +458,19 @@ fn compile_abi_method(
         .parameters
         .iter()
         .map(|param| {
-            convert_resolved_typeid(context, &param.r#type, &param.type_span)
+            convert_resolved_typeid(context, struct_names, &param.r#type, &param.type_span)
                 .map(|ty| (param.name.as_str().into(), ty, param.name.span().clone()))
         })
         .collect::<Result<Vec<(String, Type, Span)>, String>>()?;
 
-    compile_fn_with_args(context, module, ast_fn_decl, args, Some(selector))
+    compile_fn_with_args(
+        context,
+        module,
+        struct_names,
+        ast_fn_decl,
+        args,
+        Some(selector),
+    )
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -422,10 +480,16 @@ struct FnCompiler {
     function: Function,
     current_block: Block,
     symbol_map: HashMap<String, String>,
+    struct_names: StructSymbolMap,
 }
 
 impl FnCompiler {
-    fn new(context: &mut Context, module: Module, function: Function) -> Self {
+    fn new(
+        context: &mut Context,
+        module: Module,
+        function: Function,
+        struct_names: StructSymbolMap,
+    ) -> Self {
         let symbol_map = HashMap::from_iter(
             function
                 .args_iter(context)
@@ -436,6 +500,7 @@ impl FnCompiler {
             function,
             current_block: function.get_entry_block(context),
             symbol_map,
+            struct_names,
         }
     }
 
@@ -467,7 +532,7 @@ impl FnCompiler {
                         TypedDeclaration::StructDeclaration(_) => Err("struct decl".into()),
                         TypedDeclaration::EnumDeclaration(ted) => {
                             let span_md_idx = MetadataIndex::from_span(context, &ted.span);
-                            compile_enum_decl(context, ted).map(|_| ())?;
+                            compile_enum_decl(context, &mut self.struct_names, ted).map(|_| ())?;
                             Ok(Constant::get_unit(context, span_md_idx))
                         }
                         TypedDeclaration::Reassignment(tr) => {
@@ -775,7 +840,7 @@ impl FnCompiler {
                     purity: Default::default(),
                 };
 
-                compile_function(context, self.module, callee_fn_decl)?;
+                compile_function(context, self.module, &mut self.struct_names, callee_fn_decl)?;
 
                 // Then recursively create a call to it.
                 self.compile_fn_call(context, &callee_name, ast_args, None, span_md_idx)
@@ -953,7 +1018,12 @@ impl FnCompiler {
 
         // We must compile the RHS before checking for shadowing, as it will still be in the
         // previous scope.
-        let return_type = convert_resolved_typeid(context, &body.return_type, &body.span)?;
+        let return_type = convert_resolved_typeid(
+            context,
+            &mut self.struct_names,
+            &body.return_type,
+            &body.span,
+        )?;
         let init_val = self.compile_expression(context, body)?;
 
         let local_name = match self.symbol_map.get(name.as_str()) {
@@ -994,7 +1064,12 @@ impl FnCompiler {
 
         if let TypedExpressionVariant::Literal(literal) = &value.expression {
             let initialiser = convert_literal_to_constant(literal);
-            let return_type = convert_resolved_typeid(context, &value.return_type, &value.span)?;
+            let return_type = convert_resolved_typeid(
+                context,
+                &mut self.struct_names,
+                &value.return_type,
+                &value.span,
+            )?;
             let name = name.as_str().to_owned();
             self.function
                 .new_local_ptr(context, name.clone(), return_type, false, Some(initialiser))
@@ -1044,7 +1119,8 @@ impl FnCompiler {
                         acc.and_then(|(mut fld_idcs, ty)| match ty {
                             Type::Struct(aggregate) => {
                                 // Get the field index and also its type for the next iteration.
-                                match context
+                                match self
+                                    .struct_names
                                     .get_aggregate_index(&aggregate, field_name.name.as_str())
                                 {
                                     None => Err(format!(
@@ -1108,7 +1184,11 @@ impl FnCompiler {
         }
 
         // Create a new aggregate, since they're not named.
-        let elem_type = convert_resolved_typeid_no_span(context, &contents[0].return_type)?;
+        let elem_type = convert_resolved_typeid_no_span(
+            context,
+            &mut self.struct_names,
+            &contents[0].return_type,
+        )?;
         let aggregate = Aggregate::new_array(context, elem_type, contents.len() as u64);
 
         // Compile each element and insert it immediately.
@@ -1196,7 +1276,8 @@ impl FnCompiler {
         fields: Vec<TypedStructExpressionField>,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, String> {
-        let aggregate = context
+        let aggregate = self
+            .struct_names
             .get_aggregate_by_name(struct_name)
             .ok_or_else(|| format!("Unknown aggregate {}", struct_name))?;
 
@@ -1207,7 +1288,7 @@ impl FnCompiler {
                 let name = field_value.name.as_str();
                 self.compile_expression(context, field_value.value)
                     .and_then(|insert_val| {
-                        context
+                        self.struct_names
                             .get_aggregate_index(&aggregate, name)
                             .ok_or_else(|| {
                                 format!("Unknown field name {} for aggregate {}", name, struct_name)
@@ -1260,7 +1341,8 @@ impl FnCompiler {
             )),
         }?;
 
-        let field_idx = context
+        let field_idx = self
+            .struct_names
             .get_aggregate_index(&aggregate, &ast_field.name)
             .ok_or_else(|| format!("Unknown field name {} in struct ???", ast_field.name))?;
 
@@ -1289,9 +1371,12 @@ impl FnCompiler {
         // we could potentially use the wrong aggregate with the same name, different module...
         // dunno.
         let span_md_idx = MetadataIndex::from_span(context, &enum_decl.span);
-        let aggregate = match context.get_aggregate_by_name(enum_decl.name.as_str()) {
+        let aggregate = match self
+            .struct_names
+            .get_aggregate_by_name(enum_decl.name.as_str())
+        {
             Some(agg) => Ok(agg),
-            None => compile_enum_decl(context, enum_decl),
+            None => compile_enum_decl(context, &mut self.struct_names, enum_decl),
         }?;
         let tag_value = Constant::get_uint(context, 64, tag as u64, span_md_idx);
 
@@ -1337,18 +1422,21 @@ impl FnCompiler {
             let (init_values, init_types): (Vec<Value>, Vec<Type>) = fields
                 .into_iter()
                 .map(|field_expr| {
-                    convert_resolved_typeid_no_span(context, &field_expr.return_type).and_then(
-                        |init_type| {
-                            self.compile_expression(context, field_expr)
-                                .map(|init_value| (init_value, init_type))
-                        },
+                    convert_resolved_typeid_no_span(
+                        context,
+                        &mut self.struct_names,
+                        &field_expr.return_type,
                     )
+                    .and_then(|init_type| {
+                        self.compile_expression(context, field_expr)
+                            .map(|init_value| (init_value, init_type))
+                    })
                 })
                 .collect::<Result<Vec<_>, String>>()?
                 .into_iter()
                 .unzip();
 
-            let aggregate = Aggregate::new_struct(context, None, init_types);
+            let aggregate = Aggregate::new_struct(context, init_types);
             let agg_value = Constant::get_undef(context, Type::Struct(aggregate), span_md_idx);
 
             Ok(init_values.into_iter().enumerate().fold(
@@ -1377,7 +1465,9 @@ impl FnCompiler {
         span: Span,
     ) -> Result<Value, String> {
         let tuple_value = self.compile_expression(context, tuple)?;
-        if let Type::Struct(aggregate) = convert_resolved_typeid(context, &tuple_type, &span)? {
+        if let Type::Struct(aggregate) =
+            convert_resolved_typeid(context, &mut self.struct_names, &tuple_type, &span)?
+        {
             let span_md_idx = MetadataIndex::from_span(context, &span);
             Ok(self.current_block.ins(context).extract_value(
                 tuple_value,
@@ -1483,6 +1573,7 @@ fn convert_literal_to_constant(ast_literal: &Literal) -> Constant {
 
 fn convert_resolved_typeid(
     context: &mut Context,
+    struct_names: &mut StructSymbolMap,
     ast_type: &TypeId,
     span: &Span,
 ) -> Result<Type, String> {
@@ -1490,22 +1581,29 @@ fn convert_resolved_typeid(
     // other than String eventually?  IrError?
     convert_resolved_type(
         context,
+        struct_names,
         &resolve_type(*ast_type, span).map_err(|ty_err| format!("{:?}", ty_err))?,
     )
 }
 
 fn convert_resolved_typeid_no_span(
     context: &mut Context,
+    struct_names: &mut StructSymbolMap,
     ast_type: &TypeId,
 ) -> Result<Type, String> {
+    let msg = "unknown source location";
     let span = crate::span::Span {
-        span: pest::Span::new(" ".into(), 0, 0).unwrap(),
+        span: pest::Span::new(std::sync::Arc::from(msg), 0, msg.len()).unwrap(),
         path: None,
     };
-    convert_resolved_typeid(context, ast_type, &span)
+    convert_resolved_typeid(context, struct_names, ast_type, &span)
 }
 
-fn convert_resolved_type(context: &mut Context, ast_type: &TypeInfo) -> Result<Type, String> {
+fn convert_resolved_type(
+    context: &mut Context,
+    struct_names: &mut StructSymbolMap,
+    ast_type: &TypeInfo,
+) -> Result<Type, String> {
     Ok(match ast_type {
         TypeInfo::UnsignedInteger(nbits) => {
             // We need impl IntegerBits { fn num_bits() -> u64 { ... } }
@@ -1522,28 +1620,34 @@ fn convert_resolved_type(context: &mut Context, ast_type: &TypeInfo) -> Result<T
         TypeInfo::Byte => Type::Uint(8), // XXX?
         TypeInfo::B256 => Type::B256,
         TypeInfo::Str(n) => Type::String(*n),
-        TypeInfo::Struct { name, fields } => match context.get_aggregate_by_name(name) {
+        TypeInfo::Struct { name, fields } => match struct_names.get_aggregate_by_name(name) {
             Some(existing_aggregate) => Type::Struct(existing_aggregate),
             None => {
                 // Let's create a new aggregate from the TypeInfo.
-                create_struct_aggregate(context, name.clone(), fields.clone()).map(&Type::Struct)?
+                create_struct_aggregate(context, struct_names, name.clone(), fields.clone())
+                    .map(&Type::Struct)?
             }
         },
         TypeInfo::Enum {
             name,
             variant_types,
         } => {
-            match context.get_aggregate_by_name(name) {
+            match struct_names.get_aggregate_by_name(name) {
                 Some(existing_aggregate) => Type::Struct(existing_aggregate),
                 None => {
                     // Let's create a new aggregate from the TypeInfo.
-                    create_enum_aggregate(context, name.clone(), variant_types.clone())
-                        .map(&Type::Struct)?
+                    create_enum_aggregate(
+                        context,
+                        struct_names,
+                        name.clone(),
+                        variant_types.clone(),
+                    )
+                    .map(&Type::Struct)?
                 }
             }
         }
         TypeInfo::Array(elem_type_id, count) => {
-            let elem_type = convert_resolved_typeid_no_span(context, elem_type_id)?;
+            let elem_type = convert_resolved_typeid_no_span(context, struct_names, elem_type_id)?;
             Type::Array(Aggregate::new_array(context, elem_type, *count as u64))
         }
         TypeInfo::Tuple(fields) => {
@@ -1553,7 +1657,7 @@ fn convert_resolved_type(context: &mut Context, ast_type: &TypeInfo) -> Result<T
                 // aggregate which might not make as much sense as a dedicated Unit type.
                 Type::Unit
             } else {
-                create_tuple_aggregate(context, fields.clone()).map(Type::Struct)?
+                create_tuple_aggregate(context, struct_names, fields.clone()).map(Type::Struct)?
             }
         }
         TypeInfo::Custom { .. } => return Err("can't do custom types yet".into()),

--- a/sway-core/tests/ir_to_asm/bigger_asm_block.ir
+++ b/sway-core/tests/ir_to_asm/bigger_asm_block.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> bool {
         local ptr b256 a
 

--- a/sway-core/tests/ir_to_asm/if_expr.ir
+++ b/sway-core/tests/ir_to_asm/if_expr.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> u64 {
         entry:
         v0 = const bool false

--- a/sway-core/tests/ir_to_asm/impl_ret_int.ir
+++ b/sway-core/tests/ir_to_asm/impl_ret_int.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> u64 {
         entry:
         v0 = const u64 42

--- a/sway-core/tests/ir_to_asm/lazy_binops.ir
+++ b/sway-core/tests/ir_to_asm/lazy_binops.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> bool {
         entry:
         v0 = const bool false

--- a/sway-core/tests/ir_to_asm/let_reassign_while_loop.ir
+++ b/sway-core/tests/ir_to_asm/let_reassign_while_loop.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> bool {
         local ptr bool a
 

--- a/sway-core/tests/ir_to_asm/mutable_struct.ir
+++ b/sway-core/tests/ir_to_asm/mutable_struct.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> u64 {
         local mut ptr { u64, u64 } record
 

--- a/sway-core/tests/ir_to_asm/simple_array.ir
+++ b/sway-core/tests/ir_to_asm/simple_array.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> bool {
         local ptr [bool; 3] a
 

--- a/sway-core/tests/ir_to_asm/simple_enum.ir
+++ b/sway-core/tests/ir_to_asm/simple_enum.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> () {
         local ptr { u64, { () | () | u64 } } lunch
 

--- a/sway-core/tests/ir_to_asm/simple_struct.ir
+++ b/sway-core/tests/ir_to_asm/simple_struct.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> u64 {
         local ptr { u64, u64 } record
 

--- a/sway-core/tests/ir_to_asm/tiny_asm_block.ir
+++ b/sway-core/tests/ir_to_asm/tiny_asm_block.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> u64 {
         entry:
         v0 = asm(r1) -> r1 {

--- a/sway-core/tests/sway_to_ir/array_simple.ir
+++ b/sway-core/tests/sway_to_ir/array_simple.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> bool {
         local ptr [bool; 3] a
 

--- a/sway-core/tests/sway_to_ir/asm_block.ir
+++ b/sway-core/tests/sway_to_ir/asm_block.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn get_global_gas() -> u64 {
         entry:
         v0 = asm() -> ggas, !1 {

--- a/sway-core/tests/sway_to_ir/b256_immeds.ir
+++ b/sway-core/tests/sway_to_ir/b256_immeds.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn cmp(a !1: b256, b !2: b256) -> bool {
         entry:
         v0 = asm(lhs: a, rhs: b, sz, res) -> res, !3 {

--- a/sway-core/tests/sway_to_ir/empty.ir
+++ b/sway-core/tests/sway_to_ir/empty.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> () {
         entry:
         v0 = const unit ()

--- a/sway-core/tests/sway_to_ir/enum.ir
+++ b/sway-core/tests/sway_to_ir/enum.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn eat(meal !1: { u64, { () | () | u64 } }) -> bool {
         entry:
         v0 = const bool false, !2

--- a/sway-core/tests/sway_to_ir/enum_enum.ir
+++ b/sway-core/tests/sway_to_ir/enum_enum.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> () {
         entry:
         v0 = const { u64, { () | { u64, { () | bool | () } } | () } } { u64 undef, { () | { u64, { () | bool | () } } | () } undef }, !1

--- a/sway-core/tests/sway_to_ir/enum_struct.ir
+++ b/sway-core/tests/sway_to_ir/enum_struct.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> () {
         entry:
         v0 = const { u64, { () | { b256, bool, u64 } | () } } { u64 undef, { () | { b256, bool, u64 } | () } undef }, !1

--- a/sway-core/tests/sway_to_ir/fn_call.ir
+++ b/sway-core/tests/sway_to_ir/fn_call.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn a(x !1: u64) -> u64 {
         entry:
         ret u64 x

--- a/sway-core/tests/sway_to_ir/if_expr.ir
+++ b/sway-core/tests/sway_to_ir/if_expr.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> u64 {
         entry:
         v0 = const bool false, !1

--- a/sway-core/tests/sway_to_ir/impl_ret_int.ir
+++ b/sway-core/tests/sway_to_ir/impl_ret_int.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> u64 {
         entry:
         v0 = const u64 42, !1

--- a/sway-core/tests/sway_to_ir/lazy_binops.ir
+++ b/sway-core/tests/sway_to_ir/lazy_binops.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> bool {
         entry:
         v0 = const bool false, !1

--- a/sway-core/tests/sway_to_ir/let_reassign_while_loop.ir
+++ b/sway-core/tests/sway_to_ir/let_reassign_while_loop.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> bool {
         local mut ptr bool a
 

--- a/sway-core/tests/sway_to_ir/mutable_struct.ir
+++ b/sway-core/tests/sway_to_ir/mutable_struct.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> u64 {
         local mut ptr { u64, u64 } record
 

--- a/sway-core/tests/sway_to_ir/return_stmt.ir.disabled
+++ b/sway-core/tests/sway_to_ir/return_stmt.ir.disabled
@@ -1,4 +1,4 @@
-script script {
+script {
     fn go(test: bool) -> u64 {
         entry:
         cbr test, block0, block2

--- a/sway-core/tests/sway_to_ir/shadowed_locals.ir
+++ b/sway-core/tests/sway_to_ir/shadowed_locals.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> u64 {
         local ptr bool a
         local ptr u64 a_

--- a/sway-core/tests/sway_to_ir/shadowed_struct_init.ir
+++ b/sway-core/tests/sway_to_ir/shadowed_struct_init.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn new(a !1: bool, b !2: bool) -> { bool, bool } {
         local ptr bool a_
         local ptr bool b_

--- a/sway-core/tests/sway_to_ir/strings.ir.disabled
+++ b/sway-core/tests/sway_to_ir/strings.ir.disabled
@@ -1,4 +1,4 @@
-script script {
+script {
     fn f(a: string<10>, b: string<10>) -> u64 {
         entry:
         v0 = const u64 2

--- a/sway-core/tests/sway_to_ir/struct.ir
+++ b/sway-core/tests/sway_to_ir/struct.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> u64 {
         local ptr { u64, u64 } record
 

--- a/sway-core/tests/sway_to_ir/struct_enum.ir
+++ b/sway-core/tests/sway_to_ir/struct_enum.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> bool {
         local ptr { bool, { u64, { () | () | u64 } } } record
 

--- a/sway-core/tests/sway_to_ir/struct_struct.ir
+++ b/sway-core/tests/sway_to_ir/struct_struct.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> u64 {
         local ptr { b256, { bool, u64 } } record
 

--- a/sway-core/tests/sway_to_ir/trait.ir
+++ b/sway-core/tests/sway_to_ir/trait.ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn pred(self !1: { bool }) -> bool {
         entry:
         v0 = extract_value self, { bool }, 0, !2

--- a/sway-ir/src/context.rs
+++ b/sway-ir/src/context.rs
@@ -6,16 +6,13 @@
 //!
 //! It is passed around as a mutable reference to many of the Sway-IR APIs.
 
-use std::collections::HashMap;
-
 use generational_arena::Arena;
 
 use crate::{
     asm::AsmBlockContent,
     block::BlockContent,
-    error::IrError,
     function::FunctionContent,
-    irtype::{AbiInstanceContent, Aggregate, AggregateContent},
+    irtype::{AbiInstanceContent, AggregateContent},
     metadata::Metadatum,
     module::ModuleContent,
     module::ModuleIterator,
@@ -40,9 +37,6 @@ pub struct Context {
 
     pub metadata: Arena<Metadatum>,
 
-    pub(super) aggregate_names: HashMap<String, Aggregate>,
-    aggregate_symbols: HashMap<Aggregate, HashMap<String, u64>>,
-
     next_unique_sym_tag: u64,
 }
 
@@ -50,35 +44,6 @@ impl Context {
     /// Return an interator for every module in this context.
     pub fn module_iter(&self) -> ModuleIterator {
         ModuleIterator::new(self)
-    }
-
-    /// Add aggregate (struct) field names and their indicies to the context.
-    ///
-    /// Used to symbolically cross-reference the index to aggregate fields by
-    /// [`Context::get_aggregate_index`].
-    pub fn add_aggregate_symbols(
-        &mut self,
-        aggregate: Aggregate,
-        symbols: HashMap<String, u64>,
-    ) -> Result<(), IrError> {
-        match self.aggregate_symbols.insert(aggregate, symbols) {
-            None => Ok(()),
-            Some(_) => Err(IrError::ShadowedAggregates),
-        }
-    }
-
-    /// Return a named aggregate, if known.
-    pub fn get_aggregate_by_name(&self, name: &str) -> Option<Aggregate> {
-        self.aggregate_names.get(name).copied()
-    }
-
-    /// Get the field index within an aggregate (struct) by name, if known.
-    ///
-    /// The field names must be registered already using [`Context::add_aggregate_symbols`].
-    pub fn get_aggregate_index(&self, aggregate: &Aggregate, field_name: &str) -> Option<u64> {
-        self.aggregate_symbols
-            .get(aggregate)
-            .and_then(|idx_map| idx_map.get(field_name).copied())
     }
 
     /// Get a globally unique symbol.

--- a/sway-ir/src/context.rs
+++ b/sway-ir/src/context.rs
@@ -13,6 +13,7 @@ use generational_arena::Arena;
 use crate::{
     asm::AsmBlockContent,
     block::BlockContent,
+    error::IrError,
     function::FunctionContent,
     irtype::{AbiInstanceContent, Aggregate, AggregateContent},
     metadata::Metadatum,
@@ -59,10 +60,10 @@ impl Context {
         &mut self,
         aggregate: Aggregate,
         symbols: HashMap<String, u64>,
-    ) -> Result<(), String> {
+    ) -> Result<(), IrError> {
         match self.aggregate_symbols.insert(aggregate, symbols) {
             None => Ok(()),
-            Some(_) => Err("Aggregate symbols were overwritten/shadowed.".into()),
+            Some(_) => Err(IrError::ShadowedAggregates),
         }
     }
 

--- a/sway-ir/src/error.rs
+++ b/sway-ir/src/error.rs
@@ -8,7 +8,6 @@ pub enum IrError {
     MissingTerminator(String),
     NonUniquePhiLabels,
     ParseFailure(String, String),
-    ShadowedAggregates,
 }
 
 use std::fmt;
@@ -35,9 +34,6 @@ impl fmt::Display for IrError {
             IrError::NonUniquePhiLabels => write!(f, "PHI must have unique block labels."),
             IrError::ParseFailure(expecting, found) => {
                 write!(f, "Parse failure: expecting '{expecting}', found '{found}'")
-            }
-            IrError::ShadowedAggregates => {
-                write!(f, "Aggregate symbols were overwritten/shadowed.")
             }
         }
     }

--- a/sway-ir/src/error.rs
+++ b/sway-ir/src/error.rs
@@ -1,0 +1,44 @@
+#[derive(Debug)]
+pub enum IrError {
+    FunctionLocalClobbered(String, String),
+    InvalidMetadatum,
+    MismatchedReturnTypes(String),
+    MisplacedTerminator(String),
+    MissingBlock(String),
+    MissingTerminator(String),
+    NonUniquePhiLabels,
+    ParseFailure(String, String),
+    ShadowedAggregates,
+}
+
+use std::fmt;
+
+impl fmt::Display for IrError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            IrError::FunctionLocalClobbered(fn_str, var_str) => write!(
+                f,
+                "Local storage for function {fn_str} already has an entry for variable {var_str}"
+            ),
+            IrError::InvalidMetadatum => write!(f, "Unable to convert from invalid metadatum."),
+            IrError::MismatchedReturnTypes(fn_str) => write!(
+                f,
+                "Function {fn_str} return type must match its RET instructions."
+            ),
+            IrError::MisplacedTerminator(blk_str) => {
+                write!(f, "Block {blk_str} has a misplaced terminator.")
+            }
+            IrError::MissingBlock(blk_str) => write!(f, "Unable to find block {blk_str}."),
+            IrError::MissingTerminator(blk_str) => {
+                write!(f, "Block {blk_str} is missing its terminator.")
+            }
+            IrError::NonUniquePhiLabels => write!(f, "PHI must have unique block labels."),
+            IrError::ParseFailure(expecting, found) => {
+                write!(f, "Parse failure: expecting '{expecting}', found '{found}'")
+            }
+            IrError::ShadowedAggregates => {
+                write!(f, "Aggregate symbols were overwritten/shadowed.")
+            }
+        }
+    }
+}

--- a/sway-ir/src/irtype.rs
+++ b/sway-ir/src/irtype.rs
@@ -88,16 +88,12 @@ pub enum AggregateContent {
 
 impl Aggregate {
     /// Return a new struct specific aggregate.
-    pub fn new_struct(context: &mut Context, name: Option<String>, field_types: Vec<Type>) -> Self {
-        let aggregate = Aggregate(
+    pub fn new_struct(context: &mut Context, field_types: Vec<Type>) -> Self {
+        Aggregate(
             context
                 .aggregates
                 .insert(AggregateContent::FieldTypes(field_types)),
-        );
-        if let Some(name) = name {
-            context.aggregate_names.insert(name, aggregate);
-        };
-        aggregate
+        )
     }
 
     /// Returna new array specific aggregate.

--- a/sway-ir/src/lib.rs
+++ b/sway-ir/src/lib.rs
@@ -45,6 +45,8 @@ pub mod constant;
 pub use constant::*;
 pub mod context;
 pub use context::*;
+pub mod error;
+pub use error::*;
 pub mod function;
 pub use function::*;
 pub mod instruction;

--- a/sway-ir/src/module.rs
+++ b/sway-ir/src/module.rs
@@ -17,7 +17,6 @@ pub struct Module(pub generational_arena::Index);
 
 #[doc(hidden)]
 pub struct ModuleContent {
-    pub name: String, // XXX unused; remove me
     pub kind: Kind,
     pub functions: Vec<Function>,
     pub globals: HashMap<String, Value>,
@@ -36,9 +35,8 @@ impl Module {
     /// Return a new named module of a specific kind.
     ///
     /// NOTE: the name is redundant and will be removed in the future.
-    pub fn new(context: &mut Context, kind: Kind, name: &str) -> Module {
+    pub fn new(context: &mut Context, kind: Kind) -> Module {
         let content = ModuleContent {
-            name: name.to_owned(),
             kind,
             functions: Vec::new(),
             globals: HashMap::new(),

--- a/sway-ir/src/optimize/constants.rs
+++ b/sway-ir/src/optimize/constants.rs
@@ -7,13 +7,14 @@
 use crate::{
     constant::{Constant, ConstantValue},
     context::Context,
+    error::IrError,
     function::Function,
     instruction::Instruction,
     value::{Value, ValueContent, ValueDatum},
 };
 
 /// Find constant expressions which can be reduced to fewer opterations.
-pub fn combine_constants(context: &mut Context, function: &Function) -> Result<bool, String> {
+pub fn combine_constants(context: &mut Context, function: &Function) -> Result<bool, IrError> {
     let mut modified = false;
     loop {
         if combine_const_insert_values(context, function) {

--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -8,6 +8,7 @@ use crate::{
     asm::AsmArg,
     block::Block,
     context::Context,
+    error::IrError,
     function::Function,
     instruction::Instruction,
     pointer::Pointer,
@@ -21,7 +22,7 @@ use crate::{
 pub fn inline_all_function_calls(
     context: &mut Context,
     function: &Function,
-) -> Result<bool, String> {
+) -> Result<bool, IrError> {
     let mut modified = false;
     loop {
         // Find the next call site.
@@ -54,7 +55,7 @@ pub fn inline_function_call(
     block: Block,
     call_site: Value,
     inlined_function: Function,
-) -> Result<(), String> {
+) -> Result<(), IrError> {
     // Split the block at right after the call site.
     let call_site_idx = context.blocks[block.0]
         .instructions

--- a/sway-ir/src/parser.rs
+++ b/sway-ir/src/parser.rs
@@ -495,7 +495,7 @@ mod ir_builder {
                         .iter()
                         .map(|(ty, cv)| (ty.to_ir_type(context), cv.value.as_constant(context)))
                         .unzip();
-                    let aggregate = Aggregate::new_struct(context, None, types);
+                    let aggregate = Aggregate::new_struct(context, types);
                     Constant::new_struct(&aggregate, fields)
                 }
             }
@@ -555,7 +555,7 @@ mod ir_builder {
                 }
                 IrAstTy::Struct(tys) | IrAstTy::Union(tys) => {
                     let tys = tys.iter().map(|ty| ty.to_ir_type(context)).collect();
-                    Aggregate::new_struct(context, None, tys)
+                    Aggregate::new_struct(context, tys)
                 }
                 _otherwise => {
                     unreachable!("Converting non aggregate IR AST type to IR aggregate type.")

--- a/sway-ir/src/parser.rs
+++ b/sway-ir/src/parser.rs
@@ -33,9 +33,8 @@ mod ir_builder {
                 }
 
             rule script() -> IrAstModule
-                = "script" _ name:id() "{" _ fn_decls:fn_decl()* "}" _ metadata:metadata_decl()* {
+                = "script" _ "{" _ fn_decls:fn_decl()* "}" _ metadata:metadata_decl()* {
                     IrAstModule {
-                        name,
                         kind: crate::module::Kind::Script,
                         fn_decls,
                         metadata
@@ -390,7 +389,6 @@ mod ir_builder {
 
     #[derive(Debug)]
     pub(super) struct IrAstModule {
-        name: String,
         kind: Kind,
         fn_decls: Vec<IrAstFnDecl>,
         metadata: Vec<(MdIdxRef, IrMetadatum)>,
@@ -582,7 +580,7 @@ mod ir_builder {
 
     pub(super) fn build_context(ir_ast_mod: IrAstModule) -> Result<Context, IrError> {
         let mut ctx = Context::default();
-        let module = Module::new(&mut ctx, ir_ast_mod.kind, &ir_ast_mod.name);
+        let module = Module::new(&mut ctx, ir_ast_mod.kind);
         let md_map = build_metadata_map(&mut ctx, &ir_ast_mod.metadata);
         for fn_decl in ir_ast_mod.fn_decls {
             build_add_fn_decl(&mut ctx, module, fn_decl, &md_map)?;

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -96,14 +96,13 @@ fn module_to_doc<'a>(
     module: &'a ModuleContent,
 ) -> Doc {
     Doc::line(Doc::Text(format!(
-        "{} {} {{",
+        "{} {{",
         match module.kind {
             Kind::Contract => "contract",
             Kind::Library => "library",
             Kind::Predicate => "predicate ",
             Kind::Script => "script",
-        },
-        &module.name
+        }
     )))
     .append(Doc::indent(
         4,

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -13,6 +13,7 @@ use crate::{
     asm::{AsmArg, AsmBlock},
     block::{Block, BlockContent},
     context::Context,
+    error::IrError,
     function::{Function, FunctionContent},
     instruction::Instruction,
     irtype::{Aggregate, Type},
@@ -23,28 +24,32 @@ use crate::{
 
 impl Context {
     /// Verify the contents of this [`Context`] is valid.
-    pub fn verify(&self) -> Result<(), String> {
+    pub fn verify(&self) -> Result<(), IrError> {
         for (_, module) in &self.modules {
             self.verify_module(module)?;
         }
         Ok(())
     }
 
-    fn verify_module(&self, module: &ModuleContent) -> Result<(), String> {
+    fn verify_module(&self, module: &ModuleContent) -> Result<(), IrError> {
         for function in &module.functions {
             self.verify_function(&self.functions[function.0])?;
         }
         Ok(())
     }
 
-    fn verify_function(&self, function: &FunctionContent) -> Result<(), String> {
+    fn verify_function(&self, function: &FunctionContent) -> Result<(), IrError> {
         for block in &function.blocks {
             self.verify_block(function, &self.blocks[block.0])?;
         }
         Ok(())
     }
 
-    fn verify_block(&self, function: &FunctionContent, block: &BlockContent) -> Result<(), String> {
+    fn verify_block(
+        &self,
+        function: &FunctionContent,
+        block: &BlockContent,
+    ) -> Result<(), IrError> {
         for ins in &block.instructions {
             self.verify_instruction(function, &self.values[ins.0].value)?;
         }
@@ -56,11 +61,10 @@ impl Context {
                     (false, n)
                 }
             });
-        if !last_is_term || num_terms != 1 {
-            Err(format!(
-                "Block {} must have single terminator as its last instruction.\n\n{}",
-                block.label, self
-            ))
+        if !last_is_term {
+            Err(IrError::MissingTerminator(block.label.clone()))
+        } else if num_terms != 1 {
+            Err(IrError::MisplacedTerminator(block.label.clone()))
         } else {
             Ok(())
         }
@@ -70,7 +74,7 @@ impl Context {
         &self,
         function: &FunctionContent,
         instruction: &ValueDatum,
-    ) -> Result<(), String> {
+    ) -> Result<(), IrError> {
         if let ValueDatum::Instruction(instruction) = instruction {
             match instruction {
                 Instruction::AsmBlock(asm, args) => self.verify_asm_block(asm, args)?,
@@ -115,15 +119,15 @@ impl Context {
         Ok(())
     }
 
-    fn verify_asm_block(&self, _asm: &AsmBlock, _args: &[AsmArg]) -> Result<(), String> {
+    fn verify_asm_block(&self, _asm: &AsmBlock, _args: &[AsmArg]) -> Result<(), IrError> {
         Ok(())
     }
 
-    fn verify_br(&self, _block: &Block) -> Result<(), String> {
+    fn verify_br(&self, _block: &Block) -> Result<(), IrError> {
         Ok(())
     }
 
-    fn verify_call(&self, _callee: &Function, _args: &[Value]) -> Result<(), String> {
+    fn verify_call(&self, _callee: &Function, _args: &[Value]) -> Result<(), IrError> {
         // XXX We should confirm the function arg types are all correct and the return type matches
         // the call value type... but all they type info isn't stored at this stage, and it
         // should've all been checked in the typed AST.
@@ -135,7 +139,7 @@ impl Context {
         _cond_val: &Value,
         _true_block: &Block,
         _false_block: &Block,
-    ) -> Result<(), String> {
+    ) -> Result<(), IrError> {
         // XXX When we have some type info available from instructions...
         //if !cond_val.is_bool_ty(self) {
         //    Err("Condition for branch must be a bool.".into())
@@ -149,7 +153,7 @@ impl Context {
         _array: &Value,
         _ty: &Aggregate,
         _index_val: &Value,
-    ) -> Result<(), String> {
+    ) -> Result<(), IrError> {
         Ok(())
     }
 
@@ -158,13 +162,13 @@ impl Context {
         _aggregate: &Value,
         _ty: &Aggregate,
         _indices: &[u64],
-    ) -> Result<(), String> {
+    ) -> Result<(), IrError> {
         // XXX Are we checking the context knows about the aggregate and the indices are valid?  Or
         // is that the type checker's problem?
         Ok(())
     }
 
-    fn verify_get_ptr(&self, _ptr: &Pointer) -> Result<(), String> {
+    fn verify_get_ptr(&self, _ptr: &Pointer) -> Result<(), IrError> {
         // XXX get_ptr() shouldn't exist in the final IR?
         Ok(())
     }
@@ -175,7 +179,7 @@ impl Context {
         _ty: &Aggregate,
         _value: &Value,
         _index_val: &Value,
-    ) -> Result<(), String> {
+    ) -> Result<(), IrError> {
         Ok(())
     }
 
@@ -185,22 +189,22 @@ impl Context {
         _ty: &Aggregate,
         _value: &Value,
         _idcs: &[u64],
-    ) -> Result<(), String> {
+    ) -> Result<(), IrError> {
         // XXX The types should all line up.
         Ok(())
     }
 
-    fn verify_load(&self, _ptr: &Pointer) -> Result<(), String> {
+    fn verify_load(&self, _ptr: &Pointer) -> Result<(), IrError> {
         // XXX We should check the pointer type matches this load type.
         Ok(())
     }
 
-    fn verify_phi(&self, pairs: &[(Block, Value)]) -> Result<(), String> {
+    fn verify_phi(&self, pairs: &[(Block, Value)]) -> Result<(), IrError> {
         let label_set = std::collections::HashSet::<&String>::from_iter(
             pairs.iter().map(|(block, _)| &(self.blocks[block.0].label)),
         );
         if label_set.len() != pairs.len() {
-            Err("Phi must have unique block labels.".into())
+            Err(IrError::NonUniquePhiLabels)
         } else {
             Ok(())
         }
@@ -211,13 +215,10 @@ impl Context {
         function: &FunctionContent,
         _val: &Value,
         ty: &Type,
-    ) -> Result<(), String> {
+    ) -> Result<(), IrError> {
         if &function.return_type != ty {
             println!("{:?} != {:?}", &function.return_type, ty);
-            Err(format!(
-                "Function {} return type must match ret instructions.",
-                function.name
-            ))
+            Err(IrError::MismatchedReturnTypes(function.name.clone()))
         // XXX When we have some type info available from instructions...
         //} else if val.get_type(self) != Some(*ty) {
         //    Err("Ret value type must match return type.".into())
@@ -226,7 +227,7 @@ impl Context {
         }
     }
 
-    fn verify_store(&self, _ptr: &Pointer, _stored_val: &Value) -> Result<(), String> {
+    fn verify_store(&self, _ptr: &Pointer, _stored_val: &Value) -> Result<(), IrError> {
         // XXX When we have some type info available from instructions...
         //if ptr_val.get_type(self) != stored_val.get_type(self) {
         //    Err("Stored value type must match pointer type.".into())

--- a/sway-ir/tests/ir_to_ir/constants_insert_value.in_ir
+++ b/sway-ir/tests/ir_to_ir/constants_insert_value.in_ir
@@ -22,7 +22,7 @@
 //     d: u64,
 // }
 
-script script {
+script {
     fn main() -> u64 {
         local ptr { b256, { bool, u64 } } record
 

--- a/sway-ir/tests/ir_to_ir/constants_insert_value.out_ir
+++ b/sway-ir/tests/ir_to_ir/constants_insert_value.out_ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn main() -> u64 {
         local ptr { b256, { bool, u64 } } record
 

--- a/sway-ir/tests/ir_to_ir/inline_bigger.in_ir
+++ b/sway-ir/tests/ir_to_ir/inline_bigger.in_ir
@@ -17,7 +17,7 @@
 //     x
 // }
 
-script script {
+script {
     fn a(b: bool) -> u64 {
         local ptr u64 x
 

--- a/sway-ir/tests/ir_to_ir/inline_bigger.out_ir
+++ b/sway-ir/tests/ir_to_ir/inline_bigger.out_ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn a(b: bool) -> u64 {
         local ptr u64 x
 

--- a/sway-ir/tests/ir_to_ir/inline_fiddly.in_ir
+++ b/sway-ir/tests/ir_to_ir/inline_fiddly.in_ir
@@ -13,7 +13,7 @@
 //     not(true) || not(false)
 // }
 
-script script {
+script {
     fn not(v: bool) -> bool {
         entry:
         cbr v, block0, block1

--- a/sway-ir/tests/ir_to_ir/inline_fiddly.out_ir
+++ b/sway-ir/tests/ir_to_ir/inline_fiddly.out_ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn not(v: bool) -> bool {
         entry:
         cbr v, block0, block1

--- a/sway-ir/tests/ir_to_ir/inline_simple.in_ir
+++ b/sway-ir/tests/ir_to_ir/inline_simple.in_ir
@@ -11,7 +11,7 @@
 //     a(22)
 // }
 
-script script {
+script {
     fn a(b: u64) -> u64 {
         entry:
         ret u64 b

--- a/sway-ir/tests/ir_to_ir/inline_simple.out_ir
+++ b/sway-ir/tests/ir_to_ir/inline_simple.out_ir
@@ -1,4 +1,4 @@
-script script {
+script {
     fn a(b: u64) -> u64 {
         entry:
         ret u64 b


### PR DESCRIPTION
- Introduce `IrError`, which at the moment is pretty small and simple, will grow in time.
- IR API returns `Result<T, IrError>` now.
- Scrap the module name, which was never actually needed.  Hence a lot of `script script { ... }` in the tests.
- Move the aggregate symbol name management out of the IR library back into `sway-core`.  The IR doesn't have named fields for structs or enums but for convenience I originally put the symbol table needed during compilation into the IR context.  It's only needed by `sway-core/src/optimize.rs` so that's where it now lives.

Closes #647.