### PR TITLE
Update the spelling of the return register and the return length in the compiler for `asm` blocks

### DIFF
--- a/sway-core/src/asm_lang/mod.rs
+++ b/sway-core/src/asm_lang/mod.rs
@@ -1066,8 +1066,8 @@ fn four_regs(
                 "bal" => Balance,
                 "is" => InstructionStart,
                 "flag" => Flags,
-                "rl" => ReturnLength,
-                "rv" => ReturnValue,
+                "retl" => ReturnLength,
+                "ret" => ReturnValue,
                 "ds" => DataSectionStart,
                 _ => return None,
             })

--- a/sway-core/src/asm_lang/virtual_register.rs
+++ b/sway-core/src/asm_lang/virtual_register.rs
@@ -96,8 +96,8 @@ impl fmt::Display for ConstantRegister {
             ContextGas => "$cgas",
             Balance => "$bal",
             InstructionStart => "$is",
-            ReturnValue => "$rv",
-            ReturnLength => "$rl",
+            ReturnValue => "$ret",
+            ReturnLength => "$retl",
             Flags => "$flag",
             // two `$` signs denotes this is a compiler-reserved register and not a
             // VM-reserved register

--- a/test/src/e2e_vm_tests/test_programs/asm_expr_basic/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/asm_expr_basic/Forc.toml
@@ -3,3 +3,7 @@ author = "Fuel Labs <contact@fuel.sh>"
 license = "Apache-2.0"
 name = "asm_expr_basic"
 entry = "main.sw"
+
+[dependencies]
+core = { git = "http://github.com/FuelLabs/sway-lib-core" }
+std = { git = "http://github.com/FuelLabs/sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/asm_expr_basic/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/asm_expr_basic/src/main.sw
@@ -1,5 +1,7 @@
 script;
 
+use std::chain::*;
+
 // This file tests different kinds of ASM generation and parsing.
 
 fn blockheight() -> u64 {
@@ -28,5 +30,43 @@ fn get_gas() -> GasCounts {
 fn main() -> u32 {
     let block_height = blockheight();
     let remaining_gas = get_gas();
+
+    // Test the spelling of all special registers
+    let zero = asm() { zero };
+    assert(zero == 0);
+
+    let one = asm() { one };
+    assert(one == 1);
+
+    let of = asm() { of };
+    assert(of == 0);
+
+    let pc = asm() { pc };
+
+    let ssp = asm() { ssp };
+
+    let sp = asm() { sp };
+
+    let fp = asm() { fp };
+
+    let hp = asm() { hp };
+
+    let err = asm() { err };
+    assert(err == 0);
+
+    let ggas = asm() { ggas };
+
+    let cgas = asm() { cgas };
+
+    let bal = asm() { bal };
+
+    let is = asm() { is };
+    
+    let ret = asm() { ret };
+
+    let retl = asm() { retl };
+
+    let flag = asm() { flag };
+
     return 6u32;
 }


### PR DESCRIPTION
Simply changing `rv` to `ret` and `rl` to `retl` as per the [specs ](https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/main.md)

This:
```rust
script;

pub fn return_value() -> u64 {
    asm() {
       ret
    }
}

pub fn return_length() -> u64 {
    asm() {
       retl
    }
}

fn main() {
    let x = return_value();
    let y = return_length();
}
```
now compiles to:
```
.program:
ji   i4
noop
DATA_SECTION_OFFSET[0..32]
DATA_SECTION_OFFSET[32..64]
lw   $ds $is 1
add  $$ds $$ds $is
move $r0 $ret                 ; return value from inline asm
move $r0 $retl                ; return value from inline asm
ret  $zero                    ; fn main returns unit
.data:
```
as expected.