### PR TITLE
Generate tab-autocompletion scripts for zsh, bash, fish, & powershell shells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df6f3613c0a3cddfd78b41b10203eb322cb29b600cbdf808a7d3db95691b8e25"
+dependencies = [
+ "clap 3.1.2",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +990,7 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "clap 3.1.2",
+ "clap_complete",
  "dirs 3.0.2",
  "flate2",
  "fuel-asm",

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -13,6 +13,7 @@ annotate-snippets = { version = "0.9", features = ["color"] }
 ansi_term = "0.12"
 anyhow = "1.0.41"
 clap = { version = "3.1.2", features = ["env", "derive"] }
+clap_complete = "3.1"
 dirs = "3.0.2"
 flate2 = "1.0.20"
 fuel-asm = "0.1" 

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -1,0 +1,21 @@
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
+use clap_complete::{generate, Generator, Shell};
+
+/// If provided, outputs the completion file for given shell
+#[derive(Debug, Parser)]
+pub struct Command {
+    #[clap(long = "generate", short, arg_enum)]
+    generator: Shell,
+}
+
+pub(crate) fn exec(command: Command) -> Result<(), String> {
+    let mut cmd = super::super::Opt::command();
+    println!("Generating completion file for {:?}...", command.generator);
+    print_completions(command.generator, &mut cmd);
+    Ok(())
+}
+
+fn print_completions<G: Generator>(gen: G, cmd: &mut ClapCommand) {
+    generate(gen, cmd, cmd.get_name().to_string(), &mut std::io::stdout());
+}

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -2,17 +2,128 @@ use clap::Command as ClapCommand;
 use clap::{CommandFactory, Parser};
 use clap_complete::{generate, Generator, Shell};
 
-/// If provided, outputs the completion file for given shell
+pub static COMPLETIONS_HELP: &str = r#"
+DISCUSSION:
+    Enable tab completion for Bash, Fish, Zsh, or PowerShell
+    The script is output on `stdout`, allowing one to re-direct the
+    output to the file of their choosing. Where you place the file
+    will depend on which shell, and which operating system you are
+    using. Your particular configuration may also determine where
+    these scripts need to be placed.
+
+    Here are some common set ups for the three supported shells under
+    Unix and similar operating systems (such as GNU/Linux).
+
+    BASH:
+
+    Completion files are commonly stored in `/etc/bash_completion.d/` for
+    system-wide commands, but can be stored in
+    `~/.local/share/bash-completion/completions` for user-specific commands.
+    Run the command:
+
+        $ mkdir -p ~/.local/share/bash-completion/completions
+        $ forc completions --shell=bash >> ~/.local/share/bash-completion/completions/forc
+
+    This installs the completion script. You may have to log out and
+    log back in to your shell session for the changes to take effect.
+
+    BASH (macOS/Homebrew):
+
+    Homebrew stores bash completion files within the Homebrew directory.
+    With the `bash-completion` brew formula installed, run the command:
+
+        $ mkdir -p $(brew --prefix)/etc/bash_completion.d
+        $ forc completions --shell=bash > $(brew --prefix)/etc/bash_completion.d/forc.bash-completion
+
+    FISH:
+
+    Fish completion files are commonly stored in
+    `$HOME/.config/fish/completions`. Run the command:
+
+        $ mkdir -p ~/.config/fish/completions
+        $ forc completions --shell=fish > ~/.config/fish/completions/forc.fish
+
+    This installs the completion script. You may have to log out and
+    log back in to your shell session for the changes to take effect.
+
+    ZSH:
+
+    ZSH completions are commonly stored in any directory listed in
+    your `$fpath` variable. To use these completions, you must either
+    add the generated script to one of those directories, or add your
+    own to this list.
+
+    Adding a custom directory is often the safest bet if you are
+    unsure of which directory to use. First create the directory; for
+    this example we'll create a hidden directory inside our `$HOME`
+    directory:
+
+        $ mkdir ~/.zfunc
+
+    Then add the following lines to your `.zshrc` just before
+    `compinit`:
+
+        fpath+=~/.zfunc
+
+    Now you can install the completions script using the following
+    command:
+
+        $ forc completions --shell=zsh > ~/.zfunc/_forc
+
+    You must then either log out and log back in, or simply run
+
+        $ exec zsh
+
+    for the new completions to take effect.
+
+    CUSTOM LOCATIONS:
+
+    Alternatively, you could save these files to the place of your
+    choosing, such as a custom directory inside your $HOME. Doing so
+    will require you to add the proper directives, such as `source`ing
+    inside your login script. Consult your shells documentation for
+    how to add such directives.
+
+    POWERSHELL:
+
+    The powershell completion scripts require PowerShell v5.0+ (which
+    comes with Windows 10, but can be downloaded separately for windows 7
+    or 8.1).
+
+    First, check if a profile has already been set
+
+        PS C:\> Test-Path $profile
+
+    If the above command returns `False` run the following
+
+        PS C:\> New-Item -path $profile -type file -force
+
+    Now open the file provided by `$profile` (if you used the
+    `New-Item` command it will be
+    `${env:USERPROFILE}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
+
+    Next, we either save the completions file into our profile, or
+    into a separate file and source it inside our profile. To save the
+    completions into our profile simply use
+
+        PS C:\> forc completions --shell=powershell >>
+${env:USERPROFILE}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1
+"#;
+
+/// Generate tab-completion scripts for your shell
 #[derive(Debug, Parser)]
 pub struct Command {
-    #[clap(long = "generate", short, arg_enum)]
-    generator: Shell,
+    #[clap(
+        short,
+        long,
+        help("[possible values: zsh, bash, fish, powershell, elvish]")
+    )]
+    shell: Shell,
 }
 
 pub(crate) fn exec(command: Command) -> Result<(), String> {
     let mut cmd = super::super::Opt::command();
-    println!("Generating completion file for {:?}...", command.generator);
-    print_completions(command.generator, &mut cmd);
+    print_completions(command.shell, &mut cmd);
     Ok(())
 }
 

--- a/forc/src/cli/commands/mod.rs
+++ b/forc/src/cli/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod addr2line;
 pub mod build;
 pub mod clean;
+pub mod completions;
 pub mod deploy;
 pub mod explorer;
 pub mod format;

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -35,6 +35,7 @@ enum Forc {
     Addr2Line(Addr2LineCommand),
     Build(BuildCommand),
     Clean(CleanCommand),
+    #[clap(after_help = completions::COMPLETIONS_HELP)]
     Completions(CompletionsCommand),
     Deploy(DeployCommand),
     Explorer(ExplorerCommand),

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -2,13 +2,14 @@ use clap::Parser;
 
 mod commands;
 use self::commands::{
-    addr2line, build, clean, deploy, explorer, format, init, json_abi, lsp, parse_bytecode, run,
-    test, update,
+    addr2line, build, clean, completions, deploy, explorer, format, init, json_abi, lsp,
+    parse_bytecode, run, test, update,
 };
 
 use addr2line::Command as Addr2LineCommand;
 pub use build::Command as BuildCommand;
 pub use clean::Command as CleanCommand;
+pub use completions::Command as CompletionsCommand;
 pub use deploy::Command as DeployCommand;
 pub use explorer::Command as ExplorerCommand;
 pub use format::Command as FormatCommand;
@@ -34,6 +35,7 @@ enum Forc {
     Addr2Line(Addr2LineCommand),
     Build(BuildCommand),
     Clean(CleanCommand),
+    Completions(CompletionsCommand),
     Deploy(DeployCommand),
     Explorer(ExplorerCommand),
     #[clap(name = "fmt")]
@@ -49,10 +51,12 @@ enum Forc {
 
 pub(crate) async fn run_cli() -> Result<(), String> {
     let opt = Opt::parse();
+
     match opt.command {
         Forc::Addr2Line(command) => addr2line::exec(command),
         Forc::Build(command) => build::exec(command),
         Forc::Clean(command) => clean::exec(command),
+        Forc::Completions(command) => completions::exec(command),
         Forc::Deploy(command) => deploy::exec(command).await,
         Forc::Explorer(command) => explorer::exec(command).await,
         Forc::Format(command) => format::exec(command),


### PR DESCRIPTION
`forc` now supports generating completion scripts for Bash, Fish, Zsh, and PowerShell. See `forc completions --help` for full details, but the gist is as simple as using one of the following and then restarting your shell for the changes to take effect:

```
# Bash
$ forc completions --shell=bash > ~/.local/share/bash-completion/completions/forc

# Bash (macOS/Homebrew)
$ forc completions --shell=bash > $(brew --prefix)/etc/bash_completion.d/forc.bash-completion

# Fish
$ mkdir -p ~/.config/fish/completions
$ forc completions --shell=fish > ~/.config/fish/completions/forc.fish

# Zsh
$ forc completions --shell=zsh > ~/.zfunc/_forc

# PowerShell v5.0+
$ forc completions --shell=powershell >> $PROFILE.CurrentUserCurrentHost
# or
$ forc completions --shell=powershell | Out-String | Invoke-Expression
```

addresses the autocompletion step in #482 