### PR TITLE
Provision IR for future storage API.

### DIFF
--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -163,8 +163,8 @@ struct AsmBuilder<'ir> {
     // Label map is from IR block to label name.
     label_map: HashMap<Block, Label>,
 
-    // Reg map, const map and var map are all tracking IR values to VM values.  Var map has an
-    // optional (None) register until its first assignment.
+    // Reg map is tracking IR values to VM values.  Ptr map is tracking IR pointers to local
+    // storage types.
     reg_map: HashMap<Value, VirtualRegister>,
     ptr_map: HashMap<Pointer, Storage>,
 
@@ -407,13 +407,27 @@ impl<'ir> AsmBuilder<'ir> {
                     value,
                     indices,
                 } => self.compile_insert_value(instr_val, aggregate, ty, value, indices),
-                Instruction::Load(ptr) => self.compile_load(instr_val, ptr),
+                Instruction::Load(src_val) => check!(
+                    self.compile_load(instr_val, src_val),
+                    return err(warnings, errors),
+                    warnings,
+                    errors
+                ),
                 Instruction::Nop => (),
                 Instruction::Phi(_) => (), // Managing the phi value is done in br and cbr compilation.
+                Instruction::PointerCast(..) => todo!(),
                 Instruction::Ret(ret_val, ty) => self.compile_ret(instr_val, ret_val, ty),
-                Instruction::Store { ptr, stored_val } => {
-                    self.compile_store(instr_val, ptr, stored_val)
-                }
+                Instruction::StateLoad { .. } => todo!(),
+                Instruction::StateStore { .. } => todo!(),
+                Instruction::Store {
+                    dst_val,
+                    stored_val,
+                } => check!(
+                    self.compile_store(instr_val, dst_val, stored_val),
+                    return err(warnings, errors),
+                    warnings,
+                    errors
+                ),
             }
         } else {
             errors.push(CompileError::Internal(
@@ -1021,11 +1035,16 @@ impl<'ir> AsmBuilder<'ir> {
         self.reg_map.insert(*instr_val, base_reg);
     }
 
-    fn compile_load(&mut self, instr_val: &Value, ptr: &Pointer) {
+    fn compile_load(&mut self, instr_val: &Value, src_val: &Value) -> CompileResult<()> {
+        let ptr = self.resolve_ptr(src_val);
+        if ptr.value.is_none() {
+            return ptr.map(|_| ());
+        }
+        let ptr = ptr.value.unwrap();
         let load_size_in_words =
             size_bytes_in_words!(self.ir_type_size_in_bytes(ptr.get_type(self.context)));
         let instr_reg = self.reg_seqr.next();
-        match self.ptr_map.get(ptr) {
+        match self.ptr_map.get(&ptr) {
             None => unimplemented!("BUG? Uninitialised pointer."),
             Some(storage) => match storage.clone() {
                 Storage::Data(data_id) => {
@@ -1118,6 +1137,7 @@ impl<'ir> AsmBuilder<'ir> {
             },
         }
         self.reg_map.insert(*instr_val, instr_reg);
+        ok((), Vec::new(), Vec::new())
     }
 
     fn compile_ret(&mut self, instr_val: &Value, ret_val: &Value, ret_type: &Type) {
@@ -1165,10 +1185,20 @@ impl<'ir> AsmBuilder<'ir> {
         }
     }
 
-    fn compile_store(&mut self, instr_val: &Value, ptr: &Pointer, stored_val: &Value) {
+    fn compile_store(
+        &mut self,
+        instr_val: &Value,
+        dst_val: &Value,
+        stored_val: &Value,
+    ) -> CompileResult<()> {
+        let ptr = self.resolve_ptr(dst_val);
+        if ptr.value.is_none() {
+            return ptr.map(|_| ());
+        }
+        let ptr = ptr.value.unwrap();
         let stored_reg = self.value_to_register(stored_val);
-        let is_struct_ptr = ptr.is_struct_ptr(self.context);
-        match self.ptr_map.get(ptr) {
+        let is_aggregate_ptr = ptr.is_aggregate_ptr(self.context);
+        match self.ptr_map.get(&ptr) {
             None => unreachable!("Bug! Trying to store to an unknown pointer."),
             Some(storage) => match storage {
                 Storage::Data(_) => unreachable!("BUG! Trying to store to the data section."),
@@ -1191,7 +1221,7 @@ impl<'ir> AsmBuilder<'ir> {
                             let base_reg = self.stack_base_reg.as_ref().unwrap().clone();
 
                             // A single word can be stored with SW.
-                            let stored_reg = if !is_struct_ptr {
+                            let stored_reg = if !is_aggregate_ptr {
                                 // stored_reg is a value.
                                 stored_reg
                             } else {
@@ -1319,6 +1349,24 @@ impl<'ir> AsmBuilder<'ir> {
                 }
             },
         };
+        ok((), Vec::new(), Vec::new())
+    }
+
+    fn resolve_ptr(&self, ptr_val: &Value) -> CompileResult<Pointer> {
+        match &self.context.values[ptr_val.0].value {
+            ValueDatum::Instruction(Instruction::GetPointer(ptr)) => {
+                ok(*ptr, Vec::new(), Vec::new())
+            }
+            _otherwise => err(
+                Vec::new(),
+                vec![CompileError::Internal(
+                    "Pointer arg for load/store is not a get_ptr instruction.",
+                    ptr_val
+                        .get_span(self.context)
+                        .unwrap_or_else(Self::empty_span),
+                )],
+            ),
+        }
     }
 
     fn value_to_register(&mut self, value: &Value) -> VirtualRegister {

--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -981,10 +981,11 @@ impl FnCompiler {
             .get(name)
             .and_then(|local_name| self.function.get_local_ptr(context, local_name))
         {
-            Ok(if ptr.is_struct_ptr(context) {
-                self.current_block.ins(context).get_ptr(ptr, span_md_idx)
+            let ptr_val = self.current_block.ins(context).get_ptr(ptr, span_md_idx);
+            Ok(if ptr.is_aggregate_ptr(context) {
+                ptr_val
             } else {
-                self.current_block.ins(context).load(ptr, span_md_idx)
+                self.current_block.ins(context).load(ptr_val, span_md_idx)
             })
         } else if let Some(val) = self.function.get_arg(context, name) {
             Ok(val)
@@ -1038,9 +1039,10 @@ impl FnCompiler {
             .new_local_ptr(context, local_name, return_type, is_mutable.into(), None)
             .map_err(|ir_error| ir_error.to_string())?;
 
+        let ptr_val = self.current_block.ins(context).get_ptr(ptr, span_md_idx);
         self.current_block
             .ins(context)
-            .store(ptr, init_val, span_md_idx);
+            .store(ptr_val, init_val, span_md_idx);
         Ok(init_val)
     }
 
@@ -1089,7 +1091,7 @@ impl FnCompiler {
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, String> {
         let name = ast_reassignment.lhs[0].name.as_str();
-        let ptr_val = self
+        let ptr = self
             .function
             .get_local_ptr(context, name)
             .ok_or(format!("variable not found: {}", name))?;
@@ -1098,6 +1100,7 @@ impl FnCompiler {
 
         if ast_reassignment.lhs.len() == 1 {
             // A non-aggregate; use a `store`.
+            let ptr_val = self.current_block.ins(context).get_ptr(ptr, span_md_idx);
             self.current_block
                 .ins(context)
                 .store(ptr_val, reassign_val, span_md_idx);
@@ -1107,7 +1110,7 @@ impl FnCompiler {
             let field_idcs = ast_reassignment.lhs[1..]
                 .iter()
                 .fold(
-                    Ok((Vec::new(), *ptr_val.get_type(context))),
+                    Ok((Vec::new(), *ptr.get_type(context))),
                     |acc, field_name| {
                         // Make sure we have an aggregate to index into.
                         acc.and_then(|(mut fld_idcs, ty)| match ty {
@@ -1140,19 +1143,16 @@ impl FnCompiler {
                 )?
                 .0;
 
-            let ty = match ptr_val.get_type(context) {
+            let ty = match ptr.get_type(context) {
                 Type::Struct(aggregate) => *aggregate,
                 _otherwise => {
                     return Err("Reassignment with multiple accessors to non-aggregate.".into())
                 }
             };
 
-            let get_ptr_val = self
-                .current_block
-                .ins(context)
-                .get_ptr(ptr_val, span_md_idx);
+            let ptr_val = self.current_block.ins(context).get_ptr(ptr, span_md_idx);
             self.current_block.ins(context).insert_value(
-                get_ptr_val,
+                ptr_val,
                 ty,
                 reassign_val,
                 field_idcs,

--- a/sway-core/tests/ir_to_asm/bigger_asm_block.asm
+++ b/sway-core/tests/ir_to_asm/bigger_asm_block.asm
@@ -7,9 +7,11 @@ lw   $ds $is 1
 add  $$ds $$ds $is
 move $r2 $sp                  ; save locals base register
 cfei i32                      ; allocate 32 bytes for all locals
+addi $r0 $r2 i0               ; get_ptr
 lw   $r1 data_0               ; literal instantiation
 addi $r0 $r2 i0               ; get store offset
 mcpi $r0 $r1 i32              ; store value
+addi $r0 $r2 i0               ; get_ptr
 addi $r2 $r2 i0               ; load address
 lw   $r1 data_1               ; literal instantiation
 addi $r0 $zero i32            ; asm block

--- a/sway-core/tests/ir_to_asm/bigger_asm_block.ir
+++ b/sway-core/tests/ir_to_asm/bigger_asm_block.ir
@@ -3,18 +3,20 @@ script {
         local ptr b256 a
 
         entry:
-        v0 = const b256 0x0202020202020202020202020202020202020202020202020202020202020202
-        store v0, ptr b256 a
-        v1 = load ptr b256 a
-        v2 = const b256 0x0303030303030303030303030303030303030303030303030303030303030303
-        v3 = asm(lhs: v1, rhs: v2, sz, res) -> res {
+        v0 = get_ptr ptr b256 a
+        v1 = const b256 0x0202020202020202020202020202020202020202020202020202020202020202
+        store v1, ptr v0
+        v2 = get_ptr ptr b256 a
+        v3 = load ptr v2
+        v4 = const b256 0x0303030303030303030303030303030303030303030303030303030303030303
+        v5 = asm(lhs: v3, rhs: v4, sz, res) -> res {
             addi   sz zero i32
             meq    res lhs rhs sz
         }
         br block0
 
         block0:
-        v4 = phi(entry: v3)
-        ret bool v4
+        v6 = phi(entry: v5)
+        ret bool v6
     }
 }

--- a/sway-core/tests/ir_to_asm/let_reassign_while_loop.ir
+++ b/sway-core/tests/ir_to_asm/let_reassign_while_loop.ir
@@ -1,32 +1,37 @@
 script {
     fn main() -> bool {
-        local ptr bool a
+        local mut ptr bool a
 
         entry:
-        v0 = const bool true
-        store v0, ptr bool a
+        v0 = get_ptr mut ptr bool a
+        v1 = const bool true
+        store v1, ptr v0
         br while
 
         while:
-        v1 = load ptr bool a
-        cbr v1, while_body, end_while
+        v2 = get_ptr mut ptr bool a
+        v3 = load ptr v2
+        cbr v3, while_body, end_while
 
         while_body:
-        v2 = load ptr bool a
-        cbr v2, block0, block1
+        v4 = get_ptr mut ptr bool a
+        v5 = load ptr v4
+        cbr v5, block0, block1
 
         block0:
-        v3 = phi(while_body: v2)
-        v4 = const bool false
+        v6 = phi(while_body: v5)
+        v7 = const bool false
         br block1
 
         block1:
-        v5 = phi(while_body: v2, block0: v4)
-        store v5, ptr bool a
+        v8 = phi(while_body: v5, block0: v7)
+        v9 = get_ptr mut ptr bool a
+        store v8, ptr v9
         br while
 
         end_while:
-        v6 = load ptr bool a
-        ret bool v6
+        v10 = get_ptr mut ptr bool a
+        v11 = load ptr v10
+        ret bool v11
     }
 }

--- a/sway-core/tests/ir_to_asm/mutable_struct.asm
+++ b/sway-core/tests/ir_to_asm/mutable_struct.asm
@@ -13,6 +13,7 @@ lw   $r0 data_0               ; literal instantiation
 sw   $r1 $r0 i0               ; insert_value @ 0
 lw   $r0 data_1               ; literal instantiation
 sw   $r1 $r0 i1               ; insert_value @ 1
+addi $r0 $r2 i0               ; get_ptr
 addi $r0 $r2 i0               ; get store offset
 mcpi $r0 $r1 i16              ; store value
 addi $r1 $r2 i0               ; get_ptr
@@ -21,7 +22,6 @@ sw   $r1 $r0 i0               ; insert_value @ 0
 addi $r0 $r2 i0               ; get_ptr
 lw   $r0 $r0 i1               ; extract_value @ 1
 ret  $r0
-noop                          ; word-alignment of data section
 .data:
 data_0 .u64 0x28
 data_1 .u64 0x02

--- a/sway-core/tests/ir_to_asm/mutable_struct.ir
+++ b/sway-core/tests/ir_to_asm/mutable_struct.ir
@@ -8,13 +8,13 @@ script {
         v2 = insert_value v0, { u64, u64 }, v1, 0
         v3 = const u64 2
         v4 = insert_value v2, { u64, u64 }, v3, 1
-        store v4, mut ptr { u64, u64 } record
         v5 = get_ptr mut ptr { u64, u64 } record
-        v6 = const u64 50
-        v7 = insert_value v5, { u64, u64 }, v6, 0
-        v8 = get_ptr mut ptr { u64, u64 } record
-        v9 = extract_value v8, { u64, u64 }, 1
-        ret u64 v9
+        store v4, ptr v5
+        v6 = get_ptr mut ptr { u64, u64 } record
+        v7 = const u64 50
+        v8 = insert_value v6, { u64, u64 }, v7, 0
+        v9 = get_ptr mut ptr { u64, u64 } record
+        v10 = extract_value v9, { u64, u64 }, 1
+        ret u64 v10
     }
 }
-

--- a/sway-core/tests/ir_to_asm/simple_array.asm
+++ b/sway-core/tests/ir_to_asm/simple_array.asm
@@ -24,14 +24,16 @@ lw   $r0 data_4               ; literal instantiation
 muli $r0 $r0 i8               ; insert_element relative offset
 add  $r0 $r2 $r0              ; insert_element absolute offset
 sw   $r0 $r1 i0               ; insert_element
+addi $r0 $r3 i0               ; get_ptr
 addi $r0 $r3 i0               ; get store offset
 mcpi $r0 $r2 i24              ; store value
-addi $r1 $r3 i0               ; load address
+addi $r1 $r3 i0               ; get_ptr
 lw   $r0 data_3               ; literal instantiation
 muli $r0 $r0 i8               ; extract_element relative offset
 add  $r0 $r1 $r0              ; extract_element absolute offset
 lw   $r0 $r0 i0               ; extract_element
 ret  $r0
+noop                          ; word-alignment of data section
 .data:
 data_0 .bool 0x00
 data_1 .u64 0x00

--- a/sway-core/tests/ir_to_asm/simple_array.ir
+++ b/sway-core/tests/ir_to_asm/simple_array.ir
@@ -13,10 +13,11 @@ script {
         v7 = const bool false
         v8 = const u64 2
         v9 = insert_element v6, [bool; 3], v7, v8
-        store v9, ptr [bool; 3] a
-        v10 = load ptr [bool; 3] a
-        v11 = const u64 1
-        v12 = extract_element v10, [bool; 3], v11
-        ret bool v12
+        v10 = get_ptr ptr [bool; 3] a
+        store v9, ptr v10
+        v11 = get_ptr ptr [bool; 3] a
+        v12 = const u64 1
+        v13 = extract_element v11, [bool; 3], v12
+        ret bool v13
     }
 }

--- a/sway-core/tests/ir_to_asm/simple_enum.asm
+++ b/sway-core/tests/ir_to_asm/simple_enum.asm
@@ -11,6 +11,7 @@ move $r1 $sp                  ; save register for temporary stack value
 cfei i16                      ; allocate 16 bytes for temporary struct
 lw   $r0 data_0               ; literal instantiation
 sw   $r1 $r0 i0               ; insert_value @ 0
+addi $r0 $r2 i0               ; get_ptr
 addi $r0 $r2 i0               ; get store offset
 mcpi $r0 $r1 i16              ; store value
 addi $r0 $r2 i0               ; get_ptr
@@ -23,7 +24,6 @@ lw   $r0 data_3               ; literal instantiation
 sw   $r1 $r0 i1               ; insert_value @ 1
 lw   $r0 data_1               ; literal instantiation
 ret  $zero                    ; returning unit as zero
-noop                          ; word-alignment of data section
 .data:
 data_0 .u64 0x01
 data_1 .bool 0x00

--- a/sway-core/tests/ir_to_asm/simple_enum.ir
+++ b/sway-core/tests/ir_to_asm/simple_enum.ir
@@ -6,23 +6,24 @@ script {
         v0 = const { u64, { () | () | u64 } } { u64 undef, { () | () | u64 } undef }
         v1 = const u64 1
         v2 = insert_value v0, { u64, { () | () | u64 } }, v1, 0
-        store v2, ptr { u64, { () | () | u64 } } lunch
         v3 = get_ptr ptr { u64, { () | () | u64 } } lunch
-        v4 = const bool false
+        store v2, ptr v3
+        v4 = get_ptr ptr { u64, { () | () | u64 } } lunch
+        v5 = const bool false
         br block0
 
         block0:
-        v5 = phi(entry: v4)
-        v6 = const { u64, { () | () | u64 } } { u64 undef, { () | () | u64 } undef }
-        v7 = const u64 2
-        v8 = insert_value v6, { u64, { () | () | u64 } }, v7, 0
-        v9 = const u64 3
-        v10 = insert_value v8, { u64, { () | () | u64 } }, v9, 1
-        v4 = const bool false
+        v6 = phi(entry: v5)
+        v7 = const { u64, { () | () | u64 } } { u64 undef, { () | () | u64 } undef }
+        v8 = const u64 2
+        v9 = insert_value v7, { u64, { () | () | u64 } }, v8, 0
+        v10 = const u64 3
+        v11 = insert_value v9, { u64, { () | () | u64 } }, v10, 1
+        v12 = const bool false
         br block1
 
         block1:
-        v11 = phi(block0: v4)
-        ret () v11
+        v13 = phi(block0: v12)
+        ret () v13
     }
 }

--- a/sway-core/tests/ir_to_asm/simple_struct.asm
+++ b/sway-core/tests/ir_to_asm/simple_struct.asm
@@ -13,11 +13,13 @@ lw   $r0 data_0               ; literal instantiation
 sw   $r1 $r0 i0               ; insert_value @ 0
 lw   $r0 data_1               ; literal instantiation
 sw   $r1 $r0 i1               ; insert_value @ 1
+addi $r0 $r2 i0               ; get_ptr
 addi $r0 $r2 i0               ; get store offset
 mcpi $r0 $r1 i16              ; store value
 addi $r0 $r2 i0               ; get_ptr
 lw   $r0 $r0 i0               ; extract_value @ 0
 ret  $r0
+noop                          ; word-alignment of data section
 .data:
 data_0 .u64 0x28
 data_1 .u64 0x02

--- a/sway-core/tests/ir_to_asm/simple_struct.ir
+++ b/sway-core/tests/ir_to_asm/simple_struct.ir
@@ -8,9 +8,10 @@ script {
         v2 = insert_value v0, { u64, u64 }, v1, 0
         v3 = const u64 2
         v4 = insert_value v2, { u64, u64 }, v3, 1
-        store v4, ptr { u64, u64 } record
         v5 = get_ptr ptr { u64, u64 } record
-        v6 = extract_value v5, { u64, u64 }, 0
-        ret u64 v6
+        store v4, ptr v5
+        v6 = get_ptr ptr { u64, u64 } record
+        v7 = extract_value v6, { u64, u64 }, 0
+        ret u64 v7
     }
 }

--- a/sway-core/tests/sway_to_ir/array_simple.ir
+++ b/sway-core/tests/sway_to_ir/array_simple.ir
@@ -13,11 +13,12 @@ script {
         v7 = const bool false, !4
         v8 = const u64 2, !1
         v9 = insert_element v6, [bool; 3], v7, v8, !1
-        store v9, ptr [bool; 3] a, !5
-        v10 = load ptr [bool; 3] a, !6
-        v11 = const u64 1, !7
-        v12 = extract_element v10, [bool; 3], v11, !8
-        ret bool v12
+        v10 = get_ptr ptr [bool; 3] a, !5
+        store v9, ptr v10, !5
+        v11 = get_ptr ptr [bool; 3] a, !6
+        v12 = const u64 1, !7
+        v13 = extract_element v11, [bool; 3], v12, !8
+        ret bool v13
     }
 }
 

--- a/sway-core/tests/sway_to_ir/b256_immeds.ir
+++ b/sway-core/tests/sway_to_ir/b256_immeds.ir
@@ -3,12 +3,14 @@ script {
         local ptr b256 a
 
         entry:
-        v0 = const b256 0x0202020202020202020202020202020202020202020202020202020202020202, !1
-        store v0, ptr b256 a, !2
-        v1 = load ptr b256 a, !3
-        v2 = const b256 0x0303030303030303030303030303030303030303030303030303030303030303, !4
-        v3 = call anon_0(v1, v2), !5
-        ret bool v3
+        v0 = get_ptr ptr b256 a, !1
+        v1 = const b256 0x0202020202020202020202020202020202020202020202020202020202020202, !2
+        store v1, ptr v0, !1
+        v2 = get_ptr ptr b256 a, !3
+        v3 = load ptr v2, !3
+        v4 = const b256 0x0303030303030303030303030303030303030303030303030303030303030303, !4
+        v5 = call anon_0(v3, v4), !5
+        ret bool v5
     }
 
     fn anon_0(a !6: b256, b !7: b256) -> bool {
@@ -22,8 +24,8 @@ script {
 }
 
 !0 = filepath "/path/to/b256_immeds.sw"
-!1 = span !0 41 107
-!2 = span !0 33 108
+!1 = span !0 33 108
+!2 = span !0 41 107
 !3 = span !0 117 118
 !4 = span !0 120 186
 !5 = span !0 191 340

--- a/sway-core/tests/sway_to_ir/enum.ir
+++ b/sway-core/tests/sway_to_ir/enum.ir
@@ -6,16 +6,17 @@ script {
         v0 = const { u64, { () | () | u64 } } { u64 undef, { () | () | u64 } undef }, !1
         v1 = const u64 1, !1
         v2 = insert_value v0, { u64, { () | () | u64 } }, v1, 0, !1
-        store v2, ptr { u64, { () | () | u64 } } lunch, !2
-        v3 = get_ptr ptr { u64, { () | () | u64 } } lunch, !3
-        v4 = call anon_0(v3), !4
-        v5 = const { u64, { () | () | u64 } } { u64 undef, { () | () | u64 } undef }, !5
-        v6 = const u64 2, !5
-        v7 = insert_value v5, { u64, { () | () | u64 } }, v6, 0, !5
-        v8 = const u64 3, !6
-        v9 = insert_value v7, { u64, { () | () | u64 } }, v8, 1, !5
-        v10 = call anon_1(v9), !7
-        ret () v10
+        v3 = get_ptr ptr { u64, { () | () | u64 } } lunch, !2
+        store v2, ptr v3, !2
+        v4 = get_ptr ptr { u64, { () | () | u64 } } lunch, !3
+        v5 = call anon_0(v4), !4
+        v6 = const { u64, { () | () | u64 } } { u64 undef, { () | () | u64 } undef }, !5
+        v7 = const u64 2, !5
+        v8 = insert_value v6, { u64, { () | () | u64 } }, v7, 0, !5
+        v9 = const u64 3, !6
+        v10 = insert_value v8, { u64, { () | () | u64 } }, v9, 1, !5
+        v11 = call anon_1(v10), !7
+        ret () v11
     }
 
     fn anon_0(meal !8: { u64, { () | () | u64 } }) -> bool {

--- a/sway-core/tests/sway_to_ir/let_reassign_while_loop.ir
+++ b/sway-core/tests/sway_to_ir/let_reassign_while_loop.ir
@@ -3,37 +3,42 @@ script {
         local mut ptr bool a
 
         entry:
-        v0 = const bool true, !1
-        store v0, mut ptr bool a, !2
+        v0 = get_ptr mut ptr bool a, !1
+        v1 = const bool true, !2
+        store v1, ptr v0, !1
         br while
 
         while:
-        v1 = load mut ptr bool a, !3
-        cbr v1, while_body, end_while
+        v2 = get_ptr mut ptr bool a, !3
+        v3 = load ptr v2, !3
+        cbr v3, while_body, end_while
 
         while_body:
-        v2 = load mut ptr bool a, !4
-        cbr v2, block0, block1, !5
+        v4 = get_ptr mut ptr bool a, !4
+        v5 = load ptr v4, !4
+        cbr v5, block0, block1, !5
 
         block0:
-        v3 = phi(while_body: v2)
-        v4 = const bool false, !6
+        v6 = phi(while_body: v5)
+        v7 = const bool false, !6
         br block1, !5
 
         block1:
-        v5 = phi(while_body: v2, block0: v4)
-        store v5, mut ptr bool a, !7
+        v8 = phi(while_body: v5, block0: v7)
+        v9 = get_ptr mut ptr bool a, !7
+        store v8, ptr v9, !7
         br while
 
         end_while:
-        v6 = load mut ptr bool a, !8
-        ret bool v6
+        v10 = get_ptr mut ptr bool a, !8
+        v11 = load ptr v10, !8
+        ret bool v11
     }
 }
 
 !0 = filepath "/path/to/let_reassign_while_loop.sw"
-!1 = span !0 45 49
-!2 = span !0 33 50
+!1 = span !0 33 50
+!2 = span !0 45 49
 !3 = span !0 61 62
 !4 = span !0 77 78
 !5 = span !0 77 87

--- a/sway-core/tests/sway_to_ir/mutable_struct.ir
+++ b/sway-core/tests/sway_to_ir/mutable_struct.ir
@@ -8,13 +8,14 @@ script {
         v2 = insert_value v0, { u64, u64 }, v1, 0, !1
         v3 = const u64 2, !3
         v4 = insert_value v2, { u64, u64 }, v3, 1, !1
-        store v4, mut ptr { u64, u64 } record, !4
-        v5 = get_ptr mut ptr { u64, u64 } record, !5
-        v6 = const u64 50, !6
-        v7 = insert_value v5, { u64, u64 }, v6, 0, !5
-        v8 = get_ptr mut ptr { u64, u64 } record, !7
-        v9 = extract_value v8, { u64, u64 }, 1, !8
-        ret u64 v9
+        v5 = get_ptr mut ptr { u64, u64 } record, !4
+        store v4, ptr v5, !4
+        v6 = get_ptr mut ptr { u64, u64 } record, !5
+        v7 = const u64 50, !6
+        v8 = insert_value v6, { u64, u64 }, v7, 0, !5
+        v9 = get_ptr mut ptr { u64, u64 } record, !7
+        v10 = extract_value v9, { u64, u64 }, 1, !8
+        ret u64 v10
     }
 }
 

--- a/sway-core/tests/sway_to_ir/shadowed_locals.ir
+++ b/sway-core/tests/sway_to_ir/shadowed_locals.ir
@@ -5,35 +5,40 @@ script {
         local ptr { u64 } a__
 
         entry:
-        v0 = const bool true, !1
-        store v0, ptr bool a, !2
-        v1 = load ptr bool a, !3
-        cbr v1, block0, block1, !4
+        v0 = get_ptr ptr bool a, !1
+        v1 = const bool true, !2
+        store v1, ptr v0, !1
+        v2 = get_ptr ptr bool a, !3
+        v3 = load ptr v2, !3
+        cbr v3, block0, block1, !4
 
         block0:
-        v2 = const u64 12, !5
+        v4 = const u64 12, !5
         br block2
 
         block1:
-        v3 = const u64 21, !6
+        v5 = const u64 21, !6
         br block2
 
         block2:
-        v4 = phi(block0: v2, block1: v3)
-        store v4, ptr u64 a_, !7
-        v5 = load ptr u64 a_, !8
-        v6 = const { u64 } { u64 undef }, !9
-        v7 = insert_value v6, { u64 }, v5, 0, !9
-        store v7, ptr { u64 } a__, !10
-        v8 = get_ptr ptr { u64 } a__, !11
-        v9 = extract_value v8, { u64 }, 0, !12
-        ret u64 v9
+        v6 = phi(block0: v4, block1: v5)
+        v7 = get_ptr ptr u64 a_, !7
+        store v6, ptr v7, !7
+        v8 = get_ptr ptr u64 a_, !8
+        v9 = load ptr v8, !8
+        v10 = const { u64 } { u64 undef }, !9
+        v11 = insert_value v10, { u64 }, v9, 0, !9
+        v12 = get_ptr ptr { u64 } a__, !10
+        store v11, ptr v12, !10
+        v13 = get_ptr ptr { u64 } a__, !11
+        v14 = extract_value v13, { u64 }, 0, !12
+        ret u64 v14
     }
 }
 
 !0 = filepath "/path/to/shadowed_locals.sw"
-!1 = span !0 66 70
-!2 = span !0 58 71
+!1 = span !0 58 71
+!2 = span !0 66 70
 !3 = span !0 87 88
 !4 = span !0 87 88
 !5 = span !0 91 93

--- a/sway-core/tests/sway_to_ir/shadowed_struct_init.ir
+++ b/sway-core/tests/sway_to_ir/shadowed_struct_init.ir
@@ -12,16 +12,20 @@ script {
         local ptr bool b_
 
         entry:
-        v0 = const bool false, !6
-        store v0, ptr bool a_, !7
-        v1 = const bool true, !8
-        store v1, ptr bool b_, !9
-        v2 = load ptr bool a_, !10
-        v3 = load ptr bool b_, !11
-        v4 = const { bool, bool } { bool undef, bool undef }, !12
-        v5 = insert_value v4, { bool, bool }, v2, 0, !12
-        v6 = insert_value v5, { bool, bool }, v3, 1, !12
-        ret { bool, bool } v6
+        v0 = get_ptr ptr bool a_, !6
+        v1 = const bool false, !7
+        store v1, ptr v0, !6
+        v2 = get_ptr ptr bool b_, !8
+        v3 = const bool true, !9
+        store v3, ptr v2, !8
+        v4 = get_ptr ptr bool a_, !10
+        v5 = load ptr v4, !10
+        v6 = get_ptr ptr bool b_, !11
+        v7 = load ptr v6, !11
+        v8 = const { bool, bool } { bool undef, bool undef }, !12
+        v9 = insert_value v8, { bool, bool }, v5, 0, !12
+        v10 = insert_value v9, { bool, bool }, v7, 1, !12
+        ret { bool, bool } v10
     }
 }
 
@@ -31,10 +35,10 @@ script {
 !3 = span !0 49 227
 !4 = span !0 56 57
 !5 = span !0 65 66
-!6 = span !0 93 98
-!7 = span !0 85 99
-!8 = span !0 112 116
-!9 = span !0 104 117
+!6 = span !0 85 99
+!7 = span !0 93 98
+!8 = span !0 104 117
+!9 = span !0 112 116
 !10 = span !0 137 138
 !11 = span !0 217 218
 !12 = span !0 122 225

--- a/sway-core/tests/sway_to_ir/struct.ir
+++ b/sway-core/tests/sway_to_ir/struct.ir
@@ -8,10 +8,11 @@ script {
         v2 = insert_value v0, { u64, u64 }, v1, 0, !1
         v3 = const u64 2, !3
         v4 = insert_value v2, { u64, u64 }, v3, 1, !1
-        store v4, ptr { u64, u64 } record, !4
-        v5 = get_ptr ptr { u64, u64 } record, !5
-        v6 = extract_value v5, { u64, u64 }, 0, !6
-        ret u64 v6
+        v5 = get_ptr ptr { u64, u64 } record, !4
+        store v4, ptr v5, !4
+        v6 = get_ptr ptr { u64, u64 } record, !5
+        v7 = extract_value v6, { u64, u64 }, 0, !6
+        ret u64 v7
     }
 }
 

--- a/sway-core/tests/sway_to_ir/struct_enum.ir
+++ b/sway-core/tests/sway_to_ir/struct_enum.ir
@@ -10,10 +10,11 @@ script {
         v4 = const bool false, !3
         v5 = insert_value v3, { bool, { u64, { () | () | u64 } } }, v4, 0, !2
         v6 = insert_value v5, { bool, { u64, { () | () | u64 } } }, v2, 1, !2
-        store v6, ptr { bool, { u64, { () | () | u64 } } } record, !4
-        v7 = get_ptr ptr { bool, { u64, { () | () | u64 } } } record, !5
-        v8 = extract_value v7, { bool, { u64, { () | () | u64 } } }, 0, !6
-        ret bool v8
+        v7 = get_ptr ptr { bool, { u64, { () | () | u64 } } } record, !4
+        store v6, ptr v7, !4
+        v8 = get_ptr ptr { bool, { u64, { () | () | u64 } } } record, !5
+        v9 = extract_value v8, { bool, { u64, { () | () | u64 } } }, 0, !6
+        ret bool v9
     }
 }
 

--- a/sway-core/tests/sway_to_ir/struct_struct.ir
+++ b/sway-core/tests/sway_to_ir/struct_struct.ir
@@ -12,11 +12,12 @@ script {
         v6 = const b256 0x0102030405060708010203040506070801020304050607080102030405060708, !5
         v7 = insert_value v5, { b256, { bool, u64 } }, v6, 0, !4
         v8 = insert_value v7, { b256, { bool, u64 } }, v4, 1, !4
-        store v8, ptr { b256, { bool, u64 } } record, !6
-        v9 = get_ptr ptr { b256, { bool, u64 } } record, !7
-        v10 = extract_value v9, { b256, { bool, u64 } }, 1, !8
-        v11 = extract_value v10, { bool, u64 }, 1, !9
-        ret u64 v11
+        v9 = get_ptr ptr { b256, { bool, u64 } } record, !6
+        store v8, ptr v9, !6
+        v10 = get_ptr ptr { b256, { bool, u64 } } record, !7
+        v11 = extract_value v10, { b256, { bool, u64 } }, 1, !8
+        v12 = extract_value v11, { bool, u64 }, 1, !9
+        ret u64 v12
     }
 }
 

--- a/sway-core/tests/sway_to_ir/trait.ir
+++ b/sway-core/tests/sway_to_ir/trait.ir
@@ -7,15 +7,17 @@ script {
         v0 = const { bool } { bool undef }, !1
         v1 = const bool true, !2
         v2 = insert_value v0, { bool }, v1, 0, !1
-        store v2, ptr { bool } foo, !3
-        v3 = const { bool } { bool undef }, !4
-        v4 = const bool false, !5
-        v5 = insert_value v3, { bool }, v4, 0, !4
-        store v5, ptr { bool } bar, !6
-        v6 = get_ptr ptr { bool } foo, !7
-        v7 = get_ptr ptr { bool } bar, !8
-        v8 = call anon_0(v6, v7), !9
-        ret bool v8
+        v3 = get_ptr ptr { bool } foo, !3
+        store v2, ptr v3, !3
+        v4 = const { bool } { bool undef }, !4
+        v5 = const bool false, !5
+        v6 = insert_value v4, { bool }, v5, 0, !4
+        v7 = get_ptr ptr { bool } bar, !6
+        store v6, ptr v7, !6
+        v8 = get_ptr ptr { bool } foo, !7
+        v9 = get_ptr ptr { bool } bar, !8
+        v10 = call anon_0(v8, v9), !9
+        ret bool v10
     }
 
     fn anon_0(self !10: { bool }, other !11: { bool }) -> bool {

--- a/sway-ir/src/instruction.rs
+++ b/sway-ir/src/instruction.rs
@@ -18,7 +18,7 @@ use crate::{
     irtype::{Aggregate, Type},
     metadata::MetadataIndex,
     pointer::Pointer,
-    value::Value,
+    value::{Value, ValueDatum},
 };
 
 #[derive(Debug, Clone)]
@@ -64,15 +64,23 @@ pub enum Instruction {
         indices: Vec<u64>,
     },
     /// Read a value from a memory pointer.
-    Load(Pointer),
+    Load(Value),
     /// No-op, handy as a placeholder instruction.
     Nop,
     /// Choose a value from a list depending on the preceding block.
     Phi(Vec<(Block, Value)>),
+    /// A cast from one pointer type to another.  Value must be either a GetPointer instruction or
+    /// another PointerCast.
+    PointerCast(Value, Type),
     /// Return from a function.
     Ret(Value, Type),
+    /// Read a value from a storage slot.  Type of `load_val` must be a Uint(64) or B256 ptr.
+    StateLoad { load_val: Value, key: Value },
+    /// Write a value to a storage slot.  Key must be a B256, type of `stored_val` must be a
+    /// Uint(64) or B256 ptr.
+    StateStore { stored_val: Value, key: Value },
     /// Write a value to a memory pointer.
-    Store { ptr: Pointer, stored_val: Value },
+    Store { dst_val: Value, stored_val: Value },
 }
 
 impl Instruction {
@@ -86,22 +94,31 @@ impl Instruction {
             Instruction::Call(function, _) => Some(context.functions[function.0].return_type),
             Instruction::ExtractElement { ty, .. } => ty.get_elem_type(context),
             Instruction::ExtractValue { ty, indices, .. } => ty.get_field_type(context, indices),
-            Instruction::Load(ptr) => Some(context.pointers[ptr.0].ty),
+            Instruction::Load(ptr_val) => {
+                if let ValueDatum::Instruction(ins) = &context.values[ptr_val.0].value {
+                    ins.get_type(context)
+                } else {
+                    None
+                }
+            }
             Instruction::Phi(_alts) => {
                 unimplemented!("phi get type -- I think we should put the type in the enum.")
             }
+
+            // These can be recursed to via Load, so we return the pointer type.
+            Instruction::GetPointer(ptr) => Some(context.pointers[ptr.0].ty),
+            Instruction::PointerCast(_, ty) => Some(*ty),
 
             // These are all terminators which don't return, essentially.  No type.
             Instruction::Branch(_) => None,
             Instruction::ConditionalBranch { .. } => None,
             Instruction::Ret(..) => None,
 
-            // GetPointer returns a pointer type which we don't expose.
-            Instruction::GetPointer(_) => None,
-
             // These write values but don't return one.  If we're explicit we could return Unit.
             Instruction::InsertElement { .. } => None,
             Instruction::InsertValue { .. } => None,
+            Instruction::StateLoad { .. } => None,
+            Instruction::StateStore { .. } => None,
             Instruction::Store { .. } => None,
 
             // No-op is also no-type.
@@ -112,7 +129,7 @@ impl Instruction {
     /// Some [`Instruction`]s may have struct arguments.  Return it if so for this instruction.
     pub fn get_aggregate(&self, context: &Context) -> Option<Aggregate> {
         match self {
-            Instruction::GetPointer(ptr) | Instruction::Load(ptr) => match ptr.get_type(context) {
+            Instruction::GetPointer(ptr) => match ptr.get_type(context) {
                 Type::Array(aggregate) => Some(*aggregate),
                 Type::Struct(aggregate) => Some(*aggregate),
                 _otherwise => None,
@@ -182,7 +199,16 @@ impl Instruction {
             Instruction::Load(_) => (),
             Instruction::Nop => (),
             Instruction::Phi(pairs) => pairs.iter_mut().for_each(|(_, val)| replace(val)),
+            Instruction::PointerCast(..) => (),
             Instruction::Ret(ret_val, _) => replace(ret_val),
+            Instruction::StateLoad { load_val, key } => {
+                replace(load_val);
+                replace(key);
+            }
+            Instruction::StateStore { stored_val, key } => {
+                replace(key);
+                replace(stored_val);
+            }
             Instruction::Store { stored_val, .. } => {
                 replace(stored_val);
             }
@@ -238,7 +264,9 @@ impl<'a> InstructionInserter<'a> {
     }
 
     //
-    // XXX maybe these should return result, in case they get bad args?
+    // XXX Maybe these should return result, in case they get bad args?
+    //
+    // XXX Also, these are all the same and could probably be created with a local macro.
     //
 
     /// Append a new [`Instruction::AsmBlock`] from `args` and a `body`.
@@ -428,8 +456,9 @@ impl<'a> InstructionInserter<'a> {
         insert_val
     }
 
-    pub fn load(self, ptr: Pointer, span_md_idx: Option<MetadataIndex>) -> Value {
-        let load_val = Value::new_instruction(self.context, Instruction::Load(ptr), span_md_idx);
+    pub fn load(self, src_val: Value, span_md_idx: Option<MetadataIndex>) -> Value {
+        let load_val =
+            Value::new_instruction(self.context, Instruction::Load(src_val), span_md_idx);
         self.context.blocks[self.block.0]
             .instructions
             .push(load_val);
@@ -442,6 +471,18 @@ impl<'a> InstructionInserter<'a> {
         nop_val
     }
 
+    pub fn ptr_cast(self, ptr_val: Value, ty: Type, span_md_idx: Option<MetadataIndex>) -> Value {
+        let ptr_cast_val = Value::new_instruction(
+            self.context,
+            Instruction::PointerCast(ptr_val, ty),
+            span_md_idx,
+        );
+        self.context.blocks[self.block.0]
+            .instructions
+            .push(ptr_cast_val);
+        ptr_cast_val
+    }
+
     pub fn ret(self, value: Value, ty: Type, span_md_idx: Option<MetadataIndex>) -> Value {
         let ret_val =
             Value::new_instruction(self.context, Instruction::Ret(value, ty), span_md_idx);
@@ -449,15 +490,52 @@ impl<'a> InstructionInserter<'a> {
         ret_val
     }
 
+    pub fn state_load(
+        self,
+        load_val: Value,
+        key: Value,
+        span_md_idx: Option<MetadataIndex>,
+    ) -> Value {
+        let state_load_val = Value::new_instruction(
+            self.context,
+            Instruction::StateLoad { load_val, key },
+            span_md_idx,
+        );
+        self.context.blocks[self.block.0]
+            .instructions
+            .push(state_load_val);
+        state_load_val
+    }
+
+    pub fn state_store(
+        self,
+        stored_val: Value,
+        key: Value,
+        span_md_idx: Option<MetadataIndex>,
+    ) -> Value {
+        let state_store_val = Value::new_instruction(
+            self.context,
+            Instruction::StateStore { stored_val, key },
+            span_md_idx,
+        );
+        self.context.blocks[self.block.0]
+            .instructions
+            .push(state_store_val);
+        state_store_val
+    }
+
     pub fn store(
         self,
-        ptr: Pointer,
+        dst_val: Value,
         stored_val: Value,
         span_md_idx: Option<MetadataIndex>,
     ) -> Value {
         let store_val = Value::new_instruction(
             self.context,
-            Instruction::Store { ptr, stored_val },
+            Instruction::Store {
+                dst_val,
+                stored_val,
+            },
             span_md_idx,
         );
         self.context.blocks[self.block.0]

--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -284,18 +284,38 @@ fn inline_instruction(
                 indices,
                 span_md_idx,
             ),
-            Instruction::Load(ptr) => new_block.ins(context).load(map_ptr(ptr), span_md_idx),
+            Instruction::Load(src_val) => {
+                new_block.ins(context).load(map_value(src_val), span_md_idx)
+            }
             Instruction::Nop => new_block.ins(context).nop(),
+            Instruction::PointerCast(ptr_val, ty) => {
+                new_block
+                    .ins(context)
+                    .ptr_cast(map_value(ptr_val), ty, span_md_idx)
+            }
             // We convert `ret` to `br post_block` and add the returned value as a phi value.
             Instruction::Ret(val, _) => {
                 new_block
                     .ins(context)
                     .branch(*post_block, Some(map_value(val)), span_md_idx)
             }
-            Instruction::Store { ptr, stored_val } => {
+            Instruction::StateLoad { load_val, key } => {
                 new_block
                     .ins(context)
-                    .store(map_ptr(ptr), map_value(stored_val), span_md_idx)
+                    .state_load(map_value(load_val), map_value(key), span_md_idx)
+            }
+            Instruction::StateStore { stored_val, key } => new_block.ins(context).state_store(
+                map_value(stored_val),
+                map_value(key),
+                span_md_idx,
+            ),
+            Instruction::Store {
+                dst_val,
+                stored_val,
+            } => {
+                new_block
+                    .ins(context)
+                    .store(map_value(dst_val), map_value(stored_val), span_md_idx)
             }
 
             // NOTE: We're not translating the phi value yet, since this is the single instance of

--- a/sway-ir/src/pointer.rs
+++ b/sway-ir/src/pointer.rs
@@ -39,7 +39,10 @@ impl Pointer {
     }
 
     /// Return whether this pointer is to a [`Type::Struct`] in particular.
-    pub fn is_struct_ptr(&self, context: &Context) -> bool {
-        matches!(&context.pointers[self.0].ty, Type::Struct(_))
+    pub fn is_aggregate_ptr(&self, context: &Context) -> bool {
+        matches!(
+            &context.pointers[self.0].ty,
+            Type::Array(_) | Type::Struct(_) | Type::Union(_)
+        )
     }
 }

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -111,8 +111,18 @@ impl Context {
                 Instruction::Load(ptr) => self.verify_load(ptr)?,
                 Instruction::Nop => (),
                 Instruction::Phi(pairs) => self.verify_phi(&pairs[..])?,
+                Instruction::PointerCast(ptr_val, ty) => self.verify_ptr_cast(ptr_val, ty)?,
                 Instruction::Ret(val, ty) => self.verify_ret(function, val, ty)?,
-                Instruction::Store { ptr, stored_val } => self.verify_store(ptr, stored_val)?,
+                Instruction::StateLoad { load_val, key } => {
+                    self.verify_state_load(load_val, key)?
+                }
+                Instruction::StateStore { stored_val, key } => {
+                    self.verify_state_store(stored_val, key)?
+                }
+                Instruction::Store {
+                    dst_val,
+                    stored_val,
+                } => self.verify_store(dst_val, stored_val)?,
             }
         } else {
             unreachable!("Verify instruction is not an instruction.");
@@ -195,7 +205,8 @@ impl Context {
         Ok(())
     }
 
-    fn verify_load(&self, _ptr: &Pointer) -> Result<(), IrError> {
+    fn verify_load(&self, _src_val: &Value) -> Result<(), IrError> {
+        // XXX src_val must be a pointer.
         // XXX We should check the pointer type matches this load type.
         Ok(())
     }
@@ -209,6 +220,12 @@ impl Context {
         } else {
             Ok(())
         }
+    }
+
+    fn verify_ptr_cast(&self, _ptr_val: &Value, _ty: &Type) -> Result<(), IrError> {
+        // XXX Make sure the pointer itself doesn't change, just the type, and is definitely either
+        // a get_ptr or ptr_cast.
+        Ok(())
     }
 
     fn verify_ret(
@@ -228,8 +245,20 @@ impl Context {
         }
     }
 
-    fn verify_store(&self, _ptr: &Pointer, _stored_val: &Value) -> Result<(), IrError> {
+    fn verify_state_load(&self, _load_val: &Value, _key: &Value) -> Result<(), IrError> {
+        // XXX key must be a pointer to B256, load_val ty must by pointer to either Uint(64) or B256.
+        Ok(())
+    }
+
+    fn verify_state_store(&self, _stored_val: &Value, _key: &Value) -> Result<(), IrError> {
+        // XXX key must be a pointer to B256, stored val ty must be pointer to either Uint(64) or B256.
+        Ok(())
+    }
+
+    fn verify_store(&self, _dst_val: &Value, _stored_val: &Value) -> Result<(), IrError> {
         // XXX When we have some type info available from instructions...
+        // XXX dst must be a pointer.
+        // XXX Pointer destinations must be mutable.
         //if ptr_val.get_type(self) != stored_val.get_type(self) {
         //    Err("Stored value type must match pointer type.".into())
         //} else {

--- a/sway-ir/tests/ir_to_ir/constants_insert_value.in_ir
+++ b/sway-ir/tests/ir_to_ir/constants_insert_value.in_ir
@@ -36,10 +36,11 @@ script {
         v6 = const b256 0x0102030405060708010203040506070801020304050607080102030405060708
         v7 = insert_value v5, { b256, { bool, u64 } }, v6, 0
         v8 = insert_value v7, { b256, { bool, u64 } }, v4, 1
-        store v8, ptr { b256, { bool, u64 } } record
         v9 = get_ptr ptr { b256, { bool, u64 } } record
-        v10 = extract_value v9, { b256, { bool, u64 } }, 1
-        v11 = extract_value v10, { bool, u64 }, 1
-        ret u64 v11
+        store v8, ptr v9
+        v10 = get_ptr ptr { b256, { bool, u64 } } record
+        v11 = extract_value v10, { b256, { bool, u64 } }, 1
+        v12 = extract_value v11, { bool, u64 }, 1
+        ret u64 v12
     }
 }

--- a/sway-ir/tests/ir_to_ir/constants_insert_value.out_ir
+++ b/sway-ir/tests/ir_to_ir/constants_insert_value.out_ir
@@ -3,11 +3,12 @@ script {
         local ptr { b256, { bool, u64 } } record
 
         entry:
-        v0 = const { b256, { bool, u64 } } { b256 0x0102030405060708010203040506070801020304050607080102030405060708, { bool, u64 } { bool true, u64 76 } }
-        store v0, ptr { b256, { bool, u64 } } record
-        v1 = get_ptr ptr { b256, { bool, u64 } } record
-        v2 = extract_value v1, { b256, { bool, u64 } }, 1
-        v3 = extract_value v2, { bool, u64 }, 1
-        ret u64 v3
+        v0 = get_ptr ptr { b256, { bool, u64 } } record
+        v1 = const { b256, { bool, u64 } } { b256 0x0102030405060708010203040506070801020304050607080102030405060708, { bool, u64 } { bool true, u64 76 } }
+        store v1, ptr v0
+        v2 = get_ptr ptr { b256, { bool, u64 } } record
+        v3 = extract_value v2, { b256, { bool, u64 } }, 1
+        v4 = extract_value v3, { bool, u64 }, 1
+        ret u64 v4
     }
 }

--- a/sway-ir/tests/ir_to_ir/constants_storage.in_ir
+++ b/sway-ir/tests/ir_to_ir/constants_storage.in_ir
@@ -1,0 +1,23 @@
+script {
+    fn main() -> () {
+        local ptr b256 key
+        local mut ptr { u64, u64 } pair
+        local mut ptr u64 stored_number
+
+        entry:
+        v0 = get_ptr ptr b256 key
+        v1 = const b256 0x1111111111111111111111111111111111111111111111111111111111111111
+        store v1, ptr v0
+        v2 = get_ptr mut ptr u64 stored_number
+        state_load ptr v2, key v0
+        v3 = const { u64, u64 } { u64 undef, u64 undef }
+        v4 = insert_value v3, { u64, u64 }, v2, 0
+        v5 = insert_value v4, { u64, u64 }, v2, 1
+        v6 = get_ptr mut ptr { u64, u64 } pair
+        store v5, ptr v6
+        v7 = ptr_cast ptr v6 to ptr b256
+        state_store ptr v7, key v0
+        v8 = const unit ()
+        ret () v8
+    }
+}

--- a/sway-ir/tests/ir_to_ir/constants_storage.out_ir
+++ b/sway-ir/tests/ir_to_ir/constants_storage.out_ir
@@ -1,0 +1,23 @@
+script {
+    fn main() -> () {
+        local ptr b256 key
+        local mut ptr { u64, u64 } pair
+        local mut ptr u64 stored_number
+
+        entry:
+        v0 = get_ptr ptr b256 key
+        v1 = const b256 0x1111111111111111111111111111111111111111111111111111111111111111
+        store v1, ptr v0
+        v2 = get_ptr mut ptr u64 stored_number
+        state_load ptr v2, key v0
+        v3 = const { u64, u64 } { u64 undef, u64 undef }
+        v4 = insert_value v3, { u64, u64 }, v2, 0
+        v5 = insert_value v4, { u64, u64 }, v2, 1
+        v6 = get_ptr mut ptr { u64, u64 } pair
+        store v5, ptr v6
+        v7 = ptr_cast ptr v6 to ptr b256
+        state_store ptr v7, key v0
+        v8 = const unit ()
+        ret () v8
+    }
+}

--- a/sway-ir/tests/ir_to_ir/inline_bigger.in_ir
+++ b/sway-ir/tests/ir_to_ir/inline_bigger.in_ir
@@ -22,33 +22,38 @@ script {
         local ptr u64 x
 
         entry:
-        v0 = const u64 10
-        store v0, ptr u64 x
+        v0 = get_ptr ptr u64 x
+        v1 = const u64 10
+        store v1, ptr v0
         cbr b, block0, block1
 
         block0:
-        v1 = load ptr u64 x
+        v2 = get_ptr ptr u64 x
+        v3 = load ptr v2
         br block2
 
         block1:
-        v2 = const u64 1
+        v4 = const u64 1
         br block2
 
         block2:
-        v3 = phi(block0: v1, block1: v2)
-        ret u64 v3
+        v5 = phi(block0: v3, block1: v4)
+        ret u64 v5
     }
 
     fn main() -> u64 {
-        local ptr u64 x
+        local mut ptr u64 x
 
         entry:
-        v0 = const u64 0
-        store v0, ptr u64 x
-        v1 = const bool true
-        v2 = call a(v1)
-        store v2, ptr u64 x
-        v3 = load ptr u64 x
-        ret u64 v3
+        v0 = get_ptr mut ptr u64 x
+        v1 = const u64 0
+        store v1, ptr v0
+        v2 = const bool true
+        v3 = call a(v2)
+        v4 = get_ptr mut ptr u64 x
+        store v3, ptr v4
+        v5 = get_ptr mut ptr u64 x
+        v6 = load ptr v5
+        ret u64 v6
     }
 }

--- a/sway-ir/tests/ir_to_ir/inline_bigger.out_ir
+++ b/sway-ir/tests/ir_to_ir/inline_bigger.out_ir
@@ -3,51 +3,58 @@ script {
         local ptr u64 x
 
         entry:
-        v0 = const u64 10
-        store v0, ptr u64 x
+        v0 = get_ptr ptr u64 x
+        v1 = const u64 10
+        store v1, ptr v0
         cbr b, block0, block1
 
         block0:
-        v1 = load ptr u64 x
+        v2 = get_ptr ptr u64 x
+        v3 = load ptr v2
         br block2
 
         block1:
-        v2 = const u64 1
+        v4 = const u64 1
         br block2
 
         block2:
-        v3 = phi(block0: v1, block1: v2)
-        ret u64 v3
+        v5 = phi(block0: v3, block1: v4)
+        ret u64 v5
     }
 
     fn main() -> u64 {
-        local ptr u64 x
+        local mut ptr u64 x
         local ptr u64 x0
 
         entry:
-        v0 = const u64 0
-        store v0, ptr u64 x
-        v1 = const u64 10
-        store v1, ptr u64 x0
-        v2 = const bool true
-        cbr v2, a_block0, a_block1
+        v0 = get_ptr mut ptr u64 x
+        v1 = const u64 0
+        store v1, ptr v0
+        v2 = get_ptr ptr u64 x0
+        v3 = const u64 10
+        store v3, ptr v2
+        v4 = const bool true
+        cbr v4, a_block0, a_block1
 
         a_block0:
-        v3 = load ptr u64 x0
+        v5 = get_ptr ptr u64 x0
+        v6 = load ptr v5
         br a_block2
 
         a_block1:
-        v4 = const u64 1
+        v7 = const u64 1
         br a_block2
 
         a_block2:
-        v5 = phi(a_block0: v3, a_block1: v4)
+        v8 = phi(a_block0: v6, a_block1: v7)
         br block0
 
         block0:
-        v6 = phi(a_block2: v5)
-        store v6, ptr u64 x
-        v7 = load ptr u64 x
-        ret u64 v7
+        v9 = phi(a_block2: v8)
+        v10 = get_ptr mut ptr u64 x
+        store v9, ptr v10
+        v11 = get_ptr mut ptr u64 x
+        v12 = load ptr v11
+        ret u64 v12
     }
 }

--- a/sway-ir/tests/tests.rs
+++ b/sway-ir/tests/tests.rs
@@ -50,7 +50,14 @@ fn test_inline(mut path: PathBuf) {
     let expected_bytes = std::fs::read(&path).unwrap();
     let expected = String::from_utf8_lossy(&expected_bytes);
 
-    let mut ir = sway_ir::parser::parse(&input).unwrap();
+    let mut ir = match sway_ir::parser::parse(&input) {
+        Ok(ir) => ir,
+        Err(parse_err) => {
+            println!("{parse_err}");
+            panic!()
+        }
+    };
+
     let main_fn = ir
         .functions
         .iter()
@@ -77,7 +84,13 @@ fn test_constants(mut path: PathBuf) {
     let expected_bytes = std::fs::read(&path).unwrap();
     let expected = String::from_utf8_lossy(&expected_bytes);
 
-    let mut ir = sway_ir::parser::parse(&input).unwrap();
+    let mut ir = match sway_ir::parser::parse(&input) {
+        Ok(ir) => ir,
+        Err(parse_err) => {
+            println!("{parse_err}");
+            panic!()
+        }
+    };
 
     let fn_idcs: Vec<_> = ir.functions.iter().map(|func| func.0).collect();
     for fn_idx in fn_idcs {


### PR DESCRIPTION
This adds the ability implement the storage instructions via IR.  They're not exercised at all yet, other than a little IR test, but not all the way to ASM.  Once #646 is done we can do it then.

Closes #856.  Will probably conflict with #857.

