### PR TITLE
Fix panic on empty contract impl with expected return value

### DIFF
--- a/forc/src/utils/helpers.rs
+++ b/forc/src/utils/helpers.rs
@@ -401,7 +401,7 @@ fn construct_window<'a>(
     let total_lines_in_input = input.chars().filter(|x| *x == '\n').count();
     debug_assert!(end.line >= start.line);
     let total_lines_of_highlight = end.line - start.line;
-    debug_assert!(total_lines_in_input > total_lines_of_highlight);
+    debug_assert!(total_lines_in_input >= total_lines_of_highlight);
 
     let mut current_line = 0;
     let mut lines_to_start_of_snippet = 0;


### PR DESCRIPTION
closes https://github.com/FuelLabs/sway/issues/676

Two things:
* The change in `forc/src/utils/helpers.rs` helps display the internal compiler error that was being created but not displayed: `Attempted to construct return path error...`.
* The change in `sway-core/src/control_flow_analysis/analyze_return_paths.rs` avoids the internal error.  

For this code:
```rust
contract;

abi Foo {
    fn foo(gas_to_forward: u64, coins_to_forward: u64, asset_id_of_coins: b256, storage: ()) -> u64;
}

impl Foo for Contract {
    fn foo(gas_to_forward: u64, coins_to_forward: u64, asset_id_of_coins: b256, storage: ()) -> u64 {

    }
}
```
we now display the error:
```
 7 |   impl Foo for Contract {
 8 |       fn foo(gas_to_forward: u64, coins_to_forward: u64, asset_id_of_coins: b256, storage: ()) -> u64 {
   |  _____^
 9 | | 
10 | |     }
   | |_____^ This path must return a value of type "u64" from function "foo", but it does not.
11 |   }
   |
  Aborting due to 1 error.
```
instead of panicking. 