### PR TITLE
changes format to join in path creation

### DIFF
--- a/forc/src/ops/forc_init.rs
+++ b/forc/src/ops/forc_init.rs
@@ -1,44 +1,45 @@
 use crate::utils::defaults;
 use anyhow::Result;
 use std::fs;
+use std::path::Path;
 use sway_utils::constants;
 
 pub(crate) fn init_new_project(project_name: String) -> Result<()> {
     let neat_name: String = project_name.split('/').last().unwrap().to_string();
 
     // Make a new directory for the project
-    fs::create_dir_all(format!("{}/src", project_name))?;
+    fs::create_dir_all(Path::new(&project_name).join("src"))?;
 
     // Make directory for tests
-    fs::create_dir_all(format!("{}/tests", project_name))?;
+    fs::create_dir_all(Path::new(&project_name).join("tests"))?;
 
     // Insert default manifest file
     fs::write(
-        format!("{}/{}", project_name, constants::MANIFEST_FILE_NAME),
+        Path::new(&project_name).join(constants::MANIFEST_FILE_NAME),
         defaults::default_manifest(&neat_name),
     )?;
 
     // Insert default test manifest file
     fs::write(
-        format!("{}/{}", project_name, constants::TEST_MANIFEST_FILE_NAME),
+        Path::new(&project_name).join(constants::TEST_MANIFEST_FILE_NAME),
         defaults::default_tests_manifest(&neat_name),
     )?;
 
     // Insert default main function
     fs::write(
-        format!("{}/src/main.sw", project_name),
+        Path::new(&project_name).join("src").join("main.sw"),
         defaults::default_program(),
     )?;
 
     // Insert default test function
     fs::write(
-        format!("{}/tests/harness.rs", project_name),
+        Path::new(&project_name).join("tests").join("harness.rs"),
         defaults::default_test_program(),
     )?;
 
     // Ignore default `out` and `target` directories created by forc and cargo.
     fs::write(
-        format!("{}/.gitignore", project_name),
+        Path::new(&project_name).join(".gitignore"),
         defaults::default_gitignore(),
     )?;
 


### PR DESCRIPTION
closes #872

`format!` uses the `/` path dividers as they're written which can be a problem on Windows where the path dividers are `\`. When we use `Path::join` it should insert either `/` or `\` depending on whether the path is evaluated on Unix or Windows respectively.