### PR TITLE
prints a warning for unused manifest keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,7 @@ dependencies = [
  "petgraph",
  "semver 1.0.4",
  "serde",
+ "serde_ignored",
  "sway-core",
  "sway-types",
  "sway-utils",
@@ -2784,6 +2785,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2c7d39d14f2f2ea82239de71594782f186fd03501ac81f0ce08e674819ff2f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -15,6 +15,7 @@ git2 = "0.14"
 petgraph = { version = "0.6", features = ["serde-1"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_ignored = "0.1.2"
 sway-core = { version = "0.6.0", path = "../sway-core" }
 sway-types = { version = "0.6.0", path = "../sway-types" }
 sway-utils = { version = "0.6.0", path = "../sway-utils" }


### PR DESCRIPTION
closes #694 

Adds a function that takes in `manifest` as a `String`, uses `toml::de::Deserializer` to create a new deserializer which will be deserializing the string provided, which can then be passed to `serde_ignored` to find out which `keys` are being ignored.