### PR TITLE
Migrate from using lspower to tower-lsp

### DIFF
--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -10,7 +10,7 @@ description = "LSP server for Sway."
 
 [dependencies]
 dashmap = "4.0.2"
-lspower = "1.0.0"
+tower-lsp = "0.16.0"
 ropey = "1.2"
 serde_json = "1.0.60"
 sway-core = { version = "0.6.1", path = "../sway-core" }

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -1,6 +1,8 @@
 use crate::core::{session::Session, token::Token, token_type::TokenType};
-use lspower::lsp::{CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse};
 use std::sync::Arc;
+use tower_lsp::lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse,
+};
 
 pub fn get_completion(
     session: Arc<Session>,

--- a/sway-lsp/src/capabilities/diagnostic.rs
+++ b/sway-lsp/src/capabilities/diagnostic.rs
@@ -1,5 +1,4 @@
-use lsp::{Diagnostic, DiagnosticSeverity, Position, Range};
-use lspower::lsp::{self};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 
 use sway_core::{CompileError, CompileWarning};
 

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -1,6 +1,6 @@
 use crate::core::{session::Session, token::Token, token_type::TokenType};
-use lspower::lsp::{DocumentSymbolResponse, Location, SymbolInformation, SymbolKind, Url};
 use std::sync::Arc;
+use tower_lsp::lsp_types::{DocumentSymbolResponse, Location, SymbolInformation, SymbolKind, Url};
 
 pub fn document_symbol(session: Arc<Session>, url: Url) -> Option<DocumentSymbolResponse> {
     session

--- a/sway-lsp/src/capabilities/file_sync.rs
+++ b/sway-lsp/src/capabilities/file_sync.rs
@@ -1,6 +1,6 @@
 use crate::core::session::Session;
-use lspower::lsp::{FileChangeType, FileEvent};
 use std::sync::Arc;
+use tower_lsp::lsp_types::{FileChangeType, FileEvent};
 
 pub fn handle_watched_files(session: Arc<Session>, events: Vec<FileEvent>) {
     for event in events {

--- a/sway-lsp/src/capabilities/formatting.rs
+++ b/sway-lsp/src/capabilities/formatting.rs
@@ -1,7 +1,9 @@
 use crate::core::session::Session;
-use lspower::lsp::{DocumentFormattingParams, Position, Range, TextDocumentIdentifier, TextEdit};
 use std::sync::Arc;
 use sway_fmt::{get_formatted_data, FormattingOptions};
+use tower_lsp::lsp_types::{
+    DocumentFormattingParams, Position, Range, TextDocumentIdentifier, TextEdit,
+};
 
 pub fn format_document(
     session: Arc<Session>,

--- a/sway-lsp/src/capabilities/go_to.rs
+++ b/sway-lsp/src/capabilities/go_to.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::core::{session::Session, token::Token};
-use lspower::lsp::{GotoDefinitionParams, GotoDefinitionResponse, Location, Url};
+use tower_lsp::lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location, Url};
 
 pub fn go_to_definition(
     session: Arc<Session>,

--- a/sway-lsp/src/capabilities/highlight.rs
+++ b/sway-lsp/src/capabilities/highlight.rs
@@ -1,6 +1,6 @@
 use crate::core::session::Session;
-use lspower::lsp::{DocumentHighlight, DocumentHighlightParams};
 use std::sync::Arc;
+use tower_lsp::lsp_types::{DocumentHighlight, DocumentHighlightParams};
 
 pub fn get_highlights(
     session: Arc<Session>,

--- a/sway-lsp/src/capabilities/hover.rs
+++ b/sway-lsp/src/capabilities/hover.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     utils::common::extract_visibility,
 };
-use lspower::lsp::{Hover, HoverContents, HoverParams, MarkupContent, MarkupKind};
 use std::sync::Arc;
+use tower_lsp::lsp_types::{Hover, HoverContents, HoverParams, MarkupContent, MarkupKind};
 
 pub fn get_hover_data(session: Arc<Session>, params: HoverParams) -> Option<Hover> {
     let position = params.text_document_position_params.position;

--- a/sway-lsp/src/capabilities/rename.rs
+++ b/sway-lsp/src/capabilities/rename.rs
@@ -1,13 +1,15 @@
 use std::{collections::HashMap, sync::Arc};
 
-use lspower::lsp::{self, WorkspaceEdit};
+use tower_lsp::lsp_types::{
+    PrepareRenameResponse, RenameParams, TextDocumentPositionParams, TextEdit, WorkspaceEdit,
+};
 
 use crate::{
     core::{session::Session, token::Token, token_type::TokenType},
     utils::lsp_helpers::make_range_end_inclusive,
 };
 
-pub fn rename(session: Arc<Session>, params: lsp::RenameParams) -> Option<lsp::WorkspaceEdit> {
+pub fn rename(session: Arc<Session>, params: RenameParams) -> Option<WorkspaceEdit> {
     let new_name = params.new_name;
     let url = params.text_document_position.text_document.uri;
     let position = params.text_document_position.position;
@@ -35,8 +37,8 @@ pub fn rename(session: Arc<Session>, params: lsp::RenameParams) -> Option<lsp::W
 
 pub fn prepare_rename(
     session: Arc<Session>,
-    params: lsp::TextDocumentPositionParams,
-) -> Option<lsp::PrepareRenameResponse> {
+    params: TextDocumentPositionParams,
+) -> Option<PrepareRenameResponse> {
     let url = params.text_document.uri;
 
     match session.documents.get(url.path()) {
@@ -44,7 +46,7 @@ pub fn prepare_rename(
             if let Some(token) = document.get_token_at_position(params.position) {
                 match token.token_type {
                     TokenType::Library | TokenType::Reassignment => None,
-                    _ => Some(lsp::PrepareRenameResponse::RangeWithPlaceholder {
+                    _ => Some(PrepareRenameResponse::RangeWithPlaceholder {
                         range: token.range,
                         placeholder: token.name.clone(),
                     }),
@@ -57,9 +59,9 @@ pub fn prepare_rename(
     }
 }
 
-fn prepare_token_rename(tokens: &[&Token], new_name: String) -> Vec<lsp::TextEdit> {
+fn prepare_token_rename(tokens: &[&Token], new_name: String) -> Vec<TextEdit> {
     tokens
         .iter()
-        .map(|token| lsp::TextEdit::new(make_range_end_inclusive(token.range), new_name.clone()))
+        .map(|token| TextEdit::new(make_range_end_inclusive(token.range), new_name.clone()))
         .collect()
 }

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -1,10 +1,10 @@
 use crate::core::{session::Session, token::Token, token_type::TokenType};
-use lspower::lsp::{
+use std::sync::Arc;
+use tower_lsp::lsp_types::{
     SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
     SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams,
     SemanticTokensResult, SemanticTokensServerCapabilities,
 };
-use std::sync::Arc;
 
 // https://github.com/microsoft/vscode-extension-samples/blob/5ae1f7787122812dcc84e37427ca90af5ee09f14/semantic-tokens-sample/vscode.proposed.d.ts#L71
 pub fn get_semantic_tokens_full(

--- a/sway-lsp/src/capabilities/text_sync.rs
+++ b/sway-lsp/src/capabilities/text_sync.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use lspower::lsp::{
+use tower_lsp::lsp_types::{
     Diagnostic, DidChangeTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
 };
 

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -1,11 +1,11 @@
 use super::token::Token;
 use super::token_type::TokenType;
 use crate::{capabilities, core::token::traverse_node};
-use lspower::lsp::{Diagnostic, Position, Range, TextDocumentContentChangeEvent};
 use ropey::Rope;
 use std::collections::HashMap;
 use std::sync::Arc;
 use sway_core::{parse, TreeType};
+use tower_lsp::lsp_types::{Diagnostic, Position, Range, TextDocumentContentChangeEvent};
 
 #[derive(Debug)]
 pub struct TextDocument {

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -4,12 +4,12 @@ use crate::{
     sway_config::SwayConfig,
 };
 use dashmap::DashMap;
-use lspower::lsp::{
+use serde_json::Value;
+use std::sync::{Arc, LockResult, RwLock};
+use tower_lsp::lsp_types::{
     CompletionItem, Diagnostic, GotoDefinitionResponse, Position, Range, SemanticToken,
     SymbolInformation, TextDocumentContentChangeEvent, TextEdit, Url,
 };
-use serde_json::Value;
-use std::sync::{Arc, LockResult, RwLock};
 
 pub type Documents = DashMap<String, TextDocument>;
 

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -3,9 +3,9 @@ use crate::{
     core::token_type::{get_function_details, get_struct_details},
     utils::common::extract_var_body,
 };
-use lspower::lsp::{Position, Range};
 use sway_core::{AstNode, AstNodeContent, Declaration, Expression, VariableDeclaration};
 use sway_types::{ident::Ident, span::Span};
+use tower_lsp::lsp_types::{Position, Range};
 
 #[derive(Debug, Clone)]
 pub struct Token {

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -1,4 +1,4 @@
-use lspower::{LspService, Server};
+use tower_lsp::{LspService, Server};
 
 mod capabilities;
 mod core;
@@ -11,9 +11,6 @@ pub async fn start() {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let (service, messages) = LspService::new(Backend::new);
-    Server::new(stdin, stdout)
-        .interleave(messages)
-        .serve(service)
-        .await;
+    let (service, socket) = LspService::new(Backend::new);
+    Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/sway-lsp/src/utils/lsp_helpers.rs
+++ b/sway-lsp/src/utils/lsp_helpers.rs
@@ -1,4 +1,4 @@
-use lspower::lsp::{Position, Range};
+use tower_lsp::lsp_types::{Position, Range};
 
 pub(crate) fn make_range_end_inclusive(range: Range) -> Range {
     Range {


### PR DESCRIPTION
`lspower` has recently been deprecated. It was originally a fork of `tower-lsp` which now has active development again. The main author of `lspower` has now joined in on the `tower-lsp` crate and all work will be done there from now on. See[ this issue](https://github.com/ebkalderon/tower-lsp/issues/308) for more context. 
