### PR TITLE
Update default Forc manifest

### DIFF
--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -11,8 +11,7 @@ license = "Apache-2.0"
 name = "{project_name}"
 
 [dependencies]
-core = {{ git = "http://github.com/FuelLabs/sway-lib-core" }}
-std = {{ git = "http://github.com/FuelLabs/sway-lib-std" }}
+std = {{ git = "https://github.com/FuelLabs/sway-lib-std" }}
 "#
     )
 }


### PR DESCRIPTION
1. Remove `core` as a dependency since 100% (rounded) of users will not use `core` directly.
1. Use `https` instead of `http`.