### PR TITLE
Some fixes to contract calls in both codegens

### DIFF
--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -463,6 +463,7 @@ impl<'ir> AsmBuilder<'ir> {
                     coins,
                     asset_id,
                     gas,
+                    ..
                 } => self.compile_contract_call(instr_val, params, coins, asset_id, gas),
                 Instruction::ExtractElement {
                     array,
@@ -1334,7 +1335,7 @@ impl<'ir> AsmBuilder<'ir> {
     fn compile_read_register(&mut self, instr_val: &Value, reg: &sway_ir::Register) {
         let instr_reg = self.reg_seqr.next();
         self.bytecode.push(Op {
-            opcode: Either::Left(VirtualOp::LW(
+            opcode: Either::Left(VirtualOp::MOVE(
                 instr_reg.clone(),
                 VirtualRegister::Constant(match reg {
                     sway_ir::Register::Of => ConstantRegister::Overflow,
@@ -1352,9 +1353,8 @@ impl<'ir> AsmBuilder<'ir> {
                     sway_ir::Register::Retl => ConstantRegister::ReturnLength,
                     sway_ir::Register::Flag => ConstantRegister::Flags,
                 }),
-                VirtualImmediate12 { value: 0 },
             )),
-            comment: "loading register into abi function".to_owned(),
+            comment: "move register into abi function".to_owned(),
             owning_span: instr_val.get_span(self.context),
         });
 

--- a/sway-core/src/asm_generation/mod.rs
+++ b/sway-core/src/asm_generation/mod.rs
@@ -1385,12 +1385,11 @@ fn load_bundled_arguments(return_register: VirtualRegister) -> Op {
 /// Given a register, load the current value of $cgas into it
 fn load_gas(return_register: VirtualRegister) -> Op {
     Op {
-        opcode: Either::Left(VirtualOp::LW(
+        opcode: Either::Left(VirtualOp::MOVE(
             return_register,
             VirtualRegister::Constant(ConstantRegister::ContextGas),
-            VirtualImmediate12::new_unchecked(0, "infallible constant 0"),
         )),
-        comment: "loading $cgas (gas) into abi function".into(),
+        comment: "move $cgas (gas) into abi function".into(),
         owning_span: None,
     }
 }

--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -533,6 +533,7 @@ impl FnCompiler {
                         context,
                         name.suffix.as_str(),
                         arguments,
+                        ast_expr.return_type,
                         span_md_idx,
                     )
                 } else {
@@ -741,6 +742,7 @@ impl FnCompiler {
         context: &mut Context,
         ast_name: &str,
         ast_args: Vec<(Ident, TypedExpression)>,
+        return_type: TypeId,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, String> {
         // Compile each user argument
@@ -877,8 +879,12 @@ impl FnCompiler {
                 .read_register(sway_ir::Register::Cgas, span_md_idx),
         };
 
+        let return_type = convert_resolved_typeid_no_span(context, &return_type)?;
+
         // Insert the contract_call instruction
         Ok(self.current_block.ins(context).contract_call(
+            return_type,
+            ast_name.to_string(),
             ra_struct_val,
             coins,
             asset_id,

--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -735,6 +735,7 @@ impl FnCompiler {
 
     // ---------------------------------------------------------------------------------------------
 
+    #[allow(clippy::too_many_arguments)]
     fn compile_contract_call(
         &mut self,
         metadata: &ContractCallMetadata,

--- a/sway-core/tests/ir_to_asm/simple_contract_call.asm
+++ b/sway-core/tests/ir_to_asm/simple_contract_call.asm
@@ -6,7 +6,7 @@ DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
 move $r4 $sp                  ; save locals base register
-cfei i80                      ; allocate 80 bytes for all locals
+cfei i152                     ; allocate 152 bytes for all locals
 addi $r1 $r4 i72              ; get_ptr
 lw   $r0 data_0               ; literal instantiation
 sw   $r1 $r0 i0               ; insert_value @ 0
@@ -19,10 +19,10 @@ lw   $r0 data_2               ; literal instantiation
 sw   $r2 $r0 i4               ; insert_value @ 1
 addi $r0 $r4 i72              ; get_ptr
 sw   $r2 $r0 i5               ; insert_value @ 2
-lw   $r1 data_3               ; literal instantiation
-lw   $r0 data_4               ; literal instantiation
-lw   $r3 data_5               ; literal instantiation
-call $r2 $r1 $r0 $r3          ; call external contract
+lw   $r0 data_3               ; literal instantiation
+lw   $r3 data_4               ; literal instantiation
+lw   $r1 data_5               ; literal instantiation
+call $r2 $r0 $r3 $r1          ; call external contract
 move $r0 $ret
 addi $r0 $r4 i0               ; get_ptr
 lw   $r1 data_6               ; literal instantiation
@@ -41,7 +41,10 @@ lw   $r2 data_3               ; literal instantiation
 lw   $r1 data_4               ; literal instantiation
 lw   $r0 data_8               ; literal instantiation
 call $r3 $r2 $r1 $r0          ; call external contract
-move $r0 $ret
+move $r1 $ret
+addi $r0 $r4 i80              ; get_ptr
+addi $r0 $r4 i80              ; get store offset
+mcpi $r0 $r1 i32              ; store value
 addi $r2 $r4 i32              ; get_ptr
 lw   $r0 data_9               ; literal instantiation
 sw   $r2 $r0 i0               ; insert_value @ 0
@@ -57,11 +60,14 @@ lw   $r0 data_11              ; literal instantiation
 sw   $r3 $r0 i4               ; insert_value @ 1
 addi $r0 $r4 i32              ; get_ptr
 sw   $r3 $r0 i5               ; insert_value @ 2
-lw   $r2 $cgas i0             ; loading register into abi function
+move $r2 $cgas                ; move register into abi function
 lw   $r1 data_3               ; literal instantiation
 lw   $r0 data_4               ; literal instantiation
 call $r3 $r1 $r0 $r2          ; call external contract
-move $r0 $ret
+move $r1 $ret
+addi $r0 $r4 i112             ; get_ptr
+addi $r0 $r4 i112             ; get store offset
+mcpi $r0 $r1 i40              ; store value
 lw   $r0 data_3               ; literal instantiation
 ret  $r0
 .data:

--- a/sway-core/tests/ir_to_asm/simple_contract_call.ir
+++ b/sway-core/tests/ir_to_asm/simple_contract_call.ir
@@ -1,8 +1,11 @@
 script {
     fn main() -> u64 {
+        local ptr u64 a
         local mut ptr { b256 } args_struct_for_get_b256
         local mut ptr { u64, b256 } args_struct_for_get_s
         local mut ptr { u64 } args_struct_for_get_u64
+        local ptr b256 b
+        local ptr { u64, b256 } s
 
         entry:
         v0 = get_ptr mut ptr { u64 } args_struct_for_get_u64, ptr { u64 }, 0
@@ -18,38 +21,44 @@ script {
         v10 = const u64 0
         v11 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
         v12 = const u64 10000
-        v13 = contract_call v9, v10, v11, v12
-        v14 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr { b256 }, 0
-        v15 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333
-        v16 = insert_value v14, { b256 }, v15, 0
-        v17 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
-        v18 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
-        v19 = insert_value v17, { b256, u64, u64 }, v18, 0
-        v20 = const u64 1108491158
-        v21 = insert_value v19, { b256, u64, u64 }, v20, 1
-        v22 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr u64, 0
-        v23 = insert_value v21, { b256, u64, u64 }, v22, 2
-        v24 = const u64 0
-        v25 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
-        v26 = const u64 20000
-        v27 = contract_call v23, v24, v25, v26
-        v28 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0
-        v29 = const u64 5555
-        v30 = insert_value v28, { u64, b256 }, v29, 0
-        v31 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555
-        v32 = insert_value v30, { u64, b256 }, v31, 1
-        v33 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
-        v34 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
-        v35 = insert_value v33, { b256, u64, u64 }, v34, 0
-        v36 = const u64 4234334249
-        v37 = insert_value v35, { b256, u64, u64 }, v36, 1
-        v38 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0
-        v39 = insert_value v37, { b256, u64, u64 }, v38, 2
-        v40 = read_register cgas
-        v41 = const u64 0
-        v42 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
-        v43 = contract_call v39, v41, v42, v40
-        v44 = const u64 0
-        ret u64 v44
+        v13 = contract_call u64 get_u64 v9, v10, v11, v12
+        v14 = get_ptr ptr u64 a, ptr u64, 0
+        store v13, ptr v14
+        v15 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr { b256 }, 0
+        v16 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333
+        v17 = insert_value v15, { b256 }, v16, 0
+        v18 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
+        v19 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
+        v20 = insert_value v18, { b256, u64, u64 }, v19, 0
+        v21 = const u64 1108491158
+        v22 = insert_value v20, { b256, u64, u64 }, v21, 1
+        v23 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr u64, 0
+        v24 = insert_value v22, { b256, u64, u64 }, v23, 2
+        v25 = const u64 0
+        v26 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
+        v27 = const u64 20000
+        v28 = contract_call b256 get_b256 v24, v25, v26, v27
+        v29 = get_ptr ptr b256 b, ptr b256, 0
+        store v28, ptr v29
+        v30 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0
+        v31 = const u64 5555
+        v32 = insert_value v30, { u64, b256 }, v31, 0
+        v33 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555
+        v34 = insert_value v32, { u64, b256 }, v33, 1
+        v35 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
+        v36 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
+        v37 = insert_value v35, { b256, u64, u64 }, v36, 0
+        v38 = const u64 4234334249
+        v39 = insert_value v37, { b256, u64, u64 }, v38, 1
+        v40 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0
+        v41 = insert_value v39, { b256, u64, u64 }, v40, 2
+        v42 = read_register cgas
+        v43 = const u64 0
+        v44 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
+        v45 = contract_call { u64, b256 } get_s v41, v43, v44, v42
+        v46 = get_ptr ptr { u64, b256 } s, ptr { u64, b256 }, 0
+        store v45, ptr v46
+        v47 = const u64 0
+        ret u64 v47
     }
 }

--- a/sway-core/tests/sway_to_ir/simple_contract_call.ir
+++ b/sway-core/tests/sway_to_ir/simple_contract_call.ir
@@ -1,8 +1,11 @@
 script {
     fn main() -> u64 {
+        local ptr u64 a
         local mut ptr { b256 } args_struct_for_get_b256
         local mut ptr { u64, b256 } args_struct_for_get_s
         local mut ptr { u64 } args_struct_for_get_u64
+        local ptr b256 b
+        local ptr { u64, b256 } s
 
         entry:
         v0 = get_ptr mut ptr { u64 } args_struct_for_get_u64, ptr { u64 }, 0, !1
@@ -18,59 +21,68 @@ script {
         v10 = const u64 0, !4
         v11 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !5
         v12 = const u64 10000, !6
-        v13 = contract_call v9, v10, v11, v12, !1
-        v14 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr { b256 }, 0, !7
-        v15 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333, !8
-        v16 = insert_value v14, { b256 }, v15, 0, !7
-        v17 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !7
-        v18 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !9
-        v19 = insert_value v17, { b256, u64, u64 }, v18, 0, !7
-        v20 = const u64 1108491158, !7
-        v21 = insert_value v19, { b256, u64, u64 }, v20, 1, !7
-        v22 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr u64, 0, !7
-        v23 = insert_value v21, { b256, u64, u64 }, v22, 2, !7
-        v24 = const u64 0, !10
-        v25 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !11
-        v26 = const u64 20000, !12
-        v27 = contract_call v23, v24, v25, v26, !7
-        v28 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0, !13
-        v29 = const u64 5555, !14
-        v30 = insert_value v28, { u64, b256 }, v29, 0, !13
-        v31 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555, !15
-        v32 = insert_value v30, { u64, b256 }, v31, 1, !13
-        v33 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !13
-        v34 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !16
-        v35 = insert_value v33, { b256, u64, u64 }, v34, 0, !13
-        v36 = const u64 4234334249, !13
-        v37 = insert_value v35, { b256, u64, u64 }, v36, 1, !13
-        v38 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0, !13
-        v39 = insert_value v37, { b256, u64, u64 }, v38, 2, !13
-        v40 = read_register cgas, !13
-        v41 = const u64 0, !17
-        v42 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !18
-        v43 = contract_call v39, v41, v42, v40, !13
-        v44 = const u64 0, !19
-        ret u64 v44
+        v13 = contract_call u64 get_u64 v9, v10, v11, v12, !1
+        v14 = get_ptr ptr u64 a, ptr u64, 0, !7
+        store v13, ptr v14, !7
+        v15 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr { b256 }, 0, !8
+        v16 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333, !9
+        v17 = insert_value v15, { b256 }, v16, 0, !8
+        v18 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !8
+        v19 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !10
+        v20 = insert_value v18, { b256, u64, u64 }, v19, 0, !8
+        v21 = const u64 1108491158, !8
+        v22 = insert_value v20, { b256, u64, u64 }, v21, 1, !8
+        v23 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr u64, 0, !8
+        v24 = insert_value v22, { b256, u64, u64 }, v23, 2, !8
+        v25 = const u64 0, !11
+        v26 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !12
+        v27 = const u64 20000, !13
+        v28 = contract_call b256 get_b256 v24, v25, v26, v27, !8
+        v29 = get_ptr ptr b256 b, ptr b256, 0, !14
+        store v28, ptr v29, !14
+        v30 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0, !15
+        v31 = const u64 5555, !16
+        v32 = insert_value v30, { u64, b256 }, v31, 0, !15
+        v33 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555, !17
+        v34 = insert_value v32, { u64, b256 }, v33, 1, !15
+        v35 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !15
+        v36 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !18
+        v37 = insert_value v35, { b256, u64, u64 }, v36, 0, !15
+        v38 = const u64 4234334249, !15
+        v39 = insert_value v37, { b256, u64, u64 }, v38, 1, !15
+        v40 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0, !15
+        v41 = insert_value v39, { b256, u64, u64 }, v40, 2, !15
+        v42 = read_register cgas, !15
+        v43 = const u64 0, !19
+        v44 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !20
+        v45 = contract_call { u64, b256 } get_s v41, v43, v44, v42, !15
+        v46 = get_ptr ptr { u64, b256 } s, ptr { u64, b256 }, 0, !21
+        store v45, ptr v46, !21
+        v47 = const u64 0, !22
+        ret u64 v47
     }
 }
 
 !0 = filepath "/path/to/simple_contract_call.sw"
-!1 = span !0 386 543
-!2 = span !0 538 542
+!1 = span !0 301 458
+!2 = span !0 453 457
 !3 = span !0 0 66
-!4 = span !0 418 419
-!5 = span !0 439 505
-!6 = span !0 520 525
-!7 = span !0 564 784
-!8 = span !0 717 783
-!9 = span !0 0 66
-!10 = span !0 597 598
-!11 = span !0 618 684
-!12 = span !0 699 704
-!13 = span !0 805 1007
-!14 = span !0 934 938
-!15 = span !0 940 1006
-!16 = span !0 0 66
-!17 = span !0 835 836
-!18 = span !0 855 921
-!19 = span !0 1013 1014
+!4 = span !0 333 334
+!5 = span !0 354 420
+!6 = span !0 435 440
+!7 = span !0 293 459
+!8 = span !0 473 693
+!9 = span !0 626 692
+!10 = span !0 0 66
+!11 = span !0 506 507
+!12 = span !0 527 593
+!13 = span !0 608 613
+!14 = span !0 465 694
+!15 = span !0 708 910
+!16 = span !0 837 841
+!17 = span !0 843 909
+!18 = span !0 0 66
+!19 = span !0 738 739
+!20 = span !0 758 824
+!21 = span !0 700 911
+!22 = span !0 916 917

--- a/sway-core/tests/sway_to_ir/simple_contract_call.sw
+++ b/sway-core/tests/sway_to_ir/simple_contract_call.sw
@@ -14,25 +14,21 @@ abi Test {
 fn main() -> u64 {
     let caller = abi(Test, 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0);
 
-    // We can't use the result of a contract call yet as its type isn't known.
-    //let a =
-    caller.get_u64 {
+    let a = caller.get_u64 {
         coins: 0,
         asset_id: 0x0000000000000000000000000000000000000000000000000000000000000000,
         gas: 10000,
     }
     (1111);
 
-    //let b =
-    caller.get_b256 {
+    let b = caller.get_b256 {
         coins: 0,
         asset_id: 0x0000000000000000000000000000000000000000000000000000000000000000,
         gas: 20000,
     }
     (0x3333333333333333333333333333333333333333333333333333333333333333);
 
-    //let s =
-    caller.get_s {
+    let s = caller.get_s {
         coins: 0,
         asset_id:0x0000000000000000000000000000000000000000000000000000000000000000,
     }

--- a/sway-ir/src/instruction.rs
+++ b/sway-ir/src/instruction.rs
@@ -39,6 +39,8 @@ pub enum Instruction {
     },
     /// A contract call with a list of arguments
     ContractCall {
+        return_type: Type,
+        name: String,
         params: Value,
         coins: Value,
         asset_id: Value,
@@ -150,7 +152,7 @@ impl Instruction {
             Instruction::AsmBlock(asm_block, _) => asm_block.get_type(context),
             Instruction::Call(function, _) => Some(context.functions[function.0].return_type),
             Instruction::Cmp(..) => Some(Type::Bool),
-            Instruction::ContractCall { .. } => None, // TODO fix this
+            Instruction::ContractCall { return_type, .. } => Some(*return_type),
             Instruction::ExtractElement { ty, .. } => ty.get_elem_type(context),
             Instruction::ExtractValue { ty, indices, .. } => ty.get_field_type(context, indices),
             Instruction::InsertElement { array, .. } => array.get_type(context),
@@ -462,6 +464,8 @@ impl<'a> InstructionInserter<'a> {
     #[allow(clippy::too_many_arguments)]
     pub fn contract_call(
         self,
+        return_type: Type,
+        name: String,
         params: Value,
         coins: Value,    // amount of coins to forward
         asset_id: Value, // b256 asset ID of the coint being forwarded
@@ -471,6 +475,8 @@ impl<'a> InstructionInserter<'a> {
         let contract_call_val = Value::new_instruction(
             self.context,
             Instruction::ContractCall {
+                return_type,
+                name,
                 params,
                 coins,
                 asset_id,

--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -245,11 +245,15 @@ fn inline_instruction(
                 span_md_idx,
             ),
             Instruction::ContractCall {
+                return_type,
+                name,
                 params,
                 coins,
                 asset_id,
                 gas,
             } => new_block.ins(context).contract_call(
+                return_type,
+                name,
                 map_value(params),
                 map_value(coins),
                 map_value(asset_id),

--- a/sway-ir/src/parser.rs
+++ b/sway-ir/src/parser.rs
@@ -185,8 +185,9 @@ mod ir_builder {
 
             rule op_contract_call() -> IrAstOperation
                 = "contract_call" _
+                ty:ast_ty() _ name:id() _ 
                 params:id() comma() coins:id() comma() asset_id:id() comma() gas:id() _ {
-                    IrAstOperation::ContractCall(params, coins, asset_id, gas)
+                    IrAstOperation::ContractCall(ty, name, params, coins, asset_id, gas)
             }
 
             rule op_extract_element() -> IrAstOperation
@@ -520,7 +521,7 @@ mod ir_builder {
         Cbr(String, String, String),
         Cmp(String, String, String),
         Const(IrAstConst),
-        ContractCall(String, String, String, String),
+        ContractCall(IrAstTy, String, String, String, String, String),
         ExtractElement(String, IrAstTy, String),
         ExtractValue(String, IrAstTy, Vec<u64>),
         GetPtr(String, IrAstTy, u64),
@@ -859,8 +860,11 @@ mod ir_builder {
                     opt_ins_md_idx,
                 ),
                 IrAstOperation::Const(val) => val.value.as_value(context, opt_ins_md_idx),
-                IrAstOperation::ContractCall(params, coins, asset_id, gas) => {
+                IrAstOperation::ContractCall(return_type, name, params, coins, asset_id, gas) => {
+                    let ir_ty = return_type.to_ir_type(context);
                     block.ins(context).contract_call(
+                        ir_ty,
+                        name,
                         *val_map.get(&params).unwrap(),
                         *val_map.get(&coins).unwrap(),
                         *val_map.get(&asset_id).unwrap(),

--- a/sway-ir/src/parser.rs
+++ b/sway-ir/src/parser.rs
@@ -185,7 +185,7 @@ mod ir_builder {
 
             rule op_contract_call() -> IrAstOperation
                 = "contract_call" _
-                ty:ast_ty() _ name:id() _ 
+                ty:ast_ty() _ name:id() _
                 params:id() comma() coins:id() comma() asset_id:id() comma() gas:id() _ {
                     IrAstOperation::ContractCall(ty, name, params, coins, asset_id, gas)
             }

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -353,6 +353,8 @@ fn instruction_to_doc<'a>(
                     )))
             }
             Instruction::ContractCall {
+                return_type,
+                name,
                 params,
                 coins,
                 asset_id,
@@ -361,8 +363,10 @@ fn instruction_to_doc<'a>(
                 .append(maybe_constant_to_doc(context, md_namer, namer, asset_id))
                 .append(maybe_constant_to_doc(context, md_namer, namer, gas))
                 .append(Doc::text_line(format!(
-                    "{} = contract_call {}, {}, {}, {}{}",
+                    "{} = contract_call {} {} {}, {}, {}, {}{}",
                     namer.name(context, ins_value),
+                    return_type.as_string(context),
+                    name,
                     namer.name(context, params),
                     namer.name(context, coins),
                     namer.name(context, asset_id),

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -110,6 +110,7 @@ impl<'a> InstructionVerifier<'a> {
                         coins,
                         asset_id,
                         gas,
+                        ..
                     } => self.verify_contract_call(params, coins, asset_id, gas)?,
                     Instruction::ExtractElement {
                         array,

--- a/sway-ir/tests/ir_to_ir/constants_contract_calls.in_ir
+++ b/sway-ir/tests/ir_to_ir/constants_contract_calls.in_ir
@@ -1,8 +1,11 @@
 script {
     fn main() -> u64 {
+        local ptr u64 a
         local mut ptr { b256 } args_struct_for_get_b256
         local mut ptr { u64, b256 } args_struct_for_get_s
         local mut ptr { u64 } args_struct_for_get_u64
+        local ptr b256 b
+        local ptr { u64, b256 } s
 
         entry:
         v0 = get_ptr mut ptr { u64 } args_struct_for_get_u64, ptr { u64 }, 0
@@ -18,38 +21,44 @@ script {
         v10 = const u64 0
         v11 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
         v12 = const u64 10000
-        v13 = contract_call v9, v10, v11, v12
-        v14 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr { b256 }, 0
-        v15 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333
-        v16 = insert_value v14, { b256 }, v15, 0
-        v17 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
-        v18 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
-        v19 = insert_value v17, { b256, u64, u64 }, v18, 0
-        v20 = const u64 1108491158
-        v21 = insert_value v19, { b256, u64, u64 }, v20, 1
-        v22 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr u64, 0
-        v23 = insert_value v21, { b256, u64, u64 }, v22, 2
-        v24 = const u64 0
-        v25 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
-        v26 = const u64 20000
-        v27 = contract_call v23, v24, v25, v26
-        v28 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0
-        v29 = const u64 5555
-        v30 = insert_value v28, { u64, b256 }, v29, 0
-        v31 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555
-        v32 = insert_value v30, { u64, b256 }, v31, 1
-        v33 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
-        v34 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
-        v35 = insert_value v33, { b256, u64, u64 }, v34, 0
-        v36 = const u64 4234334249
-        v37 = insert_value v35, { b256, u64, u64 }, v36, 1
-        v38 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0
-        v39 = insert_value v37, { b256, u64, u64 }, v38, 2
-        v40 = read_register cgas
-        v41 = const u64 0
-        v42 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
-        v43 = contract_call v39, v41, v42, v40
-        v44 = const u64 0
-        ret u64 v44
+        v13 = contract_call u64 get_u64 v9, v10, v11, v12
+        v14 = get_ptr ptr u64 a, ptr u64, 0
+        store v13, ptr v14
+        v15 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr { b256 }, 0
+        v16 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333
+        v17 = insert_value v15, { b256 }, v16, 0
+        v18 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
+        v19 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
+        v20 = insert_value v18, { b256, u64, u64 }, v19, 0
+        v21 = const u64 1108491158
+        v22 = insert_value v20, { b256, u64, u64 }, v21, 1
+        v23 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr u64, 0
+        v24 = insert_value v22, { b256, u64, u64 }, v23, 2
+        v25 = const u64 0
+        v26 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
+        v27 = const u64 20000
+        v28 = contract_call b256 get_b256 v24, v25, v26, v27
+        v29 = get_ptr ptr b256 b, ptr b256, 0
+        store v28, ptr v29
+        v30 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0
+        v31 = const u64 5555
+        v32 = insert_value v30, { u64, b256 }, v31, 0
+        v33 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555
+        v34 = insert_value v32, { u64, b256 }, v33, 1
+        v35 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
+        v36 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
+        v37 = insert_value v35, { b256, u64, u64 }, v36, 0
+        v38 = const u64 4234334249
+        v39 = insert_value v37, { b256, u64, u64 }, v38, 1
+        v40 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0
+        v41 = insert_value v39, { b256, u64, u64 }, v40, 2
+        v42 = read_register cgas
+        v43 = const u64 0
+        v44 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
+        v45 = contract_call { u64, b256 } get_s v41, v43, v44, v42
+        v46 = get_ptr ptr { u64, b256 } s, ptr { u64, b256 }, 0
+        store v45, ptr v46
+        v47 = const u64 0
+        ret u64 v47
     }
 }

--- a/sway-ir/tests/ir_to_ir/constants_contract_calls.out_ir
+++ b/sway-ir/tests/ir_to_ir/constants_contract_calls.out_ir
@@ -1,8 +1,11 @@
 script {
     fn main() -> u64 {
+        local ptr u64 a
         local mut ptr { b256 } args_struct_for_get_b256
         local mut ptr { u64, b256 } args_struct_for_get_s
         local mut ptr { u64 } args_struct_for_get_u64
+        local ptr b256 b
+        local ptr { u64, b256 } s
 
         entry:
         v0 = get_ptr mut ptr { u64 } args_struct_for_get_u64, ptr { u64 }, 0
@@ -14,30 +17,36 @@ script {
         v6 = const u64 0
         v7 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
         v8 = const u64 10000
-        v9 = contract_call v5, v6, v7, v8
-        v10 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr { b256 }, 0
-        v11 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333
-        v12 = insert_value v10, { b256 }, v11, 0
-        v13 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr u64, 0
-        v14 = const { b256, u64, u64 } { b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, u64 1108491158, u64 undef }
-        v15 = insert_value v14, { b256, u64, u64 }, v13, 2
-        v16 = const u64 0
-        v17 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
-        v18 = const u64 20000
-        v19 = contract_call v15, v16, v17, v18
-        v20 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0
-        v21 = const u64 5555
-        v22 = insert_value v20, { u64, b256 }, v21, 0
-        v23 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555
-        v24 = insert_value v22, { u64, b256 }, v23, 1
-        v25 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0
-        v26 = const { b256, u64, u64 } { b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, u64 4234334249, u64 undef }
-        v27 = insert_value v26, { b256, u64, u64 }, v25, 2
-        v28 = read_register cgas
-        v29 = const u64 0
-        v30 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
-        v31 = contract_call v27, v29, v30, v28
-        v32 = const u64 0
-        ret u64 v32
+        v9 = contract_call u64 get_u64 v5, v6, v7, v8
+        v10 = get_ptr ptr u64 a, ptr u64, 0
+        store v9, ptr v10
+        v11 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr { b256 }, 0
+        v12 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333
+        v13 = insert_value v11, { b256 }, v12, 0
+        v14 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr u64, 0
+        v15 = const { b256, u64, u64 } { b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, u64 1108491158, u64 undef }
+        v16 = insert_value v15, { b256, u64, u64 }, v14, 2
+        v17 = const u64 0
+        v18 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
+        v19 = const u64 20000
+        v20 = contract_call b256 get_b256 v16, v17, v18, v19
+        v21 = get_ptr ptr b256 b, ptr b256, 0
+        store v20, ptr v21
+        v22 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0
+        v23 = const u64 5555
+        v24 = insert_value v22, { u64, b256 }, v23, 0
+        v25 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555
+        v26 = insert_value v24, { u64, b256 }, v25, 1
+        v27 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0
+        v28 = const { b256, u64, u64 } { b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, u64 4234334249, u64 undef }
+        v29 = insert_value v28, { b256, u64, u64 }, v27, 2
+        v30 = read_register cgas
+        v31 = const u64 0
+        v32 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
+        v33 = contract_call { u64, b256 } get_s v29, v31, v32, v30
+        v34 = get_ptr ptr { u64, b256 } s, ptr { u64, b256 }, 0
+        store v33, ptr v34
+        v35 = const u64 0
+        ret u64 v35
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/Forc.toml
@@ -5,8 +5,8 @@ license = "Apache-2.0"
 name = "call_basic_storage"
 
 [dependencies.std]
-git = "https://github.com/FuelLabs/sway-lib-std"
 branch = "master"
+git = "https://github.com/FuelLabs/sway-lib-std"
 
 [dependencies.basic_storage_abi]
 path = "../../test_abis/basic_storage_abi"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -2,18 +2,12 @@ script;
 use basic_storage_abi::StoreU64;
 
 fn main() -> u64 {
-    let addr = abi(StoreU64, 0xc664e47a0de686a029134e5122383d99d0d29e54179e14c92dd433413a07620a);
+    let addr = abi(StoreU64, 0x3eedeb06664177bd0dea0a1fe0d6e9645c45b8693c902f3a6f67649044f41c9a);
     let key = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 
-    addr.store_u64 {
-        gas: 10000
-    }
-    (key, value);
+    addr.store_u64(key, value);
 
-    let res = addr.get_u64 {
-        gas: 10000
-    }
-    (key);
+    let res = addr.get_u64(key);
     res
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
@@ -5,22 +5,10 @@ use std::chain::assert;
 
 fn main() {
     let abi = abi(Incrementor, 0x4c30f62e9947cff714c802afc0c900de272dbeec57ae12ed96aacbfd32c3e3a8);
-    abi.initialize {
-        gas: 10000
-    }
-    (0); // comment this line out to just increment without initializing
-    abi.increment {
-        gas: 10000
-    }
-    (5);
-    abi.increment {
-        gas: 10000
-    }
-    (5);
-    let result = abi.get {
-        gas: 10000
-    }
-    ();
+    abi.initialize(0); // comment this line out to just increment without initializing
+    abi.increment(5);
+    abi.increment(5);
+    let result = abi.get();
     assert(result == 10);
     log(result);
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "caller_auth_test"
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway-lib-std", branch = "master" }
 auth_testing_abi = { path = "../../test_abis/auth_testing_abi" }
+std = { git = "https://github.com/FuelLabs/sway-lib-std", branch = "master" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/src/main.sw
@@ -6,8 +6,5 @@ use auth_testing_abi::AuthTesting;
 fn main() -> bool {
     let caller = abi(AuthTesting, 0x4bc450bf26a5ebca955ed8e58ca281bcba64065a802a2b1cfa5cdefdeec1610e);
 
-    caller.returns_gm_one {
-        gas: 1000
-    }
-    ()
+    caller.returns_gm_one()
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/src/main.sw
@@ -5,6 +5,5 @@ use auth_testing_abi::AuthTesting;
 // should be false in the case of a script
 fn main() -> bool {
     let caller = abi(AuthTesting, 0x4bc450bf26a5ebca955ed8e58ca281bcba64065a802a2b1cfa5cdefdeec1610e);
-
     caller.returns_gm_one()
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/Forc.lock
@@ -1,19 +1,19 @@
 [[package]]
 name = 'call_basic_storage'
 dependencies = [
-    'std git+http://github.com/FuelLabs/sway-lib-std?reference=master#06b5bbbf6d04e25b510c960f7acb6e7ff3f2aed2',
+    'std git+http://github.com/FuelLabs/sway-lib-std?reference=master#a1d77e1140d1b57ee18cc914d320dc7ffdff98fd',
     'storage_access_abi',
 ]
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+http://github.com/FuelLabs/sway-lib-std?reference=master#06b5bbbf6d04e25b510c960f7acb6e7ff3f2aed2'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+http://github.com/FuelLabs/sway-lib-std?reference=master#a1d77e1140d1b57ee18cc914d320dc7ffdff98fd'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'storage_access_abi'

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
@@ -3,28 +3,16 @@ use storage_access_abi::{S, StorageAccess, T};
 use std::chain::*;
 
 fn main() -> bool {
-    let contract_id = 0x35248b197c9f5ba30a2dfc20414c508efcd1bc4ad110efb26ac187fe81f1e57b;
+    let contract_id = 0x19280009c101a694ec13061a4d1853826dd04ec5594a0ab05fd275904c2e4dbf;
     let caller = abi(StorageAccess, contract_id);
 
     // Test 1
-    caller.set_x {
-        gas: 10000
-    }
-    (1);
-    assert(caller.get_x {
-        gas: 10000
-    }
-    () == 1);
+    caller.set_x(1);
+    assert(caller.get_x() == 1);
 
     // Test 2
-    caller.set_y {
-        gas: 10000
-    }
-    (0x0000000000000000000000000000000000000000000000000000000000000001);
-    assert(caller.get_y {
-        gas: 10000
-    }
-    () == 0x0000000000000000000000000000000000000000000000000000000000000001);
+    caller.set_y(0x0000000000000000000000000000000000000000000000000000000000000001);
+    assert(caller.get_y() == 0x0000000000000000000000000000000000000000000000000000000000000001);
 
     // Test 3
     let s = S {
@@ -37,34 +25,13 @@ fn main() -> bool {
             z: 0x0000000000000000000000000000000000000000000000000000000000000003,
         },
     };
-    caller.set_s {
-        gas: 10000
-    }
-    (s);
-    assert(caller.get_s_dot_x {
-        gas: 10000
-    }
-    () == 3);
-    assert(caller.get_s_dot_y {
-        gas: 10000
-    }
-    () == 4);
-    assert(caller.get_s_dot_z {
-        gas: 10000
-    }
-    () == 0x0000000000000000000000000000000000000000000000000000000000000002);
-    assert(caller.get_s_dot_t_dot_x {
-        gas: 10000
-    }
-    () == 5);
-    assert(caller.get_s_dot_t_dot_y {
-        gas: 10000
-    }
-    () == 6);
-    assert(caller.get_s_dot_t_dot_z {
-        gas: 10000
-    }
-    () == 0x0000000000000000000000000000000000000000000000000000000000000003);
+    caller.set_s(s);
+    assert(caller.get_s_dot_x() == 3);
+    assert(caller.get_s_dot_y() == 4);
+    assert(caller.get_s_dot_z() == 0x0000000000000000000000000000000000000000000000000000000000000002);
+    assert(caller.get_s_dot_t_dot_x() == 5);
+    assert(caller.get_s_dot_t_dot_y() == 6);
+    assert(caller.get_s_dot_t_dot_z() == 0x0000000000000000000000000000000000000000000000000000000000000003);
 
     // Test 4
     let t = T {
@@ -72,85 +39,37 @@ fn main() -> bool {
         y: 8,
         z: 0x0000000000000000000000000000000000000000000000000000000000000004,
     };
-    caller.set_s_dot_t {
-        gas: 10000
-    }
-    (t);
-    assert(caller.get_s_dot_t_dot_x {
-        gas: 10000
-    }
-    () == 7);
-    assert(caller.get_s_dot_t_dot_y {
-        gas: 10000
-    }
-    () == 8);
-    assert(caller.get_s_dot_t_dot_z {
-        gas: 10000
-    }
-    () == 0x0000000000000000000000000000000000000000000000000000000000000004);
+    caller.set_s_dot_t(t);
+    assert(caller.get_s_dot_t_dot_x() == 7);
+    assert(caller.get_s_dot_t_dot_y() == 8);
+    assert(caller.get_s_dot_t_dot_z() == 0x0000000000000000000000000000000000000000000000000000000000000004);
 
     // Test 5
-    caller.set_s_dot_x {
-        gas: 10000
-    }
-    (9);
-    assert(caller.get_s_dot_x {
-        gas: 10000
-    }
-    () == 9);
+    caller.set_s_dot_x(9);
+    assert(caller.get_s_dot_x() == 9);
 
     // Test 6
-    caller.set_s_dot_y {
-        gas: 10000
-    }
-    (10);
-    assert(caller.get_s_dot_y {
-        gas: 10000
-    }
-    () == 10);
+    caller.set_s_dot_y(10);
+    assert(caller.get_s_dot_y() == 10);
 
     // Test 7
-    caller.set_s_dot_z {
-        gas: 10000
-    }
-    (0x0000000000000000000000000000000000000000000000000000000000000005);
-    assert(caller.get_s_dot_z {
-        gas: 10000
-    }
-    () == 0x0000000000000000000000000000000000000000000000000000000000000005);
+    caller.set_s_dot_z(0x0000000000000000000000000000000000000000000000000000000000000005);
+    assert(caller.get_s_dot_z() == 0x0000000000000000000000000000000000000000000000000000000000000005);
 
     // Test 8
-    caller.set_s_dot_t_dot_x {
-        gas: 10000
-    }
-    (11);
-    assert(caller.get_s_dot_t_dot_x {
-        gas: 10000
-    }
-    () == 11);
+    caller.set_s_dot_t_dot_x(11);
+    assert(caller.get_s_dot_t_dot_x() == 11);
 
     // Test 9
-    caller.set_s_dot_t_dot_y {
-        gas: 10000
-    }
-    (12);
-    assert(caller.get_s_dot_t_dot_y {
-        gas: 10000
-    }
-    () == 12);
+    caller.set_s_dot_t_dot_y(12);
+    assert(caller.get_s_dot_t_dot_y() == 12);
 
     // Test 10
-    caller.set_s_dot_t_dot_z {
-        gas: 10000
-    }
-    (0x0000000000000000000000000000000000000000000000000000000000000006);
-    assert(caller.get_s_dot_t_dot_z {
-        gas: 10000
-    }
-    () == 0x0000000000000000000000000000000000000000000000000000000000000006);
+    caller.set_s_dot_t_dot_z(0x0000000000000000000000000000000000000000000000000000000000000006);
+    assert(caller.get_s_dot_t_dot_z() == 0x0000000000000000000000000000000000000000000000000000000000000006);
 
     // Test 11
-    let s = caller.get_s{gas: 10000}();
+    let s = caller.get_s();
     assert(s.x == 9);
     assert(s.y == 10);
     assert(s.z == 0x0000000000000000000000000000000000000000000000000000000000000005);
@@ -159,7 +78,7 @@ fn main() -> bool {
     assert(s.t.z == 0x0000000000000000000000000000000000000000000000000000000000000006);
 
     // Test 12
-    let t = caller.get_s_dot_t{gas: 10000}();
+    let t = caller.get_s_dot_t();
     assert(t.x == 11);
     assert(t.y == 12);
     assert(t.z == 0x0000000000000000000000000000000000000000000000000000000000000006);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/Forc.lock
@@ -1,12 +1,12 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+http://github.com/FuelLabs/sway-lib-std?reference=master#06b5bbbf6d04e25b510c960f7acb6e7ff3f2aed2'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+http://github.com/FuelLabs/sway-lib-std?reference=master#a1d77e1140d1b57ee18cc914d320dc7ffdff98fd'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'storage_access_abi'
@@ -15,6 +15,6 @@ dependencies = []
 [[package]]
 name = 'storage_access_contract'
 dependencies = [
-    'std git+http://github.com/FuelLabs/sway-lib-std?reference=master#06b5bbbf6d04e25b510c960f7acb6e7ff3f2aed2',
+    'std git+http://github.com/FuelLabs/sway-lib-std?reference=master#a1d77e1140d1b57ee18cc914d320dc7ffdff98fd',
     'storage_access_abi',
 ]


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway/issues/1015 and parts of https://github.com/FuelLabs/sway/issues/1003
* Added two more fields to the `contract_call`instruction:
  * A return type to be used by the verifier
  * A contract name which is not really used but helps when reading the IR
* Changed `lw` from `$cgas` and other special registers to a `move`, for both codegens. Now, the `gas` parameters don't need to be set in every test. Updated some tests accordingly.
* The new storage tests `storage_accesses` passes with `--use-ir` again (and doesn't need the `gas` parameter to be set for any call)