### PR TITLE
Use `stable` Rust toolchain when installing Forc -- update installation.md

### DIFF
--- a/docs/src/introduction/installation.md
+++ b/docs/src/introduction/installation.md
@@ -16,7 +16,11 @@ The Sway toolchain and Fuel Core full node can be installed with:
 cargo install forc fuel-core
 ```
 
-Note, please use the `stable` Rust toolchain when installing `forc`.
+`forc` and `fuel-core` are built and tested against the `stable` Rust toolchain. There is no guarantee that they will work with the `nightly` Rust toolchain, so ensure you are using `stable` with:
+
+```sh
+rustup default stable
+```
 
 ### Updating `forc`
 

--- a/docs/src/introduction/installation.md
+++ b/docs/src/introduction/installation.md
@@ -16,6 +16,8 @@ The Sway toolchain and Fuel Core full node can be installed with:
 cargo install forc fuel-core
 ```
 
+Note, please use the `stable` Rust toolchain when installing `forc`.
+
 ### Updating `forc`
 
 You can update `forc` and `fuel-core` with:


### PR DESCRIPTION
I got some heavy errors when trying to install `forc` from cargo on `nightly`. We should ensure developers know to use `stable` for now.