### PR TITLE
More IR updates.

### DIFF
--- a/sway-core/src/asm_generation/compiler_constants.rs
+++ b/sway-core/src/asm_generation/compiler_constants.rs
@@ -1,5 +1,6 @@
-/// The number of registers available for the compiler to use. Registers reserved by the
-/// compiler are contained within these.
+/// The total number of registers available and the number of registers available for the compiler
+/// to use. Registers reserved by the compiler are contained within these.
+const NUM_TOTAL_REGISTERS: u8 = 64;
 const NUM_FREE_REGISTERS: u8 = 48;
 pub(crate) const TWENTY_FOUR_BITS: u64 = 0b1111_1111_1111_1111_1111_1111;
 pub(crate) const EIGHTEEN_BITS: u64 = 0b11_1111_1111_1111_1111;
@@ -11,6 +12,6 @@ pub(crate) const SIX_BITS: u64 = 0b11_1111;
 /// So far, the compiler-reserved registers are:
 /// 1. DATA_SECTION_BEGIN
 const NUM_COMPILER_RESERVED_REGISTERS: u8 = 1;
-pub(crate) const DATA_SECTION_REGISTER: u8 = NUM_FREE_REGISTERS - 2;
+pub(crate) const DATA_SECTION_REGISTER: u8 = NUM_TOTAL_REGISTERS - 1;
 pub(crate) const NUM_ALLOCATABLE_REGISTERS: u8 =
     NUM_FREE_REGISTERS - NUM_COMPILER_RESERVED_REGISTERS;

--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -184,8 +184,7 @@ struct AsmBuilder<'ir> {
 
 #[derive(Clone, Debug)]
 pub(super) enum Storage {
-    Data(DataId),              // Const storage in the data section.
-    Register(VirtualRegister), // Storage in a register.
+    Data(DataId), // Const storage in the data section.
     Stack(u64), // Storage in the runtime stack starting at an absolute word offset.  Essentially a global.
 }
 
@@ -333,8 +332,8 @@ impl<'ir> AsmBuilder<'ir> {
             } else {
                 match ptr_content.ty {
                     Type::Unit | Type::Bool | Type::Uint(_) => {
-                        let reg = self.reg_seqr.next();
-                        self.ptr_map.insert(*ptr, Storage::Register(reg));
+                        self.ptr_map.insert(*ptr, Storage::Stack(stack_base));
+                        stack_base += 1;
                     }
                     Type::B256 => {
                         self.ptr_map.insert(*ptr, Storage::Stack(stack_base));
@@ -992,12 +991,6 @@ impl<'ir> AsmBuilder<'ir> {
                     // Not sure if we'll ever need this.
                     unimplemented!("TODO get_ptr() into the data section.");
                 }
-                Storage::Register(var_reg) => {
-                    // Not expecting an offset here nor a pointer cast
-                    assert!(offset == 0);
-                    assert!(ptr_ty.eq(self.context, base_ptr.get_type(self.context)));
-                    self.reg_map.insert(*instr_val, var_reg);
-                }
                 Storage::Stack(word_offs) => {
                     let ptr_ty_size_in_bytes = ir_type_size_in_bytes(self.context, ptr_ty);
 
@@ -1246,13 +1239,6 @@ impl<'ir> AsmBuilder<'ir> {
                         owning_span: instr_val.get_span(self.context),
                     });
                 }
-                Storage::Register(var_reg) => {
-                    self.bytecode.push(Op {
-                        opcode: Either::Left(VirtualOp::MOVE(instr_reg.clone(), var_reg)),
-                        comment: String::new(),
-                        owning_span: instr_val.get_span(self.context),
-                    });
-                }
                 Storage::Stack(word_offs) => {
                     let base_reg = self.stack_base_reg.as_ref().unwrap().clone();
                     // XXX Need to check for zero sized types?
@@ -1375,19 +1361,19 @@ impl<'ir> AsmBuilder<'ir> {
             });
         } else {
             let ret_reg = self.value_to_register(ret_val);
-            let size_in_bytes = ir_type_size_in_bytes(self.context, ret_type);
 
-            if size_in_bytes <= 8 {
+            if matches!(ret_type, Type::Unit | Type::Bool | Type::Uint(_)) {
                 self.bytecode.push(Op {
                     owning_span: instr_val.get_span(self.context),
                     opcode: Either::Left(VirtualOp::RET(ret_reg)),
                     comment: "".into(),
                 });
             } else {
-                // If the type is larger than one word, then we use RETD to return data.  First put
-                // the size into the data section, then add a LW to get it, then add a RETD which
-                // uses it.
+                // If the type not a reference type then we use RETD to return data.  First put the
+                // size into the data section, then add a LW to get it, then add a RETD which uses
+                // it.
                 let size_reg = self.reg_seqr.next();
+                let size_in_bytes = ir_type_size_in_bytes(self.context, ret_type);
                 let size_data_id = self
                     .data_section
                     .insert_data_value(&Literal::U64(size_in_bytes));
@@ -1612,13 +1598,6 @@ impl<'ir> AsmBuilder<'ir> {
             None => unreachable!("Bug! Trying to store to an unknown pointer."),
             Some(storage) => match storage {
                 Storage::Data(_) => unreachable!("BUG! Trying to store to the data section."),
-                Storage::Register(reg) => {
-                    self.bytecode.push(Op {
-                        opcode: Either::Left(VirtualOp::MOVE(reg.clone(), stored_reg)),
-                        comment: String::new(),
-                        owning_span: instr_val.get_span(self.context),
-                    });
-                }
                 Storage::Stack(word_offs) => {
                     let word_offs = *word_offs;
                     let store_size_in_words = size_bytes_in_words!(ir_type_size_in_bytes(

--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -1362,7 +1362,7 @@ impl<'ir> AsmBuilder<'ir> {
         } else {
             let ret_reg = self.value_to_register(ret_val);
 
-            if matches!(ret_type, Type::Unit | Type::Bool | Type::Uint(_)) {
+            if ret_type.is_copy_type() {
                 self.bytecode.push(Op {
                     owning_span: instr_val.get_span(self.context),
                     opcode: Either::Left(VirtualOp::RET(ret_reg)),

--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -1290,14 +1290,18 @@ impl FnCompiler {
             .new_local_ptr(context, local_name, return_type, is_mutable.into(), None)
             .map_err(|ir_error| ir_error.to_string())?;
 
+        // We can have empty aggregates, especially arrays, which shouldn't be initialised, but
+        // otherwise use a store.
         let ptr_ty = *ptr.get_type(context);
-        let ptr_val = self
-            .current_block
-            .ins(context)
-            .get_ptr(ptr, ptr_ty, 0, span_md_idx);
-        self.current_block
-            .ins(context)
-            .store(ptr_val, init_val, span_md_idx);
+        if ir_type_size_in_bytes(context, &ptr_ty) > 0 {
+            let ptr_val = self
+                .current_block
+                .ins(context)
+                .get_ptr(ptr, ptr_ty, 0, span_md_idx);
+            self.current_block
+                .ins(context)
+                .store(ptr_val, init_val, span_md_idx);
+        }
         Ok(init_val)
     }
 
@@ -1438,12 +1442,14 @@ impl FnCompiler {
         contents: Vec<TypedExpression>,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, String> {
-        if contents.is_empty() {
-            return Err("Unable to create zero sized static arrays.".into());
-        }
-
-        // Create a new aggregate, since they're not named.
-        let elem_type = convert_resolved_typeid_no_span(context, &contents[0].return_type)?;
+        let elem_type = if contents.is_empty() {
+            // A zero length array is a pointer to nothing, which is still supported by Sway.
+            // We're unable to get the type though it's irrelevant because it can't be indexed, so
+            // we'll just use Unit.
+            Type::Unit
+        } else {
+            convert_resolved_typeid_no_span(context, &contents[0].return_type)?
+        };
         let aggregate = Aggregate::new_array(context, elem_type, contents.len() as u64);
 
         // Compile each element and insert it immediately.

--- a/sway-core/tests/ir_to_asm/let_reassign_while_loop.asm
+++ b/sway-core/tests/ir_to_asm/let_reassign_while_loop.asm
@@ -5,13 +5,25 @@ DATA_SECTION_OFFSET[0..32]
 DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
-move $r0 $sp                  ; save locals base register
+move $r2 $sp                  ; save locals base register
+cfei i8                       ; allocate 8 bytes for all locals
+addi $r0 $r2 i0               ; get_ptr
 lw   $r0 data_0               ; literal instantiation
-jnei $r0 $one i12
-jnei $r0 $one i11
+sw   $r2 $r0 i0               ; store value
+addi $r0 $r2 i0               ; get_ptr
+lw   $r0 $r2 i0               ; load value
+jnei $r0 $one i21
+addi $r0 $r2 i0               ; get_ptr
+lw   $r0 $r2 i0               ; load value
+jnei $r0 $one i18
 lw   $r0 data_1               ; literal instantiation
-ji   i8
+addi $r1 $r2 i0               ; get_ptr
+sw   $r2 $r0 i0               ; store value
+ji   i11
+addi $r0 $r2 i0               ; get_ptr
+lw   $r0 $r2 i0               ; load value
 ret  $r0
+noop                          ; word-alignment of data section
 .data:
 data_0 .bool 0x01
 data_1 .bool 0x00

--- a/sway-core/tests/ir_to_asm/simple_contract_call.asm
+++ b/sway-core/tests/ir_to_asm/simple_contract_call.asm
@@ -6,8 +6,8 @@ DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
 move $r4 $sp                  ; save locals base register
-cfei i152                     ; allocate 152 bytes for all locals
-addi $r1 $r4 i72              ; get_ptr
+cfei i160                     ; allocate 160 bytes for all locals
+addi $r1 $r4 i80              ; get_ptr
 lw   $r0 data_0               ; literal instantiation
 sw   $r1 $r0 i0               ; insert_value @ 0
 move $r2 $sp                  ; save register for temporary stack value
@@ -17,14 +17,16 @@ addi $r0 $r2 i0               ; get struct field(s) 0 offset
 mcpi $r0 $r1 i32              ; store struct field value
 lw   $r0 data_2               ; literal instantiation
 sw   $r2 $r0 i4               ; insert_value @ 1
-addi $r0 $r4 i72              ; get_ptr
+addi $r0 $r4 i80              ; get_ptr
 sw   $r2 $r0 i5               ; insert_value @ 2
-lw   $r0 data_3               ; literal instantiation
-lw   $r3 data_4               ; literal instantiation
-lw   $r1 data_5               ; literal instantiation
-call $r2 $r0 $r3 $r1          ; call external contract
-move $r0 $ret
+lw   $r1 data_3               ; literal instantiation
+lw   $r0 data_4               ; literal instantiation
+lw   $r3 data_5               ; literal instantiation
+call $r2 $r1 $r0 $r3          ; call external contract
+move $r1 $ret
 addi $r0 $r4 i0               ; get_ptr
+sw   $r4 $r1 i0               ; store value
+addi $r0 $r4 i8               ; get_ptr
 lw   $r1 data_6               ; literal instantiation
 addi $r0 $r0 i0               ; get struct field(s) 0 offset
 mcpi $r0 $r1 i32              ; store struct field value
@@ -35,17 +37,17 @@ addi $r0 $r3 i0               ; get struct field(s) 0 offset
 mcpi $r0 $r1 i32              ; store struct field value
 lw   $r0 data_7               ; literal instantiation
 sw   $r3 $r0 i4               ; insert_value @ 1
-addi $r0 $r4 i0               ; get_ptr
+addi $r0 $r4 i8               ; get_ptr
 sw   $r3 $r0 i5               ; insert_value @ 2
 lw   $r2 data_3               ; literal instantiation
 lw   $r1 data_4               ; literal instantiation
 lw   $r0 data_8               ; literal instantiation
 call $r3 $r2 $r1 $r0          ; call external contract
 move $r1 $ret
-addi $r0 $r4 i80              ; get_ptr
-addi $r0 $r4 i80              ; get store offset
+addi $r0 $r4 i88              ; get_ptr
+addi $r0 $r4 i88              ; get store offset
 mcpi $r0 $r1 i32              ; store value
-addi $r2 $r4 i32              ; get_ptr
+addi $r2 $r4 i40              ; get_ptr
 lw   $r0 data_9               ; literal instantiation
 sw   $r2 $r0 i0               ; insert_value @ 0
 lw   $r1 data_10              ; literal instantiation
@@ -58,15 +60,15 @@ addi $r0 $r3 i0               ; get struct field(s) 0 offset
 mcpi $r0 $r1 i32              ; store struct field value
 lw   $r0 data_11              ; literal instantiation
 sw   $r3 $r0 i4               ; insert_value @ 1
-addi $r0 $r4 i32              ; get_ptr
+addi $r0 $r4 i40              ; get_ptr
 sw   $r3 $r0 i5               ; insert_value @ 2
 move $r2 $cgas                ; move register into abi function
 lw   $r1 data_3               ; literal instantiation
 lw   $r0 data_4               ; literal instantiation
 call $r3 $r1 $r0 $r2          ; call external contract
 move $r1 $ret
-addi $r0 $r4 i112             ; get_ptr
-addi $r0 $r4 i112             ; get store offset
+addi $r0 $r4 i120             ; get_ptr
+addi $r0 $r4 i120             ; get store offset
 mcpi $r0 $r1 i40              ; store value
 lw   $r0 data_3               ; literal instantiation
 ret  $r0

--- a/sway-core/tests/ir_to_asm/simple_if_let.asm
+++ b/sway-core/tests/ir_to_asm/simple_if_let.asm
@@ -5,24 +5,28 @@ DATA_SECTION_OFFSET[0..32]
 DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
-move $r2 $sp                  ; save locals base register
-cfei i16                      ; allocate 16 bytes for all locals
+move $r3 $sp                  ; save locals base register
+cfei i24                      ; allocate 24 bytes for all locals
 move $r1 $sp                  ; save register for temporary stack value
 cfei i16                      ; allocate 16 bytes for temporary struct
 lw   $r0 data_0               ; literal instantiation
 sw   $r1 $r0 i0               ; insert_value @ 0
 lw   $r0 data_1               ; literal instantiation
 sw   $r1 $r0 i1               ; insert_value @ 1
-addi $r0 $r2 i0               ; get_ptr
-addi $r0 $r2 i0               ; get store offset
+addi $r0 $r3 i8               ; get_ptr
+addi $r0 $r3 i8               ; get store offset
 mcpi $r0 $r1 i16              ; store value
-addi $r2 $r2 i0               ; get_ptr
+addi $r2 $r3 i8               ; get_ptr
 lw   $r1 $r2 i0               ; extract_value @ 0
 lw   $r0 data_2               ; literal instantiation
 eq   $r0 $r1 $r0
-jnei $r0 $one i24
-lw   $r0 $r2 i1               ; extract_value @ 1,1
-ji   i25
+jnei $r0 $one i28
+lw   $r1 $r2 i1               ; extract_value @ 1,1
+addi $r0 $r3 i0               ; get_ptr
+sw   $r3 $r1 i0               ; store value
+addi $r0 $r3 i0               ; get_ptr
+lw   $r0 $r3 i0               ; load value
+ji   i29
 lw   $r0 data_0               ; literal instantiation
 ret  $r0
 noop                          ; word-alignment of data section

--- a/sway-core/tests/ir_to_asm/storage_load.asm
+++ b/sway-core/tests/ir_to_asm/storage_load.asm
@@ -11,29 +11,33 @@ eq   $r0 $r1 $r0              ; function selector comparison
 jnei $zero $r0 i14            ; jump to selected function
 lw   $r0 data_4               ; load fn selector for comparison
 eq   $r0 $r1 $r0              ; function selector comparison
-jnei $zero $r0 i24            ; jump to selected function
+jnei $zero $r0 i28            ; jump to selected function
 rvrt $zero                    ; revert if no selectors matched
 move $r2 $sp                  ; save locals base register
-cfei i32                      ; allocate 32 bytes for all locals
+cfei i40                      ; allocate 40 bytes for all locals
 addi $r0 $r2 i0               ; get_ptr
 lw   $r1 data_0               ; literal instantiation
 addi $r0 $r2 i0               ; get store offset
 mcpi $r0 $r1 i32              ; store value
+addi $r0 $r2 i32              ; get_ptr
 addi $r0 $r2 i0               ; get offset
 srw  $r0 $r0                  ; single word state access
+sw   $r2 $r0 i4               ; store value
+addi $r0 $r2 i32              ; get_ptr
+lw   $r0 $r2 i4               ; load value
 ret  $r0
-move $r1 $sp                  ; save locals base register
+move $r0 $sp                  ; save locals base register
 cfei i64                      ; allocate 64 bytes for all locals
-addi $r0 $r1 i0               ; get_ptr
+addi $r1 $r0 i0               ; get_ptr
 lw   $r2 data_1               ; literal instantiation
-addi $r0 $r1 i0               ; get store offset
-mcpi $r0 $r2 i32              ; store value
-addi $r0 $r1 i32              ; get_ptr
-addi $r2 $r1 i32              ; get offset
-addi $r0 $r1 i0               ; get offset
-srwq $r2 $r0                  ; quad word state access
-addi $r0 $r1 i32              ; get_ptr
-addi $r1 $r1 i32              ; load address
+addi $r1 $r0 i0               ; get store offset
+mcpi $r1 $r2 i32              ; store value
+addi $r1 $r0 i32              ; get_ptr
+addi $r2 $r0 i32              ; get offset
+addi $r1 $r0 i0               ; get offset
+srwq $r2 $r1                  ; quad word state access
+addi $r1 $r0 i32              ; get_ptr
+addi $r1 $r0 i32              ; load address
 lw   $r0 data_2               ; loading size for RETD
 retd  $r1 $r0
 .data:

--- a/sway-core/tests/ir_to_asm/storage_store.asm
+++ b/sway-core/tests/ir_to_asm/storage_store.asm
@@ -11,11 +11,13 @@ eq   $r0 $r1 $r0              ; function selector comparison
 jnei $zero $r0 i14            ; jump to selected function
 lw   $r0 data_5               ; load fn selector for comparison
 eq   $r0 $r1 $r0              ; function selector comparison
-jnei $zero $r0 i26            ; jump to selected function
+jnei $zero $r0 i28            ; jump to selected function
 rvrt $zero                    ; revert if no selectors matched
 move $r2 $sp                  ; save locals base register
-cfei i32                      ; allocate 32 bytes for all locals
+cfei i40                      ; allocate 40 bytes for all locals
+addi $r0 $r2 i32              ; get_ptr
 lw   $r0 data_0               ; literal instantiation
+sw   $r2 $r0 i4               ; store value
 addi $r0 $r2 i0               ; get_ptr
 lw   $r1 data_1               ; literal instantiation
 addi $r0 $r2 i0               ; get store offset

--- a/sway-ir/src/irtype.rs
+++ b/sway-ir/src/irtype.rs
@@ -24,6 +24,11 @@ pub enum Type {
 }
 
 impl Type {
+    /// Return whether this is a 'copy' type, one whose value will always fit in a register.
+    pub fn is_copy_type(&self) -> bool {
+        matches!(self, Type::Unit | Type::Bool | Type::Uint(_))
+    }
+
     /// Return a string representation of type, used for printing.
     pub fn as_string(&self, context: &Context) -> String {
         let sep_types_str = |agg_content: &AggregateContent, sep: &str| {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
-name = 'asm_expr_basic'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+name = 'core'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
+dependencies = []
 
 [[package]]
-name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
-dependencies = []
+name = 'fix_opcode_bug'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/Forc.toml
@@ -1,7 +1,7 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
-name = "asm_expr_basic"
+name = "fix_opcode_bug"
 entry = "main.sw"
 
 [dependencies]


### PR DESCRIPTION
A couple of E2E tests were failing again.  The new `RETD` behaviour needed to be ported across.  Also, the IR->ASM was performing an optimisation which turned out to be buggy (causing a couple of E2E failures).

It would decide at ASMgen whether a local would be stored on the stack or in a register, but it wasn't quite working all the time.  This is something that should be done by an IR pass anyway -- e.g., [llvm -mem2reg](https://llvm.org/docs/Passes.html#mem2reg-promote-memory-to-register).

By maximising stack use it changed a bunch of the tests, but also requires a extra registers for some code to manage the stack.  The `fix_opcode_bug` already uses a tonne of registers and using more tipped the code into using `$r30` which happens to be the reserved 'data section start' register.

There are 64 registers.  The first 16 are reserved by the VM.  The general purpose registers start at register 16, or `$r0`. The compiler may want to reserve some too, so it uses the last registers.   It makes sense then that the 'data section start' reserved register would be the last register, register 63, or `$r47`.  But a bug in the implementation made it register 46 / `$r30`.