### PR TITLE
Improve support for git reference kinds (`branch`, `tag`, `rev`), improve fetching behaviour

### DIFF
--- a/examples/counter/Forc.lock
+++ b/examples/counter/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'counter'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/examples/fizzbuzz/Forc.lock
+++ b/examples/fizzbuzz/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'fizzbuzz'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/examples/hello_world/Forc.lock
+++ b/examples/hello_world/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'hello_world'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/examples/subcurrency/Forc.lock
+++ b/examples/subcurrency/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#aa36aea9362575c769781e7ab640d1d75dce13c8'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'subcurrency'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#aa36aea9362575c769781e7ab640d1d75dce13c8']

--- a/examples/subcurrency/Forc.lock
+++ b/examples/subcurrency/Forc.lock
@@ -5,9 +5,9 @@ dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#aa36aea9362575c769781e7ab640d1d75dce13c8'
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
 dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'subcurrency'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#aa36aea9362575c769781e7ab640d1d75dce13c8']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']

--- a/examples/subcurrency/src/main.sw
+++ b/examples/subcurrency/src/main.sw
@@ -3,6 +3,7 @@ contract;
 
 use std::chain::*;
 use std::hash::*;
+use std::panic::panic;
 use std::storage::*;
 use std::address::Address;
 

--- a/examples/wallet_smart_contract/Forc.lock
+++ b/examples/wallet_smart_contract/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'wallet_smart_contract'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -55,6 +55,7 @@ pub struct DependencyDetails {
     pub(crate) branch: Option<String>,
     pub(crate) tag: Option<String>,
     pub(crate) package: Option<String>,
+    pub(crate) rev: Option<String>,
 }
 
 impl Dependency {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abort_control_flow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abort_control_flow/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'abort_control_flow'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/enum_if_let_invalid_variable/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/enum_if_let_invalid_variable/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'enum_if_let_invalid_variable'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'excess_fn_arguments'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_enums/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_enums/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'match_expressions_enums'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'match_expressions_non_exhaustive'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_wrong_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_wrong_struct/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'match_expressions_wrong_struct'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'missing_fn_arguments'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/dependency_package_field/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/dependency_package_field/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'dependency_package_field'
-dependencies = ['(std-alt) std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['(std-alt) std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/abort_control_flow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/abort_control_flow/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'abort_control_flow'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/abort_control_flow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/abort_control_flow/src/main.sw
@@ -1,6 +1,8 @@
 script;
 
 use std::chain::*;
+use std::panic::panic;
+
 enum Result<T, E> {
     Ok: T,
     Err: E,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/aliased_imports/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/aliased_imports/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'aliased_imports'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'array_basics'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_expr_basic/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_expr_basic/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'asm_expr_basic'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_bad_jumps/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_bad_jumps/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'b256_bad_jumps'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_ops/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_ops/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'b256_ops'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/basic_func_decl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/basic_func_decl/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'basic_func_decl'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'const_decl'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl_in_library/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl_in_library/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'const_decl_in_library'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/empty_method_initializer/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/empty_method_initializer/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'empty_method_initializer'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_destructuring/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_destructuring/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'enum_destructuring'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'enum_if_let'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let_large_type/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let_large_type/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'enum_if_let_large_type'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_in_fn_decl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_in_fn_decl/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'enum_in_fn_decl'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/eq_4_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/eq_4_test/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'eq_4_test'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'fix_opcode_bug'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_enum/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_enum/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'generic_enum'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+http://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+http://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'generic_impl_self'
-dependencies = ['core git+http://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+http://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/if_elseif_enum/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/if_elseif_enum/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'if_elseif_enum'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/inline_if_expr_const/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/inline_if_expr_const/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'inline_if_expr_const'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/is_prime/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/is_prime/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'is_prime'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#a1d77e1140d1b57ee18cc914d320dc7ffdff98fd']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#a1d77e1140d1b57ee18cc914d320dc7ffdff98fd'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/local_impl_for_ord/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/local_impl_for_ord/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'local_impl_for_ord'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'match_expressions'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_structs/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_structs/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'match_expressions_structs'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/modulo_uint_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/modulo_uint_test/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'modulo_uint_test'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/neq_4_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/neq_4_test/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'neq_4_test'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/nested_structs/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/nested_structs/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'nested_structs'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/new_allocator_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/new_allocator_test/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'new_alloc'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/op_precedence/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/op_precedence/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'unary_not_basic'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/size_of/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/size_of/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'size_of'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/supertraits/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/supertraits/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'supertraits'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_override_bug/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_override_bug/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'trait_override_bug'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_desugaring/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_desugaring/Forc.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'tuple_desugaring'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#c331ed20ebc9d646acec6b8ee8f408627ce3b573']
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_in_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_in_struct/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'tuple_in_struct'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'unary_not_basic'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic_2/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic_2/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'unary_not_basic_2'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/while_loops/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/while_loops/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'while_loops'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#aa36aea9362575c769781e7ab640d1d75dce13c8']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/Forc.lock
@@ -2,7 +2,7 @@
 name = 'bal_opcode'
 dependencies = [
     'balance_test_abi',
-    'std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549',
+    'std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3',
 ]
 
 [[package]]
@@ -11,10 +11,10 @@ dependencies = []
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/Forc.lock
@@ -6,15 +6,15 @@ dependencies = []
 name = 'call_basic_storage'
 dependencies = [
     'basic_storage_abi',
-    'std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549',
+    'std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3',
 ]
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/Forc.lock
@@ -2,12 +2,12 @@
 name = 'call_increment_contract'
 dependencies = [
     'increment_abi',
-    'std git+https://github.com/FuelLabs/sway-lib-std?reference=master#a1d77e1140d1b57ee18cc914d320dc7ffdff98fd',
+    'std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3',
 ]
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
@@ -16,5 +16,5 @@ dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#a1d77e1140d1b57ee18cc914d320dc7ffdff98fd'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/Forc.lock
@@ -6,15 +6,15 @@ dependencies = []
 name = 'caller_auth_test'
 dependencies = [
     'auth_testing_abi',
-    'std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549',
+    'std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3',
 ]
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/Forc.lock
@@ -2,19 +2,19 @@
 name = 'caller_context_test'
 dependencies = [
     'context_testing_abi',
-    'std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549',
+    'std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3',
 ]
 
 [[package]]
 name = 'context_testing_abi'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/token_ops_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/token_ops_test/Forc.lock
@@ -1,20 +1,20 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'test_fuel_coin_abi'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'token_ops_test'
 dependencies = [
-    'std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549',
+    'std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3',
     'test_fuel_coin_abi',
 ]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/token_ops_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/token_ops_test/src/main.sw
@@ -1,7 +1,7 @@
 script;
 
 // use std::constants::ETH_ID;
-use std::context::balance_of_contract;
+use std::context::balance_of;
 use std::chain::assert;
 use std::address::Address;
 use std::contract_id::ContractId;
@@ -26,7 +26,7 @@ fn main() -> bool {
     // todo: use correct type ContractId
     let fuel_coin = abi(TestFuelCoin, 0xff95564b8f788b6a2a884813eadfff2dbfe008a881008e7b298ce14208a73864);
 
-    let mut fuelcoin_balance = balance_of_contract(fuelcoin_id, fuelcoin_id);
+    let mut fuelcoin_balance = balance_of(fuelcoin_id, fuelcoin_id);
     assert(fuelcoin_balance == 0);
 
     fuel_coin.mint {
@@ -35,7 +35,7 @@ fn main() -> bool {
     (11);
 
     // check that the mint was successful
-    fuelcoin_balance = balance_of_contract(fuelcoin_id, fuelcoin_id);
+    fuelcoin_balance = balance_of(fuelcoin_id, fuelcoin_id);
     assert(fuelcoin_balance == 11);
 
     fuel_coin.burn {
@@ -44,7 +44,7 @@ fn main() -> bool {
     (7);
 
     // check that the burn was successful
-    fuelcoin_balance = balance_of_contract(fuelcoin_id, fuelcoin_id);
+    fuelcoin_balance = balance_of(fuelcoin_id, fuelcoin_id);
     assert(fuelcoin_balance == 4);
 
     // force transfer coins
@@ -54,8 +54,8 @@ fn main() -> bool {
     (3, fuelcoin_id, balance_test_id);
 
     // check that the transfer was successful
-    fuelcoin_balance = balance_of_contract(fuelcoin_id, fuelcoin_id);
-    let balance_test_contract_balance = balance_of_contract(fuelcoin_id, balance_test_id);
+    fuelcoin_balance = balance_of(fuelcoin_id, fuelcoin_id);
+    let balance_test_contract_balance = balance_of(fuelcoin_id, balance_test_id);
     assert(fuelcoin_balance == 1);
     assert(balance_test_contract_balance == 3);
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/address_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/address_test/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'address_test'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_test/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'assert_test'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_struct_alignment/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_struct_alignment/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'b512_panic_test'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_test/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'b512_test'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/block_height/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/block_height/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'block_height'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ec_recover_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ec_recover_test/Forc.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'ec_recover_test'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/auth_testing_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/auth_testing_contract/Forc.lock
@@ -6,15 +6,15 @@ dependencies = []
 name = 'auth_testing_contract'
 dependencies = [
     'auth_testing_abi',
-    'std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549',
+    'std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3',
 ]
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/balance_test_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/balance_test_contract/Forc.lock
@@ -6,15 +6,15 @@ dependencies = []
 name = 'balance_test_contract'
 dependencies = [
     'balance_test_abi',
-    'std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549',
+    'std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3',
 ]
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/Forc.lock
@@ -2,7 +2,7 @@
 name = 'basic_storage'
 dependencies = [
     'basic_storage_abi',
-    'std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549',
+    'std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3',
 ]
 
 [[package]]
@@ -11,10 +11,10 @@ dependencies = []
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/context_testing_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/context_testing_contract/Forc.lock
@@ -1,20 +1,20 @@
 [[package]]
 name = 'context_testing_abi'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'context_testing_contract'
 dependencies = [
     'context_testing_abi',
-    'std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549',
+    'std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3',
 ]
 
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/context_testing_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/context_testing_contract/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::{context::{*, call_frames::*}, contract_id::ContractId};
+use std::{context::{*, call_frames::*, registers::global_gas}, contract_id::ContractId};
 use context_testing_abi::*;
 
 impl ContextTesting for Contract {
@@ -13,7 +13,7 @@ impl ContextTesting for Contract {
     }
 
     fn get_balance_of_contract(asset_id: ContractId, cid: ContractId) -> u64 {
-        balance_of_contract(asset_id, cid)
+        balance_of(asset_id, cid)
     }
 
     fn get_amount() -> u64 {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/increment_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/increment_contract/Forc.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
@@ -11,10 +11,10 @@ dependencies = []
 name = 'increment_contract'
 dependencies = [
     'increment_abi',
-    'std git+https://github.com/FuelLabs/sway-lib-std?reference=master#a1d77e1140d1b57ee18cc914d320dc7ffdff98fd',
+    'std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3',
 ]
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#a1d77e1140d1b57ee18cc914d320dc7ffdff98fd'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/test_fuel_coin_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/test_fuel_coin_contract/Forc.lock
@@ -1,20 +1,20 @@
 [[package]]
 name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549'
-dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?reference=master#30274cf817c1848e28f984c2e8703eb25e7a3a44']
+source = 'git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3'
+dependencies = ['core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f']
 
 [[package]]
 name = 'test_fuel_coin_abi'
-dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549']
+dependencies = ['std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3']
 
 [[package]]
 name = 'test_fuel_coin_contract'
 dependencies = [
-    'std git+https://github.com/FuelLabs/sway-lib-std?reference=master#7b973a638d5220228be616f1f89a249846001549',
+    'std git+https://github.com/FuelLabs/sway-lib-std?branch=master#3884e9bbadb7c2567700dae847017366629241d3',
     'test_fuel_coin_abi',
 ]


### PR DESCRIPTION
Previously, we initialised the temporary git repository with a `clone` operation. By default, this only fetches a subset of git references, meaning that using references other than those provided by default with `clone` failed to resolve.

Inspired by cargo, this commit updates the behaviour to instead first initialise the repository, then attempt to fetch only those references that are relevant to the user specified git reference.

In order to construct an accurate set of `refspecs` and fetch only the relevant commits, its useful to retain knowledge about the *kind* of git reference. This introduces a new `GitReference` type and updates the git source lock file serialization to account for this.

The lock files of all examples and tests have been updated for the new approach to serializing the pinned git sources.

Closes #1019 
Closes #1016 
Unblocks #978