### PR TITLE
Handle ImplicitReturnExpression variant when parsing lsp tokens

### DIFF
--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -90,6 +90,7 @@ pub fn traverse_node(node: AstNode, tokens: &mut Vec<Token>) {
     match node.content {
         AstNodeContent::Declaration(dec) => handle_declaration(dec, tokens),
         AstNodeContent::Expression(exp) => handle_expression(exp, tokens),
+        AstNodeContent::ImplicitReturnExpression(exp) => handle_expression(exp, tokens),
         // TODO
         // handle other content types
         _ => {}


### PR DESCRIPTION
Issue #1017 documents the variants that are currently being ignored. This is one of them.