### PR TITLE
Add ReturnStatement variant for Lsp token parsing

### DIFF
--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -91,6 +91,9 @@ pub fn traverse_node(node: AstNode, tokens: &mut Vec<Token>) {
         AstNodeContent::Declaration(dec) => handle_declaration(dec, tokens),
         AstNodeContent::Expression(exp) => handle_expression(exp, tokens),
         AstNodeContent::ImplicitReturnExpression(exp) => handle_expression(exp, tokens),
+        AstNodeContent::ReturnStatement(return_statement) => {
+            handle_expression(return_statement.expr, tokens)
+        }
         AstNodeContent::WhileLoop(while_loop) => handle_while_loop(while_loop, tokens),
         // TODO
         // handle other content types


### PR DESCRIPTION
Issue #1017 documents the variants that are currently being ignored. This is another one of them.

only 2 variants left for `AstNodeContent` ... `UseStatement` and `IncludeStatement`.