### PR TITLE
bump to v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,7 +1075,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "forc-pkg"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "forc-util",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "forc-util"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "parser"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ariadne",
  "chumsky",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "sway-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "clap 3.1.6",
  "derivative",
@@ -3198,7 +3198,7 @@ dependencies = [
 
 [[package]]
 name = "sway-fmt"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ropey",
  "sway-core",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "fuel-pest",
  "generational-arena",
@@ -3218,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "sway-lsp"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "dashmap 4.0.2",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "sway-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "fuel-asm",
  "fuel-crypto 0.4.0",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "sway-utils"
-version = "0.9.0"
+version = "0.9.1"
 
 [[package]]
 name = "syn"

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-pkg"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,15 +10,15 @@ description = "Building, locking, fetching and updating Sway projects as Forc pa
 
 [dependencies]
 anyhow = "1"
-forc-util = { version = "0.9.0", path = "../forc-util" }
+forc-util = { version = "0.9.1", path = "../forc-util" }
 git2 = "0.14"
 petgraph = { version = "0.6", features = ["serde-1"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
-sway-core = { version = "0.9.0", path = "../sway-core" }
-sway-types = { version = "0.9.0", path = "../sway-types" }
-sway-utils = { version = "0.9.0", path = "../sway-utils" }
+sway-core = { version = "0.9.1", path = "../sway-core" }
+sway-types = { version = "0.9.1", path = "../sway-types" }
+sway-utils = { version = "0.9.1", path = "../sway-utils" }
 toml = "0.5"
 url = { version = "2.2", features = ["serde"] }
 walkdir = "2"

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-util"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,7 +12,7 @@ description = "Utility items shared between forc crates."
 annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1"
 dirs = "3.0.2"
-sway-core = { version = "0.9.0", path = "../sway-core" }
-sway-utils = { version = "0.9.0", path = "../sway-utils" }
+sway-core = { version = "0.9.1", path = "../sway-core" }
+sway-utils = { version = "0.9.1", path = "../sway-utils" }
 termcolor = "1.1"
 unicode-xid = "0.2.2"

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -13,8 +13,8 @@ annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1.0.41"
 clap = { version = "3.1", features = ["env", "derive"] }
 clap_complete = "3.1"
-forc-pkg = { version = "0.9.0", path = "../forc-pkg" }
-forc-util = { version = "0.9.0", path = "../forc-util" }
+forc-pkg = { version = "0.9.1", path = "../forc-pkg" }
+forc-util = { version = "0.9.1", path = "../forc-util" }
 fuel-asm = "0.3"
 fuel-gql-client = { version = "0.5", default-features = false }
 fuel-tx = "0.7"
@@ -25,11 +25,11 @@ prettydiff = "0.5.0"
 reqwest = { version = "0.11.4", default-features = false, features = ["json", "rustls-tls"] }
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0.73"
-sway-core = { version = "0.9.0", path = "../sway-core" }
-sway-fmt = { version = "0.9.0", path = "../sway-fmt" }
-sway-lsp = { version = "0.9.0", path = "../sway-lsp" }
-sway-utils = { version = "0.9.0", path = "../sway-utils" }
-sway-types = { version = "0.9.0", path = "../sway-types" }
+sway-core = { version = "0.9.1", path = "../sway-core" }
+sway-fmt = { version = "0.9.1", path = "../sway-fmt" }
+sway-lsp = { version = "0.9.1", path = "../sway-lsp" }
+sway-utils = { version = "0.9.1", path = "../sway-utils" }
+sway-types = { version = "0.9.1", path = "../sway-types" }
 taplo = "0.7"
 tar = "0.4.35"
 term-table = "1.3"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parser"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 publish = false
 

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-core"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -31,9 +31,9 @@ regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.9"
 smallvec = "1.7"
-sway-ir = { version = "0.9.0", path = "../sway-ir" }
-sway-types = { version = "0.9.0", path = "../sway-types" }
-sway-utils = { version = "0.9.0", path = "../sway-utils" }
+sway-ir = { version = "0.9.1", path = "../sway-ir" }
+sway-types = { version = "0.9.1", path = "../sway-types" }
+sway-utils = { version = "0.9.1", path = "../sway-utils" }
 generational-arena = "0.2"
 thiserror = "1.0"
 

--- a/sway-fmt/Cargo.toml
+++ b/sway-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-fmt"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,6 +10,6 @@ description = "Sway sway-fmt."
 
 [dependencies]
 ropey = "1.2"
-sway-core = { version = "0.9.0", path = "../sway-core" }
-sway-types = { version = "0.9.0", path = "../sway-types" }
+sway-core = { version = "0.9.1", path = "../sway-core" }
+sway-types = { version = "0.9.1", path = "../sway-types" }
 

--- a/sway-ir/Cargo.toml
+++ b/sway-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ir"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -16,4 +16,4 @@ generational-arena = "0.2"
 peg = "0.7"
 pest = { version = "3.0.4", package = "fuel-pest" }
 prettydiff = "0.5"
-sway-types = { version = "0.9.0", path = "../sway-types" }
+sway-types = { version = "0.9.1", path = "../sway-types" }

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-lsp"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,14 +10,14 @@ description = "LSP server for Sway."
 
 [dependencies]
 dashmap = "4.0.2"
-forc-util = { version = "0.9.0", path = "../forc-util" }
+forc-util = { version = "0.9.1", path = "../forc-util" }
 tower-lsp = "0.16.0"
 ropey = "1.2"
 serde_json = "1.0.60"
-sway-core = { version = "0.9.0", path = "../sway-core" }
-sway-fmt = { version = "0.9.0", path = "../sway-fmt" }
-sway-types = { version = "0.9.0", path = "../sway-types" }
-sway-utils = { version = "0.9.0", path = "../sway-utils" }
+sway-core = { version = "0.9.1", path = "../sway-core" }
+sway-fmt = { version = "0.9.1", path = "../sway-fmt" }
+sway-types = { version = "0.9.1", path = "../sway-types" }
+sway-utils = { version = "0.9.1", path = "../sway-utils" }
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]

--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-types"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/sway-utils/Cargo.toml
+++ b/sway-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-utils"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.41"
-forc = { version = "0.9.0", path = "../forc", features = ["test"], default-features = false }
+forc = { version = "0.9.1", path = "../forc", features = ["test"], default-features = false }
 fuel-asm = "0.3"
 fuel-tx = "0.7"
 fuel-vm = { version = "0.6", features = ["random"] }


### PR DESCRIPTION
v0.9.0 had a broken standard library so the release never published. The broken code was fixed in #1052 though, so just tagging a new release should work.