### PR TITLE
Add build script for stdlib test projects

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Place in root of project and run to build the project and all its tests and artifacts
+FILES="./tests/test_*/*"
+for f in $FILES
+do
+if [ -d "${f}" ];
+then
+echo "building test $f..."
+  forc build -o temp -p $f
+  if ! [ -f temp ];
+  then
+  echo "Failed to build $f"
+  exit 1
+  fi
+  rm temp
+fi
+done
+
+echo "building project..."
+cd tests && forc build

--- a/build.sh
+++ b/build.sh
@@ -18,4 +18,6 @@ fi
 done
 
 echo "building project..."
-cd sway-lib-std/tests && forc build
+pushd sway-lib-std/tests
+cargo test
+popd

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Place in root of project and run to build the project and all its tests and artifacts
-FILES="./tests/test_*/*"
+FILES="./sway-lib-std/tests/test_*/*"
 for f in $FILES
 do
 if [ -d "${f}" ];
@@ -18,4 +18,4 @@ fi
 done
 
 echo "building project..."
-cd tests && forc build
+cd sway-lib-std/tests && forc build


### PR DESCRIPTION
This is a bash script that @simonr0204 wrote to simplify building multiple test projects and dependencies.

Ref: (Old PR in `sway-lib-std` repo) https://github.com/FuelLabs/sway-lib-std/pull/100