### PR TITLE
Add Forc lockfiles to test projects

### DIFF
--- a/sway-lib-std/tests/Cargo.toml
+++ b/sway-lib-std/tests/Cargo.toml
@@ -22,3 +22,5 @@ tokio = { version = "1.12", features = ["rt", "macros"] }
 harness = true
 name = "integration_tests"
 path = "test_projects/harness.rs"
+
+[workspace]

--- a/sway-lib-std/tests/test_artifacts/auth_caller_contract/Forc.lock
+++ b/sway-lib-std/tests/test_artifacts/auth_caller_contract/Forc.lock
@@ -1,0 +1,18 @@
+[[package]]
+name = 'auth_caller_contract'
+dependencies = [
+    'auth_testing_abi',
+    'std',
+]
+
+[[package]]
+name = 'auth_testing_abi'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_artifacts/auth_caller_script/Forc.lock
+++ b/sway-lib-std/tests/test_artifacts/auth_caller_script/Forc.lock
@@ -1,0 +1,18 @@
+[[package]]
+name = 'auth_caller_script'
+dependencies = [
+    'auth_testing_abi',
+    'std',
+]
+
+[[package]]
+name = 'auth_testing_abi'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_artifacts/auth_testing_abi/Forc.lock
+++ b/sway-lib-std/tests/test_artifacts/auth_testing_abi/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'auth_testing_abi'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_artifacts/auth_testing_contract/Forc.lock
+++ b/sway-lib-std/tests/test_artifacts/auth_testing_contract/Forc.lock
@@ -1,0 +1,18 @@
+[[package]]
+name = 'auth_testing_abi'
+dependencies = ['std']
+
+[[package]]
+name = 'auth_testing_contract'
+dependencies = [
+    'auth_testing_abi',
+    'std',
+]
+
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_artifacts/balance_contract/Forc.lock
+++ b/sway-lib-std/tests/test_artifacts/balance_contract/Forc.lock
@@ -1,17 +1,9 @@
 [[package]]
 name = 'balance_contract'
-dependencies = [
-    'core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f',
-    'std',
-]
+dependencies = ['std']
 
 [[package]]
 name = 'core'
-dependencies = []
-
-[[package]]
-name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
 dependencies = []
 
 [[package]]

--- a/sway-lib-std/tests/test_artifacts/balance_contract/Forc.lock
+++ b/sway-lib-std/tests/test_artifacts/balance_contract/Forc.lock
@@ -1,0 +1,19 @@
+[[package]]
+name = 'balance_contract'
+dependencies = [
+    'core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f',
+    'std',
+]
+
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'core'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_artifacts/balance_contract/Forc.toml
+++ b/sway-lib-std/tests/test_artifacts/balance_contract/Forc.toml
@@ -5,5 +5,4 @@ license = "Apache-2.0"
 name = "balance_contract"
 
 [dependencies]
-core = { git = "https://github.com/FuelLabs/sway-lib-core", branch = "master" }
 std = { path = "../../../" }

--- a/sway-lib-std/tests/test_artifacts/call_frames_test_abi/Forc.lock
+++ b/sway-lib-std/tests/test_artifacts/call_frames_test_abi/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'call_frames_test_abi'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_artifacts/context_caller_contract/Forc.lock
+++ b/sway-lib-std/tests/test_artifacts/context_caller_contract/Forc.lock
@@ -1,0 +1,18 @@
+[[package]]
+name = 'context_caller_contract'
+dependencies = [
+    'context_testing_abi',
+    'std',
+]
+
+[[package]]
+name = 'context_testing_abi'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_artifacts/context_testing_abi/Forc.lock
+++ b/sway-lib-std/tests/test_artifacts/context_testing_abi/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'context_testing_abi'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_artifacts/tx_contract/Forc.lock
+++ b/sway-lib-std/tests/test_artifacts/tx_contract/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']
+
+[[package]]
+name = 'tx_contract'
+dependencies = ['std']

--- a/sway-lib-std/tests/test_projects/auth/Forc.lock
+++ b/sway-lib-std/tests/test_projects/auth/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'auth'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_projects/call_frames/Forc.lock
+++ b/sway-lib-std/tests/test_projects/call_frames/Forc.lock
@@ -1,0 +1,18 @@
+[[package]]
+name = 'call_frames'
+dependencies = [
+    'call_frames_test_abi',
+    'std',
+]
+
+[[package]]
+name = 'call_frames_test_abi'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_projects/context/Forc.lock
+++ b/sway-lib-std/tests/test_projects/context/Forc.lock
@@ -1,0 +1,18 @@
+[[package]]
+name = 'context'
+dependencies = [
+    'context_testing_abi',
+    'std',
+]
+
+[[package]]
+name = 'context_testing_abi'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_projects/contract_id_type/Forc.lock
+++ b/sway-lib-std/tests/test_projects/contract_id_type/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'contract_id_type'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_projects/option/Forc.lock
+++ b/sway-lib-std/tests/test_projects/option/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'option'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_projects/registers/Forc.lock
+++ b/sway-lib-std/tests/test_projects/registers/Forc.lock
@@ -1,0 +1,19 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'core'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
+dependencies = []
+
+[[package]]
+name = 'registers'
+dependencies = [
+    'core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f',
+    'std',
+]
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_projects/registers/Forc.lock
+++ b/sway-lib-std/tests/test_projects/registers/Forc.lock
@@ -3,16 +3,8 @@ name = 'core'
 dependencies = []
 
 [[package]]
-name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
-dependencies = []
-
-[[package]]
 name = 'registers'
-dependencies = [
-    'core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f',
-    'std',
-]
+dependencies = ['std']
 
 [[package]]
 name = 'std'

--- a/sway-lib-std/tests/test_projects/registers/Forc.toml
+++ b/sway-lib-std/tests/test_projects/registers/Forc.toml
@@ -5,5 +5,4 @@ license = "Apache-2.0"
 name = "registers"
 
 [dependencies]
-core = { git = "https://github.com/FuelLabs/sway-lib-core", branch = "master" }
 std = { path = "../../../" }

--- a/sway-lib-std/tests/test_projects/result/Forc.lock
+++ b/sway-lib-std/tests/test_projects/result/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'result'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_projects/token_ops/Forc.lock
+++ b/sway-lib-std/tests/test_projects/token_ops/Forc.lock
@@ -1,0 +1,19 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'core'
+source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']
+
+[[package]]
+name = 'token_ops'
+dependencies = [
+    'core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f',
+    'std',
+]

--- a/sway-lib-std/tests/test_projects/token_ops/Forc.lock
+++ b/sway-lib-std/tests/test_projects/token_ops/Forc.lock
@@ -3,17 +3,9 @@ name = 'core'
 dependencies = []
 
 [[package]]
-name = 'core'
-source = 'git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f'
-dependencies = []
-
-[[package]]
 name = 'std'
 dependencies = ['core']
 
 [[package]]
 name = 'token_ops'
-dependencies = [
-    'core git+https://github.com/FuelLabs/sway-lib-core?branch=master#082bc8eb0616586ac0000825bfe6e9d47b0c713f',
-    'std',
-]
+dependencies = ['std']

--- a/sway-lib-std/tests/test_projects/token_ops/Forc.toml
+++ b/sway-lib-std/tests/test_projects/token_ops/Forc.toml
@@ -5,5 +5,4 @@ license = "Apache-2.0"
 name = "token_ops"
 
 [dependencies]
-core = { git = "https://github.com/FuelLabs/sway-lib-core", branch = "master" }
 std = { path = "../../../" }


### PR DESCRIPTION
- This adds the lock files for each test project in `sway-lib-std`, otherwise, the first PR to add tests to the std lib will need to contain these unrelated changes.

- also adds an empty `[workspace]` the  `sway-lib-std/tests/cargo.toml` to resolve error when running `sway/build.sh`.