### PR TITLE
Add dedicated CI job for `sway-lib-std` tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,30 @@ jobs:
           command: run
           args: --release --bin test
 
+  # TODO: Remove this upon merging std tests with the rest of the E2E tests.
+  cargo-test-lib-std:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    services:
+      fuel-core:
+        image: ghcr.io/fuellabs/fuel-core:v0.5.0
+        ports:
+          - 4000:4000
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Build All Tests
+        run: cd sway-lib-std && bash build.sh && cd ..
+      - name: Cargo Test sway-lib-std
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --test --manifest-path ./sway-lib-std/tests/Cargo.toml -- --test-threads=1 --no-capture
+
   cargo-test-workspace:
     needs: cancel-previous-runs
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,8 +172,8 @@ jobs:
       - name: Cargo Test sway-lib-std
         uses: actions-rs/cargo@v1
         with:
-          command: run
-          args: --test --manifest-path ./sway-lib-std/tests/Cargo.toml -- --test-threads=1 --no-capture
+          command: test
+          args: --manifest-path ./sway-lib-std/tests/Cargo.toml -- --test-threads=1 --no-capture
 
   cargo-test-workspace:
     needs: cancel-previous-runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,11 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
+      - name: Install Forc
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc
       - name: Build All Tests
         run: cd sway-lib-std && bash build.sh && cd ..
       - name: Cargo Test sway-lib-std

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path ./sway-lib-std/tests/Cargo.toml -- --test-threads=1 --no-capture
+          args: --manifest-path ./sway-lib-std/tests/Cargo.toml -- --test-threads=1 --nocapture
 
   cargo-test-workspace:
     needs: cancel-previous-runs

--- a/sway-lib-std/build.sh
+++ b/sway-lib-std/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Place in root of project and run to build the project and all its tests and artifacts
-FILES="./sway-lib-std/tests/test_*/*"
+FILES="./tests/test_*/*"
 for f in $FILES
 do
 if [ -d "${f}" ];

--- a/sway-lib-std/tests/README.md
+++ b/sway-lib-std/tests/README.md
@@ -4,10 +4,17 @@ As we currently don't have a CI job which runs these automatically, make sure te
 
 ## Building test projects
 
+First, ensure we have the current version of `forc` installed.
+
+```sh
+$ cd sway
+$ cargo install --path ./forc
+```
+
 In the root of the `sway-lib-std` is a bash build script. To run it:
 
 ```sh
-$ cd sway/sway-lib-std
+$ cd sway-lib-std
 $ ./build.sh
 ```
 
@@ -15,7 +22,7 @@ This will build all contracts and scripts under the `sway/sway-lib-std/tests/` d
 After a sucessfull build of all the projects:
 
 ```sh
-$ cd sway-lib-std/tests
+$ cd tests
 ```
 
 ## To run all tests single threaded

--- a/sway-lib-std/tests/README.md
+++ b/sway-lib-std/tests/README.md
@@ -4,10 +4,10 @@ As we currently don't have a CI job which runs these automatically, make sure te
 
 ## Building test projects
 
-In the root of the `sway` repo is a bash build script. To run it:
+In the root of the `sway-lib-std` is a bash build script. To run it:
 
 ```sh
-$ cd sway
+$ cd sway/sway-lib-std
 $ ./build.sh
 ```
 
@@ -27,7 +27,7 @@ $ cargo test --  --test-threads=1
 ## To capture output (ie: logs from println!) even for passing tests
 
 ```sh
-$ cargo test --  --test-threads=1 --no-capture
+$ cargo test --  --test-threads=1 --nocapture
 ```
 
 ## To run a subset of tests, use the filter option


### PR DESCRIPTION
**NOTE: This PR is based against @nfurfaro's branch at #1097 - not `master`.** I'm happy to see either #1097 land first or for this to get merged into the work at #1097.

This gets some CI testing happening for the `sway-lib-std` tests pending further discussion on consolidation of the `sway-lib-std` tests and the rest of the E2E tests. #1058

This PR
- Moves the build script for lib-std tests to `sway-lib-std` subdirectory.
- Adds a CI job for sway-lib-std tests.
- Fix sway-lib-std tests README for build script move and `--no-capture` -> `--nocapture` flag.

cc @nfurfaro