### PR TITLE
Improve strings for IR.

### DIFF
--- a/sway-core/tests/ir_to_asm/enum_struct_string.asm
+++ b/sway-core/tests/ir_to_asm/enum_struct_string.asm
@@ -1,0 +1,48 @@
+.program:
+ji   i4
+noop
+DATA_SECTION_OFFSET[0..32]
+DATA_SECTION_OFFSET[32..64]
+lw   $ds $is 1
+add  $$ds $$ds $is
+move $r4 $sp                  ; save locals base register
+cfei i32                      ; allocate 32 bytes for all locals
+move $r3 $sp                  ; save register for temporary stack value
+cfei i40                      ; allocate 40 bytes for temporary struct
+lw   $r0 data_0               ; literal instantiation
+sw   $r3 $r0 i0               ; insert_value @ 0
+move $r2 $sp                  ; save register for temporary stack value
+cfei i16                      ; allocate 16 bytes for temporary struct
+lw   $r0 data_1               ; literal instantiation
+sw   $r2 $r0 i0               ; insert_value @ 0
+lw   $r0 data_2               ; literal instantiation
+sw   $r2 $r0 i1               ; insert_value @ 1
+move $r1 $sp                  ; save register for temporary stack value
+cfei i32                      ; allocate 32 bytes for temporary struct
+addi $r0 $r1 i0               ; get struct field(s) 0 offset
+mcpi $r0 $r2 i16              ; store struct field value
+lw   $r0 data_3               ; literal instantiation
+sw   $r1 $r0 i2               ; insert_value @ 1
+lw   $r0 data_4               ; literal instantiation
+sw   $r1 $r0 i3               ; insert_value @ 2
+addi $r0 $r3 i8               ; get struct field(s) 1 offset
+mcpi $r0 $r1 i32              ; store struct field value
+lw   $r1 $r3 i0               ; extract_value @ 0
+lw   $r0 data_0               ; literal instantiation
+eq   $r0 $r1 $r0
+jnei $r0 $one i40
+addi $r1 $r3 i8               ; extract address
+addi $r0 $r4 i0               ; get_ptr
+addi $r0 $r4 i0               ; get store offset
+mcpi $r0 $r1 i32              ; store value
+addi $r0 $r4 i0               ; get_ptr
+lw   $r0 $r0 i2               ; extract_value @ 1
+ji   i41
+lw   $r0 data_0               ; literal instantiation
+ret  $r0
+.data:
+data_0 .u64 0x00
+data_1 .str " an odd length"
+data_2 .u64 0x14
+data_3 .u64 0x0a
+data_4 .bool 0x00

--- a/sway-core/tests/ir_to_asm/enum_struct_string.ir
+++ b/sway-core/tests/ir_to_asm/enum_struct_string.ir
@@ -1,0 +1,44 @@
+// Copied from the sway_to_ir test of the same name.
+
+script {
+    fn main() -> u64 {
+        local ptr { { string<17>, u64 }, u64, bool } b
+
+        entry:
+        v0 = const { u64, ( { { string<17>, u64 }, u64, bool } ) } { u64 undef, ( { { string<17>, u64 }, u64, bool } ) undef }
+        v1 = const u64 0
+        v2 = insert_value v0, { u64, ( { { string<17>, u64 }, u64, bool } ) }, v1, 0
+        v3 = const { string<17>, u64 } { string<17> undef, u64 undef }
+        v4 = const string<17> "\xee\x82\xb0 an odd length"
+        v5 = insert_value v3, { string<17>, u64 }, v4, 0
+        v6 = const u64 20
+        v7 = insert_value v5, { string<17>, u64 }, v6, 1
+        v8 = const { { string<17>, u64 }, u64, bool } { { string<17>, u64 } { string<17> undef, u64 undef }, u64 undef, bool undef }
+        v9 = insert_value v8, { { string<17>, u64 }, u64, bool }, v7, 0
+        v10 = const u64 10
+        v11 = insert_value v9, { { string<17>, u64 }, u64, bool }, v10, 1
+        v12 = const bool false
+        v13 = insert_value v11, { { string<17>, u64 }, u64, bool }, v12, 2
+        v14 = insert_value v2, { u64, ( { { string<17>, u64 }, u64, bool } ) }, v13, 1
+        v15 = extract_value v14, { u64, ( { { string<17>, u64 }, u64, bool } ) }, 0
+        v16 = const u64 0
+        v17 = cmp eq v15 v16
+        cbr v17, block0, block1
+
+        block0:
+        v18 = extract_value v14, { u64, ( { { string<17>, u64 }, u64, bool } ) }, 1, 0
+        v19 = get_ptr ptr { { string<17>, u64 }, u64, bool } b, ptr { { string<17>, u64 }, u64, bool }, 0
+        store v18, ptr v19
+        v20 = get_ptr ptr { { string<17>, u64 }, u64, bool } b, ptr { { string<17>, u64 }, u64, bool }, 0
+        v21 = extract_value v20, { { string<17>, u64 }, u64, bool }, 1
+        br block2
+
+        block1:
+        v22 = const u64 0
+        br block2
+
+        block2:
+        v23 = phi(block0: v21, block1: v22)
+        ret u64 v23
+    }
+}

--- a/sway-core/tests/ir_to_asm/simple_enum.ir
+++ b/sway-core/tests/ir_to_asm/simple_enum.ir
@@ -1,20 +1,20 @@
 script {
     fn main() -> () {
-        local ptr { u64, { () | () | u64 } } lunch
+        local ptr { u64, ( () | () | u64 ) } lunch
 
         entry:
-        v0 = const { u64, { () | () | u64 } } { u64 undef, { () | () | u64 } undef }
+        v0 = const { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef }
         v1 = const u64 1
-        v2 = insert_value v0, { u64, { () | () | u64 } }, v1, 0
-        v3 = get_ptr ptr { u64, { () | () | u64 } } lunch, ptr { u64, { () | () | u64 } }, 0
+        v2 = insert_value v0, { u64, ( () | () | u64 ) }, v1, 0
+        v3 = get_ptr ptr { u64, ( () | () | u64 ) } lunch, ptr { u64, ( () | () | u64 ) }, 0
         store v2, ptr v3
-        v4 = get_ptr ptr { u64, { () | () | u64 } } lunch, ptr { u64, { () | () | u64 } }, 0
+        v4 = get_ptr ptr { u64, ( () | () | u64 ) } lunch, ptr { u64, ( () | () | u64 ) }, 0
         v5 = const bool false
-        v6 = const { u64, { () | () | u64 } } { u64 undef, { () | () | u64 } undef }
+        v6 = const { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef }
         v7 = const u64 2
-        v8 = insert_value v6, { u64, { () | () | u64 } }, v7, 0
+        v8 = insert_value v6, { u64, ( () | () | u64 ) }, v7, 0
         v9 = const u64 3
-        v10 = insert_value v8, { u64, { () | () | u64 } }, v9, 1
+        v10 = insert_value v8, { u64, ( () | () | u64 ) }, v9, 1
         v11 = const bool false
         v12 = const unit ()
         ret () v12

--- a/sway-core/tests/ir_to_asm/simple_if_let.ir
+++ b/sway-core/tests/ir_to_asm/simple_if_let.ir
@@ -1,24 +1,24 @@
 script {
     fn main() -> u64 {
         local ptr u64 n
-        local ptr { u64, { bool | u64 } } thing
+        local ptr { u64, ( bool | u64 ) } thing
 
         entry:
-        v0 = const { u64, { bool | u64 } } { u64 undef, { bool | u64 } undef }
+        v0 = const { u64, ( bool | u64 ) } { u64 undef, ( bool | u64 ) undef }
         v1 = const u64 0
-        v2 = insert_value v0, { u64, { bool | u64 } }, v1, 0
+        v2 = insert_value v0, { u64, ( bool | u64 ) }, v1, 0
         v3 = const bool true
-        v4 = insert_value v2, { u64, { bool | u64 } }, v3, 1
-        v5 = get_ptr ptr { u64, { bool | u64 } } thing, ptr { u64, { bool | u64 } }, 0
+        v4 = insert_value v2, { u64, ( bool | u64 ) }, v3, 1
+        v5 = get_ptr ptr { u64, ( bool | u64 ) } thing, ptr { u64, ( bool | u64 ) }, 0
         store v4, ptr v5
-        v6 = get_ptr ptr { u64, { bool | u64 } } thing, ptr { u64, { bool | u64 } }, 0
-        v7 = extract_value v6, { u64, { bool | u64 } }, 0
+        v6 = get_ptr ptr { u64, ( bool | u64 ) } thing, ptr { u64, ( bool | u64 ) }, 0
+        v7 = extract_value v6, { u64, ( bool | u64 ) }, 0
         v8 = const u64 1
         v9 = cmp eq v7 v8
         cbr v9, block0, block1
 
         block0:
-        v10 = extract_value v6, { u64, { bool | u64 } }, 1, 1
+        v10 = extract_value v6, { u64, ( bool | u64 ) }, 1, 1
         v11 = get_ptr ptr u64 n, ptr u64, 0
         store v10, ptr v11
         v12 = get_ptr ptr u64 n, ptr u64, 0

--- a/sway-core/tests/sway_to_ir/enum.ir
+++ b/sway-core/tests/sway_to_ir/enum.ir
@@ -1,32 +1,32 @@
 script {
     fn main() -> () {
-        local ptr { u64, { () | () | u64 } } lunch
+        local ptr { u64, ( () | () | u64 ) } lunch
 
         entry:
-        v0 = const { u64, { () | () | u64 } } { u64 undef, { () | () | u64 } undef }, !1
+        v0 = const { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef }, !1
         v1 = const u64 1, !1
-        v2 = insert_value v0, { u64, { () | () | u64 } }, v1, 0, !1
-        v3 = get_ptr ptr { u64, { () | () | u64 } } lunch, ptr { u64, { () | () | u64 } }, 0, !2
+        v2 = insert_value v0, { u64, ( () | () | u64 ) }, v1, 0, !1
+        v3 = get_ptr ptr { u64, ( () | () | u64 ) } lunch, ptr { u64, ( () | () | u64 ) }, 0, !2
         store v2, ptr v3, !2
-        v4 = get_ptr ptr { u64, { () | () | u64 } } lunch, ptr { u64, { () | () | u64 } }, 0, !3
+        v4 = get_ptr ptr { u64, ( () | () | u64 ) } lunch, ptr { u64, ( () | () | u64 ) }, 0, !3
         v5 = call anon_0(v4), !4
-        v6 = const { u64, { () | () | u64 } } { u64 undef, { () | () | u64 } undef }, !5
+        v6 = const { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef }, !5
         v7 = const u64 2, !5
-        v8 = insert_value v6, { u64, { () | () | u64 } }, v7, 0, !5
+        v8 = insert_value v6, { u64, ( () | () | u64 ) }, v7, 0, !5
         v9 = const u64 3, !6
-        v10 = insert_value v8, { u64, { () | () | u64 } }, v9, 1, !5
+        v10 = insert_value v8, { u64, ( () | () | u64 ) }, v9, 1, !5
         v11 = call anon_1(v10), !7
         v12 = const unit ()
         ret () v12
     }
 
-    fn anon_0(meal !8: { u64, { () | () | u64 } }) -> bool {
+    fn anon_0(meal !8: { u64, ( () | () | u64 ) }) -> bool {
         entry:
         v0 = const bool false, !9
         ret bool v0
     }
 
-    fn anon_1(meal !10: { u64, { () | () | u64 } }) -> bool {
+    fn anon_1(meal !10: { u64, ( () | () | u64 ) }) -> bool {
         entry:
         v0 = const bool false, !11
         ret bool v0

--- a/sway-core/tests/sway_to_ir/enum_enum.ir
+++ b/sway-core/tests/sway_to_ir/enum_enum.ir
@@ -1,13 +1,13 @@
 script {
     fn main() -> () {
         entry:
-        v0 = const { u64, { () | { u64, { () | bool | () } } | () } } { u64 undef, { () | { u64, { () | bool | () } } | () } undef }, !1
+        v0 = const { u64, ( () | { u64, ( () | bool | () ) } | () ) } { u64 undef, ( () | { u64, ( () | bool | () ) } | () ) undef }, !1
         v1 = const u64 1, !1
-        v2 = insert_value v0, { u64, { () | { u64, { () | bool | () } } | () } }, v1, 0, !1
-        v3 = const { u64, { () | bool | () } } { u64 undef, { () | bool | () } undef }, !2
+        v2 = insert_value v0, { u64, ( () | { u64, ( () | bool | () ) } | () ) }, v1, 0, !1
+        v3 = const { u64, ( () | bool | () ) } { u64 undef, ( () | bool | () ) undef }, !2
         v4 = const u64 0, !2
-        v5 = insert_value v3, { u64, { () | bool | () } }, v4, 0, !2
-        v6 = insert_value v2, { u64, { () | { u64, { () | bool | () } } | () } }, v5, 1, !1
+        v5 = insert_value v3, { u64, ( () | bool | () ) }, v4, 0, !2
+        v6 = insert_value v2, { u64, ( () | { u64, ( () | bool | () ) } | () ) }, v5, 1, !1
         v7 = const unit ()
         ret () v7
     }

--- a/sway-core/tests/sway_to_ir/enum_struct.ir
+++ b/sway-core/tests/sway_to_ir/enum_struct.ir
@@ -1,9 +1,9 @@
 script {
     fn main() -> () {
         entry:
-        v0 = const { u64, { () | { b256, bool, u64 } | () } } { u64 undef, { () | { b256, bool, u64 } | () } undef }, !1
+        v0 = const { u64, ( () | { b256, bool, u64 } | () ) } { u64 undef, ( () | { b256, bool, u64 } | () ) undef }, !1
         v1 = const u64 1, !1
-        v2 = insert_value v0, { u64, { () | { b256, bool, u64 } | () } }, v1, 0, !1
+        v2 = insert_value v0, { u64, ( () | { b256, bool, u64 } | () ) }, v1, 0, !1
         v3 = const { b256, bool, u64 } { b256 undef, bool undef, u64 undef }, !2
         v4 = const b256 0x0001010101010101000101010101010100010101010101010001010101010101, !3
         v5 = insert_value v3, { b256, bool, u64 }, v4, 0, !2
@@ -11,7 +11,7 @@ script {
         v7 = insert_value v5, { b256, bool, u64 }, v6, 1, !2
         v8 = const u64 53, !5
         v9 = insert_value v7, { b256, bool, u64 }, v8, 2, !2
-        v10 = insert_value v2, { u64, { () | { b256, bool, u64 } | () } }, v9, 1, !1
+        v10 = insert_value v2, { u64, ( () | { b256, bool, u64 } | () ) }, v9, 1, !1
         v11 = const unit ()
         ret () v11
     }

--- a/sway-core/tests/sway_to_ir/enum_struct_string.ir
+++ b/sway-core/tests/sway_to_ir/enum_struct_string.ir
@@ -1,0 +1,56 @@
+script {
+    fn main() -> u64 {
+        local ptr { { string<17>, u64 }, u64, bool } b
+
+        entry:
+        v0 = const { u64, ( { { string<17>, u64 }, u64, bool } ) } { u64 undef, ( { { string<17>, u64 }, u64, bool } ) undef }, !1
+        v1 = const u64 0, !1
+        v2 = insert_value v0, { u64, ( { { string<17>, u64 }, u64, bool } ) }, v1, 0, !1
+        v3 = const { string<17>, u64 } { string<17> undef, u64 undef }, !2
+        v4 = const string<17> "\xee\x82\xb0 an odd length", !3
+        v5 = insert_value v3, { string<17>, u64 }, v4, 0, !2
+        v6 = const u64 20, !4
+        v7 = insert_value v5, { string<17>, u64 }, v6, 1, !2
+        v8 = const { { string<17>, u64 }, u64, bool } { { string<17>, u64 } { string<17> undef, u64 undef }, u64 undef, bool undef }, !5
+        v9 = insert_value v8, { { string<17>, u64 }, u64, bool }, v7, 0, !5
+        v10 = const u64 10, !6
+        v11 = insert_value v9, { { string<17>, u64 }, u64, bool }, v10, 1, !5
+        v12 = const bool false, !7
+        v13 = insert_value v11, { { string<17>, u64 }, u64, bool }, v12, 2, !5
+        v14 = insert_value v2, { u64, ( { { string<17>, u64 }, u64, bool } ) }, v13, 1, !1
+        v15 = extract_value v14, { u64, ( { { string<17>, u64 }, u64, bool } ) }, 0, !8
+        v16 = const u64 0, !8
+        v17 = cmp eq v15 v16, !8
+        cbr v17, block0, block1, !8
+
+        block0:
+        v18 = extract_value v14, { u64, ( { { string<17>, u64 }, u64, bool } ) }, 1, 0, !9
+        v19 = get_ptr ptr { { string<17>, u64 }, u64, bool } b, ptr { { string<17>, u64 }, u64, bool }, 0, !9
+        store v18, ptr v19, !9
+        v20 = get_ptr ptr { { string<17>, u64 }, u64, bool } b, ptr { { string<17>, u64 }, u64, bool }, 0, !10
+        v21 = extract_value v20, { { string<17>, u64 }, u64, bool }, 1, !11
+        br block2
+
+        block1:
+        v22 = const u64 0, !12
+        br block2
+
+        block2:
+        v23 = phi(block0: v21, block1: v22)
+        ret u64 v23
+    }
+}
+
+!0 = filepath "/path/to/enum_struct_string.sw"
+!1 = span !0 100 120
+!2 = span !0 174 209
+!3 = span !0 181 200
+!4 = span !0 205 207
+!5 = span !0 167 228
+!6 = span !0 214 216
+!7 = span !0 221 226
+!8 = span !0 165 166
+!9 = span !0 157 158
+!10 = span !0 240 241
+!11 = span !0 76 77
+!12 = span !0 265 266

--- a/sway-core/tests/sway_to_ir/enum_struct_string.sw
+++ b/sway-core/tests/sway_to_ir/enum_struct_string.sw
@@ -1,0 +1,24 @@
+script;
+
+struct S {
+    n: str[17],
+    v: u64,
+}
+
+struct A {
+    s: S,
+    a: u64,
+    b: bool,
+}
+
+enum B {
+    B: A,
+}
+
+fn main() -> u64 {
+    if let B::B(b) = B::B(A { s: S { n: " an odd length", v: 20 }, a: 10, b: false }) {
+        b.a
+    } else {
+        0
+    }
+}

--- a/sway-core/tests/sway_to_ir/if_let_simple.ir
+++ b/sway-core/tests/sway_to_ir/if_let_simple.ir
@@ -1,24 +1,24 @@
 script {
     fn main() -> u64 {
         local ptr u64 n
-        local ptr { u64, { bool | u64 } } thing
+        local ptr { u64, ( bool | u64 ) } thing
 
         entry:
-        v0 = const { u64, { bool | u64 } } { u64 undef, { bool | u64 } undef }, !1
+        v0 = const { u64, ( bool | u64 ) } { u64 undef, ( bool | u64 ) undef }, !1
         v1 = const u64 0, !1
-        v2 = insert_value v0, { u64, { bool | u64 } }, v1, 0, !1
+        v2 = insert_value v0, { u64, ( bool | u64 ) }, v1, 0, !1
         v3 = const bool true, !2
-        v4 = insert_value v2, { u64, { bool | u64 } }, v3, 1, !1
-        v5 = get_ptr ptr { u64, { bool | u64 } } thing, ptr { u64, { bool | u64 } }, 0, !3
+        v4 = insert_value v2, { u64, ( bool | u64 ) }, v3, 1, !1
+        v5 = get_ptr ptr { u64, ( bool | u64 ) } thing, ptr { u64, ( bool | u64 ) }, 0, !3
         store v4, ptr v5, !3
-        v6 = get_ptr ptr { u64, { bool | u64 } } thing, ptr { u64, { bool | u64 } }, 0, !4
-        v7 = extract_value v6, { u64, { bool | u64 } }, 0, !5
+        v6 = get_ptr ptr { u64, ( bool | u64 ) } thing, ptr { u64, ( bool | u64 ) }, 0, !4
+        v7 = extract_value v6, { u64, ( bool | u64 ) }, 0, !5
         v8 = const u64 1, !5
         v9 = cmp eq v7 v8, !5
         cbr v9, block0, block1, !5
 
         block0:
-        v10 = extract_value v6, { u64, { bool | u64 } }, 1, 1, !6
+        v10 = extract_value v6, { u64, ( bool | u64 ) }, 1, 1, !6
         v11 = get_ptr ptr u64 n, ptr u64, 0, !6
         store v10, ptr v11, !6
         v12 = get_ptr ptr u64 n, ptr u64, 0, !7

--- a/sway-core/tests/sway_to_ir/lazy_binops.ir
+++ b/sway-core/tests/sway_to_ir/lazy_binops.ir
@@ -2,7 +2,6 @@ script {
     fn main() -> bool {
         entry:
         v0 = const bool false, !1
-        v0 = const bool false, !1
         cbr v0, block0, block1, !2
 
         block0:

--- a/sway-core/tests/sway_to_ir/struct_enum.ir
+++ b/sway-core/tests/sway_to_ir/struct_enum.ir
@@ -1,19 +1,19 @@
 script {
     fn main() -> bool {
-        local ptr { bool, { u64, { () | () | u64 } } } record
+        local ptr { bool, { u64, ( () | () | u64 ) } } record
 
         entry:
-        v0 = const { u64, { () | () | u64 } } { u64 undef, { () | () | u64 } undef }, !1
+        v0 = const { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef }, !1
         v1 = const u64 0, !1
-        v2 = insert_value v0, { u64, { () | () | u64 } }, v1, 0, !1
-        v3 = const { bool, { u64, { () | () | u64 } } } { bool undef, { u64, { () | () | u64 } } { u64 undef, { () | () | u64 } undef } }, !2
+        v2 = insert_value v0, { u64, ( () | () | u64 ) }, v1, 0, !1
+        v3 = const { bool, { u64, ( () | () | u64 ) } } { bool undef, { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef } }, !2
         v4 = const bool false, !3
-        v5 = insert_value v3, { bool, { u64, { () | () | u64 } } }, v4, 0, !2
-        v6 = insert_value v5, { bool, { u64, { () | () | u64 } } }, v2, 1, !2
-        v7 = get_ptr ptr { bool, { u64, { () | () | u64 } } } record, ptr { bool, { u64, { () | () | u64 } } }, 0, !4
+        v5 = insert_value v3, { bool, { u64, ( () | () | u64 ) } }, v4, 0, !2
+        v6 = insert_value v5, { bool, { u64, ( () | () | u64 ) } }, v2, 1, !2
+        v7 = get_ptr ptr { bool, { u64, ( () | () | u64 ) } } record, ptr { bool, { u64, ( () | () | u64 ) } }, 0, !4
         store v6, ptr v7, !4
-        v8 = get_ptr ptr { bool, { u64, { () | () | u64 } } } record, ptr { bool, { u64, { () | () | u64 } } }, 0, !5
-        v9 = extract_value v8, { bool, { u64, { () | () | u64 } } }, 0, !6
+        v8 = get_ptr ptr { bool, { u64, ( () | () | u64 ) } } record, ptr { bool, { u64, ( () | () | u64 ) } }, 0, !5
+        v9 = extract_value v8, { bool, { u64, ( () | () | u64 ) } }, 0, !6
         ret bool v9
     }
 }

--- a/sway-ir/src/constant.rs
+++ b/sway-ir/src/constant.rs
@@ -22,7 +22,7 @@ pub enum ConstantValue {
     Bool(bool),
     Uint(u64),
     B256([u8; 32]),
-    String(String),
+    String(Vec<u8>),
     Array(Vec<Constant>),
     Struct(Vec<Constant>),
 }
@@ -78,10 +78,9 @@ impl Constant {
         }
     }
 
-    pub fn new_string(string: String) -> Self {
-        // XXX Need to parse the string for escapes?  To do.
+    pub fn new_string(string: Vec<u8>) -> Self {
         Constant {
-            ty: Type::String(string.chars().count() as u64),
+            ty: Type::String(string.len() as u64),
             value: ConstantValue::String(string),
         }
     }
@@ -135,7 +134,7 @@ impl Constant {
 
     pub fn get_string(
         context: &mut Context,
-        value: String,
+        value: Vec<u8>,
         span_md_idx: Option<MetadataIndex>,
     ) -> Value {
         Value::new_constant(context, Constant::new_string(value), span_md_idx)

--- a/sway-ir/src/irtype.rs
+++ b/sway-ir/src/irtype.rs
@@ -52,7 +52,7 @@ impl Type {
             }
             Type::Union(agg) => {
                 let agg_content = &context.aggregates[agg.0];
-                format!("{{ {} }}", sep_types_str(agg_content, " | "))
+                format!("( {} )", sep_types_str(agg_content, " | "))
             }
             Type::Struct(agg) => {
                 let agg_content = &context.aggregates[agg.0];

--- a/sway-ir/src/parser.rs
+++ b/sway-ir/src/parser.rs
@@ -365,10 +365,6 @@ mod ir_builder {
                     (ty.clone(), IrAstConst { value: IrAstConstValue::Undef(ty), meta_idx: None })
                 }
 
-            // NOTE: a struct with a single element and a union with a single variant have the same
-            // syntax, and below we assume it to be a struct.  A union with a single variant isn't
-            // really a union, but they *could* exist, so perhaps the syntax should change to be
-            // unambiguous.
             rule ast_ty() -> IrAstTy
                 = ("unit" / "()") _ { IrAstTy::Unit }
                 / "bool" _ { IrAstTy::Bool }
@@ -385,7 +381,7 @@ mod ir_builder {
                 }
 
             rule union_ty() -> IrAstTy
-                = "{" _ tys:(ast_ty() ++ ("|" _)) "}" _ {
+                = "(" _ tys:(ast_ty() ++ ("|" _)) ")" _ {
                     IrAstTy::Union(tys)
                 }
 

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -252,7 +252,8 @@ fn maybe_constant_to_doc(
     namer: &mut Namer,
     maybe_const_val: &Value,
 ) -> Doc {
-    if maybe_const_val.is_constant(context) {
+    // Create a new doc only if value is new and unknown, and is a constant.
+    if !namer.is_known(maybe_const_val) && maybe_const_val.is_constant(context) {
         constant_to_doc(context, md_namer, namer, maybe_const_val)
     } else {
         Doc::Empty
@@ -391,7 +392,7 @@ fn instruction_to_doc<'a>(
                 aggregate,
                 ty,
                 indices,
-            } => Doc::line(
+            } => maybe_constant_to_doc(context, md_namer, namer, aggregate).append(Doc::line(
                 Doc::text(format!(
                     "{} = extract_value {}, {}, ",
                     namer.name(context, ins_value),
@@ -409,7 +410,7 @@ fn instruction_to_doc<'a>(
                     None => Doc::Empty,
                     Some(_) => Doc::text(md_namer.meta_as_string(context, span_md_idx, true)),
                 }),
-            ),
+            )),
             Instruction::GetPointer {
                 base_ptr,
                 ptr_ty,
@@ -762,6 +763,10 @@ impl Namer {
             self.names.insert(*value, new_name.clone());
             new_name
         })
+    }
+
+    fn is_known(&self, value: &Value) -> bool {
+        self.names.contains_key(value)
     }
 }
 

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -697,7 +697,20 @@ impl Constant {
                     .collect::<Vec<String>>()
                     .concat()
             ),
-            ConstantValue::String(s) => format!("{} \"{s}\"", self.ty.as_string(context)),
+            ConstantValue::String(bs) => format!(
+                "{} \"{}\"",
+                self.ty.as_string(context),
+                bs.iter()
+                    .map(
+                        |b| if b.is_ascii() && !b.is_ascii_control() && *b != b'\\' && *b != b'"' {
+                            format!("{}", *b as char)
+                        } else {
+                            format!("\\x{b:02x}")
+                        }
+                    )
+                    .collect::<Vec<_>>()
+                    .join("")
+            ),
             ConstantValue::Array(elems) => format!(
                 "{} [{}]",
                 self.ty.as_string(context),

--- a/sway-ir/tests/ir_to_ir/inline_fiddly.out_ir
+++ b/sway-ir/tests/ir_to_ir/inline_fiddly.out_ir
@@ -43,11 +43,9 @@ script {
         cbr v6, not_block03, not_block14
 
         not_block03:
-        v1 = const bool false
         br not_block25
 
         not_block14:
-        v2 = const bool true
         br not_block25
 
         not_block25:


### PR DESCRIPTION
This was one of the final tasks on my list and now we're yet again passing E2E with IR.

I've decided to just represent strings as `Vec<u8>` in the IR, there's no point in trying to get tricky with UTF-8 support.  UTF-8 strings will still 'work', but in IR they're serialised with escaped hex representation.

I also updated the serialiser so it doesn't write out constants which are re-used more than once.  And I changed the syntax for unions to be less ambiguous.