### PR TITLE
Implicitly add `std` dependency if unspecified

### DIFF
--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -91,7 +91,7 @@ impl Manifest {
             println_yellow_err(&warning);
         })
         .map_err(|e| anyhow!("failed to parse manifest: {}.", e))?;
-        manifest.implicitly_include_core_std_if_missing(sway_git_tag);
+        manifest.implicitly_include_std_if_missing(sway_git_tag);
         manifest.validate(path)?;
         Ok(manifest)
     }
@@ -178,7 +178,7 @@ impl Manifest {
     ///
     /// Note: If only `core` is specified, we are unable to implicitly add `std` as we cannot
     /// guarantee that the user's `core` is compatible with the implicit `std`.
-    fn implicitly_include_core_std_if_missing(&mut self, sway_git_tag: &str) {
+    fn implicitly_include_std_if_missing(&mut self, sway_git_tag: &str) {
         const CORE: &str = "core";
         const STD: &str = "std";
         // Don't include `std` if:

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -170,14 +170,13 @@ impl Manifest {
     }
 
     /// Check for the `core` and `std` packages under `[dependencies]`. If both are missing, add
-    /// them implicitly.
+    /// `std` implicitly.
     ///
-    /// This makes the common case of depending on `core` and `std` a lot smoother for most users,
-    /// while still allowing for the uncommon case of custom `core`/`std` deps.
+    /// This makes the common case of depending on `std` a lot smoother for most users, while still
+    /// allowing for the uncommon case of custom `core`/`std` deps.
     ///
     /// Note: If only `core` is specified, we are unable to implicitly add `std` as we cannot
-    /// guarantee that the user's `core` is compatible with the implicit `std`. Similarly if only
-    /// `std` is specified, we are unable to implicitly include `core`.
+    /// guarantee that the user's `core` is compatible with the implicit `std`.
     fn implicitly_include_core_std_if_missing(&mut self) {
         const CORE: &str = "core";
         const STD: &str = "std";
@@ -187,9 +186,10 @@ impl Manifest {
         }
         // Add a `[dependencies]` table if there isn't one.
         let deps = self.dependencies.get_or_insert_with(Default::default);
-        // Add the missing dependencies.
-        deps.insert(CORE.to_string(), implicit_core_std_dep());
-        deps.insert(STD.to_string(), implicit_core_std_dep());
+        // Add the missing dependency.
+        let sway_git_tag =
+            unimplemented!("pass through the semver string from `forc`, i.e. \"v1.0.0\"");
+        deps.insert(STD.to_string(), implicit_std_dep(sway_git_tag));
     }
 
     /// Finds and returns the name of the dependency associated with a package of the specified
@@ -206,14 +206,12 @@ impl Manifest {
     }
 }
 
-/// The definition for the implicit `core`/`std` dependency.
-///
-/// By default, the `core` and `std` dependencies
-fn implicit_core_std_dep() -> Dependency {
-    const SWAY_GIT_REPO: &str = "https://github.com/fuellabs/sway";
+/// The definition for the implicit `std` dependency.
+fn implicit_std_dep(sway_git_tag: String) -> Dependency {
+    const SWAY_GIT_REPO_URL: &str = "https://github.com/fuellabs/sway";
     let det = DependencyDetails {
-        git: Some(SWAY_GIT_REPO.to_string()),
-        tag: unimplemented!("pass through the semver string from `forc`, i.e. \"v1.0.0\""),
+        git: Some(SWAY_GIT_REPO_URL.to_string()),
+        tag: Some(sway_git_tag),
         ..Default::default()
     };
     Dependency::Detailed(det)

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -181,9 +181,16 @@ impl Manifest {
     fn implicitly_include_core_std_if_missing(&mut self, sway_git_tag: &str) {
         const CORE: &str = "core";
         const STD: &str = "std";
-        // If either of the `core` or `std` packages is user-specified, or if a dependency already
-        // exists with the name "std", we do not implicitly include anything.
-        if self.pkg_dep(CORE).is_some() || self.pkg_dep(STD).is_some() || self.dep(STD).is_some() {
+        // Don't include `std` if:
+        // - this *is* `core` or `std`.
+        // - either `core` or `std` packages are already specified.
+        // - a dependency already exists with the name "std".
+        if self.project.name == CORE
+            || self.project.name == STD
+            || self.pkg_dep(CORE).is_some()
+            || self.pkg_dep(STD).is_some()
+            || self.dep(STD).is_some()
+        {
             return;
         }
         // Add a `[dependencies]` table if there isn't one.

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -180,9 +180,10 @@ pub type DependencyName = String;
 
 impl BuildPlan {
     /// Create a new build plan for the project by fetching and pinning dependenies.
-    pub fn new(manifest_dir: &Path, offline: bool) -> Result<Self> {
-        let manifest = Manifest::from_dir(manifest_dir)?;
-        let (graph, path_map) = fetch_deps(manifest_dir.to_path_buf(), &manifest, offline)?;
+    pub fn new(manifest_dir: &Path, sway_git_tag: &str, offline: bool) -> Result<Self> {
+        let manifest = Manifest::from_dir(manifest_dir, sway_git_tag)?;
+        let (graph, path_map) =
+            fetch_deps(manifest_dir.to_path_buf(), &manifest, sway_git_tag, offline)?;
         let compilation_order = compilation_order(&graph)?;
         Ok(Self {
             graph,
@@ -192,10 +193,10 @@ impl BuildPlan {
     }
 
     /// Attempt to load the build plan from the `Lock`.
-    pub fn from_lock(proj_path: &Path, lock: &Lock) -> Result<Self> {
+    pub fn from_lock(proj_path: &Path, lock: &Lock, sway_git_tag: &str) -> Result<Self> {
         let graph = lock.to_graph()?;
         let compilation_order = compilation_order(&graph)?;
-        let path_map = graph_to_path_map(proj_path, &graph, &compilation_order)?;
+        let path_map = graph_to_path_map(proj_path, &graph, &compilation_order, sway_git_tag)?;
         Ok(Self {
             graph,
             path_map,
@@ -204,14 +205,14 @@ impl BuildPlan {
     }
 
     /// Attempt to load the build plan from the `Forc.lock` file.
-    pub fn from_lock_file(lock_path: &Path) -> Result<Self> {
+    pub fn from_lock_file(lock_path: &Path, sway_git_tag: &str) -> Result<Self> {
         let proj_path = lock_path.parent().unwrap();
         let lock = Lock::from_path(lock_path)?;
-        Self::from_lock(proj_path, &lock)
+        Self::from_lock(proj_path, &lock, sway_git_tag)
     }
 
     /// Ensure that the build plan is valid for the given manifest.
-    pub fn validate(&self, manifest: &Manifest) -> Result<()> {
+    pub fn validate(&self, manifest: &Manifest, sway_git_tag: &str) -> Result<()> {
         // Retrieve project's graph node.
         let proj_node = *self
             .compilation_order
@@ -233,10 +234,7 @@ impl BuildPlan {
         let proj_id = self.graph[proj_node].id();
         let proj_path = &self.path_map[&proj_id];
         let manifest_dep_pkgs = manifest
-            .dependencies
-            .as_ref()
-            .into_iter()
-            .flat_map(|deps| deps.iter())
+            .deps()
             .map(|(dep_name, dep)| {
                 // NOTE: Temporarily warn about `version` until we have support for registries.
                 if let Dependency::Detailed(det) = dep {
@@ -266,7 +264,7 @@ impl BuildPlan {
             let pkg = &self.graph[node];
             let id = pkg.id();
             let path = &self.path_map[&id];
-            let manifest = Manifest::from_dir(path)?;
+            let manifest = Manifest::from_dir(path, sway_git_tag)?;
             if pkg.name != manifest.project.name {
                 bail!(
                     "package name {:?} does not match the associated manifest project name {:?}",
@@ -490,6 +488,7 @@ pub fn graph_to_path_map(
     proj_manifest_dir: &Path,
     graph: &Graph,
     compilation_order: &[NodeIx],
+    sway_git_tag: &str,
 ) -> Result<PathMap> {
     let mut path_map = PathMap::new();
 
@@ -518,7 +517,7 @@ pub fn graph_to_path_map(
                     println!("  Fetching {}", git.to_string());
                     fetch_git(fetch_id, &dep.name, git)?;
                 }
-                find_dir_within(&repo_path, &dep.name).ok_or_else(|| {
+                find_dir_within(&repo_path, &dep.name, sway_git_tag).ok_or_else(|| {
                     anyhow!(
                         "failed to find package `{}` in {}",
                         dep.name,
@@ -534,7 +533,7 @@ pub fn graph_to_path_map(
                     .source();
                 let parent = &graph[parent_node];
                 let parent_path = &path_map[&parent.id()];
-                let parent_manifest = Manifest::from_dir(parent_path)?;
+                let parent_manifest = Manifest::from_dir(parent_path, sway_git_tag)?;
                 let detailed = parent_manifest
                     .dependencies
                     .as_ref()
@@ -570,6 +569,7 @@ pub fn graph_to_path_map(
 pub(crate) fn fetch_deps(
     proj_manifest_dir: PathBuf,
     proj_manifest: &Manifest,
+    sway_git_tag: &str,
     offline_mode: bool,
 ) -> Result<(Graph, PathMap)> {
     let mut graph = Graph::new();
@@ -592,12 +592,13 @@ pub(crate) fn fetch_deps(
     // TODO: Convert this recursion to use loop & stack to ensure deps can't cause stack overflow.
     let fetch_ts = std::time::Instant::now();
     let fetch_id = fetch_id(&path_map[&pkg_id], fetch_ts);
-    let manifest = Manifest::from_dir(&path_map[&pkg_id])?;
+    let manifest = Manifest::from_dir(&path_map[&pkg_id], sway_git_tag)?;
     fetch_children(
         fetch_id,
         offline_mode,
         root,
         &manifest,
+        sway_git_tag,
         &mut graph,
         &mut path_map,
         &mut visited,
@@ -622,6 +623,7 @@ fn fetch_children(
     offline_mode: bool,
     node: NodeIx,
     manifest: &Manifest,
+    sway_git_tag: &str,
     graph: &mut Graph,
     path_map: &mut PathMap,
     visited: &mut HashMap<Pinned, NodeIx>,
@@ -635,9 +637,9 @@ fn fetch_children(
             bail!("Unable to fetch pkg {:?} in offline mode", source);
         }
         let pkg = Pkg { name, source };
-        let pinned = pin_pkg(fetch_id, &pkg, path_map)?;
+        let pinned = pin_pkg(fetch_id, &pkg, path_map, sway_git_tag)?;
         let pkg_id = pinned.id();
-        let manifest = Manifest::from_dir(&path_map[&pkg_id])?;
+        let manifest = Manifest::from_dir(&path_map[&pkg_id], sway_git_tag)?;
         if pinned.name != manifest.project.name {
             bail!(
                 "dependency name {:?} must match the manifest project name {:?} \
@@ -655,6 +657,7 @@ fn fetch_children(
                 offline_mode,
                 node,
                 &manifest,
+                sway_git_tag,
                 graph,
                 path_map,
                 visited,
@@ -786,7 +789,7 @@ fn pin_git(fetch_id: u64, name: &str, source: SourceGit) -> Result<SourceGitPinn
 /// Given a package source, attempt to determine the pinned version or commit.
 ///
 /// Also updates the `path_map` with a path to the local copy of the source.
-fn pin_pkg(fetch_id: u64, pkg: &Pkg, path_map: &mut PathMap) -> Result<Pinned> {
+fn pin_pkg(fetch_id: u64, pkg: &Pkg, path_map: &mut PathMap, sway_git_tag: &str) -> Result<Pinned> {
     let name = pkg.name.clone();
     let pinned = match &pkg.source {
         Source::Path(path) => {
@@ -813,13 +816,14 @@ fn pin_pkg(fetch_id: u64, pkg: &Pkg, path_map: &mut PathMap) -> Result<Pinned> {
                     println!("  Fetching {}", pinned_git.to_string());
                     fetch_git(fetch_id, &pinned.name, &pinned_git)?;
                 }
-                let path = find_dir_within(&repo_path, &pinned.name).ok_or_else(|| {
-                    anyhow!(
-                        "failed to find package `{}` in {}",
-                        pinned.name,
-                        pinned_git.to_string()
-                    )
-                })?;
+                let path =
+                    find_dir_within(&repo_path, &pinned.name, sway_git_tag).ok_or_else(|| {
+                        anyhow!(
+                            "failed to find package `{}` in {}",
+                            pinned.name,
+                            pinned_git.to_string()
+                        )
+                    })?;
                 entry.insert(path);
             }
             pinned
@@ -919,16 +923,15 @@ fn dep_to_source(pkg_path: &Path, dep: &Dependency) -> Result<Source> {
 /// Given a `forc_pkg::BuildConfig`, produce the necessary `sway_core::BuildConfig` required for
 /// compilation.
 pub fn sway_build_config(
-    path: PathBuf,
-    manifest: &Manifest,
+    manifest_dir: &Path,
+    entry_path: &Path,
     build_conf: &BuildConfig,
 ) -> Result<sway_core::BuildConfig> {
     // Prepare the build config to pass through to the compiler.
-    let entry_path = manifest.entry_path(&path);
-    let file_name = find_file_name(&path, &entry_path)?;
+    let file_name = find_file_name(&manifest_dir, &entry_path)?;
     let build_config = sway_core::BuildConfig::root_from_file_name_and_manifest_path(
         file_name.to_path_buf(),
-        path.to_path_buf(),
+        manifest_dir.to_path_buf(),
     )
     .use_orig_asm(build_conf.use_orig_asm)
     .print_finalized_asm(build_conf.print_finalized_asm)
@@ -993,13 +996,14 @@ pub fn dependency_namespace(
 pub fn compile(
     pkg: &Pinned,
     pkg_path: &Path,
+    manifest: &Manifest,
     build_config: &BuildConfig,
     namespace: NamespaceRef,
     source_map: &mut SourceMap,
 ) -> Result<(Compiled, Option<NamespaceRef>)> {
-    let manifest = Manifest::from_dir(pkg_path)?;
+    let entry_path = manifest.entry_path(pkg_path);
     let source = manifest.entry_string(pkg_path)?;
-    let sway_build_config = sway_build_config(pkg_path.to_path_buf(), &manifest, build_config)?;
+    let sway_build_config = sway_build_config(pkg_path, &entry_path, build_config)?;
     let silent_mode = build_config.silent;
 
     // First, compile to an AST. We'll update the namespace and check for JSON ABI output.
@@ -1057,7 +1061,11 @@ pub fn compile(
 /// This compiles all packages (including dependencies) in the order specified by the `BuildPlan`.
 ///
 /// Also returns the resulting `sway_core::SourceMap` which may be useful for debugging purposes.
-pub fn build(plan: &BuildPlan, conf: &BuildConfig) -> anyhow::Result<(Compiled, SourceMap)> {
+pub fn build(
+    plan: &BuildPlan,
+    conf: &BuildConfig,
+    sway_git_tag: &str,
+) -> anyhow::Result<(Compiled, SourceMap)> {
     let mut namespace_map = Default::default();
     let mut source_map = SourceMap::new();
     let mut json_abi = vec![];
@@ -1067,7 +1075,8 @@ pub fn build(plan: &BuildPlan, conf: &BuildConfig) -> anyhow::Result<(Compiled, 
             dependency_namespace(&namespace_map, &plan.graph, &plan.compilation_order, node);
         let pkg = &plan.graph[node];
         let path = &plan.path_map[&pkg.id()];
-        let res = compile(pkg, path, conf, dep_namespace, &mut source_map)?;
+        let manifest = Manifest::from_dir(path, sway_git_tag)?;
+        let res = compile(pkg, path, &manifest, conf, dep_namespace, &mut source_map)?;
         let (compiled, maybe_namespace) = res;
         if let Some(namespace) = maybe_namespace {
             namespace_map.insert(node, namespace);
@@ -1083,14 +1092,14 @@ pub fn build(plan: &BuildPlan, conf: &BuildConfig) -> anyhow::Result<(Compiled, 
 /// Attempt to find a `Forc.toml` with the given project name within the given directory.
 ///
 /// Returns the path to the package on success, or `None` in the case it could not be found.
-pub fn find_within(dir: &Path, pkg_name: &str) -> Option<PathBuf> {
+pub fn find_within(dir: &Path, pkg_name: &str, sway_git_tag: &str) -> Option<PathBuf> {
     walkdir::WalkDir::new(dir)
         .into_iter()
         .filter_map(Result::ok)
         .filter(|entry| entry.path().ends_with(constants::MANIFEST_FILE_NAME))
         .find_map(|entry| {
             let path = entry.path();
-            let manifest = Manifest::from_file(path).ok()?;
+            let manifest = Manifest::from_file(path, sway_git_tag).ok()?;
             if manifest.project.name == pkg_name {
                 Some(path.to_path_buf())
             } else {
@@ -1100,8 +1109,8 @@ pub fn find_within(dir: &Path, pkg_name: &str) -> Option<PathBuf> {
 }
 
 /// The same as [find_within], but returns the package's project directory.
-pub fn find_dir_within(dir: &Path, pkg_name: &str) -> Option<PathBuf> {
-    find_within(dir, pkg_name).and_then(|path| path.parent().map(Path::to_path_buf))
+pub fn find_dir_within(dir: &Path, pkg_name: &str, sway_git_tag: &str) -> Option<PathBuf> {
+    find_within(dir, pkg_name, sway_git_tag).and_then(|path| path.parent().map(Path::to_path_buf))
 }
 
 // TODO: Update this to match behaviour described in the `compile` doc comment above.

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -618,6 +618,7 @@ fn fetch_id(path: &Path, timestamp: std::time::Instant) -> u64 {
 }
 
 /// Fetch children nodes of the given node and add unvisited nodes to the graph.
+#[allow(clippy::too_many_arguments)]
 fn fetch_children(
     fetch_id: u64,
     offline_mode: bool,
@@ -928,7 +929,7 @@ pub fn sway_build_config(
     build_conf: &BuildConfig,
 ) -> Result<sway_core::BuildConfig> {
     // Prepare the build config to pass through to the compiler.
-    let file_name = find_file_name(&manifest_dir, &entry_path)?;
+    let file_name = find_file_name(manifest_dir, entry_path)?;
     let build_config = sway_core::BuildConfig::root_from_file_name_and_manifest_path(
         file_name.to_path_buf(),
         manifest_dir.to_path_buf(),

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -11,7 +11,7 @@ description = "Fuel Orchestrator."
 [dependencies]
 annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1.0.41"
-clap = { version = "3.1", features = ["env", "derive"] }
+clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 clap_complete = "3.1"
 forc-pkg = { version = "0.9.2", path = "../forc-pkg" }
 forc-util = { version = "0.9.2", path = "../forc-util" }

--- a/forc/src/ops/forc_abi_json.rs
+++ b/forc/src/ops/forc_abi_json.rs
@@ -1,4 +1,7 @@
-use crate::cli::{BuildCommand, JsonAbiCommand};
+use crate::{
+    cli::{BuildCommand, JsonAbiCommand},
+    utils::SWAY_GIT_TAG,
+};
 use anyhow::Result;
 use forc_pkg::{check_program_type, manifest_file_missing, Manifest};
 use forc_util::find_manifest_dir;
@@ -15,7 +18,7 @@ pub fn build(command: JsonAbiCommand) -> Result<Value> {
     };
     let manifest_dir =
         find_manifest_dir(&curr_dir).ok_or_else(|| manifest_file_missing(curr_dir))?;
-    let manifest = Manifest::from_dir(&manifest_dir)?;
+    let manifest = Manifest::from_dir(&manifest_dir, SWAY_GIT_TAG)?;
     check_program_type(&manifest, manifest_dir, TreeType::Contract)?;
 
     let build_command = BuildCommand {

--- a/forc/src/ops/forc_deploy.rs
+++ b/forc/src/ops/forc_deploy.rs
@@ -1,9 +1,9 @@
-use anyhow::{bail, Result};
 use crate::ops::forc_build;
 use crate::{
     cli::{BuildCommand, DeployCommand},
     utils::SWAY_GIT_TAG,
 };
+use anyhow::{bail, Result};
 use forc_pkg::{check_program_type, manifest_file_missing, Manifest};
 use forc_util::find_manifest_dir;
 use fuel_gql_client::client::FuelClient;

--- a/forc/src/ops/forc_deploy.rs
+++ b/forc/src/ops/forc_deploy.rs
@@ -1,4 +1,4 @@
-use crate::cli::{BuildCommand, DeployCommand};
+use crate::{cli::{BuildCommand, DeployCommand}, utils::SWAY_GIT_TAG};
 use crate::ops::forc_build;
 use anyhow::{bail, Result};
 use forc_pkg::{check_program_type, manifest_file_missing, Manifest};
@@ -18,7 +18,7 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
     };
     let manifest_dir =
         find_manifest_dir(&curr_dir).ok_or_else(|| manifest_file_missing(curr_dir))?;
-    let manifest = Manifest::from_dir(&manifest_dir)?;
+    let manifest = Manifest::from_dir(&manifest_dir, SWAY_GIT_TAG)?;
     check_program_type(&manifest, manifest_dir, TreeType::Contract)?;
 
     let DeployCommand {

--- a/forc/src/ops/forc_deploy.rs
+++ b/forc/src/ops/forc_deploy.rs
@@ -1,6 +1,9 @@
-use crate::{cli::{BuildCommand, DeployCommand}, utils::SWAY_GIT_TAG};
-use crate::ops::forc_build;
 use anyhow::{bail, Result};
+use crate::ops::forc_build;
+use crate::{
+    cli::{BuildCommand, DeployCommand},
+    utils::SWAY_GIT_TAG,
+};
 use forc_pkg::{check_program_type, manifest_file_missing, Manifest};
 use forc_util::find_manifest_dir;
 use fuel_gql_client::client::FuelClient;

--- a/forc/src/ops/forc_run.rs
+++ b/forc/src/ops/forc_run.rs
@@ -1,8 +1,8 @@
-use anyhow::{anyhow, bail, Result};
 use crate::cli::{BuildCommand, RunCommand};
 use crate::ops::forc_build;
 use crate::utils::parameters::TxParameters;
 use crate::utils::SWAY_GIT_TAG;
+use anyhow::{anyhow, bail, Result};
 use forc_pkg::{check_program_type, fuel_core_not_running, manifest_file_missing, Manifest};
 use forc_util::find_manifest_dir;
 use fuel_gql_client::client::FuelClient;

--- a/forc/src/ops/forc_run.rs
+++ b/forc/src/ops/forc_run.rs
@@ -1,7 +1,8 @@
+use anyhow::{anyhow, bail, Result};
 use crate::cli::{BuildCommand, RunCommand};
 use crate::ops::forc_build;
 use crate::utils::parameters::TxParameters;
-use anyhow::{anyhow, bail, Result};
+use crate::utils::SWAY_GIT_TAG;
 use forc_pkg::{check_program_type, fuel_core_not_running, manifest_file_missing, Manifest};
 use forc_util::find_manifest_dir;
 use fuel_gql_client::client::FuelClient;
@@ -20,7 +21,7 @@ pub async fn run(command: RunCommand) -> Result<()> {
     };
     let manifest_dir =
         find_manifest_dir(&path_dir).ok_or_else(|| manifest_file_missing(path_dir))?;
-    let manifest = Manifest::from_dir(&manifest_dir)?;
+    let manifest = Manifest::from_dir(&manifest_dir, SWAY_GIT_TAG)?;
     check_program_type(&manifest, manifest_dir, TreeType::Script)?;
 
     let input_data = &command.data.unwrap_or_else(|| "".into());
@@ -61,15 +62,12 @@ pub async fn run(command: RunCommand) -> Result<()> {
             Some(network) => &network.url,
             _ => &command.node_url,
         };
-
         let child = try_send_tx(node_url, &tx, command.pretty_print).await?;
-
         if command.kill_node {
             if let Some(mut child) = child {
                 child.kill().await.expect("Node should be killed");
             }
         }
-
         Ok(())
     }
 }

--- a/forc/src/ops/forc_update.rs
+++ b/forc/src/ops/forc_update.rs
@@ -1,4 +1,4 @@
-use crate::cli::UpdateCommand;
+use crate::{cli::UpdateCommand, utils::SWAY_GIT_TAG};
 use anyhow::{anyhow, Result};
 use forc_pkg::{self as pkg, lock, Lock, Manifest};
 use forc_util::{find_manifest_dir, lock_path};
@@ -40,11 +40,11 @@ pub async fn update(command: UpdateCommand) -> Result<()> {
         }
     };
 
-    let manifest = Manifest::from_dir(&manifest_dir)?;
+    let manifest = Manifest::from_dir(&manifest_dir, SWAY_GIT_TAG)?;
     let lock_path = lock_path(&manifest_dir);
     let old_lock = Lock::from_path(&lock_path).ok().unwrap_or_default();
     let offline = false;
-    let new_plan = pkg::BuildPlan::new(&manifest_dir, offline)?;
+    let new_plan = pkg::BuildPlan::new(&manifest_dir, SWAY_GIT_TAG, offline)?;
     let new_lock = Lock::from_graph(new_plan.graph());
     let diff = new_lock.diff(&old_lock);
     lock::print_diff(&manifest.project.name, &diff);

--- a/forc/src/utils/mod.rs
+++ b/forc/src/utils/mod.rs
@@ -1,3 +1,9 @@
 pub mod client;
 pub mod defaults;
 pub mod parameters;
+
+/// The `forc` crate version formatted with the `v` prefix. E.g. "v1.2.3".
+///
+/// This git tag is used during `Manifest` construction to pin the version of the implicit `std`
+/// dependency to the `forc` version.
+pub const SWAY_GIT_TAG: &str = concat!("v", clap::crate_version!());

--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_bad_index/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_bad_index/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
 name = 'array_bad_index'
+dependencies = ['core']
+
+[[package]]
+name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_bad_index/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_bad_index/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "array_bad_index"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_oob/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_oob/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
 name = 'array_oob'
+dependencies = ['core']
+
+[[package]]
+name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_oob/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_oob/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "array_oob"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/asm_missing_return/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/asm_missing_return/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
 name = 'asm_missing_return'
+dependencies = ['core']
+
+[[package]]
+name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/asm_missing_return/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/asm_missing_return/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "asm_missing_return"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/asm_should_not_have_return/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/asm_should_not_have_return/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
 name = 'asm_should_not_have_return'
+dependencies = ['core']
+
+[[package]]
+name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/asm_should_not_have_return/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/asm_should_not_have_return/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "asm_should_not_have_return"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_annotation/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_annotation/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
 name = 'bad_generic_annotation'
+dependencies = ['core']
+
+[[package]]
+name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_annotation/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_annotation/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "bad_generic_annotation"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_var_annotation/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_var_annotation/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
 name = 'bad_generic_var_annotation'
+dependencies = ['core']
+
+[[package]]
+name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_var_annotation/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_var_annotation/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "bad_generic_var_annotation"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
 name = 'chained_if_let_missing_branch'
+dependencies = ['core']
+
+[[package]]
+name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.toml
@@ -4,3 +4,5 @@ entry = "main.sw"
 license = "Apache-2.0"
 name = "chained_if_let_missing_branch"
 
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/contract_pure_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/contract_pure_calls_impure/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'valid_impurity'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'valid_impurity'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/contract_pure_calls_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/contract_pure_calls_impure/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "valid_impurity"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/dependency_parsing_error/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/dependency_parsing_error/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'dependencies_parsing_error'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'dependencies_parsing_error'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/dependency_parsing_error/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/dependency_parsing_error/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "dependencies_parsing_error"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/disallow_turbofish/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/disallow_turbofish/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'disallow_turbofish'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'disallow_turbofish'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/disallow_turbofish/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/disallow_turbofish/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "disallow_turbofish"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/disallowed_gm/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/disallowed_gm/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'disallowed_opcodes'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'disallowed_opcodes'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/disallowed_gm/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/disallowed_gm/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "disallowed_opcodes"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/empty_impl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/empty_impl/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'empty_impl'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'empty_impl'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/empty_impl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/empty_impl/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "empty_impl"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/enum_bad_type_inference/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/enum_bad_type_inference/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'enum_bad_type_inference'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'enum_bad_type_inference'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/enum_bad_type_inference/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/enum_bad_type_inference/Forc.toml
@@ -4,3 +4,5 @@ entry = "main.sw"
 license = "Apache-2.0"
 name = "enum_bad_type_inference"
 
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_shadows_generic/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_shadows_generic/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'generic_shadows_generic'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'generic_shadows_generic'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_shadows_generic/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_shadows_generic/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "generic_shadows_generic"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generics_unhelpful_error/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generics_unhelpful_error/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'generics_unhelpful_error'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'generics_unhelpful_error'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generics_unhelpful_error/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generics_unhelpful_error/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "generics_unhelpful_error"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/infinite_dependencies/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/infinite_dependencies/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "infinite_dependencies"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/item_used_without_import/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/item_used_without_import/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'item_used_without_import'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'item_used_without_import'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/item_used_without_import/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/item_used_without_import/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "item_used_without_import"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/literal_too_large_for_type/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/literal_too_large_for_type/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'literal_too_large_for_type'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'literal_too_large_for_type'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/literal_too_large_for_type/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/literal_too_large_for_type/Forc.toml
@@ -4,3 +4,5 @@ license = "Apache-2.0"
 name = "literal_too_large_for_type"
 entry = "main.sw"
 
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_func_from_supertrait_impl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_func_from_supertrait_impl/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'missing_func_from_supertrait_impl'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'missing_func_from_supertrait_impl'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_func_from_supertrait_impl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_func_from_supertrait_impl/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "missing_func_from_supertrait_impl"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_supertrait_impl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_supertrait_impl/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'missing_supertrait_impl'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'missing_supertrait_impl'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_supertrait_impl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_supertrait_impl/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "missing_supertrait_impl"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/name_shadowing/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/name_shadowing/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'name_shadowing'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'name_shadowing'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/name_shadowing/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/name_shadowing/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "name_shadowing"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/nested_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/nested_impure/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'nested_impure'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'nested_impure'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/nested_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/nested_impure/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "nested_impure"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_calls_impure/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'script_calls_impure'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'script_calls_impure'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_calls_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_calls_impure/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "script_calls_impure"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/pure_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/pure_calls_impure/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'pure_calls_impure'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'pure_calls_impure'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/pure_calls_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/pure_calls_impure/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "pure_calls_impure"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'recursive_calls'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'recursive_calls'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "recursive_calls"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/script_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/script_calls_impure/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'script_calls_impure'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'script_calls_impure'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/script_calls_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/script_calls_impure/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "script_calls_impure"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'shadow_import'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'shadow_import'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "shadow_import"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'star_import_alias'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'star_import_alias'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "star_import_alias"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'supertrait_does_not_exist'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'supertrait_does_not_exist'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "supertrait_does_not_exist"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/top_level_vars/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/top_level_vars/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'top_level_vars'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'top_level_vars'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/top_level_vars/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/top_level_vars/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "top_level_vars"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unify_identical_unknowns/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unify_identical_unknowns/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'unify_identical_unknowns'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'unify_identical_unknowns'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unify_identical_unknowns/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unify_identical_unknowns/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "unify_identical_unknowns"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array_generics/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array_generics/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
 name = 'array_generics'
+dependencies = ['core']
+
+[[package]]
+name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array_generics/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array_generics/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "array_generics"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_without_return/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_without_return/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
 name = 'asm_without_return'
+dependencies = ['core']
+
+[[package]]
+name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_without_return/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_without_return/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "asm_without_return"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/bool_and_or/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/bool_and_or/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
 name = 'bool_and_or'
+dependencies = ['core']
+
+[[package]]
+name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/bool_and_or/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/bool_and_or/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "bool_and_or"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/chained_if_let/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/chained_if_let/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
 name = 'chained_if_let'
+dependencies = ['core']
+
+[[package]]
+name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/chained_if_let/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/chained_if_let/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "chained_if_let"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/dependencies/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/dependencies/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'dependencies'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'dependencies'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/dependencies/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/dependencies/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "dependencies"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_init_fn_call/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_init_fn_call/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'enum_init_fn_call'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'enum_init_fn_call'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_init_fn_call/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_init_fn_call/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "enum_init_fn_call"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_type_inference/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_type_inference/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'enum_type_inference'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'enum_type_inference'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_type_inference/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_type_inference/Forc.toml
@@ -4,3 +4,5 @@ entry = "main.sw"
 license = "Apache-2.0"
 name = "enum_type_inference"
 
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/funcs_with_generic_types/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/funcs_with_generic_types/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'funcs_with_generic_types'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'funcs_with_generic_types'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/funcs_with_generic_types/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/funcs_with_generic_types/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "funcs_with_generic_types"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_functions/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_functions/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'generic_functions'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'generic_functions'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_functions/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_functions/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "generic_functions"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_struct/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'generic_struct'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'generic_struct'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_struct/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_struct/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "generic_struct"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_structs/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_structs/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'generic_structs'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'generic_structs'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_structs/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_structs/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "generic_structs"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/if_implicit_unit/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/if_implicit_unit/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'if_implicit_unit'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'if_implicit_unit'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/if_implicit_unit/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/if_implicit_unit/Forc.toml
@@ -3,3 +3,6 @@ name = "if_implicit_unit"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_method_from_other_file/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_method_from_other_file/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'import_method_from_other_file'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'import_method_from_other_file'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_method_from_other_file/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_method_from_other_file/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "import_method_from_other_file"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_returns_unit/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_returns_unit/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'main_returns_unit'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'main_returns_unit'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_returns_unit/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_returns_unit/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "main_returns_unit"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/method_on_empty_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/method_on_empty_struct/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'method_on_empty_struct'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'method_on_empty_struct'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/method_on_empty_struct/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/method_on_empty_struct/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "method_on_empty_struct"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/missing_type_parameters/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/missing_type_parameters/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "missing_type_parameters"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_item_import/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_item_import/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'multi_item_import'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'multi_item_import'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_item_import/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_item_import/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "multi_item_import"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/out_of_order_decl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/out_of_order_decl/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'out_of_order_decl'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'out_of_order_decl'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/out_of_order_decl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/out_of_order_decl/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "out_of_order_decl"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_b256/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_b256/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'retd_b256'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'retd_b256'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_b256/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_b256/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "retd_b256"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_small_array/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_small_array/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'retd_small_array'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'retd_small_array'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_small_array/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_small_array/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "retd_small_array"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_struct/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'retd_struct'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'retd_struct'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_struct/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_struct/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "retd_struct"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_zero_len_array/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_zero_len_array/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'retd_zero_len_array'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'retd_zero_len_array'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_zero_len_array/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_zero_len_array/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "retd_zero_len_array"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/storage_declaration/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/storage_declaration/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "storage_declaration"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_access/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_access/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'struct_field_access'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'struct_field_access'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_access/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_access/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "struct_field_access"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_reassignment/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_reassignment/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'struct_field_reassignment'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'struct_field_reassignment'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_reassignment/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_reassignment/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "struct_field_reassignment"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_import_with_star/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_import_with_star/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'trait_impl_import'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'trait_impl_import'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_import_with_star/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_import_with_star/Forc.toml
@@ -4,3 +4,5 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_access/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_access/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'tuple_access'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'tuple_access'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_access/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_access/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "tuple_access"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_indexing/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_indexing/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'tuple_indexing'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'tuple_indexing'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_indexing/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_indexing/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "tuple_indexing"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_types/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_types/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'tuple_types'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'tuple_types'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_types/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_types/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "tuple_types"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/use_full_path_names/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/use_full_path_names/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'use_full_path_names'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'use_full_path_names'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/use_full_path_names/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/use_full_path_names/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "use_full_path_names"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/valid_impurity/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/valid_impurity/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'valid_impurity'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'valid_impurity'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/valid_impurity/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/valid_impurity/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "valid_impurity"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/zero_field_types/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/zero_field_types/Forc.lock
@@ -1,3 +1,7 @@
 [[package]]
-name = 'zero_field_types'
+name = 'core'
 dependencies = []
+
+[[package]]
+name = 'zero_field_types'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/zero_field_types/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/zero_field_types/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "zero_field_types"
 entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/auth_testing_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/auth_testing_abi/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "auth_testing_abi"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/balance_test_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/balance_test_abi/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "balance_test_abi"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/basic_storage_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/basic_storage_abi/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "basic_storage_abi"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/increment_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/increment_abi/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "increment_abi"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/storage_access_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/storage_access_abi/Forc.toml
@@ -3,3 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "storage_access_abi"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }


### PR DESCRIPTION
While loading a `Manifest` with the `from_file` constructor, we check for dependencies declared with either `std` or `core` packages.

If neither `core` or `std` exist, we add their associated `git` dependencies pointing to this sway repo at the `tag` equal to `forc`'s current `semver` version. This way, the implicit `core` and `std` deps are pinned alongside the version of `forc` that fetches them, guaranteeing that the manifests are compatible and that the `core` and `std` versions are compatible with eachother.

If both `core` and `std` are supplied by the user, or if only one of either `core` or `std` are provided by the user, then we don't implicitly include either. This is because in the case that only either `core` or `std` are provided, we cannot guarantee that an implicitly included `core` or `std` would be compatible with the user-specified one.

Closes #330

### Sway repo examples/tests

It's best we leave the examples and test suite with the explicit `path` dependencies in order to ensure that they remain tested against the current state of `forc` rather than the latest tagged commit. This will also avoid running into CI issues during the PRs where `forc`'s version is updated but the tag hasn't yet been pushed.

This also adds a `core` dependency declaration to all tests that otherwise contained an empty `[dependencies]` table. By overriding either the `core` or `std` dependency manually, we disable the implicit inclusion of the `std` dependency.

## TODO

- [x] Pass `forc` semver version through to `Manifest::from_file` constructor in order to set `tag` for `core` and `std` git dependencies.
- [x] Ensure build plan validation works with implicit `core`/`std`.