### PR TITLE
print all parsed LSP tokens as warnings in VScode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.92.0"
+version = "0.92.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a69d4142d51b208c9fc3cea68b1a7fcef30354e7aa6ccad07250fd8430fc76"
+checksum = "c79d4897790e8fd2550afa6d6125821edb5716e60e0e285046e070f0f6a06e0e"
 dependencies = [
  "bitflags",
  "serde",

--- a/forc/src/cli/commands/lsp.rs
+++ b/forc/src/cli/commands/lsp.rs
@@ -1,11 +1,19 @@
-use anyhow::Result;
+use crate::ops::forc_lsp;
+use anyhow::{bail, Result};
 use clap::Parser;
 
 /// Run the LSP server.
 #[derive(Debug, Parser)]
-pub(crate) struct Command {}
+pub struct Command {
+    /// Instructs the client to draw squiggly lines
+    /// under all of the tokens that our server managed to parse
+    #[clap(long)]
+    pub parsed_tokens_as_warnings: bool,
+}
 
-pub(crate) async fn exec(_command: Command) -> Result<()> {
-    sway_lsp::start().await;
-    Ok(())
+pub(crate) async fn exec(command: Command) -> Result<()> {
+    match forc_lsp::exec(command).await {
+        Err(e) => bail!(e),
+        _ => Ok(()),
+    }
 }

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -16,7 +16,7 @@ pub use explorer::Command as ExplorerCommand;
 pub use format::Command as FormatCommand;
 pub use init::Command as InitCommand;
 pub use json_abi::Command as JsonAbiCommand;
-use lsp::Command as LspCommand;
+pub use lsp::Command as LspCommand;
 use parse_bytecode::Command as ParseBytecodeCommand;
 pub use run::Command as RunCommand;
 use test::Command as TestCommand;

--- a/forc/src/ops/forc_lsp.rs
+++ b/forc/src/ops/forc_lsp.rs
@@ -1,0 +1,13 @@
+use crate::cli::LspCommand;
+use anyhow::Result;
+use sway_lsp::utils::debug;
+
+pub async fn exec(command: LspCommand) -> Result<()> {
+    let config = debug::DebugFlags {
+        parsed_tokens_as_warnings: command.parsed_tokens_as_warnings,
+    };
+
+    sway_lsp::start(config).await;
+
+    Ok(())
+}

--- a/forc/src/ops/mod.rs
+++ b/forc/src/ops/mod.rs
@@ -5,5 +5,6 @@ pub mod forc_deploy;
 pub mod forc_explorer;
 pub mod forc_fmt;
 pub mod forc_init;
+pub mod forc_lsp;
 pub mod forc_run;
 pub mod forc_update;

--- a/sway-lsp/src/capabilities/diagnostic.rs
+++ b/sway-lsp/src/capabilities/diagnostic.rs
@@ -1,7 +1,6 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 
 use sway_core::{CompileError, CompileWarning};
-use crate::core::token::Token;
 
 pub fn get_diagnostics(
     warnings: Vec<CompileWarning>,
@@ -34,21 +33,6 @@ pub fn get_diagnostics(
         .collect();
 
     vec![warnings, errors].into_iter().flatten().collect()
-}
-
-pub fn generate_warnings_for_parsed_tokens(tokens: &Vec<Token>) -> Vec<Diagnostic> {
-    let warnings = tokens
-        .iter()
-        .map(|token| {
-            Diagnostic {
-                range: token.range,
-                severity: Some(DiagnosticSeverity::WARNING),
-                ..Default::default()
-            }
-        })
-        .collect();
-
-    warnings
 }
 
 fn get_range(warning_or_error: &WarningOrError<'_>) -> Range {

--- a/sway-lsp/src/capabilities/diagnostic.rs
+++ b/sway-lsp/src/capabilities/diagnostic.rs
@@ -1,6 +1,7 @@
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 
 use sway_core::{CompileError, CompileWarning};
+use crate::core::token::Token;
 
 pub fn get_diagnostics(
     warnings: Vec<CompileWarning>,
@@ -33,6 +34,21 @@ pub fn get_diagnostics(
         .collect();
 
     vec![warnings, errors].into_iter().flatten().collect()
+}
+
+pub fn generate_warnings_for_parsed_tokens(tokens: &Vec<Token>) -> Vec<Diagnostic> {
+    let warnings = tokens
+        .iter()
+        .map(|token| {
+            Diagnostic {
+                range: token.range,
+                severity: Some(DiagnosticSeverity::WARNING),
+                ..Default::default()
+            }
+        })
+        .collect();
+
+    warnings
 }
 
 fn get_range(warning_or_error: &WarningOrError<'_>) -> Range {

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -12,7 +12,6 @@ pub async fn start(config: DebugFlags) {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    // let (service, socket) = LspService::new(Backend::new);
     let (service, socket) = LspService::new(|client| Backend::new(client, config));
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -4,13 +4,15 @@ mod capabilities;
 mod core;
 mod server;
 mod sway_config;
-mod utils;
+pub mod utils;
 use server::Backend;
+use utils::debug::DebugFlags;
 
-pub async fn start() {
+pub async fn start(config: DebugFlags) {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let (service, socket) = LspService::new(Backend::new);
+    // let (service, socket) = LspService::new(Backend::new);
+    let (service, socket) = LspService::new(|client| Backend::new(client, config));
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -3,6 +3,7 @@ use crate::core::{
     document::{DocumentError, TextDocument},
     session::Session,
 };
+use crate::utils::debug;
 use forc_util::find_manifest_dir;
 use std::sync::Arc;
 use sway_utils::helpers::get_sway_files;
@@ -13,12 +14,20 @@ use tower_lsp::{jsonrpc, Client, LanguageServer};
 pub struct Backend {
     pub client: Client,
     session: Arc<Session>,
+    debug: debug::DebugFlags,
 }
 
 impl Backend {
     pub fn new(client: Client) -> Self {
         let session = Arc::new(Session::new());
-        Backend { client, session }
+        let debug = debug::DebugFlags {
+            parsed_tokens_as_warnings: false,
+        };
+        Backend {
+            client,
+            session,
+            debug,
+        }
     }
 
     async fn log_info_message(&self, message: &str) {
@@ -110,20 +119,22 @@ impl LanguageServer for Backend {
 
     // Document Handlers
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let uri = params.text_document.uri.clone();
         let diagnostics = capabilities::text_sync::handle_open_file(self.session.clone(), &params);
 
-        let mut diagnostics = vec![];
-        self.session.documents
-            .iter()
-            .for_each(|document| {
-                diagnostics.extend(capabilities::diagnostic::generate_warnings_for_parsed_tokens(document.get_tokens()))
-            });
-
-        eprintln!("{:#?}", diagnostics);
-        
-        if !diagnostics.is_empty() {
+        // If parsed_tokens_as_warnings is true, take over the normal error and warning display behavior
+        // and instead show the parsed tokens as warnings.
+        // This is useful for debugging the lsp parser.
+        if self.debug.parsed_tokens_as_warnings {
+            if let Some(document) = self.session.documents.get(uri.path()) {
+                let diagnostics = debug::generate_warnings_for_parsed_tokens(document.get_tokens());
+                self.client
+                    .publish_diagnostics(uri, diagnostics, None)
+                    .await;
+            }
+        } else if !diagnostics.is_empty() {
             self.client
-                .publish_diagnostics(params.text_document.uri, diagnostics, None)
+                .publish_diagnostics(uri, diagnostics, None)
                 .await;
         }
     }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -112,6 +112,15 @@ impl LanguageServer for Backend {
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         let diagnostics = capabilities::text_sync::handle_open_file(self.session.clone(), &params);
 
+        let mut diagnostics = vec![];
+        self.session.documents
+            .iter()
+            .for_each(|document| {
+                diagnostics.extend(capabilities::diagnostic::generate_warnings_for_parsed_tokens(document.get_tokens()))
+            });
+
+        eprintln!("{:#?}", diagnostics);
+        
         if !diagnostics.is_empty() {
             self.client
                 .publish_diagnostics(params.text_document.uri, diagnostics, None)

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -356,7 +356,7 @@ fn main() {
 
     fn config() -> DebugFlags {
         Default::default()
-    } 
+    }
 
     #[tokio::test]
     async fn initialize() {

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -354,9 +354,13 @@ fn main() {
         assert_eq!(response, Ok(None));
     }
 
+    fn config() -> DebugFlags {
+        Default::default()
+    } 
+
     #[tokio::test]
     async fn initialize() {
-        let (mut service, _) = LspService::new(Backend::new);
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
 
         // send "initialize" request
         let _ = initialize_request(&mut service).await;
@@ -364,7 +368,7 @@ fn main() {
 
     #[tokio::test]
     async fn initialized() {
-        let (mut service, _) = LspService::new(Backend::new);
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
 
         // send "initialize" request
         let _ = initialize_request(&mut service).await;
@@ -375,7 +379,7 @@ fn main() {
 
     #[tokio::test]
     async fn initializes_only_once() {
-        let (mut service, _) = LspService::new(Backend::new);
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
 
         // send "initialize" request
         let initialize = initialize_request(&mut service).await;
@@ -391,7 +395,7 @@ fn main() {
 
     #[tokio::test]
     async fn shutdown() {
-        let (mut service, _) = LspService::new(Backend::new);
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
 
         // send "initialize" request
         let _ = initialize_request(&mut service).await;
@@ -413,7 +417,7 @@ fn main() {
 
     #[tokio::test]
     async fn refuses_requests_after_shutdown() {
-        let (mut service, _) = LspService::new(Backend::new);
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
 
         // send "initialize" request
         let _ = initialize_request(&mut service).await;
@@ -428,7 +432,7 @@ fn main() {
 
     #[tokio::test]
     async fn did_open() {
-        let (mut service, mut messages) = LspService::new(Backend::new);
+        let (mut service, mut messages) = LspService::new(|client| Backend::new(client, config()));
 
         // send "initialize" request
         let _ = initialize_request(&mut service).await;
@@ -453,7 +457,7 @@ fn main() {
 
     #[tokio::test]
     async fn did_close() {
-        let (mut service, _) = LspService::new(Backend::new);
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
 
         // send "initialize" request
         let _ = initialize_request(&mut service).await;
@@ -478,7 +482,7 @@ fn main() {
 
     #[tokio::test]
     async fn did_change() {
-        let (mut service, mut messages) = LspService::new(Backend::new);
+        let (mut service, mut messages) = LspService::new(|client| Backend::new(client, config()));
 
         // send "initialize" request
         let _ = initialize_request(&mut service).await;

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -3,7 +3,7 @@ use crate::core::{
     document::{DocumentError, TextDocument},
     session::Session,
 };
-use crate::utils::debug;
+use crate::utils::debug::{self, DebugFlags};
 use forc_util::find_manifest_dir;
 use std::sync::Arc;
 use sway_utils::helpers::get_sway_files;
@@ -14,19 +14,16 @@ use tower_lsp::{jsonrpc, Client, LanguageServer};
 pub struct Backend {
     pub client: Client,
     session: Arc<Session>,
-    debug: debug::DebugFlags,
+    config: DebugFlags,
 }
 
 impl Backend {
-    pub fn new(client: Client) -> Self {
+    pub fn new(client: Client, config: DebugFlags) -> Self {
         let session = Arc::new(Session::new());
-        let debug = debug::DebugFlags {
-            parsed_tokens_as_warnings: false,
-        };
         Backend {
             client,
             session,
-            debug,
+            config,
         }
     }
 
@@ -125,7 +122,7 @@ impl LanguageServer for Backend {
         // If parsed_tokens_as_warnings is true, take over the normal error and warning display behavior
         // and instead show the parsed tokens as warnings.
         // This is useful for debugging the lsp parser.
-        if self.debug.parsed_tokens_as_warnings {
+        if self.config.parsed_tokens_as_warnings {
             if let Some(document) = self.session.documents.get(uri.path()) {
                 let diagnostics = debug::generate_warnings_for_parsed_tokens(document.get_tokens());
                 self.client

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -2,7 +2,7 @@ use crate::core::token::Token;
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
 // Flags for debugging various parts of the server
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct DebugFlags {
     /// Instructs the client to draw squiggly lines
     /// under all of the tokens that our server managed to parse

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -1,0 +1,24 @@
+use crate::core::token::Token;
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
+
+// Flags for debugging various parts of the server
+#[derive(Debug)]
+pub struct DebugFlags {
+    /// Instructs the client to draw squiggly lines
+    /// under all of the tokens that our server managed to parse
+    pub parsed_tokens_as_warnings: bool,
+}
+
+pub fn generate_warnings_for_parsed_tokens(tokens: &[Token]) -> Vec<Diagnostic> {
+    let warnings = tokens
+        .iter()
+        .map(|token| Diagnostic {
+            range: token.range,
+            severity: Some(DiagnosticSeverity::WARNING),
+            message: token.name.clone(),
+            ..Default::default()
+        })
+        .collect();
+
+    warnings
+}

--- a/sway-lsp/src/utils/mod.rs
+++ b/sway-lsp/src/utils/mod.rs
@@ -1,3 +1,3 @@
 pub(crate) mod common;
-pub(crate) mod debug;
+pub mod debug;
 pub(crate) mod function;

--- a/sway-lsp/src/utils/mod.rs
+++ b/sway-lsp/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod common;
+pub(crate) mod debug;
 pub(crate) mod function;


### PR DESCRIPTION
This enables a flag to be set when developing and debugging the sway-lsp server. See issue #1123 for more context, but essentially it visually shows the successfully parsed tokens in VSCode. This allows for quickly scanning a bunch of sway files to see what tokens are being ignored by our current implementation of the sway-lsp parser. See the below image for how this looks in the editor when enabled. For example, In the image below we can see that the entire `impl` block is being ignored.

![parsed_tokens_as_warnings](https://user-images.githubusercontent.com/1289413/161683966-e2fcc570-e3cf-4ebd-b50d-73dde70f2241.jpg)

closes #1123