### PR TITLE
Add a reverse map for looking up metadata location indices.

### DIFF
--- a/sway-ir/src/context.rs
+++ b/sway-ir/src/context.rs
@@ -9,8 +9,14 @@
 use generational_arena::Arena;
 
 use crate::{
-    asm::AsmBlockContent, block::BlockContent, function::FunctionContent, irtype::AggregateContent,
-    metadata::Metadatum, module::ModuleContent, module::ModuleIterator, pointer::PointerContent,
+    asm::AsmBlockContent,
+    block::BlockContent,
+    function::FunctionContent,
+    irtype::AggregateContent,
+    metadata::{MetadataIndex, Metadatum},
+    module::ModuleContent,
+    module::ModuleIterator,
+    pointer::PointerContent,
     value::ValueContent,
 };
 
@@ -28,7 +34,10 @@ pub struct Context {
     pub aggregates: Arena<AggregateContent>,
     pub asm_blocks: Arena<AsmBlockContent>,
 
+    // The metadata indices for locations need a fast lookup, hence the metadata_reverse_map.
+    // Using a HashMap might be overkill as most projects have only a handful of source files.
     pub metadata: Arena<Metadatum>,
+    pub metadata_reverse_map: std::collections::HashMap<*const std::path::PathBuf, MetadataIndex>,
 
     next_unique_sym_tag: u64,
 }


### PR DESCRIPTION
This improves performance a fair bit as it was doing an O(n) search for the location when creating any new span.

It reduces the time for me to run the E2E tests by about 30%, which is OK.

I don't see any obvious outliers in the profile any more but there are very likely some higher level algorithmic changes we could make, and identifying redundant work.  I'm especially suspicious of the function construction the IR does when compiling a call, which will recreate every function called redundantly.  It's very hard to avoid this at the moment though, since functions have no unique identifiers -- we need to enforce using full module callpaths.  Right now they're still optional.