### PR TITLE
Adding token minting helper functions.

### DIFF
--- a/sway-lib-std/src/token.sw
+++ b/sway-lib-std/src/token.sw
@@ -5,6 +5,22 @@ use ::address::Address;
 use ::contract_id::ContractId;
 use ::panic::panic;
 use ::tx::*;
+use ::context::call_frames::contract_id;
+
+
+/// Mint `amount` coins of the current contract's `asset_id` and send them (!!! UNCONDITIONALLY !!!) to the contract at `destination`.
+/// This will allow the transfer of coins even if there is no way to retrieve them !!!
+/// Use of this function can lead to irretrievable loss of coins if not used with caution.
+pub fn mint_to_contract(amount: u64, destination: ContractId) {
+    mint(amount);
+    force_transfer(amount, contract_id(), destination);
+}
+
+/// Mint `amount` coins of the current contract's `asset_id` and send them to the Address `recipient`.
+pub fn mint_to_address(amount: u64, recipient: Address) {
+    mint(amount);
+    transfer_to_output(amount, contract_id(), recipient);
+}
 
 /// Mint `amount` coins of the current contract's `asset_id`.
 pub fn mint(amount: u64) {
@@ -20,15 +36,16 @@ pub fn burn(amount: u64) {
     }
 }
 
-/// !!! UNCONDITIONAL transfer of `amount` coins of type `asset_id` to contract at `contract_id`.
+/// !!! UNCONDITIONAL transfer of `amount` coins of type `asset_id` to contract at `destination`.
 /// This will allow the transfer of coins even if there is no way to retrieve them !!!
 /// Use of this function can lead to irretrievable loss of coins if not used with caution.
-pub fn force_transfer(amount: u64, asset_id: ContractId, contract_id: ContractId) {
-    asm(r1: amount, r2: asset_id.value, r3: contract_id.value) {
+pub fn force_transfer(amount: u64, asset_id: ContractId, destination: ContractId) {
+    asm(r1: amount, r2: asset_id.value, r3: destination.value) {
         tr r3 r1 r2;
     }
 }
 
+/// Transfer `amount` coins of tof type `asset_id` and send them to the address `recipient`.
 pub fn transfer_to_output(amount: u64, asset_id: ContractId, recipient: Address) {
     const OUTPUT_VARIABLE_TYPE: u8 = 4;
 

--- a/sway-lib-std/src/token.sw
+++ b/sway-lib-std/src/token.sw
@@ -7,7 +7,6 @@ use ::panic::panic;
 use ::tx::*;
 use ::context::call_frames::contract_id;
 
-
 /// Mint `amount` coins of the current contract's `asset_id` and send them (!!! UNCONDITIONALLY !!!) to the contract at `destination`.
 /// This will allow the transfer of coins even if there is no way to retrieve them !!!
 /// Use of this function can lead to irretrievable loss of coins if not used with caution.

--- a/sway-lib-std/tests/test_projects/token_ops/mod.rs
+++ b/sway-lib-std/tests/test_projects/token_ops/mod.rs
@@ -185,7 +185,7 @@ async fn can_mint_and_send_to_address() {
         value: address.into(),
     };
 
-    let result = fuelcoin_instance
+    fuelcoin_instance
         .mint_and_send_to_address(amount, recipient)
         .append_variable_outputs(1)
         .call()

--- a/sway-lib-std/tests/test_projects/token_ops/mod.rs
+++ b/sway-lib-std/tests/test_projects/token_ops/mod.rs
@@ -171,11 +171,11 @@ async fn can_mint_and_send_to_contract() {
     assert_eq!(result.value, amount)
 }
 
+#[tokio::test]
 async fn can_mint_and_send_to_address() {
     let (provider, wallet) = setup_test_provider_and_wallet().await;
     let (fuelcoin_instance, fuelcoin_id) =
         get_fuelcoin_instance(provider.clone(), wallet.clone()).await;
-    let balance_id = get_balance_contract_id(provider, wallet.clone()).await;
     let amount = 55u64;
 
     let asset_id_array: [u8; 32] = fuelcoin_id.into();
@@ -185,12 +185,13 @@ async fn can_mint_and_send_to_address() {
         value: address.into(),
     };
 
-    fuelcoin_instance
+    let result = fuelcoin_instance
         .mint_and_send_to_address(amount, recipient)
-        .set_contracts(&[balance_id])
+        .append_variable_outputs(1)
         .call()
         .await
         .unwrap();
+    dbg!(&result);
 
     assert_eq!(
         wallet

--- a/sway-lib-std/tests/test_projects/token_ops/mod.rs
+++ b/sway-lib-std/tests/test_projects/token_ops/mod.rs
@@ -1,9 +1,9 @@
-use fuel_tx::{ContractId, AssetId, Salt};
+use fuel_tx::{AssetId, ContractId, Salt};
 use fuels_abigen_macro::abigen;
 use fuels_contract::{contract::Contract, parameters::TxParameters};
 use fuels_signers::provider::Provider;
-use fuels_signers::{util::test_helpers::setup_test_provider_and_wallet, Signer};
 use fuels_signers::wallet::Wallet;
+use fuels_signers::{util::test_helpers::setup_test_provider_and_wallet, Signer};
 
 abigen!(
     TestFuelCoinContract,
@@ -192,11 +192,13 @@ async fn can_mint_and_send_to_address() {
         .await
         .unwrap();
 
-    assert_eq!(wallet
-        .get_spendable_coins(&AssetId::from(asset_id_array), 1)
-        .await
-        .unwrap()[0]
-        .amount, amount.into()
+    assert_eq!(
+        wallet
+            .get_spendable_coins(&AssetId::from(asset_id_array), 1)
+            .await
+            .unwrap()[0]
+            .amount,
+        amount.into()
     );
 }
 

--- a/sway-lib-std/tests/test_projects/token_ops/mod.rs
+++ b/sway-lib-std/tests/test_projects/token_ops/mod.rs
@@ -191,7 +191,6 @@ async fn can_mint_and_send_to_address() {
         .call()
         .await
         .unwrap();
-    dbg!(&result);
 
     assert_eq!(
         wallet

--- a/sway-lib-std/tests/test_projects/token_ops/src/main.sw
+++ b/sway-lib-std/tests/test_projects/token_ops/src/main.sw
@@ -8,6 +8,8 @@ abi TestFuelCoin {
     fn force_transfer_coins(coins: u64, asset_id: ContractId, target: ContractId);
     fn transfer_coins_to_output(coins: u64, asset_id: ContractId, recipient: Address);
     fn get_balance(target: ContractId, asset_id: ContractId) -> u64;
+    fn mint_and_send_to_contract(amount: u64, destination: ContractId);
+    fn mint_and_send_to_address(amount: u64, recipient: Address);
 }
 
 impl TestFuelCoin for Contract {
@@ -29,5 +31,13 @@ impl TestFuelCoin for Contract {
 
     fn get_balance(target: ContractId, asset_id: ContractId) -> u64 {
         balance_of(target, asset_id)
+    }
+
+    fn mint_and_send_to_contract(amount: u64, destination: ContractId) {
+        mint_to_contract(amount, destination);
+    }
+
+    fn mint_and_send_to_address(amount: u64, recipient: Address) {
+        mint_to_address(amount, recipient);
     }
 }


### PR DESCRIPTION
this PR adds:
 - a `mint_to_contract()` function (a simple wrapper around `mint()` and `force_transfer()` )
 - a `mint_to_address()` function (a simple wrapper around `mint()` and `transfer_to_output()` )
 - tests for both

These are convenience functions, wrapping existing functions in the `token` module to allow minting and sending tokens in one function call.

closes #1083
closes #1084