### PR TITLE
Explicitly declare `[lib]` and `[[bin]]` targets for `forc`

### DIFF
--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -8,6 +8,14 @@ license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/sway"
 description = "Fuel Orchestrator."
 
+[lib]
+name = "forc"
+path = "src/lib.rs"
+
+[[bin]]
+name = "forc"
+path = "src/main.rs"
+
 [dependencies]
 annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1.0.41"

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -51,7 +51,7 @@ enum Forc {
     Lsp(LspCommand),
 }
 
-pub(crate) async fn run_cli() -> Result<()> {
+pub async fn run_cli() -> Result<()> {
     let opt = Opt::parse();
 
     match opt.command {

--- a/forc/src/lib.rs
+++ b/forc/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-mod cli;
+pub mod cli;
 mod ops;
 mod utils;
 

--- a/forc/src/main.rs
+++ b/forc/src/main.rs
@@ -1,11 +1,6 @@
-#![allow(warnings)]
-mod cli;
-mod ops;
-mod utils;
-
 use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    cli::run_cli().await
+    forc::cli::run_cli().await
 }


### PR DESCRIPTION
This allows to remove some duplication between the `lib.rs` and
`main.rs` modules, and should allow us to remove the catch-all
`#![allow(dead_code)]` attribute in `lib.rs` in a follow-up PR.