### PR TITLE
Add support for `forc` CLI plugins

### DIFF
--- a/forc/src/cli/plugin.rs
+++ b/forc/src/cli/plugin.rs
@@ -1,0 +1,62 @@
+//! Items related to plugin support for `forc`.
+
+use anyhow::{bail, Result};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process,
+};
+
+/// Attempt to execute the unknown subcommand as an external plugin.
+///
+/// The subcommand is assumed to be the first element, with the following elements representing
+/// following arguments to the external subcommand.
+///
+/// E.g. given `foo bar baz` where `foo` is an unrecognized subcommand to `forc`, tries to execute
+/// `forc-foo bar baz`.
+pub(crate) fn execute_external_subcommand(args: Vec<String>) -> Result<process::Output> {
+    let cmd = args.get(0).expect("`args` must not be empty");
+    let args = &args[1..];
+    let path = find_external_subcommand(cmd);
+    let command = match path {
+        Some(command) => command,
+        None => bail!("no such subcommand: `{}`", cmd),
+    };
+    let output = process::Command::new(&command)
+        .stdin(process::Stdio::inherit())
+        .stdout(process::Stdio::inherit())
+        .stderr(process::Stdio::inherit())
+        .args(args)
+        .output()?;
+    Ok(output)
+}
+
+/// Find an exe called `forc-<cmd>` and return its path.
+fn find_external_subcommand(cmd: &str) -> Option<PathBuf> {
+    let command_exe = format!("forc-{}{}", cmd, env::consts::EXE_SUFFIX);
+    search_directories()
+        .iter()
+        .map(|dir| dir.join(&command_exe))
+        .find(|file| is_executable(file))
+}
+
+/// Search the user's `PATH` for `forc-*` exes.
+fn search_directories() -> Vec<PathBuf> {
+    if let Some(val) = env::var_os("PATH") {
+        return env::split_paths(&val).collect();
+    }
+    vec![]
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::prelude::*;
+    fs::metadata(path)
+        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(windows)]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}


### PR DESCRIPTION
Adds support for treating external executables as `forc` plugins, provided they are of the name `forc-*` and are available via `PATH`.

For example, this allows for using an installed `forc-foo <args>` plugin via `forc foo <args>`.

This should enable us to cut down on some of `forc`'s bloat by moving support for things like the block explorer, language server and running a fuel node into dedicated plugins.

This approach to plugin support is very much inspired by `cargo`'s, but also takes advantage of `clap`'s support for external commands to keep things a bit tidier.

Tested locally with the new `forc-lsp` plugin - see #1179.

Closes #944.
Related: #946, #1175.