### PR TITLE
Add a `forc plugins` command for listing all plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,6 +1089,7 @@ dependencies = [
  "ureq",
  "url",
  "uwuify",
+ "walkdir",
  "whoami",
 ]
 

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -41,7 +41,7 @@ toml_edit = "0.13"
 ureq = { version = "2.4", features = ["json"] }
 url = "2.2"
 uwuify = { version = "^0.2", optional = true }
-walkdir = "2"
+walkdir = "2.3"
 whoami = "1.1"
 
 [features]

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -41,6 +41,7 @@ toml_edit = "0.13"
 ureq = { version = "2.4", features = ["json"] }
 url = "2.2"
 uwuify = { version = "^0.2", optional = true }
+walkdir = "2"
 whoami = "1.1"
 
 [features]

--- a/forc/src/cli/commands/mod.rs
+++ b/forc/src/cli/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod deploy;
 pub mod init;
 pub mod json_abi;
 pub mod parse_bytecode;
+pub mod plugins;
 pub mod run;
 pub mod test;
 pub mod update;

--- a/forc/src/cli/commands/plugins.rs
+++ b/forc/src/cli/commands/plugins.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+
+pub(crate) fn exec() -> Result<()> {
+    for path in crate::cli::plugin::find_all() {
+        println!("{}", path.display());
+    }
+    Ok(())
+}

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -1,5 +1,6 @@
 use self::commands::{
-    addr2line, build, clean, completions, deploy, init, json_abi, parse_bytecode, run, test, update,
+    addr2line, build, clean, completions, deploy, init, json_abi, parse_bytecode, plugins, run,
+    test, update,
 };
 use addr2line::Command as Addr2LineCommand;
 use anyhow::{anyhow, Result};
@@ -41,6 +42,10 @@ enum Forc {
     Test(TestCommand),
     Update(UpdateCommand),
     JsonAbi(JsonAbiCommand),
+    /// Find all forc plugins available via `PATH`.
+    ///
+    /// Prints the absolute path to each discovered plugin on a new line.
+    Plugins,
     /// This is a catch-all for unknown subcommands and their arguments.
     ///
     /// When we receive an unknown subcommand, we check for a plugin exe named
@@ -63,6 +68,7 @@ pub async fn run_cli() -> Result<()> {
         Forc::Deploy(command) => deploy::exec(command).await,
         Forc::Init(command) => init::exec(command),
         Forc::ParseBytecode(command) => parse_bytecode::exec(command),
+        Forc::Plugins => plugins::exec(),
         Forc::Run(command) => run::exec(command).await,
         Forc::Test(command) => test::exec(command),
         Forc::Update(command) => update::exec(command).await,

--- a/forc/src/cli/plugin.rs
+++ b/forc/src/cli/plugin.rs
@@ -60,3 +60,23 @@ fn is_executable(path: &Path) -> bool {
 fn is_executable(path: &Path) -> bool {
     path.is_file()
 }
+
+/// Whether or not the given path points to a valid forc plugin.
+fn is_plugin(path: &Path) -> bool {
+    if let Some(stem) = path.file_name().and_then(|os_str| os_str.to_str()) {
+        if stem.starts_with("forc-") && is_executable(path) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Find all forc plugins available via `PATH`.
+pub(crate) fn find_all() -> impl Iterator<Item = PathBuf> {
+    search_directories()
+        .into_iter()
+        .flat_map(walkdir::WalkDir::new)
+        .filter_map(Result::ok)
+        .map(|entry| entry.path().to_path_buf())
+        .filter(|p| is_plugin(p))
+}


### PR DESCRIPTION
Closes #1198.

Lists the full path to every `forc-*` plugin discovered under the user's
`PATH`.

For example:

```sh
[mindtree@minddesk:~]$ forc plugins
/home/mindtree/.cargo/bin/forc-fmt
/home/mindtree/.cargo/bin/forc-explore
/home/mindtree/.cargo/bin/forc-lsp
```

We could potentially add flags to this command in the future for:

- only emitting executable names (not full paths)
- printing versions and descriptions in a table
- outputting via JSON or TOML for easier machine digestion.

For now, this PR just aims to add initial support.

The logic included in this should make it easier to include available
plugin commands in a future `forc --list` command too (ala #702).