### PR TITLE
Remove duplicate errors

### DIFF
--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -190,9 +190,6 @@ pub fn print_on_failure(silent_mode: bool, warnings: &[CompileWarning], errors: 
         errors.iter().for_each(format_err);
     }
 
-    warnings.iter().for_each(format_warning);
-    errors.iter().for_each(format_err);
-
     println_red_err(&format!(
         "  Aborting due to {} {}.",
         e_len,


### PR DESCRIPTION
These two lines were probably added by mistake while resolving some merge conflicts. Removing them here. 

The more involved fix for the general duplicate errors problem is https://github.com/FuelLabs/sway/pull/1165