### PR TITLE
Exposing methods of a trait to its subtraits and some additional things

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -1094,7 +1094,7 @@ fn reassignment(
     }
 }
 
-fn recursive_function(
+fn handle_supertraits(
     supertraits: &[Supertrait],
     trait_namespace: NamespaceRef,
     namespace: NamespaceRef,
@@ -1138,7 +1138,7 @@ fn recursive_function(
                 // Recurse to insert dummy versions of interfaces and methods of the *super*
                 // supertraits
                 check!(
-                    recursive_function(supertraits, trait_namespace, namespace),
+                    handle_supertraits(supertraits, trait_namespace, namespace),
                     return err(warnings, errors),
                     warnings,
                     errors
@@ -1186,7 +1186,12 @@ fn type_check_trait_decl(
 
     let trait_namespace = create_new_scope(namespace);
 
-    recursive_function(&trait_decl.supertraits, trait_namespace, namespace);
+    check!(
+        handle_supertraits(&trait_decl.supertraits, trait_namespace, namespace),
+        return err(warnings, errors),
+        warnings,
+        errors
+    );
 
     // insert placeholder functions representing the interface surface
     // to allow methods to use those functions

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -413,16 +413,6 @@ impl TypedAstNode {
                                 warnings,
                                 errors
                             )
-                            /*let trait_decl =
-                                TypedDeclaration::TraitDeclaration(TypedTraitDeclaration {
-                                    name: name.clone(),
-                                    interface_surface,
-                                    methods,
-                                    supertraits,
-                                    visibility,
-                                });
-                            namespace.insert(name, trait_decl.clone());
-                            trait_decl*/
                         }
                         Declaration::Reassignment(Reassignment { lhs, rhs, span }) => {
                             check!(
@@ -1094,6 +1084,8 @@ fn reassignment(
     }
 }
 
+/// Recursively handle supertraits by adding all their interfaces and methods to some namespace
+/// which is meant to be the namespace of the subtrait in question
 fn handle_supertraits(
     supertraits: &[Supertrait],
     trait_namespace: NamespaceRef,
@@ -1186,6 +1178,7 @@ fn type_check_trait_decl(
 
     let trait_namespace = create_new_scope(namespace);
 
+    // Recursively handle supertraits: make their interfaces and methods available to this trait
     check!(
         handle_supertraits(&trait_decl.supertraits, trait_namespace, namespace),
         return err(warnings, errors),

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -394,98 +394,26 @@ impl TypedAstNode {
                             );
                             TypedDeclaration::FunctionDeclaration(decl)
                         }
-                        Declaration::TraitDeclaration(TraitDeclaration {
-                            name,
-                            interface_surface,
-                            methods,
-                            supertraits,
-                            visibility,
-                        }) => {
-                            // type check the interface surface
-                            let interface_surface = check!(
-                                type_check_interface_surface(interface_surface, namespace),
+                        Declaration::TraitDeclaration(trait_decl) => {
+                            check!(
+                                type_check_trait_decl(TypeCheckArguments {
+                                    checkee: trait_decl,
+                                    namespace,
+                                    crate_namespace,
+                                    self_type,
+                                    build_config,
+                                    dead_code_graph,
+                                    // this is unused by `type_check_trait`
+                                    return_type_annotation: insert_type(TypeInfo::Unknown),
+                                    help_text: Default::default(),
+                                    mode: Mode::NonAbi,
+                                    opts,
+                                }),
                                 return err(warnings, errors),
                                 warnings,
                                 errors
-                            );
-
-                            let trait_namespace = create_new_scope(namespace);
-                            // Error checking. Make sure that each supertrait exists and that none
-                            // of the supertraits are actually an ABI declaration
-                            for supertrait in &supertraits {
-                                match namespace
-                                    .get_call_path(&supertrait.name)
-                                    .ok(&mut warnings, &mut errors)
-                                {
-                                    Some(TypedDeclaration::TraitDeclaration(
-                                        TypedTraitDeclaration {
-                                            ref interface_surface,
-                                            ref methods,
-                                            ..
-                                        },
-                                    )) => {
-                                        // insert trait implementations for all of the supertraits
-                                        trait_namespace.insert_trait_implementation(
-                                            supertrait.name.clone(),
-                                            TypeInfo::SelfType,
-                                            interface_surface
-                                                .iter()
-                                                .map(|x| x.to_dummy_func(Mode::NonAbi))
-                                                .collect(),
-                                        );
-
-                                        // insert dummy versions of the methods of all of the supertraits
-                                        trait_namespace.insert_trait_implementation(
-                                            supertrait.name.clone(),
-                                            TypeInfo::SelfType,
-                                            check!(
-                                                convert_methods_to_dummy_funcs(methods, namespace),
-                                                return err(warnings, errors),
-                                                warnings,
-                                                errors
-                                            ),
-                                        );
-                                    }
-                                    Some(TypedDeclaration::AbiDeclaration(_)) => {
-                                        errors.push(CompileError::AbiAsSupertrait {
-                                            span: name.span().clone(),
-                                        })
-                                    }
-                                    _ => errors.push(CompileError::TraitNotFound {
-                                        name: supertrait.name.span().as_str().to_string(),
-                                        span: name.span().clone(),
-                                    }),
-                                }
-                            }
-                            // insert placeholder functions representing the interface surface
-                            // to allow methods to use those functions
-                            trait_namespace.insert_trait_implementation(
-                                CallPath {
-                                    prefixes: vec![],
-                                    suffix: name.clone(),
-                                    is_absolute: false,
-                                },
-                                TypeInfo::SelfType,
-                                interface_surface
-                                    .iter()
-                                    .map(|x| x.to_dummy_func(Mode::NonAbi))
-                                    .collect(),
-                            );
-                            // check the methods for errors but throw them away and use vanilla [FunctionDeclaration]s
-                            let _methods = check!(
-                                type_check_trait_methods(
-                                    methods.clone(),
-                                    trait_namespace,
-                                    crate_namespace,
-                                    insert_type(TypeInfo::SelfType),
-                                    build_config,
-                                    dead_code_graph,
-                                ),
-                                vec![],
-                                warnings,
-                                errors
-                            );
-                            let trait_decl =
+                            )
+                            /*let trait_decl =
                                 TypedDeclaration::TraitDeclaration(TypedTraitDeclaration {
                                     name: name.clone(),
                                     interface_surface,
@@ -494,7 +422,7 @@ impl TypedAstNode {
                                     visibility,
                                 });
                             namespace.insert(name, trait_decl.clone());
-                            trait_decl
+                            trait_decl*/
                         }
                         Declaration::Reassignment(Reassignment { lhs, rhs, span }) => {
                             check!(
@@ -1166,73 +1094,137 @@ fn reassignment(
     }
 }
 
-fn convert_methods_to_dummy_funcs(
-    methods: &[FunctionDeclaration],
-    namespace: crate::semantic_analysis::NamespaceRef,
-) -> CompileResult<Vec<TypedFunctionDeclaration>> {
-    let mut warnings = vec![];
-    let mut errors = vec![];
-    let dummy_funcs = methods
-        .into_iter()
-        .map(
-            |FunctionDeclaration {
-                 name,
-                 parameters,
-                 return_type,
-                 return_type_span,
-                 ..
-             }| TypedFunctionDeclaration {
-                purity: Default::default(),
-                name: name.clone(),
-                body: TypedCodeBlock {
-                    contents: vec![],
-                    whole_block_span: name.span().clone(),
-                },
-                parameters: parameters
-                    .into_iter()
-                    .map(
-                        |FunctionParameter {
-                             name,
-                             type_id,
-                             type_span,
-                         }| TypedFunctionParameter {
-                            name: name.clone(),
-                            r#type: check!(
-                                namespace.resolve_type_with_self(
-                                    look_up_type_id(*type_id),
-                                    crate::type_engine::insert_type(TypeInfo::SelfType),
-                                    type_span.clone(),
-                                    true
-                                ),
-                                insert_type(TypeInfo::ErrorRecovery),
-                                warnings,
-                                errors,
-                            ),
-                            type_span: type_span.clone(),
-                        },
-                    )
-                    .collect(),
-                span: name.span().clone(),
-                return_type: check!(
-                    namespace.resolve_type_with_self(
-                        return_type.clone(),
-                        crate::type_engine::insert_type(TypeInfo::SelfType),
-                        return_type_span.clone(),
-                        true
-                    ),
-                    insert_type(TypeInfo::ErrorRecovery),
-                    warnings,
-                    errors,
-                ),
-                return_type_span: return_type_span.clone(),
-                visibility: Visibility::Public,
-                type_parameters: vec![],
-                is_contract_call: false,
-            },
-        )
-        .collect::<Vec<_>>();
+fn recursive_function(
+    supertraits: &[Supertrait],
+    trait_namespace: NamespaceRef,
+    namespace: NamespaceRef,
+) -> CompileResult<()> {
+    let mut warnings = Vec::new();
+    let mut errors = Vec::new();
 
-    ok(dummy_funcs, warnings, errors)
+    for supertrait in supertraits.iter() {
+        match namespace
+            .get_call_path(&supertrait.name)
+            .ok(&mut warnings, &mut errors)
+        {
+            Some(TypedDeclaration::TraitDeclaration(TypedTraitDeclaration {
+                ref interface_surface,
+                ref methods,
+                ref supertraits,
+                ..
+            })) => {
+                // insert dummy versions of the interfaces for all of the supertraits
+                trait_namespace.insert_trait_implementation(
+                    supertrait.name.clone(),
+                    TypeInfo::SelfType,
+                    interface_surface
+                        .iter()
+                        .map(|x| x.to_dummy_func(Mode::NonAbi))
+                        .collect(),
+                );
+
+                // insert dummy versions of the methods of all of the supertraits
+                trait_namespace.insert_trait_implementation(
+                    supertrait.name.clone(),
+                    TypeInfo::SelfType,
+                    check!(
+                        convert_trait_methods_to_dummy_funcs(methods, namespace),
+                        return err(warnings, errors),
+                        warnings,
+                        errors
+                    ),
+                );
+
+                // Recurse to insert dummy versions of interfaces and methods of the *super*
+                // supertraits
+                check!(
+                    recursive_function(supertraits, trait_namespace, namespace),
+                    return err(warnings, errors),
+                    warnings,
+                    errors
+                );
+            }
+            Some(TypedDeclaration::AbiDeclaration(_)) => {
+                errors.push(CompileError::AbiAsSupertrait {
+                    span: supertrait.name.span().clone(),
+                })
+            }
+            _ => errors.push(CompileError::TraitNotFound {
+                name: supertrait.name.span().as_str().to_string(),
+                span: supertrait.name.span().clone(),
+            }),
+        }
+    }
+
+    ok((), warnings, errors)
+}
+
+fn type_check_trait_decl(
+    arguments: TypeCheckArguments<'_, TraitDeclaration>,
+) -> CompileResult<TypedDeclaration> {
+    let TypeCheckArguments {
+        checkee: trait_decl,
+        namespace,
+        crate_namespace,
+        return_type_annotation: _return_type_annotation,
+        help_text: _help_text,
+        build_config,
+        dead_code_graph,
+        ..
+    } = arguments;
+
+    let mut warnings = Vec::new();
+    let mut errors = Vec::new();
+
+    // type check the interface surface
+    let interface_surface = check!(
+        type_check_interface_surface(trait_decl.interface_surface.to_vec(), namespace),
+        return err(warnings, errors),
+        warnings,
+        errors
+    );
+
+    let trait_namespace = create_new_scope(namespace);
+
+    recursive_function(&trait_decl.supertraits, trait_namespace, namespace);
+
+    // insert placeholder functions representing the interface surface
+    // to allow methods to use those functions
+    trait_namespace.insert_trait_implementation(
+        CallPath {
+            prefixes: vec![],
+            suffix: trait_decl.name.clone(),
+            is_absolute: false,
+        },
+        TypeInfo::SelfType,
+        interface_surface
+            .iter()
+            .map(|x| x.to_dummy_func(Mode::NonAbi))
+            .collect(),
+    );
+    // check the methods for errors but throw them away and use vanilla [FunctionDeclaration]s
+    let _methods = check!(
+        type_check_trait_methods(
+            trait_decl.methods.clone(),
+            trait_namespace,
+            crate_namespace,
+            insert_type(TypeInfo::SelfType),
+            build_config,
+            dead_code_graph,
+        ),
+        vec![],
+        warnings,
+        errors
+    );
+    let typed_trait_decl = TypedDeclaration::TraitDeclaration(TypedTraitDeclaration {
+        name: trait_decl.name.clone(),
+        interface_surface,
+        methods: trait_decl.methods.to_vec(),
+        supertraits: trait_decl.supertraits.to_vec(),
+        visibility: trait_decl.visibility,
+    });
+    namespace.insert(trait_decl.name, typed_trait_decl.clone());
+    ok(typed_trait_decl, warnings, errors)
 }
 
 fn type_check_interface_surface(
@@ -1465,6 +1457,77 @@ fn type_check_trait_methods(
         });
     }
     ok(methods_buf, warnings, errors)
+}
+
+/// Convert a vector of FunctionDeclarations into a vector of TypedFunctionDeclarations where only
+/// the parameters and the return types are type checked.
+fn convert_trait_methods_to_dummy_funcs(
+    methods: &[FunctionDeclaration],
+    namespace: crate::semantic_analysis::NamespaceRef,
+) -> CompileResult<Vec<TypedFunctionDeclaration>> {
+    let mut warnings = vec![];
+    let mut errors = vec![];
+    let dummy_funcs = methods
+        .iter()
+        .map(
+            |FunctionDeclaration {
+                 name,
+                 parameters,
+                 return_type,
+                 return_type_span,
+                 ..
+             }| TypedFunctionDeclaration {
+                purity: Default::default(),
+                name: name.clone(),
+                body: TypedCodeBlock {
+                    contents: vec![],
+                    whole_block_span: name.span().clone(),
+                },
+                parameters: parameters
+                    .iter()
+                    .map(
+                        |FunctionParameter {
+                             name,
+                             type_id,
+                             type_span,
+                         }| TypedFunctionParameter {
+                            name: name.clone(),
+                            r#type: check!(
+                                namespace.resolve_type_with_self(
+                                    look_up_type_id(*type_id),
+                                    crate::type_engine::insert_type(TypeInfo::SelfType),
+                                    type_span.clone(),
+                                    true
+                                ),
+                                insert_type(TypeInfo::ErrorRecovery),
+                                warnings,
+                                errors,
+                            ),
+                            type_span: type_span.clone(),
+                        },
+                    )
+                    .collect(),
+                span: name.span().clone(),
+                return_type: check!(
+                    namespace.resolve_type_with_self(
+                        return_type.clone(),
+                        crate::type_engine::insert_type(TypeInfo::SelfType),
+                        return_type_span.clone(),
+                        true
+                    ),
+                    insert_type(TypeInfo::ErrorRecovery),
+                    warnings,
+                    errors,
+                ),
+                return_type_span: return_type_span.clone(),
+                visibility: Visibility::Public,
+                type_parameters: vec![],
+                is_contract_call: false,
+            },
+        )
+        .collect::<Vec<_>>();
+
+    ok(dummy_funcs, warnings, errors)
 }
 
 /// Used to create a stubbed out function when the function fails to compile, preventing cascading

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/supertraits/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/supertraits/src/main.sw
@@ -2,6 +2,19 @@ script;
 
 use std::assert::assert;
 
+/// Inheritence tree:
+///      A 
+///      |
+///      |
+///      B     
+///     /|
+///    / |
+///   C  |
+///    \ |
+///     \|
+///      D
+///
+
 trait A {
     fn f(self) -> u64;
 } {
@@ -22,8 +35,18 @@ trait B: A {
     fn mul_g(self, x: u64) -> u64 {
         self.g() * x
     }
-    fn test_inheritance(self) {
-        self.f();
+
+    // Test access to A's interface 
+    fn b_calls_f(self) -> u64 {
+        self.f() + 1
+    }
+
+    // Test access to A's methods 
+    fn b_calls_add_f(self, x: u64) -> u64 {
+        self.add_f(x) + 1
+    }
+    fn b_calls_mul_f(self, x: u64) -> u64 {
+        self.mul_f(x) + 1
     }
 }
 
@@ -36,6 +59,41 @@ trait C: B {
     fn mul_h(self, x: u64) -> u64 {
         self.h() * x
     }
+    
+    // Test access to A's interface 
+    fn c_calls_f(self) -> u64 {
+        self.f() + 2
+    }
+
+    // Test access to B's interface 
+    fn c_calls_g(self) -> u64 {
+        self.g() + 2
+    }
+    
+    // Test access to A's methods 
+    fn c_calls_add_f(self, x: u64) -> u64 {
+        self.add_f(x) + 2
+    }
+    fn c_calls_mul_f(self, x: u64) -> u64 {
+        self.mul_f(x) + 2
+    }
+    
+    // Test access to B's methods 
+    fn c_calls_add_g(self, x: u64) -> u64 {
+        self.add_g(x) + 2
+    }
+    fn c_calls_mul_g(self, x: u64) -> u64 {
+        self.mul_g(x) + 2
+    }
+    fn c_calls_b_calls_f(self) -> u64 {
+        self.b_calls_f() + 2
+    }
+    fn c_calls_b_calls_add_f(self, x: u64) -> u64 {
+        self.b_calls_add_f(x) + 2
+    }
+    fn c_calls_b_calls_mul_f(self, x: u64) -> u64 {
+        self.b_calls_mul_f(x) + 2
+    }
 }
 
 trait D: B + C {
@@ -46,6 +104,81 @@ trait D: B + C {
     }
     fn mul_i(self, x: u64) -> u64 {
         self.i() * x
+    }
+
+    // Test access to A's interface 
+    fn d_calls_f(self) -> u64 {
+        self.f() + 3
+    }
+
+    // Test access to B's interface 
+    fn d_calls_g(self) -> u64 {
+        self.g() + 3
+    }
+
+    // Test access to C's interface 
+    fn d_calls_h(self) -> u64 {
+        self.h() + 3
+    }
+    
+    // Test access to A's methods 
+    fn d_calls_add_f(self, x: u64) -> u64 {
+        self.add_f(x) + 3
+    }
+    fn d_calls_mul_f(self, x: u64) -> u64 {
+        self.mul_f(x) + 3
+    }
+    
+    // Test access to B's methods 
+    fn d_calls_add_g(self, x: u64) -> u64 {
+        self.add_g(x) + 3
+    }
+    fn d_calls_mul_g(self, x: u64) -> u64 {
+        self.mul_g(x) + 3
+    }
+    fn d_calls_b_calls_f(self) -> u64 {
+        self.b_calls_f() + 3
+    }
+    fn d_calls_b_calls_add_f(self, x: u64) -> u64 {
+        self.b_calls_add_f(x) + 3
+    }
+    fn d_calls_b_calls_mul_f(self, x: u64) -> u64 {
+        self.b_calls_mul_f(x) + 3
+    }
+
+    // Test access to C's methods
+    fn d_calls_add_h(self, x: u64) -> u64 {
+        self.add_h(x) + 3
+    }
+    fn d_calls_mul_h(self, x: u64) -> u64 {
+        self.mul_h(x) + 3
+    }
+    fn d_calls_c_calls_f(self) -> u64 {
+        self.c_calls_f() + 3
+    }
+    fn d_calls_c_calls_g(self) -> u64 {
+        self.c_calls_g() + 3
+    }
+    fn d_calls_c_calls_add_f(self, x: u64) -> u64 {
+        self.c_calls_add_f(x) + 3
+    }
+    fn d_calls_c_calls_mul_f(self, x: u64) -> u64 {
+        self.c_calls_mul_f(x) + 3
+    }
+    fn d_calls_c_calls_add_g(self, x: u64) -> u64 {
+        self.c_calls_add_g(x) + 3
+    }
+    fn d_calls_c_calls_mul_g(self, x: u64) -> u64 {
+        self.c_calls_mul_g(x) + 3
+    }
+    fn d_calls_c_calls_b_calls_f(self) -> u64 {
+        self.c_calls_b_calls_f() + 3
+    }
+    fn d_calls_c_calls_b_calls_add_f(self, x: u64) -> u64 {
+        self.c_calls_b_calls_add_f(x) + 3
+    }
+    fn d_calls_c_calls_b_calls_mul_f(self, x: u64) -> u64 {
+        self.c_calls_b_calls_mul_f(x) + 3
     }
 }
 
@@ -107,24 +240,80 @@ impl C for U {
 
 fn main() -> bool {
     let s = S {
-        x: 1,
+        x: 42,
         y: 2,
         z: 3,
         w: 4,
     };
 
-    assert(s.f() == 1);
-    assert(s.add_f(5) == 6);
-    assert(s.mul_f(5) == 5);
-    assert(s.g() == 2);
-    assert(s.add_g(5) == 7);
-    assert(s.mul_g(5) == 10);
-    assert(s.h() == 3);
-    assert(s.add_h(5) == 8);
-    assert(s.mul_h(5) == 15);
-    assert(s.i() == 4);
-    assert(s.add_i(5) == 9);
-    assert(s.mul_i(5) == 20);
+    // To follow all the tests below, note that 
+    // * each call from B (i.e. call with `calls_b`) adds 1
+    // * each call from C (i.e. call with `calls_b`) adds 2
+    // * each call from D (i.e. call with `calls_b`) adds 3    
+
+    // Test access to f()
+    assert(s.f() == s.x);
+    assert(s.b_calls_f() == s.x + 1);
+    assert(s.c_calls_f() == s.x + 2);
+    assert(s.d_calls_f() == s.x + 3);
+  
+    // Test access to add_f()
+    assert(s.add_f(5) == s.x + 5);
+    assert(s.b_calls_add_f(5) == s.x + 5 + 1 );
+    assert(s.c_calls_add_f(5) == s.x + 5 + 2);
+    assert(s.c_calls_b_calls_add_f(5) == s.x + 5 + 1 + 2);
+    assert(s.d_calls_add_f(5) == s.x + 5 + 3);
+    assert(s.d_calls_b_calls_add_f(5) == s.x + 5 + 1 + 3);
+    assert(s.d_calls_c_calls_add_f(5) == s.x + 5 + 2 + 3);
+    assert(s.d_calls_c_calls_b_calls_add_f(5) == s.x + 5 + 1 + 2 + 3);
+
+    // Test access to mul_f()
+    assert(s.mul_f(5) == s.x * 5);
+    assert(s.b_calls_mul_f(5) == s.x * 5 + 1 );
+    assert(s.c_calls_mul_f(5) == s.x * 5 + 2);
+    assert(s.c_calls_b_calls_mul_f(5) == s.x * 5 + 1 + 2);
+    assert(s.d_calls_mul_f(5) == s.x * 5 + 3);
+    assert(s.d_calls_b_calls_mul_f(5) == s.x * 5 + 1 + 3);
+    assert(s.d_calls_c_calls_mul_f(5) == s.x * 5 + 2 + 3);
+    assert(s.d_calls_c_calls_b_calls_mul_f(5) == s.x * 5 + 1 + 2 + 3);
+
+    // Test access to g()
+    assert(s.g() == s.y);
+    assert(s.c_calls_g() == s.y + 2);
+    assert(s.d_calls_g() == s.y + 3);
+  
+    // Test access to add_g()
+    assert(s.add_g(5) == s.y + 5);
+    assert(s.c_calls_add_g(5) == s.y + 5 + 2);
+    assert(s.d_calls_add_g(5) == s.y + 5 + 3);
+    assert(s.d_calls_c_calls_add_g(5) == s.y + 5 + 2 + 3);
+
+    // Test access to mul_g()
+    assert(s.mul_g(5) == s.y * 5);
+    assert(s.c_calls_mul_g(5) == s.y * 5 + 2);
+    assert(s.d_calls_mul_g(5) == s.y * 5 + 3);
+    assert(s.d_calls_c_calls_mul_g(5) == s.y * 5 + 2 + 3);
+
+    // Test access to h()
+    assert(s.h() == s.z);
+    assert(s.d_calls_h() == s.z + 3);
+  
+    // Test access to add_h()
+    assert(s.add_h(5) == s.z + 5);
+    assert(s.d_calls_add_h(5) == s.z + 5 + 3);
+
+    // Test access to mul_h()
+    assert(s.mul_h(5) == s.z * 5);
+    assert(s.d_calls_mul_h(5) == s.z * 5 + 3);
+
+    // Test access to i()
+    assert(s.i() == s.w);
+  
+    // Test access to add_i()
+    assert(s.add_i(5) == s.w + 5);
+
+    // Test access to mul_i()
+    assert(s.mul_i(5) == s.w * 5);
 
     let u = U {
         x: 5,
@@ -133,15 +322,48 @@ fn main() -> bool {
         w: 8,
     };
 
-    assert(u.f() == 6);
-    assert(u.add_f(5) == 11);
-    assert(u.mul_f(5) == 30);
-    assert(u.g() == 7);
-    assert(u.add_g(5) == 12);
-    assert(u.mul_g(5) == 35);
-    assert(u.h() == 8);
-    assert(u.add_h(5) == 13);
-    assert(u.mul_h(5) == 40);
+    // To follow all the tests below, note that 
+    // * each call from B (i.e. call with `calls_b`) adds 1
+    // * each call from C (i.e. call with `calls_b`) adds 2
+    // Note: no calls from D are allowed because U doesn't implement D
 
+    // Test access to f()
+    assert(u.f() == (u.x + 1));
+    assert(u.b_calls_f() == (u.x + 1) + 1);
+    assert(u.c_calls_f() == (u.x + 1) + 2);
+  
+    // Test access to add_f()
+    assert(u.add_f(5) == (u.x + 1) + 5);
+    assert(u.b_calls_add_f(5) == (u.x + 1) + 5 + 1 );
+    assert(u.c_calls_add_f(5) == (u.x + 1) + 5 + 2);
+    assert(u.c_calls_b_calls_add_f(5) == (u.x + 1) + 5 + 1 + 2);
+
+    // Test access to mul_f()
+    assert(u.mul_f(5) == (u.x + 1) * 5);
+    assert(u.b_calls_mul_f(5) == (u.x + 1) * 5 + 1 );
+    assert(u.c_calls_mul_f(5) == (u.x + 1) * 5 + 2);
+    assert(u.c_calls_b_calls_mul_f(5) == (u.x + 1) * 5 + 1 + 2);
+
+    // Test access to g()
+    assert(u.g() == (u.y + 1));
+    assert(u.c_calls_g() == (u.y + 1) + 2);
+  
+    // Test access to add_g()
+    assert(u.add_g(5) == (u.y + 1) + 5);
+    assert(u.c_calls_add_g(5) == (u.y + 1) + 5 + 2);
+
+    // Test access to mul_g()
+    assert(u.mul_g(5) == (u.y + 1) * 5);
+    assert(u.c_calls_mul_g(5) == (u.y + 1) * 5 + 2);
+
+    // Test access to h()
+    assert(u.h() == (u.z + 1));
+  
+    // Test access to add_h()
+    assert(u.add_h(5) == (u.z + 1) + 5);
+
+    // Test access to mul_h()
+    assert(u.mul_h(5) == (u.z + 1) * 5);
+ 
     true
 }


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway/pull/1091

Three things: 
* https://github.com/FuelLabs/sway/pull/1092 makes the interface of a supertrait available in the namespace of a trait. This patch also makes this recursive so that we can climb the chain of supertraits and make their interfaces also available to the trait. 
* Similarly to the above, this change also makes the methods of supertraits (and their supertraits, etc.) available to the trait. For that, we need to make dummy versions of the methods of the supertraits by converting each `FunctionDeclaration` (each method) into a `TypedFunctionDeclaration` where we only care about the types of the parameters and the value returned.
* Pulled out all the logic into separate functions for code cleanliness.