### PR TITLE
Updated `from_dir` to check parent directories

### DIFF
--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -1,4 +1,4 @@
-use crate::pkg::parsing_failed;
+use crate::pkg::{parsing_failed, wrong_program_type};
 use anyhow::{anyhow, bail, Result};
 use forc_util::{println_yellow_err, validate_name};
 use serde::{Deserialize, Serialize};
@@ -167,6 +167,20 @@ impl Manifest {
         match program_type.value {
             Some(parse_tree) => Ok(parse_tree.tree_type),
             None => bail!(parsing_failed(&self.project.name, program_type.errors)),
+        }
+    }
+
+    /// Given the current directory and expected program type, determines whether the correct program type is present.
+    pub fn check_program_type(&self, manifest_dir: PathBuf, expected_type: TreeType) -> Result<()> {
+        let parsed_type = self.program_type(manifest_dir)?;
+        if parsed_type != expected_type {
+            bail!(wrong_program_type(
+                &self.project.name,
+                expected_type,
+                parsed_type
+            ));
+        } else {
+            Ok(())
         }
     }
 

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -96,13 +96,13 @@ impl Manifest {
         Ok(manifest)
     }
 
-    /// Given a path to a forc project containing a `Forc.toml` in any parent directory, read the manifest.
+    /// Read the manifest from the `Forc.toml` in the directory specified by the given `path` or any of its parent directories.
     ///
     /// This is short for `Manifest::from_file`, but takes care of constructing the path to the
     /// file.
-    pub fn from_dir(manifest_dir: &Path, sway_git_tag: &str) -> Result<Self> {
-        find_manifest_dir(manifest_dir)
-            .ok_or_else(|| manifest_file_missing(manifest_dir.to_path_buf()))?;
+    pub fn from_dir(dir: &Path, sway_git_tag: &str) -> Result<Self> {
+        let manifest_dir =
+            find_manifest_dir(dir).ok_or_else(|| manifest_file_missing(dir.to_path_buf()))?;
         let file_path = manifest_dir.join(constants::MANIFEST_FILE_NAME);
         Self::from_file(&file_path, sway_git_tag)
     }

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -1,6 +1,6 @@
-use crate::pkg::{parsing_failed, wrong_program_type};
+use crate::pkg::{manifest_file_missing, parsing_failed, wrong_program_type};
 use anyhow::{anyhow, bail, Result};
-use forc_util::{println_yellow_err, validate_name};
+use forc_util::{find_manifest_dir, println_yellow_err, validate_name};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -96,11 +96,13 @@ impl Manifest {
         Ok(manifest)
     }
 
-    /// Given a directory to a forc project containing a `Forc.toml`, read the manifest.
+    /// Given a path to a forc project containing a `Forc.toml` in any parent directory, read the manifest.
     ///
     /// This is short for `Manifest::from_file`, but takes care of constructing the path to the
     /// file.
     pub fn from_dir(manifest_dir: &Path, sway_git_tag: &str) -> Result<Self> {
+        find_manifest_dir(manifest_dir)
+            .ok_or_else(|| manifest_file_missing(manifest_dir.to_path_buf()))?;
         let file_path = manifest_dir.join(constants::MANIFEST_FILE_NAME);
         Self::from_file(&file_path, sway_git_tag)
     }

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1221,21 +1221,3 @@ pub fn fuel_core_not_running(node_url: &str) -> anyhow::Error {
     let message = format!("could not get a response from node at the URL {}. Start a node with `fuel-core`. See https://github.com/FuelLabs/fuel-core#running for more information", node_url);
     Error::msg(message)
 }
-
-/// Given the current directory and expected program type, determines whether the correct program type is present.
-pub fn check_program_type(
-    manifest: &Manifest,
-    manifest_dir: PathBuf,
-    expected_type: TreeType,
-) -> Result<()> {
-    let parsed_type = manifest.program_type(manifest_dir)?;
-    if parsed_type != expected_type {
-        bail!(wrong_program_type(
-            &manifest.project.name,
-            expected_type,
-            parsed_type
-        ));
-    } else {
-        Ok(())
-    }
-}

--- a/forc/src/ops/forc_abi_json.rs
+++ b/forc/src/ops/forc_abi_json.rs
@@ -3,8 +3,7 @@ use crate::{
     utils::SWAY_GIT_TAG,
 };
 use anyhow::Result;
-use forc_pkg::{manifest_file_missing, Manifest};
-use forc_util::find_manifest_dir;
+use forc_pkg::Manifest;
 use serde_json::{json, Value};
 use std::fs::File;
 use std::path::PathBuf;
@@ -16,10 +15,8 @@ pub fn build(command: JsonAbiCommand) -> Result<Value> {
     } else {
         std::env::current_dir()?
     };
-    let manifest_dir =
-        find_manifest_dir(&curr_dir).ok_or_else(|| manifest_file_missing(curr_dir))?;
-    let manifest = Manifest::from_dir(&manifest_dir, SWAY_GIT_TAG)?;
-    manifest.check_program_type(manifest_dir, TreeType::Contract)?;
+    Manifest::from_dir(&curr_dir, SWAY_GIT_TAG)?
+        .check_program_type(curr_dir, TreeType::Contract)?;
 
     let build_command = BuildCommand {
         path: command.path,

--- a/forc/src/ops/forc_abi_json.rs
+++ b/forc/src/ops/forc_abi_json.rs
@@ -3,7 +3,7 @@ use crate::{
     utils::SWAY_GIT_TAG,
 };
 use anyhow::Result;
-use forc_pkg::{check_program_type, manifest_file_missing, Manifest};
+use forc_pkg::{manifest_file_missing, Manifest};
 use forc_util::find_manifest_dir;
 use serde_json::{json, Value};
 use std::fs::File;
@@ -19,7 +19,7 @@ pub fn build(command: JsonAbiCommand) -> Result<Value> {
     let manifest_dir =
         find_manifest_dir(&curr_dir).ok_or_else(|| manifest_file_missing(curr_dir))?;
     let manifest = Manifest::from_dir(&manifest_dir, SWAY_GIT_TAG)?;
-    check_program_type(&manifest, manifest_dir, TreeType::Contract)?;
+    manifest.check_program_type(manifest_dir, TreeType::Contract)?;
 
     let build_command = BuildCommand {
         path: command.path,

--- a/forc/src/ops/forc_abi_json.rs
+++ b/forc/src/ops/forc_abi_json.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use anyhow::Result;
 use forc_pkg::Manifest;
+use forc_util::find_manifest_dir;
 use serde_json::{json, Value};
 use std::fs::File;
 use std::path::PathBuf;
@@ -15,8 +16,9 @@ pub fn build(command: JsonAbiCommand) -> Result<Value> {
     } else {
         std::env::current_dir()?
     };
-    Manifest::from_dir(&curr_dir, SWAY_GIT_TAG)?
-        .check_program_type(curr_dir, TreeType::Contract)?;
+    let manifest = Manifest::from_dir(&curr_dir, SWAY_GIT_TAG)?;
+    let manifest_dir = find_manifest_dir(&curr_dir).unwrap();
+    manifest.check_program_type(manifest_dir, TreeType::Contract)?;
 
     let build_command = BuildCommand {
         path: command.path,

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -1,12 +1,11 @@
 use crate::{cli::BuildCommand, utils::SWAY_GIT_TAG};
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use forc_pkg::{self as pkg, lock, Lock, Manifest};
-use forc_util::{default_output_directory, find_manifest_dir, lock_path};
+use forc_util::{default_output_directory, lock_path};
 use std::{
     fs::{self, File},
     path::PathBuf,
 };
-use sway_utils::MANIFEST_FILE_NAME;
 
 pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
     let BuildCommand {
@@ -37,19 +36,8 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
     } else {
         std::env::current_dir()?
     };
-
-    let manifest_dir = match find_manifest_dir(&this_dir) {
-        Some(dir) => dir,
-        None => {
-            bail!(
-                "could not find `{}` in `{}` or any parent directory",
-                MANIFEST_FILE_NAME,
-                this_dir.display(),
-            );
-        }
-    };
-    let manifest = Manifest::from_dir(&manifest_dir, SWAY_GIT_TAG)?;
-    let lock_path = lock_path(&manifest_dir);
+    let manifest = Manifest::from_dir(&this_dir, SWAY_GIT_TAG)?;
+    let lock_path = lock_path(&this_dir);
 
     // Load the build plan from the lock file.
     let plan_result = pkg::BuildPlan::from_lock_file(&lock_path, SWAY_GIT_TAG);
@@ -69,7 +57,7 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
     let plan: pkg::BuildPlan = plan_result.or_else(|e| -> Result<pkg::BuildPlan> {
         println!("  Creating a new `Forc.lock` file");
         println!("    Cause: {}", e);
-        let plan = pkg::BuildPlan::new(&manifest_dir, SWAY_GIT_TAG, offline)?;
+        let plan = pkg::BuildPlan::new(&this_dir, SWAY_GIT_TAG, offline)?;
         let lock = Lock::from_graph(plan.graph());
         let diff = lock.diff(&old_lock);
         lock::print_diff(&manifest.project.name, &diff);
@@ -98,7 +86,7 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
     // Create the output directory for build artifacts.
     let output_dir = output_directory
         .map(PathBuf::from)
-        .unwrap_or_else(|| default_output_directory(&manifest_dir).join(profile));
+        .unwrap_or_else(|| default_output_directory(&this_dir).join(profile));
     if !output_dir.exists() {
         fs::create_dir_all(&output_dir)?;
     }

--- a/forc/src/ops/forc_deploy.rs
+++ b/forc/src/ops/forc_deploy.rs
@@ -4,8 +4,7 @@ use crate::{
     utils::SWAY_GIT_TAG,
 };
 use anyhow::{bail, Result};
-use forc_pkg::{manifest_file_missing, Manifest};
-use forc_util::find_manifest_dir;
+use forc_pkg::Manifest;
 use fuel_gql_client::client::FuelClient;
 use fuel_tx::{Output, Salt, Transaction};
 use fuel_vm::prelude::*;
@@ -19,10 +18,8 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
     } else {
         std::env::current_dir()?
     };
-    let manifest_dir =
-        find_manifest_dir(&curr_dir).ok_or_else(|| manifest_file_missing(curr_dir))?;
-    let manifest = Manifest::from_dir(&manifest_dir, SWAY_GIT_TAG)?;
-    manifest.check_program_type(manifest_dir, TreeType::Contract)?;
+    let manifest = Manifest::from_dir(&curr_dir, SWAY_GIT_TAG)?;
+    manifest.check_program_type(curr_dir, TreeType::Contract)?;
 
     let DeployCommand {
         path,

--- a/forc/src/ops/forc_deploy.rs
+++ b/forc/src/ops/forc_deploy.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use forc_pkg::Manifest;
+use forc_util::find_manifest_dir;
 use fuel_gql_client::client::FuelClient;
 use fuel_tx::{Output, Salt, Transaction};
 use fuel_vm::prelude::*;
@@ -19,7 +20,8 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
         std::env::current_dir()?
     };
     let manifest = Manifest::from_dir(&curr_dir, SWAY_GIT_TAG)?;
-    manifest.check_program_type(curr_dir, TreeType::Contract)?;
+    let manifest_dir = find_manifest_dir(&curr_dir).unwrap();
+    manifest.check_program_type(manifest_dir, TreeType::Contract)?;
 
     let DeployCommand {
         path,

--- a/forc/src/ops/forc_deploy.rs
+++ b/forc/src/ops/forc_deploy.rs
@@ -4,7 +4,7 @@ use crate::{
     utils::SWAY_GIT_TAG,
 };
 use anyhow::{bail, Result};
-use forc_pkg::{check_program_type, manifest_file_missing, Manifest};
+use forc_pkg::{manifest_file_missing, Manifest};
 use forc_util::find_manifest_dir;
 use fuel_gql_client::client::FuelClient;
 use fuel_tx::{Output, Salt, Transaction};
@@ -22,7 +22,7 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
     let manifest_dir =
         find_manifest_dir(&curr_dir).ok_or_else(|| manifest_file_missing(curr_dir))?;
     let manifest = Manifest::from_dir(&manifest_dir, SWAY_GIT_TAG)?;
-    check_program_type(&manifest, manifest_dir, TreeType::Contract)?;
+    manifest.check_program_type(manifest_dir, TreeType::Contract)?;
 
     let DeployCommand {
         path,

--- a/forc/src/ops/forc_run.rs
+++ b/forc/src/ops/forc_run.rs
@@ -3,8 +3,7 @@ use crate::ops::forc_build;
 use crate::utils::parameters::TxParameters;
 use crate::utils::SWAY_GIT_TAG;
 use anyhow::{anyhow, bail, Result};
-use forc_pkg::{fuel_core_not_running, manifest_file_missing, Manifest};
-use forc_util::find_manifest_dir;
+use forc_pkg::{fuel_core_not_running, Manifest};
 use fuel_gql_client::client::FuelClient;
 use fuel_tx::Transaction;
 use futures::TryFutureExt;
@@ -19,10 +18,8 @@ pub async fn run(command: RunCommand) -> Result<()> {
     } else {
         std::env::current_dir().map_err(|e| anyhow!("{:?}", e))?
     };
-    let manifest_dir =
-        find_manifest_dir(&path_dir).ok_or_else(|| manifest_file_missing(path_dir))?;
-    let manifest = Manifest::from_dir(&manifest_dir, SWAY_GIT_TAG)?;
-    manifest.check_program_type(manifest_dir, TreeType::Script)?;
+    let manifest = Manifest::from_dir(&path_dir, SWAY_GIT_TAG)?;
+    manifest.check_program_type(path_dir, TreeType::Script)?;
 
     let input_data = &command.data.unwrap_or_else(|| "".into());
     let data = format_hex_data(input_data);

--- a/forc/src/ops/forc_run.rs
+++ b/forc/src/ops/forc_run.rs
@@ -4,6 +4,7 @@ use crate::utils::parameters::TxParameters;
 use crate::utils::SWAY_GIT_TAG;
 use anyhow::{anyhow, bail, Result};
 use forc_pkg::{fuel_core_not_running, Manifest};
+use forc_util::find_manifest_dir;
 use fuel_gql_client::client::FuelClient;
 use fuel_tx::Transaction;
 use futures::TryFutureExt;
@@ -18,7 +19,8 @@ pub async fn run(command: RunCommand) -> Result<Vec<fuel_tx::Receipt>> {
         std::env::current_dir().map_err(|e| anyhow!("{:?}", e))?
     };
     let manifest = Manifest::from_dir(&path_dir, SWAY_GIT_TAG)?;
-    manifest.check_program_type(path_dir, TreeType::Script)?;
+    let manifest_dir = find_manifest_dir(&path_dir).unwrap();
+    manifest.check_program_type(manifest_dir, TreeType::Script)?;
 
     let input_data = &command.data.unwrap_or_else(|| "".into());
     let data = format_hex_data(input_data);

--- a/forc/src/ops/forc_run.rs
+++ b/forc/src/ops/forc_run.rs
@@ -3,7 +3,7 @@ use crate::ops::forc_build;
 use crate::utils::parameters::TxParameters;
 use crate::utils::SWAY_GIT_TAG;
 use anyhow::{anyhow, bail, Result};
-use forc_pkg::{check_program_type, fuel_core_not_running, manifest_file_missing, Manifest};
+use forc_pkg::{fuel_core_not_running, manifest_file_missing, Manifest};
 use forc_util::find_manifest_dir;
 use fuel_gql_client::client::FuelClient;
 use fuel_tx::Transaction;
@@ -22,7 +22,7 @@ pub async fn run(command: RunCommand) -> Result<()> {
     let manifest_dir =
         find_manifest_dir(&path_dir).ok_or_else(|| manifest_file_missing(path_dir))?;
     let manifest = Manifest::from_dir(&manifest_dir, SWAY_GIT_TAG)?;
-    check_program_type(&manifest, manifest_dir, TreeType::Script)?;
+    manifest.check_program_type(manifest_dir, TreeType::Script)?;
 
     let input_data = &command.data.unwrap_or_else(|| "".into());
     let data = format_hex_data(input_data);

--- a/forc/src/ops/forc_update.rs
+++ b/forc/src/ops/forc_update.rs
@@ -1,7 +1,7 @@
 use crate::{cli::UpdateCommand, utils::SWAY_GIT_TAG};
 use anyhow::{anyhow, Result};
 use forc_pkg::{self as pkg, lock, Lock, Manifest};
-use forc_util::lock_path;
+use forc_util::{find_manifest_dir, lock_path};
 use std::{fs, path::PathBuf};
 
 /// Running `forc update` will check for updates for the entire dependency graph and commit new
@@ -32,10 +32,11 @@ pub async fn update(command: UpdateCommand) -> Result<()> {
     };
 
     let manifest = Manifest::from_dir(&this_dir, SWAY_GIT_TAG)?;
-    let lock_path = lock_path(&this_dir);
+    let manifest_dir = find_manifest_dir(&this_dir).unwrap();
+    let lock_path = lock_path(&manifest_dir);
     let old_lock = Lock::from_path(&lock_path).ok().unwrap_or_default();
     let offline = false;
-    let new_plan = pkg::BuildPlan::new(&this_dir, SWAY_GIT_TAG, offline)?;
+    let new_plan = pkg::BuildPlan::new(&manifest_dir, SWAY_GIT_TAG, offline)?;
     let new_lock = Lock::from_graph(new_plan.graph());
     let diff = new_lock.diff(&old_lock);
     lock::print_diff(&manifest.project.name, &diff);

--- a/forc/src/ops/forc_update.rs
+++ b/forc/src/ops/forc_update.rs
@@ -1,7 +1,7 @@
 use crate::{cli::UpdateCommand, utils::SWAY_GIT_TAG};
 use anyhow::{anyhow, Result};
 use forc_pkg::{self as pkg, lock, Lock, Manifest};
-use forc_util::{find_manifest_dir, lock_path};
+use forc_util::lock_path;
 use std::{fs, path::PathBuf};
 
 /// Running `forc update` will check for updates for the entire dependency graph and commit new
@@ -30,21 +30,12 @@ pub async fn update(command: UpdateCommand) -> Result<()> {
         Some(path) => PathBuf::from(path),
         None => std::env::current_dir()?,
     };
-    let manifest_dir = match find_manifest_dir(&this_dir) {
-        Some(dir) => dir,
-        None => {
-            return Err(anyhow!(
-                "No manifest file found in this directory or any parent directories of it: {:?}",
-                this_dir
-            ))
-        }
-    };
 
-    let manifest = Manifest::from_dir(&manifest_dir, SWAY_GIT_TAG)?;
-    let lock_path = lock_path(&manifest_dir);
+    let manifest = Manifest::from_dir(&this_dir, SWAY_GIT_TAG)?;
+    let lock_path = lock_path(&this_dir);
     let old_lock = Lock::from_path(&lock_path).ok().unwrap_or_default();
     let offline = false;
-    let new_plan = pkg::BuildPlan::new(&manifest_dir, SWAY_GIT_TAG, offline)?;
+    let new_plan = pkg::BuildPlan::new(&this_dir, SWAY_GIT_TAG, offline)?;
     let new_lock = Lock::from_graph(new_plan.graph());
     let diff = new_lock.diff(&old_lock);
     lock::print_diff(&manifest.project.name, &diff);


### PR DESCRIPTION
Adds `find_manifest_dir` function to `manifest::from_dir` method since we commonly check that a parent directory contains a `Forc.toml`. I've also moved `check_project_type` function as a method on `Manifest` as well since its use case was associated with `Manifest` and may later be moved into a `from_dir_expecting_program_type` method.

Tracking: #1107 