### PR TITLE
Fix forc init --template counter 

### DIFF
--- a/forc/src/ops/forc_init.rs
+++ b/forc/src/ops/forc_init.rs
@@ -1,7 +1,7 @@
 use crate::cli::InitCommand;
 use crate::utils::defaults;
 use anyhow::{anyhow, Context, Result};
-use forc_util::validate_name;
+use forc_util::{println_green, validate_name};
 use serde::Deserialize;
 use std::fs;
 use std::fs::File;
@@ -113,6 +113,8 @@ pub(crate) fn init_new_project(project_name: String) -> Result<()> {
         defaults::default_gitignore(),
     )?;
 
+    println_green(&format!("Successfully created: {}", project_name));
+
     Ok(())
 }
 
@@ -161,7 +163,7 @@ pub(crate) fn init_from_git_template(project_name: String, example_url: &Url) ->
 
         fs::write(
             out_dir.join("tests").join("harness.rs"),
-            defaults::basic_test_program(),
+            defaults::default_test_program(&project_name),
         )?;
 
         fs::write(
@@ -169,6 +171,9 @@ pub(crate) fn init_from_git_template(project_name: String, example_url: &Url) ->
             defaults::default_tests_manifest(&project_name),
         )?;
     }
+
+    println_green(&format!("Successfully created: {}", project_name));
+    println_green("Now try and run 'forc test'");
 
     Ok(())
 }

--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -32,10 +32,10 @@ version = "0.1.0"
 [dependencies]
 fuel-gql-client = {{ version = "0.5", default-features = false }}
 fuel-tx = "0.7"
-fuels-abigen-macro = "0.8"
-fuels-contract = "0.8"
-fuels-core = "0.8"
-fuels-signers = "0.8"
+fuels-abigen-macro = "0.9"
+fuels-contract = "0.9"
+fuels-core = "0.9"
+fuels-signers = "0.9"
 rand = "0.8"
 tokio = {{ version = "1.12", features = ["rt", "macros"] }}
 
@@ -104,16 +104,6 @@ async fn can_get_contract_id() {
     // Now you have an instance of your contract you can use to test each function
 }"#
     )
-}
-
-pub(crate) fn basic_test_program() -> String {
-    r#"
-#[tokio::test]
-async fn harness() {
-    assert_eq!(true, true);
-}
-"#
-    .into()
 }
 
 pub(crate) fn default_gitignore() -> String {

--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -106,6 +106,16 @@ async fn can_get_contract_id() {
     )
 }
 
+pub(crate) fn basic_test_program() -> String {
+    r#"
+#[tokio::test]
+async fn harness() {
+    assert_eq!(true, true);
+}
+"#
+    .into()
+}
+
 pub(crate) fn default_gitignore() -> String {
     r#"out
 target


### PR DESCRIPTION
Fixes a bug with `forc init --template counter`. It was expecting a `Cargo.toml` file to be there but since the /tests were removed from the `examples` folder there was nothing there to edit. 

We now check if the `tests` folder exists, if not, we create a default test harness to go along with the `counter` example. 

Currently, we are just using the `default_test_program`. There seems to be a bug related to the whole by-copy v.s. by-ref issue that the IR introduced. Once this is resolved, we can update the test harness file to reflect what is mentioned in the sway book here. https://fuellabs.github.io/sway/latest/testing/testing-with-rust.html

closes #1233
closes #1234 

