### PR TITLE
Introduce a path-aware `ManifestFile` type

### DIFF
--- a/forc-pkg/src/lib.rs
+++ b/forc-pkg/src/lib.rs
@@ -9,6 +9,6 @@ pub mod manifest;
 mod pkg;
 
 pub use lock::Lock;
-pub use manifest::Manifest;
+pub use manifest::{Manifest, ManifestFile};
 #[doc(inline)]
 pub use pkg::*;

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -95,7 +95,8 @@ impl ManifestFile {
         Ok(Self { manifest, path })
     }
 
-    /// Given a directory to a forc project containing a `Forc.toml`, read the manifest.
+    /// Read the manifest from the `Forc.toml` in the directory specified by the given `path` or
+    /// any of its parent directories.
     ///
     /// This is short for `Manifest::from_file`, but takes care of constructing the path to the
     /// file.

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -11,6 +11,16 @@ use std::{
 use sway_core::{parse, TreeType};
 use sway_utils::constants;
 
+/// A [Manifest] that was deserialized from a file at a particular path.
+#[derive(Debug)]
+pub struct ManifestFile {
+    /// The deserialized `Forc.toml`.
+    manifest: Manifest,
+    /// The path from which the `Forc.toml` file was read.
+    path: PathBuf,
+}
+
+/// A direct mapping to a `Forc.toml`.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Manifest {
@@ -71,6 +81,107 @@ impl Dependency {
     }
 }
 
+impl ManifestFile {
+    /// Given a path to a `Forc.toml`, read it and construct a `Manifest`.
+    ///
+    /// This also `validate`s the manifest, returning an `Err` in the case that invalid names,
+    /// fields were used.
+    ///
+    /// If `core` and `std` are unspecified, `std` will be added to the `dependencies` table
+    /// implicitly. In this case, the `sway_git_tag` is used to specify the pinned commit at which
+    /// we fetch `std`.
+    pub fn from_file(path: PathBuf, sway_git_tag: &str) -> Result<Self> {
+        let manifest = Manifest::from_file(&path, sway_git_tag)?;
+        Ok(Self { manifest, path })
+    }
+
+    /// Given a directory to a forc project containing a `Forc.toml`, read the manifest.
+    ///
+    /// This is short for `Manifest::from_file`, but takes care of constructing the path to the
+    /// file.
+    pub fn from_dir(manifest_dir: &Path, sway_git_tag: &str) -> Result<Self> {
+        let dir = forc_util::find_manifest_dir(manifest_dir).ok_or_else(|| {
+            anyhow!(
+                "could not find {} in this or any parent directory",
+                constants::MANIFEST_FILE_NAME
+            )
+        })?;
+        let path = dir.join(constants::MANIFEST_FILE_NAME);
+        Self::from_file(path, sway_git_tag)
+    }
+
+    /// Validate the `Manifest`.
+    ///
+    /// This checks the project and organization names against a set of reserved/restricted
+    /// keywords and patterns, and if a given entry point exists.
+    pub fn validate(&self, path: &Path) -> Result<()> {
+        self.manifest.validate()?;
+        let mut entry_path = path.to_path_buf();
+        entry_path.pop();
+        let entry_path = entry_path
+            .join(constants::SRC_DIR)
+            .join(&self.project.entry);
+        if !entry_path.exists() {
+            bail!(
+                "failed to validate path from entry field {:?} in Forc manifest file.",
+                self.project.entry
+            )
+        }
+        Ok(())
+    }
+
+    /// The path to the `Forc.toml` from which this manifest was loaded.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// The path to the directory containing the `Forc.toml` from which this manfiest was loaded.
+    pub fn dir(&self) -> &Path {
+        self.path()
+            .parent()
+            .expect("failed to retrieve manifest directory")
+    }
+
+    /// Given the directory in which the file associated with this `Manifest` resides, produce the
+    /// path to the entry file as specified in the manifest.
+    pub fn entry_path(&self) -> PathBuf {
+        self.dir()
+            .join(constants::SRC_DIR)
+            .join(&self.project.entry)
+    }
+
+    /// Produces the string of the entry point file.
+    pub fn entry_string(&self) -> Result<Arc<str>> {
+        let entry_path = self.entry_path();
+        let entry_string = std::fs::read_to_string(&entry_path)?;
+        Ok(Arc::from(entry_string))
+    }
+
+    /// Parse and return the associated project's program type.
+    pub fn program_type(&self) -> Result<TreeType> {
+        let entry_string = self.entry_string()?;
+        let program_type = parse(entry_string, None);
+        match program_type.value {
+            Some(parse_tree) => Ok(parse_tree.tree_type),
+            None => bail!(parsing_failed(&self.project.name, program_type.errors)),
+        }
+    }
+
+    /// Given the current directory and expected program type, determines whether the correct program type is present.
+    pub fn check_program_type(&self, expected_type: TreeType) -> Result<()> {
+        let parsed_type = self.program_type()?;
+        if parsed_type != expected_type {
+            bail!(wrong_program_type(
+                &self.project.name,
+                expected_type,
+                parsed_type
+            ));
+        } else {
+            Ok(())
+        }
+    }
+}
+
 impl Manifest {
     pub const DEFAULT_ENTRY_FILE_NAME: &'static str = "main.sw";
 
@@ -92,11 +203,23 @@ impl Manifest {
         })
         .map_err(|e| anyhow!("failed to parse manifest: {}.", e))?;
         manifest.implicitly_include_std_if_missing(sway_git_tag);
-        manifest.validate(path)?;
+        manifest.validate()?;
         Ok(manifest)
     }
 
-    /// Read the manifest from the `Forc.toml` in the directory specified by the given `path` or any of its parent directories.
+    /// Validate the `Manifest`.
+    ///
+    /// This checks the project and organization names against a set of reserved/restricted
+    /// keywords and patterns.
+    pub fn validate(&self) -> Result<()> {
+        validate_name(&self.project.name, "package name")?;
+        if let Some(ref org) = self.project.organization {
+            validate_name(org, "organization name")?;
+        }
+        Ok(())
+    }
+
+    /// Given a directory to a forc project containing a `Forc.toml`, read the manifest.
     ///
     /// This is short for `Manifest::from_file`, but takes care of constructing the path to the
     /// file.
@@ -105,44 +228,6 @@ impl Manifest {
             find_manifest_dir(dir).ok_or_else(|| manifest_file_missing(dir.to_path_buf()))?;
         let file_path = manifest_dir.join(constants::MANIFEST_FILE_NAME);
         Self::from_file(&file_path, sway_git_tag)
-    }
-
-    /// Validate the `Manifest`.
-    ///
-    /// This checks the project and organization names against a set of reserved/restricted
-    /// keywords and patterns, and if a given entry point exists.
-    pub fn validate(&self, path: &Path) -> Result<()> {
-        let mut entry_path = path.to_path_buf();
-        entry_path.pop();
-        let entry_path = entry_path
-            .join(constants::SRC_DIR)
-            .join(&self.project.entry);
-        if !entry_path.exists() {
-            bail!(
-                "failed to validate path from entry field {:?} in Forc manifest file.",
-                self.project.entry
-            )
-        }
-        validate_name(&self.project.name, "package name")?;
-        if let Some(ref org) = self.project.organization {
-            validate_name(org, "organization name")?;
-        }
-        Ok(())
-    }
-
-    /// Given the directory in which the file associated with this `Manifest` resides, produce the
-    /// path to the entry file as specified in the manifest.
-    pub fn entry_path(&self, manifest_dir: &Path) -> PathBuf {
-        manifest_dir
-            .join(constants::SRC_DIR)
-            .join(&self.project.entry)
-    }
-
-    /// Produces the string of the entry point file.
-    pub fn entry_string(&self, manifest_dir: &Path) -> Result<Arc<str>> {
-        let entry_path = self.entry_path(manifest_dir);
-        let entry_string = std::fs::read_to_string(&entry_path)?;
-        Ok(Arc::from(entry_string))
     }
 
     /// Produce an iterator yielding all listed dependencies.
@@ -159,31 +244,6 @@ impl Manifest {
             Dependency::Detailed(ref det) => Some((name, det)),
             Dependency::Simple(_) => None,
         })
-    }
-
-    /// Parse and return the associated project's program type.
-    pub fn program_type(&self, manifest_dir: PathBuf) -> Result<TreeType> {
-        let entry_string = self.entry_string(&manifest_dir)?;
-        let program_type = parse(entry_string, None);
-
-        match program_type.value {
-            Some(parse_tree) => Ok(parse_tree.tree_type),
-            None => bail!(parsing_failed(&self.project.name, program_type.errors)),
-        }
-    }
-
-    /// Given the current directory and expected program type, determines whether the correct program type is present.
-    pub fn check_program_type(&self, manifest_dir: PathBuf, expected_type: TreeType) -> Result<()> {
-        let parsed_type = self.program_type(manifest_dir)?;
-        if parsed_type != expected_type {
-            bail!(wrong_program_type(
-                &self.project.name,
-                expected_type,
-                parsed_type
-            ));
-        } else {
-            Ok(())
-        }
     }
 
     /// Check for the `core` and `std` packages under `[dependencies]`. If both are missing, add
@@ -234,6 +294,13 @@ impl Manifest {
             }
         }
         None
+    }
+}
+
+impl std::ops::Deref for ManifestFile {
+    type Target = Manifest;
+    fn deref(&self) -> &Self::Target {
+        &self.manifest
     }
 }
 

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -101,12 +101,8 @@ impl ManifestFile {
     /// This is short for `Manifest::from_file`, but takes care of constructing the path to the
     /// file.
     pub fn from_dir(manifest_dir: &Path, sway_git_tag: &str) -> Result<Self> {
-        let dir = forc_util::find_manifest_dir(manifest_dir).ok_or_else(|| {
-            anyhow!(
-                "could not find {} in this or any parent directory",
-                constants::MANIFEST_FILE_NAME
-            )
-        })?;
+        let dir = forc_util::find_manifest_dir(manifest_dir)
+            .ok_or_else(|| manifest_file_missing(manifest_dir))?;
         let path = dir.join(constants::MANIFEST_FILE_NAME);
         Self::from_file(path, sway_git_tag)
     }
@@ -225,8 +221,7 @@ impl Manifest {
     /// This is short for `Manifest::from_file`, but takes care of constructing the path to the
     /// file.
     pub fn from_dir(dir: &Path, sway_git_tag: &str) -> Result<Self> {
-        let manifest_dir =
-            find_manifest_dir(dir).ok_or_else(|| manifest_file_missing(dir.to_path_buf()))?;
+        let manifest_dir = find_manifest_dir(dir).ok_or_else(|| manifest_file_missing(dir))?;
         let file_path = manifest_dir.join(constants::MANIFEST_FILE_NAME);
         Self::from_file(&file_path, sway_git_tag)
     }

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -181,7 +181,7 @@ pub type DependencyName = String;
 impl BuildPlan {
     /// Create a new build plan for the project by fetching and pinning dependenies.
     pub fn new(manifest: &ManifestFile, sway_git_tag: &str, offline: bool) -> Result<Self> {
-        let path = manifest.path().to_path_buf();
+        let path = manifest.dir().to_path_buf();
         let (graph, path_map) = fetch_deps(path, manifest, sway_git_tag, offline)?;
         let compilation_order = compilation_order(&graph)?;
         Ok(Self {

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1,6 +1,6 @@
 use crate::{
     lock::Lock,
-    manifest::{Dependency, Manifest},
+    manifest::{Dependency, Manifest, ManifestFile},
 };
 use anyhow::{anyhow, bail, Context, Error, Result};
 use forc_util::{
@@ -180,10 +180,9 @@ pub type DependencyName = String;
 
 impl BuildPlan {
     /// Create a new build plan for the project by fetching and pinning dependenies.
-    pub fn new(manifest_dir: &Path, sway_git_tag: &str, offline: bool) -> Result<Self> {
-        let manifest = Manifest::from_dir(manifest_dir, sway_git_tag)?;
-        let (graph, path_map) =
-            fetch_deps(manifest_dir.to_path_buf(), &manifest, sway_git_tag, offline)?;
+    pub fn new(manifest: &ManifestFile, sway_git_tag: &str, offline: bool) -> Result<Self> {
+        let path = manifest.path().to_path_buf();
+        let (graph, path_map) = fetch_deps(path, manifest, sway_git_tag, offline)?;
         let compilation_order = compilation_order(&graph)?;
         Ok(Self {
             graph,
@@ -264,7 +263,7 @@ impl BuildPlan {
             let pkg = &self.graph[node];
             let id = pkg.id();
             let path = &self.path_map[&id];
-            let manifest = Manifest::from_dir(path, sway_git_tag)?;
+            let manifest = ManifestFile::from_dir(path, sway_git_tag)?;
             if pkg.name != manifest.project.name {
                 bail!(
                     "package name {:?} does not match the associated manifest project name {:?}",
@@ -533,7 +532,7 @@ pub fn graph_to_path_map(
                     .source();
                 let parent = &graph[parent_node];
                 let parent_path = &path_map[&parent.id()];
-                let parent_manifest = Manifest::from_dir(parent_path, sway_git_tag)?;
+                let parent_manifest = ManifestFile::from_dir(parent_path, sway_git_tag)?;
                 let detailed = parent_manifest
                     .dependencies
                     .as_ref()
@@ -996,15 +995,14 @@ pub fn dependency_namespace(
 /// Scripts and Predicates will be compiled to bytecode and will not emit any JSON ABI.
 pub fn compile(
     pkg: &Pinned,
-    pkg_path: &Path,
-    manifest: &Manifest,
+    manifest: &ManifestFile,
     build_config: &BuildConfig,
     namespace: NamespaceRef,
     source_map: &mut SourceMap,
 ) -> Result<(Compiled, Option<NamespaceRef>)> {
-    let entry_path = manifest.entry_path(pkg_path);
-    let source = manifest.entry_string(pkg_path)?;
-    let sway_build_config = sway_build_config(pkg_path, &entry_path, build_config)?;
+    let entry_path = manifest.entry_path();
+    let source = manifest.entry_string()?;
+    let sway_build_config = sway_build_config(manifest.dir(), &entry_path, build_config)?;
     let silent_mode = build_config.silent;
 
     // First, compile to an AST. We'll update the namespace and check for JSON ABI output.
@@ -1076,8 +1074,8 @@ pub fn build(
             dependency_namespace(&namespace_map, &plan.graph, &plan.compilation_order, node);
         let pkg = &plan.graph[node];
         let path = &plan.path_map[&pkg.id()];
-        let manifest = Manifest::from_dir(path, sway_git_tag)?;
-        let res = compile(pkg, path, &manifest, conf, dep_namespace, &mut source_map)?;
+        let manifest = ManifestFile::from_dir(path, sway_git_tag)?;
+        let res = compile(pkg, &manifest, conf, dep_namespace, &mut source_map)?;
         let (compiled, maybe_namespace) = res;
         if let Some(namespace) = maybe_namespace {
             namespace_map.insert(node, namespace);

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1181,11 +1181,11 @@ fn test_source_git_pinned_parsing() {
 }
 
 /// Format an error message for an absent `Forc.toml`.
-pub fn manifest_file_missing(curr_dir: PathBuf) -> anyhow::Error {
+pub fn manifest_file_missing(dir: &Path) -> anyhow::Error {
     let message = format!(
         "could not find `{}` in `{}` or any parent directory",
         constants::MANIFEST_FILE_NAME,
-        curr_dir.display()
+        dir.display()
     );
     Error::msg(message)
 }

--- a/forc/src/ops/forc_abi_json.rs
+++ b/forc/src/ops/forc_abi_json.rs
@@ -3,8 +3,7 @@ use crate::{
     utils::SWAY_GIT_TAG,
 };
 use anyhow::Result;
-use forc_pkg::Manifest;
-use forc_util::find_manifest_dir;
+use forc_pkg::ManifestFile;
 use serde_json::{json, Value};
 use std::fs::File;
 use std::path::PathBuf;
@@ -16,9 +15,8 @@ pub fn build(command: JsonAbiCommand) -> Result<Value> {
     } else {
         std::env::current_dir()?
     };
-    let manifest = Manifest::from_dir(&curr_dir, SWAY_GIT_TAG)?;
-    let manifest_dir = find_manifest_dir(&curr_dir).unwrap();
-    manifest.check_program_type(manifest_dir, TreeType::Contract)?;
+    let manifest = ManifestFile::from_dir(&curr_dir, SWAY_GIT_TAG)?;
+    manifest.check_program_type(TreeType::Contract)?;
 
     let build_command = BuildCommand {
         path: command.path,

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -1,7 +1,7 @@
 use crate::{cli::BuildCommand, utils::SWAY_GIT_TAG};
 use anyhow::{anyhow, Result};
-use forc_pkg::{self as pkg, lock, Lock, Manifest};
-use forc_util::{default_output_directory, find_manifest_dir, lock_path};
+use forc_pkg::{self as pkg, lock, Lock, ManifestFile};
+use forc_util::{default_output_directory, lock_path};
 use std::{
     fs::{self, File},
     path::PathBuf,
@@ -35,9 +35,9 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
     } else {
         std::env::current_dir()?
     };
-    let manifest = Manifest::from_dir(&this_dir, SWAY_GIT_TAG)?;
-    let manifest_dir = find_manifest_dir(&this_dir).unwrap();
-    let lock_path = lock_path(&manifest_dir);
+
+    let manifest = ManifestFile::from_dir(&this_dir, SWAY_GIT_TAG)?;
+    let lock_path = lock_path(manifest.dir());
 
     // Load the build plan from the lock file.
     let plan_result = pkg::BuildPlan::from_lock_file(&lock_path, SWAY_GIT_TAG);
@@ -57,7 +57,7 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
     let plan: pkg::BuildPlan = plan_result.or_else(|e| -> Result<pkg::BuildPlan> {
         println!("  Creating a new `Forc.lock` file");
         println!("    Cause: {}", e);
-        let plan = pkg::BuildPlan::new(&manifest_dir, SWAY_GIT_TAG, offline)?;
+        let plan = pkg::BuildPlan::new(&manifest, SWAY_GIT_TAG, offline)?;
         let lock = Lock::from_graph(plan.graph());
         let diff = lock.diff(&old_lock);
         lock::print_diff(&manifest.project.name, &diff);
@@ -86,7 +86,7 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
     // Create the output directory for build artifacts.
     let output_dir = output_directory
         .map(PathBuf::from)
-        .unwrap_or_else(|| default_output_directory(&manifest_dir).join(profile));
+        .unwrap_or_else(|| default_output_directory(manifest.dir()).join(profile));
     if !output_dir.exists() {
         fs::create_dir_all(&output_dir)?;
     }

--- a/forc/src/ops/forc_deploy.rs
+++ b/forc/src/ops/forc_deploy.rs
@@ -4,8 +4,7 @@ use crate::{
     utils::SWAY_GIT_TAG,
 };
 use anyhow::{bail, Result};
-use forc_pkg::Manifest;
-use forc_util::find_manifest_dir;
+use forc_pkg::ManifestFile;
 use fuel_gql_client::client::FuelClient;
 use fuel_tx::{Output, Salt, Transaction};
 use fuel_vm::prelude::*;
@@ -19,9 +18,8 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
     } else {
         std::env::current_dir()?
     };
-    let manifest = Manifest::from_dir(&curr_dir, SWAY_GIT_TAG)?;
-    let manifest_dir = find_manifest_dir(&curr_dir).unwrap();
-    manifest.check_program_type(manifest_dir, TreeType::Contract)?;
+    let manifest = ManifestFile::from_dir(&curr_dir, SWAY_GIT_TAG)?;
+    manifest.check_program_type(TreeType::Contract)?;
 
     let DeployCommand {
         path,

--- a/forc/src/ops/forc_run.rs
+++ b/forc/src/ops/forc_run.rs
@@ -3,8 +3,7 @@ use crate::ops::forc_build;
 use crate::utils::parameters::TxParameters;
 use crate::utils::SWAY_GIT_TAG;
 use anyhow::{anyhow, bail, Result};
-use forc_pkg::{fuel_core_not_running, Manifest};
-use forc_util::find_manifest_dir;
+use forc_pkg::{fuel_core_not_running, ManifestFile};
 use fuel_gql_client::client::FuelClient;
 use fuel_tx::Transaction;
 use futures::TryFutureExt;
@@ -18,9 +17,8 @@ pub async fn run(command: RunCommand) -> Result<Vec<fuel_tx::Receipt>> {
     } else {
         std::env::current_dir().map_err(|e| anyhow!("{:?}", e))?
     };
-    let manifest = Manifest::from_dir(&path_dir, SWAY_GIT_TAG)?;
-    let manifest_dir = find_manifest_dir(&path_dir).unwrap();
-    manifest.check_program_type(manifest_dir, TreeType::Script)?;
+    let manifest = ManifestFile::from_dir(&path_dir, SWAY_GIT_TAG)?;
+    manifest.check_program_type(TreeType::Script)?;
 
     let input_data = &command.data.unwrap_or_else(|| "".into());
     let data = format_hex_data(input_data);

--- a/forc/src/ops/forc_update.rs
+++ b/forc/src/ops/forc_update.rs
@@ -1,7 +1,7 @@
 use crate::{cli::UpdateCommand, utils::SWAY_GIT_TAG};
 use anyhow::{anyhow, Result};
-use forc_pkg::{self as pkg, lock, Lock, Manifest};
-use forc_util::{find_manifest_dir, lock_path};
+use forc_pkg::{self as pkg, lock, Lock, ManifestFile};
+use forc_util::lock_path;
 use std::{fs, path::PathBuf};
 
 /// Running `forc update` will check for updates for the entire dependency graph and commit new
@@ -31,12 +31,11 @@ pub async fn update(command: UpdateCommand) -> Result<()> {
         None => std::env::current_dir()?,
     };
 
-    let manifest = Manifest::from_dir(&this_dir, SWAY_GIT_TAG)?;
-    let manifest_dir = find_manifest_dir(&this_dir).unwrap();
-    let lock_path = lock_path(&manifest_dir);
+    let manifest = ManifestFile::from_dir(&this_dir, SWAY_GIT_TAG)?;
+    let lock_path = lock_path(manifest.dir());
     let old_lock = Lock::from_path(&lock_path).ok().unwrap_or_default();
     let offline = false;
-    let new_plan = pkg::BuildPlan::new(&manifest_dir, SWAY_GIT_TAG, offline)?;
+    let new_plan = pkg::BuildPlan::new(&manifest, SWAY_GIT_TAG, offline)?;
     let new_lock = Lock::from_graph(new_plan.graph());
     let diff = new_lock.diff(&old_lock);
     lock::print_diff(&manifest.project.name, &diff);


### PR DESCRIPTION
Follow-up to #1232

After loading a `Manifest`, most useful operations involving it require
knowledge of the directory path from which it was loaded from (i.e.
`entry_string`, `program_type`).

This introduces a `ManifestFile` type that stores the path to the
`Forc.toml` from which its inner `Manifest` was read. This allows to
avoid a lot of unnecessary code duplication related to traversing the
parents to find the root manifest directory. Now, we can just load the
`ManifestFile` and call `manifest.path()` or `manifest.dir()` to get the
path to the `Forc.toml` or its enclosing directory respectively.

cc @eureka-cpu this is what I had in mind w.r.t. my comment [here](https://github.com/FuelLabs/sway/pull/1232#pullrequestreview-940319984) - I'll merge #1232 then rebase this work onto master. Edit: done.
Closes #1242 