### PR TITLE
Missing span for TypeProperty

### DIFF
--- a/sway-core/src/asm_generation/expression/mod.rs
+++ b/sway-core/src/asm_generation/expression/mod.rs
@@ -339,7 +339,9 @@ pub(crate) fn convert_expression_to_asm(
             namespace,
             register_sequencer,
         ),
-        TypedExpressionVariant::TypeProperty { property, type_id } => match property {
+        TypedExpressionVariant::TypeProperty {
+            property, type_id, ..
+        } => match property {
             BuiltinProperty::SizeOfType => convert_size_of_to_asm(
                 None,
                 type_id,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -2411,6 +2411,7 @@ impl TypedExpression {
             expression: TypedExpressionVariant::TypeProperty {
                 property: builtin,
                 type_id,
+                span: span.clone(),
             },
             return_type,
             is_constant: IsConstant::No,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -108,6 +108,7 @@ pub(crate) enum TypedExpressionVariant {
     TypeProperty {
         property: BuiltinProperty,
         type_id: TypeId,
+        span: Span,
     },
     SizeOfValue {
         expr: Box<TypedExpression>,
@@ -331,10 +332,12 @@ impl PartialEq for TypedExpressionVariant {
                 Self::TypeProperty {
                     property: l_prop,
                     type_id: l_type_id,
+                    ..
                 },
                 Self::TypeProperty {
                     property: r_prop,
                     type_id: r_type_id,
+                    ..
                 },
             ) => l_prop == r_prop && look_up_type_id(*l_type_id) == look_up_type_id(*r_type_id),
             (Self::SizeOfValue { expr: l_expr }, Self::SizeOfValue { expr: r_expr }) => {
@@ -499,7 +502,9 @@ impl TypedExpressionVariant {
             TypedExpressionVariant::StorageAccess(access) => {
                 format!("storage field {} access", access.storage_field_name())
             }
-            TypedExpressionVariant::TypeProperty { property, type_id } => {
+            TypedExpressionVariant::TypeProperty {
+                property, type_id, ..
+            } => {
                 let type_str = look_up_type_id(*type_id).friendly_type_str();
                 match property {
                     BuiltinProperty::SizeOfType => format!("size_of({type_str:?})"),


### PR DESCRIPTION
Closes #1231 

These are internal errors and the user shouldn't try to decode them, but it's still worth passing a span to help us debug issues.

E.g. we now get this error for the test case in the issue:
```bash
error
  --> proj/src/main.sw:11:16
   |
 9 |
10 |   fn new() -> RawVec<T> {
11 |     let size = size_of::<T>();
   |                ^^^^^^^^^^^^^^ Internal compiler error: Generic type cannot be resolved in IR.
Please file an issue on the repository and include the code that triggered this error.
12 |     RawVec {
13 |       ptr: 0,
   |
____
```