### PR TITLE
Properly handle TypeProperty in `dead_code_analysis`

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -1012,7 +1012,7 @@ fn connect_expression(
                 graph.add_edge(*leaf, node, "".into());
             }
             Ok(vec![node])
-        },
+        }
         SizeOfValue { expr } => {
             let expr = connect_expression(
                 &(*expr).expression,

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -1006,7 +1006,13 @@ fn connect_expression(
             }
             Ok(vec![this_ix])
         }
-        TypeProperty { .. } => Ok(Vec::new()),
+        TypeProperty { .. } => {
+            let node = graph.add_node("Type Property".into());
+            for leaf in leaves {
+                graph.add_edge(*leaf, node, "".into());
+            }
+            Ok(vec![node])
+        },
         SizeOfValue { expr } => {
             let expr = connect_expression(
                 &(*expr).expression,


### PR DESCRIPTION
Closes #1236 

Warnings from the issue now go away.