### PR TITLE
forc init welcome message

### DIFF
--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -34,8 +34,8 @@ serde_json = "1.0.73"
 sway-core = { version = "0.10.1", path = "../sway-core" }
 sway-types = { version = "0.10.1", path = "../sway-types" }
 sway-utils = { version = "0.10.1", path = "../sway-utils" }
-terminal-link = "0.1.0"
 term-table = "1.3"
+terminal-link = "0.1.0"
 tokio = { version = "1.8.0", features = ["macros", "rt-multi-thread", "process"] }
 toml = "0.5"
 toml_edit = "0.13"

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -35,7 +35,6 @@ sway-core = { version = "0.10.1", path = "../sway-core" }
 sway-types = { version = "0.10.1", path = "../sway-types" }
 sway-utils = { version = "0.10.1", path = "../sway-utils" }
 term-table = "1.3"
-terminal-link = "0.1.0"
 tokio = { version = "1.8.0", features = ["macros", "rt-multi-thread", "process"] }
 toml = "0.5"
 toml_edit = "0.13"

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = "1.0.73"
 sway-core = { version = "0.10.1", path = "../sway-core" }
 sway-types = { version = "0.10.1", path = "../sway-types" }
 sway-utils = { version = "0.10.1", path = "../sway-utils" }
+terminal-link = "0.1.0"
 term-table = "1.3"
 tokio = { version = "1.8.0", features = ["macros", "rt-multi-thread", "process"] }
 toml = "0.5"
@@ -43,7 +44,6 @@ url = "2.2"
 uwuify = { version = "^0.2", optional = true }
 walkdir = "2.3"
 whoami = "1.1"
-terminal-link = "0.1.0"
 
 [features]
 default = []

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -43,6 +43,7 @@ url = "2.2"
 uwuify = { version = "^0.2", optional = true }
 walkdir = "2.3"
 whoami = "1.1"
+terminal-link = "0.1.0"
 
 [features]
 default = []

--- a/forc/src/ops/forc_init.rs
+++ b/forc/src/ops/forc_init.rs
@@ -63,8 +63,7 @@ fn print_welcome_message() {
     let join_the_community = format!(
         "Join the Community:\n- Follow us {}
 - Ask questions in dev-chat on {}",
-        "@SwayLang: https://twitter.com/SwayLang",
-        "Discord: https://discord.com/invite/xfpK4Pe"
+        "@SwayLang: https://twitter.com/SwayLang", "Discord: https://discord.com/invite/xfpK4Pe"
     );
 
     let report_bugs = format!(

--- a/forc/src/ops/forc_init.rs
+++ b/forc/src/ops/forc_init.rs
@@ -8,7 +8,6 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use sway_utils::constants;
-use terminal_link::Link;
 use url::Url;
 
 #[derive(Debug)]
@@ -56,30 +55,24 @@ struct ContentResponse {
 fn print_welcome_message() {
     let read_the_docs = format!(
         "Read the Docs:\n- {}\n- {}\n- {}",
-        Link::new("Sway Book", "https://fuellabs.github.io/sway/latest/"),
-        Link::new(
-            "Rust SDK Book",
-            "https://fuellabs.github.io/fuels-rs/latest/index.html"
-        ),
-        Link::new(
-            "Typescript SDK Docs",
-            "https://github.com/FuelLabs/fuels-ts"
-        )
+        "Sway Book: https://fuellabs.github.io/sway/latest",
+        "Rust SDK Book: https://fuellabs.github.io/fuels-rs/latest",
+        "TypeScript SDK: https://github.com/FuelLabs/fuels-ts"
     );
 
     let join_the_community = format!(
         "Join the Community:\n- Follow us {}
 - Ask questions in dev-chat on {}",
-        Link::new("@SwayLang", "https://twitter.com/SwayLang"),
-        Link::new("Discord", "https://discord.com/invite/xfpK4Pe")
+        "@SwayLang: https://twitter.com/SwayLang",
+        "Discord: https://discord.com/invite/xfpK4Pe"
     );
 
     let report_bugs = format!(
         "Report Bugs:\n- {}",
-        Link::new("Sway Issues", "https://github.com/FuelLabs/sway/issues/new")
+        "Sway Issues: https://github.com/FuelLabs/sway/issues/new"
     );
 
-    let try_forc = "Now try `forc build` or `forc test`".to_string();
+    let try_forc = "To compile, use `forc build`, and to run tests use `forc test`";
 
     println!(
         "\n{}\n\n----\n\n{}\n\n{}\n\n{}\n\n",

--- a/forc/src/ops/forc_init.rs
+++ b/forc/src/ops/forc_init.rs
@@ -53,6 +53,40 @@ struct ContentResponse {
     url: String,
 }
 
+fn print_welcome_message() {
+    let read_the_docs = format!(
+        "Read the Docs:\n- {}\n- {}\n- {}",
+        Link::new("Sway Book", "https://fuellabs.github.io/sway/latest/"),
+        Link::new(
+            "Rust SDK Book",
+            "https://fuellabs.github.io/fuels-rs/latest/index.html"
+        ),
+        Link::new(
+            "Typescript SDK Docs",
+            "https://github.com/FuelLabs/fuels-ts"
+        )
+    );
+
+    let join_the_community = format!(
+        "Join the Community:\n- Follow us {}
+- Ask questions in dev-chat on {}",
+        Link::new("@SwayLang", "https://twitter.com/SwayLang"),
+        Link::new("Discord", "https://discord.com/invite/xfpK4Pe")
+    );
+
+    let report_bugs = format!(
+        "Report Bugs:\n- {}",
+        Link::new("Sway Issues", "https://github.com/FuelLabs/sway/issues/new")
+    );
+
+    let try_forc = "Now try `forc build` or `forc test`".to_string();
+
+    println!(
+        "\n{}\n\n----\n\n{}\n\n{}\n\n{}\n\n",
+        try_forc, read_the_docs, join_the_community, report_bugs
+    );
+}
+
 pub fn init(command: InitCommand) -> Result<()> {
     let project_name = command.project_name;
     validate_name(&project_name, "project name")?;
@@ -116,37 +150,7 @@ pub(crate) fn init_new_project(project_name: String) -> Result<()> {
 
     println_green(&format!("Successfully created: {}", project_name));
 
-    let read_the_docs = format!(
-        "Read the Docs:\n- {}\n- {}\n- {}",
-        Link::new("Sway Book", "https://fuellabs.github.io/sway/latest/"),
-        Link::new(
-            "Rust SDK Book",
-            "https://fuellabs.github.io/fuels-rs/latest/index.html"
-        ),
-        Link::new(
-            "Typescript SDK Docs",
-            "https://github.com/FuelLabs/fuels-ts"
-        )
-    );
-
-    let join_the_community = format!(
-        "Join the Community:\n- Follow us {}
-- Ask questions in dev-chat on {}",
-        Link::new("@SwayLang", "https://twitter.com/SwayLang"),
-        Link::new("Discord", "https://discord.com/invite/xfpK4Pe")
-    );
-
-    let report_bugs = format!(
-        "Report Bugs:\n- {}",
-        Link::new("Sway Issues", "https://github.com/FuelLabs/sway/issues/new")
-    );
-
-    let try_forc = "Now try `forc build` or `forc test`".to_string();
-
-    println!(
-        "\n{}\n\n----\n\n{}\n\n{}\n\n{}\n\n",
-        try_forc, read_the_docs, join_the_community, report_bugs
-    );
+    print_welcome_message();
 
     Ok(())
 }
@@ -206,7 +210,8 @@ pub(crate) fn init_from_git_template(project_name: String, example_url: &Url) ->
     }
 
     println_green(&format!("Successfully created: {}", project_name));
-    println_green("Now try and run 'forc test'");
+
+    print_welcome_message();
 
     Ok(())
 }

--- a/forc/src/ops/forc_init.rs
+++ b/forc/src/ops/forc_init.rs
@@ -132,7 +132,7 @@ pub(crate) fn init_new_project(project_name: String) -> Result<()> {
         Link::new("Sway Issues", "https://github.com/FuelLabs/sway/issues/new")
     );
 
-    let try_forc = format!("Now try `forc build` or `forc test`");
+    let try_forc = "Now try `forc build` or `forc test`".to_string();
 
     println!(
         "\n{}\n\n----\n\n{}\n\n{}\n\n{}\n\n",

--- a/forc/src/ops/forc_init.rs
+++ b/forc/src/ops/forc_init.rs
@@ -8,8 +8,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use sway_utils::constants;
-use url::Url;
 use terminal_link::Link;
+use url::Url;
 
 #[derive(Debug)]
 struct GitPathInfo {
@@ -116,19 +116,28 @@ pub(crate) fn init_new_project(project_name: String) -> Result<()> {
 
     println_green(&format!("Successfully created: {}", project_name));
 
-    let read_the_docs = format!("Read the Docs:\n- {}\n- {}\n- {}",
+    let read_the_docs = format!(
+        "Read the Docs:\n- {}\n- {}\n- {}",
         Link::new("Sway Book", "https://fuellabs.github.io/sway/latest/"),
-        Link::new("Rust SDK Book", "https://fuellabs.github.io/fuels-rs/latest/index.html"),
-        Link::new("Typescript SDK Docs", "https://github.com/FuelLabs/fuels-ts")
+        Link::new(
+            "Rust SDK Book",
+            "https://fuellabs.github.io/fuels-rs/latest/index.html"
+        ),
+        Link::new(
+            "Typescript SDK Docs",
+            "https://github.com/FuelLabs/fuels-ts"
+        )
     );
 
-    let join_the_community = format!("Join the Community:\n- Follow us {}
+    let join_the_community = format!(
+        "Join the Community:\n- Follow us {}
 - Ask questions in dev-chat on {}",
         Link::new("@SwayLang", "https://twitter.com/SwayLang"),
         Link::new("Discord", "https://discord.com/invite/xfpK4Pe")
     );
 
-    let report_bugs = format!("Report Bugs:\n- {}",
+    let report_bugs = format!(
+        "Report Bugs:\n- {}",
         Link::new("Sway Issues", "https://github.com/FuelLabs/sway/issues/new")
     );
 
@@ -136,10 +145,7 @@ pub(crate) fn init_new_project(project_name: String) -> Result<()> {
 
     println!(
         "\n{}\n\n----\n\n{}\n\n{}\n\n{}\n\n",
-        try_forc,
-        read_the_docs,
-        join_the_community,
-        report_bugs
+        try_forc, read_the_docs, join_the_community, report_bugs
     );
 
     Ok(())

--- a/forc/src/ops/forc_init.rs
+++ b/forc/src/ops/forc_init.rs
@@ -9,6 +9,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use sway_utils::constants;
 use url::Url;
+use terminal_link::Link;
 
 #[derive(Debug)]
 struct GitPathInfo {
@@ -114,6 +115,32 @@ pub(crate) fn init_new_project(project_name: String) -> Result<()> {
     )?;
 
     println_green(&format!("Successfully created: {}", project_name));
+
+    let read_the_docs = format!("Read the Docs:\n- {}\n- {}\n- {}",
+        Link::new("Sway Book", "https://fuellabs.github.io/sway/latest/"),
+        Link::new("Rust SDK Book", "https://fuellabs.github.io/fuels-rs/latest/index.html"),
+        Link::new("Typescript SDK Docs", "https://github.com/FuelLabs/fuels-ts")
+    );
+
+    let join_the_community = format!("Join the Community:\n- Follow us {}
+- Ask questions in dev-chat on {}",
+        Link::new("@SwayLang", "https://twitter.com/SwayLang"),
+        Link::new("Discord", "https://discord.com/invite/xfpK4Pe")
+    );
+
+    let report_bugs = format!("Report Bugs:\n- {}",
+        Link::new("Sway Issues", "https://github.com/FuelLabs/sway/issues/new")
+    );
+
+    let try_forc = format!("Now try `forc build` or `forc test`");
+
+    println!(
+        "\n{}\n\n----\n\n{}\n\n{}\n\n{}\n\n",
+        try_forc,
+        read_the_docs,
+        join_the_community,
+        report_bugs
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Added a welcome message to `forc init`, with some nice links and helpful information.

Uses: https://crates.io/crates/terminal-link which is fairly light no dependency library (recommended by Brandon K).

Related: https://github.com/FuelLabs/sway/issues/1252

Looks something like this below the success message (in green):

```bash
Now try `forc build` or `forc test`

----

Read the Docs:
- Sway Book
- Rust SDK Book
- Typescript SDK Docs

Join the Community:
- Follow us @SwayLang
- Ask questions in dev-chat on Discord

Report Bugs:
- Sway Issues
```