### PR TITLE
add log_b256 method to std library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
  "sway-types",
  "sway-utils",
  "term-table",
+ "terminal-link",
  "tokio",
  "toml",
  "toml_edit",
@@ -3359,6 +3360,12 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "terminal-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "253bcead4f3aa96243b0f8fa46f9010e87ca23bd5d0c723d474ff1d2417bbdf8"
 
 [[package]]
 name = "test"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,7 +1083,6 @@ dependencies = [
  "sway-types",
  "sway-utils",
  "term-table",
- "terminal-link",
  "tokio",
  "toml",
  "toml_edit",
@@ -3360,12 +3359,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "terminal-link"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "253bcead4f3aa96243b0f8fa46f9010e87ca23bd5d0c723d474ff1d2417bbdf8"
 
 [[package]]
 name = "test"

--- a/sway-lib-std/src/chain.sw
+++ b/sway-lib-std/src/chain.sw
@@ -4,6 +4,12 @@ dep chain/auth;
 use ::panic::panic;
 
 // When generics land, these will be generic.
+pub fn log_b256(value: b256) {
+    asm(r1: value, r2: 32) {
+        logd zero zero r1 r2;
+    }
+}
+
 pub fn log_u64(val: u64) {
     asm(r1: val) {
         log r1 zero zero zero;

--- a/sway-lib-std/tests/Cargo.toml
+++ b/sway-lib-std/tests/Cargo.toml
@@ -17,6 +17,7 @@ fuels-core = "0.8"
 fuels-signers = { version = "0.8", features=["test-helpers"] }
 rand = "0.8"
 tokio = { version = "1.12", features = ["rt", "macros"] }
+hex = "0.4.3"
 
 [[test]]
 harness = true

--- a/sway-lib-std/tests/Cargo.toml
+++ b/sway-lib-std/tests/Cargo.toml
@@ -15,9 +15,9 @@ fuels-abigen-macro = "0.8"
 fuels-contract = "0.8"
 fuels-core = "0.8"
 fuels-signers = { version = "0.8", features=["test-helpers"] }
+hex = "0.4.3"
 rand = "0.8"
 tokio = { version = "1.12", features = ["rt", "macros"] }
-hex = "0.4.3"
 
 [[test]]
 harness = true

--- a/sway-lib-std/tests/test_projects/harness.rs
+++ b/sway-lib-std/tests/test_projects/harness.rs
@@ -4,6 +4,7 @@ mod auth;
 mod call_frames;
 mod context;
 mod contract_id_type;
+mod logging;
 mod option;
 mod reentrancy;
 mod registers;

--- a/sway-lib-std/tests/test_projects/logging/Forc.lock
+++ b/sway-lib-std/tests/test_projects/logging/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'logging'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/sway-lib-std/tests/test_projects/logging/Forc.toml
+++ b/sway-lib-std/tests/test_projects/logging/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "logging"
+
+[dependencies]
+std = { path = "../../../" }

--- a/sway-lib-std/tests/test_projects/logging/mod.rs
+++ b/sway-lib-std/tests/test_projects/logging/mod.rs
@@ -1,0 +1,33 @@
+use fuel_core::service::Config;
+use fuel_tx::{consts::MAX_GAS_PER_TX, Transaction};
+use fuels_contract::script::Script;
+use fuels_signers::provider::Provider;
+use hex;
+
+#[tokio::test]
+async fn run_valid() {
+    let bin = std::fs::read("test_projects/logging/out/debug/logging.bin");
+    let client = Provider::launch(Config::local_node()).await.unwrap();
+
+    let tx = Transaction::Script {
+        gas_price: 0,
+        gas_limit: MAX_GAS_PER_TX,
+        maturity: 0,
+        byte_price: 0,
+        receipts_root: Default::default(),
+        script: bin.unwrap(),
+        script_data: vec![],
+        inputs: vec![],
+        outputs: vec![],
+        witnesses: vec![vec![].into()],
+        metadata: None,
+    };
+
+    let script = Script::new(tx);
+    let receipts = script.call(&client).await.unwrap();
+
+    let correct_hex =
+        hex::decode("ef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a");
+
+    assert!(correct_hex.unwrap() == receipts[0].data().unwrap());
+}

--- a/sway-lib-std/tests/test_projects/logging/src/main.sw
+++ b/sway-lib-std/tests/test_projects/logging/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+use std::chain::log_b256;
+
+fn main() {
+    let k:b256 = 0xef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a;
+
+    log_b256(k);
+}


### PR DESCRIPTION
- Adding a method to allow the logging of `b256` type in the standard library.