### PR TITLE
Remove workaround for including `lib-std` from the Sway Book

### DIFF
--- a/docs/src/advanced/assembly.md
+++ b/docs/src/advanced/assembly.md
@@ -33,7 +33,7 @@ Note that in the above example:
 
 ## Helpful Links
 
-For examples of assembly in action, check out the [Sway standard library](https://github.com/FuelLabs/sway-lib-std).
+For examples of assembly in action, check out the [Sway standard library](https://github.com/FuelLabs/sway/tree/master/sway-lib-std).
 
 For a complete list of all instructions supported in the FuelVM: [Instructions](https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/opcodes.md).
 

--- a/docs/src/basics/blockchain_types.md
+++ b/docs/src/basics/blockchain_types.md
@@ -2,7 +2,7 @@
 
 Sway is fundamentally a blockchain language, and it offers a selection of types tailored for the blockchain use case.
 
-These are provided via the standard library ([`lib-std`](https://github.com/FuelLabs/sway-lib-std)) which both add a degree of type-safety, as well as make the intention of the developer more clear.
+These are provided via the standard library ([`lib-std`](https://github.com/FuelLabs/sway/tree/master/sway-lib-std)) which both add a degree of type-safety, as well as make the intention of the developer more clear.
 
 ## `Address` Type
 

--- a/docs/src/reference/temporary_workarounds.md
+++ b/docs/src/reference/temporary_workarounds.md
@@ -1,16 +1,5 @@
 # Temporary Workarounds
 
-## Standard Library
-
-The standard library is currently not distributed with `forc` if [installed via `cargo`](../introduction/installation.md#installing-from-cargo). It must be downloaded manually or specified as a dependency in the Forc manifest file. A variation of the following must be included in your project's `Forc.toml` file:
-
-```toml
-[dependencies]
-std = { git = "https://github.com/FuelLabs/sway", branch = "master" }
-```
-
-Note that the default `Forc.toml` generated with `forc init` already includes these lines, so no further action is necessary.
-
 ## Storage Variables and Mappings
 
 Storage variables (or more specifically, automatic assignment of storage slots) are not yet implemented. Storage slots will have to be assigned manually.


### PR DESCRIPTION
I think this section is no longer needed.

Also, fixing some links.