### PR TITLE
Added test for trailing `,` in import lists

### DIFF
--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -289,6 +289,10 @@ pub fn run(filter_regex: Option<regex::Regex>) {
             "should_pass/language/self_impl_reassignment",
             ProgramState::Return(1),
         ),
+        (
+            "should_pass/language/import_trailing_comma",
+            ProgramState::Return(0),
+        ),
     ];
 
     let mut number_of_tests_run =

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_trailing_comma/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_trailing_comma/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'import_trailing_comma'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_trailing_comma/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_trailing_comma/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "import_trailing_comma"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_trailing_comma/src/lib.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_trailing_comma/src/lib.sw
@@ -1,0 +1,11 @@
+library A;
+
+pub struct B {
+    b: u64,
+}
+pub struct C {
+    c: u64,
+}
+pub struct D {
+    d: u64,
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_trailing_comma/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_trailing_comma/src/main.sw
@@ -1,0 +1,18 @@
+script;
+
+dep lib;
+use A::{B, C, D,};
+
+fn main() -> u64 {
+    let x = B {
+        b: 0,
+    };
+    let y = C {
+        c: 0,
+    };
+    let z = D {
+        d: 0,
+    };
+    let foo = x.b + y.c + z.d;
+    foo
+}


### PR DESCRIPTION
Closes #1217 

Added test case that @mohammadfawaz provided via the aforementioned issue