### PR TITLE
docs: add short instruction to install forc lsp

### DIFF
--- a/docs/src/introduction/sway-toolchain.md
+++ b/docs/src/introduction/sway-toolchain.md
@@ -10,7 +10,7 @@ The "Fuel Orchestrator" [Forc](https://github.com/FuelLabs/sway/tree/master/forc
 
 The Sway Language Server `forc-lsp` is provided to expose features to IDEs, which you can install with cargo:
 
-```console
+```sh
 cargo install forc-lsp
 ```
 

--- a/docs/src/introduction/sway-toolchain.md
+++ b/docs/src/introduction/sway-toolchain.md
@@ -6,9 +6,15 @@ The Sway toolchain consists of several components.
 
 The "Fuel Orchestrator" [Forc](https://github.com/FuelLabs/sway/tree/master/forc) is our equivalent of Rust's [Cargo](https://doc.rust-lang.org/cargo/). It is the primary entry point for creating, building, testing, and deploying Sway projects.
 
-## Sway Language Server (`forc lsp`)
+## Sway Language Server (`forc-lsp`)
 
-The Sway Language Server `forc lsp` is provided to expose features to IDEs. Currently, only [Visual Studio Code is supported through a plugin](https://marketplace.visualstudio.com/items?itemName=FuelLabs.sway-vscode-plugin). Vim support is forthcoming, though [syntax highlighting is provided](https://github.com/FuelLabs/sway.vim).
+The Sway Language Server `forc-lsp` is provided to expose features to IDEs, which you can install with cargo:
+
+```console
+cargo install forc-lsp
+```
+
+Currently, only [Visual Studio Code is supported through a plugin](https://marketplace.visualstudio.com/items?itemName=FuelLabs.sway-vscode-plugin). Vim support is forthcoming, though [syntax highlighting is provided](https://github.com/FuelLabs/sway.vim).
 
 Note that there is no need to manually run `forc lsp` (the plugin will automatically start it), however `forc` must be in your `$PATH`. To check if `forc` is in your `$PATH`, type `forc --help` in your terminal.
 


### PR DESCRIPTION
Related:
https://github.com/FuelLabs/sway-vscode-plugin/issues/42#issuecomment-1100123224
https://github.com/FuelLabs/sway/pull/1179

`forc lsp` now comes with the forc-lsp plugin crate - updating the documentation to provide a simple `cargo install` instruction to reflect this.