### PR TITLE
Doc Fixes - `forc-documenter`, assembly, tuples, smart-contracts link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,3 +13,13 @@ To serve locally:
 ```sh
 mdbook serve
 ```
+
+## Regenerate Forc SubCommand Docs
+
+With forc installed running the command
+
+```sh
+cargo run --bin forc-documenter write-docs
+```
+
+will generate the proper docs for `forc` and it's commands based on `forc --help`. This behavior is further documented in [the Forc Documenter README](../scripts/forc-documenter/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,4 +22,4 @@ With forc installed running the command
 cargo run --bin forc-documenter write-docs
 ```
 
-will generate the proper docs for `forc` and it's commands based on `forc --help`. This behavior is further documented in [the Forc Documenter README](../scripts/forc-documenter/README.md).
+will generate the proper docs for `forc` and its commands based on `forc --help`. This behavior is further documented in [the Forc documenter README](../scripts/forc-documenter/README.md).

--- a/docs/src/advanced/assembly.md
+++ b/docs/src/advanced/assembly.md
@@ -31,7 +31,7 @@ Note that in the above example:
 - `one` is an example of a "reserved register", of which there are 16 in total. Further reading on this is linked below under "Semantics".
 - we return `r2` & specify the return type as being u32 (the return type is u64 by default).
 
-An important note is that the `ji` and `jnei` opcodes are not available with the `asm` block. For those looking to use control structure with assembly it is reccomended to use `if`, `else`, and `while` control structures in surrounding sway, to the combine multiple smaller `asm` blocks. 
+An important note is that the `ji` and `jnei` opcodes are not available within an `asm` block. For those looking to introduce control flow to `asm` blocks, it is recommended to surround smaller chunks of `asm` with control flow (`if`, `else`, and `while`).
 
 ## Helpful Links
 

--- a/docs/src/advanced/assembly.md
+++ b/docs/src/advanced/assembly.md
@@ -31,6 +31,8 @@ Note that in the above example:
 - `one` is an example of a "reserved register", of which there are 16 in total. Further reading on this is linked below under "Semantics".
 - we return `r2` & specify the return type as being u32 (the return type is u64 by default).
 
+An important note is that the `ji` and `jnei` opcodes are not available with the `asm` block. For those looking to use control structure with assembly it is reccomended to use `if`, `else`, and `while` control structures in surrounding sway, to the combine multiple smaller `asm` blocks. 
+
 ## Helpful Links
 
 For examples of assembly in action, check out the [Sway standard library](https://github.com/FuelLabs/sway/tree/master/sway-lib-std).

--- a/docs/src/basics/structs_and_tuples.md
+++ b/docs/src/basics/structs_and_tuples.md
@@ -43,7 +43,7 @@ Structs have zero memory overhead. What that means is that in memory, each struc
 
 ## Tuples
 
-Tuples are static-length types which contain multiple different types within themselves. The type of a type is defined by the values within it, and a tuple can contain basic types as well as structs and enums. An example of a tuple declaration is provided below.
+Tuples are a [basic static-length type](./built_in_types.md#tuple-types) which contain multiple different types within themselves. The type of a type is defined by the values within it, and a tuple can contain basic types as well as structs and enums. An example of a tuple declaration is provided below.
 
 ```sway
 let my_tuple: (u64, bool, u64) = (100, false, 10000);
@@ -56,7 +56,7 @@ let x: u64 = my_tuple.0;
 let y: bool = my_tuple.1;
 ```
 
-Tuples can also contain tuplees within themselves, and be used in destructing syntax to declare multiple values at once.
+Tuples can also contain tuples within themselves, and be used in destructing syntax to declare multiple values at once.
 
 Common usecases for tuples are returning multiple values from a function, packing parameters into a function, or storing a series of related values.
 ## Enums

--- a/docs/src/basics/structs_and_tuples.md
+++ b/docs/src/basics/structs_and_tuples.md
@@ -41,6 +41,24 @@ _This information is not vital if you are new to the language, or programming in
 
 Structs have zero memory overhead. What that means is that in memory, each struct field is laid out sequentially. No metadata regarding the struct's name or other properties is preserved at runtime. In other words, structs are compile-time constructs. This is the same in Rust, but different in other languages with runtimes like Java.
 
+## Tuples
+
+Tuples are static-length types which contain multiple different types within themselves. The type of a type is defined by the values within it, and a tuple can contain basic types as well as structs and enums. An example of a tuple declaration is provided below.
+
+```sway
+let my_tuple: (u64, bool, u64) = (100, false, 10000);
+```
+
+The values within this tuple can then be accessed with a `.` syntax in order of the type, starting at an index of 0 like shown in the example provided below.
+
+```sway
+let x: u64 = my_tuple.0;
+let y: bool = my_tuple.1;
+```
+
+Tuples can also contain tuplees within themselves, and be used in destructing syntax to declare multiple values at once.
+
+Common usecases for tuples are returning multiple values from a function, packing parameters into a function, or storing a series of related values.
 ## Enums
 
 _Enumerations_, or _enums_, are also known as _sum types_. An enum is a type that could be one of several variants. To declare an enum, you enumerate all potential variants. Let's look at _enum declaration syntax_:

--- a/docs/src/basics/structs_and_tuples.md
+++ b/docs/src/basics/structs_and_tuples.md
@@ -43,7 +43,7 @@ Structs have zero memory overhead. What that means is that in memory, each struc
 
 ## Tuples
 
-Tuples are a [basic static-length type](./built_in_types.md#tuple-types) which contain multiple different types within themselves. The type of a type is defined by the values within it, and a tuple can contain basic types as well as structs and enums. An example of a tuple declaration is provided below.
+Tuples are a [basic static-length type](./built_in_types.md#tuple-types) which contain multiple different types within themselves. The type of a tuple is defined by the types of the values within it, and a tuple can contain basic types as well as structs and enums. An example of a tuple declaration is provided below.
 
 ```sway
 let my_tuple: (u64, bool, u64) = (100, false, 10000);

--- a/docs/src/blockchain-development/storage.md
+++ b/docs/src/blockchain-development/storage.md
@@ -1,6 +1,6 @@
 # Storage
 
-When developing a [smart contract](../sway-on-chain/smart_contracts.md), you will typically need some sort of persistent storage. In this case, persistent storage, often just called _storage_ in this context, is a place where you can store values that are persisted inside the contract itself. This is in contrast to a regular value in _memory_, which disappears after the contract exits.
+When developing a [smart contract](../sway-program-types/smart_contracts.md), you will typically need some sort of persistent storage. In this case, persistent storage, often just called _storage_ in this context, is a place where you can store values that are persisted inside the contract itself. This is in contrast to a regular value in _memory_, which disappears after the contract exits.
 
 Put in conventional programming terms, contract storage is like saving data to a hard drive. That data is saved even after the program which saved it exits. That data is persistent. Using memory is like declaring a variable in a program: it exists for the duration of the program and is non-persistent.
 


### PR DESCRIPTION
Wanted to do some quick docs fixes and decided to merge them all into one PR as 4 less than 10 line PRs felt a bit spammy. (Can break up if needed though)

This fixes
#1277 
#1271 
#1270 
#1156 

Tried to keep with docs style but if any stylistic or errors I missed are there lmk and I can get them resolved.