### PR TITLE
Added option to not include std implicitly

### DIFF
--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -254,7 +254,6 @@ impl Manifest {
     fn implicitly_include_std_if_missing(&mut self, sway_git_tag: &str) {
         const CORE: &str = "core";
         const STD: &str = "std";
-        let include_implicit_std = self.project.implicit_std.unwrap_or(true);
         // Don't include `std` if:
         // - this *is* `core` or `std`.
         // - either `core` or `std` packages are already specified.
@@ -264,21 +263,15 @@ impl Manifest {
             || self.pkg_dep(CORE).is_some()
             || self.pkg_dep(STD).is_some()
             || self.dep(STD).is_some()
+            || !self.project.implicit_std.unwrap_or(true)
         {
-            if !include_implicit_std {
-                println_yellow_err("Warning: You specified an STD path but set `implicit-std` to `false`.\
-                 Your custom std path will take precdence and be imported regardless.");
-            }
             return;
         }
         // Add a `[dependencies]` table if there isn't one.
         let deps = self.dependencies.get_or_insert_with(Default::default);
         // Add the missing dependency.
-        if !include_implicit_std {
-            println_yellow_err("Warning: Project being built without an STD");
-            let std_dep = implicit_std_dep(sway_git_tag.to_string());
-            deps.insert(STD.to_string(), std_dep);
-        }
+        let std_dep = implicit_std_dep(sway_git_tag.to_string());
+        deps.insert(STD.to_string(), std_dep);
     }
 
     /// Retrieve a reference to the dependency with the given name.


### PR DESCRIPTION
Resolves #1150 , implementation is pretty straightforward, as described, defaults to including the std implicitly if the field is not specified.

Added some warnings when this option is used since I assume it's an uncommon use-case outside of working on sway itself or on some hyper-specialized program, also added a warning when the option is used *and* a path to the std is specified, which clarifies the explicit std will still be used (maybe not worth mentioning though, could remove).

---

Bikesheding:

I used `println_yellow_err` for the warnings since I've seen that behavior, but it might be worth having a specific `println_yellow_warning` function instead for greater clarity, or even setting a yellow == warning standard and renaming this function to `println_yellow_warning` or just `println_warning`.