### PR TITLE
Shorthand for build and test

### DIFF
--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -31,8 +31,8 @@ struct Opt {
 enum Forc {
     #[clap(name = "addr2line")]
     Addr2Line(Addr2LineCommand),
+    #[clap(alias = "b")]
     Build(BuildCommand),
-    B(BuildCommand),
     Clean(CleanCommand),
     #[clap(after_help = completions::COMPLETIONS_HELP)]
     Completions(CompletionsCommand),
@@ -40,8 +40,8 @@ enum Forc {
     Init(InitCommand),
     ParseBytecode(ParseBytecodeCommand),
     Run(RunCommand),
+    #[clap(alias = "t")]
     Test(TestCommand),
-    T(TestCommand),
     Update(UpdateCommand),
     JsonAbi(JsonAbiCommand),
     /// Find all forc plugins available via `PATH`.
@@ -64,7 +64,7 @@ pub async fn run_cli() -> Result<()> {
     let opt = Opt::parse();
     match opt.command {
         Forc::Addr2Line(command) => addr2line::exec(command),
-        Forc::Build(command) | Forc::B(command) => build::exec(command),
+        Forc::Build(command) => build::exec(command),
         Forc::Clean(command) => clean::exec(command),
         Forc::Completions(command) => completions::exec(command),
         Forc::Deploy(command) => deploy::exec(command).await,
@@ -72,7 +72,7 @@ pub async fn run_cli() -> Result<()> {
         Forc::ParseBytecode(command) => parse_bytecode::exec(command),
         Forc::Plugins => plugins::exec(),
         Forc::Run(command) => run::exec(command).await,
-        Forc::Test(command) | Forc::T(command) => test::exec(command),
+        Forc::Test(command) => test::exec(command),
         Forc::Update(command) => update::exec(command).await,
         Forc::JsonAbi(command) => json_abi::exec(command),
         Forc::Plugin(args) => {

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -32,6 +32,7 @@ enum Forc {
     #[clap(name = "addr2line")]
     Addr2Line(Addr2LineCommand),
     Build(BuildCommand),
+    B(BuildCommand),
     Clean(CleanCommand),
     #[clap(after_help = completions::COMPLETIONS_HELP)]
     Completions(CompletionsCommand),
@@ -40,6 +41,7 @@ enum Forc {
     ParseBytecode(ParseBytecodeCommand),
     Run(RunCommand),
     Test(TestCommand),
+    T(TestCommand),
     Update(UpdateCommand),
     JsonAbi(JsonAbiCommand),
     /// Find all forc plugins available via `PATH`.
@@ -62,7 +64,7 @@ pub async fn run_cli() -> Result<()> {
     let opt = Opt::parse();
     match opt.command {
         Forc::Addr2Line(command) => addr2line::exec(command),
-        Forc::Build(command) => build::exec(command),
+        Forc::Build(command) | Forc::B(command) => build::exec(command),
         Forc::Clean(command) => clean::exec(command),
         Forc::Completions(command) => completions::exec(command),
         Forc::Deploy(command) => deploy::exec(command).await,
@@ -70,7 +72,7 @@ pub async fn run_cli() -> Result<()> {
         Forc::ParseBytecode(command) => parse_bytecode::exec(command),
         Forc::Plugins => plugins::exec(),
         Forc::Run(command) => run::exec(command).await,
-        Forc::Test(command) => test::exec(command),
+        Forc::Test(command) | Forc::T(command) => test::exec(command),
         Forc::Update(command) => update::exec(command).await,
         Forc::JsonAbi(command) => json_abi::exec(command),
         Forc::Plugin(args) => {

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -31,7 +31,7 @@ struct Opt {
 enum Forc {
     #[clap(name = "addr2line")]
     Addr2Line(Addr2LineCommand),
-    #[clap(alias = "b")]
+    #[clap(visible_alias = "b")]
     Build(BuildCommand),
     Clean(CleanCommand),
     #[clap(after_help = completions::COMPLETIONS_HELP)]
@@ -40,7 +40,7 @@ enum Forc {
     Init(InitCommand),
     ParseBytecode(ParseBytecodeCommand),
     Run(RunCommand),
-    #[clap(alias = "t")]
+    #[clap(visible_alias = "t")]
     Test(TestCommand),
     Update(UpdateCommand),
     JsonAbi(JsonAbiCommand),


### PR DESCRIPTION
Resolves #1025 -- mainly opening the PR to ask some questions though

@otrho 's suggestion there was to find a library that procedurally generates shorthand for all arguments in a disambiguous way. This doesn't seem possible if we want said library to integrate with `clap`. Even if there were, shorthand/short arguments doesn't seem to be an option for enum-based parsing, which is a fairly elegant way to handle the first argument.

That being said, I think it'd be doable to annotate the enum with a proc macro that generates shorthands, but I'd wager it's too much bother writing it for not that much gain(?)

The other option would be to have a function the full command in `run_cli`, generates the shorthands based on all subcommands (and optionally all the flags/options), then transforms the command (with this approach you could get a behavior where `forc b -pa -p -pi` becomes `forc build --print-intermediate-asm --path --print-ir --silent` becomes`)  ... this would also require a macro-based approach but it seems like I'd make generating the appropriate docs very annoying (right now clap handles this automatically)

I myself am a fan of having the shorthands written by hand in the codebase or ideally not having them at all, I find that APIs are a horrible place to cut code-volume cost via code generation.

---

Anyway, if you think the manual approach is the best feel free to close this PR since I don't want to steal too many easy issues from other newbies. If you think an automatic-generated approach is best I'd love some more details about the ideal behavior and I can go ahead and try implementing it.