### PR TITLE
Fix import of submodules within `std::context`

### DIFF
--- a/sway-lib-std/src/context.sw
+++ b/sway-lib-std/src/context.sw
@@ -4,8 +4,8 @@ dep context/call_frames;
 dep context/registers;
 
 use ::contract_id::ContractId;
-use ::call_frames::*;
-use ::registers::balance;
+use call_frames::*;
+use registers::balance;
 
 /// Get the balance of coin `asset_id` for the current contract.
 pub fn this_balance(asset_id: ContractId) -> u64 {


### PR DESCRIPTION
I noticed these when they resulted in compilation errors while working
on the `Namespace` refactor in #1213.

It appears that on `master` we're leaking submodules into the root
namespace, and as a result these haven't been caught yet. #1213 appears
to fix this and results in a compilation error. I might add a
`should_fail` E2E test as a part of #1213 to ensure we don't
accidentally leak submodules into the root in the future.