### PR TITLE
Scripts + instructions to git hook formatting checks and/or gh-action suite

### DIFF
--- a/scripts/local_testing/README.md
+++ b/scripts/local_testing/README.md
@@ -1,0 +1,27 @@
+# Local Testing
+Tiny scripts for running formatting checks or tests locally. [act](https://github.com/nektos/act) is required for running all github actions.
+
+## To run as git hooks
+*Example shows running them as a pre-push hook, but can work pre-commit to, I find that to be a bit of an overkill*
+
+Add the following in `.git/hooks/pre-push`:
+```
+#!/bin/bash
+
+for hook in .git/hooks/pre-push.d/*; do
+    bash $hook
+    RESULT=$?
+    if [ $RESULT != 0 ]; then
+        echo ".git/hooks/pre-push.d/$hook returned non-zero: $RESULT, abort commit"
+        exit $RESULT
+    fi
+done
+
+exit 0
+```
+
+Then `mkdir .git/hooks/pre-push.d/`
+
+Then link the script you want to run, e.g:
+`ln -s $PWD/scripts/local_testing/formatting.sh .git/hooks/pre-push.d/`
+`ln -s $PWD/scripts/local_testing/local_gh_actions.sh .git/hooks/pre-push.d/`

--- a/scripts/local_testing/formatting.sh
+++ b/scripts/local_testing/formatting.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cargo fmt --all -- --check &&
+git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint &&
+cargo clippy --all-features --all-targets -- -D warnings

--- a/scripts/local_testing/local_gh_actions.sh
+++ b/scripts/local_testing/local_gh_actions.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+act


### PR DESCRIPTION
Based on the quick discussion here #1283

Adds two one-liners for running all formatting checks and all github actions respectively + instructions for how to add these as git hooks. Part of the instructions could also included in the remote's .git instead (the short script in `pre-push` to run everything in the `pre-push.d` dir)

Not sure if it's worth adding to the repo though, might be that everyone has their own preference for these and nobody but me might end up using these.

