### PR TITLE
Forc deploy docs update

### DIFF
--- a/docs/src/forc/commands/forc_deploy.md
+++ b/docs/src/forc/commands/forc_deploy.md
@@ -85,18 +85,8 @@ Whether to compile using the original (pre- IR) pipeline
 
 ## EXAMPLES:
 
-Deploy contract project. Crafts a contract deployment transaction then sends it to a running node.
+You can use `forc deploy` to trigger a contract deployment transaction and then send it to a running node.
 
-Alternatively, you could deploy your contract programmatically using our SDK:
+Alternatively, you can deploy your Sway contract programmatically using [fuels-rs](https://github.com/FuelLabs/fuels-rs), our Rust SDK.
 
-```rust
-// Build the contract
-let salt: [u8; 32] = rng.gen();
-let salt = Salt::from(salt);
-let compiled = Contract::compile_sway_contract("./", salt).unwrap();
-
-// Launch a local network and deploy the contract
-let compiled = Contract::compile_sway_contract("./", salt).unwrap();
-let client = Provider::launch(Config::local_node()).await.unwrap();
-let contract_id = Contract::deploy(&compiled, &client).await.unwrap();
-```
+You can find an example within our [fuels-rs book](https://fuellabs.github.io/fuels-rs/latest/getting-started/basics.html).

--- a/docs/src/forc/commands/forc_deploy.md
+++ b/docs/src/forc/commands/forc_deploy.md
@@ -85,8 +85,8 @@ Whether to compile using the original (pre- IR) pipeline
 
 ## EXAMPLES:
 
-You can use `forc deploy` to trigger a contract deployment transaction and then send it to a running node.
+You can use `forc deploy`, which triggers a contract deployment transaction and sends it to a running node.
 
 Alternatively, you can deploy your Sway contract programmatically using [fuels-rs](https://github.com/FuelLabs/fuels-rs), our Rust SDK.
 
-You can find an example within our [fuels-rs book](https://fuellabs.github.io/fuels-rs/latest/getting-started/basics.html).
+You can find an example within our [fuels-rs book](https://fuellabs.github.io/fuels-rs/latest/getting-started/basics.html#deploying-a-sway-contract).

--- a/scripts/forc-documenter/src/constants.rs
+++ b/scripts/forc-documenter/src/constants.rs
@@ -48,11 +48,11 @@ You can find an example under the [Testing with Rust](../../testing/testing-with
 "#;
 
 pub static FORC_DEPLOY_EXAMPLE: &str = r#"
-You can use `forc deploy` to trigger a contract deployment transaction and then send it to a running node.
+You can use `forc deploy`, which triggers a contract deployment transaction and sends it to a running node.
 
 Alternatively, you can deploy your Sway contract programmatically using [fuels-rs](https://github.com/FuelLabs/fuels-rs), our Rust SDK.
 
-You can find an example within our [fuels-rs book](https://fuellabs.github.io/fuels-rs/latest/getting-started/basics.html).
+You can find an example within our [fuels-rs book](https://fuellabs.github.io/fuels-rs/latest/getting-started/basics.html#deploying-a-sway-contract).
 "#;
 
 pub static FORC_PARSE_BYTECODE_EXAMPLE: &str = r#"

--- a/scripts/forc-documenter/src/constants.rs
+++ b/scripts/forc-documenter/src/constants.rs
@@ -48,7 +48,7 @@ You can find an example under the [Testing with Rust](../../testing/testing-with
 "#;
 
 pub static FORC_DEPLOY_EXAMPLE: &str = r#"
-Deploy contract project. Crafts a contract deployment transaction then sends it to a running node.
+You can use `forc deploy` to trigger a contract deployment transaction and then send it to a running node.
 
 Alternatively, you can deploy your Sway contract programmatically using [fuels-rs](https://github.com/FuelLabs/fuels-rs), our Rust SDK.
 

--- a/scripts/forc-documenter/src/constants.rs
+++ b/scripts/forc-documenter/src/constants.rs
@@ -50,19 +50,9 @@ You can find an example under the [Testing with Rust](../../testing/testing-with
 pub static FORC_DEPLOY_EXAMPLE: &str = r#"
 Deploy contract project. Crafts a contract deployment transaction then sends it to a running node.
 
-Alternatively, you could deploy your contract programmatically using our SDK:
+Alternatively, you can deploy your Sway contract programmatically using [fuels-rs](https://github.com/FuelLabs/fuels-rs), our Rust SDK.
 
-```rust
-// Build the contract
-let salt: [u8; 32] = rng.gen();
-let salt = Salt::from(salt);
-let compiled = Contract::compile_sway_contract("./", salt).unwrap();
-
-// Launch a local network and deploy the contract
-let compiled = Contract::compile_sway_contract("./", salt).unwrap();
-let client = Provider::launch(Config::local_node()).await.unwrap();
-let contract_id = Contract::deploy(&compiled, &client).await.unwrap();
-```
+You can find an example within our [fuels-rs book](https://fuellabs.github.io/fuels-rs/latest/getting-started/basics.html).
 "#;
 
 pub static FORC_PARSE_BYTECODE_EXAMPLE: &str = r#"


### PR DESCRIPTION
Fixes https://github.com/FuelLabs/fuels-rs/issues/216

Instead of having an example of how to deploy using the Rust SDK within the Sway book, we link it to the [page on deploying contracts in the fuels-rs book instead](https://fuellabs.github.io/fuels-rs/latest/getting-started/basics.html#deploying-a-sway-contract), so that only the fuels-rs book has to be updated in future.