### PR TITLE
Sway Book counter init code

### DIFF
--- a/docs/src/examples/counter.md
+++ b/docs/src/examples/counter.md
@@ -2,7 +2,11 @@
 
 The following is a simple example of a contract which implements a counter. Both the `initialize()` and `increment()` functions return the currently set value.
 
-The use of `storage` here is **new and is still being stabilized**, please see the [Subcurrency](./subcurrency.md) example for writing storage by-hand.
+```bash
+forc init --template counter my_counter_project
+```
+
+The use of `storage` here is **new and is still being stabilized**, please see the [Subcurrency](./subcurrency.md) example for writing storage manually.
 
 ```sway
 {{#include ../../../examples/counter/src/main.sw}}


### PR DESCRIPTION
- Added the handy `forc init --template counter my_counter_project` command.
- Changed "by-hand" to "manual" in line with other documentation.
- Decided to not specify more about the `forc init`, as it's kind of self explanatory.

Closes: https://github.com/FuelLabs/sway/issues/1307