### PR TITLE
Show hexdump instead of decimal arrays in parse-bytecode

### DIFF
--- a/forc/src/cli/commands/parse_bytecode.rs
+++ b/forc/src/cli/commands/parse_bytecode.rs
@@ -62,7 +62,10 @@ pub(crate) fn exec(command: Command) -> Result<()> {
             TableCell::new_with_alignment(word_ix, 1, Alignment::Right),
             TableCell::new(word_ix * 4),
             TableCell::new(format!("{:?}", instruction.1)),
-            TableCell::new(format!("{:?}", instruction.0)),
+            TableCell::new(format!(
+                "{:02x} {:02x} {:02x} {:02x}",
+                instruction.0[0], instruction.0[1], instruction.0[2], instruction.0[3],
+            )),
             TableCell::new(notes),
         ]));
     }


### PR DESCRIPTION
Instead of this:

```
  half-word   byte   op                 raw                 notes
          0   0      JI(4)              [144, 0, 0, 4]      conditionally jumps to byte 16
          1   4      NOOP               [71, 0, 0, 0]
          2   8      Undefined          [0, 0, 0, 0]        data section offset lo (0)
          3   12     Undefined          [0, 0, 1, 76]       data section offset hi (332)
          4   16     LW(63, 12, 1)      [93, 252, 192, 1]
          5   20     ADD(63, 63, 12)    [16, 255, 243, 0]
          6   24     MOVE(23, 5)        [26, 92, 80, 0]
          7   28     CFEI(64)           [145, 0, 0, 64]
```

make it look like this

```
  half-word   byte   op                 raw           notes
          0   0      JI(4)              90 00 00 04   conditionally jumps to byte 16
          1   4      NOOP               47 00 00 00
          2   8      Undefined          00 00 00 00   data section offset lo (0)
          3   12     Undefined          00 00 01 4c   data section offset hi (332)
          4   16     LW(63, 12, 1)      5d fc c0 01
          5   20     ADD(63, 63, 12)    10 ff f3 00
          6   24     MOVE(23, 5)        1a 5c 50 00
          7   28     CFEI(64)           91 00 00 40
```