### PR TITLE
Add forc rust version check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,6 +1077,7 @@ dependencies = [
  "fuel-vm",
  "futures",
  "hex",
+ "rustc_version 0.2.3",
  "serde",
  "serde_json",
  "sway-core",

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/sway"
 description = "Fuel Orchestrator."
+rust-version = "1.58.0"
 
 [lib]
 name = "forc"
@@ -43,6 +44,7 @@ url = "2.2"
 uwuify = { version = "^0.2", optional = true }
 walkdir = "2.3"
 whoami = "1.1"
+rustc_version = "0.2"
 
 [features]
 default = []

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -1,4 +1,6 @@
 use crate::ops::forc_build;
+use crate::utils::check_rust_version;
+
 use anyhow::Result;
 use clap::Parser;
 use std::io::{BufRead, BufReader};
@@ -42,6 +44,9 @@ pub(crate) struct Command {
 
 pub(crate) fn exec(command: Command) -> Result<()> {
     // Ensure the project builds before running tests.
+
+    check_rust_version()?;
+
     forc_build::build(Default::default())?;
 
     let mut cmd = process::Command::new("cargo");

--- a/forc/src/ops/forc_init.rs
+++ b/forc/src/ops/forc_init.rs
@@ -1,5 +1,5 @@
 use crate::cli::InitCommand;
-use crate::utils::defaults;
+use crate::utils::{check_rust_version, defaults};
 use anyhow::{anyhow, Context, Result};
 use forc_util::{println_green, validate_name};
 use serde::Deserialize;
@@ -102,6 +102,8 @@ pub fn init(command: InitCommand) -> Result<()> {
 }
 
 pub(crate) fn init_new_project(project_name: String) -> Result<()> {
+    check_rust_version()?;
+
     let neat_name: String = project_name.split('/').last().unwrap().to_string();
 
     // Make a new directory for the project

--- a/forc/src/utils/mod.rs
+++ b/forc/src/utils/mod.rs
@@ -1,8 +1,56 @@
 pub mod defaults;
 pub mod parameters;
 
+use anyhow::Result;
+use forc_util::{println_red_err, println_yellow_err};
+use rustc_version::{version, Version};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
 /// The `forc` crate version formatted with the `v` prefix. E.g. "v1.2.3".
 ///
 /// This git tag is used during `Manifest` construction to pin the version of the implicit `std`
 /// dependency to the `forc` version.
 pub const SWAY_GIT_TAG: &str = concat!("v", clap::crate_version!());
+
+pub(crate) fn forc_cargo_toml_as_str() -> Result<String> {
+    let cargo_dir = env!("CARGO_MANIFEST_DIR");
+    let cargo_file = format!("{}/Cargo.toml", cargo_dir);
+    let toml_path = Path::new(&cargo_file);
+
+    let mut file = File::open(toml_path)?;
+    let mut toml = String::new();
+    file.read_to_string(&mut toml)?;
+
+    Ok(toml)
+}
+
+pub(crate) fn check_rust_version() -> Result<()> {
+    let toml = forc_cargo_toml_as_str()?;
+    let rustc_version = match version() {
+        Ok(v) => v,
+        Err(_e) => {
+            println_red_err("rustc was not found in this environment.\n\nPlease see https://www.rust-lang.org/tools/install for more details on how you can install rustc.");
+            std::process::exit(0x01);
+        }
+    };
+
+    let cargo_toml: toml::Value = toml::de::from_str(&toml)?;
+
+    if let Some(table) = cargo_toml.as_table() {
+        if let Some(version) = table.get("package").unwrap().get("rust-version") {
+            let version_str = &version.as_str().unwrap();
+            let forc_rustc_version = Version::parse(version_str)?;
+            if rustc_version > forc_rustc_version {
+                let warning = format!(
+                    "\nFound rustc version {}, which is greater than the suggested version {}\n",
+                    &rustc_version, &forc_rustc_version
+                );
+                println_yellow_err(&warning);
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION

## Description:
This PR adds a check to `forc init` and `forc test` to ensure that Rust is installed

## Steps to test this PR:
- [ ] Try to `rustup install` and `rustup default` a few `rustc` versions
  - 1.57, 1.58, 1.60 
- [ ] Try to run `forc init` or `forc test` using some of these different versions
  - Note the warning when using a version > 1.58
- [ ] Update your `$PATH` to not include `cargo` (to simulate not having cargo installed), then try `forc init` and `forc test`
  - Note the error message

---
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
[List of cached micro services](https://dub.duckduckgo.com/duckduckgo/ddg/wiki/Microservice-caching)
[Dealing with broken integration tests](https://app.asana.com/0/411841517318433/1200020138263066)
