### PR TITLE
Remove `sway_types::{JsonABI, Function, Property}` in favour of `fuels_types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,13 +1131,13 @@ version = "0.12.1"
 dependencies = [
  "anyhow",
  "forc-util",
+ "fuels-types",
  "git2",
  "petgraph",
  "semver 1.0.7",
  "serde",
  "serde_ignored",
  "sway-core",
- "sway-types",
  "sway-utils",
  "toml",
  "url",
@@ -1325,6 +1325,18 @@ dependencies = [
  "sha3 0.9.1",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "fuels-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e41f0c46afe4389edc34aa84064808ab8d41cb0e4e06fd7ea2a8e19abc82eaed"
+dependencies = [
+ "anyhow",
+ "serde",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -3153,6 +3165,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+
+[[package]]
+name = "strum_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3193,6 +3223,7 @@ dependencies = [
  "fuel-pest",
  "fuel-pest_derive",
  "fuel-vm",
+ "fuels-types",
  "generational-arena",
  "hex",
  "itertools",

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -11,13 +11,13 @@ description = "Building, locking, fetching and updating Sway projects as Forc pa
 [dependencies]
 anyhow = "1"
 forc-util = { version = "0.12.1", path = "../forc-util" }
+fuels-types = "0.10"
 git2 = "0.14"
 petgraph = { version = "0.6", features = ["serde-1"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
 sway-core = { version = "0.12.1", path = "../sway-core" }
-sway-types = { version = "0.12.1", path = "../sway-types" }
 sway-utils = { version = "0.12.1", path = "../sway-utils" }
 toml = "0.5"
 url = { version = "2.2", features = ["serde"] }

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -7,6 +7,7 @@ use forc_util::{
     find_file_name, git_checkouts_directory, kebab_to_snake_case, print_on_failure,
     print_on_success, print_on_success_library, println_yellow_err,
 };
+use fuels_types::JsonABI;
 use petgraph::{self, visit::EdgeRef, Directed, Direction};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -19,7 +20,6 @@ use sway_core::{
     source_map::SourceMap, BytecodeCompilationResult, CompileAstResult, CompileError, NamespaceRef,
     NamespaceWrapper, TreeType, TypedParseTree,
 };
-use sway_types::JsonABI;
 use sway_utils::constants;
 use url::Url;
 

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -19,6 +19,7 @@ either = "1.6"
 fuel-asm = "0.4"
 fuel-crypto = "0.4"
 fuel-vm = "0.8"
+fuels-types = "0.10"
 generational-arena = "0.2"
 hex = { version = "0.4", optional = true }
 itertools = "0.10"

--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -7,7 +7,8 @@ use crate::{
     CodeBlock, Rule,
 };
 
-use sway_types::{ident::Ident, span::Span, Function, Property};
+use fuels_types::{Function, Property};
+use sway_types::{ident::Ident, span::Span};
 
 use pest::iterators::Pair;
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -3,11 +3,10 @@ use crate::{
     error::*, parse_tree::*, semantic_analysis::TypeCheckedStorageReassignment, type_engine::*,
     Ident, NamespaceRef, NamespaceWrapper,
 };
-
-use sway_types::{Property, Span};
-
 use derivative::Derivative;
+use fuels_types::Property;
 use std::hash::{Hash, Hasher};
+use sway_types::Span;
 
 mod function;
 mod storage;

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -12,10 +12,9 @@ use crate::{
     type_engine::*,
     Ident, TypeParameter,
 };
-
-use sway_types::{Function, Property, Span};
-
+use fuels_types::{Function, Property};
 use sha2::{Digest, Sha256};
+use sway_types::Span;
 
 mod function_parameter;
 pub use function_parameter::*;

--- a/sway-core/src/type_engine.rs
+++ b/sway-core/src/type_engine.rs
@@ -7,8 +7,8 @@ mod integer_bits;
 mod type_info;
 mod unresolved_type_check;
 pub use engine::*;
+use fuels_types::Property;
 pub use integer_bits::*;
-use sway_types::Property;
 pub use type_info::*;
 pub(crate) use unresolved_type_check::UnresolvedTypeCheck;
 

--- a/sway-types/src/lib.rs
+++ b/sway-types/src/lib.rs
@@ -339,28 +339,3 @@ impl Context {
         }
     }
 }
-
-/// Fuel/Sway ABI representation in JSON, originally
-/// specified here: `<https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/abi.md>`
-/// This type is used by the compiler and the tooling around it convert
-/// an ABI representation into native Rust structs and vice-versa.
-pub type JsonABI = Vec<Function>;
-
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Function {
-    #[serde(rename = "type")]
-    pub type_field: String,
-    pub inputs: Vec<Property>,
-    pub name: String,
-    pub outputs: Vec<Property>,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Property {
-    pub name: String,
-    #[serde(rename = "type")]
-    pub type_field: String,
-    pub components: Option<Vec<Property>>, // Used for custom types
-}


### PR DESCRIPTION
See https://github.com/FuelLabs/fuels-rs/pull/219 for context.

## Blockers

- [x] Await `fuels-types` to get published.

## TODO

- [x] Update `Cargo.toml`s to point to published version.
- [x] Update `Cargo.lock`.