### PR TITLE
Swap core dep for implicit-std

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_bad_index/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_bad_index/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "array_bad_index"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_oob/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_oob/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "array_oob"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/asm_missing_return/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/asm_missing_return/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "asm_missing_return"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/asm_should_not_have_return/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/asm_should_not_have_return/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "asm_should_not_have_return"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_annotation/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_annotation/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "bad_generic_annotation"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_var_annotation/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_var_annotation/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "bad_generic_var_annotation"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "chained_if_let_missing_branch"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/contract_pure_calls_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/contract_pure_calls_impure/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "valid_impurity"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/dependency_parsing_error/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/dependency_parsing_error/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "dependencies_parsing_error"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/different_contract_caller_types/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/different_contract_caller_types/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "different_contract_caller_types"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/disallow_turbofish/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/disallow_turbofish/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "disallow_turbofish"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/disallowed_gm/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/disallowed_gm/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "disallowed_opcodes"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/empty_impl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/empty_impl/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "empty_impl"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/enum_if_let_invalid_variable/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/enum_if_let_invalid_variable/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "enum_if_let_invalid_variable"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "excess_fn_arguments"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_shadows_generic/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_shadows_generic/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "generic_shadows_generic"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generics_unhelpful_error/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generics_unhelpful_error/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "generics_unhelpful_error"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/infinite_dependencies/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/infinite_dependencies/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "infinite_dependencies"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/item_used_without_import/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/item_used_without_import/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "item_used_without_import"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/literal_too_large_for_type/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/literal_too_large_for_type/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "literal_too_large_for_type"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_enums/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_enums/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "match_expressions_enums"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "match_expressions_non_exhaustive"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_wrong_struct/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_wrong_struct/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "match_expressions_wrong_struct"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "missing_fn_arguments"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_func_from_supertrait_impl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_func_from_supertrait_impl/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "missing_func_from_supertrait_impl"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_supertrait_impl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_supertrait_impl/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "missing_supertrait_impl"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/name_shadowing/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/name_shadowing/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "name_shadowing"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/nested_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/nested_impure/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "nested_impure"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_calls_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_calls_impure/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "script_calls_impure"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/pure_calls_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/pure_calls_impure/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "pure_calls_impure"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "recursive_calls"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/script_calls_impure/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/script_calls_impure/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "script_calls_impure"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "shadow_import"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "star_import_alias"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "supertrait_does_not_exist"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/top_level_vars/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/top_level_vars/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "top_level_vars"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unify_identical_unknowns/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unify_identical_unknowns/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "unify_identical_unknowns"
 entry = "main.sw"
-
-[dependencies]
-core = { path = "../../../../../../sway-lib-core" }
+implicit-std = false


### PR DESCRIPTION
### Description

This PR swaps the `core` dependency for an `implicity-std = false` setting in all e2e test manifest files

### Testing steps
- [ ] `cargo test` should pass