### PR TITLE
Remove prefix from parse/lex error messages

### DIFF
--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -929,9 +929,9 @@ pub enum CompileError {
         #[from]
         error: ConvertParseTreeError,
     },
-    #[error("lex error: {}", error)]
+    #[error("{}", error)]
     Lex { error: sway_parse::LexError },
-    #[error("parse error: {}", error)]
+    #[error("{}", error)]
     Parse { error: sway_parse::ParseError },
 }
 


### PR DESCRIPTION
Putting "parse error: ..."/"lex error: ..." at the start of error messages isn't necessary.