### PR TITLE
`forc-gm` starter plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "forc-gm"
+version = "0.1.0"
+dependencies = [
+ "clap 3.1.8",
+]
+
+[[package]]
 name = "forc-lsp"
 version = "0.10.3"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "docstrings",
     "examples/build-all-examples",
     "forc",
+    "forc-gm",
     "forc-explore",
     "forc-fmt",
     "forc-lsp",

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -35,6 +35,7 @@
   - [Calling Contracts](./blockchain-development/calling_contracts.md)
 - [Forc](./forc/index.md)
   - [Dependencies](./forc/dependencies.md)
+  - [Plugins](./forc/plugins.md)
   - [Commands](./forc/commands/index.md)
     - [forc addr2line](./forc/commands/forc_addr2line.md)
     - [forc build](./forc/commands/forc_build.md)

--- a/docs/src/forc/plugins.md
+++ b/docs/src/forc/plugins.md
@@ -1,0 +1,37 @@
+# Plugins
+
+The Fuel ecosystem has a few plugins which can be easily installed via cargo, and anyone can write their own plugins.
+
+Let's install a starter plugin, `forc-gm`, and take a look at how it works underneath:
+
+```sh
+cargo install forc-gm
+```
+
+Check that we have installed `forc-gm`:
+
+```console
+$ forc plugins
+/Users/<USER>/.cargo/bin/forc-gm
+```
+
+Underneath, `forc-gm` is a simple CLI app, with [clap](https://docs.rs/clap/latest/clap/) as the only dependency:
+
+```rust
+{{#include ../../../forc-gm/src/main.rs}}
+```
+
+You can say gm, or you can greet Fuel:
+
+```console
+$ forc gm
+gn!
+$ forc gm fuel
+gn from Fuel!
+```
+
+## Writing your own plugin
+
+We encourage anyone to write and publish their own `forc` plugin to enhance their development experience.
+
+Your plugin must be named in the format `forc-<MY_PLUGIN>` and you may use the above template as a starting point. You can use [clap](https://docs.rs/clap/latest/clap/) and add more subcommands, options and configurations to suit your plugin's needs.

--- a/forc-gm/Cargo.toml
+++ b/forc-gm/Cargo.toml
@@ -8,7 +8,5 @@ license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/sway"
 description = "A sample `forc` plugin."
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 clap = { version = "=3.1.8", features = ["derive"] }

--- a/forc-gm/Cargo.toml
+++ b/forc-gm/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "forc-gm"
+version = "0.1.0"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+edition = "2021"
+homepage = "https://fuel.network/"
+license = "Apache-2.0"
+repository = "https://github.com/FuelLabs/sway"
+description = "A sample `forc` plugin."
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = { version = "=3.1.8", features = ["derive"] }

--- a/forc-gm/src/main.rs
+++ b/forc-gm/src/main.rs
@@ -1,0 +1,44 @@
+//! A sample `forc` plugin example.
+//!
+//! Once installed and available via `PATH`, can be executed via `forc gm`.
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[clap(name = "forc-gm", about = "Sample Forc plugin", version)]
+struct App {
+    // Your name which Forc should greet!
+    #[clap(short = 'n', long = "name", default_value = "")]
+    pub name: String,
+    #[clap(subcommand)]
+    pub subcmd: Option<Subcommand>,
+}
+
+#[derive(Debug, Parser)]
+enum Subcommand {
+    // Say 'gm' to Sway Language!
+    Sway,
+}
+
+fn main() {
+    let app = App::parse();
+
+    match app.subcmd {
+        Some(Subcommand::Sway) => greet_sway(),
+        None => run(app),
+    }
+}
+
+fn greet_sway() {
+    println!("gn from Fuel!");
+}
+
+fn run(app: App) {
+    let App { name, .. } = app;
+
+    if name.is_empty() {
+        println!("gn!");
+    } else {
+        println!("gn {}!", &name);
+    }
+}

--- a/forc-gm/src/main.rs
+++ b/forc-gm/src/main.rs
@@ -1,44 +1,39 @@
-//! A sample `forc` plugin example.
+//! A sample `forc` plugin that greets you!
 //!
 //! Once installed and available via `PATH`, can be executed via `forc gm`.
 
 use clap::Parser;
 
 #[derive(Debug, Parser)]
-#[clap(name = "forc-gm", about = "Sample Forc plugin", version)]
+#[clap(
+    name = "forc-gm",
+    about = "Sample Forc plugin that greets you!",
+    version
+)]
 struct App {
-    // Your name which Forc should greet!
-    #[clap(short = 'n', long = "name", default_value = "")]
-    pub name: String,
     #[clap(subcommand)]
     pub subcmd: Option<Subcommand>,
 }
 
 #[derive(Debug, Parser)]
 enum Subcommand {
-    // Say 'gm' to Sway Language!
-    Sway,
+    /// Say 'gm' to Fuel!
+    Fuel,
 }
 
 fn main() {
     let app = App::parse();
 
     match app.subcmd {
-        Some(Subcommand::Sway) => greet_sway(),
-        None => run(app),
+        Some(Subcommand::Fuel) => greet_fuel(),
+        None => greet(),
     }
 }
 
-fn greet_sway() {
+fn greet_fuel() {
     println!("gn from Fuel!");
 }
 
-fn run(app: App) {
-    let App { name, .. } = app;
-
-    if name.is_empty() {
-        println!("gn!");
-    } else {
-        println!("gn {}!", &name);
-    }
+fn greet() {
+    println!("gn!");
 }


### PR DESCRIPTION
Fixes #1200 

So, this addresses #1200, but I have a suggestion to instead make this its own repo instead so that someone wanting to write their own plugin can use [cargo generate](https://github.com/cargo-generate/cargo-generate) to instantly clone and start working on their plugin. 

Assuming we have a repo named `forc-plugin-template`:

```console
$ cargo generate https://github.com/FuelLabs/forc-plugin-template
🤷   Project Name : forc-my-plugin
🔧   Generating template ...
[1/5]   Done: .gitignore
[2/5]   Done: Cargo.toml
[3/5]   Done: README.md
[4/5]   Done: src/lib.rs
[5/5]   Done: src
🔧   Moving generated files into: `/path/to/plugin/forc-my-plugin`...
💡   Initializing a fresh Git repository
✨   Done! New project created /path/to/plugin/forc-my-plugin
```

Developer can then `cd` into the project directory and start working.

If the above sounds good, we can change this PR to just updating the docs in `/forcs/plugins.md`, remove the `forc-gm` directory and use that project in its own repo instead.