### PR TITLE
update `forc plugins` to emit file names only, with option of full paths

### DIFF
--- a/docs/src/forc/commands/forc_plugins.md
+++ b/docs/src/forc/commands/forc_plugins.md
@@ -1,11 +1,11 @@
 # forc-plugins
 Find all forc plugins available via `PATH`.
 
-Prints the absolute path to each discovered plugin on a new line.
+Prints information about each discovered plugin.
 
 
 ## USAGE:
-forc plugins
+forc plugins [OPTIONS]
 
 
 ## OPTIONS:
@@ -14,3 +14,9 @@ forc plugins
 
 
 Print help information
+
+
+`-p`, `--paths` 
+
+
+Prints the absolute path to each discovered plugin

--- a/forc/src/cli/commands/plugins.rs
+++ b/forc/src/cli/commands/plugins.rs
@@ -1,7 +1,6 @@
 use crate::cli::PluginsCommand;
 use anyhow::Result;
 use clap::Parser;
-use std::ffi::OsStr;
 use std::path::PathBuf;
 
 /// Find all forc plugins available via `PATH`.
@@ -10,7 +9,7 @@ use std::path::PathBuf;
 #[derive(Debug, Parser)]
 pub struct Command {
     /// Prints the absolute path to each discovered plugin.
-    #[clap(long = "verbose", short = 'v')]
+    #[clap(long = "paths", short = 'p')]
     print_full_path: bool,
 }
 
@@ -23,6 +22,12 @@ pub(crate) fn exec(command: PluginsCommand) -> Result<()> {
     Ok(())
 }
 
+/// # Panics
+///
+/// This function assumes that file names will never be empty since it is only used with
+/// paths yielded from plugin::find_all(), as well as that the file names are in valid
+/// unicode format since file names should be prefixed with `forc-`. Should one of these 2
+/// assumptions fail, this function panics.
 fn print_plugin(path: PathBuf, print_full_path: bool) {
     if print_full_path {
         println!("{}", path.display());
@@ -30,9 +35,9 @@ fn print_plugin(path: PathBuf, print_full_path: bool) {
         println!(
             "{}",
             path.file_name()
-                .unwrap_or_else(|| OsStr::new(""))
+                .expect("Failed to read file name")
                 .to_str()
-                .unwrap()
+                .expect("Failed to print file name")
         );
     }
 }

--- a/forc/src/cli/commands/plugins.rs
+++ b/forc/src/cli/commands/plugins.rs
@@ -1,8 +1,35 @@
+use crate::cli::PluginsCommand;
 use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
 
-pub(crate) fn exec() -> Result<()> {
+/// Find all forc plugins available via `PATH`.
+///
+/// Prints information about each discovered plugin.
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// Prints the absolute path to each discovered plugin.
+    #[clap(long = "verbose", short = 'v')]
+    print_full_path: bool,
+}
+
+pub(crate) fn exec(command: PluginsCommand) -> Result<()> {
+    let PluginsCommand { print_full_path } = command;
+
     for path in crate::cli::plugin::find_all() {
-        println!("{}", path.display());
+        print_plugin(path, print_full_path);
     }
     Ok(())
+}
+
+fn print_plugin(path: PathBuf, print_full_path: bool) {
+    if print_full_path {
+        println!("{}", path.display());
+    } else {
+        if let Some(file_name) = path.file_name() {
+            println!("{}", file_name.to_str().unwrap());
+        } else {
+            println!("{}", path.display());
+        }
+    }
 }

--- a/forc/src/cli/commands/plugins.rs
+++ b/forc/src/cli/commands/plugins.rs
@@ -1,6 +1,7 @@
 use crate::cli::PluginsCommand;
 use anyhow::Result;
 use clap::Parser;
+use std::ffi::OsStr;
 use std::path::PathBuf;
 
 /// Find all forc plugins available via `PATH`.
@@ -26,10 +27,12 @@ fn print_plugin(path: PathBuf, print_full_path: bool) {
     if print_full_path {
         println!("{}", path.display());
     } else {
-        if let Some(file_name) = path.file_name() {
-            println!("{}", file_name.to_str().unwrap());
-        } else {
-            println!("{}", path.display());
-        }
+        println!(
+            "{}",
+            path.file_name()
+                .unwrap_or_else(|| OsStr::new(""))
+                .to_str()
+                .unwrap()
+        );
     }
 }

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -12,10 +12,10 @@ pub use deploy::Command as DeployCommand;
 pub use init::Command as InitCommand;
 pub use json_abi::Command as JsonAbiCommand;
 use parse_bytecode::Command as ParseBytecodeCommand;
+pub use plugins::Command as PluginsCommand;
 pub use run::Command as RunCommand;
 use test::Command as TestCommand;
 pub use update::Command as UpdateCommand;
-pub use plugins::Command as PluginsCommand;
 
 mod commands;
 mod plugin;

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -15,7 +15,7 @@ use parse_bytecode::Command as ParseBytecodeCommand;
 pub use run::Command as RunCommand;
 use test::Command as TestCommand;
 pub use update::Command as UpdateCommand;
-use  plugins::Command as PluginsCommand;
+pub use plugins::Command as PluginsCommand;
 
 mod commands;
 mod plugin;

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -15,6 +15,7 @@ use parse_bytecode::Command as ParseBytecodeCommand;
 pub use run::Command as RunCommand;
 use test::Command as TestCommand;
 pub use update::Command as UpdateCommand;
+use  plugins::Command as PluginsCommand;
 
 mod commands;
 mod plugin;
@@ -44,10 +45,7 @@ enum Forc {
     Test(TestCommand),
     Update(UpdateCommand),
     JsonAbi(JsonAbiCommand),
-    /// Find all forc plugins available via `PATH`.
-    ///
-    /// Prints the absolute path to each discovered plugin on a new line.
-    Plugins,
+    Plugins(PluginsCommand),
     /// This is a catch-all for unknown subcommands and their arguments.
     ///
     /// When we receive an unknown subcommand, we check for a plugin exe named
@@ -70,7 +68,7 @@ pub async fn run_cli() -> Result<()> {
         Forc::Deploy(command) => deploy::exec(command).await,
         Forc::Init(command) => init::exec(command),
         Forc::ParseBytecode(command) => parse_bytecode::exec(command),
-        Forc::Plugins => plugins::exec(),
+        Forc::Plugins(command) => plugins::exec(command),
         Forc::Run(command) => run::exec(command).await,
         Forc::Test(command) => test::exec(command),
         Forc::Update(command) => update::exec(command).await,


### PR DESCRIPTION
Closes #1214

Extends `forc plugins` to emit file names only by default and with the option of adding `-v` or `--verbose` to print full paths.

@mitchmindtree i went ahead and inversed the behaviour you described in the issue, if this is undesirable I can change it.

