### PR TITLE
Check examples formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,16 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
+      - name: Install Forc
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc
+      - name: Build Sway Examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --bin build-all-examples
       - uses: actions-rs/cargo@v1
         name: Cargo Build Workspace
         with:
@@ -129,6 +139,16 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
+      - name: Install Forc
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc
+      - name: Build Sway Examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --bin build-all-examples
       - name: Check Clippy Linter
         uses: actions-rs/cargo@v1
         with:
@@ -207,6 +227,11 @@ jobs:
         with:
           command: install
           args: --debug --path ./forc
+      - name: Build Sway Examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --bin build-all-examples
       - name: Build All Tests
         run: cd test/src/sdk-harness && bash build.sh && cd ../../../
       - name: Cargo Test sway-lib-std
@@ -225,6 +250,16 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
+      - name: Install Forc
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc
+      - name: Build Sway Examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --bin build-all-examples
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -262,6 +297,16 @@ jobs:
           toolchain: nightly
           default: true
       - uses: Swatinem/rust-cache@v1
+      - name: Install Forc
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc
+      - name: Build Sway Examples
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --bin build-all-examples
       - name: Install cargo-udeps
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,16 +112,6 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
-      - name: Install Forc
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc
-      - name: Build Sway Examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --bin build-all-examples
       - uses: actions-rs/cargo@v1
         name: Cargo Build Workspace
         with:
@@ -139,16 +129,6 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
-      - name: Install Forc
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc
-      - name: Build Sway Examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --bin build-all-examples
       - name: Check Clippy Linter
         uses: actions-rs/cargo@v1
         with:
@@ -227,11 +207,6 @@ jobs:
         with:
           command: install
           args: --debug --path ./forc
-      - name: Build Sway Examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --bin build-all-examples
       - name: Build All Tests
         run: cd test/src/sdk-harness && bash build.sh && cd ../../../
       - name: Cargo Test sway-lib-std
@@ -250,16 +225,6 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
-      - name: Install Forc
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc
-      - name: Build Sway Examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --bin build-all-examples
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -297,16 +262,6 @@ jobs:
           toolchain: nightly
           default: true
       - uses: Swatinem/rust-cache@v1
-      - name: Install Forc
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc
-      - name: Build Sway Examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --bin build-all-examples
       - name: Install cargo-udeps
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,12 @@ jobs:
         with:
           command: install
           args: --debug --path ./forc
-      - name: Build Sway Examples
+      - name: Install Forc fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc-fmt
+      - name: Build Sway examples and check formatting
         uses: actions-rs/cargo@v1
         with:
           command: run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,12 @@ jobs:
         with:
           command: install
           args: --debug --path ./forc
-      - name: Build Sway Examples
+      - name: Install Forc fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc-fmt
+      - name: Build Sway examples and check formatting
         uses: actions-rs/cargo@v1
         with:
           command: run
@@ -144,7 +149,12 @@ jobs:
         with:
           command: install
           args: --debug --path ./forc
-      - name: Build Sway Examples
+      - name: Install Forc fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc-fmt
+      - name: Build Sway examples and check formatting
         uses: actions-rs/cargo@v1
         with:
           command: run
@@ -227,7 +237,12 @@ jobs:
         with:
           command: install
           args: --debug --path ./forc
-      - name: Build Sway Examples
+      - name: Install Forc fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc-fmt
+      - name: Build Sway examples and check formatting
         uses: actions-rs/cargo@v1
         with:
           command: run
@@ -255,7 +270,12 @@ jobs:
         with:
           command: install
           args: --debug --path ./forc
-      - name: Build Sway Examples
+      - name: Install Forc fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc-fmt
+      - name: Build Sway examples and check formatting
         uses: actions-rs/cargo@v1
         with:
           command: run
@@ -302,7 +322,12 @@ jobs:
         with:
           command: install
           args: --debug --path ./forc
-      - name: Build Sway Examples
+      - name: Install Forc fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc-fmt
+      - name: Build Sway examples and check formatting
         uses: actions-rs/cargo@v1
         with:
           command: run

--- a/examples/counter/src/main.sw
+++ b/examples/counter/src/main.sw
@@ -6,7 +6,7 @@ abi TestContract {
 }
 
 storage {
-    counter: u64
+    counter: u64,
 }
 
 impl TestContract for Contract {

--- a/examples/hello_world/src/main.sw
+++ b/examples/hello_world/src/main.sw
@@ -6,7 +6,7 @@ abi TestContract {
 }
 
 storage {
-    counter: u64
+    counter: u64,
 }
 
 impl TestContract for Contract {

--- a/examples/liquidity_pool/src/main.sw
+++ b/examples/liquidity_pool/src/main.sw
@@ -1,19 +1,6 @@
 contract;
 
-use std::{
-    address::Address,
-    assert::assert,
-    context::call_frames::{
-        contract_id,
-        msg_asset_id
-    },
-    context::msg_amount,
-    contract_id::ContractId,
-    token::{
-        mint_to_address,
-        transfer_to_output
-    }
-};
+use std::{address::Address, assert::assert, context::call_frames::{contract_id, msg_asset_id}, context::msg_amount, contract_id::ContractId, token::{mint_to_address, transfer_to_output}};
 
 abi LiquidityPool {
     fn deposit(recipient: Address);
@@ -45,4 +32,3 @@ impl LiquidityPool for Contract {
         transfer_to_output(amount_to_transfer, ~ContractId::from(BASE_TOKEN), recipient);
     }
 }
-

--- a/examples/msg_sender/src/main.sw
+++ b/examples/msg_sender/src/main.sw
@@ -1,18 +1,12 @@
 contract;
 
-use std::{
-    address::Address, 
-    assert::assert,
-    chain::auth::{AuthError, Sender, msg_sender}, 
-    panic::panic, 
-    result::*
-};
+use std::{address::Address, assert::assert, chain::auth::{AuthError, Sender, msg_sender}, panic::panic, result::*};
 
 abi MyOwnedContract {
     fn receive(field_1: u64) -> bool;
 }
 
-const OWNER:b256 = 0x9ae5b658754e096e4d681c548daf46354495a437cc61492599e33fc64dcdc30c;
+const OWNER: b256 = 0x9ae5b658754e096e4d681c548daf46354495a437cc61492599e33fc64dcdc30c;
 
 impl MyOwnedContract for Contract {
     fn receive(field_1: u64) -> bool {
@@ -26,4 +20,3 @@ impl MyOwnedContract for Contract {
         true
     }
 }
-

--- a/examples/native_token/src/main.sw
+++ b/examples/native_token/src/main.sw
@@ -1,12 +1,6 @@
 contract;
 
-use std::{
-    address::Address,
-    assert::assert,
-    context::*,
-    contract_id::ContractId,
-    token::*
-};
+use std::{address::Address, assert::assert, context::*, contract_id::ContractId, token::*};
 
 abi NativeAssetToken {
     fn mint_coins(mint_amount: u64);
@@ -60,4 +54,3 @@ impl NativeAssetToken for Contract {
         mint_to_address(amount, recipient);
     }
 }
-

--- a/examples/storage_example/src/main.sw
+++ b/examples/storage_example/src/main.sw
@@ -1,8 +1,6 @@
 contract;
 
-use std::{
-    storage::{get, store}
-};
+use std::storage::{get, store};
 
 abi StorageExample {
     fn store_something(amount: u64);

--- a/examples/subcurrency/src/main.sw
+++ b/examples/subcurrency/src/main.sw
@@ -1,15 +1,7 @@
 // ANCHOR: body
 contract;
 
-use std::{
-    address::Address, 
-    assert::assert, 
-    chain::auth::{AuthError, Sender, msg_sender}, 
-    hash::*, 
-    panic::panic, 
-    result::*, 
-    storage::{get, store}
-};
+use std::{address::Address, assert::assert, chain::auth::{AuthError, Sender, msg_sender}, hash::*, panic::panic, result::*, storage::{get, store}};
 
 ////////////////////////////////////////
 // Event declarations

--- a/examples/wallet_smart_contract/src/main.sw
+++ b/examples/wallet_smart_contract/src/main.sw
@@ -1,16 +1,6 @@
 contract;
 
-use std::{
-    address::Address, 
-    assert::assert, 
-    chain::auth::{AuthError, Sender, msg_sender}, 
-    constants::NATIVE_ASSET_ID, 
-    context::{call_frames::msg_asset_id, msg_amount}, 
-    contract_id::ContractId, 
-    panic::panic, 
-    result::*, 
-    token::transfer_to_output
-};
+use std::{address::Address, assert::assert, chain::auth::{AuthError, Sender, msg_sender}, constants::NATIVE_ASSET_ID, context::{call_frames::msg_asset_id, msg_amount}, contract_id::ContractId, panic::panic, result::*, token::transfer_to_output};
 
 const OWNER_ADDRESS: b256 = 0x8900c5bec4ca97d4febf9ceb4754a60d782abbf3cd815836c1872116f203f861;
 


### PR DESCRIPTION
Fixes #1376

Primary changes:

1. Add a `forc fmt --check` pass to `build-all-examples`. Maybe not the prettiest, but it's only used for CI anyways so :shrug:. Filed #1386 to clean up. ([414e5b8](https://github.com/FuelLabs/sway/pull/1384/commits/414e5b8d645b626501f138758fecbbeea0351dcc))
2. Format examples ([b25e41c](https://github.com/FuelLabs/sway/pull/1384/commits/b25e41cca994416158a86929d83dbbcef87868fd))
3. ~~For some reason `build-all-examples` was being run in a bunch of jobs?? Might have been because of copy-paste. ([8cbaaf1](https://github.com/FuelLabs/sway/pull/1384/commits/8cbaaf1c43ffbaeeffa41c4d8157341dcd48fdec))~~