### PR TITLE
Fix leading comma being inserted by formatter

### DIFF
--- a/sway-fmt/src/traversal_helper.rs
+++ b/sway-fmt/src/traversal_helper.rs
@@ -255,11 +255,15 @@ mod tests {
             "a::b::{c, d::e};"
         );
         assert_eq!(
+            sort_and_filter_use_expression("a::{foo,bar,};"),
+            "a::{bar, foo};"
+        );
+        assert_eq!(
             sort_and_filter_use_expression(
                 "a::{
-                foo,
-                bar,
-            };"
+    foo,
+    bar,
+};"
             ),
             "a::{bar, foo};"
         );

--- a/sway-fmt/src/traversal_helper.rs
+++ b/sway-fmt/src/traversal_helper.rs
@@ -102,7 +102,7 @@ fn sort_and_filter_use_expression(line: &str) -> String {
                     .chars()
                     .filter(|c| !c.is_whitespace())
                     .collect();
-                if to_push.len() > 0 {
+                if !to_push.is_empty() {
                     buffer.push(to_push);
                 }
             }

--- a/sway-fmt/src/traversal_helper.rs
+++ b/sway-fmt/src/traversal_helper.rs
@@ -94,7 +94,17 @@ fn sort_and_filter_use_expression(line: &str) -> String {
         let mut current = 0;
         for (index, separator) in line.match_indices(|c: char| c == ',' || c == '{' || c == '}') {
             if index != current {
-                buffer.push(line[current..index].to_string());
+                // Chomp all whitespace including newlines, and only push
+                // resulting token if what's left is not an empty string. This
+                // is needed to ignore trailing commas with newlines.
+                let to_push: String = line[current..index]
+                    .to_string()
+                    .chars()
+                    .filter(|c| !c.is_whitespace())
+                    .collect();
+                if to_push.len() > 0 {
+                    buffer.push(to_push);
+                }
             }
             buffer.push(separator.to_string());
             current = index + separator.len();

--- a/sway-fmt/src/traversal_helper.rs
+++ b/sway-fmt/src/traversal_helper.rs
@@ -254,5 +254,14 @@ mod tests {
             sort_and_filter_use_expression("a::b::{c,d::{e}};"),
             "a::b::{c, d::e};"
         );
+        assert_eq!(
+            sort_and_filter_use_expression(
+                "a::{
+                foo,
+                bar,
+            };"
+            ),
+            "a::{bar, foo};"
+        );
     }
 }


### PR DESCRIPTION
Fixes #1329

For `use` statements that spanned multiple lines, e.g.

```rust
use std::{
    option::*,
    result::*,
};
```

the whitespace following the last `,` was considered a token, i.e. something being imported. It happens to lexicographically precede letters, so this bug was manifesting as a leading `,` being inserted into the list of items being imported.

The proposed fix is to chomp the whitespace and avoid keeping around empty tokens in the tokenization logic.