### PR TITLE
Add the bitcast instruction to the IR.

### DIFF
--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -828,7 +828,9 @@ impl FnCompiler {
                 // Going with type for now.
                 let arg0_type = arg0.get_type(context).unwrap();
                 if arg0_type.is_copy_type() {
-                    arg0
+                    self.current_block
+                        .ins(context)
+                        .bitcast(arg0, Type::Uint(64), span_md_idx)
                 } else {
                     // Copy this value to a new location.  This is quite inefficient but we need to
                     // pass by reference rather than by value.  Optimisation passes can remove all
@@ -854,6 +856,7 @@ impl FnCompiler {
                     self.current_block.ins(context).store(arg0_ptr, arg0, None);
 
                     // NOTE: Here we're fetching the original stack pointer, cast to u64.
+                    // TODO: Instead of casting here, we should use an `ptrtoint` instruction.
                     self.current_block.ins(context).get_ptr(
                         by_reference_arg,
                         Type::Uint(64),

--- a/sway-core/tests/sway_to_ir/simple_contract_call.ir
+++ b/sway-core/tests/sway_to_ir/simple_contract_call.ir
@@ -7,62 +7,63 @@ script {
         local ptr { u64, b256 } s
 
         entry:
-        v0 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !1
-        v1 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !2
-        v2 = insert_value v0, { b256, u64, u64 }, v1, 0, !1
-        v3 = const u64 2559618804, !1
-        v4 = insert_value v2, { b256, u64, u64 }, v3, 1, !1
-        v5 = const u64 1111, !3
-        v6 = insert_value v4, { b256, u64, u64 }, v5, 2, !1
-        v7 = const u64 0, !4
-        v8 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !5
-        v9 = const u64 10000, !6
-        v10 = contract_call u64 get_u64 v6, v7, v8, v9, !1
-        v11 = get_ptr ptr u64 a, ptr u64, 0, !7
-        store v10, ptr v11, !7
-        v12 = get_ptr ptr b256 arg_for_get_b256, ptr b256, 0
-        v13 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333, !8
-        store v13, ptr v12
-        v14 = get_ptr ptr b256 arg_for_get_b256, ptr u64, 0, !9
-        v15 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !9
-        v16 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !10
-        v17 = insert_value v15, { b256, u64, u64 }, v16, 0, !9
-        v18 = const u64 1108491158, !9
-        v19 = insert_value v17, { b256, u64, u64 }, v18, 1, !9
-        v20 = insert_value v19, { b256, u64, u64 }, v14, 2, !9
-        v21 = const u64 0, !11
-        v22 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !12
-        v23 = const u64 20000, !13
-        v24 = contract_call b256 get_b256 v20, v21, v22, v23, !9
-        v25 = get_ptr ptr b256 b, ptr b256, 0, !14
-        store v24, ptr v25, !14
-        v26 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0, !15
-        v27 = const u64 5555, !16
-        v28 = insert_value v26, { u64, b256 }, v27, 0, !15
-        v29 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555, !17
-        v30 = insert_value v28, { u64, b256 }, v29, 1, !15
-        v31 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0, !15
-        v32 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !15
-        v33 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !18
-        v34 = insert_value v32, { b256, u64, u64 }, v33, 0, !15
-        v35 = const u64 4234334249, !15
-        v36 = insert_value v34, { b256, u64, u64 }, v35, 1, !15
-        v37 = insert_value v36, { b256, u64, u64 }, v31, 2, !15
-        v38 = read_register cgas, !15
-        v39 = const u64 0, !19
-        v40 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !20
-        v41 = contract_call { u64, b256 } get_s v37, v39, v40, v38, !15
-        v42 = get_ptr ptr { u64, b256 } s, ptr { u64, b256 }, 0, !21
-        store v41, ptr v42, !21
-        v43 = const u64 0, !22
-        ret u64 v43
+        v0 = const u64 1111, !1
+        v1 = bitcast v0 to u64, !2
+        v2 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !2
+        v3 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !3
+        v4 = insert_value v2, { b256, u64, u64 }, v3, 0, !2
+        v5 = const u64 2559618804, !2
+        v6 = insert_value v4, { b256, u64, u64 }, v5, 1, !2
+        v7 = insert_value v6, { b256, u64, u64 }, v1, 2, !2
+        v8 = const u64 0, !4
+        v9 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !5
+        v10 = const u64 10000, !6
+        v11 = contract_call u64 get_u64 v7, v8, v9, v10, !2
+        v12 = get_ptr ptr u64 a, ptr u64, 0, !7
+        store v11, ptr v12, !7
+        v13 = get_ptr ptr b256 arg_for_get_b256, ptr b256, 0
+        v14 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333, !8
+        store v14, ptr v13
+        v15 = get_ptr ptr b256 arg_for_get_b256, ptr u64, 0, !9
+        v16 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !9
+        v17 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !10
+        v18 = insert_value v16, { b256, u64, u64 }, v17, 0, !9
+        v19 = const u64 1108491158, !9
+        v20 = insert_value v18, { b256, u64, u64 }, v19, 1, !9
+        v21 = insert_value v20, { b256, u64, u64 }, v15, 2, !9
+        v22 = const u64 0, !11
+        v23 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !12
+        v24 = const u64 20000, !13
+        v25 = contract_call b256 get_b256 v21, v22, v23, v24, !9
+        v26 = get_ptr ptr b256 b, ptr b256, 0, !14
+        store v25, ptr v26, !14
+        v27 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0, !15
+        v28 = const u64 5555, !16
+        v29 = insert_value v27, { u64, b256 }, v28, 0, !15
+        v30 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555, !17
+        v31 = insert_value v29, { u64, b256 }, v30, 1, !15
+        v32 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0, !15
+        v33 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !15
+        v34 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !18
+        v35 = insert_value v33, { b256, u64, u64 }, v34, 0, !15
+        v36 = const u64 4234334249, !15
+        v37 = insert_value v35, { b256, u64, u64 }, v36, 1, !15
+        v38 = insert_value v37, { b256, u64, u64 }, v32, 2, !15
+        v39 = read_register cgas, !15
+        v40 = const u64 0, !19
+        v41 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !20
+        v42 = contract_call { u64, b256 } get_s v38, v40, v41, v39, !15
+        v43 = get_ptr ptr { u64, b256 } s, ptr { u64, b256 }, 0, !21
+        store v42, ptr v43, !21
+        v44 = const u64 0, !22
+        ret u64 v44
     }
 }
 
 !0 = filepath "/path/to/simple_contract_call.sw"
-!1 = span !0 301 458
-!2 = span !0 0 66
-!3 = span !0 453 457
+!1 = span !0 453 457
+!2 = span !0 301 458
+!3 = span !0 0 66
 !4 = span !0 333 334
 !5 = span !0 354 420
 !6 = span !0 435 440

--- a/sway-ir/src/error.rs
+++ b/sway-ir/src/error.rs
@@ -20,6 +20,10 @@ pub enum IrError {
     VerifyAccessValueInvalidIndices,
     VerifyAccessValueOnNonStruct,
     VerifyArgumentValueIsNotArgument(String),
+    VerifyBitcastUnknownSourceType,
+    VerifyBitcastFromNonCopyType(String),
+    VerifyBitcastToNonCopyType(String),
+    VerifyBitcastBetweenInvalidTypes(String, String),
     VerifyBranchToMissingBlock(String),
     VerifyCallArgTypeMismatch(String),
     VerifyCallToMissingFunction(String),
@@ -107,6 +111,22 @@ impl fmt::Display for IrError {
             IrError::VerifyArgumentValueIsNotArgument(callee) => write!(
                 f,
                 "Verification failed: Argument specifier for function '{callee}' is not an argument value."
+            ),
+            IrError::VerifyBitcastUnknownSourceType => write!(
+                f,
+                "Verification failed: Bitcast unable to determine source type."
+            ),
+            IrError::VerifyBitcastFromNonCopyType(ty) => write!(
+                f,
+                "Verification failed: Bitcast cannot be from a {ty}."
+            ),
+            IrError::VerifyBitcastToNonCopyType(ty) => write!(
+                f,
+                "Verification failed: Bitcast cannot be to a {ty}."
+            ),
+            IrError::VerifyBitcastBetweenInvalidTypes(from_ty, to_ty) => write!(
+                f,
+                "Verification failed: Bitcast not allowed from a {from_ty} to a {to_ty}."
             ),
             IrError::VerifyBranchToMissingBlock(label) => {
                 write!(

--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -212,6 +212,11 @@ fn inline_instruction(
                     .ins(context)
                     .asm_block_from_asm(asm, new_args, span_md_idx)
             }
+            Instruction::BitCast(value, ty) => {
+                new_block
+                    .ins(context)
+                    .bitcast(map_value(value), ty, span_md_idx)
+            }
             // For `br` and `cbr` below we don't need to worry about the phi values, they're
             // adjusted later in `inline_function_call()`.
             Instruction::Branch(b) => {

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -295,6 +295,16 @@ fn instruction_to_doc<'a>(
             Instruction::AsmBlock(asm, args) => {
                 asm_block_to_doc(context, md_namer, namer, ins_value, asm, args, span_md_idx)
             }
+            Instruction::BitCast(value, ty) => maybe_constant_to_doc(
+                context, md_namer, namer, value,
+            )
+            .append(Doc::text_line(format!(
+                "{} = bitcast {} to {}{}",
+                namer.name(context, ins_value),
+                namer.name(context, value),
+                ty.as_string(context),
+                md_namer.meta_as_string(context, span_md_idx, true)
+            ))),
             Instruction::Branch(to_block) => maybe_constant_phi_to_doc(
                 context, md_namer, namer, block, to_block,
             )

--- a/sway-ir/tests/ir_to_ir/constants_contract_calls.in_ir
+++ b/sway-ir/tests/ir_to_ir/constants_contract_calls.in_ir
@@ -1,64 +1,61 @@
 script {
     fn main() -> u64 {
         local ptr u64 a
-        local mut ptr { b256 } args_struct_for_get_b256
+        local ptr b256 arg_for_get_b256
         local mut ptr { u64, b256 } args_struct_for_get_s
-        local mut ptr { u64 } args_struct_for_get_u64
         local ptr b256 b
         local ptr { u64, b256 } s
 
         entry:
-        v0 = get_ptr mut ptr { u64 } args_struct_for_get_u64, ptr { u64 }, 0
-        v1 = const u64 1111
-        v2 = insert_value v0, { u64 }, v1, 0
-        v3 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
-        v4 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
-        v5 = insert_value v3, { b256, u64, u64 }, v4, 0
-        v6 = const u64 2559618804
-        v7 = insert_value v5, { b256, u64, u64 }, v6, 1
-        v8 = get_ptr mut ptr { u64 } args_struct_for_get_u64, ptr u64, 0
-        v9 = insert_value v7, { b256, u64, u64 }, v8, 2
-        v10 = const u64 0
-        v11 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
-        v12 = const u64 10000
-        v13 = contract_call u64 get_u64 v9, v10, v11, v12
-        v14 = get_ptr ptr u64 a, ptr u64, 0
-        store v13, ptr v14
-        v15 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr { b256 }, 0
-        v16 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333
-        v17 = insert_value v15, { b256 }, v16, 0
-        v18 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
-        v19 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
-        v20 = insert_value v18, { b256, u64, u64 }, v19, 0
-        v21 = const u64 1108491158
-        v22 = insert_value v20, { b256, u64, u64 }, v21, 1
-        v23 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr u64, 0
-        v24 = insert_value v22, { b256, u64, u64 }, v23, 2
-        v25 = const u64 0
-        v26 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
-        v27 = const u64 20000
-        v28 = contract_call b256 get_b256 v24, v25, v26, v27
-        v29 = get_ptr ptr b256 b, ptr b256, 0
-        store v28, ptr v29
-        v30 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0
-        v31 = const u64 5555
-        v32 = insert_value v30, { u64, b256 }, v31, 0
-        v33 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555
-        v34 = insert_value v32, { u64, b256 }, v33, 1
-        v35 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
-        v36 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
-        v37 = insert_value v35, { b256, u64, u64 }, v36, 0
-        v38 = const u64 4234334249
-        v39 = insert_value v37, { b256, u64, u64 }, v38, 1
-        v40 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0
-        v41 = insert_value v39, { b256, u64, u64 }, v40, 2
-        v42 = read_register cgas
-        v43 = const u64 0
-        v44 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
-        v45 = contract_call { u64, b256 } get_s v41, v43, v44, v42
-        v46 = get_ptr ptr { u64, b256 } s, ptr { u64, b256 }, 0
-        store v45, ptr v46
-        v47 = const u64 0
-        ret u64 v47
+        v0 = const u64 1111
+        v1 = bitcast v0 to u64
+        v2 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
+        v3 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
+        v4 = insert_value v2, { b256, u64, u64 }, v3, 0
+        v5 = const u64 2559618804
+        v6 = insert_value v4, { b256, u64, u64 }, v5, 1
+        v7 = insert_value v6, { b256, u64, u64 }, v1, 2
+        v8 = const u64 0
+        v9 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
+        v10 = const u64 10000
+        v11 = contract_call u64 get_u64 v7, v8, v9, v10
+        v12 = get_ptr ptr u64 a, ptr u64, 0
+        store v11, ptr v12
+        v13 = get_ptr ptr b256 arg_for_get_b256, ptr b256, 0
+        v14 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333
+        store v14, ptr v13
+        v15 = get_ptr ptr b256 arg_for_get_b256, ptr u64, 0
+        v16 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
+        v17 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
+        v18 = insert_value v16, { b256, u64, u64 }, v17, 0
+        v19 = const u64 1108491158
+        v20 = insert_value v18, { b256, u64, u64 }, v19, 1
+        v21 = insert_value v20, { b256, u64, u64 }, v15, 2
+        v22 = const u64 0
+        v23 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
+        v24 = const u64 20000
+        v25 = contract_call b256 get_b256 v21, v22, v23, v24
+        v26 = get_ptr ptr b256 b, ptr b256, 0
+        store v25, ptr v26
+        v27 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0
+        v28 = const u64 5555
+        v29 = insert_value v27, { u64, b256 }, v28, 0
+        v30 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555
+        v31 = insert_value v29, { u64, b256 }, v30, 1
+        v32 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0
+        v33 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }
+        v34 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
+        v35 = insert_value v33, { b256, u64, u64 }, v34, 0
+        v36 = const u64 4234334249
+        v37 = insert_value v35, { b256, u64, u64 }, v36, 1
+        v38 = insert_value v37, { b256, u64, u64 }, v32, 2
+        v39 = read_register cgas
+        v40 = const u64 0
+        v41 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
+        v42 = contract_call { u64, b256 } get_s v38, v40, v41, v39
+        v43 = get_ptr ptr { u64, b256 } s, ptr { u64, b256 }, 0
+        store v42, ptr v43
+        v44 = const u64 0
+        ret u64 v44
     }
 }

--- a/sway-ir/tests/ir_to_ir/constants_contract_calls.out_ir
+++ b/sway-ir/tests/ir_to_ir/constants_contract_calls.out_ir
@@ -1,52 +1,49 @@
 script {
     fn main() -> u64 {
         local ptr u64 a
-        local mut ptr { b256 } args_struct_for_get_b256
+        local ptr b256 arg_for_get_b256
         local mut ptr { u64, b256 } args_struct_for_get_s
-        local mut ptr { u64 } args_struct_for_get_u64
         local ptr b256 b
         local ptr { u64, b256 } s
 
         entry:
-        v0 = get_ptr mut ptr { u64 } args_struct_for_get_u64, ptr { u64 }, 0
-        v1 = const u64 1111
-        v2 = insert_value v0, { u64 }, v1, 0
-        v3 = get_ptr mut ptr { u64 } args_struct_for_get_u64, ptr u64, 0
-        v4 = const { b256, u64, u64 } { b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, u64 2559618804, u64 undef }
-        v5 = insert_value v4, { b256, u64, u64 }, v3, 2
-        v6 = const u64 0
-        v7 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
-        v8 = const u64 10000
-        v9 = contract_call u64 get_u64 v5, v6, v7, v8
-        v10 = get_ptr ptr u64 a, ptr u64, 0
-        store v9, ptr v10
-        v11 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr { b256 }, 0
-        v12 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333
-        v13 = insert_value v11, { b256 }, v12, 0
-        v14 = get_ptr mut ptr { b256 } args_struct_for_get_b256, ptr u64, 0
-        v15 = const { b256, u64, u64 } { b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, u64 1108491158, u64 undef }
-        v16 = insert_value v15, { b256, u64, u64 }, v14, 2
-        v17 = const u64 0
-        v18 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
-        v19 = const u64 20000
-        v20 = contract_call b256 get_b256 v16, v17, v18, v19
-        v21 = get_ptr ptr b256 b, ptr b256, 0
-        store v20, ptr v21
-        v22 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0
-        v23 = const u64 5555
-        v24 = insert_value v22, { u64, b256 }, v23, 0
-        v25 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555
-        v26 = insert_value v24, { u64, b256 }, v25, 1
-        v27 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0
-        v28 = const { b256, u64, u64 } { b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, u64 4234334249, u64 undef }
-        v29 = insert_value v28, { b256, u64, u64 }, v27, 2
-        v30 = read_register cgas
-        v31 = const u64 0
-        v32 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
-        v33 = contract_call { u64, b256 } get_s v29, v31, v32, v30
-        v34 = get_ptr ptr { u64, b256 } s, ptr { u64, b256 }, 0
-        store v33, ptr v34
-        v35 = const u64 0
-        ret u64 v35
+        v0 = const u64 1111
+        v1 = bitcast v0 to u64
+        v2 = const { b256, u64, u64 } { b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, u64 2559618804, u64 undef }
+        v3 = insert_value v2, { b256, u64, u64 }, v1, 2
+        v4 = const u64 0
+        v5 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
+        v6 = const u64 10000
+        v7 = contract_call u64 get_u64 v3, v4, v5, v6
+        v8 = get_ptr ptr u64 a, ptr u64, 0
+        store v7, ptr v8
+        v9 = get_ptr ptr b256 arg_for_get_b256, ptr b256, 0
+        v10 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333
+        store v10, ptr v9
+        v11 = get_ptr ptr b256 arg_for_get_b256, ptr u64, 0
+        v12 = const { b256, u64, u64 } { b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, u64 1108491158, u64 undef }
+        v13 = insert_value v12, { b256, u64, u64 }, v11, 2
+        v14 = const u64 0
+        v15 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
+        v16 = const u64 20000
+        v17 = contract_call b256 get_b256 v13, v14, v15, v16
+        v18 = get_ptr ptr b256 b, ptr b256, 0
+        store v17, ptr v18
+        v19 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0
+        v20 = const u64 5555
+        v21 = insert_value v19, { u64, b256 }, v20, 0
+        v22 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555
+        v23 = insert_value v21, { u64, b256 }, v22, 1
+        v24 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0
+        v25 = const { b256, u64, u64 } { b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, u64 4234334249, u64 undef }
+        v26 = insert_value v25, { b256, u64, u64 }, v24, 2
+        v27 = read_register cgas
+        v28 = const u64 0
+        v29 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
+        v30 = contract_call { u64, b256 } get_s v26, v28, v29, v27
+        v31 = get_ptr ptr { u64, b256 } s, ptr { u64, b256 }, 0
+        store v30, ptr v31
+        v32 = const u64 0
+        ret u64 v32
     }
 }


### PR DESCRIPTION
Needed for contract calls, where the user args need to be a `u64` but could be provided as any copy type.

Closes #1335 which is blocking @digorithm

The test are minimal -- just updating those which make a contract call with a single immedate arg as it will now use a `bitcast` to ensure it's a `u64`.

Strictly speaking a `bitcast` shouldn't change the value, only its type.  In the ASMgen though if the dest type is `bool` I'm ensuring it's a 1 or 0.  This might be overkill.

A progression of this PR is to introduce `ptr_to_int` and possibly `int_to_ptr` instructions.