### PR TITLE
specify local dep for `asm_return_tuple_pointer` to prevent pulling in git dep

### DIFF
--- a/examples/asm_return_tuple_pointer/Forc.lock
+++ b/examples/asm_return_tuple_pointer/Forc.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = 'asm_return_tuple_pointer'
-dependencies = ['std git+https://github.com/fuellabs/sway?tag=v0.10.3#e7676db6f4ebc7a3885f87514d16a703a99410d7']
+dependencies = ['std']
 
 [[package]]
 name = 'core'
@@ -8,5 +8,4 @@ dependencies = []
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.10.3#e7676db6f4ebc7a3885f87514d16a703a99410d7'
 dependencies = ['core']

--- a/examples/asm_return_tuple_pointer/Forc.toml
+++ b/examples/asm_return_tuple_pointer/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "asm_return_tuple_pointer"
 
 [dependencies]
+std = { path = "../../sway-lib-std" }


### PR DESCRIPTION
This is blocking #1402  -- we need to specify this locally so it doesn't implicitly pull the libraries from `git`. 