### PR TITLE
Add build-forc-test-project to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,6 +464,7 @@ jobs:
   build-publish-master-image:
     needs:
       [
+        build-forc-test-project,
         build-sway-examples,
         build-sway-lib-core,
         build-sway-lib-std,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,7 @@ jobs:
   notify-slack-on-failure:
     needs:
       [
+        build-forc-test-project,
         build-sway-examples,
         build-sway-lib-core,
         build-sway-lib-std,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Build test project
         run: forc build --path test-proj
       - name: Run test project's test suite
-        run: furc test --path test-proj
+        run: forc test --path test-proj
 
   cargo-build-workspace:
     needs: cancel-previous-runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Build test project
         run: forc build --path test-proj
       - name: Run test project's test suite
-        run: forc test --path test-proj
+        run: cd test-proj && forc test
 
   cargo-build-workspace:
     needs: cancel-previous-runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,7 @@ jobs:
     # Only do this job if publishing a release
     needs:
       [
+        build-forc-test-project,
         build-sway-examples,
         build-sway-lib-core,
         build-sway-lib-std,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,33 @@ jobs:
             rm tmp.txt && exit 0
           fi
 
+  build-forc-test-project:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Install Forc
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc
+      - name: Install Forc fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc-fmt
+      - name: Initialize test project
+        run: forc init test-proj
+      - name: Build test project
+        run: forc build --path test-proj
+      - name: Run test project's test suite
+        run: furc test --path test-proj
+
   cargo-build-workspace:
     needs: cancel-previous-runs
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
- This PR adds a `build-forc-test-project` CI job that simply builds, formats, and tests a new forc project to ensure basic commands aren't broken

### Testing steps
- [ ] Added `build-forc-test-project` CI job should pass