### PR TITLE
Update the `Forc.lock` files for the `should_fail` E2E tests.

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_oob/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_oob/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
 name = 'array_oob'
-dependencies = ['core']
-
-[[package]]
-name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/asm_missing_return/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/asm_missing_return/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
 name = 'asm_missing_return'
-dependencies = ['core']
-
-[[package]]
-name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/asm_should_not_have_return/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/asm_should_not_have_return/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
 name = 'asm_should_not_have_return'
-dependencies = ['core']
-
-[[package]]
-name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_annotation/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_annotation/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
 name = 'bad_generic_annotation'
-dependencies = ['core']
-
-[[package]]
-name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_var_annotation/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_var_annotation/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
 name = 'bad_generic_var_annotation'
-dependencies = ['core']
-
-[[package]]
-name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
 name = 'chained_if_let_missing_branch'
-dependencies = ['core']
-
-[[package]]
-name = 'core'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/contract_pure_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/contract_pure_calls_impure/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'valid_impurity'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/dependency_parsing_error/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/dependency_parsing_error/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'dependencies_parsing_error'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/different_contract_caller_types/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/different_contract_caller_types/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'different_contract_caller_types'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/disallow_turbofish/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/disallow_turbofish/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'disallow_turbofish'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/disallowed_gm/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/disallowed_gm/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'disallowed_opcodes'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/empty_impl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/empty_impl/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'empty_impl'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/enum_if_let_invalid_variable/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/enum_if_let_invalid_variable/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'enum_if_let_invalid_variable'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'excess_fn_arguments'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_shadows_generic/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_shadows_generic/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'generic_shadows_generic'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generics_unhelpful_error/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generics_unhelpful_error/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'generics_unhelpful_error'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/item_used_without_import/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/item_used_without_import/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'item_used_without_import'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/literal_too_large_for_type/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/literal_too_large_for_type/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'literal_too_large_for_type'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_enums/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_enums/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'match_expressions_enums'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'match_expressions_non_exhaustive'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_wrong_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_wrong_struct/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'match_expressions_wrong_struct'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'missing_fn_arguments'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_func_from_supertrait_impl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_func_from_supertrait_impl/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'missing_func_from_supertrait_impl'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_supertrait_impl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_supertrait_impl/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'missing_supertrait_impl'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/name_shadowing/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/name_shadowing/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'name_shadowing'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/nested_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/nested_impure/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'nested_impure'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_calls_impure/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'script_calls_impure'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/pure_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/pure_calls_impure/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'pure_calls_impure'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'recursive_calls'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/script_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/script_calls_impure/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'script_calls_impure'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'shadow_import'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'star_import_alias'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'supertrait_does_not_exist'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/top_level_vars/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/top_level_vars/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'top_level_vars'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unify_identical_unknowns/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unify_identical_unknowns/Forc.lock
@@ -1,7 +1,3 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'unify_identical_unknowns'
-dependencies = ['core']
+dependencies = []


### PR DESCRIPTION
They were accidentally left uncommitted after the switch from an explicit `core` dependency to `implicit-std = false`.