### PR TITLE
Parse patterns in function parameter position

### DIFF
--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -17,11 +17,11 @@ use {
     std::{convert::TryFrom, iter, mem::MaybeUninit, ops::ControlFlow},
     sway_parse::{
         AbiCastArgs, AngleBrackets, AsmBlock, Assignable, Braces, CodeBlockContents, Dependency,
-        DoubleColonToken, Expr, ExprArrayDescriptor, ExprStructField, ExprTupleDescriptor, FnArgs,
-        FnSignature, GenericArgs, GenericParams, IfCondition, IfExpr, ImpureToken, Instruction,
-        Item, ItemAbi, ItemConst, ItemEnum, ItemFn, ItemImpl, ItemStorage, ItemStruct, ItemTrait,
-        ItemUse, LitInt, LitIntType, MatchBranchKind, PathExpr, PathExprSegment, PathType,
-        PathTypeSegment, Pattern, PatternStructField, Program, ProgramKind, PubToken,
+        DoubleColonToken, Expr, ExprArrayDescriptor, ExprStructField, ExprTupleDescriptor, FnArg,
+        FnArgs, FnSignature, GenericArgs, GenericParams, IfCondition, IfExpr, ImpureToken,
+        Instruction, Item, ItemAbi, ItemConst, ItemEnum, ItemFn, ItemImpl, ItemStorage, ItemStruct,
+        ItemTrait, ItemUse, LitInt, LitIntType, MatchBranchKind, PathExpr, PathExprSegment,
+        PathType, PathTypeSegment, Pattern, PatternStructField, Program, ProgramKind, PubToken,
         QualifiedPathRoot, Statement, StatementLet, Traits, Ty, TypeField, UseTree,
     },
     sway_types::{Ident, Span},
@@ -155,6 +155,8 @@ pub enum ConvertParseTreeError {
     StructPatternsNotSupportedHere { span: Span },
     #[error("wildcard patterns not supported in this position")]
     WildcardPatternsNotSupportedHere { span: Span },
+    #[error("tuple patterns not supported in this position")]
+    TuplePatternsNotSupportedHere { span: Span },
     #[error("constructor patterns require a single argument")]
     ConstructorPatternOneArg { span: Span },
     #[error("mutable bindings are not supported in this position")]
@@ -208,6 +210,7 @@ impl ConvertParseTreeError {
             ConvertParseTreeError::ConstructorPatternsNotSupportedHere { span } => span,
             ConvertParseTreeError::StructPatternsNotSupportedHere { span } => span,
             ConvertParseTreeError::WildcardPatternsNotSupportedHere { span } => span,
+            ConvertParseTreeError::TuplePatternsNotSupportedHere { span } => span,
             ConvertParseTreeError::ConstructorPatternOneArg { span } => span,
             ConvertParseTreeError::MutableBindingsNotSupportedHere { span } => span,
             ConvertParseTreeError::ConstructorPatternSubPatterns { span } => span,
@@ -723,7 +726,7 @@ fn fn_args_to_function_parameters(
     let function_parameters = match fn_args {
         FnArgs::Static(args) => args
             .into_iter()
-            .map(|type_field| type_field_to_function_parameter(ec, type_field))
+            .map(|fn_arg| fn_arg_to_function_parameter(ec, fn_arg))
             .collect::<Result<_, _>>()?,
         FnArgs::NonStatic {
             self_token,
@@ -736,7 +739,7 @@ fn fn_args_to_function_parameters(
             }];
             if let Some((_comma_token, args)) = args_opt {
                 for arg in args {
-                    let function_parameter = type_field_to_function_parameter(ec, arg)?;
+                    let function_parameter = fn_arg_to_function_parameter(ec, arg)?;
                     function_parameters.push(function_parameter);
                 }
             }
@@ -1525,14 +1528,51 @@ fn statement_to_ast_nodes(
     Ok(ast_nodes)
 }
 
-fn type_field_to_function_parameter(
+fn fn_arg_to_function_parameter(
     ec: &mut ErrorContext,
-    type_field: TypeField,
+    fn_arg: FnArg,
 ) -> Result<FunctionParameter, ErrorEmitted> {
-    let type_span = type_field.ty.span();
+    let type_span = fn_arg.ty.span();
+    let pat_span = fn_arg.pattern.span();
+    let name = match fn_arg.pattern {
+        Pattern::Wildcard { .. } => {
+            let error = ConvertParseTreeError::WildcardPatternsNotSupportedHere { span: pat_span };
+            return Err(ec.error(error));
+        }
+        Pattern::Var { mutable, name } => {
+            if let Some(mut_token) = mutable {
+                let error = ConvertParseTreeError::MutableBindingsNotSupportedHere {
+                    span: mut_token.span(),
+                };
+                return Err(ec.error(error));
+            }
+            name
+        }
+        Pattern::Literal(..) => {
+            let error = ConvertParseTreeError::LiteralPatternsNotSupportedHere { span: pat_span };
+            return Err(ec.error(error));
+        }
+        Pattern::Constant(..) => {
+            let error = ConvertParseTreeError::ConstantPatternsNotSupportedHere { span: pat_span };
+            return Err(ec.error(error));
+        }
+        Pattern::Constructor { .. } => {
+            let error =
+                ConvertParseTreeError::ConstructorPatternsNotSupportedHere { span: pat_span };
+            return Err(ec.error(error));
+        }
+        Pattern::Struct { .. } => {
+            let error = ConvertParseTreeError::StructPatternsNotSupportedHere { span: pat_span };
+            return Err(ec.error(error));
+        }
+        Pattern::Tuple(..) => {
+            let error = ConvertParseTreeError::TuplePatternsNotSupportedHere { span: pat_span };
+            return Err(ec.error(error));
+        }
+    };
     let function_parameter = FunctionParameter {
-        name: type_field.name,
-        type_id: insert_type(ty_to_type_info(ec, type_field.ty)?),
+        name,
+        type_id: insert_type(ty_to_type_info(ec, fn_arg.ty)?),
         type_span,
     };
     Ok(function_parameter)

--- a/sway-parse/src/item/mod.rs
+++ b/sway-parse/src/item/mod.rs
@@ -118,11 +118,24 @@ impl Parse for TypeField {
 
 #[derive(Clone, Debug)]
 pub enum FnArgs {
-    Static(Punctuated<TypeField, CommaToken>),
+    Static(Punctuated<FnArg, CommaToken>),
     NonStatic {
         self_token: SelfToken,
-        args_opt: Option<(CommaToken, Punctuated<TypeField, CommaToken>)>,
+        args_opt: Option<(CommaToken, Punctuated<FnArg, CommaToken>)>,
     },
+}
+
+#[derive(Clone, Debug)]
+pub struct FnArg {
+    pub pattern: Pattern,
+    pub colon_token: ColonToken,
+    pub ty: Ty,
+}
+
+impl FnArg {
+    pub fn span(&self) -> Span {
+        Span::join(self.pattern.span(), self.ty.span())
+    }
 }
 
 impl ParseToEnd for FnArgs {
@@ -159,6 +172,19 @@ impl ParseToEnd for FnArgs {
                 Ok((fn_args, consumed))
             }
         }
+    }
+}
+
+impl Parse for FnArg {
+    fn parse(parser: &mut Parser) -> ParseResult<FnArg> {
+        let pattern = parser.parse()?;
+        let colon_token = parser.parse()?;
+        let ty = parser.parse()?;
+        Ok(FnArg {
+            pattern,
+            colon_token,
+            ty,
+        })
     }
 }
 

--- a/sway-parse/src/lib.rs
+++ b/sway-parse/src/lib.rs
@@ -41,7 +41,7 @@ pub use crate::{
         item_struct::ItemStruct,
         item_trait::{ItemTrait, Traits},
         item_use::{ItemUse, UseTree},
-        FnArgs, FnSignature, Item, TypeField,
+        FnArg, FnArgs, FnSignature, Item, TypeField,
     },
     keywords::{DoubleColonToken, ImpureToken, PubToken},
     literal::{LitInt, LitIntType, Literal},


### PR DESCRIPTION
This is the first step toward fixing #1188. The new parser now parses function arguments as patterns rather than idents, allowing them to be `mut`. This still isn't handled in the lower layers of the compiler though.