### PR TITLE
Add forc --list

### DIFF
--- a/docs/src/forc/commands/forc_list.md
+++ b/docs/src/forc/commands/forc_list.md
@@ -1,0 +1,8 @@
+# forc-list
+List all forc plugins available via `PATH`
+
+Prints information about each discovered plugin.
+
+
+## USAGE:
+forc list

--- a/forc/src/cli/commands/list.rs
+++ b/forc/src/cli/commands/list.rs
@@ -1,0 +1,30 @@
+use crate::cli::ListCommand;
+use crate::utils::plugin_descriptions::plugin_description;
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+
+#[derive(Debug, Parser)]
+pub struct Command {}
+
+pub(crate) fn exec(command: ListCommand) -> Result<()> {
+    let ListCommand {} = command;
+
+    for path in crate::cli::plugin::find_all() {
+        print_plugin_and_description(path);
+    }
+    Ok(())
+}
+
+fn print_plugin_and_description(path: PathBuf) {
+    let plugin_name = path
+        .file_name()
+        .expect("Failed to read file name")
+        .to_str()
+        .expect("Failed to print file name");
+
+    let description = plugin_description(plugin_name);
+
+    println!("{}\t\t{}", plugin_name, description);
+}

--- a/forc/src/cli/commands/mod.rs
+++ b/forc/src/cli/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod completions;
 pub mod deploy;
 pub mod init;
 pub mod json_abi;
+pub mod list;
 pub mod parse_bytecode;
 pub mod plugins;
 pub mod run;

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -1,6 +1,6 @@
 use self::commands::{
-    addr2line, build, clean, completions, deploy, init, json_abi, parse_bytecode, plugins, run,
-    test, update,
+    addr2line, build, clean, completions, deploy, init, json_abi, list, parse_bytecode, plugins,
+    run, test, update,
 };
 use addr2line::Command as Addr2LineCommand;
 use anyhow::{anyhow, Result};
@@ -11,6 +11,7 @@ pub use completions::Command as CompletionsCommand;
 pub use deploy::Command as DeployCommand;
 pub use init::Command as InitCommand;
 pub use json_abi::Command as JsonAbiCommand;
+pub use list::Command as ListCommand;
 use parse_bytecode::Command as ParseBytecodeCommand;
 pub use plugins::Command as PluginsCommand;
 pub use run::Command as RunCommand;
@@ -56,6 +57,7 @@ enum Forc {
     /// ```
     #[clap(external_subcommand)]
     Plugin(Vec<String>),
+    List(ListCommand),
 }
 
 pub async fn run_cli() -> Result<()> {
@@ -81,5 +83,6 @@ pub async fn run_cli() -> Result<()> {
                 .ok_or_else(|| anyhow!("plugin exit status unknown"))?;
             std::process::exit(code);
         }
+        Forc::List(command) => list::exec(command),
     }
 }

--- a/forc/src/utils/mod.rs
+++ b/forc/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod defaults;
 pub mod parameters;
+pub mod plugin_descriptions;
 pub mod program_type;
 
 /// The `forc` crate version formatted with the `v` prefix. E.g. "v1.2.3".

--- a/forc/src/utils/plugin_descriptions.rs
+++ b/forc/src/utils/plugin_descriptions.rs
@@ -1,0 +1,27 @@
+pub enum Plugin {
+    ForcFormat,
+    ForcLsp,
+    ForcExplore,
+    None,
+}
+
+pub fn plugin_name_to_enum(n: &str) -> Plugin {
+    match n {
+        "forc-fmt" => Plugin::ForcFormat,
+        "forc-explore" => Plugin::ForcExplore,
+        "forc-lsp" => Plugin::ForcLsp,
+        _ => Plugin::None,
+    }
+}
+
+pub fn plugin_description(n: &str) -> String {
+    let e = plugin_name_to_enum(n);
+    match e {
+        Plugin::ForcFormat => "Forc plugin for running the Sway code formatter.".to_string(),
+        Plugin::ForcLsp => {
+            "Forc plugin for the Sway LSP (Language Server Protocol) implementation".to_string()
+        }
+        Plugin::ForcExplore => "Forc plugin for running the Fuel Block Explorer.".to_string(),
+        Plugin::None => "Unidentified plugin".to_string(),
+    }
+}


### PR DESCRIPTION
### Description

This PR adds `forc --list` which should be similar to `cargo --list`

### Testing steps
- [ ] Run `forc --list` and you should see a list and description  of all installed forc plugins