### PR TITLE
.in_ir and .out_ir are no longer used in the `sway-ir` unit tests.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,3 @@
 
 # Syntax highlighting of ir files as LLVM
 *.ir linguist-language=LLVM
-*.in_ir linguist-language=LLVM
-*.out_ir linguist-language=LLVM


### PR DESCRIPTION
They no longer need to be tagged as IR for Linguist.

Closes #1206.