### PR TITLE
Temporarily remove rename capabilities from language server

### DIFF
--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -66,12 +66,6 @@ fn capabilities() -> ServerCapabilities {
             trigger_characters: None,
             ..Default::default()
         }),
-        rename_provider: Some(OneOf::Right(RenameOptions {
-            prepare_provider: Some(true),
-            work_done_progress_options: WorkDoneProgressOptions {
-                work_done_progress: Some(true),
-            },
-        })),
         execute_command_provider: Some(ExecuteCommandOptions {
             commands: vec![],
             ..Default::default()


### PR DESCRIPTION
Currently, we are only collecting tokens in the language server from the `SwayParseTree` when parsing. This representation has limited knowledge of types and no knowledge of the symbol table. 

Without access to a symbol table (namespace) we have no knowledge of scope, thus it becomes impossible to offer reliable LSP features such as `rename`. As such, this PR temporarily disables support for `rename` until we traverse the `TypedParseTree`. Which is next on my to-do list. 

We were getting away with having this enabled until now as we have been ignoring ~70% of the tokens when traversing the `SwayParseTree`. Now that we are accounting for these tokens in #1430, we can no longer offer rename functionality without potentially breaking the users code. 