### PR TITLE
add test for type inference via return type

### DIFF
--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -301,6 +301,10 @@ pub fn run(filter_regex: Option<regex::Regex>) {
             "should_pass/language/primitive_type_argument",
             ProgramState::Return(5),
         ),
+        (
+            "should_pass/language/generic-type-inference",
+            ProgramState::Return(0),
+        ),
     ];
 
     let mut number_of_tests_run =

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic-type-inference/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic-type-inference/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic-type-inference/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic-type-inference/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'generic-type-inference'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic-type-inference/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic-type-inference/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "generic-type-inference"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic-type-inference/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic-type-inference/src/main.sw
@@ -1,0 +1,24 @@
+script;
+
+struct CustomType {
+    name: str[3],
+}
+
+enum Result<T, E> {
+    Ok: T,
+    Err: E,
+}
+
+fn main() {
+  sell_product();
+}
+
+fn sell_product() -> Result<bool, CustomType> {
+    if false {
+        return Result::Err(CustomType {
+            name: "foo"
+        });
+    };
+
+    return Result::Ok(false);
+}


### PR DESCRIPTION
#858 was fixed somewhere along the line by type inference improvements. This PR introduces a test to ensure it doesn't regress.