### PR TITLE
Script test helper

### DIFF
--- a/test/src/sdk-harness/Cargo.toml
+++ b/test/src/sdk-harness/Cargo.toml
@@ -19,6 +19,9 @@ hex = "0.4.3"
 rand = "0.8"
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
+[dev-dependencies]
+test-helpers = { path = "./test-helpers"}
+
 [[test]]
 harness = true
 name = "integration_tests"

--- a/test/src/sdk-harness/test-helpers/Cargo.toml
+++ b/test/src/sdk-harness/test-helpers/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "test-helpers"
+version = "0.1.0"
+edition = "2021"
+
+
+[dependencies]
+fuel-core = { version = "0.5", default-features = false }
+fuel-tx = "0.7"
+fuels-contract = "0.8"
+fuels-signers = { version = "0.8", features=["test-helpers"] }

--- a/test/src/sdk-harness/test-helpers/src/lib.rs
+++ b/test/src/sdk-harness/test-helpers/src/lib.rs
@@ -1,7 +1,7 @@
 //! util & helper functions to support working with the Rust SDK (fuels-rs)
 
 use fuel_core::service::Config;
-use fuel_tx::Transaction;
+use fuel_tx::{consts::MAX_GAS_PER_TX, Transaction};
 use fuels_contract::script::Script;
 use fuels_signers::provider::Provider;
 use std::fs::read;
@@ -15,7 +15,7 @@ pub async fn script_runner(bin_path: &str) -> u64 {
 
     let tx = Transaction::Script {
         gas_price: 0,
-        gas_limit: 1_000_000,
+        gas_limit: MAX_GAS_PER_TX,
         maturity: 0,
         byte_price: 0,
         receipts_root: Default::default(),

--- a/test/src/sdk-harness/test-helpers/src/lib.rs
+++ b/test/src/sdk-harness/test-helpers/src/lib.rs
@@ -1,0 +1,34 @@
+//! util & helper functions to support working with the Rust SDK (fuels-rs)
+
+use fuel_core::service::Config;
+use fuel_tx::Transaction;
+use fuels_contract::script::Script;
+use fuels_signers::provider::Provider;
+use std::fs::read;
+
+
+/// Helper function to reduce boilerplate code in tests.
+/// Used to run a script which returns a boolean value.
+pub async fn script_runner(bin_path: &str) -> u64 {
+    let bin = read(bin_path);
+    let client = Provider::launch(Config::local_node()).await.unwrap();
+
+    let tx = Transaction::Script {
+        gas_price: 0,
+        gas_limit: 1_000_000,
+        maturity: 0,
+        byte_price: 0,
+        receipts_root: Default::default(),
+        script: bin.unwrap(), // Here we pass the compiled script into the transaction
+        script_data: vec![],
+        inputs: vec![],
+        outputs: vec![],
+        witnesses: vec![vec![].into()],
+        metadata: None,
+    };
+
+    let script = Script::new(tx);
+    let receipts = script.call(&client).await.unwrap();
+
+    receipts[0].val().unwrap()
+}

--- a/test/src/sdk-harness/test-helpers/src/lib.rs
+++ b/test/src/sdk-harness/test-helpers/src/lib.rs
@@ -6,7 +6,6 @@ use fuels_contract::script::Script;
 use fuels_signers::provider::Provider;
 use std::fs::read;
 
-
 /// Helper function to reduce boilerplate code in tests.
 /// Used to run a script which returns a boolean value.
 pub async fn script_runner(bin_path: &str) -> u64 {

--- a/test/src/sdk-harness/test_projects/contract_id_type/mod.rs
+++ b/test/src/sdk-harness/test_projects/contract_id_type/mod.rs
@@ -1,38 +1,8 @@
-use fuel_core::service::Config;
-use fuel_tx::{Receipt, Transaction};
-use fuel_types::ContractId;
-use fuels_contract::script::Script;
-use fuels_signers::provider::Provider;
-use std::fs::read;
+use test_helpers::script_runner;
 
 #[tokio::test]
 async fn contract_id_eq_implementation() {
-    let bin = read("test_projects/contract_id_type/out/debug/contract_id_type.bin");
-    let client = Provider::launch(Config::local_node()).await.unwrap();
-
-    let tx = Transaction::Script {
-        gas_price: 0,
-        gas_limit: 1_000_000,
-        maturity: 0,
-        byte_price: 0,
-        receipts_root: Default::default(),
-        script: bin.unwrap(), // Here we pass the compiled script into the transaction
-        script_data: vec![],
-        inputs: vec![],
-        outputs: vec![],
-        witnesses: vec![vec![].into()],
-        metadata: None,
-    };
-
-    let script = Script::new(tx);
-    let receipts = script.call(&client).await.unwrap();
-
-    let expected_receipt = Receipt::Return {
-        id: ContractId::new([0u8; 32]),
-        val: 1,
-        pc: receipts[0].pc().unwrap(),
-        is: 10352,
-    };
-
-    assert_eq!(expected_receipt, receipts[0]);
+    let path_to_bin = "test_projects/contract_id_type/out/debug/contract_id_type.bin";
+    let return_val = script_runner(path_to_bin).await;
+    assert_eq!(1, return_val);
 }

--- a/test/src/sdk-harness/test_projects/evm_ecr/mod.rs
+++ b/test/src/sdk-harness/test_projects/evm_ecr/mod.rs
@@ -1,6 +1,5 @@
 use test_helpers::script_runner;
 
-
 #[tokio::test]
 async fn evm_ecr_implementation() {
     let path_to_bin = "test_projects/evm_ecr/out/debug/evm_ecr.bin";

--- a/test/src/sdk-harness/test_projects/evm_ecr/mod.rs
+++ b/test/src/sdk-harness/test_projects/evm_ecr/mod.rs
@@ -1,36 +1,9 @@
-use fuel_core::service::Config;
-use fuel_tx::Transaction;
-use fuels_contract::script::Script;
-use fuels_signers::provider::Provider;
-use std::fs::read;
+use test_helpers::script_runner;
 
-async fn execute_script(bin_path: &str) -> u64 {
-    let bin = read(bin_path);
-    let client = Provider::launch(Config::local_node()).await.unwrap();
-
-    let tx = Transaction::Script {
-        gas_price: 0,
-        gas_limit: 1_000_000,
-        maturity: 0,
-        byte_price: 0,
-        receipts_root: Default::default(),
-        script: bin.unwrap(), // Here we pass the compiled script into the transaction
-        script_data: vec![],
-        inputs: vec![],
-        outputs: vec![],
-        witnesses: vec![vec![].into()],
-        metadata: None,
-    };
-
-    let script = Script::new(tx);
-    let receipts = script.call(&client).await.unwrap();
-
-    receipts[0].val().unwrap()
-}
 
 #[tokio::test]
 async fn evm_ecr_implementation() {
     let path_to_bin = "test_projects/evm_ecr/out/debug/evm_ecr.bin";
-    let return_val = execute_script(path_to_bin).await;
+    let return_val = script_runner(path_to_bin).await;
     assert_eq!(1, return_val);
 }


### PR DESCRIPTION
This adds a simple test helper used to run scripts via the SDK.
As the project grows we'll have more an d more tests running scripts, and every time the SDK releases breaking changes we'll have to update the syntax in numerous places.
This adds the `script_runner()` function which can be used in SDK tests like this:
```
use test_helpers::script_runner;

#[tokio::test]
async fn contract_id_eq_implementation() {
    let path_to_bin = "test_projects/contract_id_type/out/debug/contract_id_type.bin";
    let return_val = script_runner(path_to_bin).await;
    assert_eq!(1, return_val);
}
```

Curent limitations: ATM, it just returns a  `u64` value to compare against, which works well for scripts that return `bool` values or `u64`s.
A future improvement would be to have `script_runner` return an array of `Receipt`s perhaps.