### PR TITLE
Make all string types non-copy

### DIFF
--- a/sway-core/tests/ir_to_asm/takes_string_returns_string.asm
+++ b/sway-core/tests/ir_to_asm/takes_string_returns_string.asm
@@ -1,0 +1,27 @@
+.program:
+ji   i4
+noop
+DATA_SECTION_OFFSET[0..32]
+DATA_SECTION_OFFSET[32..64]
+lw   $ds $is 1
+add  $$ds $$ds $is
+lw   $r1 $fp i73              ; load input function selector
+lw   $r0 data_2               ; load fn selector for comparison
+eq   $r0 $r1 $r0              ; function selector comparison
+jnei $zero $r0 i14            ; jump to selected function
+lw   $r0 data_3               ; load fn selector for comparison
+eq   $r0 $r1 $r0              ; function selector comparison
+jnei $zero $r0 i17            ; jump to selected function
+rvrt $zero                    ; revert if no selectors matched
+lw   $r1 $fp i74              ; Base register for method parameter
+lw   $r0 data_0               ; loading size for RETD
+retd  $r1 $r0
+lw   $r1 $fp i74              ; Base register for method parameter
+lw   $r0 data_1               ; loading size for RETD
+retd  $r1 $r0
+noop                          ; word-alignment of data section
+.data:
+data_0 .u64 0x08
+data_1 .u64 0x10
+data_2 .u32 0x80da70e2
+data_3 .u32 0x28c0f699

--- a/sway-core/tests/ir_to_asm/takes_string_returns_string.ir
+++ b/sway-core/tests/ir_to_asm/takes_string_returns_string.ir
@@ -1,0 +1,11 @@
+contract {
+    fn small_string<80da70e2>(s: string<7>) -> string<7> {
+        entry:
+        ret string<7> s
+    }
+
+    fn large_string<28c0f699>(s: string<9>) -> string<9> {
+        entry:
+        ret string<9> s
+    }
+}

--- a/sway-core/tests/sway_to_ir/takes_string_returns_string.ir
+++ b/sway-core/tests/sway_to_ir/takes_string_returns_string.ir
@@ -1,0 +1,15 @@
+contract {
+    fn small_string<80da70e2>(s !1: string<7>) -> string<7> {
+        entry:
+        ret string<7> s
+    }
+
+    fn large_string<28c0f699>(s !2: string<9>) -> string<9> {
+        entry:
+        ret string<9> s
+    }
+}
+
+!0 = filepath "/path/to/takes_string_returns_string.sw"
+!1 = span !0 166 167
+!2 = span !0 226 227

--- a/sway-core/tests/sway_to_ir/takes_string_returns_string.sw
+++ b/sway-core/tests/sway_to_ir/takes_string_returns_string.sw
@@ -1,0 +1,15 @@
+contract;
+
+abi MyContract {
+    fn small_string(s: str[7]) -> str[7];
+    fn large_string(s: str[9]) -> str[9];
+}
+
+impl MyContract for Contract {
+    fn small_string(s: str[7]) -> str[7] {
+        s 
+    }
+    fn large_string(s: str[9]) -> str[9] {
+        s 
+    }
+}

--- a/sway-ir/src/irtype.rs
+++ b/sway-ir/src/irtype.rs
@@ -26,9 +26,6 @@ pub enum Type {
 impl Type {
     /// Return whether this is a 'copy' type, one whose value will always fit in a register.
     pub fn is_copy_type(&self) -> bool {
-        if let Type::String(n) = self {
-            return *n <= 8;
-        }
         matches!(self, Type::Unit | Type::Bool | Type::Uint(_))
     }
 


### PR DESCRIPTION
This was the old behavior which was changed in #1292. We agreed to bring back the old behavior for consistency. So, the compiler now does not differentiate between small strings (<= 8 bytes) and large strings.

Closes #1424.