### PR TITLE
Fix `forc run` default URL

### DIFF
--- a/docs/src/forc/commands/forc_run.md
+++ b/docs/src/forc/commands/forc_run.md
@@ -12,7 +12,7 @@ forc run [OPTIONS] [NODE_URL]
 URL of the Fuel Client Node
 
 [env: FUEL_NODE_URL=]
-[default: 127.0.0.1:4000]
+[default: http://127.0.0.1:4000]
 
 
 ## OPTIONS:

--- a/forc/src/cli/commands/run.rs
+++ b/forc/src/cli/commands/run.rs
@@ -27,7 +27,7 @@ pub struct Command {
     pub dry_run: bool,
 
     /// URL of the Fuel Client Node
-    #[clap(env = "FUEL_NODE_URL", default_value = "127.0.0.1:4000")]
+    #[clap(env = "FUEL_NODE_URL", default_value = "http://127.0.0.1:4000")]
     pub node_url: String,
 
     /// Kill Fuel Node Client after running the code.


### PR DESCRIPTION
The default url needs to start with `http://` now.