### PR TITLE
Add --locked to forc

### DIFF
--- a/docs/src/forc/commands/forc_build.md
+++ b/docs/src/forc/commands/forc_build.md
@@ -93,11 +93,6 @@ Whether to compile using the original (pre- IR) pipeline
 
 Whether to compile using the original (pest based) parser
 
-`--locked` 
-
-
-Requires that the Forc.lock file is up-to-date. If the lock file is missing, or it needs to be updated, Forc will exit with an error
-
 ## EXAMPLES:
 
 Compile the sway files of the current project.

--- a/docs/src/forc/commands/forc_build.md
+++ b/docs/src/forc/commands/forc_build.md
@@ -24,6 +24,13 @@ If set, outputs source file mapping in JSON format
 Print help information
 
 
+`--locked` 
+
+
+Requires that the Forc.lock file is up-to-date. If the lock file is missing, or it needs
+to be updated, Forc will exit with an error
+
+
 `--minify-json-abi` 
 
 

--- a/docs/src/forc/commands/forc_build.md
+++ b/docs/src/forc/commands/forc_build.md
@@ -93,6 +93,11 @@ Whether to compile using the original (pre- IR) pipeline
 
 Whether to compile using the original (pest based) parser
 
+`--locked` 
+
+
+Requires that the Forc.lock file is up-to-date. If the lock file is missing, or it needs to be updated, Forc will exit with an error
+
 ## EXAMPLES:
 
 Compile the sway files of the current project.

--- a/docs/src/forc/commands/forc_deploy.md
+++ b/docs/src/forc/commands/forc_deploy.md
@@ -20,6 +20,13 @@ If set, outputs source file mapping in JSON format
 Print help information
 
 
+`--locked` 
+
+
+Requires that the Forc.lock file is up-to-date. If the lock file is missing, or it needs
+to be updated, Forc will exit with an error
+
+
 `--minify-json-abi` 
 
 

--- a/docs/src/forc/commands/forc_run.md
+++ b/docs/src/forc/commands/forc_run.md
@@ -72,6 +72,13 @@ Kill Fuel Node Client after running the code. This is only available if the node
 started from `forc run`
 
 
+`--locked` 
+
+
+Requires that the Forc.lock file is up-to-date. If the lock file is missing, or it needs
+to be updated, Forc will exit with an error
+
+
 `--minify-json-abi` 
 
 

--- a/forc/src/cli/commands/build.rs
+++ b/forc/src/cli/commands/build.rs
@@ -50,6 +50,10 @@ pub struct Command {
     /// output will be "minified", i.e. all on one line without whitespace.
     #[clap(long)]
     pub minify_json_abi: bool,
+    /// Requires that the Forc.lock file is up-to-date. If the lock file is missing, or it
+    /// needs to be updated, Forc will exit with an error
+    #[clap(long)]
+    pub locked: bool,
 }
 
 pub(crate) fn exec(command: Command) -> Result<()> {

--- a/forc/src/cli/commands/deploy.rs
+++ b/forc/src/cli/commands/deploy.rs
@@ -46,6 +46,10 @@ pub struct Command {
     /// output will be "minified", i.e. all on one line without whitespace.
     #[clap(long)]
     pub minify_json_abi: bool,
+    /// Requires that the Forc.lock file is up-to-date. If the lock file is missing, or it
+    /// needs to be updated, Forc will exit with an error
+    #[clap(long)]
+    pub locked: bool,
 }
 
 pub(crate) async fn exec(command: Command) -> Result<()> {

--- a/forc/src/cli/commands/run.rs
+++ b/forc/src/cli/commands/run.rs
@@ -89,6 +89,11 @@ pub struct Command {
     /// Set the transaction gas price. Defaults to 0.
     #[clap(long)]
     pub gas_price: Option<u64>,
+
+    /// Requires that the Forc.lock file is up-to-date. If the lock file is missing, or it
+    /// needs to be updated, Forc will exit with an error
+    #[clap(long)]
+    pub locked: bool,
 }
 
 pub(crate) async fn exec(command: Command) -> Result<()> {

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -21,6 +21,7 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
         silent_mode,
         output_directory,
         minify_json_abi,
+        locked,
     } = command;
 
     let config = pkg::BuildConfig {
@@ -57,7 +58,11 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
 
     // If necessary, construct a new build plan.
     let plan: pkg::BuildPlan = plan_result.or_else(|e| -> Result<pkg::BuildPlan> {
+        println!("Error is: {}", e);
         let cause = if e.to_string().contains("No such file or directory") {
+            if locked {
+                panic!("Foo");
+            }
             anyhow!("lock file did not exist")
         } else {
             e

--- a/forc/src/ops/forc_deploy.rs
+++ b/forc/src/ops/forc_deploy.rs
@@ -34,6 +34,7 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
         silent_mode,
         output_directory,
         minify_json_abi,
+        locked,
     } = command;
 
     let build_command = BuildCommand {
@@ -49,6 +50,7 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
         silent_mode,
         output_directory,
         minify_json_abi,
+        locked,
     };
 
     let compiled = forc_build::build(build_command)?;

--- a/forc/src/ops/forc_run.rs
+++ b/forc/src/ops/forc_run.rs
@@ -37,6 +37,7 @@ pub async fn run(command: RunCommand) -> Result<Vec<fuel_tx::Receipt>> {
         silent_mode: command.silent_mode,
         output_directory: command.output_directory,
         minify_json_abi: command.minify_json_abi,
+        locked: command.locked,
     };
 
     let compiled = forc_build::build(build_command)?;


### PR DESCRIPTION
### Description

This PR adds a `--locked` flag to `forc` which closely resembles [Cargo's --locked flag](https://doc.rust-lang.org/cargo/commands/cargo-install.html)

### Testing steps
- [ ] Try to `forc build/deploy/run` after deleting your `Forc.lock`
- [ ] Try to `forc build/deploy/run` after changing your dependencies without updating your `Forc.lock` (or visa-versa)