### PR TITLE
Clearer failure message for forc-documenter

### DIFF
--- a/scripts/forc-documenter/src/constants.rs
+++ b/scripts/forc-documenter/src/constants.rs
@@ -1,7 +1,7 @@
 pub const SUBHEADERS: &[&str] = &["USAGE:", "ARGS:", "OPTIONS:", "SUBCOMMANDS:"];
 pub const INDEX_HEADER: &str = "Here are a list of commands available to forc:\n\n";
 
-pub static RUN_WRITE_DOCS_MESSAGE: &str = "please run `cargo run --bin forc-documenter write-docs. If you have made local changes to any forc native commands, please install forc from path first: `cargo install --path ./forc`, then run the command.";
+pub static RUN_WRITE_DOCS_MESSAGE: &str = "please run `cargo run --bin forc-documenter write-docs`. If you have made local changes to any forc native commands, please install forc from path first: `cargo install --path ./forc`, then run the command.";
 
 pub static EXAMPLES_HEADER: &str = "\n## EXAMPLES:\n";
 pub static FORC_INIT_EXAMPLE: &str = r#"

--- a/scripts/forc-documenter/src/constants.rs
+++ b/scripts/forc-documenter/src/constants.rs
@@ -1,7 +1,7 @@
 pub const SUBHEADERS: &[&str] = &["USAGE:", "ARGS:", "OPTIONS:", "SUBCOMMANDS:"];
 pub const INDEX_HEADER: &str = "Here are a list of commands available to forc:\n\n";
 
-pub static RUN_WRITE_DOCS_MESSAGE: &str = "please run `cargo run --bin forc-documenter write-docs`";
+pub static RUN_WRITE_DOCS_MESSAGE: &str = "please run `cargo run --bin forc-documenter write-docs. If you have made local changes to any forc native commands, please install forc from path first: `cargo install --path ./forc`, then run the command.";
 
 pub static EXAMPLES_HEADER: &str = "\n## EXAMPLES:\n";
 pub static FORC_INIT_EXAMPLE: &str = r#"


### PR DESCRIPTION
Related: #1441 

The CI gives an [unclear action message](https://github.com/FuelLabs/sway/runs/6241495673?check_suite_focus=true#step:6:27) with regards to running `forc-documenter` after local changes to forc commands. The right action should be to install `forc` from path so that the developer actively working on local changes receives the latest `forc --help`, before running the script.

