### PR TITLE
Add --describe -d opt to forc plugins

### DIFF
--- a/docs/src/forc/commands/forc_plugins.md
+++ b/docs/src/forc/commands/forc_plugins.md
@@ -10,6 +10,12 @@ forc plugins [OPTIONS]
 
 ## OPTIONS:
 
+`-d`, `--describe` 
+
+
+Prints the long description associated with each listed plugin
+
+
 `-h`, `--help` 
 
 

--- a/docs/src/forc/commands/forc_run.md
+++ b/docs/src/forc/commands/forc_run.md
@@ -12,7 +12,7 @@ forc run [OPTIONS] [NODE_URL]
 URL of the Fuel Client Node
 
 [env: FUEL_NODE_URL=]
-[default: http://127.0.0.1:4000]
+[default: 127.0.0.1:4000]
 
 
 ## OPTIONS:

--- a/docs/src/forc/commands/forc_run.md
+++ b/docs/src/forc/commands/forc_run.md
@@ -12,7 +12,7 @@ forc run [OPTIONS] [NODE_URL]
 URL of the Fuel Client Node
 
 [env: FUEL_NODE_URL=]
-[default: 127.0.0.1:4000]
+[default: http://127.0.0.1:4000]
 
 
 ## OPTIONS:

--- a/forc/src/cli/commands/plugins.rs
+++ b/forc/src/cli/commands/plugins.rs
@@ -42,12 +42,18 @@ fn parse_description_for_plugin(plugin: &str) -> String {
         .expect("Could not get plugin description.");
 
     let stdout = String::from_utf8_lossy(&proc.stdout);
-    stdout
-        .split('\n')
-        .nth(1)
-        .map(|x| if x.is_empty() { default_description } else { x })
-        .unwrap()
-        .to_owned()
+
+    // If the plugin doesn't support a -h flag
+    match stdout.split('\n').nth(1) {
+        Some(x) => {
+            if x.is_empty() {
+                default_description.to_owned()
+            } else {
+                x.to_owned()
+            }
+        }
+        None => default_description.to_owned(),
+    }
 }
 
 /// # Panics

--- a/forc/src/cli/commands/plugins.rs
+++ b/forc/src/cli/commands/plugins.rs
@@ -11,15 +11,57 @@ pub struct Command {
     /// Prints the absolute path to each discovered plugin.
     #[clap(long = "paths", short = 'p')]
     print_full_path: bool,
+    /// Prints the long description associated with each listed plugin
+    #[clap(long = "describe", short = 'd')]
+    describe: bool,
 }
 
 pub(crate) fn exec(command: PluginsCommand) -> Result<()> {
-    let PluginsCommand { print_full_path } = command;
+    let PluginsCommand {
+        print_full_path,
+        describe,
+    } = command;
 
+    println!("Installed Plugins:");
     for path in crate::cli::plugin::find_all() {
-        print_plugin(path, print_full_path);
+        print_plugin(path, print_full_path, describe);
     }
     Ok(())
+}
+
+fn parse_description_for_plugin(plugin: &str) -> String {
+    use std::process::Command;
+    let proc = Command::new(plugin)
+        .arg("-h")
+        .output()
+        .expect("Could not get plugin description.");
+
+    let stdout = String::from_utf8_lossy(&proc.stdout);
+    stdout
+        .split('\n')
+        .nth(1)
+        .unwrap_or("No description found for this plugin.")
+        .to_owned()
+}
+
+fn format_print_description(path: PathBuf, print_full_path: bool, describe: bool) -> String {
+    let display = if print_full_path {
+        path.display().to_string()
+    } else {
+        path.file_name()
+            .expect("Failed to read file name")
+            .to_str()
+            .expect("Failed to print file name")
+            .to_string()
+    };
+
+    let description = parse_description_for_plugin(&display);
+
+    if describe {
+        return format!("  {} \t\t{}", display, description);
+    }
+
+    display
 }
 
 /// # Panics
@@ -28,16 +70,9 @@ pub(crate) fn exec(command: PluginsCommand) -> Result<()> {
 /// paths yielded from plugin::find_all(), as well as that the file names are in valid
 /// unicode format since file names should be prefixed with `forc-`. Should one of these 2
 /// assumptions fail, this function panics.
-fn print_plugin(path: PathBuf, print_full_path: bool) {
-    if print_full_path {
-        println!("{}", path.display());
-    } else {
-        println!(
-            "{}",
-            path.file_name()
-                .expect("Failed to read file name")
-                .to_str()
-                .expect("Failed to print file name")
-        );
-    }
+fn print_plugin(path: PathBuf, print_full_path: bool, describe: bool) {
+    println!(
+        "{}",
+        format_print_description(path, print_full_path, describe)
+    )
 }


### PR DESCRIPTION
### Description
- This PR adds flags to include long descriptions for `forc plugins`

### Testing steps
- [ ] Try passing `-d` and/or `--describe` to `forc plugins`

Output should resemble
```text
➜  sway git:(rashad/1215-add-forc-plugins-opt) ✗ forc plugins --describe
Installed Plugins:
  forc-explore          Forc plugin for running the Fuel Block Explorer.
  forc-lsp              Forc plugin for the Sway LSP (Language Server Protocol) implementation.
  forc-fmt              Forc plugin for running the Sway code formatter.
````
### Notes
- Every `forc plugins` description starts with `Forc plugin for...` which is a little redundant. 
  - We know it's a plugin because it's listed via `forc plugin`
- I see `cargo` has something similar to:
```text
➜  sway git:(rashad/1215-add-forc-plugins-opt) ✗ cargo --list
Installed Commands:
    add
    audit
    b                    alias: build
    bench                Execute all benchmarks of a local package
    build                Compile a local package and all of its dependencies
    c                    alias: check
    check                Check a local package and all of its dependencies for errors
    clean                Remove artifacts that cargo has generated in the past
    clippy               Checks a package to catch common mistakes and improve your Rust code.
    config               Inspect configuration values
    d                    alias: doc
    doc                  Build a package's documentation
```
- If there is buy in, we could potentially either (1) update these descriptions to remove the redundant prefix, or (2) Add a separate type of description