### PR TITLE
Adding a `bitcast` to make sure that the IR generated for storage accesses is legal

### DIFF
--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -2102,13 +2102,29 @@ impl FnCompiler {
                     Type::Uint(_) | Type::Bool => {
                         // These types fit in a word. use state_store_word/state_load_word
                         match access_type {
-                            StateAccessType::Read => self
-                                .current_block
-                                .ins(context)
-                                .state_load_word(key_ptr_val, span_md_idx),
+                            StateAccessType::Read => {
+                                // `state_load_word` always returns a `u64`. Cast the result back
+                                // to the right type before returning
+                                let load_val = self
+                                    .current_block
+                                    .ins(context)
+                                    .state_load_word(key_ptr_val, span_md_idx);
+                                self.current_block.ins(context).bitcast(
+                                    load_val,
+                                    *r#type,
+                                    span_md_idx,
+                                )
+                            }
                             StateAccessType::Write => {
-                                self.current_block.ins(context).state_store_word(
+                                // `state_store_word` requires a `u64`. Cast the value to store to
+                                // `u64` first before actually storing.
+                                let rhs_u64 = self.current_block.ins(context).bitcast(
                                     rhs.expect("expecting a rhs for write"),
+                                    Type::Uint(64),
+                                    span_md_idx,
+                                );
+                                self.current_block.ins(context).state_store_word(
+                                    rhs_u64,
                                     key_ptr_val,
                                     span_md_idx,
                                 );

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
@@ -3,7 +3,7 @@ use storage_access_abi::{S, StorageAccess, T};
 use std::assert::assert;
 
 fn main() -> bool {
-    let contract_id = 0xdb2bece194526c53b53bb4e896e4e3f38c7ec9a2b4c73f8c6668c012bf3ce6a1;
+    let contract_id = 0x6acd5f067ccfaab80d77065e3613a41523fc951acf73e24e51ffb64a9f83826a;
     let caller = abi(StorageAccess, contract_id);
 
     // Test 1
@@ -23,6 +23,10 @@ fn main() -> bool {
             x: 5,
             y: 6,
             z: 0x0000000000000000000000000000000000000000000000000000000000000003,
+            boolean: true,
+            int8: 88,
+            int16: 1616,
+            int32: 3232,
         },
     };
     caller.set_s(s);
@@ -33,16 +37,35 @@ fn main() -> bool {
     assert(caller.get_s_dot_t_dot_y() == 6);
     assert(caller.get_s_dot_t_dot_z() == 0x0000000000000000000000000000000000000000000000000000000000000003);
 
+    caller.set_boolean(true);
+    assert(caller.get_boolean() == true);
+    caller.set_boolean(false);
+    assert(caller.get_boolean() == false);
+    caller.set_int8(8u8);
+    assert(caller.get_int8() == 8u8);
+    caller.set_int16(16u16);
+    assert(caller.get_int16() == 16u16);
+    caller.set_int32(32u32);
+    assert(caller.get_int32() == 32u32);
+
     // Test 4
     let t = T {
         x: 7,
         y: 8,
         z: 0x0000000000000000000000000000000000000000000000000000000000000004,
+        boolean: true,
+        int8: 222u8,
+        int16: 1616u16,
+        int32: 323232u32,
     };
     caller.set_s_dot_t(t);
     assert(caller.get_s_dot_t_dot_x() == 7);
     assert(caller.get_s_dot_t_dot_y() == 8);
     assert(caller.get_s_dot_t_dot_z() == 0x0000000000000000000000000000000000000000000000000000000000000004);
+    assert(caller.get_s_dot_t_dot_boolean() == true);
+    assert(caller.get_s_dot_t_dot_int8() == 222u8);
+    assert(caller.get_s_dot_t_dot_int16() == 1616u16);
+    assert(caller.get_s_dot_t_dot_int32() == 323232u32);
 
     // Test 5
     caller.set_s_dot_x(9);
@@ -67,6 +90,18 @@ fn main() -> bool {
     // Test 10
     caller.set_s_dot_t_dot_z(0x0000000000000000000000000000000000000000000000000000000000000006);
     assert(caller.get_s_dot_t_dot_z() == 0x0000000000000000000000000000000000000000000000000000000000000006);
+
+    caller.set_s_dot_t_dot_boolean(true);
+    assert(caller.get_s_dot_t_dot_boolean() == true);
+
+    caller.set_s_dot_t_dot_int8(22u8);
+    assert(caller.get_s_dot_t_dot_int8() == 22u8);
+
+    caller.set_s_dot_t_dot_int16(33u16);
+    assert(caller.get_s_dot_t_dot_int16() == 33u16);
+
+    caller.set_s_dot_t_dot_int32(44u32);
+    assert(caller.get_s_dot_t_dot_int32() == 44u32);
 
     // Test 11
     let s = caller.get_s();

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/storage_access_abi/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/storage_access_abi/src/main.sw
@@ -11,6 +11,10 @@ pub struct T {
     x: u64,
     y: u64,
     z: b256,
+    boolean: bool,
+    int8: u8,
+    int16: u16,
+    int32: u32,
 }
 
 abi StorageAccess {
@@ -18,6 +22,10 @@ abi StorageAccess {
     fn set_x(x: u64);
     fn set_y(y: b256);
     fn set_s(s: S);
+    fn set_boolean(boolean: bool);
+    fn set_int8(int8: u8);
+    fn set_int16(int16: u16);
+    fn set_int32(int32: u32);
     fn set_s_dot_t(t: T);
     fn set_s_dot_x(x: u64);
     fn set_s_dot_y(y: u64);
@@ -25,11 +33,19 @@ abi StorageAccess {
     fn set_s_dot_t_dot_x(a: u64);
     fn set_s_dot_t_dot_y(b: u64);
     fn set_s_dot_t_dot_z(c: b256);
+    fn set_s_dot_t_dot_boolean(boolean: bool);
+    fn set_s_dot_t_dot_int8(int8: u8);
+    fn set_s_dot_t_dot_int16(int16: u16);
+    fn set_s_dot_t_dot_int32(int32: u32);
 
     // Getters
     fn get_x() -> u64;
     fn get_y() -> b256;
     fn get_s() -> S;
+    fn get_boolean() -> bool;
+    fn get_int8() -> u8;
+    fn get_int16() -> u16;
+    fn get_int32() -> u32;
     fn get_s_dot_x() -> u64;
     fn get_s_dot_y() -> u64;
     fn get_s_dot_z() -> b256;
@@ -37,4 +53,8 @@ abi StorageAccess {
     fn get_s_dot_t_dot_x() -> u64;
     fn get_s_dot_t_dot_y() -> u64;
     fn get_s_dot_t_dot_z() -> b256;
+    fn get_s_dot_t_dot_boolean() -> bool;
+    fn get_s_dot_t_dot_int8() -> u8;
+    fn get_s_dot_t_dot_int16() -> u16;
+    fn get_s_dot_t_dot_int32() -> u32;
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/json_abi_oracle.json
@@ -70,6 +70,26 @@
                 "components": null,
                 "name": "z",
                 "type": "b256"
+              },
+              {
+                "components": null,
+                "name": "boolean",
+                "type": "bool"
+              },
+              {
+                "components": null,
+                "name": "int8",
+                "type": "u8"
+              },
+              {
+                "components": null,
+                "name": "int16",
+                "type": "u16"
+              },
+              {
+                "components": null,
+                "name": "int32",
+                "type": "u32"
               }
             ],
             "name": "t",
@@ -81,6 +101,78 @@
       }
     ],
     "name": "set_s",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "()"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": null,
+        "name": "boolean",
+        "type": "bool"
+      }
+    ],
+    "name": "set_boolean",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "()"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": null,
+        "name": "int8",
+        "type": "u8"
+      }
+    ],
+    "name": "set_int8",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "()"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": null,
+        "name": "int16",
+        "type": "u16"
+      }
+    ],
+    "name": "set_int16",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "()"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": null,
+        "name": "int32",
+        "type": "u32"
+      }
+    ],
+    "name": "set_int32",
     "outputs": [
       {
         "components": null,
@@ -162,6 +254,26 @@
             "components": null,
             "name": "z",
             "type": "b256"
+          },
+          {
+            "components": null,
+            "name": "boolean",
+            "type": "bool"
+          },
+          {
+            "components": null,
+            "name": "int8",
+            "type": "u8"
+          },
+          {
+            "components": null,
+            "name": "int16",
+            "type": "u16"
+          },
+          {
+            "components": null,
+            "name": "int32",
+            "type": "u32"
           }
         ],
         "name": "t",
@@ -233,6 +345,78 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "components": null,
+        "name": "boolean",
+        "type": "bool"
+      }
+    ],
+    "name": "set_s_dot_t_dot_boolean",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "()"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": null,
+        "name": "int8",
+        "type": "u8"
+      }
+    ],
+    "name": "set_s_dot_t_dot_int8",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "()"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": null,
+        "name": "int16",
+        "type": "u16"
+      }
+    ],
+    "name": "set_s_dot_t_dot_int16",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "()"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": null,
+        "name": "int32",
+        "type": "u32"
+      }
+    ],
+    "name": "set_s_dot_t_dot_int32",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "()"
+      }
+    ],
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "get_x",
     "outputs": [
@@ -293,6 +477,26 @@
                 "components": null,
                 "name": "z",
                 "type": "b256"
+              },
+              {
+                "components": null,
+                "name": "boolean",
+                "type": "bool"
+              },
+              {
+                "components": null,
+                "name": "int8",
+                "type": "u8"
+              },
+              {
+                "components": null,
+                "name": "int16",
+                "type": "u16"
+              },
+              {
+                "components": null,
+                "name": "int32",
+                "type": "u32"
               }
             ],
             "name": "t",
@@ -301,6 +505,54 @@
         ],
         "name": "",
         "type": "struct S"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "get_boolean",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "get_int8",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "u8"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "get_int16",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "u16"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "get_int32",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "u32"
       }
     ],
     "type": "function"
@@ -361,6 +613,26 @@
             "components": null,
             "name": "z",
             "type": "b256"
+          },
+          {
+            "components": null,
+            "name": "boolean",
+            "type": "bool"
+          },
+          {
+            "components": null,
+            "name": "int8",
+            "type": "u8"
+          },
+          {
+            "components": null,
+            "name": "int16",
+            "type": "u16"
+          },
+          {
+            "components": null,
+            "name": "int32",
+            "type": "u32"
           }
         ],
         "name": "",
@@ -401,6 +673,54 @@
         "components": null,
         "name": "",
         "type": "b256"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "get_s_dot_t_dot_boolean",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "get_s_dot_t_dot_int8",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "u8"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "get_s_dot_t_dot_int16",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "u16"
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "get_s_dot_t_dot_int32",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "u32"
       }
     ],
     "type": "function"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/src/main.sw
@@ -1,74 +1,127 @@
 contract;
 
 use storage_access_abi::{S, StorageAccess, T};
-use std::constants::NATIVE_ASSET_ID;
 
 storage {
-    x: u64, y: b256, s: S
+    x: u64,
+    y: b256,
+    s: S,
+    boolean: bool,
+    int8: u8,
+    int16: u16,
+    int32: u32,
 }
 
 impl StorageAccess for Contract {
     // Setters
-    impure fn set_x(x: u64) {
+    fn set_x(x: u64) {
         storage.x = x;
     }
-    impure fn set_y(y: b256) {
+    fn set_y(y: b256) {
         storage.y = y;
     }
-    impure fn set_s(s: S) {
+    fn set_s(s: S) {
         storage.s = s;
     }
-    impure fn set_s_dot_x(x: u64) {
+    fn set_boolean(boolean: bool) {
+        storage.boolean = boolean;
+    }
+    fn set_int8(int8: u8) {
+        storage.int8 = int8;
+    }
+    fn set_int16(int16: u16) {
+        storage.int16 = int16;
+    }
+    fn set_int32(int32: u32) {
+        storage.int32 = int32;
+    }
+    fn set_s_dot_x(x: u64) {
         storage.s.x = x;
     }
-    impure fn set_s_dot_y(y: u64) {
+    fn set_s_dot_y(y: u64) {
         storage.s.y = y;
     }
-    impure fn set_s_dot_z(z: b256) {
+    fn set_s_dot_z(z: b256) {
         storage.s.z = z;
     }
-    impure fn set_s_dot_t(t: T) {
+    fn set_s_dot_t(t: T) {
         storage.s.t = t;
     }
-    impure fn set_s_dot_t_dot_x(x: u64) {
+    fn set_s_dot_t_dot_x(x: u64) {
         storage.s.t.x = x;
     }
-    impure fn set_s_dot_t_dot_y(y: u64) {
+    fn set_s_dot_t_dot_y(y: u64) {
         storage.s.t.y = y;
     }
-    impure fn set_s_dot_t_dot_z(z: b256) {
+    fn set_s_dot_t_dot_z(z: b256) {
         storage.s.t.z = z;
+    }
+    fn set_s_dot_t_dot_boolean(boolean: bool) {
+        storage.s.t.boolean = boolean;
+    }
+    fn set_s_dot_t_dot_int8(int8: u8) {
+        storage.s.t.int8 = int8;
+    }
+    fn set_s_dot_t_dot_int16(int16: u16) {
+        storage.s.t.int16 = int16;
+    }
+    fn set_s_dot_t_dot_int32(int32: u32) {
+        storage.s.t.int32 = int32;
     }
 
     // Getters
-    impure fn get_x() -> u64 {
+    fn get_x() -> u64 {
         storage.x
     }
-    impure fn get_y() -> b256 {
+    fn get_y() -> b256 {
         storage.y
     }
-    impure fn get_s() -> S {
+    fn get_s() -> S {
         storage.s
     }
-    impure fn get_s_dot_x() -> u64 {
+    fn get_boolean() -> bool {
+        storage.boolean
+    }
+    fn get_int8() -> u8 {
+        storage.int8
+    }
+    fn get_int16() -> u16 {
+        storage.int16
+    }
+    fn get_int32() -> u32 {
+        storage.int32
+    }
+    fn get_s_dot_x() -> u64 {
         storage.s.x
     }
-    impure fn get_s_dot_y() -> u64 {
+    fn get_s_dot_y() -> u64 {
         storage.s.y
     }
-    impure fn get_s_dot_z() -> b256 {
+    fn get_s_dot_z() -> b256 {
         storage.s.z
     }
-    impure fn get_s_dot_t() -> T {
+    fn get_s_dot_t() -> T {
         storage.s.t
     }
-    impure fn get_s_dot_t_dot_x() -> u64 {
+    fn get_s_dot_t_dot_x() -> u64 {
         storage.s.t.x
     }
-    impure fn get_s_dot_t_dot_y() -> u64 {
+    fn get_s_dot_t_dot_y() -> u64 {
         storage.s.t.y
     }
-    impure fn get_s_dot_t_dot_z() -> b256 {
+    fn get_s_dot_t_dot_z() -> b256 {
         storage.s.t.z
+    }
+    fn get_s_dot_t_dot_boolean() -> bool {
+        storage.s.t.boolean
+    }
+    fn get_s_dot_t_dot_int8() -> u8 {
+        storage.s.t.int8
+    }
+    fn get_s_dot_t_dot_int16() -> u16 {
+        storage.s.t.int16
+    }
+    fn get_s_dot_t_dot_int32() -> u32 {
+        storage.s.t.int32
     }
 }


### PR DESCRIPTION
closes #1451 

Even though we're changing how storage is implemented, this is a trivial fix and the test that I keep expanding is going to be useful for coverage in the future.