### PR TITLE
Add [workspace] to forc manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,7 @@ jobs:
       - name: Update project forc manifest to use local sway-lib-std
         run: echo "std = { path = \"../sway-lib-std/\" }" >> test-proj/Forc.toml
       - name: Update project cargo manifest with workspace
-        run: |
-        echo "\n[workspace]" >> test-proj/Cargo.toml
+        run: echo "\n[workspace]" >> test-proj/Cargo.toml
       - name: Build test project
         run: forc build --path test-proj
       - name: Run test project's test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,10 @@ jobs:
       - name: Update project forc manifest to use local sway-lib-std
         run: echo "std = { path = \"../sway-lib-std/\" }" >> test-proj/Forc.toml
       - name: Update project cargo manifest with workspace
-        run: echo "\n[workspace]" >> test-proj/Cargo.toml
+        run: |
+          echo "
+          
+          [workspace]" >> test-proj/Cargo.toml
       - name: Build test project
         run: forc build --path test-proj
       - name: Run test project's test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,11 @@ jobs:
           args: --debug --path ./forc-fmt
       - name: Initialize test project
         run: forc init test-proj
-      - name: Update project manifest to use local sway-lib-std
+      - name: Update project forc manifest to use local sway-lib-std
         run: echo "std = { path = \"../sway-lib-std/\" }" >> test-proj/Forc.toml
+      - name: Update project cargo manifest with workspace
+        run: |
+        echo "\n[workspace]" >> test-proj/Cargo.toml
       - name: Build test project
         run: forc build --path test-proj
       - name: Run test project's test suite


### PR DESCRIPTION
### Description
- This PR adds a `[manifest]` to the `build-forc-test-project` job's cargo manifest

### Testing Steps
- [ ] CI should pass and `build-forc-test-project` specifically should have no errors during any steps