### PR TITLE
Add forc binary CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,79 +54,79 @@ jobs:
             target: x86_64-pc-windows-msvc
             arch: amd64
             svm_target_platform: macosx-amd64
-      steps:
-        - name: Checkout sources
-          uses: actions/checkout@v2
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
 
-        - name: Install toolchain
-          uses: actions-rs/toolchain@v1
-          with:
-            profile: minimal
-            toolchain: stable
-            target: ${{ matrix.job.target }}
-            override: true
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{ matrix.job.target }}
+          override: true
 
-        - uses: Swatinem/rust-cache@v1
-          with:
-            cache-on-failure: true
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
 
-        - name: Apple M1 setup
-          if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
-          run: |
-            echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
-            echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
+      - name: Apple M1 setup
+        if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
+        run: |
+          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
 
-        - name: Linux ARM setup
-          if: ${{ matrix.job.target == 'aarch64-unknown-linux-gnu' }}
-          run: |
-            sudo apt-get update -y
-            sudo apt-get install -y gcc-aarch64-linux-gnu
-            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      - name: Linux ARM setup
+        if: ${{ matrix.job.target == 'aarch64-unknown-linux-gnu' }}
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
-        - name: Install Forc
-          uses: actions-rs/cargo@v1
-          with:
-            command: install
-            args: --debug --path ./forc
+      - name: Install Forc
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc
 
-        - name: Initialize project
-          run: forc init forc-bins
+      - name: Initialize project
+        run: forc init forc-bins
 
-        - name: Build release
-          env:
-            SVM_TARGET_PLATFORM: ${{ matrix.job.svm_target_platform }}
-          run: forc build --path ./forc-bins
+      - name: Build release
+        env:
+          SVM_TARGET_PLATFORM: ${{ matrix.job.svm_target_platform }}
+        run: forc build --path ./forc-bins
 
-        # - name: Archive binaries
-        #   uses: actions/upload-release-asset@v1
-        #   env:
-        #     PLATFORM_NAME: ${{ matrix.job.platform }}
-        #     TARGET: ${{ matrix.job.target }}
-        #     ARCH: ${{ matrix.job.arch }}
-        #     VERSION_NAME: ${{ needs.prepare.outputs.tag_name }}
-        #   run: |
-        #     if [ "$PLATFORM_NAME" == "linux" ]; then
-        #       echo "ASSET_FILENAME=forc_${{ VERSION_NAME }}_${{ PLATFORM_NAME }}_${{ ARCH}.tar.gz" >> $GITHUB_ENV
-        #       tar -czvf $ASSET_FILENAME -C forc-bins/out/debug
-        #     elif [ "$PLATFORM_NAME" == "darwin" ]; then
-        #       echo "ASSET_FILENAME=forc_${{ VERSION_NAME }}_${{ PLATFORM_NAME }}_${{ ARCH}.tar.gz" >> $GITHUB_ENV
-        #       # We need to use gtar here otherwise the archive is corrupt.
-        #       # See: https://github.com/actions/virtual-environments/issues/2619
-        #       gtar -czvf $ASSET_FILENAME -C forc-bins/out/debug
-        #     else
-        #       echo "ASSET_FILENAME=forc_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" >> $GITHUB_ENV
-        #       cd forc-bins/out/debug
-        #       7z a -tzip $ASSET_FILENAME
-        #       mv $ASSET_FILENAME ../../../
-        #     fi
-        #   shell: bash
-        #   env:
-        #     GITHUB_TOKEN: ${{ github.token }}
-        #   with:
-        #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-        #     asset_path: forc-bins/out/debug/forc-bins.bin
-        #     asset_name: $ASSET_FILENAME
-        #     asset_content_type: application/gzip
+      # - name: Archive binaries
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     PLATFORM_NAME: ${{ matrix.job.platform }}
+      #     TARGET: ${{ matrix.job.target }}
+      #     ARCH: ${{ matrix.job.arch }}
+      #     VERSION_NAME: ${{ needs.prepare.outputs.tag_name }}
+      #   run: |
+      #     if [ "$PLATFORM_NAME" == "linux" ]; then
+      #       echo "ASSET_FILENAME=forc_${{ VERSION_NAME }}_${{ PLATFORM_NAME }}_${{ ARCH}.tar.gz" >> $GITHUB_ENV
+      #       tar -czvf $ASSET_FILENAME -C forc-bins/out/debug
+      #     elif [ "$PLATFORM_NAME" == "darwin" ]; then
+      #       echo "ASSET_FILENAME=forc_${{ VERSION_NAME }}_${{ PLATFORM_NAME }}_${{ ARCH}.tar.gz" >> $GITHUB_ENV
+      #       # We need to use gtar here otherwise the archive is corrupt.
+      #       # See: https://github.com/actions/virtual-environments/issues/2619
+      #       gtar -czvf $ASSET_FILENAME -C forc-bins/out/debug
+      #     else
+      #       echo "ASSET_FILENAME=forc_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" >> $GITHUB_ENV
+      #       cd forc-bins/out/debug
+      #       7z a -tzip $ASSET_FILENAME
+      #       mv $ASSET_FILENAME ../../../
+      #     fi
+      #   shell: bash
+      #   env:
+      #     GITHUB_TOKEN: ${{ github.token }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_path: forc-bins/out/debug/forc-bins.bin
+      #     asset_name: $ASSET_FILENAME
+      #     asset_content_type: application/gzip
 
   build-sway-lib-core:
     needs: cancel-previous-runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,113 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+  build-and-publish-forc-binary:
+    if: github.event_name == 'release' && github.event.action == 'published'
+    name: Forc Binary - ${{ matrix.job.target }} (${{ matrix.job.os }})
+    runs-on: ${{ matrix.job.os }}
+    needs: cancel-previous-runs
+    strategy:
+      matrix:
+        job:
+          - os: ubuntu-latest
+            platform: linux
+            target: x86_64-unknown-linux-gnu
+            arch: amd64
+            svm_target_platform: linux-amd64
+          - os: ubuntu-latest
+            platform: linux
+            target: aarch64-unknown-linux-gnu
+            arch: arm64
+            svm_target_platform: linux-aarch64
+          - os: macos-latest
+            platform: darwin
+            target: x86_64-apple-darwin
+            arch: amd64
+            svm_target_platform: macosx-amd64
+          - os: macos-latest
+            platform: darwin
+            target: aarch64-apple-darwin
+            arch: arm64
+            svm_target_platform: macosx-aarch64
+          - os: windows-latest
+            platform: win32
+            target: x86_64-pc-windows-msvc
+            arch: amd64
+            svm_target_platform: macosx-amd64
+      steps:
+        - name: Checkout sources
+          uses: actions/checkout@v2
+
+        - name: Install toolchain
+          uses: actions-rs/toolchain@v1
+          with:
+            profile: minimal
+            toolchain: stable
+            target: ${{ matrix.job.target }}
+            override: true
+
+        - uses: Swatinem/rust-cache@v1
+          with:
+            cache-on-failure: true
+
+        - name: Apple M1 setup
+          if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
+          run: |
+            echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+            echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
+
+        - name: Linux ARM setup
+          if: ${{ matrix.job.target == 'aarch64-unknown-linux-gnu' }}
+          run: |
+            sudo apt-get update -y
+            sudo apt-get install -y gcc-aarch64-linux-gnu
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+        - name: Install Forc
+          uses: actions-rs/cargo@v1
+          with:
+            command: install
+            args: --debug --path ./forc
+
+        - name: Initialize project
+          run: forc init forc-bins
+
+        - name: Build release
+          env:
+            SVM_TARGET_PLATFORM: ${{ matrix.job.svm_target_platform }}
+          run: forc build --path ./forc-bins
+
+        # - name: Archive binaries
+        #   uses: actions/upload-release-asset@v1
+        #   env:
+        #     PLATFORM_NAME: ${{ matrix.job.platform }}
+        #     TARGET: ${{ matrix.job.target }}
+        #     ARCH: ${{ matrix.job.arch }}
+        #     VERSION_NAME: ${{ needs.prepare.outputs.tag_name }}
+        #   run: |
+        #     if [ "$PLATFORM_NAME" == "linux" ]; then
+        #       echo "ASSET_FILENAME=forc_${{ VERSION_NAME }}_${{ PLATFORM_NAME }}_${{ ARCH}.tar.gz" >> $GITHUB_ENV
+        #       tar -czvf $ASSET_FILENAME -C forc-bins/out/debug
+        #     elif [ "$PLATFORM_NAME" == "darwin" ]; then
+        #       echo "ASSET_FILENAME=forc_${{ VERSION_NAME }}_${{ PLATFORM_NAME }}_${{ ARCH}.tar.gz" >> $GITHUB_ENV
+        #       # We need to use gtar here otherwise the archive is corrupt.
+        #       # See: https://github.com/actions/virtual-environments/issues/2619
+        #       gtar -czvf $ASSET_FILENAME -C forc-bins/out/debug
+        #     else
+        #       echo "ASSET_FILENAME=forc_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" >> $GITHUB_ENV
+        #       cd forc-bins/out/debug
+        #       7z a -tzip $ASSET_FILENAME
+        #       mv $ASSET_FILENAME ../../../
+        #     fi
+        #   shell: bash
+        #   env:
+        #     GITHUB_TOKEN: ${{ github.token }}
+        #   with:
+        #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+        #     asset_path: forc-bins/out/debug/forc-bins.bin
+        #     asset_name: $ASSET_FILENAME
+        #     asset_content_type: application/gzip
+
   build-sway-lib-core:
     needs: cancel-previous-runs
     runs-on: ubuntu-latest
@@ -400,6 +507,7 @@ jobs:
   notify-slack-on-failure:
     needs:
       [
+        build-and-publish-forc-binary,
         build-forc-test-project,
         build-sway-examples,
         build-sway-lib-core,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           access_token: ${{ github.token }}
 
   build-and-publish-forc-binary:
-    if: github.event_name == 'release' && github.event.action == 'published'
+    # if: github.event_name == 'release' && github.event.action == 'published'
     name: Forc Binary - ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}
     needs: cancel-previous-runs


### PR DESCRIPTION
### Description
- This PR adds a CI job that creates `forc` binary assets for a few popular architectures

### Testing steps
- [ ] CI should pass
- [ ] Compressed binary assets for each target architecture should be uploaded to the appropriate place when CI finishes