### PR TITLE
Remove test crate forc versioning

### DIFF
--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.41"
-forc = { version = "0.12.0", path = "../forc", features = ["test"], default-features = false }
+forc = { path = "../forc", features = ["test"], default-features = false }
 fuel-asm = "0.4"
 fuel-tx = "0.9"
 fuel-vm = { version = "0.8", features = ["random"] }


### PR DESCRIPTION
Closes #1463 

- unpublished crate does not need versioning to use a crate from path