### PR TITLE
Hide use orig asm and parser in the help text for forc build, deploy, run

### DIFF
--- a/docs/src/forc/commands/forc_build.md
+++ b/docs/src/forc/commands/forc_build.md
@@ -81,18 +81,6 @@ Whether to compile to bytecode (false) or to print out the generated IR (true)
 
 Silent mode. Don't output any warnings or errors to the command line
 
-
-`--use-orig-asm` 
-
-
-Whether to compile using the original (pre- IR) pipeline
-
-
-`--use-orig-parser` 
-
-
-Whether to compile using the original (pest based) parser
-
 ## EXAMPLES:
 
 Compile the sway files of the current project.

--- a/docs/src/forc/commands/forc_deploy.md
+++ b/docs/src/forc/commands/forc_deploy.md
@@ -77,18 +77,6 @@ Whether to compile to bytecode (false) or to print out the IR (true)
 
 Silent mode. Don't output any warnings or errors to the command line
 
-
-`--use-orig-asm` 
-
-
-Whether to compile using the original (pre- IR) pipeline
-
-
-`--use-orig-parser` 
-
-
-Whether to compile using the original (pest based) parser
-
 ## EXAMPLES:
 
 You can use `forc deploy`, which triggers a contract deployment transaction and sends it to a running node.

--- a/docs/src/forc/commands/forc_run.md
+++ b/docs/src/forc/commands/forc_run.md
@@ -127,15 +127,3 @@ Pretty-print the outputs from the node
 
 
 Silent mode. Don't output any warnings or errors to the command line
-
-
-`--use-orig-asm` 
-
-
-Whether to compile using the original (pre- IR) pipeline
-
-
-`--use-orig-parser` 
-
-
-Whether to compile using the original (pest based) parser

--- a/forc/src/cli/commands/build.rs
+++ b/forc/src/cli/commands/build.rs
@@ -14,10 +14,10 @@ pub struct Command {
     #[clap(short, long)]
     pub path: Option<String>,
     /// Whether to compile using the original (pre- IR) pipeline.
-    #[clap(long)]
+    #[clap(long, hide = true)]
     pub use_orig_asm: bool,
     /// Whether to compile using the original (pest based) parser.
-    #[clap(long)]
+    #[clap(long, hide = true)]
     pub use_orig_parser: bool,
     /// Whether to compile to bytecode (false) or to print out the generated ASM (true).
     #[clap(long)]

--- a/forc/src/cli/commands/deploy.rs
+++ b/forc/src/cli/commands/deploy.rs
@@ -10,10 +10,10 @@ pub struct Command {
     #[clap(short, long)]
     pub path: Option<String>,
     /// Whether to compile using the original (pre- IR) pipeline.
-    #[clap(long)]
+    #[clap(long, hide = true)]
     pub use_orig_asm: bool,
     /// Whether to compile using the original (pest based) parser.
-    #[clap(long)]
+    #[clap(long, hide = true)]
     pub use_orig_parser: bool,
     /// Whether to compile to bytecode (false) or to print out the generated ASM (true).
     #[clap(long)]

--- a/forc/src/cli/commands/run.rs
+++ b/forc/src/cli/commands/run.rs
@@ -15,11 +15,11 @@ pub struct Command {
     pub path: Option<String>,
 
     /// Whether to compile using the original (pre- IR) pipeline.
-    #[clap(long)]
+    #[clap(long, hide = true)]
     pub use_orig_asm: bool,
 
     /// Whether to compile using the original (pest based) parser.
-    #[clap(long)]
+    #[clap(long, hide = true)]
     pub use_orig_parser: bool,
 
     /// Only craft transaction and print it out.


### PR DESCRIPTION
Closes #1462 

- Add `hide = true` to `use_orig_parser` and `use_orig_asm` to hide them from the help text found in `build`, `deploy` and `run` while maintaining functionality
- Remove corresponding documentation about the options