### PR TITLE
Small fix to `hash_u64`

### DIFF
--- a/sway-lib-std/src/hash.sw
+++ b/sway-lib-std/src/hash.sw
@@ -37,7 +37,7 @@ pub fn hash_u64(value: u64, method: HashMethod) -> b256 {
             move hashed_b256_ptr sp;
             cfei i32;
             addi r3 zero i8; // hash eight bytes since a u64 is eight bytes
-            s256 hashed_b256_ptr r1 r3;
+            s256 hashed_b256_ptr value_ptr r3;
             hashed_b256_ptr: b256
         }
     } else {
@@ -49,7 +49,7 @@ pub fn hash_u64(value: u64, method: HashMethod) -> b256 {
             move hashed_b256_ptr sp;
             cfei i32;
             addi r3 zero i8; // hash eight bytes since a u64 is eight bytes
-            k256 hashed_b256_ptr r1 r3;
+            k256 hashed_b256_ptr value_ptr r3;
             hashed_b256_ptr: b256
         }
     }

--- a/test/src/sdk-harness/test_projects/harness.rs
+++ b/test/src/sdk-harness/test_projects/harness.rs
@@ -5,6 +5,7 @@ mod call_frames;
 mod context;
 mod contract_id_type;
 mod evm_ecr;
+mod hashing;
 mod logging;
 mod option;
 mod reentrancy;

--- a/test/src/sdk-harness/test_projects/hashing/.gitignore
+++ b/test/src/sdk-harness/test_projects/hashing/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/sdk-harness/test_projects/hashing/Forc.lock
+++ b/test/src/sdk-harness/test_projects/hashing/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'hashing'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/test/src/sdk-harness/test_projects/hashing/Forc.toml
+++ b/test/src/sdk-harness/test_projects/hashing/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "hashing"
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/test/src/sdk-harness/test_projects/hashing/mod.rs
+++ b/test/src/sdk-harness/test_projects/hashing/mod.rs
@@ -1,0 +1,32 @@
+use fuel_tx::{ContractId, Salt};
+use fuels::prelude::*;
+use fuels::test_helpers;
+use fuels_abigen_macro::abigen;
+
+abigen!(
+    HashingTestContract,
+    "test_projects/hashing/out/debug/hashing-abi.json"
+);
+
+async fn get_hashing_instance() -> (HashingTestContract, ContractId) {
+    let salt = Salt::from([0u8; 32]);
+    let compiled =
+        Contract::load_sway_contract("test_projects/hashing/out/debug/hashing.bin", salt)
+            .unwrap();
+    let (provider, wallet) = test_helpers::setup_test_provider_and_wallet().await;
+    let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default())
+        .await
+        .unwrap();
+    let instance = HashingTestContract::new(id.to_string(), provider, wallet);
+
+    (instance, id)
+}
+
+#[tokio::test]
+async fn test_hash_u64() {
+    let (instance, _id) = get_hashing_instance().await;
+    // Check that hashing the same `u64` results in the same hash
+    let result1 = instance.get_hash_u64(42).call().await.unwrap();
+    let result2 = instance.get_hash_u64(42).call().await.unwrap();
+    assert_eq!(result1.value, result2.value);
+}

--- a/test/src/sdk-harness/test_projects/hashing/mod.rs
+++ b/test/src/sdk-harness/test_projects/hashing/mod.rs
@@ -26,7 +26,11 @@ async fn get_hashing_instance() -> (HashingTestContract, ContractId) {
 async fn test_hash_u64() {
     let (instance, _id) = get_hashing_instance().await;
     // Check that hashing the same `u64` results in the same hash
-    let result1 = instance.get_hash_u64(42).call().await.unwrap();
-    let result2 = instance.get_hash_u64(42).call().await.unwrap();
-    assert_eq!(result1.value, result2.value);
+    let sha256_result1 = instance.get_s256_hash_u64(42).call().await.unwrap();
+    let sha256_result2 = instance.get_s256_hash_u64(42).call().await.unwrap();
+    assert_eq!(sha256_result1.value, sha256_result2.value);
+
+    let keccak256_result1 = instance.get_k256_hash_u64(42).call().await.unwrap();
+    let keccak256_result2 = instance.get_k256_hash_u64(42).call().await.unwrap();
+    assert_eq!(keccak256_result1.value, keccak256_result2.value);
 }

--- a/test/src/sdk-harness/test_projects/hashing/src/main.sw
+++ b/test/src/sdk-harness/test_projects/hashing/src/main.sw
@@ -1,0 +1,13 @@
+contract;
+
+use std::hash::{HashMethod, hash_u64};
+
+abi MyContract {
+    fn get_hash_u64(value: u64 ) -> b256;
+}
+
+impl MyContract for Contract {
+    fn get_hash_u64(value: u64) -> b256 {
+        hash_u64(value, HashMethod::Sha256)
+    }
+}

--- a/test/src/sdk-harness/test_projects/hashing/src/main.sw
+++ b/test/src/sdk-harness/test_projects/hashing/src/main.sw
@@ -3,11 +3,16 @@ contract;
 use std::hash::{HashMethod, hash_u64};
 
 abi MyContract {
-    fn get_hash_u64(value: u64 ) -> b256;
+    fn get_s256_hash_u64(value: u64 ) -> b256;
+    fn get_k256_hash_u64(value: u64 ) -> b256;
 }
 
 impl MyContract for Contract {
-    fn get_hash_u64(value: u64) -> b256 {
+    fn get_s256_hash_u64(value: u64) -> b256 {
         hash_u64(value, HashMethod::Sha256)
+    }
+
+    fn get_k256_hash_u64(value: u64) -> b256 {
+        hash_u64(value, HashMethod::Keccak256)
     }
 }


### PR DESCRIPTION
I noticed some nondeterminism in the `hash_u64` function from the standard library. Turns out there was a bug in its implementation. 

Also added the beginning of a library test on hashing. We should expand that test to cover all hash functions and validate their results.