### PR TITLE
Publish Diagnostics from language server even when no errors or warnings detected

### DIFF
--- a/sway-lsp/src/capabilities/diagnostic.rs
+++ b/sway-lsp/src/capabilities/diagnostic.rs
@@ -42,10 +42,10 @@ fn get_range(warning_or_error: &WarningOrError<'_>) -> Range {
     };
 
     let start_line = start.line as u32 - 1;
-    let start_character = start.col as u32;
+    let start_character = start.col as u32 - 1;
 
     let end_line = end.line as u32 - 1;
-    let end_character = end.col as u32;
+    let end_character = end.col as u32 - 1;
 
     Range {
         start: Position::new(start_line, start_character),

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -444,6 +444,9 @@ fn main() {
         // send "textDocument/didOpen" notification for `uri`
         did_open_notification(&mut service, &uri, SWAY_PROGRAM).await;
 
+        // ignore the "textDocument/publishDiagnostics" notification
+        messages.next().await.unwrap();
+
         // send "shutdown" request
         let _ = shutdown_request(&mut service).await;
 
@@ -510,6 +513,9 @@ fn main() {
         // send "textDocument/didOpen" notification for `uri`
         did_open_notification(&mut service, &uri, text).await;
 
+        // ignore the "textDocument/publishDiagnostics" notification
+        messages.next().await.unwrap();
+
         // send "textDocument/didChange" notification for `uri`
         let params = json!({
             "textDocument": {
@@ -538,6 +544,9 @@ fn main() {
             .finish();
         let response = service.ready().await.unwrap().call(did_change).await;
         assert_eq!(response, Ok(None));
+
+        // ignore the "textDocument/publishDiagnostics" notification
+        messages.next().await.unwrap();
 
         // send "shutdown" request
         let _ = shutdown_request(&mut service).await;

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -77,12 +77,7 @@ fn capabilities() -> ServerCapabilities {
 }
 
 impl Backend {
-    async fn publish_diagnostics(
-        &self,
-        uri: Url,
-        diagnostics: Vec<Diagnostic>,
-        version: Option<i32>,
-    ) {
+    async fn publish_diagnostics(&self, uri: Url, diagnostics: Vec<Diagnostic>) {
         // If parsed_tokens_as_warnings is true, take over the normal error and warning display behavior
         // and instead show the parsed tokens as warnings.
         // This is useful for debugging the lsp parser.
@@ -90,14 +85,14 @@ impl Backend {
             if let Some(document) = self.session.documents.get(uri.path()) {
                 let diagnostics = debug::generate_warnings_for_parsed_tokens(document.get_tokens());
                 self.client
-                    .publish_diagnostics(uri, diagnostics, version)
+                    .publish_diagnostics(uri, diagnostics, None)
                     .await;
             }
         } else {
             // Note: Even if the computed diagnostics vec is empty, we still have to push the empty Vec
             // in order to clear former diagnostics. Newly pushed diagnostics always replace previously pushed diagnostics.
             self.client
-                .publish_diagnostics(uri, diagnostics, version)
+                .publish_diagnostics(uri, diagnostics, None)
                 .await;
         }
     }
@@ -138,22 +133,20 @@ impl LanguageServer for Backend {
     // Document Handlers
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         let uri = params.text_document.uri.clone();
-        let version = Some(params.text_document.version);
         let diagnostics = capabilities::text_sync::handle_open_file(self.session.clone(), &params);
-        self.publish_diagnostics(uri, diagnostics, version).await;
+        self.publish_diagnostics(uri, diagnostics).await;
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         let uri = params.text_document.uri.clone();
-        let version = Some(params.text_document.version);
         let diagnostics = capabilities::text_sync::handle_change_file(self.session.clone(), params);
-        self.publish_diagnostics(uri, diagnostics, version).await;
+        self.publish_diagnostics(uri, diagnostics).await;
     }
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
         let uri = params.text_document.uri.clone();
         let diagnostics = capabilities::text_sync::handle_save_file(self.session.clone(), &params);
-        self.publish_diagnostics(uri, diagnostics, None).await;
+        self.publish_diagnostics(uri, diagnostics).await;
     }
 
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {


### PR DESCRIPTION
Incorrect warnings and errors were being reported in VS-Code after updating the document. It appears that we have only been publishing diagnostics back to the client if any errors or warnings were reported by the parser. This meant that if an error was rectified, then we were not clearing the previously reported diagnostic information and the Client would display the incorrect warnings and errors. 

Also fixes an off-by-one error when reporting diagnostic ranges to the Client. 

closes #1315