### PR TITLE
Add build-and-publish-forc-binary CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,3 +630,105 @@ jobs:
           notify_when: 'failure'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
+
+  build-and-publish-forc-binary:
+    name: Forc Binary - ${{ matrix.job.target }} (${{ matrix.job.os }})
+    runs-on: ${{ matrix.job.os }}
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs: [
+      cancel-previous-runs,
+      publish,
+    ]
+    strategy:
+      matrix:
+        job:
+          - os: ubuntu-latest
+            platform: linux
+            target: x86_64-unknown-linux-gnu
+            arch: amd64
+            svm_target_platform: linux-amd64
+          - os: ubuntu-latest
+            platform: linux
+            target: aarch64-unknown-linux-gnu
+            arch: arm64
+            svm_target_platform: linux-aarch64
+          - os: macos-latest
+            platform: darwin
+            target: x86_64-apple-darwin
+            arch: amd64
+            svm_target_platform: macosx-amd64
+          - os: macos-latest
+            platform: darwin
+            target: aarch64-apple-darwin
+            arch: arm64
+            svm_target_platform: macosx-aarch64
+          # FIXME: Have no idea what to do on a Windows machine <(-_-<)
+          # - os: windows-latest
+          #   platform: win32
+          #   target: x86_64-pc-windows-msvc
+          #   arch: amd64
+          #   svm_target_platform: macosx-amd64
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{ matrix.job.target }}
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
+      - name: Apple M1 setup
+        if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
+        run: |
+          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
+      - name: Linux ARM setup
+        if: ${{ matrix.job.target == 'aarch64-unknown-linux-gnu' }}
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      - name: Install Forc
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc
+
+      - name: Prep Assets
+        id: prep_assets
+        env:
+          PLATFORM_NAME: ${{ matrix.job.platform }}
+          TARGET: ${{ matrix.job.target }}
+          ARCH: ${{ matrix.job.arch }}
+        run: |
+          ZIP_FILE_NAME=forc.${{ env.PLATFORM_NAME }}_${{ env.ARCH }}.gz
+          if [ "${{ env.PLATFORM_NAME }}" == "linux" ]; then
+            echo "ZIP_FILE_NAME=$ZIP_FILE_NAME" >> $GITHUB_ENV
+            gzip -c $(which forc) > ./$ZIP_FILE_NAME
+          elif [ "${{ env.PLATFORM_NAME }}" == "darwin" ]; then
+            echo "ZIP_FILE_NAME=$ZIP_FILE_NAME" >> $GITHUB_ENV
+            gzip -c $(which forc) > ./$ZIP_FILE_NAME
+          else
+            # FIXME: Have no idea what to do on a Windows machine <(-_-<)
+            ZIP_FILE_NAME=forc_${{ env.PLATFORM_NAME }}_${{ env.ARCH }}.zip
+            echo "ZIP_FILE_NAME=$ZIP_FILE_NAME" >> $GITHUB_ENV
+            cd ./forcbin/out/debug
+            7z a -tzip $ZIP_FILE_NAME
+            mv ${{ env.ZIP_FILE_NAME }} ../../../
+          fi
+      - name: Archive binaries
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./${{ env.ZIP_FILE_NAME }}
+          asset_name: ${{ env.ZIP_FILE_NAME }}
+          asset_content_type: application/gzip


### PR DESCRIPTION
### Description
- This PR adds a `build-and-publish-forc-binary` CI job that uploads `forc` binaries for different architectures to a release, when the release is published

### Testing Steps
- [ ] CI should fully pass after a release is published (after this is merged)