### PR TITLE
Fix bug in node dependencies related to `if let` codeblocks.

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/out_of_order_decl/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/out_of_order_decl/src/main.sw
@@ -24,6 +24,10 @@ fn main() -> bool {
 
     let v = WrapperEnum::Variant(u);
 
+    if let AnEnum::Variant = AnEnum::Variant {
+        void();
+    }
+
     true
 }
 
@@ -58,4 +62,7 @@ impl FuelTrait for u64 {
 
 trait FuelTrait {
     fn foo() -> bool;
+}
+
+fn void() {
 }


### PR DESCRIPTION
The little change made to the `out_of_order_decl' test will make it fail without the code changes.  Just had to include the `if let` bodies to the dependency gathering.

Closes #1508.