### PR TITLE
Remove `rand` dependency from default Cargo.toml

### DIFF
--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -34,7 +34,6 @@ fuel-gql-client = {{ version = "0.6", default-features = false }}
 fuel-tx = "0.9"
 fuels = "0.12"
 fuels-abigen-macro = "0.12"
-rand = "0.8"
 tokio = {{ version = "1.12", features = ["rt", "macros"] }}
 
 [[test]]


### PR DESCRIPTION
It's only used for a random salt, which is 1) hidden under the hood, and 2) not needed since you can just use zero.