### PR TITLE
Fix non-deterministic tuple names

### DIFF
--- a/sway-core/src/constants.rs
+++ b/sway-core/src/constants.rs
@@ -22,4 +22,4 @@ pub const CONTRACT_CALL_ASSET_ID_PARAMETER_DEFAULT_VALUE: [u8; 32] = [0; 32];
 pub const DEFAULT_ENTRY_POINT_FN_NAME: &str = "main";
 
 /// The default prefix for the compiler generated names of tuples
-pub const TUPLE_NAME_PREFIX: &str = "__tuple__";
+pub const TUPLE_NAME_PREFIX: &str = "__tuple";

--- a/sway-core/src/constants.rs
+++ b/sway-core/src/constants.rs
@@ -22,4 +22,4 @@ pub const CONTRACT_CALL_ASSET_ID_PARAMETER_DEFAULT_VALUE: [u8; 32] = [0; 32];
 pub const DEFAULT_ENTRY_POINT_FN_NAME: &str = "main";
 
 /// The default prefix for the compiler generated names of tuples
-pub const TUPLE_NAME_PREFIX: &str = "__tuple";
+pub const TUPLE_NAME_PREFIX: &str = "__tuple_";

--- a/sway-core/src/constants.rs
+++ b/sway-core/src/constants.rs
@@ -20,3 +20,6 @@ pub const CONTRACT_CALL_ASSET_ID_PARAMETER_DEFAULT_VALUE: [u8; 32] = [0; 32];
 
 /// The default entry point for scripts and predicates.
 pub const DEFAULT_ENTRY_POINT_FN_NAME: &str = "main";
+
+/// The default prefix for the compiler generated names of tuples
+pub const TUPLE_NAME_PREFIX: &str = "__tuple__";


### PR DESCRIPTION
The names of tuples in the compiler are currently non-deterministic. This change is one way we could generate unique stable names for them.

The reason we want stable names is because the names of variables impact their order in IR. That order determines the order in which variables get allocated which impacts the generated bytecode.