### PR TITLE
Update book links to `sway-lib-core` in Section 3.2

### DIFF
--- a/docs/src/sway-program-types/libraries.md
+++ b/docs/src/sway-program-types/libraries.md
@@ -1,6 +1,6 @@
 # Libraries
 
-Libraries in Sway are files used to define new common behavior. An example of this is the [Sway Core Library](https://github.com/FuelLabs/sway-lib-core) which outlines various methods that the `u64` type implements.
+Libraries in Sway are files used to define new common behavior. An example of this is the [Sway Core Library](https://github.com/FuelLabs/sway/tree/master/sway-lib-core) which outlines various methods that the `u64` type implements.
 
 ## Writing Libraries
 
@@ -10,7 +10,7 @@ Libraries are denoted using the `library` keyword at the beginning of the file, 
 library my_library;
 ```
 
-A good reference library to use when learning library design is the [Sway Core Library](https://github.com/FuelLabs/sway-lib-core). The `add` function interface is defined via the `Add` trait and then implemented for `u64`. This attaches this `add` function to the type so that, when the trait is imported, `u64`s can utilize the `add` function.
+A good reference library to use when learning library design is the [Sway Core Library](https://github.com/FuelLabs/sway/tree/master/sway-lib-core). The `add` function interface is defined via the `Add` trait and then implemented for `u64`. This attaches this `add` function to the type so that, when the trait is imported, `u64`s can utilize the `add` function.
 
 ```sway
 pub trait Add {


### PR DESCRIPTION
Noticed that the `sway-lib-core` links within the [book](https://fuellabs.github.io/sway/latest/sway-program-types/libraries.html) link you to the [archived sway-lib-core](https://github.com/FuelLabs/sway-lib-core) instead of the [one within the sway repo](https://github.com/FuelLabs/sway/tree/master/sway-lib-core).