### PR TITLE
Parse tuple field reassignments

### DIFF
--- a/sway-parse/src/assignable.rs
+++ b/sway-parse/src/assignable.rs
@@ -12,6 +12,12 @@ pub enum Assignable {
         dot_token: DotToken,
         name: Ident,
     },
+    TupleFieldProjection {
+        target: Box<Assignable>,
+        dot_token: DotToken,
+        field: BigUint,
+        field_span: Span,
+    },
 }
 
 impl Assignable {
@@ -22,6 +28,9 @@ impl Assignable {
             Assignable::FieldProjection { target, name, .. } => {
                 Span::join(target.span(), name.span().clone())
             }
+            Assignable::TupleFieldProjection {
+                target, field_span, ..
+            } => Span::join(target.span(), field_span.clone()),
         }
     }
 }

--- a/sway-parse/src/expr/mod.rs
+++ b/sway-parse/src/expr/mod.rs
@@ -1128,6 +1128,25 @@ impl Expr {
                     name,
                 }),
             },
+            Expr::TupleFieldProjection {
+                target,
+                dot_token,
+                field,
+                field_span,
+            } => match target.try_into_assignable() {
+                Ok(target) => Ok(Assignable::TupleFieldProjection {
+                    target: Box::new(target),
+                    dot_token,
+                    field,
+                    field_span,
+                }),
+                Err(target) => Err(Expr::TupleFieldProjection {
+                    target: Box::new(target),
+                    dot_token,
+                    field,
+                    field_span,
+                }),
+            },
             expr => Err(expr),
         }
     }


### PR DESCRIPTION
This is a partial fix for #905. Tuple field reassignments are now accepted by the parser and the parse tree converter, however they are still rejected by the semantic analysis phase of the compiler.