### PR TITLE
Fix CI not installing mdbook-forc-documenter preprocessor. Fix out-of-date `Cargo.lock` file missing pest dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Install mdbook-forc-documenter
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./scripts/mdbook-forc-documenter
       - name: Run mdbook build
         uses: peaceiris/actions-mdbook@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
           args: --bin examples-checker fmt --all-examples
 
   build-mdbook:
+    needs: cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -117,6 +118,11 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
+      - name: Install Forc
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc
       - name: Install mdbook-forc-documenter
         uses: actions-rs/cargo@v1
         with:
@@ -129,7 +135,6 @@ jobs:
       - name: Emit logs to tmp.txt, fail if build logs contain 'ERROR'
         run: |
           mdbook build docs &> tmp.txt
-          cat tmp.txt
           if cat tmp.txt | grep 'ERROR'
           then
             rm tmp.txt && exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,6 @@ jobs:
           args: --bin examples-checker fmt --all-examples
 
   build-mdbook:
-    needs: cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -126,10 +125,11 @@ jobs:
       - name: Run mdbook build
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.4.7'
+          mdbook-version: '0.4.15'
       - name: Emit logs to tmp.txt, fail if build logs contain 'ERROR'
         run: |
           mdbook build docs &> tmp.txt
+          cat tmp.txt
           if cat tmp.txt | grep 'ERROR'
           then
             rm tmp.txt && exit 1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Install mdbook-forc-documenter
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./scripts/mdbook-forc-documenter
+
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+      - name: Install Forc
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./forc
       - name: Install mdbook-forc-documenter
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.4.7'
+          mdbook-version: '0.4.15'
 
       - run: mdbook build docs
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,6 +2062,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3988,6 +3994,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"


### PR DESCRIPTION
Fixes CI not installing `mdbook-forc-documenter` as a preprocessor before trying to do `mdbook build`, which ended up creating empty Forc command pages.