### PR TITLE
Remove compiler warnings

### DIFF
--- a/sway-lib-core/src/num.sw
+++ b/sway-lib-core/src/num.sw
@@ -2,72 +2,72 @@ library num;
 
 impl u64 {
     /// The smallest value that can be represented by this integer type.
-    pub fn MIN() -> u64 {
+    pub fn min() -> u64 {
         0
     }
 
     /// The largest value that can be represented by this integer type,
     /// 2<sup>64</sup> - 1.
-    pub fn MAX() -> u64 {
+    pub fn max() -> u64 {
         18446744073709551615
     }
 
     /// The size of this integer type in bits.
-    pub fn BITS() -> u32 {
+    pub fn bits() -> u32 {
         64
     }
 }
 
 impl u32 {
     /// The smallest value that can be represented by this integer type.
-    pub fn MIN() -> u32 {
+    pub fn min() -> u32 {
         0
     }
 
     /// The largest value that can be represented by this integer type,
     /// 2<sup>32</sup> - 1.
-    pub fn MAX() -> u32 {
+    pub fn max() -> u32 {
         4294967295
     }
 
     /// The size of this integer type in bits.
-    pub fn BITS() -> u32 {
+    pub fn bits() -> u32 {
         32
     }
 }
 
 impl u16 {
     /// The smallest value that can be represented by this integer type.
-    pub fn MIN() -> u16 {
+    pub fn min() -> u16 {
         0
     }
 
     /// The largest value that can be represented by this integer type,
     /// 2<sup>16</sup> - 1.
-    pub fn MAX() -> u16 {
+    pub fn max() -> u16 {
         65535
     }
 
     /// The size of this integer type in bits.
-    pub fn BITS() -> u32 {
+    pub fn bits() -> u32 {
         16
     }
 }
 
 impl u8 {
     /// The smallest value that can be represented by this integer type.
-    pub fn MIN() -> u8 {
+    pub fn min() -> u8 {
         0
     }
 
     /// The largest value that can be represented by this integer type,
     /// 2<sup>8</sup> - 1.
-    pub fn MAX() -> u8 {
+    pub fn max() -> u8 {
         255
     }
 
     /// The size of this integer type in bits.
-    pub fn BITS() -> u32 {
+    pub fn bits() -> u32 {
         8
     }
 }

--- a/sway-lib-core/src/ops.sw
+++ b/sway-lib-core/src/ops.sw
@@ -432,7 +432,7 @@ impl Ord for b256 {
             self_word_1.lt(other_word_1)
         } else if self_word_2.neq(other_word_2) {
             self_word_2.lt(other_word_2)
-        } else if self_word_3.neq(other_word_3){
+        } else if self_word_3.neq(other_word_3) {
             self_word_3.lt(other_word_3)
         } else {
             self_word_4.lt(other_word_4)
@@ -557,7 +557,7 @@ impl OrdEq for b256 {
 /// Extract a single 64 bit word from a b256 value using the specified offset.
 fn get_word_from_b256(val: b256, offset: u64) -> u64 {
     let mut empty: u64 = 0;
-    asm(r1: val, offset: offset, r2,  res: empty) {
+    asm(r1: val, offset: offset, r2, res: empty) {
         add r2 r1 offset;
         lw res r2 i0;
         res: u64

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -130,6 +130,7 @@ pub fn run(filter_regex: Option<regex::Regex>) {
             ProgramState::Return(1), // true
         ),
         ("should_pass/language/generic_enum", ProgramState::Return(1)), // true
+        ("should_pass/language/numeric_constants", ProgramState::Return(1)), // true
         ("should_pass/language/u64_ops", ProgramState::Return(1)),      // true
         (
             "should_pass/language/import_method_from_other_file",

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -130,7 +130,10 @@ pub fn run(filter_regex: Option<regex::Regex>) {
             ProgramState::Return(1), // true
         ),
         ("should_pass/language/generic_enum", ProgramState::Return(1)), // true
-        ("should_pass/language/numeric_constants", ProgramState::Return(1)), // true
+        (
+            "should_pass/language/numeric_constants",
+            ProgramState::Return(1),
+        ), // true
         ("should_pass/language/u64_ops", ProgramState::Return(1)),      // true
         (
             "should_pass/language/import_method_from_other_file",

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'numeric_constants'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+name = "numeric_constants"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/src/main.sw
@@ -1,0 +1,22 @@
+script;
+
+use std::assert::assert;
+use core::num::*;
+
+fn main() -> bool {
+
+    assert(~u64::max() == 18446744073709551615);
+    assert(~u64::min() == 0u64);
+    assert(~u64::bits() == 64u32);
+    assert(~u32::max() == 4294967295u32);
+    assert(~u32::min() == 0u32);
+    assert(~u32::bits() == 32u16);
+    assert(~u16::max() == 65535u16);
+    assert(~u16::min() == 0u16);
+    assert(~u16::bits() == 16u8);
+    assert(~u8::max() == 255u8);
+    assert(~u8::min() == 0u8);
+    assert(~u8::bits() == 8u32);
+
+    true
+}


### PR DESCRIPTION
This switches the function names in `core/num` to use snake_case, and adds tests for the numeric constants.