### PR TITLE
add failing test for issue

### DIFF
--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -236,6 +236,10 @@ pub fn run(filter_regex: Option<regex::Regex>) {
             ProgramState::Return(42), // true
         ),
         (
+            "should_pass/language/new_allocator_test_2",
+            ProgramState::Return(42), // true
+        ),
+        (
             "should_pass/language/chained_if_let",
             ProgramState::Return(5), // true
         ),

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/new_allocator_test_2/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/new_allocator_test_2/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'new_alloc'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/new_allocator_test_2/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/new_allocator_test_2/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "new_alloc"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/new_allocator_test_2/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/new_allocator_test_2/src/main.sw
@@ -1,0 +1,8 @@
+script;
+
+fn main() -> u64 {
+    while false {
+        
+    };
+    42
+}


### PR DESCRIPTION
This following script is failing to compile and I've added an e2e_vm_test for it:
```rs
script;

fn main() -> u64 {
    while false {

    };
    42
}
```

Error:
```
  Compiled library "core".
  Compiled library "std".
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', sway-core/src/asm_lang/virtual_ops.rs:461:57
stack backtrace:
   0: rust_begin_unwind
             at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/core/src/panicking.rs:116:14
   2: core::panicking::panic
             at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/core/src/panicking.rs:48:5
   3: sway_core::asm_lang::virtual_ops::VirtualOp::successors
   4: sway_core::asm_generation::RealizedAbstractInstructionSet::allocate_registers
   5: sway_core::asm_generation::JumpOptimizedAsmSet::allocate_registers
   6: sway_core::asm_generation::from_ir::compile_ir_to_asm
   7: sway_core::ast_to_asm
   8: forc_pkg::pkg::compile
   9: forc_pkg::pkg::build
  10: forc::ops::forc_build::build
  11: forc::cli::commands::build::exec
  12: forc::cli::run_cli::{{closure}}
  13: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
  14: tokio::park::thread::CachedParkThread::block_on
  15: tokio::runtime::thread_pool::ThreadPool::block_on
  16: forc::main
```

![image](https://user-images.githubusercontent.com/412180/169182454-84773396-29a2-4c9d-ab01-eb3dbe55d99f.png)
