### PR TITLE
Fix space formatting between parenthesis and opening quotation marks

### DIFF
--- a/examples/hashing/src/main.sw
+++ b/examples/hashing/src/main.sw
@@ -45,7 +45,7 @@ fn main() {
     let sha_hashed_bool = sha256(true);
 
     // Strings are not a problem either
-    let sha_hashed_str = sha256( "Fastest Modular Execution Layer!");
+    let sha_hashed_str = sha256("Fastest Modular Execution Layer!");
 
     // Tuples of any size work too
     let sha_hashed_tuple = sha256((true, 7));

--- a/sway-fmt/src/code_builder.rs
+++ b/sway-fmt/src/code_builder.rs
@@ -115,7 +115,11 @@ impl CodeBuilder {
                         // handle beginning of the string
                         '"' => {
                             if !code_line.is_string() {
-                                code_line.append_with_whitespace("\"");
+                                if code_line.get_last_char() == Some('(') {
+                                    code_line.push_char('"');
+                                } else {
+                                    code_line.append_with_whitespace("\"");
+                                }
                                 code_line.become_string();
                             }
                         }

--- a/sway-fmt/src/code_line.rs
+++ b/sway-fmt/src/code_line.rs
@@ -81,10 +81,11 @@ impl CodeLine {
 
     pub fn append_with_whitespace(&mut self, value: &str) {
         let last = self.text.chars().last();
-        let is_previous_whitespace = Some(' ') == last;
 
-        if !is_previous_whitespace && last != None {
-            self.push_char(' ');
+        if let Some(c) = last {
+            if c != ' ' && c != '(' {
+                self.push_char(' ');
+            }
         }
 
         self.push_str(value);

--- a/sway-fmt/src/code_line.rs
+++ b/sway-fmt/src/code_line.rs
@@ -81,11 +81,10 @@ impl CodeLine {
 
     pub fn append_with_whitespace(&mut self, value: &str) {
         let last = self.text.chars().last();
+        let is_previous_whitespace = Some(' ') == last;
 
-        if let Some(c) = last {
-            if c != ' ' && c != '(' {
-                self.push_char(' ');
-            }
+        if !is_previous_whitespace && last != None {
+            self.push_char(' ');
         }
 
         self.push_str(value);

--- a/sway-fmt/src/fmt.rs
+++ b/sway-fmt/src/fmt.rs
@@ -715,4 +715,29 @@ fn main() {
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
     }
+
+    #[test]
+    fn test_string_in_brackets() {
+        let correct_sway_code = r#"script;
+fn main() {
+    let sha_hashed_str = sha256("Fastest Modular Execution Layer!");
+}
+"#;
+
+        let result = get_formatted_data(correct_sway_code.into(), OPTIONS, None);
+        assert!(result.is_ok());
+        let (_, formatted_code) = result.unwrap();
+        assert_eq!(correct_sway_code, formatted_code);
+
+        let sway_code = r#"script;
+fn main() {
+    let sha_hashed_str = sha256(  "Fastest Modular Execution Layer!"  );
+}
+"#;
+
+        let result = get_formatted_data(sway_code.into(), OPTIONS, None);
+        assert!(result.is_ok());
+        let (_, formatted_code) = result.unwrap();
+        assert_eq!(correct_sway_code, formatted_code);
+    }
 }


### PR DESCRIPTION
Closes #1598 

When checking for `"` we should check if the previous char is a `(`, and append without whitespace if it is.