### PR TITLE
Fix Shiftable trait to shift by u64.

### DIFF
--- a/sway-lib-core/src/ops.sw
+++ b/sway-lib-core/src/ops.sw
@@ -201,18 +201,18 @@ impl Mod for u8 {
 }
 
 pub trait Shiftable {
-    fn lsh(self, other: Self) -> Self;
-    fn rsh(self, other: Self) -> Self;
+    fn lsh(self, other: u64) -> Self;
+    fn rsh(self, other: u64) -> Self;
 }
 
 impl Shiftable for u64 {
-    fn lsh(self, other: Self) -> Self {
+    fn lsh(self, other: u64) -> Self {
         asm(r1: self, r2: other, r3) {
             sll r3 r1 r2;
             r3: u64
         }
     }
-    fn rsh(self, other: Self) -> Self {
+    fn rsh(self, other: u64) -> Self {
         asm(r1: self, r2: other, r3) {
             srl r3 r1 r2;
             r3: u64
@@ -221,13 +221,13 @@ impl Shiftable for u64 {
 }
 
 impl Shiftable for u32 {
-    fn lsh(self, other: Self) -> Self {
+    fn lsh(self, other: u64) -> Self {
         asm(r1: self, r2: other, r3) {
             sll r3 r1 r2;
             r3: u32
         }
     }
-    fn rsh(self, other: Self) -> Self {
+    fn rsh(self, other: u64) -> Self {
         asm(r1: self, r2: other, r3) {
             srl r3 r1 r2;
             r3: u32
@@ -236,13 +236,13 @@ impl Shiftable for u32 {
 }
 
 impl Shiftable for u16 {
-    fn lsh(self, other: Self) -> Self {
+    fn lsh(self, other: u64) -> Self {
         asm(r1: self, r2: other, r3) {
             sll r3 r1 r2;
             r3: u16
         }
     }
-    fn rsh(self, other: Self) -> Self {
+    fn rsh(self, other: u64) -> Self {
         asm(r1: self, r2: other, r3) {
             srl r3 r1 r2;
             r3: u16
@@ -251,13 +251,13 @@ impl Shiftable for u16 {
 }
 
 impl Shiftable for u8 {
-    fn lsh(self, other: Self) -> Self {
+    fn lsh(self, other: u64) -> Self {
         asm(r1: self, r2: other, r3) {
             sll r3 r1 r2;
             r3: u8
         }
     }
-    fn rsh(self, other: Self) -> Self {
+    fn rsh(self, other: u64) -> Self {
         asm(r1: self, r2: other, r3) {
             srl r3 r1 r2;
             r3: u8

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/if_implicit_unit/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/if_implicit_unit/src/main.sw
@@ -8,14 +8,14 @@ pub trait Shiftable {
 }
 
 impl Shiftable for u64 {
-    fn lsh(self, other: Self) -> Self {
+    fn lsh(self, other: u64) -> Self {
         asm(r1 : self, r2: other, r3) {
             sll r3 r1 r2;
             r3: u64
         }
     }
 
-    fn rsh(self, other: Self) -> Self {
+    fn rsh(self, other: u64) -> Self {
         asm(r1 : self, r2: other, r3) {
             srl r3 r1 r2;
             r3: u64

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_import_with_star/src/shiftable.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_import_with_star/src/shiftable.sw
@@ -5,13 +5,13 @@ pub trait Shiftable {
 }
 
 impl Shiftable for u64 {
-    fn lsh(self, other: Self) -> Self {
+    fn lsh(self, other: u64) -> Self {
         asm(r1: self, r2: other, r3) {
             sll r3 r1 r2;
             r3: u64
         }
     }
-    fn rsh(self, other: Self) -> Self {
+    fn rsh(self, other: u64) -> Self {
         asm(r1: self, r2: other, r3) {
             srl r3 r1 r2;
             r3: u64

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_override_bug/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_override_bug/src/main.sw
@@ -3,20 +3,20 @@ script;
 // This bug was found by Nebula in discord. Adding this trait was causing other implementations on u64s to be overridden.
 
 pub trait Shiftable {
-    fn lsh(self, other: Self) -> Self;
-    fn rsh(self, other: Self) -> Self;
+    fn lsh(self, other: u64) -> Self;
+    fn rsh(self, other: u64) -> Self;
 
 }
 
 impl Shiftable for u64 {
-    fn lsh(self, other: Self) -> Self {
+    fn lsh(self, other: u64) -> Self {
         asm(r1 : self, r2: other, r3) {
             sll r3 r1 r2;
             r3: u64
         }
     }
 
-    fn rsh(self, other: Self) -> Self {
+    fn rsh(self, other: u64) -> Self {
         asm(r1 : self, r2: other, r3) {
             srl r3 r1 r2;
             r3: u64


### PR DESCRIPTION
`Shiftable` shouldn't be restricted to only shifting by the same type. This seems fine for primitive unsigned integers, but e.g. for a `U128` type or potentially some string type then it doesn't make sense to shift by that type.