### PR TITLE
Enable to deploy a contract to another node with --url option

### DIFF
--- a/forc/src/cli/commands/deploy.rs
+++ b/forc/src/cli/commands/deploy.rs
@@ -47,6 +47,10 @@ pub struct Command {
     /// needs to be updated, Forc will exit with an error
     #[clap(long)]
     pub locked: bool,
+    /// The node url to deploy, if not specified uses DEFAULT_NODE_URL.
+    /// If url is specified overrides network url in manifest file (if there is one).
+    #[clap(long, short)]
+    pub url: Option<String>,
 }
 
 pub(crate) async fn exec(command: Command) -> Result<()> {

--- a/forc/src/ops/forc_deploy.rs
+++ b/forc/src/ops/forc_deploy.rs
@@ -34,6 +34,7 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
         output_directory,
         minify_json_abi,
         locked,
+        url,
     } = command;
 
     let build_command = BuildCommand {
@@ -61,6 +62,11 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
     let node_url = match &manifest.network {
         Some(network) => &network.url,
         _ => DEFAULT_NODE_URL,
+    };
+
+    let node_url = match url {
+        Some(url_str) => url_str,
+        None => node_url.to_string(),
     };
 
     let client = FuelClient::new(node_url)?;


### PR DESCRIPTION
closes #1308.

With this implementation if `--url` is specified, `forc deploy` passes that `url` to `FuelClient::new()` and `--url ` overrides other URL options which means:

- If `url` is specified and there is a `url` in the `[network]` section of `Forc.toml`, `forc deploy` deploys to the specified `url`.
- If `url` is specified and there is no `url` in the `[network]` section of `Forc.toml`, `forc deploy` deploys to the specified `url` rather than the `DEFAULT_NODE_URL`.
-  If `url` is not specified and there is a `url` in the `[network]` section of `Forc.toml`, `forc deploy` deploys to the `url` in the `Forc.toml` `[network]` section.
- If `url` is not specified and there is no `url` in the `[network]` section of `Forc.toml`, `forc deploy` deploys to the `DEFAULT_NODE_URL`.

### Testing Steps

1. Run fuel-core with a different port (default is `4000`). (`cargo run --bin fuel-core -- --db-type in-memory --port 7000`)
2. Run forc deploy in an example project with `--url http://127.0.0.1:7000`