### PR TITLE
Fixing how the number of predecessors of an IR block is calculated

### DIFF
--- a/sway-core/tests/sway_to_ir/implicit_return.ir
+++ b/sway-core/tests/sway_to_ir/implicit_return.ir
@@ -1,0 +1,21 @@
+script {
+    fn main() -> u64 {
+        entry:
+        br while
+
+        while:
+        v0 = const bool false, !1
+        cbr v0, while_body, end_while
+
+        while_body:
+        br while
+
+        end_while:
+        v1 = const u64 42, !2
+        ret u64 v1
+    }
+}
+
+!0 = filepath "/path/to/implicit_return.sw"
+!1 = span !0 38 43
+!2 = span !0 57 59

--- a/sway-core/tests/sway_to_ir/implicit_return.sw
+++ b/sway-core/tests/sway_to_ir/implicit_return.sw
@@ -1,0 +1,7 @@
+script;
+
+fn main() -> u64 {
+    while false {
+    };
+    42
+}

--- a/sway-ir/src/block.rs
+++ b/sway-ir/src/block.rs
@@ -259,9 +259,10 @@ impl Block {
 #[doc(hidden)]
 impl BlockContent {
     pub(super) fn num_predecessors(&self, context: &Context) -> usize {
-        self.function.block_iter(context).fold(0, |mut acc, b| {
-            acc += b.instruction_iter(context).fold(0, |mut acc, i| {
-                acc += match context.values[i.0].value {
+        self.function
+            .instruction_iter(context)
+            .filter(
+                |(_block, ins_value)| match &context.values[ins_value.0].value {
                     ValueDatum::Instruction(Instruction::ConditionalBranch {
                         true_block,
                         false_block,
@@ -273,12 +274,10 @@ impl BlockContent {
                     ValueDatum::Instruction(Instruction::Branch(block)) => {
                         block.get_label(context) == self.label
                     }
-                    _ => false,
-                } as usize;
-                acc
-            });
-            acc
-        })
+                    _otherwise => false,
+                },
+            )
+            .count()
     }
 }
 

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -339,6 +339,10 @@ pub fn run(filter_regex: Option<regex::Regex>) {
             "should_pass/language/multi_impl_self",
             ProgramState::Return(42),
         ),
+        (
+            "should_pass/language/implicit_return",
+            ProgramState::Return(42),
+        ),
     ];
 
     let mut number_of_tests_run =

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_return/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_return/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'implicit_return'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_return/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_return/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+name = "implicit_return"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false
+
+[dependencies]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_return/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_return/src/main.sw
@@ -1,0 +1,7 @@
+script;
+
+fn main() -> u64 {
+    while false {
+    };
+    42
+}


### PR DESCRIPTION
Fixes the issue flagged by @AlicanC in https://github.com/FuelLabs/sway/pull/1602

The symptom is an issue in the final asm generator. The reason being a missing `ret` for an implicit return in the user code. Basically, the check in https://github.com/FuelLabs/sway/blob/6eef7ab750cd3282f08b6014960cbc02afae717a/sway-core/src/optimize.rs#L337 fails, and so, we don't create a `ret`. Turns out that the number of predecessor blocks is incorrectly calculated (should be 1 instead of 0 for the example that JC provided).