### PR TITLE
Differentiate different impl selfs in node dependencies

### DIFF
--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -525,7 +525,7 @@ impl Dependencies {
 enum DependentSymbol {
     Symbol(String),
     Fn(Ident, Option<Span>),
-    Impl(Ident, String), // Trait or self, and type implementing for.
+    Impl(Ident, String, String), // Trait or self, type implementing for, and method names concatenated.
 }
 
 // We'll use a custom Hash and PartialEq here to explicitly ignore the span in the Fn variant.
@@ -535,8 +535,8 @@ impl PartialEq for DependentSymbol {
         match (self, rhs) {
             (DependentSymbol::Symbol(l), DependentSymbol::Symbol(r)) => l.eq(r),
             (DependentSymbol::Fn(l, _), DependentSymbol::Fn(r, _)) => l.eq(r),
-            (DependentSymbol::Impl(lt, ls), DependentSymbol::Impl(rt, rs)) => {
-                lt.eq(rt) && ls.eq(rs)
+            (DependentSymbol::Impl(lt, ls, lm), DependentSymbol::Impl(rt, rs, rm)) => {
+                lt.eq(rt) && ls.eq(rs) && lm.eq(rm)
             }
             _ => false,
         }
@@ -550,9 +550,10 @@ impl Hash for DependentSymbol {
         match self {
             DependentSymbol::Symbol(s) => s.hash(state),
             DependentSymbol::Fn(s, _) => s.hash(state),
-            DependentSymbol::Impl(t, s) => {
+            DependentSymbol::Impl(t, s, m) => {
                 t.hash(state);
-                s.hash(state)
+                s.hash(state);
+                m.hash(state)
             }
         }
     }
@@ -560,8 +561,15 @@ impl Hash for DependentSymbol {
 
 fn decl_name(decl: &Declaration) -> Option<DependentSymbol> {
     let dep_sym = |name| Some(DependentSymbol::Symbol(name));
-    let impl_sym = |trait_name, type_info: &TypeInfo| {
-        Some(DependentSymbol::Impl(trait_name, type_info_name(type_info)))
+    // `method_names` is the concatenation of all the method names defined in an impl block.
+    // This is needed because there can exist multiple impl self blocks for a single type in a
+    // file and we need some way to disambiguate them.
+    let impl_sym = |trait_name, type_info: &TypeInfo, method_names| {
+        Some(DependentSymbol::Impl(
+            trait_name,
+            type_info_name(type_info),
+            method_names,
+        ))
     };
 
     match decl {
@@ -580,11 +588,27 @@ fn decl_name(decl: &Declaration) -> Option<DependentSymbol> {
         Declaration::ImplSelf(decl) => {
             let trait_name =
                 Ident::new_with_override("self", decl.type_implementing_for_span.clone());
-            impl_sym(trait_name, &decl.type_implementing_for)
+            impl_sym(
+                trait_name,
+                &decl.type_implementing_for,
+                decl.functions
+                    .iter()
+                    .map(|x| x.name.as_str())
+                    .collect::<Vec<&str>>()
+                    .join(""),
+            )
         }
         Declaration::ImplTrait(decl) => {
             if decl.trait_name.prefixes.is_empty() {
-                impl_sym(decl.trait_name.suffix.clone(), &decl.type_implementing_for)
+                impl_sym(
+                    decl.trait_name.suffix.clone(),
+                    &decl.type_implementing_for,
+                    decl.functions
+                        .iter()
+                        .map(|x| x.name.as_str())
+                        .collect::<Vec<&str>>()
+                        .join(""),
+                )
             } else {
                 None
             }

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -335,6 +335,10 @@ pub fn run(filter_regex: Option<regex::Regex>) {
                 0x67, 0x6e, 0x5f, 0x13,
             ])),
         ),
+        (
+            "should_pass/language/multi_impl_self",
+            ProgramState::Return(42),
+        ),
     ];
 
     let mut number_of_tests_run =

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'multi_impl_self'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "multi_impl_self"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/src/main.sw
@@ -1,0 +1,21 @@
+script;
+
+struct MyStruct {
+}
+
+impl MyStruct {
+    pub fn my_fun() -> u64 {
+        fun()
+    }
+}
+
+impl MyStruct {
+}
+
+fn fun() -> u64 {
+    42
+}
+
+fn main() -> u64 {
+    ~MyStruct::my_fun()
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/tests/harness.rs
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/tests/harness.rs
@@ -1,0 +1,30 @@
+use fuel_tx::ContractId;
+use fuels_abigen_macro::abigen;
+use fuels::prelude::*;
+use fuels::test_helpers;
+
+// Load abi from json
+abigen!(MyContract, "out/debug/multi_impl_self-abi.json");
+
+async fn get_contract_instance() -> (MyContract, ContractId) {
+    // Deploy the compiled contract
+    let compiled = Contract::load_sway_contract("./out/debug/multi_impl_self.bin").unwrap();
+
+    // Launch a local network and deploy the contract
+    let (provider, wallet) = test_helpers::setup_test_provider_and_wallet().await;
+
+    let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default())
+        .await
+        .unwrap();
+
+    let instance = MyContract::new(id.to_string(), provider, wallet);
+
+    (instance, id)
+}
+
+#[tokio::test]
+async fn can_get_contract_id() {
+    let (_instance, _id) = get_contract_instance().await;
+
+    // Now you have an instance of your contract you can use to test each function
+}


### PR DESCRIPTION
Closes #1601 

We previously were not differentiating between different impl selves in a single file for `node_dependencies`, which determines order of compilation. This PR includes the function names, concatenated, as an additional source of distinction for these impl self blocks. This allows us to disambiguate. I also included this disambiguation for impl trait blocks, although it isn't strictly necessary, for consistency. 