### PR TITLE
Fix bug where `mdbook-forc-documenter` would panic if `mdbook build` called not in Sway root

### DIFF
--- a/scripts/mdbook-forc-documenter/src/plugins.rs
+++ b/scripts/mdbook-forc-documenter/src/plugins.rs
@@ -1,27 +1,17 @@
-use anyhow::{anyhow, Result};
+use anyhow::{bail, Result};
 use std::fs;
 use std::path::PathBuf;
 
 fn find_forc_plugins_dir() -> Result<PathBuf> {
-    let mut curr_path = std::env::current_dir().unwrap();
-
-    loop {
-        if let Ok(entries) = fs::read_dir(&curr_path) {
-            if !curr_path.join("Cargo.toml").exists() {
-                continue;
-            }
-            for entry in entries.filter_map(Result::ok) {
-                let path = entry.path();
-                if path.is_dir() && path.ends_with("forc-plugins") {
-                    return Ok(path);
-                }
-            }
-        }
-        curr_path = curr_path
-            .parent()
-            .ok_or_else(|| anyhow!("Could not find Cargo.toml in the project directory"))?
-            .to_path_buf();
+    let sway_dir = crate::find_sway_repo_root()?;
+    let plugins_dir = sway_dir.join("forc-plugins");
+    if !plugins_dir.exists() || !plugins_dir.is_dir() {
+        bail!(
+            "Failed to find plugins directory at {}",
+            plugins_dir.display()
+        );
     }
+    Ok(plugins_dir)
 }
 
 pub fn plugin_commands() -> Vec<String> {


### PR DESCRIPTION
While testing, I noticed that the build would panic if you attempted to
`mdbook build` the book while in the `docs` directory. I then realised
we had a misuse of the `current_dir` function which must have slipped
through in a previous PR review. I've fixed this by adding a
`find_sway_repo_root` fn and implementing functions to find the plugins
and examples directories in terms of it.

cc @binggh this PR is against #1582 - landing this will apply the fixes there, then we can land #1582.