### PR TITLE
`Storable` trait and `Mapping`

### DIFF
--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -7,6 +7,8 @@
 // But this is not ideal and needs to be refactored:
 // - AsmNamespace is tied to data structures from other stages like Ident and Literal.
 
+use fuel_crypto::Hasher;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
@@ -499,6 +501,7 @@ impl<'ir> AsmBuilder<'ir> {
                 Instruction::ExtractValue {
                     aggregate, indices, ..
                 } => self.compile_extract_value(instr_val, aggregate, indices),
+                Instruction::GenerateB256Seed => self.compile_generate_b256_seed(instr_val),
                 Instruction::GetPointer {
                     base_ptr,
                     ptr_ty,
@@ -1030,6 +1033,32 @@ impl<'ir> AsmBuilder<'ir> {
         }
 
         self.reg_map.insert(*instr_val, instr_reg);
+    }
+
+    fn compile_generate_b256_seed(&mut self, instr_val: &Value) {
+        // Replace each call to __generate_b256_seed with a new value
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let storage_slot_to_hash = format!(
+            "{}{}",
+            crate::constants::GENERATE_B256_SEED_SEPARATOR,
+            COUNTER.load(Ordering::SeqCst)
+        );
+        COUNTER.fetch_add(1, Ordering::SeqCst);
+
+        let hashed_storage_slot = Hasher::hash(storage_slot_to_hash);
+
+        let data_id = self
+            .data_section
+            .insert_data_value(&Literal::B256(hashed_storage_slot.into()));
+
+        // Allocate a register for it, and a load instruction.
+        let reg = self.reg_seqr.next();
+        self.bytecode.push(Op {
+            opcode: either::Either::Left(VirtualOp::LWDataId(reg.clone(), data_id)),
+            comment: "literal instantiation".into(),
+            owning_span: instr_val.get_span(self.context),
+        });
+        self.reg_map.insert(*instr_val, reg);
     }
 
     fn compile_get_pointer(

--- a/sway-core/src/constants.rs
+++ b/sway-core/src/constants.rs
@@ -24,6 +24,8 @@ pub const DEFAULT_ENTRY_POINT_FN_NAME: &str = "main";
 /// The default prefix for the compiler generated names of tuples
 pub const TUPLE_NAME_PREFIX: &str = "__tuple_";
 
+pub const GENERATE_B256_SEED_SEPARATOR: &str = "__generate_b256_separator_";
+
 /// The valid attribute strings related to storage and purity.
 pub const STORAGE_PURITY_ATTRIBUTE_NAME: &str = "storage";
 pub const STORAGE_PURITY_READ_NAME: &str = "read";

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -1035,6 +1035,13 @@ fn connect_expression(
             )?;
             Ok(expr)
         }
+        GenerateB256Seed { .. } => {
+            let node = graph.add_node("Generate B256 Seed".into());
+            for leaf in leaves {
+                graph.add_edge(*leaf, node, "".into());
+            }
+            Ok(vec![node])
+        }
         AbiName(abi_name) => {
             if let crate::type_engine::AbiName::Known(abi_name) = abi_name {
                 // abis are treated as traits here

--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -179,6 +179,8 @@ pub enum ConvertParseTreeError {
     InvalidAttributeArgument { attribute: String, span: Span },
     #[error("cannot find type \"{ty_name}\" in this scope")]
     ConstrainedNonExistentType { ty_name: Ident, span: Span },
+    #[error("__generate_b256_seed does not take arguments")]
+    GenerateB256SeedTooManyArgs { span: Span },
 }
 
 impl ConvertParseTreeError {
@@ -228,6 +230,7 @@ impl ConvertParseTreeError {
             ConvertParseTreeError::ContractCallerNamedTypeGenericArg { span } => span.clone(),
             ConvertParseTreeError::InvalidAttributeArgument { span, .. } => span.clone(),
             ConvertParseTreeError::ConstrainedNonExistentType { span, .. } => span.clone(),
+            ConvertParseTreeError::GenerateB256SeedTooManyArgs { span, .. } => span.clone(),
         }
     }
 }
@@ -1372,6 +1375,20 @@ fn expr_to_expression(ec: &mut ErrorContext, expr: Expr) -> Result<Expression, E
                             type_span,
                             span,
                         }
+                    } else if call_path.prefixes.is_empty()
+                        && !call_path.is_absolute
+                        && Intrinsic::try_from_str(call_path.suffix.as_str())
+                            == Some(Intrinsic::GenerateB256Seed)
+                    {
+                        if !arguments.is_empty() {
+                            let error = ConvertParseTreeError::GenerateB256SeedTooManyArgs { span };
+                            return Err(ec.error(error));
+                        }
+                        if generics_opt.is_some() {
+                            let error = ConvertParseTreeError::GenericsNotSupportedHere { span };
+                            return Err(ec.error(error));
+                        }
+                        Expression::BuiltinGenerateB256Seed { span }
                     } else if call_path.prefixes.is_empty()
                         && !call_path.is_absolute
                         && Intrinsic::try_from_str(call_path.suffix.as_str())

--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -748,10 +748,24 @@ impl FnCompiler {
             TypedExpressionVariant::AbiName(_) => {
                 Ok(Value::new_constant(context, Constant::new_unit(), None))
             }
+            TypedExpressionVariant::GenerateB256Seed { span } => {
+                let span_md_idx = MetadataIndex::from_span(context, &span);
+                self.compile_generate_b256_seed(context, span_md_idx)
+            }
         }
     }
 
     // ---------------------------------------------------------------------------------------------
+    fn compile_generate_b256_seed(
+        &mut self,
+        context: &mut Context,
+        span_md_idx: Option<MetadataIndex>,
+    ) -> Result<Value, CompileError> {
+        Ok(self
+            .current_block
+            .ins(context)
+            .generate_b256_seed(span_md_idx))
+    }
 
     fn compile_return_statement(
         &mut self,

--- a/sway-core/src/parse_tree/expression/mod.rs
+++ b/sway-core/src/parse_tree/expression/mod.rs
@@ -170,6 +170,9 @@ pub enum Expression {
         type_span: Span,
         span: Span,
     },
+    BuiltinGenerateB256Seed {
+        span: Span,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -273,6 +276,7 @@ impl Expression {
             IfLet { span, .. } => span,
             SizeOfVal { span, .. } => span,
             BuiltinGetTypeProperty { span, .. } => span,
+            BuiltinGenerateB256Seed { span, .. } => span,
         })
         .clone()
     }

--- a/sway-core/src/semantic_analysis/ast_node/expression/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/mod.rs
@@ -1,7 +1,7 @@
 mod enum_instantiation;
 mod func_app_instantiation;
 mod struct_expr_field;
-mod typed_expression;
+pub mod typed_expression;
 mod typed_expression_variant;
 mod usefulness;
 pub(crate) use enum_instantiation::instantiate_enum;

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -110,6 +110,9 @@ pub(crate) enum TypedExpressionVariant {
         type_id: TypeId,
         span: Span,
     },
+    GenerateB256Seed {
+        span: Span,
+    },
     SizeOfValue {
         expr: Box<TypedExpression>,
     },
@@ -471,6 +474,7 @@ impl CopyTypes for TypedExpressionVariant {
                 };
                 variant.copy_types(type_mapping);
             }
+            GenerateB256Seed { .. } => (),
             AbiName(_) => (),
         }
     }
@@ -642,6 +646,7 @@ impl TypedExpressionVariant {
             TypedExpressionVariant::SizeOfValue { expr } => {
                 format!("size_of_val({:?})", expr.pretty_print())
             }
+            TypedExpressionVariant::GenerateB256Seed { .. } => "generate_b256_seed".to_string(),
             TypedExpressionVariant::AbiName(n) => format!("ABI name {}", n),
         }
     }

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -416,6 +416,7 @@ impl Dependencies {
                 .gather_from_opt_expr(r#else.as_deref()),
             Expression::SizeOfVal { exp, .. } => self.gather_from_expr(exp),
             Expression::BuiltinGetTypeProperty { .. } => self,
+            Expression::BuiltinGenerateB256Seed { .. } => self,
         }
     }
 

--- a/sway-core/src/type_engine/unresolved_type_check.rs
+++ b/sway-core/src/type_engine/unresolved_type_check.rs
@@ -1,4 +1,3 @@
-//! This module handles the process of iterating through the typed AST and ensuring that all types
 //! are well-defined and well-formed. This process is run on the AST before we pass it into the IR,
 //! as the IR assumes all types are well-formed and will throw an ICE (internal compiler error) if
 //! that is not the case.
@@ -189,7 +188,11 @@ impl UnresolvedTypeCheck for TypedExpression {
             SizeOfValue { expr } => expr.check_for_unresolved_types(),
             AbiCast { address, .. } => address.check_for_unresolved_types(),
             // storage access can never be generic
-            StorageAccess { .. } | Literal(_) | AbiName(_) | FunctionParameter => vec![],
+            StorageAccess { .. }
+            | Literal(_)
+            | AbiName(_)
+            | FunctionParameter
+            | GenerateB256Seed { .. } => vec![],
         }
     }
 }

--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -284,6 +284,7 @@ fn inline_instruction(
                     .ins(context)
                     .extract_value(map_value(aggregate), ty, indices, span_md_idx)
             }
+            Instruction::GenerateB256Seed => new_block.ins(context).generate_b256_seed(span_md_idx),
             Instruction::GetPointer {
                 base_ptr,
                 ptr_ty,

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -421,6 +421,11 @@ fn instruction_to_doc<'a>(
                     Some(_) => Doc::text(md_namer.meta_as_string(context, span_md_idx, true)),
                 }),
             )),
+            Instruction::GenerateB256Seed => Doc::text_line(format!(
+                "{} = generate_b256_seed{}",
+                namer.name(context, ins_value),
+                md_namer.meta_as_string(context, span_md_idx, true),
+            )),
             Instruction::GetPointer {
                 base_ptr,
                 ptr_ty,

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -123,6 +123,7 @@ impl<'a> InstructionVerifier<'a> {
                         ty,
                         indices,
                     } => self.verify_extract_value(aggregate, ty, indices)?,
+                    Instruction::GenerateB256Seed => (),
                     Instruction::GetPointer {
                         base_ptr,
                         ptr_ty,

--- a/sway-lib-core/src/lib.sw
+++ b/sway-lib-core/src/lib.sw
@@ -2,3 +2,4 @@ library core;
 
 dep num;
 dep ops;
+dep storable;

--- a/sway-lib-core/src/storable.sw
+++ b/sway-lib-core/src/storable.sw
@@ -1,0 +1,92 @@
+library storable;
+
+pub trait Storable {
+    fn write(self, key: b256);
+    fn read(key: b256) -> Self;
+}
+
+impl Storable for u64 {
+    fn write(self, key: b256) {
+        asm(r1: key, r2: self) {
+            sww r1 r2;
+        };
+    }
+    fn read(key: b256) -> u64 {
+        asm(r1: key, r2) {
+            srw r2 r1;
+            r2: u64
+        }
+    }
+}
+
+impl Storable for u32 {
+    fn write(self, key: b256) {
+        asm(r1: key, r2: self) {
+            sww r1 r2;
+        };
+    }
+    fn read(key: b256) -> u32 {
+        asm(r1: key, r2) {
+            srw r2 r1;
+            r2: u32
+        }
+    }
+}
+
+impl Storable for u16 {
+    fn write(self, key: b256) {
+        asm(r1: key, r2: self) {
+            sww r1 r2;
+        };
+    }
+    fn read(key: b256) -> u16 {
+        asm(r1: key, r2) {
+            srw r2 r1;
+            r2: u16
+        }
+    }
+}
+
+impl Storable for u8 {
+    fn write(self, key: b256) {
+        asm(r1: key, r2: self) {
+            sww r1 r2;
+        };
+    }
+    fn read(key: b256) -> u8 {
+        asm(r1: key, r2) {
+            srw r2 r1;
+            r2: u8
+        }
+    }
+}
+
+impl Storable for bool {
+    fn write(self, key: b256) {
+        asm(r1: key, r2: self) {
+            sww r1 r2;
+        };
+    }
+    fn read(key: b256) -> bool {
+        asm(r1: key, r2) {
+            srw r2 r1;
+            r2: bool
+        }
+    }
+}
+
+impl Storable for b256 {
+    fn write(self, key: b256) {
+        asm(r1: key, r2: self) {
+            swwq r1 r2;
+        };
+    }
+    fn read(key: b256) -> b256 {
+        asm(r1: key, r2) {
+            move r2 sp;
+            cfei i32;
+            srwq r2 r1;
+            r2: b256
+        }
+    }
+}

--- a/sway-lib-std/src/lib.sw
+++ b/sway-lib-std/src/lib.sw
@@ -21,5 +21,6 @@ dep token;
 dep ecr;
 dep reentrancy;
 dep vm/mod;
+dep mapping;
 
 use core::*;

--- a/sway-lib-std/src/mapping.sw
+++ b/sway-lib-std/src/mapping.sw
@@ -1,0 +1,34 @@
+library mapping;
+
+use ::hash::*;
+use core::storable::*;
+
+pub struct Mapping {
+    seed_key: b256
+}
+
+impl core::storable::Storable for Mapping {
+    fn write(self, key: b256) {
+        self.seed_key.write(key);
+    }
+    fn read(key: b256) -> Mapping {
+        Mapping {
+            seed_key: ~b256::read(key),
+        }
+    }
+}
+
+// Will be generic
+impl Mapping {
+    fn new() -> Mapping {
+        Mapping { seed_key: __generate_b256_seed() }
+    }
+
+    fn insert(self, key: u64, value: u64) {
+        value.write(sha256((key, self.seed_key)));
+    }
+
+    fn get(self, key: u64) -> u64 {
+        ~u64::read(sha256((key, self.seed_key)))
+    }
+}

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -450,6 +450,9 @@ fn handle_expression(exp: Expression, tokens: &mut Vec<Token>) {
         Expression::BuiltinGetTypeProperty { .. } => {
             //TODO handle built in get type property?
         }
+        Expression::BuiltinGenerateB256Seed { .. } => {
+            //TODO handle built in generate b256 seed?
+        }
     }
 }
 

--- a/sway-parse/src/intrinsics.rs
+++ b/sway-parse/src/intrinsics.rs
@@ -1,5 +1,6 @@
 #[derive(Eq, PartialEq)]
 pub enum Intrinsic {
+    GenerateB256Seed,
     IsReferenceType,
     SizeOf,
     SizeOfVal,
@@ -9,6 +10,7 @@ impl Intrinsic {
     pub fn try_from_str(raw: &str) -> Option<Intrinsic> {
         use Intrinsic::*;
         Some(match raw {
+            "__generate_b256_seed" => GenerateB256Seed,
             "__is_reference_type" => IsReferenceType,
             "__size_of" => SizeOf,
             "__size_of_val" => SizeOfVal,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -3,14 +3,14 @@ use basic_storage_abi::StoreU64;
 use std::assert::assert;
 
 fn main() -> u64 {
-    let addr = abi(StoreU64, 0xee9dd0202c77b119a284bc16b380f5273bbbdfed311de8d581438dc2d7cb00b5);
+    let addr = abi(StoreU64,0x6b3a8abb373c57d3027acd6c11e83bd6247f55aa4db4545c41506d8ce0b238f8);
     let key = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 
     addr.store_u64(key, value);
 
     let res = addr.get_u64(key);
-    assert(res == value);
+    assert(res == 3*value);
 
     res
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/Forc.lock
@@ -1,18 +1,11 @@
 [[package]]
 name = 'basic_storage'
-dependencies = [
-    'basic_storage_abi',
-    'std',
-]
+dependencies = ['basic_storage_abi']
 
 [[package]]
 name = 'basic_storage_abi'
-dependencies = []
+dependencies = ['core']
 
 [[package]]
 name = 'core'
 dependencies = []
-
-[[package]]
-name = 'std'
-dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/Forc.toml
@@ -1,9 +1,9 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
+implicit-std = false
 license = "Apache-2.0"
 name = "basic_storage"
 
 [dependencies]
 basic_storage_abi = { path = "../../test_abis/basic_storage_abi" }
-std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/src/main.sw
@@ -1,13 +1,41 @@
 contract;
-use std::storage::*;
 use basic_storage_abi::*;
+use core::storable::*;
+
+struct S {
+    a: u64,
+//    b: u64, // once we have addition for b256
+}
+
+impl core::storable::Storable for S {
+    fn write(self, key: b256) {
+        self.a.write(key);
+        // self.b.write(key + 1); // once we have addition for b256
+    }
+    fn read(key: b256) -> S {
+        S {
+            a: ~u64::read(key),
+            // b: ~u64::read(key + 1), // once we have addition for b256
+        }
+    }
+}
+
+storage {
+    x: u64,
+    y: u64,
+    s: S,
+}
 
 impl StoreU64 for Contract {
     fn get_u64(storage_key: b256) -> u64 {
-        get(storage_key)
+        let sum1 = storage.x + storage.y;
+        let local_s = storage.s; 
+        local_s.a + sum1
     }
 
     fn store_u64(key: b256, value: u64) {
-        store(key, value);
+        storage.x = value;
+        storage.y = value;
+        storage.s = S { a: value };
     }
 }

--- a/test/src/sdk-harness/test_projects/harness.rs
+++ b/test/src/sdk-harness/test_projects/harness.rs
@@ -9,6 +9,7 @@ mod evm_ecr;
 mod hashing;
 mod intrinsics;
 mod logging;
+mod mapping;
 mod option;
 mod reentrancy;
 mod registers;

--- a/test/src/sdk-harness/test_projects/mapping/.gitignore
+++ b/test/src/sdk-harness/test_projects/mapping/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/sdk-harness/test_projects/mapping/Forc.lock
+++ b/test/src/sdk-harness/test_projects/mapping/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'mapping'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/test/src/sdk-harness/test_projects/mapping/Forc.toml
+++ b/test/src/sdk-harness/test_projects/mapping/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "mapping"
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/test/src/sdk-harness/test_projects/mapping/mod.rs
+++ b/test/src/sdk-harness/test_projects/mapping/mod.rs
@@ -1,0 +1,40 @@
+use fuel_tx::ContractId;
+use fuels_abigen_macro::abigen;
+use fuels::prelude::*;
+use fuels::test_helpers;
+
+// Load abi from json
+abigen!(MyContract, "out/debug/mapping-abi.json");
+
+async fn get_contract_instance() -> (MyContract, ContractId) {
+    // Deploy the compiled contract
+    let compiled = Contract::load_sway_contract("./out/debug/mapping.bin").unwrap();
+
+    // Launch a local network and deploy the contract
+    let (provider, wallet) = test_helpers::setup_test_provider_and_wallet().await;
+
+    let id = Contract::deploy(&compiled, &provider, &wallet, TxParameters::default())
+        .await
+        .unwrap();
+
+    let instance = MyContract::new(id.to_string(), provider, wallet);
+
+    (instance, id)
+}
+
+#[tokio::test]
+async fn can_get_contract_id() {
+    let (instance, _id) = get_contract_instance().await;
+
+    instance.init().call().await;
+
+    instance.insert_into_mapping1(1, 42).call().await;
+    instance.insert_into_mapping1(2, 77).call().await;
+    instance.insert_into_mapping2(1, 66).call().await;
+    instance.insert_into_mapping2(2, 99).call().await;
+
+    assert_eq!(instance.get_from_mapping1(1).call().await.unwrap().value, 42);
+    assert_eq!(instance.get_from_mapping1(2).call().await.unwrap().value, 77);
+    assert_eq!(instance.get_from_mapping2(1).call().await.unwrap().value, 66);
+    assert_eq!(instance.get_from_mapping2(2).call().await.unwrap().value, 99);
+}

--- a/test/src/sdk-harness/test_projects/mapping/src/main.sw
+++ b/test/src/sdk-harness/test_projects/mapping/src/main.sw
@@ -1,0 +1,41 @@
+contract;
+
+use std::mapping::Mapping;
+
+storage {
+    mapping1: Mapping,
+    mapping2: Mapping
+}
+
+abi MyContract {
+    fn init();
+
+    fn insert_into_mapping1(key: u64, value: u64 );
+    fn get_from_mapping1(key: u64) -> u64;
+
+    fn insert_into_mapping2(key: u64, value: u64 );
+    fn get_from_mapping2(key: u64) -> u64;
+}
+
+impl MyContract for Contract {
+    fn init() {
+        storage.mapping1 = ~Mapping::new();
+        storage.mapping2 = ~Mapping::new();
+    }
+
+    fn insert_into_mapping1(key: u64, value: u64 ) {
+        storage.mapping1.insert(key, value);
+    }
+
+    fn get_from_mapping1(key: u64) -> u64 {
+        storage.mapping1.get(key)
+    }
+
+    fn insert_into_mapping2(key: u64, value: u64 ) {
+        storage.mapping2.insert(key, value);
+    }
+
+    fn get_from_mapping2(key: u64) -> u64 {
+        storage.mapping2.get(key)
+    }
+}


### PR DESCRIPTION
🚨  THIS IS A DRAFT FOR EARLY FEEDBACK ONLY AND IS FAR FROM DONE 🚨 

Meant to close https://github.com/FuelLabs/sway/issues/1399 and also implement `Mapping`.

Blockers:
* [ ] https://github.com/FuelLabs/sway/issues/1159 to be able to see `impl<K, V> Mapping<K, V> where V: Storable`
* [ ] https://github.com/FuelLabs/sway/issues/1143 to be able to have `Mapping` to not need to use `K` and `V` in its data members.