### PR TITLE
Fixing how the tx receipts root is obtained

### DIFF
--- a/sway-lib-std/src/tx.sw
+++ b/sway-lib-std/src/tx.sw
@@ -122,8 +122,7 @@ pub fn tx_witnesses_count() -> u64 {
 
 /// Get the transaction receipts root.
 pub fn tx_receipts_root() -> b256 {
-    asm(r1, r2: TX_RECEIPTS_ROOT_OFFSET) {
-        lw r1 r2 i0;
+    asm(r1: TX_RECEIPTS_ROOT_OFFSET) {
         r1: b256
     }
 }

--- a/test/src/sdk-harness/test_projects/tx_fields/mod.rs
+++ b/test/src/sdk-harness/test_projects/tx_fields/mod.rs
@@ -165,7 +165,7 @@ async fn can_get_receipts_root() {
         .call()
         .await
         .unwrap();
-    assert_ne!(Bytes32::from(result.value), zero_receipts_root);
+    assert_eq!(Bytes32::from(result.value), zero_receipts_root);
 }
 
 #[tokio::test]

--- a/test/src/sdk-harness/test_projects/tx_fields/mod.rs
+++ b/test/src/sdk-harness/test_projects/tx_fields/mod.rs
@@ -165,6 +165,10 @@ async fn can_get_receipts_root() {
         .call()
         .await
         .unwrap();
+
+    // TODO: `tx_receipts_root()` currently always returns zero because the receipts root is only
+    // updated in post script execution and its initial value is zero. Change the `assert_eq` below
+    // to `assert_ne` once this behavior is fixed: https://github.com/FuelLabs/fuel-vm/issues/125
     assert_eq!(Bytes32::from(result.value), zero_receipts_root);
 }
 


### PR DESCRIPTION
The updated version current always returns zero. See https://github.com/FuelLabs/fuel-vm/issues/125