### PR TITLE
Compile predicates in IR

### DIFF
--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -24,13 +24,15 @@ pub(crate) fn compile_ast(ast: TypedParseTree) -> Result<Context, CompileError> 
             main_function,
             declarations,
             all_nodes: _,
-        } => compile_script(&mut ctx, main_function, &namespace, declarations),
-        TypedParseTree::Predicate {
-            namespace: _,
-            main_function: _,
-            declarations: _,
+        }
+        | TypedParseTree::Predicate {
+            namespace,
+            main_function,
+            declarations,
             all_nodes: _,
-        } => unimplemented!("compile predicate to ir"),
+            // predicates and scripts have the same codegen, their only difference is static
+            // type-check time checks.
+        } => compile_script(&mut ctx, main_function, &namespace, declarations),
         TypedParseTree::Contract {
             abi_entries,
             namespace,


### PR DESCRIPTION
Predicates are the same as scripts, with the unique characteristic that the type system checks that the main function returns a boolean. There are also some opcode checks at the end. IR doesn't need to know about any of this, so we can reuse `compile_script`, as predicates are essentially a subset of scripts with some special properties.

Closes #1641 