### PR TITLE
Add missing dependency in 2 test cases to supress unnecessary warnings

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_enums/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_enums/Forc.toml
@@ -4,3 +4,6 @@ license = "Apache-2.0"
 name = "match_expressions_enums"
 entry = "main.sw"
 implicit-std = false
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/Forc.toml
@@ -4,3 +4,6 @@ license = "Apache-2.0"
 name = "match_expressions_non_exhaustive"
 entry = "main.sw"
 implicit-std = false
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }


### PR DESCRIPTION
This was generating a bunch of additional warnings about how it can't find `core::ops::eq` and I forgot to add the dependency in the test cases where failure is expected.