### PR TITLE
Parsing precedence fixes

### DIFF
--- a/sway-parse/src/expr/mod.rs
+++ b/sway-parse/src/expr/mod.rs
@@ -605,73 +605,65 @@ fn parse_logical_and(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr
 }
 
 fn parse_comparison(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
-    let mut expr = parse_bit_or(parser, ctx)?;
+    let expr = parse_bit_or(parser, ctx)?;
     if expr.is_control_flow() && ctx.at_start_of_statement {
         return Ok(expr);
     }
-    loop {
-        if let Some(double_eq_token) = parser.take() {
-            let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
-            expr = Expr::Equal {
-                lhs,
-                double_eq_token,
-                rhs,
-            };
-            continue;
-        }
-        if let Some(bang_eq_token) = parser.take() {
-            let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
-            expr = Expr::NotEqual {
-                lhs,
-                bang_eq_token,
-                rhs,
-            };
-            continue;
-        }
-        if let Some(less_than_token) = parser.take() {
-            let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
-            expr = Expr::LessThan {
-                lhs,
-                less_than_token,
-                rhs,
-            };
-            continue;
-        }
-        if let Some(greater_than_token) = parser.take() {
-            let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
-            expr = Expr::GreaterThan {
-                lhs,
-                greater_than_token,
-                rhs,
-            };
-            continue;
-        }
-        if let Some(less_than_eq_token) = parser.take() {
-            let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
-            expr = Expr::LessThanEq {
-                lhs,
-                less_than_eq_token,
-                rhs,
-            };
-            continue;
-        }
-        if let Some(greater_than_eq_token) = parser.take() {
-            let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
-            expr = Expr::GreaterThanEq {
-                lhs,
-                greater_than_eq_token,
-                rhs,
-            };
-            continue;
-        }
-        return Ok(expr);
+    if let Some(double_eq_token) = parser.take() {
+        let lhs = Box::new(expr);
+        let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
+        return Ok(Expr::Equal {
+            lhs,
+            double_eq_token,
+            rhs,
+        });
     }
+    if let Some(bang_eq_token) = parser.take() {
+        let lhs = Box::new(expr);
+        let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
+        return Ok(Expr::NotEqual {
+            lhs,
+            bang_eq_token,
+            rhs,
+        });
+    }
+    if let Some(less_than_token) = parser.take() {
+        let lhs = Box::new(expr);
+        let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
+        return Ok(Expr::LessThan {
+            lhs,
+            less_than_token,
+            rhs,
+        });
+    }
+    if let Some(greater_than_token) = parser.take() {
+        let lhs = Box::new(expr);
+        let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
+        return Ok(Expr::GreaterThan {
+            lhs,
+            greater_than_token,
+            rhs,
+        });
+    }
+    if let Some(less_than_eq_token) = parser.take() {
+        let lhs = Box::new(expr);
+        let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
+        return Ok(Expr::LessThanEq {
+            lhs,
+            less_than_eq_token,
+            rhs,
+        });
+    }
+    if let Some(greater_than_eq_token) = parser.take() {
+        let lhs = Box::new(expr);
+        let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
+        return Ok(Expr::GreaterThanEq {
+            lhs,
+            greater_than_eq_token,
+            rhs,
+        });
+    }
+    Ok(expr)
 }
 
 fn parse_bit_or(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {

--- a/sway-parse/src/expr/mod.rs
+++ b/sway-parse/src/expr/mod.rs
@@ -418,7 +418,7 @@ impl Spanned for MatchBranchKind {
 
 impl Parse for Expr {
     fn parse(parser: &mut Parser) -> ParseResult<Expr> {
-        parse_reassignment(parser, true)
+        parse_reassignment(parser, ParseExprCtx::default())
     }
 }
 
@@ -480,7 +480,7 @@ impl ParseToEnd for CodeBlockContents {
                 statements.push(statement);
                 continue;
             }
-            let expr = parser.parse::<Expr>()?;
+            let expr = parse_statement_expr(&mut parser)?;
             if let Some(semicolon_token) = parser.take() {
                 let statement = Statement::Expr {
                     expr,
@@ -511,12 +511,39 @@ impl ParseToEnd for CodeBlockContents {
     }
 }
 
-fn parse_condition(parser: &mut Parser) -> ParseResult<Expr> {
-    parse_reassignment(parser, false)
+#[derive(Clone, Copy, Debug, Default)]
+struct ParseExprCtx {
+    pub parsing_conditional: bool,
+    pub at_start_of_statement: bool,
 }
 
-fn parse_reassignment(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
-    let expr = parse_logical_or(parser, allow_struct_exprs)?;
+impl ParseExprCtx {
+    pub fn not_statement(self) -> ParseExprCtx {
+        ParseExprCtx {
+            at_start_of_statement: false,
+            ..self
+        }
+    }
+}
+
+fn parse_condition(parser: &mut Parser) -> ParseResult<Expr> {
+    let ctx = ParseExprCtx {
+        parsing_conditional: true,
+        at_start_of_statement: false,
+    };
+    parse_reassignment(parser, ctx)
+}
+
+fn parse_statement_expr(parser: &mut Parser) -> ParseResult<Expr> {
+    let ctx = ParseExprCtx {
+        parsing_conditional: false,
+        at_start_of_statement: true,
+    };
+    parse_reassignment(parser, ctx)
+}
+
+fn parse_reassignment(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
+    let expr = parse_logical_or(parser, ctx)?;
     if let Some(eq_token) = parser.take() {
         let assignable = match expr.try_into_assignable() {
             Ok(assignable) => assignable,
@@ -527,7 +554,7 @@ fn parse_reassignment(parser: &mut Parser, allow_struct_exprs: bool) -> ParseRes
                 );
             }
         };
-        let expr = Box::new(parse_reassignment(parser, allow_struct_exprs)?);
+        let expr = Box::new(parse_reassignment(parser, ctx.not_statement())?);
         return Ok(Expr::Reassignment {
             assignable,
             eq_token,
@@ -537,12 +564,15 @@ fn parse_reassignment(parser: &mut Parser, allow_struct_exprs: bool) -> ParseRes
     Ok(expr)
 }
 
-fn parse_logical_or(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
-    let mut expr = parse_logical_and(parser, allow_struct_exprs)?;
+fn parse_logical_or(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
+    let mut expr = parse_logical_and(parser, ctx)?;
+    if expr.is_control_flow() && ctx.at_start_of_statement {
+        return Ok(expr);
+    }
     loop {
         if let Some(double_pipe_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_logical_and(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_logical_and(parser, ctx.not_statement())?);
             expr = Expr::LogicalOr {
                 lhs,
                 double_pipe_token,
@@ -554,12 +584,15 @@ fn parse_logical_or(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResul
     }
 }
 
-fn parse_logical_and(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
-    let mut expr = parse_comparison(parser, allow_struct_exprs)?;
+fn parse_logical_and(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
+    let mut expr = parse_comparison(parser, ctx)?;
+    if expr.is_control_flow() && ctx.at_start_of_statement {
+        return Ok(expr);
+    }
     loop {
         if let Some(double_ampersand_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_comparison(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_comparison(parser, ctx.not_statement())?);
             expr = Expr::LogicalAnd {
                 lhs,
                 double_ampersand_token,
@@ -571,12 +604,15 @@ fn parse_logical_and(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResu
     }
 }
 
-fn parse_comparison(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
-    let mut expr = parse_bit_or(parser, allow_struct_exprs)?;
+fn parse_comparison(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
+    let mut expr = parse_bit_or(parser, ctx)?;
+    if expr.is_control_flow() && ctx.at_start_of_statement {
+        return Ok(expr);
+    }
     loop {
         if let Some(double_eq_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_or(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
             expr = Expr::Equal {
                 lhs,
                 double_eq_token,
@@ -586,7 +622,7 @@ fn parse_comparison(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResul
         }
         if let Some(bang_eq_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_or(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
             expr = Expr::NotEqual {
                 lhs,
                 bang_eq_token,
@@ -596,7 +632,7 @@ fn parse_comparison(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResul
         }
         if let Some(less_than_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_or(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
             expr = Expr::LessThan {
                 lhs,
                 less_than_token,
@@ -606,7 +642,7 @@ fn parse_comparison(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResul
         }
         if let Some(greater_than_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_or(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
             expr = Expr::GreaterThan {
                 lhs,
                 greater_than_token,
@@ -616,7 +652,7 @@ fn parse_comparison(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResul
         }
         if let Some(less_than_eq_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_or(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
             expr = Expr::LessThanEq {
                 lhs,
                 less_than_eq_token,
@@ -626,7 +662,7 @@ fn parse_comparison(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResul
         }
         if let Some(greater_than_eq_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_or(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_bit_or(parser, ctx.not_statement())?);
             expr = Expr::GreaterThanEq {
                 lhs,
                 greater_than_eq_token,
@@ -638,12 +674,15 @@ fn parse_comparison(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResul
     }
 }
 
-fn parse_bit_or(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
-    let mut expr = parse_bit_xor(parser, allow_struct_exprs)?;
+fn parse_bit_or(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
+    let mut expr = parse_bit_xor(parser, ctx)?;
+    if expr.is_control_flow() && ctx.at_start_of_statement {
+        return Ok(expr);
+    }
     loop {
         if let Some(pipe_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_xor(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_bit_xor(parser, ctx.not_statement())?);
             expr = Expr::BitOr {
                 lhs,
                 pipe_token,
@@ -655,12 +694,15 @@ fn parse_bit_or(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Ex
     }
 }
 
-fn parse_bit_xor(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
-    let mut expr = parse_bit_and(parser, allow_struct_exprs)?;
+fn parse_bit_xor(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
+    let mut expr = parse_bit_and(parser, ctx)?;
+    if expr.is_control_flow() && ctx.at_start_of_statement {
+        return Ok(expr);
+    }
     loop {
         if let Some(caret_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_bit_and(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_bit_and(parser, ctx.not_statement())?);
             expr = Expr::BitXor {
                 lhs,
                 caret_token,
@@ -672,12 +714,15 @@ fn parse_bit_xor(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<E
     }
 }
 
-fn parse_bit_and(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
-    let mut expr = parse_shift(parser, allow_struct_exprs)?;
+fn parse_bit_and(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
+    let mut expr = parse_shift(parser, ctx)?;
+    if expr.is_control_flow() && ctx.at_start_of_statement {
+        return Ok(expr);
+    }
     loop {
         if let Some(ampersand_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_shift(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_shift(parser, ctx.not_statement())?);
             expr = Expr::BitAnd {
                 lhs,
                 ampersand_token,
@@ -689,12 +734,15 @@ fn parse_bit_and(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<E
     }
 }
 
-fn parse_shift(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
-    let mut expr = parse_add(parser, allow_struct_exprs)?;
+fn parse_shift(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
+    let mut expr = parse_add(parser, ctx)?;
+    if expr.is_control_flow() && ctx.at_start_of_statement {
+        return Ok(expr);
+    }
     loop {
         if let Some(shl_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_add(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_add(parser, ctx.not_statement())?);
             expr = Expr::Shl {
                 lhs,
                 shl_token,
@@ -704,7 +752,7 @@ fn parse_shift(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Exp
         }
         if let Some(shr_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_add(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_add(parser, ctx.not_statement())?);
             expr = Expr::Shr {
                 lhs,
                 shr_token,
@@ -716,12 +764,15 @@ fn parse_shift(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Exp
     }
 }
 
-fn parse_add(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
-    let mut expr = parse_mul(parser, allow_struct_exprs)?;
+fn parse_add(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
+    let mut expr = parse_mul(parser, ctx)?;
+    if expr.is_control_flow() && ctx.at_start_of_statement {
+        return Ok(expr);
+    }
     loop {
         if let Some(add_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_mul(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_mul(parser, ctx.not_statement())?);
             expr = Expr::Add {
                 lhs,
                 add_token,
@@ -731,7 +782,7 @@ fn parse_add(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr>
         }
         if let Some(sub_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_mul(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_mul(parser, ctx.not_statement())?);
             expr = Expr::Sub {
                 lhs,
                 sub_token,
@@ -743,12 +794,15 @@ fn parse_add(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr>
     }
 }
 
-fn parse_mul(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
-    let mut expr = parse_unary_op(parser, allow_struct_exprs)?;
+fn parse_mul(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
+    let mut expr = parse_unary_op(parser, ctx)?;
+    if expr.is_control_flow() && ctx.at_start_of_statement {
+        return Ok(expr);
+    }
     loop {
         if let Some(star_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_unary_op(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_unary_op(parser, ctx.not_statement())?);
             expr = Expr::Mul {
                 lhs,
                 star_token,
@@ -758,7 +812,7 @@ fn parse_mul(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr>
         }
         if let Some(forward_slash_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_unary_op(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_unary_op(parser, ctx.not_statement())?);
             expr = Expr::Div {
                 lhs,
                 forward_slash_token,
@@ -768,7 +822,7 @@ fn parse_mul(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr>
         }
         if let Some(percent_token) = parser.take() {
             let lhs = Box::new(expr);
-            let rhs = Box::new(parse_unary_op(parser, allow_struct_exprs)?);
+            let rhs = Box::new(parse_unary_op(parser, ctx.not_statement())?);
             expr = Expr::Modulo {
                 lhs,
                 percent_token,
@@ -780,24 +834,24 @@ fn parse_mul(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr>
     }
 }
 
-fn parse_unary_op(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
+fn parse_unary_op(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
     if let Some(ref_token) = parser.take() {
-        let expr = Box::new(parse_unary_op(parser, allow_struct_exprs)?);
+        let expr = Box::new(parse_unary_op(parser, ctx.not_statement())?);
         return Ok(Expr::Ref { ref_token, expr });
     }
     if let Some(deref_token) = parser.take() {
-        let expr = Box::new(parse_unary_op(parser, allow_struct_exprs)?);
+        let expr = Box::new(parse_unary_op(parser, ctx.not_statement())?);
         return Ok(Expr::Deref { deref_token, expr });
     }
     if let Some(bang_token) = parser.take() {
-        let expr = Box::new(parse_unary_op(parser, allow_struct_exprs)?);
+        let expr = Box::new(parse_unary_op(parser, ctx.not_statement())?);
         return Ok(Expr::Not { bang_token, expr });
     }
-    parse_projection(parser, allow_struct_exprs)
+    parse_projection(parser, ctx)
 }
 
-fn parse_projection(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
-    let mut expr = parse_func_app(parser, allow_struct_exprs)?;
+fn parse_projection(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
+    let mut expr = parse_func_app(parser, ctx)?;
     loop {
         if let Some(arg) = SquareBrackets::try_parse_all_inner(parser, |mut parser| {
             parser.emit_error(ParseErrorKind::UnexpectedTokenAfterArrayIndex)
@@ -809,7 +863,7 @@ fn parse_projection(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResul
         if let Some(dot_token) = parser.take() {
             let target = Box::new(expr);
             if let Some(name) = parser.take() {
-                if allow_struct_exprs {
+                if !ctx.parsing_conditional {
                     if let Some(contract_args) = Braces::try_parse(parser)? {
                         let contract_args_opt = Some(contract_args);
                         let args = Parens::parse(parser)?;
@@ -876,8 +930,11 @@ fn parse_projection(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResul
     }
 }
 
-fn parse_func_app(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
-    let mut expr = parse_atom(parser, allow_struct_exprs)?;
+fn parse_func_app(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
+    let mut expr = parse_atom(parser, ctx)?;
+    if expr.is_control_flow() && ctx.at_start_of_statement {
+        return Ok(expr);
+    }
     loop {
         if let Some(args) = Parens::try_parse(parser)? {
             let func = Box::new(expr);
@@ -888,7 +945,7 @@ fn parse_func_app(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<
     }
 }
 
-fn parse_atom(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr> {
+fn parse_atom(parser: &mut Parser, ctx: ParseExprCtx) -> ParseResult<Expr> {
     if let Some(code_block_inner) = Braces::try_parse(parser)? {
         return Ok(Expr::Block(code_block_inner));
     }
@@ -973,7 +1030,7 @@ fn parse_atom(parser: &mut Parser, allow_struct_exprs: bool) -> ParseResult<Expr
         || parser.peek::<Ident>().is_some()
     {
         let path = parser.parse()?;
-        if allow_struct_exprs {
+        if !ctx.parsing_conditional {
             if let Some(fields) = Braces::try_parse(parser)? {
                 return Ok(Expr::Struct { path, fields });
             }


### PR DESCRIPTION
This PR fixes two places in the parser where precedence was wrong, or at least didn't match what rust does.

Firstly, brace-postfixed expressions (ie. `{ ... }`/`if x { .. }`/`match x { ... }`/`while x { ... }`)  have low precedence if they appear at the start of a statement. This means that is no longer accepted:

```
fn foo() -> u32 {
    if true { 1 } else { 2 } + 3
}
```

but this still is:

```
fn foo() {
    let bar = if true { 1 } else { 2 } + 3;
}
```

Secondly, comparison operators can longer be chained together. This means that `x < y < z` is now a parse error rather than being parsed as `(x < y) < z`.