### PR TITLE
Improve grammar for type argument error

### DIFF
--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -554,7 +554,7 @@ pub enum CompileError {
         missing_functions: String,
         span: Span,
     },
-    #[error("Expected {expected} type arguments, but instead found {given}.")]
+    #[error("Expected {} type {}, but instead found {}.", expected, if *expected == 1usize { "argument" } else { "arguments" }, given)]
     IncorrectNumberOfTypeArguments {
         given: usize,
         expected: usize,


### PR DESCRIPTION
The pluralization when there was only 1 argument was bothering me...