### PR TITLE
Small improvements to the Sway Book

### DIFF
--- a/docs/src/basics/control_flow.md
+++ b/docs/src/basics/control_flow.md
@@ -16,13 +16,9 @@ fn main() {
         // do something else
     } else {
         // do something else
-    }; // <------------ note this semicolon
+    }
 }
 ```
-
-In Sway, note that a _statement_ is a _declaration **or** expression with a semicolon after it_. This means that you need to add a semicolon after an `if` to turn it into a statement, if it is being used for control flow.
-
-This need for a semicolon after if expressions to turn them into statements may be removed eventually.
 
 ### Using `if` in a `let` statement
 
@@ -60,7 +56,7 @@ You need the `while` keyword, some condition (`value < 10` in this case) which w
 
 There are no `break` or `continue` keywords yet, but [they're coming](https://github.com/FuelLabs/sway/issues/587).
 
-For now, the way to break out of a `while` loop early is to manually invalidate the condition. In this case, that just means setting `counter` to be >= 10.
+For now, the way to break out of a `while` loop early is to manually invalidate the condition. In this case, that just means setting `counter` to be `>= 10`.
 
 Building on the previous example, here's what that might look like:
 
@@ -75,7 +71,7 @@ while counter < 10 {
         // calling some other function to set the bool value
         break_early = get_bool_value();
         counter = counter + 1;
-    };
+    }
 }
 ```
 

--- a/docs/src/reference/rust_differences.md
+++ b/docs/src/reference/rust_differences.md
@@ -34,23 +34,3 @@ struct MyStruct {
     field_two: bool,
 }
 ```
-
-## If Expressions
-
-In Sway, a _statement_ is a _declaration **or** expression with a semicolon after it_. This means that you need to add a semicolon after an `if` to turn it into a statement, if it is being used for control flow:
-
-```sway
-fn main() {
-    let number = 6;
-
-    if number % 4 == 0 {
-        // do something
-    } else if number % 3 == 0 {
-        // do something else
-    } else {
-        // do something else
-    };  // <------------ note this semicolon
-}
-```
-
-This need for a semicolon after if expressions to turn them into statements will be removed eventually, but it hasn't been removed yet.

--- a/examples/msg_sender/src/main.sw
+++ b/examples/msg_sender/src/main.sw
@@ -21,7 +21,7 @@ impl MyOwnedContract for Contract {
             assert(addr.into() == OWNER);
         } else {
             revert(0);
-        };
+        }
 
         true
     }

--- a/examples/signatures/src/main.sw
+++ b/examples/signatures/src/main.sw
@@ -22,5 +22,5 @@ fn main() {
         log(address.value);
     } else {
         revert(0);
-    };
+    }
 }

--- a/examples/wallet_smart_contract/src/main.sw
+++ b/examples/wallet_smart_contract/src/main.sw
@@ -25,9 +25,9 @@ abi Wallet {
 
 impl Wallet for Contract {
     fn receive_funds() {
-        if (msg_asset_id()).into() == NATIVE_ASSET_ID {
+        if msg_asset_id().into() == NATIVE_ASSET_ID {
             storage.balance = storage.balance + msg_amount();
-        };
+        }
     }
 
     fn send_funds(amount_to_send: u64, recipient_address: Address) {
@@ -36,7 +36,7 @@ impl Wallet for Contract {
             assert(addr.into() == OWNER_ADDRESS);
         } else {
             revert(0);
-        };
+        }
 
         let current_balance = storage.balance;
         assert(current_balance > amount_to_send);


### PR DESCRIPTION
* A semicolon is no longer required after an `if` unless the `if` is a RHS of an assignment. Same for `if let`.
* Parentheses around `msg_asset_id()` are no longer needed to call `into()`.

All thanks to the new parser.