### PR TITLE
Remove unnecessary docker cache step in CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,7 +525,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            ghcr.io/fuellabs/forc
+            ghcr.io/fuellabs/sway
           tags: |
             type=sha
             type=ref,event=branch
@@ -538,15 +538,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          # Key is named differently to avoid collision
-          key: ${{ runner.os }}-multi-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-multi-buildx
 
       - name: Log in to the ghcr.io registry
         uses: docker/login-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,7 +525,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            ghcr.io/fuellabs/sway
+            ghcr.io/fuellabs/forc
           tags: |
             type=sha
             type=ref,event=branch


### PR DESCRIPTION
undo a previous change which pointed the docker image to a non-existent registry

also removed unneeded cache step since it's already using `gha`