### PR TITLE
Remove `forc-gm` in the docs for now

### DIFF
--- a/docs/src/forc/plugins.md
+++ b/docs/src/forc/plugins.md
@@ -2,34 +2,6 @@
 
 Plugins can be used to extend `forc` with new commands that go beyond the native commands mentioned in the previous chapter. While the Fuel ecosystem provides a few commonly useful plugins (`forc-fmt`, `forc-lsp`, `forc-explore`), anyone can write their own!
 
-Let's install a starter plugin, `forc-gm`, and take a look at how it works underneath:
-
-```sh
-cargo install forc-gm
-```
-
-Check that we have installed `forc-gm`:
-
-```console
-$ forc plugins
-/Users/<USER>/.cargo/bin/forc-gm
-```
-
-Underneath, `forc-gm` is a simple CLI app, with [clap](https://docs.rs/clap/latest/clap/) as the only dependency:
-
-```rust
-{{#include ../../../forc-gm/src/main.rs}}
-```
-
-You can say gm, or you can greet Fuel:
-
-```console
-$ forc gm
-gn!
-$ forc gm fuel
-gn from Fuel!
-```
-
 ## Writing your own plugin
 
 We encourage anyone to write and publish their own `forc` plugin to enhance their development experience.

--- a/docs/src/forc/plugins.md
+++ b/docs/src/forc/plugins.md
@@ -2,6 +2,29 @@
 
 Plugins can be used to extend `forc` with new commands that go beyond the native commands mentioned in the previous chapter. While the Fuel ecosystem provides a few commonly useful plugins (`forc-fmt`, `forc-lsp`, `forc-explore`), anyone can write their own!
 
+Let's install a plugin, `forc-explore`, and see what's underneath the plugin:
+
+```sh
+cargo install forc-explore
+```
+
+Check that we have installed `forc-explore`:
+
+```console
+$ forc plugins
+Installed Plugins:
+forc-explore
+```
+
+`forc-explore` runs the Forc Network Explorer, which you can run and check out for yourself:
+
+```console
+$ forc explore
+Fuel Network Explorer 0.1.1
+Running server on http://127.0.0.1:3030
+Server::run{addr=127.0.0.1:3030}: listening on http://127.0.0.1:3030
+```
+
 ## Writing your own plugin
 
 We encourage anyone to write and publish their own `forc` plugin to enhance their development experience.

--- a/docs/src/forc/plugins.md
+++ b/docs/src/forc/plugins.md
@@ -25,6 +25,8 @@ Running server on http://127.0.0.1:3030
 Server::run{addr=127.0.0.1:3030}: listening on http://127.0.0.1:3030
 ```
 
+You can visit http://127.0.0.1:3030 to check out the network explorer!
+
 ## Writing your own plugin
 
 We encourage anyone to write and publish their own `forc` plugin to enhance their development experience.

--- a/docs/src/forc/plugins.md
+++ b/docs/src/forc/plugins.md
@@ -16,7 +16,7 @@ Installed Plugins:
 forc-explore
 ```
 
-`forc-explore` runs the Forc Network Explorer, which you can run and check out for yourself:
+`forc-explore` runs the Fuel Network Explorer, which you can run and check out for yourself:
 
 ```console
 $ forc explore


### PR DESCRIPTION
Let's remove this section first until we get the crate name back or if we have an alternative solution.