### PR TITLE
Fix the `template` command for the `counter` example

### DIFF
--- a/docs/src/examples/counter.md
+++ b/docs/src/examples/counter.md
@@ -3,10 +3,8 @@
 The following is a simple example of a contract which implements a counter. Both the `initialize()` and `increment()` functions return the currently set value.
 
 ```bash
-forc init --template counter my_counter_project
+forc template --template-name counter my_counter_project
 ```
-
-The use of `storage` here is **new and is still being stabilized**, please see the [Subcurrency](./subcurrency.md) example for writing storage manually.
 
 ```sway
 {{#include ../../../examples/counter/src/main.sw}}


### PR DESCRIPTION
Also removing the sentence about `storage` in the same file. The `storage` keyword works. This sentence was added back when we had issues while testing related to IR and the SDK.