### PR TITLE
Use release for sdk harness tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,12 +315,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --debug --path ./forc
+          args: --release --path ./forc
       - name: Install Forc fmt
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --debug --path ./forc-plugins/forc-fmt
+          args: --release --path ./forc-plugins/forc-fmt
       - name: Build Sway examples
         uses: actions-rs/cargo@v1
         with:
@@ -332,7 +332,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path ./test/src/sdk-harness/Cargo.toml -- --test-threads=1 --nocapture
+          args: --release --manifest-path ./test/src/sdk-harness/Cargo.toml -- --test-threads=1 --nocapture
 
   cargo-test-workspace:
     needs: cancel-previous-runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,12 +315,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --release --path ./forc
+          args: --path ./forc
       - name: Install Forc fmt
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --release --path ./forc-plugins/forc-fmt
+          args: --path ./forc-plugins/forc-fmt
       - name: Build Sway examples
         uses: actions-rs/cargo@v1
         with:
@@ -332,7 +332,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --manifest-path ./test/src/sdk-harness/Cargo.toml -- --test-threads=1 --nocapture
+          args: --manifest-path ./test/src/sdk-harness/Cargo.toml -- --test-threads=1 --nocapture
 
   cargo-test-workspace:
     needs: cancel-previous-runs


### PR DESCRIPTION
Building Forc projects is very slow with debug, so turn on release.