### PR TITLE
Add a full recursive check of the AST for purity mismatches.

### DIFF
--- a/examples/counter/src/main.sw
+++ b/examples/counter/src/main.sw
@@ -1,8 +1,8 @@
 contract;
 
 abi TestContract {
-    fn initialize_counter(value: u64) -> u64;
-    fn increment_counter(amount: u64) -> u64;
+    #[storage(write)]fn initialize_counter(value: u64) -> u64;
+    #[storage(read, write)]fn increment_counter(amount: u64) -> u64;
 }
 
 storage {
@@ -10,12 +10,12 @@ storage {
 }
 
 impl TestContract for Contract {
-    fn initialize_counter(value: u64) -> u64 {
+    #[storage(write)]fn initialize_counter(value: u64) -> u64 {
         storage.counter = value;
         value
     }
 
-    fn increment_counter(amount: u64) -> u64 {
+    #[storage(read, write)]fn increment_counter(amount: u64) -> u64 {
         let incremented = storage.counter + amount;
         storage.counter = incremented;
         incremented

--- a/examples/storage_example/src/main.sw
+++ b/examples/storage_example/src/main.sw
@@ -3,18 +3,18 @@ contract;
 use std::storage::{get, store};
 
 abi StorageExample {
-    fn store_something(amount: u64);
-    fn get_something() -> u64;
+    #[storage(write)]fn store_something(amount: u64);
+    #[storage(read)]fn get_something() -> u64;
 }
 
 const STORAGE_KEY: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
 impl StorageExample for Contract {
-    fn store_something(amount: u64) {
+    #[storage(write)]fn store_something(amount: u64) {
         store(STORAGE_KEY, amount);
     }
 
-    fn get_something() -> u64 {
+    #[storage(read)]fn get_something() -> u64 {
         let value = get::<u64>(STORAGE_KEY);
         value
     }

--- a/examples/storage_map/src/main.sw
+++ b/examples/storage_map/src/main.sw
@@ -14,29 +14,29 @@ storage {
 }
 
 abi StorageMapExample {
-    fn insert_into_map1(key: u64, value: u64);
+    #[storage(write)]fn insert_into_map1(key: u64, value: u64);
 
-    fn get_from_map1(key: u64, value: u64);
+    #[storage(write)]fn get_from_map1(key: u64, value: u64);
 
-    fn insert_into_map2(key: (b256, bool), value: Data);
+    #[storage(read)]fn insert_into_map2(key: (b256, bool), value: Data);
 
-    fn get_from_map2(key: (b256, bool), value: Data);
+    #[storage(read)]fn get_from_map2(key: (b256, bool), value: Data);
 }
 
 impl StorageMapExample for Contract {
-    fn insert_into_map1(key: u64, value: u64) {
+    #[storage(write)]fn insert_into_map1(key: u64, value: u64) {
         storage.map1.insert(key, value);
     }
 
-    fn get_from_map1(key: u64, value: u64) {
+    #[storage(write)]fn get_from_map1(key: u64, value: u64) {
         storage.map1.insert(key, value);
     }
 
-    fn insert_into_map2(key: (b256, bool), value: Data) {
+    #[storage(read)]fn insert_into_map2(key: (b256, bool), value: Data) {
         storage.map2.get(key);
     }
 
-    fn get_from_map2(key: (b256, bool), value: Data) {
+    #[storage(read)]fn get_from_map2(key: (b256, bool), value: Data) {
         storage.map2.get(key);
     }
 }

--- a/examples/subcurrency/src/main.sw
+++ b/examples/subcurrency/src/main.sw
@@ -37,11 +37,11 @@ struct Sent {
 abi Token {
     // Mint new tokens and send to an address.
     // Can only be called by the contract creator.
-    fn mint(receiver: Address, amount: u64);
+    #[storage(read, write)]fn mint(receiver: Address, amount: u64);
 
     // Sends an amount of an existing token.
     // Can be called from any address.
-    fn send(receiver: Address, amount: u64);
+    #[storage(read, write)]fn send(receiver: Address, amount: u64);
 }
 
 ////////////////////////////////////////
@@ -67,7 +67,7 @@ storage {
 
 /// Contract implements the `Token` ABI.
 impl Token for Contract {
-    fn mint(receiver: Address, amount: u64) {
+    #[storage(read, write)]fn mint(receiver: Address, amount: u64) {
         // Note: The return type of `msg_sender()` can be inferred by the
         // compiler. It is shown here for explicitness.
         let sender: Result<Identity, AuthError> = msg_sender();
@@ -85,7 +85,7 @@ impl Token for Contract {
         storage.balances.insert(receiver, storage.balances.get(receiver) + amount)
     }
 
-    fn send(receiver: Address, amount: u64) {
+    #[storage(read, write)]fn send(receiver: Address, amount: u64) {
         // Note: The return type of `msg_sender()` can be inferred by the
         // compiler. It is shown here for explicitness.
         let sender: Result<Identity, AuthError> = msg_sender();

--- a/examples/wallet_smart_contract/src/main.sw
+++ b/examples/wallet_smart_contract/src/main.sw
@@ -20,21 +20,21 @@ storage {
 }
 
 abi Wallet {
-    fn receive_funds();
-    fn send_funds(amount_to_send: u64, recipient_address: Address);
+    #[storage(read, write)]fn receive_funds();
+    #[storage(read, write)]fn send_funds(amount_to_send: u64, recipient_address: Address);
 }
 
 impl Wallet for Contract {
-    fn receive_funds() {
+    #[storage(read, write)]fn receive_funds() {
         if msg_asset_id() == ~ContractId::from(BASE_ASSET_ID) {
-            // If we received `BASE_ASSET_ID` then keep track of the balance.
+            // If we received `NATIVE_ASSET_ID` then keep track of the balance.
             // Otherwise, we're receiving other native assets and don't care
             // about our balance of tokens.
             storage.balance = storage.balance + msg_amount();
         }
     }
 
-    fn send_funds(amount_to_send: u64, recipient_address: Address) {
+    #[storage(read, write)]fn send_funds(amount_to_send: u64, recipient_address: Address) {
         // Note: The return type of `msg_sender()` can be inferred by the
         // compiler. It is shown here for explicitness.
         let sender: Result<Identity, AuthError> = msg_sender();

--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -1,8 +1,8 @@
 use crate::{
     asm_generation::from_ir::ir_type_size_in_bytes,
     constants,
-    error::CompileError,
-    parse_tree::{AsmOp, AsmRegister, LazyOp, Literal, Visibility},
+    error::*,
+    parse_tree::{promote_purity, AsmOp, AsmRegister, LazyOp, Literal, Purity, Visibility},
     semantic_analysis::{ast_node::*, *},
     type_engine::*,
 };
@@ -18,6 +18,7 @@ use sway_ir::*;
 
 pub(crate) fn compile_program(program: TypedProgram) -> Result<Context, CompileError> {
     let TypedProgram { kind, root } = program;
+
     let mut ctx = Context::default();
     match kind {
         TypedProgramKind::Script {
@@ -290,6 +291,8 @@ fn compile_fn_with_args(
         return_type,
         return_type_span,
         visibility,
+        purity,
+        span,
         ..
     } = ast_fn_decl;
 
@@ -298,6 +301,20 @@ fn compile_fn_with_args(
         .map(|(name, ty, span)| (name, ty, MetadataIndex::from_span(context, &span)))
         .collect();
     let ret_type = convert_resolved_typeid(context, &return_type, &return_type_span)?;
+    let span_md_idx = MetadataIndex::from_span(context, &span);
+    let storage_md_idx = if purity == Purity::Pure {
+        None
+    } else {
+        Some(MetadataIndex::get_storage_index(
+            context,
+            match purity {
+                Purity::Pure => unreachable!("Already checked for Pure above."),
+                Purity::Reads => StorageOperation::Reads,
+                Purity::Writes => StorageOperation::Writes,
+                Purity::ReadsWrites => StorageOperation::ReadsWrites,
+            },
+        ))
+    };
     let func = Function::new(
         context,
         module,
@@ -306,6 +323,8 @@ fn compile_fn_with_args(
         ret_type,
         selector,
         visibility == Visibility::Public,
+        span_md_idx,
+        storage_md_idx,
     );
 
     // We clone the struct symbols here, as they contain the globals; any new local declarations
@@ -600,6 +619,8 @@ impl FnCompiler {
                 contract_call_params,
                 arguments,
                 function_body,
+                function_body_name_span,
+                function_body_purity,
                 self_state_idx,
                 selector,
             } => {
@@ -616,9 +637,10 @@ impl FnCompiler {
                 } else {
                     self.compile_fn_call(
                         context,
-                        name.suffix.as_str(),
                         arguments,
-                        Some(function_body),
+                        function_body,
+                        function_body_name_span,
+                        function_body_purity,
                         self_state_idx,
                         span_md_idx,
                     )
@@ -1043,12 +1065,14 @@ impl FnCompiler {
 
     // ---------------------------------------------------------------------------------------------
 
+    #[allow(clippy::too_many_arguments)]
     fn compile_fn_call(
         &mut self,
         context: &mut Context,
-        _ast_name: &str,
         ast_args: Vec<(Ident, TypedExpression)>,
-        callee_body: Option<TypedCodeBlock>,
+        callee_body: TypedCodeBlock,
+        callee_span: Span,
+        callee_purity: Purity,
         self_state_idx: Option<StateIndex>,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
@@ -1082,8 +1106,6 @@ impl FnCompiler {
                 })
                 .collect();
 
-            let callee_body = callee_body.unwrap();
-
             // We're going to have to reverse engineer the return type.
             let return_type = Self::get_codeblock_return_type(&callee_body).unwrap_or_else(||
                     // This code block is missing a return or implicit return.  The only time I've
@@ -1096,13 +1118,13 @@ impl FnCompiler {
                 name: callee_ident,
                 body: callee_body,
                 parameters,
-                span: crate::span::Span::new(" ".into(), 0, 0, None).unwrap(),
+                span: callee_span,
                 return_type,
                 type_parameters: Vec::new(),
                 return_type_span: crate::span::Span::new(" ".into(), 0, 0, None).unwrap(),
                 visibility: Visibility::Private,
                 is_contract_call: false,
-                purity: Default::default(),
+                purity: callee_purity,
             };
 
             let callee = compile_function(context, self.module, callee_fn_decl)?;
@@ -2615,6 +2637,16 @@ fn convert_resolved_type(
     ast_type: &TypeInfo,
     span: &Span,
 ) -> Result<Type, CompileError> {
+    // A handy macro for rejecting unsupported types.
+    macro_rules! reject_type {
+        ($name_str:literal) => {{
+            return Err(CompileError::Internal(
+                concat!($name_str, " type cannot be resolved in IR."),
+                span.clone(),
+            ));
+        }};
+    }
+
     Ok(match ast_type {
         // All integers are `u64`, see comment in convert_literal_to_value() above.
         TypeInfo::UnsignedInteger(_) => Type::Uint(64),
@@ -2653,60 +2685,15 @@ fn convert_resolved_type(
 
         // Unsupported types which shouldn't exist in the AST after type checking and
         // monomorphisation.
-        TypeInfo::Custom { .. } => {
-            return Err(CompileError::Internal(
-                "Custom type cannot be resolved in IR.",
-                span.clone(),
-            ))
-        }
-        TypeInfo::SelfType { .. } => {
-            return Err(CompileError::Internal(
-                "Self type cannot be resolved in IR.",
-                span.clone(),
-            ))
-        }
-        TypeInfo::Contract => {
-            return Err(CompileError::Internal(
-                "Contract type cannot be resolved in IR.",
-                span.clone(),
-            ))
-        }
-        TypeInfo::ContractCaller { .. } => {
-            return Err(CompileError::Internal(
-                "ContractCaller type cannot be reoslved in IR.",
-                span.clone(),
-            ))
-        }
-        TypeInfo::Unknown => {
-            return Err(CompileError::Internal(
-                "Unknown type cannot be resolved in IR.",
-                span.clone(),
-            ))
-        }
-        TypeInfo::UnknownGeneric { .. } => {
-            return Err(CompileError::Internal(
-                "Generic type cannot be resolved in IR.",
-                span.clone(),
-            ))
-        }
-        TypeInfo::Ref(..) => {
-            return Err(CompileError::Internal(
-                "Ref type cannot be resolved in IR.",
-                span.clone(),
-            ))
-        }
-        TypeInfo::ErrorRecovery => {
-            return Err(CompileError::Internal(
-                "Error recovery type cannot be resolved in IR.",
-                span.clone(),
-            ))
-        }
-        TypeInfo::Storage { .. } => {
-            return Err(CompileError::Internal(
-                "Storage type cannot be resolved in IR.",
-                span.clone(),
-            ))
-        }
+        TypeInfo::Custom { .. } => reject_type!("Custom"),
+        TypeInfo::SelfType { .. } => reject_type!("Self"),
+        TypeInfo::Contract => reject_type!("Contract"),
+        TypeInfo::ContractCaller { .. } => reject_type!("ContractCaller"),
+        TypeInfo::Unknown => reject_type!("Unknown"),
+        TypeInfo::UnknownGeneric { .. } => reject_type!("Generic"),
+        TypeInfo::Ref(..) => reject_type!("Ref"),
+        TypeInfo::ErrorRecovery => reject_type!("Error recovery"),
+        TypeInfo::Storage { .. } => reject_type!("Storage"),
     })
 }
 
@@ -2727,12 +2714,142 @@ fn add_to_b256(x: fuel_types::Bytes32, y: u64) -> fuel_types::Bytes32 {
 
 // -------------------------------------------------------------------------------------------------
 
+#[derive(Default)]
+pub(crate) struct PurityChecker {
+    memos: HashMap<Function, (bool, bool)>,
+
+    // Final results.
+    pub warnings: Vec<CompileWarning>,
+    pub errors: Vec<CompileError>,
+}
+
+impl PurityChecker {
+    /// Designed to be called for each entry point, _prior_ to inlining or other optimizations.
+    /// The checker will check this function and any that it calls.
+    ///
+    /// Returns bools for whether it (reads, writes).
+    pub(crate) fn check_function(
+        &mut self,
+        context: &Context,
+        function: &Function,
+    ) -> (bool, bool) {
+        // Iterate for each instruction in the function and gather whether we have read and/or
+        // write storage operations:
+        // - via the storage IR instructions,
+        // - via ASM blocks with storage VM instructions or
+        // - via calls into functions with the above.
+        let (reads, writes) = function.instruction_iter(context).fold(
+            (false, false),
+            |(reads, writes), (_block, ins_value)| match &context.values[ins_value.0].value {
+                ValueDatum::Instruction(Instruction::StateLoadQuadWord { .. })
+                | ValueDatum::Instruction(Instruction::StateLoadWord(_)) => (true, writes),
+
+                ValueDatum::Instruction(Instruction::StateStoreQuadWord { .. })
+                | ValueDatum::Instruction(Instruction::StateStoreWord { .. }) => (reads, true),
+
+                // Iterate for and check each instruction in the ASM block.
+                ValueDatum::Instruction(Instruction::AsmBlock(asm_block, _args)) => {
+                    context.asm_blocks[asm_block.0].body.iter().fold(
+                        (reads, writes),
+                        |(reads, writes), asm_op| match asm_op.name.as_str() {
+                            "srw" | "srwq" => (true, writes),
+                            "sww" | "swwq" => (reads, true),
+                            _ => (reads, writes),
+                        },
+                    )
+                }
+
+                // Recurse to find the called function purity.  Use memoisation to avoid redoing
+                // work.
+                ValueDatum::Instruction(Instruction::Call(callee, _args)) => {
+                    let (called_fn_reads, called_fn_writes) =
+                        self.memos.get(callee).copied().unwrap_or_else(|| {
+                            let r_w = self.check_function(context, callee);
+                            self.memos.insert(*callee, r_w);
+                            r_w
+                        });
+                    (reads || called_fn_reads, writes || called_fn_writes)
+                }
+
+                _otherwise => (reads, writes),
+            },
+        );
+
+        let function = &context.functions[function.0];
+        let attributed_purity =
+            function
+                .storage_md_idx
+                .and_then(|idx| match &context.metadata[idx.0] {
+                    Metadatum::StorageAttribute(storage_op) => Some(storage_op),
+                    _otherwise => None,
+                });
+        let span = function
+            .span_md_idx
+            .and_then(|idx| idx.to_span(context).ok())
+            .unwrap_or_else(Span::dummy);
+
+        // Simple macros for each of the error types, which also grab `span`.
+        macro_rules! mk_err {
+            ($op_str:literal, $existing_attrib:ident, $needed_attrib:ident) => {{
+                self.errors.push(CompileError::ImpureInPureContext {
+                    storage_op: $op_str,
+                    attrs: promote_purity(Purity::$existing_attrib, Purity::$needed_attrib)
+                        .to_attribute_syntax(),
+                    span,
+                });
+            }};
+        }
+        macro_rules! mk_warn {
+            ($unneeded_attrib:ident) => {{
+                self.warnings.push(CompileWarning {
+                    warning_content: Warning::DeadStorageDeclarationForFunction {
+                        unneeded_attrib: Purity::$unneeded_attrib.to_attribute_syntax(),
+                    },
+                    span,
+                });
+            }};
+        }
+
+        match (attributed_purity, reads, writes) {
+            // Has no attributes but needs some.
+            (None, true, false) => mk_err!("read", Pure, Reads),
+            (None, false, true) => mk_err!("write", Pure, Writes),
+            (None, true, true) => mk_err!("read & write", Pure, ReadsWrites),
+
+            // Or the attribute must match the behaviour.
+            (Some(StorageOperation::Reads), _, true) => mk_err!("write", Reads, Writes),
+            (Some(StorageOperation::Writes), true, _) => mk_err!("read", Writes, Reads),
+
+            // Or we have unneeded attributes.
+            (Some(StorageOperation::ReadsWrites), false, true) => mk_warn!(Reads),
+            (Some(StorageOperation::ReadsWrites), true, false) => mk_warn!(Writes),
+            (Some(StorageOperation::Reads), false, false) => mk_warn!(Reads),
+            (Some(StorageOperation::Writes), false, false) => mk_warn!(Writes),
+
+            // (Pure, false, false) is OK, as is (ReadsWrites, true, true).
+            _otherwise => (),
+        };
+
+        (reads, writes)
+    }
+
+    pub(crate) fn results(self) -> CompileResult<()> {
+        if self.errors.is_empty() {
+            ok((), self.warnings, self.errors)
+        } else {
+            err(self.warnings, self.errors)
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
 #[cfg(test)]
 mod tests {
     use crate::semantic_analysis::{namespace, TypedProgram};
     use std::path::PathBuf;
 
-    // -------------------------------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------------------------
 
     #[test]
     fn sway_to_ir_tests() {
@@ -2785,7 +2902,7 @@ mod tests {
         }
     }
 
-    // -------------------------------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------------------------
 
     #[test]
     fn ir_printer_parser_tests() {
@@ -2837,7 +2954,7 @@ mod tests {
         }
     }
 
-    // -------------------------------------------------------------------------------------------------
+    // ---------------------------------------------------------------------------------------------
 
     fn parse_to_typed_program(path: PathBuf, input: &str) -> TypedProgram {
         let root_module = std::sync::Arc::new(path);

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -37,7 +37,7 @@ pub(crate) fn instantiate_function_application(
     if !opts.purity.can_call(function_decl.purity) {
         errors.push(CompileError::StorageAccessMismatch {
             attrs: promote_purity(opts.purity, function_decl.purity).to_attribute_syntax(),
-            span: function_decl.name.span(),
+            span: call_path.span(),
         });
     }
 
@@ -138,6 +138,8 @@ fn instantiate_function_application_inner(
                     contract_call_params,
                     arguments,
                     function_body: function_decl.body.clone(),
+                    function_body_name_span: function_decl.name.span(),
+                    function_body_purity: function_decl.purity,
                     self_state_idx,
                     selector,
                 },

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -60,15 +60,15 @@ pub(crate) fn type_check_method_application(
         None
     };
 
-    // 'method.purity' is that of the callee, 'opts.purity' of the caller.
-    if !opts.purity.can_call(method.purity) {
-        errors.push(CompileError::StorageAccessMismatch {
-            attrs: promote_purity(opts.purity, method.purity).to_attribute_syntax(),
-            span: method_name.easy_name().span(),
-        });
-    }
-
     if !method.is_contract_call {
+        // 'method.purity' is that of the callee, 'opts.purity' of the caller.
+        if !opts.purity.can_call(method.purity) {
+            errors.push(CompileError::StorageAccessMismatch {
+                attrs: promote_purity(opts.purity, method.purity).to_attribute_syntax(),
+                span: method_name.easy_name().span(),
+            });
+        }
+
         if !contract_call_params.is_empty() {
             errors.push(CompileError::CallParamForNonContractCallMethod {
                 span: contract_call_params[0].name.span(),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -21,6 +21,8 @@ pub enum TypedExpressionVariant {
         contract_call_params: HashMap<String, TypedExpression>,
         arguments: Vec<(Ident, TypedExpression)>,
         function_body: TypedCodeBlock,
+        function_body_name_span: Span,
+        function_body_purity: Purity,
         /// If this is `Some(val)` then `val` is the metadata. If this is `None`, then
         /// there is no selector.
         self_state_idx: Option<StateIndex>,

--- a/sway-core/src/semantic_analysis/program.rs
+++ b/sway-core/src/semantic_analysis/program.rs
@@ -103,7 +103,9 @@ impl TypedProgram {
         // Some checks that are specific to non-contracts
         if kind != TreeType::Contract {
             // impure functions are disallowed in non-contracts
-            errors.extend(disallow_impure_functions(&declarations, &mains));
+            if !matches!(kind, TreeType::Library { .. }) {
+                errors.extend(disallow_impure_functions(&declarations, &mains));
+            }
 
             // `storage` declarations are not allowed in non-contracts
             let storage_decl = declarations

--- a/sway-core/tests/sway_to_ir/array_simple.ir
+++ b/sway-core/tests/sway_to_ir/array_simple.ir
@@ -1,33 +1,34 @@
 script {
-    fn main() -> bool {
+    fn main() -> bool, !1 {
         local ptr [bool; 3] a
 
         entry:
-        v0 = const [bool; 3] [bool undef, bool undef, bool undef], !1
-        v1 = const bool false, !2
-        v2 = const u64 0, !1
-        v3 = insert_element v0, [bool; 3], v1, v2, !1
-        v4 = const bool true, !3
-        v5 = const u64 1, !1
-        v6 = insert_element v3, [bool; 3], v4, v5, !1
-        v7 = const bool false, !4
-        v8 = const u64 2, !1
-        v9 = insert_element v6, [bool; 3], v7, v8, !1
-        v10 = get_ptr ptr [bool; 3] a, ptr [bool; 3], 0, !5
-        store v9, ptr v10, !5
-        v11 = get_ptr ptr [bool; 3] a, ptr [bool; 3], 0, !6
-        v12 = const u64 1, !7
-        v13 = extract_element v11, [bool; 3], v12, !8
+        v0 = const [bool; 3] [bool undef, bool undef, bool undef], !2
+        v1 = const bool false, !3
+        v2 = const u64 0, !2
+        v3 = insert_element v0, [bool; 3], v1, v2, !2
+        v4 = const bool true, !4
+        v5 = const u64 1, !2
+        v6 = insert_element v3, [bool; 3], v4, v5, !2
+        v7 = const bool false, !5
+        v8 = const u64 2, !2
+        v9 = insert_element v6, [bool; 3], v7, v8, !2
+        v10 = get_ptr ptr [bool; 3] a, ptr [bool; 3], 0, !6
+        store v9, ptr v10, !6
+        v11 = get_ptr ptr [bool; 3] a, ptr [bool; 3], 0, !7
+        v12 = const u64 1, !8
+        v13 = extract_element v11, [bool; 3], v12, !9
         ret bool v13
     }
 }
 
 !0 = filepath "/path/to/array_simple.sw"
-!1 = span !0 41 61
-!2 = span !0 42 47
-!3 = span !0 49 53
-!4 = span !0 55 60
-!5 = span !0 33 62
-!6 = span !0 67 68
-!7 = span !0 69 70
-!8 = span !0 67 71
+!1 = span !0 9 73
+!2 = span !0 41 61
+!3 = span !0 42 47
+!4 = span !0 49 53
+!5 = span !0 55 60
+!6 = span !0 33 62
+!7 = span !0 67 68
+!8 = span !0 69 70
+!9 = span !0 67 71

--- a/sway-core/tests/sway_to_ir/asm_block.ir
+++ b/sway-core/tests/sway_to_ir/asm_block.ir
@@ -1,23 +1,25 @@
 script {
-    fn main() -> u64 {
+    fn main() -> u64, !1 {
         entry:
-        v0 = call anon_0(), !1
-        v1 = asm(r1) -> u64 r1, !2 {
-            bhei   r1, !3
+        v0 = call anon_0(), !2
+        v1 = asm(r1) -> u64 r1, !3 {
+            bhei   r1, !4
         }
         ret u64 v1
     }
 
-    fn anon_0() -> u64 {
+    fn anon_0() -> u64, !5 {
         entry:
-        v0 = asm() -> u64 ggas, !4 {
+        v0 = asm() -> u64 ggas, !6 {
         }
         ret u64 v0
     }
 }
 
 !0 = filepath "/path/to/asm_block.sw"
-!1 = span !0 9 167
-!2 = span !0 214 262
-!3 = span !0 232 239
-!4 = span !0 139 165
+!1 = span !0 169 264
+!2 = span !0 9 167
+!3 = span !0 214 262
+!4 = span !0 232 239
+!5 = span !0 12 26
+!6 = span !0 139 165

--- a/sway-core/tests/sway_to_ir/b256_immeds.ir
+++ b/sway-core/tests/sway_to_ir/b256_immeds.ir
@@ -1,36 +1,38 @@
 script {
-    fn main() -> bool {
+    fn main() -> bool, !1 {
         local ptr b256 a
 
         entry:
-        v0 = get_ptr ptr b256 a, ptr b256, 0, !1
-        v1 = const b256 0x0202020202020202020202020202020202020202020202020202020202020202, !2
-        store v1, ptr v0, !1
-        v2 = get_ptr ptr b256 a, ptr b256, 0, !3
-        v3 = load ptr v2, !3
-        v4 = const b256 0x0303030303030303030303030303030303030303030303030303030303030303, !4
-        v5 = call anon_0(v3, v4), !5
+        v0 = get_ptr ptr b256 a, ptr b256, 0, !2
+        v1 = const b256 0x0202020202020202020202020202020202020202020202020202020202020202, !3
+        store v1, ptr v0, !2
+        v2 = get_ptr ptr b256 a, ptr b256, 0, !4
+        v3 = load ptr v2, !4
+        v4 = const b256 0x0303030303030303030303030303030303030303030303030303030303030303, !5
+        v5 = call anon_0(v3, v4), !6
         ret bool v5
     }
 
-    fn anon_0(a !6: b256, b !7: b256) -> bool {
+    fn anon_0(a !7: b256, b !8: b256) -> bool, !9 {
         entry:
-        v0 = asm(lhs: a, rhs: b, sz, res) -> bool res, !8 {
-            addi   sz zero i32, !9
-            meq    res lhs rhs sz, !10
+        v0 = asm(lhs: a, rhs: b, sz, res) -> bool res, !10 {
+            addi   sz zero i32, !11
+            meq    res lhs rhs sz, !12
         }
         ret bool v0
     }
 }
 
 !0 = filepath "/path/to/b256_immeds.sw"
-!1 = span !0 33 108
-!2 = span !0 41 107
-!3 = span !0 117 118
-!4 = span !0 120 186
-!5 = span !0 191 340
-!6 = span !0 198 199
-!7 = span !0 207 208
-!8 = span !0 230 338
-!9 = span !0 269 285
-!10 = span !0 295 313
+!1 = span !0 9 189
+!2 = span !0 33 108
+!3 = span !0 41 107
+!4 = span !0 117 118
+!5 = span !0 120 186
+!6 = span !0 191 340
+!7 = span !0 198 199
+!8 = span !0 207 208
+!9 = span !0 194 197
+!10 = span !0 230 338
+!11 = span !0 269 285
+!12 = span !0 295 313

--- a/sway-core/tests/sway_to_ir/enum.ir
+++ b/sway-core/tests/sway_to_ir/enum.ir
@@ -1,47 +1,50 @@
 script {
-    fn main() -> () {
+    fn main() -> (), !1 {
         local ptr { u64, ( () | () | u64 ) } lunch
 
         entry:
-        v0 = const { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef }, !1
-        v1 = const u64 1, !1
-        v2 = insert_value v0, { u64, ( () | () | u64 ) }, v1, 0, !1
-        v3 = get_ptr ptr { u64, ( () | () | u64 ) } lunch, ptr { u64, ( () | () | u64 ) }, 0, !2
-        store v2, ptr v3, !2
-        v4 = get_ptr ptr { u64, ( () | () | u64 ) } lunch, ptr { u64, ( () | () | u64 ) }, 0, !3
-        v5 = call anon_0(v4), !4
-        v6 = const { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef }, !5
-        v7 = const u64 2, !5
-        v8 = insert_value v6, { u64, ( () | () | u64 ) }, v7, 0, !5
-        v9 = const u64 3, !6
-        v10 = insert_value v8, { u64, ( () | () | u64 ) }, v9, 1, !5
-        v11 = call anon_1(v10), !7
+        v0 = const { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef }, !2
+        v1 = const u64 1, !2
+        v2 = insert_value v0, { u64, ( () | () | u64 ) }, v1, 0, !2
+        v3 = get_ptr ptr { u64, ( () | () | u64 ) } lunch, ptr { u64, ( () | () | u64 ) }, 0, !3
+        store v2, ptr v3, !3
+        v4 = get_ptr ptr { u64, ( () | () | u64 ) } lunch, ptr { u64, ( () | () | u64 ) }, 0, !4
+        v5 = call anon_0(v4), !5
+        v6 = const { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef }, !6
+        v7 = const u64 2, !6
+        v8 = insert_value v6, { u64, ( () | () | u64 ) }, v7, 0, !6
+        v9 = const u64 3, !7
+        v10 = insert_value v8, { u64, ( () | () | u64 ) }, v9, 1, !6
+        v11 = call anon_1(v10), !8
         v12 = const unit ()
         ret () v12
     }
 
-    fn anon_0(meal !8: { u64, ( () | () | u64 ) }) -> bool {
+    fn anon_0(meal !9: { u64, ( () | () | u64 ) }) -> bool, !10 {
         entry:
-        v0 = const bool false, !9
+        v0 = const bool false, !11
         ret bool v0
     }
 
-    fn anon_1(meal !10: { u64, ( () | () | u64 ) }) -> bool {
+    fn anon_1(meal !12: { u64, ( () | () | u64 ) }) -> bool, !13 {
         entry:
-        v0 = const bool false, !11
+        v0 = const bool false, !14
         ret bool v0
     }
 }
 
 !0 = filepath "/path/to/enum.sw"
-!1 = span !0 9 71
-!2 = span !0 89 115
-!3 = span !0 124 129
-!4 = span !0 162 203
-!5 = span !0 9 71
-!6 = span !0 154 155
-!7 = span !0 162 203
-!8 = span !0 169 173
-!9 = span !0 196 201
-!10 = span !0 169 173
+!1 = span !0 73 160
+!2 = span !0 9 71
+!3 = span !0 89 115
+!4 = span !0 124 129
+!5 = span !0 162 203
+!6 = span !0 9 71
+!7 = span !0 154 155
+!8 = span !0 162 203
+!9 = span !0 169 173
+!10 = span !0 165 168
 !11 = span !0 196 201
+!12 = span !0 169 173
+!13 = span !0 165 168
+!14 = span !0 196 201

--- a/sway-core/tests/sway_to_ir/enum_enum.ir
+++ b/sway-core/tests/sway_to_ir/enum_enum.ir
@@ -1,18 +1,19 @@
 script {
-    fn main() -> () {
+    fn main() -> (), !1 {
         entry:
-        v0 = const { u64, ( () | { u64, ( () | bool | () ) } | () ) } { u64 undef, ( () | { u64, ( () | bool | () ) } | () ) undef }, !1
-        v1 = const u64 1, !1
-        v2 = insert_value v0, { u64, ( () | { u64, ( () | bool | () ) } | () ) }, v1, 0, !1
-        v3 = const { u64, ( () | bool | () ) } { u64 undef, ( () | bool | () ) undef }, !2
-        v4 = const u64 0, !2
-        v5 = insert_value v3, { u64, ( () | bool | () ) }, v4, 0, !2
-        v6 = insert_value v2, { u64, ( () | { u64, ( () | bool | () ) } | () ) }, v5, 1, !1
+        v0 = const { u64, ( () | { u64, ( () | bool | () ) } | () ) } { u64 undef, ( () | { u64, ( () | bool | () ) } | () ) undef }, !2
+        v1 = const u64 1, !2
+        v2 = insert_value v0, { u64, ( () | { u64, ( () | bool | () ) } | () ) }, v1, 0, !2
+        v3 = const { u64, ( () | bool | () ) } { u64 undef, ( () | bool | () ) undef }, !3
+        v4 = const u64 0, !3
+        v5 = insert_value v3, { u64, ( () | bool | () ) }, v4, 0, !3
+        v6 = insert_value v2, { u64, ( () | { u64, ( () | bool | () ) } | () ) }, v5, 1, !2
         v7 = const unit ()
         ret () v7
     }
 }
 
 !0 = filepath "/path/to/enum_enum.sw"
-!1 = span !0 9 55
-!2 = span !0 57 104
+!1 = span !0 106 139
+!2 = span !0 9 55
+!3 = span !0 57 104

--- a/sway-core/tests/sway_to_ir/enum_in_storage_read.ir
+++ b/sway-core/tests/sway_to_ir/enum_in_storage_read.ir
@@ -1,5 +1,5 @@
 contract {
-    fn get_e<01665bf4>() -> { { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } } {
+    fn get_e<01665bf4>() -> { { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } }, !1 {
         local mut ptr b256 key_for_0_0
         local mut ptr b256 key_for_0_1
         local mut ptr b256 key_for_1_0
@@ -8,52 +8,53 @@ contract {
         local mut ptr [b256; 2] val_for_1_1
 
         entry:
-        v0 = get_ptr mut ptr b256 key_for_0_0, ptr b256, 0, !1
-        v1 = const b256 0xd625ff6d8e88efd7bb3476e748e5d5935618d78bfc7eedf584fe909ce0809fc3, !1
-        store v1, ptr v0, !1
-        v2 = state_load_word key ptr v0, !1
-        v3 = bitcast v2 to u64, !1
-        v4 = const { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } { u64 undef, ( { u64, u64, u64, u64, u64 } | u64 ) undef }, !1
-        v5 = insert_value v4, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, v3, 0, !1
-        v6 = get_ptr mut ptr b256 key_for_0_1, ptr b256, 0, !1
-        v7 = const b256 0xc4f29cca5a7266ecbc35c82c55dd2b0059a3db4c83a3410653ec33aded8e9840, !1
-        store v7, ptr v6, !1
-        v8 = get_ptr mut ptr [b256; 2] val_for_0_1, ptr ( { u64, u64, u64, u64, u64 } | u64 ), 0, !1
-        v9 = get_ptr mut ptr [b256; 2] val_for_0_1, ptr b256, 0, !1
-        state_load_quad_word ptr v9, key ptr v6, !1
-        v10 = get_ptr mut ptr b256 key_for_0_1, ptr b256, 0, !1
-        v11 = const b256 0xc4f29cca5a7266ecbc35c82c55dd2b0059a3db4c83a3410653ec33aded8e9841, !1
-        store v11, ptr v10, !1
-        v12 = get_ptr mut ptr [b256; 2] val_for_0_1, ptr b256, 1, !1
-        state_load_quad_word ptr v12, key ptr v10, !1
-        v13 = insert_value v5, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, v8, 1, !1
-        v14 = get_ptr mut ptr b256 key_for_1_0, ptr b256, 0, !2
-        v15 = const b256 0x2817e0819d6fcad797114fbcf350fa281aca33a39b0abf977797bddd69b8e7af, !2
-        store v15, ptr v14, !2
-        v16 = state_load_word key ptr v14, !2
-        v17 = bitcast v16 to u64, !2
-        v18 = const { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } { u64 undef, ( { u64, u64, u64, u64, u64 } | u64 ) undef }, !2
-        v19 = insert_value v18, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, v17, 0, !2
-        v20 = get_ptr mut ptr b256 key_for_1_1, ptr b256, 0, !2
-        v21 = const b256 0x12ea9b9b05214a0d64996d259c59202b80a21415bb68b83121353e2a5925ec47, !2
-        store v21, ptr v20, !2
-        v22 = get_ptr mut ptr [b256; 2] val_for_1_1, ptr ( { u64, u64, u64, u64, u64 } | u64 ), 0, !2
-        v23 = get_ptr mut ptr [b256; 2] val_for_1_1, ptr b256, 0, !2
-        state_load_quad_word ptr v23, key ptr v20, !2
-        v24 = get_ptr mut ptr b256 key_for_1_1, ptr b256, 0, !2
-        v25 = const b256 0x12ea9b9b05214a0d64996d259c59202b80a21415bb68b83121353e2a5925ec48, !2
-        store v25, ptr v24, !2
-        v26 = get_ptr mut ptr [b256; 2] val_for_1_1, ptr b256, 1, !2
-        state_load_quad_word ptr v26, key ptr v24, !2
-        v27 = insert_value v19, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, v22, 1, !2
-        v28 = const { { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } } { { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } { u64 undef, ( { u64, u64, u64, u64, u64 } | u64 ) undef }, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } { u64 undef, ( { u64, u64, u64, u64, u64 } | u64 ) undef } }, !3
-        v29 = insert_value v28, { { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } }, v13, 0, !3
-        v30 = insert_value v29, { { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } }, v27, 1, !3
+        v0 = get_ptr mut ptr b256 key_for_0_0, ptr b256, 0, !2
+        v1 = const b256 0xd625ff6d8e88efd7bb3476e748e5d5935618d78bfc7eedf584fe909ce0809fc3, !2
+        store v1, ptr v0, !2
+        v2 = state_load_word key ptr v0, !2
+        v3 = bitcast v2 to u64, !2
+        v4 = const { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } { u64 undef, ( { u64, u64, u64, u64, u64 } | u64 ) undef }, !2
+        v5 = insert_value v4, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, v3, 0, !2
+        v6 = get_ptr mut ptr b256 key_for_0_1, ptr b256, 0, !2
+        v7 = const b256 0xc4f29cca5a7266ecbc35c82c55dd2b0059a3db4c83a3410653ec33aded8e9840, !2
+        store v7, ptr v6, !2
+        v8 = get_ptr mut ptr [b256; 2] val_for_0_1, ptr ( { u64, u64, u64, u64, u64 } | u64 ), 0, !2
+        v9 = get_ptr mut ptr [b256; 2] val_for_0_1, ptr b256, 0, !2
+        state_load_quad_word ptr v9, key ptr v6, !2
+        v10 = get_ptr mut ptr b256 key_for_0_1, ptr b256, 0, !2
+        v11 = const b256 0xc4f29cca5a7266ecbc35c82c55dd2b0059a3db4c83a3410653ec33aded8e9841, !2
+        store v11, ptr v10, !2
+        v12 = get_ptr mut ptr [b256; 2] val_for_0_1, ptr b256, 1, !2
+        state_load_quad_word ptr v12, key ptr v10, !2
+        v13 = insert_value v5, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, v8, 1, !2
+        v14 = get_ptr mut ptr b256 key_for_1_0, ptr b256, 0, !3
+        v15 = const b256 0x2817e0819d6fcad797114fbcf350fa281aca33a39b0abf977797bddd69b8e7af, !3
+        store v15, ptr v14, !3
+        v16 = state_load_word key ptr v14, !3
+        v17 = bitcast v16 to u64, !3
+        v18 = const { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } { u64 undef, ( { u64, u64, u64, u64, u64 } | u64 ) undef }, !3
+        v19 = insert_value v18, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, v17, 0, !3
+        v20 = get_ptr mut ptr b256 key_for_1_1, ptr b256, 0, !3
+        v21 = const b256 0x12ea9b9b05214a0d64996d259c59202b80a21415bb68b83121353e2a5925ec47, !3
+        store v21, ptr v20, !3
+        v22 = get_ptr mut ptr [b256; 2] val_for_1_1, ptr ( { u64, u64, u64, u64, u64 } | u64 ), 0, !3
+        v23 = get_ptr mut ptr [b256; 2] val_for_1_1, ptr b256, 0, !3
+        state_load_quad_word ptr v23, key ptr v20, !3
+        v24 = get_ptr mut ptr b256 key_for_1_1, ptr b256, 0, !3
+        v25 = const b256 0x12ea9b9b05214a0d64996d259c59202b80a21415bb68b83121353e2a5925ec48, !3
+        store v25, ptr v24, !3
+        v26 = get_ptr mut ptr [b256; 2] val_for_1_1, ptr b256, 1, !3
+        state_load_quad_word ptr v26, key ptr v24, !3
+        v27 = insert_value v19, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, v22, 1, !3
+        v28 = const { { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } } { { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } { u64 undef, ( { u64, u64, u64, u64, u64 } | u64 ) undef }, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } { u64 undef, ( { u64, u64, u64, u64, u64 } | u64 ) undef } }, !4
+        v29 = insert_value v28, { { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } }, v13, 0, !4
+        v30 = insert_value v29, { { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } }, v27, 1, !4
         ret { { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } } v30
     }
 }
 
 !0 = filepath "/path/to/enum_in_storage_read.sw"
-!1 = span !0 285 287
-!2 = span !0 297 299
-!3 = span !0 276 300
+!1 = span !0 245 306
+!2 = span !0 285 287
+!3 = span !0 297 299
+!4 = span !0 276 300

--- a/sway-core/tests/sway_to_ir/enum_in_storage_write.ir
+++ b/sway-core/tests/sway_to_ir/enum_in_storage_write.ir
@@ -1,5 +1,5 @@
 contract {
-    fn set_e<c1c7877c>(s !1: { u64, u64, u64, u64, u64 }, u !2: u64) -> () {
+    fn set_e<c1c7877c>(s !1: { u64, u64, u64, u64, u64 }, u !2: u64) -> (), !3 {
         local mut ptr b256 key_for_0_0
         local mut ptr b256 key_for_0_1
         local mut ptr b256 key_for_1_0
@@ -8,52 +8,52 @@ contract {
         local mut ptr [b256; 2] val_for_1_1
 
         entry:
-        v0 = const { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } { u64 undef, ( { u64, u64, u64, u64, u64 } | u64 ) undef }, !3
-        v1 = const u64 0, !3
-        v2 = insert_value v0, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, v1, 0, !3
-        v3 = insert_value v2, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, s, 1, !3
-        v4 = extract_value v3, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, 0, !4
-        v5 = get_ptr mut ptr b256 key_for_0_0, ptr b256, 0, !4
-        v6 = const b256 0xd625ff6d8e88efd7bb3476e748e5d5935618d78bfc7eedf584fe909ce0809fc3, !4
-        store v6, ptr v5, !4
-        v7 = bitcast v4 to u64, !4
-        state_store_word v7, key ptr v5, !4
-        v8 = extract_value v3, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, 1, !4
-        v9 = get_ptr mut ptr b256 key_for_0_1, ptr b256, 0, !4
-        v10 = const b256 0xc4f29cca5a7266ecbc35c82c55dd2b0059a3db4c83a3410653ec33aded8e9840, !4
-        store v10, ptr v9, !4
-        v11 = get_ptr mut ptr [b256; 2] val_for_0_1, ptr ( { u64, u64, u64, u64, u64 } | u64 ), 0, !4
-        store v8, ptr v11, !4
-        v12 = get_ptr mut ptr [b256; 2] val_for_0_1, ptr b256, 0, !4
-        state_store_quad_word ptr v12, key ptr v9, !4
-        v13 = get_ptr mut ptr b256 key_for_0_1, ptr b256, 0, !4
-        v14 = const b256 0xc4f29cca5a7266ecbc35c82c55dd2b0059a3db4c83a3410653ec33aded8e9841, !4
-        store v14, ptr v13, !4
-        v15 = get_ptr mut ptr [b256; 2] val_for_0_1, ptr b256, 1, !4
-        state_store_quad_word ptr v15, key ptr v13, !4
-        v16 = const { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } { u64 undef, ( { u64, u64, u64, u64, u64 } | u64 ) undef }, !5
-        v17 = const u64 1, !5
-        v18 = insert_value v16, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, v17, 0, !5
-        v19 = insert_value v18, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, u, 1, !5
-        v20 = extract_value v19, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, 0, !6
-        v21 = get_ptr mut ptr b256 key_for_1_0, ptr b256, 0, !6
-        v22 = const b256 0x2817e0819d6fcad797114fbcf350fa281aca33a39b0abf977797bddd69b8e7af, !6
-        store v22, ptr v21, !6
-        v23 = bitcast v20 to u64, !6
-        state_store_word v23, key ptr v21, !6
-        v24 = extract_value v19, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, 1, !6
-        v25 = get_ptr mut ptr b256 key_for_1_1, ptr b256, 0, !6
-        v26 = const b256 0x12ea9b9b05214a0d64996d259c59202b80a21415bb68b83121353e2a5925ec47, !6
-        store v26, ptr v25, !6
-        v27 = get_ptr mut ptr [b256; 2] val_for_1_1, ptr ( { u64, u64, u64, u64, u64 } | u64 ), 0, !6
-        store v24, ptr v27, !6
-        v28 = get_ptr mut ptr [b256; 2] val_for_1_1, ptr b256, 0, !6
-        state_store_quad_word ptr v28, key ptr v25, !6
-        v29 = get_ptr mut ptr b256 key_for_1_1, ptr b256, 0, !6
-        v30 = const b256 0x12ea9b9b05214a0d64996d259c59202b80a21415bb68b83121353e2a5925ec48, !6
-        store v30, ptr v29, !6
-        v31 = get_ptr mut ptr [b256; 2] val_for_1_1, ptr b256, 1, !6
-        state_store_quad_word ptr v31, key ptr v29, !6
+        v0 = const { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } { u64 undef, ( { u64, u64, u64, u64, u64 } | u64 ) undef }, !4
+        v1 = const u64 0, !4
+        v2 = insert_value v0, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, v1, 0, !4
+        v3 = insert_value v2, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, s, 1, !4
+        v4 = extract_value v3, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, 0, !5
+        v5 = get_ptr mut ptr b256 key_for_0_0, ptr b256, 0, !5
+        v6 = const b256 0xd625ff6d8e88efd7bb3476e748e5d5935618d78bfc7eedf584fe909ce0809fc3, !5
+        store v6, ptr v5, !5
+        v7 = bitcast v4 to u64, !5
+        state_store_word v7, key ptr v5, !5
+        v8 = extract_value v3, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, 1, !5
+        v9 = get_ptr mut ptr b256 key_for_0_1, ptr b256, 0, !5
+        v10 = const b256 0xc4f29cca5a7266ecbc35c82c55dd2b0059a3db4c83a3410653ec33aded8e9840, !5
+        store v10, ptr v9, !5
+        v11 = get_ptr mut ptr [b256; 2] val_for_0_1, ptr ( { u64, u64, u64, u64, u64 } | u64 ), 0, !5
+        store v8, ptr v11, !5
+        v12 = get_ptr mut ptr [b256; 2] val_for_0_1, ptr b256, 0, !5
+        state_store_quad_word ptr v12, key ptr v9, !5
+        v13 = get_ptr mut ptr b256 key_for_0_1, ptr b256, 0, !5
+        v14 = const b256 0xc4f29cca5a7266ecbc35c82c55dd2b0059a3db4c83a3410653ec33aded8e9841, !5
+        store v14, ptr v13, !5
+        v15 = get_ptr mut ptr [b256; 2] val_for_0_1, ptr b256, 1, !5
+        state_store_quad_word ptr v15, key ptr v13, !5
+        v16 = const { u64, ( { u64, u64, u64, u64, u64 } | u64 ) } { u64 undef, ( { u64, u64, u64, u64, u64 } | u64 ) undef }, !6
+        v17 = const u64 1, !6
+        v18 = insert_value v16, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, v17, 0, !6
+        v19 = insert_value v18, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, u, 1, !6
+        v20 = extract_value v19, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, 0, !7
+        v21 = get_ptr mut ptr b256 key_for_1_0, ptr b256, 0, !7
+        v22 = const b256 0x2817e0819d6fcad797114fbcf350fa281aca33a39b0abf977797bddd69b8e7af, !7
+        store v22, ptr v21, !7
+        v23 = bitcast v20 to u64, !7
+        state_store_word v23, key ptr v21, !7
+        v24 = extract_value v19, { u64, ( { u64, u64, u64, u64, u64 } | u64 ) }, 1, !7
+        v25 = get_ptr mut ptr b256 key_for_1_1, ptr b256, 0, !7
+        v26 = const b256 0x12ea9b9b05214a0d64996d259c59202b80a21415bb68b83121353e2a5925ec47, !7
+        store v26, ptr v25, !7
+        v27 = get_ptr mut ptr [b256; 2] val_for_1_1, ptr ( { u64, u64, u64, u64, u64 } | u64 ), 0, !7
+        store v24, ptr v27, !7
+        v28 = get_ptr mut ptr [b256; 2] val_for_1_1, ptr b256, 0, !7
+        state_store_quad_word ptr v28, key ptr v25, !7
+        v29 = get_ptr mut ptr b256 key_for_1_1, ptr b256, 0, !7
+        v30 = const b256 0x12ea9b9b05214a0d64996d259c59202b80a21415bb68b83121353e2a5925ec48, !7
+        store v30, ptr v29, !7
+        v31 = get_ptr mut ptr [b256; 2] val_for_1_1, ptr b256, 1, !7
+        state_store_quad_word ptr v31, key ptr v29, !7
         v32 = const unit ()
         ret () v32
     }
@@ -62,7 +62,8 @@ contract {
 !0 = filepath "/path/to/enum_in_storage_write.sw"
 !1 = span !0 256 257
 !2 = span !0 262 263
-!3 = span !0 85 121
-!4 = span !0 280 300
-!5 = span !0 85 121
-!6 = span !0 310 330
+!3 = span !0 247 337
+!4 = span !0 85 121
+!5 = span !0 280 300
+!6 = span !0 85 121
+!7 = span !0 310 330

--- a/sway-core/tests/sway_to_ir/enum_struct.ir
+++ b/sway-core/tests/sway_to_ir/enum_struct.ir
@@ -1,25 +1,26 @@
 script {
-    fn main() -> () {
+    fn main() -> (), !1 {
         entry:
-        v0 = const { u64, ( () | { b256, bool, u64 } | () ) } { u64 undef, ( () | { b256, bool, u64 } | () ) undef }, !1
-        v1 = const u64 1, !1
-        v2 = insert_value v0, { u64, ( () | { b256, bool, u64 } | () ) }, v1, 0, !1
-        v3 = const { b256, bool, u64 } { b256 undef, bool undef, u64 undef }, !2
-        v4 = const b256 0x0001010101010101000101010101010100010101010101010001010101010101, !3
-        v5 = insert_value v3, { b256, bool, u64 }, v4, 0, !2
-        v6 = const bool true, !4
-        v7 = insert_value v5, { b256, bool, u64 }, v6, 1, !2
-        v8 = const u64 53, !5
-        v9 = insert_value v7, { b256, bool, u64 }, v8, 2, !2
-        v10 = insert_value v2, { u64, ( () | { b256, bool, u64 } | () ) }, v9, 1, !1
+        v0 = const { u64, ( () | { b256, bool, u64 } | () ) } { u64 undef, ( () | { b256, bool, u64 } | () ) undef }, !2
+        v1 = const u64 1, !2
+        v2 = insert_value v0, { u64, ( () | { b256, bool, u64 } | () ) }, v1, 0, !2
+        v3 = const { b256, bool, u64 } { b256 undef, bool undef, u64 undef }, !3
+        v4 = const b256 0x0001010101010101000101010101010100010101010101010001010101010101, !4
+        v5 = insert_value v3, { b256, bool, u64 }, v4, 0, !3
+        v6 = const bool true, !5
+        v7 = insert_value v5, { b256, bool, u64 }, v6, 1, !3
+        v8 = const u64 53, !6
+        v9 = insert_value v7, { b256, bool, u64 }, v8, 2, !3
+        v10 = insert_value v2, { u64, ( () | { b256, bool, u64 } | () ) }, v9, 1, !2
         v11 = const unit ()
         ret () v11
     }
 }
 
 !0 = filepath "/path/to/enum_struct.sw"
-!1 = span !0 9 55
-!2 = span !0 134 256
-!3 = span !0 151 217
-!4 = span !0 230 234
-!5 = span !0 247 249
+!1 = span !0 111 260
+!2 = span !0 9 55
+!3 = span !0 134 256
+!4 = span !0 151 217
+!5 = span !0 230 234
+!6 = span !0 247 249

--- a/sway-core/tests/sway_to_ir/fn_call.ir
+++ b/sway-core/tests/sway_to_ir/fn_call.ir
@@ -1,28 +1,31 @@
 script {
-    fn main() -> u64 {
+    fn main() -> u64, !1 {
         entry:
-        v0 = const u64 0, !1
-        v1 = call anon_0(v0), !2
-        v2 = const u64 1, !3
-        v3 = call anon_1(v2), !4
+        v0 = const u64 0, !2
+        v1 = call anon_0(v0), !3
+        v2 = const u64 1, !4
+        v3 = call anon_1(v2), !5
         ret u64 v3
     }
 
-    fn anon_0(x !5: u64) -> u64 {
+    fn anon_0(x !6: u64) -> u64, !7 {
         entry:
         ret u64 x
     }
 
-    fn anon_1(x !6: u64) -> u64 {
+    fn anon_1(x !8: u64) -> u64, !9 {
         entry:
         ret u64 x
     }
 }
 
 !0 = filepath "/path/to/fn_call.sw"
-!1 = span !0 65 66
-!2 = span !0 9 38
-!3 = span !0 75 76
-!4 = span !0 9 38
-!5 = span !0 14 15
+!1 = span !0 40 79
+!2 = span !0 65 66
+!3 = span !0 9 38
+!4 = span !0 75 76
+!5 = span !0 9 38
 !6 = span !0 14 15
+!7 = span !0 12 13
+!8 = span !0 14 15
+!9 = span !0 12 13

--- a/sway-core/tests/sway_to_ir/get_storage_key.ir
+++ b/sway-core/tests/sway_to_ir/get_storage_key.ir
@@ -1,33 +1,37 @@
 contract {
-    fn foo1<2994c98e>() -> b256 {
+    fn foo1<2994c98e>() -> b256, !1 {
         entry:
-        v0 = call anon_0(), !1, !2
+        v0 = call anon_0(), !2, !3
         ret b256 v0
     }
 
-    fn anon_0() -> b256 {
+    fn anon_0() -> b256, !4 {
         entry:
-        v0 = get_storage_key, !3
+        v0 = get_storage_key, !5
         ret b256 v0
     }
 
-    fn foo2<f57bdec8>() -> b256 {
+    fn foo2<f57bdec8>() -> b256, !6 {
         entry:
-        v0 = call anon_1(), !4, !5
+        v0 = call anon_1(), !7, !8
         ret b256 v0
     }
 
-    fn anon_1() -> b256 {
+    fn anon_1() -> b256, !9 {
         entry:
-        v0 = get_storage_key, !6
+        v0 = get_storage_key, !10
         ret b256 v0
     }
 }
 
 !0 = filepath "/path/to/get_storage_key.sw"
-!1 = span !0 287 303
-!2 = state_index 0
-!3 = span !0 72 91
-!4 = span !0 342 358
-!5 = state_index 1
-!6 = span !0 72 91
+!1 = span !0 259 309
+!2 = span !0 287 303
+!3 = state_index 0
+!4 = span !0 48 51
+!5 = span !0 72 91
+!6 = span !0 314 364
+!7 = span !0 342 358
+!8 = state_index 1
+!9 = span !0 48 51
+!10 = span !0 72 91

--- a/sway-core/tests/sway_to_ir/if_expr.ir
+++ b/sway-core/tests/sway_to_ir/if_expr.ir
@@ -1,15 +1,15 @@
 script {
-    fn main() -> u64 {
+    fn main() -> u64, !1 {
         entry:
-        v0 = const bool false, !1
-        cbr v0, block0, block1, !2
+        v0 = const bool false, !2
+        cbr v0, block0, block1, !3
 
         block0:
-        v1 = const u64 1000000, !3
+        v1 = const u64 1000000, !4
         br block2
 
         block1:
-        v2 = const u64 42, !4
+        v2 = const u64 42, !5
         br block2
 
         block2:
@@ -19,7 +19,8 @@ script {
 }
 
 !0 = filepath "/path/to/if_expr.sw"
-!1 = span !0 35 40
+!1 = span !0 9 92
 !2 = span !0 35 40
-!3 = span !0 51 60
-!4 = span !0 82 84
+!3 = span !0 35 40
+!4 = span !0 51 60
+!5 = span !0 82 84

--- a/sway-core/tests/sway_to_ir/impl_ret_int.ir
+++ b/sway-core/tests/sway_to_ir/impl_ret_int.ir
@@ -1,10 +1,11 @@
 script {
-    fn main() -> u64 {
+    fn main() -> u64, !1 {
         entry:
-        v0 = const u64 42, !1
+        v0 = const u64 42, !2
         ret u64 v0
     }
 }
 
 !0 = filepath "/path/to/impl_ret_int.sw"
-!1 = span !0 32 34
+!1 = span !0 9 36
+!2 = span !0 32 34

--- a/sway-core/tests/sway_to_ir/implicit_return.ir
+++ b/sway-core/tests/sway_to_ir/implicit_return.ir
@@ -1,21 +1,22 @@
 script {
-    fn main() -> u64 {
+    fn main() -> u64, !1 {
         entry:
         br while
 
         while:
-        v0 = const bool false, !1
+        v0 = const bool false, !2
         cbr v0, while_body, end_while
 
         while_body:
         br while
 
         end_while:
-        v1 = const u64 42, !2
+        v1 = const u64 42, !3
         ret u64 v1
     }
 }
 
 !0 = filepath "/path/to/implicit_return.sw"
-!1 = span !0 38 43
-!2 = span !0 57 59
+!1 = span !0 9 61
+!2 = span !0 38 43
+!3 = span !0 57 59

--- a/sway-core/tests/sway_to_ir/lazy_binops.ir
+++ b/sway-core/tests/sway_to_ir/lazy_binops.ir
@@ -1,22 +1,22 @@
 script {
-    fn main() -> bool {
+    fn main() -> bool, !1 {
         entry:
-        v0 = const bool false, !1
-        cbr v0, block0, block1, !2
+        v0 = const bool false, !2
+        cbr v0, block0, block1, !3
 
         block0:
         v1 = phi(entry: v0)
-        v2 = const bool true, !3
-        br block1, !2
+        v2 = const bool true, !4
+        br block1, !3
 
         block1:
         v3 = phi(entry: v0, block0: v2)
-        cbr v3, block3, block2, !4
+        cbr v3, block3, block2, !5
 
         block2:
         v4 = phi(block1: v3)
-        v5 = const bool true, !5
-        br block3, !4
+        v5 = const bool true, !6
+        br block3, !5
 
         block3:
         v6 = phi(block1: v3, block2: v5)
@@ -25,8 +25,9 @@ script {
 }
 
 !0 = filepath "/path/to/lazy_binops.sw"
-!1 = span !0 34 39
-!2 = span !0 34 47
-!3 = span !0 43 47
-!4 = span !0 33 56
-!5 = span !0 52 56
+!1 = span !0 9 58
+!2 = span !0 34 39
+!3 = span !0 34 47
+!4 = span !0 43 47
+!5 = span !0 33 56
+!6 = span !0 52 56

--- a/sway-core/tests/sway_to_ir/let_reassign_while_loop.ir
+++ b/sway-core/tests/sway_to_ir/let_reassign_while_loop.ir
@@ -1,47 +1,48 @@
 script {
-    fn main() -> bool {
+    fn main() -> bool, !1 {
         local mut ptr bool a
 
         entry:
-        v0 = get_ptr mut ptr bool a, ptr bool, 0, !1
-        v1 = const bool true, !2
-        store v1, ptr v0, !1
+        v0 = get_ptr mut ptr bool a, ptr bool, 0, !2
+        v1 = const bool true, !3
+        store v1, ptr v0, !2
         br while
 
         while:
-        v2 = get_ptr mut ptr bool a, ptr bool, 0, !3
-        v3 = load ptr v2, !3
+        v2 = get_ptr mut ptr bool a, ptr bool, 0, !4
+        v3 = load ptr v2, !4
         cbr v3, while_body, end_while
 
         while_body:
-        v4 = get_ptr mut ptr bool a, ptr bool, 0, !4
-        v5 = get_ptr mut ptr bool a, ptr bool, 0, !5
-        v6 = load ptr v5, !5
-        cbr v6, block0, block1, !6
+        v4 = get_ptr mut ptr bool a, ptr bool, 0, !5
+        v5 = get_ptr mut ptr bool a, ptr bool, 0, !6
+        v6 = load ptr v5, !6
+        cbr v6, block0, block1, !7
 
         block0:
         v7 = phi(while_body: v6)
-        v8 = const bool false, !7
-        br block1, !6
+        v8 = const bool false, !8
+        br block1, !7
 
         block1:
         v9 = phi(while_body: v6, block0: v8)
-        store v9, ptr v4, !4
+        store v9, ptr v4, !5
         br while
 
         end_while:
-        v10 = get_ptr mut ptr bool a, ptr bool, 0, !8
-        v11 = load ptr v10, !8
+        v10 = get_ptr mut ptr bool a, ptr bool, 0, !9
+        v11 = load ptr v10, !9
         ret bool v11
     }
 }
 
 !0 = filepath "/path/to/let_reassign_while_loop.sw"
-!1 = span !0 33 50
-!2 = span !0 45 49
-!3 = span !0 61 62
-!4 = span !0 73 87
-!5 = span !0 77 78
-!6 = span !0 77 87
-!7 = span !0 82 87
-!8 = span !0 99 100
+!1 = span !0 9 102
+!2 = span !0 33 50
+!3 = span !0 45 49
+!4 = span !0 61 62
+!5 = span !0 73 87
+!6 = span !0 77 78
+!7 = span !0 77 87
+!8 = span !0 82 87
+!9 = span !0 99 100

--- a/sway-core/tests/sway_to_ir/mutable_struct.ir
+++ b/sway-core/tests/sway_to_ir/mutable_struct.ir
@@ -1,30 +1,31 @@
 script {
-    fn main() -> u64 {
+    fn main() -> u64, !1 {
         local mut ptr { u64, u64 } record
 
         entry:
-        v0 = const { u64, u64 } { u64 undef, u64 undef }, !1
-        v1 = const u64 40, !2
-        v2 = insert_value v0, { u64, u64 }, v1, 0, !1
-        v3 = const u64 2, !3
-        v4 = insert_value v2, { u64, u64 }, v3, 1, !1
-        v5 = get_ptr mut ptr { u64, u64 } record, ptr { u64, u64 }, 0, !4
-        store v4, ptr v5, !4
-        v6 = get_ptr mut ptr { u64, u64 } record, ptr { u64, u64 }, 0, !5
-        v7 = const u64 50, !6
-        v8 = insert_value v6, { u64, u64 }, v7, 0, !5
-        v9 = get_ptr mut ptr { u64, u64 } record, ptr { u64, u64 }, 0, !7
-        v10 = extract_value v9, { u64, u64 }, 1, !8
+        v0 = const { u64, u64 } { u64 undef, u64 undef }, !2
+        v1 = const u64 40, !3
+        v2 = insert_value v0, { u64, u64 }, v1, 0, !2
+        v3 = const u64 2, !4
+        v4 = insert_value v2, { u64, u64 }, v3, 1, !2
+        v5 = get_ptr mut ptr { u64, u64 } record, ptr { u64, u64 }, 0, !5
+        store v4, ptr v5, !5
+        v6 = get_ptr mut ptr { u64, u64 } record, ptr { u64, u64 }, 0, !6
+        v7 = const u64 50, !7
+        v8 = insert_value v6, { u64, u64 }, v7, 0, !6
+        v9 = get_ptr mut ptr { u64, u64 } record, ptr { u64, u64 }, 0, !8
+        v10 = extract_value v9, { u64, u64 }, 1, !9
         ret u64 v10
     }
 }
 
 !0 = filepath "/path/to/mutable_struct.sw"
-!1 = span !0 49 92
-!2 = span !0 69 71
-!3 = span !0 84 85
-!4 = span !0 32 93
-!5 = span !0 98 111
-!6 = span !0 109 111
-!7 = span !0 117 123
-!8 = span !0 84 85
+!1 = span !0 9 127
+!2 = span !0 49 92
+!3 = span !0 69 71
+!4 = span !0 84 85
+!5 = span !0 32 93
+!6 = span !0 98 111
+!7 = span !0 109 111
+!8 = span !0 117 123
+!9 = span !0 84 85

--- a/sway-core/tests/sway_to_ir/ret_unit.ir
+++ b/sway-core/tests/sway_to_ir/ret_unit.ir
@@ -1,12 +1,12 @@
 script {
-    fn main() -> () {
+    fn main() -> (), !1 {
         entry:
-        v0 = call anon_0(), !1
+        v0 = call anon_0(), !2
         v1 = const unit ()
         ret () v1
     }
 
-    fn anon_0() -> () {
+    fn anon_0() -> (), !3 {
         entry:
         v0 = const unit ()
         ret () v0
@@ -14,4 +14,6 @@ script {
 }
 
 !0 = filepath "/path/to/ret_unit.sw"
-!1 = span !0 9 18
+!1 = span !0 20 41
+!2 = span !0 9 18
+!3 = span !0 12 13

--- a/sway-core/tests/sway_to_ir/shadowed_locals.ir
+++ b/sway-core/tests/sway_to_ir/shadowed_locals.ir
@@ -1,51 +1,52 @@
 script {
-    fn main() -> u64 {
+    fn main() -> u64, !1 {
         local ptr bool a
         local ptr u64 a_
         local ptr { u64 } a__
 
         entry:
-        v0 = get_ptr ptr bool a, ptr bool, 0, !1
-        v1 = const bool true, !2
-        store v1, ptr v0, !1
-        v2 = get_ptr ptr bool a, ptr bool, 0, !3
-        v3 = load ptr v2, !3
-        cbr v3, block0, block1, !4
+        v0 = get_ptr ptr bool a, ptr bool, 0, !2
+        v1 = const bool true, !3
+        store v1, ptr v0, !2
+        v2 = get_ptr ptr bool a, ptr bool, 0, !4
+        v3 = load ptr v2, !4
+        cbr v3, block0, block1, !5
 
         block0:
-        v4 = const u64 12, !5
+        v4 = const u64 12, !6
         br block2
 
         block1:
-        v5 = const u64 21, !6
+        v5 = const u64 21, !7
         br block2
 
         block2:
         v6 = phi(block0: v4, block1: v5)
-        v7 = get_ptr ptr u64 a_, ptr u64, 0, !7
-        store v6, ptr v7, !7
-        v8 = get_ptr ptr u64 a_, ptr u64, 0, !8
-        v9 = load ptr v8, !8
-        v10 = const { u64 } { u64 undef }, !9
-        v11 = insert_value v10, { u64 }, v9, 0, !9
-        v12 = get_ptr ptr { u64 } a__, ptr { u64 }, 0, !10
-        store v11, ptr v12, !10
-        v13 = get_ptr ptr { u64 } a__, ptr { u64 }, 0, !11
-        v14 = extract_value v13, { u64 }, 0, !12
+        v7 = get_ptr ptr u64 a_, ptr u64, 0, !8
+        store v6, ptr v7, !8
+        v8 = get_ptr ptr u64 a_, ptr u64, 0, !9
+        v9 = load ptr v8, !9
+        v10 = const { u64 } { u64 undef }, !10
+        v11 = insert_value v10, { u64 }, v9, 0, !10
+        v12 = get_ptr ptr { u64 } a__, ptr { u64 }, 0, !11
+        store v11, ptr v12, !11
+        v13 = get_ptr ptr { u64 } a__, ptr { u64 }, 0, !12
+        v14 = extract_value v13, { u64 }, 0, !13
         ret u64 v14
     }
 }
 
 !0 = filepath "/path/to/shadowed_locals.sw"
-!1 = span !0 58 71
-!2 = span !0 66 70
-!3 = span !0 87 88
+!1 = span !0 35 142
+!2 = span !0 58 71
+!3 = span !0 66 70
 !4 = span !0 87 88
-!5 = span !0 91 93
-!6 = span !0 103 105
-!7 = span !0 76 108
-!8 = span !0 128 129
-!9 = span !0 121 131
-!10 = span !0 113 132
-!11 = span !0 137 138
-!12 = span !0 128 129
+!5 = span !0 87 88
+!6 = span !0 91 93
+!7 = span !0 103 105
+!8 = span !0 76 108
+!9 = span !0 128 129
+!10 = span !0 121 131
+!11 = span !0 113 132
+!12 = span !0 137 138
+!13 = span !0 128 129

--- a/sway-core/tests/sway_to_ir/shadowed_struct_init.ir
+++ b/sway-core/tests/sway_to_ir/shadowed_struct_init.ir
@@ -1,45 +1,47 @@
 script {
-    fn main() -> () {
+    fn main() -> (), !1 {
         entry:
-        v0 = const bool true, !1
-        v1 = const bool false, !2
-        v2 = call anon_0(v0, v1), !3
+        v0 = const bool true, !2
+        v1 = const bool false, !3
+        v2 = call anon_0(v0, v1), !4
         v3 = const unit ()
         ret () v3
     }
 
-    fn anon_0(a !4: bool, b !5: bool) -> { bool, bool } {
+    fn anon_0(a !5: bool, b !6: bool) -> { bool, bool }, !7 {
         local ptr bool a_
         local ptr bool b_
 
         entry:
-        v0 = get_ptr ptr bool a_, ptr bool, 0, !6
-        v1 = const bool false, !7
-        store v1, ptr v0, !6
-        v2 = get_ptr ptr bool b_, ptr bool, 0, !8
-        v3 = const bool true, !9
-        store v3, ptr v2, !8
-        v4 = get_ptr ptr bool a_, ptr bool, 0, !10
-        v5 = load ptr v4, !10
-        v6 = get_ptr ptr bool b_, ptr bool, 0, !11
-        v7 = load ptr v6, !11
-        v8 = const { bool, bool } { bool undef, bool undef }, !12
-        v9 = insert_value v8, { bool, bool }, v5, 0, !12
-        v10 = insert_value v9, { bool, bool }, v7, 1, !12
+        v0 = get_ptr ptr bool a_, ptr bool, 0, !8
+        v1 = const bool false, !9
+        store v1, ptr v0, !8
+        v2 = get_ptr ptr bool b_, ptr bool, 0, !10
+        v3 = const bool true, !11
+        store v3, ptr v2, !10
+        v4 = get_ptr ptr bool a_, ptr bool, 0, !12
+        v5 = load ptr v4, !12
+        v6 = get_ptr ptr bool b_, ptr bool, 0, !13
+        v7 = load ptr v6, !13
+        v8 = const { bool, bool } { bool undef, bool undef }, !14
+        v9 = insert_value v8, { bool, bool }, v5, 0, !14
+        v10 = insert_value v9, { bool, bool }, v7, 1, !14
         ret { bool, bool } v10
     }
 }
 
 !0 = filepath "/path/to/shadowed_struct_init.sw"
-!1 = span !0 249 253
-!2 = span !0 255 260
-!3 = span !0 49 227
-!4 = span !0 56 57
-!5 = span !0 65 66
-!6 = span !0 85 99
-!7 = span !0 93 98
-!8 = span !0 104 117
-!9 = span !0 112 116
-!10 = span !0 137 138
-!11 = span !0 217 218
-!12 = span !0 122 225
+!1 = span !0 229 264
+!2 = span !0 249 253
+!3 = span !0 255 260
+!4 = span !0 49 227
+!5 = span !0 56 57
+!6 = span !0 65 66
+!7 = span !0 52 55
+!8 = span !0 85 99
+!9 = span !0 93 98
+!10 = span !0 104 117
+!11 = span !0 112 116
+!12 = span !0 137 138
+!13 = span !0 217 218
+!14 = span !0 122 225

--- a/sway-core/tests/sway_to_ir/simple_contract.ir
+++ b/sway-core/tests/sway_to_ir/simple_contract.ir
@@ -1,26 +1,29 @@
 contract {
-    fn get_u64<9890aef4>(val !1: u64) -> u64 {
+    fn get_u64<9890aef4>(val !1: u64) -> u64, !2 {
         entry:
         ret u64 val
     }
 
-    fn get_b256<42123b96>(val !2: b256) -> b256 {
+    fn get_b256<42123b96>(val !3: b256) -> b256, !4 {
         entry:
         ret b256 val
     }
 
-    fn get_s<fc62d029>(val1 !3: u64, val2 !4: b256) -> { u64, b256 } {
+    fn get_s<fc62d029>(val1 !5: u64, val2 !6: b256) -> { u64, b256 }, !7 {
         entry:
-        v0 = const { u64, b256 } { u64 undef, b256 undef }, !5
-        v1 = insert_value v0, { u64, b256 }, val1, 0, !5
-        v2 = insert_value v1, { u64, b256 }, val2, 1, !5
+        v0 = const { u64, b256 } { u64 undef, b256 undef }, !8
+        v1 = insert_value v0, { u64, b256 }, val1, 0, !8
+        v2 = insert_value v1, { u64, b256 }, val2, 1, !8
         ret { u64, b256 } v2
     }
 }
 
 !0 = filepath "/path/to/simple_contract.sw"
 !1 = span !0 215 218
-!2 = span !0 269 272
-!3 = span !0 322 326
-!4 = span !0 333 337
-!5 = span !0 360 415
+!2 = span !0 204 251
+!3 = span !0 269 272
+!4 = span !0 257 307
+!5 = span !0 322 326
+!6 = span !0 333 337
+!7 = span !0 313 421
+!8 = span !0 360 415

--- a/sway-core/tests/sway_to_ir/simple_contract_call.ir
+++ b/sway-core/tests/sway_to_ir/simple_contract_call.ir
@@ -1,5 +1,5 @@
 script {
-    fn main() -> u64 {
+    fn main() -> u64, !1 {
         local ptr u64 a
         local ptr b256 arg_for_get_b256
         local mut ptr { u64, b256 } args_struct_for_get_s
@@ -7,79 +7,80 @@ script {
         local ptr { u64, b256 } s
 
         entry:
-        v0 = const u64 1111, !1
-        v1 = bitcast v0 to u64, !2
-        v2 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !2
-        v3 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !3
-        v4 = insert_value v2, { b256, u64, u64 }, v3, 0, !2
-        v5 = const u64 2559618804, !2
-        v6 = insert_value v4, { b256, u64, u64 }, v5, 1, !2
-        v7 = insert_value v6, { b256, u64, u64 }, v1, 2, !2
-        v8 = const u64 0, !4
-        v9 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !5
-        v10 = const u64 10000, !6
-        v11 = contract_call u64 get_u64 v7, v8, v9, v10, !2
-        v12 = get_ptr ptr u64 a, ptr u64, 0, !7
-        store v11, ptr v12, !7
+        v0 = const u64 1111, !2
+        v1 = bitcast v0 to u64, !3
+        v2 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !3
+        v3 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !4
+        v4 = insert_value v2, { b256, u64, u64 }, v3, 0, !3
+        v5 = const u64 2559618804, !3
+        v6 = insert_value v4, { b256, u64, u64 }, v5, 1, !3
+        v7 = insert_value v6, { b256, u64, u64 }, v1, 2, !3
+        v8 = const u64 0, !5
+        v9 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !6
+        v10 = const u64 10000, !7
+        v11 = contract_call u64 get_u64 v7, v8, v9, v10, !3
+        v12 = get_ptr ptr u64 a, ptr u64, 0, !8
+        store v11, ptr v12, !8
         v13 = get_ptr ptr b256 arg_for_get_b256, ptr b256, 0
-        v14 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333, !8
+        v14 = const b256 0x3333333333333333333333333333333333333333333333333333333333333333, !9
         store v14, ptr v13
-        v15 = get_ptr ptr b256 arg_for_get_b256, ptr u64, 0, !9
-        v16 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !9
-        v17 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !10
-        v18 = insert_value v16, { b256, u64, u64 }, v17, 0, !9
-        v19 = const u64 1108491158, !9
-        v20 = insert_value v18, { b256, u64, u64 }, v19, 1, !9
-        v21 = insert_value v20, { b256, u64, u64 }, v15, 2, !9
-        v22 = const u64 0, !11
-        v23 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !12
-        v24 = const u64 20000, !13
-        v25 = contract_call b256 get_b256 v21, v22, v23, v24, !9
-        v26 = get_ptr ptr b256 b, ptr b256, 0, !14
-        store v25, ptr v26, !14
-        v27 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0, !15
-        v28 = const u64 5555, !16
-        v29 = insert_value v27, { u64, b256 }, v28, 0, !15
-        v30 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555, !17
-        v31 = insert_value v29, { u64, b256 }, v30, 1, !15
-        v32 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0, !15
-        v33 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !15
-        v34 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !18
-        v35 = insert_value v33, { b256, u64, u64 }, v34, 0, !15
-        v36 = const u64 4234334249, !15
-        v37 = insert_value v35, { b256, u64, u64 }, v36, 1, !15
-        v38 = insert_value v37, { b256, u64, u64 }, v32, 2, !15
-        v39 = read_register cgas, !15
-        v40 = const u64 0, !19
-        v41 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !20
-        v42 = contract_call { u64, b256 } get_s v38, v40, v41, v39, !15
-        v43 = get_ptr ptr { u64, b256 } s, ptr { u64, b256 }, 0, !21
-        store v42, ptr v43, !21
-        v44 = const u64 0, !22
+        v15 = get_ptr ptr b256 arg_for_get_b256, ptr u64, 0, !10
+        v16 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !10
+        v17 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !11
+        v18 = insert_value v16, { b256, u64, u64 }, v17, 0, !10
+        v19 = const u64 1108491158, !10
+        v20 = insert_value v18, { b256, u64, u64 }, v19, 1, !10
+        v21 = insert_value v20, { b256, u64, u64 }, v15, 2, !10
+        v22 = const u64 0, !12
+        v23 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !13
+        v24 = const u64 20000, !14
+        v25 = contract_call b256 get_b256 v21, v22, v23, v24, !10
+        v26 = get_ptr ptr b256 b, ptr b256, 0, !15
+        store v25, ptr v26, !15
+        v27 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr { u64, b256 }, 0, !16
+        v28 = const u64 5555, !17
+        v29 = insert_value v27, { u64, b256 }, v28, 0, !16
+        v30 = const b256 0x5555555555555555555555555555555555555555555555555555555555555555, !18
+        v31 = insert_value v29, { u64, b256 }, v30, 1, !16
+        v32 = get_ptr mut ptr { u64, b256 } args_struct_for_get_s, ptr u64, 0, !16
+        v33 = const { b256, u64, u64 } { b256 undef, u64 undef, u64 undef }, !16
+        v34 = const b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0, !19
+        v35 = insert_value v33, { b256, u64, u64 }, v34, 0, !16
+        v36 = const u64 4234334249, !16
+        v37 = insert_value v35, { b256, u64, u64 }, v36, 1, !16
+        v38 = insert_value v37, { b256, u64, u64 }, v32, 2, !16
+        v39 = read_register cgas, !16
+        v40 = const u64 0, !20
+        v41 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !21
+        v42 = contract_call { u64, b256 } get_s v38, v40, v41, v39, !16
+        v43 = get_ptr ptr { u64, b256 } s, ptr { u64, b256 }, 0, !22
+        store v42, ptr v43, !22
+        v44 = const u64 0, !23
         ret u64 v44
     }
 }
 
 !0 = filepath "/path/to/simple_contract_call.sw"
-!1 = span !0 453 457
-!2 = span !0 301 458
-!3 = span !0 219 285
-!4 = span !0 333 334
-!5 = span !0 354 420
-!6 = span !0 435 440
-!7 = span !0 293 459
-!8 = span !0 626 692
-!9 = span !0 473 693
-!10 = span !0 219 285
-!11 = span !0 506 507
-!12 = span !0 527 593
-!13 = span !0 608 613
-!14 = span !0 465 694
-!15 = span !0 708 910
-!16 = span !0 837 841
-!17 = span !0 843 909
-!18 = span !0 219 285
-!19 = span !0 738 739
-!20 = span !0 758 824
-!21 = span !0 700 911
-!22 = span !0 916 917
+!1 = span !0 173 919
+!2 = span !0 453 457
+!3 = span !0 301 458
+!4 = span !0 219 285
+!5 = span !0 333 334
+!6 = span !0 354 420
+!7 = span !0 435 440
+!8 = span !0 293 459
+!9 = span !0 626 692
+!10 = span !0 473 693
+!11 = span !0 219 285
+!12 = span !0 506 507
+!13 = span !0 527 593
+!14 = span !0 608 613
+!15 = span !0 465 694
+!16 = span !0 708 910
+!17 = span !0 837 841
+!18 = span !0 843 909
+!19 = span !0 219 285
+!20 = span !0 738 739
+!21 = span !0 758 824
+!22 = span !0 700 911
+!23 = span !0 916 917

--- a/sway-core/tests/sway_to_ir/storage_metadata.ir
+++ b/sway-core/tests/sway_to_ir/storage_metadata.ir
@@ -1,0 +1,56 @@
+contract {
+    fn initialize<557ac400>(initial_value !1: u64) -> u64, !2, !3 {
+        entry:
+        v0 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !4
+        v1 = asm(key: v0, v: initial_value) {
+            sww    key v, !5
+        }
+        ret u64 initial_value
+    }
+
+    fn increment<e543c666>(increment_by !6: u64) -> u64, !7, !8 {
+        local ptr u64 new_val
+
+        entry:
+        v0 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !4
+        v1 = asm(key: v0, i: increment_by, res) -> u64 res, !9 {
+            srw    res key, !10
+            add    res res i, !11
+            sww    key res, !12
+        }
+        v2 = get_ptr ptr u64 new_val, ptr u64, 0, !13
+        store v1, ptr v2, !13
+        v3 = get_ptr ptr u64 new_val, ptr u64, 0, !14
+        v4 = load ptr v3, !14
+        ret u64 v4
+    }
+
+    fn get<75b70457>() -> u64, !15, !16 {
+        entry:
+        v0 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000, !4
+        v1 = asm(key: v0, res) -> u64 res, !17 {
+            srw    key res, !18
+        }
+        ret u64 v1
+    }
+}
+
+!0 = filepath "/path/to/storage_metadata.sw"
+!1 = span !0 370 383
+!2 = span !0 356 501
+!3 = storage write
+!4 = span !0 23 89
+!5 = span !0 453 462
+!6 = span !0 548 560
+!7 = span !0 535 766
+!8 = storage readwrite
+!9 = span !0 598 743
+!10 = span !0 648 659
+!11 = span !0 673 686
+!12 = span !0 700 711
+!13 = span !0 584 744
+!14 = span !0 753 760
+!15 = span !0 793 901
+!16 = storage read
+!17 = span !0 819 895
+!18 = span !0 852 863

--- a/sway-core/tests/sway_to_ir/storage_metadata.sw
+++ b/sway-core/tests/sway_to_ir/storage_metadata.sw
@@ -1,0 +1,43 @@
+contract;
+
+const KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
+
+abi Incrementor {
+    #[storage(write)]
+    fn initialize(initial_value: u64) -> u64;
+
+    #[storage(read, write)]
+    fn increment(initial_value: u64) -> u64;
+
+    #[storage(read)]
+    fn get() -> u64;
+}
+
+impl Incrementor for Contract {
+    #[storage(write)]
+    fn initialize(initial_value: u64) -> u64 {
+        asm(key: KEY, v: initial_value) {
+            sww key v;
+        }
+        initial_value
+    }
+
+    #[storage(read, write)]
+    fn increment(increment_by: u64) -> u64 {
+        let new_val = asm(key: KEY, i: increment_by, res) {
+            srw res key;
+            add res res i;
+            sww key res;
+            res: u64
+        };
+        new_val
+    }
+
+    #[storage(read)]
+    fn get() -> u64 {
+        asm(key: KEY, res) {
+            srw key res;
+            res: u64
+        }
+    }
+}

--- a/sway-core/tests/sway_to_ir/strings_in_storage.ir
+++ b/sway-core/tests/sway_to_ir/strings_in_storage.ir
@@ -1,26 +1,5 @@
 contract {
-    fn set_s<e63a9733>(s !1: string<40>) -> () {
-        local mut ptr b256 key_for_0
-        local mut ptr [b256; 2] val_for_0
-
-        entry:
-        v0 = get_ptr mut ptr b256 key_for_0, ptr b256, 0, !2
-        v1 = const b256 0xf383b0ce51358be57daa3b725fe44acdb2d880604e367199080b4379c41bb6ed, !2
-        store v1, ptr v0, !2
-        v2 = get_ptr mut ptr [b256; 2] val_for_0, ptr string<40>, 0, !2
-        store s, ptr v2, !2
-        v3 = get_ptr mut ptr [b256; 2] val_for_0, ptr b256, 0, !2
-        state_store_quad_word ptr v3, key ptr v0, !2
-        v4 = get_ptr mut ptr b256 key_for_0, ptr b256, 0, !2
-        v5 = const b256 0xf383b0ce51358be57daa3b725fe44acdb2d880604e367199080b4379c41bb6ee, !2
-        store v5, ptr v4, !2
-        v6 = get_ptr mut ptr [b256; 2] val_for_0, ptr b256, 1, !2
-        state_store_quad_word ptr v6, key ptr v4, !2
-        v7 = const unit ()
-        ret () v7
-    }
-
-    fn get_s<b8c27db9>() -> string<40> {
+    fn set_s<e63a9733>(s !1: string<40>) -> (), !2 {
         local mut ptr b256 key_for_0
         local mut ptr [b256; 2] val_for_0
 
@@ -29,18 +8,41 @@ contract {
         v1 = const b256 0xf383b0ce51358be57daa3b725fe44acdb2d880604e367199080b4379c41bb6ed, !3
         store v1, ptr v0, !3
         v2 = get_ptr mut ptr [b256; 2] val_for_0, ptr string<40>, 0, !3
+        store s, ptr v2, !3
         v3 = get_ptr mut ptr [b256; 2] val_for_0, ptr b256, 0, !3
-        state_load_quad_word ptr v3, key ptr v0, !3
+        state_store_quad_word ptr v3, key ptr v0, !3
         v4 = get_ptr mut ptr b256 key_for_0, ptr b256, 0, !3
         v5 = const b256 0xf383b0ce51358be57daa3b725fe44acdb2d880604e367199080b4379c41bb6ee, !3
         store v5, ptr v4, !3
         v6 = get_ptr mut ptr [b256; 2] val_for_0, ptr b256, 1, !3
-        state_load_quad_word ptr v6, key ptr v4, !3
+        state_store_quad_word ptr v6, key ptr v4, !3
+        v7 = const unit ()
+        ret () v7
+    }
+
+    fn get_s<b8c27db9>() -> string<40>, !4 {
+        local mut ptr b256 key_for_0
+        local mut ptr [b256; 2] val_for_0
+
+        entry:
+        v0 = get_ptr mut ptr b256 key_for_0, ptr b256, 0, !5
+        v1 = const b256 0xf383b0ce51358be57daa3b725fe44acdb2d880604e367199080b4379c41bb6ed, !5
+        store v1, ptr v0, !5
+        v2 = get_ptr mut ptr [b256; 2] val_for_0, ptr string<40>, 0, !5
+        v3 = get_ptr mut ptr [b256; 2] val_for_0, ptr b256, 0, !5
+        state_load_quad_word ptr v3, key ptr v0, !5
+        v4 = get_ptr mut ptr b256 key_for_0, ptr b256, 0, !5
+        v5 = const b256 0xf383b0ce51358be57daa3b725fe44acdb2d880604e367199080b4379c41bb6ee, !5
+        store v5, ptr v4, !5
+        v6 = get_ptr mut ptr [b256; 2] val_for_0, ptr b256, 1, !5
+        state_load_quad_word ptr v6, key ptr v4, !5
         ret string<40> v2
     }
 }
 
 !0 = filepath "/path/to/strings_in_storage.sw"
 !1 = span !0 178 179
-!2 = span !0 200 213
-!3 = span !0 266 267
+!2 = span !0 169 220
+!3 = span !0 200 213
+!4 = span !0 226 273
+!5 = span !0 266 267

--- a/sway-core/tests/sway_to_ir/struct.ir
+++ b/sway-core/tests/sway_to_ir/struct.ir
@@ -1,25 +1,26 @@
 script {
-    fn main() -> u64 {
+    fn main() -> u64, !1 {
         local ptr { u64, u64 } record
 
         entry:
-        v0 = const { u64, u64 } { u64 undef, u64 undef }, !1
-        v1 = const u64 40, !2
-        v2 = insert_value v0, { u64, u64 }, v1, 0, !1
-        v3 = const u64 2, !3
-        v4 = insert_value v2, { u64, u64 }, v3, 1, !1
-        v5 = get_ptr ptr { u64, u64 } record, ptr { u64, u64 }, 0, !4
-        store v4, ptr v5, !4
-        v6 = get_ptr ptr { u64, u64 } record, ptr { u64, u64 }, 0, !5
-        v7 = extract_value v6, { u64, u64 }, 0, !6
+        v0 = const { u64, u64 } { u64 undef, u64 undef }, !2
+        v1 = const u64 40, !3
+        v2 = insert_value v0, { u64, u64 }, v1, 0, !2
+        v3 = const u64 2, !4
+        v4 = insert_value v2, { u64, u64 }, v3, 1, !2
+        v5 = get_ptr ptr { u64, u64 } record, ptr { u64, u64 }, 0, !5
+        store v4, ptr v5, !5
+        v6 = get_ptr ptr { u64, u64 } record, ptr { u64, u64 }, 0, !6
+        v7 = extract_value v6, { u64, u64 }, 0, !7
         ret u64 v7
     }
 }
 
 !0 = filepath "/path/to/struct.sw"
-!1 = span !0 45 88
-!2 = span !0 65 67
-!3 = span !0 80 81
-!4 = span !0 32 89
-!5 = span !0 94 100
-!6 = span !0 65 67
+!1 = span !0 9 104
+!2 = span !0 45 88
+!3 = span !0 65 67
+!4 = span !0 80 81
+!5 = span !0 32 89
+!6 = span !0 94 100
+!7 = span !0 65 67

--- a/sway-core/tests/sway_to_ir/struct_enum.ir
+++ b/sway-core/tests/sway_to_ir/struct_enum.ir
@@ -1,27 +1,28 @@
 script {
-    fn main() -> bool {
+    fn main() -> bool, !1 {
         local ptr { bool, { u64, ( () | () | u64 ) } } record
 
         entry:
-        v0 = const { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef }, !1
-        v1 = const u64 0, !1
-        v2 = insert_value v0, { u64, ( () | () | u64 ) }, v1, 0, !1
-        v3 = const { bool, { u64, ( () | () | u64 ) } } { bool undef, { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef } }, !2
-        v4 = const bool false, !3
-        v5 = insert_value v3, { bool, { u64, ( () | () | u64 ) } }, v4, 0, !2
-        v6 = insert_value v5, { bool, { u64, ( () | () | u64 ) } }, v2, 1, !2
-        v7 = get_ptr ptr { bool, { u64, ( () | () | u64 ) } } record, ptr { bool, { u64, ( () | () | u64 ) } }, 0, !4
-        store v6, ptr v7, !4
-        v8 = get_ptr ptr { bool, { u64, ( () | () | u64 ) } } record, ptr { bool, { u64, ( () | () | u64 ) } }, 0, !5
-        v9 = extract_value v8, { bool, { u64, ( () | () | u64 ) } }, 0, !6
+        v0 = const { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef }, !2
+        v1 = const u64 0, !2
+        v2 = insert_value v0, { u64, ( () | () | u64 ) }, v1, 0, !2
+        v3 = const { bool, { u64, ( () | () | u64 ) } } { bool undef, { u64, ( () | () | u64 ) } { u64 undef, ( () | () | u64 ) undef } }, !3
+        v4 = const bool false, !4
+        v5 = insert_value v3, { bool, { u64, ( () | () | u64 ) } }, v4, 0, !3
+        v6 = insert_value v5, { bool, { u64, ( () | () | u64 ) } }, v2, 1, !3
+        v7 = get_ptr ptr { bool, { u64, ( () | () | u64 ) } } record, ptr { bool, { u64, ( () | () | u64 ) } }, 0, !5
+        store v6, ptr v7, !5
+        v8 = get_ptr ptr { bool, { u64, ( () | () | u64 ) } } record, ptr { bool, { u64, ( () | () | u64 ) } }, 0, !6
+        v9 = extract_value v8, { bool, { u64, ( () | () | u64 ) } }, 0, !7
         ret bool v9
     }
 }
 
 !0 = filepath "/path/to/struct_enum.sw"
-!1 = span !0 167 229
-!2 = span !0 46 103
-!3 = span !0 66 71
-!4 = span !0 33 104
-!5 = span !0 109 115
-!6 = span !0 66 71
+!1 = span !0 9 119
+!2 = span !0 167 229
+!3 = span !0 46 103
+!4 = span !0 66 71
+!5 = span !0 33 104
+!6 = span !0 109 115
+!7 = span !0 66 71

--- a/sway-core/tests/sway_to_ir/struct_struct.ir
+++ b/sway-core/tests/sway_to_ir/struct_struct.ir
@@ -1,33 +1,34 @@
 script {
-    fn main() -> u64 {
+    fn main() -> u64, !1 {
         local ptr { b256, { bool, u64 } } record
 
         entry:
-        v0 = const { bool, u64 } { bool undef, u64 undef }, !1
-        v1 = const bool true, !2
-        v2 = insert_value v0, { bool, u64 }, v1, 0, !1
-        v3 = const u64 76, !3
-        v4 = insert_value v2, { bool, u64 }, v3, 1, !1
-        v5 = const { b256, { bool, u64 } } { b256 undef, { bool, u64 } { bool undef, u64 undef } }, !4
-        v6 = const b256 0x0102030405060708010203040506070801020304050607080102030405060708, !5
-        v7 = insert_value v5, { b256, { bool, u64 } }, v6, 0, !4
-        v8 = insert_value v7, { b256, { bool, u64 } }, v4, 1, !4
-        v9 = get_ptr ptr { b256, { bool, u64 } } record, ptr { b256, { bool, u64 } }, 0, !6
-        store v8, ptr v9, !6
-        v10 = get_ptr ptr { b256, { bool, u64 } } record, ptr { b256, { bool, u64 } }, 0, !7
-        v11 = extract_value v10, { b256, { bool, u64 } }, 1, !8
-        v12 = extract_value v11, { bool, u64 }, 1, !9
+        v0 = const { bool, u64 } { bool undef, u64 undef }, !2
+        v1 = const bool true, !3
+        v2 = insert_value v0, { bool, u64 }, v1, 0, !2
+        v3 = const u64 76, !4
+        v4 = insert_value v2, { bool, u64 }, v3, 1, !2
+        v5 = const { b256, { bool, u64 } } { b256 undef, { bool, u64 } { bool undef, u64 undef } }, !5
+        v6 = const b256 0x0102030405060708010203040506070801020304050607080102030405060708, !6
+        v7 = insert_value v5, { b256, { bool, u64 } }, v6, 0, !5
+        v8 = insert_value v7, { b256, { bool, u64 } }, v4, 1, !5
+        v9 = get_ptr ptr { b256, { bool, u64 } } record, ptr { b256, { bool, u64 } }, 0, !7
+        store v8, ptr v9, !7
+        v10 = get_ptr ptr { b256, { bool, u64 } } record, ptr { b256, { bool, u64 } }, 0, !8
+        v11 = extract_value v10, { b256, { bool, u64 } }, 1, !9
+        v12 = extract_value v11, { bool, u64 }, 1, !10
         ret u64 v12
     }
 }
 
 !0 = filepath "/path/to/struct_struct.sw"
-!1 = span !0 144 201
-!2 = span !0 167 171
-!3 = span !0 188 190
-!4 = span !0 45 207
-!5 = span !0 65 131
-!6 = span !0 32 208
-!7 = span !0 213 219
-!8 = span !0 144 201
-!9 = span !0 305 311
+!1 = span !0 9 225
+!2 = span !0 144 201
+!3 = span !0 167 171
+!4 = span !0 188 190
+!5 = span !0 45 207
+!6 = span !0 65 131
+!7 = span !0 32 208
+!8 = span !0 213 219
+!9 = span !0 144 201
+!10 = span !0 305 311

--- a/sway-core/tests/sway_to_ir/takes_string_returns_string.ir
+++ b/sway-core/tests/sway_to_ir/takes_string_returns_string.ir
@@ -1,10 +1,10 @@
 contract {
-    fn small_string<80da70e2>(s !1: string<7>) -> string<7> {
+    fn small_string<80da70e2>(s !1: string<7>) -> string<7>, !2 {
         entry:
         ret string<7> s
     }
 
-    fn large_string<28c0f699>(s !2: string<9>) -> string<9> {
+    fn large_string<28c0f699>(s !3: string<9>) -> string<9>, !4 {
         entry:
         ret string<9> s
     }
@@ -12,4 +12,6 @@ contract {
 
 !0 = filepath "/path/to/takes_string_returns_string.sw"
 !1 = span !0 166 167
-!2 = span !0 226 227
+!2 = span !0 150 205
+!3 = span !0 226 227
+!4 = span !0 210 265

--- a/sway-core/tests/sway_to_ir/trait.ir
+++ b/sway-core/tests/sway_to_ir/trait.ir
@@ -1,69 +1,73 @@
 script {
-    fn main() -> bool {
+    fn main() -> bool, !1 {
         local ptr { bool } bar
         local ptr { bool } foo
 
         entry:
-        v0 = const { bool } { bool undef }, !1
-        v1 = const bool true, !2
-        v2 = insert_value v0, { bool }, v1, 0, !1
-        v3 = get_ptr ptr { bool } foo, ptr { bool }, 0, !3
-        store v2, ptr v3, !3
-        v4 = const { bool } { bool undef }, !4
-        v5 = const bool false, !5
-        v6 = insert_value v4, { bool }, v5, 0, !4
-        v7 = get_ptr ptr { bool } bar, ptr { bool }, 0, !6
-        store v6, ptr v7, !6
-        v8 = get_ptr ptr { bool } foo, ptr { bool }, 0, !7
-        v9 = get_ptr ptr { bool } bar, ptr { bool }, 0, !8
-        v10 = call anon_0(v8, v9), !9
+        v0 = const { bool } { bool undef }, !2
+        v1 = const bool true, !3
+        v2 = insert_value v0, { bool }, v1, 0, !2
+        v3 = get_ptr ptr { bool } foo, ptr { bool }, 0, !4
+        store v2, ptr v3, !4
+        v4 = const { bool } { bool undef }, !5
+        v5 = const bool false, !6
+        v6 = insert_value v4, { bool }, v5, 0, !5
+        v7 = get_ptr ptr { bool } bar, ptr { bool }, 0, !7
+        store v6, ptr v7, !7
+        v8 = get_ptr ptr { bool } foo, ptr { bool }, 0, !8
+        v9 = get_ptr ptr { bool } bar, ptr { bool }, 0, !9
+        v10 = call anon_0(v8, v9), !10
         ret bool v10
     }
 
-    fn anon_0(self !10: { bool }, other !11: { bool }) -> bool {
+    fn anon_0(self !11: { bool }, other !12: { bool }) -> bool, !13 {
         entry:
-        v0 = call anon_1(self), !12
-        cbr v0, block1, block0, !13
+        v0 = call anon_1(self), !14
+        cbr v0, block1, block0, !15
 
         block0:
         v1 = phi(entry: v0)
-        v2 = call anon_2(other), !14
-        br block1, !13
+        v2 = call anon_2(other), !16
+        br block1, !15
 
         block1:
         v3 = phi(entry: v0, block0: v2)
         ret bool v3
     }
 
-    fn anon_1(self !15: { bool }) -> bool {
+    fn anon_1(self !17: { bool }) -> bool, !18 {
         entry:
-        v0 = extract_value self, { bool }, 0, !16
+        v0 = extract_value self, { bool }, 0, !19
         ret bool v0
     }
 
-    fn anon_2(self !17: { bool }) -> bool {
+    fn anon_2(self !20: { bool }) -> bool, !21 {
         entry:
-        v0 = extract_value self, { bool }, 0, !18
+        v0 = extract_value self, { bool }, 0, !22
         ret bool v0
     }
 }
 
 !0 = filepath "/path/to/trait.sw"
-!1 = span !0 277 304
-!2 = span !0 294 298
-!3 = span !0 267 305
-!4 = span !0 320 348
-!5 = span !0 337 342
-!6 = span !0 310 349
-!7 = span !0 354 357
-!8 = span !0 366 369
-!9 = span !0 354 370
-!10 = span !0 68 72
-!11 = span !0 74 79
-!12 = span !0 105 116
-!13 = span !0 105 132
-!14 = span !0 120 132
-!15 = span !0 203 207
-!16 = span !0 159 166
+!1 = span !0 243 372
+!2 = span !0 277 304
+!3 = span !0 294 298
+!4 = span !0 267 305
+!5 = span !0 320 348
+!6 = span !0 337 342
+!7 = span !0 310 349
+!8 = span !0 354 357
+!9 = span !0 366 369
+!10 = span !0 354 370
+!11 = span !0 68 72
+!12 = span !0 74 79
+!13 = span !0 60 67
+!14 = span !0 105 116
+!15 = span !0 105 132
+!16 = span !0 120 132
 !17 = span !0 203 207
-!18 = span !0 159 166
+!18 = span !0 198 202
+!19 = span !0 159 166
+!20 = span !0 203 207
+!21 = span !0 198 202
+!22 = span !0 159 166

--- a/sway-core/tests/sway_to_ir/unit_type_variants.ir
+++ b/sway-core/tests/sway_to_ir/unit_type_variants.ir
@@ -1,12 +1,13 @@
 script {
-    fn main() -> { u64 } {
+    fn main() -> { u64 }, !1 {
         entry:
-        v0 = const { u64 } { u64 undef }, !1
-        v1 = const u64 2, !1
-        v2 = insert_value v0, { u64 }, v1, 0, !1
+        v0 = const { u64 } { u64 undef }, !2
+        v1 = const u64 2, !2
+        v2 = insert_value v0, { u64 }, v1, 0, !2
         ret { u64 } v2
     }
 }
 
 !0 = filepath "/path/to/unit_type_variants.sw"
-!1 = span !0 9 52
+!1 = span !0 54 81
+!2 = span !0 9 52

--- a/sway-ir/src/context.rs
+++ b/sway-ir/src/context.rs
@@ -6,6 +6,8 @@
 //!
 //! It is passed around as a mutable reference to many of the Sway-IR APIs.
 
+use std::collections::HashMap;
+
 use generational_arena::Arena;
 
 use crate::{
@@ -13,7 +15,7 @@ use crate::{
     block::BlockContent,
     function::FunctionContent,
     irtype::AggregateContent,
-    metadata::{MetadataIndex, Metadatum},
+    metadata::{MetadataIndex, Metadatum, StorageOperation},
     module::ModuleContent,
     module::ModuleIterator,
     pointer::PointerContent,
@@ -37,7 +39,8 @@ pub struct Context {
     // The metadata indices for locations need a fast lookup, hence the metadata_reverse_map.
     // Using a HashMap might be overkill as most projects have only a handful of source files.
     pub metadata: Arena<Metadatum>,
-    pub metadata_reverse_map: std::collections::HashMap<*const std::path::PathBuf, MetadataIndex>,
+    pub metadata_reverse_map: HashMap<*const std::path::PathBuf, MetadataIndex>,
+    pub(crate) metadata_storage_indices: HashMap<StorageOperation, MetadataIndex>,
 
     next_unique_sym_tag: u64,
 }

--- a/sway-ir/src/function.rs
+++ b/sway-ir/src/function.rs
@@ -33,6 +33,8 @@ pub struct FunctionContent {
     pub blocks: Vec<Block>,
     pub is_public: bool,
     pub selector: Option<[u8; 4]>,
+    pub span_md_idx: Option<MetadataIndex>,
+    pub storage_md_idx: Option<MetadataIndex>,
 
     pub local_storage: BTreeMap<String, Pointer>, // BTree rather than Hash for deterministic ordering.
 
@@ -47,6 +49,7 @@ impl Function {
     /// `name`, `args`, `return_type` and `is_public` are the usual suspects.  `selector` is a
     /// special value used for Sway contract calls; much like `name` is unique and not particularly
     /// used elsewhere in the IR.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         context: &mut Context,
         module: Module,
@@ -55,6 +58,8 @@ impl Function {
         return_type: Type,
         selector: Option<[u8; 4]>,
         is_public: bool,
+        span_md_idx: Option<MetadataIndex>,
+        storage_md_idx: Option<MetadataIndex>,
     ) -> Function {
         let arguments = args
             .into_iter()
@@ -67,6 +72,8 @@ impl Function {
             blocks: Vec::new(),
             is_public,
             selector,
+            span_md_idx,
+            storage_md_idx,
             local_storage: BTreeMap::new(),
             next_label_idx: 0,
         };

--- a/sway-ir/src/metadata.rs
+++ b/sway-ir/src/metadata.rs
@@ -1,12 +1,12 @@
-/// Associated metadata attached mostly to values.
-///
-/// Each value (instruction, function argument or constant) has associated metadata which helps
-/// describe properties which aren't required for code generation, but help with other
-/// introspective tools (e.g., the debugger) or compiler error messages.
-///
-/// NOTE: At the moment the Spans contain a source string and optional path.  Any spans with no
-/// path are ignored/rejected by this module.  The source string is not (de)serialised and so the
-/// string is assumed to always represent the entire contents of the file path.
+///! Associated metadata attached mostly to values.
+///!
+///! Each value (instruction, function argument or constant) has associated metadata which helps
+///! describe properties which aren't required for code generation, but help with other
+///! introspective tools (e.g., the debugger) or compiler error messages.
+///!
+///! NOTE: At the moment the Spans contain a source string and optional path.  Any spans with no
+///! path are ignored/rejected by this module.  The source string is not (de)serialised and so the
+///! string is assumed to always represent the entire contents of the file path.
 use std::sync::Arc;
 
 use sway_types::span::Span;
@@ -14,13 +14,21 @@ use sway_types::span::Span;
 use crate::{context::Context, error::IrError};
 
 pub enum Metadatum {
+    /// A path to a source file.
     FileLocation(Arc<std::path::PathBuf>, Arc<str>),
+
+    /// A specific section within a source file.
     Span {
         loc_idx: MetadataIndex,
         start: usize,
         end: usize,
     },
+
+    /// A unique token for storage operations.
     StateIndex(usize),
+
+    /// An attribute indicating the permitted/expected storage operations with a function.
+    StorageAttribute(StorageOperation),
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -81,6 +89,44 @@ impl MetadataIndex {
         match &context.metadata[self.0] {
             Metadatum::StateIndex(ix) => Ok(*ix),
             _otherwise => Err(IrError::InvalidMetadatum),
+        }
+    }
+
+    pub fn get_storage_index(context: &mut Context, storage_op: StorageOperation) -> MetadataIndex {
+        *context
+            .metadata_storage_indices
+            .entry(storage_op)
+            .or_insert_with(|| {
+                MetadataIndex(
+                    context
+                        .metadata
+                        .insert(Metadatum::StorageAttribute(storage_op)),
+                )
+            })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum StorageOperation {
+    Reads,
+    Writes,
+    ReadsWrites,
+}
+
+use std::fmt::{Display, Error, Formatter};
+
+impl Display for StorageOperation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        write!(f, "{}", self.simple_string())
+    }
+}
+
+impl StorageOperation {
+    pub fn simple_string(&self) -> &'static str {
+        match self {
+            StorageOperation::Reads => "read",
+            StorageOperation::Writes => "write",
+            StorageOperation::ReadsWrites => "readwrite",
         }
     }
 }

--- a/sway-ir/src/parser.rs
+++ b/sway-ir/src/parser.rs
@@ -31,8 +31,8 @@ mod ir_builder {
                 = _ s:script() eoi() {
                     s
                 }
-                / _ s:contract() eoi() {
-                    s
+                / _ c:contract() eoi() {
+                    c
                 }
 
             rule script() -> IrAstModule
@@ -55,7 +55,8 @@ mod ir_builder {
 
             rule fn_decl() -> IrAstFnDecl
                 = "fn" _ name:id() _ selector:selector_id()? _ "(" _
-                      args:(fn_arg() ** comma()) ")" _ "->" _ ret_type:ast_ty() "{" _
+                      args:(fn_arg() ** comma()) ")" _ "->" _ ret_type:ast_ty()
+                          span_md_idx:comma_metadata_idx()? storage_md_idx:comma_metadata_idx()? "{" _
                       locals:fn_local()*
                       blocks:block_decl()*
                   "}" _ {
@@ -63,6 +64,8 @@ mod ir_builder {
                         name,
                         args,
                         ret_type,
+                        span_md_idx,
+                        storage_md_idx,
                         locals,
                         blocks,
                         selector
@@ -99,13 +102,13 @@ mod ir_builder {
 
             rule instr_decl() -> IrAstInstruction
                 = value_name:value_assign()? op:operation()
-                        meta_idx:comma_metadata_idx()?
+                    span_md_idx:comma_metadata_idx()?
                     state_idx_md_idx:comma_metadata_idx()?
-                        {
+                {
                     IrAstInstruction {
                         value_name,
                         op,
-                        meta_idx,
+                        span_md_idx,
                         state_idx_md_idx,
                     }
                 }
@@ -448,6 +451,21 @@ mod ir_builder {
                 / "state_index" _ idx:decimal() {
                     IrMetadatum::StateIndex { idx: idx as usize}
                 }
+                / "storage" _ sk:metadata_storage_kind() {
+                    IrMetadatum::Storage(sk)
+                }
+
+            rule metadata_storage_kind() -> IrMetadatumStorageKind
+                // 'readwrite' must go first to disambiguate between 'read' and 'readwrite'.
+                = "readwrite" _ {
+                    IrMetadatumStorageKind::ReadWrites
+                }
+                / "read" _ {
+                    IrMetadatumStorageKind::Reads
+                }
+                / "write" _ {
+                    IrMetadatumStorageKind::Writes
+                }
 
             rule id_char0()
                 = quiet!{ ['A'..='Z' | 'a'..='z' | '_'] }
@@ -500,7 +518,7 @@ mod ir_builder {
         function::Function,
         instruction::{Instruction, Predicate, Register},
         irtype::{Aggregate, Type},
-        metadata::{MetadataIndex, Metadatum},
+        metadata::{MetadataIndex, Metadatum, StorageOperation},
         module::{Kind, Module},
         pointer::Pointer,
         value::Value,
@@ -518,6 +536,8 @@ mod ir_builder {
         name: String,
         args: Vec<(IrAstTy, String, Option<MdIdxRef>)>,
         ret_type: IrAstTy,
+        span_md_idx: Option<MdIdxRef>,
+        storage_md_idx: Option<MdIdxRef>,
         locals: Vec<(IrAstTy, String, bool, Option<IrAstOperation>)>,
         blocks: Vec<IrAstBlock>,
         selector: Option<[u8; 4]>,
@@ -533,7 +553,7 @@ mod ir_builder {
     struct IrAstInstruction {
         value_name: Option<String>,
         op: IrAstOperation,
-        meta_idx: Option<MdIdxRef>,
+        span_md_idx: Option<MdIdxRef>,
         state_idx_md_idx: Option<MdIdxRef>,
     }
 
@@ -715,6 +735,14 @@ mod ir_builder {
         StateIndex {
             idx: usize,
         },
+        Storage(IrMetadatumStorageKind),
+    }
+
+    #[derive(Debug)]
+    enum IrMetadatumStorageKind {
+        Reads,
+        Writes,
+        ReadWrites,
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -748,16 +776,13 @@ mod ir_builder {
             Option<MetadataIndex>,
         )>,
     ) -> Result<(), IrError> {
+        let convert_md_idx = |opt_md_idx: &Option<MdIdxRef>| {
+            opt_md_idx.map(|mdi| md_map.get(&mdi).copied().unwrap())
+        };
         let args: Vec<(String, Type, Option<MetadataIndex>)> = fn_decl
             .args
             .iter()
-            .map(|(ty, name, md_idx)| {
-                (
-                    name.into(),
-                    ty.to_ir_type(context),
-                    md_idx.map(|mdi| md_map.get(&mdi).copied().unwrap()),
-                )
-            })
+            .map(|(ty, name, md_idx)| (name.into(), ty.to_ir_type(context), convert_md_idx(md_idx)))
             .collect();
         let ret_type = fn_decl.ret_type.to_ir_type(context);
         let func = Function::new(
@@ -768,6 +793,8 @@ mod ir_builder {
             ret_type,
             fn_decl.selector,
             false,
+            convert_md_idx(&fn_decl.span_md_idx),
+            convert_md_idx(&fn_decl.storage_md_idx),
         );
 
         // Gather all the (new) arg values by name into a map.
@@ -837,7 +864,10 @@ mod ir_builder {
     ) {
         let block = named_blocks.get(&ir_block.label).unwrap();
         for ins in ir_block.instructions {
-            let opt_ins_md_idx = ins.meta_idx.map(|mdi| md_map.get(&mdi).unwrap()).copied();
+            let opt_ins_span_md_idx = ins
+                .span_md_idx
+                .map(|mdi| md_map.get(&mdi).unwrap())
+                .copied();
             let opt_ins_state_idx_md_idx = ins
                 .state_idx_md_idx
                 .map(|mdi| md_map.get(&mdi).unwrap())
@@ -884,13 +914,17 @@ mod ir_builder {
                 }
                 IrAstOperation::BitCast(val, ty) => {
                     let to_ty = ty.to_ir_type(context);
-                    block
-                        .ins(context)
-                        .bitcast(*val_map.get(&val).unwrap(), to_ty, opt_ins_md_idx)
+                    block.ins(context).bitcast(
+                        *val_map.get(&val).unwrap(),
+                        to_ty,
+                        opt_ins_span_md_idx,
+                    )
                 }
                 IrAstOperation::Br(to_block_name) => {
                     let to_block = named_blocks.get(&to_block_name).unwrap();
-                    block.ins(context).branch(*to_block, None, opt_ins_md_idx)
+                    block
+                        .ins(context)
+                        .branch(*to_block, None, opt_ins_span_md_idx)
                 }
                 IrAstOperation::Call(callee, args) => {
                     // We can't resolve calls to other functions until we've done a first pass and
@@ -905,7 +939,7 @@ mod ir_builder {
                             .map(|arg_name| val_map.get(arg_name).unwrap())
                             .cloned()
                             .collect::<Vec<Value>>(),
-                        opt_ins_md_idx,
+                        opt_ins_span_md_idx,
                         opt_ins_state_idx_md_idx,
                     ));
                     nop
@@ -916,7 +950,7 @@ mod ir_builder {
                         *named_blocks.get(&true_block_name).unwrap(),
                         *named_blocks.get(&false_block_name).unwrap(),
                         None,
-                        opt_ins_md_idx,
+                        opt_ins_span_md_idx,
                     )
                 }
                 IrAstOperation::Cmp(pred_str, lhs, rhs) => block.ins(context).cmp(
@@ -926,9 +960,11 @@ mod ir_builder {
                     },
                     *val_map.get(&lhs).unwrap(),
                     *val_map.get(&rhs).unwrap(),
-                    opt_ins_md_idx,
+                    opt_ins_span_md_idx,
                 ),
-                IrAstOperation::Const(ty, val) => val.value.as_value(context, ty, opt_ins_md_idx),
+                IrAstOperation::Const(ty, val) => {
+                    val.value.as_value(context, ty, opt_ins_span_md_idx)
+                }
                 IrAstOperation::ContractCall(return_type, name, params, coins, asset_id, gas) => {
                     let ir_ty = return_type.to_ir_type(context);
                     block.ins(context).contract_call(
@@ -938,7 +974,7 @@ mod ir_builder {
                         *val_map.get(&coins).unwrap(),
                         *val_map.get(&asset_id).unwrap(),
                         *val_map.get(&gas).unwrap(),
-                        opt_ins_md_idx,
+                        opt_ins_span_md_idx,
                     )
                 }
                 IrAstOperation::ExtractElement(aval, ty, idx) => {
@@ -947,7 +983,7 @@ mod ir_builder {
                         *val_map.get(&aval).unwrap(),
                         ir_ty,
                         *val_map.get(&idx).unwrap(),
-                        opt_ins_md_idx,
+                        opt_ins_span_md_idx,
                     )
                 }
                 IrAstOperation::ExtractValue(val, ty, idcs) => {
@@ -956,19 +992,19 @@ mod ir_builder {
                         *val_map.get(&val).unwrap(),
                         ir_ty,
                         idcs,
-                        opt_ins_md_idx,
+                        opt_ins_span_md_idx,
                     )
                 }
                 IrAstOperation::GetStorageKey() => block
                     .ins(context)
-                    .get_storage_key(opt_ins_md_idx, opt_ins_state_idx_md_idx),
+                    .get_storage_key(opt_ins_span_md_idx, opt_ins_state_idx_md_idx),
                 IrAstOperation::GetPtr(base_ptr, ptr_ty, offset) => {
                     let ptr_ir_ty = ptr_ty.to_ir_type(context);
                     block.ins(context).get_ptr(
                         *ptr_map.get(&base_ptr).unwrap(),
                         ptr_ir_ty,
                         offset,
-                        opt_ins_md_idx,
+                        opt_ins_span_md_idx,
                     )
                 }
                 IrAstOperation::InsertElement(aval, ty, val, idx) => {
@@ -978,7 +1014,7 @@ mod ir_builder {
                         ir_ty,
                         *val_map.get(&val).unwrap(),
                         *val_map.get(&idx).unwrap(),
-                        opt_ins_md_idx,
+                        opt_ins_span_md_idx,
                     )
                 }
                 IrAstOperation::InsertValue(aval, ty, ival, idcs) => {
@@ -988,12 +1024,12 @@ mod ir_builder {
                         ir_ty,
                         *val_map.get(&ival).unwrap(),
                         idcs,
-                        opt_ins_md_idx,
+                        opt_ins_span_md_idx,
                     )
                 }
                 IrAstOperation::Load(src_name) => block
                     .ins(context)
-                    .load(*val_map.get(&src_name).unwrap(), opt_ins_md_idx),
+                    .load(*val_map.get(&src_name).unwrap(), opt_ins_span_md_idx),
                 IrAstOperation::Nop => block.ins(context).nop(),
                 IrAstOperation::Phi(pairs) => {
                     for (block_name, val_name) in pairs {
@@ -1023,40 +1059,42 @@ mod ir_builder {
                         "flag" => Register::Flag,
                         _ => unreachable!("Guaranteed by grammar."),
                     },
-                    opt_ins_md_idx,
+                    opt_ins_span_md_idx,
                 ),
                 IrAstOperation::Ret(ty, ret_val_name) => {
                     let ty = ty.to_ir_type(context);
-                    block
-                        .ins(context)
-                        .ret(*val_map.get(&ret_val_name).unwrap(), ty, opt_ins_md_idx)
+                    block.ins(context).ret(
+                        *val_map.get(&ret_val_name).unwrap(),
+                        ty,
+                        opt_ins_span_md_idx,
+                    )
                 }
                 IrAstOperation::StateLoadQuadWord(dst, key) => {
                     block.ins(context).state_load_quad_word(
                         *val_map.get(&dst).unwrap(),
                         *val_map.get(&key).unwrap(),
-                        opt_ins_md_idx,
+                        opt_ins_span_md_idx,
                     )
                 }
                 IrAstOperation::StateLoadWord(key) => block
                     .ins(context)
-                    .state_load_word(*val_map.get(&key).unwrap(), opt_ins_md_idx),
+                    .state_load_word(*val_map.get(&key).unwrap(), opt_ins_span_md_idx),
                 IrAstOperation::StateStoreQuadWord(src, key) => {
                     block.ins(context).state_store_quad_word(
                         *val_map.get(&src).unwrap(),
                         *val_map.get(&key).unwrap(),
-                        opt_ins_md_idx,
+                        opt_ins_span_md_idx,
                     )
                 }
                 IrAstOperation::StateStoreWord(src, key) => block.ins(context).state_store_word(
                     *val_map.get(&src).unwrap(),
                     *val_map.get(&key).unwrap(),
-                    opt_ins_md_idx,
+                    opt_ins_span_md_idx,
                 ),
                 IrAstOperation::Store(stored_val_name, dst_val_name) => block.ins(context).store(
                     *val_map.get(&dst_val_name).unwrap(),
                     *val_map.get(&stored_val_name).unwrap(),
-                    opt_ins_md_idx,
+                    opt_ins_span_md_idx,
                 ),
             };
             ins.value_name.map(|vn| val_map.insert(vn, ins_val));
@@ -1106,7 +1144,19 @@ mod ir_builder {
                         MetadataIndex(context.metadata.insert(Metadatum::StateIndex(*idx))),
                     );
                 }
-                _ => {}
+                IrMetadatum::Storage(kind) => {
+                    let attrib = match kind {
+                        IrMetadatumStorageKind::Reads => StorageOperation::Reads,
+                        IrMetadatumStorageKind::Writes => StorageOperation::Writes,
+                        IrMetadatumStorageKind::ReadWrites => StorageOperation::ReadsWrites,
+                    };
+                    md_map.insert(
+                        *idx_ref,
+                        MetadataIndex(context.metadata.insert(Metadatum::StorageAttribute(attrib))),
+                    );
+                }
+
+                IrMetadatum::FilePath { .. } => (),
             }
         }
         md_map
@@ -1128,7 +1178,8 @@ mod ir_builder {
         // calls.  We couldn't do it above until we'd gone and created all the functions first.
         //
         // Now we can loop and find the callee function for each call and replace the NOPs.
-        for (block, nop, callee, args, opt_ins_md_idx, opt_ins_state_idx_md_idx) in unresolved_calls
+        for (block, nop, callee, args, opt_ins_span_md_idx, opt_ins_state_idx_md_idx) in
+            unresolved_calls
         {
             let function = context
                 .functions
@@ -1144,7 +1195,7 @@ mod ir_builder {
             let call_val = Value::new_instruction(
                 context,
                 Instruction::Call(function, args),
-                opt_ins_md_idx,
+                opt_ins_span_md_idx,
                 opt_ins_state_idx_md_idx,
             );
             block.replace_instruction(context, nop, call_val)?;

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -166,8 +166,10 @@ fn function_to_doc<'a>(
                 .collect(),
         ))
         .append(Doc::text(format!(
-            " -> {} {{",
-            function.return_type.as_string(context)
+            " -> {}{}{} {{",
+            function.return_type.as_string(context),
+            md_namer.meta_as_string(context, &function.span_md_idx, true),
+            md_namer.meta_as_string(context, &function.storage_md_idx, true),
         ))),
     )
     .append(Doc::indent(
@@ -696,6 +698,9 @@ fn metadata_to_doc(context: &Context, md_namer: &MetadataNamer) -> Doc {
                     .get(loc_idx)
                     .map(|loc_ref_idx| format!("!{ref_idx} = span !{loc_ref_idx} {start} {end}")),
                 Metadatum::StateIndex(idx) => Some(format!("!{ref_idx} = state_index {idx:?}")),
+                Metadatum::StorageAttribute(storage_op) => {
+                    Some(format!("!{ref_idx} = storage {storage_op}"))
+                }
             }
             .map(&Doc::text_line)
         })

--- a/sway-lib-std/src/storage.sw
+++ b/sway-lib-std/src/storage.sw
@@ -4,6 +4,7 @@ use ::hash::sha256;
 use ::context::registers::stack_ptr;
 
 /// Store a stack variable in storage.
+#[storage(write)]
 pub fn store<T>(key: b256, value: T) {
     if !__is_reference_type::<T>() {
         // If copy type, then it's a single word and can be stored with a single SWW.
@@ -45,6 +46,7 @@ pub fn store<T>(key: b256, value: T) {
 }
 
 /// Load a stack variable from storage.
+#[storage(read)]
 pub fn get<T>(key: b256) -> T {
     if !__is_reference_type::<T>() {
         // If copy type, then it's a single word and can be read with a single
@@ -95,11 +97,13 @@ pub fn get<T>(key: b256) -> T {
 pub struct StorageMap<K, V> { }
 
 impl<K, V> StorageMap<K, V> {
+    #[storage(write)]
     fn insert(self, key: K, value: V) {
         let key = sha256((key, __get_storage_key()));
         store::<V>(key, value);
     }
 
+    #[storage(read)]
     fn get(self, key: K) -> V {
         let key = sha256((key, __get_storage_key()));
         get::<V>(key)

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -584,6 +584,7 @@ pub fn run(filter_regex: Option<regex::Regex>) {
         "should_fail/repeated_enum_variant",
         "should_fail/repeated_storage_field",
         "should_fail/repeated_struct_field",
+        "should_fail/storage_conflict",
     ];
     number_of_tests_run += negative_project_names.iter().fold(0, |acc, name| {
         if filter(name) {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_conflict/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_conflict/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'storage_conflict'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_conflict/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_conflict/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "storage_conflict"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_conflict/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_conflict/src/main.sw
@@ -1,0 +1,136 @@
+contract;
+
+abi MyContract {
+    fn test_function_a() -> bool;
+    fn test_function_b() -> bool;
+    fn test_function_c() -> bool;
+    fn test_function_d() -> bool;
+    #[storage(read)]
+    fn test_function_e() -> bool;
+}
+
+impl MyContract for Contract {
+    fn test_function_a() -> bool {
+        do_impure_stuff_a(true)
+    }
+    fn test_function_b() -> bool {
+        do_impure_stuff_b()
+    }
+    fn test_function_c() -> bool {
+        do_impure_stuff_c()
+    }
+    fn test_function_d() -> bool {
+        do_impure_stuff_d()
+    }
+    #[storage(read)]
+    fn test_function_e() -> bool {
+        do_pure_stuff_e()
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+fn do_impure_stuff_a(choice: bool) -> bool {
+    if choice {
+        let s = do_more_impure_stuff_a();
+        false
+    } else {
+        true
+    }
+}
+
+struct S {
+    a: u64,
+}
+
+fn do_more_impure_stuff_a() -> S {
+    let a = read_storage_word();
+    S { a }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+fn do_impure_stuff_b() -> bool {
+    do_more_impure_stuff_b()
+}
+
+fn do_more_impure_stuff_b() -> bool {
+    let a = read_storage_b256();
+    true
+}
+
+// -------------------------------------------------------------------------------------------------
+
+fn do_impure_stuff_c() -> bool {
+    while true {
+        do_more_impure_stuff_c();
+    }
+    true
+}
+
+fn do_more_impure_stuff_c() {
+    write_storage_word();
+}
+
+// -------------------------------------------------------------------------------------------------
+
+enum E {
+    a: (),
+    b: bool,
+}
+
+fn do_impure_stuff_d() -> bool {
+    let a = E::b(do_more_impure_stuff_d());
+    true
+}
+
+fn do_more_impure_stuff_d() -> bool {
+    write_storage_b256();
+    false
+}
+
+// -------------------------------------------------------------------------------------------------
+
+#[storage(read)]
+fn do_pure_stuff_e() -> bool {
+    true
+}
+
+// -------------------------------------------------------------------------------------------------
+
+const KEY: b256 = 0xfefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe;
+
+fn read_storage_word() -> u64 {
+    asm (key: KEY, res, a, b, c) {
+        move a b;
+        srw res key;
+        addi b c i1;
+        res: u64
+    }
+}
+
+fn read_storage_b256() -> b256 {
+    let res = 0x0000000000000000000000000000000000000000000000000000000000000000;
+    asm (key: KEY, buf: res, a, b, c) {
+        modi a b i10;
+        lt a b c;
+        srwq buf key;
+        and a b c;
+    }
+    res
+}
+
+fn write_storage_word() {
+    asm (key: KEY, val: 42) {
+        sww key val;
+    }
+}
+
+fn write_storage_b256() {
+    let val = 0xbabababababababababababababababababababababababababababababababa;
+    asm (key: KEY, val: val) {
+        swwq key val;
+    }
+}
+
+// -------------------------------------------------------------------------------------------------

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_ops_in_library/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_ops_in_library/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'storage_ops_in_library'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_ops_in_library/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_ops_in_library/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "storage_ops_in_library"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_ops_in_library/src/do_storage.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_ops_in_library/src/do_storage.sw
@@ -1,0 +1,11 @@
+library do_storage;
+
+const KEY: b256 = 0xfafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafa;
+
+#[storage(read, write)]
+pub fn side_effects() {
+    asm(key: KEY, v) {
+        srw v key;
+        sww key v;
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_ops_in_library/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_ops_in_library/src/main.sw
@@ -1,0 +1,7 @@
+script;
+
+dep do_storage;
+
+fn main() {
+    do_storage::side_effects();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/basic_storage_abi/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/basic_storage_abi/src/main.sw
@@ -1,6 +1,8 @@
 library basic_storage_abi;
 
 abi StoreU64 {
+    #[storage(write)]
     fn store_u64(key: b256, value: u64);
+    #[storage(read)]
     fn get_u64(key: b256) -> u64;
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/increment_abi/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/increment_abi/src/main.sw
@@ -1,7 +1,10 @@
 library increment_abi;
 
 abi Incrementor {
+    #[storage(write)]
     fn initialize(initial_value: u64) -> u64;
+    #[storage(read, write)]
     fn increment(initial_value: u64) -> u64;
+    #[storage(read)]
     fn get() -> u64;
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/storage_access_abi/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/storage_access_abi/src/main.sw
@@ -24,46 +24,86 @@ pub enum E {
 
 abi StorageAccess {
     // Setters
+    #[storage(write)]
     fn set_x(x: u64);
+    #[storage(write)]
     fn set_y(y: b256);
+    #[storage(write)]
     fn set_s(s: S);
+    #[storage(write)]
     fn set_boolean(boolean: bool);
+    #[storage(write)]
     fn set_int8(int8: u8);
+    #[storage(write)]
     fn set_int16(int16: u16);
+    #[storage(write)]
     fn set_int32(int32: u32);
+    #[storage(write)]
     fn set_s_dot_t(t: T);
+    #[storage(write)]
     fn set_s_dot_x(x: u64);
+    #[storage(write)]
     fn set_s_dot_y(y: u64);
+    #[storage(write)]
     fn set_s_dot_z(z: b256);
+    #[storage(write)]
     fn set_s_dot_t_dot_x(a: u64);
+    #[storage(write)]
     fn set_s_dot_t_dot_y(b: u64);
+    #[storage(write)]
     fn set_s_dot_t_dot_z(c: b256);
+    #[storage(write)]
     fn set_s_dot_t_dot_boolean(boolean: bool);
+    #[storage(write)]
     fn set_s_dot_t_dot_int8(int8: u8);
+    #[storage(write)]
     fn set_s_dot_t_dot_int16(int16: u16);
+    #[storage(write)]
     fn set_s_dot_t_dot_int32(int32: u32);
+    #[storage(write)]
     fn set_e(e: E);
+    #[storage(write)]
     fn set_string(s: str[40]);
 
     // Getters
+    #[storage(read)]
     fn get_x() -> u64;
+    #[storage(read)]
     fn get_y() -> b256;
+    #[storage(read)]
     fn get_s() -> S;
+    #[storage(read)]
     fn get_boolean() -> bool;
+    #[storage(read)]
     fn get_int8() -> u8;
+    #[storage(read)]
     fn get_int16() -> u16;
+    #[storage(read)]
     fn get_int32() -> u32;
+    #[storage(read)]
     fn get_s_dot_x() -> u64;
+    #[storage(read)]
     fn get_s_dot_y() -> u64;
+    #[storage(read)]
     fn get_s_dot_z() -> b256;
+    #[storage(read)]
     fn get_s_dot_t() -> T;
+    #[storage(read)]
     fn get_s_dot_t_dot_x() -> u64;
+    #[storage(read)]
     fn get_s_dot_t_dot_y() -> u64;
+    #[storage(read)]
     fn get_s_dot_t_dot_z() -> b256;
+    #[storage(read)]
     fn get_s_dot_t_dot_boolean() -> bool;
+    #[storage(read)]
     fn get_s_dot_t_dot_int8() -> u8;
+    #[storage(read)]
     fn get_s_dot_t_dot_int16() -> u16;
+    #[storage(read)]
     fn get_s_dot_t_dot_int32() -> u32;
+    #[storage(read)]
     fn get_e() -> E;
+    #[storage(read)]
     fn get_string() -> str[40];
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/src/main.sw
@@ -3,10 +3,12 @@ use std::storage::*;
 use basic_storage_abi::*;
 
 impl StoreU64 for Contract {
+    #[storage(read)]
     fn get_u64(storage_key: b256) -> u64 {
         get(storage_key)
     }
 
+    #[storage(write)]
     fn store_u64(key: b256, value: u64) {
         store(key, value);
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/increment_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/increment_contract/src/main.sw
@@ -6,10 +6,12 @@ use std::storage::{get, store};
 const KEY = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
 impl Incrementor for Contract {
+    #[storage(write)]
     fn initialize(initial_value: u64) -> u64 {
         store(KEY, initial_value);
         initial_value
     }
+    #[storage(read, write)]
     fn increment(increment_by: u64) -> u64 {
         let new_val = get::<u64>(KEY) + increment_by;
         // check that monomorphization doesn't overwrite the type of the above
@@ -17,6 +19,7 @@ impl Incrementor for Contract {
         store(KEY, new_val);
         new_val
     }
+    #[storage(read)]
     fn get() -> u64 {
         get::<u64>(KEY)
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/src/main.sw
@@ -16,125 +16,165 @@ storage {
 
 impl StorageAccess for Contract {
     // Setters
+    #[storage(write)]
     fn set_x(x: u64) {
         storage.x = x;
     }
+    #[storage(write)]
     fn set_y(y: b256) {
         storage.y = y;
     }
+    #[storage(write)]
     fn set_s(s: S) {
         storage.s = s;
     }
+    #[storage(write)]
     fn set_boolean(boolean: bool) {
         storage.boolean = boolean;
     }
+    #[storage(write)]
     fn set_int8(int8: u8) {
         storage.int8 = int8;
     }
+    #[storage(write)]
     fn set_int16(int16: u16) {
         storage.int16 = int16;
     }
+    #[storage(write)]
     fn set_int32(int32: u32) {
         storage.int32 = int32;
     }
+    #[storage(write)]
     fn set_s_dot_x(x: u64) {
         storage.s.x = x;
     }
+    #[storage(write)]
     fn set_s_dot_y(y: u64) {
         storage.s.y = y;
     }
+    #[storage(write)]
     fn set_s_dot_z(z: b256) {
         storage.s.z = z;
     }
+    #[storage(write)]
     fn set_s_dot_t(t: T) {
         storage.s.t = t;
     }
+    #[storage(write)]
     fn set_s_dot_t_dot_x(x: u64) {
         storage.s.t.x = x;
     }
+    #[storage(write)]
     fn set_s_dot_t_dot_y(y: u64) {
         storage.s.t.y = y;
     }
+    #[storage(write)]
     fn set_s_dot_t_dot_z(z: b256) {
         storage.s.t.z = z;
     }
+    #[storage(write)]
     fn set_s_dot_t_dot_boolean(boolean: bool) {
         storage.s.t.boolean = boolean;
     }
+    #[storage(write)]
     fn set_s_dot_t_dot_int8(int8: u8) {
         storage.s.t.int8 = int8;
     }
+    #[storage(write)]
     fn set_s_dot_t_dot_int16(int16: u16) {
         storage.s.t.int16 = int16;
     }
+    #[storage(write)]
     fn set_s_dot_t_dot_int32(int32: u32) {
         storage.s.t.int32 = int32;
     }
+    #[storage(write)]
     fn set_e(e: E) {
         storage.e = e;
     }
+    #[storage(write)]
     fn set_string(string: str[40]) {
         storage.string = string;
     }
 
     // Getters
+    #[storage(read)]
     fn get_x() -> u64 {
         storage.x
     }
+    #[storage(read)]
     fn get_y() -> b256 {
         storage.y
     }
+    #[storage(read)]
     fn get_s() -> S {
         storage.s
     }
+    #[storage(read)]
     fn get_boolean() -> bool {
         storage.boolean
     }
+    #[storage(read)]
     fn get_int8() -> u8 {
         storage.int8
     }
+    #[storage(read)]
     fn get_int16() -> u16 {
         storage.int16
     }
+    #[storage(read)]
     fn get_int32() -> u32 {
         storage.int32
     }
+    #[storage(read)]
     fn get_s_dot_x() -> u64 {
         storage.s.x
     }
+    #[storage(read)]
     fn get_s_dot_y() -> u64 {
         storage.s.y
     }
+    #[storage(read)]
     fn get_s_dot_z() -> b256 {
         storage.s.z
     }
+    #[storage(read)]
     fn get_s_dot_t() -> T {
         storage.s.t
     }
+    #[storage(read)]
     fn get_s_dot_t_dot_x() -> u64 {
         storage.s.t.x
     }
+    #[storage(read)]
     fn get_s_dot_t_dot_y() -> u64 {
         storage.s.t.y
     }
+    #[storage(read)]
     fn get_s_dot_t_dot_z() -> b256 {
         storage.s.t.z
     }
+    #[storage(read)]
     fn get_s_dot_t_dot_boolean() -> bool {
         storage.s.t.boolean
     }
+    #[storage(read)]
     fn get_s_dot_t_dot_int8() -> u8 {
         storage.s.t.int8
     }
+    #[storage(read)]
     fn get_s_dot_t_dot_int16() -> u16 {
         storage.s.t.int16
     }
+    #[storage(read)]
     fn get_s_dot_t_dot_int32() -> u32 {
         storage.s.t.int32
     }
+    #[storage(read)]
     fn get_e() -> E {
         storage.e
     }
+    #[storage(read)]
     fn get_string() -> str[40] {
         storage.string
     }

--- a/test/src/sdk-harness/test_projects/script_data/Forc.lock
+++ b/test/src/sdk-harness/test_projects/script_data/Forc.lock
@@ -1,6 +1,11 @@
 [[package]]
 name = 'core'
 source = 'path+from-root-239143CAFD6AF819'
+dependencies = ['core_utils']
+
+[[package]]
+name = 'core_utils'
+source = 'path+from-root-239143CAFD6AF819'
 dependencies = []
 
 [[package]]
@@ -11,4 +16,7 @@ dependencies = ['std']
 [[package]]
 name = 'std'
 source = 'path+from-root-239143CAFD6AF819'
-dependencies = ['core']
+dependencies = [
+    'core',
+    'core_utils',
+]

--- a/test/src/sdk-harness/test_projects/storage/src/main.sw
+++ b/test/src/sdk-harness/test_projects/storage/src/main.sw
@@ -52,153 +52,209 @@ const S_13: b256 = 0x00000000000000000000000000000000000000000000000000000000000
 const S_14: b256 = 0x0000000000000000000000000000000000000000000000000000000000000014;
 
 abi StorageTest {
+    #[storage(write)]
     fn store_bool(value: bool);
+    #[storage(read)]
     fn get_bool() -> bool;
+    #[storage(write)]
     fn store_u8(value: u8);
+    #[storage(read)]
     fn get_u8() -> u8;
+    #[storage(write)]
     fn store_u16(value: u16);
+    #[storage(read)]
     fn get_u16() -> u16;
+    #[storage(write)]
     fn store_u32(value: u32);
+    #[storage(read)]
     fn get_u32() -> u32;
+    #[storage(write)]
     fn store_u64(value: u64);
+    #[storage(read)]
     fn get_u64() -> u64;
+    #[storage(write)]
     fn store_b256(value: b256);
+    #[storage(read)]
     fn get_b256() -> b256;
 
+    #[storage(write)]
     fn store_small_struct(value: SmallStruct);
+    #[storage(read)]
     fn get_small_struct() -> SmallStruct;
+    #[storage(write)]
     fn store_medium_struct(value: MediumStruct);
+    #[storage(read)]
     fn get_medium_struct() -> MediumStruct;
+    #[storage(write)]
     fn store_large_struct(value: LargeStruct);
+    #[storage(read)]
     fn get_large_struct() -> LargeStruct;
+    #[storage(write)]
     fn store_very_large_struct(value: VeryLargeStruct);
+    #[storage(read)]
     fn get_very_large_struct() -> VeryLargeStruct;
 
+    #[storage(write)]
     fn store_enum(value: StorageEnum);
+    #[storage(read)]
     fn get_enum() -> StorageEnum;
 
+    #[storage(write)]
     fn store_tuple(value: (b256, u8, b256));
+    #[storage(read)]
     fn get_tuple() -> (b256, u8, b256);
 
+    #[storage(write)]
     fn store_string(value: str[31]);
+    #[storage(read)]
     fn get_string() -> str[31];
 
+    #[storage(write)]
     fn store_array();
+    #[storage(read)]
     fn get_array() -> [b256;
     3];
 }
 
 impl StorageTest for Contract {
+    #[storage(write)]
     fn store_bool(value: bool) {
         store(S_1, value);
     }
 
+    #[storage(read)]
     fn get_bool() -> bool {
         get(S_1)
     }
 
+    #[storage(write)]
     fn store_u8(value: u8) {
         store(S_2, value);
     }
 
+    #[storage(read)]
     fn get_u8() -> u8 {
         get(S_2)
     }
 
+    #[storage(write)]
     fn store_u16(value: u16) {
         store(S_3, value);
     }
 
+    #[storage(read)]
     fn get_u16() -> u16 {
         get(S_3)
     }
 
+    #[storage(write)]
     fn store_u32(value: u32) {
         store(S_4, value);
     }
 
+    #[storage(read)]
     fn get_u32() -> u32 {
         get(S_4)
     }
 
+    #[storage(write)]
     fn store_u64(value: u64) {
         store(S_5, value);
     }
 
+    #[storage(read)]
     fn get_u64() -> u64 {
         get(S_5)
     }
 
+    #[storage(write)]
     fn store_b256(value: b256) {
         store(S_6, value);
     }
 
+    #[storage(read)]
     fn get_b256() -> b256 {
         get(S_6)
     }
 
+    #[storage(write)]
     fn store_small_struct(value: SmallStruct) {
         store(S_8, value);
     }
 
+    #[storage(read)]
     fn get_small_struct() -> SmallStruct {
         get(S_8)
     }
 
+    #[storage(write)]
     fn store_medium_struct(value: MediumStruct) {
         store(S_9, value);
     }
 
+    #[storage(read)]
     fn get_medium_struct() -> MediumStruct {
         get(S_9)
     }
 
+    #[storage(write)]
     fn store_large_struct(value: LargeStruct) {
         store(S_9, value);
     }
 
+    #[storage(read)]
     fn get_large_struct() -> LargeStruct {
         get(S_9)
     }
 
+    #[storage(write)]
     fn store_very_large_struct(value: VeryLargeStruct) {
         store(S_10, value);
     }
 
+    #[storage(read)]
     fn get_very_large_struct() -> VeryLargeStruct {
         get(S_10)
     }
 
+    #[storage(write)]
     fn store_enum(value: StorageEnum) {
         store(S_11, value);
     }
 
+    #[storage(read)]
     fn get_enum() -> StorageEnum {
         get(S_11)
     }
 
+    #[storage(write)]
     fn store_tuple(value: (b256, u8, b256)) {
         store(S_12, value);
     }
 
+    #[storage(read)]
     fn get_tuple() -> (b256, u8, b256) {
         get(S_12)
     }
 
+    #[storage(write)]
     fn store_string(value: str[31]) {
         store(S_13, value);
     }
 
+    #[storage(read)]
     fn get_string() -> str[31] {
         get(S_13)
     }
 
     // Passing arrays into contract methods is not working at the moment
+    #[storage(write)]
     fn store_array() {
         let a = [0x9999999999999999999999999999999999999999999999999999999999999999, 0x8888888888888888888888888888888888888888888888888888888888888888, 0x7777777777777777777777777777777777777777777777777777777777777777];
         store(S_14, a);
     }
 
+    #[storage(read)]
     fn get_array() -> [b256;
     3] {
         get(S_14)

--- a/test/src/sdk-harness/test_projects/storage_map/src/main.sw
+++ b/test/src/sdk-harness/test_projects/storage_map/src/main.sw
@@ -40,221 +40,299 @@ storage {
 }
 
 abi StorageMapTest {
+    #[storage(write)]
     fn insert_into_u64_to_bool_map(key: u64, value: bool);
+    #[storage(read)]
     fn get_from_u64_to_bool_map(key: u64) -> bool;
 
+    #[storage(write)]
     fn insert_into_u64_to_u8_map(key: u64, value: u8);
+    #[storage(read)]
     fn get_from_u64_to_u8_map(key: u64) -> u8;
 
+    #[storage(write)]
     fn insert_into_u64_to_u16_map(key: u64, value: u16);
+    #[storage(read)]
     fn get_from_u64_to_u16_map(key: u64) -> u16;
 
+    #[storage(write)]
     fn insert_into_u64_to_u32_map(key: u64, value: u32);
+    #[storage(read)]
     fn get_from_u64_to_u32_map(key: u64) -> u32;
 
+    #[storage(write)]
     fn insert_into_u64_to_u64_map(key: u64, value: u64);
+    #[storage(read)]
     fn get_from_u64_to_u64_map(key: u64) -> u64;
 
+    #[storage(write)]
     fn insert_into_u64_to_tuple_map(key: u64, value: (b256, u8, bool));
+    #[storage(read)]
     fn get_from_u64_to_tuple_map(key: u64) -> (b256, u8, bool);
 
+    #[storage(write)]
     fn insert_into_u64_to_struct_map(key: u64, value: Struct);
+    #[storage(read)]
     fn get_from_u64_to_struct_map(key: u64) -> Struct;
 
+    #[storage(write)]
     fn insert_into_u64_to_enum_map(key: u64, value: Enum);
+    #[storage(read)]
     fn get_from_u64_to_enum_map(key: u64) -> Enum;
 
+    #[storage(write)]
     fn insert_into_u64_to_str_map(key: u64, value: str[33]);
+    #[storage(read)]
     fn get_from_u64_to_str_map(key: u64) -> str[33];
 
+    #[storage(write)]
     fn insert_into_u64_to_array_map(key: u64, value: [b256;
     3]);
+    #[storage(read)]
     fn get_from_u64_to_array_map(key: u64) -> [b256;
     3];
 
+    #[storage(write)]
     fn insert_into_bool_to_u64_map(key: bool, value: u64);
+    #[storage(read)]
     fn get_from_bool_to_u64_map(key: bool) -> u64;
 
+    #[storage(write)]
     fn insert_into_u8_to_u64_map(key: u8, value: u64);
+    #[storage(read)]
     fn get_from_u8_to_u64_map(key: u8) -> u64;
 
+    #[storage(write)]
     fn insert_into_u16_to_u64_map(key: u16, value: u64);
+    #[storage(read)]
     fn get_from_u16_to_u64_map(key: u16) -> u64;
 
+    #[storage(write)]
     fn insert_into_u32_to_u64_map(key: u32, value: u64);
+    #[storage(read)]
     fn get_from_u32_to_u64_map(key: u32) -> u64;
 
+    #[storage(write)]
     fn insert_into_tuple_to_u64_map(key: (b256, u8, bool), value: u64);
+    #[storage(read)]
     fn get_from_tuple_to_u64_map(key: (b256, u8, bool)) -> u64;
 
+    #[storage(write)]
     fn insert_into_struct_to_u64_map(key: Struct, value: u64);
+    #[storage(read)]
     fn get_from_struct_to_u64_map(key: Struct) -> u64;
 
+    #[storage(write)]
     fn insert_into_enum_to_u64_map(key: Enum, value: u64);
+    #[storage(read)]
     fn get_from_enum_to_u64_map(key: Enum) -> u64;
 
+    #[storage(write)]
     fn insert_into_str_to_u64_map(key: str[33], value: u64);
+    #[storage(read)]
     fn get_from_str_to_u64_map(key: str[33]) -> u64;
 
+    #[storage(write)]
     fn insert_into_array_to_u64_map(key: [b256;
     3], value: u64);
+    #[storage(read)]
     fn get_from_array_to_u64_map(key: [b256;
     3]) -> u64;
 }
 
+#[storage(write)]
 fn _insert_into_u64_to_bool_map_inner(key: u64, value: bool) {
     storage.map1.insert(key, value);
 }
 
+#[storage(read)]
 fn _get_from_u64_to_bool_map_inner(key: u64) -> bool {
     storage.map1.get(key)
 }
 
 impl StorageMapTest for Contract {
+    #[storage(write)]
     fn insert_into_u64_to_bool_map(key: u64, value: bool) {
         _insert_into_u64_to_bool_map_inner(key, value)
     }
 
+    #[storage(read)]
     fn get_from_u64_to_bool_map(key: u64) -> bool {
         _get_from_u64_to_bool_map_inner(key)
     }
 
+    #[storage(write)]
     fn insert_into_u64_to_u8_map(key: u64, value: u8) {
         storage.map2.insert(key, value);
     }
 
+    #[storage(read)]
     fn get_from_u64_to_u8_map(key: u64) -> u8 {
         storage.map2.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_u64_to_u16_map(key: u64, value: u16) {
         storage.map3.insert(key, value);
     }
 
+    #[storage(read)]
     fn get_from_u64_to_u16_map(key: u64) -> u16 {
         storage.map3.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_u64_to_u32_map(key: u64, value: u32) {
         storage.map4.insert(key, value);
     }
 
+    #[storage(read)]
     fn get_from_u64_to_u32_map(key: u64) -> u32 {
         storage.map4.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_u64_to_u64_map(key: u64, value: u64) {
         storage.map5.insert(key, value);
     }
 
+    #[storage(read)]
     fn get_from_u64_to_u64_map(key: u64) -> u64 {
         storage.map5.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_u64_to_tuple_map(key: u64, value: (b256, u8, bool)) {
         storage.map6.insert(key, value);
     }
 
+    #[storage(read)]
     fn get_from_u64_to_tuple_map(key: u64) -> (b256, u8, bool) {
         storage.map6.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_u64_to_struct_map(key: u64, value: Struct) {
         storage.map7.insert(key, value);
     }
 
+    #[storage(read)]
     fn get_from_u64_to_struct_map(key: u64) -> Struct {
         storage.map7.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_u64_to_enum_map(key: u64, value: Enum) {
         storage.map8.insert(key, value);
     }
 
+    #[storage(read)]
     fn get_from_u64_to_enum_map(key: u64) -> Enum {
         storage.map8.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_u64_to_str_map(key: u64, value: str[33]) {
         storage.map9.insert(key, value);
     }
 
+    #[storage(read)]
     fn get_from_u64_to_str_map(key: u64) -> str[33] {
         storage.map9.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_u64_to_array_map(key: u64, value: [b256;
     3]) {
         storage.map10.insert(key, value);
     }
 
+    #[storage(read)]
     fn get_from_u64_to_array_map(key: u64) -> [b256;
     3] {
         storage.map10.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_bool_to_u64_map(key: bool, value: u64) {
         storage.map11.insert(key, value);
     }
+    #[storage(read)]
     fn get_from_bool_to_u64_map(key: bool) -> u64 {
         storage.map11.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_u8_to_u64_map(key: u8, value: u64) {
         storage.map12.insert(key, value);
     }
+    #[storage(read)]
     fn get_from_u8_to_u64_map(key: u8) -> u64 {
         storage.map12.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_u16_to_u64_map(key: u16, value: u64) {
         storage.map13.insert(key, value);
     }
+    #[storage(read)]
     fn get_from_u16_to_u64_map(key: u16) -> u64 {
         storage.map13.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_u32_to_u64_map(key: u32, value: u64) {
         storage.map14.insert(key, value);
     }
+    #[storage(read)]
     fn get_from_u32_to_u64_map(key: u32) -> u64 {
         storage.map14.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_tuple_to_u64_map(key: (b256, u8, bool), value: u64) {
         storage.map15.insert(key, value);
     }
+    #[storage(read)]
     fn get_from_tuple_to_u64_map(key: (b256, u8, bool)) -> u64 {
         storage.map15.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_struct_to_u64_map(key: Struct, value: u64) {
         storage.map16.insert(key, value);
     }
 
+    #[storage(read)]
     fn get_from_struct_to_u64_map(key: Struct) -> u64 {
         storage.map16.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_enum_to_u64_map(key: Enum, value: u64) {
         storage.map17.insert(key, value);
     }
 
+    #[storage(read)]
     fn get_from_enum_to_u64_map(key: Enum) -> u64 {
         storage.map17.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_str_to_u64_map(key: str[33], value: u64) {
         storage.map18.insert(key, value);
     }
+    #[storage(read)]
     fn get_from_str_to_u64_map(key: str[33]) -> u64 {
         storage.map18.get(key)
     }
 
+    #[storage(write)]
     fn insert_into_array_to_u64_map(key: [b256;
     3], value: u64) {
         storage.map19.insert(key, value)
     }
+    #[storage(read)]
     fn get_from_array_to_u64_map(key: [b256;
     3]) -> u64 {
         storage.map19.get(key)


### PR DESCRIPTION
In particular, locate storage ASM operations and confirm the enclosing function has the correct `storage` attributes.

I spent/wasted a couple of days trying to make this more efficient by annotating the AST as we build it so we don't need to search it like this does, but I simply couldn't make it work in a non-hacky way with our current data structures.  Perhaps the proposed big refactor we have planned might allow it to happen, dunno.

Closes #1151.
Closes #1183.

### Update:

This has taken me five different attempts:
1. Recurse through the typed tree gathering errors.  Was almost working but needed data structure tweaks to get the errors correct.
1. Simplify by iterating over IR instructions from the compiled program.  Was ugly and didn't fit -- this is a semantic check which belongs more in the front end.
2. Try again but with the untyped parse tree which is a less complex data structure.  Was unable to follow function calls because they aren't inlined yet.
3. Back to 1) with the typed tree, but found that parts of the tree e.g., impl methods, are still untyped parse tree nodes, so would require recursion code for both types of tree, which seemed ridiculous.
4. Back to 2) but from within the front-end as a semantic check, but performed after IR is compiled. i.e., the purity check itself is not in the IR library but back in `sway-core`.

### Also...

~~Two remaining issues: I had to allow storage ops in libraries as mentioned in #1151.  I've also disabled a couple of E2E tests because they try to run contracts which have storage ops, so similarly to the library issue, it complains about storage ops in a script.~~

~~These restrictions need to be loosened somehow.~~

Also the formatter can't handle attributes.