### PR TITLE
Test suite does not print test names, tracing usage in test suite fixed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,6 +3783,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "forc",
+ "forc-util",
  "fuel-asm",
  "fuel-tx",
  "fuel-vm",

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -322,7 +322,7 @@ fn format_err(err: &sway_core::CompileError) {
             ..Default::default()
         },
     };
-    println!("{}\n____\n", DisplayList::from(snippet))
+    tracing::error!("{}\n____\n", DisplayList::from(snippet))
 }
 
 fn format_warning(err: &sway_core::CompileWarning) {
@@ -364,7 +364,7 @@ fn format_warning(err: &sway_core::CompileWarning) {
             ..Default::default()
         },
     };
-    println!("{}\n____\n", DisplayList::from(snippet))
+    tracing::warn!("{}\n____\n", DisplayList::from(snippet))
 }
 
 /// Given a start and an end position and an input, determine how much of a window to show in the

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.41"
 forc = { path = "../forc", features = ["test"], default-features = false }
+forc-util = { version = "0.14.1", path = "../forc-util" }
 fuel-asm = "0.5"
 fuel-tx = "0.12"
 fuel-vm = { version = "0.11", features = ["random"] }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.41"
 forc = { path = "../forc", features = ["test"], default-features = false }
-forc-util = { version = "0.14.1", path = "../forc-util" }
+forc-util = { path = "../forc-util" }
 fuel-asm = "0.5"
 fuel-tx = "0.12"
 fuel-vm = { version = "0.11", features = ["random"] }

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -1,7 +1,8 @@
 mod harness;
+use forc_util::init_tracing_subscriber;
 use fuel_vm::prelude::*;
-
 pub fn run(filter_regex: Option<regex::Regex>) {
+    init_tracing_subscriber();
     let filter = |name| {
         filter_regex
             .as_ref()


### PR DESCRIPTION
closes #1719.

and related to #1702.


## Testing Steps

1. Run `SWAY_TEST_VERBOSE=1 cargo run --locked --release --bin test`
2. Run `cargo run --locked --release --bin test`