### PR TITLE
update README related to Forc commands/plugins

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,6 @@ mdbook serve
 
 ## Generating documentation for Forc commands/plugins
 
-The `mdbook-forc-documenter` now automatically handles documenting forc commands and plugins. This behavior is further documented in [the mdbook-forc-documenter README](../scripts/mdbook-forc-documenter/README.md).
+The `mdbook-forc-documenter` [preprocessor](https://rust-lang.github.io/mdBook/for_developers/preprocessors.html) now automatically handles documenting forc commands and plugins, but some actions have to be taken for the preprocessor to work. Please read the [mdbook-forc-documenter README](../scripts/mdbook-forc-documenter/README.md) before making changes to Forc commands or plugins.
 
 **It is important to note that changing the chapter names `Commands` and `Plugins` will affect the behaviour of the preprocessor**. When renaming the chapters, please make the same change [here](https://github.com/FuelLabs/sway/blob/master/scripts/mdbook-forc-documenter/src/lib.rs#L45,L56).

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,4 +24,4 @@ mdbook serve
 
 The `mdbook-forc-documenter` [preprocessor](https://rust-lang.github.io/mdBook/for_developers/preprocessors.html) now automatically handles documenting forc commands and plugins, but some actions have to be taken for the preprocessor to work. Please read the [mdbook-forc-documenter README](../scripts/mdbook-forc-documenter/README.md) before making changes to Forc commands or plugins.
 
-**It is important to note that changing the chapter names `Commands` and `Plugins` will affect the behaviour of the preprocessor**. When renaming the chapters, please make the same change [here](https://github.com/FuelLabs/sway/blob/master/scripts/mdbook-forc-documenter/src/lib.rs#L45,L56).
+**It is important to note that changing the chapter names `Commands` and `Plugins` will affect the behavior of the preprocessor**. When renaming the chapters, please make the same change [here](https://github.com/FuelLabs/sway/blob/master/scripts/mdbook-forc-documenter/src/lib.rs#L45,L56).

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@ To serve locally:
 mdbook serve
 ```
 
-## Generating Forc commands documentation
+## Generating documentation for Forc commands/plugins
 
-The `mdbook-forc-documenter` now automatically handles documenting forc commands. This behavior is further documented in [the mdbook-forc-documenter README](../scripts/mdbook-forc-documenter/README.md).
+The `mdbook-forc-documenter` now automatically handles documenting forc commands and plugins. This behavior is further documented in [the mdbook-forc-documenter README](../scripts/mdbook-forc-documenter/README.md).
+
+**It is important to note that changing the chapter names `Commands` and `Plugins` will affect the behaviour of the preprocessor**. When renaming the chapters, please make the same change [here](https://github.com/FuelLabs/sway/blob/master/scripts/mdbook-forc-documenter/src/lib.rs#L45,L56).

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,4 +24,4 @@ mdbook serve
 
 The `mdbook-forc-documenter` [preprocessor](https://rust-lang.github.io/mdBook/for_developers/preprocessors.html) now automatically handles documenting forc commands and plugins, but some actions have to be taken for the preprocessor to work. Please read the [mdbook-forc-documenter README](../scripts/mdbook-forc-documenter/README.md) before making changes to Forc commands or plugins.
 
-**It is important to note that changing the chapter names `Commands` and `Plugins` will affect the behavior of the preprocessor**. When renaming the chapters, please make the same change [here](https://github.com/FuelLabs/sway/blob/master/scripts/mdbook-forc-documenter/src/lib.rs#L45,L56).
+**It is important to note that changing the chapter names `Commands` and `Plugins` will affect the behavior of the preprocessor**. When renaming the chapters, please make the same change [here](https://github.com/FuelLabs/sway/blob/a19681c2165402d289bc6bae7a46a580ef3be5b5/scripts/mdbook-forc-documenter/src/lib.rs#L45,L56).

--- a/scripts/mdbook-forc-documenter/README.md
+++ b/scripts/mdbook-forc-documenter/README.md
@@ -28,7 +28,7 @@ Delete the entry from `SUMMARY.md`.
 
 ### Removing a forc plugin
 
-Do the same as the above, along with the step within `ci.yml` and `gh-pages.yml`.
+Do the same as the above, with an extra step of removing the installation command within `ci.yml` and `gh-pages.yml`.
 
 ### Adding an example
 

--- a/scripts/mdbook-forc-documenter/README.md
+++ b/scripts/mdbook-forc-documenter/README.md
@@ -10,17 +10,25 @@ This preprocessor is automatically run on every build, as long as the `book.toml
 
 ## Usage
 
-### Adding a new forc command or plugin
+### Adding a new forc command
 
-Enter a new entry under the `Commands` or `Plugins` section within `SUMMARY.md`, in this format:
+Enter a new entry under the `Commands` section within `SUMMARY.md`, in this format:
 
 ```md
 - [forc explore](./forc_explore.md)
 ```
 
-### Removing a forc command or plugin
+### Adding a new forc plugin
+
+Do the same as the above, with an extra step of adding an installation step within the CI. The preprocessor needs to be aware of the plugin when building the book, since it is calling `forc <plugin> --help` to generate the documentation. You can add this installation step within [`ci.yml`](https://github.com/FuelLabs/sway/blob/master/.github/workflows/ci.yml#L126) and [`gh-pages.yml`](https://github.com/FuelLabs/sway/blob/master/.github/workflows/gh-pages.yml#L26).
+
+### Removing a forc command
 
 Delete the entry from `SUMMARY.md`.
+
+### Removing a forc plugin
+
+Delete the entry from `SUMMARY.md`, along with the step within `ci.yml` and `gh-pages.yml`.
 
 ### Adding an example
 
@@ -29,3 +37,4 @@ Create a new Markdown file within `scripts/mdbook-forc-documenter/examples`, nam
 ### Removing an example
 
 Delete the Markdown file from within the above examples directory.
+

--- a/scripts/mdbook-forc-documenter/README.md
+++ b/scripts/mdbook-forc-documenter/README.md
@@ -37,4 +37,3 @@ Create a new Markdown file within `scripts/mdbook-forc-documenter/examples`, nam
 ### Removing an example
 
 Delete the Markdown file from within the above examples directory.
-

--- a/scripts/mdbook-forc-documenter/README.md
+++ b/scripts/mdbook-forc-documenter/README.md
@@ -20,7 +20,7 @@ Enter a new entry under the `Commands` section within `SUMMARY.md`, in this form
 
 ### Adding a new forc plugin
 
-Do the same as the above, with an extra step of adding an installation step within the CI. The preprocessor needs to be aware of the plugin when building the book, since it is calling `forc <plugin> --help` to generate the documentation. You can add this installation step within [`ci.yml`](https://github.com/FuelLabs/sway/blob/master/.github/workflows/ci.yml#L126) and [`gh-pages.yml`](https://github.com/FuelLabs/sway/blob/master/.github/workflows/gh-pages.yml#L26).
+Do the same as the above, with an extra step of adding an installation step within the CI. The preprocessor needs to be aware of the plugin when building the book, since it is calling `forc <plugin> --help` to generate the documentation. You can add this installation step within [`ci.yml`](https://github.com/FuelLabs/sway/blob/a19681c2165402d289bc6bae7a46a580ef3be5b5/.github/workflows/ci.yml#L126) and [`gh-pages.yml`](https://github.com/FuelLabs/sway/blob/a19681c2165402d289bc6bae7a46a580ef3be5b5/.github/workflows/gh-pages.yml#L26).
 
 ### Removing a forc command
 

--- a/scripts/mdbook-forc-documenter/README.md
+++ b/scripts/mdbook-forc-documenter/README.md
@@ -28,7 +28,7 @@ Delete the entry from `SUMMARY.md`.
 
 ### Removing a forc plugin
 
-Delete the entry from `SUMMARY.md`, along with the step within `ci.yml` and `gh-pages.yml`.
+Do the same as the above, along with the step within `ci.yml` and `gh-pages.yml`.
 
 ### Adding an example
 

--- a/scripts/mdbook-forc-documenter/README.md
+++ b/scripts/mdbook-forc-documenter/README.md
@@ -1,6 +1,6 @@
 # mdbook-forc-preprocessor
 
-A preprocessor for [mdBook](https://github.com/rust-lang/mdBook) to update the Forc commands section of the Sway book based on the output we get when running `forc --help`.
+A preprocessor for [mdBook](https://github.com/rust-lang/mdBook) to update the Forc commands and plugins section of the Sway book based on the output we get when running `forc --help`.
 
 This preprocessor is automatically run on every build, as long as the `book.toml` file contains the preprocessor:
 
@@ -10,21 +10,21 @@ This preprocessor is automatically run on every build, as long as the `book.toml
 
 ## Usage
 
-### Adding a new forc command
+### Adding a new forc command or plugin
 
-Enter a new entry under the `Commands` section within `SUMMARY.md`, in this format:
+Enter a new entry under the `Commands` or `Plugins` section within `SUMMARY.md`, in this format:
 
 ```md
-- [forc gm](./forc_gm.md)
+- [forc explore](./forc_explore.md)
 ```
 
-### Removing a forc command
+### Removing a forc command or plugin
 
-Delete the forc command entry from `SUMMARY.md`.
+Delete the entry from `SUMMARY.md`.
 
 ### Adding an example
 
-Create a new Markdown file within `scripts/mdbook-forc-documenter/examples`, named after the desired forc command in snake case. The preprocessor automatically detects the example if there is a matching forc command with the same name as the file name, and includes it in the build.
+Create a new Markdown file within `scripts/mdbook-forc-documenter/examples`, named after the desired forc command or plugin in snake case. The preprocessor automatically detects the example if there is a matching forc command or plugin with the same name as the file name, and includes it in the build.
 
 ### Removing an example
 


### PR DESCRIPTION
Closes #1726 

- Added an important warning for changing chapter names of `Commands` and/or `Plugins` within the book, in `docs/README.md`
- Added previously missing instructions in `scripts/mdbook-forc-documenter/README.md` on adding plugins, including instructions for CI