### PR TITLE
Change any instance of `if let .. { .. } else { .. }` in the standard library to use match expressions

### DIFF
--- a/docs/src/basics/comments_and_logging.md
+++ b/docs/src/basics/comments_and_logging.md
@@ -35,15 +35,77 @@ fn main() {
 
 ## Logging
 
-To log integers, you can use the `log_u64`, `log_u32`, `log_u16`, or `log_u8` functions from the standard library.
+The `logging` library provides a generic `log` function that can be imported using `use std::logging::log` and used to log variables of any type. Each call to `log` appends a `receipt` to the list of receipts. There are two types of receipts that a `log` can generate: `Log` and `LogData`.
 
-```sway
-use std::chain::log_u64;
+**_Note that the receipts shown below are being re-worked to become more readable in [#1717](https://github.com/FuelLabs/sway/pull/1717)._**
 
-fn main() {
-    let baz = 8;
-    log_u64(baz);
+### `Log` Receipt
+
+The `Log` receipt is generated for _non-reference_ types, namely `bool`, `u8`, `u16`, `u32`, and `u64`. For example, logging an integer variable `x` that holds the value `42` using `log(x)` may generate the following receipt:
+
+```console
+Log {
+    id: 0x0000000000000000000000000000000000000000000000000000000000000000,
+    ra: 42,
+    rb: 0,
+    rc: 0,
+    rd: 0,
+    pc: 10404,
+    is: 10352,
 }
 ```
 
-Note that you cannot log arbitrary structs yet because [we do not yet support serialization](../reference/temporary_workarounds.html#serialization-and-deserialization).
+Note that `ra` will include the value being logged. The additional registers `rb` to `rd` will be zero when using `log(x)`.
+
+### `LogData` Receipt
+
+`LogData` is generated for _reference_ types which include all types except for the _non_reference_ types mentioned above. For example, logging a `b256` variable `b` that holds the value `0x1111111111111111111111111111111111111111111111111111111111111111` using `log(b)` may generate the following receipt:
+
+```console
+LogData {
+    id: 0x0000000000000000000000000000000000000000000000000000000000000000,
+    ra: 0,
+    rb: 0,
+    ptr: 10468,
+    len: 32,
+    digest: 0x02d449a31fbb267c8f352e9968a79e3e5fc95c1bbeaa502fd6454ebde5a4bedc,
+    data: [
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+        17,
+    ],
+    pc: 10444,
+    is: 10352,
+}
+```
+
+Note that `data` in the receipt above is a essentially a list of bytes where each entry is the decimal representation of a given byte in the data being logged (e.g. `17 = 0x11`). 

--- a/sway-lib-std/src/chain/auth.sw
+++ b/sway-lib-std/src/chain/auth.sw
@@ -42,10 +42,9 @@ pub fn caller_contract_id() -> ContractId {
 pub fn msg_sender() -> Result<Sender, AuthError> {
     if caller_is_external() {
         let sender_res = get_coins_owner();
-        if let Result::Ok(sender) = sender_res {
-            Result::Ok(sender)
-        } else {
-            sender_res
+        match sender_res {
+            Result::Ok(sender) => Result::Ok(sender),
+            sender_res => sender_res,
         }
     } else {
         // Get caller's `ContractId`.

--- a/sway-lib-std/src/option.sw
+++ b/sway-lib-std/src/option.sw
@@ -29,19 +29,17 @@ impl<T> Option<T> {
 
     /// Returns `true` if the result is [`Some`].
     fn is_some(self) -> bool {
-        if let Option::Some(t) = self {
-            true
-        } else {
-            false
+        match self {
+            Option::Some(_) => true,
+            _ => false,
         }
     }
 
     /// Returns `true` if the result is [`None`].
     fn is_none(self) -> bool {
-        if let Option::Some(t) = self {
-            false
-        } else {
-            true
+        match self {
+            Option::Some(_) => false,
+            _ => true,
         }
     }
 
@@ -51,10 +49,11 @@ impl<T> Option<T> {
     /// Instead, prefer to use pattern matching and handle the [`None`]
     /// case explicitly.
     fn unwrap(self) -> T {
-        if let Option::Some(inner_value) = self {
-            inner_value
-        } else {
-            revert(0);
+        match self {
+            Option::Some(inner_value) => inner_value,
+            _ => {
+                revert(0);
+            }
         }
     }
 }

--- a/sway-lib-std/src/option.sw
+++ b/sway-lib-std/src/option.sw
@@ -51,9 +51,7 @@ impl<T> Option<T> {
     fn unwrap(self) -> T {
         match self {
             Option::Some(inner_value) => inner_value,
-            _ => {
-                revert(0);
-            }
+            _ => revert(0),
         }
     }
 }

--- a/sway-lib-std/src/result.sw
+++ b/sway-lib-std/src/result.sw
@@ -30,19 +30,17 @@ impl<T, E> Result<T, E> {
 
     /// Returns `true` if the result is [`Ok`].
     fn is_ok(self) -> bool {
-        if let Result::Ok(t) = self {
-            true
-        } else {
-            false
+        match self {
+            Result::Ok(_) => true,
+            _ => false,
         }
     }
 
     /// Returns `true` if the result is [`Err`].
     fn is_err(self) -> bool {
-        if let Result::Ok(t) = self {
-            false
-        } else {
-            true
+        match self {
+            Result::Ok(_) => false,
+            _ => true,
         }
     }
 
@@ -52,10 +50,11 @@ impl<T, E> Result<T, E> {
     /// Instead, prefer to use pattern matching and handle the [`Err`]
     /// case explicitly.
     fn unwrap(self) -> T {
-        if let Result::Ok(inner_value) = self {
-            inner_value
-        } else {
-            revert(0);
+        match self {
+            Result::Ok(inner_value) => inner_value,
+            _ => {
+                revert(0);
+            }
         }
     }
 }

--- a/sway-lib-std/src/result.sw
+++ b/sway-lib-std/src/result.sw
@@ -52,9 +52,7 @@ impl<T, E> Result<T, E> {
     fn unwrap(self) -> T {
         match self {
             Result::Ok(inner_value) => inner_value,
-            _ => {
-                revert(0);
-            }
+            _ => revert(0),
         }
     }
 }

--- a/sway-lib-std/src/vm/evm/ecr.sw
+++ b/sway-lib-std/src/vm/evm/ecr.sw
@@ -12,15 +12,13 @@ use ::result::*;
 pub fn ec_recover_evm_address(signature: B512, msg_hash: b256) -> Result<EvmAddress, EcRecoverError> {
     let pub_key_result = ec_recover(signature, msg_hash);
 
-    if let Result::Err(e) = pub_key_result {
-        // propagate the error if it exists
-        Result::Err(e)
-    } else {
-        let pub_key = pub_key_result.unwrap();
-
-        // Note that EVM addresses are derived from the Keccak256 hash of the pubkey (not sha256)
-        let pubkey_hash = keccak256(((pub_key.bytes)[0], (pub_key.bytes)[1]));
-
-        Result::Ok(~EvmAddress::from(pubkey_hash))
+    match pub_key_result {
+        Result::Err(e) => Result::Err(e),
+        _ => {
+            let pub_key = pub_key_result.unwrap();
+            // Note that EVM addresses are derived from the Keccak256 hash of the pubkey (not sha256)
+            let pubkey_hash = keccak256(((pub_key.bytes)[0], (pub_key.bytes)[1]));
+            Result::Ok(~EvmAddress::from(pubkey_hash))
+        }
     }
 }


### PR DESCRIPTION
This PR changes any instance of a `if let .. { .. } else { .. }` in the standard library to use match expressions. This is done for readability, maintainability, and to make it future-proof.

To be clear, this change is not necessary, nor will cause any user-facing changes to the standard library. This is simple a refactoring to improve code quality---the `_` branch now clearly exists visually, for if it needs to be used.