### PR TITLE
Remove unnecessary error in order to allow match expressions on generic types

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -934,7 +934,7 @@ impl TypedExpression {
         );
         let type_id = typed_value.return_type;
 
-        check!(
+        let _ = check!(
             look_up_type_id(type_id).expect_is_supported_in_match_expressions(&typed_value.span),
             return err(warnings, errors),
             warnings,

--- a/sway-core/src/type_engine/type_info.rs
+++ b/sway-core/src/type_engine/type_info.rs
@@ -793,9 +793,9 @@ impl TypeInfo {
             | TypeInfo::Tuple(_)
             | TypeInfo::Byte
             | TypeInfo::B256
+            | TypeInfo::UnknownGeneric { .. }
             | TypeInfo::Numeric => ok((), warnings, errors),
             TypeInfo::Unknown
-            | TypeInfo::UnknownGeneric { .. }
             | TypeInfo::ContractCaller { .. }
             | TypeInfo::Custom { .. }
             | TypeInfo::SelfType

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -383,6 +383,10 @@ pub fn run(filter_regex: Option<regex::Regex>) {
                 0xfb, 0xc7, 0x88, 0x4e,
             ])),
         ),
+        (
+            "should_pass/language/match_expressions_inside_generic_functions",
+            ProgramState::Return(1),
+        ),
     ];
 
     let mut number_of_tests_run =

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_inside_generic_functions/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_inside_generic_functions/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'match_expressions_inside_generic_functions'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_inside_generic_functions/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_inside_generic_functions/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "match_expressions_inside_generic_functions"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_inside_generic_functions/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_inside_generic_functions/src/main.sw
@@ -1,0 +1,98 @@
+script;
+
+use std::assert::*;
+use std::revert::*;
+
+// fn third_match<V>(value: V) -> u8 {
+//   match value {
+//     foo => 5u8,
+//   }
+// }
+
+// fn second_match<U>(value: U) -> bool {
+//   match third_match(value) {
+//     1u8 => false,
+//     2u8 => false,
+//     3u8 => false,
+//     4u8 => false,
+//     5u8 => true,
+//     _ => false,
+//   }
+// }
+
+// fn first_match<T>(value: T) -> u64 {
+//   match second_match(value) {
+//     false => 2u64,
+//     true => 3u64,
+//   }
+// }
+
+// fn third_if<V>(value: V) -> u8 {
+//   if true {
+//     5u8
+//   } else {
+//     revert(0);
+//   }
+// }
+
+// fn second_if<U>(value: U) -> bool {
+//   let third = third_if(value);
+//   if third == 1u8 || third == 2u8 || third == 3u8 || third == 4u8 {
+//     false
+//   } else if third == 5u8 {
+//     true
+//   } else {
+//     false
+//   }
+// }
+
+// fn first_if<T>(value: T) -> u64 {
+//   let second = second_match(value);
+//   if second == false {
+//     2u64
+//   } else {
+//     3u64
+//   }
+// }
+
+fn generic_match<T>(value: T) -> u64 {
+  match value {
+    foo => 3u64,
+  }
+}
+
+fn generic_if<T>(value: T) -> u64 {
+  if true {
+    3u64
+  } else {
+    1u64
+  }
+}
+
+fn main() -> u64 {
+  // let a = first_match(true);
+  // assert(a == 3);
+
+  // let b = first_match(1u8);
+  // assert(b == 3);
+
+  // let c = first_if(true);
+  // assert(c == 3);
+
+  // let d = first_if(1u8);
+  // assert(d == 3);
+
+  let e = generic_match(6);
+  assert(e == 3);
+
+  let f = generic_match(false);
+  assert(f == 3);
+
+  let g = generic_if(6);
+  assert(g == 3);
+
+  let h = generic_if(false);
+  assert(h == 3);
+
+  1
+}


### PR DESCRIPTION
There was an unnecessary error that was causing match expressions on generic types to error in the compiler, this PR removes that.