### PR TITLE
Standardize "notes" in the Sway Book

### DIFF
--- a/docs/src/basics/comments_and_logging.md
+++ b/docs/src/basics/comments_and_logging.md
@@ -37,7 +37,7 @@ fn main() {
 
 The `logging` library provides a generic `log` function that can be imported using `use std::logging::log` and used to log variables of any type. Each call to `log` appends a `receipt` to the list of receipts. There are two types of receipts that a `log` can generate: `Log` and `LogData`.
 
-**_Note that the receipts shown below are being re-worked to become more readable in [#1717](https://github.com/FuelLabs/sway/pull/1717)._**
+> **Note**: The receipts shown below are being re-worked to become more readable in [#1717](https://github.com/FuelLabs/sway/pull/1717).
 
 ### `Log` Receipt
 

--- a/docs/src/basics/structs_and_tuples.md
+++ b/docs/src/basics/structs_and_tuples.md
@@ -135,6 +135,6 @@ let event = InventoryEvent::ItemLoss(Claim {
 
 ### Enum Memory Layout
 
-_This information is not vital if you are new to the language, or programming in general._
+> **Note**: This information is not vital if you are new to the language, or programming in general.
 
 Enums do have some memory overhead. To know which variant is being represented, Sway stores a one-word (8-byte) tag for the enum variant. The space reserved after the tag is equivalent to the size of the _largest_ enum variant. So, to calculate the size of an enum in memory, add 8 bytes to the size of the largest variant. For example, in the case of `Color` above, where the variants are all `()`, the size would be 8 bytes since the size of the largest variant is 0 bytes.

--- a/docs/src/blockchain-development/calling_contracts.md
+++ b/docs/src/blockchain-development/calling_contracts.md
@@ -49,7 +49,7 @@ impl ContractB for Contract {
 }
 ```
 
-> **NOTE** The ABI is for external calls only therefore you cannot define a method in the ABI and call it in the same contract. If you want to define a function for a contract, but keep it private so that only your contract can call it, you can define it outside of the `impl` and call it inside the contract, similar to the `return_45()` function above.
+> **Note**: The ABI is for external calls only therefore you cannot define a method in the ABI and call it in the same contract. If you want to define a function for a contract, but keep it private so that only your contract can call it, you can define it outside of the `impl` and call it inside the contract, similar to the `return_45()` function above.
 
 ## Advanced Calls
 

--- a/docs/src/blockchain-development/hashing_and_cryptography.md
+++ b/docs/src/blockchain-development/hashing_and_cryptography.md
@@ -14,4 +14,4 @@ The Sway standard library provides easy access to a selection of cryptographic h
 {{#include ../../../examples/signatures/src/main.sw}}
 ```
 
-> **Note** Recovery of EVM addresses is also supported via `std::vm::evm`.
+> **Note**: Recovery of EVM addresses is also supported via `std::vm::evm`.

--- a/docs/src/blockchain-development/storage.md
+++ b/docs/src/blockchain-development/storage.md
@@ -48,4 +48,4 @@ An example is as follows:
 {{#include ../../../examples/storage_example/src/main.sw}}
 ```
 
-Note, if you are looking to store non-primitive types (e.g. b256), please refer to [this issue](https://github.com/FuelLabs/sway/issues/1229).
+> **Note**: if you are looking to store non-primitive types (e.g. b256), please refer to [this issue](https://github.com/FuelLabs/sway/issues/1229).

--- a/docs/src/introduction/installation.md
+++ b/docs/src/introduction/installation.md
@@ -6,7 +6,7 @@ Note that if you want to run (e.g. for testing) Sway smart contracts, a Fuel Cor
 
 Pre-compiled release binaries for Linux and macOS are available for the Sway toolchain. They can be found attached to the release notes of the respective release. The latest `forc` release can be found here: <https://github.com/FuelLabs/sway/releases/latest>.
 
-> **Note** [`fuelup`](https://github.com/FuelLabs/fuelup) is a work-in-progress equivalent of `rustup` for the Sway toolchain. Once ready, it will be able to easily download and manage Sway toolchain versions.
+> **Note**: [`fuelup`](https://github.com/FuelLabs/fuelup) is a work-in-progress equivalent of `rustup` for the Sway toolchain. Once ready, it will be able to easily download and manage Sway toolchain versions.
 
 ## Installing from Source
 
@@ -50,7 +50,7 @@ cargo install forc fuel-core
 
 The Fuel ecosystem has a few plugins which can be easily installed via Cargo.
 
-> **Note** `forc` detects anything in your `$PATH` prefixed with `forc-` as a plugin. Use `forc plugins` to see what you currently have installed.
+> **Note**: `forc` detects anything in your `$PATH` prefixed with `forc-` as a plugin. Use `forc plugins` to see what you currently have installed.
 
 ```sh
 # Sway Formatter

--- a/docs/src/introduction/overview.md
+++ b/docs/src/introduction/overview.md
@@ -65,7 +65,7 @@ In the first line, we declare the name of this ABI: `Wallet`. To import this ABI
 
 In the second line we declare an ABI method called `receive_funds` which, when called, should receive funds into this wallet. This method takes no parameters and does not return anything.
 
-_Note that we are simply defining an interface here, so there is no function body or implementation of the function. We only need to define the interface itself. In this way, ABI declarations are similar to [trait declarations](../advanced/traits.md)._
+> **Note**: We are simply defining an interface here, so there is no function body or implementation of the function. We only need to define the interface itself. In this way, ABI declarations are similar to [trait declarations](../advanced/traits.md).
 
 In the third line we declare another ABI method, this time called `send_funds`. It takes two parameters: the amount to send, and the address to send the funds to.
 
@@ -160,7 +160,7 @@ Note the contract ID—you will need it in the next step.
 
 ## Write a Sway Script to Call a Sway Contract
 
-_Note that if you are using the SDK you do not need to write a script to call the Sway contract, this is all handled automagically by the SDK._
+> **Note**: If you are using the SDK you do not need to write a script to call the Sway contract, this is all handled automagically by the SDK.
 
 Now that we have deployed our wallet contract, we need to actually _call_ our contract. We can do this by calling the contract from a script.
 

--- a/docs/src/introduction/sway-toolchain.md
+++ b/docs/src/introduction/sway-toolchain.md
@@ -12,7 +12,7 @@ The Sway Language Server `forc-lsp` is provided to expose features to IDEs. [Ins
 
 Currently, only [Visual Studio Code is supported through a plugin](https://marketplace.visualstudio.com/items?itemName=FuelLabs.sway-vscode-plugin). Vim support is forthcoming, though [syntax highlighting is provided](https://github.com/FuelLabs/sway.vim).
 
-> **Note** There is no need to manually run `forc-lsp` (the plugin will automatically start it), however both `forc` and `forc-lsp` must be in your `$PATH`. To check if `forc` is in your `$PATH`, type `forc --help` in your terminal.
+> **Note**: There is no need to manually run `forc-lsp` (the plugin will automatically start it), however both `forc` and `forc-lsp` must be in your `$PATH`. To check if `forc` is in your `$PATH`, type `forc --help` in your terminal.
 
 ## Sway Formatter (`forc-fmt`)
 


### PR DESCRIPTION
I went with the added `:` after `Note` because that's what I saw the Rust Book doing. Also, without the colon, notes look like:
![image](https://user-images.githubusercontent.com/59666792/170826961-c987fad0-e374-4a48-9629-be6fa6c8ce49.png)