### PR TITLE
Fix bugs with resolving type parameters

### DIFF
--- a/docs/src/reference/known_issues_and_workarounds.md
+++ b/docs/src/reference/known_issues_and_workarounds.md
@@ -4,8 +4,6 @@
 
 * [#1663](https://github.com/FuelLabs/sway/issues/1663): Using an explicit `return` in all branches of an `if let` expression causes a compile error. The workaround is to use implicit returns instead.
 
-* [#1682](https://github.com/FuelLabs/sway/issues/1682): The compiler currently emits warnings from `sway-lib-std/src/u128.sw` about some unreachable code. Those warnings can be ignored.
-
 * [#1664](https://github.com/FuelLabs/sway/issues/1664): Binary and hex literals cannot be used for integer types (i.e. `u8`, `u16`, `u32`, `u64`). Only decimal literals can be used at the moment.
 
 * [#1657](https://github.com/FuelLabs/sway/issues/1657): Accessing data members of a `struct` directly from a function call does not currently work. The same applies to `enum` types and arrays. The workaround is to store the result of the function call in a temporary variable and accessing the required elements from that variable instead.

--- a/sway-core/src/type_engine/type_info.rs
+++ b/sway-core/src/type_engine/type_info.rs
@@ -1,7 +1,10 @@
 use super::*;
 
 use crate::{
-    semantic_analysis::ast_node::{TypedEnumVariant, TypedExpression, TypedStructField},
+    semantic_analysis::{
+        ast_node::{TypedEnumVariant, TypedExpression, TypedStructField},
+        TypeMapping,
+    },
     CallPath, Ident, TypeArgument, TypeParameter,
 };
 
@@ -217,26 +220,30 @@ impl PartialEq for TypeInfo {
                 Self::Enum {
                     name: l_name,
                     variant_types: l_variant_types,
-                    ..
+                    type_parameters: l_type_parameters,
                 },
                 Self::Enum {
                     name: r_name,
                     variant_types: r_variant_types,
-                    ..
+                    type_parameters: r_type_parameters,
                 },
-            ) => l_name == r_name && l_variant_types == r_variant_types,
+            ) => {
+                l_name == r_name
+                    && l_variant_types == r_variant_types
+                    && l_type_parameters == r_type_parameters
+            }
             (
                 Self::Struct {
                     name: l_name,
                     fields: l_fields,
-                    ..
+                    type_parameters: l_type_parameters,
                 },
                 Self::Struct {
                     name: r_name,
                     fields: r_fields,
-                    ..
+                    type_parameters: r_type_parameters,
                 },
-            ) => l_name == r_name && l_fields == r_fields,
+            ) => l_name == r_name && l_fields == r_fields && l_type_parameters == r_type_parameters,
             (Self::Ref(l, _sp1), Self::Ref(r, _sp2)) => look_up_type_id(*l) == look_up_type_id(*r),
             (Self::Tuple(l), Self::Tuple(r)) => l
                 .iter()
@@ -304,15 +311,19 @@ impl TypeInfo {
             ErrorRecovery => "unknown due to error".into(),
             Enum {
                 name,
-                variant_types,
+                type_parameters,
                 ..
             } => print_inner_types(
-                format!("enum {}", name),
-                variant_types.iter().map(|x| x.r#type),
+                name.as_str().to_string(),
+                type_parameters.iter().map(|x| x.type_id),
             ),
-            Struct { name, fields, .. } => print_inner_types(
-                format!("struct {}", name),
-                fields.iter().map(|field| field.r#type),
+            Struct {
+                name,
+                type_parameters,
+                ..
+            } => print_inner_types(
+                name.as_str().to_string(),
+                type_parameters.iter().map(|x| x.type_id),
             ),
             ContractCaller { abi_name, .. } => {
                 format!("contract caller {}", abi_name)
@@ -627,30 +638,21 @@ impl TypeInfo {
         }
     }
 
-    pub(crate) fn matches_type_parameter(
-        &self,
-        mapping: &[(TypeParameter, TypeId)],
-    ) -> Option<TypeId> {
+    pub(crate) fn matches_type_parameter(&self, mapping: &TypeMapping) -> Option<TypeId> {
         use TypeInfo::*;
         match self {
             TypeInfo::Custom { .. } => {
                 for (param, ty_id) in mapping.iter() {
-                    let param_type_info = look_up_type_id(param.type_id);
-                    if param_type_info == *self {
+                    if look_up_type_id(param.type_id) == *self {
                         return Some(*ty_id);
                     }
                 }
                 None
             }
-            TypeInfo::UnknownGeneric { name, .. } => {
+            TypeInfo::UnknownGeneric { .. } => {
                 for (param, ty_id) in mapping.iter() {
-                    if let TypeInfo::Custom {
-                        name: other_name, ..
-                    } = look_up_type_id(param.type_id)
-                    {
-                        if name.clone() == other_name {
-                            return Some(*ty_id);
-                        }
+                    if look_up_type_id(param.type_id) == *self {
+                        return Some(*ty_id);
                     }
                 }
                 None

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -387,6 +387,10 @@ pub fn run(filter_regex: Option<regex::Regex>) {
             "should_pass/language/match_expressions_inside_generic_functions",
             ProgramState::Return(1),
         ),
+        (
+            "should_pass/language/generic_inside_generic",
+            ProgramState::Return(7),
+        ),
     ];
 
     let mut number_of_tests_run =
@@ -532,6 +536,7 @@ pub fn run(filter_regex: Option<regex::Regex>) {
         "should_fail/trait_impl_purity_mismatch",
         "should_fail/trait_pure_calls_impure",
         "should_fail/match_expressions_empty_arms",
+        "should_fail/type_mismatch_error_message",
     ];
     number_of_tests_run += negative_project_names.iter().fold(0, |acc, name| {
         if filter(name) {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_mismatch_error_message/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_mismatch_error_message/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'type_mismatch_error_message'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_mismatch_error_message/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_mismatch_error_message/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "type_mismatch_error_message"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_mismatch_error_message/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_mismatch_error_message/src/main.sw
@@ -1,0 +1,20 @@
+script;
+
+pub enum Result<T, E> {
+    Ok: T,
+    Err: E,
+}
+
+struct Data<T> {
+  value: T,
+  other: u64
+}
+
+fn example() {
+  let foo = Result::Ok::<Data<bool>, str[4]>(Data { value: true, other: 1 });
+  foo.does_not_exist();
+}
+
+fn main() {
+
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_inside_generic/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_inside_generic/Forc.lock
@@ -1,0 +1,7 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'generic_inside_generic'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_inside_generic/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_inside_generic/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "generic_inside_generic"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_inside_generic/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_inside_generic/src/main.sw
@@ -1,0 +1,43 @@
+script;
+
+struct Generic1<T> {
+    a: T,
+}
+
+struct Generic2<T> {
+    b: Generic1<T>,
+}
+
+enum Generic3<T> {
+    A: T,
+    B: T
+}
+
+enum Generic4<T> {
+    C: Generic3<T>,
+    D: Generic3<T>
+}
+
+fn main() -> u64 {
+    let a = Generic1 {
+        a: 7u64
+    };
+    let b = Generic2 {
+        b: a
+    };
+    let c = Generic3::B(b);
+    let d = Generic4::C(c);
+
+    match d {
+        Generic4::C(
+            Generic3::B(
+                Generic2 {
+                    b: Generic1 {
+                        a
+                    }
+                }
+            )
+        ) => { a },
+        _ => { 0 }
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_inside_generic_functions/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_inside_generic_functions/src/main.sw
@@ -3,57 +3,57 @@ script;
 use std::assert::*;
 use std::revert::*;
 
-// fn third_match<V>(value: V) -> u8 {
-//   match value {
-//     foo => 5u8,
-//   }
-// }
+fn third_match<V>(value: V) -> u8 {
+  match value {
+    foo => 5u8,
+  }
+}
 
-// fn second_match<U>(value: U) -> bool {
-//   match third_match(value) {
-//     1u8 => false,
-//     2u8 => false,
-//     3u8 => false,
-//     4u8 => false,
-//     5u8 => true,
-//     _ => false,
-//   }
-// }
+fn second_match<U>(value: U) -> bool {
+  match third_match(value) {
+    1u8 => false,
+    2u8 => false,
+    3u8 => false,
+    4u8 => false,
+    5u8 => true,
+    _ => false,
+  }
+}
 
-// fn first_match<T>(value: T) -> u64 {
-//   match second_match(value) {
-//     false => 2u64,
-//     true => 3u64,
-//   }
-// }
+fn first_match<T>(value: T) -> u64 {
+  match second_match(value) {
+    false => 2u64,
+    true => 3u64,
+  }
+}
 
-// fn third_if<V>(value: V) -> u8 {
-//   if true {
-//     5u8
-//   } else {
-//     revert(0);
-//   }
-// }
+fn third_if<V>(value: V) -> u8 {
+  if true {
+    5u8
+  } else {
+    revert(0);
+  }
+}
 
-// fn second_if<U>(value: U) -> bool {
-//   let third = third_if(value);
-//   if third == 1u8 || third == 2u8 || third == 3u8 || third == 4u8 {
-//     false
-//   } else if third == 5u8 {
-//     true
-//   } else {
-//     false
-//   }
-// }
+fn second_if<U>(value: U) -> bool {
+  let third = third_if(value);
+  if third == 1u8 || third == 2u8 || third == 3u8 || third == 4u8 {
+    false
+  } else if third == 5u8 {
+    true
+  } else {
+    false
+  }
+}
 
-// fn first_if<T>(value: T) -> u64 {
-//   let second = second_match(value);
-//   if second == false {
-//     2u64
-//   } else {
-//     3u64
-//   }
-// }
+fn first_if<T>(value: T) -> u64 {
+  let second = second_match(value);
+  if second == false {
+    2u64
+  } else {
+    3u64
+  }
+}
 
 fn generic_match<T>(value: T) -> u64 {
   match value {
@@ -70,17 +70,17 @@ fn generic_if<T>(value: T) -> u64 {
 }
 
 fn main() -> u64 {
-  // let a = first_match(true);
-  // assert(a == 3);
+  let a = first_match(true);
+  assert(a == 3);
 
-  // let b = first_match(1u8);
-  // assert(b == 3);
+  let b = first_match(1u8);
+  assert(b == 3);
 
-  // let c = first_if(true);
-  // assert(c == 3);
+  let c = first_if(true);
+  assert(c == 3);
 
-  // let d = first_if(1u8);
-  // assert(d == 3);
+  let d = first_if(1u8);
+  assert(d == 3);
 
   let e = generic_match(6);
   assert(e == 3);


### PR DESCRIPTION
The type parameters in `TypeInfo::Struct` and `TypeInfo::Enum` were not being resolved properly.

This PR:
1. Fixes the bug where type parameters in structs and enums were not being resolved properly. This bug fix is critical for  #1143 and #1118 
2. Updates the definition of `Eq` on `TypeInfo` to consider the type parameters, as the invariant from `Hash` to `Eq` had previously been broken. This will also be critical for  #1143 and #1118 as it affects how methods for types are looked up inside the namespace
3. Updates the way that types are displayed to the user, such that the only types that appear in `<..>` in `Name<..>` are the type parameters for `Name`
4. Fixes the bug where you couldn't have a generic struct as a field in another generic struct #1116 
5. Fixes the bug where nested generic functions were not resolving types properly #1734 

- Closes #1738 
- Closes #1116
- Closes #1734 