### PR TITLE
refactor(forc-pkg): use vendored openssl and git2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,6 +2318,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.20.0+1.1.1o"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92892c4f87d56e376e469ace79f1128fdaded07646ddf73aa0be4706ff712dec"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,6 +2335,7 @@ dependencies = [
  "autocfg 1.1.0",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -12,7 +12,7 @@ description = "Building, locking, fetching and updating Sway projects as Forc pa
 anyhow = "1"
 forc-util = { version = "0.14.2", path = "../forc-util" }
 fuels-types = "0.12"
-git2 = "0.14"
+git2 = { version = "0.14", features = ["vendored-libgit2", "vendored-openssl"] }
 petgraph = { version = "0.6", features = ["serde-1"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Closes #1742, fixes FuelLabs/fuelup#39. Replaces #1748 with a much simpler solution: use vendored libraries and statically link them.

`forc` binary provided by `fuelup` links to `openssl`:

```
$ otool -L ~/.fuelup/bin/forc
/Users/brightone/.fuelup/bin/forc:
	...
	/usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	...
```

On my M1 Mac, `forc` no longer links to `openssl`:

```
$ otool -L ./target/release/forc
./target/release/forc:
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1858.112.0)
	/System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration (compatibility version 1.0.0, current version 1163.100.19)
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 60158.100.133)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
	/usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
```