### PR TITLE
update printing of generic types

### DIFF
--- a/sway-core/src/type_engine/type_info.rs
+++ b/sway-core/src/type_engine/type_info.rs
@@ -1026,12 +1026,16 @@ impl TypeInfo {
 }
 
 fn print_inner_types(name: String, inner_types: impl Iterator<Item = TypeId>) -> String {
+    let inner_types = inner_types
+        .map(|x| x.friendly_type_str())
+        .collect::<Vec<_>>();
     format!(
-        "{}<{}>",
+        "{}{}",
         name,
-        inner_types
-            .map(|x| x.friendly_type_str())
-            .collect::<Vec<_>>()
-            .join(", ")
+        if inner_types.is_empty() {
+            "".into()
+        } else {
+            format!("<{}>", inner_types.join(", "))
+        }
     )
 }


### PR DESCRIPTION
We are currently printing out an empty `<>`  after every custom type if there are no generics. Previously, we'd print out all the inner fields, but now we are only printing out generics, so this is common:
<img width="218" alt="image" src="https://user-images.githubusercontent.com/12157751/170888548-87a6cf17-cb23-42dc-a375-572bb4ed8ddf.png">

This PR updates the type printing to omit `<>` if there are no generics.