### PR TITLE
Improve the error message for when using unsupported RHS values in const declarations.

### DIFF
--- a/docs/src/reference/known_issues_and_workarounds.md
+++ b/docs/src/reference/known_issues_and_workarounds.md
@@ -10,7 +10,7 @@
 
 * [#1387](https://github.com/FuelLabs/sway/issues/1387): In order to use `unwrap()` from the `result` library, all symbols of `result` needs to be imported via `use::result::*;`.
 
-* [#1665](https://github.com/FuelLabs/sway/issues/1665): Constants defined via the `const` keyword can only have primitive types. That is, it is not possible to define a `ContractId` or an `Address` as `const` for example.
+* [#996](https://github.com/FuelLabs/sway/issues/996): Constants defined via the `const` keyword can only have primitive types. That is, it is not possible to define a `ContractId` or an `Address` as `const` for example.
 
 * [#870](https://github.com/FuelLabs/sway/issues/870): All `impl` blocks need to be defined before any of the functions they define can be called.
 

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -961,6 +961,11 @@ pub enum CompileError {
     Parse { error: sway_parse::ParseError },
     #[error("\"where\" clauses are not yet supported")]
     WhereClauseNotYetSupported { span: Span },
+    #[error(
+        "Initializing a constant value via `const` is currently limited to primitive values \
+        such as numbers, bools, strings or b256s."
+    )]
+    NonLiteralConstantDeclValue { span: Span },
 }
 
 impl std::convert::From<TypeError> for CompileError {
@@ -1153,6 +1158,7 @@ impl CompileError {
             Parse { error } => error.span.clone(),
             EnumNotFound { span, .. } => span.clone(),
             TupleIndexOutOfBounds { span, .. } => span.clone(),
+            NonLiteralConstantDeclValue { span } => span.clone(),
         }
     }
 

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -542,6 +542,7 @@ pub fn run(filter_regex: Option<regex::Regex>) {
         "should_fail/trait_pure_calls_impure",
         "should_fail/match_expressions_empty_arms",
         "should_fail/type_mismatch_error_message",
+        "should_fail/non_literal_const_decl",
     ];
     number_of_tests_run += negative_project_names.iter().fold(0, |acc, name| {
         if filter(name) {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/non_literal_const_decl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/non_literal_const_decl/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'non_literal_const_decl'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/non_literal_const_decl/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/non_literal_const_decl/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "non_literal_const_decl"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/non_literal_const_decl/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/non_literal_const_decl/src/main.sw
@@ -1,0 +1,12 @@
+script;
+
+const GLOBAL_NUM = a_number(1, 2, 3);
+
+fn a_number(_a: u64, _b: u64, _c: u64) -> u64 {
+    42
+}
+
+fn main() -> u64 {
+    let a = a_number(4, 5, 6);
+    GLOBAL_NUM
+}


### PR DESCRIPTION
Closes #1665.