### PR TITLE
Format the `exponentiation` std-lib test

### DIFF
--- a/test/src/sdk-harness/test_projects/exponentiation/mod.rs
+++ b/test/src/sdk-harness/test_projects/exponentiation/mod.rs
@@ -1,19 +1,17 @@
 use fuels::prelude::*;
+use fuels::signers::LocalWallet;
 use fuels::tx::ContractId;
 use fuels_abigen_macro::abigen;
-use fuels::signers::LocalWallet;
 
-abigen!(
-    TestPowContract,
-    "test_artifacts/pow/out/debug/pow-abi.json"
-);
+abigen!(TestPowContract, "test_artifacts/pow/out/debug/pow-abi.json");
 
 #[tokio::test]
 #[should_panic(expected = "ArithmeticOverflow")]
 async fn overflowing_pow_u64_panics() {
     let wallet = launch_provider_and_get_single_wallet().await;
     let (pow_instance, _) = get_pow_test_instance(wallet).await;
-    pow_instance.u64_overflow(100u64, 100u64)
+    pow_instance
+        .u64_overflow(100u64, 100u64)
         .call()
         .await
         .unwrap();
@@ -25,7 +23,8 @@ async fn overflowing_pow_u64_panics() {
 async fn overflowing_pow_u32_panics() {
     let wallet = launch_provider_and_get_single_wallet().await;
     let (pow_instance, _) = get_pow_test_instance(wallet).await;
-    pow_instance.u32_overflow(10u32, 11u32)
+    pow_instance
+        .u32_overflow(10u32, 11u32)
         .call()
         .await
         .unwrap();
@@ -36,7 +35,8 @@ async fn overflowing_pow_u32_panics() {
 async fn overflowing_pow_u32_panics_max() {
     let wallet = launch_provider_and_get_single_wallet().await;
     let (pow_instance, _) = get_pow_test_instance(wallet).await;
-    pow_instance.u32_overflow(u32::MAX, u32::MAX)
+    pow_instance
+        .u32_overflow(u32::MAX, u32::MAX)
         .call()
         .await
         .unwrap();
@@ -48,10 +48,7 @@ async fn overflowing_pow_u32_panics_max() {
 async fn overflowing_pow_u16_panics() {
     let wallet = launch_provider_and_get_single_wallet().await;
     let (pow_instance, _) = get_pow_test_instance(wallet).await;
-    pow_instance.u16_overflow(10u16, 5u16)
-        .call()
-        .await
-        .unwrap();
+    pow_instance.u16_overflow(10u16, 5u16).call().await.unwrap();
 }
 
 #[tokio::test]
@@ -59,7 +56,8 @@ async fn overflowing_pow_u16_panics() {
 async fn overflowing_pow_u16_panics_max() {
     let wallet = launch_provider_and_get_single_wallet().await;
     let (pow_instance, _) = get_pow_test_instance(wallet).await;
-    pow_instance.u16_overflow(u16::MAX, u16::MAX)
+    pow_instance
+        .u16_overflow(u16::MAX, u16::MAX)
         .call()
         .await
         .unwrap();
@@ -71,10 +69,7 @@ async fn overflowing_pow_u16_panics_max() {
 async fn overflowing_pow_u8_panics() {
     let wallet = launch_provider_and_get_single_wallet().await;
     let (pow_instance, _) = get_pow_test_instance(wallet).await;
-    pow_instance.u8_overflow(10u8, 3u8)
-        .call()
-        .await
-        .unwrap();
+    pow_instance.u8_overflow(10u8, 3u8).call().await.unwrap();
 }
 
 #[tokio::test]
@@ -82,7 +77,8 @@ async fn overflowing_pow_u8_panics() {
 async fn overflowing_pow_u8_panics_max() {
     let wallet = launch_provider_and_get_single_wallet().await;
     let (pow_instance, _) = get_pow_test_instance(wallet).await;
-    pow_instance.u8_overflow(u8::MAX, u8::MAX)
+    pow_instance
+        .u8_overflow(u8::MAX, u8::MAX)
         .call()
         .await
         .unwrap();


### PR DESCRIPTION
Just running `cargo fmt` in the `sdk-harness` directory.