### PR TITLE
Collect tokens from the `TypedParseTree` for the language server.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3674,6 +3674,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-lsp",
+ "tracing",
 ]
 
 [[package]]

--- a/sway-core/src/parse_tree.rs
+++ b/sway-core/src/parse_tree.rs
@@ -5,7 +5,7 @@ pub mod declaration;
 mod expression;
 pub mod ident;
 mod include_statement;
-mod literal;
+pub mod literal;
 mod return_statement;
 mod use_statement;
 mod visibility;

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -6,8 +6,8 @@ use derivative::Derivative;
 
 #[derive(Clone, Debug, Eq, Derivative)]
 #[derivative(PartialEq)]
-pub(crate) struct TypedCodeBlock {
-    pub(crate) contents: Vec<TypedAstNode>,
+pub struct TypedCodeBlock {
+    pub contents: Vec<TypedAstNode>,
     #[derivative(PartialEq = "ignore")]
     pub(crate) whole_block_span: Span,
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -414,7 +414,7 @@ impl CopyTypes for TypedConstantDeclaration {
 #[derivative(PartialEq, Eq)]
 pub struct TypedTraitDeclaration {
     pub name: Ident,
-    pub(crate) interface_surface: Vec<TypedTraitFn>,
+    pub interface_surface: Vec<TypedTraitFn>,
     // NOTE: deriving partialeq and hash on this element may be important in the
     // future, but I am not sure. For now, adding this would 2x the amount of
     // work, so I am just going to exclude it
@@ -440,7 +440,7 @@ pub struct TypedTraitFn {
     pub name: Ident,
     pub(crate) purity: Purity,
     pub(crate) parameters: Vec<TypedFunctionParameter>,
-    pub(crate) return_type: TypeId,
+    pub return_type: TypeId,
     #[derivative(PartialEq = "ignore")]
     #[derivative(Eq(bound = ""))]
     pub(crate) return_type_span: Span,
@@ -482,7 +482,7 @@ impl TypedTraitFn {
 #[derive(Clone, Debug, Eq)]
 pub struct ReassignmentLhs {
     pub name: Ident,
-    pub(crate) r#type: TypeId,
+    pub r#type: TypeId,
 }
 
 // NOTE: Hash and PartialEq must uphold the invariant:

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -222,7 +222,7 @@ impl TypedDeclaration {
     }
 
     /// friendly name string used for error reporting.
-    pub(crate) fn friendly_name(&self) -> &'static str {
+    pub fn friendly_name(&self) -> &'static str {
         use TypedDeclaration::*;
         match self {
             VariableDeclaration(_) => "variable",

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -374,9 +374,9 @@ impl TypedDeclaration {
 #[derivative(PartialEq, Eq)]
 pub struct TypedAbiDeclaration {
     /// The name of the abi trait (also known as a "contract trait")
-    pub(crate) name: Ident,
+    pub name: Ident,
     /// The methods a contract is required to implement in order opt in to this interface
-    pub(crate) interface_surface: Vec<TypedTraitFn>,
+    pub interface_surface: Vec<TypedTraitFn>,
     /// The methods provided to a contract "for free" upon opting in to this interface
     // NOTE: It may be important in the future to include this component
     #[derivative(PartialEq = "ignore")]
@@ -437,7 +437,7 @@ impl CopyTypes for TypedTraitDeclaration {
 #[derive(Clone, Debug, Derivative)]
 #[derivative(PartialEq, Eq)]
 pub struct TypedTraitFn {
-    pub(crate) name: Ident,
+    pub name: Ident,
     pub(crate) purity: Purity,
     pub(crate) parameters: Vec<TypedFunctionParameter>,
     pub(crate) return_type: TypeId,

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -400,7 +400,7 @@ impl TypedAbiDeclaration {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypedConstantDeclaration {
     pub(crate) name: Ident,
-    pub(crate) value: TypedExpression,
+    pub value: TypedExpression,
     pub(crate) visibility: Visibility,
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -399,7 +399,7 @@ impl TypedAbiDeclaration {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypedConstantDeclaration {
-    pub(crate) name: Ident,
+    pub name: Ident,
     pub value: TypedExpression,
     pub(crate) visibility: Visibility,
 }
@@ -413,7 +413,7 @@ impl CopyTypes for TypedConstantDeclaration {
 #[derive(Clone, Debug, Derivative)]
 #[derivative(PartialEq, Eq)]
 pub struct TypedTraitDeclaration {
-    pub(crate) name: Ident,
+    pub name: Ident,
     pub(crate) interface_surface: Vec<TypedTraitFn>,
     // NOTE: deriving partialeq and hash on this element may be important in the
     // future, but I am not sure. For now, adding this would 2x the amount of
@@ -481,7 +481,7 @@ impl TypedTraitFn {
 /// in asm generation.
 #[derive(Clone, Debug, Eq)]
 pub struct ReassignmentLhs {
-    pub(crate) name: Ident,
+    pub name: Ident,
     pub(crate) r#type: TypeId,
 }
 
@@ -504,8 +504,8 @@ impl ReassignmentLhs {
 pub struct TypedReassignment {
     // either a direct variable, so length of 1, or
     // at series of struct fields/array indices (array syntax)
-    pub(crate) lhs: Vec<ReassignmentLhs>,
-    pub(crate) rhs: TypedExpression,
+    pub lhs: Vec<ReassignmentLhs>,
+    pub rhs: TypedExpression,
 }
 
 impl CopyTypes for TypedReassignment {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -184,7 +184,7 @@ impl TypedEnumDeclaration {
 #[derive(Debug, Clone, Eq)]
 pub struct TypedEnumVariant {
     pub name: Ident,
-    pub(crate) r#type: TypeId,
+    pub r#type: TypeId,
     pub(crate) tag: usize,
     pub(crate) span: Span,
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -16,9 +16,9 @@ use super::{monomorphize_inner, CreateTypeId, MonomorphizeHelper};
 
 #[derive(Clone, Debug, Eq)]
 pub struct TypedEnumDeclaration {
-    pub(crate) name: Ident,
+    pub name: Ident,
     pub(crate) type_parameters: Vec<TypeParameter>,
-    pub(crate) variants: Vec<TypedEnumVariant>,
+    pub variants: Vec<TypedEnumVariant>,
     pub(crate) span: Span,
     pub(crate) visibility: Visibility,
 }
@@ -183,7 +183,7 @@ impl TypedEnumDeclaration {
 
 #[derive(Debug, Clone, Eq)]
 pub struct TypedEnumVariant {
-    pub(crate) name: Ident,
+    pub name: Ident,
     pub(crate) r#type: TypeId,
     pub(crate) tag: usize,
     pub(crate) span: Span,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -25,8 +25,8 @@ use super::{EnforceTypeArguments, MonomorphizeHelper};
 
 #[derive(Clone, Debug, Eq)]
 pub struct TypedFunctionDeclaration {
-    pub(crate) name: Ident,
-    pub(crate) body: TypedCodeBlock,
+    pub name: Ident,
+    pub body: TypedCodeBlock,
     pub(crate) parameters: Vec<TypedFunctionParameter>,
     pub(crate) span: Span,
     pub(crate) return_type: TypeId,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -27,7 +27,7 @@ use super::{EnforceTypeArguments, MonomorphizeHelper};
 pub struct TypedFunctionDeclaration {
     pub name: Ident,
     pub body: TypedCodeBlock,
-    pub(crate) parameters: Vec<TypedFunctionParameter>,
+    pub parameters: Vec<TypedFunctionParameter>,
     pub(crate) span: Span,
     pub(crate) return_type: TypeId,
     pub(crate) type_parameters: Vec<TypeParameter>,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
@@ -9,7 +9,7 @@ use sway_types::span::Span;
 #[derive(Debug, Clone, Eq)]
 pub struct TypedFunctionParameter {
     pub name: Ident,
-    pub(crate) r#type: TypeId,
+    pub r#type: TypeId,
     pub(crate) type_span: Span,
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
@@ -8,7 +8,7 @@ use sway_types::span::Span;
 
 #[derive(Debug, Clone, Eq)]
 pub struct TypedFunctionParameter {
-    pub(crate) name: Ident,
+    pub name: Ident,
     pub(crate) r#type: TypeId,
     pub(crate) type_span: Span,
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
@@ -14,7 +14,7 @@ use derivative::Derivative;
 #[derive(Clone, Debug, Derivative)]
 #[derivative(PartialEq, Eq)]
 pub struct TypedStorageDeclaration {
-    pub(crate) fields: Vec<TypedStorageField>,
+    pub fields: Vec<TypedStorageField>,
     #[derivative(PartialEq = "ignore")]
     #[derivative(Eq(bound = ""))]
     span: Span,
@@ -138,7 +138,7 @@ impl TypedStorageDeclaration {
 
 #[derive(Clone, Debug, Eq)]
 pub struct TypedStorageField {
-    pub(crate) name: Ident,
+    pub name: Ident,
     pub(crate) r#type: TypeId,
     pub(crate) span: Span,
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
@@ -139,7 +139,7 @@ impl TypedStorageDeclaration {
 #[derive(Clone, Debug, Eq)]
 pub struct TypedStorageField {
     pub name: Ident,
-    pub(crate) r#type: TypeId,
+    pub r#type: TypeId,
     pub(crate) span: Span,
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
@@ -14,8 +14,8 @@ use super::{monomorphize_inner, CreateTypeId, EnforceTypeArguments, Monomorphize
 
 #[derive(Clone, Debug, Eq)]
 pub struct TypedStructDeclaration {
-    pub(crate) name: Ident,
-    pub(crate) fields: Vec<TypedStructField>,
+    pub name: Ident,
+    pub fields: Vec<TypedStructField>,
     pub(crate) type_parameters: Vec<TypeParameter>,
     pub(crate) visibility: Visibility,
     pub(crate) span: Span,
@@ -178,7 +178,7 @@ impl TypedStructDeclaration {
 
 #[derive(Debug, Clone, Eq)]
 pub struct TypedStructField {
-    pub(crate) name: Ident,
+    pub name: Ident,
     pub(crate) r#type: TypeId,
     pub(crate) span: Span,
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
@@ -179,7 +179,7 @@ impl TypedStructDeclaration {
 #[derive(Debug, Clone, Eq)]
 pub struct TypedStructField {
     pub name: Ident,
-    pub(crate) r#type: TypeId,
+    pub r#type: TypeId,
     pub(crate) span: Span,
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
@@ -55,10 +55,10 @@ impl From<VariableMutability> for bool {
 }
 #[derive(Clone, Debug, Eq)]
 pub struct TypedVariableDeclaration {
-    pub(crate) name: Ident,
-    pub(crate) body: TypedExpression,
+    pub name: Ident,
+    pub body: TypedExpression,
     pub(crate) is_mutable: VariableMutability,
-    pub(crate) type_ascription: TypeId,
+    pub type_ascription: TypeId,
     pub(crate) const_decl_origin: bool,
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/mod.rs
@@ -1,7 +1,7 @@
 mod match_expression;
 mod struct_expr_field;
-mod typed_expression;
-mod typed_expression_variant;
+pub mod typed_expression;
+pub mod typed_expression_variant;
 
 pub(crate) use struct_expr_field::TypedStructExpressionField;
 pub(crate) use typed_expression::{error_recovery_expr, TypedExpression};

--- a/sway-core/src/semantic_analysis/ast_node/expression/struct_expr_field.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/struct_expr_field.rs
@@ -2,9 +2,9 @@ use crate::semantic_analysis::{CopyTypes, TypeMapping, TypedExpression};
 use crate::Ident;
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct TypedStructExpressionField {
-    pub(crate) name: Ident,
-    pub(crate) value: TypedExpression,
+pub struct TypedStructExpressionField {
+    pub name: Ident,
+    pub value: TypedExpression,
 }
 
 impl CopyTypes for TypedStructExpressionField {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -28,8 +28,8 @@ use ast_node::declaration::CreateTypeId;
 
 #[derive(Clone, Debug, Eq)]
 pub struct TypedExpression {
-    pub(crate) expression: TypedExpressionVariant,
-    pub(crate) return_type: TypeId,
+    pub expression: TypedExpressionVariant,
+    pub return_type: TypeId,
     /// whether or not this expression is constantly evaluable (if the result is known at compile
     /// time)
     pub(crate) is_constant: IsConstant,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -439,7 +439,7 @@ impl CopyTypes for TypedExpressionVariant {
 /// Describes the full storage access including all the subfields
 #[derive(Clone, Debug)]
 pub struct TypeCheckedStorageAccess {
-    pub(crate) fields: Vec<TypeCheckedStorageAccessDescriptor>,
+    pub fields: Vec<TypeCheckedStorageAccessDescriptor>,
     pub(crate) ix: StateIndex,
 }
 
@@ -459,7 +459,7 @@ impl TypeCheckedStorageAccess {
 /// Describes a single subfield access in the sequence when accessing a subfield within storage.
 #[derive(Clone, Debug)]
 pub struct TypeCheckedStorageAccessDescriptor {
-    pub(crate) name: Ident,
+    pub name: Ident,
     pub(crate) r#type: TypeId,
     pub(crate) span: Span,
 }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -7,14 +7,14 @@ use sway_types::state::StateIndex;
 use derivative::Derivative;
 
 #[derive(Clone, Debug)]
-pub(crate) struct ContractCallMetadata {
+pub struct ContractCallMetadata {
     pub(crate) func_selector: [u8; 4],
     pub(crate) contract_address: Box<TypedExpression>,
 }
 
 #[derive(Clone, Debug, Derivative)]
 #[derivative(Eq)]
-pub(crate) enum TypedExpressionVariant {
+pub enum TypedExpressionVariant {
     Literal(Literal),
     FunctionApplication {
         call_path: CallPath,
@@ -465,7 +465,7 @@ pub struct TypeCheckedStorageAccessDescriptor {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct TypedAsmRegisterDeclaration {
+pub struct TypedAsmRegisterDeclaration {
     pub(crate) initializer: Option<TypedExpression>,
     pub(crate) name: Ident,
 }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -493,7 +493,7 @@ impl CopyTypes for TypedAsmRegisterDeclaration {
 }
 
 impl TypedExpressionVariant {
-    pub(crate) fn pretty_print(&self) -> String {
+    pub fn pretty_print(&self) -> String {
         match self {
             TypedExpressionVariant::Literal(lit) => format!(
                 "literal {}",

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -1531,7 +1531,7 @@ fn error_recovery_function_declaration(decl: FunctionDeclaration) -> TypedFuncti
 /// Describes each field being drilled down into in storage and its type.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeCheckedStorageReassignment {
-    pub(crate) fields: Vec<TypeCheckedStorageReassignDescriptor>,
+    pub fields: Vec<TypeCheckedStorageReassignDescriptor>,
     pub(crate) ix: StateIndex,
     pub rhs: TypedExpression,
 }
@@ -1557,7 +1557,7 @@ impl TypeCheckedStorageReassignment {
 #[derive(Clone, Debug, Eq)]
 pub struct TypeCheckedStorageReassignDescriptor {
     pub name: Ident,
-    pub(crate) r#type: TypeId,
+    pub r#type: TypeId,
     pub(crate) span: Span,
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -44,7 +44,7 @@ pub(crate) use expression::*;
 mod return_statement;
 pub(crate) use return_statement::TypedReturnStatement;
 
-mod while_loop;
+pub mod while_loop;
 pub(crate) use while_loop::TypedWhileLoop;
 
 mod copy_types;
@@ -1533,7 +1533,7 @@ fn error_recovery_function_declaration(decl: FunctionDeclaration) -> TypedFuncti
 pub struct TypeCheckedStorageReassignment {
     pub(crate) fields: Vec<TypeCheckedStorageReassignDescriptor>,
     pub(crate) ix: StateIndex,
-    pub(crate) rhs: TypedExpression,
+    pub rhs: TypedExpression,
 }
 
 impl TypeCheckedStorageReassignment {
@@ -1556,7 +1556,7 @@ impl TypeCheckedStorageReassignment {
 /// storage.
 #[derive(Clone, Debug, Eq)]
 pub struct TypeCheckedStorageReassignDescriptor {
-    pub(crate) name: Ident,
+    pub name: Ident,
     pub(crate) r#type: TypeId,
     pub(crate) span: Span,
 }

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -13,12 +13,12 @@ use sway_types::{span::Span, state::StateIndex};
 use derivative::Derivative;
 use std::sync::Arc;
 
-use crate::semantic_analysis::ast_node::declaration::TypedStorageField;
+pub use crate::semantic_analysis::ast_node::declaration::TypedStorageField;
 
-pub(crate) use crate::semantic_analysis::ast_node::declaration::ReassignmentLhs;
+pub use crate::semantic_analysis::ast_node::declaration::ReassignmentLhs;
 
 pub mod declaration;
-use declaration::TypedTraitFn;
+pub use declaration::TypedTraitFn;
 
 pub use declaration::{
     TypedAbiDeclaration, TypedConstantDeclaration, TypedDeclaration, TypedEnumDeclaration,

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -38,7 +38,7 @@ pub(crate) use impl_trait::Mode;
 mod code_block;
 pub(crate) use code_block::TypedCodeBlock;
 
-mod expression;
+pub mod expression;
 pub(crate) use expression::*;
 
 mod return_statement;
@@ -59,7 +59,7 @@ pub(crate) enum IsConstant {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum TypedAstNodeContent {
+pub enum TypedAstNodeContent {
     ReturnStatement(TypedReturnStatement),
     Declaration(TypedDeclaration),
     Expression(TypedExpression),
@@ -72,7 +72,7 @@ pub(crate) enum TypedAstNodeContent {
 #[derive(Clone, Debug, Eq, Derivative)]
 #[derivative(PartialEq)]
 pub struct TypedAstNode {
-    pub(crate) content: TypedAstNodeContent,
+    pub content: TypedAstNodeContent,
     #[derivative(PartialEq = "ignore")]
     pub(crate) span: Span,
 }

--- a/sway-core/src/semantic_analysis/ast_node/return_statement.rs
+++ b/sway-core/src/semantic_analysis/ast_node/return_statement.rs
@@ -2,7 +2,7 @@ use super::{CopyTypes, TypeMapping, TypedExpression};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TypedReturnStatement {
-    pub(crate) expr: TypedExpression,
+    pub expr: TypedExpression,
 }
 
 impl CopyTypes for TypedReturnStatement {

--- a/sway-core/src/semantic_analysis/ast_node/return_statement.rs
+++ b/sway-core/src/semantic_analysis/ast_node/return_statement.rs
@@ -1,7 +1,7 @@
 use super::{CopyTypes, TypeMapping, TypedExpression};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct TypedReturnStatement {
+pub struct TypedReturnStatement {
     pub(crate) expr: TypedExpression,
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/while_loop.rs
+++ b/sway-core/src/semantic_analysis/ast_node/while_loop.rs
@@ -1,7 +1,7 @@
 use super::{TypedCodeBlock, TypedExpression};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct TypedWhileLoop {
+pub struct TypedWhileLoop {
     pub(crate) condition: TypedExpression,
     pub(crate) body: TypedCodeBlock,
 }

--- a/sway-core/src/semantic_analysis/ast_node/while_loop.rs
+++ b/sway-core/src/semantic_analysis/ast_node/while_loop.rs
@@ -2,8 +2,8 @@ use super::{TypedCodeBlock, TypedExpression};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypedWhileLoop {
-    pub(crate) condition: TypedExpression,
-    pub(crate) body: TypedCodeBlock,
+    pub condition: TypedExpression,
+    pub body: TypedCodeBlock,
 }
 
 impl TypedWhileLoop {

--- a/sway-core/src/semantic_analysis/syntax_tree.rs
+++ b/sway-core/src/semantic_analysis/syntax_tree.rs
@@ -126,7 +126,7 @@ impl TypedParseTree {
     ///
     /// This is called from both the top-level `compile_*` functions, as well as internally for
     /// each submodule dependency library.
-    pub(crate) fn type_check(
+    pub fn type_check(
         parsed: ParseTree,
         namespace: &mut Namespace,
         tree_type: &TreeType,

--- a/sway-core/src/type_engine/engine.rs
+++ b/sway-core/src/type_engine/engine.rs
@@ -353,7 +353,7 @@ pub fn insert_type(ty: TypeInfo) -> TypeId {
     TYPE_ENGINE.insert_type(ty)
 }
 
-pub(crate) fn look_up_type_id(id: TypeId) -> TypeInfo {
+pub fn look_up_type_id(id: TypeId) -> TypeInfo {
     TYPE_ENGINE.look_up_type_id(id)
 }
 

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -19,6 +19,7 @@ sway-types = { version = "0.14.4", path = "../sway-types" }
 sway-utils = { version = "0.14.4", path = "../sway-utils" }
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tower-lsp = "0.16.0"
+tracing = "0.1"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -2,7 +2,7 @@ use super::token::Token;
 use super::token_type::TokenType;
 use crate::{capabilities, core::token::traverse_node};
 use ropey::Rope;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use sway_core::{parse, TreeType};
 use sway_core::{
@@ -121,7 +121,7 @@ impl TextDocument {
         use sway_core::semantic_analysis::ast_node::TypedAstNodeContent;
         use super::traverse_typed_tree as ttt;
 
-        let mut tokens: HashMap<Ident, TypedAstNodeContent> = HashMap::new();
+        let mut tokens: BTreeMap<Ident, TypedAstNodeContent> = BTreeMap::new();
 
         if let Some(all_nodes) = self.parse_typed_tokens_from_text() {
             for node in &all_nodes {
@@ -140,7 +140,7 @@ impl TextDocument {
 
         // Check if the code editor's cursor is currently over an of our collected tokens
         if let Some(ident) = ttt::ident_at_position(cursor_position, &tokens) {
-            // Retrieve the typed_ast_node from our HashMap
+            // Retrieve the typed_ast_node from our BTreeMap
             if let Some(token) = tokens.get(ident) {
                 //eprintln!("token = {:#?}", token);
 

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -129,7 +129,11 @@ impl TextDocument {
             }
         }
 
-        eprintln!("{:#?}", tokens.keys());
+        for (ident, token) in &tokens {
+            ttt::debug_print_ident(ident, token);
+        }
+
+        //eprintln!("{:#?}", tokens.keys());
     
         let cursor_position = Position::new(25, 14); //Cursor's hovered over the position var decl in main()
         //let cursor_position = Position::new(29, 18); //Cursor's hovered over the ~Particle in p = decl in main()

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -128,13 +128,14 @@ impl TextDocument {
                 ttt::traverse_node(node, &mut tokens);
             }
         }
+
+        eprintln!("{:#?}", tokens.keys());
     
-        let file_name = std::path::PathBuf::from(self.get_uri());
-        let cursor_position = Position::new(25, 14); //Cursos hovered over the position var decl in main()
-        let code_pos = ttt::CodeEditorPosition::new(file_name, cursor_position);
+        let cursor_position = Position::new(25, 14); //Cursor's hovered over the position var decl in main()
+        //let cursor_position = Position::new(29, 18); //Cursor's hovered over the ~Particle in p = decl in main()
 
         // Check if the code editor's cursor is currently over an of our collected tokens
-        if let Some(ident) = ttt::ident_at_position(&code_pos, &tokens) {
+        if let Some(ident) = ttt::ident_at_position(cursor_position, &tokens) {
             // Retrieve the typed_ast_node from our HashMap
             if let Some(token) = tokens.get(ident) {
                 //eprintln!("token = {:#?}", token);

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -117,7 +117,6 @@ impl TextDocument {
     }
 
     pub fn test_typed_parse(&self) {
-        use sway_types::ident::Ident;
         use super::traverse_typed_tree as ttt;
 
         let mut tokens: ttt::TokenMap = HashMap::new();
@@ -128,7 +127,7 @@ impl TextDocument {
             }
         }
 
-        for ((ident,span), token) in &tokens {
+        for ((ident, _span), token) in &tokens {
             ttt::debug_print_ident_and_token(ident, token);
         }
 

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use super::token::Token;
 use super::token_type::TokenType;
 use super::typed_token_type::TokenMap;
@@ -11,11 +13,10 @@ use sway_core::{
     parse, 
     TreeType,
     BuildConfig,
-    CompileResult,
     CompileAstResult,
     TypedParseTree,
     semantic_analysis::{
-        namespace, Namespace,
+        namespace,
         ast_node::TypedAstNode,
     },
 };
@@ -181,7 +182,7 @@ impl TextDocument {
             },
             CompileAstResult::Success {
                 parse_tree,
-                ..,
+                ..
             } => {
                 match *parse_tree {
                     TypedParseTree::Script{ all_nodes, .. } => {

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -131,8 +131,6 @@ impl TextDocument {
             utils::debug::debug_print_ident_and_token(ident, token);
         }
 
-        //eprintln!("{:#?}", tokens.keys());
-
         //let cursor_position = Position::new(25, 14); //Cursor's hovered over the position var decl in main()
         let cursor_position = Position::new(29, 18); //Cursor's hovered over the ~Particle in p = decl in main()
 
@@ -142,15 +140,13 @@ impl TextDocument {
         {
             // Retrieve the typed_ast_node from our BTreeMap
             if let Some(token) = self.token_map.get(&(ident, span)) {
-                //eprintln!("token = {:#?}", token);
-
                 // Look up the tokens TypeId
                 if let Some(type_id) = traverse_typed_tree::get_type_id(token) {
-                    eprintln!("type_id = {:#?}", type_id);
+                    tracing::info!("type_id = {:#?}", type_id);
 
                     // Use the TypeId to look up the actual type (I think there is a method in the type_engine for this)
                     let type_info = sway_core::type_engine::look_up_type_id(type_id);
-                    eprintln!("type_info = {:#?}", type_info);
+                    tracing::info!("type_info = {:#?}", type_info);
                 }
 
                 // Find the ident / span on the returned type

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -118,10 +118,9 @@ impl TextDocument {
 
     pub fn test_typed_parse(&self) {
         use sway_types::ident::Ident;
-        use sway_core::semantic_analysis::ast_node::TypedAstNodeContent;
         use super::traverse_typed_tree as ttt;
 
-        let mut tokens: BTreeMap<Ident, TypedAstNodeContent> = BTreeMap::new();
+        let mut tokens: ttt::TokenMap = HashMap::new();
 
         if let Some(all_nodes) = self.parse_typed_tokens_from_text() {
             for node in &all_nodes {
@@ -129,19 +128,19 @@ impl TextDocument {
             }
         }
 
-        for (ident, token) in &tokens {
-            ttt::debug_print_ident(ident, token);
+        for ((ident,span), token) in &tokens {
+            ttt::debug_print_ident_and_token(ident, token);
         }
 
         //eprintln!("{:#?}", tokens.keys());
     
-        let cursor_position = Position::new(25, 14); //Cursor's hovered over the position var decl in main()
-        //let cursor_position = Position::new(29, 18); //Cursor's hovered over the ~Particle in p = decl in main()
+        //let cursor_position = Position::new(25, 14); //Cursor's hovered over the position var decl in main()
+        let cursor_position = Position::new(29, 18); //Cursor's hovered over the ~Particle in p = decl in main()
 
         // Check if the code editor's cursor is currently over an of our collected tokens
-        if let Some(ident) = ttt::ident_at_position(cursor_position, &tokens) {
+        if let Some( (ident, span) ) = ttt::ident_and_span_at_position(cursor_position, &tokens) {
             // Retrieve the typed_ast_node from our BTreeMap
-            if let Some(token) = tokens.get(ident) {
+            if let Some(token) = tokens.get(&(ident, span)) {
                 //eprintln!("token = {:#?}", token);
 
                 // Look up the tokens TypeId

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -145,13 +145,14 @@ impl TextDocument {
                 //eprintln!("token = {:#?}", token);
 
                 // Look up the tokens TypeId
-                let type_id = ttt::type_id(token);
-                eprintln!("type_id = {:#?}", type_id);
+                if let Some(type_id) = ttt::type_id(token) {
+                    eprintln!("type_id = {:#?}", type_id);
 
-                // Use the TypeId to look up the actual type (I think there is a method in the type_engine for this)
-                let type_info = sway_core::type_engine::look_up_type_id(type_id);
-                eprintln!("type_info = {:#?}", type_info);
-
+                    // Use the TypeId to look up the actual type (I think there is a method in the type_engine for this)
+                    let type_info = sway_core::type_engine::look_up_type_id(type_id);
+                    eprintln!("type_info = {:#?}", type_info);
+                }
+                
                 // Find the ident / span on the returned type
     
                 // Contruct a go_to LSP request from the declerations span

--- a/sway-lsp/src/core/mod.rs
+++ b/sway-lsp/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod document;
 pub mod session;
+pub mod traverse_typed_tree;
 pub(crate) mod token;
 pub(crate) mod token_type;

--- a/sway-lsp/src/core/mod.rs
+++ b/sway-lsp/src/core/mod.rs
@@ -3,3 +3,4 @@ pub mod session;
 pub mod traverse_typed_tree;
 pub(crate) mod token;
 pub(crate) mod token_type;
+pub(crate) mod typed_token_type;

--- a/sway-lsp/src/core/mod.rs
+++ b/sway-lsp/src/core/mod.rs
@@ -1,6 +1,6 @@
 pub mod document;
 pub mod session;
-pub mod traverse_typed_tree;
 pub(crate) mod token;
 pub(crate) mod token_type;
+pub mod traverse_typed_tree;
 pub(crate) mod typed_token_type;

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -3,7 +3,7 @@ use crate::{
         get_const_details, get_enum_details, get_function_details, get_struct_details,
         get_struct_field_details, get_trait_details, TokenType, VariableDetails,
     },
-    utils::common::extract_var_body,
+    utils::common::{extract_var_body, get_range_from_span},
 };
 use sway_core::{
     constants::TUPLE_NAME_PREFIX, parse_tree::MethodName, type_engine::TypeInfo, AstNode,
@@ -11,7 +11,7 @@ use sway_core::{
     VariableDeclaration, WhileLoop,
 };
 use sway_types::{ident::Ident, span::Span};
-use tower_lsp::lsp_types::{Position, Range};
+use tower_lsp::lsp_types::Range;
 
 #[derive(Debug, Clone)]
 pub struct Token {
@@ -470,20 +470,4 @@ fn desugared_op(method_name: &MethodName) -> bool {
         }
     }
     false
-}
-
-fn get_range_from_span(span: &Span) -> Range {
-    let start = span.start_pos().line_col();
-    let end = span.end_pos().line_col();
-
-    let start_line = start.0 as u32 - 1;
-    let start_character = start.1 as u32 - 1;
-
-    let end_line = end.0 as u32 - 1;
-    let end_character = end.1 as u32 - 1;
-
-    Range {
-        start: Position::new(start_line, start_character),
-        end: Position::new(end_line, end_character),
-    }
 }

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -182,20 +182,20 @@ fn handle_expression(expression: &TypedExpression, tokens: &mut TokenMap) {
     match &expression.expression {
         TypedExpressionVariant::Literal { .. } => {}
         TypedExpressionVariant::FunctionApplication {
-            name,
+            call_path,
             contract_call_params,
             arguments,
             function_body,
             ..
         } => {
-            for ident in &name.prefixes {
+            for ident in &call_path.prefixes {
                 tokens.insert(
                     to_ident_key(ident),
                     TokenType::TypedExpression(expression.clone()),
                 );
             }
             tokens.insert(
-                to_ident_key(&name.suffix),
+                to_ident_key(&call_path.suffix),
                 TokenType::TypedExpression(expression.clone()),
             );
 
@@ -281,30 +281,6 @@ fn handle_expression(expression: &TypedExpression, tokens: &mut TokenMap) {
                 TokenType::TypedExpression(expression.clone()),
             );
         }
-        TypedExpressionVariant::IfLet {
-            expr,
-            variant,
-            variable_to_assign,
-            then,
-            r#else,
-            ..
-        } => {
-            handle_expression(expr, tokens);
-            tokens.insert(
-                to_ident_key(&variant.name),
-                TokenType::TypedExpression(expression.clone()),
-            );
-            tokens.insert(
-                to_ident_key(variable_to_assign),
-                TokenType::TypedExpression(expression.clone()),
-            );
-            for node in &then.contents {
-                traverse_node(node, tokens);
-            }
-            if let Some(r#else) = r#else {
-                handle_expression(r#else, tokens);
-            }
-        }
         TypedExpressionVariant::TupleElemAccess { prefix, .. } => {
             handle_expression(prefix, tokens);
         }
@@ -333,10 +309,21 @@ fn handle_expression(expression: &TypedExpression, tokens: &mut TokenMap) {
             }
         }
         TypedExpressionVariant::TypeProperty { .. } => {}
+        TypedExpressionVariant::GenerateUid { .. } => {}
         TypedExpressionVariant::SizeOfValue { expr } => {
             handle_expression(expr, tokens);
         }
         TypedExpressionVariant::AbiName { .. } => {}
+        TypedExpressionVariant::EnumTag { exp } => {
+            handle_expression(exp, tokens);
+        }
+        TypedExpressionVariant::UnsafeDowncast { exp, variant } => {
+            handle_expression(exp, tokens);
+            tokens.insert(
+                to_ident_key(&variant.name),
+                TokenType::TypedExpression(expression.clone()),
+            );
+        }
     }
 }
 

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
 };
 use sway_types::{
     ident::Ident,
@@ -17,7 +17,7 @@ use sway_core::type_engine::TypeId;
 use sway_core::parse_tree::literal::Literal;
 use tower_lsp::lsp_types::{Position, Range, SymbolKind};
 
-pub fn traverse_node(node: &TypedAstNode, tokens: &mut HashMap<Ident, TypedAstNodeContent>) {
+pub fn traverse_node(node: &TypedAstNode, tokens: &mut BTreeMap<Ident, TypedAstNodeContent>) {
     match &node.content {
         TypedAstNodeContent::ReturnStatement(return_statement) => handle_expression(&return_statement.expr, tokens),
         TypedAstNodeContent::Declaration(declaration) => handle_declaration(declaration, tokens),
@@ -28,7 +28,7 @@ pub fn traverse_node(node: &TypedAstNode, tokens: &mut HashMap<Ident, TypedAstNo
     };
 }
 
-fn handle_declaration(declaration: &TypedDeclaration, tokens: &mut HashMap<Ident, TypedAstNodeContent>) {
+fn handle_declaration(declaration: &TypedDeclaration, tokens: &mut BTreeMap<Ident, TypedAstNodeContent>) {
     match declaration {
         TypedDeclaration::VariableDeclaration(variable) => {
             tokens.insert(variable.name.clone(), TypedAstNodeContent::Declaration(declaration.clone()));
@@ -100,7 +100,7 @@ fn handle_declaration(declaration: &TypedDeclaration, tokens: &mut HashMap<Ident
     }
 }
 
-fn handle_expression(expression: &TypedExpression, tokens: &mut HashMap<Ident, TypedAstNodeContent>) {
+fn handle_expression(expression: &TypedExpression, tokens: &mut BTreeMap<Ident, TypedAstNodeContent>) {
     match &expression.expression {
         TypedExpressionVariant::Literal{..} => {}
         TypedExpressionVariant::FunctionApplication{name, contract_call_params, arguments,function_body, ..} => {
@@ -201,7 +201,7 @@ fn handle_expression(expression: &TypedExpression, tokens: &mut HashMap<Ident, T
     }
 }
 
-fn handle_while_loop(while_loop: &TypedWhileLoop, tokens: &mut HashMap<Ident, TypedAstNodeContent>) {
+fn handle_while_loop(while_loop: &TypedWhileLoop, tokens: &mut BTreeMap<Ident, TypedAstNodeContent>) {
     handle_expression(&while_loop.condition, tokens);
     for node in &while_loop.body.contents {
         traverse_node(node, tokens);
@@ -268,7 +268,7 @@ fn to_symbol_kind(typed_ast_node: &TypedAstNodeContent) -> SymbolKind {
     }
 }
 
-pub fn ident_at_position<'a>(cursor_position: Position, tokens: &'a HashMap<Ident, TypedAstNodeContent>) -> Option<&'a Ident> {
+pub fn ident_at_position<'a>(cursor_position: Position, tokens: &'a BTreeMap<Ident, TypedAstNodeContent>) -> Option<&'a Ident> {
     for ident in tokens.keys() {
         let range = get_range_from_span(ident.span());
         if cursor_position >= range.start && cursor_position <= range.end {

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use sway_types::{
     ident::Ident,
     span::Span,

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -406,6 +406,27 @@ fn ast_node_type(token: &TokenType) -> String {
         TokenType::TypedExpression(exp) => {
             exp.expression.pretty_print()
         }
+        TokenType::TypedFunctionParameter(_) => {
+            "function parameter".to_string()
+        }
+        TokenType::TypedStructField(_) => {
+            "struct field".to_string()
+        }
+        TokenType::TypedEnumVariant(_) => {
+            "enum variant".to_string()
+        }
+        TokenType::TypedTraitFn(_) => {
+            "trait function".to_string()
+        }
+        TokenType::TypedStorageField(_) => {
+            "storage field".to_string()
+        }
+        TokenType::TypeCheckedStorageReassignDescriptor(_) => {
+            "storage reassignment descriptor".to_string()
+        }
+        TokenType::ReassignmentLhs(_) => {
+            "reassignment lhs".to_string()
+        }        
         _ => "".to_string()
     }
 }

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -1,27 +1,26 @@
 #![allow(dead_code)]
 
-use sway_types::{
-    ident::Ident,
-    span::Span,
-};
+use crate::core::typed_token_type::{TokenMap, TokenType};
 use sway_core::semantic_analysis::ast_node::{
-    {TypedAstNode, TypedAstNodeContent, TypedDeclaration},
     expression::{
-        typed_expression::TypedExpression,
-        typed_expression_variant::TypedExpressionVariant,
+        typed_expression::TypedExpression, typed_expression_variant::TypedExpressionVariant,
     },
     while_loop::TypedWhileLoop,
+    {TypedAstNode, TypedAstNodeContent, TypedDeclaration},
 };
 use sway_core::type_engine::TypeId;
-use crate::core::typed_token_type::{TokenMap, TokenType};
-
+use sway_types::{ident::Ident, span::Span};
 
 pub fn traverse_node(node: &TypedAstNode, tokens: &mut TokenMap) {
     match &node.content {
-        TypedAstNodeContent::ReturnStatement(return_statement) => handle_expression(&return_statement.expr, tokens),
+        TypedAstNodeContent::ReturnStatement(return_statement) => {
+            handle_expression(&return_statement.expr, tokens)
+        }
         TypedAstNodeContent::Declaration(declaration) => handle_declaration(declaration, tokens),
         TypedAstNodeContent::Expression(expression) => handle_expression(expression, tokens),
-        TypedAstNodeContent::ImplicitReturnExpression(expression) => handle_expression(expression, tokens),
+        TypedAstNodeContent::ImplicitReturnExpression(expression) => {
+            handle_expression(expression, tokens)
+        }
         TypedAstNodeContent::WhileLoop(while_loop) => handle_while_loop(while_loop, tokens),
         TypedAstNodeContent::SideEffect => (),
     };
@@ -36,135 +35,220 @@ fn to_ident_key(ident: &Ident) -> (Ident, Span) {
 fn handle_declaration(declaration: &TypedDeclaration, tokens: &mut TokenMap) {
     match declaration {
         TypedDeclaration::VariableDeclaration(variable) => {
-            tokens.insert(to_ident_key(&variable.name), TokenType::TypedDeclaration(declaration.clone()));
+            tokens.insert(
+                to_ident_key(&variable.name),
+                TokenType::TypedDeclaration(declaration.clone()),
+            );
             handle_expression(&variable.body, tokens);
         }
         TypedDeclaration::ConstantDeclaration(const_decl) => {
-            tokens.insert(to_ident_key(&const_decl.name), TokenType::TypedDeclaration(declaration.clone()));
+            tokens.insert(
+                to_ident_key(&const_decl.name),
+                TokenType::TypedDeclaration(declaration.clone()),
+            );
             handle_expression(&const_decl.value, tokens);
         }
         TypedDeclaration::FunctionDeclaration(func) => {
-            tokens.insert(to_ident_key(&func.name), TokenType::TypedFunctionDeclaration(func.clone()));
+            tokens.insert(
+                to_ident_key(&func.name),
+                TokenType::TypedFunctionDeclaration(func.clone()),
+            );
             for node in &func.body.contents {
                 traverse_node(node, tokens);
             }
             for parameter in &func.parameters {
-                tokens.insert(to_ident_key(&parameter.name), TokenType::TypedFunctionParameter(parameter.clone()));
+                tokens.insert(
+                    to_ident_key(&parameter.name),
+                    TokenType::TypedFunctionParameter(parameter.clone()),
+                );
             }
         }
         TypedDeclaration::TraitDeclaration(trait_decl) => {
-            tokens.insert(to_ident_key(&trait_decl.name), TokenType::TypedDeclaration(declaration.clone()));
+            tokens.insert(
+                to_ident_key(&trait_decl.name),
+                TokenType::TypedDeclaration(declaration.clone()),
+            );
             for train_fn in &trait_decl.interface_surface {
-                tokens.insert(to_ident_key(&train_fn.name), TokenType::TypedTraitFn(train_fn.clone()));
+                tokens.insert(
+                    to_ident_key(&train_fn.name),
+                    TokenType::TypedTraitFn(train_fn.clone()),
+                );
             }
         }
         TypedDeclaration::StructDeclaration(struct_dec) => {
-            tokens.insert(to_ident_key(&struct_dec.name), TokenType::TypedDeclaration(declaration.clone()));
+            tokens.insert(
+                to_ident_key(&struct_dec.name),
+                TokenType::TypedDeclaration(declaration.clone()),
+            );
             for field in &struct_dec.fields {
-                tokens.insert(to_ident_key(&field.name), TokenType::TypedStructField(field.clone()));
+                tokens.insert(
+                    to_ident_key(&field.name),
+                    TokenType::TypedStructField(field.clone()),
+                );
             }
         }
         TypedDeclaration::EnumDeclaration(enum_decl) => {
-            tokens.insert(to_ident_key(&enum_decl.name), TokenType::TypedDeclaration(declaration.clone()));
+            tokens.insert(
+                to_ident_key(&enum_decl.name),
+                TokenType::TypedDeclaration(declaration.clone()),
+            );
             for variant in &enum_decl.variants {
-                tokens.insert(to_ident_key(&variant.name), TokenType::TypedEnumVariant(variant.clone()));
+                tokens.insert(
+                    to_ident_key(&variant.name),
+                    TokenType::TypedEnumVariant(variant.clone()),
+                );
             }
-        }  
+        }
         TypedDeclaration::Reassignment(reassignment) => {
             handle_expression(&reassignment.rhs, tokens);
             for lhs in &reassignment.lhs {
-                tokens.insert(to_ident_key(&lhs.name), TokenType::ReassignmentLhs(lhs.clone()));
+                tokens.insert(
+                    to_ident_key(&lhs.name),
+                    TokenType::ReassignmentLhs(lhs.clone()),
+                );
             }
-        }  
-        TypedDeclaration::ImplTrait{trait_name, methods, ..} => {
+        }
+        TypedDeclaration::ImplTrait {
+            trait_name,
+            methods,
+            ..
+        } => {
             for ident in &trait_name.prefixes {
-                tokens.insert(to_ident_key(&ident), TokenType::TypedDeclaration(declaration.clone()));
+                tokens.insert(
+                    to_ident_key(ident),
+                    TokenType::TypedDeclaration(declaration.clone()),
+                );
             }
             // This is reporting the train name as r#Self and not the actual name
-            // Also the span is referencing the declerations span. 
+            // Also the span is referencing the declerations span.
             //tokens.insert(to_ident_key(&trait_name.suffix), TokenType::TypedDeclaration(declaration.clone()));
 
             for method in methods {
-                tokens.insert(to_ident_key(&method.name), TokenType::TypedFunctionDeclaration(method.clone()));
+                tokens.insert(
+                    to_ident_key(&method.name),
+                    TokenType::TypedFunctionDeclaration(method.clone()),
+                );
                 for node in &method.body.contents {
                     traverse_node(node, tokens);
                 }
                 for paramater in &method.parameters {
-                    tokens.insert(to_ident_key(&paramater.name), TokenType::TypedFunctionParameter(paramater.clone()));
+                    tokens.insert(
+                        to_ident_key(&paramater.name),
+                        TokenType::TypedFunctionParameter(paramater.clone()),
+                    );
                 }
             }
-        }  
+        }
         TypedDeclaration::AbiDeclaration(abi_decl) => {
-            tokens.insert(to_ident_key(&abi_decl.name), TokenType::TypedDeclaration(declaration.clone()));
+            tokens.insert(
+                to_ident_key(&abi_decl.name),
+                TokenType::TypedDeclaration(declaration.clone()),
+            );
             for trait_fn in &abi_decl.interface_surface {
-                tokens.insert(to_ident_key(&trait_fn.name), TokenType::TypedTraitFn(trait_fn.clone()));
+                tokens.insert(
+                    to_ident_key(&trait_fn.name),
+                    TokenType::TypedTraitFn(trait_fn.clone()),
+                );
             }
-        }  
-        TypedDeclaration::GenericTypeForFunctionScope{name} => {
-            tokens.insert(to_ident_key(&name), TokenType::TypedDeclaration(declaration.clone()));
-        }  
-        TypedDeclaration::ErrorRecovery => {}  
+        }
+        TypedDeclaration::GenericTypeForFunctionScope { name } => {
+            tokens.insert(
+                to_ident_key(name),
+                TokenType::TypedDeclaration(declaration.clone()),
+            );
+        }
+        TypedDeclaration::ErrorRecovery => {}
         TypedDeclaration::StorageDeclaration(storage_decl) => {
             for field in &storage_decl.fields {
-                tokens.insert(to_ident_key(&field.name), TokenType::TypedStorageField(field.clone()));
+                tokens.insert(
+                    to_ident_key(&field.name),
+                    TokenType::TypedStorageField(field.clone()),
+                );
             }
-        }  
-        TypedDeclaration::StorageReassignment(storage_reassignment) => { 
+        }
+        TypedDeclaration::StorageReassignment(storage_reassignment) => {
             for field in &storage_reassignment.fields {
-                tokens.insert(to_ident_key(&field.name), TokenType::TypeCheckedStorageReassignDescriptor(field.clone()));
+                tokens.insert(
+                    to_ident_key(&field.name),
+                    TokenType::TypeCheckedStorageReassignDescriptor(field.clone()),
+                );
             }
             handle_expression(&storage_reassignment.rhs, tokens);
-        }        
+        }
     }
 }
 
 fn handle_expression(expression: &TypedExpression, tokens: &mut TokenMap) {
     match &expression.expression {
-        TypedExpressionVariant::Literal{..} => {}
-        TypedExpressionVariant::FunctionApplication{name, contract_call_params, arguments,function_body, ..} => {
+        TypedExpressionVariant::Literal { .. } => {}
+        TypedExpressionVariant::FunctionApplication {
+            name,
+            contract_call_params,
+            arguments,
+            function_body,
+            ..
+        } => {
             for ident in &name.prefixes {
-                tokens.insert(to_ident_key(&ident), TokenType::TypedExpression(expression.clone()));
+                tokens.insert(
+                    to_ident_key(ident),
+                    TokenType::TypedExpression(expression.clone()),
+                );
             }
-            tokens.insert(to_ident_key(&name.suffix), TokenType::TypedExpression(expression.clone()));
+            tokens.insert(
+                to_ident_key(&name.suffix),
+                TokenType::TypedExpression(expression.clone()),
+            );
 
             for exp in contract_call_params.values() {
-                handle_expression(&exp, tokens);
+                handle_expression(exp, tokens);
             }
 
             for (ident, exp) in arguments {
-                tokens.insert(to_ident_key(&ident), TokenType::TypedExpression(exp.clone()));
-                handle_expression(&exp, tokens);
+                tokens.insert(to_ident_key(ident), TokenType::TypedExpression(exp.clone()));
+                handle_expression(exp, tokens);
             }
 
             for node in &function_body.contents {
                 traverse_node(node, tokens);
             }
         }
-        TypedExpressionVariant::LazyOperator{lhs, rhs,..} => {
+        TypedExpressionVariant::LazyOperator { lhs, rhs, .. } => {
             handle_expression(lhs, tokens);
             handle_expression(rhs, tokens);
         }
-        TypedExpressionVariant::VariableExpression{ ref name } => {
-            tokens.insert(to_ident_key(&name), TokenType::TypedExpression(expression.clone()));
+        TypedExpressionVariant::VariableExpression { ref name } => {
+            tokens.insert(
+                to_ident_key(name),
+                TokenType::TypedExpression(expression.clone()),
+            );
         }
-        TypedExpressionVariant::Tuple{fields} => {
+        TypedExpressionVariant::Tuple { fields } => {
             for exp in fields {
-                handle_expression(&exp, tokens);
-            }   
-        }
-        TypedExpressionVariant::Array{ contents } => {
-            for exp in contents {
-                handle_expression(&exp, tokens);
+                handle_expression(exp, tokens);
             }
         }
-        TypedExpressionVariant::ArrayIndex{prefix, index} => {
+        TypedExpressionVariant::Array { contents } => {
+            for exp in contents {
+                handle_expression(exp, tokens);
+            }
+        }
+        TypedExpressionVariant::ArrayIndex { prefix, index } => {
             handle_expression(prefix, tokens);
             handle_expression(index, tokens);
-        } 
-        TypedExpressionVariant::StructExpression{ ref struct_name, ref fields } => { 
-            tokens.insert(to_ident_key(&struct_name), TokenType::TypedExpression(expression.clone()));
-            for field in fields { 
-                tokens.insert(to_ident_key(&field.name), TokenType::TypedExpression(field.value.clone()));
+        }
+        TypedExpressionVariant::StructExpression {
+            ref struct_name,
+            ref fields,
+        } => {
+            tokens.insert(
+                to_ident_key(struct_name),
+                TokenType::TypedExpression(expression.clone()),
+            );
+            for field in fields {
+                tokens.insert(
+                    to_ident_key(&field.name),
+                    TokenType::TypedExpression(field.value.clone()),
+                );
                 handle_expression(&field.value, tokens);
             }
         }
@@ -173,23 +257,47 @@ fn handle_expression(expression: &TypedExpression, tokens: &mut TokenMap) {
                 traverse_node(node, tokens);
             }
         }
-        TypedExpressionVariant::FunctionParameter{..} => {}
-        TypedExpressionVariant::IfExp{condition, then, r#else} => {
+        TypedExpressionVariant::FunctionParameter { .. } => {}
+        TypedExpressionVariant::IfExp {
+            condition,
+            then,
+            r#else,
+        } => {
             handle_expression(condition, tokens);
             handle_expression(then, tokens);
             if let Some(r#else) = r#else {
                 handle_expression(r#else, tokens);
             }
         }
-        TypedExpressionVariant::AsmExpression{..} => {}
-        TypedExpressionVariant::StructFieldAccess{prefix, field_to_access, ..} => {
+        TypedExpressionVariant::AsmExpression { .. } => {}
+        TypedExpressionVariant::StructFieldAccess {
+            prefix,
+            field_to_access,
+            ..
+        } => {
             handle_expression(prefix, tokens);
-            tokens.insert(to_ident_key(&field_to_access.name), TokenType::TypedExpression(expression.clone()));
+            tokens.insert(
+                to_ident_key(&field_to_access.name),
+                TokenType::TypedExpression(expression.clone()),
+            );
         }
-        TypedExpressionVariant::IfLet{expr, variant, variable_to_assign, then, r#else, ..} => {
-            handle_expression(&expr, tokens);
-            tokens.insert(to_ident_key(&variant.name), TokenType::TypedExpression(expression.clone()));
-            tokens.insert(to_ident_key(&variable_to_assign), TokenType::TypedExpression(expression.clone()));
+        TypedExpressionVariant::IfLet {
+            expr,
+            variant,
+            variable_to_assign,
+            then,
+            r#else,
+            ..
+        } => {
+            handle_expression(expr, tokens);
+            tokens.insert(
+                to_ident_key(&variant.name),
+                TokenType::TypedExpression(expression.clone()),
+            );
+            tokens.insert(
+                to_ident_key(variable_to_assign),
+                TokenType::TypedExpression(expression.clone()),
+            );
             for node in &then.contents {
                 traverse_node(node, tokens);
             }
@@ -197,27 +305,38 @@ fn handle_expression(expression: &TypedExpression, tokens: &mut TokenMap) {
                 handle_expression(r#else, tokens);
             }
         }
-        TypedExpressionVariant::TupleElemAccess{prefix, ..} => {
+        TypedExpressionVariant::TupleElemAccess { prefix, .. } => {
             handle_expression(prefix, tokens);
         }
-        TypedExpressionVariant::EnumInstantiation{..} => {}
-        TypedExpressionVariant::AbiCast{abi_name, address, ..} => {
+        TypedExpressionVariant::EnumInstantiation { .. } => {}
+        TypedExpressionVariant::AbiCast {
+            abi_name, address, ..
+        } => {
             for ident in &abi_name.prefixes {
-                tokens.insert(to_ident_key(&ident), TokenType::TypedExpression(expression.clone()));
+                tokens.insert(
+                    to_ident_key(ident),
+                    TokenType::TypedExpression(expression.clone()),
+                );
             }
-            tokens.insert(to_ident_key(&abi_name.suffix), TokenType::TypedExpression(expression.clone()));
+            tokens.insert(
+                to_ident_key(&abi_name.suffix),
+                TokenType::TypedExpression(expression.clone()),
+            );
             handle_expression(address, tokens);
         }
         TypedExpressionVariant::StorageAccess(storage_access) => {
             for field in &storage_access.fields {
-                tokens.insert(to_ident_key(&field.name), TokenType::TypedExpression(expression.clone()));
+                tokens.insert(
+                    to_ident_key(&field.name),
+                    TokenType::TypedExpression(expression.clone()),
+                );
             }
         }
-        TypedExpressionVariant::TypeProperty{..} => {}
-        TypedExpressionVariant::SizeOfValue{expr} => {
+        TypedExpressionVariant::TypeProperty { .. } => {}
+        TypedExpressionVariant::SizeOfValue { expr } => {
             handle_expression(expr, tokens);
         }
-        TypedExpressionVariant::AbiName{..} => {}
+        TypedExpressionVariant::AbiName { .. } => {}
     }
 }
 
@@ -230,41 +349,19 @@ fn handle_while_loop(while_loop: &TypedWhileLoop, tokens: &mut TokenMap) {
 
 pub fn get_type_id(token: &TokenType) -> Option<TypeId> {
     match token {
-        TokenType::TypedDeclaration(dec) => {
-            match dec {
-                TypedDeclaration::VariableDeclaration(var_decl) => {
-                    Some(var_decl.type_ascription)
-                },
-                TypedDeclaration::ConstantDeclaration(const_decl) => {
-                    Some(const_decl.value.return_type)
-                },
-                _ => None,
-            }
-        }
-        TokenType::TypedExpression(exp) => {
-            Some(exp.return_type)
-        }
-        TokenType::TypedFunctionParameter(func_param) => {
-            Some(func_param.r#type)
-        }
-        TokenType::TypedStructField(struct_field) => {
-            Some(struct_field.r#type)
-        }
-        TokenType::TypedEnumVariant(enum_var) => {
-            Some(enum_var.r#type)
-        }
-        TokenType::TypedTraitFn(trait_fn) => {
-            Some(trait_fn.return_type)
-        }
-        TokenType::TypedStorageField(storage_field) => {
-            Some(storage_field.r#type)
-        }
-        TokenType::TypeCheckedStorageReassignDescriptor(storage_desc) => {
-            Some(storage_desc.r#type)
-        }
-        TokenType::ReassignmentLhs(lhs) => {
-            Some(lhs.r#type)
-        }
+        TokenType::TypedDeclaration(dec) => match dec {
+            TypedDeclaration::VariableDeclaration(var_decl) => Some(var_decl.type_ascription),
+            TypedDeclaration::ConstantDeclaration(const_decl) => Some(const_decl.value.return_type),
+            _ => None,
+        },
+        TokenType::TypedExpression(exp) => Some(exp.return_type),
+        TokenType::TypedFunctionParameter(func_param) => Some(func_param.r#type),
+        TokenType::TypedStructField(struct_field) => Some(struct_field.r#type),
+        TokenType::TypedEnumVariant(enum_var) => Some(enum_var.r#type),
+        TokenType::TypedTraitFn(trait_fn) => Some(trait_fn.return_type),
+        TokenType::TypedStorageField(storage_field) => Some(storage_field.r#type),
+        TokenType::TypeCheckedStorageReassignDescriptor(storage_desc) => Some(storage_desc.r#type),
+        TokenType::ReassignmentLhs(lhs) => Some(lhs.r#type),
         _ => None,
     }
 }

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -1,0 +1,280 @@
+use std::{
+    collections::HashMap,
+};
+use sway_types::{
+    ident::Ident,
+    span::Span,
+};
+use sway_core::semantic_analysis::ast_node::{
+    {TypedAstNode, TypedAstNodeContent, TypedDeclaration},
+    expression::{
+        typed_expression::TypedExpression,
+        typed_expression_variant::TypedExpressionVariant,
+    },
+    while_loop::TypedWhileLoop,
+};
+use sway_core::type_engine::TypeId;
+use sway_core::parse_tree::literal::Literal;
+use tower_lsp::lsp_types::{Position, Range, SymbolKind};
+
+pub fn traverse_node(node: &TypedAstNode, tokens: &mut HashMap<Ident, TypedAstNodeContent>) {
+    match &node.content {
+        TypedAstNodeContent::ReturnStatement(return_statement) => handle_expression(&return_statement.expr, tokens),
+        TypedAstNodeContent::Declaration(declaration) => handle_declaration(declaration, tokens),
+        TypedAstNodeContent::Expression(expression) => handle_expression(expression, tokens),
+        TypedAstNodeContent::ImplicitReturnExpression(expression) => handle_expression(expression, tokens),
+        TypedAstNodeContent::WhileLoop(while_loop) => handle_while_loop(while_loop, tokens),
+        TypedAstNodeContent::SideEffect => (),
+    };
+}
+
+fn handle_declaration(declaration: &TypedDeclaration, tokens: &mut HashMap<Ident, TypedAstNodeContent>) {
+    match declaration {
+        TypedDeclaration::VariableDeclaration(variable) => {
+            tokens.insert(variable.name.clone(), TypedAstNodeContent::Declaration(declaration.clone()));
+            handle_expression(&variable.body, tokens);
+        }
+        TypedDeclaration::ConstantDeclaration(const_decl) => {
+            tokens.insert(const_decl.name.clone(), TypedAstNodeContent::Declaration(declaration.clone()));
+            handle_expression(&const_decl.value, tokens);
+        }
+        TypedDeclaration::FunctionDeclaration(func) => {
+            tokens.insert(func.name.clone(), TypedAstNodeContent::Declaration(declaration.clone()));
+            for node in &func.body.contents {
+                traverse_node(node, tokens);
+            }
+        }
+        TypedDeclaration::TraitDeclaration(trait_decl) => {
+            tokens.insert(trait_decl.name.clone(), TypedAstNodeContent::Declaration(declaration.clone()));
+        }
+        TypedDeclaration::StructDeclaration(struct_dec) => {
+            tokens.insert(struct_dec.name.clone(), TypedAstNodeContent::Declaration(declaration.clone()));
+            for field in &struct_dec.fields {
+                tokens.insert(field.name.clone(), TypedAstNodeContent::Declaration(declaration.clone()));
+            }
+        }
+        TypedDeclaration::EnumDeclaration(enum_decl) => {
+            tokens.insert(enum_decl.name.clone(), TypedAstNodeContent::Declaration(declaration.clone()));
+            for variant in &enum_decl.variants {
+                tokens.insert(variant.name.clone(), TypedAstNodeContent::Declaration(declaration.clone()));
+            }
+        }  
+        TypedDeclaration::Reassignment(reassignment) => {
+            handle_expression(&reassignment.rhs, tokens);
+            for lhs in &reassignment.lhs {
+                tokens.insert(lhs.name.clone(), TypedAstNodeContent::Declaration(declaration.clone()));
+            }
+        }  
+        TypedDeclaration::ImplTrait{..} => {}  
+        TypedDeclaration::AbiDeclaration(abi_decl) => {}  
+        TypedDeclaration::GenericTypeForFunctionScope{name} => {
+            tokens.insert(name.clone(), TypedAstNodeContent::Declaration(declaration.clone()));
+        }  
+        TypedDeclaration::ErrorRecovery => {}  
+        TypedDeclaration::StorageDeclaration(storage_decl) => {
+            for field in &storage_decl.fields {
+                tokens.insert(field.name.clone(), TypedAstNodeContent::Declaration(declaration.clone()));
+            }
+        }  
+        TypedDeclaration::StorageReassignment(storage_reassignment) => {
+            for ident in &storage_reassignment.names() {
+                tokens.insert(ident.clone(), TypedAstNodeContent::Declaration(declaration.clone()));
+            }
+            handle_expression(&storage_reassignment.rhs, tokens);
+        }        
+    }
+}
+
+fn handle_expression(expression: &TypedExpression, tokens: &mut HashMap<Ident, TypedAstNodeContent>) {
+    match &expression.expression {
+        TypedExpressionVariant::Literal{..} => {}
+        TypedExpressionVariant::FunctionApplication{name, contract_call_params, arguments,function_body, ..} => {
+            for ident in &name.prefixes {
+                tokens.insert(ident.clone(), TypedAstNodeContent::Expression(expression.clone()));
+            }
+            tokens.insert(name.suffix.clone(), TypedAstNodeContent::Expression(expression.clone()));
+
+            for exp in contract_call_params.values() {
+                handle_expression(&exp, tokens);
+            }
+
+            for (ident, exp) in arguments {
+                tokens.insert(ident.clone(), TypedAstNodeContent::Expression(exp.clone()));
+            }
+
+            for node in &function_body.contents {
+                traverse_node(node, tokens);
+            }
+        }
+        TypedExpressionVariant::LazyOperator{lhs, rhs,..} => {
+            handle_expression(lhs, tokens);
+            handle_expression(rhs, tokens);
+        }
+        TypedExpressionVariant::VariableExpression{ ref name } => {
+            tokens.insert(name.clone(), TypedAstNodeContent::Expression(expression.clone()));
+        }
+        TypedExpressionVariant::Tuple{fields} => {
+            for exp in fields {
+                handle_expression(&exp, tokens);
+            }   
+        }
+        TypedExpressionVariant::Array{ contents } => {
+            for exp in contents {
+                handle_expression(&exp, tokens);
+            }
+        }
+        TypedExpressionVariant::ArrayIndex{prefix, index} => {
+            handle_expression(prefix, tokens);
+            handle_expression(index, tokens);
+        } 
+        TypedExpressionVariant::StructExpression{ ref struct_name, ref fields } => { 
+            tokens.insert(struct_name.clone(), TypedAstNodeContent::Expression(expression.clone()));
+            for field in fields { 
+                tokens.insert(field.name.clone(), TypedAstNodeContent::Expression(field.value.clone()));
+            }
+        }
+        TypedExpressionVariant::CodeBlock(code_block) => {
+            for node in &code_block.contents {
+                traverse_node(node, tokens);
+            }
+        }
+        TypedExpressionVariant::FunctionParameter{..} => {}
+        TypedExpressionVariant::IfExp{condition, then, r#else} => {
+            handle_expression(condition, tokens);
+            handle_expression(then, tokens);
+            if let Some(r#else) = r#else {
+                handle_expression(r#else, tokens);
+            }
+        }
+        TypedExpressionVariant::AsmExpression{..} => {}
+        TypedExpressionVariant::StructFieldAccess{prefix, field_to_access, ..} => {
+            handle_expression(prefix, tokens);
+            tokens.insert(field_to_access.name.clone(), TypedAstNodeContent::Expression(expression.clone()));
+        }
+        TypedExpressionVariant::IfLet{expr, variant, variable_to_assign, then, r#else, ..} => {
+            handle_expression(&expr, tokens);
+            tokens.insert(variant.name.clone(), TypedAstNodeContent::Expression(expression.clone()));
+            tokens.insert(variable_to_assign.clone(), TypedAstNodeContent::Expression(expression.clone()));
+            for node in &then.contents {
+                traverse_node(node, tokens);
+            }
+            if let Some(r#else) = r#else {
+                handle_expression(r#else, tokens);
+            }
+        }
+        TypedExpressionVariant::TupleElemAccess{prefix, ..} => {
+            handle_expression(prefix, tokens);
+        }
+        TypedExpressionVariant::EnumInstantiation{..} => {}
+        TypedExpressionVariant::AbiCast{abi_name, address, ..} => {
+            for ident in &abi_name.prefixes {
+                tokens.insert(ident.clone(), TypedAstNodeContent::Expression(expression.clone()));
+            }
+            tokens.insert(abi_name.suffix.clone(), TypedAstNodeContent::Expression(expression.clone()));
+            handle_expression(address, tokens);
+        }
+        TypedExpressionVariant::StorageAccess(storage_access) => {
+            for field in &storage_access.fields {
+                tokens.insert(field.name.clone(), TypedAstNodeContent::Expression(expression.clone()));
+            }
+        }
+        TypedExpressionVariant::TypeProperty{..} => {}
+        TypedExpressionVariant::SizeOfValue{expr} => {
+            handle_expression(expr, tokens);
+        }
+        TypedExpressionVariant::AbiName{..} => {}
+    }
+}
+
+fn handle_while_loop(while_loop: &TypedWhileLoop, tokens: &mut HashMap<Ident, TypedAstNodeContent>) {
+    handle_expression(&while_loop.condition, tokens);
+    for node in &while_loop.body.contents {
+        traverse_node(node, tokens);
+    }
+}
+
+pub fn type_id(typed_ast_node: &TypedAstNodeContent) -> TypeId {
+    match typed_ast_node {
+        TypedAstNodeContent::Declaration(dec) => {
+            match dec {
+                TypedDeclaration::VariableDeclaration(var_decl) => {
+                    var_decl.type_ascription
+                },
+                TypedDeclaration::ConstantDeclaration(const_decl) => {
+                    const_decl.value.return_type
+                },
+                _ => todo!(),
+            }
+        }
+        TypedAstNodeContent::Expression(exp) => {
+            exp.return_type
+        }
+        _ => todo!(),
+    }
+}
+
+fn to_symbol_kind(typed_ast_node: &TypedAstNodeContent) -> SymbolKind {
+    match typed_ast_node {
+        TypedAstNodeContent::Declaration(dec) => {
+            match dec {
+                TypedDeclaration::VariableDeclaration(_) => SymbolKind::VARIABLE,
+                TypedDeclaration::ConstantDeclaration(_) => SymbolKind::CONSTANT,
+                TypedDeclaration::FunctionDeclaration(_) => SymbolKind::FUNCTION,
+                TypedDeclaration::StructDeclaration(_) => SymbolKind::STRUCT,
+                TypedDeclaration::EnumDeclaration(_) => SymbolKind::ENUM,
+                TypedDeclaration::Reassignment(_) => SymbolKind::OPERATOR,
+                TypedDeclaration::ImplTrait{..} => SymbolKind::INTERFACE,
+                TypedDeclaration::AbiDeclaration(_) => SymbolKind::INTERFACE,
+                TypedDeclaration::GenericTypeForFunctionScope{..} => SymbolKind::TYPE_PARAMETER,
+                // currently we return `variable` type as default
+                _ => SymbolKind::VARIABLE,
+            }
+        }
+        TypedAstNodeContent::Expression(exp) => {
+            match &exp.expression {
+                TypedExpressionVariant::Literal(lit) => {
+                    match lit {
+                        Literal::String(_) => SymbolKind::STRING,
+                        Literal::Boolean(_) => SymbolKind::BOOLEAN,
+                        _ => SymbolKind::NUMBER,
+                    }
+                }
+                TypedExpressionVariant::FunctionApplication{..} => SymbolKind::FUNCTION,
+                TypedExpressionVariant::VariableExpression{..} => SymbolKind::VARIABLE,
+                TypedExpressionVariant::Array{..} => SymbolKind::ARRAY,
+                TypedExpressionVariant::StructExpression{..} => SymbolKind::STRUCT,
+                TypedExpressionVariant::StructFieldAccess{..} => SymbolKind::FIELD,
+                // currently we return `variable` type as default
+                _ => SymbolKind::VARIABLE,
+            }
+        }
+        // currently we return `variable` type as default
+        _ => SymbolKind::VARIABLE,
+    }
+}
+
+pub fn ident_at_position<'a>(cursor_position: Position, tokens: &'a HashMap<Ident, TypedAstNodeContent>) -> Option<&'a Ident> {
+    for ident in tokens.keys() {
+        let range = get_range_from_span(ident.span());
+        if cursor_position >= range.start && cursor_position <= range.end {
+            return Some(ident);
+        }    
+    }
+    None
+}
+
+fn get_range_from_span(span: &Span) -> Range {
+    let start = span.start_pos().line_col();
+    let end = span.end_pos().line_col();
+
+    let start_line = start.0 as u32 - 1;
+    let start_character = start.1 as u32 - 1;
+
+    let end_line = end.0 as u32 - 1;
+    let end_character = end.1 as u32 - 1;
+
+    Range {
+        start: Position::new(start_line, start_character),
+        end: Position::new(end_line, end_character),
+    }
+}

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -18,6 +18,8 @@ use sway_core::type_engine::TypeId;
 use sway_core::parse_tree::literal::Literal;
 use tower_lsp::lsp_types::{Position, Range, SymbolKind};
 
+pub type TokenMap = HashMap<(Ident, Span), TokenType>;
+
 #[derive(Debug, Clone)]
 pub enum TokenType {
     TypedDeclaration(TypedDeclaration),
@@ -41,8 +43,6 @@ pub enum TokenType {
     TypeCheckedStorageReassignDescriptor(TypeCheckedStorageReassignDescriptor),
     ReassignmentLhs(ReassignmentLhs),
 }
-
-pub type TokenMap = HashMap<(Ident, Span), TokenType>;
 
 pub fn traverse_node(node: &TypedAstNode, tokens: &mut TokenMap) {
     match &node.content {
@@ -361,7 +361,7 @@ pub fn ident_and_span_at_position(cursor_position: Position, tokens: &TokenMap) 
     None
 }
 
-fn get_range_from_span(span: &Span) -> Range {
+pub fn get_range_from_span(span: &Span) -> Range {
     let start = span.start_pos().line_col();
     let end = span.end_pos().line_col();
 

--- a/sway-lsp/src/core/typed_token_type.rs
+++ b/sway-lsp/src/core/typed_token_type.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
-use sway_types::{Ident, Span};
-use sway_core::semantic_analysis::ast_node::{TypedDeclaration, TypedFunctionDeclaration, TypedFunctionParameter, TypedStructField, 
-    TypedEnumVariant, TypedTraitFn, TypedStorageField, TypeCheckedStorageReassignDescriptor, ReassignmentLhs,
-    expression::{
-        typed_expression::TypedExpression,
-    },
+use sway_core::semantic_analysis::ast_node::{
+    expression::typed_expression::TypedExpression, ReassignmentLhs,
+    TypeCheckedStorageReassignDescriptor, TypedDeclaration, TypedEnumVariant,
+    TypedFunctionDeclaration, TypedFunctionParameter, TypedStorageField, TypedStructField,
+    TypedTraitFn,
 };
+use sway_types::{Ident, Span};
 
 pub type TokenMap = HashMap<(Ident, Span), TokenType>;
 

--- a/sway-lsp/src/core/typed_token_type.rs
+++ b/sway-lsp/src/core/typed_token_type.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+use sway_types::{Ident, Span};
+use sway_core::semantic_analysis::ast_node::{TypedDeclaration, TypedFunctionDeclaration, TypedFunctionParameter, TypedStructField, 
+    TypedEnumVariant, TypedTraitFn, TypedStorageField, TypeCheckedStorageReassignDescriptor, ReassignmentLhs,
+    expression::{
+        typed_expression::TypedExpression,
+    },
+};
+
+pub type TokenMap = HashMap<(Ident, Span), TokenType>;
+
+#[derive(Debug, Clone)]
+pub enum TokenType {
+    TypedDeclaration(TypedDeclaration),
+    TypedExpression(TypedExpression),
+
+    TypedFunctionDeclaration(TypedFunctionDeclaration),
+    TypedFunctionParameter(TypedFunctionParameter),
+    TypedStructField(TypedStructField),
+    TypedEnumVariant(TypedEnumVariant),
+    TypedTraitFn(TypedTraitFn),
+    TypedStorageField(TypedStorageField),
+    TypeCheckedStorageReassignDescriptor(TypeCheckedStorageReassignDescriptor),
+    ReassignmentLhs(ReassignmentLhs),
+}

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -425,7 +425,7 @@ fn main() {
         let err = Response::from_error(1.into(), jsonrpc::Error::invalid_request());
         assert_eq!(response, Ok(Some(err)));
     }
-
+    
     #[tokio::test]
     async fn did_open() {
         let (mut service, mut messages) = LspService::new(|client| Backend::new(client, config()));

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -84,6 +84,7 @@ impl Backend {
         if self.config.parsed_tokens_as_warnings {
             if let Some(document) = self.session.documents.get(uri.path()) {
                 let diagnostics = debug::generate_warnings_for_parsed_tokens(document.get_tokens());
+                let diagnostics = debug::generate_warnings_for_typed_tokens(&document.token_map);
                 self.client
                     .publish_diagnostics(uri, diagnostics, None)
                     .await;

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -426,7 +426,7 @@ fn main() {
         let err = Response::from_error(1.into(), jsonrpc::Error::invalid_request());
         assert_eq!(response, Ok(Some(err)));
     }
-    
+
     #[tokio::test]
     async fn did_open() {
         let (mut service, mut messages) = LspService::new(|client| Backend::new(client, config()));

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -84,7 +84,7 @@ impl Backend {
         if self.config.parsed_tokens_as_warnings {
             if let Some(document) = self.session.documents.get(uri.path()) {
                 let diagnostics = debug::generate_warnings_for_parsed_tokens(document.get_tokens());
-                let diagnostics = debug::generate_warnings_for_typed_tokens(&document.token_map);
+                //let diagnostics = debug::generate_warnings_for_typed_tokens(&document.get_token_map());
                 self.client
                     .publish_diagnostics(uri, diagnostics, None)
                     .await;
@@ -427,39 +427,6 @@ fn main() {
         assert_eq!(response, Ok(Some(err)));
     }
     
-    const SWAY_PROGRAM2: &str = r#"script;
-
-//use std::*;
-    
-/// A simple Particle struct
-struct Particle {
-    position: [u64; 3],
-    velocity: [u64; 3],
-    acceleration: [u64; 3],
-    mass: u64,
-}
-
-impl Particle {
-    /// Creates a new Particle with the given position, velocity, acceleration, and mass
-    fn new(position: [u64; 3], velocity: [u64; 3], acceleration: [u64; 3], mass: u64) -> Particle {
-        Particle {
-            position: position,
-            velocity: velocity,
-            acceleration: acceleration,
-            mass: mass,
-        }
-    }
-}
-
-fn main() {
-    let position = [0, 0, 0];
-    let velocity = [0, 1, 0];
-    let acceleration = [1, 1, 0];
-    let mass = 10;
-    let p = ~Particle::new(position, velocity, acceleration, mass);
-}
-    "#;
-
     #[tokio::test]
     async fn did_open() {
         let (mut service, mut messages) = LspService::new(|client| Backend::new(client, config()));
@@ -473,10 +440,10 @@ fn main() {
         // ignore the "window/logMessage" notification: "Initializing the Sway Language Server"
         messages.next().await.unwrap();
 
-        let uri = load_test_sway_file(SWAY_PROGRAM2);
+        let uri = load_test_sway_file(SWAY_PROGRAM);
 
         // send "textDocument/didOpen" notification for `uri`
-        did_open_notification(&mut service, &uri, SWAY_PROGRAM2).await;
+        did_open_notification(&mut service, &uri, SWAY_PROGRAM).await;
 
         // ignore the "textDocument/publishDiagnostics" notification
         messages.next().await.unwrap();

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -252,7 +252,7 @@ mod tests {
     // Simple sway script used for testing LSP capabilites
     const SWAY_PROGRAM: &str = r#"script;
 
-use std::*;
+//use std::*;
 
 /// A simple Particle struct
 struct Particle {

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -427,6 +427,39 @@ fn main() {
         assert_eq!(response, Ok(Some(err)));
     }
     
+    const SWAY_PROGRAM2: &str = r#"script;
+
+//use std::*;
+    
+/// A simple Particle struct
+struct Particle {
+    position: [u64; 3],
+    velocity: [u64; 3],
+    acceleration: [u64; 3],
+    mass: u64,
+}
+
+impl Particle {
+    /// Creates a new Particle with the given position, velocity, acceleration, and mass
+    fn new(position: [u64; 3], velocity: [u64; 3], acceleration: [u64; 3], mass: u64) -> Particle {
+        Particle {
+            position: position,
+            velocity: velocity,
+            acceleration: acceleration,
+            mass: mass,
+        }
+    }
+}
+
+fn main() {
+    let position = [0, 0, 0];
+    let velocity = [0, 1, 0];
+    let acceleration = [1, 1, 0];
+    let mass = 10;
+    let p = ~Particle::new(position, velocity, acceleration, mass);
+}
+    "#;
+
     #[tokio::test]
     async fn did_open() {
         let (mut service, mut messages) = LspService::new(|client| Backend::new(client, config()));
@@ -440,10 +473,10 @@ fn main() {
         // ignore the "window/logMessage" notification: "Initializing the Sway Language Server"
         messages.next().await.unwrap();
 
-        let uri = load_test_sway_file(SWAY_PROGRAM);
+        let uri = load_test_sway_file(SWAY_PROGRAM2);
 
         // send "textDocument/didOpen" notification for `uri`
-        did_open_notification(&mut service, &uri, SWAY_PROGRAM).await;
+        did_open_notification(&mut service, &uri, SWAY_PROGRAM2).await;
 
         // ignore the "textDocument/publishDiagnostics" notification
         messages.next().await.unwrap();

--- a/sway-lsp/src/utils/common.rs
+++ b/sway-lsp/src/utils/common.rs
@@ -1,7 +1,7 @@
-use sway_core::{Expression, Literal, VariableDeclaration, Visibility};
-use sway_types::{Ident, Span};
 use crate::core::token_type::VarBody;
 use crate::core::typed_token_type::TokenMap;
+use sway_core::{Expression, Literal, VariableDeclaration, Visibility};
+use sway_types::{Ident, Span};
 use tower_lsp::lsp_types::{Position, Range};
 
 pub(crate) fn extract_visibility(visibility: &Visibility) -> String {
@@ -34,12 +34,15 @@ pub(crate) fn extract_var_body(var_dec: &VariableDeclaration) -> VarBody {
     }
 }
 
-pub(crate) fn ident_and_span_at_position(cursor_position: Position, tokens: &TokenMap) -> Option<(Ident, Span)> {
-    for (ident,span) in tokens.keys() {
+pub(crate) fn ident_and_span_at_position(
+    cursor_position: Position,
+    tokens: &TokenMap,
+) -> Option<(Ident, Span)> {
+    for (ident, span) in tokens.keys() {
         let range = get_range_from_span(span);
         if cursor_position >= range.start && cursor_position <= range.end {
             return Some((ident.clone(), span.clone()));
-        }    
+        }
     }
     None
 }

--- a/sway-lsp/src/utils/common.rs
+++ b/sway-lsp/src/utils/common.rs
@@ -1,7 +1,8 @@
-use sway_core::{Literal, VariableDeclaration, Visibility};
-
+use sway_core::{Expression, Literal, VariableDeclaration, Visibility};
+use sway_types::{Ident, Span};
 use crate::core::token_type::VarBody;
-use sway_core::Expression;
+use crate::core::typed_token_type::TokenMap;
+use tower_lsp::lsp_types::{Position, Range};
 
 pub(crate) fn extract_visibility(visibility: &Visibility) -> String {
     match visibility {
@@ -30,5 +31,31 @@ pub(crate) fn extract_var_body(var_dec: &VariableDeclaration) -> VarBody {
             Literal::B256(_) => VarBody::Type("b256".into()),
         },
         _ => VarBody::Other,
+    }
+}
+
+pub(crate) fn ident_and_span_at_position(cursor_position: Position, tokens: &TokenMap) -> Option<(Ident, Span)> {
+    for (ident,span) in tokens.keys() {
+        let range = get_range_from_span(span);
+        if cursor_position >= range.start && cursor_position <= range.end {
+            return Some((ident.clone(), span.clone()));
+        }    
+    }
+    None
+}
+
+pub(crate) fn get_range_from_span(span: &Span) -> Range {
+    let start = span.start_pos().line_col();
+    let end = span.end_pos().line_col();
+
+    let start_line = start.0 as u32 - 1;
+    let start_character = start.1 as u32 - 1;
+
+    let end_line = end.0 as u32 - 1;
+    let end_character = end.1 as u32 - 1;
+
+    Range {
+        start: Position::new(start_line, start_character),
+        end: Position::new(end_line, end_character),
     }
 }

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -1,6 +1,6 @@
 use crate::core::token::Token;
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
-
+use crate::core::traverse_typed_tree::{get_range_from_span, TokenMap};
 // Flags for debugging various parts of the server
 #[derive(Debug, Default)]
 pub struct DebugFlags {
@@ -16,6 +16,20 @@ pub fn generate_warnings_for_parsed_tokens(tokens: &[Token]) -> Vec<Diagnostic> 
             range: token.range,
             severity: Some(DiagnosticSeverity::WARNING),
             message: token.name.clone(),
+            ..Default::default()
+        })
+        .collect();
+
+    warnings
+}
+
+pub fn generate_warnings_for_typed_tokens(tokens: &TokenMap) -> Vec<Diagnostic> {
+    let warnings = tokens
+        .keys()
+        .map(|(ident, span)| Diagnostic {
+            range: get_range_from_span(span),
+            severity: Some(DiagnosticSeverity::WARNING),
+            message: ident.as_str().to_string(),
             ..Default::default()
         })
         .collect();

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -46,7 +46,8 @@ pub fn generate_warnings_for_typed_tokens(tokens: &TokenMap) -> Vec<Diagnostic> 
 pub fn debug_print_ident_and_token(ident: &Ident, token: &TokenType) {
     let pos = ident.span().start_pos().line_col();
     let line_num = pos.0 as u32;
-    eprintln!(
+
+    tracing::info!(
         "line num = {:?} | name: = {:?} | ast_node_type = {:?} | type_id = {:?}",
         line_num,
         ident.as_str(),

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -1,11 +1,11 @@
-use sway_types::Ident;
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 use crate::core::{
     token::Token,
-    typed_token_type::{TokenType, TokenMap},
-    traverse_typed_tree::get_type_id
+    traverse_typed_tree::get_type_id,
+    typed_token_type::{TokenMap, TokenType},
 };
 use crate::utils::common::get_range_from_span;
+use sway_types::Ident;
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
 // Flags for debugging various parts of the server
 #[derive(Debug, Default)]
@@ -44,45 +44,30 @@ pub fn generate_warnings_for_typed_tokens(tokens: &TokenMap) -> Vec<Diagnostic> 
 }
 
 pub fn debug_print_ident_and_token(ident: &Ident, token: &TokenType) {
-	let pos = ident.span().start_pos().line_col();
-	let line_num = pos.0 as u32;	
-    eprintln!("line num = {:?} | name: = {:?} | ast_node_type = {:?} | type_id = {:?}", 
+    let pos = ident.span().start_pos().line_col();
+    let line_num = pos.0 as u32;
+    eprintln!(
+        "line num = {:?} | name: = {:?} | ast_node_type = {:?} | type_id = {:?}",
         line_num,
         ident.as_str(),
-        ast_node_type(&token),
-        get_type_id(&token),
+        ast_node_type(token),
+        get_type_id(token),
     );
 }
 
 fn ast_node_type(token: &TokenType) -> String {
     match &token {
-        TokenType::TypedDeclaration(dec) => {
-            dec.friendly_name().to_string()
-        }
-        TokenType::TypedExpression(exp) => {
-            exp.expression.pretty_print()
-        }
-        TokenType::TypedFunctionParameter(_) => {
-            "function parameter".to_string()
-        }
-        TokenType::TypedStructField(_) => {
-            "struct field".to_string()
-        }
-        TokenType::TypedEnumVariant(_) => {
-            "enum variant".to_string()
-        }
-        TokenType::TypedTraitFn(_) => {
-            "trait function".to_string()
-        }
-        TokenType::TypedStorageField(_) => {
-            "storage field".to_string()
-        }
+        TokenType::TypedDeclaration(dec) => dec.friendly_name().to_string(),
+        TokenType::TypedExpression(exp) => exp.expression.pretty_print(),
+        TokenType::TypedFunctionParameter(_) => "function parameter".to_string(),
+        TokenType::TypedStructField(_) => "struct field".to_string(),
+        TokenType::TypedEnumVariant(_) => "enum variant".to_string(),
+        TokenType::TypedTraitFn(_) => "trait function".to_string(),
+        TokenType::TypedStorageField(_) => "storage field".to_string(),
         TokenType::TypeCheckedStorageReassignDescriptor(_) => {
             "storage reassignment descriptor".to_string()
         }
-        TokenType::ReassignmentLhs(_) => {
-            "reassignment lhs".to_string()
-        }        
-        _ => "".to_string()
+        TokenType::ReassignmentLhs(_) => "reassignment lhs".to_string(),
+        _ => "".to_string(),
     }
 }

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -1,6 +1,12 @@
-use crate::core::token::Token;
+use sway_types::Ident;
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
-use crate::core::traverse_typed_tree::{get_range_from_span, TokenMap};
+use crate::core::{
+    token::Token,
+    typed_token_type::{TokenType, TokenMap},
+    traverse_typed_tree::get_type_id
+};
+use crate::utils::common::get_range_from_span;
+
 // Flags for debugging various parts of the server
 #[derive(Debug, Default)]
 pub struct DebugFlags {
@@ -35,4 +41,48 @@ pub fn generate_warnings_for_typed_tokens(tokens: &TokenMap) -> Vec<Diagnostic> 
         .collect();
 
     warnings
+}
+
+pub fn debug_print_ident_and_token(ident: &Ident, token: &TokenType) {
+	let pos = ident.span().start_pos().line_col();
+	let line_num = pos.0 as u32;	
+    eprintln!("line num = {:?} | name: = {:?} | ast_node_type = {:?} | type_id = {:?}", 
+        line_num,
+        ident.as_str(),
+        ast_node_type(&token),
+        get_type_id(&token),
+    );
+}
+
+fn ast_node_type(token: &TokenType) -> String {
+    match &token {
+        TokenType::TypedDeclaration(dec) => {
+            dec.friendly_name().to_string()
+        }
+        TokenType::TypedExpression(exp) => {
+            exp.expression.pretty_print()
+        }
+        TokenType::TypedFunctionParameter(_) => {
+            "function parameter".to_string()
+        }
+        TokenType::TypedStructField(_) => {
+            "struct field".to_string()
+        }
+        TokenType::TypedEnumVariant(_) => {
+            "enum variant".to_string()
+        }
+        TokenType::TypedTraitFn(_) => {
+            "trait function".to_string()
+        }
+        TokenType::TypedStorageField(_) => {
+            "storage field".to_string()
+        }
+        TokenType::TypeCheckedStorageReassignDescriptor(_) => {
+            "storage reassignment descriptor".to_string()
+        }
+        TokenType::ReassignmentLhs(_) => {
+            "reassignment lhs".to_string()
+        }        
+        _ => "".to_string()
+    }
 }


### PR DESCRIPTION
This PR introduces the traversal of the `TypedParseTree` in order to collect tokens for the language server, but now with type information. We are extracting nearly all the tokens apart from a few struct reference tokens. The reason we are not collecting those currently is described in [this issue](https://github.com/FuelLabs/sway/issues/1773).

We aren't currently using any of the collected typed tokens, that work will be done in future PR's. Just wanted to put up the traversal and token collection work as it stands to keep the PR size down. 