### PR TITLE
Add additional operators as syntactic sugar

### DIFF
--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -1,3 +1,5 @@
+use sway_parse::expr::{ReassignmentOp, ReassignmentOpVariant};
+
 use {
     crate::{
         constants::{
@@ -1073,14 +1075,39 @@ fn expr_to_ast_node(
             span,
         },
         Expr::Reassignment {
-            assignable, expr, ..
-        } => AstNode {
-            content: AstNodeContent::Declaration(Declaration::Reassignment(Reassignment {
-                lhs: assignable_to_reassignment_target(ec, assignable)?,
-                rhs: expr_to_expression(ec, *expr)?,
-                span: span.clone(),
-            })),
-            span,
+            assignable,
+            expr,
+            reassignment_op:
+                ReassignmentOp {
+                    variant: op_variant,
+                    span: op_span,
+                },
+        } => match op_variant {
+            ReassignmentOpVariant::Equals => AstNode {
+                content: AstNodeContent::Declaration(Declaration::Reassignment(Reassignment {
+                    lhs: assignable_to_reassignment_target(ec, assignable)?,
+                    rhs: expr_to_expression(ec, *expr)?,
+                    span: span.clone(),
+                })),
+                span,
+            },
+            op_variant => {
+                let lhs = assignable_to_reassignment_target(ec, assignable.clone())?;
+                let rhs = binary_op_call(
+                    op_variant.core_name(),
+                    op_span,
+                    span.clone(),
+                    assignable_to_expression(ec, assignable)?,
+                    expr_to_expression(ec, *expr)?,
+                )?;
+                let content =
+                    AstNodeContent::Declaration(Declaration::Reassignment(Reassignment {
+                        lhs,
+                        rhs,
+                        span: span.clone(),
+                    }));
+                AstNode { content, span }
+            }
         },
         expr => {
             let expression = expr_to_expression(ec, expr)?;
@@ -1550,82 +1577,146 @@ fn expr_to_expression(ec: &mut ErrorContext, expr: Expr) -> Result<Expression, E
             lhs,
             star_token,
             rhs,
-        } => binary_op_call(ec, "multiply", star_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("multiply", star_token.span(), span, lhs, rhs)?
+        }
         Expr::Div {
             lhs,
             forward_slash_token,
             rhs,
-        } => binary_op_call(ec, "divide", forward_slash_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("divide", forward_slash_token.span(), span, lhs, rhs)?
+        }
         Expr::Modulo {
             lhs,
             percent_token,
             rhs,
-        } => binary_op_call(ec, "modulo", percent_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("modulo", percent_token.span(), span, lhs, rhs)?
+        }
         Expr::Add {
             lhs,
             add_token,
             rhs,
-        } => binary_op_call(ec, "add", add_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("add", add_token.span(), span, lhs, rhs)?
+        }
         Expr::Sub {
             lhs,
             sub_token,
             rhs,
-        } => binary_op_call(ec, "subtract", sub_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("subtract", sub_token.span(), span, lhs, rhs)?
+        }
         Expr::Shl {
             lhs,
             shl_token,
             rhs,
-        } => binary_op_call(ec, "lsh", shl_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("lsh", shl_token.span(), span, lhs, rhs)?
+        }
         Expr::Shr {
             lhs,
             shr_token,
             rhs,
-        } => binary_op_call(ec, "rsh", shr_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("rsh", shr_token.span(), span, lhs, rhs)?
+        }
         Expr::BitAnd {
             lhs,
             ampersand_token,
             rhs,
-        } => binary_op_call(ec, "binary_and", ampersand_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("binary_and", ampersand_token.span(), span, lhs, rhs)?
+        }
         Expr::BitXor {
             lhs,
             caret_token,
             rhs,
-        } => binary_op_call(ec, "binary_xor", caret_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("binary_xor", caret_token.span(), span, lhs, rhs)?
+        }
         Expr::BitOr {
             lhs,
             pipe_token,
             rhs,
-        } => binary_op_call(ec, "binary_or", pipe_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("binary_or", pipe_token.span(), span, lhs, rhs)?
+        }
         Expr::Equal {
             lhs,
             double_eq_token,
             rhs,
-        } => binary_op_call(ec, "eq", double_eq_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("eq", double_eq_token.span(), span, lhs, rhs)?
+        }
         Expr::NotEqual {
             lhs,
             bang_eq_token,
             rhs,
-        } => binary_op_call(ec, "neq", bang_eq_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("neq", bang_eq_token.span(), span, lhs, rhs)?
+        }
         Expr::LessThan {
             lhs,
             less_than_token,
             rhs,
-        } => binary_op_call(ec, "lt", less_than_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("lt", less_than_token.span(), span, lhs, rhs)?
+        }
         Expr::GreaterThan {
             lhs,
             greater_than_token,
             rhs,
-        } => binary_op_call(ec, "gt", greater_than_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("gt", greater_than_token.span(), span, lhs, rhs)?
+        }
         Expr::LessThanEq {
             lhs,
             less_than_eq_token,
             rhs,
-        } => binary_op_call(ec, "le", less_than_eq_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("le", less_than_eq_token.span(), span, lhs, rhs)?
+        }
         Expr::GreaterThanEq {
             lhs,
             greater_than_eq_token,
             rhs,
-        } => binary_op_call(ec, "ge", greater_than_eq_token.span(), span, *lhs, *rhs)?,
+        } => {
+            let lhs = expr_to_expression(ec, *lhs)?;
+            let rhs = expr_to_expression(ec, *rhs)?;
+            binary_op_call("ge", greater_than_eq_token.span(), span, lhs, rhs)?
+        }
         Expr::LogicalAnd { lhs, rhs, .. } => Expression::LazyOperator {
             op: LazyOp::And,
             lhs: Box::new(expr_to_expression(ec, *lhs)?),
@@ -1669,12 +1760,11 @@ fn unary_op_call(
 }
 
 fn binary_op_call(
-    ec: &mut ErrorContext,
     name: &'static str,
     op_span: Span,
     span: Span,
-    lhs: Expr,
-    rhs: Expr,
+    lhs: Expression,
+    rhs: Expression,
 ) -> Result<Expression, ErrorEmitted> {
     Ok(Expression::MethodApplication {
         method_name: MethodName::FromTrait {
@@ -1688,7 +1778,7 @@ fn binary_op_call(
             },
         },
         contract_call_params: Vec::new(),
-        arguments: vec![expr_to_expression(ec, lhs)?, expr_to_expression(ec, rhs)?],
+        arguments: vec![lhs, rhs],
         type_arguments: Vec::new(),
         span,
     })

--- a/sway-parse/src/keywords.rs
+++ b/sway-parse/src/keywords.rs
@@ -120,14 +120,19 @@ macro_rules! define_token (
 );
 
 define_token!(SemicolonToken, "a semicolon", [Semicolon], []);
-define_token!(ForwardSlashToken, "a forward slash", [ForwardSlash], []);
+define_token!(
+    ForwardSlashToken,
+    "a forward slash",
+    [ForwardSlash],
+    [Equals]
+);
 define_token!(
     DoubleColonToken,
     "a double colon (::)",
     [Colon, Colon],
     [Colon]
 );
-define_token!(StarToken, "an asterisk (*)", [Star], []);
+define_token!(StarToken, "an asterisk (*)", [Star], [Equals]);
 define_token!(CommaToken, "a comma", [Comma], []);
 define_token!(ColonToken, "a colon", [Colon], [Colon]);
 define_token!(
@@ -147,6 +152,12 @@ define_token!(OpenAngleBracketToken, "`<`", [LessThan], []);
 define_token!(CloseAngleBracketToken, "`>`", [GreaterThan], []);
 define_token!(TildeToken, "`~`", [Tilde], []);
 define_token!(EqToken, "`=`", [Equals], [GreaterThan, Equals]);
+define_token!(AddEqToken, "`+=`", [Add, Equals], []);
+define_token!(SubEqToken, "`-=`", [Sub, Equals], []);
+define_token!(StarEqToken, "`*=`", [Star, Equals], []);
+define_token!(DivEqToken, "`/=`", [ForwardSlash, Equals], []);
+define_token!(ShlEqToken, "`<<=`", [LessThan, LessThan, Equals], []);
+define_token!(ShrEqToken, "`>>=`", [GreaterThan, GreaterThan, Equals], []);
 define_token!(
     FatRightArrowToken,
     "`=>`",
@@ -156,8 +167,8 @@ define_token!(
 define_token!(DotToken, "`.`", [Dot], []);
 define_token!(BangToken, "`!`", [Bang], [Equals]);
 define_token!(PercentToken, "`%`", [Percent], []);
-define_token!(AddToken, "`+`", [Add], []);
-define_token!(SubToken, "`-`", [Sub], []);
+define_token!(AddToken, "`+`", [Add], [Equals]);
+define_token!(SubToken, "`-`", [Sub], [Equals]);
 define_token!(
     ShrToken,
     "`>>`",

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -396,6 +396,10 @@ pub fn run(filter_regex: Option<regex::Regex>) {
             "should_pass/language/generic_inside_generic",
             ProgramState::Return(7),
         ),
+        (
+            "should_pass/language/reassignment_operators",
+            ProgramState::Return(1),
+        ),
     ];
 
     let mut number_of_tests_run =

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/reassignment_operators/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/reassignment_operators/Forc.lock
@@ -1,0 +1,11 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'reassignment_operators'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/reassignment_operators/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/reassignment_operators/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "reassignment_operators"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/reassignment_operators/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/reassignment_operators/src/main.sw
@@ -1,0 +1,29 @@
+script;
+
+use std::assert::assert;
+
+fn main() -> u64 {
+    let mut a = 0;
+    
+    a += 99;
+    assert(a == 99);
+
+    a -= 5;
+    assert(a == 94);
+
+    a *= 2;
+    assert(a == 188);
+
+    a /= 47;
+    assert(a == 4);
+
+    a = 999;
+
+    a >>= 1;
+    assert(a == 499);
+
+    a <<= 2;
+    assert(a == 1996);
+
+    1
+}


### PR DESCRIPTION
This introduces the operators `+=`, `-=`, `*=`, `/=`, `<<=`, and `>>=`. They are implemented as syntactic sugar.

For example this:

```rust
let mut counter = 0;
while counter < 10 {
  counter += 1;
}
```

is desugared to this:

```rust
let mut counter = 0;
while counter < 10 {
  counter = counter + 1;
}
```

- Closes #1574