### PR TITLE
Tuple field reassignments

### DIFF
--- a/sway-core/src/optimize.rs
+++ b/sway-core/src/optimize.rs
@@ -1715,7 +1715,7 @@ impl FnCompiler {
             )),
         }?;
 
-        let field_kind = ReassignmentLhsKind::StructField {
+        let field_kind = ProjectionKind::StructField {
             name: ast_field.name.clone(),
         };
         let field_idx = match get_struct_name_and_field_index(struct_type_id, field_kind) {
@@ -2359,13 +2359,13 @@ impl LexicalMap {
 
 fn get_struct_name_and_field_index(
     field_type: TypeId,
-    field_kind: ReassignmentLhsKind,
+    field_kind: ProjectionKind,
 ) -> Option<(String, Option<u64>)> {
     let ty_info = resolve_type(field_type, &field_kind.span()).ok()?;
     match (ty_info, field_kind) {
         (
             TypeInfo::Struct { name, fields, .. },
-            ReassignmentLhsKind::StructField { name: field_name },
+            ProjectionKind::StructField { name: field_name },
         ) => Some((
             name.as_str().to_owned(),
             fields
@@ -2385,7 +2385,7 @@ fn get_struct_name_and_field_index(
 
 trait TypedNamedField {
     fn get_type(&self) -> TypeId;
-    fn get_field_kind(&self) -> ReassignmentLhsKind;
+    fn get_field_kind(&self) -> ProjectionKind;
 }
 
 macro_rules! impl_typed_named_field_for {
@@ -2394,8 +2394,8 @@ macro_rules! impl_typed_named_field_for {
             fn get_type(&self) -> TypeId {
                 self.r#type
             }
-            fn get_field_kind(&self) -> ReassignmentLhsKind {
-                ReassignmentLhsKind::StructField {
+            fn get_field_kind(&self) -> ProjectionKind {
+                ProjectionKind::StructField {
                     name: self.name.clone(),
                 }
             }
@@ -2407,7 +2407,7 @@ impl TypedNamedField for ReassignmentLhs {
     fn get_type(&self) -> TypeId {
         self.r#type
     }
-    fn get_field_kind(&self) -> ReassignmentLhsKind {
+    fn get_field_kind(&self) -> ProjectionKind {
         self.kind.clone()
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -500,16 +500,6 @@ impl PartialEq for ReassignmentLhs {
     }
 }
 
-impl ReassignmentLhs {
-    pub(crate) fn span(&self) -> Span {
-        self.kind.span()
-    }
-
-    pub(crate) fn pretty_print(&self) -> &str {
-        self.kind.pretty_print()
-    }
-}
-
 impl ProjectionKind {
     pub(crate) fn span(&self) -> Span {
         match self {
@@ -530,7 +520,7 @@ pub struct TypedReassignment {
     // at series of struct fields/array indices (array syntax)
     pub lhs_base_name: Ident,
     pub lhs_type: TypeId,
-    pub lhs_indices: Vec<ReassignmentLhs>,
+    pub lhs_indices: Vec<ProjectionKind>,
     pub rhs: TypedExpression,
 }
 
@@ -539,18 +529,5 @@ impl CopyTypes for TypedReassignment {
         self.rhs.copy_types(type_mapping);
         self.lhs_type
             .update_type(type_mapping, self.lhs_base_name.span());
-        self.lhs_indices.iter_mut().for_each(
-            |ReassignmentLhs {
-                 ref mut r#type,
-                 kind,
-                 ..
-             }| {
-                match kind {
-                    ProjectionKind::StructField { name } => {
-                        r#type.update_type(type_mapping, name.span());
-                    }
-                }
-            },
-        );
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -15,6 +15,7 @@ pub use variable::*;
 
 use crate::{error::*, parse_tree::*, semantic_analysis::*, type_engine::*, types::*};
 use derivative::Derivative;
+use std::borrow::Cow;
 use sway_types::{Ident, Span};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -342,8 +343,12 @@ impl TypedDeclaration {
                     lhs_indices,
                     ..
                 }) => {
-                    std::iter::once(lhs_base_name.as_str())
-                        .chain(lhs_indices.iter().flat_map(|x| [".", x.pretty_print()]))
+                    std::iter::once(Cow::Borrowed(lhs_base_name.as_str()))
+                        .chain(
+                            lhs_indices
+                                .iter()
+                                .flat_map(|x| [Cow::Borrowed("."), x.pretty_print()]),
+                        )
                         .collect::<String>()
                 }
                 _ => String::new(),
@@ -489,6 +494,7 @@ pub struct ReassignmentLhs {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ProjectionKind {
     StructField { name: Ident },
+    TupleField { index: usize, index_span: Span },
 }
 
 // NOTE: Hash and PartialEq must uphold the invariant:
@@ -504,12 +510,14 @@ impl ProjectionKind {
     pub(crate) fn span(&self) -> Span {
         match self {
             ProjectionKind::StructField { name } => name.span().clone(),
+            ProjectionKind::TupleField { index_span, .. } => index_span.clone(),
         }
     }
 
-    pub(crate) fn pretty_print(&self) -> &str {
+    pub(crate) fn pretty_print(&self) -> Cow<str> {
         match self {
-            ProjectionKind::StructField { name } => name.as_str(),
+            ProjectionKind::StructField { name } => Cow::Borrowed(name.as_str()),
+            ProjectionKind::TupleField { index, .. } => Cow::Owned(index.to_string()),
         }
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -482,12 +482,12 @@ impl TypedTraitFn {
 /// in asm generation.
 #[derive(Clone, Debug, Eq)]
 pub struct ReassignmentLhs {
-    pub kind: ReassignmentLhsKind,
+    pub kind: ProjectionKind,
     pub r#type: TypeId,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ReassignmentLhsKind {
+pub enum ProjectionKind {
     StructField { name: Ident },
 }
 
@@ -510,16 +510,16 @@ impl ReassignmentLhs {
     }
 }
 
-impl ReassignmentLhsKind {
+impl ProjectionKind {
     pub(crate) fn span(&self) -> Span {
         match self {
-            ReassignmentLhsKind::StructField { name } => name.span().clone(),
+            ProjectionKind::StructField { name } => name.span().clone(),
         }
     }
 
     pub(crate) fn pretty_print(&self) -> &str {
         match self {
-            ReassignmentLhsKind::StructField { name } => name.as_str(),
+            ProjectionKind::StructField { name } => name.as_str(),
         }
     }
 }
@@ -546,7 +546,7 @@ impl CopyTypes for TypedReassignment {
                  ..
              }| {
                 match kind {
-                    ReassignmentLhsKind::StructField { name } => {
+                    ProjectionKind::StructField { name } => {
                         r#type.update_type(type_mapping, name.span());
                     }
                 }

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -844,7 +844,9 @@ fn reassignment(
                                 ..
                             } => {
                                 names_vec.push(ReassignmentLhs {
-                                    name: field_to_access,
+                                    kind: ReassignmentLhsKind::StructField {
+                                        name: field_to_access,
+                                    },
                                     r#type: type_checked.return_type,
                                 });
                                 expr = *prefix;
@@ -858,18 +860,20 @@ fn reassignment(
 
                     let mut names_vec = names_vec.into_iter().rev().collect::<Vec<_>>();
                     names_vec.push(ReassignmentLhs {
-                        name: field_to_access,
+                        kind: ReassignmentLhsKind::StructField {
+                            name: field_to_access,
+                        },
                         r#type: final_return_type,
                     });
 
                     let (ty_of_field, _ty_of_parent) = check!(
                         namespace.find_subfield_type(
                             std::iter::once(base_name.clone())
-                                .chain(
-                                    names_vec
-                                        .iter()
-                                        .map(|ReassignmentLhs { name, .. }| name.clone())
-                                )
+                                .chain(names_vec.iter().map(|ReassignmentLhs { kind, .. }| {
+                                    match kind {
+                                        ReassignmentLhsKind::StructField { name } => name.clone(),
+                                    }
+                                }))
                                 .collect::<Vec<_>>()
                                 .as_slice()
                         ),

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -868,14 +868,11 @@ fn reassignment(
 
                     let (ty_of_field, _ty_of_parent) = check!(
                         namespace.find_subfield_type(
-                            std::iter::once(base_name.clone())
-                                .chain(names_vec.iter().map(|ReassignmentLhs { kind, .. }| {
-                                    match kind {
-                                        ProjectionKind::StructField { name } => name.clone(),
-                                    }
-                                }))
-                                .collect::<Vec<_>>()
-                                .as_slice()
+                            &base_name,
+                            &names_vec
+                                .iter()
+                                .map(|ReassignmentLhs { kind, .. }| kind.clone())
+                                .collect::<Vec<_>>(),
                         ),
                         return err(warnings, errors),
                         warnings,

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -844,7 +844,7 @@ fn reassignment(
                                 ..
                             } => {
                                 names_vec.push(ReassignmentLhs {
-                                    kind: ReassignmentLhsKind::StructField {
+                                    kind: ProjectionKind::StructField {
                                         name: field_to_access,
                                     },
                                     r#type: type_checked.return_type,
@@ -860,7 +860,7 @@ fn reassignment(
 
                     let mut names_vec = names_vec.into_iter().rev().collect::<Vec<_>>();
                     names_vec.push(ReassignmentLhs {
-                        kind: ReassignmentLhsKind::StructField {
+                        kind: ProjectionKind::StructField {
                             name: field_to_access,
                         },
                         r#type: final_return_type,
@@ -871,7 +871,7 @@ fn reassignment(
                             std::iter::once(base_name.clone())
                                 .chain(names_vec.iter().map(|ReassignmentLhs { kind, .. }| {
                                     match kind {
-                                        ReassignmentLhsKind::StructField { name } => name.clone(),
+                                        ProjectionKind::StructField { name } => name.clone(),
                                     }
                                 }))
                                 .collect::<Vec<_>>()

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -778,10 +778,9 @@ fn reassignment(
 
                     ok(
                         TypedDeclaration::Reassignment(TypedReassignment {
-                            lhs: vec![ReassignmentLhs {
-                                name: variable_decl.name,
-                                r#type: rhs_type_id,
-                            }],
+                            lhs_base_name: variable_decl.name,
+                            lhs_type: rhs_type_id,
+                            lhs_indices: vec![],
                             rhs,
                         }),
                         warnings,
@@ -795,7 +794,7 @@ fn reassignment(
                 } => {
                     let mut expr = *prefix;
                     let mut names_vec = vec![];
-                    let final_return_type = loop {
+                    let (base_name, final_return_type) = loop {
                         let type_checked = check!(
                             TypedExpression::type_check(TypeCheckArguments {
                                 checkee: expr.clone(),
@@ -837,11 +836,7 @@ fn reassignment(
                                         return err(warnings, errors);
                                     }
                                 }
-                                names_vec.push(ReassignmentLhs {
-                                    name,
-                                    r#type: type_checked.return_type,
-                                });
-                                break type_checked.return_type;
+                                break (name, type_checked.return_type);
                             }
                             Expression::SubfieldExpression {
                                 field_to_access,
@@ -869,9 +864,12 @@ fn reassignment(
 
                     let (ty_of_field, _ty_of_parent) = check!(
                         namespace.find_subfield_type(
-                            names_vec
-                                .iter()
-                                .map(|ReassignmentLhs { name, .. }| name.clone())
+                            std::iter::once(base_name.clone())
+                                .chain(
+                                    names_vec
+                                        .iter()
+                                        .map(|ReassignmentLhs { name, .. }| name.clone())
+                                )
                                 .collect::<Vec<_>>()
                                 .as_slice()
                         ),
@@ -897,7 +895,9 @@ fn reassignment(
 
                     ok(
                         TypedDeclaration::Reassignment(TypedReassignment {
-                            lhs: names_vec,
+                            lhs_base_name: base_name,
+                            lhs_type: final_return_type,
+                            lhs_indices: names_vec,
                             rhs,
                         }),
                         warnings,

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -843,11 +843,8 @@ fn reassignment(
                                 prefix,
                                 ..
                             } => {
-                                names_vec.push(ReassignmentLhs {
-                                    kind: ProjectionKind::StructField {
-                                        name: field_to_access,
-                                    },
-                                    r#type: type_checked.return_type,
+                                names_vec.push(ProjectionKind::StructField {
+                                    name: field_to_access,
                                 });
                                 expr = *prefix;
                             }
@@ -859,21 +856,12 @@ fn reassignment(
                     };
 
                     let mut names_vec = names_vec.into_iter().rev().collect::<Vec<_>>();
-                    names_vec.push(ReassignmentLhs {
-                        kind: ProjectionKind::StructField {
-                            name: field_to_access,
-                        },
-                        r#type: final_return_type,
+                    names_vec.push(ProjectionKind::StructField {
+                        name: field_to_access,
                     });
 
                     let (ty_of_field, _ty_of_parent) = check!(
-                        namespace.find_subfield_type(
-                            &base_name,
-                            &names_vec
-                                .iter()
-                                .map(|ReassignmentLhs { kind, .. }| kind.clone())
-                                .collect::<Vec<_>>(),
-                        ),
+                        namespace.find_subfield_type(&base_name, &names_vec),
                         return err(warnings, errors),
                         warnings,
                         errors

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -176,36 +176,6 @@ impl Items {
         self.use_synonyms.get(symbol).map(|v| &v[..]).unwrap_or(&[])
     }
 
-    /// Given a declaration that may refer to a variable which contains a struct, find that
-    /// struct's fields and name for use in determining if a subfield expression is valid.
-    ///
-    /// E.g. `foo.bar.baz`
-    ///
-    /// Is foo a struct? Does it contain a field bar? Is foo.bar a struct? Does `foo.bar` contain a
-    /// field `baz`? This is the problem this function addresses.
-    pub(crate) fn get_struct_type_fields(
-        &self,
-        ty: TypeId,
-        debug_string: impl Into<String>,
-        debug_span: &Span,
-    ) -> CompileResult<(Vec<TypedStructField>, Ident)> {
-        let ty = look_up_type_id(ty);
-        match ty {
-            TypeInfo::Struct { name, fields, .. } => ok((fields.to_vec(), name), vec![], vec![]),
-            // If we hit `ErrorRecovery` then the source of that type should have populated
-            // the error buffer elsewhere
-            TypeInfo::ErrorRecovery => err(vec![], vec![]),
-            a => err(
-                vec![],
-                vec![CompileError::NotAStruct {
-                    name: debug_string.into(),
-                    span: debug_span.clone(),
-                    actually: a.friendly_type_str(),
-                }],
-            ),
-        }
-    }
-
     pub(crate) fn has_storage_declared(&self) -> bool {
         self.declared_storage.is_some()
     }
@@ -229,7 +199,6 @@ impl Items {
     ) -> CompileResult<(TypeId, TypeId)> {
         let mut warnings = vec![];
         let mut errors = vec![];
-        let mut projection_iter = projections.iter().peekable();
         let symbol = match self.symbols.get(base_name).cloned() {
             Some(s) => s,
             None => {
@@ -239,69 +208,75 @@ impl Items {
                 return err(warnings, errors);
             }
         };
-        if projection_iter.peek().is_none() {
-            let ty = check!(
-                symbol.return_type(),
-                return err(warnings, errors),
-                warnings,
-                errors
-            );
-            return ok((ty, ty), warnings, errors);
-        }
         let mut symbol = check!(
             symbol.return_type(),
             return err(warnings, errors),
             warnings,
             errors
         );
-        let mut type_fields =
-            self.get_struct_type_fields(symbol, base_name.as_str(), base_name.span());
-        warnings.append(&mut type_fields.warnings);
-        errors.append(&mut type_fields.errors);
-        let (mut fields, struct_name): (Vec<TypedStructField>, Ident) = match type_fields.value {
-            // if it is missing, the error message comes from within the above method
-            // so we don't need to re-add it here
-            None => return err(warnings, errors),
-            Some(value) => value,
-        };
-
+        let mut symbol_span = base_name.span().clone();
         let mut parent_rover = symbol;
-
-        for kind in projection_iter {
-            let ident = match kind {
-                ProjectionKind::StructField { name } => name,
-            };
-            // find the ident in the currently available fields
-            let TypedStructField { r#type, .. } =
-                match fields.iter().find(|x| x.name.as_str() == ident.as_str()) {
-                    Some(field) => field.clone(),
-                    None => {
-                        // gather available fields for the error message
-                        let available_fields =
-                            fields.iter().map(|x| x.name.as_str()).collect::<Vec<_>>();
-
-                        errors.push(CompileError::FieldNotFound {
-                            field_name: ident.clone(),
-                            struct_name,
-                            available_fields: available_fields.join(", "),
-                        });
-                        return err(warnings, errors);
-                    }
-                };
-
-            match look_up_type_id(r#type) {
-                TypeInfo::Struct {
-                    fields: ref l_fields,
-                    ..
-                } => {
-                    parent_rover = symbol;
-                    fields = l_fields.clone();
-                    symbol = r#type;
+        let mut full_name_for_error = base_name.to_string();
+        let mut full_span_for_error = base_name.span().clone();
+        for projection in projections {
+            let resolved_type = match resolve_type(symbol, &symbol_span) {
+                Ok(resolved_type) => resolved_type,
+                Err(error) => {
+                    errors.push(CompileError::TypeError(error));
+                    return err(warnings, errors);
                 }
-                _ => {
-                    fields = vec![];
+            };
+            match (resolved_type, projection) {
+                (
+                    TypeInfo::Struct {
+                        name: struct_name,
+                        fields,
+                        ..
+                    },
+                    ProjectionKind::StructField { name: field_name },
+                ) => {
+                    let field_type_opt = {
+                        fields
+                            .iter()
+                            .find_map(|TypedStructField { r#type, name, .. }| {
+                                if name == field_name {
+                                    Some(r#type)
+                                } else {
+                                    None
+                                }
+                            })
+                    };
+                    let field_type = match field_type_opt {
+                        Some(field_type) => field_type,
+                        None => {
+                            // gather available fields for the error message
+                            let available_fields = fields
+                                .iter()
+                                .map(|field| field.name.as_str())
+                                .collect::<Vec<_>>();
+
+                            errors.push(CompileError::FieldNotFound {
+                                field_name: field_name.clone(),
+                                struct_name,
+                                available_fields: available_fields.join(", "),
+                            });
+                            return err(warnings, errors);
+                        }
+                    };
                     parent_rover = symbol;
-                    symbol = r#type;
+                    symbol = *field_type;
+                    symbol_span = field_name.span().clone();
+                    full_name_for_error.push_str(field_name.as_str());
+                    full_span_for_error =
+                        Span::join(full_span_for_error, field_name.span().clone());
+                }
+                (actually, ProjectionKind::StructField { .. }) => {
+                    errors.push(CompileError::NotAStruct {
+                        name: full_name_for_error,
+                        span: full_span_for_error,
+                        actually: actually.friendly_type_str(),
+                    });
+                    return err(warnings, errors);
                 }
             }
         }

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -101,12 +101,10 @@ fn handle_declaration(declaration: &TypedDeclaration, tokens: &mut TokenMap) {
         }
         TypedDeclaration::Reassignment(reassignment) => {
             handle_expression(&reassignment.rhs, tokens);
-            for lhs in &reassignment.lhs {
-                tokens.insert(
-                    to_ident_key(&lhs.name),
-                    TokenType::ReassignmentLhs(lhs.clone()),
-                );
-            }
+            tokens.insert(
+                to_ident_key(&reassignment.lhs_base_name),
+                TokenType::TypedReassignment(reassignment.clone()),
+            );
         }
         TypedDeclaration::ImplTrait {
             trait_name,
@@ -348,7 +346,7 @@ pub fn get_type_id(token: &TokenType) -> Option<TypeId> {
         TokenType::TypedTraitFn(trait_fn) => Some(trait_fn.return_type),
         TokenType::TypedStorageField(storage_field) => Some(storage_field.r#type),
         TokenType::TypeCheckedStorageReassignDescriptor(storage_desc) => Some(storage_desc.r#type),
-        TokenType::ReassignmentLhs(lhs) => Some(lhs.r#type),
+        TokenType::TypedReassignment(reassignment) => Some(reassignment.lhs_type),
         _ => None,
     }
 }

--- a/sway-lsp/src/core/typed_token_type.rs
+++ b/sway-lsp/src/core/typed_token_type.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 use sway_core::semantic_analysis::ast_node::{
-    expression::typed_expression::TypedExpression, ReassignmentLhs,
-    TypeCheckedStorageReassignDescriptor, TypedDeclaration, TypedEnumVariant,
-    TypedFunctionDeclaration, TypedFunctionParameter, TypedStorageField, TypedStructField,
-    TypedTraitFn,
+    expression::typed_expression::TypedExpression, TypeCheckedStorageReassignDescriptor,
+    TypedDeclaration, TypedEnumVariant, TypedFunctionDeclaration, TypedFunctionParameter,
+    TypedReassignment, TypedStorageField, TypedStructField, TypedTraitFn,
 };
 use sway_types::{Ident, Span};
 
@@ -21,5 +20,5 @@ pub enum TokenType {
     TypedTraitFn(TypedTraitFn),
     TypedStorageField(TypedStorageField),
     TypeCheckedStorageReassignDescriptor(TypeCheckedStorageReassignDescriptor),
-    ReassignmentLhs(ReassignmentLhs),
+    TypedReassignment(TypedReassignment),
 }

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -68,7 +68,7 @@ fn ast_node_type(token: &TokenType) -> String {
         TokenType::TypeCheckedStorageReassignDescriptor(_) => {
             "storage reassignment descriptor".to_string()
         }
-        TokenType::ReassignmentLhs(_) => "reassignment lhs".to_string(),
+        TokenType::TypedReassignment(_) => "reassignment".to_string(),
         _ => "".to_string(),
     }
 }

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -48,6 +48,10 @@ pub fn run(filter_regex: Option<regex::Regex>) {
             ProgramState::Return(0),
         ),
         (
+            "should_pass/language/tuple_field_reassignment",
+            ProgramState::Return(320),
+        ),
+        (
             "should_pass/language/enum_in_fn_decl",
             ProgramState::Return(255),
         ),

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_field_reassignment/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_field_reassignment/Forc.lock
@@ -1,0 +1,7 @@
+[[package]]
+name = 'core'
+dependencies = []
+
+[[package]]
+name = 'tuple_field_reassignment'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_field_reassignment/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_field_reassignment/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "tuple_field_reassignment"
+entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_field_reassignment/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_field_reassignment/src/main.sw
@@ -1,0 +1,68 @@
+script;
+
+struct Pair {
+    x: u64,
+    y: u64,
+}
+
+struct MyCoolStruct {
+    tuple0: (u64, u32),
+    tuple1: (u32, u64),
+    pair: Pair,
+    tuple_of_pairs: (Pair, Pair),
+}
+
+fn main() -> u64 {
+    let mut foo0: (u32, u64) = (1, 2);
+    foo0.0 = 3;
+    foo0.1 = 4;
+
+    let mut foo1: (Pair, u64) = (Pair { x: 5, y: 6 }, 7);
+    foo1.0.x = 8;
+    foo1.0.y = 9;
+    foo1.1 = 10;
+
+    let mut foo2: (u32, Pair) = (11, Pair { x: 12, y: 13 });
+    foo2.0 = 14;
+    foo2.1.x = 15;
+    foo2.1.y = 16;
+
+    let mut foo3: MyCoolStruct = MyCoolStruct {
+        tuple0: (17, 18),
+        tuple1: (19, 20),
+        pair: Pair { x: 21, y: 22 },
+        tuple_of_pairs: (Pair { x: 23, y: 24 }, Pair { x: 25, y: 26 }),
+    };
+    foo3.tuple0.0 = 27;
+    foo3.tuple0.1 = 28;
+    foo3.tuple1.0 = 29;
+    foo3.tuple1.1 = 30;
+    foo3.pair.x = 31;
+    foo3.pair.y = 32;
+    foo3.tuple_of_pairs.0.x = 33;
+    foo3.tuple_of_pairs.0.y = 34;
+    foo3.tuple_of_pairs.1.x = 35;
+    foo3.tuple_of_pairs.1.y = 36;
+
+    let ret = {
+        0
+        + foo0.1
+        + foo1.0.x
+        + foo1.0.y
+        + foo1.1
+        + foo2.1.x
+        + foo2.1.y
+        + foo3.tuple0.0
+        + foo3.tuple1.1
+        + foo3.pair.x
+        + foo3.pair.y
+        + foo3.tuple_of_pairs.0.x
+        + foo3.tuple_of_pairs.0.y
+        + foo3.tuple_of_pairs.1.x
+        + foo3.tuple_of_pairs.1.y
+    };
+
+    // 320
+    return ret;
+}
+


### PR DESCRIPTION
This PR allows tuple field projections to be on the left-hand-side of a reassignment.