### PR TITLE
Disambiguate `path` dependencies using the ID of the package at the path root

### DIFF
--- a/examples/asm_return_tuple_pointer/Forc.lock
+++ b/examples/asm_return_tuple_pointer/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'asm_return_tuple_pointer'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-25602139F18DA3F2'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-25602139F18DA3F2'
 dependencies = ['core']

--- a/examples/counter/Forc.lock
+++ b/examples/counter/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-D8BC155605882939'
 dependencies = []
 
 [[package]]
 name = 'counter'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-D8BC155605882939'
 dependencies = ['core']

--- a/examples/enums/Forc.lock
+++ b/examples/enums/Forc.lock
@@ -1,12 +1,4 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'enums'
+source = 'root'
 dependencies = []
-
-[[package]]
-name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.14.5#60c626cf486d5c53c44d84db1ec81cb90174cad3'
-dependencies = ['core']

--- a/examples/fizzbuzz/Forc.lock
+++ b/examples/fizzbuzz/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-08CA839BA84C13D2'
 dependencies = []
 
 [[package]]
 name = 'fizzbuzz'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-08CA839BA84C13D2'
 dependencies = ['core']

--- a/examples/hashing/Forc.lock
+++ b/examples/hashing/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-BFCC9E74738B0693'
 dependencies = []
 
 [[package]]
 name = 'hashing'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-BFCC9E74738B0693'
 dependencies = ['core']

--- a/examples/liquidity_pool/Forc.lock
+++ b/examples/liquidity_pool/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-FEF37F026EFAF705'
 dependencies = []
 
 [[package]]
 name = 'liquidity_pool'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-FEF37F026EFAF705'
 dependencies = ['core']

--- a/examples/match_statements/Forc.lock
+++ b/examples/match_statements/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-AA21FAE5126585F4'
 dependencies = []
 
 [[package]]
 name = 'match_statements'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-AA21FAE5126585F4'
 dependencies = ['core']

--- a/examples/msg_sender/Forc.lock
+++ b/examples/msg_sender/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-8AE06FACEC4CD701'
 dependencies = []
 
 [[package]]
 name = 'msg_sender'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-8AE06FACEC4CD701'
 dependencies = ['core']

--- a/examples/native_token/Forc.lock
+++ b/examples/native_token/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-A779871B261C194D'
 dependencies = []
 
 [[package]]
 name = 'native_token'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-A779871B261C194D'
 dependencies = ['core']

--- a/examples/signatures/Forc.lock
+++ b/examples/signatures/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-1C601C86FBCFA98F'
 dependencies = []
 
 [[package]]
 name = 'signatures'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-1C601C86FBCFA98F'
 dependencies = ['core']

--- a/examples/storage_example/Forc.lock
+++ b/examples/storage_example/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-009C3999B9A47E51'
 dependencies = []
 
 [[package]]
-name = 'storage_example'
-dependencies = ['std']
+name = 'std'
+source = 'path+from-root-009C3999B9A47E51'
+dependencies = ['core']
 
 [[package]]
-name = 'std'
-dependencies = ['core']
+name = 'storage_example'
+source = 'root'
+dependencies = ['std']

--- a/examples/storage_map/Forc.lock
+++ b/examples/storage_map/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-E6A0C4C40B2C3193'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-E6A0C4C40B2C3193'
 dependencies = ['core']
 
 [[package]]
 name = 'storage_map'
+source = 'root'
 dependencies = ['std']

--- a/examples/structs/Forc.lock
+++ b/examples/structs/Forc.lock
@@ -1,12 +1,4 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
-name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.14.5#60c626cf486d5c53c44d84db1ec81cb90174cad3'
-dependencies = ['core']
-
-[[package]]
 name = 'structs'
+source = 'root'
 dependencies = []

--- a/examples/subcurrency/Forc.lock
+++ b/examples/subcurrency/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-237819BD98C87E84'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-237819BD98C87E84'
 dependencies = ['core']
 
 [[package]]
 name = 'subcurrency'
+source = 'root'
 dependencies = ['std']

--- a/examples/tuples/Forc.lock
+++ b/examples/tuples/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'tuples'
+source = 'root'
 dependencies = []

--- a/examples/wallet_smart_contract/Forc.lock
+++ b/examples/wallet_smart_contract/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-E11027628D2FC8AD'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-E11027628D2FC8AD'
 dependencies = ['core']
 
 [[package]]
 name = 'wallet_smart_contract'
+source = 'root'
 dependencies = ['std']

--- a/forc-pkg/src/lock.rs
+++ b/forc-pkg/src/lock.rs
@@ -163,6 +163,13 @@ impl Lock {
             }
         }
 
+        // Validate the `path_root` of each of the path nodes.
+        for n in graph.node_indices() {
+            if let pkg::SourcePinned::Path(ref src) = graph[n].source {
+                pkg::validate_path_root(&graph, n, src.path_root)?;
+            }
+        }
+
         Ok(graph)
     }
 

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -517,11 +517,11 @@ impl PinnedId {
 }
 
 impl SourcePathPinned {
-    const PREFIX: &'static str = "path";
+    pub const PREFIX: &'static str = "path";
 }
 
 impl SourceGitPinned {
-    const PREFIX: &'static str = "git";
+    pub const PREFIX: &'static str = "git";
 }
 
 impl fmt::Display for PinnedId {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_purity_mismatch/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_purity_mismatch/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'abi_impl_purity_mismatch'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_method_signature_mismatch/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_method_signature_mismatch/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'abi_method_signature_mismatch'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pure_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pure_calls_impure/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'abi_pure_calls_impure'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abort_control_flow_bad/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abort_control_flow_bad/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'abort_control_flow_bad'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-B1D8665D445379A4'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-B1D8665D445379A4'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_bad_index/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_bad_index/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'array_bad_index'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_oob/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_oob/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'array_oob'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/asm_missing_return/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/asm_missing_return/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'asm_missing_return'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/asm_should_not_have_return/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/asm_should_not_have_return/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'asm_should_not_have_return'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/assign_to_field_of_non_mutable_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/assign_to_field_of_non_mutable_struct/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'assign_to_field_of_non_mutable_struct'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_annotation/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_annotation/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'bad_generic_annotation'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_var_annotation/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_var_annotation/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'bad_generic_var_annotation'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/better_type_error_message/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/better_type_error_message/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'better_type_error_message'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-935B8AC4AE1B30EB'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-935B8AC4AE1B30EB'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'chained_if_let_missing_branch'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/contract_pure_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/contract_pure_calls_impure/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'valid_impurity'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/dependency_parsing_error/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/dependency_parsing_error/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'dependencies_parsing_error'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/different_contract_caller_types/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/different_contract_caller_types/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'different_contract_caller_types'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/disallow_turbofish/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/disallow_turbofish/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'disallow_turbofish'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/disallowed_gm/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/disallowed_gm/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'disallowed_opcodes'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_enum/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_enum/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'double_underscore_enum'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_fn/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_fn/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'double_underscore_fn'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_impl_self_fn/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_impl_self_fn/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'double_underscore_fn'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_struct/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'double_underscore_struct'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_trait_fn/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_trait_fn/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'double_underscore_fn'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_var/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_var/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'double_underscore_var'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/empty_impl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/empty_impl/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'empty_impl'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/enum_bad_type_inference/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/enum_bad_type_inference/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-00DDFF012B1D3F04'
 dependencies = []
 
 [[package]]
 name = 'enum_bad_type_inference'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/enum_if_let_invalid_variable/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/enum_if_let_invalid_variable/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-34C7BC23940E55C7'
 dependencies = []
 
 [[package]]
 name = 'enum_if_let_invalid_variable'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'excess_fn_arguments'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_shadows_generic/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_shadows_generic/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'generic_shadows_generic'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generics_unhelpful_error/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generics_unhelpful_error/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'generics_unhelpful_error'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/impure_abi_read_calls_impure_write/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/impure_abi_read_calls_impure_write/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'impure_abi_read_calls_impure_write'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/impure_read_calls_impure_write/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/impure_read_calls_impure_write/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'impure_read_calls_impure_write'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/impure_trait_read_calls_impure_write/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/impure_trait_read_calls_impure_write/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'impure_trait_read_calls_impure_write'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-687D7B6A23A7C9DF'
 dependencies = []
 
 [[package]]
 name = 'insufficient_type_info'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-687D7B6A23A7C9DF'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/item_used_without_import/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/item_used_without_import/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'item_used_without_import'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/literal_too_large_for_type/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/literal_too_large_for_type/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'literal_too_large_for_type'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_empty_arms/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_empty_arms/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-F11E2642DB254865'
 dependencies = []
 
 [[package]]
 name = 'match_expressions_empty_arms'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-F11E2642DB254865'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-BAB60FDDAFE6CA68'
 dependencies = []
 
 [[package]]
 name = 'match_expressions_non_exhaustive'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_wrong_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_wrong_struct/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-2E3E6F17B80A063E'
 dependencies = []
 
 [[package]]
 name = 'match_expressions_wrong_struct'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'missing_fn_arguments'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_func_from_supertrait_impl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_func_from_supertrait_impl/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'missing_func_from_supertrait_impl'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_supertrait_impl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_supertrait_impl/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'missing_supertrait_impl'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/multiple_impl_abi/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/multiple_impl_abi/Forc.lock
@@ -1,11 +1,4 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'multiple_impl_abi'
-dependencies = ['std']
-
-[[package]]
-name = 'std'
-dependencies = ['core']
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/multiple_impl_fns/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/multiple_impl_fns/Forc.lock
@@ -1,11 +1,4 @@
 [[package]]
-name = 'core'
-dependencies = []
-
-[[package]]
 name = 'multiple_impl_fns'
-dependencies = ['std']
-
-[[package]]
-name = 'std'
-dependencies = ['core']
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/name_shadowing/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/name_shadowing/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'name_shadowing'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/nested_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/nested_impure/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'nested_impure'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/non_literal_const_decl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/non_literal_const_decl/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'non_literal_const_decl'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_calls_impure/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'script_calls_impure'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/primitive_type_argument/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/primitive_type_argument/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'unused_generic'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/pure_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/pure_calls_impure/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'pure_calls_impure'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'recursive_calls'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_enum/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_enum/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'recursive_enum'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_struct/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'recursive_struct'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_chain/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_chain/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'recursive_type_chain'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/script_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/script_calls_impure/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'script_calls_impure'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'shadow_import'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'star_import_alias'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_in_library/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_in_library/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'storage_in_library'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_in_predicate/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_in_predicate/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'storage_in_predicate'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_in_script/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_in_script/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'storage_in_script'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'supertrait_does_not_exist'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/top_level_vars/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/top_level_vars/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'top_level_vars'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_purity_mismatch/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_purity_mismatch/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'trait_impl_purity_mismatch'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_method_signature_mismatch/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_method_signature_mismatch/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'trait_method_signature_mismatch'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_pure_calls_impure/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_pure_calls_impure/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'trait_pure_calls_impure'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_mismatch_error_message/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_mismatch_error_message/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'type_mismatch_error_message'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unify_identical_unknowns/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unify_identical_unknowns/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'unify_identical_unknowns'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/dependency_package_field/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/dependency_package_field/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-0CE46803927952E6'
 dependencies = []
 
 [[package]]
 name = 'dependency_package_field'
+source = 'root'
 dependencies = ['(std-alt) std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-0CE46803927952E6'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/abort_control_flow_good/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/abort_control_flow_good/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'abort_control_flow_good'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-CB060A17C0778A7E'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-CB060A17C0778A7E'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/aliased_imports/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/aliased_imports/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'aliased_imports'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-2EBF01AEC6158688'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-2EBF01AEC6158688'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'array_basics'
+source = 'root'
 dependencies = ['core']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-E87F696D35D6ACBA'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array_generics/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array_generics/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'array_generics'
+source = 'root'
 dependencies = ['core']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-9063F6813E94C772'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_expr_basic/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_expr_basic/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'asm_expr_basic'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-C1BABCC798F19F0B'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-C1BABCC798F19F0B'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_without_return/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_without_return/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'asm_without_return'
+source = 'root'
 dependencies = ['core']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-8F74D3135E693ACB'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_bad_jumps/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_bad_jumps/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'b256_bad_jumps'
+source = 'root'
 dependencies = ['core']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-652305F040D8F1D1'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_bitwise_ops/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_bitwise_ops/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'b256_bitwise_ops'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-EA508AA5D7F81EEF'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-EA508AA5D7F81EEF'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_ops/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_ops/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'b256_ops'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-963ABD293AAA1DE4'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-963ABD293AAA1DE4'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/basic_func_decl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/basic_func_decl/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'basic_func_decl'
+source = 'root'
 dependencies = ['core']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-F183EF8FCF238B3D'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/basic_predicate/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/basic_predicate/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'basic_predicate'
+source = 'root'
 dependencies = ['core']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-FF1DD40DF1571ED3'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/bool_and_or/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/bool_and_or/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'bool_and_or'
+source = 'root'
 dependencies = ['core']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-50A99C5EBA1BDE7E'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/builtin_type_method_call/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/builtin_type_method_call/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
-name = 'core'
-dependencies = []
+name = 'builtin_type_method_call'
+source = 'root'
+dependencies = ['core']
 
 [[package]]
-name = 'builtin_type_method_call'
-dependencies = ['core']
+name = 'core'
+source = 'path+from-root-B0B251C3B3A5AB8E'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/chained_if_let/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/chained_if_let/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'chained_if_let'
+source = 'root'
 dependencies = ['core']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-152613234D2C9EC5'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'const_decl'
+source = 'root'
 dependencies = ['core']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-FBEF090568E90A96'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl_in_library/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl_in_library/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'const_decl_in_library'
+source = 'root'
 dependencies = ['core']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-1F4E24303F7BFF73'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_type/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_type/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'contract_caller_as_type'
+source = 'root'
 dependencies = ['core']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-2FCDD40F7AA61941'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/dependencies/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/dependencies/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-6DF7ACF6DF315C32'
 dependencies = []
 
 [[package]]
 name = 'dependencies'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/empty_method_initializer/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/empty_method_initializer/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-5A54E336CA715EAA'
 dependencies = []
 
 [[package]]
 name = 'empty_method_initializer'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-5A54E336CA715EAA'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_destructuring/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_destructuring/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-4F875AA377BDB49F'
 dependencies = []
 
 [[package]]
 name = 'enum_destructuring'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-70323834FF9E0867'
 dependencies = []
 
 [[package]]
 name = 'enum_if_let'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let_large_type/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let_large_type/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-D69404CFF5CF10E1'
 dependencies = []
 
 [[package]]
 name = 'enum_if_let_large_type'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_in_fn_decl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_in_fn_decl/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-504AD282DD5E5B18'
 dependencies = []
 
 [[package]]
 name = 'enum_in_fn_decl'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-504AD282DD5E5B18'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_init_fn_call/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_init_fn_call/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-9ED436919AA602B8'
 dependencies = []
 
 [[package]]
 name = 'enum_init_fn_call'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-9ED436919AA602B8'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_type_inference/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_type_inference/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-6ADF79A3BE26848E'
 dependencies = []
 
 [[package]]
 name = 'enum_type_inference'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/eq_and_neq/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/eq_and_neq/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-0AF85F21A8536CE1'
 dependencies = []
 
 [[package]]
 name = 'eq_and_neq'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-0AF85F21A8536CE1'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-818C6EA3A80B47C0'
 dependencies = []
 
 [[package]]
 name = 'fix_opcode_bug'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/funcs_with_generic_types/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/funcs_with_generic_types/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-EE30911CC58544F9'
 dependencies = []
 
 [[package]]
 name = 'funcs_with_generic_types'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic-type-inference/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic-type-inference/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-9B9AE112CEA21882'
 dependencies = []
 
 [[package]]
 name = 'generic-type-inference'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-9B9AE112CEA21882'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_enum/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_enum/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-A3D1AEE50B42FAC3'
 dependencies = []
 
 [[package]]
 name = 'generic_enum'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_functions/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_functions/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-41715E5E6E7DF930'
 dependencies = []
 
 [[package]]
 name = 'generic_functions'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-DA3FEDB2AB26E552'
 dependencies = []
 
 [[package]]
 name = 'generic_impl_self'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_inside_generic/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_inside_generic/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-2171B95500509358'
 dependencies = []
 
 [[package]]
 name = 'generic_inside_generic'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_struct/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-B83AF983C6574F96'
 dependencies = []
 
 [[package]]
 name = 'generic_struct'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_structs/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_structs/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-275E66803932EADF'
 dependencies = []
 
 [[package]]
 name = 'generic_structs'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/if_elseif_enum/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/if_elseif_enum/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-D01E1B7A46372E9A'
 dependencies = []
 
 [[package]]
 name = 'if_elseif_enum'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/if_implicit_unit/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/if_implicit_unit/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-BA5855EE7F3492BE'
 dependencies = []
 
 [[package]]
 name = 'if_implicit_unit'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_return/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_return/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'implicit_return'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_method_from_other_file/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_method_from_other_file/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-7AD6FC8AD1F79D10'
 dependencies = []
 
 [[package]]
 name = 'import_method_from_other_file'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_trailing_comma/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_trailing_comma/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
-name = 'import_trailing_comma'
-dependencies = ['std']
-
-[[package]]
 name = 'core'
+source = 'path+from-root-4A56ACA38DD902C5'
 dependencies = []
 
 [[package]]
+name = 'import_trailing_comma'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
 name = 'std'
+source = 'path+from-root-4A56ACA38DD902C5'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/inline_if_expr_const/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/inline_if_expr_const/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-D43362F14BA36B33'
 dependencies = []
 
 [[package]]
 name = 'inline_if_expr_const'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-D43362F14BA36B33'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/is_prime/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/is_prime/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-84D18B0DDD7EC1D4'
 dependencies = []
 
 [[package]]
 name = 'is_prime'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-84D18B0DDD7EC1D4'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/is_reference_type/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/is_reference_type/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-38E071C478B5BD90'
 dependencies = []
 
 [[package]]
 name = 'is_reference_type'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-38E071C478B5BD90'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/local_impl_for_ord/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/local_impl_for_ord/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-FE72F77802732C1A'
 dependencies = []
 
 [[package]]
 name = 'local_impl_for_ord'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_returns_unit/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_returns_unit/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-FA2A8FF2F74B6948'
 dependencies = []
 
 [[package]]
 name = 'main_returns_unit'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/many_stack_variables/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/many_stack_variables/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-5A0A8AEC06508E21'
 dependencies = []
 
 [[package]]
 name = 'many_stack_variables'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-C27B2C742213E5AD'
 dependencies = []
 
 [[package]]
 name = 'match_expressions'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_enums/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_enums/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-9AF4E3EA6EDCE00F'
 dependencies = []
 
 [[package]]
 name = 'match_expressions_enums'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-9AF4E3EA6EDCE00F'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_inside_generic_functions/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_inside_generic_functions/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-C52D55288A4557F3'
 dependencies = []
 
 [[package]]
 name = 'match_expressions_inside_generic_functions'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-C52D55288A4557F3'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_mismatched/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_mismatched/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-7A1B884B71AD4E6C'
 dependencies = []
 
 [[package]]
 name = 'match_expressions_mismatched'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-7A1B884B71AD4E6C'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_nested/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_nested/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-0FAC91CD97E3941F'
 dependencies = []
 
 [[package]]
 name = 'match_expressions_nested'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-0FAC91CD97E3941F'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_simple/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_simple/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-D97961F846794409'
 dependencies = []
 
 [[package]]
 name = 'simple'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_structs/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_structs/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-E081FBDDEF62D471'
 dependencies = []
 
 [[package]]
 name = 'match_expressions_structs'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/method_on_empty_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/method_on_empty_struct/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-81DEAB773E69E2BF'
 dependencies = []
 
 [[package]]
 name = 'method_on_empty_struct'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/modulo_uint_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/modulo_uint_test/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-281118E0AC5E0D35'
 dependencies = []
 
 [[package]]
 name = 'modulo_uint_test'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-281118E0AC5E0D35'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'multi_impl_self'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_item_import/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_item_import/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-0840D11631A9C24C'
 dependencies = []
 
 [[package]]
 name = 'multi_item_import'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/nested_structs/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/nested_structs/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-CD761B243EFCCAC4'
 dependencies = []
 
 [[package]]
 name = 'nested_structs'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-CD761B243EFCCAC4'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/nested_while_and_if/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/nested_while_and_if/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-454A4726DFB746F1'
 dependencies = []
 
 [[package]]
 name = 'nested_while_and_if'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-454A4726DFB746F1'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/new_allocator_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/new_allocator_test/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-22C1B8FFEA31F7F0'
 dependencies = []
 
 [[package]]
 name = 'new_alloc'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-22C1B8FFEA31F7F0'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-1D28A47FA12C061E'
 dependencies = []
 
 [[package]]
 name = 'numeric_constants'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-1D28A47FA12C061E'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/op_precedence/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/op_precedence/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-A0109FA90E360C97'
 dependencies = []
 
 [[package]]
 name = 'unary_not_basic'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/out_of_order_decl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/out_of_order_decl/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-02BB6BAC50786DCA'
 dependencies = []
 
 [[package]]
 name = 'out_of_order_decl'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/primitive_type_argument/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/primitive_type_argument/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-6EDE444F0E13D974'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-6EDE444F0E13D974'
 dependencies = ['core']
 
 [[package]]
 name = 'unused_generic'
+source = 'root'
 dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/reassignment_operators/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/reassignment_operators/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-D3718BE02F4F019A'
 dependencies = []
 
 [[package]]
 name = 'reassignment_operators'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-D3718BE02F4F019A'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/ret_small_string/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/ret_small_string/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'ret_small_string'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/ret_string_in_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/ret_string_in_struct/Forc.lock
@@ -1,3 +1,4 @@
 [[package]]
 name = 'ret_string_in_struct'
+source = 'root'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_b256/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_b256/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-369A2B47EEBEB803'
 dependencies = []
 
 [[package]]
 name = 'retd_b256'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_small_array/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_small_array/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-D892E29A6FC98019'
 dependencies = []
 
 [[package]]
 name = 'retd_small_array'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_struct/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-615AD0AE63423614'
 dependencies = []
 
 [[package]]
 name = 'retd_struct'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_zero_len_array/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_zero_len_array/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-50944FCCF39703ED'
 dependencies = []
 
 [[package]]
 name = 'retd_zero_len_array'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/size_of/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/size_of/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-6C3D67A2839FB64B'
 dependencies = []
 
 [[package]]
 name = 'size_of'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-6C3D67A2839FB64B'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_access/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_access/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-E679204875B87008'
 dependencies = []
 
 [[package]]
 name = 'struct_field_access'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_reassignment/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_reassignment/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-53919E193550072B'
 dependencies = []
 
 [[package]]
 name = 'struct_field_reassignment'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/supertraits/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/supertraits/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-6F8C00D302E9D79E'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-6F8C00D302E9D79E'
 dependencies = ['core']
 
 [[package]]
 name = 'supertraits'
+source = 'root'
 dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_import_with_star/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_import_with_star/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-B3139936C693DF4E'
 dependencies = []
 
 [[package]]
 name = 'trait_impl_import'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_override_bug/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_override_bug/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-19202DB015C3C015'
 dependencies = []
 
 [[package]]
 name = 'trait_override_bug'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_access/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_access/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-A4EDABC95499A7B6'
 dependencies = []
 
 [[package]]
 name = 'tuple_access'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_desugaring/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_desugaring/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-7056B8159EB7375D'
 dependencies = []
 
 [[package]]
 name = 'tuple_desugaring'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_field_reassignment/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_field_reassignment/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-2F4123B4F8C8D13B'
 dependencies = []
 
 [[package]]
 name = 'tuple_field_reassignment'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_in_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_in_struct/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-D84378A37D7A2DA6'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-D84378A37D7A2DA6'
 dependencies = ['core']
 
 [[package]]
 name = 'tuple_in_struct'
+source = 'root'
 dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_indexing/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_indexing/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-77B89972CE8D8BC6'
 dependencies = []
 
 [[package]]
 name = 'tuple_indexing'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_single_element/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_single_element/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-E22D083410030709'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-E22D083410030709'
 dependencies = ['core']
 
 [[package]]
 name = 'tuple_single_element'
+source = 'root'
 dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_types/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_types/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-8222DC735DC134D4'
 dependencies = []
 
 [[package]]
 name = 'tuple_types'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/u64_ops/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/u64_ops/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-B08F2781506278F6'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-B08F2781506278F6'
 dependencies = ['core']
 
 [[package]]
 name = 'u64_ops'
+source = 'root'
 dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-A0109FA90E360C97'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-A0109FA90E360C97'
 dependencies = ['core']
 
 [[package]]
 name = 'unary_not_basic'
+source = 'root'
 dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic_2/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic_2/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-7F8340D0C491D223'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-7F8340D0C491D223'
 dependencies = ['core']
 
 [[package]]
 name = 'unary_not_basic_2'
+source = 'root'
 dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/use_full_path_names/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/use_full_path_names/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-17B0AE322441F666'
 dependencies = []
 
 [[package]]
 name = 'use_full_path_names'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/valid_impurity/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/valid_impurity/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-C5124BA2E9BCE152'
 dependencies = []
 
 [[package]]
 name = 'valid_impurity'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/while_loops/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/while_loops/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-6B3FD71CFD9E5DB8'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-6B3FD71CFD9E5DB8'
 dependencies = ['core']
 
 [[package]]
 name = 'while_loops'
+source = 'root'
 dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/zero_field_types/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/zero_field_types/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-086E35205BD410DF'
 dependencies = []
 
 [[package]]
 name = 'zero_field_types'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/Forc.lock
@@ -1,9 +1,11 @@
 [[package]]
 name = 'array_of_structs_abi'
+source = 'path+from-root-40616FC980A839AE'
 dependencies = []
 
 [[package]]
 name = 'array_of_structs_caller'
+source = 'root'
 dependencies = [
     'array_of_structs_abi',
     'std',
@@ -11,8 +13,10 @@ dependencies = [
 
 [[package]]
 name = 'core'
+source = 'path+from-root-40616FC980A839AE'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-40616FC980A839AE'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/Forc.lock
@@ -1,5 +1,6 @@
 [[package]]
 name = 'bal_opcode'
+source = 'root'
 dependencies = [
     'balance_test_abi',
     'std',
@@ -7,12 +8,15 @@ dependencies = [
 
 [[package]]
 name = 'balance_test_abi'
-dependencies = []
+source = 'path+from-root-22833226E3BC014E'
+dependencies = ['core']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-22833226E3BC014E'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-22833226E3BC014E'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/Forc.lock
@@ -1,9 +1,11 @@
 [[package]]
 name = 'abi_with_tuples'
+source = 'path+from-root-A94357F7D125B65F'
 dependencies = ['core']
 
 [[package]]
 name = 'call_abi_with_tuples'
+source = 'root'
 dependencies = [
     'abi_with_tuples',
     'std',
@@ -11,8 +13,10 @@ dependencies = [
 
 [[package]]
 name = 'core'
+source = 'path+from-root-A94357F7D125B65F'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-A94357F7D125B65F'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/Forc.lock
@@ -1,9 +1,11 @@
 [[package]]
 name = 'basic_storage_abi'
-dependencies = []
+source = 'path+from-root-B0443BE7AC0A62F9'
+dependencies = ['core']
 
 [[package]]
 name = 'call_basic_storage'
+source = 'root'
 dependencies = [
     'basic_storage_abi',
     'std',
@@ -11,8 +13,10 @@ dependencies = [
 
 [[package]]
 name = 'core'
+source = 'path+from-root-B0443BE7AC0A62F9'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-B0443BE7AC0A62F9'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/Forc.lock
@@ -1,5 +1,6 @@
 [[package]]
 name = 'call_increment_contract'
+source = 'root'
 dependencies = [
     'increment_abi',
     'std',
@@ -7,12 +8,15 @@ dependencies = [
 
 [[package]]
 name = 'core'
+source = 'path+from-root-2711CA1D0E2938B8'
 dependencies = []
 
 [[package]]
 name = 'increment_abi'
-dependencies = []
+source = 'path+from-root-2711CA1D0E2938B8'
+dependencies = ['core']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-2711CA1D0E2938B8'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/Forc.lock
@@ -1,9 +1,11 @@
 [[package]]
 name = 'auth_testing_abi'
-dependencies = []
+source = 'path+from-root-F99221C76F6FEEFB'
+dependencies = ['core']
 
 [[package]]
 name = 'caller_auth_test'
+source = 'root'
 dependencies = [
     'auth_testing_abi',
     'std',
@@ -11,8 +13,10 @@ dependencies = [
 
 [[package]]
 name = 'core'
+source = 'path+from-root-F99221C76F6FEEFB'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-F99221C76F6FEEFB'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/Forc.lock
@@ -1,5 +1,6 @@
 [[package]]
 name = 'caller_context_test'
+source = 'root'
 dependencies = [
     'context_testing_abi',
     'std',
@@ -7,12 +8,15 @@ dependencies = [
 
 [[package]]
 name = 'context_testing_abi'
+source = 'path+from-root-D12893745757AE0B'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-D12893745757AE0B'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-D12893745757AE0B'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/get_storage_key_caller/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/get_storage_key_caller/Forc.lock
@@ -1,13 +1,16 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-B3844A485BCDB5F7'
 dependencies = []
 
 [[package]]
 name = 'get_storage_key_abi'
+source = 'path+from-root-B3844A485BCDB5F7'
 dependencies = []
 
 [[package]]
 name = 'get_storage_key_caller'
+source = 'root'
 dependencies = [
     'get_storage_key_abi',
     'std',
@@ -15,4 +18,5 @@ dependencies = [
 
 [[package]]
 name = 'std'
+source = 'path+from-root-B3844A485BCDB5F7'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/Forc.lock
@@ -1,17 +1,21 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-323E392CC41F43FA'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-323E392CC41F43FA'
 dependencies = ['core']
 
 [[package]]
 name = 'storage_access_abi'
+source = 'path+from-root-323E392CC41F43FA'
 dependencies = ['core']
 
 [[package]]
 name = 'storage_access_caller'
+source = 'root'
 dependencies = [
     'std',
     'storage_access_abi',

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/token_ops_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/token_ops_test/Forc.lock
@@ -1,17 +1,21 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-7D510AAC4A67C807'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-7D510AAC4A67C807'
 dependencies = ['core']
 
 [[package]]
 name = 'test_fuel_coin_abi'
+source = 'path+from-root-7D510AAC4A67C807'
 dependencies = ['std']
 
 [[package]]
 name = 'token_ops_test'
+source = 'root'
 dependencies = [
     'std',
     'test_fuel_coin_abi',

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/address_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/address_test/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'address_test'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-E4CD281CB63A3D38'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-E4CD281CB63A3D38'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_test/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'assert_test'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-000DE2BD47DE0A72'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-000DE2BD47DE0A72'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_struct_alignment/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_struct_alignment/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'b512_panic_test'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-668AEDF20AD093DA'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-668AEDF20AD093DA'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_test/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'b512_test'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-036C2C548FDF30D8'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-036C2C548FDF30D8'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/block_height/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/block_height/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'block_height'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-F04660A5553D7A09'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-F04660A5553D7A09'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/contract_id_type/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/contract_id_type/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'contract_id_type'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-042F076988000CAA'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-042F076988000CAA'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ec_recover_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ec_recover_test/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-219CAA2B0E1853AB'
 dependencies = []
 
 [[package]]
 name = 'ec_recover_test'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-219CAA2B0E1853AB'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/evm_ecr/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/evm_ecr/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-0F8B93B33FD67819'
 dependencies = []
 
 [[package]]
 name = 'evm_ecr'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-0F8B93B33FD67819'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/exponentiation_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/exponentiation_test/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-31441D12B1FE5745'
 dependencies = []
 
 [[package]]
 name = 'exponentiation_test'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-31441D12B1FE5745'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ge_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ge_test/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-601D0A0C12E350CD'
 dependencies = []
 
 [[package]]
 name = 'ge_test'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-601D0A0C12E350CD'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/intrinsics/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/intrinsics/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-89DFACC7FCC0773C'
 dependencies = []
 
 [[package]]
 name = 'intrinsics'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-89DFACC7FCC0773C'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/option/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/option/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-188A2A51DABCB20F'
 dependencies = []
 
 [[package]]
 name = 'option'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-188A2A51DABCB20F'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/require/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/require/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-F350654F839E7174'
 dependencies = []
 
 [[package]]
 name = 'require'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-F350654F839E7174'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/result/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/result/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-43D6EED06DDE4680'
 dependencies = []
 
 [[package]]
 name = 'result'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-43D6EED06DDE4680'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_div_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_div_test/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-7A6EE51863736987'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-7A6EE51863736987'
 dependencies = ['core']
 
 [[package]]
 name = 'u128_div_test_pass'
+source = 'root'
 dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_mul_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_mul_test/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-971B87177979B9DC'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-971B87177979B9DC'
 dependencies = ['core']
 
 [[package]]
 name = 'u128_mul_test_pass'
+source = 'root'
 dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_test/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-69C0D5A249F24B1D'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-69C0D5A249F24B1D'
 dependencies = ['core']
 
 [[package]]
 name = 'u128_test_pass'
+source = 'root'
 dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_tuples_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_tuples_contract/Forc.lock
@@ -1,9 +1,11 @@
 [[package]]
 name = 'abi_with_tuples'
+source = 'path+from-root-382FED6391B53E08'
 dependencies = ['core']
 
 [[package]]
 name = 'abi_with_tuples_contract'
+source = 'root'
 dependencies = [
     'abi_with_tuples',
     'core',
@@ -11,4 +13,5 @@ dependencies = [
 
 [[package]]
 name = 'core'
+source = 'path+from-root-382FED6391B53E08'
 dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/array_of_structs_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/array_of_structs_contract/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'array_of_structs_abi'
+source = 'path+from-root-E723F3A4C3992EF1'
 dependencies = []
 
 [[package]]
 name = 'basic_storage'
+source = 'root'
 dependencies = ['array_of_structs_abi']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/auth_testing_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/auth_testing_contract/Forc.lock
@@ -1,9 +1,11 @@
 [[package]]
 name = 'auth_testing_abi'
-dependencies = []
+source = 'path+from-root-26340C23417C943C'
+dependencies = ['core']
 
 [[package]]
 name = 'auth_testing_contract'
+source = 'root'
 dependencies = [
     'auth_testing_abi',
     'std',
@@ -11,8 +13,10 @@ dependencies = [
 
 [[package]]
 name = 'core'
+source = 'path+from-root-26340C23417C943C'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-26340C23417C943C'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/balance_test_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/balance_test_contract/Forc.lock
@@ -1,9 +1,11 @@
 [[package]]
 name = 'balance_test_abi'
-dependencies = []
+source = 'path+from-root-58C52EDC3AE3855E'
+dependencies = ['core']
 
 [[package]]
 name = 'balance_test_contract'
+source = 'root'
 dependencies = [
     'balance_test_abi',
     'std',
@@ -11,8 +13,10 @@ dependencies = [
 
 [[package]]
 name = 'core'
+source = 'path+from-root-58C52EDC3AE3855E'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-58C52EDC3AE3855E'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/Forc.lock
@@ -1,5 +1,6 @@
 [[package]]
 name = 'basic_storage'
+source = 'root'
 dependencies = [
     'basic_storage_abi',
     'std',
@@ -7,12 +8,15 @@ dependencies = [
 
 [[package]]
 name = 'basic_storage_abi'
-dependencies = []
+source = 'path+from-root-E723F3A4C3992EF1'
+dependencies = ['core']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-E723F3A4C3992EF1'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-E723F3A4C3992EF1'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/context_testing_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/context_testing_contract/Forc.lock
@@ -1,9 +1,11 @@
 [[package]]
 name = 'context_testing_abi'
+source = 'path+from-root-90643B2C4CCDCD70'
 dependencies = ['std']
 
 [[package]]
 name = 'context_testing_contract'
+source = 'root'
 dependencies = [
     'context_testing_abi',
     'std',
@@ -11,8 +13,10 @@ dependencies = [
 
 [[package]]
 name = 'core'
+source = 'path+from-root-90643B2C4CCDCD70'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-90643B2C4CCDCD70'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/get_storage_key_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/get_storage_key_contract/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'get_storage_key_abi'
+source = 'path+from-root-35549077EBF4FDB5'
 dependencies = []
 
 [[package]]
 name = 'get_storage_key_contract'
+source = 'root'
 dependencies = ['get_storage_key_abi']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/increment_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/increment_contract/Forc.lock
@@ -1,13 +1,16 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-A6DC921B8A5962D5'
 dependencies = []
 
 [[package]]
 name = 'increment_abi'
-dependencies = []
+source = 'path+from-root-A6DC921B8A5962D5'
+dependencies = ['core']
 
 [[package]]
 name = 'increment_contract'
+source = 'root'
 dependencies = [
     'increment_abi',
     'std',
@@ -15,4 +18,5 @@ dependencies = [
 
 [[package]]
 name = 'std'
+source = 'path+from-root-A6DC921B8A5962D5'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/issue_1512_repro/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/issue_1512_repro/Forc.lock
@@ -1,7 +1,9 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-C086F5BB5B0BA300'
 dependencies = []
 
 [[package]]
 name = 'issue_1512_repro'
+source = 'root'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/multiple_impl/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/multiple_impl/Forc.lock
@@ -1,17 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-8E8009A1AAF68612'
 dependencies = []
 
 [[package]]
 name = 'multiple_impl'
-dependencies = []
-
-[[package]]
-name = 'multiple_impl'
-dependencies = [
-    'std',
-]
+source = 'root'
+dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-8E8009A1AAF68612'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/nested_struct_args_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/nested_struct_args_contract/Forc.lock
@@ -1,13 +1,16 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-AC1F77B55CB45700'
 dependencies = []
 
 [[package]]
 name = 'nested_struct_args_abi'
+source = 'path+from-root-AC1F77B55CB45700'
 dependencies = ['core']
 
 [[package]]
 name = 'nested_struct_args_contract'
+source = 'root'
 dependencies = [
     'nested_struct_args_abi',
     'std',
@@ -15,4 +18,5 @@ dependencies = [
 
 [[package]]
 name = 'std'
+source = 'path+from-root-AC1F77B55CB45700'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/Forc.lock
@@ -1,17 +1,21 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-EE5FEA38729D9DF2'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-EE5FEA38729D9DF2'
 dependencies = ['core']
 
 [[package]]
 name = 'storage_access_abi'
-dependencies = []
+source = 'path+from-root-EE5FEA38729D9DF2'
+dependencies = ['core']
 
 [[package]]
 name = 'storage_access_contract'
+source = 'root'
 dependencies = [
     'std',
     'storage_access_abi',

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/test_fuel_coin_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/test_fuel_coin_contract/Forc.lock
@@ -1,17 +1,21 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-C35C1CB8B551E0E6'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-C35C1CB8B551E0E6'
 dependencies = ['core']
 
 [[package]]
 name = 'test_fuel_coin_abi'
+source = 'path+from-root-C35C1CB8B551E0E6'
 dependencies = ['std']
 
 [[package]]
 name = 'test_fuel_coin_contract'
+source = 'root'
 dependencies = [
     'std',
     'test_fuel_coin_abi',

--- a/test/src/sdk-harness/test_artifacts/auth_caller_contract/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/auth_caller_contract/Forc.lock
@@ -1,5 +1,6 @@
 [[package]]
 name = 'auth_caller_contract'
+source = 'root'
 dependencies = [
     'auth_testing_abi',
     'std',
@@ -7,12 +8,15 @@ dependencies = [
 
 [[package]]
 name = 'auth_testing_abi'
+source = 'path+from-root-A1F9585323389F4F'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-A1F9585323389F4F'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-A1F9585323389F4F'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_artifacts/auth_caller_script/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/auth_caller_script/Forc.lock
@@ -1,5 +1,6 @@
 [[package]]
 name = 'auth_caller_script'
+source = 'root'
 dependencies = [
     'auth_testing_abi',
     'std',
@@ -7,12 +8,15 @@ dependencies = [
 
 [[package]]
 name = 'auth_testing_abi'
+source = 'path+from-root-26A86FBDE3EF930E'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-26A86FBDE3EF930E'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-26A86FBDE3EF930E'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_artifacts/auth_testing_abi/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/auth_testing_abi/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'auth_testing_abi'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-5781B31F5E4458CC'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-5781B31F5E4458CC'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_artifacts/auth_testing_contract/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/auth_testing_contract/Forc.lock
@@ -1,9 +1,11 @@
 [[package]]
 name = 'auth_testing_abi'
+source = 'path+from-root-26340C23417C943C'
 dependencies = ['std']
 
 [[package]]
 name = 'auth_testing_contract'
+source = 'root'
 dependencies = [
     'auth_testing_abi',
     'std',
@@ -11,8 +13,10 @@ dependencies = [
 
 [[package]]
 name = 'core'
+source = 'path+from-root-26340C23417C943C'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-26340C23417C943C'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_artifacts/balance_contract/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/balance_contract/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'balance_contract'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-448CB6CD985B149D'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-448CB6CD985B149D'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_artifacts/call_frames_test_abi/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/call_frames_test_abi/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'call_frames_test_abi'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-5E1AE3B7DA5CAD9F'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-5E1AE3B7DA5CAD9F'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_artifacts/context_caller_contract/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/context_caller_contract/Forc.lock
@@ -1,5 +1,6 @@
 [[package]]
 name = 'context_caller_contract'
+source = 'root'
 dependencies = [
     'context_testing_abi',
     'std',
@@ -7,12 +8,15 @@ dependencies = [
 
 [[package]]
 name = 'context_testing_abi'
+source = 'path+from-root-1CAC8651C9045C85'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-1CAC8651C9045C85'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-1CAC8651C9045C85'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_artifacts/context_testing_abi/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/context_testing_abi/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'context_testing_abi'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-BE6A0D2FFDF9E2AB'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-BE6A0D2FFDF9E2AB'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_artifacts/pow/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/pow/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-CD2E393B1D6B5576'
 dependencies = []
 
 [[package]]
 name = 'pow'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-CD2E393B1D6B5576'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_artifacts/reentrancy_attacker_abi/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/reentrancy_attacker_abi/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-01ECD3B6EBEB3EFB'
 dependencies = []
 
 [[package]]
 name = 'reentrancy_attacker_abi'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-01ECD3B6EBEB3EFB'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_artifacts/reentrancy_attacker_contract/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/reentrancy_attacker_contract/Forc.lock
@@ -1,13 +1,16 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-6EFBB843E0F64456'
 dependencies = []
 
 [[package]]
 name = 'reentrancy_attacker_abi'
+source = 'path+from-root-6EFBB843E0F64456'
 dependencies = ['std']
 
 [[package]]
 name = 'reentrancy_attacker_contract'
+source = 'root'
 dependencies = [
     'reentrancy_attacker_abi',
     'reentrancy_target_abi',
@@ -16,8 +19,10 @@ dependencies = [
 
 [[package]]
 name = 'reentrancy_target_abi'
+source = 'path+from-root-6EFBB843E0F64456'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-6EFBB843E0F64456'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_artifacts/reentrancy_target_abi/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/reentrancy_target_abi/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-838442FFC03D3788'
 dependencies = []
 
 [[package]]
 name = 'reentrancy_target_abi'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-838442FFC03D3788'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_artifacts/reentrancy_target_contract/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/reentrancy_target_contract/Forc.lock
@@ -1,17 +1,21 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-F53252C7DB7025EE'
 dependencies = []
 
 [[package]]
 name = 'reentrancy_attacker_abi'
+source = 'path+from-root-F53252C7DB7025EE'
 dependencies = ['std']
 
 [[package]]
 name = 'reentrancy_target_abi'
+source = 'path+from-root-F53252C7DB7025EE'
 dependencies = ['std']
 
 [[package]]
 name = 'reentrancy_target_contract'
+source = 'root'
 dependencies = [
     'reentrancy_attacker_abi',
     'reentrancy_target_abi',
@@ -20,4 +24,5 @@ dependencies = [
 
 [[package]]
 name = 'std'
+source = 'path+from-root-F53252C7DB7025EE'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_artifacts/tx_contract/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/tx_contract/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-A627FA3EA4D62336'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-A627FA3EA4D62336'
 dependencies = ['core']
 
 [[package]]
 name = 'tx_contract'
+source = 'root'
 dependencies = ['std']

--- a/test/src/sdk-harness/test_projects/auth/Forc.lock
+++ b/test/src/sdk-harness/test_projects/auth/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'auth'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-2DA4FC95F5834167'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-2DA4FC95F5834167'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_projects/call_frames/Forc.lock
+++ b/test/src/sdk-harness/test_projects/call_frames/Forc.lock
@@ -1,5 +1,6 @@
 [[package]]
 name = 'call_frames'
+source = 'root'
 dependencies = [
     'call_frames_test_abi',
     'std',
@@ -7,12 +8,15 @@ dependencies = [
 
 [[package]]
 name = 'call_frames_test_abi'
+source = 'path+from-root-E8321A5D38B55E37'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-E8321A5D38B55E37'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-E8321A5D38B55E37'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_projects/context/Forc.lock
+++ b/test/src/sdk-harness/test_projects/context/Forc.lock
@@ -1,5 +1,6 @@
 [[package]]
 name = 'context'
+source = 'root'
 dependencies = [
     'context_testing_abi',
     'std',
@@ -7,12 +8,15 @@ dependencies = [
 
 [[package]]
 name = 'context_testing_abi'
+source = 'path+from-root-F879D47D7CAE7172'
 dependencies = ['std']
 
 [[package]]
 name = 'core'
+source = 'path+from-root-F879D47D7CAE7172'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-F879D47D7CAE7172'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_projects/hashing/Forc.lock
+++ b/test/src/sdk-harness/test_projects/hashing/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-BFCC9E74738B0693'
 dependencies = []
 
 [[package]]
 name = 'hashing'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-BFCC9E74738B0693'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_projects/logging/Forc.lock
+++ b/test/src/sdk-harness/test_projects/logging/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-B183794502AF314F'
 dependencies = []
 
 [[package]]
 name = 'logging'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-B183794502AF314F'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_projects/registers/Forc.lock
+++ b/test/src/sdk-harness/test_projects/registers/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-A46277EC5F63F4E2'
 dependencies = []
 
 [[package]]
 name = 'registers'
+source = 'root'
 dependencies = ['std']
 
 [[package]]
 name = 'std'
+source = 'path+from-root-A46277EC5F63F4E2'
 dependencies = ['core']

--- a/test/src/sdk-harness/test_projects/storage/Forc.lock
+++ b/test/src/sdk-harness/test_projects/storage/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-37E4B1588712FA61'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-37E4B1588712FA61'
 dependencies = ['core']
 
 [[package]]
 name = 'storage'
+source = 'root'
 dependencies = ['std']

--- a/test/src/sdk-harness/test_projects/storage_map/Forc.lock
+++ b/test/src/sdk-harness/test_projects/storage_map/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-E6A0C4C40B2C3193'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-E6A0C4C40B2C3193'
 dependencies = ['core']
 
 [[package]]
 name = 'storage_map'
+source = 'root'
 dependencies = ['std']

--- a/test/src/sdk-harness/test_projects/token_ops/Forc.lock
+++ b/test/src/sdk-harness/test_projects/token_ops/Forc.lock
@@ -1,11 +1,14 @@
 [[package]]
 name = 'core'
+source = 'path+from-root-979F3DC775724FBC'
 dependencies = []
 
 [[package]]
 name = 'std'
+source = 'path+from-root-979F3DC775724FBC'
 dependencies = ['core']
 
 [[package]]
 name = 'token_ops'
+source = 'root'
 dependencies = ['std']


### PR DESCRIPTION
Implements and closes #1789. Also closes #1637.

TODO:

- [x] Disambiguate `path` dependencies using parent package ID.
- [x] Impl `Display` and `FromStr` for `PinnedId` to convert it to and
  from hex for path source string in lock file.
- [x] Address #1637 now to reduce this PR adding even more noise in the
  lock file `dependencies` lists.
- [x] Update lock files of all examples and tests in repository.