### PR TITLE
Refactor `token` module functions

### DIFF
--- a/examples/native_token/src/main.sw
+++ b/examples/native_token/src/main.sw
@@ -26,7 +26,7 @@ impl NativeAssetToken for Contract {
 
     /// Transfer coins to a target contract.
     fn force_transfer_coins(coins: u64, asset_id: ContractId, target: ContractId) {
-        force_transfer(coins, asset_id, target);
+        force_transfer_to_contract(coins, asset_id, target);
     }
 
     /// Transfer coins to a transaction output to be spent later.

--- a/sway-lib-std/src/token.sw
+++ b/sway-lib-std/src/token.sw
@@ -8,7 +8,7 @@ use ::tx::*;
 use ::context::call_frames::contract_id;
 use ::identity::Identity;
 
-/// Mint `amount` coins of the current contract's `asset_id` and send them to `destination` by calling either force_transfer() or transfer_to_output(), depending on the type of `Identity`.
+/// Mint `amount` coins of the current contract's `asset_id` and transfer them to `destination` by calling either force_transfer_to_contract() or transfer_to_output(), depending on the type of `Identity`.
 pub fn mint_to(amount: u64, recipient: Identity) {
     mint(amount);
     transfer_to(amount, recipient);
@@ -19,7 +19,7 @@ pub fn mint_to(amount: u64, recipient: Identity) {
 /// Use of this function can lead to irretrievable loss of coins if not used with caution.
 pub fn mint_to_contract(amount: u64, destination: ContractId) {
     mint(amount);
-    force_transfer(amount, contract_id(), destination);
+    force_transfer_to_contract(amount, contract_id(), destination);
 }
 
 /// Mint `amount` coins of the current contract's `asset_id` and send them to the Address `recipient`.
@@ -42,14 +42,14 @@ pub fn burn(amount: u64) {
     }
 }
 
-/// Transfer `amount` coins of the current contract's `asset_id` and send them to `destination` by calling either force_transfer() or transfer_to_output(), depending on the type of `Identity`.
+/// Transfer `amount` coins of the current contract's `asset_id` and send them to `destination` by calling either force_transfer_to_contract() or transfer_to_output(), depending on the type of `Identity`.
 pub fn transfer_to(amount: u64, recipient: Identity) {
     match recipient {
         Identity::Address(addr) => {
             transfer_to_output(amount, contract_id(), addr);
         },
         Identity::ContractId(id) => {
-            force_transfer(amount, contract_id(), id);
+            force_transfer_to_contract(amount, contract_id(), id);
         },
     }
 }
@@ -57,7 +57,7 @@ pub fn transfer_to(amount: u64, recipient: Identity) {
 /// !!! UNCONDITIONAL transfer of `amount` coins of type `asset_id` to contract at `destination`.
 /// This will allow the transfer of coins even if there is no way to retrieve them !!!
 /// Use of this function can lead to irretrievable loss of coins if not used with caution.
-pub fn force_transfer(amount: u64, asset_id: ContractId, destination: ContractId) {
+pub fn force_transfer_to_contract(amount: u64, asset_id: ContractId, destination: ContractId) {
     asm(r1: amount, r2: asset_id.value, r3: destination.value) {
         tr r3 r1 r2;
     }

--- a/sway-lib-std/src/token.sw
+++ b/sway-lib-std/src/token.sw
@@ -11,16 +11,8 @@ use ::identity::Identity;
 /// Mint `amount` coins of the current contract's `asset_id` and send them to `destination` by calling either force_transfer() or transfer_to_output(), depending on the type of `Identity`.
 pub fn mint_to(amount: u64, recipient: Identity) {
     mint(amount);
-    match recipient {
-        Identity::Address(addr) => {
-            transfer_to_output(amount, contract_id(), addr);
-        },
-        Identity::ContractId(id) => {
-            force_transfer(amount, contract_id(), id);
-        },
-    }
+    transfer_to(amount, recipient);
 }
-
 
 /// Mint `amount` coins of the current contract's `asset_id` and send them (!!! UNCONDITIONALLY !!!) to the contract at `destination`.
 /// This will allow the transfer of coins even if there is no way to retrieve them !!!
@@ -47,6 +39,18 @@ pub fn mint(amount: u64) {
 pub fn burn(amount: u64) {
     asm(r1: amount) {
         burn r1;
+    }
+}
+
+/// Transfer `amount` coins of the current contract's `asset_id` and send them to `destination` by calling either force_transfer() or transfer_to_output(), depending on the type of `Identity`.
+pub fn transfer_to(amount: u64, recipient: Identity) {
+    match recipient {
+        Identity::Address(addr) => {
+            transfer_to_output(amount, contract_id(), addr);
+        },
+        Identity::ContractId(id) => {
+            force_transfer(amount, contract_id(), id);
+        },
     }
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/test_fuel_coin_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/test_fuel_coin_contract/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::{contract_id::ContractId, token::{burn, force_transfer, mint}};
+use std::{contract_id::ContractId, token::{burn, force_transfer_to_contract, mint}};
 use test_fuel_coin_abi::*;
 
 impl TestFuelCoin for Contract {
@@ -14,6 +14,6 @@ impl TestFuelCoin for Contract {
     }
 
     fn force_transfer(coins: u64, asset_id: ContractId, c_id: ContractId) {
-        force_transfer(coins, asset_id, c_id)
+        force_transfer_to_contract(coins, asset_id, c_id)
     }
 }

--- a/test/src/sdk-harness/test_projects/token_ops/src/main.sw
+++ b/test/src/sdk-harness/test_projects/token_ops/src/main.sw
@@ -24,7 +24,7 @@ impl TestFuelCoin for Contract {
     }
 
     fn force_transfer_coins(coins: u64, asset_id: ContractId, target: ContractId) {
-        force_transfer(coins, asset_id, target);
+        force_transfer_to_contract(coins, asset_id, target);
     }
 
     fn transfer_coins_to_output(coins: u64, asset_id: ContractId, recipient: Address) {


### PR DESCRIPTION
This PR:
- Adds a `transfer_to()` function which is then used by `mint_to()`. This better separates the minting and transfer functionality and allows more reuse.
- tentatively renames `force_transfer()` to `force_transfer_to_contract()` for clarity. Bikeshed time.