### PR TITLE
Reduce conservatism in the allocation algorithm

### DIFF
--- a/sway-core/src/asm_generation/abstract_instruction_set.rs
+++ b/sway-core/src/asm_generation/abstract_instruction_set.rs
@@ -1,7 +1,5 @@
 use crate::{
-    asm_generation::{
-        compiler_constants, register_allocator, DataSection, InstructionSet, RegisterSequencer,
-    },
+    asm_generation::{register_allocator, DataSection, InstructionSet, RegisterSequencer},
     asm_lang::{
         allocated_ops::AllocatedOp, Label, Op, OrganizationalOp, RealizedOp, VirtualImmediate12,
         VirtualImmediate18, VirtualImmediate24, VirtualOp,
@@ -223,10 +221,7 @@ impl RealizedAbstractInstructionSet {
 
         // Step 4: Simplify - i.e. color the interference graph and return a stack that contains
         // each colorable node and its neighbors.
-        let mut stack = register_allocator::color_interference_graph(
-            &mut interference_graph,
-            compiler_constants::NUM_ALLOCATABLE_REGISTERS,
-        );
+        let mut stack = register_allocator::color_interference_graph(&mut interference_graph);
 
         // Step 5: Use the stack to assign a register for each virtual register.
         let pool = register_allocator::assign_registers(&mut stack);


### PR DESCRIPTION
As we don't implement spilling just yet, I've modified the coloring algorithm for register allocation to assume k=infinity in the phase that builds that stack moving the colorability checking until the register assignment phase (where the stack is consumed). The reason for this is that the current algorithm can be too conservative and may bail our early even though a valid assignment is actually available.

With this change, the [NFT design](https://github.com/FuelLabs/sway-applications/pull/48) compiles and only requires 14 registers actually. 
