### PR TITLE
Fix how the state index metadata is inlined

### DIFF
--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -203,6 +203,7 @@ fn inline_instruction(
     if let ValueContent {
         value: ValueDatum::Instruction(old_ins),
         span_md_idx,
+        state_idx_md_idx: current_state_idx_md_idx,
         ..
     } = context.values[instruction.0].clone()
     {
@@ -240,7 +241,7 @@ fn inline_instruction(
                     .collect::<Vec<Value>>()
                     .as_slice(),
                 span_md_idx,
-                state_idx_md_idx,
+                current_state_idx_md_idx,
             ),
             Instruction::Cmp(pred, lhs_value, rhs_value) => new_block.ins(context).cmp(
                 pred,

--- a/sway-ir/tests/inline/get_storage_key.ir
+++ b/sway-ir/tests/inline/get_storage_key.ir
@@ -3,13 +3,13 @@
 // regex: LABEL=[[:alpha:]0-9]+:
 
 script {
-    fn anon_0() -> b256 {
+    fn return_storage_key_wrapper() -> b256 {
         entry:
-        v0 = call anon_1(), !2, !3
+        v0 = call return_storage_key(), !2, !3
         ret b256 v0
     }
 
-    fn anon_1() -> b256 {
+    fn return_storage_key() -> b256 {
         entry:
         v0 = get_storage_key, !2
         ret b256 v0
@@ -18,7 +18,7 @@ script {
 // check: fn main
     fn main() -> b256 {
         entry:
-        v0 = call anon_0(), !1, !3
+        v0 = call return_storage_key_wrapper(), !1, !3
 // check: $(arg0=$VAR) = get_storage_key, !1, $(md0=$MD)
 
 // check: $(arg1=$VAR) = phi($LABEL $arg0)

--- a/sway-ir/tests/inline/get_storage_key.ir
+++ b/sway-ir/tests/inline/get_storage_key.ir
@@ -5,6 +5,12 @@
 script {
     fn anon_0() -> b256 {
         entry:
+        v0 = call anon_1(), !2, !3
+        ret b256 v0
+    }
+
+    fn anon_1() -> b256 {
+        entry:
         v0 = get_storage_key, !2
         ret b256 v0
     }
@@ -16,7 +22,8 @@ script {
 // check: $(arg0=$VAR) = get_storage_key, !1, $(md0=$MD)
 
 // check: $(arg1=$VAR) = phi($LABEL $arg0)
-// check: ret b256 $arg1
+// check: $(arg2=$VAR) = phi($LABEL $arg1)
+// check: ret b256 $arg2
         ret b256 v0
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/get_storage_key_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/get_storage_key_caller/src/main.sw
@@ -3,7 +3,7 @@ use get_storage_key_abi::TestContract;
 use std::assert::assert;
 
 fn main() -> u64 {
-    let caller = abi(TestContract, 0x2ecaf8fd525af004f5c9e1368b4cd0a5b30fa7f93ddfdb140695b4ce4eece8da);
+    let caller = abi(TestContract, 0x6ca909825bd62bbce25b964613f7b4d4b0fd2c702c2c852ed281a706615da1fa);
 
     let f1 = caller.from_f1();
     assert(f1 == caller.from_f1());
@@ -25,6 +25,12 @@ fn main() -> u64 {
     assert(f2 != f4);
 
     assert(f3 != f4);
+
+    let(cf1, cf2, cf3, cf4) = caller.from_callers();
+    assert(f1 == cf1);
+    assert(f2 == cf2);
+    assert(f3 == cf3);
+    assert(f4 == cf4);
 
     1
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/get_storage_key_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/get_storage_key_caller/src/main.sw
@@ -5,6 +5,9 @@ use std::assert::assert;
 fn main() -> u64 {
     let caller = abi(TestContract, 0x6ca909825bd62bbce25b964613f7b4d4b0fd2c702c2c852ed281a706615da1fa);
 
+    // Get the storage keys directly by calling the contract methods from_f1,
+    // from_f2, from_f3, from_f4. The keys correspond to different entries in
+    // the storage block so they should return different values.
     let f1 = caller.from_f1();
     assert(f1 == caller.from_f1());
 
@@ -26,11 +29,14 @@ fn main() -> u64 {
 
     assert(f3 != f4);
 
-    let(cf1, cf2, cf3, cf4) = caller.from_callers();
-    assert(f1 == cf1);
-    assert(f2 == cf2);
-    assert(f3 == cf3);
-    assert(f4 == cf4);
+    // Get the storage keys but using from_callers. This should work and the
+    // same keys as above should be returned. This checks that inlining is
+    // working as intended.
+    let(caller_f1, caller_f2, caller_f3, caller_f4) = caller.from_callers();
+    assert(f1 == caller_f1);
+    assert(f2 == caller_f2);
+    assert(f3 == caller_f3);
+    assert(f4 == caller_f4);
 
     1
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/get_storage_key_abi/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/get_storage_key_abi/src/main.sw
@@ -5,4 +5,5 @@ abi TestContract {
     fn from_f2() -> b256;
     fn from_f3() -> b256;
     fn from_f4() -> b256;
+    fn from_callers() -> (b256, b256, b256, b256);
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/get_storage_key_contract/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/get_storage_key_contract/json_abi_oracle.json
@@ -46,5 +46,38 @@
       }
     ],
     "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "from_callers",
+    "outputs": [
+      {
+        "components": [
+          {
+            "components": null,
+            "name": "__tuple_element",
+            "type": "b256"
+          },
+          {
+            "components": null,
+            "name": "__tuple_element",
+            "type": "b256"
+          },
+          {
+            "components": null,
+            "name": "__tuple_element",
+            "type": "b256"
+          },
+          {
+            "components": null,
+            "name": "__tuple_element",
+            "type": "b256"
+          }
+        ],
+        "name": "",
+        "type": "(b256, b256, b256, b256)"
+      }
+    ],
+    "type": "function"
   }
 ]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/get_storage_key_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/get_storage_key_contract/src/main.sw
@@ -20,6 +20,14 @@ storage {
     f4: Foo,
 }
 
+fn calls_foo() -> (b256, b256, b256, b256) {
+    (storage.f1.foo(), storage.f2.foo(), storage.f3.foo(), storage.f4.foo())
+}
+
+fn calls_calls_foo() -> (b256, b256, b256, b256) {
+    calls_foo()
+}
+
 impl TestContract for Contract {
     fn from_f1() -> b256 {
         storage.f1.foo()
@@ -32,5 +40,8 @@ impl TestContract for Contract {
     }
     fn from_f4() -> b256 {
         storage.f4.foo()
+    }
+    fn from_callers() -> (b256, b256, b256, b256) {
+        calls_calls_foo()
     }
 }

--- a/test/src/sdk-harness/test_projects/storage_map/src/main.sw
+++ b/test/src/sdk-harness/test_projects/storage_map/src/main.sw
@@ -39,6 +39,7 @@ storage {
     u64>, 
 }
 
+
 abi StorageMapTest {
     fn insert_into_u64_to_bool_map(key: u64, value: bool);
     fn get_from_u64_to_bool_map(key: u64) -> bool;
@@ -102,13 +103,21 @@ abi StorageMapTest {
     3]) -> u64;
 }
 
+fn insert_into_u64_to_bool_map_inner(key: u64, value: bool) {
+    storage.map1.insert(key, value);
+}
+
+fn get_from_u64_to_bool_map_inner(key: u64) -> bool {
+    storage.map1.get(key)
+}
+
 impl StorageMapTest for Contract {
     fn insert_into_u64_to_bool_map(key: u64, value: bool) {
-        storage.map1.insert(key, value);
+        insert_into_u64_to_bool_map_inner(key, value)
     }
 
     fn get_from_u64_to_bool_map(key: u64) -> bool {
-        storage.map1.get(key)
+        get_from_u64_to_bool_map_inner(key)
     }
 
     fn insert_into_u64_to_u8_map(key: u64, value: u8) {

--- a/test/src/sdk-harness/test_projects/storage_map/src/main.sw
+++ b/test/src/sdk-harness/test_projects/storage_map/src/main.sw
@@ -39,7 +39,6 @@ storage {
     u64>, 
 }
 
-
 abi StorageMapTest {
     fn insert_into_u64_to_bool_map(key: u64, value: bool);
     fn get_from_u64_to_bool_map(key: u64) -> bool;
@@ -103,21 +102,21 @@ abi StorageMapTest {
     3]) -> u64;
 }
 
-fn insert_into_u64_to_bool_map_inner(key: u64, value: bool) {
+fn _insert_into_u64_to_bool_map_inner(key: u64, value: bool) {
     storage.map1.insert(key, value);
 }
 
-fn get_from_u64_to_bool_map_inner(key: u64) -> bool {
+fn _get_from_u64_to_bool_map_inner(key: u64) -> bool {
     storage.map1.get(key)
 }
 
 impl StorageMapTest for Contract {
     fn insert_into_u64_to_bool_map(key: u64, value: bool) {
-        insert_into_u64_to_bool_map_inner(key, value)
+        _insert_into_u64_to_bool_map_inner(key, value)
     }
 
     fn get_from_u64_to_bool_map(key: u64) -> bool {
-        get_from_u64_to_bool_map_inner(key)
+        _get_from_u64_to_bool_map_inner(key)
     }
 
     fn insert_into_u64_to_u8_map(key: u64, value: u8) {


### PR DESCRIPTION
Calling functions that contain calls to `insert()` and `get()` from `StorageMap` because of a bug of how inlining of the state index metadata was being inlined.