### PR TITLE
Made transfer_to a little more generic

### DIFF
--- a/sway-lib-std/src/token.sw
+++ b/sway-lib-std/src/token.sw
@@ -11,7 +11,7 @@ use ::identity::Identity;
 /// Mint `amount` coins of the current contract's `asset_id` and transfer them to `destination` by calling either force_transfer_to_contract() or transfer_to_output(), depending on the type of `Identity`.
 pub fn mint_to(amount: u64, recipient: Identity) {
     mint(amount);
-    transfer_to(amount, recipient);
+    transfer(recipient, amount, contract_id());
 }
 
 /// Mint `amount` coins of the current contract's `asset_id` and send them (!!! UNCONDITIONALLY !!!) to the contract at `destination`.
@@ -42,15 +42,12 @@ pub fn burn(amount: u64) {
     }
 }
 
-/// Transfer `amount` coins of the current contract's `asset_id` and send them to `destination` by calling either force_transfer_to_contract() or transfer_to_output(), depending on the type of `Identity`.
-pub fn transfer_to(amount: u64, recipient: Identity) {
-    match recipient {
-        Identity::Address(addr) => {
-            transfer_to_output(amount, contract_id(), addr);
-        },
-        Identity::ContractId(id) => {
-            force_transfer_to_contract(amount, contract_id(), id);
-        },
+/// Transfer `amount` coins of the specified `asset` and send them to `to` by calling either 
+/// force_transfer_to_contract() or transfer_to_output(), depending on the type of `Identity`.
+pub fn transfer(to: Identity, amount: u64, asset: ContractId) {
+    match to {
+        Identity::Address(address) => transfer_to_output(amount, asset, address),
+        Identity::ContractId(id) => force_transfer_to_contract(amount, asset, id),
     }
 }
 


### PR DESCRIPTION
# Summary

Changes made:

- Renamed `transfer_to()` to `transfer()`
- `transfer()` now takes an `asset` of type `ContractId` instead of having a hardcoded `contract_id()` embedded

# Related

Closes #1851