### PR TITLE
Add missing oracle file to `tuple_field_reassignment` test

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_field_reassignment/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_field_reassignment/json_abi_oracle.json
@@ -1,0 +1,14 @@
+[
+  {
+    "inputs": [],
+    "name": "main",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "u64"
+      }
+    ],
+    "type": "function"
+  }
+]


### PR DESCRIPTION
Fixes CI failure due to #1788 landing and introducing a new test *after* PR #1838 landed which adds a requirement that all scripts and contracts have oracle files.

I.e. yet another case of #1343.