### PR TITLE
better mdbook <> mdbook-forc-documenter setup instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,12 +8,15 @@ Install `mdbook` and then open a new terminal session in order to run the subseq
 cargo install mdbook
 ```
 
-To set up and build the book locally, you must also have `mdbook-forc-documenter` preprocessor installed, the pre-existing forc plugins in the book as well as any new plugins you want to add to the book. If changes have to be made to the Forc commands or plugins chapters, please read the next section first.
-
-From the project root, run:
+To set up and build the book locally, you must also have `mdbook-forc-documenter` preprocessor installed. From the project root, install `mdbook-forc-documenter`:
 
 ```sh
 cargo install --path ./scripts/mdbook-forc-documenter
+```
+
+You should also install forc plugins that are already documented within the book. You can skip plugins that are going to be removed and install plugins that are going to be added to the book:
+
+```sh
 cargo install --path ./forc-plugins/forc-fmt
 cargo install --path ./forc-plugins/forc-lsp
 cargo install --path ./forc-plugins/forc-explore

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Install `mdbook` and then open a new terminal session in order to run the subseq
 cargo install mdbook
 ```
 
-To set up and build the book locally, you must also have `mdbook-forc-documenter` preprocessor installed, the necessary forc plugins as well as any new plugins you want to add to the book. Before making changes to the book, please read the next section on generating documentation for Forc commands/plugins.
+To set up and build the book locally, you must also have `mdbook-forc-documenter` preprocessor installed, the pre-existing forc plugins in the book as well as any new plugins you want to add to the book. If changes have to be made to the Forc commands or plugins chapters, please read the next section first.
 
 From the project root, run:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,11 @@ Install `mdbook` and then open a new terminal session in order to run the subseq
 cargo install mdbook
 ```
 
-To set up and build the book locally, you must also have `mdbook-forc-documenter` preprocessor installed. From the project root, install `mdbook-forc-documenter`:
+To set up and build the book locally, you must also have `mdbook-forc-documenter` preprocessor and relevant forc plugins installed.
+
+If you wish to make changes to the `Commands` or `Plugins` chapters, please read the [next section](#Generating-documentation-for-Forc-commandsplugins) first.
+
+From the project root, install `mdbook-forc-documenter`:
 
 ```sh
 cargo install --path ./scripts/mdbook-forc-documenter

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ To set up and build the book locally, you must also have `mdbook-forc-documenter
 cargo install --path ./scripts/mdbook-forc-documenter
 ```
 
-You should also install forc plugins that are already documented within the book. You can skip plugins that are going to be removed and install plugins that are going to be added to the book:
+You must also install forc plugins that are already documented within the book. You can skip plugins that are going to be removed and install plugins that are going to be added to the book:
 
 ```sh
 cargo install --path ./forc-plugins/forc-fmt

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,18 @@ Install `mdbook` and then open a new terminal session in order to run the subseq
 cargo install mdbook
 ```
 
+To set up and build the book locally, you must also have `mdbook-forc-documenter` preprocessor installed, the necessary forc plugins as well as any new plugins you want to add to the book. Before making changes to the book, please read the next section on generating documentation for Forc commands/plugins.
+
+From the project root, run:
+
+```sh
+cargo install --path ./scripts/mdbook-forc-documenter
+cargo install --path ./forc-plugins/forc-fmt
+cargo install --path ./forc-plugins/forc-lsp
+cargo install --path ./forc-plugins/forc-explore
+```
+
+
 To build book:
 
 ```sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,6 @@ cargo install --path ./forc-plugins/forc-lsp
 cargo install --path ./forc-plugins/forc-explore
 ```
 
-
 To build book:
 
 ```sh


### PR DESCRIPTION
Closes #1860 

Context: 
Previously updated the README for `mdbook-forc-documenter`, but did not do the same for the README in the actual book on setup instructions. This PR includes basic instructions on how to build the mdbook locally.

