### PR TITLE
Bump to v0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "forc-explore"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "clap 3.1.8",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "forc-fmt"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "clap 3.1.8",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "forc-fmt-v2"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "clap 3.1.8",
@@ -1181,14 +1181,14 @@ dependencies = [
 
 [[package]]
 name = "forc-gm"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "clap 3.1.8",
 ]
 
 [[package]]
 name = "forc-lsp"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "clap 3.1.8",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "forc-pkg"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "forc-util",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "forc-util"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "sway-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "clap 3.1.8",
  "derivative",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "sway-fmt"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "ropey",
  "sway-core",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "sway-fmt-v2"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "forc-util",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "filecheck",
  "generational-arena",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "sway-lsp"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-trait",
  "dashmap 4.0.2",
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "sway-parse"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "extension-trait",
  "num-bigint",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "sway-types"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "fuel-asm",
  "fuel-crypto",
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "sway-utils"
-version = "0.15.0"
+version = "0.15.1"
 
 [[package]]
 name = "syn"

--- a/forc-gm/Cargo.toml
+++ b/forc-gm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-gm"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-pkg"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,15 +10,15 @@ description = "Building, locking, fetching and updating Sway projects as Forc pa
 
 [dependencies]
 anyhow = "1"
-forc-util = { version = "0.15.0", path = "../forc-util" }
+forc-util = { version = "0.15.1", path = "../forc-util" }
 fuels-types = "0.12"
 git2 = { version = "0.14", features = ["vendored-libgit2", "vendored-openssl"] }
 petgraph = { version = "0.6", features = ["serde-1"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
-sway-core = { version = "0.15.0", path = "../sway-core" }
-sway-utils = { version = "0.15.0", path = "../sway-utils" }
+sway-core = { version = "0.15.1", path = "../sway-core" }
+sway-utils = { version = "0.15.1", path = "../sway-utils" }
 toml = "0.5"
 tracing = "0.1"
 url = { version = "2.2", features = ["serde"] }

--- a/forc-plugins/forc-explore/Cargo.toml
+++ b/forc-plugins/forc-explore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-explore"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,7 +11,7 @@ description = "A `forc` plugin for running the fuel block explorer."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-forc-util = { version = "0.15.0", path = "../../forc-util" }
+forc-util = { version = "0.15.1", path = "../../forc-util" }
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 tar = "0.4"

--- a/forc-plugins/forc-fmt-v2/Cargo.toml
+++ b/forc-plugins/forc-fmt-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-fmt-v2"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,10 +12,10 @@ description = "A `forc` plugin for running the Sway code formatter."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-forc-util = { version = "0.15.0", path = "../../forc-util" }
+forc-util = { version = "0.15.1", path = "../../forc-util" }
 prettydiff = "0.5"
-sway-core = { version = "0.15.0", path = "../../sway-core" }
-sway-fmt-v2 = { version = "0.15.0", path = "../../sway-fmt-v2" }
-sway-utils = { version = "0.15.0", path = "../../sway-utils" }
+sway-core = { version = "0.15.1", path = "../../sway-core" }
+sway-fmt-v2 = { version = "0.15.1", path = "../../sway-fmt-v2" }
+sway-utils = { version = "0.15.1", path = "../../sway-utils" }
 taplo = "0.7"
 tracing = "0.1"

--- a/forc-plugins/forc-fmt/Cargo.toml
+++ b/forc-plugins/forc-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-fmt"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,10 +11,10 @@ description = "A `forc` plugin for running the Sway code formatter."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-forc-util = { version = "0.15.0", path = "../../forc-util" }
+forc-util = { version = "0.15.1", path = "../../forc-util" }
 prettydiff = "0.5"
-sway-core = { version = "0.15.0", path = "../../sway-core" }
-sway-fmt = { version = "0.15.0", path = "../../sway-fmt" }
-sway-utils = { version = "0.15.0", path = "../../sway-utils" }
+sway-core = { version = "0.15.1", path = "../../sway-core" }
+sway-fmt = { version = "0.15.1", path = "../../sway-fmt" }
+sway-utils = { version = "0.15.1", path = "../../sway-utils" }
 taplo = "0.7"
 tracing = "0.1"

--- a/forc-plugins/forc-lsp/Cargo.toml
+++ b/forc-plugins/forc-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-lsp"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,5 +11,5 @@ description = "A simple `forc` plugin for starting the sway language server."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-sway-lsp = { version = "0.15.0", path = "../../sway-lsp" }
+sway-lsp = { version = "0.15.1", path = "../../sway-lsp" }
 tokio = { version = "1.8" }

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-util"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,8 +12,8 @@ description = "Utility items shared between forc crates."
 annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1"
 dirs = "3.0.2"
-sway-core = { version = "0.15.0", path = "../sway-core" }
-sway-utils = { version = "0.15.0", path = "../sway-utils" }
+sway-core = { version = "0.15.1", path = "../sway-core" }
+sway-utils = { version = "0.15.1", path = "../sway-utils" }
 termcolor = "1.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -21,8 +21,8 @@ annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1.0.41"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 clap_complete = "3.1"
-forc-pkg = { version = "0.15.0", path = "../forc-pkg" }
-forc-util = { version = "0.15.0", path = "../forc-util" }
+forc-pkg = { version = "0.15.1", path = "../forc-pkg" }
+forc-util = { version = "0.15.1", path = "../forc-util" }
 fs_extra = "1.2"
 fuel-asm = "0.5"
 fuel-gql-client = { version = "0.8", default-features = false }
@@ -32,9 +32,9 @@ futures = "0.3"
 hex = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.73"
-sway-core = { version = "0.15.0", path = "../sway-core" }
-sway-types = { version = "0.15.0", path = "../sway-types" }
-sway-utils = { version = "0.15.0", path = "../sway-utils" }
+sway-core = { version = "0.15.1", path = "../sway-core" }
+sway-types = { version = "0.15.1", path = "../sway-types" }
+sway-utils = { version = "0.15.1", path = "../sway-utils" }
 term-table = "1.3"
 tokio = { version = "1.8.0", features = ["macros", "rt-multi-thread", "process"] }
 toml = "0.5"

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-core"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -28,10 +28,10 @@ regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.9"
 smallvec = "1.7"
-sway-ir = { version = "0.15.0", path = "../sway-ir" }
-sway-parse = { version = "0.15.0", path = "../sway-parse" }
-sway-types = { version = "0.15.0", path = "../sway-types" }
-sway-utils = { version = "0.15.0", path = "../sway-utils" }
+sway-ir = { version = "0.15.1", path = "../sway-ir" }
+sway-parse = { version = "0.15.1", path = "../sway-parse" }
+sway-types = { version = "0.15.1", path = "../sway-types" }
+sway-utils = { version = "0.15.1", path = "../sway-utils" }
 thiserror = "1.0"
 tracing = "0.1"
 uint = "0.9"

--- a/sway-fmt-v2/Cargo.toml
+++ b/sway-fmt-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-fmt-v2"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,11 +11,11 @@ description = "Sway sway-fmt-v2."
 
 [dependencies]
 anyhow = "1"
-forc-util = { version = "0.15.0", path = "../forc-util" }
+forc-util = { version = "0.15.1", path = "../forc-util" }
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
-sway-core = { version = "0.15.0", path = "../sway-core" }
-sway-parse = { version = "0.15.0", path = "../sway-parse" }
-sway-types = { version = "0.15.0", path = "../sway-types" }
+sway-core = { version = "0.15.1", path = "../sway-core" }
+sway-parse = { version = "0.15.1", path = "../sway-parse" }
+sway-types = { version = "0.15.1", path = "../sway-types" }
 thiserror = "1.0.30"
 toml = "0.5"

--- a/sway-fmt/Cargo.toml
+++ b/sway-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-fmt"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,6 +10,6 @@ description = "Sway sway-fmt."
 
 [dependencies]
 ropey = "1.2"
-sway-core = { version = "0.15.0", path = "../sway-core" }
-sway-types = { version = "0.15.0", path = "../sway-types" }
+sway-core = { version = "0.15.1", path = "../sway-core" }
+sway-types = { version = "0.15.1", path = "../sway-types" }
 

--- a/sway-ir/Cargo.toml
+++ b/sway-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ir"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,5 +12,5 @@ description = "Sway intermediate representation."
 filecheck = "0.5"
 generational-arena = "0.2"
 peg = "0.7"
-sway-types = { version = "0.15.0", path = "../sway-types" }
+sway-types = { version = "0.15.1", path = "../sway-types" }
 tracing = "0.1"

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-lsp"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,13 +10,13 @@ description = "LSP server for Sway."
 
 [dependencies]
 dashmap = "4.0.2"
-forc-util = { version = "0.15.0", path = "../forc-util" }
+forc-util = { version = "0.15.1", path = "../forc-util" }
 ropey = "1.2"
 serde_json = "1.0.60"
-sway-core = { version = "0.15.0", path = "../sway-core" }
-sway-fmt = { version = "0.15.0", path = "../sway-fmt" }
-sway-types = { version = "0.15.0", path = "../sway-types" }
-sway-utils = { version = "0.15.0", path = "../sway-utils" }
+sway-core = { version = "0.15.1", path = "../sway-core" }
+sway-fmt = { version = "0.15.1", path = "../sway-fmt" }
+sway-types = { version = "0.15.1", path = "../sway-types" }
+sway-utils = { version = "0.15.1", path = "../sway-utils" }
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tower-lsp = "0.16.0"
 tracing = "0.1"

--- a/sway-parse/Cargo.toml
+++ b/sway-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-parse"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,7 +12,7 @@ description = "Sway's parser"
 extension-trait = "1.0.1"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
-sway-types = { version = "0.15.0", path = "../sway-types" }
+sway-types = { version = "0.15.1", path = "../sway-types" }
 thiserror = "1.0"
 unicode-xid = "0.2.2"
 

--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-types"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/sway-utils/Cargo.toml
+++ b/sway-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-utils"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
`0.15.0` failed to publish due to some weird issue with the `bigint` crate. Dependence on `bigint` is now removed in favour of `uint`. 