### PR TITLE
Minor updates to `storage` in the Sway Book

### DIFF
--- a/docs/src/blockchain-development/storage.md
+++ b/docs/src/blockchain-development/storage.md
@@ -49,10 +49,10 @@ Because storage maps have to be defined inside a `storage` block, the `storage` 
 
 ## Manual Storage Management
 
-It is possible to leverage FuelVM storage operations using the `std::storage::store` and `std::storage::get` functions provided in the standard library. With this approach you will have to manually assign the internal key used for storage. An example is as follows:
+It is possible to leverage FuelVM storage operations directly using the `std::storage::store` and `std::storage::get` functions provided in the standard library. With this approach you will have to manually assign the internal key used for storage. An example is as follows:
 
 ```sway
 {{#include ../../../examples/storage_example/src/main.sw}}
 ```
 
-This is currently useful for variables of type `str[]`, `enum`, and arrays because those cannot be used in a `storage` block yet. They can, however, be used as types for keys and values in `StorageMap<K, V>`.
+> **Note**: Though these functions can be used for any data type, they should mostly be used for arrays because arrays are not yet supported in `storage` blocks. Note, however, that _all_ data types can be used as types for keys and/or values in `StorageMap<K, V>` without any restrictions.

--- a/docs/src/reference/known_issues_and_workarounds.md
+++ b/docs/src/reference/known_issues_and_workarounds.md
@@ -16,7 +16,7 @@
 
 ## General
 
-* Storage variables of types `str[]`, `enum`, and arrays are not yet supported in a `storage` block. See the [Manual Storage Management](../blockchain-development/storage.md#manual-storage-management) section for details on how to use `store` and `get` from the standard library to handle those types. Note, however, that `StorageMap<K, V>` _does_ support arbitrary types for `K` and `V` without any limitations.
+* Arrays in a `storage` block are not yet supported. See the [Manual Storage Management](../blockchain-development/storage.md#manual-storage-management) section for details on how to use `store` and `get` from the standard library to manage storage slots directly. Note, however, that `StorageMap<K, V>` _does_ support arbitrary types for `K` and `V` without any limitations.
 
 * The optimizing pass of the compiler is not yet implemented, therefore bytecode will be more expensive and larger than it would be in production. Note that eventually the optimizer will support zero-cost abstractions, avoiding the need for developers to go down to inline assembly to produce optimal code.
 


### PR DESCRIPTION
Now that `enum` and `str[]` work in `storage` blocks, all that remains is arrays.