### PR TITLE
Add VS Code config

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -1,0 +1,9 @@
+# VS Code Configuration
+
+This directory contains essential VS Code configuration that should be useful to most developers planning to work on this project.
+
+If you want to personalize these, you can create your own workspace as always.
+
+## Contributing
+
+Make sure you are adding things that will be useful to almost all developers.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    // Rust language support
+    "rust-lang.rust-analyzer",
+    // Rust debugging
+    "vadimcn.vscode-lldb"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    // Debugs the `test` project using the `vadimcn.vscode-lldb` extension.
+    // You can run `lldb.getCargoLaunchConfigs` from the command palette to
+    // generate configurations for other projects in the workspace.
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug Tests",
+      "cargo": {
+        "args": ["build", "--bin=test", "--package=test"],
+        "filter": {
+          "name": "test",
+          "kind": "bin"
+        }
+      },
+      "args": [
+        // You can add a filter here to debug a specific test
+        // "should_pass/stdlib/my_test"
+      ],
+      "env": {
+        "SWAY_TEST_VERBOSE": "1"
+      },
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds some essential VSC config to the project. This config will be picked up by VSC and it will offer to install the recommended extensions. It also has a launch configuration that will debug the tests with in-editor breakpoint, etc. support.

Another popular option is to gitignore the `.vscode` directory, but choosing the right extensions and writing the correct launch configurations might be a real hassle so it is nice to provide some examples using this directory.

If a developer wants their own config they can create their own VSC workspace and personalize that as usual.

Non-VSC devs won't be affected by this PR, and VSC devs will see a recommendation dialog if they don't have all the extensions installed which can be dismissed forever.

Note: Helps with https://github.com/FuelLabs/pm/issues/24 as a side effect.