### PR TITLE
Fix incorrect `CallPath` suffix on `TypedImplTrait`

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -18,7 +18,7 @@ pub struct TypedFunctionDeclaration {
     pub(crate) type_parameters: Vec<TypeParameter>,
     /// Used for error messages -- the span pointing to the return type
     /// annotation of the function
-    pub(crate) return_type_span: Span,
+    pub return_type_span: Span,
     pub(crate) visibility: Visibility,
     /// whether this function exists in another contract and requires a call to it or not
     pub(crate) is_contract_call: bool,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -183,6 +183,15 @@ impl TypedImplTrait {
             namespace.insert_symbol(type_parameter.name_ident.clone(), type_parameter.into());
         }
 
+        let trait_name = CallPath {
+            prefixes: vec![],
+            suffix: match &type_implementing_for {
+                TypeInfo::Custom { name, .. } => name.clone(),
+                _ => Ident::new_with_override("r#Self", block_span.clone()),
+            },
+            is_absolute: false,
+        };
+
         // Resolve the Self type as it's most likely still 'Custom' and use the
         // resolved type for self instead.
         let implementing_for_type_id = check!(
@@ -228,11 +237,6 @@ impl TypedImplTrait {
                 errors
             ));
         }
-        let trait_name = CallPath {
-            prefixes: vec![],
-            suffix: Ident::new_with_override("r#Self", block_span.clone()),
-            is_absolute: false,
-        };
 
         let impl_trait = TypedImplTrait {
             trait_name,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1186,7 +1186,7 @@ impl TypedExpression {
         }
         let exp = TypedExpression {
             expression: TypedExpressionVariant::StructExpression {
-                struct_name: struct_decl.name.clone(),
+                struct_name: call_path.suffix,
                 fields: typed_fields_buf,
             },
             return_type: struct_decl.create_type_id(),

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -118,9 +118,11 @@ fn handle_declaration(declaration: &TypedDeclaration, tokens: &mut TokenMap) {
                     TokenType::TypedDeclaration(declaration.clone()),
                 );
             }
-            // This is reporting the train name as r#Self and not the actual name
-            // Also the span is referencing the declerations span.
-            //tokens.insert(to_ident_key(&trait_name.suffix), TokenType::TypedDeclaration(declaration.clone()));
+
+            tokens.insert(
+                to_ident_key(&trait_name.suffix),
+                TokenType::TypedDeclaration(declaration.clone()),
+            );
 
             for method in methods {
                 tokens.insert(
@@ -136,6 +138,12 @@ fn handle_declaration(declaration: &TypedDeclaration, tokens: &mut TokenMap) {
                         TokenType::TypedFunctionParameter(paramater.clone()),
                     );
                 }
+
+                let return_type_ident = Ident::new(method.return_type_span.clone());
+                tokens.insert(
+                    to_ident_key(&return_type_ident),
+                    TokenType::TypedFunctionDeclaration(method.clone()),
+                );
             }
         }
         TypedDeclaration::AbiDeclaration(abi_decl) => {


### PR DESCRIPTION
Previously, the `trait_name.suffix` on `ImplTrait` was being assigned `Ident::new_with_override("r#Self", block_span.clone())`. This meant in the language server, the name and span for the token was in-correct. See issue #1773 

This PR creates the correct `Ident` if the type_implementing_for matches `TypeInfo::Custom`, otherwise the original behavior is retained. I'm not 100% sure why the original Ident was created with the name `r#Self` and with the whole block as the span but maybe @canndrew has a better idea?

This is my first PR to `sway-core` so please let me know if I have done anything incorrectly. 