### PR TITLE
Make `BuildConfig` an `Option` for the `compile_to_ast` fn

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1131,7 +1131,7 @@ pub fn compile(
     let silent_mode = build_config.silent;
 
     // First, compile to an AST. We'll update the namespace and check for JSON ABI output.
-    let ast_res = sway_core::compile_to_ast(source, namespace, &sway_build_config);
+    let ast_res = sway_core::compile_to_ast(source, namespace, Some(&sway_build_config));
     match &ast_res {
         CompileAstResult::Failure { warnings, errors } => {
             print_on_failure(silent_mode, warnings, errors);

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -208,7 +208,7 @@ pub enum BytecodeCompilationResult {
 pub fn compile_to_ast(
     input: Arc<str>,
     initial_namespace: namespace::Module,
-    build_config: &BuildConfig,
+    build_config: Option<&BuildConfig>,
 ) -> CompileAstResult {
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
@@ -217,7 +217,7 @@ pub fn compile_to_ast(
         value: parse_program_opt,
         warnings: new_warnings,
         errors: new_errors,
-    } = parse(input, Some(build_config));
+    } = parse(input, build_config);
     warnings.extend(new_warnings);
     errors.extend(new_errors);
     let parse_program = match parse_program_opt {
@@ -268,7 +268,7 @@ pub fn compile_to_asm(
     initial_namespace: namespace::Module,
     build_config: BuildConfig,
 ) -> CompilationResult {
-    let ast_res = compile_to_ast(input, initial_namespace, &build_config);
+    let ast_res = compile_to_ast(input, initial_namespace, Some(&build_config));
     ast_to_asm(ast_res, &build_config)
 }
 

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use sway_core::{
     parse,
     semantic_analysis::{ast_node::TypedAstNode, namespace},
-    BuildConfig, CompileAstResult, TreeType,
+    CompileAstResult, TreeType,
 };
 use tower_lsp::lsp_types::{Diagnostic, Position, Range, TextDocumentContentChangeEvent};
 
@@ -162,10 +162,7 @@ impl TextDocument {
     fn parse_typed_tokens_from_text(&self) -> Option<Vec<TypedAstNode>> {
         let text = Arc::from(self.get_text());
         let namespace = namespace::Module::default();
-        let file_name = std::path::PathBuf::from(self.get_uri());
-        let build_config =
-            BuildConfig::root_from_file_name_and_manifest_path(file_name, Default::default());
-        let ast_res = sway_core::compile_to_ast(text, namespace, &build_config);
+        let ast_res = sway_core::compile_to_ast(text, namespace, None);
         match ast_res {
             CompileAstResult::Failure { .. } => None,
             CompileAstResult::Success { typed_program, .. } => Some(typed_program.root.all_nodes),


### PR DESCRIPTION
This change means we can call `compile_to_ast` in tests where there is no manifest directory and still get back a `CompileAstResult`.