### PR TITLE
Fix for accidentally skipping the print_intermediate_asm user config item.

### DIFF
--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -60,13 +60,19 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
     };
 
     // Check if any cli parameter is passed by the user if not fetch the build profile from manifest.
-    if !print_ir && !print_finalized_asm && !silent_mode {
-        config = manifest.build_profile.as_ref()
-        .and_then(|profiles| profiles.get(&selected_build_profile))
-        .unwrap_or_else(||{
-            warn!("provided profile option {} is not present in the manifest file. Using default config.", selected_build_profile);
-            config
-        });
+    if !print_ir && !print_intermediate_asm && !print_finalized_asm && !silent_mode {
+        config = manifest
+            .build_profile
+            .as_ref()
+            .and_then(|profiles| profiles.get(&selected_build_profile))
+            .unwrap_or_else(|| {
+                warn!(
+                    "provided profile option {} is not present in the manifest file. \
+                Using default config.",
+                    selected_build_profile
+                );
+                config
+            });
     }
 
     let lock_path = lock_path(manifest.dir());


### PR DESCRIPTION
Closes #1895.