### PR TITLE
sway-fmt-v2 Formatter struct should have a Shape field that can keep track of the current indentation

### DIFF
--- a/forc-plugins/forc-fmt-v2/src/main.rs
+++ b/forc-plugins/forc-fmt-v2/src/main.rs
@@ -49,12 +49,12 @@ fn run() -> Result<()> {
         Some(path) => PathBuf::from(path),
         None => std::env::current_dir()?,
     };
-    let config = Formatter::from_dir(&dir)?;
-    format_pkg_at_dir(app, &dir, config)
+    let mut config = Formatter::from_dir(&dir)?;
+    format_pkg_at_dir(app, &dir, &mut config)
 }
 
 /// Format the package at the given directory.
-fn format_pkg_at_dir(app: App, dir: &Path, config: Formatter) -> Result<()> {
+fn format_pkg_at_dir(app: App, dir: &Path, config: &mut Formatter) -> Result<()> {
     match find_manifest_dir(dir) {
         Some(path) => {
             let manifest_path = path.clone();
@@ -69,7 +69,7 @@ fn format_pkg_at_dir(app: App, dir: &Path, config: Formatter) -> Result<()> {
                         file.clone(),
                         manifest_path.clone(),
                     );
-                    match Formatter::format(&config, file_content.clone(), Some(&build_config)) {
+                    match Formatter::format(config, file_content.clone(), Some(&build_config)) {
                         Ok(formatted_content) => {
                             if app.check {
                                 if *file_content != formatted_content {

--- a/sway-fmt-v2/src/fmt.rs
+++ b/sway-fmt-v2/src/fmt.rs
@@ -1,3 +1,4 @@
+use crate::utils::indent_style::Shape;
 use std::{path::Path, sync::Arc};
 use sway_core::BuildConfig;
 use sway_parse::ItemKind;
@@ -9,13 +10,14 @@ pub use crate::{
 
 #[derive(Debug, Default)]
 pub struct Formatter {
+    pub shape: Shape,
     pub config: Config,
 }
 
 pub type FormattedCode = String;
 
 pub trait Format {
-    fn format(&self, formatter: &Formatter) -> FormattedCode;
+    fn format(&self, formatter: &mut Formatter) -> FormattedCode;
 }
 
 impl Formatter {
@@ -25,10 +27,11 @@ impl Formatter {
             Err(ConfigError::NotFound) => Config::default(),
             Err(e) => return Err(e),
         };
-        Ok(Self { config })
+        let shape = Shape::default();
+        Ok(Self { config, shape })
     }
     pub fn format(
-        &self,
+        &mut self,
         src: Arc<str>,
         build_config: Option<&BuildConfig>,
     ) -> Result<FormattedCode, FormatterError> {

--- a/sway-fmt-v2/src/items/item_abi.rs
+++ b/sway-fmt-v2/src/items/item_abi.rs
@@ -2,7 +2,7 @@ use crate::fmt::{Format, FormattedCode, Formatter};
 use sway_parse::ItemAbi;
 
 impl Format for ItemAbi {
-    fn format(&self, _formatter: &Formatter) -> FormattedCode {
+    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/items/item_const.rs
+++ b/sway-fmt-v2/src/items/item_const.rs
@@ -2,7 +2,7 @@ use crate::fmt::{Format, FormattedCode, Formatter};
 use sway_parse::ItemConst;
 
 impl Format for ItemConst {
-    fn format(&self, _formatter: &Formatter) -> FormattedCode {
+    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/items/item_enum.rs
+++ b/sway-fmt-v2/src/items/item_enum.rs
@@ -2,7 +2,7 @@ use crate::fmt::{Format, FormattedCode, Formatter};
 use sway_parse::ItemEnum;
 
 impl Format for ItemEnum {
-    fn format(&self, _formatter: &Formatter) -> FormattedCode {
+    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/items/item_fn.rs
+++ b/sway-fmt-v2/src/items/item_fn.rs
@@ -2,7 +2,7 @@ use crate::fmt::{Format, FormattedCode, Formatter};
 use sway_parse::ItemFn;
 
 impl Format for ItemFn {
-    fn format(&self, _formatter: &Formatter) -> FormattedCode {
+    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/items/item_impl.rs
+++ b/sway-fmt-v2/src/items/item_impl.rs
@@ -2,7 +2,7 @@ use crate::fmt::{Format, FormattedCode, Formatter};
 use sway_parse::ItemImpl;
 
 impl Format for ItemImpl {
-    fn format(&self, _formatter: &Formatter) -> FormattedCode {
+    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/items/item_storage.rs
+++ b/sway-fmt-v2/src/items/item_storage.rs
@@ -2,7 +2,7 @@ use crate::fmt::{Format, FormattedCode, Formatter};
 use sway_parse::ItemStorage;
 
 impl Format for ItemStorage {
-    fn format(&self, _formatter: &Formatter) -> FormattedCode {
+    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/items/item_struct.rs
+++ b/sway-fmt-v2/src/items/item_struct.rs
@@ -2,7 +2,7 @@ use crate::fmt::{Format, FormattedCode, Formatter};
 use sway_parse::ItemStruct;
 
 impl Format for ItemStruct {
-    fn format(&self, _formatter: &Formatter) -> FormattedCode {
+    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/items/item_trait.rs
+++ b/sway-fmt-v2/src/items/item_trait.rs
@@ -2,7 +2,7 @@ use crate::fmt::{Format, FormattedCode, Formatter};
 use sway_parse::ItemTrait;
 
 impl Format for ItemTrait {
-    fn format(&self, _formatter: &Formatter) -> FormattedCode {
+    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/items/item_use.rs
+++ b/sway-fmt-v2/src/items/item_use.rs
@@ -2,7 +2,7 @@ use crate::fmt::{Format, FormattedCode, Formatter};
 use sway_parse::ItemUse;
 
 impl Format for ItemUse {
-    fn format(&self, _formatter: &Formatter) -> FormattedCode {
+    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/utils/indent_style.rs
+++ b/sway-fmt-v2/src/utils/indent_style.rs
@@ -10,24 +10,24 @@ use crate::{
     fmt::Formatter,
 };
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub(crate) struct Indent {
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub struct Indent {
     /// Width of the block indent, in characters. Must be a multiple of
     /// Config::tab_spaces.
-    pub(crate) block_indent: usize,
+    pub block_indent: usize,
     /// Alignment in characters.
-    pub(crate) alignment: usize,
+    pub alignment: usize,
 }
 
 impl Indent {
-    pub(crate) fn new(block_indent: usize, alignment: usize) -> Self {
+    pub fn new(block_indent: usize, alignment: usize) -> Self {
         Self {
             block_indent,
             alignment,
         }
     }
 
-    pub(crate) fn from_width(formatter: &Formatter, width: usize) -> Self {
+    pub fn from_width(formatter: &Formatter, width: usize) -> Self {
         let tab_spaces = formatter.config.whitespace.tab_spaces;
         if formatter.config.whitespace.hard_tabs {
             let tab_num = width / tab_spaces;
@@ -38,23 +38,23 @@ impl Indent {
         }
     }
 
-    pub(crate) fn empty() -> Self {
+    pub fn empty() -> Self {
         Self::new(0, 0)
     }
 
-    pub(crate) fn block_only(&self) -> Self {
+    pub fn block_only(&self) -> Self {
         Self {
             block_indent: self.block_indent,
             alignment: 0,
         }
     }
 
-    pub(crate) fn block_indent(mut self, formatter: &Formatter) -> Self {
+    pub fn block_indent(mut self, formatter: &Formatter) -> Self {
         self.block_indent += formatter.config.whitespace.tab_spaces;
         self
     }
 
-    pub(crate) fn block_unindent(mut self, formatter: &Formatter) -> Self {
+    pub fn block_unindent(mut self, formatter: &Formatter) -> Self {
         let tab_spaces = formatter.config.whitespace.tab_spaces;
         if self.block_indent < tab_spaces {
             Indent::new(self.block_indent, 0)
@@ -64,15 +64,15 @@ impl Indent {
         }
     }
 
-    pub(crate) fn width(&self) -> usize {
+    pub fn width(&self) -> usize {
         self.block_indent + self.alignment
     }
 
-    pub(crate) fn to_string(self, formatter: &Formatter) -> Cow<'static, str> {
+    pub fn to_string(self, formatter: &Formatter) -> Cow<'static, str> {
         self.to_string_inner(formatter, 1)
     }
 
-    pub(crate) fn to_string_with_newline(self, formatter: &Formatter) -> Cow<'static, str> {
+    pub fn to_string_with_newline(self, formatter: &Formatter) -> Cow<'static, str> {
         self.to_string_inner(formatter, 0)
     }
 
@@ -142,14 +142,14 @@ impl Sub<usize> for Indent {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub(crate) struct Shape {
-    pub(crate) width: usize,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub struct Shape {
+    pub width: usize,
     // The current indentation of code.
-    pub(crate) indent: Indent,
+    pub indent: Indent,
     // Indentation + any already emitted text on the first line of the current
     // statement.
-    pub(crate) offset: usize,
+    pub offset: usize,
 }
 
 impl Shape {
@@ -169,7 +169,7 @@ impl Shape {
     // |<------------>|  max width
     // |<---->|          indent
     //        |<--->|    width
-    pub(crate) fn legacy(width: usize, indent: Indent) -> Self {
+    pub fn legacy(width: usize, indent: Indent) -> Self {
         Self {
             width,
             indent,
@@ -177,7 +177,7 @@ impl Shape {
         }
     }
 
-    pub(crate) fn indented(indent: Indent, formatter: &Formatter) -> Self {
+    pub fn indented(indent: Indent, formatter: &Formatter) -> Self {
         Self {
             width: formatter
                 .config
@@ -189,7 +189,7 @@ impl Shape {
         }
     }
 
-    pub(crate) fn with_max_width(&self, formatter: &Formatter) -> Self {
+    pub fn with_max_width(&self, formatter: &Formatter) -> Self {
         Self {
             width: formatter
                 .config
@@ -200,7 +200,7 @@ impl Shape {
         }
     }
 
-    pub(crate) fn visual_indent(&self, extra_width: usize) -> Self {
+    pub fn visual_indent(&self, extra_width: usize) -> Self {
         let alignment = self.offset + extra_width;
         Self {
             width: self.width,
@@ -209,7 +209,7 @@ impl Shape {
         }
     }
 
-    pub(crate) fn block_indent(&self, extra_width: usize) -> Self {
+    pub fn block_indent(&self, extra_width: usize) -> Self {
         if self.indent.alignment == 0 {
             Self {
                 width: self.width,
@@ -225,36 +225,36 @@ impl Shape {
         }
     }
 
-    pub(crate) fn block_left(&self, width: usize) -> Option<Self> {
+    pub fn block_left(&self, width: usize) -> Option<Self> {
         self.block_indent(width).sub_width(width)
     }
 
-    pub(crate) fn add_offset(&self, extra_width: usize) -> Self {
+    pub fn add_offset(&self, extra_width: usize) -> Self {
         Self {
             offset: self.offset + extra_width,
             ..*self
         }
     }
 
-    pub(crate) fn block(&self) -> Self {
+    pub fn block(&self) -> Self {
         Self {
             indent: self.indent.block_only(),
             ..*self
         }
     }
 
-    pub(crate) fn saturating_sub_width(&self, width: usize) -> Self {
+    pub fn saturating_sub_width(&self, width: usize) -> Self {
         self.sub_width(width).unwrap_or(Self { width: 0, ..*self })
     }
 
-    pub(crate) fn sub_width(&self, width: usize) -> Option<Self> {
+    pub fn sub_width(&self, width: usize) -> Option<Self> {
         Some(Self {
             width: self.width.checked_sub(width)?,
             ..*self
         })
     }
 
-    pub(crate) fn shrink_left(&self, width: usize) -> Option<Self> {
+    pub fn shrink_left(&self, width: usize) -> Option<Self> {
         Some(Self {
             width: self.width.checked_sub(width)?,
             indent: self.indent + width,
@@ -262,15 +262,15 @@ impl Shape {
         })
     }
 
-    pub(crate) fn offset_left(&self, width: usize) -> Option<Self> {
+    pub fn offset_left(&self, width: usize) -> Option<Self> {
         self.add_offset(width).sub_width(width)
     }
 
-    pub(crate) fn used_width(&self) -> usize {
+    pub fn used_width(&self) -> usize {
         self.indent.block_indent + self.offset
     }
 
-    pub(crate) fn rhs_overhead(&self, formatter: &Formatter) -> usize {
+    pub fn rhs_overhead(&self, formatter: &Formatter) -> usize {
         formatter
             .config
             .whitespace
@@ -278,7 +278,7 @@ impl Shape {
             .saturating_sub(self.used_width() + self.width)
     }
 
-    pub(crate) fn comment(&self, formatter: &Formatter) -> Self {
+    pub fn comment(&self, formatter: &Formatter) -> Self {
         let width = min(
             self.width,
             formatter
@@ -290,14 +290,14 @@ impl Shape {
         Self { width, ..*self }
     }
 
-    pub(crate) fn to_string_with_newline(self, formatter: &Formatter) -> Cow<'static, str> {
+    pub fn to_string_with_newline(self, formatter: &Formatter) -> Cow<'static, str> {
         let mut offset_indent = self.indent;
         offset_indent.alignment = self.offset;
         offset_indent.to_string_inner(formatter, 0)
     }
 
     /// Creates a `Shape` with a virtually infinite width.
-    pub(crate) fn infinite_width(&self) -> Self {
+    pub fn infinite_width(&self) -> Self {
         Self {
             width: INFINITE_SHAPE_WIDTH,
             ..*self


### PR DESCRIPTION
closes #1924 

This PR adds a shape field to the Formatter so that from each implementation of the format trait we can reach a shared shape instance. This way we can keep track of the last indentation level before adding a newly formatted code result. 