### PR TITLE
sway-fmt-v2 should actually use the newline style utils implemented before

### DIFF
--- a/sway-fmt-v2/src/fmt.rs
+++ b/sway-fmt-v2/src/fmt.rs
@@ -2,6 +2,7 @@ use std::{path::Path, sync::Arc};
 use sway_core::BuildConfig;
 use sway_parse::ItemKind;
 
+use crate::{utils::newline_style::apply_newline_style, config::whitespace::NewlineStyle};
 pub use crate::{
     config::manifest::Config,
     error::{ConfigError, FormatterError},
@@ -34,7 +35,7 @@ impl Formatter {
     ) -> Result<FormattedCode, FormatterError> {
         let path = build_config.map(|build_config| build_config.canonical_root_module());
         let items = sway_parse::parse_file(src, path)?.items;
-        Ok(items
+        let formatted_raw_newline = items
             .into_iter()
             .map(|item| -> Result<String, FormatterError> {
                 use ItemKind::*;
@@ -51,6 +52,9 @@ impl Formatter {
                 })
             })
             .collect::<Result<Vec<String>, _>>()?
-            .join("\n"))
-    }
+            .join("\n");
+            let mut formatted_code = String::from(&formatted_raw_newline);
+            apply_newline_style(NewlineStyle::Auto, &mut formatted_code, &formatted_raw_newline);
+            Ok(formatted_code)
+        }
 }

--- a/sway-fmt-v2/src/fmt.rs
+++ b/sway-fmt-v2/src/fmt.rs
@@ -2,11 +2,11 @@ use std::{path::Path, sync::Arc};
 use sway_core::BuildConfig;
 use sway_parse::ItemKind;
 
-use crate::{utils::newline_style::apply_newline_style, config::whitespace::NewlineStyle};
 pub use crate::{
     config::manifest::Config,
     error::{ConfigError, FormatterError},
 };
+use crate::{config::whitespace::NewlineStyle, utils::newline_style::apply_newline_style};
 
 #[derive(Debug, Default)]
 pub struct Formatter {
@@ -53,8 +53,12 @@ impl Formatter {
             })
             .collect::<Result<Vec<String>, _>>()?
             .join("\n");
-            let mut formatted_code = String::from(&formatted_raw_newline);
-            apply_newline_style(NewlineStyle::Auto, &mut formatted_code, &formatted_raw_newline);
-            Ok(formatted_code)
-        }
+        let mut formatted_code = String::from(&formatted_raw_newline);
+        apply_newline_style(
+            NewlineStyle::Auto,
+            &mut formatted_code,
+            &formatted_raw_newline,
+        );
+        Ok(formatted_code)
+    }
 }


### PR DESCRIPTION
closes #1926.

After formatting is done and the result is collected, we are now applying the newline style to the resulting `FormattedCode`.