### PR TITLE
Add `std::tx::get_script_data`

### DIFF
--- a/sway-lib-std/src/tx.sw
+++ b/sway-lib-std/src/tx.sw
@@ -4,6 +4,7 @@ library tx;
 
 use ::address::Address;
 use ::contract_id::ContractId;
+use ::intrinsics::is_reference_type;
 
 ////////////////////////////////////////
 // Transaction fields
@@ -14,18 +15,19 @@ use ::contract_id::ContractId;
 //
 // Note that everything when serialized is padded to word length.
 //
-// type             = TX_START +  0*WORD_SIZE = 10240 +  0*8 = 10240
-// gasPrice         = TX_START +  1*WORD_SIZE = 10240 +  1*8 = 10248
-// gasLimit         = TX_START +  2*WORD_SIZE = 10240 +  2*8 = 10256
-// bytePrice        = TX_START +  3*WORD_SIZE = 10240 +  3*8 = 10264
-// maturity         = TX_START +  4*WORD_SIZE = 10240 +  4*8 = 10272
-// scriptLength     = TX_START +  5*WORD_SIZE = 10240 +  5*8 = 10280
-// scriptDataLength = TX_START +  6*WORD_SIZE = 10240 +  6*8 = 10288
-// inputsCount      = TX_START +  7*WORD_SIZE = 10240 +  7*8 = 10296
-// outputsCount     = TX_START +  8*WORD_SIZE = 10240 +  8*8 = 10304
-// witnessesCount   = TX_START +  9*WORD_SIZE = 10240 +  9*8 = 10312
-// receiptsRoot     = TX_START + 10*WORD_SIZE = 10240 + 10*8 = 10320
-// script start     = TX_START + 11*WORD_SIZE = 10240 + 14*8 = 10352
+// type              = TX_START +  0*WORD_SIZE = 10240 +  0*8 = 10240
+// gasPrice          = TX_START +  1*WORD_SIZE = 10240 +  1*8 = 10248
+// gasLimit          = TX_START +  2*WORD_SIZE = 10240 +  2*8 = 10256
+// bytePrice         = TX_START +  3*WORD_SIZE = 10240 +  3*8 = 10264
+// maturity          = TX_START +  4*WORD_SIZE = 10240 +  4*8 = 10272
+// scriptLength      = TX_START +  5*WORD_SIZE = 10240 +  5*8 = 10280
+// scriptDataLength  = TX_START +  6*WORD_SIZE = 10240 +  6*8 = 10288
+// inputsCount       = TX_START +  7*WORD_SIZE = 10240 +  7*8 = 10296
+// outputsCount      = TX_START +  8*WORD_SIZE = 10240 +  8*8 = 10304
+// witnessesCount    = TX_START +  9*WORD_SIZE = 10240 +  9*8 = 10312
+// receiptsRoot      = TX_START + 10*WORD_SIZE = 10240 + 10*8 = 10320
+// SCRIPT_START      = TX_START + 11*WORD_SIZE = 10240 + 14*8 = 10352
+// SCRIPT_DATA_START = SCRIPT_START + SCRIPT_LENGTH
 
 const TX_TYPE_OFFSET = 10240;
 const TX_GAS_PRICE_OFFSET = 10248;
@@ -139,24 +141,30 @@ pub fn tx_script_start_offset() -> u32 {
 // Script
 ////////////////////////////////////////
 
+/// Get the transaction script data start offset.
+pub fn tx_script_data_start_offset() -> u32 {
+    asm(r1, r2: TX_SCRIPT_START_OFFSET, r3: TX_SCRIPT_LENGTH_OFFSET) {
+        lw r3 r3 i0;
+        add r1 r2 r3;
+        r1: u32
+    }
+}
+
 /// Get the script data, typed. Unsafe.
-// pub fn get_script_data<T>() -> T {
-//     // TODO some safety checks on the input data? We are going to assume it is the right type for now.
-//     // TODO test this before uncommenting.
-//     asm(script_data_len, to_return, script_data_ptr, script_len, script_len_ptr: 10280, script_data_len_ptr: 10288) {
-//         lw script_len script_len_ptr i0;
-//         lw script_data_len script_data_len_ptr i0;
-//         // get the start of the script data
-//         // script_len + script_start
-//         add script_data_ptr script_len is;
-//         // allocate memory to copy script data into
-//         aloc script_data_len;
-//         move to_return sp;
-//         // copy script data into above buffer
-//         mcp to_return script_data_ptr script_data_len;
-//         to_return: T
-//     }
-// }
+pub fn get_script_data<T>() -> T {
+    // TODO some safety checks on the input data? We are going to assume it is the right type for now.
+    let ptr = tx_script_data_start_offset();
+    if is_reference_type::<T>() {
+        asm(r1: ptr) {
+            r1: T
+        }
+    } else {
+        asm(r1: ptr) {
+            lw r1 r1 i0;
+            r1: T
+        }
+    }
+}
 
 ////////////////////////////////////////
 // Inputs

--- a/test/src/sdk-harness/Cargo.toml
+++ b/test/src/sdk-harness/Cargo.toml
@@ -6,6 +6,7 @@ name = "tests"
 version = "0.0.0"
 
 [dependencies]
+assert_matches = "1.5.0"
 fuel-core = { version = "0.8", default-features = false }
 fuel-gql-client = { version = "0.8", default-features = false }
 fuel-types = "0.5"

--- a/test/src/sdk-harness/test_projects/harness.rs
+++ b/test/src/sdk-harness/test_projects/harness.rs
@@ -8,6 +8,7 @@ mod hashing;
 mod logging;
 mod reentrancy;
 mod registers;
+mod script_data;
 mod storage;
 mod storage_map;
 mod token_ops;

--- a/test/src/sdk-harness/test_projects/script_data/Forc.lock
+++ b/test/src/sdk-harness/test_projects/script_data/Forc.lock
@@ -1,0 +1,14 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-239143CAFD6AF819'
+dependencies = []
+
+[[package]]
+name = 'script_data'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-239143CAFD6AF819'
+dependencies = ['core']

--- a/test/src/sdk-harness/test_projects/script_data/Forc.toml
+++ b/test/src/sdk-harness/test_projects/script_data/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "script_data"
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/test/src/sdk-harness/test_projects/script_data/mod.rs
+++ b/test/src/sdk-harness/test_projects/script_data/mod.rs
@@ -1,0 +1,43 @@
+use assert_matches::assert_matches;
+use fuel_core::service::{Config, FuelService};
+use fuel_gql_client::client::FuelClient;
+use fuels::contract::script::Script;
+use fuels::tx::{default_parameters::MAX_GAS_PER_TX, Receipt, Transaction};
+
+async fn call_script(script_data: Vec<u8>) -> Result<Vec<Receipt>, fuels::prelude::Error> {
+    let bin = std::fs::read("test_projects/script_data/out/debug/script_data.bin");
+    let server = FuelService::new_node(Config::local_node()).await.unwrap();
+    let client = FuelClient::from(server.bound_address);
+
+    let tx = Transaction::Script {
+        gas_price: 0,
+        gas_limit: MAX_GAS_PER_TX,
+        maturity: 0,
+        byte_price: 0,
+        receipts_root: Default::default(),
+        script: bin.unwrap(),
+        script_data,
+        inputs: vec![],
+        outputs: vec![],
+        witnesses: vec![vec![].into()],
+        metadata: None,
+    };
+
+    let script = Script::new(tx);
+    script.call(&client).await
+}
+
+#[tokio::test]
+async fn script_data() {
+    let correct_hex =
+        hex::decode("ef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a").unwrap();
+    let call_result = call_script(correct_hex.clone()).await;
+    assert_matches!(call_result, Ok(_));
+    let receipts = call_result.unwrap();
+    assert!(correct_hex == receipts[0].data().unwrap());
+
+    let bad_hex =
+        hex::decode("bad6afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a").unwrap();
+    let call_result = call_script(bad_hex).await;
+    assert_matches!(call_result, Err(_));
+}

--- a/test/src/sdk-harness/test_projects/script_data/src/main.sw
+++ b/test/src/sdk-harness/test_projects/script_data/src/main.sw
@@ -1,0 +1,19 @@
+script;
+
+use std::logging::log;
+use std::assert::assert;
+use std::tx::get_script_data;
+
+fn main() {
+    // Reference type
+    let received: b256 = get_script_data();
+    let expected: b256 = 0xef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a;
+    log(received);
+    assert(received == expected);
+
+    // Copy type
+    let received: u64 = get_script_data();
+    let expected: u64 = 17259675764097085660;
+    log(received);
+    assert(received == expected);
+}


### PR DESCRIPTION
Adds `std::tx::get_script_data` to allow accessing script data conveniently:

```rs
script;

use std::assert::assert;
use std::tx::get_script_data;

fn main() {
    // Reference type
    let received: b256 = get_script_data();
    let expected: b256 = 0xef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a;
    assert(received == expected);

    // Copy type
    let received: u64 = get_script_data();
    let expected: u64 = 17259675764097085660;
    assert(received == expected);
}
```