### PR TITLE
Add `ReplaceSelfType` trait

### DIFF
--- a/sway-core/src/parse_tree/declaration/type_argument.rs
+++ b/sway-core/src/parse_tree/declaration/type_argument.rs
@@ -62,3 +62,9 @@ impl ToJsonAbi for TypeArgument {
         }
     }
 }
+
+impl ReplaceSelfType for TypeArgument {
+    fn replace_self_type(&mut self, self_type: TypeId) {
+        self.type_id.replace_self_type(self_type);
+    }
+}

--- a/sway-core/src/parse_tree/declaration/type_parameter.rs
+++ b/sway-core/src/parse_tree/declaration/type_parameter.rs
@@ -89,6 +89,12 @@ impl Spanned for TypeParameter {
     }
 }
 
+impl ReplaceSelfType for TypeParameter {
+    fn replace_self_type(&mut self, self_type: TypeId) {
+        self.type_id.replace_self_type(self_type);
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub(crate) struct TraitConstraint {
     pub(crate) call_path: CallPath,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -1,5 +1,14 @@
 use crate::{
-    error::*, namespace::*, parse_tree::*, semantic_analysis::*, type_engine::*, types::*,
+    error::*,
+    namespace::*,
+    parse_tree::*,
+    semantic_analysis::*,
+    type_engine::{
+        insert_type, insert_type_parameters, look_up_type_id, CopyTypes, ReplaceSelfType, TypeId,
+        TypeMapping, UpdateTypes,
+    },
+    types::{JsonAbiString, ToJsonAbi},
+    TypeInfo,
 };
 use fuels_types::Property;
 use std::hash::{Hash, Hasher};
@@ -210,6 +219,12 @@ impl ToJsonAbi for TypedEnumVariant {
             type_field: self.r#type.json_abi_str(),
             components: self.r#type.generate_json_abi(),
         }
+    }
+}
+
+impl ReplaceSelfType for TypedEnumVariant {
+    fn replace_self_type(&mut self, self_type: TypeId) {
+        self.r#type.replace_self_type(self_type);
     }
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
@@ -206,6 +206,12 @@ impl ToJsonAbi for TypedStructField {
     }
 }
 
+impl ReplaceSelfType for TypedStructField {
+    fn replace_self_type(&mut self, self_type: TypeId) {
+        self.r#type.replace_self_type(self_type);
+    }
+}
+
 impl TypedStructField {
     pub(crate) fn type_check(
         field: StructField,

--- a/sway-core/src/type_engine/engine.rs
+++ b/sway-core/src/type_engine/engine.rs
@@ -320,22 +320,14 @@ impl Engine {
 
     pub fn unify_with_self(
         &self,
-        received: TypeId,
-        expected: TypeId,
+        mut received: TypeId,
+        mut expected: TypeId,
         self_type: TypeId,
         span: &Span,
         help_text: impl Into<String>,
     ) -> (Vec<CompileWarning>, Vec<TypeError>) {
-        let received = if self.look_up_type_id(received) == TypeInfo::SelfType {
-            self_type
-        } else {
-            received
-        };
-        let expected = if self.look_up_type_id(expected) == TypeInfo::SelfType {
-            self_type
-        } else {
-            expected
-        };
+        received.replace_self_type(self_type);
+        expected.replace_self_type(self_type);
         self.unify(received, expected, span, help_text)
     }
 

--- a/sway-core/src/type_engine/mod.rs
+++ b/sway-core/src/type_engine/mod.rs
@@ -1,6 +1,7 @@
 mod copy_types;
 mod engine;
 mod integer_bits;
+mod replace_self_type;
 mod resolved_type;
 mod type_id;
 mod type_info;
@@ -11,6 +12,7 @@ mod update_types;
 pub(crate) use copy_types::*;
 pub use engine::*;
 pub use integer_bits::*;
+pub(crate) use replace_self_type::*;
 pub(crate) use resolved_type::*;
 pub use type_id::*;
 pub use type_info::*;

--- a/sway-core/src/type_engine/replace_self_type.rs
+++ b/sway-core/src/type_engine/replace_self_type.rs
@@ -1,0 +1,6 @@
+use super::TypeId;
+
+/// replace any instances of `TypeInfo::SelfType` with a provided [TypeId] `self_type`.
+pub(crate) trait ReplaceSelfType {
+    fn replace_self_type(&mut self, self_type: TypeId);
+}


### PR DESCRIPTION
This PR adds the `ReplaceSelfType` trait which allows us to replace the `TypeInfo::SelfType` type recursively.