### PR TITLE
Fix sway formatting turns `op` + `=` into `op` + ` ` + `=` which breaks the build command because it is not a valid expression

### DIFF
--- a/sway-fmt/src/code_builder.rs
+++ b/sway-fmt/src/code_builder.rs
@@ -10,9 +10,9 @@ use crate::code_builder_helpers::{
 use super::{
     code_builder_helpers::{
         clean_all_whitespace, handle_ampersand_case, handle_assignment_case, handle_colon_case,
-        handle_dash_case, handle_logical_not_case, handle_multiline_comment_case, handle_pipe_case,
-        handle_plus_case, handle_string_case, handle_whitespace_case, is_comment,
-        is_multiline_comment,
+        handle_dash_case, handle_forward_slash_case, handle_logical_not_case,
+        handle_multiline_comment_case, handle_multiply_case, handle_pipe_case, handle_plus_case,
+        handle_string_case, handle_whitespace_case, is_comment, is_multiline_comment,
     },
     code_line::{CodeLine, CodeType},
 };
@@ -91,7 +91,7 @@ impl CodeBuilder {
                         '&' => handle_ampersand_case(&mut code_line, &mut iter),
 
                         '+' => handle_plus_case(&mut code_line, &mut iter),
-                        '*' => code_line.append_with_whitespace("* "),
+                        '*' => handle_multiply_case(&mut code_line, &mut iter),
                         '/' => {
                             match iter.peek() {
                                 Some((_, '*')) => {
@@ -106,7 +106,7 @@ impl CodeBuilder {
                                     code_line.append_with_whitespace(comment);
                                     return self.complete_and_add_line(code_line);
                                 }
-                                _ => code_line.append_with_whitespace("/ "),
+                                _ => handle_forward_slash_case(&mut code_line, &mut iter),
                             }
                         }
                         '%' => code_line.append_with_whitespace("% "),

--- a/sway-fmt/src/code_builder.rs
+++ b/sway-fmt/src/code_builder.rs
@@ -11,7 +11,8 @@ use super::{
     code_builder_helpers::{
         clean_all_whitespace, handle_ampersand_case, handle_assignment_case, handle_colon_case,
         handle_dash_case, handle_logical_not_case, handle_multiline_comment_case, handle_pipe_case,
-        handle_string_case, handle_whitespace_case, is_comment, is_multiline_comment,
+        handle_plus_case, handle_string_case, handle_whitespace_case, is_comment,
+        is_multiline_comment,
     },
     code_line::{CodeLine, CodeType},
 };
@@ -89,7 +90,7 @@ impl CodeBuilder {
                         '|' => handle_pipe_case(&mut code_line, &mut iter),
                         '&' => handle_ampersand_case(&mut code_line, &mut iter),
 
-                        '+' => code_line.append_with_whitespace("+ "),
+                        '+' => handle_plus_case(&mut code_line, &mut iter),
                         '*' => code_line.append_with_whitespace("* "),
                         '/' => {
                             match iter.peek() {

--- a/sway-fmt/src/code_builder_helpers.rs
+++ b/sway-fmt/src/code_builder_helpers.rs
@@ -108,6 +108,7 @@ pub fn handle_plus_case(code_line: &mut CodeLine, iter: &mut Peekable<Enumerate<
     if let Some((_, next_char)) = iter.peek() {
         let next_char = *next_char;
         if next_char == '=' {
+            // it's a += operator
             code_line.append_with_whitespace("+= ");
             iter.next();
         } else {
@@ -139,12 +140,31 @@ pub fn handle_dash_case(code_line: &mut CodeLine, iter: &mut Peekable<Enumerate<
             // it's a return arrow
             code_line.append_with_whitespace("-> ");
             iter.next();
+        } else if *next_char == '=' {
+            // it's a -= operator
+            code_line.append_with_whitespace("-= ");
+            iter.next();
         } else {
             // it's just a single '-'
             code_line.append_with_whitespace("- ");
         }
     } else {
         code_line.append_with_whitespace("- ");
+    }
+}
+
+pub fn handle_multiply_case(code_line: &mut CodeLine, iter: &mut Peekable<Enumerate<Chars>>) {
+    if let Some((_, next_char)) = iter.peek() {
+        let next_char = *next_char;
+        if next_char == '=' {
+            // it's a *= operator
+            code_line.append_with_whitespace("*= ");
+            iter.next();
+        } else {
+            code_line.append_with_whitespace("* ");
+        }
+    } else {
+        code_line.append_with_whitespace("* ");
     }
 }
 
@@ -160,6 +180,22 @@ pub fn handle_pipe_case(code_line: &mut CodeLine, iter: &mut Peekable<Enumerate<
         }
     } else {
         code_line.append_with_whitespace("| ");
+    }
+}
+
+pub fn handle_forward_slash_case(code_line: &mut CodeLine, iter: &mut Peekable<Enumerate<Chars>>) {
+    // Handles non-comment related /.
+    if let Some((_, next_char)) = iter.peek() {
+        let next_char = *next_char;
+        if next_char == '=' {
+            // it's a /= operator
+            code_line.append_with_whitespace("/= ");
+            iter.next();
+        } else {
+            code_line.append_with_whitespace("/ ");
+        }
+    } else {
+        code_line.append_with_whitespace("/ ");
     }
 }
 

--- a/sway-fmt/src/code_builder_helpers.rs
+++ b/sway-fmt/src/code_builder_helpers.rs
@@ -104,6 +104,20 @@ pub fn handle_assignment_case(code_line: &mut CodeLine, iter: &mut Peekable<Enum
     }
 }
 
+pub fn handle_plus_case(code_line: &mut CodeLine, iter: &mut Peekable<Enumerate<Chars>>) {
+    if let Some((_, next_char)) = iter.peek() {
+        let next_char = *next_char;
+        if next_char == '=' {
+            code_line.append_with_whitespace("+= ");
+            iter.next();
+        } else {
+            code_line.append_with_whitespace("+ ");
+        }
+    } else {
+        code_line.append_with_whitespace("+ ");
+    }
+}
+
 pub fn handle_colon_case(code_line: &mut CodeLine, iter: &mut Peekable<Enumerate<Chars>>) {
     if let Some((_, next_char)) = iter.peek() {
         let next_char = *next_char;

--- a/sway-fmt/src/fmt.rs
+++ b/sway-fmt/src/fmt.rs
@@ -740,4 +740,30 @@ fn main() {
         let (_, formatted_code) = result.unwrap();
         assert_eq!(correct_sway_code, formatted_code);
     }
+
+    #[test]
+    fn test_op_equal() {
+        let correct_sway_code = r#"script;
+fn main() {
+    let mut a = 1;
+    a += 1;
+    a -= 1;
+    a /= 1;
+    a *= 1;
+}
+"#;
+        let sway_code = r#"script;
+fn main() {
+    let mut a = 1;
+    a += 1;
+    a -= 1;
+    a /= 1;
+    a *= 1;
+}
+"#;
+        let result = get_formatted_data(sway_code.into(), OPTIONS, None);
+        assert!(result.is_ok());
+        let (_, formatted_code) = result.unwrap();
+        assert_eq!(correct_sway_code, formatted_code);
+    }
 }

--- a/sway-fmt/src/fmt.rs
+++ b/sway-fmt/src/fmt.rs
@@ -750,6 +750,8 @@ fn main() {
     a -= 1;
     a /= 1;
     a *= 1;
+    a <<= 1;
+    a >>= 1;
 }
 "#;
         let sway_code = r#"script;
@@ -759,6 +761,8 @@ fn main() {
     a -= 1;
     a /= 1;
     a *= 1;
+    a <<= 1;
+    a >>= 1;
 }
 "#;
         let result = get_formatted_data(sway_code.into(), OPTIONS, None);


### PR DESCRIPTION
closes #1945 

Until we are ready to switch to formatter v2, I am pushing a quick fix as this seems fairly easy to fix and the bug is breaking the build process. 