### PR TITLE
Use `--locked` option when building tests to ensure up-to-date lock file

### DIFF
--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -25,6 +25,7 @@ pub(crate) fn deploy_contract(file_name: &str) -> ContractId {
                 manifest_dir, file_name
             )),
             silent_mode: !verbose,
+            locked: true,
             ..Default::default()
         }))
         .unwrap()
@@ -54,6 +55,7 @@ pub(crate) fn runs_on_node(
         node_url: "http://127.0.0.1:4000".into(),
         silent_mode: !verbose,
         contract: Some(contracts),
+        locked: true,
         ..Default::default()
     };
     tokio::runtime::Runtime::new()
@@ -116,6 +118,7 @@ pub(crate) fn compile_to_bytes(file_name: &str) -> Result<Vec<u8>> {
             "{}/src/e2e_vm_tests/test_programs/{}",
             manifest_dir, file_name
         )),
+        locked: true,
         silent_mode: !verbose,
         ..Default::default()
     })

--- a/test/src/sdk-harness/build.sh
+++ b/test/src/sdk-harness/build.sh
@@ -28,7 +28,7 @@ test_dirs="${base_dir}/test_artifacts/* ${base_dir}/test_projects/*"
 for test_dir in $test_dirs; do
   if [[ -f "${test_dir}/Forc.toml" ]]; then
     echo "Building test $test_dir..."
-    ${forc} build -o temp -p "${test_dir}" && echo ✔
+    ${forc} build --locked -o temp -p "${test_dir}" && echo ✔
     if ! [[ -f temp ]]; then
       echo  "❌  Failed to build $test_dir"
       exit 1


### PR DESCRIPTION
Every now and then the lock files for examples fall out-of-date or are
accidentally omitted from PRs/commits. This means that they sometimes
accidentally slip into other unrelated PRs when someone else runs the
test suites locally.

Using `--locked` causes the command to fail if the existing lock file is
out of date, or if no lock file exists yet. This will help to ensure
lock files must be updated when their associated manifest dependencies
are updated.