### PR TITLE
Allow struct field expressions to be on function calls.

### DIFF
--- a/sway-ir/src/instruction.rs
+++ b/sway-ir/src/instruction.rs
@@ -200,6 +200,11 @@ impl Instruction {
     /// Some [`Instruction`]s may have struct arguments.  Return it if so for this instruction.
     pub fn get_aggregate(&self, context: &Context) -> Option<Aggregate> {
         match self {
+            Instruction::Call(func, _args) => match &context.functions[func.0].return_type {
+                Type::Array(aggregate) => Some(*aggregate),
+                Type::Struct(aggregate) => Some(*aggregate),
+                _otherwise => None,
+            },
             Instruction::GetPointer { ptr_ty, .. } => match ptr_ty {
                 Type::Array(aggregate) => Some(*aggregate),
                 Type::Struct(aggregate) => Some(*aggregate),

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/src/main.sw
@@ -13,15 +13,20 @@ fn main() -> bool {
     let e: [[u64; 4]; 2] = [[1, 2, 3, 4], [5, 6, 7, 8]];
     //let f: [u64; 1 + 1] = [0, 0];
     let g = [S { foo: 10, bar: 20 }, S { foo: 1, bar: 2 }];
+    let h = i()[2];
 
     b[0] == b[9] &&
     e[0][1] + e[1][2] == 9 &&
     g[0].foo + g[1].bar == 12 &&
-    h(g) &&
+    j(g) &&
     //a.len() == 5 &&
     true
 }
 
-fn h(ary_arg: [S; 2]) -> bool {
+fn i() -> [u64; 4] {
+    [0, 1, 2, 3]
+}
+
+fn j(ary_arg: [S; 2]) -> bool {
     ary_arg[0].foo + ary_arg[1].bar == 12
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_access/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_access/Forc.toml
@@ -1,8 +1,8 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
 license = "Apache-2.0"
 name = "struct_field_access"
-entry = "main.sw"
 
 [dependencies]
 core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_access/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_access/src/main.sw
@@ -1,15 +1,24 @@
 script;
-// this file tests struct field reassignments
-fn main() -> u64 {
-  let mut data = Data { 
-		uselessnumber: 42
-  };
-  data.uselessnumber = 43;
 
-  return data.uselessnumber;
+// Tests struct field reassignments and accessing fields from a returned struct.
+
+fn main() -> u64 {
+    let mut data = Data {
+        uselessnumber: 42,
+    };
+    data.uselessnumber = 43;
+
+    let other = ret_struct().uselessnumber;
+
+    return data.uselessnumber;
 }
 
 struct Data {
-  uselessnumber: u64
+    uselessnumber: u64,
 }
 
+fn ret_struct() -> Data {
+    Data {
+        uselessnumber: 44,
+    }
+}


### PR DESCRIPTION
Whoops, that was ridiculously simple and should've been done ages ago.

Closes #1657.