### PR TITLE
Fix `master` CI error due to test that slipped by the `--locked` PR

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_inits/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_inits/Forc.lock
@@ -1,17 +1,22 @@
 [[package]]
+name = 'const_inits'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
 name = 'core'
-dependencies = []
+source = 'path+from-root-76FD265A93458D61'
+dependencies = ['core_utils']
 
 [[package]]
-name = 'const_inits'
+name = 'core_utils'
+source = 'path+from-root-76FD265A93458D61'
 dependencies = []
-
-[[package]]
-name = 'const_inits'
-dependencies = [
-    'std',
-]
 
 [[package]]
 name = 'std'
-dependencies = ['core']
+source = 'path+from-root-76FD265A93458D61'
+dependencies = [
+    'core',
+    'core_utils',
+]


### PR DESCRIPTION
It looks like this test landed in the tiny window of time between #1951 being opened and merging :smiling_face_with_tear:

This may happen again with some of the open PRs if we forget to merge `master`, but it's easy enough to address by just running `cargo run --bin forc -- build --path <path/to/test>` to update the lock file.

Another case of #1343.