### PR TITLE
Use `TypeId` in `TypeMapping` and in `TraitMap`.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -405,13 +405,13 @@ fn type_check_trait_implementation(
             suffix: trait_name.suffix.clone(),
             is_absolute: false,
         },
-        match resolve_type(self_type, self_type_span) {
+        insert_type(match resolve_type(self_type, self_type_span) {
             Ok(o) => o,
             Err(e) => {
                 errors.push(e.into());
                 return err(warnings, errors);
             }
-        },
+        }),
         functions_buf.clone(),
     );
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/monomorphize.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/monomorphize.rs
@@ -198,10 +198,6 @@ where
     let old_type_id = decl.create_type_id();
     let mut new_decl = decl;
     new_decl.copy_types(type_mapping);
-    namespace.copy_methods_to_type(
-        look_up_type_id(old_type_id),
-        look_up_type_id(new_decl.create_type_id()),
-        type_mapping,
-    );
+    namespace.copy_methods_to_type(old_type_id, new_decl.create_type_id(), type_mapping);
     new_decl
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -76,7 +76,7 @@ impl TypedTraitDeclaration {
                 suffix: trait_decl.name.clone(),
                 is_absolute: false,
             },
-            TypeInfo::SelfType,
+            insert_type(TypeInfo::SelfType),
             interface_surface
                 .iter()
                 .map(|x| x.to_dummy_func(Mode::NonAbi))
@@ -128,7 +128,7 @@ fn handle_supertraits(
                 // insert dummy versions of the interfaces for all of the supertraits
                 trait_namespace.insert_trait_implementation(
                     supertrait.name.clone(),
-                    TypeInfo::SelfType,
+                    insert_type(TypeInfo::SelfType),
                     interface_surface
                         .iter()
                         .map(|x| x.to_dummy_func(Mode::NonAbi))
@@ -144,7 +144,7 @@ fn handle_supertraits(
                 );
                 trait_namespace.insert_trait_implementation(
                     supertrait.name.clone(),
-                    TypeInfo::SelfType,
+                    insert_type(TypeInfo::SelfType),
                     dummy_funcs,
                 );
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1623,11 +1623,7 @@ impl TypedExpression {
         }
 
         functions_buf.append(&mut type_checked_fn_buf);
-        namespace.insert_trait_implementation(
-            abi_name.clone(),
-            look_up_type_id(return_type),
-            functions_buf,
-        );
+        namespace.insert_trait_implementation(abi_name.clone(), return_type, functions_buf);
         let exp = TypedExpression {
             expression: TypedExpressionVariant::AbiCast {
                 abi_name,

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -428,7 +428,7 @@ impl TypedAstNode {
                             );
                             namespace.insert_trait_implementation(
                                 impl_trait.trait_name.clone(),
-                                look_up_type_id(implementing_for_type_id),
+                                implementing_for_type_id,
                                 impl_trait.methods.clone(),
                             );
                             TypedDeclaration::ImplTrait(impl_trait)
@@ -442,7 +442,7 @@ impl TypedAstNode {
                             );
                             namespace.insert_trait_implementation(
                                 impl_trait.trait_name.clone(),
-                                look_up_type_id(impl_trait.implementing_for_type_id),
+                                impl_trait.implementing_for_type_id,
                                 impl_trait.methods.clone(),
                             );
                             TypedDeclaration::ImplTrait(impl_trait)

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -110,7 +110,7 @@ impl Items {
     pub(crate) fn insert_trait_implementation(
         &mut self,
         trait_name: CallPath,
-        type_implementing_for: TypeInfo,
+        implementing_for_type_id: TypeId,
         functions_buf: Vec<TypedFunctionDeclaration>,
     ) {
         let new_prefixes = if trait_name.prefixes.is_empty() {
@@ -127,12 +127,15 @@ impl Items {
             is_absolute: trait_name.is_absolute,
         };
         self.implemented_traits
-            .insert(trait_name, type_implementing_for, functions_buf);
+            .insert(trait_name, implementing_for_type_id, functions_buf);
     }
 
-    pub(crate) fn get_methods_for_type(&self, r#type: TypeId) -> Vec<TypedFunctionDeclaration> {
+    pub(crate) fn get_methods_for_type(
+        &self,
+        implementing_for_type_id: TypeId,
+    ) -> Vec<TypedFunctionDeclaration> {
         self.implemented_traits
-            .get_methods_for_type(look_up_type_id(r#type))
+            .get_methods_for_type(implementing_for_type_id)
     }
 
     // Given a TypeInfo old_type with a set of methods available to it, make those same methods
@@ -141,8 +144,8 @@ impl Items {
     // methods for new_type as it does for old_type.
     pub(crate) fn copy_methods_to_type(
         &mut self,
-        old_type: TypeInfo,
-        new_type: TypeInfo,
+        old_type: TypeId,
+        new_type: TypeId,
         type_mapping: &TypeMapping,
     ) {
         // This map grabs all (trait name, vec of methods) from self.implemented_traits
@@ -158,7 +161,7 @@ impl Items {
                 .iter_mut()
                 .for_each(|method| method.copy_types(type_mapping));
             self.implemented_traits
-                .insert(trait_name, new_type.clone(), trait_methods);
+                .insert(trait_name, new_type, trait_methods);
         }
     }
 

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -2,7 +2,6 @@ use crate::{
     error::*,
     parse_tree::Visibility,
     semantic_analysis::{ast_node::TypedVariableDeclaration, declaration::VariableMutability},
-    type_engine::*,
     CompileResult, Ident, TypedDeclaration,
 };
 
@@ -181,9 +180,7 @@ impl Module {
                 let a = decl.return_type().value;
                 //  if this is an enum or struct, import its implementations
                 let mut res = match a {
-                    Some(a) => src_ns
-                        .implemented_traits
-                        .get_call_path_and_type_info(look_up_type_id(a)),
+                    Some(a) => src_ns.implemented_traits.get_call_path_and_type_info(a),
                     None => vec![],
                 };
                 impls_to_insert.append(&mut res);

--- a/sway-core/src/type_engine/type_info.rs
+++ b/sway-core/src/type_engine/type_info.rs
@@ -556,7 +556,7 @@ impl TypeInfo {
         match self {
             TypeInfo::Custom { .. } => {
                 for (param, ty_id) in mapping.iter() {
-                    if look_up_type_id(param.type_id) == *self {
+                    if look_up_type_id(*param) == *self {
                         return Some(*ty_id);
                     }
                 }
@@ -564,7 +564,7 @@ impl TypeInfo {
             }
             TypeInfo::UnknownGeneric { .. } => {
                 for (param, ty_id) in mapping.iter() {
-                    if look_up_type_id(param.type_id) == *self {
+                    if look_up_type_id(*param) == *self {
                         return Some(*ty_id);
                     }
                 }

--- a/sway-core/src/type_engine/type_mapping.rs
+++ b/sway-core/src/type_engine/type_mapping.rs
@@ -2,14 +2,14 @@ use crate::TypeParameter;
 
 use super::*;
 
-pub(crate) type TypeMapping = Vec<(TypeParameter, TypeId)>;
+pub(crate) type TypeMapping = Vec<(TypeId, TypeId)>;
 
 pub(crate) fn insert_type_parameters(type_parameters: &[TypeParameter]) -> TypeMapping {
     type_parameters
         .iter()
         .map(|x| {
             (
-                x.clone(),
+                x.type_id,
                 insert_type(TypeInfo::UnknownGeneric {
                     name: x.name_ident.clone(),
                 }),


### PR DESCRIPTION
This PR changes `TypeMapping` to use a `TypeId` instead of a `TypeParameter` and changes `TraitMap` to use `TypeId`'s instead of `TypeInfo`'s.

- Blocked by https://github.com/FuelLabs/sway/pull/1941