### PR TITLE
preprocessor strictness change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
           mdbook-version: "0.4.15"
       - name: Emit logs to tmp.txt, fail if build logs contain 'ERROR'
         run: |
-          mdbook build docs &> tmp.txt
+          MDBOOK_preprocessor__FORC_documenter__STRICT="true" mdbook build docs &> tmp.txt
           if cat tmp.txt | grep 'ERROR'
           then
             rm tmp.txt && exit 1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           mdbook-version: '0.4.15'
 
-      - run: mdbook build docs
+      - run: MDBOOK_preprocessor__FORC_documenter__STRICT="true" mdbook build docs
 
       - name: Deploy latest
         uses: peaceiris/actions-gh-pages@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,6 +2169,7 @@ dependencies = [
  "semver 1.0.7",
  "serde",
  "serde_json",
+ "toml",
 ]
 
 [[package]]

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,12 @@ To build book:
 mdbook build
 ```
 
+To build the book on strict mode to detect Forc documentation errors:
+
+```sh
+MDBOOK_preprocessor__FORC_documenter__STRICT="true" mdbook build docs
+```
+
 To serve locally:
 
 ```sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ To build book:
 mdbook build
 ```
 
-To build the book on strict mode to detect Forc documentation errors:
+To build the book on strict mode to check if pages should be removed or added within the Forc Reference:
 
 ```sh
 MDBOOK_preprocessor__FORC_documenter__STRICT="true" mdbook build docs

--- a/scripts/mdbook-forc-documenter/Cargo.toml
+++ b/scripts/mdbook-forc-documenter/Cargo.toml
@@ -20,3 +20,4 @@ mdbook = { version = "0.4", default-features = false }
 semver = "1.0"
 serde = "1.0"
 serde_json = "1.0"
+toml = "0.5"

--- a/scripts/mdbook-forc-documenter/README.md
+++ b/scripts/mdbook-forc-documenter/README.md
@@ -8,6 +8,12 @@ This preprocessor is automatically run on every build, as long as the `book.toml
 [preprocessor.forc-documenter]
 ```
 
+The preprocessor runs with strict mode **off** by default to enable building the book regardless of errors in the Forc Reference pages. To check if pages should be added or are missing, run with the `strict` [environment variable](https://rust-lang.github.io/mdBook/format/configuration/environment-variables.html):
+
+```sh
+MDBOOK_preprocessor__FORC_documenter__STRICT="true" mdbook build docs
+```
+
 ## Usage
 
 ### Adding a new forc command

--- a/scripts/mdbook-forc-documenter/README.md
+++ b/scripts/mdbook-forc-documenter/README.md
@@ -8,7 +8,7 @@ This preprocessor is automatically run on every build, as long as the `book.toml
 [preprocessor.forc-documenter]
 ```
 
-The preprocessor runs with strict mode **off** by default to enable building the book regardless of errors in the Forc Reference pages. To check if pages should be added or are missing, run with the `strict` [environment variable](https://rust-lang.github.io/mdBook/format/configuration/environment-variables.html):
+The preprocessor runs with strict mode **off** by default to enable building the book regardless of errors in the Forc Reference pages. To check if pages should be added or removed, run with the `strict` [environment variable](https://rust-lang.github.io/mdBook/format/configuration/environment-variables.html):
 
 ```sh
 MDBOOK_preprocessor__FORC_documenter__STRICT="true" mdbook build docs


### PR DESCRIPTION
Closes #1918 

mdbook preprocessors allow you to use [environment variables](https://rust-lang.github.io/mdBook/format/configuration/environment-variables.html) to do certain things within the preprocessor. Introduced a new `strict` env var here that causes `mdbook build` to behave like before (failing at any errors), or pass the build regardless if it's not enabled. 

## Motivation: 

Local builds were failing erroneously since the addition of `forc-fmt-v2`, since it wasn't included in the book as a chapter but was getting detected by the preprocessor.

This env var is **false** by default - the command that the CI runs will run `mdbook build` on strict mode which fails the build:

```sh
MDBOOK_preprocessor__FORC_documenter__STRICT="true" mdbook build docs
```