### PR TITLE
Translate assignments to `_` as variable declaration

### DIFF
--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -2552,14 +2552,12 @@ fn statement_let_to_ast_nodes(
         span: Span,
     ) -> Result<Vec<AstNode>, ErrorEmitted> {
         let ast_nodes = match pattern {
-            Pattern::Wildcard { .. } => {
-                let ast_node = AstNode {
-                    content: AstNodeContent::Expression(expression),
-                    span,
+            Pattern::Wildcard { .. } | Pattern::Var { .. } => {
+                let (mutable, name) = match pattern {
+                    Pattern::Var { mutable, name } => (mutable, name),
+                    Pattern::Wildcard { .. } => (None, Ident::new_no_span("_")),
+                    _ => panic!("Internal error"),
                 };
-                vec![ast_node]
-            }
-            Pattern::Var { mutable, name } => {
                 let (type_ascription, type_ascription_span) = match ty_opt {
                     Some(ty) => {
                         let type_ascription_span = ty.span();

--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -2556,7 +2556,7 @@ fn statement_let_to_ast_nodes(
                 let (mutable, name) = match pattern {
                     Pattern::Var { mutable, name } => (mutable, name),
                     Pattern::Wildcard { .. } => (None, Ident::new_no_span("_")),
-                    _ => panic!("Internal error"),
+                    _ => unreachable!()
                 };
                 let (type_ascription, type_ascription_span) = match ty_opt {
                     Some(ty) => {

--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -2556,7 +2556,7 @@ fn statement_let_to_ast_nodes(
                 let (mutable, name) = match pattern {
                     Pattern::Var { mutable, name } => (mutable, name),
                     Pattern::Wildcard { .. } => (None, Ident::new_no_span("_")),
-                    _ => unreachable!()
+                    _ => unreachable!(),
                 };
                 let (type_ascription, type_ascription_span) = match ty_opt {
                     Some(ty) => {


### PR DESCRIPTION
Closes #1867.

A new no-span variable named `_` is created and the assignment to `_` is now compiled as if it was being assigned to an actual
variable. This stops the warning about the RHS expression being ignored.