### PR TITLE
Adds `SquareBracket` trait to `utils::bracket`

### DIFF
--- a/sway-fmt-v2/src/items/item_enum.rs
+++ b/sway-fmt-v2/src/items/item_enum.rs
@@ -12,18 +12,18 @@ impl Format for ItemEnum {
 }
 
 impl CurlyBrace for ItemEnum {
-    fn open_curly_brace(push_to: &mut String, formatter: &mut Formatter) {
+    fn open_curly_brace(line: &mut String, formatter: &mut Formatter) {
         let brace_style = formatter.config.items.item_brace_style;
         let mut shape = formatter.shape;
         match brace_style {
             ItemBraceStyle::AlwaysNextLine => {
                 // Add openning brace to the next line.
-                push_to.push_str("\n{\n");
+                line.push_str("\n{\n");
                 shape = shape.block_indent(1);
             }
             _ => {
                 // Add opening brace to the same line
-                push_to.push_str(" {\n");
+                line.push_str(" {\n");
                 shape = shape.block_indent(1);
             }
         }
@@ -31,8 +31,8 @@ impl CurlyBrace for ItemEnum {
         formatter.shape = shape;
     }
 
-    fn close_curly_brace(push_to: &mut String, formatter: &mut Formatter) {
-        push_to.push('}');
+    fn close_curly_brace(line: &mut String, formatter: &mut Formatter) {
+        line.push('}');
         // If shape is becoming left-most alligned or - indent just have the defualt shape
         formatter.shape = formatter.shape.shrink_left(1).unwrap_or_default();
     }

--- a/sway-fmt-v2/src/items/item_enum.rs
+++ b/sway-fmt-v2/src/items/item_enum.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::items::ItemBraceStyle,
     fmt::{Format, FormattedCode, Formatter},
-    utils::bracket::CurlyDelimiter,
+    utils::bracket::CurlyBrace,
 };
 use sway_parse::ItemEnum;
 
@@ -11,8 +11,8 @@ impl Format for ItemEnum {
     }
 }
 
-impl CurlyDelimiter for ItemEnum {
-    fn handle_open_brace(push_to: &mut String, formatter: &mut Formatter) {
+impl CurlyBrace for ItemEnum {
+    fn open_curly_brace(push_to: &mut String, formatter: &mut Formatter) {
         let brace_style = formatter.config.items.item_brace_style;
         let mut shape = formatter.shape;
         match brace_style {
@@ -31,7 +31,7 @@ impl CurlyDelimiter for ItemEnum {
         formatter.shape = shape;
     }
 
-    fn handle_closed_brace(push_to: &mut String, formatter: &mut Formatter) {
+    fn close_curly_brace(push_to: &mut String, formatter: &mut Formatter) {
         push_to.push('}');
         // If shape is becoming left-most alligned or - indent just have the defualt shape
         formatter.shape = formatter.shape.shrink_left(1).unwrap_or_default();

--- a/sway-fmt-v2/src/utils/bracket.rs
+++ b/sway-fmt-v2/src/utils/bracket.rs
@@ -1,11 +1,17 @@
 use crate::Formatter;
 
-pub trait CurlyDelimiter {
+pub trait CurlyBrace {
     /// Handles brace open scenerio. Checks the config for the placement of the brace.
     /// Modifies the current shape of the formatter.
-    fn handle_open_brace(push_to: &mut String, formatter: &mut Formatter);
+    fn open_curly_brace(push_to: &mut String, formatter: &mut Formatter);
 
     /// Handles brace close scenerio.
     /// Currently it simply pushes a `}` and modifies the shape.
-    fn handle_closed_brace(push_to: &mut String, formatter: &mut Formatter);
+    fn close_curly_brace(push_to: &mut String, formatter: &mut Formatter);
+}
+
+pub trait SquareBracket {
+    fn open_square_bracket(push_to: &mut String, formatter: &mut Formatter);
+
+    fn close_square_bracket(push_to: &mut String, formatter: &mut Formatter);
 }

--- a/sway-fmt-v2/src/utils/bracket.rs
+++ b/sway-fmt-v2/src/utils/bracket.rs
@@ -3,15 +3,15 @@ use crate::Formatter;
 pub trait CurlyBrace {
     /// Handles brace open scenerio. Checks the config for the placement of the brace.
     /// Modifies the current shape of the formatter.
-    fn open_curly_brace(push_to: &mut String, formatter: &mut Formatter);
+    fn open_curly_brace(line: &mut String, formatter: &mut Formatter);
 
     /// Handles brace close scenerio.
     /// Currently it simply pushes a `}` and modifies the shape.
-    fn close_curly_brace(push_to: &mut String, formatter: &mut Formatter);
+    fn close_curly_brace(line: &mut String, formatter: &mut Formatter);
 }
 
 pub trait SquareBracket {
-    fn open_square_bracket(push_to: &mut String, formatter: &mut Formatter);
+    fn open_square_bracket(line: &mut String, formatter: &mut Formatter);
 
-    fn close_square_bracket(push_to: &mut String, formatter: &mut Formatter);
+    fn close_square_bracket(line: &mut String, formatter: &mut Formatter);
 }


### PR DESCRIPTION
Some small changes to naming conventions, but this adds the trait and associated functions for handling square brackets.

Closes #1977 