### PR TITLE
Don't emit hashes for predicates

### DIFF
--- a/forc/src/cli/commands/build.rs
+++ b/forc/src/cli/commands/build.rs
@@ -5,8 +5,9 @@ use clap::Parser;
 /// Compile the current or target project.
 ///
 /// The output produced will depend on the project's program type. Building script, predicate and
-/// contract projects will produce their bytecode in binary format `<project-name>.bin` as well as
-/// a file containing the hash of the bytecode binary `<project-name>-bin-hash` (hashed using `fuel_cypto::Hasher`).
+/// contract projects will produce their bytecode in binary format `<project-name>.bin`. Building
+/// script projects will also produce a file containing the hash of the bytecode binary
+/// `<project-name>-bin-hash` (hashed using `fuel_cypto::Hasher`).
 ///
 /// Building contracts and libraries will also produce the public ABI in JSON format
 /// `<project-name>-abi.json`.

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -164,8 +164,8 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
 
     info!("  Bytecode size is {} bytes.", compiled.bytecode.len());
 
-    if let TreeType::Script | TreeType::Predicate = compiled.tree_type {
-        // hash the bytecode for scripts/predicates and store it in a file in the output directory
+    if let TreeType::Script = compiled.tree_type {
+        // hash the bytecode for scripts and store the result in a file in the output directory
         let bytecode_hash = format!("0x{}", fuel_crypto::Hasher::hash(&compiled.bytecode));
         let hash_file_name = format!("{}{}", &manifest.project.name, SWAY_BIN_HASH_SUFFIX);
         let hash_path = output_dir.join(hash_file_name);

--- a/forc/src/utils/mod.rs
+++ b/forc/src/utils/mod.rs
@@ -8,6 +8,6 @@ pub mod program_type;
 /// dependency to the `forc` version.
 pub const SWAY_GIT_TAG: &str = concat!("v", clap::crate_version!());
 
-/// The suffix that helps identify the file which contains the hash of the binary file
-/// created when scripts/predicates are built.
+/// The suffix that helps identify the file which contains the hash of the binary file created when
+/// scripts are built.
 pub const SWAY_BIN_HASH_SUFFIX: &str = "-bin-hash";


### PR DESCRIPTION
Before fixing https://github.com/FuelLabs/sway/issues/1985 properly, I'm stopping `forc build` from emitting the bytecode hash for predicates.