### PR TITLE
Fix unnecessary check inside of the match exhaustivity algorithm

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/constructor_factory.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/constructor_factory.rs
@@ -629,22 +629,18 @@ impl ConstructorFactory {
     }
 
     fn resolve_possible_types(&self, pattern: &Pattern, span: &Span) -> CompileResult<&TypeInfo> {
-        let mut warnings = vec![];
+        let warnings = vec![];
         let mut errors = vec![];
         let mut type_info = None;
         for possible_type in self.possible_types.iter() {
-            let matches = check!(
-                pattern.matches_type_info(possible_type, span),
-                continue,
-                warnings,
-                errors
-            );
+            let matches = pattern.matches_type_info(possible_type, span);
             if matches {
                 type_info = Some(possible_type);
                 break;
             }
         }
         match type_info {
+            // purposefully throw away the errors if we encounter a match
             Some(type_info) => ok(type_info, warnings, errors),
             None => {
                 errors.push(CompileError::Internal(

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/constructor_factory.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/constructor_factory.rs
@@ -640,7 +640,6 @@ impl ConstructorFactory {
             }
         }
         match type_info {
-            // purposefully throw away the errors if we encounter a match
             Some(type_info) => ok(type_info, warnings, errors),
             None => {
                 errors.push(CompileError::Internal(

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
@@ -657,13 +657,7 @@ impl Pattern {
         }
     }
 
-    pub(crate) fn matches_type_info(
-        &self,
-        type_info: &TypeInfo,
-        span: &Span,
-    ) -> CompileResult<bool> {
-        let warnings = vec![];
-        let mut errors = vec![];
+    pub(crate) fn matches_type_info(&self, type_info: &TypeInfo, span: &Span) -> bool {
         match (self, type_info) {
             (pattern, TypeInfo::Ref(type_id, _)) => {
                 pattern.matches_type_info(&look_up_type_id(*type_id), span)
@@ -680,20 +674,13 @@ impl Pattern {
                     ..
                 },
             ) => {
-                let res = l_enum_name.as_str() == r_enum_name.as_str()
+                l_enum_name.as_str() == r_enum_name.as_str()
                     && variant_types
                         .iter()
                         .map(|x| x.name.clone())
-                        .any(|x| x.as_str() == variant_name.as_str());
-                ok(res, warnings, errors)
+                        .any(|x| x.as_str() == variant_name.as_str())
             }
-            _ => {
-                errors.push(CompileError::Unimplemented(
-                    "cannot yet compare this pattern with this type",
-                    span.clone(),
-                ));
-                err(warnings, errors)
-            }
+            _ => false, // NOTE: We may need to expand this in the future
         }
     }
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
@@ -678,7 +678,7 @@ impl Pattern {
                     && variant_types
                         .iter()
                         .map(|variant_type| variant_type.name.clone())
-                        .any(|variant_name| variant_name.as_str() == variant_name.as_str())
+                        .any(|name| name.as_str() == variant_name.as_str())
             }
             _ => false, // NOTE: We may need to expand this in the future
         }

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
@@ -677,8 +677,8 @@ impl Pattern {
                 l_enum_name.as_str() == r_enum_name.as_str()
                     && variant_types
                         .iter()
-                        .map(|x| x.name.clone())
-                        .any(|x| x.as_str() == variant_name.as_str())
+                        .map(|variant_type| variant_type.name.clone())
+                        .any(|variant_name| variant_name.as_str() == variant_name.as_str())
             }
             _ => false, // NOTE: We may need to expand this in the future
         }

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -444,6 +444,10 @@ pub fn run(locked: bool, filter_regex: Option<regex::Regex>) {
             ])), // "ReturnData":{"data":"0000000000000002", .. }
         ),
         (
+            "should_pass/language/match_expressions_with_self",
+            ProgramState::Return(1),
+        ),
+        (
             "should_pass/test_contracts/auth_testing_contract",
             ProgramState::Revert(0),
         ),

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_with_self/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_with_self/Forc.lock
@@ -1,0 +1,14 @@
+[[package]]
+name = 'abort_control_flow_good'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+source = 'path+from-root-CB060A17C0778A7E'
+dependencies = []
+
+[[package]]
+name = 'std'
+source = 'path+from-root-CB060A17C0778A7E'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_with_self/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_with_self/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "abort_control_flow_good"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_with_self/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_with_self/json_abi_oracle.json
@@ -1,0 +1,14 @@
+[
+  {
+    "inputs": [],
+    "name": "main",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "u64"
+      }
+    ],
+    "type": "function"
+  }
+]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_with_self/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_with_self/src/main.sw
@@ -1,0 +1,28 @@
+script;
+
+use core::ops::Eq;
+use std::assert::*;
+
+enum Initialized {
+    True: (),
+    False: (),
+}
+
+impl Eq for Initialized {
+    fn eq(self, other: Self) -> bool {
+        match (self, other) {
+            (Initialized::True, Initialized::True) => true,
+            (Initialized::False, Initialized::False) => true,
+            _ => false,
+        }
+    }
+}
+
+fn main() -> u64 {
+    let a = Initialized::True;
+    let b = Initialized::False;
+    let c = a == b;
+    assert(c == false);
+
+    1
+}


### PR DESCRIPTION
This allows to implementing `Eq` on complex types:

```rust
use core::ops::Eq;

enum Initialized {
    True: (),
    False: (),
}

impl Eq for Initialized {
    fn eq(self, other: Self) -> bool {
        match (self, other) {
            (Initialized::True, Initialized::True) => true,
            (Initialized::False, Initialized::False) => true,
            _ => false,
        }
    }
}
```

- Closes #1852 