### PR TITLE
Make sure that reallocating zero sized allocations works as expected

### DIFF
--- a/sway-lib-std/src/alloc.sw
+++ b/sway-lib-std/src/alloc.sw
@@ -37,7 +37,9 @@ pub fn alloc(size: u64) -> u64 {
 pub fn realloc(ptr: u64, size: u64, new_size: u64) -> u64 {
     if new_size > size {
         let new_ptr = alloc(new_size);
-        copy(new_ptr, ptr, size);
+        if size > 0 {
+            copy(new_ptr, ptr, size);
+        }
         new_ptr
     } else {
         ptr

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/alloc/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/alloc/src/main.sw
@@ -49,5 +49,12 @@ fn main() -> bool {
     assert(ptr == hp - 16 + 1);
     assert(heap_ptr() == hp - 16);
 
+    // Make sure that reallocating an old allocation of size 0 does not cause a
+    // panic. 
+    let hp = heap_ptr(); // old allocation of size 0
+    let ptr = realloc(hp, 0, 16);
+    assert(ptr == hp - 16 + 1);
+    assert(heap_ptr() == hp - 16);
+
     true
 }


### PR DESCRIPTION
Needed to be able to use `realloc` in `Vec<T>` here: https://github.com/FuelLabs/sway/pull/1118

Specifically, `realloc` should behave like `alloc` if the old allocation has size zero. There is no need to call `copy`.

Relevant: https://github.com/FuelLabs/fuel-vm/issues/147