### PR TITLE
Minor fix to test warning.

### DIFF
--- a/test/src/sdk-harness/test_projects/logging/src/main.sw
+++ b/test/src/sdk-harness/test_projects/logging/src/main.sw
@@ -17,7 +17,7 @@ fn main() {
     let k: b256 = 0xef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a;
     let a: str[4] = "Fuel";
     let b: [u8;
-    3] = [1, 2, 3];
+    3] = [1u8, 2u8, 3u8];
     let test_struct = TestStruct {
         field_1: true,
         field_2: k,


### PR DESCRIPTION
Tests throw a warning of loss of precision. Use same type to avoid warning.