### PR TITLE
Improve struct patterns with new warnings and rest pattern support.

### DIFF
--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -2759,17 +2759,42 @@ fn pattern_to_scrutinee(
                 span,
             }
         }
-        Pattern::Struct { path, fields } => Scrutinee::StructScrutinee {
-            struct_name: path_expr_to_ident(ec, path)?,
-            fields: {
-                fields
-                    .into_inner()
-                    .into_iter()
-                    .map(|field| pattern_struct_field_to_struct_scrutinee_field(ec, field))
-                    .collect::<Result<_, _>>()?
-            },
-            span,
-        },
+        Pattern::Struct { path, fields } => {
+            let mut errors = Vec::new();
+            let fields = fields.into_inner();
+
+            // Make sure each struct field is declared once
+            let mut names_of_fields = std::collections::HashSet::new();
+            fields.clone().into_iter().for_each(|v| {
+                if let PatternStructField::Field {
+                    field_name,
+                    pattern_opt: _,
+                } = v
+                {
+                    if !names_of_fields.insert(field_name.clone()) {
+                        errors.push(ConvertParseTreeError::DuplicateStructField {
+                            name: field_name.clone(),
+                            span: field_name.span(),
+                        });
+                    }
+                }
+            });
+
+            if let Some(errors) = ec.errors(errors) {
+                return Err(errors);
+            }
+
+            let scrutinee_fields = fields
+                .into_iter()
+                .map(|field| pattern_struct_field_to_struct_scrutinee_field(ec, field))
+                .collect::<Result<_, _>>()?;
+
+            Scrutinee::StructScrutinee {
+                struct_name: path_expr_to_ident(ec, path)?,
+                fields: { scrutinee_fields },
+                span,
+            }
+        }
         Pattern::Tuple(pat_tuple) => Scrutinee::Tuple {
             elems: {
                 pat_tuple
@@ -2841,15 +2866,26 @@ fn pattern_struct_field_to_struct_scrutinee_field(
     pattern_struct_field: PatternStructField,
 ) -> Result<StructScrutineeField, ErrorEmitted> {
     let span = pattern_struct_field.span();
-    let struct_scrutinee_field = StructScrutineeField {
-        field: pattern_struct_field.field_name,
-        scrutinee: match pattern_struct_field.pattern_opt {
-            Some((_colon_token, pattern)) => Some(pattern_to_scrutinee(ec, *pattern)?),
-            None => None,
-        },
-        span,
-    };
-    Ok(struct_scrutinee_field)
+    match pattern_struct_field {
+        PatternStructField::Rest { token } => {
+            let struct_scrutinee_field = StructScrutineeField::Rest { span: token.span() };
+            Ok(struct_scrutinee_field)
+        }
+        PatternStructField::Field {
+            field_name,
+            pattern_opt,
+        } => {
+            let struct_scrutinee_field = StructScrutineeField::Field {
+                field: field_name,
+                scrutinee: match pattern_opt {
+                    Some((_colon_token, pattern)) => Some(pattern_to_scrutinee(ec, *pattern)?),
+                    None => None,
+                },
+                span,
+            };
+            Ok(struct_scrutinee_field)
+        }
+    }
 }
 
 fn assignable_to_expression(

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -883,6 +883,13 @@ pub enum CompileError {
         missing_patterns: String,
         span: Span,
     },
+    #[error("Pattern does not mention {}: {}",
+        if missing_fields.len() == 1 { "field" } else { "fields" },
+        missing_fields.join(", "))]
+    MatchStructPatternMissingFields {
+        missing_fields: Vec<String>,
+        span: Span,
+    },
     #[error(
         "Storage attribute access mismatch. Try giving the surrounding function more access by \
         adding \"#[{STORAGE_PURITY_ATTRIBUTE_NAME}({attrs})]\" to the function declaration."
@@ -1107,6 +1114,7 @@ impl Spanned for CompileError {
             StarImportShadowsOtherSymbol { name } => name.span(),
             MatchWrongType { span, .. } => span.clone(),
             MatchExpressionNonExhaustive { span, .. } => span.clone(),
+            MatchStructPatternMissingFields { span, .. } => span.clone(),
             NotAnEnum { span, .. } => span.clone(),
             StorageAccessMismatch { span, .. } => span.clone(),
             TraitDeclPureImplImpure { span, .. } => span.clone(),

--- a/sway-core/src/parse_tree/expression/scrutinee.rs
+++ b/sway-core/src/parse_tree/expression/scrutinee.rs
@@ -36,10 +36,15 @@ pub enum Scrutinee {
 }
 
 #[derive(Debug, Clone)]
-pub struct StructScrutineeField {
-    pub field: Ident,
-    pub scrutinee: Option<Scrutinee>,
-    pub span: Span,
+pub enum StructScrutineeField {
+    Rest {
+        span: Span,
+    },
+    Field {
+        field: Ident,
+        scrutinee: Option<Scrutinee>,
+        span: Span,
+    },
 }
 
 impl Spanned for Scrutinee {
@@ -122,9 +127,12 @@ impl Scrutinee {
                 }];
                 let fields = fields
                     .iter()
-                    .flat_map(|StructScrutineeField { scrutinee, .. }| match scrutinee {
-                        Some(scrutinee) => scrutinee.gather_approximate_typeinfo_dependencies(),
-                        None => vec![],
+                    .flat_map(|f| match f {
+                        StructScrutineeField::Field {
+                            scrutinee: Some(scrutinee),
+                            ..
+                        } => scrutinee.gather_approximate_typeinfo_dependencies(),
+                        _ => vec![],
                     })
                     .collect::<Vec<TypeInfo>>();
                 vec![name, fields].concat()

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
@@ -140,20 +140,22 @@ impl Pattern {
                 ..
             } => {
                 let mut new_fields = vec![];
-                for StructScrutineeField {
-                    field, scrutinee, ..
-                } in fields.into_iter()
-                {
-                    let f = match scrutinee {
-                        Some(scrutinee) => check!(
-                            Pattern::from_scrutinee(scrutinee),
-                            return err(warnings, errors),
-                            warnings,
-                            errors
-                        ),
-                        None => Pattern::Wildcard,
-                    };
-                    new_fields.push((field.as_str().to_string(), f));
+                for field in fields.into_iter() {
+                    if let StructScrutineeField::Field {
+                        field, scrutinee, ..
+                    } = field
+                    {
+                        let f = match scrutinee {
+                            Some(scrutinee) => check!(
+                                Pattern::from_scrutinee(scrutinee),
+                                return err(warnings, errors),
+                                warnings,
+                                errors
+                            ),
+                            None => Pattern::Wildcard,
+                        };
+                        new_fields.push((field.as_str().to_string(), f));
+                    }
                 }
                 Pattern::Struct(StructPattern {
                     struct_name: struct_name.to_string(),

--- a/sway-parse/src/error.rs
+++ b/sway-parse/src/error.rs
@@ -64,6 +64,8 @@ pub enum ParseErrorKind {
     UnexpectedTokenAfterAttribute,
     #[error("Identifiers cannot begin with a double underscore, as that naming convention is reserved for compiler intrinsics.")]
     InvalidDoubleUnderscore,
+    #[error("Unexpected rest token, must be at the end of pattern.")]
+    UnexpectedRestPattern,
 }
 
 #[derive(Debug, Error, Clone, PartialEq, Hash)]

--- a/sway-parse/src/keywords.rs
+++ b/sway-parse/src/keywords.rs
@@ -165,6 +165,7 @@ define_token!(
     [GreaterThan, Equals]
 );
 define_token!(DotToken, "`.`", [Dot], []);
+define_token!(DoubleDotToken, "`..`", [Dot, Dot], [Dot]);
 define_token!(BangToken, "`!`", [Bang], [Equals]);
 define_token!(PercentToken, "`%`", [Percent], []);
 define_token!(AddToken, "`+`", [Add], [Equals]);

--- a/sway-parse/src/pattern.rs
+++ b/sway-parse/src/pattern.rs
@@ -75,6 +75,19 @@ impl Parse for Pattern {
             return Ok(Pattern::Constructor { path, args });
         }
         if let Some(fields) = Braces::try_parse(parser)? {
+            let _fields: &Punctuated<PatternStructField, CommaToken> = fields.get();
+            let rest_pattern = _fields
+                .value_separator_pairs
+                .iter()
+                .find(|(p, _)| matches!(p, PatternStructField::Rest { token: _ }));
+
+            if let Some((rest_pattern, _)) = rest_pattern {
+                return Err(parser.emit_error_with_span(
+                    ParseErrorKind::UnexpectedRestPattern,
+                    rest_pattern.span(),
+                ));
+            }
+
             return Ok(Pattern::Struct { path, fields });
         }
         match path.try_into_ident() {
@@ -88,22 +101,39 @@ impl Parse for Pattern {
 }
 
 #[derive(Clone, Debug)]
-pub struct PatternStructField {
-    pub field_name: Ident,
-    pub pattern_opt: Option<(ColonToken, Box<Pattern>)>,
+pub enum PatternStructField {
+    Rest {
+        token: DoubleDotToken,
+    },
+    Field {
+        field_name: Ident,
+        pattern_opt: Option<(ColonToken, Box<Pattern>)>,
+    },
 }
 
 impl Spanned for PatternStructField {
     fn span(&self) -> Span {
-        match &self.pattern_opt {
-            Some((_colon_token, pattern)) => Span::join(self.field_name.span(), pattern.span()),
-            None => self.field_name.span(),
+        use PatternStructField::*;
+        match &self {
+            Rest { token } => token.span(),
+            Field {
+                field_name,
+                pattern_opt,
+            } => match pattern_opt {
+                Some((_colon_token, pattern)) => Span::join(field_name.span(), pattern.span()),
+                None => field_name.span(),
+            },
         }
     }
 }
 
 impl Parse for PatternStructField {
     fn parse(parser: &mut Parser) -> ParseResult<PatternStructField> {
+        if parser.peek::<DoubleDotToken>().is_some() {
+            let token = parser.parse()?;
+            return Ok(PatternStructField::Rest { token });
+        }
+
         let field_name = parser.parse()?;
         let pattern_opt = match parser.take() {
             Some(colon_token) => {
@@ -112,7 +142,7 @@ impl Parse for PatternStructField {
             }
             None => None,
         };
-        Ok(PatternStructField {
+        Ok(PatternStructField::Field {
             field_name,
             pattern_opt,
         })

--- a/sway-parse/src/pattern.rs
+++ b/sway-parse/src/pattern.rs
@@ -75,8 +75,8 @@ impl Parse for Pattern {
             return Ok(Pattern::Constructor { path, args });
         }
         if let Some(fields) = Braces::try_parse(parser)? {
-            let _fields: &Punctuated<PatternStructField, CommaToken> = fields.get();
-            let rest_pattern = _fields
+            let inner_fields: &Punctuated<_, _> = fields.get();
+            let rest_pattern = inner_fields
                 .value_separator_pairs
                 .iter()
                 .find(|(p, _)| matches!(p, PatternStructField::Rest { token: _ }));

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_multiple_rest/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_multiple_rest/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'match_expressions_multiple_rest'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_multiple_rest/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_multiple_rest/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "match_expressions_multiple_rest"
+entry = "main.sw"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_multiple_rest/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_multiple_rest/src/main.sw
@@ -1,0 +1,21 @@
+script;
+
+struct Point {
+  x: u64,
+  y: u64
+}
+
+// this should fail because of multiple rest patterns 
+
+fn main() -> u64 {
+    let p = Point {
+        x: 1u64,
+        y: 2u64,
+    };
+
+    match p {
+        Point { x, .., .. } => { x },
+    };
+
+    0
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_multiple_rest/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_multiple_rest/test.toml
@@ -1,0 +1,1 @@
+category = "fail"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_rest/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_rest/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'match_expressions_rest'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_rest/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_rest/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "match_expressions_rest"
+entry = "main.sw"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_rest/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_rest/src/main.sw
@@ -1,0 +1,21 @@
+script;
+
+struct Point {
+  x: u64,
+  y: u64
+}
+
+// this should fail because rest patterns must appear at the end
+
+fn main() -> u64 {
+    let p = Point {
+        x: 1u64,
+        y: 2u64,
+    };
+
+    match p {
+        Point { .., x } => { x },
+    };
+
+    0
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_rest/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_rest/test.toml
@@ -1,0 +1,1 @@
+category = "fail"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_struct_missing_fields/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_struct_missing_fields/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'match_expressions_struct_missing_fields'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_struct_missing_fields/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_struct_missing_fields/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "match_expressions_struct_missing_fields"
+entry = "main.sw"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_struct_missing_fields/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_struct_missing_fields/src/main.sw
@@ -1,0 +1,21 @@
+script;
+
+struct Point {
+  x: u64,
+  y: u64
+}
+
+// this should fail because the pattern is missing the y field
+
+fn main() -> u64 {
+    let p = Point {
+        x: 1u64,
+        y: 2u64,
+    };
+
+    match p {
+        Point { x } => { x },
+    };
+
+    0
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_struct_missing_fields/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_struct_missing_fields/test.toml
@@ -1,0 +1,1 @@
+category = "fail"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'match_expressions_rest'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/Forc.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = 'core'
-source = 'path+from-root-8F0E3A0B953247F5'
+source = 'path+from-root-A102296F39438745'
 dependencies = []
 
 [[package]]
@@ -10,5 +10,5 @@ dependencies = ['std']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.16.0#948f7aba42b4138433fb5b61c698c8f4a60db424'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.16.1#dcf22453aeb054335d96ef810da9d4f756d869b7'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/Forc.lock
@@ -1,4 +1,14 @@
 [[package]]
+name = 'core'
+source = 'path+from-root-8F0E3A0B953247F5'
+dependencies = []
+
+[[package]]
 name = 'match_expressions_rest'
 source = 'root'
-dependencies = []
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.16.0#948f7aba42b4138433fb5b61c698c8f4a60db424'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "match_expressions_rest"
+entry = "main.sw"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/Forc.toml
@@ -3,4 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "match_expressions_rest"
 entry = "main.sw"
-implicit-std = false
+implicit-std = true

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/json_abi_oracle.json
@@ -1,0 +1,14 @@
+[
+  {
+    "inputs": [],
+    "name": "main",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "u64"
+      }
+    ],
+    "type": "function"
+  }
+]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/src/main.sw
@@ -1,0 +1,19 @@
+script;
+
+struct Point {
+  x: u64,
+  y: u64
+}
+
+fn main() -> u64 {
+    let p = Point {
+        x: 1u64,
+        y: 2u64,
+    };
+
+    match p {
+        Point { x, .. } => { x },
+    };
+
+    0
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/src/main.sw
@@ -5,6 +5,23 @@ struct Point {
   y: u64
 }
 
+struct Point3D {
+  x: u64,
+  y: u64,
+  z: u64
+}
+
+struct Line {
+    p1: Point,
+    p2: Point
+}
+
+enum Kind {
+    Point: Point,
+    Point3D: Point3D,
+    Line: Line
+}
+
 fn main() -> u64 {
     let p = Point {
         x: 1u64,
@@ -14,6 +31,34 @@ fn main() -> u64 {
     match p {
         Point { x, .. } => { x },
     };
+
+    let p2 = Point3D {
+        x: 1u64,
+        y: 2u64,
+        z: 3u64,
+    };
+
+    match p2 {
+        Point3D { x, .. } => { x },
+    };
+
+    let l = Line { p1: p, p2: p };
+
+    match l {
+        Line { p1, .. } => {}
+    }
+
+    match l {
+        Line { p1: Point { .. }, p2: Point { .. } } => {}
+    }
+
+    let k = Kind::Point(p);
+
+    match k {
+        Kind::Point(Point { x, .. }) => {},
+        Kind::Point3D(Point3D { z, .. }) => {},
+        Kind::Line(Line { p1: Point { .. }, p2: Point { .. } }) => {},
+    }
 
     0
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 0 }
+validate_abi = true


### PR DESCRIPTION
This commit improves a couple aspects of handling of struct patterns.

First of all, it adds semantic checking (with a new error) when
patterns are missing usage of all fields, which previously compiled fine with no errors:

```
error
  --> src/main.sw:15:9
   |
13 | 
14 |     let z = match p {
15 |         Point { x } => { x },
   |         ^^^^^^^^^^^ Pattern does not mention field: y
16 |     };
   |
____
```

Then it adds support for rest pattern, `..`, which can be used as the
last token in a pattern to not have to specify all the struct fields, like so:

```rust
fn rest_pattern() {
    let p = Point {
        x: 1u64,
        y: 2u64,
    };

    match p {
        Point { x, .. } => { x },
    };
}
```

The semantic AST model was updated to support modeling this pattern,
and further type checking was added to the code.

There is also a new error for when the rest pattern doesn't appear as
the last location, or when it appears multiple times:

```
error
  --> src/main.sw:15:20
   |
13 | 
14 |     match p {
15 |         Point { x, .., .. } => { x },
   |                    ^^ Unexpected rest token, must be at the end of pattern.
16 |     };
17 | }
   |
____

```

And lastly, tests were added to cover the changes and new functionality.

Closes https://github.com/FuelLabs/sway/issues/1568.