### PR TITLE
Some updates to the known issues section

### DIFF
--- a/docs/src/reference/known_issues_and_workarounds.md
+++ b/docs/src/reference/known_issues_and_workarounds.md
@@ -2,8 +2,6 @@
 
 ## Known Issues
 
-* [#1663](https://github.com/FuelLabs/sway/issues/1663): Using an explicit `return` in all branches of an `if let` expression causes a compile error. The workaround is to use implicit returns instead.
-
 * [#870](https://github.com/FuelLabs/sway/issues/870): All `impl` blocks need to be defined before any of the functions they define can be called.
 
 ## Missing Features
@@ -12,7 +10,9 @@
 
 * [#428](https://github.com/FuelLabs/sway/issues/428): Arrays are currently immutable which means that changing elements of an array once initialized is not yet possible.
 
-* [#1077](https://github.com/FuelLabs/sway/issues/1077): Dynamic vectors, i.e. `Vec<T>`, have not yet been implemented.
+* [#2035](https://github.com/FuelLabs/sway/issues/2035): Dynamic vectors _in storage_ have not yet been implemented. Only [vectors in memory](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/vec.sw) are available at the moment.
+
+* [#1188](https://github.com/FuelLabs/sway/issues/1188): Mutable function arguments are not yet allowed except for `self`.
 
 ## General
 


### PR DESCRIPTION
* https://github.com/FuelLabs/sway/issues/1663 has been closed.
* Added some comments about vectors in storage. We still need a full section on `Vec<T>` itself.