### PR TITLE
Bump non-transitive `dashmap` to v5.3.4.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3636,7 +3636,7 @@ name = "sway-lsp"
 version = "0.16.1"
 dependencies = [
  "async-trait",
- "dashmap 4.0.2",
+ "dashmap 5.3.4",
  "forc-util",
  "futures",
  "ropey",

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/FuelLabs/sway"
 description = "LSP server for Sway."
 
 [dependencies]
-dashmap = "4.0.2"
+dashmap = "5.3.4"
 forc-util = { version = "0.16.1", path = "../forc-util" }
 ropey = "1.2"
 serde_json = "1.0.60"


### PR DESCRIPTION
Fixes half of https://github.com/FuelLabs/sway/security/dependabot/10. The other half will be resolved once https://github.com/FuelLabs/fuel-core/pull/428 lands.

Bump non-transitive `dashmap` to `v5.3.4`.