### PR TITLE
Update all the E2E should_fail tests to verify their output.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,6 +1510,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "gag"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a713bee13966e9fbffdf7193af71d54a6b35a0bb34997cd6c9519ebeb5005972"
+dependencies = [
+ "filedescriptor",
+ "tempfile",
 ]
 
 [[package]]
@@ -3769,11 +3790,13 @@ name = "test"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "filecheck",
  "forc",
  "forc-util",
  "fuel-asm",
  "fuel-tx",
  "fuel-vm",
+ "gag",
  "rand 0.8.5",
  "regex",
  "serde_json",

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -7,11 +7,13 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.41"
+filecheck = "0.5"
 forc = { path = "../forc", features = ["test"], default-features = false }
 forc-util = { path = "../forc-util" }
 fuel-asm = "0.5"
 fuel-tx = "0.12"
 fuel-vm = { version = "0.11", features = ["random"] }
+gag = "1.0"
 rand = "0.8"
 regex = "1"
 serde_json = "1.0.73"

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -98,22 +98,51 @@ pub(crate) fn runs_in_vm(file_name: &str, locked: bool) -> ProgramState {
     *i.transact(tx_to_test).unwrap().state()
 }
 
-/// Panics if code _does_ compile, used for test cases where the source
-/// code should have been rejected by the compiler.
-pub(crate) fn does_not_compile(file_name: &str, locked: bool) {
-    assert!(
-        compile_to_bytes(file_name, locked).is_err(),
-        "{} should not have compiled.",
-        file_name,
-    )
+/// Returns Err(()) if code _does_ compile, used for test cases where the source
+/// code should have been rejected by the compiler.  When it fails to compile the
+/// captured stdout is returned.
+pub(crate) fn does_not_compile(file_name: &str, locked: bool) -> Result<String, ()> {
+    use std::io::Read;
+
+    tracing::info!(" Compiling {}", file_name);
+
+    // Capture stdout to a buffer, compile the test and save stdout to a string.
+    let mut buf = gag::BufferRedirect::stdout().unwrap();
+    let result = compile_to_bytes_verbose(file_name, locked, true);
+    let mut output = String::new();
+    buf.read_to_string(&mut output).unwrap();
+    drop(buf);
+
+    // If verbosity is requested then print it out.
+    if get_test_config_from_env() {
+        tracing::info!("{output}");
+    }
+
+    // Invert the result; if it succeeds then return an Err.
+    match result {
+        Ok(_) => Err(()),
+        Err(e) => {
+            // Capture the result of the compilation (i.e., any errors Forc produces) and append to
+            // the stdout from the compiler.
+            output.push_str(&format!("\n{e}"));
+            Ok(output)
+        }
+    }
 }
 
 /// Returns `true` if a file compiled without any errors or warnings,
 /// and `false` if it did not.
 pub(crate) fn compile_to_bytes(file_name: &str, locked: bool) -> Result<Vec<u8>> {
+    compile_to_bytes_verbose(file_name, locked, get_test_config_from_env())
+}
+
+pub(crate) fn compile_to_bytes_verbose(
+    file_name: &str,
+    locked: bool,
+    verbose: bool,
+) -> Result<Vec<u8>> {
     tracing::info!(" Compiling {}", file_name);
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let verbose = get_test_config_from_env();
     forc_build::build(BuildCommand {
         path: Some(format!(
             "{}/src/e2e_vm_tests/test_programs/{}",

--- a/test/src/e2e_vm_tests/test_programs/README.md
+++ b/test/src/e2e_vm_tests/test_programs/README.md
@@ -3,12 +3,12 @@
 Each of the tests in this suite are controlled by a TOML descriptor file which describes how the
 test should be run and what result to expect if any.
 
-## `test.toml`
+## test.toml
 
 To add a new test to the E2E suite place a `test.toml` file at the root of the test Forc package,
 i.e., next to the `Forc.toml` file.  This file may contain a few basic fields.
 
-## `category`
+## category
 
 The `category` field is mandatory and must be one of the following strings:
 
@@ -18,7 +18,7 @@ The `category` field is mandatory and must be one of the following strings:
 * `"fail"` - The test is expected to fail to compile.
 * `"disabled"` - The test is disabled.
 
-## `expected_result`
+## expected_result
 
 The `expected_result` field is mandatory for `"run"` and `"run_on_node"` tests.  It is a table with
 two fields, `action` and `value`.
@@ -35,7 +35,7 @@ it must be an integer.
 
 For `"return_data"` actions it must be an array of byte values, each an integer between 0 and 255.
 
-## `contracts`
+## contracts
 
 Tests in the `"run_on_node"` category will usually specify one or more contracts which must be
 deployed to the node prior to deploying and running the test code.  These are specified with the
@@ -45,10 +45,30 @@ It must be an array of strings each containing only the path to the Forc project
 be compiled and deployed.  It is important that these paths remain relative to the
 `test/src/e2e_vm_tests/test_programs` directory.
 
-## `validate_abi`
+## validate_abi
 
 Some tests also require their ABI is verified.  To indicate this the `validate_abi` field may be
 specified, as a boolean value.
+
+# FileCheck for 'fail' tests
+
+The tests in the `fail` category _must_ employ verification using pattern matching via the [FileCheck](https://docs.rs/filecheck/latest/filecheck/)
+crate.  The checker directives are specified in comments (lines beginning with `#`) in the `test.toml`
+file.
+
+Typically this is as simple as just adding a `# check: ...` line to the line specifying the full
+error or warning message expected from compiling the test.  `FileCheck` also has other directives for
+fancier pattern matching, as specified in the [FileCheck docs](https://docs.rs/filecheck/latest/filecheck/).
+
+**Note:** The output from the compiler is colorized, usually to red or yellow, and this involves
+printing ANSI escape sequences to the terminal.  These sequences can confuse `FileCheck` as it tries
+to match patterns on 'word' boundaries.  The first word in an error message is most likely prefixed
+with an escape sequence and can cause the check to fail.
+
+To avoid this problem one may either not use the first word in the error message, or use the 'empty
+string' pattern `$()` to direct the matcher as to where the pattern starts.
+
+E.g, `# check: $()The name "S" shadows another symbol with the same name.`
 
 # Examples
 
@@ -76,6 +96,19 @@ The following tests a contract on a Fuel Core node.
 category = "run_on_node"
 expected_result = { action = "result", value = 11 }
 contracts = ["should_pass/test_contracts/test_contract_a", "should_pass/test_contracts/test_contract_b"]
+```
+
+Tests which fail can have fairly elaborate checks.
+
+```toml
+category = "fail"
+
+# check: // this asm block should return unit, i.e. nothing
+# nextln: asm(r1: 5) {
+# check: $()Mismatched types.
+# nextln: $()expected: ()
+# nextln: $()found:    u64.
+# nextln: $()help: Implicit return must match up with block's type.
 ```
 
 And there are already hundreds of existing tests with `test.toml` descriptors which may be consulted

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_purity_mismatch/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_purity_mismatch/test.toml
@@ -1,1 +1,3 @@
 category = "fail"
+
+# check: $()Storage attribute access mismatch. The trait function "test_function" in trait "MyContract" requires the storage attribute(s) #[storage(read)].

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_method_signature_mismatch/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_method_signature_mismatch/test.toml
@@ -1,1 +1,5 @@
 category = "fail"
+
+# check: fn foo(s: str[7]) -> str[7] {
+# nextln: $()Expected: u64
+# nextln: $()found:    str[7]. The definition of this function must match the one in the trait declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pure_calls_impure/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pure_calls_impure/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: f()
+# nextln: $()Storage attribute access mismatch. Try giving the surrounding function more access by adding "#[storage(read)]" to the function declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abort_control_flow_bad/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abort_control_flow_bad/test.toml
@@ -1,1 +1,16 @@
 category = "fail"
+
+# check: return 42;
+# nextln: $()Mismatched types.
+# nextln: $()expected: ()
+# nextln: $()found:    u64.
+# nextln: $()help: Return statement must return the declared function return type.
+
+# This 'return true' line appears in both error messages..
+# check: return true;
+
+# check: return true;
+# nextln: $()Mismatched types.
+# nextln: $()expected: ()
+# nextln: $()found:    bool.
+# nextln: $()help: Return statement must return the declared function return type.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_bad_index/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_bad_index/test.toml
@@ -1,1 +1,6 @@
 category = "fail"
+
+# check: ary[false]
+# nextln: $()Mismatched types.
+# nextln: $()expected: u64
+# nextln: $()found:    bool.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_oob/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_oob/test.toml
@@ -1,1 +1,3 @@
 category = "fail"
+
+# check: $()Array index out of bounds; the length is 3 but the index is 4.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/asm_missing_return/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/asm_missing_return/test.toml
@@ -1,1 +1,13 @@
 category = "fail"
+
+# check: asm(r1: 5) {
+# check: $()Mismatched types.
+# nextln: $()expected: u64
+# nextln: $()found:    ().
+# nextln: $()help: Implicit return must match up with block's type.
+
+# check: asm(r1: 5) {
+# check: $()Mismatched types.
+# nextln: $()expected: u64
+# nextln: $()found:    ().
+# nextln: $()help: Function body's return type does not match up with its return type annotation.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/asm_should_not_have_return/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/asm_should_not_have_return/test.toml
@@ -1,1 +1,15 @@
 category = "fail"
+
+# check: // this asm block should return unit, i.e. nothing
+# nextln: asm(r1: 5) {
+# check: $()Mismatched types.
+# nextln: $()expected: ()
+# nextln: $()found:    u64.
+# nextln: $()help: Implicit return must match up with block's type.
+
+# check: // this asm block should return unit, i.e. nothing
+# nextln: asm(r1: 5) {
+# check: $()Mismatched types.
+# nextln: $()expected: ()
+# nextln: $()found:    u64.
+# nextln: $()help: Function body's return type does not match up with its return type annotation.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/assign_to_field_of_non_mutable_struct/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/assign_to_field_of_non_mutable_struct/test.toml
@@ -1,1 +1,3 @@
 category = "fail"
+
+# check: $()Assignment to immutable variable. Variable thing is not declared as mutable.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_annotation/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_annotation/test.toml
@@ -1,1 +1,7 @@
 category = "fail"
+
+# check: let g: u32 = three_generics(true, "foo", 10);
+# nextln: $()Mismatched types.
+# nextln: $()expected: u32
+# nextln: $()found:    str[3].
+# nextln: $()help: Variable declaration's type annotation does not match up with the assigned expression's type.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_var_annotation/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/bad_generic_var_annotation/test.toml
@@ -1,1 +1,13 @@
 category = "fail"
+
+# check: let g: str[3] = three_generics(true, "foo", 10);
+# nextln: $()Mismatched types.
+# nextln: $()expected: bool
+# nextln: $()found:    str[3].
+# nextln: $()help: The argument that has been provided to this function's type does not match the declared type of the parameter in the function declaration.
+
+# check: let g: str[3] = three_generics(true, "foo", 10);
+# nextln: $()Mismatched types.
+# nextln: $()expected: str[3]
+# nextln: $()found:    bool.
+# nextln: $()help: Variable declaration's type annotation does not match up with the assigned expression's type.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/better_type_error_message/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/better_type_error_message/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: $()Could not find symbol "Result" in this scope.
+# check: $()Unknown type name "Result".

--- a/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/test.toml
@@ -1,1 +1,3 @@
 category = "fail"
+
+# check: $()Variable "num" does not exist in this scope.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/contract_pure_calls_impure/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/contract_pure_calls_impure/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: foo();
+# nextln: $()Storage attribute access mismatch. Try giving the surrounding function more access by adding "#[storage(read, write)]" to the function declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/cyclic_dependency/dependency_a/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/cyclic_dependency/dependency_a/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: dependency cycle detected: dependency_a -> dependency_b -> dependency_a

--- a/test/src/e2e_vm_tests/test_programs/should_fail/cyclic_dependency/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/cyclic_dependency/test.toml
@@ -1,1 +1,0 @@
-category = "fail"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/dependency_parsing_error/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/dependency_parsing_error/test.toml
@@ -1,1 +1,5 @@
 category = "fail"
+
+# Not sure if this is the originally expected error:
+# check: let baz = 43;
+# nextln: $()Expected an item.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/different_contract_caller_types/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/different_contract_caller_types/test.toml
@@ -1,1 +1,15 @@
 category = "fail"
+
+# check: let caller = abi(OtherAbi, ADDRESS);
+# nextln: caller
+# nextln: $()Mismatched types.
+# nextln: $()expected: contract caller SomeAbi
+# nextln: $()found:    contract caller OtherAbi.
+# nextln: $()help: Implicit return must match up with block's type.
+
+# check: let caller = abi(OtherAbi, ADDRESS);
+# nextln: caller
+# nextln: $()Mismatched types.
+# nextln: $()expected: contract caller SomeAbi
+# nextln: $()found:    contract caller OtherAbi.
+# nextln: $()help: Function body's return type does not match up with its return type annotation.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/disallow_turbofish/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/disallow_turbofish/test.toml
@@ -1,1 +1,10 @@
 category = "fail"
+
+# check: let data = Data::<bool> {
+# nextln: $()"Data" does not take type arguments.
+
+# check: let res1 = Result::<bool> {
+# nextln: $()Expected 2 type arguments, but instead found 1.
+
+# check: foo::<u64>();
+# nextln: $()"foo" does not take type arguments.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/disallowed_gm/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/disallowed_gm/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: gm r1 i1;
+# nextln: $()The GM (get-metadata) opcode, when called from an external context, will cause the VM to panic.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_enum/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_enum/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: enum __MyEnum {
+# nextln: $()Identifiers cannot begin with a double underscore, as that naming convention is reserved for compiler intrinsics.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_fn/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_fn/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: __test()
+# nextln: $()Identifiers cannot begin with a double underscore, as that naming convention is reserved for compiler intrinsics.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_impl_self_fn/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_impl_self_fn/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: fn __double_underscore(self, x: bool) -> bool {
+# nextln: $()Identifiers cannot begin with a double underscore, as that naming convention is reserved for compiler intrinsics.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_struct/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_struct/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: struct __MyStruct {
+# nextln: $()Identifiers cannot begin with a double underscore, as that naming convention is reserved for compiler intrinsics.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_trait_fn/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_trait_fn/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: __test()
+# nextln: $()Identifiers cannot begin with a double underscore, as that naming convention is reserved for compiler intrinsics.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_var/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_var/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: __a
+# nextln: $()Identifiers cannot begin with a double underscore, as that naming convention is reserved for compiler intrinsics.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/empty_impl/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/empty_impl/test.toml
@@ -1,1 +1,3 @@
 category = "fail"
+
+# check: $()Could not find symbol "Coin" in this scope.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/enum_bad_type_inference/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/enum_bad_type_inference/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "enum_bad_type_inference"
 
 [dependencies]
-core = { path = "../../../../../../../sway-lib-core" }
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/enum_bad_type_inference/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/enum_bad_type_inference/test.toml
@@ -1,1 +1,12 @@
 category = "fail"
+
+
+# check: Ok: T,
+# nextln: $()Mismatched types.
+# nextln: $()expected: bool
+# nextln: $()found:    u64.
+
+# check: enum Result<T, E> {
+# nextln: $()Mismatched types.
+# nextln: $()expected: bool
+# nextln: $()found:    u64.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/enum_if_let_invalid_variable/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/enum_if_let_invalid_variable/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: if let
+# nextln: $()Variable "y" does not exist in this scope.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/Forc.lock
@@ -1,4 +1,9 @@
 [[package]]
+name = 'core'
+source = 'path+from-root-8EECC8A749908BB3'
+dependencies = []
+
+[[package]]
 name = 'excess_fn_arguments'
 source = 'root'
-dependencies = []
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/Forc.toml
@@ -3,4 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "excess_fn_arguments"
 entry = "main.sw"
-implicit-std = false
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/excess_fn_arguments/test.toml
@@ -1,1 +1,5 @@
-category = "fail"
+# This test should be a "fail" but it's currently passing.
+# See https://github.com/FuelLabs/sway/issues/2081
+category = "compile"
+
+# check: ... something about too many args ...

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_shadows_generic/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_shadows_generic/test.toml
@@ -1,1 +1,3 @@
 category = "fail"
+
+# check: $()The name "T" is already used for a generic parameter in this scope.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generics_unhelpful_error/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generics_unhelpful_error/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: fn f(a: DoubleIdentity<u64>) {
+# nextln: $()Expected 2 type arguments, but instead found 1.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/impl_method_recursion/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/impl_method_recursion/test.toml
@@ -1,1 +1,0 @@
-category = "fail"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/impl_with_bad_generic/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/impl_with_bad_generic/test.toml
@@ -1,1 +1,7 @@
 category = "fail"
+
+# check: impl<T> S {
+# nextln: $()The generic type parameter "T" is unconstrained.
+
+# check: (S{}).f(true);
+# nextln: $()No method named "f" found for type "S".

--- a/test/src/e2e_vm_tests/test_programs/should_fail/impl_with_semantic_type_constraints/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/impl_with_semantic_type_constraints/test.toml
@@ -1,1 +1,10 @@
 category = "fail"
+
+# check: let i = b.add();
+# nextln: $()No method named "add" found for type "DoubleIdentity<bool, bool>".
+
+# check: let j = c.get_first();
+# nextln: $()No method named "get_first" found for type "DoubleIdentity<u64, str[2]>".
+
+# check: let l = c.add();
+# nextln: $()No method named "add" found for type "DoubleIdentity<u64, str[2]>".

--- a/test/src/e2e_vm_tests/test_programs/should_fail/impure_abi_read_calls_impure_write/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/impure_abi_read_calls_impure_write/test.toml
@@ -1,1 +1,5 @@
 category = "fail"
+
+# check: fn test_function() -> bool {
+# nextln: f()
+# nextln: $()Storage attribute access mismatch. Try giving the surrounding function more access by adding "#[storage(read, write)]" to the function declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/impure_read_calls_impure_write/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/impure_read_calls_impure_write/test.toml
@@ -1,1 +1,5 @@
 category = "fail"
+
+# check: fn can_read() {
+# nextln: can_write();
+# nextln: $()Storage attribute access mismatch. Try giving the surrounding function more access by adding "#[storage(read, write)]" to the function declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/impure_trait_read_calls_impure_write/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/impure_trait_read_calls_impure_write/test.toml
@@ -1,1 +1,5 @@
 category = "fail"
+
+# check: pub fn g() -> bool {
+# nextln: true.f()
+# nextln: $()Storage attribute access mismatch. Try giving the surrounding function more access by adding "#[storage(read, write)]" to the function declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/infinite_dependencies/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/infinite_dependencies/test.toml
@@ -1,5 +1,5 @@
 # The feature for this test, detecting infinite deps, was reverted. When that is re-implemented we
 # should re-enable this test.
 
-#category = "fails"
+#category = "fail"
 category = "disabled"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info/src/main.sw
@@ -1,7 +1,7 @@
 script;
 
 fn foo<T>() {
-    let x = size_of::<T>();
+    let x = __size_of::<T>();
 }
 
 fn main() {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: __size_of::<T>();
+# nextln: $()Cannot infer type for type parameter "T". Insufficient type information provided. Try annotating its type.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/item_used_without_import/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/item_used_without_import/test.toml
@@ -1,1 +1,3 @@
 category = "fail"
+
+# check: $()Could not find symbol "Bar" in this scope.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/literal_too_large_for_type/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/literal_too_large_for_type/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: let x:u8 = 256;
+# nextln: $()Literal value is too large for type u8.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_empty_arms/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_empty_arms/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: match foo {
+# check: $()Non-exhaustive match expression. Missing patterns `_`

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_multiple_rest/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_multiple_rest/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: Point { x, .., .. } => { x },
+# nextln: $()Unexpected rest token, must be at the end of pattern.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/Forc.toml
@@ -6,4 +6,4 @@ entry = "main.sw"
 implicit-std = false
 
 [dependencies]
-core = { path = "../../../../../../../sway-lib-core" }
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_non_exhaustive/test.toml
@@ -1,1 +1,34 @@
 category = "fail"
+
+# check: match_expressions_non_exhaustive/src/main.sw:41:9
+# check: $()This match arm is unreachable.
+
+# check: match_expressions_non_exhaustive/src/main.sw:61:9
+# check: $()This match arm is unreachable.
+
+# check: match_expressions_non_exhaustive/src/main.sw:90:9
+# check: $()This match arm is unreachable.
+
+# check: match_expressions_non_exhaustive/src/main.sw:95:9
+# check: $()This match arm is unreachable.
+
+# check: match_expressions_non_exhaustive/src/main.sw:101:9
+# check: $()This match arm is unreachable.
+
+# check: match_expressions_non_exhaustive/src/main.sw:107:9
+# check: $()This match arm is unreachable.
+
+# check: match_expressions_non_exhaustive/src/main.sw:37:13
+# check: $()Non-exhaustive match expression. Missing patterns `[1...4]`, `[6...9]`, `[11...MAX]`
+
+# check: match_expressions_non_exhaustive/src/main.sw:58:13
+# check: $()Non-exhaustive match expression. Missing patterns `(_, [2...MAX])`
+
+# check: match_expressions_non_exhaustive/src/main.sw:88:15
+# check: $()Non-exhaustive match expression. Missing patterns `Point { x: [MIN...2], ... }`, `Point { x: [4...MAX], ... }`
+
+# check: match_expressions_non_exhaustive/src/main.sw:122:15
+# check: $()Non-exhaustive match expression. Missing patterns `CrazyPoint { p1: Point { x: [1...MAX], ... }, ... }`
+
+# check: match_expressions_non_exhaustive/src/main.sw:128:16
+# check: $()Variable "newvariable" does not exist in this scope.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_rest/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_rest/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: Point { .., x } => { x },
+# nextnl: $()Unexpected rest token, must be at the end of pattern.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_struct_missing_fields/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_struct_missing_fields/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: Point { x } => { x },
+# nextln: $()Pattern does not mention field: y

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_wrong_struct/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_wrong_struct/test.toml
@@ -1,1 +1,21 @@
 category = "fail"
+
+# check: Point { x: 3, y } => { y },
+# nextln: $()Mismatched types.
+# nextln: $()expected: u64
+# nextln: $()found:    Point.
+
+# check: Point { x: 3, y: 4 } => { 24 },
+
+# check: Point { x: 3, y: 4 } => { 24 },
+# nextln: $()Mismatched types.
+# nextln: $()expected: u64
+# nextln: $()found:    Point.
+
+# check: Data { value: 1u64 } => { false },
+# nextln: $()Mismatched types.
+# nextln: $()expected: bool
+# nextln: $()found:    u64.
+
+# check: Bar(x) => x,
+# nextln: $()Enum with name "Bar" could not be found in this scope. Perhaps you need to import it?

--- a/test/src/e2e_vm_tests/test_programs/should_fail/method_requires_mut_var/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/method_requires_mut_var/test.toml
@@ -1,1 +1,3 @@
 category = "fail"
+
+# check: $()Cannot call method "f" on variable "a" because "a" is not declared as mutable.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/Forc.lock
@@ -1,4 +1,9 @@
 [[package]]
+name = 'core'
+source = 'path+from-root-535272951E66DE82'
+dependencies = []
+
+[[package]]
 name = 'missing_fn_arguments'
 source = 'root'
-dependencies = []
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/Forc.toml
@@ -3,4 +3,6 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 license = "Apache-2.0"
 name = "missing_fn_arguments"
 entry = "main.sw"
-implicit-std = false
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_fn_arguments/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: fn bar(a: bool, b: u64) -> u64 {
+# check: $()Function "bar" expects 2 arguments but you provided 1.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_func_from_supertrait_impl/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_func_from_supertrait_impl/test.toml
@@ -1,1 +1,6 @@
 category = "fail"
+
+# check: impl A for Y {
+# nextln: fn a1() { }
+# nextln: }
+# nextln: $()Functions are missing from this trait implementation: a2

--- a/test/src/e2e_vm_tests/test_programs/should_fail/missing_supertrait_impl/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/missing_supertrait_impl/test.toml
@@ -1,1 +1,7 @@
 category = "fail"
+
+# check: missing_supertrait_impl/src/main.sw:38:1
+# check: $()The trait "A" is not implemented for type "Y"
+
+# check: missing_supertrait_impl/src/main.sw:7:7
+# check: $()Implementation of trait "A" is required by this bound in "B"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/multiple_impl_abi/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/multiple_impl_abi/test.toml
@@ -1,1 +1,3 @@
 category = "fail"
+
+# check: $()Function "test_function" was already defined in scope.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/multiple_impl_fns/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/multiple_impl_fns/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: $()Function "foo" was already defined in scope.
+# check: $()Function "bar" was already defined in scope.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/name_shadowing/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/name_shadowing/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: struct S
+# nextln: $()The name "S" shadows another symbol with the same name.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/nested_impure/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/nested_impure/test.toml
@@ -1,1 +1,10 @@
 category = "fail"
+
+# check: baz();
+# nextln: $()This returns a value of type u64, which is not assigned to anything and is ignored.
+
+# check: let z = baz();
+# nextln: $()Storage attribute access mismatch. Try giving the surrounding function more access by adding "#[storage(read)]" to the function declaration.
+
+# check: baz();
+# nextln: $()Storage attribute access mismatch. Try giving the surrounding function more access by adding "#[storage(read)]" to the function declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/non_literal_const_decl/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/non_literal_const_decl/test.toml
@@ -1,1 +1,0 @@
-category = "fail"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_calls_impure/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_calls_impure/test.toml
@@ -1,1 +1,9 @@
 category = "fail"
+
+# check: #[storage(read,write)]
+# nextln: fn foo() {
+# nextln: $()Impure function inside of non-contract. Contract storage is only accessible from contracts.
+
+# check: #[storage(read, write)]
+# nextln: fn main() -> bool {
+# nextln: $()Impure function inside of non-contract. Contract storage is only accessible from contracts.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/primitive_type_argument/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/primitive_type_argument/test.toml
@@ -1,1 +1,7 @@
 category = "fail"
+
+# check: let b = foo::baz::ExampleStruct::<bool> { a_field: 5u64 };
+# nextln: $()Mismatched types.
+# nextln: $()expected: bool
+# nextln: $()found:    u64.
+# nextln: $()help: Struct field's type must match up with the type specified in its declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/pure_calls_impure/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/pure_calls_impure/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: impure_function();
+# nextln: $()Storage attribute access mismatch. Try giving the surrounding function more access by adding "#[storage(write)]" to the function declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/test.toml
@@ -1,1 +1,8 @@
 category = "fail"
+
+# check: $()Function a is recursive, which is unsupported at this time.
+# check: $()Function b is recursive via c, which is unsupported at this time.
+# check: $()Function c is recursive via b, which is unsupported at this time.
+# check: $()Function d is recursive via e and f, which is unsupported at this time.
+# check: $()Function e is recursive via f and d, which is unsupported at this time.
+# check: $()Function f is recursive via d and e, which is unsupported at this time.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_enum/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_enum/test.toml
@@ -1,1 +1,3 @@
 category = "fail"
+
+# check: $()recursive types are not supported

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_struct/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_struct/test.toml
@@ -1,1 +1,3 @@
 category = "fail"
+
+# check: $()recursive types are not supported

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_chain/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_chain/test.toml
@@ -1,1 +1,12 @@
 category = "fail"
+
+# check: $()Type F is recursive via G and E, which is unsupported at this time.
+# check: $()Type G is recursive via E and F, which is unsupported at this time.
+# check: $()Type E is recursive via F and G, which is unsupported at this time.
+# check: $()Type I is recursive via H, which is unsupported at this time.
+# check: $()Type H is recursive via I, which is unsupported at this time.
+# check: $()Type T is recursive via S, which is unsupported at this time.
+# check: $()Type S is recursive via T, which is unsupported at this time.
+# check: $()Type Y is recursive via Z and X, which is unsupported at this time.
+# check: $()Type Z is recursive via X and Y, which is unsupported at this time.
+# check: $()Type X is recursive via Y and Z, which is unsupported at this time.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/repeated_enum_variant/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/repeated_enum_variant/test.toml
@@ -1,1 +1,10 @@
 category = "fail"
+
+# check: A: u64,
+# nextln: A: b256,
+# nextln: $()enum variant "A" already declared
+# nextln: A: str[4],
+
+# check: A: b256,
+# nextln: A: str[4],
+# nextln: $()enum variant "A" already declared

--- a/test/src/e2e_vm_tests/test_programs/should_fail/repeated_storage_field/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/repeated_storage_field/test.toml
@@ -1,1 +1,10 @@
 category = "fail"
+
+# check: x: u64,
+# nextln: x: b256,
+# nextln: $()storage field "x" already declared
+# nextln: x: str[4],
+
+# check: x: b256,
+# nextln: x: str[4],
+# nextln: $()storage field "x" already declared

--- a/test/src/e2e_vm_tests/test_programs/should_fail/repeated_struct_field/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/repeated_struct_field/test.toml
@@ -1,1 +1,9 @@
 category = "fail"
+
+# check: x: b256,
+# nextln: $()struct field "x" already declared
+# nextln: x: str[4],
+
+# check: x: b256,
+# nextln: x: str[4],
+# nextln: $()struct field "x" already declared

--- a/test/src/e2e_vm_tests/test_programs/should_fail/script_calls_impure/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/script_calls_impure/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: fn main() {}
+# nextln: $()Impure function inside of non-contract. Contract storage is only accessible from contracts.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/test.toml
@@ -1,1 +1,6 @@
 category = "fail"
+
+# check: $()The name "Foo" shadows another symbol with the same name.
+# check: $()The name "Bar2" shadows another symbol with the same name.
+# check: $()The name "Bar1" imported through `*` shadows another symbol with the same name.
+# check: $()The name "Bar2" imported through `*` shadows another symbol with the same name.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/src/main.sw
@@ -3,7 +3,7 @@ script;
 dep bar;
 
 // This should not compile but `use ::bar::*;` should
-use ::bar::{* as all);
+use ::bar::{* as all};
 
 fn main() -> bool {
     false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/star_import_alias/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: use ::bar::{* as all};
+# nextln: $()Expected `,`.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_conflict/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_conflict/test.toml
@@ -1,1 +1,49 @@
 category = "fail"
+
+# check: storage_conflict/src/main.sw:103:4
+# check: $()This function performs a storage read but does not have the required attribute(s).  Try adding "#[storage(read)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:46:4
+# check: $()This function performs a storage read but does not have the required attribute(s).  Try adding "#[storage(read)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:33:4
+# check: $()This function performs a storage read but does not have the required attribute(s).  Try adding "#[storage(read)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:13:5
+# check: $()This function performs a storage read but does not have the required attribute(s).  Try adding "#[storage(read)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:112:4
+# check: $()This function performs a storage read but does not have the required attribute(s).  Try adding "#[storage(read)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:57:4
+# check: $()This function performs a storage read but does not have the required attribute(s).  Try adding "#[storage(read)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:53:4
+# check: $()This function performs a storage read but does not have the required attribute(s).  Try adding "#[storage(read)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:16:5
+# check: $()This function performs a storage read but does not have the required attribute(s).  Try adding "#[storage(read)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:123:4
+# check: $()This function performs a storage write but does not have the required attribute(s).  Try adding "#[storage(write)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:71:4
+# check: $()This function performs a storage write but does not have the required attribute(s).  Try adding "#[storage(write)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:64:4
+# check: $()This function performs a storage write but does not have the required attribute(s).  Try adding "#[storage(write)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:19:5
+# check: $()This function performs a storage write but does not have the required attribute(s).  Try adding "#[storage(write)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:129:4
+# check: $()This function performs a storage write but does not have the required attribute(s).  Try adding "#[storage(write)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:87:4
+# check: $()This function performs a storage write but does not have the required attribute(s).  Try adding "#[storage(write)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:82:4
+# check: $()This function performs a storage write but does not have the required attribute(s).  Try adding "#[storage(write)]" to the function declaration.
+
+# check: storage_conflict/src/main.sw:22:5
+# check: $()This function performs a storage write but does not have the required attribute(s).  Try adding "#[storage(write)]" to the function declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_in_library/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_in_library/test.toml
@@ -1,1 +1,9 @@
 category = "fail"
+
+# Skip the first warning.
+# check: storage {
+
+# check: storage {
+# nextln: item: u64,
+# nextln: }
+# nextln: $()Declaring storage in a library is not allowed.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_in_predicate/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_in_predicate/test.toml
@@ -1,1 +1,9 @@
 category = "fail"
+
+# Skip the warning.
+# check: storage {
+
+# check: storage {
+# nextln: item: u64,
+# nextln: }
+# nextln: $()Declaring storage in a predicate is not allowed.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_in_script/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_in_script/test.toml
@@ -1,1 +1,9 @@
 category = "fail"
+
+# Skip the warning.
+# check: storage {
+
+# check: storage {
+# nextln: item: u64,
+# nextln: }
+# nextln: $()Declaring storage in a script is not allowed.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_ops_in_library/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_ops_in_library/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: do_storage::side_effects();
+# nextln: $()Storage attribute access mismatch. Try giving the surrounding function more access by adding "#[storage(read, write)]" to the function declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/test.toml
@@ -1,1 +1,3 @@
 category = "fail"
+
+# check: $()Could not find symbol "C" in this scope.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/top_level_vars/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/top_level_vars/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: let mut forbidden = true;
+# nextln: $()Expected an item.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_purity_mismatch/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_purity_mismatch/test.toml
@@ -1,1 +1,3 @@
 category = "fail"
+
+# check: $()Storage attribute access mismatch. The trait function "f" in trait "A" requires the storage attribute(s) #[storage(read)].

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_method_signature_mismatch/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_method_signature_mismatch/test.toml
@@ -1,1 +1,5 @@
 category = "fail"
+
+# check: fn foo(s: str[7]) -> str[7] {
+# nextln: $()Expected: u64
+# nextln: $()found:    str[7]. The definition of this function must match the one in the trait declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_pure_calls_impure/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_pure_calls_impure/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: self.f()
+# nextln: $()Storage attribute access mismatch. Try giving the surrounding function more access by adding "#[storage(read)]" to the function declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_mismatch_error_message/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_mismatch_error_message/test.toml
@@ -1,1 +1,4 @@
 category = "fail"
+
+# check: foo.does_not_exist();
+# nextln: $()No method named "does_not_exist" found for type "Result<Data<bool>, str[4]>".

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unify_identical_unknowns/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unify_identical_unknowns/test.toml
@@ -1,1 +1,8 @@
 category = "fail"
+
+# check: impl Foo for NonExistant {
+# nextln: $()Could not find symbol "NonExistant" in this scope.
+
+# check: impl Foo for NonExistant {
+# nextln: $()Unknown type name "NonExistant".
+


### PR DESCRIPTION
Using the `FileCheck` crate it can now pattern match against the compiler output to be sure the errors and/or warnings are exactly what we expect.

Closes #723.
Closes #1580.