### PR TITLE
Rename formatting `trait`s to specify what they format

### DIFF
--- a/sway-fmt-v2/src/fmt.rs
+++ b/sway-fmt-v2/src/fmt.rs
@@ -10,16 +10,24 @@ pub use crate::{
     error::{ConfigError, FormatterError},
 };
 
+/// Finalized Sway formatting configurations, and code shape.
 #[derive(Debug, Default)]
 pub struct Formatter {
     pub shape: Shape,
     pub config: Config,
 }
 
+/// Formatted Sway code.
 pub type FormattedCode = String;
 
-pub trait Format {
+/// Formatting for `ItemKind`.
+pub trait FormatItem {
     fn format(&self, formatter: &mut Formatter) -> FormattedCode;
+}
+
+/// Formatting for complex `ItemKind` fields e.g. `AttributeDecl` or `FnSignature`.
+pub trait FormatInner {
+    fn format(&self, line: &mut String, formatter: &mut Formatter);
 }
 
 impl Formatter {

--- a/sway-fmt-v2/src/items/item_abi.rs
+++ b/sway-fmt-v2/src/items/item_abi.rs
@@ -1,7 +1,7 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::fmt::{FormatItem, FormattedCode, Formatter};
 use sway_parse::ItemAbi;
 
-impl Format for ItemAbi {
+impl FormatItem for ItemAbi {
     fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }

--- a/sway-fmt-v2/src/items/item_const.rs
+++ b/sway-fmt-v2/src/items/item_const.rs
@@ -1,8 +1,8 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::fmt::{FormatItem, FormattedCode, Formatter};
 use sway_parse::ItemConst;
 use sway_types::Spanned;
 
-impl Format for ItemConst {
+impl FormatItem for ItemConst {
     fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         // TODO: creating this formatted_code with String::new() will likely cause lots of
         // reallocations maybe we can explore how we can do this, starting with with_capacity may help.

--- a/sway-fmt-v2/src/items/item_enum.rs
+++ b/sway-fmt-v2/src/items/item_enum.rs
@@ -1,12 +1,12 @@
 use crate::{
     config::items::ItemBraceStyle,
-    fmt::{Format, FormattedCode, Formatter},
+    fmt::{FormatItem, FormattedCode, Formatter},
     utils::bracket::CurlyBrace,
 };
 use sway_parse::ItemEnum;
 use sway_types::Spanned;
 
-impl Format for ItemEnum {
+impl FormatItem for ItemEnum {
     fn format(&self, formatter: &mut Formatter) -> FormattedCode {
         // TODO: creating this formatted_code with String::new() will likely cause lots of
         // reallocations maybe we can explore how we can do this, starting with with_capacity may help.

--- a/sway-fmt-v2/src/items/item_fn.rs
+++ b/sway-fmt-v2/src/items/item_fn.rs
@@ -1,7 +1,7 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::fmt::{FormatItem, FormattedCode, Formatter};
 use sway_parse::ItemFn;
 
-impl Format for ItemFn {
+impl FormatItem for ItemFn {
     fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }

--- a/sway-fmt-v2/src/items/item_impl.rs
+++ b/sway-fmt-v2/src/items/item_impl.rs
@@ -1,7 +1,7 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::fmt::{FormatItem, FormattedCode, Formatter};
 use sway_parse::ItemImpl;
 
-impl Format for ItemImpl {
+impl FormatItem for ItemImpl {
     fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }

--- a/sway-fmt-v2/src/items/item_storage.rs
+++ b/sway-fmt-v2/src/items/item_storage.rs
@@ -1,7 +1,7 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::fmt::{FormatItem, FormattedCode, Formatter};
 use sway_parse::ItemStorage;
 
-impl Format for ItemStorage {
+impl FormatItem for ItemStorage {
     fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }

--- a/sway-fmt-v2/src/items/item_struct.rs
+++ b/sway-fmt-v2/src/items/item_struct.rs
@@ -1,7 +1,7 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::fmt::{FormatItem, FormattedCode, Formatter};
 use sway_parse::ItemStruct;
 
-impl Format for ItemStruct {
+impl FormatItem for ItemStruct {
     fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }

--- a/sway-fmt-v2/src/items/item_trait.rs
+++ b/sway-fmt-v2/src/items/item_trait.rs
@@ -1,7 +1,7 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::fmt::{FormatItem, FormattedCode, Formatter};
 use sway_parse::ItemTrait;
 
-impl Format for ItemTrait {
+impl FormatItem for ItemTrait {
     fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }

--- a/sway-fmt-v2/src/items/item_use.rs
+++ b/sway-fmt-v2/src/items/item_use.rs
@@ -1,7 +1,7 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::fmt::{FormatItem, FormattedCode, Formatter};
 use sway_parse::ItemUse;
 
-impl Format for ItemUse {
+impl FormatItem for ItemUse {
     fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
         todo!()
     }

--- a/sway-fmt-v2/src/utils/attribute.rs
+++ b/sway-fmt-v2/src/utils/attribute.rs
@@ -1,4 +1,4 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::fmt::{FormatInner, FormatItem, FormattedCode, Formatter};
 use sway_parse::{
     attribute::{Annotated, AttributeDecl},
     token::Delimiter,
@@ -8,7 +8,7 @@ use sway_types::Spanned;
 
 use super::bracket::{Parenthesis, SquareBracket};
 
-impl<T: Parse + Format> Format for Annotated<T> {
+impl<T: Parse + FormatItem> FormatItem for Annotated<T> {
     fn format(&self, formatter: &mut Formatter) -> FormattedCode {
         let attributes = &self.attribute_list;
         let mut formatted_code = String::new();
@@ -21,11 +21,7 @@ impl<T: Parse + Format> Format for Annotated<T> {
     }
 }
 
-trait FormatDecl {
-    fn format(&self, line: &mut String, formatter: &mut Formatter);
-}
-
-impl FormatDecl for AttributeDecl {
+impl FormatInner for AttributeDecl {
     fn format(&self, line: &mut String, formatter: &mut Formatter) {
         // At some point there will be enough attributes to warrant the need
         // of formatting the list according to `config::lists::ListTactic`.

--- a/sway-fmt-v2/src/utils/item.rs
+++ b/sway-fmt-v2/src/utils/item.rs
@@ -1,8 +1,8 @@
 use sway_parse::{Item, ItemKind::*};
 
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::fmt::{FormatItem, FormattedCode, Formatter};
 
-impl Format for Item {
+impl FormatItem for Item {
     fn format(&self, formatter: &mut Formatter) -> FormattedCode {
         match &self.value {
             Use(item_use) => item_use.format(formatter),


### PR DESCRIPTION
As a side effect of the formatter growing some code is becoming duplicated, this is an effort to reduce that by naming the formatting traits more appropriately to what they are intended to format.