### PR TITLE
forc: Improve the `print_*_asm` CLI option docs

### DIFF
--- a/forc/src/cli/commands/build.rs
+++ b/forc/src/cli/commands/build.rs
@@ -21,13 +21,18 @@ pub struct Command {
     /// Path to the project, if not specified, current working directory will be used.
     #[clap(short, long)]
     pub path: Option<String>,
-    /// Whether to compile to bytecode (false) or to print out the generated ASM (true).
+    /// Print the finalized ASM.
+    ///
+    /// This is the state of the ASM with registers allocated and optimisations applied.
     #[clap(long)]
     pub print_finalized_asm: bool,
-    /// Whether to compile to bytecode (false) or to print out the generated ASM (true).
+    /// Print the generated ASM.
+    ///
+    /// This is the state of the ASM prior to performing register allocation and other ASM
+    /// optimisations.
     #[clap(long)]
     pub print_intermediate_asm: bool,
-    /// Whether to compile to bytecode (false) or to print out the generated IR (true).
+    /// Print the generated Sway IR (Intermediate Representation).
     #[clap(long)]
     pub print_ir: bool,
     /// If set, outputs a binary file representing the script bytes.

--- a/forc/src/cli/commands/deploy.rs
+++ b/forc/src/cli/commands/deploy.rs
@@ -9,13 +9,18 @@ pub struct Command {
     /// Path to the project, if not specified, current working directory will be used.
     #[clap(short, long)]
     pub path: Option<String>,
-    /// Whether to compile to bytecode (false) or to print out the generated ASM (true).
+    /// Print the finalized ASM.
+    ///
+    /// This is the state of the ASM with registers allocated and optimisations applied.
     #[clap(long)]
     pub print_finalized_asm: bool,
-    /// Whether to compile to bytecode (false) or to print out the generated ASM (true).
+    /// Print the generated ASM.
+    ///
+    /// This is the state of the ASM prior to performing register allocation and other ASM
+    /// optimisations.
     #[clap(long)]
     pub print_intermediate_asm: bool,
-    /// Whether to compile to bytecode (false) or to print out the IR (true).
+    /// Print the generated Sway IR (Intermediate Representation).
     #[clap(long)]
     pub print_ir: bool,
     /// If set, outputs a binary file representing the script bytes.

--- a/forc/src/cli/commands/run.rs
+++ b/forc/src/cli/commands/run.rs
@@ -31,15 +31,20 @@ pub struct Command {
     #[clap(short, long)]
     pub kill_node: bool,
 
-    /// Whether to compile to bytecode (false) or to print out the generated ASM (true).
+    /// Print the finalized ASM.
+    ///
+    /// This is the state of the ASM with registers allocated and optimisations applied.
     #[clap(long)]
     pub print_finalized_asm: bool,
 
-    /// Whether to compile to bytecode (false) or to print out the generated ASM (true).
+    /// Print the generated ASM.
+    ///
+    /// This is the state of the ASM prior to performing register allocation and other ASM
+    /// optimisations.
     #[clap(long)]
     pub print_intermediate_asm: bool,
 
-    /// Whether to compile to bytecode (false) or to print out the IR (true).
+    /// Print the generated Sway IR (Intermediate Representation).
     #[clap(long)]
     pub print_ir: bool,
 


### PR DESCRIPTION
Previously, these implied no bytecode was generated if the flag was not set, however this is not the case.

cc @otrho do these ASM states in the new docs kinda make sense? Let me know if you think there's a better way to put this!