### PR TITLE
internal: Reduce amount of String::new() in sway-fmt-v2

### DIFF
--- a/sway-fmt-v2/src/error.rs
+++ b/sway-fmt-v2/src/error.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 pub enum FormatterError {
     #[error("Error parsing file: {0}")]
     ParseFileError(#[from] sway_parse::ParseFileError),
+    #[error("Error formatting a message into a stream: {0}")]
+    FormatError(#[from] std::fmt::Error),
 }
 
 #[derive(Debug, Error)]

--- a/sway-fmt-v2/src/fmt.rs
+++ b/sway-fmt-v2/src/fmt.rs
@@ -41,6 +41,7 @@ impl Formatter {
         build_config: Option<&BuildConfig>,
     ) -> Result<FormattedCode, FormatterError> {
         let path = build_config.map(|build_config| build_config.canonical_root_module());
+        let src_len = src.len();
         let module = sway_parse::parse_file(src, path)?;
         // Get parsed items
         let items = module.items;
@@ -49,7 +50,9 @@ impl Formatter {
 
         // Formatted code will be pushed here with raw newline stlye.
         // Which means newlines are not converted into system-specific versions by apply_newline_style
-        let mut raw_formatted_code = String::new();
+        // Use the length of src as a hint of the memory size needed for raw_formatted_code, 
+        // which will reduce the number of reallocations
+        let mut raw_formatted_code = String::with_capacity(src_len);
 
         // Insert program type to the formatted code.
         insert_program_type(&mut raw_formatted_code, program_type);

--- a/sway-fmt-v2/src/fmt.rs
+++ b/sway-fmt-v2/src/fmt.rs
@@ -50,14 +50,14 @@ impl Formatter {
 
         // Formatted code will be pushed here with raw newline stlye.
         // Which means newlines are not converted into system-specific versions by apply_newline_style
-        // Use the length of src as a hint of the memory size needed for raw_formatted_code, 
+        // Use the length of src as a hint of the memory size needed for raw_formatted_code,
         // which will reduce the number of reallocations
         let mut raw_formatted_code = String::with_capacity(src_len);
 
         // Insert program type to the formatted code.
         insert_program_type(&mut raw_formatted_code, program_type);
-        // Insert parsed & formatted items into the formatted code.
 
+        // Insert parsed & formatted items into the formatted code.
         let mut iter = items.iter().peekable();
         while let Some(item) = iter.next() {
             // format Annotated<ItemKind>

--- a/sway-fmt-v2/src/fmt.rs
+++ b/sway-fmt-v2/src/fmt.rs
@@ -3,7 +3,6 @@ use crate::utils::{
 };
 use std::{path::Path, sync::Arc};
 use sway_core::BuildConfig;
-use sway_parse::attribute::Annotated;
 
 pub use crate::{
     config::manifest::Config,
@@ -58,7 +57,8 @@ impl Formatter {
 
         let mut iter = items.iter().peekable();
         while let Some(item) = iter.next() {
-            Annotated::format(item, &mut raw_formatted_code, self)?;
+            // format Annotated<ItemKind>
+            item.format(&mut raw_formatted_code, self)?;
             if iter.peek().is_some() {
                 raw_formatted_code.push('\n');
             }

--- a/sway-fmt-v2/src/items/item_abi.rs
+++ b/sway-fmt-v2/src/items/item_abi.rs
@@ -36,9 +36,9 @@ impl Format for ItemAbi {
             }
             // add indent + format item
             formatted_code.push_str(&formatter.shape.indent.to_string(formatter));
-            write!(
+            writeln!(
                 formatted_code,
-                "{}{}\n",
+                "{}{}",
                 item.0.value.span().as_str(), // FnSignature formatting (todo!)
                 item.1.span().as_str()        // SemicolonToken
             )?;
@@ -91,7 +91,7 @@ impl CurlyBrace for ItemAbi {
             }
             _ => {
                 // Add opening brace to the same line
-                write!(line, " {}\n", open_brace)?;
+                writeln!(line, " {}", open_brace)?;
                 shape = shape.block_indent(extra_width);
             }
         }

--- a/sway-fmt-v2/src/items/item_abi.rs
+++ b/sway-fmt-v2/src/items/item_abi.rs
@@ -4,6 +4,7 @@ use crate::{
     utils::{attribute::FormatDecl, bracket::CurlyBrace},
     FormatterError,
 };
+use std::fmt::Write;
 use sway_parse::{token::Delimiter, ItemAbi};
 use sway_types::Spanned;
 
@@ -19,7 +20,7 @@ impl Format for ItemAbi {
 
         // Add name of the abi
         formatted_code.push_str(self.name.as_str());
-        Self::open_curly_brace(formatted_code, formatter);
+        Self::open_curly_brace(formatted_code, formatter)?;
 
         // Add item fields
         // abi_items
@@ -30,16 +31,17 @@ impl Format for ItemAbi {
             if !attribute_list.is_empty() {
                 formatted_code.push_str(&formatter.shape.indent.to_string(formatter));
                 for attr in attribute_list {
-                    attr.format(formatted_code, formatter);
+                    attr.format(formatted_code, formatter)?;
                 }
             }
             // add indent + format item
             formatted_code.push_str(&formatter.shape.indent.to_string(formatter));
-            formatted_code.push_str(&format!(
+            write!(
+                formatted_code,
                 "{}{}\n",
                 item.0.value.span().as_str(), // FnSignature formatting (todo!)
-                item.1.span().as_str(),       // SemicolonToken
-            ));
+                item.1.span().as_str()        // SemicolonToken
+            )?;
 
             if abi_items_iter.peek().is_some() {
                 formatted_code.push('\n');
@@ -55,7 +57,7 @@ impl Format for ItemAbi {
                 if !attribute_list.is_empty() {
                     formatted_code.push_str(&formatter.shape.indent.to_string(formatter));
                     for attr in attribute_list {
-                        attr.format(formatted_code, formatter);
+                        attr.format(formatted_code, formatter)?;
                     }
                 }
 
@@ -67,13 +69,16 @@ impl Format for ItemAbi {
                 }
             }
         }
-        Self::close_curly_brace(formatted_code, formatter);
+        Self::close_curly_brace(formatted_code, formatter)?;
         Ok(())
     }
 }
 
 impl CurlyBrace for ItemAbi {
-    fn open_curly_brace(line: &mut String, formatter: &mut Formatter) {
+    fn open_curly_brace(
+        line: &mut String,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         let brace_style = formatter.config.items.item_brace_style;
         let extra_width = formatter.config.whitespace.tab_spaces;
         let mut shape = formatter.shape;
@@ -81,24 +86,29 @@ impl CurlyBrace for ItemAbi {
         match brace_style {
             ItemBraceStyle::AlwaysNextLine => {
                 // Add openning brace to the next line.
-                line.push_str(&format!("\n{}\n", open_brace));
+                write!(line, "\n{}\n", open_brace)?;
                 shape = shape.block_indent(extra_width);
             }
             _ => {
                 // Add opening brace to the same line
-                line.push_str(&format!(" {}\n", open_brace));
+                write!(line, " {}\n", open_brace)?;
                 shape = shape.block_indent(extra_width);
             }
         }
 
         formatter.shape = shape;
+        Ok(())
     }
-    fn close_curly_brace(line: &mut String, formatter: &mut Formatter) {
+    fn close_curly_brace(
+        line: &mut String,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         line.push(Delimiter::Brace.as_close_char());
         // If shape is becoming left-most alligned or - indent just have the defualt shape
         formatter.shape = formatter
             .shape
             .shrink_left(formatter.config.whitespace.tab_spaces)
             .unwrap_or_default();
+        Ok(())
     }
 }

--- a/sway-fmt-v2/src/items/item_abi.rs
+++ b/sway-fmt-v2/src/items/item_abi.rs
@@ -4,7 +4,7 @@ use crate::{
     utils::{attribute::FormatDecl, bracket::CurlyBrace},
     FormatterError,
 };
-use sway_parse::{token::Delimiter, AttributeDecl, ItemAbi};
+use sway_parse::{token::Delimiter, ItemAbi};
 use sway_types::Spanned;
 
 impl Format for ItemAbi {
@@ -30,7 +30,7 @@ impl Format for ItemAbi {
             if !attribute_list.is_empty() {
                 formatted_code.push_str(&formatter.shape.indent.to_string(formatter));
                 for attr in attribute_list {
-                    AttributeDecl::format(&attr, formatted_code, formatter)
+                    attr.format(formatted_code, formatter);
                 }
             }
             // add indent + format item
@@ -55,7 +55,7 @@ impl Format for ItemAbi {
                 if !attribute_list.is_empty() {
                     formatted_code.push_str(&formatter.shape.indent.to_string(formatter));
                     for attr in attribute_list {
-                        AttributeDecl::format(&attr, formatted_code, formatter)
+                        attr.format(formatted_code, formatter);
                     }
                 }
 

--- a/sway-fmt-v2/src/items/item_abi.rs
+++ b/sway-fmt-v2/src/items/item_abi.rs
@@ -2,80 +2,73 @@ use crate::{
     config::items::ItemBraceStyle,
     fmt::{Format, FormattedCode, Formatter},
     utils::{attribute::FormatDecl, bracket::CurlyBrace},
+    FormatterError,
 };
 use sway_parse::{token::Delimiter, AttributeDecl, ItemAbi};
 use sway_types::Spanned;
 
 impl Format for ItemAbi {
-    fn format(&self, formatter: &mut Formatter) -> FormattedCode {
-        let mut formatted_code = String::new();
-
+    fn format(
+        &self,
+        formatted_code: &mut FormattedCode,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         // Add enum token
         formatted_code.push_str(self.abi_token.span().as_str());
         formatted_code.push(' ');
 
         // Add name of the abi
         formatted_code.push_str(self.name.as_str());
-        Self::open_curly_brace(&mut formatted_code, formatter);
+        Self::open_curly_brace(formatted_code, formatter);
 
         // Add item fields
         // abi_items
-        formatted_code += self
-            .abi_items
-            .clone()
-            .into_inner()
-            .iter()
-            .map(|item| -> FormattedCode {
-                let mut buf = String::new();
-                let attribute_list = item.0.attribute_list.clone();
-                // add indent + format attribute if it exists
-                if !attribute_list.is_empty() {
-                    buf.push_str(&formatter.shape.indent.to_string(formatter));
-                    for attr in attribute_list {
-                        AttributeDecl::format(&attr, &mut buf, formatter)
-                    }
+        let mut abi_items_iter = self.abi_items.get().iter().peekable();
+        while let Some(item) = abi_items_iter.next() {
+            let attribute_list = item.0.attribute_list.clone();
+            // add indent + format attribute if it exists
+            if !attribute_list.is_empty() {
+                formatted_code.push_str(&formatter.shape.indent.to_string(formatter));
+                for attr in attribute_list {
+                    AttributeDecl::format(&attr, formatted_code, formatter)
                 }
-                // add indent + format item
-                buf.push_str(&formatter.shape.indent.to_string(formatter));
-                buf.push_str(&format!(
-                    "{}{}\n",
-                    item.0.value.span().as_str(), // FnSignature formatting (todo!)
-                    item.1.span().as_str(),       // SemicolonToken
-                ));
+            }
+            // add indent + format item
+            formatted_code.push_str(&formatter.shape.indent.to_string(formatter));
+            formatted_code.push_str(&format!(
+                "{}{}\n",
+                item.0.value.span().as_str(), // FnSignature formatting (todo!)
+                item.1.span().as_str(),       // SemicolonToken
+            ));
 
-                buf
-            })
-            .collect::<Vec<String>>()
-            .join("\n")
-            .as_str();
+            if abi_items_iter.peek().is_some() {
+                formatted_code.push('\n');
+            }
+        }
+
         // abi_defs_opt
         if let Some(abi_defs) = self.abi_defs_opt.clone() {
-            formatted_code += abi_defs
-                .into_inner()
-                .iter()
-                .map(|item| -> FormattedCode {
-                    let mut buf = String::new();
-                    let attribute_list = item.attribute_list.clone();
-                    // add indent + format attribute if it exists
-                    if !attribute_list.is_empty() {
-                        buf.push_str(&formatter.shape.indent.to_string(formatter));
-                        for attr in attribute_list {
-                            AttributeDecl::format(&attr, &mut buf, formatter)
-                        }
+            let mut iter = abi_defs.get().iter().peekable();
+            while let Some(item) = iter.next() {
+                let attribute_list = item.attribute_list.clone();
+                // add indent + format attribute if it exists
+                if !attribute_list.is_empty() {
+                    formatted_code.push_str(&formatter.shape.indent.to_string(formatter));
+                    for attr in attribute_list {
+                        AttributeDecl::format(&attr, formatted_code, formatter)
                     }
-                    // add indent + format item
-                    buf.push_str(&formatter.shape.indent.to_string(formatter));
-                    buf.push_str(&item.value.format(formatter)); // ItemFn formatting (todo!)
+                }
 
-                    buf
-                })
-                .collect::<Vec<String>>()
-                .join("\n")
-                .as_str();
+                // add indent + format item
+                formatted_code.push_str(&formatter.shape.indent.to_string(formatter));
+                item.value.format(formatted_code, formatter)?; // ItemFn formatting (todo!)
+                if iter.peek().is_some() {
+                    formatted_code.push('\n');
+                }
+            }
         }
-        Self::close_curly_brace(&mut formatted_code, formatter);
-
-        formatted_code
+        Self::close_curly_brace(formatted_code, formatter);
+        Ok(())
     }
 }
 

--- a/sway-fmt-v2/src/items/item_const.rs
+++ b/sway-fmt-v2/src/items/item_const.rs
@@ -1,13 +1,16 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::{
+    fmt::{Format, FormattedCode, Formatter},
+    FormatterError,
+};
 use sway_parse::ItemConst;
 use sway_types::Spanned;
 
 impl Format for ItemConst {
-    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
-        // TODO: creating this formatted_code with String::new() will likely cause lots of
-        // reallocations maybe we can explore how we can do this, starting with with_capacity may help.
-        let mut formatted_code = String::new();
-
+    fn format(
+        &self,
+        formatted_code: &mut FormattedCode,
+        _formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         // Check if visibility token exists if so add it.
         if let Some(visibility_token) = &self.visibility {
             formatted_code.push_str(visibility_token.span().as_str());
@@ -39,6 +42,6 @@ impl Format for ItemConst {
         // TODO: We are not applying any custom formatting to expr, probably we will need to in the future.
         formatted_code.push_str(self.expr.span().as_str());
         formatted_code.push_str(self.semicolon_token.ident().as_str());
-        formatted_code
+        Ok(())
     }
 }

--- a/sway-fmt-v2/src/items/item_enum.rs
+++ b/sway-fmt-v2/src/items/item_enum.rs
@@ -28,7 +28,7 @@ impl Format for ItemEnum {
 
         // Add name of the enum.
         formatted_code.push_str(self.name.as_str());
-        ItemEnum::open_curly_brace(formatted_code, formatter);
+        Self::open_curly_brace(formatted_code, formatter);
 
         let type_fields = &self.fields.clone().into_inner().value_separator_pairs;
 
@@ -75,7 +75,7 @@ impl Format for ItemEnum {
             // from the config we may understand next enum variant should be in the same line instead.
             formatted_code.push('\n');
         }
-        ItemEnum::close_curly_brace(formatted_code, formatter);
+        Self::close_curly_brace(formatted_code, formatter);
         Ok(())
     }
 }

--- a/sway-fmt-v2/src/items/item_enum.rs
+++ b/sway-fmt-v2/src/items/item_enum.rs
@@ -13,8 +13,6 @@ impl Format for ItemEnum {
         formatted_code: &mut FormattedCode,
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        // TODO: creating this formatted_code with String::new() will likely cause lots of
-        // reallocations maybe we can explore how we can do this, starting with with_capacity may help.
         let enum_variant_align_threshold = formatter.config.structures.enum_variant_align_threshold;
 
         if let Some(visibility_token) = &self.visibility {

--- a/sway-fmt-v2/src/items/item_enum.rs
+++ b/sway-fmt-v2/src/items/item_enum.rs
@@ -2,15 +2,19 @@ use crate::{
     config::items::ItemBraceStyle,
     fmt::{Format, FormattedCode, Formatter},
     utils::bracket::CurlyBrace,
+    FormatterError,
 };
 use sway_parse::{token::Delimiter, ItemEnum};
 use sway_types::Spanned;
 
 impl Format for ItemEnum {
-    fn format(&self, formatter: &mut Formatter) -> FormattedCode {
+    fn format(
+        &self,
+        formatted_code: &mut FormattedCode,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         // TODO: creating this formatted_code with String::new() will likely cause lots of
         // reallocations maybe we can explore how we can do this, starting with with_capacity may help.
-        let mut formatted_code = String::new();
         let enum_variant_align_threshold = formatter.config.structures.enum_variant_align_threshold;
 
         if let Some(visibility_token) = &self.visibility {
@@ -24,7 +28,7 @@ impl Format for ItemEnum {
 
         // Add name of the enum.
         formatted_code.push_str(self.name.as_str());
-        ItemEnum::open_curly_brace(&mut formatted_code, formatter);
+        ItemEnum::open_curly_brace(formatted_code, formatter);
 
         let type_fields = &self.fields.clone().into_inner().value_separator_pairs;
 
@@ -71,8 +75,8 @@ impl Format for ItemEnum {
             // from the config we may understand next enum variant should be in the same line instead.
             formatted_code.push('\n');
         }
-        ItemEnum::close_curly_brace(&mut formatted_code, formatter);
-        formatted_code
+        ItemEnum::close_curly_brace(formatted_code, formatter);
+        Ok(())
     }
 }
 

--- a/sway-fmt-v2/src/items/item_enum.rs
+++ b/sway-fmt-v2/src/items/item_enum.rs
@@ -96,7 +96,7 @@ impl CurlyBrace for ItemEnum {
             }
             _ => {
                 // Add opening brace to the same line
-                write!(line, " {}\n", open_brace)?;
+                writeln!(line, " {}", open_brace)?;
                 shape = shape.block_indent(extra_width);
             }
         }

--- a/sway-fmt-v2/src/items/item_fn.rs
+++ b/sway-fmt-v2/src/items/item_fn.rs
@@ -1,8 +1,15 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::{
+    fmt::{Format, FormattedCode, Formatter},
+    FormatterError,
+};
 use sway_parse::ItemFn;
 
 impl Format for ItemFn {
-    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
+    fn format(
+        &self,
+        _formatted_code: &mut FormattedCode,
+        _formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/items/item_impl.rs
+++ b/sway-fmt-v2/src/items/item_impl.rs
@@ -1,8 +1,15 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::{
+    fmt::{Format, FormattedCode, Formatter},
+    FormatterError,
+};
 use sway_parse::ItemImpl;
 
 impl Format for ItemImpl {
-    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
+    fn format(
+        &self,
+        _formatted_code: &mut FormattedCode,
+        _formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/items/item_storage.rs
+++ b/sway-fmt-v2/src/items/item_storage.rs
@@ -1,8 +1,15 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::{
+    fmt::{Format, FormattedCode, Formatter},
+    FormatterError,
+};
 use sway_parse::ItemStorage;
 
 impl Format for ItemStorage {
-    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
+    fn format(
+        &self,
+        _formatted_code: &mut FormattedCode,
+        _formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/items/item_struct.rs
+++ b/sway-fmt-v2/src/items/item_struct.rs
@@ -5,16 +5,17 @@ use crate::{
         bracket::{AngleBracket, CurlyBrace},
         item_len::ItemLen,
     },
+    FormatterError,
 };
 use sway_parse::ItemStruct;
 use sway_types::Spanned;
 
 impl Format for ItemStruct {
-    fn format(&self, formatter: &mut Formatter) -> FormattedCode {
-        // TODO: creating this formatted_code with FormattedCode::new() will likely cause lots of
-        // reallocations maybe we can explore how we can do this, starting with with_capacity may help.
-        let mut formatted_code = FormattedCode::new();
-
+    fn format(
+        &self,
+        formatted_code: &mut FormattedCode,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         // Get the unformatted
 
         // Get struct_variant_align_threshold from config.
@@ -36,12 +37,12 @@ impl Format for ItemStruct {
         let multiline = !struct_lit_single_line || self.get_formatted_len() > struct_lit_width;
         format_struct(
             self,
-            &mut formatted_code,
+            formatted_code,
             formatter,
             multiline,
             struct_variant_align_threshold,
         );
-        formatted_code
+        Ok(())
     }
 }
 

--- a/sway-fmt-v2/src/items/item_struct.rs
+++ b/sway-fmt-v2/src/items/item_struct.rs
@@ -41,7 +41,7 @@ impl Format for ItemStruct {
             formatter,
             multiline,
             struct_variant_align_threshold,
-        );
+        )?;
         Ok(())
     }
 }
@@ -62,7 +62,7 @@ fn format_struct(
     formatter: &mut Formatter,
     multiline: bool,
     struct_variant_align_threshold: usize,
-) {
+) -> Result<(), FormatterError> {
     // If there is a visibility token add it to the formatted_code with a ` ` after it.
     if let Some(visibility) = &item_struct.visibility {
         formatted_code.push_str(visibility.span().as_str());
@@ -78,7 +78,7 @@ fn format_struct(
     // Check if there is generic provided
     if let Some(generics) = &item_struct.generics {
         // Push angle brace
-        ItemStruct::open_angle_bracket(formatted_code, formatter);
+        ItemStruct::open_angle_bracket(formatted_code, formatter)?;
         // Get generics fields
         let generics = generics.parameters.inner.value_separator_pairs.clone();
         for (index, generic) in generics.iter().enumerate() {
@@ -93,7 +93,7 @@ fn format_struct(
 
     // Handle openning brace
     if multiline {
-        ItemStruct::open_curly_brace(formatted_code, formatter);
+        ItemStruct::open_curly_brace(formatted_code, formatter)?;
         formatted_code.push('\n');
     } else {
         // Push a single whitespace before `{`
@@ -158,7 +158,8 @@ fn format_struct(
         formatted_code.push(' ');
     }
     // Handle closing brace
-    ItemStruct::close_curly_brace(formatted_code, formatter);
+    ItemStruct::close_curly_brace(formatted_code, formatter)?;
+    Ok(())
 }
 
 impl ItemLen for ItemStruct {
@@ -170,7 +171,10 @@ impl ItemLen for ItemStruct {
 }
 
 impl CurlyBrace for ItemStruct {
-    fn open_curly_brace(line: &mut String, formatter: &mut Formatter) {
+    fn open_curly_brace(
+        line: &mut String,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         let brace_style = formatter.config.items.item_brace_style;
         let extra_width = formatter.config.whitespace.tab_spaces;
         let mut shape = formatter.shape;
@@ -188,24 +192,37 @@ impl CurlyBrace for ItemStruct {
         }
 
         formatter.shape = shape;
+        Ok(())
     }
 
-    fn close_curly_brace(line: &mut String, formatter: &mut Formatter) {
+    fn close_curly_brace(
+        line: &mut String,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         line.push('}');
         // If shape is becoming left-most alligned or - indent just have the defualt shape
         formatter.shape = formatter
             .shape
             .shrink_left(formatter.config.whitespace.tab_spaces)
             .unwrap_or_default();
+        Ok(())
     }
 }
 
 impl AngleBracket for ItemStruct {
-    fn open_angle_bracket(line: &mut String, _formatter: &mut Formatter) {
+    fn open_angle_bracket(
+        line: &mut String,
+        _formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         line.push('<');
+        Ok(())
     }
 
-    fn close_angle_bracket(line: &mut String, _formatter: &mut Formatter) {
+    fn close_angle_bracket(
+        line: &mut String,
+        _formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         line.push('>');
+        Ok(())
     }
 }

--- a/sway-fmt-v2/src/items/item_trait.rs
+++ b/sway-fmt-v2/src/items/item_trait.rs
@@ -1,8 +1,15 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::{
+    fmt::{Format, FormattedCode, Formatter},
+    FormatterError,
+};
 use sway_parse::ItemTrait;
 
 impl Format for ItemTrait {
-    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
+    fn format(
+        &self,
+        _formatted_code: &mut FormattedCode,
+        _formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/items/item_use.rs
+++ b/sway-fmt-v2/src/items/item_use.rs
@@ -1,8 +1,15 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::{
+    fmt::{Format, FormattedCode, Formatter},
+    FormatterError,
+};
 use sway_parse::ItemUse;
 
 impl Format for ItemUse {
-    fn format(&self, _formatter: &mut Formatter) -> FormattedCode {
+    fn format(
+        &self,
+        _formatted_code: &mut FormattedCode,
+        _formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         todo!()
     }
 }

--- a/sway-fmt-v2/src/utils/attribute.rs
+++ b/sway-fmt-v2/src/utils/attribute.rs
@@ -84,7 +84,7 @@ impl SquareBracket for AttributeDecl {
         line: &mut String,
         _formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        write!(line, "{}\n", Delimiter::Bracket.as_close_char())?;
+        writeln!(line, "{}", Delimiter::Bracket.as_close_char())?;
         Ok(())
     }
 }

--- a/sway-fmt-v2/src/utils/attribute.rs
+++ b/sway-fmt-v2/src/utils/attribute.rs
@@ -20,7 +20,7 @@ impl<T: Parse + Format> Format for Annotated<T> {
         let attributes = &self.attribute_list;
 
         for attr in attributes {
-            AttributeDecl::format(attr, formatted_code, formatter);
+            attr.format(formatted_code, formatter);
         }
 
         self.value.format(formatted_code, formatter)

--- a/sway-fmt-v2/src/utils/attribute.rs
+++ b/sway-fmt-v2/src/utils/attribute.rs
@@ -1,4 +1,7 @@
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::{
+    fmt::{Format, FormattedCode, Formatter},
+    FormatterError,
+};
 use sway_parse::{
     attribute::{Annotated, AttributeDecl},
     token::Delimiter,
@@ -9,15 +12,18 @@ use sway_types::Spanned;
 use super::bracket::{Parenthesis, SquareBracket};
 
 impl<T: Parse + Format> Format for Annotated<T> {
-    fn format(&self, formatter: &mut Formatter) -> FormattedCode {
+    fn format(
+        &self,
+        formatted_code: &mut FormattedCode,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         let attributes = &self.attribute_list;
-        let mut formatted_code = String::new();
 
         for attr in attributes {
-            AttributeDecl::format(attr, &mut formatted_code, formatter);
+            AttributeDecl::format(attr, formatted_code, formatter);
         }
 
-        formatted_code + &self.value.format(formatter)
+        self.value.format(formatted_code, formatter)
     }
 }
 

--- a/sway-fmt-v2/src/utils/attribute.rs
+++ b/sway-fmt-v2/src/utils/attribute.rs
@@ -77,7 +77,7 @@ impl SquareBracket for AttributeDecl {
         line: &mut String,
         _formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        line.push(Delimiter::Bracket.as_open_char());
+        write!(line, "{}", Delimiter::Bracket.as_open_char())?;
         Ok(())
     }
     fn close_square_bracket(
@@ -94,14 +94,14 @@ impl Parenthesis for AttributeDecl {
         line: &mut String,
         _formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        line.push(Delimiter::Parenthesis.as_open_char());
+        write!(line, "{}", Delimiter::Parenthesis.as_open_char())?;
         Ok(())
     }
     fn close_parenthesis(
         line: &mut String,
         _formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        line.push(Delimiter::Parenthesis.as_close_char());
+        write!(line, "{}", Delimiter::Parenthesis.as_close_char())?;
         Ok(())
     }
 }

--- a/sway-fmt-v2/src/utils/bracket.rs
+++ b/sway-fmt-v2/src/utils/bracket.rs
@@ -1,35 +1,55 @@
 //! The purpose of this file is to house the traits and associated functions for formatting opening and closing delimiters.
 //! This allows us to avoid matching a second time for the `ItemKind` and keeps the code pertaining to individual formatting
 //! contained to each item's file.
-use crate::Formatter;
+use crate::{Formatter, FormatterError};
 
 pub trait CurlyBrace {
     /// Handles brace open scenerio. Checks the config for the placement of the brace.
     /// Modifies the current shape of the formatter.
-    fn open_curly_brace(line: &mut String, formatter: &mut Formatter);
+    fn open_curly_brace(line: &mut String, formatter: &mut Formatter)
+        -> Result<(), FormatterError>;
 
     /// Handles brace close scenerio.
     /// Currently it simply pushes a `}` and modifies the shape.
-    fn close_curly_brace(line: &mut String, formatter: &mut Formatter);
+    fn close_curly_brace(
+        line: &mut String,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError>;
 }
 
 pub trait SquareBracket {
-    fn open_square_bracket(line: &mut String, formatter: &mut Formatter);
+    fn open_square_bracket(
+        line: &mut String,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError>;
 
-    fn close_square_bracket(line: &mut String, formatter: &mut Formatter);
+    fn close_square_bracket(
+        line: &mut String,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError>;
 }
 
 pub trait Parenthesis {
     /// Handles open parenthesis scenarios, checking the config for placement
     /// and modifying the shape of the formatter where necessary.
-    fn open_parenthesis(line: &mut String, formatter: &mut Formatter);
+    fn open_parenthesis(line: &mut String, formatter: &mut Formatter)
+        -> Result<(), FormatterError>;
 
     /// Handles the closing parenthesis scenario.
-    fn close_parenthesis(line: &mut String, formatter: &mut Formatter);
+    fn close_parenthesis(
+        line: &mut String,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError>;
 }
 
 pub trait AngleBracket {
-    fn open_angle_bracket(line: &mut String, formatter: &mut Formatter);
+    fn open_angle_bracket(
+        line: &mut String,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError>;
 
-    fn close_angle_bracket(line: &mut String, formatter: &mut Formatter);
+    fn close_angle_bracket(
+        line: &mut String,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError>;
 }

--- a/sway-fmt-v2/src/utils/item.rs
+++ b/sway-fmt-v2/src/utils/item.rs
@@ -1,19 +1,23 @@
 use sway_parse::{Item, ItemKind::*};
 
-use crate::fmt::{Format, FormattedCode, Formatter};
+use crate::fmt::{Format, FormattedCode, Formatter, FormatterError};
 
 impl Format for Item {
-    fn format(&self, formatter: &mut Formatter) -> FormattedCode {
+    fn format(
+        &self,
+        formatted_code: &mut FormattedCode,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
         match &self.value {
-            Use(item_use) => item_use.format(formatter),
-            Struct(item_struct) => item_struct.format(formatter),
-            Enum(item_enum) => item_enum.format(formatter),
-            Fn(item_fn) => item_fn.format(formatter),
-            Trait(item_trait) => item_trait.format(formatter),
-            Impl(item_impl) => item_impl.format(formatter),
-            Abi(item_abi) => item_abi.format(formatter),
-            Const(item_const) => item_const.format(formatter),
-            Storage(item_storage) => item_storage.format(formatter),
+            Use(item_use) => item_use.format(formatted_code, formatter),
+            Struct(item_struct) => item_struct.format(formatted_code, formatter),
+            Enum(item_enum) => item_enum.format(formatted_code, formatter),
+            Fn(item_fn) => item_fn.format(formatted_code, formatter),
+            Trait(item_trait) => item_trait.format(formatted_code, formatter),
+            Impl(item_impl) => item_impl.format(formatted_code, formatter),
+            Abi(item_abi) => item_abi.format(formatted_code, formatter),
+            Const(item_const) => item_const.format(formatted_code, formatter),
+            Storage(item_storage) => item_storage.format(formatted_code, formatter),
         }
     }
 }


### PR DESCRIPTION
close #2107   

changed `format` method   
from 
``` rust
fn format(&self, formatter: &mut Formatter) -> FormattedCode;
```
to
``` rust
fn format(&self, formatted_code: &mut FormattedCode, formatter: &mut Formatter,) -> Result<(), FormatterError>;
```
This may reduce the number of memory allocations.  

~~This pr does not fully resolve the above issue, still using `push_str` instead of `write!`~~
