### PR TITLE
examples: fix renaming to BASE_ASSET_ID in comment

### DIFF
--- a/examples/wallet_smart_contract/src/main.sw
+++ b/examples/wallet_smart_contract/src/main.sw
@@ -27,7 +27,7 @@ abi Wallet {
 impl Wallet for Contract {
     #[storage(read, write)]fn receive_funds() {
         if msg_asset_id() == ~ContractId::from(BASE_ASSET_ID) {
-            // If we received `NATIVE_ASSET_ID` then keep track of the balance.
+            // If we received `BASE_ASSET_ID` then keep track of the balance.
             // Otherwise, we're receiving other native assets and don't care
             // about our balance of tokens.
             storage.balance = storage.balance + msg_amount();


### PR DESCRIPTION
Was correct at https://github.com/FuelLabs/sway/commit/3b6bfd79345741b131433473ce7504aa026a23ba, but then was accidentally renamed in https://github.com/FuelLabs/sway/commit/9fd4bb84345339a117ba3ba4a686a868511d162