### PR TITLE
Remove unnecessary "core" str check in `Span::join`

### DIFF
--- a/sway-types/src/span.rs
+++ b/sway-types/src/span.rs
@@ -156,12 +156,6 @@ impl Span {
     /// This panics if the spans are not from the same file. This should
     /// only be used on spans that are actually next to each other.
     pub fn join(s1: Span, s2: Span) -> Span {
-        // FIXME(canndrew): This is horrifying. Where did it come from and why is it needed?
-        // FIXME(sezna): I don't know, but I'm on the blame for it. Ah. We should remove this.
-        if s1.as_str() == "core" {
-            return s2;
-        }
-
         assert!(
             Arc::ptr_eq(&s1.src, &s2.src) && s1.path == s2.path,
             "Spans from different files cannot be joined.",


### PR DESCRIPTION
Noticed when looking at `Span` while working on another issue, thought I'd do a quick PR for it!