### PR TITLE
Update the book to explicitly mention that `impl` functions can't call each other yet.

### DIFF
--- a/docs/src/reference/known_issues_and_workarounds.md
+++ b/docs/src/reference/known_issues_and_workarounds.md
@@ -2,7 +2,7 @@
 
 ## Known Issues
 
-* [#870](https://github.com/FuelLabs/sway/issues/870): All `impl` blocks need to be defined before any of the functions they define can be called.
+* [#870](https://github.com/FuelLabs/sway/issues/870): All `impl` blocks need to be defined before any of the functions they define can be called.  This includes sibling functions in the same `impl` declaration, i.e., functions in an `impl` can't call each other yet.
 
 ## Missing Features
 


### PR DESCRIPTION
It comes up fairly often, again today: #2157.