### PR TITLE
Remove duplicate CI checks that already have dedicated jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,11 +162,6 @@ jobs:
         with:
           command: install
           args: --debug --path ./forc
-      - name: Install Forc fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc-plugins/forc-fmt
       - name: Initialize test project
         run: forc init test-proj
       - name: Update project forc manifest to use local sway-lib-std
@@ -191,21 +186,6 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
-      - name: Install Forc
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc
-      - name: Install Forc fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc-plugins/forc-fmt
-      - name: Build Sway examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --bin examples-checker build --all-examples
       - uses: actions-rs/cargo@v1
         name: Cargo Build Workspace
         with:
@@ -223,21 +203,6 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
-      - name: Install Forc
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc
-      - name: Install Forc fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc-plugins/forc-fmt
-      - name: Build Sway examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --bin examples-checker build --all-examples
       - name: Check Clippy Linter
         uses: actions-rs/cargo@v1
         with:
@@ -311,21 +276,6 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
-      - name: Install Forc
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc
-      - name: Install Forc fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc-plugins/forc-fmt
-      - name: Build Sway examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --locked --bin examples-checker build --all-examples
       - name: Build All Tests
         run: cd test/src/sdk-harness && bash build.sh --locked && cd ../../../
       - name: Cargo Test sway-lib-std
@@ -344,21 +294,6 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
-      - name: Install Forc
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc
-      - name: Install Forc fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc-plugins/forc-fmt
-      - name: Build Sway examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --bin examples-checker build --all-examples
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -376,21 +311,6 @@ jobs:
           toolchain: nightly
           default: true
       - uses: Swatinem/rust-cache@v1
-      - name: Install Forc
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc
-      - name: Install Forc fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug --path ./forc-plugins/forc-fmt
-      - name: Build Sway examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --locked --bin examples-checker build --all-examples
       - name: Install cargo-udeps
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
I noticed a bunch of our CI jobs were duplicating existing checks.
In particular, there was a lot of copy-paste steps of installing forc
and the forc-fmt plugin, even when unused in the following checks.

This doesn't improve the real bottleneck (our stdlib test job), but it's
a start.