### PR TITLE
Backport improvements to `U128` type.

### DIFF
--- a/sway-lib-std/src/u128.sw
+++ b/sway-lib-std/src/u128.sw
@@ -12,6 +12,10 @@ pub struct U128 {
     lower: u64,
 }
 
+pub enum U128Error {
+    LossOfPrecision: (),
+}
+
 pub trait From {
     /// Function for creating U128 from its u64 components.
     pub fn from(upper: u64, lower: u64) -> Self;
@@ -24,7 +28,7 @@ pub trait From {
 impl From for U128 {
     pub fn from(upper: u64, lower: u64) -> U128 {
         U128 {
-            upper, lower, 
+            upper, lower,
         }
     }
 }
@@ -102,14 +106,15 @@ impl U128 {
         }
     }
 
-    /// Downcast to `u64`. Err if precision would be lost, Ok otherwise.
-    pub fn to_u64(self) -> Result<u64, ()> {
+    /// Safely downcast to `u64` without loss of precision.
+    /// Returns Err if the number > ~u64::max()
+    pub fn as_u64(self) -> Result<u64, U128Error> {
         match self.upper {
             0 => {
                 Result::Ok(self.lower)
             },
             _ => {
-                Result::Err(())
+                Result::Err(U128Error::LossOfPrecision)
             },
         }
     }
@@ -245,7 +250,7 @@ impl core::ops::Subtract for U128 {
         }
 
         U128 {
-            upper, lower, 
+            upper, lower,
         }
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_test/src/main.sw
@@ -78,5 +78,30 @@ fn main() -> bool {
     assert(three_left_shift_one.upper == 0);
     assert(three_left_shift_one.lower == 6);
 
+    // test as_u64()
+    let eleven = ~U128::from(0, 11);
+    let unwrapped = eleven.as_u64().unwrap();
+    assert(unwrapped == 11);
+
+    let err_1 = ~U128::from(42, 11).as_u64();
+    assert(match err_1 {
+        Result::Err(U128Error::LossOfPrecision) => {
+            true
+        },
+        _ => {
+            false
+        },
+    });
+
+    let err_1 = ~U128::from(42, 0).as_u64();
+    assert(match err_1 {
+        Result::Err(U128Error::LossOfPrecision) => {
+            true
+        },
+        _ => {
+            false
+        },
+    });
+
     true
 }


### PR DESCRIPTION
A few improvements to the `U128` type based on the `U256` type:
- better errors
- rename `to_u64()` => `as_u64()`
- add tests for `as_u64()`