### PR TITLE
Remove unused field `const_decl_origin` from `TypedVariableDeclaration`

### DIFF
--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -63,14 +63,6 @@ fn compile_constants(
                     None
                 }
             }
-
-            TypedDeclaration::VariableDeclaration(TypedVariableDeclaration {
-                name,
-                body,
-                const_decl_origin,
-                ..
-            }) if *const_decl_origin => Some((name, body)),
-
             _otherwise => None,
         };
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
@@ -67,7 +67,6 @@ impl TypedFunctionParameter {
                 } else {
                     VariableMutability::Immutable
                 },
-                const_decl_origin: false,
                 type_ascription: type_id,
             }),
         );

--- a/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
@@ -52,7 +52,6 @@ pub struct TypedVariableDeclaration {
     pub body: TypedExpression,
     pub(crate) is_mutable: VariableMutability,
     pub type_ascription: TypeId,
-    pub(crate) const_decl_origin: bool,
 }
 
 // NOTE: Hash and PartialEq must uphold the invariant:
@@ -64,7 +63,6 @@ impl PartialEq for TypedVariableDeclaration {
             && self.body == other.body
             && self.is_mutable == other.is_mutable
             && look_up_type_id(self.type_ascription) == look_up_type_id(other.type_ascription)
-            && self.const_decl_origin == other.const_decl_origin
     }
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
@@ -68,7 +68,6 @@ impl TypedMatchBranch {
                 body: right_decl,
                 is_mutable: VariableMutability::Immutable,
                 type_ascription,
-                const_decl_origin: false,
             });
             ctx.namespace.insert_symbol(left_decl, var_decl.clone());
             code_block_contents.push(TypedAstNode {

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -291,7 +291,6 @@ impl TypedAstNode {
                                     name: name.clone(),
                                     body,
                                     is_mutable: is_mutable.into(),
-                                    const_decl_origin: false,
                                     type_ascription,
                                 });
                             ctx.namespace.insert_symbol(name, typed_var_decl.clone());
@@ -794,7 +793,6 @@ fn type_check_trait_methods(
                         },
                         // TODO allow mutable function params?
                         is_mutable: VariableMutability::Immutable,
-                        const_decl_origin: false,
                         type_ascription: r#type,
                     }),
                 );


### PR DESCRIPTION
After #2158, constant declartaions use `TypedConstantDeclaration` AST node, and hence this field is now useless. It must have been removed in #2158 itself, but I missed doing that.