### PR TITLE
Fix pointer types and use `std::mem` on `std::tx`

### DIFF
--- a/sway-lib-std/src/tx.sw
+++ b/sway-lib-std/src/tx.sw
@@ -145,27 +145,14 @@ pub fn tx_script_start_pointer() -> u64 {
 
 /// Get the transaction script data start pointer.
 pub fn tx_script_data_start_pointer() -> u64 {
-    asm(r1, r2: TX_SCRIPT_START_OFFSET, r3: TX_SCRIPT_LENGTH_OFFSET) {
-        lw r3 r3 i0;
-        add r1 r2 r3;
-        r1: u64
-    }
+    tx_script_start_pointer() + tx_script_length()
 }
 
 /// Get the script data, typed. Unsafe.
 pub fn tx_script_data<T>() -> T {
     // TODO some safety checks on the input data? We are going to assume it is the right type for now.
     let ptr = tx_script_data_start_pointer();
-    if is_reference_type::<T>() {
-        asm(r1: ptr) {
-            r1: T
-        }
-    } else {
-        asm(r1: ptr) {
-            lw r1 r1 i0;
-            r1: T
-        }
-    }
+    read(ptr)
 }
 
 /// Get the script bytecode
@@ -173,9 +160,7 @@ pub fn tx_script_data<T>() -> T {
 /// Bytecode will be padded to next whole word.
 pub fn tx_script_bytecode<T>() -> T {
     let script_ptr = tx_script_start_pointer();
-    asm(r1: script_ptr) {
-        r1: T
-    }
+    read(script_ptr)
 }
 
 ////////////////////////////////////////

--- a/sway-lib-std/src/tx.sw
+++ b/sway-lib-std/src/tx.sw
@@ -246,8 +246,7 @@ pub fn tx_predicate_data_start_pointer() -> u64 {
 }
 
 pub fn get_predicate_data<T>() -> T {
-    let ptr = tx_predicate_data_start_pointer();
-    read(ptr)
+    read(tx_predicate_data_start_pointer())
 }
 
 ////////////////////////////////////////

--- a/sway-lib-std/src/tx.sw
+++ b/sway-lib-std/src/tx.sw
@@ -131,8 +131,8 @@ pub fn tx_receipts_root() -> b256 {
     }
 }
 
-/// Get the transaction script start offset.
-pub fn tx_script_start_offset() -> u64 {
+/// Get the transaction script start pointer.
+pub fn tx_script_start_pointer() -> u64 {
     asm(r1, r2: TX_SCRIPT_START_OFFSET) {
         move r1 r2;
         r1: u64
@@ -143,8 +143,8 @@ pub fn tx_script_start_offset() -> u64 {
 // Script
 ////////////////////////////////////////
 
-/// Get the transaction script data start offset.
-pub fn tx_script_data_start_offset() -> u64 {
+/// Get the transaction script data start pointer.
+pub fn tx_script_data_start_pointer() -> u64 {
     asm(r1, r2: TX_SCRIPT_START_OFFSET, r3: TX_SCRIPT_LENGTH_OFFSET) {
         lw r3 r3 i0;
         add r1 r2 r3;
@@ -155,7 +155,7 @@ pub fn tx_script_data_start_offset() -> u64 {
 /// Get the script data, typed. Unsafe.
 pub fn tx_script_data<T>() -> T {
     // TODO some safety checks on the input data? We are going to assume it is the right type for now.
-    let ptr = tx_script_data_start_offset();
+    let ptr = tx_script_data_start_pointer();
     if is_reference_type::<T>() {
         asm(r1: ptr) {
             r1: T
@@ -172,7 +172,7 @@ pub fn tx_script_data<T>() -> T {
 /// Must be cast to a u64 array, with sufficient length to contain the bytecode.
 /// Bytecode will be padded to next whole word.
 pub fn tx_script_bytecode<T>() -> T {
-    let script_ptr = tx_script_start_offset();
+    let script_ptr = tx_script_start_pointer();
     asm(r1: script_ptr) {
         r1: T
     }
@@ -231,7 +231,7 @@ pub fn tx_input_coin_owner(index: u64) -> Address {
 // Inputs > Predicate
 ////////////////////////////////////////
 
-pub fn tx_predicate_data_start_offset() -> u64 {
+pub fn tx_predicate_data_start_pointer() -> u64 {
     // $is is word-aligned
     let is = instrs_start();
     let predicate_length_ptr = is - 16;
@@ -248,7 +248,7 @@ pub fn tx_predicate_data_start_offset() -> u64 {
 }
 
 pub fn get_predicate_data<T>() -> T {
-    let ptr = tx_predicate_data_start_offset();
+    let ptr = tx_predicate_data_start_pointer();
     read(ptr)
 }
 

--- a/sway-lib-std/src/tx.sw
+++ b/sway-lib-std/src/tx.sw
@@ -132,10 +132,10 @@ pub fn tx_receipts_root() -> b256 {
 }
 
 /// Get the transaction script start offset.
-pub fn tx_script_start_offset() -> u32 {
+pub fn tx_script_start_offset() -> u64 {
     asm(r1, r2: TX_SCRIPT_START_OFFSET) {
         move r1 r2;
-        r1: u32
+        r1: u64
     }
 }
 
@@ -144,11 +144,11 @@ pub fn tx_script_start_offset() -> u32 {
 ////////////////////////////////////////
 
 /// Get the transaction script data start offset.
-pub fn tx_script_data_start_offset() -> u32 {
+pub fn tx_script_data_start_offset() -> u64 {
     asm(r1, r2: TX_SCRIPT_START_OFFSET, r3: TX_SCRIPT_LENGTH_OFFSET) {
         lw r3 r3 i0;
         add r1 r2 r3;
-        r1: u32
+        r1: u64
     }
 }
 
@@ -183,15 +183,15 @@ pub fn tx_script_bytecode<T>() -> T {
 ////////////////////////////////////////
 
 /// Get a pointer to an input given the index of the input.
-pub fn tx_input_pointer(index: u64) -> u32 {
+pub fn tx_input_pointer(index: u64) -> u64 {
     asm(r1, r2: index) {
         xis r1 r2;
-        r1: u32
+        r1: u64
     }
 }
 
 /// Get the type of an input given a pointer to the input.
-pub fn tx_input_type_from_pointer(ptr: u32) -> u8 {
+pub fn tx_input_type_from_pointer(ptr: u64) -> u8 {
     asm(r1, r2: ptr) {
         lw r1 r2 i0;
         r1: u8
@@ -205,7 +205,7 @@ pub fn tx_input_type(index: u64) -> u8 {
 }
 
 /// Read 256 bits from memory at a given offset from a given pointer
-pub fn b256_from_pointer_offset(pointer: u32, offset: u32) -> b256 {
+pub fn b256_from_pointer_offset(pointer: u64, offset: u64) -> b256 {
     asm(buffer, ptr: pointer, off: offset) {
         // Need to skip over `off` bytes
         add ptr ptr off;
@@ -257,15 +257,15 @@ pub fn get_predicate_data<T>() -> T {
 ////////////////////////////////////////
 
 /// Get a pointer to an output given the index of the output.
-pub fn tx_output_pointer(index: u64) -> u32 {
+pub fn tx_output_pointer(index: u64) -> u64 {
     asm(r1, r2: index) {
         xos r1 r2;
-        r1: u32
+        r1: u64
     }
 }
 
 /// Get the type of an output given a pointer to the output.
-pub fn tx_output_type_from_pointer(ptr: u32) -> u8 {
+pub fn tx_output_type_from_pointer(ptr: u64) -> u8 {
     asm(r1, r2: ptr) {
         lw r1 r2 i0;
         r1: u8

--- a/sway-lib-std/src/tx.sw
+++ b/sway-lib-std/src/tx.sw
@@ -172,8 +172,7 @@ pub fn tx_script_data<T>() -> T {
 /// Must be cast to a u64 array, with sufficient length to contain the bytecode.
 /// Bytecode will be padded to next whole word.
 pub fn tx_script_bytecode<T>() -> T {
-    let script_ptr = tx_script_start_pointer();
-    read(script_ptr)
+    read(tx_script_start_pointer())
 }
 
 ////////////////////////////////////////

--- a/sway-lib-std/src/tx.sw
+++ b/sway-lib-std/src/tx.sw
@@ -164,8 +164,7 @@ pub fn tx_script_data_start_pointer() -> u64 {
 /// Get the script data, typed. Unsafe.
 pub fn tx_script_data<T>() -> T {
     // TODO some safety checks on the input data? We are going to assume it is the right type for now.
-    let ptr = tx_script_data_start_pointer();
-    read(ptr)
+    read(tx_script_data_start_pointer())
 }
 
 /// Get the script bytecode

--- a/test/src/sdk-harness/test_artifacts/tx_contract/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/tx_contract/src/main.sw
@@ -15,7 +15,7 @@ abi TxContractTest {
     fn get_tx_outputs_count() -> u64;
     fn get_tx_witnesses_count() -> u64;
     fn get_tx_receipts_root() -> b256;
-    fn get_tx_script_start_offset() -> u64;
+    fn get_tx_script_start_pointer() -> u64;
 
     fn get_tx_input_pointer(index: u64) -> u64;
     fn get_tx_input_type(ptr: u64) -> u8;
@@ -59,8 +59,8 @@ impl TxContractTest for Contract {
     fn get_tx_receipts_root() -> b256 {
         tx_receipts_root()
     }
-    fn get_tx_script_start_offset() -> u64 {
-        tx_script_start_offset()
+    fn get_tx_script_start_pointer() -> u64 {
+        tx_script_start_pointer()
     }
 
     fn get_tx_input_pointer(index: u64) -> u64 {

--- a/test/src/sdk-harness/test_artifacts/tx_contract/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/tx_contract/src/main.sw
@@ -17,12 +17,12 @@ abi TxContractTest {
     fn get_tx_receipts_root() -> b256;
     fn get_tx_script_start_offset() -> u64;
 
-    fn get_tx_input_pointer(index: u64) -> u32;
-    fn get_tx_input_type(ptr: u32) -> u8;
+    fn get_tx_input_pointer(index: u64) -> u64;
+    fn get_tx_input_type(ptr: u64) -> u8;
     fn get_tx_input_coin_owner(index: u64) -> Address;
 
-    fn get_tx_output_pointer(index: u64) -> u32;
-    fn get_tx_output_type(ptr: u32) -> u8;
+    fn get_tx_output_pointer(index: u64) -> u64;
+    fn get_tx_output_type(ptr: u64) -> u8;
 }
 
 impl TxContractTest for Contract {
@@ -63,20 +63,20 @@ impl TxContractTest for Contract {
         tx_script_start_offset()
     }
 
-    fn get_tx_input_pointer(index: u64) -> u32 {
+    fn get_tx_input_pointer(index: u64) -> u64 {
         tx_input_pointer(index)
     }
-    fn get_tx_input_type(ptr: u32) -> u8 {
+    fn get_tx_input_type(ptr: u64) -> u8 {
         tx_input_type_from_pointer(ptr)
     }
     fn get_tx_input_coin_owner(index: u64) -> Address {
         tx_input_coin_owner(index)
     }
 
-    fn get_tx_output_pointer(index: u64) -> u32 {
+    fn get_tx_output_pointer(index: u64) -> u64 {
         tx_output_pointer(index)
     }
-    fn get_tx_output_type(ptr: u32) -> u8 {
+    fn get_tx_output_type(ptr: u64) -> u8 {
         tx_output_type_from_pointer(ptr)
     }
 }

--- a/test/src/sdk-harness/test_projects/tx_fields/mod.rs
+++ b/test/src/sdk-harness/test_projects/tx_fields/mod.rs
@@ -189,7 +189,7 @@ async fn can_get_script_start_offset() {
         ConsensusParameters::DEFAULT.tx_offset() + TRANSACTION_SCRIPT_FIXED_SIZE;
 
     let result = contract_instance
-        .get_tx_script_start_offset()
+        .get_tx_script_start_pointer()
         .call()
         .await
         .unwrap();


### PR DESCRIPTION
Resolves https://github.com/FuelLabs/sway/issues/2015

---

[Make all pointers u64](https://github.com/FuelLabs/sway/pull/2208/commits/b10f54a75e51cd3df17a53d9d424211dab3ade11)

Some were `u32`s. Also checked outside `std::tx` for more and couldn't see any.

[Suffix pointer returning functions with _pointer](https://github.com/FuelLabs/sway/pull/2208/commits/b29f78daa57dd3df6490cea4d16b65a8869d6942)

Some were using `_offset`. `_ptr` is also an option but we use `_pointer` outside `std::tx` too. 

[Replace assembly with internals](https://github.com/FuelLabs/sway/pull/2208/commits/acd56a4318ea72fc00039e065a05626d87df7fa3)

Used `std::mem` and `std::tx` internals instead of asm. There were more opportunities but I think they'd be better done in a separate PR. (Probably https://github.com/FuelLabs/sway/issues/2146)