### PR TITLE
Add `parsed_to_ast` fn in `sway_core`

### DIFF
--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -206,28 +206,11 @@ pub enum BytecodeCompilationResult {
 }
 
 pub fn parsed_to_ast(
-    parsed: CompileResult<ParseProgram>,
+    parse_program: ParseProgram,
     initial_namespace: namespace::Module,
 ) -> CompileAstResult {
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
-
-    let CompileResult {
-        value: parse_program_opt,
-        warnings: new_warnings,
-        errors: new_errors,
-    } = parsed;
-
-    warnings.extend(new_warnings);
-    errors.extend(new_errors);
-    let parse_program = match parse_program_opt {
-        Some(parse_program) => parse_program,
-        None => {
-            errors = dedup_unsorted(errors);
-            warnings = dedup_unsorted(warnings);
-            return CompileAstResult::Failure { errors, warnings };
-        }
-    };
 
     let CompileResult {
         value: typed_program_result,
@@ -283,8 +266,49 @@ pub fn compile_to_ast(
     initial_namespace: namespace::Module,
     build_config: Option<&BuildConfig>,
 ) -> CompileAstResult {
-    let parsed = parse(input, build_config);
-    parsed_to_ast(parsed, initial_namespace)
+    let mut warnings = Vec::new();
+    let mut errors = Vec::new();
+
+    let CompileResult {
+        value: parse_program_opt,
+        warnings: new_warnings,
+        errors: new_errors,
+    } = parse(input, build_config);
+
+    warnings.extend(new_warnings);
+    errors.extend(new_errors);
+    let parse_program = match parse_program_opt {
+        Some(parse_program) => parse_program,
+        None => {
+            errors = dedup_unsorted(errors);
+            warnings = dedup_unsorted(warnings);
+            return CompileAstResult::Failure { errors, warnings };
+        }
+    };
+
+    match parsed_to_ast(parse_program, initial_namespace) {
+        CompileAstResult::Success {
+            typed_program,
+            warnings: new_warnings,
+        } => {
+            warnings.extend(new_warnings);
+            warnings = dedup_unsorted(warnings);
+            CompileAstResult::Success {
+                typed_program,
+                warnings,
+            }
+        }
+        CompileAstResult::Failure {
+            warnings: new_warnings,
+            errors: new_errors,
+        } => {
+            warnings.extend(new_warnings);
+            errors.extend(new_errors);
+            errors = dedup_unsorted(errors);
+            warnings = dedup_unsorted(warnings);
+            CompileAstResult::Failure { errors, warnings }
+        }
+    }
 }
 
 /// Given input Sway source code, compile to a [CompilationResult] which contains the asm in opcode

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -205,10 +205,9 @@ pub enum BytecodeCompilationResult {
     },
 }
 
-pub fn compile_to_ast(
-    input: Arc<str>,
+pub fn parsed_to_ast(
+    parsed: CompileResult<ParseProgram>,
     initial_namespace: namespace::Module,
-    build_config: Option<&BuildConfig>,
 ) -> CompileAstResult {
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
@@ -217,7 +216,8 @@ pub fn compile_to_ast(
         value: parse_program_opt,
         warnings: new_warnings,
         errors: new_errors,
-    } = parse(input, build_config);
+    } = parsed;
+
     warnings.extend(new_warnings);
     errors.extend(new_errors);
     let parse_program = match parse_program_opt {
@@ -276,6 +276,15 @@ pub fn compile_to_ast(
         typed_program: Box::new(typed_program_with_storage_slots),
         warnings,
     }
+}
+
+pub fn compile_to_ast(
+    input: Arc<str>,
+    initial_namespace: namespace::Module,
+    build_config: Option<&BuildConfig>,
+) -> CompileAstResult {
+    let parsed = parse(input, build_config);
+    parsed_to_ast(parsed, initial_namespace)
 }
 
 /// Given input Sway source code, compile to a [CompilationResult] which contains the asm in opcode


### PR DESCRIPTION
This PR refactors `compile_to_ast` and adds a `parsed_to_ast` function. This avoids reparsing the whole program again in the language server when doing the type-checking phase as we can call `parsed_to_ast` with our already obtained `CompileResult<ParseProgram>`. 
