### PR TITLE
Swap order of operands for `std::mem::copy`

### DIFF
--- a/sway-lib-std/src/alloc.sw
+++ b/sway-lib-std/src/alloc.sw
@@ -38,7 +38,7 @@ pub fn realloc(ptr: u64, size: u64, new_size: u64) -> u64 {
     if new_size > size {
         let new_ptr = alloc(new_size);
         if size > 0 {
-            copy(new_ptr, ptr, size);
+            copy(ptr, new_ptr, size);
         }
         new_ptr
     } else {

--- a/sway-lib-std/src/mem.sw
+++ b/sway-lib-std/src/mem.sw
@@ -15,7 +15,7 @@ pub fn addr_of<T>(val: T) -> u64 {
 }
 
 /// Copies `size` bytes from `src` to `dst`.
-pub fn copy(dst: u64, src: u64, size: u64) {
+pub fn copy(src: u64, dst: u64, size: u64) {
     asm(dst: dst, src: src, size: size) {
         mcp dst src size;
     };
@@ -46,7 +46,7 @@ pub fn read<T>(ptr: u64) -> T {
 /// Writes the given value to the address.
 pub fn write<T>(ptr: u64, val: T) {
     if is_reference_type::<T>() {
-        copy(ptr, addr_of(val), size_of_val(val));
+        copy(addr_of(val), ptr, size_of_val(val));
     } else {
         asm(ptr: ptr, val: val) {
             sw ptr val i0;

--- a/sway-lib-std/src/vec.sw
+++ b/sway-lib-std/src/vec.sw
@@ -159,7 +159,7 @@ impl<T> Vec<T> {
         // Shift everything down to fill in that spot.
         let end = buf_start + val_size * self.len;
         while ptr < end {
-            copy(ptr, ptr + val_size, val_size);
+            copy(ptr + val_size, ptr, val_size);
             ptr += val_size;
         }
 
@@ -188,7 +188,7 @@ impl<T> Vec<T> {
         // Shift everything over to make space.
         let mut curr_ptr = buf_start + self.len * val_size;
         while curr_ptr > index_ptr {
-            copy(curr_ptr, curr_ptr - val_size, val_size);
+            copy(curr_ptr - val_size, curr_ptr, val_size);
             curr_ptr -= val_size;
         }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/mem/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/mem/src/main.sw
@@ -35,7 +35,7 @@ fn main() -> bool {
 
     // Copy the struct into a buffer
     let buf_ptr = alloc(16);
-    copy(buf_ptr, foo_ptr, 16);
+    copy(foo_ptr, buf_ptr, 16);
     assert(eq(buf_ptr, foo_ptr, 16));
     assert(asm(r1: buf_ptr, r2: foo_ptr, r3: foo_len) {
         meq r1 r1 r2 r3;


### PR DESCRIPTION
Swapped `src` and `dst` args in `std::mem::copy` so `src` comes first:
```rs
pub fn copy(src: u64, dst: u64, size: u64) {
    // ...
}
```

Resolves #2203.