### PR TITLE
Return a `CompileResult` & a `CompileAstResult` from `forc_pkg::check`

### DIFF
--- a/forc/src/ops/forc_check.rs
+++ b/forc/src/ops/forc_check.rs
@@ -19,5 +19,6 @@ pub fn check(command: CheckCommand) -> Result<sway_core::CompileAstResult> {
     let manifest = ManifestFile::from_dir(&this_dir, SWAY_GIT_TAG)?;
     let plan = pkg::BuildPlan::from_lock_and_manifest(&manifest, locked, offline, SWAY_GIT_TAG)?;
 
-    pkg::check(&plan, silent_mode)
+    let (_, ast_res) = pkg::check(&plan, silent_mode)?;
+    Ok(ast_res)
 }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -207,7 +207,7 @@ pub enum BytecodeCompilationResult {
 }
 
 pub fn parsed_to_ast(
-    parse_program: ParseProgram,
+    parse_program: &ParseProgram,
     initial_namespace: namespace::Module,
 ) -> CompileAstResult {
     let mut warnings = Vec::new();
@@ -287,7 +287,7 @@ pub fn compile_to_ast(
         }
     };
 
-    match parsed_to_ast(parse_program, initial_namespace) {
+    match parsed_to_ast(&parse_program, initial_namespace) {
         CompileAstResult::Success {
             typed_program,
             warnings: new_warnings,

--- a/sway-core/src/semantic_analysis/program.rs
+++ b/sway-core/src/semantic_analysis/program.rs
@@ -28,7 +28,7 @@ impl TypedProgram {
     /// The given `initial_namespace` acts as an initial state for each module within this program.
     /// It should contain a submodule for each library package dependency.
     pub fn type_check(
-        parsed: ParseProgram,
+        parsed: &ParseProgram,
         initial_namespace: namespace::Module,
     ) -> CompileResult<Self> {
         let mut namespace = Namespace::init_root(initial_namespace);
@@ -37,7 +37,7 @@ impl TypedProgram {
         let mod_span = root.tree.span.clone();
         let mod_res = TypedModule::type_check(ctx, root);
         mod_res.flat_map(|root| {
-            let kind_res = Self::validate_root(&root, kind, mod_span);
+            let kind_res = Self::validate_root(&root, kind.clone(), mod_span);
             kind_res.map(|kind| Self {
                 kind,
                 root,

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -6,8 +6,8 @@ use super::traverse_typed_tree;
 use super::typed_token_type::TokenMap;
 
 use crate::{capabilities, core::token::traverse_node, utils};
-use forc_pkg::{self as pkg};
 use forc::utils::SWAY_GIT_TAG;
+use forc_pkg::{self as pkg};
 use ropey::Rope;
 use std::{collections::HashMap, path::PathBuf};
 use sway_core::{
@@ -99,9 +99,8 @@ impl TextDocument {
         self.clear_hash_maps();
 
         let manifest_dir = PathBuf::from(self.get_uri());
+        let manifest = pkg::ManifestFile::from_dir(&manifest_dir, SWAY_GIT_TAG).unwrap();
         let silent_mode = true;
-        let manifest =
-            pkg::ManifestFile::from_dir(&manifest_dir, SWAY_GIT_TAG).unwrap();
         let locked = false;
         let offline = false;
         let plan = pkg::BuildPlan::from_lock_and_manifest(&manifest, locked, offline, SWAY_GIT_TAG)

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -7,9 +7,13 @@ use super::typed_token_type::TokenMap;
 
 use crate::{capabilities, core::token::traverse_node, utils};
 use forc_pkg::{self as pkg};
+use forc::utils::SWAY_GIT_TAG;
 use ropey::Rope;
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
-use sway_core::{parse, semantic_analysis::ast_node::TypedAstNode, CompileAstResult, TreeType};
+use sway_core::{
+    semantic_analysis::ast_node::TypedAstNode, CompileAstResult, CompileResult, ParseProgram,
+    TreeType,
+};
 use tower_lsp::lsp_types::{Diagnostic, Position, Range, TextDocumentContentChangeEvent};
 
 #[derive(Debug)]
@@ -94,15 +98,25 @@ impl TextDocument {
         self.clear_tokens();
         self.clear_hash_maps();
 
-        //self.test_typed_parse();
+        let manifest_dir = PathBuf::from(self.get_uri());
+        let silent_mode = true;
+        let manifest =
+            pkg::ManifestFile::from_dir(&manifest_dir, SWAY_GIT_TAG).unwrap();
+        let locked = false;
+        let offline = false;
+        let plan = pkg::BuildPlan::from_lock_and_manifest(&manifest, locked, offline, SWAY_GIT_TAG)
+            .unwrap();
+        let (parsed_res, _ast_res) = pkg::check(&plan, silent_mode).unwrap();
 
-        match self.parse_tokens_from_text() {
+        match self.parse_tokens_from_text(parsed_res) {
             Ok((tokens, diagnostics)) => {
                 self.store_tokens(tokens);
                 Ok(diagnostics)
             }
             Err(diagnostics) => Err(DocumentError::FailedToParse(diagnostics)),
         }
+
+        //self.test_typed_parse(ast_res);
     }
 
     pub fn apply_change(&mut self, change: &TextDocumentContentChangeEvent) {
@@ -116,8 +130,8 @@ impl TextDocument {
         self.content.to_string()
     }
 
-    pub fn test_typed_parse(&mut self) {
-        if let Some(all_nodes) = self.parse_typed_tokens_from_text() {
+    pub fn test_typed_parse(&mut self, ast_res: CompileAstResult) {
+        if let Some(all_nodes) = self.parse_typed_tokens_from_text(ast_res) {
             for node in &all_nodes {
                 traverse_typed_tree::traverse_node(node, &mut self.token_map);
             }
@@ -155,26 +169,17 @@ impl TextDocument {
 
 // private methods
 impl TextDocument {
-    fn parse_typed_tokens_from_text(&self) -> Option<Vec<TypedAstNode>> {
-        use forc::utils::SWAY_GIT_TAG;
-        let manifest_dir = PathBuf::from(self.get_uri());
-        let silent_mode = true;
-        let manifest = pkg::ManifestFile::from_dir(&manifest_dir, SWAY_GIT_TAG).unwrap();
-        let locked = false;
-        let offline = false;
-        let plan = pkg::BuildPlan::from_lock_and_manifest(&manifest, locked, offline, SWAY_GIT_TAG)
-            .unwrap();
-        let res = pkg::check(&plan, silent_mode).unwrap();
-
-        match res {
+    fn parse_typed_tokens_from_text(&self, ast_res: CompileAstResult) -> Option<Vec<TypedAstNode>> {
+        match ast_res {
             CompileAstResult::Failure { .. } => None,
             CompileAstResult::Success { typed_program, .. } => Some(typed_program.root.all_nodes),
         }
     }
 
-    fn parse_tokens_from_text(&self) -> Result<(Vec<Token>, Vec<Diagnostic>), Vec<Diagnostic>> {
-        let text = Arc::from(self.get_text());
-        let parsed_result = parse(text, None);
+    fn parse_tokens_from_text(
+        &self,
+        parsed_result: CompileResult<ParseProgram>,
+    ) -> Result<(Vec<Token>, Vec<Diagnostic>), Vec<Diagnostic>> {
         match parsed_result.value {
             None => Err(capabilities::diagnostic::get_diagnostics(
                 parsed_result.warnings,

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -9,7 +9,7 @@ use crate::{capabilities, core::token::traverse_node, utils};
 use forc_pkg::{self as pkg};
 use forc::utils::SWAY_GIT_TAG;
 use ropey::Rope;
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::PathBuf};
 use sway_core::{
     semantic_analysis::ast_node::TypedAstNode, CompileAstResult, CompileResult, ParseProgram,
     TreeType,
@@ -108,6 +108,8 @@ impl TextDocument {
             .unwrap();
         let (parsed_res, _ast_res) = pkg::check(&plan, silent_mode).unwrap();
 
+        //self.test_typed_parse(ast_res);
+
         match self.parse_tokens_from_text(parsed_res) {
             Ok((tokens, diagnostics)) => {
                 self.store_tokens(tokens);
@@ -115,8 +117,6 @@ impl TextDocument {
             }
             Err(diagnostics) => Err(DocumentError::FailedToParse(diagnostics)),
         }
-
-        //self.test_typed_parse(ast_res);
     }
 
     pub fn apply_change(&mut self, change: &TextDocumentContentChangeEvent) {


### PR DESCRIPTION
This PR allows `forc_pkg::check` to return a tuple of `CompileResult` and `CompileAstResult`. 

In the language server, we need access to both types, this change improves the ergonomics of needing access to both types and eliminates the need to call `sway_core::parse` in the language server which then would need to pass the returned `ParseProgram`  into `forc_pkg::check`. 