### PR TITLE
Fix and clean up forc reference docs.

### DIFF
--- a/forc/src/cli/commands/new.rs
+++ b/forc/src/cli/commands/new.rs
@@ -3,7 +3,7 @@ use anyhow::{bail, Result};
 use clap::Parser;
 use std::path::Path;
 
-/// Create a new Forc project at <path>.
+/// Create a new Forc project at `path`.
 #[derive(Debug, Parser)]
 pub struct Command {
     /// The default program type. Excluding all flags or adding this flag creates a basic contract

--- a/forc/src/cli/commands/new.rs
+++ b/forc/src/cli/commands/new.rs
@@ -3,7 +3,7 @@ use anyhow::{bail, Result};
 use clap::Parser;
 use std::path::Path;
 
-/// Create a new Forc project at <path>.
+/// Create a new Forc project at `<path>`.
 #[derive(Debug, Parser)]
 pub struct Command {
     /// The default program type. Excluding all flags or adding this flag creates a basic contract

--- a/forc/src/cli/commands/new.rs
+++ b/forc/src/cli/commands/new.rs
@@ -3,7 +3,7 @@ use anyhow::{bail, Result};
 use clap::Parser;
 use std::path::Path;
 
-/// Create a new Forc project at `path`.
+/// Create a new Forc project at <path>.
 #[derive(Debug, Parser)]
 pub struct Command {
     /// The default program type. Excluding all flags or adding this flag creates a basic contract

--- a/scripts/mdbook-forc-documenter/examples/forc_build.md
+++ b/scripts/mdbook-forc-documenter/examples/forc_build.md
@@ -1,5 +1,5 @@
 
-## EXAMPLE:
+## EXAMPLE
 
 Compile the sway files of the current project.
 

--- a/scripts/mdbook-forc-documenter/examples/forc_completions.md
+++ b/scripts/mdbook-forc-documenter/examples/forc_completions.md
@@ -1,5 +1,5 @@
 
-## DISCUSSION:
+## DISCUSSION
 
 Enable tab completion for Bash, Fish, Zsh, or PowerShell
 The script is output on `stdout`, allowing one to re-direct the
@@ -11,7 +11,7 @@ these scripts need to be placed.
 Here are some common set ups for the three supported shells under
 Unix and similar operating systems (such as GNU/Linux).
 
-**BASH:**
+### BASH
 
 Completion files are commonly stored in `/etc/bash_completion.d/` for
 system-wide commands, but can be stored in
@@ -26,7 +26,7 @@ forc completions --shell=bash >> ~/.local/share/bash-completion/completions/forc
 This installs the completion script. You may have to log out and
 log back in to your shell session for the changes to take effect.
 
-**BASH (macOS/Homebrew):**
+### BASH (macOS/Homebrew)
 
 Homebrew stores bash completion files within the Homebrew directory.
 With the `bash-completion` brew formula installed, run the command:
@@ -36,7 +36,7 @@ mkdir -p $(brew --prefix)/etc/bash_completion.d
 forc completions --shell=bash > $(brew --prefix)/etc/bash_completion.d/forc.bash-completion
 ```
 
-**FISH:**
+### FISH
 
 Fish completion files are commonly stored in
 `$HOME/.config/fish/completions`. Run the command:
@@ -49,7 +49,7 @@ forc completions --shell=fish > ~/.config/fish/completions/forc.fish
 This installs the completion script. You may have to log out and
 log back in to your shell session for the changes to take effect.
 
-**ZSH:**
+### ZSH
 
 ZSH completions are commonly stored in any directory listed in
 your `$fpath` variable. To use these completions, you must either
@@ -87,7 +87,7 @@ exec zsh
 
 for the new completions to take effect.
 
-**CUSTOM LOCATIONS:**
+### CUSTOM LOCATIONS
 
 Alternatively, you could save these files to the place of your
 choosing, such as a custom directory inside your $HOME. Doing so
@@ -95,7 +95,7 @@ will require you to add the proper directives, such as `source`ing
 inside your login script. Consult your shells documentation for
 how to add such directives.
 
-**POWERSHELL:**
+### POWERSHELL
 
 The powershell completion scripts require PowerShell v5.0+ (which
 comes with Windows 10, but can be downloaded separately for windows 7

--- a/scripts/mdbook-forc-documenter/examples/forc_deploy.md
+++ b/scripts/mdbook-forc-documenter/examples/forc_deploy.md
@@ -1,5 +1,5 @@
 
-## EXAMPLE:
+## EXAMPLE
 
 You can use `forc deploy`, which triggers a contract deployment transaction and sends it to a running node.
 

--- a/scripts/mdbook-forc-documenter/examples/forc_init.md
+++ b/scripts/mdbook-forc-documenter/examples/forc_init.md
@@ -1,5 +1,5 @@
 
-## EXAMPLE:
+## EXAMPLE
 
 ```console
 $ forc init my-fuel-project

--- a/scripts/mdbook-forc-documenter/examples/forc_new.md
+++ b/scripts/mdbook-forc-documenter/examples/forc_new.md
@@ -1,4 +1,5 @@
-## EXAMPLE:
+
+## EXAMPLE
 
 ```console
 $ forc new my-fuel-project

--- a/scripts/mdbook-forc-documenter/examples/forc_parse-bytecode.md
+++ b/scripts/mdbook-forc-documenter/examples/forc_parse-bytecode.md
@@ -1,5 +1,5 @@
 
-## EXAMPLE:
+## EXAMPLE
 
 We can try this command with the initial project created using `forc init`, with the counter template:
 

--- a/scripts/mdbook-forc-documenter/examples/forc_template.md
+++ b/scripts/mdbook-forc-documenter/examples/forc_template.md
@@ -1,16 +1,14 @@
 
-## EXAMPLE:
-
+## EXAMPLE
 
 ```sh
 forc template --url https://github.com/owner/template/ --project_name my_example_project
 ```
 
-The command above fetches the HEAD of the `template` repo and searchs for `Forc.toml` at the root of the fetched repo. It will fetch the repo and preapare a new `Forc.toml` with new project name. Outputs everthing to `current_dir/project_name`.
-
+The command above fetches the `HEAD` of the `template` repo and searches for `Forc.toml` at the root of the fetched repo. It will fetch the repo and prepare a new `Forc.toml` with the new project name. Outputs everything to `current_dir/project_name`.
 
 ```sh
-forc template --url https://github.com/FuelLabs/sway/ --template_name counter --project_name my_example_project
+forc template --url https://github.com/FuelLabs/sway --template_name counter --project_name my_example_project
 ```
 
-The command above fetches the HEAD of the `sway` repo and searchs for `counter` example inside it (There is an example called `counter` under `sway/examples`). It will fetch the `counter` example and preapare a new `Forc.toml` with new project name. Outputs everthing to `current_dir/project_name`..
+The command above fetches the HEAD of the `sway` repo and searches for `counter` example inside it (there is an example called `counter` under `sway/examples`). It will fetch the `counter` example and prepare a new `Forc.toml` with the new project name. Outputs everything to `current_dir/project_name`.

--- a/scripts/mdbook-forc-documenter/examples/forc_test.md
+++ b/scripts/mdbook-forc-documenter/examples/forc_test.md
@@ -1,5 +1,5 @@
 
-## EXAMPLE:
+## EXAMPLE
 
 You can write tests in Rust using our [Rust SDK](https://github.com/FuelLabs/fuels-rs). These tests can be run using `forc test`, which will look for Rust tests under the `tests/` directory (which is created automatically with `forc new`).
 


### PR DESCRIPTION
- Current `forc new` doc page reads "Create a new Forc project at". Fixed to show "Create a new Forc project at `<path>`."
- Fix headers to have a leading newline and no `:`, etc.
- Minor language improvements.