### PR TITLE
Bump `openssl-src` to 111.22.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,9 +2321,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.21.0+1.1.1p"
+version = "111.22.0+1.1.1q"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0a8313729211913936f1b95ca47a5fc7f2e04cd658c115388287f8a8361008"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
Resolves https://github.com/FuelLabs/sway/security/dependabot/11 (https://github.com/advisories/GHSA-3wx7-46ch-7rq2).

```console
$ cargo update -p openssl-src
    Updating crates.io index
    Updating openssl-src v111.21.0+1.1.1p -> v111.22.0+1.1.1q
```