### PR TITLE
Fix how warnings/errors are displayed to avoid a crash

### DIFF
--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -407,7 +407,10 @@ fn construct_window<'a>(
     *start_ix -= std::cmp::min(calculated_start_ix, *start_ix);
     *end_ix -= std::cmp::min(calculated_start_ix, *end_ix);
     start.line = lines_to_start_of_snippet;
-    &input[calculated_start_ix..calculated_end_ix]
+
+    // The length of input must be at least as big as *end_ix. This is required by the
+    // annotate_snippets library
+    &input[calculated_start_ix..std::cmp::max(calculated_start_ix + *end_ix, calculated_end_ix)]
 }
 
 const LOG_FILTER: &str = "RUST_LOG";


### PR DESCRIPTION
The code linked to in https://github.com/FuelLabs/sway/issues/2240 crashes with the following panic:
```
thread 'main' panicked at 'SourceAnnotation range `(92, 1272)` is bigger than source length `1268`', /Users/mohammad/.cargo/registry/src/github.com-1ecc6299db9ec823/annotate-snippets-0.9.1/src/display_list/from_snippet.rs:286:9
```
from https://github.com/rust-lang/annotate-snippets-rs/blob/448b80421b5a9c39c3ed1a708636014aec82eac1/src/display_list/from_snippet.rs#L287

This wasn't happening in `0.17.0` because the problematic warning was dropped in DCA but now show up due to https://github.com/FuelLabs/sway/pull/2230. 

The requirement is here is that the length of `input` is at least as big as `*end_ix`.

With this change, the problematic warning shows up as intended:
<img width="722" alt="image" src="https://user-images.githubusercontent.com/59666792/177636813-f221e9a3-81ea-4469-a6d1-fdd56e7a0c0c.png">

Honestly, I'm not 100% sure that this is the best way to fix this. I don't fully understand how `construct_window()` works 🤔 . Soliciting help if someone has a better idea.