### PR TITLE
Remove unsupported LSP Capabilities

### DIFF
--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -57,20 +57,13 @@ fn capabilities() -> ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Kind(
             TextDocumentSyncKind::INCREMENTAL,
         )),
-        definition_provider: Some(OneOf::Left(true)),
         semantic_tokens_provider: capabilities::semantic_tokens::get_semantic_tokens(),
         document_symbol_provider: Some(OneOf::Left(true)),
-        hover_provider: Some(HoverProviderCapability::Simple(true)),
         completion_provider: Some(CompletionOptions {
             resolve_provider: Some(false),
             trigger_characters: None,
             ..Default::default()
         }),
-        execute_command_provider: Some(ExecuteCommandOptions {
-            commands: vec![],
-            ..Default::default()
-        }),
-        document_highlight_provider: Some(OneOf::Left(true)),
         document_formatting_provider: Some(OneOf::Left(true)),
         ..ServerCapabilities::default()
     }


### PR DESCRIPTION
The language server is going through a bit of a re-write so we can handle typed tokens. The foundation of this work is being done in #2121. Before that lands, we should disable LSP capabilities that we can't reasonably support without knowledge of the type information of the tokens. 

I've outlined my thoughts on why we can't support the definition, rename, highlighting, and hover, capabilites without knowledge about the tokens type in #2257.

I've created the following separate issues about properly adding back in support for these capabilities one by one once we have the typed tokens in the language server. 

#2258 
#2259 
#2260 
#2261 