### PR TITLE
Add a new calling context attribute to restrict functions to internal contexts.

### DIFF
--- a/sway-core/src/constants.rs
+++ b/sway-core/src/constants.rs
@@ -28,3 +28,7 @@ pub const MATCH_RETURN_VAR_NAME_PREFIX: &str = "__match_return_var_name_";
 pub const STORAGE_PURITY_ATTRIBUTE_NAME: &str = "storage";
 pub const STORAGE_PURITY_READ_NAME: &str = "read";
 pub const STORAGE_PURITY_WRITE_NAME: &str = "write";
+
+/// The valid attribute strings related to context.
+pub const CALLING_CONTEXT_ATTRIBUTE_NAME: &str = "context";
+pub const CALLING_CONTEXT_INTERNAL_ONLY_NAME: &str = "internal_only";

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -1,7 +1,7 @@
 //! Tools related to handling/recovering from Sway compile errors and reporting them to the user.
 
 use crate::{
-    constants::STORAGE_PURITY_ATTRIBUTE_NAME,
+    constants::{CALLING_CONTEXT_ATTRIBUTE_NAME, STORAGE_PURITY_ATTRIBUTE_NAME},
     convert_parse_tree::ConvertParseTreeError,
     style::{to_screaming_snake_case, to_snake_case, to_upper_camel_case},
     type_engine::*,
@@ -894,6 +894,11 @@ pub enum CompileError {
         span: Span,
     },
     #[error(
+        "Calling context attribute mismatch. Try giving the surrounding function the same context by \
+        adding \"#[{CALLING_CONTEXT_ATTRIBUTE_NAME}({attrs})]\" to the function declaration."
+    )]
+    CallingContextMismatch { attrs: String, span: Span },
+    #[error(
         "Storage attribute access mismatch. Try giving the surrounding function more access by \
         adding \"#[{STORAGE_PURITY_ATTRIBUTE_NAME}({attrs})]\" to the function declaration."
     )]
@@ -932,6 +937,8 @@ pub enum CompileError {
         attrs: String,
         span: Span,
     },
+    #[error("Internal function inside of non-contract. This function is only accessible from contracts.")]
+    InternalOnlyInNonContract { span: Span },
     #[error("Literal value is too large for type {ty}.")]
     IntegerTooLarge { span: Span, ty: String },
     #[error("Literal value underflows type {ty}.")]
@@ -1140,6 +1147,7 @@ impl Spanned for CompileError {
             MatchStructPatternMissingFields { span, .. } => span.clone(),
             NotAnEnum { span, .. } => span.clone(),
             StorageAccessMismatch { span, .. } => span.clone(),
+            CallingContextMismatch { span, .. } => span.clone(),
             TraitDeclPureImplImpure { span, .. } => span.clone(),
             TraitImplPurityMismatch { span, .. } => span.clone(),
             DeclIsNotAnEnum { span, .. } => span.clone(),
@@ -1149,6 +1157,7 @@ impl Spanned for CompileError {
             DeclIsNotAnAbi { span, .. } => span.clone(),
             ImpureInNonContract { span, .. } => span.clone(),
             ImpureInPureContext { span, .. } => span.clone(),
+            InternalOnlyInNonContract { span, .. } => span.clone(),
             IntegerTooLarge { span, .. } => span.clone(),
             IntegerTooSmall { span, .. } => span.clone(),
             IntegerContainsInvalidDigit { span, .. } => span.clone(),

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -246,6 +246,7 @@ impl FnCompiler {
                 function_body,
                 function_body_name_span,
                 function_body_purity,
+                function_body_calling_context: function_body_context,
                 self_state_idx,
                 selector,
             } => {
@@ -266,6 +267,7 @@ impl FnCompiler {
                         function_body,
                         function_body_name_span,
                         function_body_purity,
+                        function_body_context,
                         self_state_idx,
                         span_md_idx,
                     )
@@ -712,6 +714,7 @@ impl FnCompiler {
         callee_body: TypedCodeBlock,
         callee_span: Span,
         callee_purity: Purity,
+        callee_context: crate::function::CallingContext,
         self_state_idx: Option<StateIndex>,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
@@ -770,6 +773,7 @@ impl FnCompiler {
                 visibility: Visibility::Private,
                 is_contract_call: false,
                 purity: callee_purity,
+                calling_context: callee_context,
             };
 
             let callee = compile_function(context, self.module, callee_fn_decl)?;

--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -5,8 +5,12 @@ use sway_types::{ident::Ident, span::Span};
 mod purity;
 pub use purity::{promote_purity, Purity};
 
+mod calling_context;
+pub use calling_context::{promote_calling_context, CallingContext};
+
 #[derive(Debug, Clone)]
 pub struct FunctionDeclaration {
+    pub context: CallingContext,
     pub purity: Purity,
     pub name: Ident,
     pub visibility: Visibility,

--- a/sway-core/src/parse_tree/declaration/function/calling_context.rs
+++ b/sway-core/src/parse_tree/declaration/function/calling_context.rs
@@ -1,0 +1,39 @@
+/// The calling context of a function can be used to limit a function to a
+/// particular call context either internal (contract) or external (non-contract).
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub enum CallingContext {
+    Unspecified,
+    InternalOnly,
+}
+
+impl CallingContext {
+    pub fn can_call(&self, other: CallingContext) -> bool {
+        match other {
+            CallingContext::InternalOnly => *self == CallingContext::InternalOnly,
+            _ => true,
+        }
+    }
+
+    // Useful for error messages, show the syntax needed in the #[context(...)] attribute.
+    pub fn to_attribute_syntax(&self) -> String {
+        use crate::constants::*;
+        match self {
+            CallingContext::Unspecified => "".to_owned(),
+            CallingContext::InternalOnly => CALLING_CONTEXT_INTERNAL_ONLY_NAME.to_owned(),
+        }
+    }
+}
+
+impl Default for CallingContext {
+    fn default() -> Self {
+        CallingContext::Unspecified
+    }
+}
+
+/// Utility to find the union of calling contexts.
+pub fn promote_calling_context(from: CallingContext, to: CallingContext) -> CallingContext {
+    match (from, to) {
+        (CallingContext::Unspecified, CallingContext::InternalOnly) => CallingContext::InternalOnly,
+        _otherwise => to,
+    }
+}

--- a/sway-core/src/parse_tree/declaration/trait.rs
+++ b/sway-core/src/parse_tree/declaration/trait.rs
@@ -1,7 +1,7 @@
 use super::{FunctionDeclaration, FunctionParameter};
 
 use crate::{
-    function::Purity,
+    function::{CallingContext, Purity},
     parse_tree::{CallPath, Visibility},
     type_engine::TypeInfo,
 };
@@ -26,6 +26,7 @@ pub(crate) struct Supertrait {
 pub struct TraitFn {
     pub name: Ident,
     pub purity: Purity,
+    pub context: CallingContext,
     pub parameters: Vec<FunctionParameter>,
     pub return_type: TypeInfo,
     pub(crate) return_type_span: Span,

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -460,6 +460,7 @@ impl CopyTypes for TypedConstantDeclaration {
 pub struct TypedTraitFn {
     pub name: Ident,
     pub(crate) purity: Purity,
+    pub(crate) context: CallingContext,
     pub(crate) parameters: Vec<TypedFunctionParameter>,
     pub return_type: TypeId,
     #[derivative(PartialEq = "ignore")]
@@ -481,6 +482,7 @@ impl TypedTraitFn {
     pub(crate) fn to_dummy_func(&self, mode: Mode) -> TypedFunctionDeclaration {
         TypedFunctionDeclaration {
             purity: self.purity,
+            calling_context: self.context,
             name: self.name.clone(),
             body: TypedCodeBlock { contents: vec![] },
             parameters: self.parameters.clone(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -188,6 +188,7 @@ fn convert_trait_methods_to_dummy_funcs(
                  ..
              }| TypedFunctionDeclaration {
                 purity: Default::default(),
+                calling_context: Default::default(),
                 name: name.clone(),
                 body: TypedCodeBlock { contents: vec![] },
                 parameters: parameters

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -37,6 +37,18 @@ pub(crate) fn instantiate_function_application(
         });
     }
 
+    // 'calling_context' is that of the callee, 'opts.calling_context' of the caller.
+    if !ctx
+        .calling_context()
+        .can_call(function_decl.calling_context)
+    {
+        errors.push(CompileError::CallingContextMismatch {
+            attrs: promote_calling_context(ctx.calling_context(), function_decl.calling_context)
+                .to_attribute_syntax(),
+            span: call_path.span(),
+        });
+    }
+
     // check that the number of parameters and the number of the arguments is the same
     check!(
         check_function_arguments_arity(arguments.len(), &function_decl, &call_path),
@@ -175,6 +187,7 @@ fn instantiate_function_application_inner(
             function_body: function_decl.body.clone(),
             function_body_name_span: function_decl.name.span(),
             function_body_purity: function_decl.purity,
+            function_body_calling_context: function_decl.calling_context,
             self_state_idx,
             selector,
         },

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -54,6 +54,16 @@ pub(crate) fn type_check_method_application(
                 span: method_name.easy_name().span(),
             });
         }
+
+        // 'method.calling_context' is that of the callee, 'opts.calling_context' of the caller.
+        if !ctx.calling_context().can_call(method.calling_context) {
+            errors.push(CompileError::CallingContextMismatch {
+                attrs: promote_calling_context(ctx.calling_context(), method.calling_context)
+                    .to_attribute_syntax(),
+                span: method_name.easy_name().span(),
+            });
+        }
+
         if !contract_call_params.is_empty() {
             errors.push(CompileError::CallParamForNonContractCallMethod {
                 span: contract_call_params[0].name.span(),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -23,6 +23,7 @@ pub enum TypedExpressionVariant {
         function_body: TypedCodeBlock,
         function_body_name_span: Span,
         function_body_purity: Purity,
+        function_body_calling_context: CallingContext,
         /// If this is `Some(val)` then `val` is the metadata. If this is `None`, then
         /// there is no selector.
         self_state_idx: Option<StateIndex>,

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -701,12 +701,14 @@ fn type_check_interface_surface(
             |TraitFn {
                  name,
                  purity,
+                 context,
                  parameters,
                  return_type,
                  return_type_span,
              }| TypedTraitFn {
                 name,
                 purity,
+                context,
                 return_type_span: return_type_span.clone(),
                 parameters: parameters
                     .into_iter()
@@ -769,6 +771,7 @@ fn type_check_trait_methods(
         type_parameters,
         return_type_span,
         purity,
+        context,
         ..
     } in methods
     {
@@ -889,6 +892,7 @@ fn type_check_trait_methods(
         let ctx = ctx
             .by_ref()
             .with_purity(purity)
+            .with_context(context)
             .with_type_annotation(return_type)
             .with_help_text(
                 "Trait method body's return type does not match up with its return type \
@@ -914,6 +918,7 @@ fn type_check_trait_methods(
             return_type_span,
             is_contract_call: false,
             purity,
+            calling_context: context,
         });
     }
     ok(methods_buf, warnings, errors)
@@ -932,6 +937,7 @@ fn error_recovery_function_declaration(decl: FunctionDeclaration) -> TypedFuncti
     } = decl;
     TypedFunctionDeclaration {
         purity: Default::default(),
+        calling_context: Default::default(),
         name,
         body: TypedCodeBlock {
             contents: Default::default(),

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -1,4 +1,5 @@
 use crate::{
+    function::CallingContext,
     namespace::Path,
     parse_tree::declaration::Purity,
     semantic_analysis::{ast_node::Mode, Namespace},
@@ -46,6 +47,9 @@ pub struct TypeCheckContext<'ns> {
     /// Tracks the purity of the context, e.g. whether or not we should be allowed to write to
     /// storage.
     purity: Purity,
+    /// Tracks the calling context of the type check context, e.g. whether or not we should be
+    /// allowed to call into the context.
+    calling_context: CallingContext,
 }
 
 impl<'ns> TypeCheckContext<'ns> {
@@ -70,6 +74,7 @@ impl<'ns> TypeCheckContext<'ns> {
             self_type: insert_type(TypeInfo::Contract),
             mode: Mode::NonAbi,
             purity: Purity::default(),
+            calling_context: CallingContext::default(),
         }
     }
 
@@ -89,6 +94,7 @@ impl<'ns> TypeCheckContext<'ns> {
             mode: self.mode,
             help_text: self.help_text,
             purity: self.purity,
+            calling_context: self.calling_context,
         }
     }
 
@@ -101,6 +107,7 @@ impl<'ns> TypeCheckContext<'ns> {
             mode: self.mode,
             help_text: self.help_text,
             purity: self.purity,
+            calling_context: self.calling_context,
         }
     }
 
@@ -145,6 +152,14 @@ impl<'ns> TypeCheckContext<'ns> {
     }
 
     /// Map this `TypeCheckContext` instance to a new one with the given purity.
+    pub(crate) fn with_context(self, context: CallingContext) -> Self {
+        Self {
+            calling_context: context,
+            ..self
+        }
+    }
+
+    /// Map this `TypeCheckContext` instance to a new one with the given purity.
     pub(crate) fn with_self_type(self, self_type: TypeId) -> Self {
         Self { self_type, ..self }
     }
@@ -166,6 +181,10 @@ impl<'ns> TypeCheckContext<'ns> {
 
     pub(crate) fn purity(&self) -> Purity {
         self.purity
+    }
+
+    pub(crate) fn calling_context(&self) -> CallingContext {
+        self.calling_context
     }
 
     pub(crate) fn self_type(&self) -> TypeId {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_internal_only_in_script/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_internal_only_in_script/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'calling_context_internal_only_in_script'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_internal_only_in_script/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_internal_only_in_script/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "calling_context_internal_only_in_script"
+entry = "main.sw"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_internal_only_in_script/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_internal_only_in_script/src/main.sw
@@ -1,0 +1,14 @@
+script;
+
+#[context(internal_only)]
+fn bar() {}
+
+#[context(internal_only)]
+fn baz() {
+  bar();
+}
+
+#[context(internal_only)]
+fn main() {
+  baz();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_internal_only_in_script/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_internal_only_in_script/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: fn main() {
+# nextln: $()Internal function inside of non-contract. This function is only accessible from contracts.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_mismatch/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_mismatch/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'calling_context_mismatch'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_mismatch/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_mismatch/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "calling_context_mismatch"
+entry = "main.sw"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_mismatch/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_mismatch/src/main.sw
@@ -1,0 +1,12 @@
+script;
+
+#[context(internal_only)]
+fn bar() {}
+
+fn baz() {
+  bar();
+}
+
+fn main() {
+  baz();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_mismatch/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_mismatch/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: bar()
+# nextln: $()Calling context attribute mismatch. Try giving the surrounding function the same context by adding "#[context(internal_only)]" to the function declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_unknown/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_unknown/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'calling_context_unknown'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_unknown/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_unknown/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "calling_context_unknown"
+entry = "main.sw"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_unknown/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_unknown/src/main.sw
@@ -1,0 +1,8 @@
+script;
+
+#[context(unknown)]
+fn bar() {}
+
+fn main() {
+  bar();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_unknown/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/calling_context_unknown/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: #[context(unknown)]
+# nextln: $()invalid argument for 'context' attribute

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/calling_context_internal_in_contract/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/calling_context_internal_in_contract/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/calling_context_internal_in_contract/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/calling_context_internal_in_contract/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'calling_context_internal_in_contract'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/calling_context_internal_in_contract/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/calling_context_internal_in_contract/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "calling_context_internal_in_contract"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/calling_context_internal_in_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/calling_context_internal_in_contract/src/main.sw
@@ -1,0 +1,15 @@
+contract;
+
+#[context(internal_only)]
+fn bar() {}
+
+abi TestContract {
+    fn foo();
+}
+
+impl TestContract for Contract {
+    #[context(internal_only)]
+    fn foo() {
+      bar()
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/calling_context_internal_in_contract/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/calling_context_internal_in_contract/test.toml
@@ -1,0 +1,1 @@
+category = "compile"


### PR DESCRIPTION
Adds support for an attribute (i.e. `#[context(internal_only)]`) to annotate the supported calling contexts for particular functions.

This annotation is then be used by the compiler to check and restrict the calling of these functions to a compatible calling context.

The main goal is to be able to get compile-time safety when working with functions that should only be called from an internal (contract) context.

A real-world example of this is the [msg_amount() stdlib function](https://github.com/FuelLabs/sway-lib-std/blob/6a8f5bf588df5d0679fb834f05c900f2e54de426/src/context.sw#L33-L38) which only returns a proper value when used in an internal context. In an external context is returns a well-defined but not semantically representative value, specifically 0, as explained by @adlerjohn in [FueLabs/sway#963](https://github.com/FuelLabs/sway/issues/963).

Blocked by RFC https://github.com/FuelLabs/sway-rfcs/pull/9.