### PR TITLE
Account for characters that are larger than 1 byte when displaying warnings and errors

### DIFF
--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -383,23 +383,25 @@ fn construct_window<'a>(
     let mut lines_to_start_of_snippet = 0;
     let mut calculated_start_ix = None;
     let mut calculated_end_ix = None;
-    for (ix, character) in input.chars().enumerate() {
+    let mut pos = 0;
+    for character in input.chars() {
         if character == '\n' {
             current_line += 1
         }
 
         if current_line + NUM_LINES_BUFFER >= start.line && calculated_start_ix.is_none() {
-            calculated_start_ix = Some(ix);
+            calculated_start_ix = Some(pos);
             lines_to_start_of_snippet = current_line;
         }
 
         if current_line >= end.line + NUM_LINES_BUFFER && calculated_end_ix.is_none() {
-            calculated_end_ix = Some(ix);
+            calculated_end_ix = Some(pos);
         }
 
         if calculated_start_ix.is_some() && calculated_end_ix.is_some() {
             break;
         }
+        pos += character.len_utf8();
     }
     let calculated_start_ix = calculated_start_ix.unwrap_or(0);
     let calculated_end_ix = calculated_end_ix.unwrap_or(input.len());


### PR DESCRIPTION
closes https://github.com/FuelLabs/sway/issues/2266