### PR TITLE
Remove `Spanned` and add `Format` trait to `Punctuated`

### DIFF
--- a/sway-fmt-v2/src/utils/punctuated.rs
+++ b/sway-fmt-v2/src/utils/punctuated.rs
@@ -3,18 +3,18 @@ use crate::{
     FormatterError,
 };
 use std::fmt::Write;
-use sway_parse::{punctuated::Punctuated, StorageField, TypeField};
-use sway_types::Spanned;
+use sway_parse::{keywords::CommaToken, punctuated::Punctuated, StorageField, TypeField};
+use sway_types::{Ident, Spanned};
 
 impl<T, P> Format for Punctuated<T, P>
 where
-    T: Spanned,
-    P: Spanned,
+    T: Format,
+    P: Format,
 {
     fn format(
         &self,
         formatted_code: &mut FormattedCode,
-        _formatter: &mut Formatter,
+        formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         // format and add Type & Punct
         let value_pairs = &self.value_separator_pairs;
@@ -22,19 +22,26 @@ where
         // Later on we may want to handle instances
         // where the user wants to keep the trailing commas.
         for pair in value_pairs.iter() {
-            write!(
-                formatted_code,
-                "{}{} ",
-                pair.0.span().as_str(),
-                pair.1.span().as_str(),
-            )?;
+            pair.0.format(formatted_code, formatter)?;
+            pair.1.format(formatted_code, formatter)?;
         }
 
         // add final value, if any
         if let Some(final_value) = &self.final_value_opt {
-            write!(formatted_code, "{}", final_value.span().as_str())?;
+            final_value.format(formatted_code, formatter)?;
         }
 
+        Ok(())
+    }
+}
+
+impl Format for Ident {
+    fn format(
+        &self,
+        formatted_code: &mut FormattedCode,
+        _formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
+        write!(formatted_code, "{}", self.span().as_str())?;
         Ok(())
     }
 }
@@ -69,6 +76,17 @@ impl Format for StorageField {
             self.colon_token.span().as_str(),
             self.ty.span().as_str()
         )?;
+        Ok(())
+    }
+}
+
+impl Format for CommaToken {
+    fn format(
+        &self,
+        formatted_code: &mut FormattedCode,
+        _formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
+        write!(formatted_code, "{}", self.span().as_str())?;
         Ok(())
     }
 }

--- a/sway-fmt-v2/src/utils/punctuated.rs
+++ b/sway-fmt-v2/src/utils/punctuated.rs
@@ -86,7 +86,7 @@ impl Format for CommaToken {
         formatted_code: &mut FormattedCode,
         _formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        write!(formatted_code, "{}", self.span().as_str())?;
+        write!(formatted_code, "{} ", self.span().as_str())?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR removes the `Spanned` trait in favor of the `Format` trait to allow dynamic formatting for type `T` and `P` on `Punctuated`.