### PR TITLE
Switch the order of the fields for `Option` from `Some` followed by `None` to `None` followed by `Some`

### DIFF
--- a/sway-lib-std/src/option.sw
+++ b/sway-lib-std/src/option.sw
@@ -11,11 +11,11 @@ use ::revert::revert;
 /// `Option` is a type that represents either the existence of a value ([`Some`]) or a value's absence
 /// ([`None`]).
 pub enum Option<T> {
-    /// Contains the value
-    Some: T,
-
     /// Signifies the absence of a value
     None: (),
+    
+    /// Contains the value
+    Some: T,
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Changes made

- Changed Option field order from (1) to (2)

(1)

```rust
pub enum Option<T> {
    /// Contains the value
    Some: T,

    /// Signifies the absence of a value
    None: (),
}
```

(2)

```rust
pub enum Option<T> {
    /// Signifies the absence of a value
    None: (),
    
    /// Contains the value
    Some: T,
}
```

## Related

Closes #2326 