### PR TITLE
Improve opt binary in `sway-ir`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3676,7 +3676,6 @@ dependencies = [
  "generational-arena",
  "peg",
  "sway-types",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,6 +3672,7 @@ dependencies = [
 name = "sway-ir"
 version = "0.18.1"
 dependencies = [
+ "anyhow",
  "filecheck",
  "generational-arena",
  "peg",

--- a/sway-ir/Cargo.toml
+++ b/sway-ir/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/FuelLabs/sway"
 description = "Sway intermediate representation."
 
 [dependencies]
+anyhow = "1.0"
 filecheck = "0.5"
 generational-arena = "0.2"
 peg = "0.7"

--- a/sway-ir/Cargo.toml
+++ b/sway-ir/Cargo.toml
@@ -13,4 +13,3 @@ filecheck = "0.5"
 generational-arena = "0.2"
 peg = "0.7"
 sway-types = { version = "0.18.1", path = "../sway-types" }
-tracing = "0.1"

--- a/sway-ir/src/bin/opt.rs
+++ b/sway-ir/src/bin/opt.rs
@@ -51,7 +51,7 @@ fn read_from_input(path_str: &Option<String>) -> std::io::Result<String> {
 fn write_to_output<S: Into<String>>(ir_str: S, path_str: &Option<String>) -> std::io::Result<()> {
     match path_str {
         None => {
-            tracing::info!("{}", ir_str.into());
+            println!("{}", ir_str.into());
             Ok(())
         }
         Some(path_str) => {

--- a/sway-ir/src/error.rs
+++ b/sway-ir/src/error.rs
@@ -53,6 +53,8 @@ pub enum IrError {
     VerifyUntypedValuePassedToFunction,
 }
 
+impl std::error::Error for IrError {}
+
 use std::fmt;
 
 impl fmt::Display for IrError {


### PR DESCRIPTION
This started out as a quick fix to switch `sway-ir` from `tracing` back to `println`, but then @mohammadfawaz did some of it in #2335.  It only needed the `opt` binary to be switched too, and then I thought I'd fix the error reporting a bit while I was in there.