### PR TITLE
Fix bug in translating `if-let` without an `else` to `match`.

### DIFF
--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -2215,7 +2215,15 @@ fn if_expr_to_expression(
                         scrutinee: Scrutinee::CatchAll {
                             span: else_block_span.clone(),
                         },
-                        result: then_block,
+                        // If there's no else in an `if-let` expression,
+                        // then the else is equivalent to an empty block.
+                        result: Expression::CodeBlock {
+                            contents: CodeBlock {
+                                contents: vec![],
+                                whole_block_span: else_block_span.clone(),
+                            },
+                            span: else_block_span.clone(),
+                        },
                         span: else_block_span,
                     }
                 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.lock
@@ -1,4 +1,14 @@
 [[package]]
 name = 'chained_if_let_missing_branch'
 source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+source = 'path+from-root-1D19A81536866BDD'
 dependencies = []
+
+[[package]]
+name = 'std'
+source = 'path+from-root-1D19A81536866BDD'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/Forc.toml
@@ -4,3 +4,6 @@ entry = "main.sw"
 license = "Apache-2.0"
 name = "chained_if_let_missing_branch"
 implicit-std = false
+
+[dependencies]
+std = { path = "../../../../../..//sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/test.toml
@@ -1,3 +1,6 @@
 category = "fail"
 
-# check: $()Variable "num" does not exist in this scope.
+# check: $()Mismatched types
+# nextln: $()expected: u64
+# nextln: $()found:    ()
+

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let/Forc.lock
@@ -6,4 +6,12 @@ dependencies = []
 [[package]]
 name = 'enum_if_let'
 source = 'root'
+dependencies = [
+    'core',
+    'std',
+]
+
+[[package]]
+name = 'std'
+source = 'path+from-root-70323834FF9E0867'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let/Forc.toml
@@ -6,3 +6,4 @@ name = "enum_if_let"
 
 [dependencies]
 core = { path = "../../../../../../../sway-lib-core" }
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let/src/main.sw
@@ -1,14 +1,40 @@
 script;
 
+use std::{address::Address, assert::assert, identity::Identity};
+
 enum Result<T, E> {
-  Ok: T,
-  Err: E,
+    Ok: T,
+    Err: E,
 }
 
-fn main() -> u64 {
-   let x: Result<u64, u64> = Result::Ok::<u64, u64>(5u64);
+const B1 = Address {
+    value: 0x0100000000000000000000000000000000000000000000000000000000000010
+};
 
-   let result_1 = if let Result::Ok(x) = x { 100 } else { 1 };
-   let result_2 = if let Result::Err(x) = x { 3 } else { 43 };
-   result_1 + result_2
+fn main() -> u64 {
+    let sender = Identity::Address(B1);
+    if let Identity::Address(addr1) = sender {
+        match sender {
+            Identity::Address(addr2) => {
+                assert(addr1 == addr2);
+            }
+            _ => {
+                assert(false);
+            }
+        }
+    };
+
+    let x: Result<u64, u64> = Result::Ok::<u64, u64>(5u64);
+
+    let result_1 = if let Result::Ok(x) = x {
+        100
+    } else {
+        1
+    };
+    let result_2 = if let Result::Err(x) = x {
+        3
+    } else {
+        43
+    };
+    result_1 + result_2
 }


### PR DESCRIPTION
Issue #2322