### PR TITLE
Fix `Span` end for unclosed multiline comments and unclosed string literals

### DIFF
--- a/sway-parse/src/token.rs
+++ b/sway-parse/src/token.rs
@@ -403,7 +403,7 @@ pub fn lex_commented(
                         let span = Span::new(
                             src.clone(),
                             *unclosed_indices.last().unwrap(),
-                            src.len(),
+                            src.len() - 1,
                             path.clone(),
                         )
                         .unwrap();
@@ -562,7 +562,8 @@ pub fn lex_commented(
                     None => {
                         return Err(LexError {
                             kind: LexErrorKind::UnclosedStringLiteral { position: index },
-                            span: Span::new(src.clone(), index, src.len(), path.clone()).unwrap(),
+                            span: Span::new(src.clone(), index, src.len() - 1, path.clone())
+                                .unwrap(),
                         });
                     }
                 };

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_multiline_comment/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_multiline_comment/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'unclosed_multiline_comment'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_multiline_comment/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_multiline_comment/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "unclosed_multiline_comment"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_multiline_comment/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_multiline_comment/src/main.sw
@@ -1,0 +1,5 @@
+script;
+
+/*fn main() {
+    let x = 0; 
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_multiline_comment/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_multiline_comment/test.toml
@@ -1,0 +1,5 @@
+category = "fail"
+
+# check: $()let x = 0;
+# nextln: $()} 
+# nextln: $()unclosed multiline comment 

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_string_literal/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_string_literal/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'unclosed_string_literal'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_string_literal/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_string_literal/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "unclosed_string_literal"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_string_literal/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_string_literal/src/main.sw
@@ -1,0 +1,5 @@
+script;
+
+fn main() {
+    let x = "a
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_string_literal/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unclosed_string_literal/test.toml
@@ -1,0 +1,6 @@
+category = "fail"
+
+# check: $()let x = "a
+# nextln: $()
+# nextln: $()} 
+# nextln: $()unclosed string literal


### PR DESCRIPTION
Closes #704 

Low priority bug fix but it's very simple fix so I just did it.