### PR TITLE
Fix lexing of multiline comments to include the trailing '/'

### DIFF
--- a/sway-fmt-v2/src/utils/comments.rs
+++ b/sway-fmt-v2/src/utils/comments.rs
@@ -163,7 +163,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             found_comment.1.span.as_str(),
-            "/* multi-\n             * line-\n             * comment *"
+            "/* multi-\n             * line-\n             * comment */"
         );
     }
 }

--- a/sway-parse/src/token.rs
+++ b/sway-parse/src/token.rs
@@ -418,9 +418,9 @@ pub fn lex_commented(
                             None => return Err(unclosed_multiline_comment(unclosed_indices)),
                             Some((_, '*')) => match char_indices.next() {
                                 None => return Err(unclosed_multiline_comment(unclosed_indices)),
-                                Some((end, '/')) => {
-                                    let _ = char_indices.next();
+                                Some((slash_ix, '/')) => {
                                     let start = unclosed_indices.pop().unwrap();
+                                    let end = slash_ix + '/'.len_utf8();
                                     let span =
                                         Span::new(src.clone(), start, end, path.clone()).unwrap();
                                     let comment = Comment { span };
@@ -1135,7 +1135,7 @@ mod tests {
             let mut tts = group.token_stream.token_trees().iter();
             assert_eq!(
                 tts.next().unwrap().span().as_str(),
-                "/* multi-\n             * line-\n             * comment *",
+                "/* multi-\n             * line-\n             * comment */",
             );
             assert_eq!(tts.next().unwrap().span().as_str(), "bar");
             assert_eq!(tts.next().unwrap().span().as_str(), ":");


### PR DESCRIPTION
Previously, both the implementation and the test missed the trailing
slash during lexing. This fixes both, closes #2355 and unblocks #2311.