### PR TITLE
Attempt to workaround unused-deps CI error by updating mdbook to 0.4.20 and applying upstream patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2133,8 +2133,7 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 [[package]]
 name = "mdbook"
 version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13cdad8057b09a519c6c63e6d7c93ea854f5d7fbfe284df864d5e1140d215a2d"
+source = "git+https://github.com/mitchmindtree/mdBook?branch=nightly-borrowcheck-err-workaround#13035baeae417e41ce98f49c072220de0e6e4075"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,9 +2132,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "mdbook"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2468f3c25ca56d4e9e309b94a1a61626aa2a66a68d0649477f6a9fb14de972"
+checksum = "13cdad8057b09a519c6c63e6d7c93ea854f5d7fbfe284df864d5e1140d215a2d"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,8 @@ exclude = [
 
 [profile.dev.package.sway-lsp]
 debug = 2
+
+[patch.crates-io]
+# A workaround for a bug in mdbook `0.4.20` introduced by some breakage in rustc 1.64.0-nightly (62b272d25 2022-07-21).
+# This should be removed when either this PR https://github.com/rust-lang/mdBook/pull/1861 or a related fix is published.
+mdbook = { git = "https://github.com/mitchmindtree/mdBook", branch = "nightly-borrowcheck-err-workaround" }


### PR DESCRIPTION
The unused deps CI check has started failing on unrelated PRs recently, e.g. https://github.com/FuelLabs/sway/pull/2359#issuecomment-1192097008.

Seeing if updating mdbook addresses nightly-Rust's new borrow-check concerns.