### PR TITLE
Search locally for git sources before fetching them in online mode

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1333,11 +1333,39 @@ fn pin_pkg(
                     commit_hash,
                 };
                 (pinned_git, local_path)
-            } else {
+            } else if let GitReference::DefaultBranch | GitReference::Branch(_) =
+                git_source.reference
+            {
+                // If the reference is to a branch or to the default branch we need to fetch
+                // from remote even though we may have it locally. Because remote may contain a
+                // newer commit.
                 let pinned_git = pin_git(fetch_id, &name, git_source.clone())?;
                 let repo_path =
                     git_commit_path(&name, &pinned_git.source.repo, &pinned_git.commit_hash);
                 (pinned_git, repo_path)
+            } else {
+                // If we are in online mode and the reference is to a specific commit (tag or
+                // rev) we can first search it locally and re-use it.
+                match search_git_source_locally(&name, git_source) {
+                    Ok(Some((local_path, commit_hash))) => {
+                        let pinned_git = SourceGitPinned {
+                            source: git_source.clone(),
+                            commit_hash,
+                        };
+                        (pinned_git, local_path)
+                    }
+                    _ => {
+                        // If the checkout we are looking for does not exists locally or an
+                        // error happened during the search fetch it
+                        let pinned_git = pin_git(fetch_id, &name, git_source.clone())?;
+                        let repo_path = git_commit_path(
+                            &name,
+                            &pinned_git.source.repo,
+                            &pinned_git.commit_hash,
+                        );
+                        (pinned_git, repo_path)
+                    }
+                }
             };
             let source = SourcePinned::Git(pinned_git.clone());
             let pinned = Pinned { name, source };


### PR DESCRIPTION
closes #2365.

Searching locally for checkouts is faster than fetching whole repo (at least it is the case for sway repo for std dependency). 
So if the user already fetched a checkout looking for it locally first speeds-up the overall building process but if the git reference is to a branch or default branch, the remote may have a newer commit than the one we have locally. So with this PR, we are first checking if the git reference is to a specific commit (i.e: a tag or rev reference) if that is the case before fetching from remote, we are looking locally. After searching locally if we couldn't find the exact local checkout or an error happened we fallback to fetching from remote. For non specific git references (such as branch or default branch) we are directly fetching from remote to get the latest.


#### My little benchmark (project implicitly depending on std, latest tag already fetched before, lock file does not exists):

**Before this PR:** 3.45 seconds
**After this PR:** 1.82 seconds

## TODO

- [x] Merge #2366