### PR TITLE
Fix concurrency bug in ConcurrentSlab.replace.

### DIFF
--- a/sway-core/src/concurrent_slab.rs
+++ b/sway-core/src/concurrent_slab.rs
@@ -23,11 +23,20 @@ where
     }
 
     pub fn replace(&self, index: TypeId, prev_value: &T, new_value: T) -> Option<T> {
-        let mut inner = self.inner.write().unwrap();
-        let actual_prev_value = &inner[*index];
-        if actual_prev_value != prev_value {
-            return Some(actual_prev_value.clone());
+        // The comparison below ends up calling functions in the slab, which
+        // can lead to deadlocks if we used a single read/write lock.
+        // So we split the operation: we do the read only operations with
+        // a single scoped read lock below, and only after the scope do
+        // we get a write lock for writing into the slab.
+        {
+            let inner = self.inner.read().unwrap();
+            let actual_prev_value = &inner[*index];
+            if actual_prev_value != prev_value {
+                return Some(actual_prev_value.clone());
+            }
         }
+
+        let mut inner = self.inner.write().unwrap();
         inner[*index] = new_value;
         None
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_ret/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_ret/Forc.lock
@@ -1,0 +1,17 @@
+[[package]]
+name = 'contract_caller_as_ret'
+source = 'root'
+dependencies = [
+    'core',
+    'std',
+]
+
+[[package]]
+name = 'core'
+source = 'path+from-root-277F468596DF2097'
+dependencies = []
+
+[[package]]
+name = 'std'
+source = 'path+from-root-277F468596DF2097'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_ret/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_ret/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "contract_caller_as_ret"
+entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_ret/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_ret/json_abi_oracle.json
@@ -1,0 +1,15 @@
+[
+  {
+    "inputs": [],
+    "name": "test_function",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "bool",
+        "typeArguments": null
+      }
+    ],
+    "type": "function"
+  }
+]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_ret/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_ret/src/main.sw
@@ -1,0 +1,16 @@
+contract;
+use std::contract_id::ContractId;
+
+abi MyContract {
+    fn test_function() -> bool;
+}
+
+impl MyContract for Contract {
+    fn test_function() -> bool {
+        true
+    }
+}
+
+fn caller(address: ContractId) -> ContractCaller<_> {
+  abi(MyContract, address.value)
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_ret/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_ret/test.toml
@@ -1,0 +1,2 @@
+category = "compile"
+validate_abi = true


### PR DESCRIPTION
We get the following panic during `ConcurrentSlab.replace` execution:

```
thread 'main' panicked at 'rwlock read lock would result in deadlock',
/rustc/ddcbba036aee08f0709f98a92a342a278eae5c05/library/std/src/sys/unix/locks/pthread_rwlock.rs:72:13
```

This happens due to `operator !=`, we call `PartialEq` and eventually end up calling `ConcurrentSlab.get`, which fails due to existing read/write lock already on the stack.

The fix is to make sure to get a read lock only, do the comparison, and then get a read/write lock just for the write.

Closes https://github.com/FuelLabs/sway/issues/2341.