### PR TITLE
Return the local struct Span as a new field on `TypedExpressionVariant::StructExpression`

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -821,6 +821,7 @@ fn connect_expression(
         StructExpression {
             struct_name,
             fields,
+            ..
         } => {
             let decl = match graph.namespace.find_struct_decl(struct_name.as_str()) {
                 Some(ix) => *ix,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -954,13 +954,15 @@ impl TypedExpression {
 
         // extract the struct name and fields from the type info
         let type_info = look_up_type_id(type_id);
-        let (struct_name, struct_fields) = check!(
+        let struct_fields = check!(
             type_info.expect_struct(&span),
             return err(warnings, errors),
             warnings,
             errors
         );
         let mut struct_fields = struct_fields.clone();
+
+        let struct_name = Ident::new(call_path_binding.inner.suffix.1.clone());
 
         // match up the names with their type annotations from the declaration
         let mut typed_fields_buf = vec![];
@@ -1019,7 +1021,7 @@ impl TypedExpression {
         }
         let exp = TypedExpression {
             expression: TypedExpressionVariant::StructExpression {
-                struct_name: struct_name.clone(),
+                struct_name,
                 fields: typed_fields_buf,
             },
             return_type: type_id,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -954,15 +954,13 @@ impl TypedExpression {
 
         // extract the struct name and fields from the type info
         let type_info = look_up_type_id(type_id);
-        let struct_fields = check!(
+        let (struct_name, struct_fields) = check!(
             type_info.expect_struct(&span),
             return err(warnings, errors),
             warnings,
             errors
         );
         let mut struct_fields = struct_fields.clone();
-
-        let struct_name = Ident::new(call_path_binding.inner.suffix.1.clone());
 
         // match up the names with their type annotations from the declaration
         let mut typed_fields_buf = vec![];
@@ -1021,8 +1019,9 @@ impl TypedExpression {
         }
         let exp = TypedExpression {
             expression: TypedExpressionVariant::StructExpression {
-                struct_name,
+                struct_name: struct_name.clone(),
                 fields: typed_fields_buf,
+                span: call_path_binding.inner.suffix.1.clone(),
             },
             return_type: type_id,
             is_constant: IsConstant::No,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -49,6 +49,7 @@ pub enum TypedExpressionVariant {
     StructExpression {
         struct_name: Ident,
         fields: Vec<TypedStructExpressionField>,
+        span: Span,
     },
     CodeBlock(TypedCodeBlock),
     // a flag that this value will later be provided as a parameter, but is currently unknown
@@ -177,12 +178,18 @@ impl PartialEq for TypedExpressionVariant {
                 Self::StructExpression {
                     struct_name: l_struct_name,
                     fields: l_fields,
+                    span: l_span,
                 },
                 Self::StructExpression {
                     struct_name: r_struct_name,
                     fields: r_fields,
+                    span: r_span,
                 },
-            ) => l_struct_name == r_struct_name && l_fields.clone() == r_fields.clone(),
+            ) => {
+                l_struct_name == r_struct_name
+                    && l_fields.clone() == r_fields.clone()
+                    && l_span == r_span
+            }
             (Self::CodeBlock(l0), Self::CodeBlock(r0)) => l0 == r0,
             (
                 Self::IfExp {

--- a/sway-core/src/type_engine/type_info.rs
+++ b/sway-core/src/type_engine/type_info.rs
@@ -1276,14 +1276,11 @@ impl TypeInfo {
     /// and return its contents.
     ///
     /// Returns an error if `self` is not a `TypeInfo::Struct`.
-    pub(crate) fn expect_struct(
-        &self,
-        debug_span: &Span,
-    ) -> CompileResult<(&Ident, &Vec<TypedStructField>)> {
+    pub(crate) fn expect_struct(&self, debug_span: &Span) -> CompileResult<&Vec<TypedStructField>> {
         let warnings = vec![];
         let errors = vec![];
         match self {
-            TypeInfo::Struct { name, fields, .. } => ok((name, fields), warnings, errors),
+            TypeInfo::Struct { fields, .. } => ok(fields, warnings, errors),
             TypeInfo::ErrorRecovery => err(warnings, errors),
             a => err(
                 vec![],

--- a/sway-core/src/type_engine/type_info.rs
+++ b/sway-core/src/type_engine/type_info.rs
@@ -1276,11 +1276,14 @@ impl TypeInfo {
     /// and return its contents.
     ///
     /// Returns an error if `self` is not a `TypeInfo::Struct`.
-    pub(crate) fn expect_struct(&self, debug_span: &Span) -> CompileResult<&Vec<TypedStructField>> {
+    pub(crate) fn expect_struct(
+        &self,
+        debug_span: &Span,
+    ) -> CompileResult<(&Ident, &Vec<TypedStructField>)> {
         let warnings = vec![];
         let errors = vec![];
         match self {
-            TypeInfo::Struct { fields, .. } => ok(fields, warnings, errors),
+            TypeInfo::Struct { name, fields, .. } => ok((name, fields), warnings, errors),
             TypeInfo::ErrorRecovery => err(warnings, errors),
             a => err(
                 vec![],

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -230,11 +230,8 @@ fn handle_expression(expression: &TypedExpression, tokens: &TokenMap) {
             handle_expression(prefix, tokens);
             handle_expression(index, tokens);
         }
-        TypedExpressionVariant::StructExpression {
-            ref struct_name,
-            ref fields,
-        } => {
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(struct_name)) {
+        TypedExpressionVariant::StructExpression { fields, span, .. } => {
+            if let Some(mut token) = tokens.get_mut(&to_ident_key(&Ident::new(span.clone()))) {
                 token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
             }
 


### PR DESCRIPTION
This PR uses the local span of the call_path_binding to create a `Span` for the `TypedExpressionVariant::StructExpression`. Previously it was only passing along the `Ident` of the declaration which would prohibit the token from being collected in the language server. 

closes #2372 