### PR TITLE
Store the enum instantiation span within the EnumInstantiation variant 

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1222,6 +1222,7 @@ impl TypedExpression {
         let mut enum_probe_errors = vec![];
         let maybe_enum = {
             let call_path_binding = call_path_binding.clone();
+            let enum_name = call_path_binding.inner.prefixes[0].clone();
             let variant_name = call_path_binding.inner.suffix.clone();
             let enum_call_path = call_path_binding.inner.rshift();
             let mut call_path_binding = TypeBinding {
@@ -1232,16 +1233,16 @@ impl TypedExpression {
             TypeBinding::type_check_with_ident(&mut call_path_binding, &ctx)
                 .flat_map(|unknown_decl| unknown_decl.expect_enum().cloned())
                 .ok(&mut enum_probe_warnings, &mut enum_probe_errors)
-                .map(|enum_decl| (enum_decl, variant_name))
+                .map(|enum_decl| (enum_decl, enum_name, variant_name))
         };
 
         // compare the results of the checks
         let exp = match (is_module, maybe_function, maybe_enum) {
-            (false, None, Some((enum_decl, variant_name))) => {
+            (false, None, Some((enum_decl, enum_name, variant_name))) => {
                 warnings.append(&mut enum_probe_warnings);
                 errors.append(&mut enum_probe_errors);
                 check!(
-                    instantiate_enum(ctx, enum_decl, variant_name, args),
+                    instantiate_enum(ctx, enum_decl, enum_name, variant_name, args),
                     return err(warnings, errors),
                     warnings,
                     errors

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -8,6 +8,7 @@ use sway_types::{Ident, Spanned};
 pub(crate) fn instantiate_enum(
     ctx: TypeCheckContext,
     enum_decl: TypedEnumDeclaration,
+    enum_name: Ident,
     enum_variant_name: Ident,
     args: Vec<Expression>,
 ) -> CompileResult<TypedExpression> {
@@ -35,7 +36,8 @@ pub(crate) fn instantiate_enum(
                     contents: None,
                     enum_decl,
                     variant_name: enum_variant.name,
-                    instantiation_span: enum_variant_name.span(),
+                    enum_instantiation_span: enum_name.span(),
+                    variant_instantiation_span: enum_variant_name.span(),
                 },
                 is_constant: IsConstant::No,
                 span: enum_variant_name.span(),
@@ -65,7 +67,8 @@ pub(crate) fn instantiate_enum(
                         contents: Some(Box::new(typed_expr)),
                         enum_decl,
                         variant_name: enum_variant.name,
-                        instantiation_span: enum_variant_name.span(),
+                        enum_instantiation_span: enum_name.span(),
+                        variant_instantiation_span: enum_variant_name.span(),
                     },
                     is_constant: IsConstant::No,
                     span: enum_variant_name.span(),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -86,7 +86,8 @@ pub enum TypedExpressionVariant {
         tag: usize,
         contents: Option<Box<TypedExpression>>,
         /// If there is an error regarding this instantiation of the enum,
-        /// use this span as it points to the call site and not the declaration.
+        /// use these spans as it points to the call site and not the declaration.
+        /// They are also used in the language server.
         enum_instantiation_span: Span,
         variant_instantiation_span: Span,
     },

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -87,7 +87,8 @@ pub enum TypedExpressionVariant {
         contents: Option<Box<TypedExpression>>,
         /// If there is an error regarding this instantiation of the enum,
         /// use this span as it points to the call site and not the declaration.
-        instantiation_span: Span,
+        enum_instantiation_span: Span,
+        variant_instantiation_span: Span,
     },
     AbiCast {
         abi_name: CallPath,


### PR DESCRIPTION
This PR stores the instantiation span of the enum in the `TypedExpressionVariant::EnumInstantiation` variant. Previously only the declaration Ident was stored. This field has been added to capture the typed token in the language server. 