### PR TITLE
Set the CallPath prefix of `FunctionApplication` to call_path_binding suffix

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -215,11 +215,19 @@ pub(crate) fn type_check_method_application(
         MethodName::FromType {
             call_path_binding,
             method_name,
-        } => CallPath {
-            prefixes: call_path_binding.inner.prefixes,
-            suffix: method_name,
-            is_absolute: call_path_binding.inner.is_absolute,
-        },
+        } => {
+            let prefixes =
+                if let (TypeInfo::Custom { name, .. }, ..) = &call_path_binding.inner.suffix {
+                    vec![name.clone()]
+                } else {
+                    call_path_binding.inner.prefixes
+                };
+            CallPath {
+                prefixes,
+                suffix: method_name,
+                is_absolute: call_path_binding.inner.is_absolute,
+            }
+        }
         MethodName::FromModule { method_name } => CallPath {
             prefixes: vec![],
             suffix: method_name,


### PR DESCRIPTION
Previously, the `prefixes` field of `CallPath` was always set to `call_path_binding.inner.prefixes`. However, this always is an empty Vec. 

I confirmed this by putting in an `asert!(call_path_binding.inner.prefixes.len==0)` and running all the e2e tests. 

The motivation behind this change is to collect the `Ident` of the Struct name in the language server. Consider the following line:
```
let p = ~MyStruct::new();
```

the `prefixes` field now = `MyStruct`
and the `suffix` field = `new`