### PR TITLE
Fix parse tree regression handling while loop body implicit returns.

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_fail/while_implicit_ret/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/while_implicit_ret/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'while_implicit_ret'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/while_implicit_ret/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/while_implicit_ret/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "while_implicit_ret"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/while_implicit_ret/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/while_implicit_ret/src/main.sw
@@ -1,0 +1,7 @@
+script;
+
+fn main() -> u64 {
+    while true {
+        true
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/while_implicit_ret/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/while_implicit_ret/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# unordered: $()Implicit return must match up with block's type.
+# unordered: $()A while loop's loop body cannot implicitly return a value. Try assigning it to a mutable variable declared outside of the loop instead.


### PR DESCRIPTION
Take the following code as an example:

```rust
fn main() -> u64 {
    while true {
        true
    }
}
```

We were converting the body of the while to:

`CodeBlock { contents: [Expression(Literal { value: Boolean(true) })]}`

After these changes, we now convert this to:

`CodeBlock { contents: [ImplicitReturnExpression(Literal { value:
Boolean(true) })]}`

After which the existing sema checking code can correctly issue errors:

```

error
 --> main.sw:5:9
  |
3 | 
4 |     while true {
5 |         true
  |         ^^^^ Mismatched types.
expected: ()
found:    bool.
help: Implicit return must match up with block's type.
6 |     }
7 | }
  |
____

error
 --> main.sw:5:9
  |
3 | 
4 |     while true {
5 |         true
  |         ^^^^ Mismatched types.
expected: ()
found:    bool.
help: A while loop's loop body cannot implicitly return a value. Try assigning it to a mutable variable declared outside of the loop instead.
6 |     }
7 | }
  |
____
```

Closes https://github.com/FuelLabs/sway/issues/2401.