### PR TITLE
Removed angle bracket trait from sway-fmt-v2

### DIFF
--- a/sway-fmt-v2/src/utils/bracket.rs
+++ b/sway-fmt-v2/src/utils/bracket.rs
@@ -1,7 +1,9 @@
 //! The purpose of this file is to house the traits and associated functions for formatting opening and closing delimiters.
 //! This allows us to avoid matching a second time for the `ItemKind` and keeps the code pertaining to individual formatting
 //! contained to each item's file.
-use crate::{fmt::FormattedCode, Formatter, FormatterError};
+use crate::fmt::*;
+use std::fmt::Write;
+use sway_parse::token::PunctKind;
 
 pub(crate) trait CurlyBrace {
     /// Handles brace open scenerio. Checks the config for the placement of the brace.
@@ -44,4 +46,18 @@ pub(crate) trait Parenthesis {
         line: &mut FormattedCode,
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError>;
+}
+
+pub(crate) fn open_angle_bracket(formatted_code: &mut FormattedCode) -> Result<(), FormatterError> {
+    write!(formatted_code, "{}", PunctKind::LessThan.as_char())?;
+
+    Ok(())
+}
+
+pub(crate) fn close_angle_bracket(
+    formatted_code: &mut FormattedCode,
+) -> Result<(), FormatterError> {
+    write!(formatted_code, "{}", PunctKind::GreaterThan.as_char())?;
+
+    Ok(())
 }

--- a/sway-fmt-v2/src/utils/bracket.rs
+++ b/sway-fmt-v2/src/utils/bracket.rs
@@ -45,17 +45,3 @@ pub(crate) trait Parenthesis {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError>;
 }
-
-pub trait AngleBracket {
-    fn open_angle_bracket(
-        self,
-        line: &mut FormattedCode,
-        formatter: &mut Formatter,
-    ) -> Result<(), FormatterError>;
-
-    fn close_angle_bracket(
-        self,
-        line: &mut FormattedCode,
-        formatter: &mut Formatter,
-    ) -> Result<(), FormatterError>;
-}

--- a/sway-fmt-v2/src/utils/generics.rs
+++ b/sway-fmt-v2/src/utils/generics.rs
@@ -1,6 +1,5 @@
 use crate::{
     fmt::{Format, FormattedCode, Formatter, FormatterError},
-    utils::bracket::AngleBracket,
 };
 use std::fmt::Write;
 use sway_parse::{GenericArgs, GenericParams};
@@ -19,39 +18,20 @@ impl Format for GenericParams {
         let params = self.parameters.clone().into_inner();
 
         // `<`
-        Self::open_angle_bracket(self.clone(), formatted_code, formatter)?;
-        // format and add parameters
-        params.format(formatted_code, formatter)?;
-        // `>`
-        Self::close_angle_bracket(self.clone(), formatted_code, formatter)?;
-
-        Ok(())
-    }
-}
-
-impl AngleBracket for GenericParams {
-    fn open_angle_bracket(
-        self,
-        line: &mut String,
-        _formatter: &mut Formatter,
-    ) -> Result<(), FormatterError> {
         write!(
-            line,
+            formatted_code,
             "{}",
             self.parameters.open_angle_bracket_token.span().as_str()
         )?;
-        Ok(())
-    }
-    fn close_angle_bracket(
-        self,
-        line: &mut String,
-        _formatter: &mut Formatter,
-    ) -> Result<(), FormatterError> {
+        // format and add parameters
+        params.format(formatted_code, formatter)?;
+        // `>`
         write!(
-            line,
+            formatted_code,
             "{}",
             self.parameters.close_angle_bracket_token.span().as_str()
         )?;
+
         Ok(())
     }
 }
@@ -66,39 +46,20 @@ impl Format for GenericArgs {
         let params = self.parameters.clone().into_inner();
 
         // `<`
-        Self::open_angle_bracket(self.clone(), formatted_code, formatter)?;
-        // format and add parameters
-        params.format(formatted_code, formatter)?;
-        // `>`
-        Self::close_angle_bracket(self.clone(), formatted_code, formatter)?;
-
-        Ok(())
-    }
-}
-
-impl AngleBracket for GenericArgs {
-    fn open_angle_bracket(
-        self,
-        line: &mut String,
-        _formatter: &mut Formatter,
-    ) -> Result<(), FormatterError> {
         write!(
-            line,
+            formatted_code,
             "{}",
             self.parameters.open_angle_bracket_token.span().as_str()
         )?;
-        Ok(())
-    }
-    fn close_angle_bracket(
-        self,
-        line: &mut String,
-        _formatter: &mut Formatter,
-    ) -> Result<(), FormatterError> {
+        // format and add parameters
+        params.format(formatted_code, formatter)?;
+        // `>`
         write!(
-            line,
+            formatted_code,
             "{}",
             self.parameters.close_angle_bracket_token.span().as_str()
         )?;
+
         Ok(())
     }
 }

--- a/sway-fmt-v2/src/utils/generics.rs
+++ b/sway-fmt-v2/src/utils/generics.rs
@@ -1,9 +1,6 @@
-use crate::{
-    fmt::{Format, FormattedCode, Formatter, FormatterError},
-};
-use std::fmt::Write;
+use super::bracket::{close_angle_bracket, open_angle_bracket};
+use crate::fmt::{Format, FormattedCode, Formatter, FormatterError};
 use sway_parse::{GenericArgs, GenericParams};
-use sway_types::Spanned;
 
 // In the future we will need to determine whether the generic arguments
 // are better suited with a `where` clause. At present they will be
@@ -18,19 +15,11 @@ impl Format for GenericParams {
         let params = self.parameters.clone().into_inner();
 
         // `<`
-        write!(
-            formatted_code,
-            "{}",
-            self.parameters.open_angle_bracket_token.span().as_str()
-        )?;
+        open_angle_bracket(formatted_code)?;
         // format and add parameters
         params.format(formatted_code, formatter)?;
         // `>`
-        write!(
-            formatted_code,
-            "{}",
-            self.parameters.close_angle_bracket_token.span().as_str()
-        )?;
+        close_angle_bracket(formatted_code)?;
 
         Ok(())
     }
@@ -46,19 +35,11 @@ impl Format for GenericArgs {
         let params = self.parameters.clone().into_inner();
 
         // `<`
-        write!(
-            formatted_code,
-            "{}",
-            self.parameters.open_angle_bracket_token.span().as_str()
-        )?;
+        open_angle_bracket(formatted_code)?;
         // format and add parameters
         params.format(formatted_code, formatter)?;
         // `>`
-        write!(
-            formatted_code,
-            "{}",
-            self.parameters.close_angle_bracket_token.span().as_str()
-        )?;
+        close_angle_bracket(formatted_code)?;
 
         Ok(())
     }

--- a/sway-fmt-v2/src/utils/path.rs
+++ b/sway-fmt-v2/src/utils/path.rs
@@ -6,6 +6,8 @@ use std::{fmt::Write, vec};
 use sway_parse::{PathExpr, PathExprSegment, PathType, PathTypeSegment, QualifiedPathRoot};
 use sway_types::Spanned;
 
+use super::bracket::{close_angle_bracket, open_angle_bracket};
+
 impl Format for PathExpr {
     fn format(
         &self,
@@ -14,19 +16,11 @@ impl Format for PathExpr {
     ) -> Result<(), FormatterError> {
         if let Some((root, double_colon_token)) = &self.root_opt {
             if let Some(root) = &root {
-                write!(
-                    formatted_code,
-                    "{}",
-                    root.open_angle_bracket_token.span().as_str()
-                )?;
+                open_angle_bracket(formatted_code)?;
                 root.clone()
                     .into_inner()
                     .format(formatted_code, formatter)?;
-                write!(
-                    formatted_code,
-                    "{}",
-                    root.close_angle_bracket_token.span().as_str()
-                )?;
+                close_angle_bracket(formatted_code)?;
             }
             write!(formatted_code, "{}", double_colon_token.ident().as_str())?;
         }
@@ -86,19 +80,11 @@ impl Format for PathType {
     ) -> Result<(), FormatterError> {
         if let Some(root_opt) = &self.root_opt {
             if let Some(root) = &root_opt.0 {
-                write!(
-                    formatted_code,
-                    "{}",
-                    root.open_angle_bracket_token.span().as_str()
-                )?;
+                open_angle_bracket(formatted_code)?;
                 root.clone()
                     .into_inner()
                     .format(formatted_code, formatter)?;
-                write!(
-                    formatted_code,
-                    "{}",
-                    root.close_angle_bracket_token.span().as_str()
-                )?;
+                close_angle_bracket(formatted_code)?;
             }
             write!(formatted_code, "{}", root_opt.1.span().as_str())?;
         }


### PR DESCRIPTION
This PR removes the angle bracket trait from the formatter due to the implementations of the trait being the same in each use case.

Closes #2253