### PR TITLE
Rely on `is_copy_type` to lower `insert_element`/`extract_element` into asm instead of type size

### DIFF
--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -886,9 +886,9 @@ impl<'ir> AsmBuilder<'ir> {
 
         let instr_reg = self.reg_seqr.next();
         let owning_span = self.md_mgr.val_to_span(self.context, *instr_val);
-        let elem_size =
-            ir_type_size_in_bytes(self.context, &ty.get_elem_type(self.context).unwrap());
-        if elem_size <= 8 {
+        let elem_type = ty.get_elem_type(self.context).unwrap();
+        let elem_size = ir_type_size_in_bytes(self.context, &elem_type);
+        if elem_type.is_copy_type() {
             self.bytecode.push(Op {
                 opcode: Either::Left(VirtualOp::MULI(
                     index_reg.clone(),
@@ -1175,9 +1175,9 @@ impl<'ir> AsmBuilder<'ir> {
 
         let owning_span = self.md_mgr.val_to_span(self.context, *instr_val);
 
-        let elem_size =
-            ir_type_size_in_bytes(self.context, &ty.get_elem_type(self.context).unwrap());
-        if elem_size <= 8 {
+        let elem_type = ty.get_elem_type(self.context).unwrap();
+        let elem_size = ir_type_size_in_bytes(self.context, &elem_type);
+        if elem_type.is_copy_type() {
             self.bytecode.push(Op {
                 opcode: Either::Left(VirtualOp::MULI(
                     index_reg.clone(),

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
@@ -1,9 +1,9 @@
 script;
 use array_of_structs_abi::{Id, TestContract, Wrapper};
-use std::assert::assert;
+use std::{assert::assert, hash::sha256};
 
 fn main() -> u64 {
-    let addr = abi(TestContract, 0xc17fec138a64fc2ebac467ff59979cb23179a83d7574a087327af490e415526e);
+    let addr = abi(TestContract, 0xa99f286587d192c092dcbdefeb22b3f86a54c1837a80bb05328241dc24a6ac8e);
 
     let input = [Wrapper {
         id: Id {
@@ -18,9 +18,14 @@ fn main() -> u64 {
     ];
 
     let result = addr.return_array_of_structs(input);
-
     assert(result[0].id.number == 42);
     assert(result[1].id.number == 66);
+
+    let result = addr.return_element_of_array_of_structs(input);
+    assert(result.id.number == 42);
+
+    let result = addr.return_element_of_array_of_strings([ "111", "222", "333"]);
+    assert(sha256("111") == sha256(result));
 
     1
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/array_of_structs_abi/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/array_of_structs_abi/src/main.sw
@@ -9,5 +9,13 @@ pub struct Wrapper {
 }
 
 abi TestContract {
-    fn return_array_of_structs(param: [Wrapper; 2]) -> [Wrapper; 2];
+    fn return_array_of_structs(param: [Wrapper;
+    2]) -> [Wrapper;
+    2];
+
+    fn return_element_of_array_of_structs(param: [Wrapper;
+    2]) -> Wrapper;
+
+    fn return_element_of_array_of_strings(param: [str[3];
+    3]) -> str[3];
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/array_of_structs_contract/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/array_of_structs_contract/json_abi_oracle.json
@@ -60,5 +60,87 @@
       }
     ],
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "components": null,
+                    "name": "number",
+                    "type": "u64",
+                    "typeArguments": null
+                  }
+                ],
+                "name": "id",
+                "type": "struct Id",
+                "typeArguments": null
+              }
+            ],
+            "name": "__array_element",
+            "type": "struct Wrapper",
+            "typeArguments": null
+          }
+        ],
+        "name": "param",
+        "type": "[struct Wrapper; 2]",
+        "typeArguments": null
+      }
+    ],
+    "name": "return_element_of_array_of_structs",
+    "outputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "components": null,
+                "name": "number",
+                "type": "u64",
+                "typeArguments": null
+              }
+            ],
+            "name": "id",
+            "type": "struct Id",
+            "typeArguments": null
+          }
+        ],
+        "name": "",
+        "type": "struct Wrapper",
+        "typeArguments": null
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": null,
+            "name": "__array_element",
+            "type": "str[3]",
+            "typeArguments": null
+          }
+        ],
+        "name": "param",
+        "type": "[str[3]; 3]",
+        "typeArguments": null
+      }
+    ],
+    "name": "return_element_of_array_of_strings",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "str[3]",
+        "typeArguments": null
+      }
+    ],
+    "type": "function"
   }
 ]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/array_of_structs_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/array_of_structs_contract/src/main.sw
@@ -3,7 +3,19 @@ contract;
 use array_of_structs_abi::{TestContract, Wrapper};
 
 impl TestContract for Contract {
-    fn return_array_of_structs(param: [Wrapper; 2]) -> [Wrapper; 2] {
+    fn return_array_of_structs(param: [Wrapper;
+    2]) -> [Wrapper;
+    2] {
         param
+    }
+
+    fn return_element_of_array_of_structs(param: [Wrapper;
+    2]) -> Wrapper {
+        param[0]
+    }
+
+    fn return_element_of_array_of_strings(param: [str[3];
+    3]) -> str[3] {
+        param[0]
     }
 }


### PR DESCRIPTION
Closes #2410

This does fix the SDK test in https://github.com/FuelLabs/sway/issues/2410