### PR TITLE
Additional checks for unnecessary visibility qualifier (ABI definitions, ABI impls and trait impls)

### DIFF
--- a/sway-lib-core/src/ops.sw
+++ b/sway-lib-core/src/ops.sw
@@ -411,7 +411,7 @@ impl BitwiseXor for u64 {
 }
 
 impl BitwiseAnd for b256 {
-    pub fn binary_and(val: self, other: Self) -> Self {
+    fn binary_and(val: self, other: Self) -> Self {
         let(value_word_1, value_word_2, value_word_3, value_word_4) = decompose(val);
         let(other_word_1, other_word_2, other_word_3, other_word_4) = decompose(other);
         let word_1 = value_word_1.binary_and(other_word_1);
@@ -424,7 +424,7 @@ impl BitwiseAnd for b256 {
 }
 
 impl BitwiseOr for b256 {
-    pub fn binary_or(val: self, other: Self) -> Self {
+    fn binary_or(val: self, other: Self) -> Self {
         let(value_word_1, value_word_2, value_word_3, value_word_4) = decompose(val);
         let(other_word_1, other_word_2, other_word_3, other_word_4) = decompose(other);
         let word_1 = value_word_1.binary_or(other_word_1);
@@ -437,7 +437,7 @@ impl BitwiseOr for b256 {
 }
 
 impl BitwiseXor for b256 {
-    pub fn binary_xor(val: self, other: Self) -> Self {
+    fn binary_xor(val: self, other: Self) -> Self {
         let(value_word_1, value_word_2, value_word_3, value_word_4) = decompose(val);
         let(other_word_1, other_word_2, other_word_3, other_word_4) = decompose(other);
         let word_1 = value_word_1.binary_xor(other_word_1);

--- a/sway-lib-std/src/u128.sw
+++ b/sway-lib-std/src/u128.sw
@@ -23,7 +23,7 @@ pub trait From {
 }
 
 impl From for U128 {
-    pub fn from(upper: u64, lower: u64) -> U128 {
+    fn from(upper: u64, lower: u64) -> U128 {
         U128 {
             upper, lower,
         }
@@ -35,17 +35,17 @@ impl From for U128 {
 }
 
 impl core::ops::Eq for U128 {
-    pub fn eq(self, other: Self) -> bool {
+    fn eq(self, other: Self) -> bool {
         self.lower == other.lower && self.upper == other.upper
     }
 }
 
 impl core::ops::Ord for U128 {
-    pub fn gt(self, other: Self) -> bool {
+    fn gt(self, other: Self) -> bool {
         self.upper > other.upper || self.upper == other.upper && self.lower > other.lower
     }
 
-    pub fn lt(self, other: Self) -> bool {
+    fn lt(self, other: Self) -> bool {
         self.upper < other.upper || self.upper == other.upper && self.lower < other.lower
     }
 }
@@ -144,19 +144,19 @@ impl U128 {
 }
 
 impl core::ops::BitwiseAnd for U128 {
-    pub fn binary_and(self, other: Self) -> Self {
+    fn binary_and(self, other: Self) -> Self {
         ~U128::from(self.upper & other.upper, self.lower & other.lower)
     }
 }
 
 impl core::ops::BitwiseOr for U128 {
-    pub fn binary_or(self, other: Self) -> Self {
+    fn binary_or(self, other: Self) -> Self {
         ~U128::from(self.upper | other.upper, self.lower | other.lower)
     }
 }
 
 impl core::ops::Shiftable for U128 {
-    pub fn lsh(self, rhs: u64) -> Self {
+    fn lsh(self, rhs: u64) -> Self {
         // If shifting by at least the number of bits, then saturate with
         // zeroes.
         if rhs >= 128 {
@@ -181,7 +181,7 @@ impl core::ops::Shiftable for U128 {
         ~Self::from(upper, lower)
     }
 
-    pub fn rsh(self, rhs: u64) -> Self {
+    fn rsh(self, rhs: u64) -> Self {
         // If shifting by at least the number of bits, then saturate with
         // zeroes.
         if (rhs >= 128) {
@@ -210,7 +210,7 @@ impl core::ops::Shiftable for U128 {
 
 impl core::ops::Add for U128 {
     /// Add a U128 to a U128. Panics on overflow.
-    pub fn add(self, other: Self) -> Self {
+    fn add(self, other: Self) -> Self {
         let mut upper_128 = self.upper.overflowing_add(other.upper);
 
         // If the upper overflows, then the number cannot fit in 128 bits, so panic.
@@ -235,7 +235,7 @@ impl core::ops::Add for U128 {
 
 impl core::ops::Subtract for U128 {
     /// Subtract a U128 from a U128. Panics of overflow.
-    pub fn subtract(self, other: Self) -> Self {
+    fn subtract(self, other: Self) -> Self {
         // If trying to subtract a larger number, panic.
         assert(!(self < other));
 
@@ -258,7 +258,7 @@ impl core::ops::Subtract for U128 {
 
 impl core::ops::Multiply for U128 {
     /// Multiply a U128 with a U128. Panics of overflow.
-    pub fn multiply(self, other: Self) -> Self {
+    fn multiply(self, other: Self) -> Self {
         let zero = ~U128::from(0, 0);
         let one = ~U128::from(0, 1);
 
@@ -285,7 +285,7 @@ impl core::ops::Multiply for U128 {
 
 impl core::ops::Divide for U128 {
     /// Divide a U128 by a U128. Panics if divisor is zero.
-    pub fn divide(self, divisor: Self) -> Self {
+    fn divide(self, divisor: Self) -> Self {
         let zero = ~U128::from(0, 0);
         let one = ~U128::from(0, 1);
 

--- a/sway-lib-std/src/u256.sw
+++ b/sway-lib-std/src/u256.sw
@@ -23,7 +23,7 @@ pub trait From {
 }
 
 impl From for U256 {
-    pub fn from(a: u64, b: u64, c: u64, d: u64) -> U256 {
+    fn from(a: u64, b: u64, c: u64, d: u64) -> U256 {
         U256 {
             a, b, c, d,
         }
@@ -37,7 +37,7 @@ impl From for U256 {
 
 impl core::ops::Eq for U256 {
     /// Function for comparing 2 U256s for equality
-    pub fn eq(self, other: Self) -> bool {
+    fn eq(self, other: Self) -> bool {
         self.a == other.a && self.b == other.b && self.c == other.c && self.d == other.d
     }
 }

--- a/sway-parse/src/item/item_abi.rs
+++ b/sway-parse/src/item/item_abi.rs
@@ -23,8 +23,30 @@ impl Parse for ItemAbi {
     fn parse(parser: &mut Parser) -> ParseResult<ItemAbi> {
         let abi_token = parser.parse()?;
         let name = parser.parse()?;
-        let abi_items = parser.parse()?;
-        let abi_defs_opt = Braces::try_parse(parser)?;
+        let abi_items: Braces<Vec<(Annotated<FnSignature>, _)>> = parser.parse()?;
+        for (fn_signature, _) in abi_items.get().iter() {
+            if let Some(token) = &fn_signature.value.visibility {
+                return Err(parser.emit_error_with_span(
+                    ParseErrorKind::UnnecessaryVisibilityQualifier {
+                        visibility: token.ident(),
+                    },
+                    token.span(),
+                ));
+            }
+        }
+        let abi_defs_opt: Option<Braces<Vec<Annotated<ItemFn>>>> = Braces::try_parse(parser)?;
+        if let Some(abi_defs) = &abi_defs_opt {
+            for item_fn in abi_defs.get().iter() {
+                if let Some(token) = &item_fn.value.fn_signature.visibility {
+                    return Err(parser.emit_error_with_span(
+                        ParseErrorKind::UnnecessaryVisibilityQualifier {
+                            visibility: token.ident(),
+                        },
+                        token.span(),
+                    ));
+                }
+            }
+        }
         Ok(ItemAbi {
             abi_token,
             name,

--- a/sway-parse/src/item/item_impl.rs
+++ b/sway-parse/src/item/item_impl.rs
@@ -41,7 +41,19 @@ impl Parse for ItemImpl {
             }
             None => None,
         };
-        let contents = parser.parse()?;
+        let contents: Braces<Vec<Annotated<ItemFn>>> = parser.parse()?;
+        if trait_opt.is_some() {
+            for item_fn in contents.get().iter() {
+                if let Some(token) = &item_fn.value.fn_signature.visibility {
+                    return Err(parser.emit_error_with_span(
+                        ParseErrorKind::UnnecessaryVisibilityQualifier {
+                            visibility: token.ident(),
+                        },
+                        token.span(),
+                    ));
+                }
+            }
+        }
         Ok(ItemImpl {
             impl_token,
             generic_params_opt,

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_pub_fn/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_pub_fn/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'abi_impl_pub_fn'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_pub_fn/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_pub_fn/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-authors = ["Kaya Gökalp"]
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "abi_impl_pub_fn"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_pub_fn/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_pub_fn/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Kaya Gökalp"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "abi_impl_pub_fn"
+implicit-std = false
+
+[dependencies]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_pub_fn/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_pub_fn/src/main.sw
@@ -1,0 +1,11 @@
+contract;
+
+abi MyContract {
+    fn test_function() -> bool;
+}
+
+impl MyContract for Contract {
+    pub fn test_function() -> bool {
+        true
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_pub_fn/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_impl_pub_fn/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: pub fn test_function() -> bool {
+# nextln: $()Unnecessary visibility qualifier, `pub` is implied here.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/Forc.lock
@@ -1,0 +1,14 @@
+[[package]]
+name = 'abi_pub_fn_interface'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+source = 'path+from-root-0AE23D28FE158BCC'
+dependencies = []
+
+[[package]]
+name = 'std'
+source = 'path+from-root-0AE23D28FE158BCC'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/Forc.lock
@@ -1,14 +1,4 @@
 [[package]]
 name = 'abi_pub_fn_interface'
 source = 'root'
-dependencies = ['std']
-
-[[package]]
-name = 'core'
-source = 'path+from-root-0AE23D28FE158BCC'
 dependencies = []
-
-[[package]]
-name = 'std'
-source = 'path+from-root-0AE23D28FE158BCC'
-dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/Forc.toml
@@ -6,4 +6,3 @@ name = "abi_pub_fn_interface"
 implicit-std = false
 
 [dependencies]
-std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Kaya Gökalp"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "abi_pub_fn_interface"
+implicit-std = false
+
+[dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-authors = ["Kaya Gökalp"]
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "abi_pub_fn_interface"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/src/main.sw
@@ -1,0 +1,5 @@
+contract;
+
+abi MyContract {
+    pub fn f(self) -> bool;
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/src/main.sw
@@ -1,5 +1,5 @@
 contract;
 
 abi MyContract {
-    pub fn f(self) -> bool;
+    pub fn f() -> bool;
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: pub fn f(self) -> bool;
+# nextln: $()Unnecessary visibility qualifier, `pub` is implied here.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_interface/test.toml
@@ -1,4 +1,4 @@
 category = "fail"
 
-# check: pub fn f(self) -> bool;
+# check: pub fn f() -> bool;
 # nextln: $()Unnecessary visibility qualifier, `pub` is implied here.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/Forc.lock
@@ -1,14 +1,4 @@
 [[package]]
 name = 'abi_pub_fn_method'
 source = 'root'
-dependencies = ['std']
-
-[[package]]
-name = 'core'
-source = 'path+from-root-EB60D283825FED98'
 dependencies = []
-
-[[package]]
-name = 'std'
-source = 'path+from-root-EB60D283825FED98'
-dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/Forc.lock
@@ -1,0 +1,14 @@
+[[package]]
+name = 'abi_pub_fn_method'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+source = 'path+from-root-EB60D283825FED98'
+dependencies = []
+
+[[package]]
+name = 'std'
+source = 'path+from-root-EB60D283825FED98'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/Forc.toml
@@ -6,4 +6,3 @@ name = "abi_pub_fn_method"
 implicit-std = false
 
 [dependencies]
-std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Kaya Gökalp"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "abi_pub_fn_method"
+implicit-std = false
+
+[dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-authors = ["Kaya Gökalp"]
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "abi_pub_fn_method"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/src/main.sw
@@ -1,7 +1,7 @@
 contract;
 
 abi MyContract {} {
-    pub fn f(self) -> bool {
+    pub fn f() -> bool {
         false
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/src/main.sw
@@ -1,0 +1,7 @@
+contract;
+
+abi MyContract {} {
+    pub fn f(self) -> bool {
+        false
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: pub fn f(self) -> bool {
+# nextln: $()Unnecessary visibility qualifier, `pub` is implied here.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_pub_fn_method/test.toml
@@ -1,4 +1,4 @@
 category = "fail"
 
-# check: pub fn f(self) -> bool {
+# check: pub fn f() -> bool {
 # nextln: $()Unnecessary visibility qualifier, `pub` is implied here.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/Forc.lock
@@ -1,0 +1,14 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-6FBAD3B76AADD629'
+dependencies = []
+
+[[package]]
+name = 'std'
+source = 'path+from-root-6FBAD3B76AADD629'
+dependencies = ['core']
+
+[[package]]
+name = 'trait_impl_pub_fn'
+source = 'root'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/Forc.lock
@@ -1,14 +1,4 @@
 [[package]]
-name = 'core'
-source = 'path+from-root-6FBAD3B76AADD629'
-dependencies = []
-
-[[package]]
-name = 'std'
-source = 'path+from-root-6FBAD3B76AADD629'
-dependencies = ['core']
-
-[[package]]
 name = 'trait_impl_pub_fn'
 source = 'root'
-dependencies = ['std']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-authors = ["Kaya Gökalp"]
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "trait_impl_pub_fn"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Kaya Gökalp"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "trait_impl_pub_fn"
+implicit-std = false
+
+[dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/Forc.toml
@@ -6,4 +6,3 @@ name = "trait_impl_pub_fn"
 implicit-std = false
 
 [dependencies]
-std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/src/main.sw
@@ -1,0 +1,13 @@
+contract;
+
+trait A {
+    fn foo();
+}
+
+struct S {}
+
+impl A for S {
+     pub fn foo() {
+
+     }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_impl_pub_fn/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: pub fn foo() {
+# nextln: $()Unnecessary visibility qualifier, `pub` is implied here.


### PR DESCRIPTION
closes #2419.

With this PR, for the following cases, we are now emitting an error, similar to #2276.
```rust
abi MyContract {
    pub fn test_function() -> bool;
}
```
```rust
impl MyContract for Contract {
    pub fn test_function() -> bool {
        true
    }
}
```
```rust
trait A {
    fn foo();
}

struct S {}

impl A for S {
     pub fn foo() {}
}
```