### PR TITLE
Add a new 'simplify CFG` optimisation pass.

### DIFF
--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -454,7 +454,7 @@ fn inline_function_calls(ir: &mut Context, functions: &[Function]) -> CompileRes
                 Vec::new(),
                 vec![CompileError::InternalOwned(
                     ir_error.to_string(),
-                    span::Span::new("".into(), 0, 0, None).unwrap(),
+                    span::Span::dummy(),
                 )],
             );
         }
@@ -469,7 +469,7 @@ fn combine_constants(ir: &mut Context, functions: &[Function]) -> CompileResult<
                 Vec::new(),
                 vec![CompileError::InternalOwned(
                     ir_error.to_string(),
-                    span::Span::new("".into(), 0, 0, None).unwrap(),
+                    span::Span::dummy(),
                 )],
             );
         }

--- a/sway-ir/src/bin/opt.rs
+++ b/sway-ir/src/bin/opt.rs
@@ -7,13 +7,17 @@ use anyhow::anyhow;
 use sway_ir::{error::IrError, function::Function, optimize, Context};
 
 // -------------------------------------------------------------------------------------------------
-// Right now there are 2 passes - inline and constcombine.  If we are to add more, then this code
-// should be a bit more data driven, rather than comparing pass names to magic strings in `main()`,
-// `perform_xxx()` and `ConfigBuilder`.
 
 fn main() -> Result<(), anyhow::Error> {
+    // Maintain a list of named pass functions for delegation.
+    let mut pass_mgr = PassManager::default();
+
+    pass_mgr.register::<ConstCombinePass>();
+    pass_mgr.register::<InlinePass>();
+    pass_mgr.register::<SimplifyCfgPass>();
+
     // Build the config from the command line.
-    let config = ConfigBuilder::build(std::env::args())?;
+    let config = ConfigBuilder::build(&pass_mgr, std::env::args())?;
 
     // Read the input file, or standard in.
     let input_str = read_from_input(&config.input_path)?;
@@ -23,11 +27,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     // Perform optimisation passes in order.
     for pass in config.passes {
-        match pass.name.as_ref() {
-            "inline" => perform_inline(&mut ir)?,
-            "constcombine" => perform_combine_constants(&mut ir)?,
-            _otherwise => unreachable!("Unknown pass name: {}", pass.name),
-        };
+        pass_mgr.run(pass.name.as_ref(), &mut ir)?;
     }
 
     // Write the output file or standard out.
@@ -67,27 +67,116 @@ fn write_to_output<S: Into<String>>(ir_str: S, path_str: &Option<String>) -> std
 
 // -------------------------------------------------------------------------------------------------
 
-fn perform_inline(ir: &mut Context) -> Result<bool, IrError> {
-    // For now we inline everything into `main()`.  Eventually we can be more selective.
-    let main_fn = ir
-        .functions
-        .iter()
-        .find_map(|(idx, fc)| if fc.name == "main" { Some(idx) } else { None })
-        .unwrap();
-    optimize::inline_all_function_calls(ir, &Function(main_fn))
+trait NamedPass {
+    fn name() -> &'static str;
+    fn descr() -> &'static str;
+    fn run(ir: &mut Context) -> Result<bool, IrError>;
+
+    fn run_on_all_fns<F: FnMut(&mut Context, &Function) -> Result<bool, IrError>>(
+        ir: &mut Context,
+        mut run_on_fn: F,
+    ) -> Result<bool, IrError> {
+        let funcs = ir.functions.iter().map(|(idx, _)| idx).collect::<Vec<_>>();
+        let mut modified = false;
+        for idx in funcs {
+            if run_on_fn(ir, &Function(idx))? {
+                modified = true;
+            }
+        }
+        Ok(modified)
+    }
 }
 
-// -------------------------------------------------------------------------------------------------
+type NamePassPair = (&'static str, fn(&mut Context) -> Result<bool, IrError>);
 
-fn perform_combine_constants(ir: &mut Context) -> Result<bool, IrError> {
-    let funcs = ir.functions.iter().map(|(idx, _)| idx).collect::<Vec<_>>();
-    let mut modified = false;
-    for idx in funcs {
-        if optimize::combine_constants(ir, &Function(idx))? {
-            modified = true;
-        }
+#[derive(Default)]
+struct PassManager {
+    passes: HashMap<&'static str, NamePassPair>,
+}
+
+impl PassManager {
+    fn register<T: NamedPass>(&mut self) {
+        self.passes.insert(T::name(), (T::descr(), T::run));
     }
-    Ok(modified)
+
+    fn run(&self, name: &str, ir: &mut Context) -> Result<bool, IrError> {
+        self.passes.get(name).expect("Unknown pass name!").1(ir)
+    }
+
+    fn contains(&self, name: &str) -> bool {
+        self.passes.contains_key(name)
+    }
+
+    fn help_text(&self) -> String {
+        let summary = self
+            .passes
+            .iter()
+            .map(|(name, (descr, _))| format!("  {name:16} - {descr}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        format!("Valid pass names are:\n\n{summary}",)
+    }
+}
+
+// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
+struct InlinePass;
+
+impl NamedPass for InlinePass {
+    fn name() -> &'static str {
+        "inline"
+    }
+
+    fn descr() -> &'static str {
+        "inline function calls."
+    }
+
+    fn run(ir: &mut Context) -> Result<bool, IrError> {
+        // For now we inline everything into `main()`.  Eventually we can be more selective.
+        let main_fn = ir
+            .functions
+            .iter()
+            .find_map(|(idx, fc)| if fc.name == "main" { Some(idx) } else { None })
+            .unwrap();
+        optimize::inline_all_function_calls(ir, &Function(main_fn))
+    }
+}
+
+// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
+struct ConstCombinePass;
+
+impl NamedPass for ConstCombinePass {
+    fn name() -> &'static str {
+        "constcombine"
+    }
+
+    fn descr() -> &'static str {
+        "constant folding."
+    }
+
+    fn run(ir: &mut Context) -> Result<bool, IrError> {
+        Self::run_on_all_fns(ir, optimize::combine_constants)
+    }
+}
+
+// -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
+struct SimplifyCfgPass;
+
+impl NamedPass for SimplifyCfgPass {
+    fn name() -> &'static str {
+        "simplifycfg"
+    }
+
+    fn descr() -> &'static str {
+        "merge or remove redundant blocks."
+    }
+
+    fn run(ir: &mut Context) -> Result<bool, IrError> {
+        Self::run_on_all_fns(ir, optimize::simplify_cfg)
+    }
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -123,20 +212,22 @@ impl From<&str> for Pass {
 
 // This is a little clumsy in that it needs to consume items from the iterator carefully in each
 // method to ensure we don't enter a weird state.
-struct ConfigBuilder<I: Iterator<Item = String>> {
+struct ConfigBuilder<'a, I: Iterator<Item = String>> {
     next: Option<String>,
     rest: I,
     cfg: Config,
+    pass_mgr: &'a PassManager,
 }
 
-impl<I: Iterator<Item = String>> ConfigBuilder<I> {
-    fn build(mut rest: I) -> Result<Config, anyhow::Error> {
+impl<'a, I: Iterator<Item = String>> ConfigBuilder<'a, I> {
+    fn build(pass_mgr: &PassManager, mut rest: I) -> Result<Config, anyhow::Error> {
         rest.next(); // Skip the first arg which is the binary name.
         let next = rest.next();
         ConfigBuilder {
             next,
             rest,
             cfg: Config::default(),
+            pass_mgr,
         }
         .build_root()
     }
@@ -150,22 +241,11 @@ impl<I: Iterator<Item = String>> ConfigBuilder<I> {
                     "-i" => self.build_input(),
                     "-o" => self.build_output(),
 
-                    "inline" => self.build_inline_pass(),
-                    "constcombine" => self.build_const_combine_pass(),
-
-                    _otherwise => {
+                    name => {
                         if matches!(opt.chars().next(), Some('-')) {
                             Err(anyhow!("Unrecognised option '{opt}'."))
                         } else {
-                            Err(anyhow!(
-                                r#"Unrecognised pass name '{opt}'.
-
-Valid pass names are:
-
-  constcombine - constant folding.
-  inline       - inline function calls.
-"#
-                            ))
+                            self.build_pass(name)
                         }
                     }
                 }
@@ -195,20 +275,17 @@ Valid pass names are:
         }
     }
 
-    fn build_inline_pass(mut self) -> Result<Config, anyhow::Error> {
-        // No args yet.  Eventually we should allow specifying which functions are to be inlined
-        // or which functions are to have all embedded calls inlined.
-        self.cfg.passes.push("inline".into());
-        self.next = self.rest.next();
-        self.build_root()
-    }
-
-    fn build_const_combine_pass(mut self) -> Result<Config, anyhow::Error> {
-        // No args yet.  Eventually we should allow specifying which functions should have consts
-        // combined.
-        self.cfg.passes.push("constcombine".into());
-        self.next = self.rest.next();
-        self.build_root()
+    fn build_pass(mut self, name: &str) -> Result<Config, anyhow::Error> {
+        if self.pass_mgr.contains(name) {
+            self.cfg.passes.push(name.into());
+            self.next = self.rest.next();
+            self.build_root()
+        } else {
+            Err(anyhow!(
+                "Unrecognised pass name '{name}'.\n\n{}",
+                self.pass_mgr.help_text()
+            ))
+        }
     }
 }
 

--- a/sway-ir/src/block.rs
+++ b/sway-ir/src/block.rs
@@ -138,7 +138,7 @@ impl Block {
     /// Get a reference to the block terminator.
     ///
     /// Returns `None` if block is empty.
-    pub fn get_term_inst<'a>(&self, context: &'a Context) -> Option<&'a Instruction> {
+    pub fn get_terminator<'a>(&self, context: &'a Context) -> Option<&'a Instruction> {
         context.blocks[self.0].instructions.last().and_then(|val| {
             // It's guaranteed to be an instruction value.
             if let ValueDatum::Instruction(term_inst) = &context.values[val.0].value {
@@ -160,7 +160,7 @@ impl Block {
 
     /// Return whether this block is already terminated specifically by a Ret instruction.
     pub fn is_terminated_by_ret(&self, context: &Context) -> bool {
-        self.get_term_inst(context)
+        self.get_terminator(context)
             .map_or(false, |i| matches!(i, Instruction::Ret { .. }))
     }
 
@@ -244,7 +244,7 @@ impl Block {
             //
             // Copying the candidate blocks and putting them in a vector to avoid borrowing context
             // as immutable and then mutable in the loop body.
-            for to_block in match new_block.get_term_inst(context) {
+            for to_block in match new_block.get_terminator(context) {
                 Some(Instruction::Branch(to_block)) => {
                     vec![*to_block]
                 }
@@ -273,26 +273,53 @@ impl Block {
 
 #[doc(hidden)]
 impl BlockContent {
-    pub(super) fn num_predecessors(&self, context: &Context) -> usize {
-        self.function
-            .instruction_iter(context)
-            .filter(
-                |(_block, ins_value)| match &context.values[ins_value.0].value {
-                    ValueDatum::Instruction(Instruction::ConditionalBranch {
+    pub(super) fn predecessors<'a>(
+        &'a self,
+        context: &'a Context,
+    ) -> impl Iterator<Item = Block> + 'a {
+        self.function.block_iter(context).filter(|block| {
+            let has_label = |b: &Block| b.get_label(context) == self.label;
+            block
+                .get_terminator(context)
+                .map(|term_inst| match term_inst {
+                    Instruction::ConditionalBranch {
                         true_block,
                         false_block,
                         ..
-                    }) => {
-                        true_block.get_label(context) == self.label
-                            || false_block.get_label(context) == self.label
-                    }
-                    ValueDatum::Instruction(Instruction::Branch(block)) => {
-                        block.get_label(context) == self.label
-                    }
+                    } => has_label(true_block) || has_label(false_block),
+
+                    Instruction::Branch(block) => has_label(block),
+
                     _otherwise => false,
-                },
-            )
-            .count()
+                })
+                .unwrap_or(false)
+        })
+    }
+
+    pub(super) fn num_predecessors(&self, context: &Context) -> usize {
+        self.predecessors(context).count()
+    }
+
+    pub(super) fn successors<'a>(
+        &'a self,
+        context: &'a Context,
+    ) -> impl Iterator<Item = Block> + 'a {
+        self.function.block_iter(context).flat_map(|block| {
+            block
+                .get_terminator(context)
+                .map(|term_inst| match term_inst {
+                    Instruction::ConditionalBranch {
+                        true_block,
+                        false_block,
+                        ..
+                    } => vec![*true_block, *false_block].into_iter(),
+
+                    Instruction::Branch(block) => vec![*block].into_iter(),
+
+                    _otherwise => Vec::new().into_iter(),
+                })
+                .unwrap_or_else(|| Vec::new().into_iter())
+        })
     }
 }
 

--- a/sway-ir/src/block.rs
+++ b/sway-ir/src/block.rs
@@ -312,13 +312,13 @@ impl BlockContent {
                         true_block,
                         false_block,
                         ..
-                    } => vec![*true_block, *false_block].into_iter(),
+                    } => vec![*true_block, *false_block],
 
-                    Instruction::Branch(block) => vec![*block].into_iter(),
+                    Instruction::Branch(block) => vec![*block],
 
-                    _otherwise => Vec::new().into_iter(),
+                    _otherwise => Vec::new(),
                 })
-                .unwrap_or_else(|| Vec::new().into_iter())
+                .unwrap_or_default()
         })
     }
 }

--- a/sway-ir/src/error.rs
+++ b/sway-ir/src/error.rs
@@ -7,10 +7,12 @@
 pub enum IrError {
     FunctionLocalClobbered(String, String),
     InvalidMetadatum(String),
+    InvalidPhi,
     MisplacedTerminator(String),
     MissingBlock(String),
     MissingTerminator(String),
     ParseFailure(String, String),
+    RemoveMissingBlock(String),
     ValueNotFound(String),
 
     VerifyAccessElementInconsistentTypes,
@@ -65,9 +67,15 @@ impl fmt::Display for IrError {
         match self {
             IrError::FunctionLocalClobbered(fn_str, var_str) => write!(
                 f,
-                "Local storage for function {fn_str} already has an entry for variable {var_str}"
+                "Local storage for function {fn_str} already has an entry for variable {var_str}."
             ),
-            IrError::InvalidMetadatum(why_str) => write!(f, "Unable to convert from invalid metadatum: {why_str}"),
+            IrError::InvalidMetadatum(why_str) => {
+                write!(f, "Unable to convert from invalid metadatum: {why_str}.")
+            }
+            IrError::InvalidPhi => write!(
+                f,
+                "Phi instruction has invalid block or value reference list."
+            ),
             IrError::MisplacedTerminator(blk_str) => {
                 write!(f, "Block {blk_str} has a misplaced terminator.")
             }
@@ -76,10 +84,16 @@ impl fmt::Display for IrError {
                 write!(f, "Block {blk_str} is missing its terminator.")
             }
             IrError::ParseFailure(expecting, found) => {
-                write!(f, "Parse failure: expecting '{expecting}', found '{found}'")
+                write!(
+                    f,
+                    "Parse failure: expecting '{expecting}', found '{found}'."
+                )
+            }
+            IrError::RemoveMissingBlock(blk_str) => {
+                write!(f, "Unable to remove block {blk_str}; not found.")
             }
             IrError::ValueNotFound(reason) => {
-                write!(f, "Invalid value: {reason}")
+                write!(f, "Invalid value: {reason}.")
             }
 
             // Verification failures:
@@ -118,7 +132,8 @@ impl fmt::Display for IrError {
             }
             IrError::VerifyArgumentValueIsNotArgument(callee) => write!(
                 f,
-                "Verification failed: Argument specifier for function '{callee}' is not an argument value."
+                "Verification failed: Argument specifier for function '{callee}' is not an \
+                argument value."
             ),
             IrError::VerifyAddrOfUnknownSourceType => write!(
                 f,
@@ -132,14 +147,12 @@ impl fmt::Display for IrError {
                 f,
                 "Verification failed: Bitcast unable to determine source type."
             ),
-            IrError::VerifyBitcastFromNonCopyType(ty) => write!(
-                f,
-                "Verification failed: Bitcast cannot be from a {ty}."
-            ),
-            IrError::VerifyBitcastToNonCopyType(ty) => write!(
-                f,
-                "Verification failed: Bitcast cannot be to a {ty}."
-            ),
+            IrError::VerifyBitcastFromNonCopyType(ty) => {
+                write!(f, "Verification failed: Bitcast cannot be from a {ty}.")
+            }
+            IrError::VerifyBitcastToNonCopyType(ty) => {
+                write!(f, "Verification failed: Bitcast cannot be to a {ty}.")
+            }
             IrError::VerifyBitcastBetweenInvalidTypes(from_ty, to_ty) => write!(
                 f,
                 "Verification failed: Bitcast not allowed from a {from_ty} to a {to_ty}."
@@ -147,7 +160,8 @@ impl fmt::Display for IrError {
             IrError::VerifyBranchToMissingBlock(label) => {
                 write!(
                     f,
-                    "Verification failed: Branch to block '{label}' is not a block in the current function."
+                    "Verification failed: Branch to block '{label}' is not a block in the current \
+                    function."
                 )
             }
             IrError::VerifyCallArgTypeMismatch(callee) => {
@@ -171,7 +185,8 @@ impl fmt::Display for IrError {
             IrError::VerifyCmpTypeMismatch(lhs_ty, rhs_ty) => {
                 write!(
                     f,
-                    "Verification failed: Cannot compare values with different widths of {lhs_ty} and {rhs_ty}."
+                    "Verification failed: Cannot compare values with different widths of {lhs_ty} \
+                    and {rhs_ty}."
                 )
             }
             IrError::VerifyCmpUnknownTypes => {
@@ -189,7 +204,8 @@ impl fmt::Display for IrError {
             IrError::VerifyContractCallBadTypes(arg_name) => {
                 write!(
                     f,
-                    "Verification failed: Argument {arg_name} passed to contract call has the incorrect type."
+                    "Verification failed: Argument {arg_name} passed to contract call has the \
+                    incorrect type."
                 )
             }
             IrError::VerifyGetNonExistentPointer => {
@@ -210,14 +226,12 @@ impl fmt::Display for IrError {
                     "Verification failed: Attempt to insert value of incorrect type into a struct."
                 )
             }
-            IrError::VerifyIntToPtrFromNonIntegerType(ty) => write!(
-                f,
-                "Verification failed: int_to_ptr cannot be from a {ty}."
-            ),
-            IrError::VerifyIntToPtrToCopyType(ty) => write!(
-                f,
-                "Verification failed: int_to_ptr cannot be to a {ty}."
-            ),
+            IrError::VerifyIntToPtrFromNonIntegerType(ty) => {
+                write!(f, "Verification failed: int_to_ptr cannot be from a {ty}.")
+            }
+            IrError::VerifyIntToPtrToCopyType(ty) => {
+                write!(f, "Verification failed: int_to_ptr cannot be to a {ty}.")
+            }
             IrError::VerifyIntToPtrUnknownSourceType => write!(
                 f,
                 "Verification failed: int_to_ptr unable to determine source type."
@@ -231,7 +245,8 @@ impl fmt::Display for IrError {
             ),
             IrError::VerifyMismatchedReturnTypes(fn_str) => write!(
                 f,
-                "Verification failed: Function {fn_str} return type must match its RET instructions."
+                "Verification failed: Function {fn_str} return type must match its RET \
+                instructions."
             ),
             IrError::VerifyPhiFromMissingBlock(label) => {
                 write!(

--- a/sway-ir/src/function.rs
+++ b/sway-ir/src/function.rs
@@ -154,6 +154,22 @@ impl Function {
             })
     }
 
+    /// Remove a [`Block`] from this function.
+    ///
+    /// > Care must be taken to ensure the block has no predecessors otherwise the function will be
+    /// > made invalid.
+    pub fn remove_block(&self, context: &mut Context, block: &Block) -> Result<(), IrError> {
+        let label = block.get_label(context);
+        let func = context.functions.get_mut(self.0).unwrap();
+        let block_idx = func
+            .blocks
+            .iter()
+            .position(|b| b == block)
+            .ok_or(IrError::RemoveMissingBlock(label))?;
+        func.blocks.remove(block_idx);
+        Ok(())
+    }
+
     /// Get a new unique block label.
     ///
     /// If `hint` is `None` then the label will be in the form `"blockN"` where N is an

--- a/sway-ir/src/optimize.rs
+++ b/sway-ir/src/optimize.rs
@@ -13,7 +13,9 @@
 //! over blocks or instructions can be invalidated, and starting over is a safer option than trying
 //! to attempt multiple changes at once.
 
-pub mod inline;
-pub use inline::*;
 pub mod constants;
 pub use constants::*;
+pub mod inline;
+pub use inline::*;
+pub mod simplify_cfg;
+pub use simplify_cfg::*;

--- a/sway-ir/src/optimize/simplify_cfg.rs
+++ b/sway-ir/src/optimize/simplify_cfg.rs
@@ -1,0 +1,156 @@
+use crate::{
+    block::Block, context::Context, error::IrError, function::Function, instruction::Instruction,
+    value::ValueDatum,
+};
+
+pub fn simplify_cfg(context: &mut Context, function: &Function) -> Result<bool, IrError> {
+    let mut modified = false;
+    loop {
+        if remove_dead_blocks(context, function)? {
+            modified = true;
+            continue;
+        }
+
+        if merge_blocks(context, function)? {
+            modified = true;
+            continue;
+        }
+
+        // Other passes here... always continue to the top if pass returns true.
+        break;
+    }
+    Ok(modified)
+}
+
+fn remove_dead_blocks(context: &mut Context, function: &Function) -> Result<bool, IrError> {
+    // Find a block other than 'entry' which has no predecessors, remove it if found.
+    function
+        .block_iter(context)
+        .skip(1)
+        .find(|block| block.num_predecessors(context) == 0)
+        .map(|dead_block| function.remove_block(context, &dead_block))
+        .transpose()
+        .map(|result| result.is_some())
+}
+
+fn merge_blocks(context: &mut Context, function: &Function) -> Result<bool, IrError> {
+    // Get the block a block branches to iff its terminator is `br`.
+    let block_terms_with_br = |from_block: Block| -> Option<(Block, Block)> {
+        from_block.get_terminator(context).and_then(|term| {
+            if let Instruction::Branch(to_block) = term {
+                Some((from_block, *to_block))
+            } else {
+                None
+            }
+        })
+    };
+
+    // Check whether a pair of blocks are singly paired.  i.e., `from_block` is the only
+    // predecessor of `to_block`.
+    let are_uniquely_paired = |(from_block, to_block): &(Block, Block)| -> bool {
+        let preds = context.blocks[to_block.0]
+            .predecessors(context)
+            .collect::<Vec<_>>();
+        preds.len() == 1 && preds[0] == *from_block
+    };
+
+    // Find a block with an unconditional branch terminator which branches to a block with that
+    // single predecessor.
+    let twin_blocks = function
+        .block_iter(context)
+        .filter_map(|from_block| {
+            // Filter all blocks with a Branch terminator.
+            block_terms_with_br(from_block)
+        })
+        .find(|pair_candidate| {
+            // Find branching blocks where they are singly paired.
+            are_uniquely_paired(pair_candidate)
+        });
+
+    // If not found then abort here.
+    let mut block_chain = match twin_blocks {
+        Some((from_block, to_block)) => vec![from_block, to_block],
+        None => return Ok(false),
+    };
+
+    // There may be more blocks which are also singly paired with these twins, so iteratively
+    // search for more blocks in a chain which can be all merged into one.
+    loop {
+        match block_terms_with_br(block_chain.last().copied().unwrap()) {
+            None => {
+                // There is no twin for this block.
+                break;
+            }
+            Some(next_pair) => {
+                if are_uniquely_paired(&next_pair) {
+                    // Add the next `to_block` to the chain and continue.
+                    block_chain.push(next_pair.1);
+                } else {
+                    // The chain has ended.
+                    break;
+                }
+            }
+        }
+    }
+
+    // Keep a copy of the final block in the chain so we can adjust the successors below.
+    let final_to_block = block_chain.last().copied().unwrap();
+
+    // The first block in the chain will be extended with the contents of the rest of the blocks in
+    // the chain, which we'll call `from_block` since we're branching from here to the next one.
+    let mut block_chain = block_chain.into_iter();
+    let from_block = block_chain.next().unwrap();
+
+    // Loop for the rest of the chain, to all the `to_block`s.
+    for to_block in block_chain {
+        // Replace the `phi` instruction in `to_block` with its singular element.
+        let phi_val = to_block.get_phi(context);
+        match &context.values[phi_val.0].value {
+            ValueDatum::Instruction(Instruction::Phi(els)) if els.len() == 1 => {
+                // Replace all uses of the phi and then remove it so it isn't merged below.
+                let (_, ref_val) = els[0];
+                function.replace_value(context, phi_val, ref_val, None);
+                to_block.remove_instruction(context, phi_val);
+            }
+            _otherwise => return Err(IrError::InvalidPhi),
+        };
+
+        // Re-get the block contents mutably.
+        let (from_contents, to_contents) = context.blocks.get2_mut(from_block.0, to_block.0);
+        let from_contents = from_contents.unwrap();
+        let to_contents = to_contents.unwrap();
+
+        // Drop the terminator from `from_block`.
+        from_contents.instructions.pop();
+
+        // Move instructions from `to_block` to `from_block`.
+        from_contents
+            .instructions
+            .append(&mut to_contents.instructions);
+
+        // Remove `to_block`.
+        function.remove_block(context, &to_block)?;
+    }
+
+    // Adjust the successors to the final `to_block` to now be successors of the fully merged
+    // `from_block`.
+    let succs = context.blocks[final_to_block.0]
+        .successors(context)
+        .collect::<Vec<crate::block::Block>>();
+    for succ in succs {
+        if let Some(phi_content) = context.values.get_mut(succ.get_phi(context).0) {
+            if let ValueDatum::Instruction(Instruction::Phi(els)) = &mut phi_content.value {
+                // This is the phi for a successor block of `to_block` which we're about to
+                // remove/merge with `from_block`, so the predecessor needs to change from `to_block`
+                // to `from_block`.
+                els.iter_mut().for_each(|(block, _)| {
+                    if *block == final_to_block {
+                        *block = from_block;
+                    }
+                });
+            }
+        };
+    }
+
+    Ok(true)
+}

--- a/sway-ir/tests/simplify_cfg/dead_blocks.ir
+++ b/sway-ir/tests/simplify_cfg/dead_blocks.ir
@@ -1,0 +1,29 @@
+// regex: ID=[[:alpha:]0-9]+
+
+script {
+    fn main() -> u64 {
+        local ptr u64 x
+
+        entry:
+        v0 = get_ptr ptr u64 x, ptr u64, 0
+// check: const u64 11
+        v1 = const u64 11
+        store v1, ptr v0
+        br block1
+
+        // Dead block, no predecessors.
+        block0:
+        v1 = phi(entry: v0)
+// not: const u64 22
+        v2 = const u64 22
+        store v2, ptr v0
+        br block1
+
+        block1:
+        v3 = phi(entry: v0)
+// check: const u64 33
+        v4 = const u64 33
+        ret u64 v4
+    }
+}
+

--- a/sway-ir/tests/simplify_cfg/merge_all_blocks.ir
+++ b/sway-ir/tests/simplify_cfg/merge_all_blocks.ir
@@ -1,0 +1,38 @@
+// regex: ID=[[:alpha:]0-9]+
+
+script {
+    fn main() -> bool {
+        entry:
+// check: const u64 11
+        v0 = const u64 11
+        v1 = const u64 0
+        v2 = cmp eq v0 v1
+// not: br
+        br block0
+
+        block0:
+// not: phi(entry: v2)
+        v3 = phi(entry: v2)
+// check: const u64 22
+        v4 = const u64 22
+        v5 = cmp eq v4 v1
+// not: br
+        br block1
+
+// not: block1:
+        block1:
+// not: phi(block0: v5)
+        v6 = phi(block0: v5)
+// check: const u64 33
+        v7 = const u64 33
+        v8 = cmp eq v7 v1
+// not: br
+        br block2
+
+        block2:
+// not: phi(block1: v8)
+        v9 = phi(block1: v8)
+        ret bool v9
+    }
+}
+


### PR DESCRIPTION
- Remove dead blocks.
- Merge twin blocks which only jump from one to the other.

Also updated the `opt` binary to use a more structured pass manager.

Closes #2398.

> Note: this pass isn't called by the compiler yet as it will take hours to complete on very large files like the `stdlib/vec` E2E test.