### PR TITLE
Implement a runnables custom method and collect typed tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3686,6 +3686,7 @@ dependencies = [
  "forc-util",
  "futures",
  "ropey",
+ "serde",
  "serde_json",
  "sway-core",
  "sway-fmt",

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -14,6 +14,7 @@ forc = { version = "0.19.1", path = "../forc" }
 forc-pkg = { version = "0.19.1", path = "../forc-pkg" }
 forc-util = { version = "0.19.1", path = "../forc-util" }
 ropey = "1.2"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.60"
 sway-core = { version = "0.19.1", path = "../sway-core" }
 sway-fmt = { version = "0.19.1", path = "../sway-fmt" }

--- a/sway-lsp/src/capabilities/mod.rs
+++ b/sway-lsp/src/capabilities/mod.rs
@@ -5,4 +5,5 @@ pub mod formatting;
 pub mod highlight;
 pub mod hover;
 pub mod rename;
+pub mod runnable;
 pub mod semantic_tokens;

--- a/sway-lsp/src/capabilities/runnable.rs
+++ b/sway-lsp/src/capabilities/runnable.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub enum RunnableType {
+    /// This is the main_fn entry point for the predicate or script.
+    MainFn,
+    /// Place holder for when we have in language testing supported.
+    /// The field holds the index of the test to run.
+    _TestFn(u8),
+}

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -160,6 +160,7 @@ impl Session {
 
     pub fn parse_project(&self, uri: &Url) -> Result<Vec<Diagnostic>, DocumentError> {
         self.token_map.clear();
+        self.runnables.clear();
 
         let manifest_dir = PathBuf::from(uri.path());
         let silent_mode = true;

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -16,9 +16,7 @@ use std::{
     path::PathBuf,
     sync::{Arc, LockResult, RwLock},
 };
-use sway_core::{
-    CompileAstResult, CompileResult, ParseProgram, TypeInfo, TypedProgramKind,
-};
+use sway_core::{CompileAstResult, CompileResult, ParseProgram, TypeInfo, TypedProgramKind};
 use sway_types::{Ident, Spanned};
 use tower_lsp::lsp_types::{
     CompletionItem, Diagnostic, GotoDefinitionParams, GotoDefinitionResponse, Location, Position,

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -31,7 +31,7 @@ pub enum RunnableType {
     MainFn,
     /// Place holder for when we have in language testing supported.
     /// The field holds the index of the test to run.
-    TestFn(u8),
+    _TestFn(u8),
 }
 
 #[derive(Debug)]

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -1,5 +1,5 @@
 use crate::{
-    capabilities::{self, formatting::get_format_text_edits},
+    capabilities::{self, formatting::get_format_text_edits, runnable::RunnableType},
     core::{
         document::{DocumentError, TextDocument},
         token::{Token, TokenMap, TypeDefinition},
@@ -24,15 +24,6 @@ use tower_lsp::lsp_types::{
 };
 
 pub type Documents = DashMap<String, TextDocument>;
-
-#[derive(Debug, Eq, PartialEq, Hash)]
-pub enum RunnableType {
-    /// This is the main_fn entry point for the predicate or script.
-    MainFn,
-    /// Place holder for when we have in language testing supported.
-    /// The field holds the index of the test to run.
-    _TestFn(u8),
-}
 
 #[derive(Debug)]
 pub struct Session {

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -13,7 +13,7 @@ pub async fn start(config: DebugFlags) {
     let stdout = tokio::io::stdout();
 
     let (service, socket) = LspService::build(|client| Backend::new(client, config))
-        .custom_method("sway/runnable", Backend::runnable)
+        .custom_method("sway/runnables", Backend::runnables)
         .finish();
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -13,7 +13,7 @@ pub async fn start(config: DebugFlags) {
     let stdout = tokio::io::stdout();
 
     let (service, socket) = LspService::build(|client| Backend::new(client, config))
-        .custom_method("sway/file_type", Backend::file_type)
+        .custom_method("sway/runnable", Backend::runnable)
         .finish();
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -12,6 +12,8 @@ pub async fn start(config: DebugFlags) {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let (service, socket) = LspService::new(|client| Backend::new(client, config));
+    let (service, socket) = LspService::build(|client| Backend::new(client, config))
+        .custom_method("sway/file_type", Backend::file_type)
+        .finish();
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -256,7 +256,7 @@ pub struct RunnableParams {}
 
 // Custom LSP-Server Methods
 impl Backend {
-    pub async fn runnable(&self, _params: RunnableParams) -> jsonrpc::Result<Option<Vec<Range>>> {
+    pub async fn runnables(&self, _params: RunnableParams) -> jsonrpc::Result<Option<Vec<Range>>> {
         let range = self
             .session
             .runnables
@@ -295,12 +295,8 @@ mod tests {
             .join("examples/signatures")
     }
 
-    fn lsp_test_dir() -> PathBuf {
-        env::current_dir().unwrap().join("test_programs/particle")
-    }
-
     fn load_sway_example() -> (Url, String) {
-        let manifest_dir = lsp_test_dir(); // sway_example_dir();
+        let manifest_dir = sway_example_dir();
         let src_path = manifest_dir.join("src/main.sw");
         let mut file = fs::File::open(&src_path).unwrap();
         let mut sway_program = String::new();

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -6,6 +6,7 @@ use crate::core::{
 };
 use crate::utils::debug::{self, DebugFlags};
 use forc_util::find_manifest_dir;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use sway_utils::helpers::get_sway_files;
 use tower_lsp::lsp_types::*;
@@ -250,6 +251,27 @@ impl LanguageServer for Backend {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FileTypeParams {
+    // text_document: TextDocumentIdentifier,
+    path: String,
+}
+
+// Custom LSP-Server Methods
+impl Backend {
+    pub async fn file_type(&self, params: FileTypeParams) -> jsonrpc::Result<Option<String>> {
+        // self.log_info_message("client has called the file_type call back!").await;
+        // let path = params.path; // params.text_document.uri.as_str()
+        // if let Some(document) = self.session.documents.get(&path) {
+        //     if let Some(file_type) = document.sway_file_type() {
+        //         let file_type = file_type.to_string();
+        //         return Ok(Some(file_type));
+        //     }
+        // }
+        Ok(None)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
@@ -278,8 +300,12 @@ mod tests {
             .join("examples/signatures")
     }
 
+    fn lsp_test_dir() -> PathBuf {
+        env::current_dir().unwrap().join("test_programs/particle")
+    }
+
     fn load_sway_example() -> (Url, String) {
-        let manifest_dir = sway_example_dir();
+        let manifest_dir = lsp_test_dir(); // sway_example_dir();
         let src_path = manifest_dir.join("src/main.sw");
         let mut file = fs::File::open(&src_path).unwrap();
         let mut sway_program = String::new();

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -258,7 +258,7 @@ pub struct RunnableParams {
 
 // Custom LSP-Server Methods
 impl Backend {
-    pub async fn runnable(&self, params: RunnableParams) -> jsonrpc::Result<Option<Range>> {
+    pub async fn runnable(&self, params: RunnableParams) -> jsonrpc::Result<Option<Vec<Range>>> {
         self.log_info_message("client has called the runnable call back!")
             .await;
         let _path = params.text_document.uri.as_str();
@@ -267,7 +267,7 @@ impl Backend {
             .session
             .runnables
             .get(&RunnableType::MainFn)
-            .map(|item| item.value().clone());
+            .map(|item| vec![item.value().clone()]);
 
         Ok(range)
     }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -261,7 +261,7 @@ impl Backend {
             .session
             .runnables
             .get(&RunnableType::MainFn)
-            .map(|item| vec![item.value().clone()]);
+            .map(|item| vec![*item.value()]);
 
         Ok(range)
     }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -1,7 +1,7 @@
 use crate::capabilities;
 use crate::core::{
     document::{DocumentError, TextDocument},
-    session::Session,
+    session::{RunnableType, Session},
     token::TokenMap,
 };
 use crate::utils::debug::{self, DebugFlags};
@@ -252,23 +252,24 @@ impl LanguageServer for Backend {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct FileTypeParams {
-    // text_document: TextDocumentIdentifier,
-    path: String,
+pub struct RunnableParams {
+    text_document: TextDocumentIdentifier,
 }
 
 // Custom LSP-Server Methods
 impl Backend {
-    pub async fn file_type(&self, params: FileTypeParams) -> jsonrpc::Result<Option<String>> {
-        // self.log_info_message("client has called the file_type call back!").await;
-        // let path = params.path; // params.text_document.uri.as_str()
-        // if let Some(document) = self.session.documents.get(&path) {
-        //     if let Some(file_type) = document.sway_file_type() {
-        //         let file_type = file_type.to_string();
-        //         return Ok(Some(file_type));
-        //     }
-        // }
-        Ok(None)
+    pub async fn runnable(&self, params: RunnableParams) -> jsonrpc::Result<Option<Range>> {
+        self.log_info_message("client has called the runnable call back!")
+            .await;
+        let _path = params.text_document.uri.as_str();
+
+        let range = self
+            .session
+            .runnables
+            .get(&RunnableType::MainFn)
+            .map(|item| item.value().clone());
+
+        Ok(range)
     }
 }
 

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -1,7 +1,7 @@
 use crate::capabilities;
 use crate::core::{
     document::{DocumentError, TextDocument},
-    session::{RunnableType, Session},
+    session::Session,
     token::TokenMap,
 };
 use crate::utils::debug::{self, DebugFlags};
@@ -260,7 +260,7 @@ impl Backend {
         let range = self
             .session
             .runnables
-            .get(&RunnableType::MainFn)
+            .get(&capabilities::runnable::RunnableType::MainFn)
             .map(|item| vec![*item.value()]);
 
         Ok(range)

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -252,17 +252,11 @@ impl LanguageServer for Backend {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct RunnableParams {
-    text_document: TextDocumentIdentifier,
-}
+pub struct RunnableParams {}
 
 // Custom LSP-Server Methods
 impl Backend {
-    pub async fn runnable(&self, params: RunnableParams) -> jsonrpc::Result<Option<Vec<Range>>> {
-        self.log_info_message("client has called the runnable call back!")
-            .await;
-        let _path = params.text_document.uri.as_str();
-
+    pub async fn runnable(&self, _params: RunnableParams) -> jsonrpc::Result<Option<Vec<Range>>> {
         let range = self
             .session
             .runnables


### PR DESCRIPTION
This PR enables the language server to collect and use typed tokens. As a result, go to definition works for tokens that have an associated type definition (roughly 50% of tokens).

This also allows us to get the main_function for script and predicate files, allowing us to send the code position on the `main` fn back to the client. Code lens is implemented on the client side for now which allows us to have a play button show up above the `main` fn to execute `forc run`. 

Currently, we are only able to use the typed tokens, and send information about the `main` fn location if the program is able to successfully compile.  This should be fixed once #1674 is addressed. 