### PR TITLE
Add an option to print the typed program AST.

### DIFF
--- a/docs/src/forc/manifest_reference.md
+++ b/docs/src/forc/manifest_reference.md
@@ -65,6 +65,7 @@ The `[build-profiles]` tables provide a way to customize compiler settings such 
 
 The following fields needs to be provided for a build-profile:
 
+* `print-ast` - Whether to print out the generated AST (true) or not (false).
 * `print-finalized-asm` - Whether to compile to bytecode (false) or to print out the generated ASM (true).
 * `print-intermediate-asm` - Whether to compile to bytecode (false) or to print out the generated ASM (true).
 * `print-ir` - Whether to compile to bytecode (false) or to print out the generated IR (true).

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -80,6 +80,7 @@ pub struct DependencyDetails {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct BuildProfile {
+    pub print_ast: bool,
     pub print_ir: bool,
     pub print_finalized_asm: bool,
     pub print_intermediate_asm: bool,
@@ -389,6 +390,7 @@ impl BuildProfile {
 
     pub fn debug() -> Self {
         Self {
+            print_ast: false,
             print_ir: false,
             print_finalized_asm: false,
             print_intermediate_asm: false,
@@ -399,6 +401,7 @@ impl BuildProfile {
 
     pub fn release() -> Self {
         Self {
+            print_ast: false,
             print_ir: false,
             print_finalized_asm: false,
             print_intermediate_asm: false,

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1626,6 +1626,10 @@ pub fn compile(
             typed_program,
             warnings,
         } => {
+            if build_profile.print_ast {
+                tracing::info!("{:#?}", typed_program);
+            }
+
             let json_abi = time_expr!("generate JSON ABI", typed_program.kind.generate_json_abi());
             let storage_slots = typed_program.storage_slots.clone();
             let tree_type = typed_program.kind.tree_type();

--- a/forc/src/cli/commands/build.rs
+++ b/forc/src/cli/commands/build.rs
@@ -21,6 +21,9 @@ pub struct Command {
     /// Path to the project, if not specified, current working directory will be used.
     #[clap(short, long)]
     pub path: Option<String>,
+    /// Print the generated Sway AST (Abstract Syntax Tree).
+    #[clap(long)]
+    pub print_ast: bool,
     /// Print the finalized ASM.
     ///
     /// This is the state of the ASM with registers allocated and optimisations applied.

--- a/forc/src/cli/commands/deploy.rs
+++ b/forc/src/cli/commands/deploy.rs
@@ -9,6 +9,9 @@ pub struct Command {
     /// Path to the project, if not specified, current working directory will be used.
     #[clap(short, long)]
     pub path: Option<String>,
+    /// Print the generated Sway AST (Abstract Syntax Tree).
+    #[clap(long)]
+    pub print_ast: bool,
     /// Print the finalized ASM.
     ///
     /// This is the state of the ASM with registers allocated and optimisations applied.

--- a/forc/src/cli/commands/run.rs
+++ b/forc/src/cli/commands/run.rs
@@ -31,6 +31,10 @@ pub struct Command {
     #[clap(short, long)]
     pub kill_node: bool,
 
+    /// Print the generated Sway AST (Abstract Syntax Tree).
+    #[clap(long)]
+    pub print_ast: bool,
+
     /// Print the finalized ASM.
     ///
     /// This is the state of the ASM with registers allocated and optimisations applied.

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -18,6 +18,7 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
         path,
         binary_outfile,
         debug_outfile,
+        print_ast,
         print_finalized_asm,
         print_intermediate_asm,
         print_ir,
@@ -72,6 +73,7 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
             );
             Default::default()
         });
+    profile.print_ast |= print_ast;
     profile.print_ir |= print_ir;
     profile.print_finalized_asm |= print_finalized_asm;
     profile.print_intermediate_asm |= print_intermediate_asm;

--- a/forc/src/ops/forc_deploy.rs
+++ b/forc/src/ops/forc_deploy.rs
@@ -24,6 +24,7 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
 
     let DeployCommand {
         path,
+        print_ast,
         print_finalized_asm,
         print_intermediate_asm,
         print_ir,
@@ -43,6 +44,7 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
 
     let build_command = BuildCommand {
         path,
+        print_ast,
         print_finalized_asm,
         print_intermediate_asm,
         print_ir,

--- a/forc/src/ops/forc_run.rs
+++ b/forc/src/ops/forc_run.rs
@@ -28,6 +28,7 @@ pub async fn run(command: RunCommand) -> Result<Vec<fuel_tx::Receipt>> {
 
     let build_command = BuildCommand {
         path: command.path,
+        print_ast: command.print_ast,
         print_finalized_asm: command.print_finalized_asm,
         print_intermediate_asm: command.print_intermediate_asm,
         print_ir: command.print_ir,


### PR DESCRIPTION
This adds a new `--print-ast` option which prints the typed program AST.

I've now needed this a few times for helping with debugging, so might as well add it.

You can use it via: `cargo run --bin forc -- build --print-ast --path test > test.ast`

And it will print something like:

```
TypedProgram {
    kind: Script {
        main_function: TypedFunctionDeclaration {
            name: main,
            body: TypedCodeBlock {
                contents: [
                    TypedAstNode {
                        content: Declaration(
                            ConstantDeclaration(
                                TypedConstantDeclaration {
                                    name: C2,
                                    value: TypedExpression {
                                        expression: VariableExpression {
                                            name: C1,
                                        },
                                        return_type: u64,
                                        is_constant: Yes,
                                        span: Span {
                                            as_str(): "C1",
                                        },
                                    },
                                    visibility: Private,
                                },
                            ),
                        ),
                        ... etc
```

Spans and Idents are a bit verbose by default, which can be improved by commenting a few lines in their Debug trait implementation. Not sure if we should change those defaults, so left it out of the PR.