### PR TITLE
Move the `SWAY_GIT_TAG` from `forc` into `forc-pkg`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3681,7 +3681,6 @@ version = "0.19.1"
 dependencies = [
  "async-trait",
  "dashmap",
- "forc",
  "forc-pkg",
  "forc-util",
  "futures",

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -105,11 +105,11 @@ impl ManifestFile {
     /// fields were used.
     ///
     /// If `core` and `std` are unspecified, `std` will be added to the `dependencies` table
-    /// implicitly. In this case, the `sway_git_tag` is used to specify the pinned commit at which
-    /// we fetch `std`.
-    pub fn from_file(path: PathBuf, sway_git_tag: &str) -> Result<Self> {
+    /// implicitly. In this case, the git tag associated with the version of this crate is used to
+    /// specify the pinned commit at which we fetch `std`.
+    pub fn from_file(path: PathBuf) -> Result<Self> {
         let path = path.canonicalize()?;
-        let manifest = Manifest::from_file(&path, sway_git_tag)?;
+        let manifest = Manifest::from_file(&path)?;
         Ok(Self { manifest, path })
     }
 
@@ -118,11 +118,11 @@ impl ManifestFile {
     ///
     /// This is short for `Manifest::from_file`, but takes care of constructing the path to the
     /// file.
-    pub fn from_dir(manifest_dir: &Path, sway_git_tag: &str) -> Result<Self> {
+    pub fn from_dir(manifest_dir: &Path) -> Result<Self> {
         let dir = forc_util::find_manifest_dir(manifest_dir)
             .ok_or_else(|| manifest_file_missing(manifest_dir))?;
         let path = dir.join(constants::MANIFEST_FILE_NAME);
-        Self::from_file(path, sway_git_tag)
+        Self::from_file(path)
     }
 
     /// Validate the `Manifest`.
@@ -232,9 +232,9 @@ impl Manifest {
     /// fields were used.
     ///
     /// If `core` and `std` are unspecified, `std` will be added to the `dependencies` table
-    /// implicitly. In this case, the `sway_git_tag` is used to specify the pinned commit at which
-    /// we fetch `std`.
-    pub fn from_file(path: &Path, sway_git_tag: &str) -> Result<Self> {
+    /// implicitly. In this case, the git tag associated with the version of this crate is used to
+    /// specify the pinned commit at which we fetch `std`.
+    pub fn from_file(path: &Path) -> Result<Self> {
         let manifest_str = std::fs::read_to_string(path)
             .map_err(|e| anyhow!("failed to read manifest at {:?}: {}", path, e))?;
         let toml_de = &mut toml::de::Deserializer::new(&manifest_str);
@@ -243,7 +243,7 @@ impl Manifest {
             println_yellow_err(&warning);
         })
         .map_err(|e| anyhow!("failed to parse manifest: {}.", e))?;
-        manifest.implicitly_include_std_if_missing(sway_git_tag);
+        manifest.implicitly_include_std_if_missing();
         manifest.implicitly_include_default_build_profiles_if_missing();
         manifest.validate()?;
         Ok(manifest)
@@ -265,10 +265,10 @@ impl Manifest {
     ///
     /// This is short for `Manifest::from_file`, but takes care of constructing the path to the
     /// file.
-    pub fn from_dir(dir: &Path, sway_git_tag: &str) -> Result<Self> {
+    pub fn from_dir(dir: &Path) -> Result<Self> {
         let manifest_dir = find_manifest_dir(dir).ok_or_else(|| manifest_file_missing(dir))?;
         let file_path = manifest_dir.join(constants::MANIFEST_FILE_NAME);
-        Self::from_file(&file_path, sway_git_tag)
+        Self::from_file(&file_path)
     }
 
     /// Produce an iterator yielding all listed dependencies.
@@ -311,7 +311,7 @@ impl Manifest {
     ///
     /// Note: If only `core` is specified, we are unable to implicitly add `std` as we cannot
     /// guarantee that the user's `core` is compatible with the implicit `std`.
-    fn implicitly_include_std_if_missing(&mut self, sway_git_tag: &str) {
+    fn implicitly_include_std_if_missing(&mut self) {
         use crate::{CORE, STD};
         // Don't include `std` if:
         // - this *is* `core` or `std`.
@@ -329,7 +329,7 @@ impl Manifest {
         // Add a `[dependencies]` table if there isn't one.
         let deps = self.dependencies.get_or_insert_with(Default::default);
         // Add the missing dependency.
-        let std_dep = implicit_std_dep(sway_git_tag.to_string());
+        let std_dep = implicit_std_dep();
         deps.insert(STD.to_string(), std_dep);
     }
 
@@ -425,11 +425,19 @@ impl Default for BuildProfile {
 }
 
 /// The definition for the implicit `std` dependency.
-fn implicit_std_dep(sway_git_tag: String) -> Dependency {
+fn implicit_std_dep() -> Dependency {
+    // The `forc-pkg` crate version formatted with the `v` prefix. E.g. "v1.2.3".
+    //
+    // This git tag is used during `Manifest` construction to pin the version of the implicit `std`
+    // dependency to the `forc-pkg` version.
+    //
+    // This is important to ensure that the version of `sway-core` that is baked into `forc-pkg` is
+    // compatible with the version of the `std` lib.
+    const SWAY_GIT_TAG: &str = concat!("v", env!("CARGO_PKG_VERSION"));
     const SWAY_GIT_REPO_URL: &str = "https://github.com/fuellabs/sway";
     let det = DependencyDetails {
         git: Some(SWAY_GIT_REPO_URL.to_string()),
-        tag: Some(sway_git_tag),
+        tag: Some(SWAY_GIT_TAG.to_string()),
         ..Default::default()
     };
     Dependency::Detailed(det)

--- a/forc/src/ops/forc_abi_json.rs
+++ b/forc/src/ops/forc_abi_json.rs
@@ -1,7 +1,4 @@
-use crate::{
-    cli::{BuildCommand, JsonAbiCommand},
-    utils::SWAY_GIT_TAG,
-};
+use crate::cli::{BuildCommand, JsonAbiCommand};
 use anyhow::Result;
 use forc_pkg::ManifestFile;
 use serde_json::{json, Value};
@@ -16,7 +13,7 @@ pub fn build(command: JsonAbiCommand) -> Result<Value> {
     } else {
         std::env::current_dir()?
     };
-    let manifest = ManifestFile::from_dir(&curr_dir, SWAY_GIT_TAG)?;
+    let manifest = ManifestFile::from_dir(&curr_dir)?;
     manifest.check_program_type(vec![TreeType::Contract, TreeType::Script])?;
 
     let build_command = BuildCommand {

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -1,6 +1,6 @@
 use crate::{
     cli::BuildCommand,
-    utils::{SWAY_BIN_HASH_SUFFIX, SWAY_BIN_ROOT_SUFFIX, SWAY_GIT_TAG},
+    utils::{SWAY_BIN_HASH_SUFFIX, SWAY_BIN_ROOT_SUFFIX},
 };
 use anyhow::Result;
 use forc_pkg::{self as pkg, ManifestFile};
@@ -57,9 +57,9 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
         std::env::current_dir()?
     };
 
-    let manifest = ManifestFile::from_dir(&this_dir, SWAY_GIT_TAG)?;
+    let manifest = ManifestFile::from_dir(&this_dir)?;
 
-    let plan = pkg::BuildPlan::from_lock_and_manifest(&manifest, locked, offline, SWAY_GIT_TAG)?;
+    let plan = pkg::BuildPlan::from_lock_and_manifest(&manifest, locked, offline)?;
 
     // Retrieve the specified build profile
     let mut profile = manifest

--- a/forc/src/ops/forc_check.rs
+++ b/forc/src/ops/forc_check.rs
@@ -1,4 +1,4 @@
-use crate::{cli::CheckCommand, utils::SWAY_GIT_TAG};
+use crate::cli::CheckCommand;
 use anyhow::Result;
 use forc_pkg::{self as pkg, ManifestFile};
 use std::path::PathBuf;
@@ -16,8 +16,8 @@ pub fn check(command: CheckCommand) -> Result<sway_core::CompileAstResult> {
     } else {
         std::env::current_dir()?
     };
-    let manifest = ManifestFile::from_dir(&this_dir, SWAY_GIT_TAG)?;
-    let plan = pkg::BuildPlan::from_lock_and_manifest(&manifest, locked, offline, SWAY_GIT_TAG)?;
+    let manifest = ManifestFile::from_dir(&this_dir)?;
+    let plan = pkg::BuildPlan::from_lock_and_manifest(&manifest, locked, offline)?;
 
     let (_, ast_res) = pkg::check(&plan, silent_mode)?;
     Ok(ast_res)

--- a/forc/src/ops/forc_deploy.rs
+++ b/forc/src/ops/forc_deploy.rs
@@ -1,8 +1,5 @@
+use crate::cli::{BuildCommand, DeployCommand};
 use crate::ops::forc_build;
-use crate::{
-    cli::{BuildCommand, DeployCommand},
-    utils::SWAY_GIT_TAG,
-};
 use anyhow::{bail, Result};
 use forc_pkg::ManifestFile;
 use fuel_gql_client::client::FuelClient;
@@ -19,7 +16,7 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
     } else {
         std::env::current_dir()?
     };
-    let manifest = ManifestFile::from_dir(&curr_dir, SWAY_GIT_TAG)?;
+    let manifest = ManifestFile::from_dir(&curr_dir)?;
     manifest.check_program_type(vec![TreeType::Contract])?;
 
     let DeployCommand {

--- a/forc/src/ops/forc_run.rs
+++ b/forc/src/ops/forc_run.rs
@@ -2,7 +2,6 @@ use crate::cli::{BuildCommand, RunCommand};
 use crate::ops::forc_build;
 use crate::utils::defaults::NODE_URL;
 use crate::utils::parameters::TxParameters;
-use crate::utils::SWAY_GIT_TAG;
 use anyhow::{anyhow, bail, Result};
 use forc_pkg::{fuel_core_not_running, ManifestFile};
 use fuel_gql_client::client::FuelClient;
@@ -19,7 +18,7 @@ pub async fn run(command: RunCommand) -> Result<Vec<fuel_tx::Receipt>> {
     } else {
         std::env::current_dir().map_err(|e| anyhow!("{:?}", e))?
     };
-    let manifest = ManifestFile::from_dir(&path_dir, SWAY_GIT_TAG)?;
+    let manifest = ManifestFile::from_dir(&path_dir)?;
     manifest.check_program_type(vec![TreeType::Script])?;
 
     let input_data = &command.data.unwrap_or_else(|| "".into());

--- a/forc/src/ops/forc_template.rs
+++ b/forc/src/ops/forc_template.rs
@@ -1,5 +1,5 @@
 use crate::cli::TemplateCommand;
-use crate::utils::{defaults, SWAY_GIT_TAG};
+use crate::utils::defaults;
 use anyhow::{anyhow, Context, Result};
 use forc_pkg::{
     fetch_git, fetch_id, find_dir_within, git_commit_path, pin_git, Manifest, SourceGit,
@@ -46,17 +46,16 @@ pub fn init(command: TemplateCommand) -> Result<()> {
     }
 
     let from_path = match command.template_name {
-        Some(ref template_name) => find_dir_within(&repo_path, template_name, SWAY_GIT_TAG)
-            .ok_or_else(|| {
-                anyhow!(
-                    "failed to find a template `{}` in {}",
-                    template_name,
-                    command.url
-                )
-            })?,
+        Some(ref template_name) => find_dir_within(&repo_path, template_name).ok_or_else(|| {
+            anyhow!(
+                "failed to find a template `{}` in {}",
+                template_name,
+                command.url
+            )
+        })?,
         None => {
             let manifest_path = repo_path.join(constants::MANIFEST_FILE_NAME);
-            if Manifest::from_file(&manifest_path, SWAY_GIT_TAG).is_err() {
+            if Manifest::from_file(&manifest_path).is_err() {
                 anyhow::bail!("failed to find a template in {}", command.url);
             }
             repo_path

--- a/forc/src/ops/forc_update.rs
+++ b/forc/src/ops/forc_update.rs
@@ -1,4 +1,4 @@
-use crate::{cli::UpdateCommand, utils::SWAY_GIT_TAG};
+use crate::cli::UpdateCommand;
 use anyhow::{anyhow, Result};
 use forc_pkg::{self as pkg, lock, Lock, ManifestFile};
 use forc_util::lock_path;
@@ -32,11 +32,11 @@ pub async fn update(command: UpdateCommand) -> Result<()> {
         None => std::env::current_dir()?,
     };
 
-    let manifest = ManifestFile::from_dir(&this_dir, SWAY_GIT_TAG)?;
+    let manifest = ManifestFile::from_dir(&this_dir)?;
     let lock_path = lock_path(manifest.dir());
     let old_lock = Lock::from_path(&lock_path).ok().unwrap_or_default();
     let offline = false;
-    let new_plan = pkg::BuildPlan::from_manifest(&manifest, SWAY_GIT_TAG, offline)?;
+    let new_plan = pkg::BuildPlan::from_manifest(&manifest, offline)?;
     let new_lock = Lock::from_graph(new_plan.graph());
     let diff = new_lock.diff(&old_lock);
     lock::print_diff(&manifest.project.name, &diff);

--- a/forc/src/utils/mod.rs
+++ b/forc/src/utils/mod.rs
@@ -2,12 +2,6 @@ pub mod defaults;
 pub mod parameters;
 pub mod program_type;
 
-/// The `forc` crate version formatted with the `v` prefix. E.g. "v1.2.3".
-///
-/// This git tag is used during `Manifest` construction to pin the version of the implicit `std`
-/// dependency to the `forc` version.
-pub const SWAY_GIT_TAG: &str = concat!("v", clap::crate_version!());
-
 /// The suffix that helps identify the file which contains the hash of the binary file created when
 /// scripts are built.
 pub const SWAY_BIN_HASH_SUFFIX: &str = "-bin-hash";

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -10,7 +10,6 @@ description = "LSP server for Sway."
 
 [dependencies]
 dashmap = "5.3.4"
-forc = { version = "0.19.1", path = "../forc" }
 forc-pkg = { version = "0.19.1", path = "../forc-pkg" }
 forc-util = { version = "0.19.1", path = "../forc-util" }
 ropey = "1.2"

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -9,7 +9,6 @@ use crate::{
     utils,
 };
 use dashmap::DashMap;
-use forc::utils::SWAY_GIT_TAG;
 use forc_pkg::{self as pkg};
 use serde_json::Value;
 use std::{
@@ -159,10 +158,8 @@ impl Session {
         let offline = false;
 
         // TODO: match on any errors and report them back to the user in a future PR
-        if let Ok(manifest) = pkg::ManifestFile::from_dir(&manifest_dir, SWAY_GIT_TAG) {
-            if let Ok(plan) =
-                pkg::BuildPlan::from_lock_and_manifest(&manifest, locked, offline, SWAY_GIT_TAG)
-            {
+        if let Ok(manifest) = pkg::ManifestFile::from_dir(&manifest_dir) {
+            if let Ok(plan) = pkg::BuildPlan::from_lock_and_manifest(&manifest, locked, offline) {
                 //we can then use them directly to convert them to a Vec<Diagnostic>
                 if let Ok((parsed_res, ast_res)) = pkg::check(&plan, silent_mode) {
                     // First, populate our token_map with un-typed ast nodes


### PR DESCRIPTION
Closes #2447.

See this comment for context: https://github.com/FuelLabs/sway/pull/2440#discussion_r936144091.

cc @JoshuaBatty as a result, this let's us remove the `forc` dep from `sway-lsp`! :tada: 

cc @segfault-magnet this might let you remove the `forc`-as-a-library usage you mentioned [here](https://github.com/FuelLabs/sway/issues/2362#issuecomment-1196837573) in favour of just using `forc-pkg` directly? At the very least, it should remove the need for some of the ceremony required around the sway git tag. 