### PR TITLE
Send the program kind along with the range to the client code_lens request

### DIFF
--- a/sway-lsp/src/capabilities/runnable.rs
+++ b/sway-lsp/src/capabilities/runnable.rs
@@ -1,3 +1,6 @@
+use sway_core::TreeType;
+use tower_lsp::lsp_types::Range;
+
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub enum RunnableType {
     /// This is the main_fn entry point for the predicate or script.
@@ -5,4 +8,18 @@ pub enum RunnableType {
     /// Place holder for when we have in language testing supported.
     /// The field holds the index of the test to run.
     _TestFn(u8),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Runnable {
+    /// The location in the file where the runnable button should be displayed
+    pub range: Range,
+    /// The program kind of the current file
+    pub tree_type: TreeType,
+}
+
+impl Runnable {
+    pub fn new(range: Range, tree_type: TreeType) -> Self {
+        Self { range, tree_type }
+    }
 }

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -1,5 +1,9 @@
 use crate::{
-    capabilities::{self, formatting::get_format_text_edits, runnable::RunnableType},
+    capabilities::{
+        self,
+        formatting::get_format_text_edits,
+        runnable::{Runnable, RunnableType},
+    },
     core::{
         document::{DocumentError, TextDocument},
         token::{Token, TokenMap, TypeDefinition},
@@ -29,7 +33,7 @@ pub struct Session {
     pub documents: Documents,
     pub config: RwLock<SwayConfig>,
     pub token_map: TokenMap,
-    pub runnables: DashMap<RunnableType, Range>,
+    pub runnables: DashMap<RunnableType, Runnable>,
 }
 
 impl Session {
@@ -218,13 +222,17 @@ impl Session {
                 typed_program,
                 warnings,
             } => {
-                if let TypedProgramKind::Script { main_function, .. }
-                | TypedProgramKind::Predicate { main_function, .. } = typed_program.kind
+                if let TypedProgramKind::Script {
+                    ref main_function, ..
+                }
+                | TypedProgramKind::Predicate {
+                    ref main_function, ..
+                } = typed_program.kind
                 {
                     let main_fn_location =
                         utils::common::get_range_from_span(&main_function.name.span());
-                    self.runnables
-                        .insert(RunnableType::MainFn, main_fn_location);
+                    let runnable = Runnable::new(main_fn_location, typed_program.kind.tree_type());
+                    self.runnables.insert(RunnableType::MainFn, runnable);
                 }
 
                 for node in &typed_program.root.all_nodes {

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -256,14 +256,20 @@ pub struct RunnableParams {}
 
 // Custom LSP-Server Methods
 impl Backend {
-    pub async fn runnables(&self, _params: RunnableParams) -> jsonrpc::Result<Option<Vec<Range>>> {
-        let range = self
+    pub async fn runnables(
+        &self,
+        _params: RunnableParams,
+    ) -> jsonrpc::Result<Option<Vec<(Range, String)>>> {
+        let ranges = self
             .session
             .runnables
             .get(&capabilities::runnable::RunnableType::MainFn)
-            .map(|item| vec![*item.value()]);
+            .map(|item| {
+                let runnable = item.value();
+                vec![(runnable.range, format!("{}", runnable.tree_type))]
+            });
 
-        Ok(range)
+        Ok(ranges)
     }
 }
 


### PR DESCRIPTION
Currently, the LSP client has no information about the current file that is open. This changes the `runnables` callback from sending a `vec![lsp_types::Range]` to `vec![(lsp_types::Range, String)]`

The `String` can be either `"predicate"` or `"script"`

This should allow the client to match on the program kind string and call `forc run` for scripts and `forc build` for predicate files when the code_lens run button is clicked. 