### PR TITLE
Switch between viewing typed or parsed tokens as warnings in the LSP client.

### DIFF
--- a/forc-plugins/forc-lsp/src/main.rs
+++ b/forc-plugins/forc-lsp/src/main.rs
@@ -10,18 +10,18 @@ use clap::Parser;
     about = "Forc plugin for the Sway LSP (Language Server Protocol) implementation.",
     version
 )]
-pub struct App {
+struct App {
     /// Instructs the client to draw squiggly lines under all of the tokens that our server managed
-    /// to parse.
+    /// to parse. Expects either "typed" or "parsed".
     #[clap(long)]
-    pub parsed_tokens_as_warnings: bool,
+    pub collected_tokens_as_warnings: Option<String>,
 }
 
 #[tokio::main]
 async fn main() {
     let app = App::parse();
     let dbg = sway_lsp::utils::debug::DebugFlags {
-        parsed_tokens_as_warnings: app.parsed_tokens_as_warnings,
+        collected_tokens_as_warnings: app.collected_tokens_as_warnings,
     };
     sway_lsp::start(dbg).await
 }

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -9,8 +9,9 @@ use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 #[derive(Debug, Default)]
 pub struct DebugFlags {
     /// Instructs the client to draw squiggly lines
-    /// under all of the tokens that our server managed to parse
-    pub parsed_tokens_as_warnings: bool,
+    /// under all of the tokens that our server managed to parse.
+    /// String can be either "typed" or "parsed".
+    pub collected_tokens_as_warnings: Option<String>,
 }
 
 pub(crate) fn generate_warnings_non_typed_tokens(tokens: &TokenMap) -> Vec<Diagnostic> {


### PR DESCRIPTION
Change `forc-lsp` to take an optional string for specifying which tokens should be shown as warnings when debugging the language server.

This makes it much more convenient to switch back and forth between inspecting the parsed and typed tokens that have been collected by the language server.

I've opened up a PR in the VSCode plugin which allows the user to specify this using a drop-down menu under the sway plugin options tab. https://github.com/FuelLabs/sway-vscode-plugin/pull/83