### PR TITLE
Fix DCA for constant declaration value expressions.

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -366,9 +366,17 @@ fn connect_declaration(
                 )
             }
         }
-        ConstantDeclaration(TypedConstantDeclaration { name, .. }) => {
+        ConstantDeclaration(TypedConstantDeclaration { name, value, .. }) => {
             graph.namespace.insert_constant(name.clone(), entry_node);
-            Ok(leaves.to_vec())
+            connect_expression(
+                &value.expression,
+                graph,
+                &[entry_node],
+                exit_node,
+                "constant declaration expression",
+                tree_type,
+                value.span.clone(),
+            )
         }
         FunctionDeclaration(fn_decl) => {
             connect_typed_fn_decl(fn_decl, graph, entry_node, span, exit_node, tree_type)?;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/dca_constant_decl_expr/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/dca_constant_decl_expr/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'dca_constant_decl_expr'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/dca_constant_decl_expr/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/dca_constant_decl_expr/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "dca_constant_decl_expr"
+entry = "main.sw"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/dca_constant_decl_expr/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/dca_constant_decl_expr/json_abi_oracle.json
@@ -1,0 +1,15 @@
+[
+  {
+    "inputs": [],
+    "name": "main",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "u64",
+        "typeArguments": null
+      }
+    ],
+    "type": "function"
+  }
+]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/dca_constant_decl_expr/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/dca_constant_decl_expr/src/main.sw
@@ -1,0 +1,8 @@
+script;
+
+const C1 = 66;
+
+fn main() -> u64 {
+    const C2 = C1;
+    C2 
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/dca_constant_decl_expr/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/dca_constant_decl_expr/test.toml
@@ -1,0 +1,5 @@
+category = "compile"
+validate_abi = true
+
+# not: const C1 = 66;
+# not: -------------- This declaration is never used.


### PR DESCRIPTION
This connects the value expression of a constant declaration when performing dead code analysis.

Also adds a new test to make sure this does not regress.

Closes https://github.com/FuelLabs/sway/issues/2423.