### PR TITLE
Some preparation for function calls.

### DIFF
--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -34,6 +34,7 @@ pub(super) struct FnCompiler {
     pub(super) block_to_break_to: Option<Block>,
     pub(super) block_to_continue_to: Option<Block>,
     lexical_map: LexicalMap,
+    recreated_fns: HashMap<(Span, Vec<TypeId>, Vec<TypeId>), Function>,
 }
 
 pub(super) enum StateAccessType {
@@ -55,6 +56,7 @@ impl FnCompiler {
             block_to_break_to: None,
             block_to_continue_to: None,
             lexical_map,
+            recreated_fns: HashMap::new(),
         }
     }
 
@@ -787,46 +789,63 @@ impl FnCompiler {
         self_state_idx: Option<StateIndex>,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
-        // XXX OK, now, the old compiler inlines everything very lazily.  Function calls include
-        // the body of the callee (i.e., the callee_body arg above) and so codegen just pulled it
-        // straight in, no questions asked.  Library functions are provided in an initial namespace
-        // from Forc and when the parser builds the AST (or is it during type checking?) these
-        // function bodies are embedded.
+        // The compiler inlines everything very lazily.  Function calls include the body of the
+        // callee (i.e., the callee_body arg above). Library functions are provided in an initial
+        // namespace from Forc and when the parser builds the AST (or is it during type checking?)
+        // these function bodies are embedded.
         //
-        // We're going to build little single-use instantiations of the callee and then call them.
-        // For now if they're called in multiple places they'll be redundantly recreated, but also
-        // at present we are still inlining everything so it actually makes little difference.
+        // Here we build little single-use instantiations of the callee and then call them.  Naming
+        // is not yet absolute so we must ensure the function names are unique.
         //
-        // Eventually we need to Do It Properly and inline only when necessary, and compile the
-        // standard library to an actual module.
+        // Eventually we need to Do It Properly and inline into the AST only when necessary, and
+        // compile the standard library to an actual module.
 
-        {
-            let callee_name = format!("{}_{}", callee.name, context.get_unique_id());
+        // Get the callee from the cache if we've already compiled it.  We can't insert it with
+        // .entry() since `compile_function()` returns a Result we need to handle.  The key to our
+        // cache, to uniquely identify a function instance, is the span and the type IDs of any
+        // args and type parameters.  It's using the Sway types rather than IR types, which would
+        // be more accurate but also more fiddly.
+        let fn_key = (
+            callee.span(),
+            callee.parameters.iter().map(|p| p.type_id).collect(),
+            callee.type_parameters.iter().map(|tp| tp.type_id).collect(),
+        );
+        let callee = match self.recreated_fns.get(&fn_key).copied() {
+            Some(func) => func,
+            None => {
+                let callee_fn_decl = TypedFunctionDeclaration {
+                    type_parameters: Vec::new(),
+                    name: Ident::new(Span::from_string(format!(
+                        "{}_{}",
+                        callee.name,
+                        context.get_unique_id()
+                    ))),
+                    ..callee
+                };
+                let new_func =
+                    compile_function(context, md_mgr, self.module, callee_fn_decl)?.unwrap();
+                self.recreated_fns.insert(fn_key, new_func);
+                new_func
+            }
+        };
 
-            let mut callee_fn_decl = callee;
-            callee_fn_decl.type_parameters.clear();
-            callee_fn_decl.name = Ident::new(Span::from_string(callee_name));
-
-            let callee = compile_function(context, md_mgr, self.module, callee_fn_decl)?;
-
-            // Now actually call the new function.
-            let args = ast_args
-                .into_iter()
-                .map(|(_, expr)| self.compile_expression(context, md_mgr, expr))
-                .collect::<Result<Vec<Value>, CompileError>>()?;
-            let state_idx_md_idx = match self_state_idx {
-                Some(self_state_idx) => {
-                    md_mgr.storage_key_to_md(context, self_state_idx.to_usize() as u64)
-                }
-                None => None,
-            };
-            Ok(self
-                .current_block
-                .ins(context)
-                .call(callee.unwrap(), &args)
-                .add_metadatum(context, span_md_idx)
-                .add_metadatum(context, state_idx_md_idx))
-        }
+        // Now actually call the new function.
+        let args = ast_args
+            .into_iter()
+            .map(|(_, expr)| self.compile_expression(context, md_mgr, expr))
+            .collect::<Result<Vec<Value>, CompileError>>()?;
+        let state_idx_md_idx = match self_state_idx {
+            Some(self_state_idx) => {
+                md_mgr.storage_key_to_md(context, self_state_idx.to_usize() as u64)
+            }
+            None => None,
+        };
+        Ok(self
+            .current_block
+            .ins(context)
+            .call(callee, &args)
+            .add_metadatum(context, span_md_idx)
+            .add_metadatum(context, state_idx_md_idx))
     }
 
     fn compile_if(

--- a/sway-ir/src/function.rs
+++ b/sway-ir/src/function.rs
@@ -205,6 +205,18 @@ impl Function {
         idx
     }
 
+    /// Return the number of blocks in this function.
+    pub fn num_blocks(&self, context: &Context) -> usize {
+        context.functions[self.0].blocks.len()
+    }
+
+    /// Return the number of instructions in this function.
+    pub fn num_instructions(&self, context: &Context) -> usize {
+        self.block_iter(context)
+            .map(|block| block.num_instructions(context))
+            .sum()
+    }
+
     /// Return the function name.
     pub fn get_name<'a>(&self, context: &'a Context) -> &'a str {
         &context.functions[self.0].name

--- a/sway-ir/src/optimize/constants.rs
+++ b/sway-ir/src/optimize/constants.rs
@@ -62,10 +62,9 @@ fn combine_const_insert_values(context: &mut Context, function: &Function) -> bo
         });
 
     if let Some((block, ins_val, aggregate, const_val, indices)) = candidate {
-        // OK, here we have an `insert_value` of a constant directly into a constant
-        // aggregate.  We want to replace the constant aggregate with an updated one.
-        let new_aggregate =
-            combine_const_aggregate_field(context, function, aggregate, const_val, &indices);
+        // OK, here we have an `insert_value` of a constant directly into a constant aggregate.  We
+        // want to replace the constant aggregate with an updated one.
+        let new_aggregate = combine_const_aggregate_field(context, aggregate, const_val, &indices);
 
         // Replace uses of the `insert_value` instruction with the new aggregate.
         function.replace_value(context, ins_val, new_aggregate, None);
@@ -73,8 +72,8 @@ fn combine_const_insert_values(context: &mut Context, function: &Function) -> bo
         // Remove the `insert_value` instruction.
         block.remove_instruction(context, ins_val);
 
-        // Let's return now, since our iterator may get confused and let the pass
-        // iterate further itself.
+        // Let's return now, since our iterator may get confused and let the pass iterate further
+        // itself.
         return true;
     }
 
@@ -83,7 +82,6 @@ fn combine_const_insert_values(context: &mut Context, function: &Function) -> bo
 
 fn combine_const_aggregate_field(
     context: &mut Context,
-    function: &Function,
     aggregate: Value,
     const_value: Value,
     indices: &[u64],
@@ -108,20 +106,11 @@ fn combine_const_aggregate_field(
     // Update the new aggregate with the constant field, based in the indices.
     inject_constant_into_aggregate(&mut new_aggregate, const_value, indices);
 
-    // Replace the old aggregate with the new aggregate.
-    let new_aggregate_value =
-        Value::new_constant(context, new_aggregate).add_metadatum(context, metadata);
-    function.replace_value(context, aggregate, new_aggregate_value, None);
+    // NOTE: Previous versions of this pass were trying to clean up after themselves, by replacing
+    // the old aggregate with this new one, and/or removing the old aggregate altogether.  This is
+    // too dangerous without proper checking for remaining uses, and is best left to DCE anyway.
 
-    // Remove the old aggregate from the context.
-    //
-    // OR NOT!  This is too dangerous unless we can
-    // guarantee it has no uses, which is something we should implement eventually.  For now, in
-    // this case it shouldn't matter if we leave it, even if it's not used.
-    //
-    // TODO: context.values.remove(aggregate.0);
-
-    new_aggregate_value
+    Value::new_constant(context, new_aggregate).add_metadatum(context, metadata)
 }
 
 fn inject_constant_into_aggregate(aggregate: &mut Constant, value: Constant, indices: &[u64]) {

--- a/sway-ir/tests/README.md
+++ b/sway-ir/tests/README.md
@@ -1,0 +1,46 @@
+# Notes on the Inliner Unit Testing
+
+Each of the files in the `inline` directory are passed through the inliner and verified using
+`FileCheck`.
+
+## Parameters
+
+The first line of the IR file must be a comment containing the parameters for the pass.  These may
+be:
+
+* The single word `all`, indicating all `CALL`s found throughout the input will be inlined.
+* A combination of sizes which are passed to the `optimize::inline::is_small_fn()` function:
+    * `blocks N` to indicate a maximum of `N` allowed blocks constraint.
+    * `instrs N`  to indicate a maximum of `N` allowed instructions constraint.
+    * `stack N` to indicate a maximum of `N` for stack size constraint.
+
+Any keyword found later in the line will override an earlier parameter.  `all` will override any
+other constraint.
+
+### Example
+
+To just inline everything:
+
+```rust
+// all
+```
+
+To inline only functions which have at most 2 blocks:
+
+```rust
+// blocks 2
+```
+
+To inline only functions which have at most 2 blocks, at most 20 instructions and no more than 10
+stack elements:
+
+```rust
+// blocks 2 instrs 20 stack 10
+```
+
+See the source for `optimize::inline::is_small_fn()` for further clarification.
+
+### Caveats
+
+This is a little bit lame and perhaps a proper looking command line (and parser) would be better,
+e.g., `// run --blocks 2 --instrs 20` but this will do for a start.

--- a/sway-ir/tests/inline/bigger.ir
+++ b/sway-ir/tests/inline/bigger.ir
@@ -1,3 +1,5 @@
+// all
+//
 // Based on this Sway:
 //
 // script;

--- a/sway-ir/tests/inline/by_block_and_instr_count.ir
+++ b/sway-ir/tests/inline/by_block_and_instr_count.ir
@@ -1,0 +1,80 @@
+// blocks 2 instrs 4
+
+script {
+    fn two_blocks_four_instrs() -> bool {
+        entry:
+        v0 = const bool true
+        br block
+
+        block:
+        v1 = phi(entry: v0)
+        v2 = const bool false
+        v3 = cmp eq v1 v2
+        v4 = cmp eq v2 v3
+        ret bool v4
+    }
+
+    fn two_blocks_five_instrs() -> bool {
+        entry:
+        v0 = const bool true
+        br block
+
+        block:
+        v1 = phi(entry: v0)
+        v2 = const bool false
+        v3 = cmp eq v1 v2
+        v4 = cmp eq v2 v3
+        v5 = const bool true
+        v6 = cmp eq v4 v5
+        ret bool v6
+    }
+
+    fn three_blocks_four_instrs(b: bool) -> bool {
+        entry:
+        v0 = const bool false
+        v1 = cmp eq b v0
+        cbr v1, then_block, else_block
+
+        then_block:
+        v2 = const bool false
+        ret bool v2
+
+        else_block:
+        v3 = const bool true
+        ret bool v3
+    }
+
+    fn three_blocks_five_instrs(b: bool) -> bool {
+        entry:
+        v0 = const bool false
+        v1 = cmp eq b v0
+        v2 = cmp eq b v1
+        cbr v2, then_block, else_block
+
+        then_block:
+        v3 = const bool false
+        ret bool v3
+
+        else_block:
+        v4 = const bool true
+        ret bool v4
+    }
+
+    fn main() -> bool {
+// check: fn main() -> bool
+        entry:
+
+        // This is the only call which should be inlined.
+        v0 = call two_blocks_four_instrs()
+// not: call two_blocks_four_instrs()
+
+        v1 = call two_blocks_five_instrs()
+// check: call two_blocks_five_instrs()
+        v2 = call three_blocks_four_instrs()
+// check: call three_blocks_four_instrs()
+        v3 = call three_blocks_five_instrs()
+// check: call three_blocks_five_instrs()
+
+        ret bool v3
+    }
+}

--- a/sway-ir/tests/inline/by_block_count.ir
+++ b/sway-ir/tests/inline/by_block_count.ir
@@ -1,0 +1,49 @@
+// blocks 2
+
+script {
+    fn one_block() -> bool {
+        entry:
+        v0 = const bool false
+        ret bool v0
+    }
+
+    fn two_blocks() -> bool {
+        entry:
+        v0 = const bool true
+        br block
+
+        block:
+        v1 = phi(entry: v0)
+        ret bool v1
+    }
+
+    fn three_blocks(b: bool) -> bool {
+        entry:
+        cbr b, then_block, else_block
+
+        then_block:
+        v0 = const bool false
+        ret bool v0
+
+        else_block:
+        v1 = const bool true
+        ret bool v1
+    }
+
+    fn main() -> bool {
+// check: fn main() -> bool
+        entry:
+
+        v0 = call one_block()
+// not: call one_block()
+// check: const bool false
+
+        v1 = call two_blocks()
+// not: call two_blocks()
+// check: const bool true
+
+        v2 = call three_blocks(v1)
+// check: call three_blocks
+        ret bool v2
+    }
+}

--- a/sway-ir/tests/inline/by_instr_count.ir
+++ b/sway-ir/tests/inline/by_instr_count.ir
@@ -1,0 +1,130 @@
+// instrs 4
+
+script {
+    // One instruction.
+    fn less_one_block() -> u64 {
+        entry:
+        v0 = const u64 11
+        ret u64 v0
+    }
+
+    // Two instructions.
+    fn less_two_blocks() -> u64 {
+        entry:
+        v0 = const u64 22
+        br block
+
+        block:
+        v1 = phi(entry: v0)
+        ret u64 v1
+    }
+
+    // Three instrutions.
+    fn less_three_blocks(b: bool) -> u64 {
+        entry:
+        cbr b, then_block, else_block
+
+        then_block:
+        v0 = const u64 33
+        ret u64 v0
+
+        else_block:
+        v1 = const u64 44
+        ret u64 v1
+    }
+
+    // Four cmp instructions and a ret.
+    fn more_one_block() -> bool {
+        entry:
+        v0 = const u64 55
+        v1 = const u64 66
+        v2 = cmp eq v0 v1
+        v3 = const bool true
+        v4 = cmp eq v2 v3
+        v5 = const bool true
+        v6 = cmp eq v4 v5
+        v7 = const bool true
+        v8 = cmp eq v6 v7
+
+        ret bool v8
+    }
+
+    // Four cmp instructions, a br and a ret.
+    fn more_two_blocks() -> bool {
+        entry:
+        v0 = const u64 77
+        v1 = const u64 88
+        v2 = cmp eq v0 v1
+        v3 = const bool true
+        v4 = cmp eq v2 v3
+        v5 = const bool true
+        v6 = cmp eq v4 v5
+        v7 = const bool true
+        v8 = cmp eq v6 v7
+        br block
+
+        block:
+        v9 = phi(entry: v8)
+        ret bool v9
+    }
+
+    // Four cmp instructions, a cbr an two rets.
+    fn more_three_blocks(b: bool) -> bool {
+        entry:
+        cbr b, then_block, else_block
+
+        then_block:
+        v0 = const u64 99
+        v1 = const u64 1010
+        v2 = cmp eq v0 v1
+        v3 = const bool true
+        v4 = cmp eq v2 v3
+        ret bool v4
+
+        else_block:
+        v5 = const u64 1111
+        v6 = const u64 1212
+        v7 = cmp eq v5 v6
+        v8 = const bool true
+        v9 = cmp eq v7 v8
+        ret bool v9
+    }
+
+    fn main() -> bool {
+// check: fn main() -> bool
+        entry:
+
+        v0 = call less_one_block()
+// not: call less_one_block
+// check: const u64 11
+
+        v1 = call less_two_blocks()
+// not: call less_two_blocks
+// check: const u64 22
+
+        v2 = const bool true
+        v3 = call less_three_blocks(v2)
+// not: call less_three_blocks
+// check: const u64 33
+// check: const u64 44
+
+        v4 = call more_one_block()
+// check: call more_one_block
+// not: const u64 55
+// not: const u64 66
+
+        v5 = call more_two_blocks()
+// check: call more_two_blocks
+// not: const u64 77
+// not: const u64 88
+
+        v6 = call more_three_blocks(v5)
+// check: call more_three_blocks
+// not: const u64 99
+// not: const u64 1010
+// not: const u64 1111
+// not: const u64 1212
+
+        ret bool v6
+    }
+}

--- a/sway-ir/tests/inline/by_stack_count.ir
+++ b/sway-ir/tests/inline/by_stack_count.ir
@@ -1,0 +1,99 @@
+// stack 2
+
+script {
+    fn one_local() -> u64 {
+        local ptr u64 num
+
+        entry:
+        v0 = const u64 11
+        ret u64 v0
+    }
+
+    fn two_locals() -> u64 {
+        local ptr u64 num
+        local ptr bool flag
+
+        entry:
+        v0 = const u64 22
+        ret u64 v0
+    }
+
+    fn three_locals() -> u64 {
+        local ptr u64 num
+        local ptr bool flag
+        local ptr string<10> name
+
+        entry:
+        v0 = const u64 33
+        ret u64 v0
+    }
+
+    fn two_struct_locals() -> u64 {
+        local ptr { u64, u64 } pair
+
+        entry:
+        v0 = const u64 44
+        ret u64 v0
+    }
+
+    fn three_struct_locals() -> u64 {
+        local ptr { u64, u64, bool } triple
+
+        entry:
+        v0 = const u64 55
+        ret u64 v0
+    }
+
+    fn two_mixed_locals() -> u64 {
+        local ptr { u64 } single
+        local ptr bool flag
+
+        entry:
+        v0 = const u64 66
+        ret u64 v0
+    }
+
+    fn three_mixed_locals() -> u64 {
+        local ptr { u64, string<10> } pair
+        local ptr bool flag
+
+        entry:
+        v0 = const u64 77
+        ret u64 v0
+    }
+
+    fn main() -> u64 {
+// check: fn main() -> u64
+        entry:
+
+        v0 = call one_local()
+// not: call one_local()
+// check: const u64 11
+
+        v1 = call two_locals()
+// not: call two_locals()
+// check: const u64 22
+
+        v2 = call three_locals()
+// check: call three_locals()
+// not: const u64 33
+
+        v3 = call two_struct_locals()
+// not: call two_struct_locals()
+// check: const u64 44
+
+        v4 = call three_struct_locals()
+// check: call three_struct_locals()
+// not: const u64 55
+
+        v5 = call two_mixed_locals()
+// not: call two_mixed_locals()
+// check: const u64 66
+
+        v6 = call three_mixed_locals()
+// check: call three_mixed_locals()
+// not: const u64 77
+
+        ret u64 v6
+    }
+}

--- a/sway-ir/tests/inline/fiddly.ir
+++ b/sway-ir/tests/inline/fiddly.ir
@@ -1,3 +1,5 @@
+// all
+//
 // Based on this Sway which is designed to have many blocks and branches in main() before we inline
 // more blocks and branches.  In particular, we need to be sure the `phi` instructions refer to the
 // correct predecessor blocks.

--- a/sway-ir/tests/inline/get_storage_key.ir
+++ b/sway-ir/tests/inline/get_storage_key.ir
@@ -1,6 +1,8 @@
+// all
+//
 // regex: VAR=v\d+
 // regex: MD=!\d+
-// regex: LABEL=[[:alpha:]0-9]+:
+// regex: LABEL=[[:alpha:]0-9_]+:
 
 script {
     fn return_storage_key_wrapper() -> b256 {

--- a/sway-ir/tests/inline/int_to_ptr.ir
+++ b/sway-ir/tests/inline/int_to_ptr.ir
@@ -1,5 +1,7 @@
+// all
+//
 // regex: VAR=v\d+
-// regex: LABEL=[[:alpha:]0-9]+:
+// regex: LABEL=[[:alpha:]0-9_]+:
 
 script {
     fn a(b: u64) -> b256 {

--- a/sway-ir/tests/inline/simple.ir
+++ b/sway-ir/tests/inline/simple.ir
@@ -1,3 +1,5 @@
+// all
+//
 // Based on this Sway:
 //
 // script;
@@ -12,7 +14,7 @@
 // }
 
 // regex: VAR=v\d+
-// regex: LABEL=[[:alpha:]0-9]+:
+// regex: LABEL=[[:alpha:]0-9_]+:
 
 script {
     fn a(b: u64) -> u64 {

--- a/test/src/ir_generation/tests/redundant_fns.sw
+++ b/test/src/ir_generation/tests/redundant_fns.sw
@@ -1,0 +1,67 @@
+// This is to test that we don't recreate the same function for every time it's called any more.
+
+script;
+
+// -------------------------------------------------------------------------------------------------
+// `a` and `b` are called multiple times but should only exist once each in the IR.
+
+fn a(x: bool) -> bool {
+    x || x
+}
+
+fn b(y: bool) -> bool {
+    a(a(y))
+}
+
+fn c(z: bool) -> bool {
+    b(z) && b(z)
+}
+
+// -------------------------------------------------------------------------------------------------
+// `Id::id()` for `u64` and `bool` are different functions and should exist separately.
+
+trait Id {
+    fn id(self) -> Self;
+}
+
+impl Id for u64 {
+    fn id(self) -> Self {
+        self
+    }
+}
+
+impl Id for bool {
+    fn id(self) -> Self {
+        self
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+fn main() -> bool {
+    11u64.id();
+    false.id();
+
+    c(true)
+}
+
+// The names are still uniqued with a `_x` suffix though.
+//
+// regex: A_FN=a_\d
+// regex: B_FN=b_\d
+// regex: C_FN=c_\d
+
+// check: fn main
+
+// check: fn id_
+// sameln: u64
+// check: fn id_
+// sameln: bool
+
+// check: fn $C_FN
+// check: fn $B_FN
+// check: fn $A_FN
+
+// not: fn $A_FN
+// not: fn $B_FN
+// not: fn $C_FN


### PR DESCRIPTION
Two changes:
- When recreating functions from the AST inlined callees it now avoids redundancy.  There shouldn't be the same function recreated any longer.
- The inline pass takes a predicate which indicates whether the callee is suitable for inlining.

To help out there's also a function which will produce a predicate based on maximum counts for blocks, instructions and/or locals.