### PR TITLE
Removes outdated `todo` comments in `sfv2`

### DIFF
--- a/sway-fmt-v2/src/items/item_fn.rs
+++ b/sway-fmt-v2/src/items/item_fn.rs
@@ -104,7 +104,6 @@ impl Format for FnSignature {
         // FnArgs
         match self.arguments.clone().into_inner() {
             FnArgs::Static(args) => {
-                // TODO: Refactor into `Punctuated::format()`
                 args.format(formatted_code, formatter)?;
             }
             FnArgs::NonStatic {
@@ -166,7 +165,6 @@ impl Parenthesis for FnSignature {
     }
 }
 
-// TODO: Use this in `Punctuated::format()`
 impl Format for FnArg {
     fn format(
         &self,

--- a/sway-fmt-v2/src/utils/expr/asm_block.rs
+++ b/sway-fmt-v2/src/utils/expr/asm_block.rs
@@ -139,7 +139,6 @@ impl LeafSpans for AsmRegisterDeclaration {
         let mut collected_spans = vec![ByteSpan::from(self.register.span())];
         if let Some(value) = &self.value_opt {
             collected_spans.append(&mut value.leaf_spans());
-            // TODO: determine if we are allowing comments between `:` and expr
         }
         collected_spans
     }
@@ -150,7 +149,6 @@ impl LeafSpans for AsmBlockContents {
         let mut collected_spans = Vec::new();
         for instruction in &self.instructions {
             collected_spans.append(&mut instruction.leaf_spans());
-            // TODO: probably we shouldn't allow for comments in between the instruction and comma since it may/will result in build failure after formatting
         }
         collected_spans
     }
@@ -168,7 +166,6 @@ impl LeafSpans for AsmFinalExpr {
         let mut collected_spans = vec![ByteSpan::from(self.register.span())];
         if let Some(ty) = &self.ty_opt {
             collected_spans.append(&mut ty.leaf_spans());
-            // TODO: determine if we are allowing comments between `:` and ty
         }
         collected_spans
     }

--- a/sway-fmt-v2/src/utils/expr/conditional.rs
+++ b/sway-fmt-v2/src/utils/expr/conditional.rs
@@ -225,14 +225,12 @@ impl LeafSpans for MatchBranchKind {
                 comma_token_opt,
             } => {
                 collected_spans.append(&mut block.leaf_spans());
-                // TODO: determine if we allow comments between block and comma_token
                 if let Some(comma_token) = comma_token_opt {
                     collected_spans.push(ByteSpan::from(comma_token.span()));
                 }
             }
             MatchBranchKind::Expr { expr, comma_token } => {
                 collected_spans.append(&mut expr.leaf_spans());
-                // TODO: determine if we allow comments between expr and comma_token
                 collected_spans.push(ByteSpan::from(comma_token.span()));
             }
         };

--- a/sway-fmt-v2/src/utils/expr/struct_field.rs
+++ b/sway-fmt-v2/src/utils/expr/struct_field.rs
@@ -74,7 +74,6 @@ impl LeafSpans for ExprStructField {
         let mut collected_spans = vec![ByteSpan::from(self.field_name.span())];
         if let Some((colon_token, expr)) = &self.expr_opt {
             collected_spans.push(ByteSpan::from(colon_token.span()));
-            // TODO: determine if we are allowing comments between `:` and expr
             collected_spans.append(&mut expr.leaf_spans());
         }
         collected_spans

--- a/sway-fmt-v2/src/utils/expr/tests.rs
+++ b/sway-fmt-v2/src/utils/expr/tests.rs
@@ -78,10 +78,6 @@ macro_rules! fmt_test_inner {
 }
 }
 
-// TODO:
-// path, literal, abicast, struct, tuple, parens, block, array, asm, return, if, match, while, func app, index, field projection, tuple field projection, ref, deref, operators, bitwise stuff, comp operators
-// logical operators, reassignment
-
 fmt_test!(literal "5", extra_whitespace "  5 "
 );
 


### PR DESCRIPTION
Closes #2498 