### PR TITLE
Use rust 1.62 in CI docker image

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.60 as chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.62.1 as chef
 WORKDIR /build/
 # hadolint ignore=DL3008
 RUN apt-get update && \


### PR DESCRIPTION
This is what is breaking CI. We probably want to remove this docker image eventually anyway, now that we have `fuelup`. The image gets zero downloads.﻿
