### PR TITLE
Add separate expression kind types

### DIFF
--- a/sway-ast/src/lib.rs
+++ b/sway-ast/src/lib.rs
@@ -21,7 +21,7 @@ pub mod where_clause;
 pub use crate::{
     assignable::Assignable,
     attribute::AttributeDecl,
-    brackets::{AngleBrackets, Braces},
+    brackets::{AngleBrackets, Braces, Parens},
     dependency::Dependency,
     expr::{
         asm::{AsmBlock, AsmRegisterDeclaration},
@@ -44,11 +44,12 @@ pub use crate::{
         item_use::{ItemUse, UseTree},
         FnArg, FnArgs, FnSignature, Item, ItemKind, TypeField,
     },
-    keywords::{DoubleColonToken, PubToken},
+    keywords::{CommaToken, DoubleColonToken, PubToken},
     literal::{LitInt, LitIntType, Literal},
     module::{Module, ModuleKind},
     path::{PathExpr, PathExprSegment, PathType, PathTypeSegment, QualifiedPathRoot},
     pattern::{Pattern, PatternStructField},
+    punctuated::Punctuated,
     statement::{Statement, StatementLet},
     ty::Ty,
     where_clause::{WhereBound, WhereClause},

--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -1210,14 +1210,14 @@ fn expr_to_expression(ec: &mut ErrorContext, expr: Expr) -> Result<Expression, E
             let abi_name = path_type_to_call_path(ec, name)?;
             let address = Box::new(expr_to_expression(ec, *address)?);
             Expression {
-                kind: ExpressionKind::AbiCast(AbiCastExpression { abi_name, address }),
+                kind: ExpressionKind::AbiCast(Box::new(AbiCastExpression { abi_name, address })),
                 span,
             }
         }
         Expr::Struct { path, fields } => {
             let call_path_binding = path_expr_to_call_path_binding(ec, path)?;
             Expression {
-                kind: ExpressionKind::Struct(StructExpression {
+                kind: ExpressionKind::Struct(Box::new(StructExpression {
                     call_path_binding,
                     fields: {
                         fields
@@ -1228,7 +1228,7 @@ fn expr_to_expression(ec: &mut ErrorContext, expr: Expr) -> Result<Expression, E
                             })
                             .collect::<Result<_, _>>()?
                     },
-                }),
+                })),
                 span,
             }
         }
@@ -1274,7 +1274,7 @@ fn expr_to_expression(ec: &mut ErrorContext, expr: Expr) -> Result<Expression, E
         Expr::Asm(asm_block) => {
             let asm_expression = asm_block_to_asm_expression(ec, asm_block)?;
             Expression {
-                kind: ExpressionKind::Asm(asm_expression),
+                kind: ExpressionKind::Asm(Box::new(asm_expression)),
                 span,
             }
         }
@@ -1509,11 +1509,13 @@ fn expr_to_expression(ec: &mut ErrorContext, expr: Expr) -> Result<Expression, E
                             .unwrap_or_else(|| method_name.span()),
                     };
                     Expression {
-                        kind: ExpressionKind::MethodApplication(MethodApplicationExpression {
-                            method_name_binding,
-                            contract_call_params: Vec::new(),
-                            arguments,
-                        }),
+                        kind: ExpressionKind::MethodApplication(Box::new(
+                            MethodApplicationExpression {
+                                method_name_binding,
+                                contract_call_params: Vec::new(),
+                                arguments,
+                            },
+                        )),
                         span,
                     }
                 }
@@ -1560,22 +1562,22 @@ fn expr_to_expression(ec: &mut ErrorContext, expr: Expr) -> Result<Expression, E
                             };
                             if call_path.prefixes.is_empty() {
                                 Expression {
-                                    kind: ExpressionKind::FunctionApplication(
+                                    kind: ExpressionKind::FunctionApplication(Box::new(
                                         FunctionApplicationExpression {
                                             call_path_binding,
                                             arguments,
                                         },
-                                    ),
+                                    )),
                                     span,
                                 }
                             } else {
                                 Expression {
-                                    kind: ExpressionKind::DelineatedPath(
+                                    kind: ExpressionKind::DelineatedPath(Box::new(
                                         DelineatedPathExpression {
                                             call_path_binding,
                                             args: arguments,
                                         },
-                                    ),
+                                    )),
                                     span,
                                 }
                             }
@@ -1620,11 +1622,11 @@ fn expr_to_expression(ec: &mut ErrorContext, expr: Expr) -> Result<Expression, E
                 .map(|expr| expr_to_expression(ec, expr))
                 .collect::<Result<_, _>>()?;
             Expression {
-                kind: ExpressionKind::MethodApplication(MethodApplicationExpression {
+                kind: ExpressionKind::MethodApplication(Box::new(MethodApplicationExpression {
                     method_name_binding,
                     contract_call_params,
                     arguments,
-                }),
+                })),
                 span,
             }
         }
@@ -1883,10 +1885,10 @@ fn unary_op_call(
         span: op_span,
     };
     Ok(Expression {
-        kind: ExpressionKind::FunctionApplication(FunctionApplicationExpression {
+        kind: ExpressionKind::FunctionApplication(Box::new(FunctionApplicationExpression {
             call_path_binding,
             arguments: vec![expr_to_expression(ec, arg)?],
-        }),
+        })),
         span,
     })
 }
@@ -1913,11 +1915,11 @@ fn binary_op_call(
         span: op_span,
     };
     Ok(Expression {
-        kind: ExpressionKind::MethodApplication(MethodApplicationExpression {
+        kind: ExpressionKind::MethodApplication(Box::new(MethodApplicationExpression {
             method_name_binding,
             contract_call_params: Vec::new(),
             arguments: vec![lhs, rhs],
-        }),
+        })),
         span,
     })
 }
@@ -2196,10 +2198,10 @@ fn path_expr_to_expression(
             span: call_path.span(),
         };
         Expression {
-            kind: ExpressionKind::DelineatedPath(DelineatedPathExpression {
+            kind: ExpressionKind::DelineatedPath(Box::new(DelineatedPathExpression {
                 call_path_binding,
                 args: Vec::new(),
-            }),
+            })),
             span,
         }
     };

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -733,7 +733,11 @@ fn test_unary_ordering() {
     } = &prog.root.tree.root_nodes[0]
     {
         if let AstNode {
-            content: AstNodeContent::Expression(Expression::LazyOperator { op, .. }),
+            content:
+                AstNodeContent::Expression(Expression {
+                    kind: ExpressionKind::LazyOperator(LazyOperatorExpression { op, .. }),
+                    ..
+                }),
             ..
         } = &body.contents[2]
         {

--- a/sway-core/src/parse_tree/declaration/reassignment.rs
+++ b/sway-core/src/parse_tree/declaration/reassignment.rs
@@ -23,13 +23,7 @@ pub struct Reassignment {
 impl Reassignment {
     pub fn lhs_span(&self) -> Span {
         match &self.lhs {
-            ReassignmentTarget::VariableExpression(var) => match **var {
-                Expression::SubfieldExpression { ref span, .. } => span.clone(),
-                Expression::VariableExpression { ref name, .. } => name.span(),
-                _ => {
-                    unreachable!("any other reassignment lhs is invalid and cannot be constructed.")
-                }
-            },
+            ReassignmentTarget::VariableExpression(var) => var.span.clone(),
             ReassignmentTarget::StorageField(ref idents) => idents
                 .iter()
                 .fold(idents[0].span(), |acc, ident| Span::join(acc, ident.span())),

--- a/sway-core/src/parse_tree/expression/mod.rs
+++ b/sway-core/src/parse_tree/expression/mod.rs
@@ -106,19 +106,19 @@ pub struct IntrinsicFunctionExpression {
 #[derive(Debug, Clone)]
 pub enum ExpressionKind {
     Literal(Literal),
-    FunctionApplication(FunctionApplicationExpression),
+    FunctionApplication(Box<FunctionApplicationExpression>),
     LazyOperator(LazyOperatorExpression),
     Variable(Ident),
     Tuple(Vec<Expression>),
     TupleIndex(TupleIndexExpression),
     Array(Vec<Expression>),
-    Struct(StructExpression),
+    Struct(Box<StructExpression>),
     CodeBlock(CodeBlock),
     If(IfExpression),
     Match(MatchExpression),
     // separated into other struct for parsing reasons
-    Asm(AsmExpression),
-    MethodApplication(MethodApplicationExpression),
+    Asm(Box<AsmExpression>),
+    MethodApplication(Box<MethodApplicationExpression>),
     /// A _subfield expression_ is anything of the form:
     /// ```ignore
     /// <ident>.<ident>
@@ -146,9 +146,9 @@ pub enum ExpressionKind {
     ///
     /// MyEnum::Variant1
     /// ```
-    DelineatedPath(DelineatedPathExpression),
+    DelineatedPath(Box<DelineatedPathExpression>),
     /// A cast of a hash to an ABI for calling a contract.
-    AbiCast(AbiCastExpression),
+    AbiCast(Box<AbiCastExpression>),
     ArrayIndex(ArrayIndexExpression),
     StorageAccess(StorageAccessExpression),
     IntrinsicFunction(IntrinsicFunctionExpression),

--- a/sway-core/src/parse_tree/expression/mod.rs
+++ b/sway-core/src/parse_tree/expression/mod.rs
@@ -17,81 +17,114 @@ use sway_ast::intrinsics::Intrinsic;
 
 /// Represents a parsed, but not yet type checked, [Expression](https://en.wikipedia.org/wiki/Expression_(computer_science)).
 #[derive(Debug, Clone)]
-pub enum Expression {
-    Literal {
-        value: Literal,
-        span: Span,
-    },
-    FunctionApplication {
-        call_path_binding: TypeBinding<CallPath>,
-        arguments: Vec<Expression>,
-        span: Span,
-    },
-    LazyOperator {
-        op: LazyOp,
-        lhs: Box<Expression>,
-        rhs: Box<Expression>,
-        span: Span,
-    },
-    VariableExpression {
-        name: Ident,
-        span: Span,
-    },
-    Tuple {
-        fields: Vec<Expression>,
-        span: Span,
-    },
-    TupleIndex {
-        prefix: Box<Expression>,
-        index: usize,
-        index_span: Span,
-        span: Span,
-    },
-    Array {
-        contents: Vec<Expression>,
-        span: Span,
-    },
-    StructExpression {
-        call_path_binding: TypeBinding<CallPath<(TypeInfo, Span)>>,
-        fields: Vec<StructExpressionField>,
-        span: Span,
-    },
-    CodeBlock {
-        contents: CodeBlock,
-        span: Span,
-    },
-    IfExp {
-        condition: Box<Expression>,
-        then: Box<Expression>,
-        r#else: Option<Box<Expression>>,
-        span: Span,
-    },
-    MatchExp {
-        value: Box<Expression>,
-        branches: Vec<MatchBranch>,
-        span: Span,
-    },
+pub struct Expression {
+    pub kind: ExpressionKind,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionApplicationExpression {
+    pub call_path_binding: TypeBinding<CallPath>,
+    pub arguments: Vec<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LazyOperatorExpression {
+    pub op: LazyOp,
+    pub lhs: Box<Expression>,
+    pub rhs: Box<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TupleIndexExpression {
+    pub prefix: Box<Expression>,
+    pub index: usize,
+    pub index_span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub struct StructExpression {
+    pub call_path_binding: TypeBinding<CallPath<(TypeInfo, Span)>>,
+    pub fields: Vec<StructExpressionField>,
+}
+
+#[derive(Debug, Clone)]
+pub struct IfExpression {
+    pub condition: Box<Expression>,
+    pub then: Box<Expression>,
+    pub r#else: Option<Box<Expression>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MatchExpression {
+    pub value: Box<Expression>,
+    pub branches: Vec<MatchBranch>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MethodApplicationExpression {
+    pub method_name_binding: TypeBinding<MethodName>,
+    pub contract_call_params: Vec<StructExpressionField>,
+    pub arguments: Vec<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubfieldExpression {
+    pub prefix: Box<Expression>,
+    pub field_to_access: Ident,
+}
+
+#[derive(Debug, Clone)]
+pub struct DelineatedPathExpression {
+    pub call_path_binding: TypeBinding<CallPath>,
+    pub args: Vec<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AbiCastExpression {
+    pub abi_name: CallPath,
+    pub address: Box<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ArrayIndexExpression {
+    pub prefix: Box<Expression>,
+    pub index: Box<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StorageAccessExpression {
+    pub field_names: Vec<Ident>,
+}
+
+#[derive(Debug, Clone)]
+pub struct IntrinsicFunctionExpression {
+    pub kind_binding: TypeBinding<Intrinsic>,
+    pub arguments: Vec<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ExpressionKind {
+    Literal(Literal),
+    FunctionApplication(FunctionApplicationExpression),
+    LazyOperator(LazyOperatorExpression),
+    Variable(Ident),
+    Tuple(Vec<Expression>),
+    TupleIndex(TupleIndexExpression),
+    Array(Vec<Expression>),
+    Struct(StructExpression),
+    CodeBlock(CodeBlock),
+    If(IfExpression),
+    Match(MatchExpression),
     // separated into other struct for parsing reasons
-    AsmExpression {
-        span: Span,
-        asm: AsmExpression,
-    },
-    MethodApplication {
-        method_name_binding: TypeBinding<MethodName>,
-        contract_call_params: Vec<StructExpressionField>,
-        arguments: Vec<Expression>,
-        span: Span,
-    },
+    Asm(AsmExpression),
+    MethodApplication(MethodApplicationExpression),
     /// A _subfield expression_ is anything of the form:
     /// ```ignore
     /// <ident>.<ident>
     /// ```
     ///
-    SubfieldExpression {
-        prefix: Box<Expression>,
-        span: Span,
-        field_to_access: Ident,
-    },
+    Subfield(SubfieldExpression),
     /// A _delineated path_ is anything of the form:
     /// ```ignore
     /// <ident>::<ident>
@@ -113,31 +146,12 @@ pub enum Expression {
     ///
     /// MyEnum::Variant1
     /// ```
-    DelineatedPath {
-        call_path_binding: TypeBinding<CallPath>,
-        args: Vec<Expression>,
-        span: Span,
-    },
+    DelineatedPath(DelineatedPathExpression),
     /// A cast of a hash to an ABI for calling a contract.
-    AbiCast {
-        abi_name: CallPath,
-        address: Box<Expression>,
-        span: Span,
-    },
-    ArrayIndex {
-        prefix: Box<Expression>,
-        index: Box<Expression>,
-        span: Span,
-    },
-    StorageAccess {
-        field_names: Vec<Ident>,
-        span: Span,
-    },
-    IntrinsicFunction {
-        kind_binding: TypeBinding<Intrinsic>,
-        arguments: Vec<Expression>,
-        span: Span,
-    },
+    AbiCast(AbiCastExpression),
+    ArrayIndex(ArrayIndexExpression),
+    StorageAccess(StorageAccessExpression),
+    IntrinsicFunction(IntrinsicFunctionExpression),
 }
 
 #[derive(Clone, Debug, PartialEq, Hash)]
@@ -155,29 +169,7 @@ pub struct StructExpressionField {
 
 impl Spanned for Expression {
     fn span(&self) -> Span {
-        use Expression::*;
-        (match self {
-            Literal { span, .. } => span,
-            FunctionApplication { span, .. } => span,
-            LazyOperator { span, .. } => span,
-            VariableExpression { span, .. } => span,
-            Tuple { span, .. } => span,
-            TupleIndex { span, .. } => span,
-            Array { span, .. } => span,
-            StructExpression { span, .. } => span,
-            CodeBlock { span, .. } => span,
-            IfExp { span, .. } => span,
-            MatchExp { span, .. } => span,
-            AsmExpression { span, .. } => span,
-            MethodApplication { span, .. } => span,
-            SubfieldExpression { span, .. } => span,
-            DelineatedPath { span, .. } => span,
-            AbiCast { span, .. } => span,
-            ArrayIndex { span, .. } => span,
-            StorageAccess { span, .. } => span,
-            IntrinsicFunction { span, .. } => span,
-        })
-        .clone()
+        self.span.clone()
     }
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -393,124 +393,105 @@ impl TypedExpression {
 
     pub(crate) fn type_check(mut ctx: TypeCheckContext, expr: Expression) -> CompileResult<Self> {
         let expr_span = expr.span();
-        let res = match expr {
-            Expression::Literal { value: lit, span } => Self::type_check_literal(lit, span),
-            Expression::VariableExpression { name, span, .. } => {
+        let span = expr_span.clone();
+        let res = match expr.kind {
+            ExpressionKind::Literal(lit) => Self::type_check_literal(lit, span),
+            ExpressionKind::Variable(name) => {
                 Self::type_check_variable_expression(ctx.namespace, name, span)
             }
-            Expression::FunctionApplication {
+            ExpressionKind::FunctionApplication(FunctionApplicationExpression {
                 call_path_binding,
                 arguments,
-                span,
-            } => Self::type_check_function_application(
+            }) => Self::type_check_function_application(
                 ctx.by_ref(),
                 call_path_binding,
                 arguments,
                 span,
             ),
-            Expression::LazyOperator { op, lhs, rhs, span } => {
+            ExpressionKind::LazyOperator(LazyOperatorExpression { op, lhs, rhs }) => {
                 let ctx = ctx
                     .by_ref()
                     .with_type_annotation(insert_type(TypeInfo::Boolean));
                 Self::type_check_lazy_operator(ctx, op, *lhs, *rhs, span)
             }
-            Expression::CodeBlock { contents, span, .. } => {
+            ExpressionKind::CodeBlock(contents) => {
                 Self::type_check_code_block(ctx.by_ref(), contents, span)
             }
             // TODO if _condition_ is constant, evaluate it and compile this to an
             // expression with only one branch
-            Expression::IfExp {
+            ExpressionKind::If(IfExpression {
                 condition,
                 then,
                 r#else,
-                span,
-            } => Self::type_check_if_expression(
+            }) => Self::type_check_if_expression(
                 ctx.by_ref().with_help_text(""),
                 *condition,
                 *then,
                 r#else.map(|e| *e),
                 span,
             ),
-            Expression::MatchExp {
-                value,
-                branches,
-                span,
-            } => Self::type_check_match_expression(
-                ctx.by_ref().with_help_text(""),
-                *value,
-                branches,
-                span,
-            ),
-            Expression::AsmExpression { asm, span, .. } => {
-                Self::type_check_asm_expression(ctx.by_ref(), asm, span)
+            ExpressionKind::Match(MatchExpression { value, branches }) => {
+                Self::type_check_match_expression(
+                    ctx.by_ref().with_help_text(""),
+                    *value,
+                    branches,
+                    span,
+                )
             }
-            Expression::StructExpression {
+            ExpressionKind::Asm(asm) => Self::type_check_asm_expression(ctx.by_ref(), asm, span),
+            ExpressionKind::Struct(StructExpression {
                 call_path_binding,
                 fields,
-                span,
-            } => Self::type_check_struct_expression(ctx.by_ref(), call_path_binding, fields, span),
-            Expression::SubfieldExpression {
+            }) => Self::type_check_struct_expression(ctx.by_ref(), call_path_binding, fields, span),
+            ExpressionKind::Subfield(SubfieldExpression {
                 prefix,
-                span,
                 field_to_access,
-            } => Self::type_check_subfield_expression(ctx.by_ref(), *prefix, span, field_to_access),
-            Expression::MethodApplication {
+            }) => {
+                Self::type_check_subfield_expression(ctx.by_ref(), *prefix, span, field_to_access)
+            }
+            ExpressionKind::MethodApplication(MethodApplicationExpression {
                 method_name_binding,
                 contract_call_params,
                 arguments,
-                span,
-            } => type_check_method_application(
+            }) => type_check_method_application(
                 ctx.by_ref(),
                 method_name_binding,
                 contract_call_params,
                 arguments,
                 span,
             ),
-            Expression::Tuple { fields, span } => {
-                Self::type_check_tuple(ctx.by_ref(), fields, span)
-            }
-            Expression::TupleIndex {
+            ExpressionKind::Tuple(fields) => Self::type_check_tuple(ctx.by_ref(), fields, span),
+            ExpressionKind::TupleIndex(TupleIndexExpression {
                 prefix,
                 index,
                 index_span,
-                span,
-            } => Self::type_check_tuple_index(ctx.by_ref(), *prefix, index, index_span, span),
-            Expression::DelineatedPath {
+            }) => Self::type_check_tuple_index(ctx.by_ref(), *prefix, index, index_span, span),
+            ExpressionKind::DelineatedPath(DelineatedPathExpression {
                 call_path_binding,
-                span,
                 args,
-            } => Self::type_check_delineated_path(ctx.by_ref(), call_path_binding, span, args),
-            Expression::AbiCast {
-                abi_name,
-                address,
-                span,
-            } => Self::type_check_abi_cast(ctx.by_ref(), abi_name, address, span),
-            Expression::Array { contents, span } => {
-                Self::type_check_array(ctx.by_ref(), contents, span)
+            }) => Self::type_check_delineated_path(ctx.by_ref(), call_path_binding, span, args),
+            ExpressionKind::AbiCast(AbiCastExpression { abi_name, address }) => {
+                Self::type_check_abi_cast(ctx.by_ref(), abi_name, address, span)
             }
-            Expression::ArrayIndex {
-                prefix,
-                index,
-                span,
-            } => {
+            ExpressionKind::Array(contents) => Self::type_check_array(ctx.by_ref(), contents, span),
+            ExpressionKind::ArrayIndex(ArrayIndexExpression { prefix, index }) => {
                 let ctx = ctx
                     .by_ref()
                     .with_type_annotation(insert_type(TypeInfo::Unknown))
                     .with_help_text("");
                 Self::type_check_array_index(ctx, *prefix, *index, span)
             }
-            Expression::StorageAccess { field_names, .. } => {
+            ExpressionKind::StorageAccess(StorageAccessExpression { field_names }) => {
                 let ctx = ctx
                     .by_ref()
                     .with_type_annotation(insert_type(TypeInfo::Unknown))
                     .with_help_text("");
-                Self::type_check_storage_load(ctx, field_names, &expr_span)
+                Self::type_check_storage_load(ctx, field_names, &span)
             }
-            Expression::IntrinsicFunction {
+            ExpressionKind::IntrinsicFunction(IntrinsicFunctionExpression {
                 kind_binding,
                 arguments,
-                span,
-            } => Self::type_check_intrinsic_function(ctx.by_ref(), kind_binding, arguments, span),
+            }) => Self::type_check_intrinsic_function(ctx.by_ref(), kind_binding, arguments, span),
         };
         let mut typed_expression = match res.value {
             Some(r) => r,
@@ -1694,17 +1675,17 @@ mod tests {
     #[test]
     fn test_array_type_check_non_homogeneous_0() {
         // [true, 0] -- first element is correct, assumes type is [bool; 2].
-        let expr = Expression::Array {
-            contents: vec![
-                Expression::Literal {
-                    value: Literal::Boolean(true),
+        let expr = Expression {
+            kind: ExpressionKind::Array(vec![
+                Expression {
+                    kind: ExpressionKind::Literal(Literal::Boolean(true)),
                     span: Span::dummy(),
                 },
-                Expression::Literal {
-                    value: Literal::U64(0),
+                Expression {
+                    kind: ExpressionKind::Literal(Literal::U64(0)),
                     span: Span::dummy(),
                 },
-            ],
+            ]),
             span: Span::dummy(),
         };
 
@@ -1722,17 +1703,17 @@ mod tests {
     #[test]
     fn test_array_type_check_non_homogeneous_1() {
         // [0, false] -- first element is incorrect, assumes type is [u64; 2].
-        let expr = Expression::Array {
-            contents: vec![
-                Expression::Literal {
-                    value: Literal::U64(0),
+        let expr = Expression {
+            kind: ExpressionKind::Array(vec![
+                Expression {
+                    kind: ExpressionKind::Literal(Literal::U64(0)),
                     span: Span::dummy(),
                 },
-                Expression::Literal {
-                    value: Literal::Boolean(true),
+                Expression {
+                    kind: ExpressionKind::Literal(Literal::Boolean(true)),
                     span: Span::dummy(),
                 },
-            ],
+            ]),
             span: Span::dummy(),
         };
 
@@ -1757,21 +1738,21 @@ mod tests {
     #[test]
     fn test_array_type_check_bad_count() {
         // [0, false] -- first element is incorrect, assumes type is [u64; 2].
-        let expr = Expression::Array {
-            contents: vec![
-                Expression::Literal {
-                    value: Literal::Boolean(true),
+        let expr = Expression {
+            kind: ExpressionKind::Array(vec![
+                Expression {
+                    kind: ExpressionKind::Literal(Literal::Boolean(true)),
                     span: Span::dummy(),
                 },
-                Expression::Literal {
-                    value: Literal::Boolean(true),
+                Expression {
+                    kind: ExpressionKind::Literal(Literal::Boolean(true)),
                     span: Span::dummy(),
                 },
-                Expression::Literal {
-                    value: Literal::Boolean(true),
+                Expression {
+                    kind: ExpressionKind::Literal(Literal::Boolean(true)),
                     span: Span::dummy(),
                 },
-            ],
+            ]),
             span: Span::dummy(),
         };
 
@@ -1788,8 +1769,8 @@ mod tests {
 
     #[test]
     fn test_array_type_check_empty() {
-        let expr = Expression::Array {
-            contents: Vec::new(),
+        let expr = Expression {
+            kind: ExpressionKind::Array(Vec::new()),
             span: Span::dummy(),
         };
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -399,15 +399,18 @@ impl TypedExpression {
             ExpressionKind::Variable(name) => {
                 Self::type_check_variable_expression(ctx.namespace, name, span)
             }
-            ExpressionKind::FunctionApplication(FunctionApplicationExpression {
-                call_path_binding,
-                arguments,
-            }) => Self::type_check_function_application(
-                ctx.by_ref(),
-                call_path_binding,
-                arguments,
-                span,
-            ),
+            ExpressionKind::FunctionApplication(function_application_expression) => {
+                let FunctionApplicationExpression {
+                    call_path_binding,
+                    arguments,
+                } = *function_application_expression;
+                Self::type_check_function_application(
+                    ctx.by_ref(),
+                    call_path_binding,
+                    arguments,
+                    span,
+                )
+            }
             ExpressionKind::LazyOperator(LazyOperatorExpression { op, lhs, rhs }) => {
                 let ctx = ctx
                     .by_ref()
@@ -438,39 +441,49 @@ impl TypedExpression {
                     span,
                 )
             }
-            ExpressionKind::Asm(asm) => Self::type_check_asm_expression(ctx.by_ref(), asm, span),
-            ExpressionKind::Struct(StructExpression {
-                call_path_binding,
-                fields,
-            }) => Self::type_check_struct_expression(ctx.by_ref(), call_path_binding, fields, span),
+            ExpressionKind::Asm(asm) => Self::type_check_asm_expression(ctx.by_ref(), *asm, span),
+            ExpressionKind::Struct(struct_expression) => {
+                let StructExpression {
+                    call_path_binding,
+                    fields,
+                } = *struct_expression;
+                Self::type_check_struct_expression(ctx.by_ref(), call_path_binding, fields, span)
+            }
             ExpressionKind::Subfield(SubfieldExpression {
                 prefix,
                 field_to_access,
             }) => {
                 Self::type_check_subfield_expression(ctx.by_ref(), *prefix, span, field_to_access)
             }
-            ExpressionKind::MethodApplication(MethodApplicationExpression {
-                method_name_binding,
-                contract_call_params,
-                arguments,
-            }) => type_check_method_application(
-                ctx.by_ref(),
-                method_name_binding,
-                contract_call_params,
-                arguments,
-                span,
-            ),
+            ExpressionKind::MethodApplication(method_application_expression) => {
+                let MethodApplicationExpression {
+                    method_name_binding,
+                    contract_call_params,
+                    arguments,
+                } = *method_application_expression;
+                type_check_method_application(
+                    ctx.by_ref(),
+                    method_name_binding,
+                    contract_call_params,
+                    arguments,
+                    span,
+                )
+            }
             ExpressionKind::Tuple(fields) => Self::type_check_tuple(ctx.by_ref(), fields, span),
             ExpressionKind::TupleIndex(TupleIndexExpression {
                 prefix,
                 index,
                 index_span,
             }) => Self::type_check_tuple_index(ctx.by_ref(), *prefix, index, index_span, span),
-            ExpressionKind::DelineatedPath(DelineatedPathExpression {
-                call_path_binding,
-                args,
-            }) => Self::type_check_delineated_path(ctx.by_ref(), call_path_binding, span, args),
-            ExpressionKind::AbiCast(AbiCastExpression { abi_name, address }) => {
+            ExpressionKind::DelineatedPath(delineated_path_expression) => {
+                let DelineatedPathExpression {
+                    call_path_binding,
+                    args,
+                } = *delineated_path_expression;
+                Self::type_check_delineated_path(ctx.by_ref(), call_path_binding, span, args)
+            }
+            ExpressionKind::AbiCast(abi_cast_expression) => {
+                let AbiCastExpression { abi_name, address } = *abi_cast_expression;
                 Self::type_check_abi_cast(ctx.by_ref(), abi_name, address, span)
             }
             ExpressionKind::Array(contents) => Self::type_check_array(ctx.by_ref(), contents, span),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -484,7 +484,7 @@ impl TypedExpression {
             }
             ExpressionKind::AbiCast(abi_cast_expression) => {
                 let AbiCastExpression { abi_name, address } = *abi_cast_expression;
-                Self::type_check_abi_cast(ctx.by_ref(), abi_name, address, span)
+                Self::type_check_abi_cast(ctx.by_ref(), abi_name, *address, span)
             }
             ExpressionKind::Array(contents) => Self::type_check_array(ctx.by_ref(), contents, span),
             ExpressionKind::ArrayIndex(ArrayIndexExpression { prefix, index }) => {
@@ -1290,7 +1290,7 @@ impl TypedExpression {
     fn type_check_abi_cast(
         mut ctx: TypeCheckContext,
         abi_name: CallPath,
-        address: Box<Expression>,
+        address: Expression,
         span: Span,
     ) -> CompileResult<Self> {
         let mut warnings = vec![];
@@ -1304,7 +1304,7 @@ impl TypedExpression {
                 .with_help_text("An address that is being ABI cast must be of type b256")
                 .with_type_annotation(insert_type(TypeInfo::B256));
             check!(
-                TypedExpression::type_check(ctx, *address),
+                TypedExpression::type_check(ctx, address),
                 error_recovery_expr(err_span),
                 warnings,
                 errors

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -1,5 +1,4 @@
 use crate::constants;
-use crate::Expression::StorageAccess;
 use crate::{
     error::*,
     parse_tree::*,
@@ -129,8 +128,8 @@ pub(crate) fn type_check_method_application(
             errors
         );
 
-        self_state_idx = match arguments.first() {
-            Some(StorageAccess { field_names, .. }) => {
+        self_state_idx = match arguments.first().map(|expr| &expr.kind) {
+            Some(ExpressionKind::StorageAccess(StorageAccessExpression { field_names })) => {
                 let first_field = field_names[0].clone();
                 let self_state_idx = match storage_fields
                     .iter()

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -601,8 +601,8 @@ fn reassignment(
             let mut expr = var;
             let mut names_vec = Vec::new();
             let (base_name, final_return_type) = loop {
-                match *expr {
-                    Expression::VariableExpression { name, .. } => {
+                match expr.kind {
+                    ExpressionKind::Variable(name) => {
                         // check that the reassigned name exists
                         let unknown_decl = check!(
                             ctx.namespace.resolve_symbol(&name).cloned(),
@@ -622,22 +622,22 @@ fn reassignment(
                         }
                         break (name, variable_decl.body.return_type);
                     }
-                    Expression::SubfieldExpression {
+                    ExpressionKind::Subfield(SubfieldExpression {
                         prefix,
                         field_to_access,
                         ..
-                    } => {
+                    }) => {
                         names_vec.push(ProjectionKind::StructField {
                             name: field_to_access,
                         });
                         expr = prefix;
                     }
-                    Expression::TupleIndex {
+                    ExpressionKind::TupleIndex(TupleIndexExpression {
                         prefix,
                         index,
                         index_span,
                         ..
-                    } => {
+                    }) => {
                         names_vec.push(ProjectionKind::TupleField { index, index_span });
                         expr = prefix;
                     }

--- a/sway-fmt/src/traversal.rs
+++ b/sway-fmt/src/traversal.rs
@@ -1,4 +1,7 @@
-use sway_core::{AstNode, AstNodeContent, Declaration, Expression, ParseTree, ReturnStatement};
+use sway_core::{
+    AstNode, AstNodeContent, Declaration, Expression, ExpressionKind, IfExpression, ParseTree,
+    ReturnStatement,
+};
 
 use sway_types::span::Span;
 
@@ -131,32 +134,26 @@ fn handle_declaration(dec: &Declaration, ast_node: &AstNode, changes: &mut Vec<C
 }
 
 fn handle_expression(expr: &Expression, changes: &mut Vec<Change>) {
-    match &expr {
-        Expression::StructExpression { span, .. } => {
-            changes.push(Change::new(span, ChangeType::Struct))
-        }
-        Expression::IfExp {
+    let span = &expr.span;
+    match &expr.kind {
+        ExpressionKind::Struct(_) => changes.push(Change::new(span, ChangeType::Struct)),
+        ExpressionKind::If(IfExpression {
             condition: _,
             then,
             r#else,
-            span: _,
-        } => {
+        }) => {
             handle_expression(then, changes);
 
             if let Some(else_expr) = r#else {
                 handle_expression(else_expr, changes);
             }
         }
-        Expression::CodeBlock { contents, span: _ } => {
+        ExpressionKind::CodeBlock(contents) => {
             for content in &contents.contents {
                 traverse_ast_node(content, changes);
             }
         }
-        Expression::DelineatedPath {
-            span,
-            args: _,
-            call_path_binding: _,
-        } => {
+        ExpressionKind::DelineatedPath(_) => {
             changes.push(Change::new(span, ChangeType::DelineatedPath));
         }
         _ => {}

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -4,7 +4,7 @@ use sway_core::{
     semantic_analysis::ast_node::{
         expression::typed_expression_variant::TypedExpressionVariant, TypedDeclaration,
     },
-    Declaration, Expression,
+    Declaration, ExpressionKind,
 };
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
 
@@ -47,11 +47,11 @@ pub fn parsed_to_completion_kind(ast_token: &AstToken) -> Option<CompletionItemK
             | Declaration::StorageDeclaration(_) => Some(CompletionItemKind::TEXT),
             Declaration::Break { .. } | Declaration::Continue { .. } => None,
         },
-        AstToken::Expression(exp) => match &exp {
-            Expression::Literal { .. } => Some(CompletionItemKind::VALUE),
-            Expression::FunctionApplication { .. } => Some(CompletionItemKind::FUNCTION),
-            Expression::VariableExpression { .. } => Some(CompletionItemKind::VARIABLE),
-            Expression::StructExpression { .. } => Some(CompletionItemKind::STRUCT),
+        AstToken::Expression(exp) => match &exp.kind {
+            ExpressionKind::Literal { .. } => Some(CompletionItemKind::VALUE),
+            ExpressionKind::FunctionApplication { .. } => Some(CompletionItemKind::FUNCTION),
+            ExpressionKind::Variable { .. } => Some(CompletionItemKind::VARIABLE),
+            ExpressionKind::Struct { .. } => Some(CompletionItemKind::STRUCT),
             _ => None,
         },
         AstToken::FunctionDeclaration(_) => Some(CompletionItemKind::FUNCTION),

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -4,7 +4,7 @@ use sway_core::{
     semantic_analysis::ast_node::{
         expression::typed_expression_variant::TypedExpressionVariant, TypedDeclaration,
     },
-    Declaration, Expression, Literal,
+    Declaration, ExpressionKind, Literal,
 };
 use sway_types::{Ident, Spanned};
 use tower_lsp::lsp_types::{Location, SymbolInformation, SymbolKind, Url};
@@ -61,16 +61,16 @@ fn parsed_to_symbol_kind(ast_token: &AstToken) -> SymbolKind {
             }
         }
         AstToken::Expression(exp) => {
-            match &exp {
-                Expression::Literal { value, .. } => match value {
+            match &exp.kind {
+                ExpressionKind::Literal(value) => match value {
                     Literal::String(_) => SymbolKind::STRING,
                     Literal::Boolean(_) => SymbolKind::BOOLEAN,
                     _ => SymbolKind::NUMBER,
                 },
-                Expression::FunctionApplication { .. } => SymbolKind::FUNCTION,
-                Expression::VariableExpression { .. } => SymbolKind::VARIABLE,
-                Expression::Array { .. } => SymbolKind::ARRAY,
-                Expression::StructExpression { .. } => SymbolKind::STRUCT,
+                ExpressionKind::FunctionApplication(_) => SymbolKind::FUNCTION,
+                ExpressionKind::Variable(_) => SymbolKind::VARIABLE,
+                ExpressionKind::Array(_) => SymbolKind::ARRAY,
+                ExpressionKind::Struct(_) => SymbolKind::STRUCT,
                 // currently we return `variable` type as default
                 _ => SymbolKind::VARIABLE,
             }

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -3,7 +3,7 @@ use crate::core::{
     token::{AstToken, TokenMap},
 };
 use crate::utils::common::get_range_from_span;
-use sway_core::{Declaration, Expression, Literal};
+use sway_core::{Declaration, ExpressionKind, Literal};
 use sway_types::Span;
 use tower_lsp::lsp_types::{
     SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
@@ -108,14 +108,11 @@ fn type_idx(ast_token: &AstToken) -> u32 {
             }
         }
         AstToken::Expression(exp) => {
-            match &exp {
-                Expression::Literal {
-                    value: Literal::String(_),
-                    ..
-                } => TokenTypeIndex::String as u32,
-                Expression::FunctionApplication { .. } => TokenTypeIndex::Function as u32,
-                Expression::VariableExpression { .. } => TokenTypeIndex::Variable as u32,
-                Expression::StructExpression { .. } => TokenTypeIndex::Struct as u32,
+            match &exp.kind {
+                ExpressionKind::Literal(Literal::String(_)) => TokenTypeIndex::String as u32,
+                ExpressionKind::FunctionApplication(_) => TokenTypeIndex::Function as u32,
+                ExpressionKind::Variable(_) => TokenTypeIndex::Variable as u32,
+                ExpressionKind::Struct(_) => TokenTypeIndex::Struct as u32,
                 // currently we return `variable` type as default
                 _ => TokenTypeIndex::Variable as u32,
             }

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -298,11 +298,11 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                 Token::from_parsed(AstToken::Expression(expression.clone())),
             );
         }
-        ExpressionKind::FunctionApplication(FunctionApplicationExpression {
-            call_path_binding,
-            arguments,
-            ..
-        }) => {
+        ExpressionKind::FunctionApplication(function_application_expression) => {
+            let FunctionApplicationExpression {
+                call_path_binding,
+                arguments,
+            } = &**function_application_expression;
             // Don't collect applications of desugared operators due to mismatched ident lengths.
             if !desugared_op(&call_path_binding.inner.prefixes) {
                 for ident in &call_path_binding.inner.prefixes {
@@ -349,11 +349,11 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                 handle_expression(exp, tokens);
             }
         }
-        ExpressionKind::Struct(StructExpression {
-            call_path_binding,
-            fields,
-            ..
-        }) => {
+        ExpressionKind::Struct(struct_expression) => {
+            let StructExpression {
+                call_path_binding,
+                fields,
+            } = &**struct_expression;
             for ident in &call_path_binding.inner.prefixes {
                 tokens.insert(
                     to_ident_key(ident),
@@ -405,12 +405,12 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
         ExpressionKind::Asm(_) => {
             //TODO handle asm expressions
         }
-        ExpressionKind::MethodApplication(MethodApplicationExpression {
-            method_name_binding,
-            arguments,
-            contract_call_params,
-            ..
-        }) => {
+        ExpressionKind::MethodApplication(method_application_expression) => {
+            let MethodApplicationExpression {
+                method_name_binding,
+                arguments,
+                contract_call_params,
+            } = &**method_application_expression;
             let prefixes = match &method_name_binding.inner {
                 MethodName::FromType {
                     call_path_binding, ..
@@ -462,11 +462,11 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
             );
             handle_expression(prefix, tokens);
         }
-        ExpressionKind::DelineatedPath(DelineatedPathExpression {
-            call_path_binding,
-            args,
-            ..
-        }) => {
+        ExpressionKind::DelineatedPath(delineated_path_expression) => {
+            let DelineatedPathExpression {
+                call_path_binding,
+                args,
+            } = &**delineated_path_expression;
             for ident in &call_path_binding.inner.prefixes {
                 tokens.insert(
                     to_ident_key(ident),
@@ -482,9 +482,8 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                 handle_expression(exp, tokens);
             }
         }
-        ExpressionKind::AbiCast(AbiCastExpression {
-            abi_name, address, ..
-        }) => {
+        ExpressionKind::AbiCast(abi_cast_expression) => {
+            let AbiCastExpression { abi_name, address } = &**abi_cast_expression;
             for ident in &abi_name.prefixes {
                 tokens.insert(
                     to_ident_key(ident),

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -7,8 +7,11 @@ use crate::{
 use sway_core::{
     constants::{DESTRUCTURE_PREFIX, MATCH_RETURN_VAR_NAME_PREFIX, TUPLE_NAME_PREFIX},
     parse_tree::MethodName,
-    AstNode, AstNodeContent, Declaration, Expression, FunctionDeclaration, ReassignmentTarget,
-    TypeInfo, WhileLoop,
+    AbiCastExpression, ArrayIndexExpression, AstNode, AstNodeContent, Declaration,
+    DelineatedPathExpression, Expression, ExpressionKind, FunctionApplicationExpression,
+    FunctionDeclaration, IfExpression, IntrinsicFunctionExpression, LazyOperatorExpression,
+    MatchExpression, MethodApplicationExpression, ReassignmentTarget, StorageAccessExpression,
+    StructExpression, SubfieldExpression, TupleIndexExpression, TypeInfo, WhileLoop,
 };
 use sway_types::Ident;
 
@@ -287,18 +290,19 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
 }
 
 fn handle_expression(expression: &Expression, tokens: &TokenMap) {
-    match expression {
-        Expression::Literal { span, .. } => {
+    let span = &expression.span;
+    match &expression.kind {
+        ExpressionKind::Literal(_) => {
             tokens.insert(
                 to_ident_key(&Ident::new(span.clone())),
                 Token::from_parsed(AstToken::Expression(expression.clone())),
             );
         }
-        Expression::FunctionApplication {
+        ExpressionKind::FunctionApplication(FunctionApplicationExpression {
             call_path_binding,
             arguments,
             ..
-        } => {
+        }) => {
             // Don't collect applications of desugared operators due to mismatched ident lengths.
             if !desugared_op(&call_path_binding.inner.prefixes) {
                 for ident in &call_path_binding.inner.prefixes {
@@ -317,11 +321,11 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                 handle_expression(exp, tokens);
             }
         }
-        Expression::LazyOperator { lhs, rhs, .. } => {
+        ExpressionKind::LazyOperator(LazyOperatorExpression { lhs, rhs, .. }) => {
             handle_expression(lhs, tokens);
             handle_expression(rhs, tokens);
         }
-        Expression::VariableExpression { name, .. } => {
+        ExpressionKind::Variable(name) => {
             if !name.as_str().contains(TUPLE_NAME_PREFIX)
                 && !name.as_str().contains(MATCH_RETURN_VAR_NAME_PREFIX)
                 && !name.as_str().contains(DESTRUCTURE_PREFIX)
@@ -332,24 +336,24 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                 );
             }
         }
-        Expression::Tuple { fields, .. } => {
+        ExpressionKind::Tuple(fields) => {
             for exp in fields {
                 handle_expression(exp, tokens);
             }
         }
-        Expression::TupleIndex { prefix, .. } => {
+        ExpressionKind::TupleIndex(TupleIndexExpression { prefix, .. }) => {
             handle_expression(prefix, tokens);
         }
-        Expression::Array { contents, .. } => {
+        ExpressionKind::Array(contents) => {
             for exp in contents {
                 handle_expression(exp, tokens);
             }
         }
-        Expression::StructExpression {
+        ExpressionKind::Struct(StructExpression {
             call_path_binding,
             fields,
             ..
-        } => {
+        }) => {
             for ident in &call_path_binding.inner.prefixes {
                 tokens.insert(
                     to_ident_key(ident),
@@ -372,41 +376,41 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                 handle_expression(&field.value, tokens);
             }
         }
-        Expression::CodeBlock { contents, .. } => {
+        ExpressionKind::CodeBlock(contents) => {
             for node in &contents.contents {
                 traverse_node(node, tokens);
             }
         }
-        Expression::IfExp {
+        ExpressionKind::If(IfExpression {
             condition,
             then,
             r#else,
             ..
-        } => {
+        }) => {
             handle_expression(condition, tokens);
             handle_expression(then, tokens);
             if let Some(r#else) = r#else {
                 handle_expression(r#else, tokens);
             }
         }
-        Expression::MatchExp {
+        ExpressionKind::Match(MatchExpression {
             value, branches, ..
-        } => {
+        }) => {
             handle_expression(value, tokens);
             for branch in branches {
                 // TODO: handle_scrutinee(branch.scrutinee, tokens);
                 handle_expression(&branch.result, tokens);
             }
         }
-        Expression::AsmExpression { .. } => {
+        ExpressionKind::Asm(_) => {
             //TODO handle asm expressions
         }
-        Expression::MethodApplication {
+        ExpressionKind::MethodApplication(MethodApplicationExpression {
             method_name_binding,
             arguments,
             contract_call_params,
             ..
-        } => {
+        }) => {
             let prefixes = match &method_name_binding.inner {
                 MethodName::FromType {
                     call_path_binding, ..
@@ -447,22 +451,22 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                 handle_expression(&field.value, tokens);
             }
         }
-        Expression::SubfieldExpression {
+        ExpressionKind::Subfield(SubfieldExpression {
             prefix,
             field_to_access,
             ..
-        } => {
+        }) => {
             tokens.insert(
                 to_ident_key(field_to_access),
                 Token::from_parsed(AstToken::Expression(expression.clone())),
             );
             handle_expression(prefix, tokens);
         }
-        Expression::DelineatedPath {
+        ExpressionKind::DelineatedPath(DelineatedPathExpression {
             call_path_binding,
             args,
             ..
-        } => {
+        }) => {
             for ident in &call_path_binding.inner.prefixes {
                 tokens.insert(
                     to_ident_key(ident),
@@ -478,9 +482,9 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                 handle_expression(exp, tokens);
             }
         }
-        Expression::AbiCast {
+        ExpressionKind::AbiCast(AbiCastExpression {
             abi_name, address, ..
-        } => {
+        }) => {
             for ident in &abi_name.prefixes {
                 tokens.insert(
                     to_ident_key(ident),
@@ -493,11 +497,11 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
             );
             handle_expression(address, tokens);
         }
-        Expression::ArrayIndex { prefix, index, .. } => {
+        ExpressionKind::ArrayIndex(ArrayIndexExpression { prefix, index, .. }) => {
             handle_expression(prefix, tokens);
             handle_expression(index, tokens);
         }
-        Expression::StorageAccess { field_names, .. } => {
+        ExpressionKind::StorageAccess(StorageAccessExpression { field_names, .. }) => {
             for field in field_names {
                 tokens.insert(
                     to_ident_key(field),
@@ -505,7 +509,7 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                 );
             }
         }
-        Expression::IntrinsicFunction { arguments, .. } => {
+        ExpressionKind::IntrinsicFunction(IntrinsicFunctionExpression { arguments, .. }) => {
             for argument in arguments {
                 handle_expression(argument, tokens);
             }

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use crate::core::token::{AstToken, Token, TokenMap, TypedAstToken};
 use crate::utils::{common::get_range_from_span, token};
-use sway_core::{Expression, Literal};
+use sway_core::{Expression, ExpressionKind, Literal};
 use sway_types::{Ident, Spanned};
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
@@ -97,7 +97,10 @@ fn ast_node_type(token_type: &Token) -> String {
             _ => "".to_string(),
         },
         None => match &token_type.parsed {
-            AstToken::Expression(Expression::Literal { value, .. }) => literal_to_string(value),
+            AstToken::Expression(Expression {
+                kind: ExpressionKind::Literal(value),
+                ..
+            }) => literal_to_string(value),
             _ => "".to_string(),
         },
     }


### PR DESCRIPTION
* Refactor the `Expression` enum into a struct with separate fields for the span and the expression kind.
* Add an `ExpressionKind` enum, which is just `Expression` but with all the span fields removed.
* Add separate types for the different kinds of expressions, and turn all of `ExpressionKind`'s variants into single-field tuple variants.
* Box the larger `ExpressionKind` variants to reduce its size.

This fixes #2485
