### PR TITLE
Add Outer DocComment Parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,6 +3729,7 @@ dependencies = [
 name = "sway-parse"
 version = "0.19.2"
 dependencies = [
+ "assert_matches",
  "extension-trait",
  "num-bigint",
  "num-traits",

--- a/sway-ast/src/punctuated.rs
+++ b/sway-ast/src/punctuated.rs
@@ -4,6 +4,22 @@ pub struct Punctuated<T, P> {
     pub final_value_opt: Option<Box<T>>,
 }
 
+impl<T, P> Punctuated<T, P> {
+    pub fn empty() -> Self {
+        Self {
+            value_separator_pairs: vec![],
+            final_value_opt: None,
+        }
+    }
+
+    pub fn single(value: T) -> Self {
+        Self {
+            value_separator_pairs: vec![],
+            final_value_opt: Some(Box::new(value)),
+        }
+    }
+}
+
 impl<T, P> IntoIterator for Punctuated<T, P> {
     type Item = T;
     type IntoIter = PunctuatedIter<T, P>;

--- a/sway-ast/src/token.rs
+++ b/sway-ast/src/token.rs
@@ -119,6 +119,24 @@ impl Spanned for Comment {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+pub enum DocStyle {
+    Outer,
+    Inner,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+pub struct DocComment {
+    pub span: Span,
+    pub doc_style: DocStyle,
+}
+
+impl Spanned for DocComment {
+    fn span(&self) -> Span {
+        self.span.clone()
+    }
+}
+
 /// Allows for generalizing over commented and uncommented token streams.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub enum GenericTokenTree<T> {
@@ -126,6 +144,7 @@ pub enum GenericTokenTree<T> {
     Ident(Ident),
     Group(GenericGroup<T>),
     Literal(Literal),
+    DocComment(DocComment),
 }
 
 pub type TokenTree = GenericTokenTree<TokenStream>;
@@ -154,6 +173,7 @@ impl<T> Spanned for GenericTokenTree<T> {
             Self::Ident(ident) => ident.span(),
             Self::Group(group) => group.span(),
             Self::Literal(literal) => literal.span(),
+            Self::DocComment(doc_comment) => doc_comment.span(),
         }
     }
 }
@@ -188,6 +208,12 @@ impl<T> From<GenericGroup<T>> for GenericTokenTree<T> {
 impl<T> From<Literal> for GenericTokenTree<T> {
     fn from(lit: Literal) -> Self {
         Self::Literal(lit)
+    }
+}
+
+impl<T> From<DocComment> for GenericTokenTree<T> {
+    fn from(doc_comment: DocComment) -> Self {
+        Self::DocComment(doc_comment)
     }
 }
 
@@ -307,6 +333,7 @@ impl CommentedTokenTree {
             CommentedTree::Ident(ident) => ident.into(),
             CommentedTree::Group(group) => group.strip_comments().into(),
             CommentedTree::Literal(lit) => lit.into(),
+            CommentedTree::DocComment(doc_comment) => doc_comment.into(),
         };
         Some(tt)
     }

--- a/sway-ast/src/token.rs
+++ b/sway-ast/src/token.rs
@@ -128,6 +128,7 @@ pub enum DocStyle {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
 pub struct DocComment {
     pub span: Span,
+    pub content_span: Span,
     pub doc_style: DocStyle,
 }
 

--- a/sway-fmt-v2/src/fmt.rs
+++ b/sway-fmt-v2/src/fmt.rs
@@ -690,7 +690,7 @@ abi StorageMapExample {
 pub const /* TEST: blah blah tests */ TEST: u16 = 10; // This is a comment next to a const"#;
         let correct_sway_code = r#"contract;
 
-pub const /* TEST: blah blah tests */ TEST: u16 = 10;"#; // Comment next to const is not picked up by the lexer see: #2356
+pub const /* TEST: blah blah tests */ TEST: u16 = 10; // This is a comment next to a const"#;
         let mut formatter = Formatter::default();
         let formatted_sway_code =
             Formatter::format(&mut formatter, Arc::from(sway_code_to_format), None).unwrap();

--- a/sway-lib-std/src/context/call_frames.sw
+++ b/sway-lib-std/src/context/call_frames.sw
@@ -1,6 +1,6 @@
 //! Helper functions for accessing data from call frames.
-/// Call frames store metadata across untrusted inter-contract calls:
-/// https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/main.md#call-frames
+//! Call frames store metadata across untrusted inter-contract calls:
+//! https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/main.md#call-frames
 library call_frames;
 
 use ::context::registers::frame_ptr;

--- a/sway-parse/Cargo.toml
+++ b/sway-parse/Cargo.toml
@@ -17,3 +17,6 @@ sway-ast = { version = "0.19.2", path = "../sway-ast" }
 sway-types = { version = "0.19.2", path = "../sway-types" }
 thiserror = "1.0"
 unicode-xid = "0.2.2"
+
+[dev-dependencies]
+assert_matches = "1.5.0"

--- a/sway-parse/src/attribute.rs
+++ b/sway-parse/src/attribute.rs
@@ -30,7 +30,7 @@ impl<T: Parse> Parse for Annotated<T> {
         while let Some(DocComment {
             doc_style: DocStyle::Outer,
             ..
-        }) = parser.peek::<DocComment>()
+        }) = parser.peek()
         {
             let doc_comment = parser.parse::<DocComment>()?;
             // TODO: Use a Literal instead of an Ident when Attribute args

--- a/sway-parse/src/attribute.rs
+++ b/sway-parse/src/attribute.rs
@@ -33,20 +33,17 @@ impl<T: Parse> Parse for Annotated<T> {
         }) = parser.peek::<DocComment>()
         {
             let doc_comment = parser.parse::<DocComment>()?;
-            let content = doc_comment.span.as_str()[3..].to_string();
-            let content: &'static str = Box::leak(content.into_boxed_str());
-            let value = Ident::new_no_span(content);
+            // TODO: Use a Literal instead of an Ident when Attribute args
+            // start supporting them and remove `Ident::new_no_trim`.
+            let value = Ident::new_no_trim(doc_comment.content_span.clone());
             attribute_list.push(AttributeDecl {
                 hash_token: HashToken::new(doc_comment.span.clone()),
                 attribute: SquareBrackets::new(
                     Attribute {
                         name: Ident::new_with_override("doc", doc_comment.span.clone()),
                         args: Some(Parens::new(
-                            Punctuated {
-                                value_separator_pairs: vec![],
-                                final_value_opt: Some(Box::new(value)),
-                            },
-                            doc_comment.span.clone(),
+                            Punctuated::single(value),
+                            doc_comment.content_span,
                         )),
                     },
                     doc_comment.span,

--- a/sway-parse/src/error.rs
+++ b/sway-parse/src/error.rs
@@ -72,6 +72,8 @@ pub enum ParseErrorKind {
     ReservedKeywordIdentifier,
     #[error("Unnecessary visibility qualifier, `{}` is implied here.", visibility)]
     UnnecessaryVisibilityQualifier { visibility: Ident },
+    #[error("Expected a doc comment.")]
+    ExpectedDocComment,
 }
 
 #[derive(Debug, Error, Clone, PartialEq, Eq, Hash)]

--- a/sway-parse/src/expr/mod.rs
+++ b/sway-parse/src/expr/mod.rs
@@ -697,10 +697,7 @@ impl ParseToEnd for ExprArrayDescriptor {
         mut parser: Parser<'a, 'e>,
     ) -> ParseResult<(ExprArrayDescriptor, ParserConsumed<'a>)> {
         if let Some(consumed) = parser.check_empty() {
-            let punctuated = Punctuated {
-                value_separator_pairs: Vec::new(),
-                final_value_opt: None,
-            };
+            let punctuated = Punctuated::empty();
             let descriptor = ExprArrayDescriptor::Sequence(punctuated);
             return Ok((descriptor, consumed));
         }
@@ -729,10 +726,7 @@ impl ParseToEnd for ExprArrayDescriptor {
             return Ok((descriptor, consumed));
         }
         if let Some(consumed) = parser.check_empty() {
-            let punctuated = Punctuated {
-                value_separator_pairs: Vec::new(),
-                final_value_opt: Some(Box::new(value)),
-            };
+            let punctuated = Punctuated::single(value);
             let descriptor = ExprArrayDescriptor::Sequence(punctuated);
             return Ok((descriptor, consumed));
         }

--- a/sway-parse/src/item/mod.rs
+++ b/sway-parse/src/item/mod.rs
@@ -85,6 +85,7 @@ impl Parse for TypeField {
         {
             let _ = parser.parse::<DocComment>()?;
         }
+
         Ok(TypeField {
             name: parser.parse()?,
             colon_token: parser.parse()?,
@@ -169,7 +170,8 @@ impl Parse for FnSignature {
 mod tests {
     use super::*;
     use std::sync::Arc;
-    use sway_ast::Item;
+    use sway_ast::{AttributeDecl, CommaToken, Item, Punctuated};
+    use sway_types::Ident;
 
     fn parse_item(input: &str) -> Item {
         let token_stream = crate::token::lex(&Arc::from(input), 0, input.len(), None).unwrap();
@@ -181,6 +183,10 @@ mod tests {
                 panic!("Parse error: {:?}", errors);
             }
         }
+    }
+
+    fn get_attribute_args(attrib: &AttributeDecl) -> &Punctuated<Ident, CommaToken> {
+        attrib.attribute.get().args.as_ref().unwrap().get()
     }
 
     #[test]
@@ -206,14 +212,7 @@ mod tests {
         assert_eq!(attrib.attribute.get().name.as_str(), "doc");
         assert!(attrib.attribute.get().args.is_some());
 
-        let mut args = attrib
-            .attribute
-            .get()
-            .args
-            .as_ref()
-            .unwrap()
-            .get()
-            .into_iter();
+        let mut args = get_attribute_args(attrib).into_iter();
         assert_eq!(
             args.next().map(|arg| arg.as_str()),
             Some(" This is a doc comment.")
@@ -299,14 +298,7 @@ mod tests {
         assert_eq!(attrib.attribute.get().name.as_str(), "foo");
         assert!(attrib.attribute.get().args.is_some());
 
-        let mut args = attrib
-            .attribute
-            .get()
-            .args
-            .as_ref()
-            .unwrap()
-            .get()
-            .into_iter();
+        let mut args = get_attribute_args(attrib).into_iter();
         assert_eq!(args.next().map(|arg| arg.as_str()), Some("one"));
         assert_eq!(args.next().map(|arg| arg.as_str()), None);
     }
@@ -332,14 +324,7 @@ mod tests {
         // Args are still parsed as 'some' but with an empty collection.
         assert!(attrib.attribute.get().args.is_some());
 
-        let mut args = attrib
-            .attribute
-            .get()
-            .args
-            .as_ref()
-            .unwrap()
-            .get()
-            .into_iter();
+        let mut args = get_attribute_args(attrib).into_iter();
         assert_eq!(args.next().map(|arg| arg.as_str()), None);
     }
 
@@ -367,14 +352,7 @@ mod tests {
         assert_eq!(attrib.attribute.get().name.as_str(), "foo");
         assert!(attrib.attribute.get().args.is_some());
 
-        let mut args = attrib
-            .attribute
-            .get()
-            .args
-            .as_ref()
-            .unwrap()
-            .get()
-            .into_iter();
+        let mut args = get_attribute_args(attrib).into_iter();
         assert_eq!(args.next().map(|arg| arg.as_str()), Some("one"));
         assert_eq!(args.next().map(|arg| arg.as_str()), None);
     }
@@ -399,14 +377,7 @@ mod tests {
         assert_eq!(attrib.attribute.get().name.as_str(), "foo");
         assert!(attrib.attribute.get().args.is_some());
 
-        let mut args = attrib
-            .attribute
-            .get()
-            .args
-            .as_ref()
-            .unwrap()
-            .get()
-            .into_iter();
+        let mut args = get_attribute_args(attrib).into_iter();
         assert_eq!(args.next().map(|arg| arg.as_str()), Some("one"));
         assert_eq!(args.next().map(|arg| arg.as_str()), None);
 
@@ -434,14 +405,7 @@ mod tests {
         assert_eq!(attrib.attribute.get().name.as_str(), "foo");
         assert!(attrib.attribute.get().args.is_some());
 
-        let mut args = attrib
-            .attribute
-            .get()
-            .args
-            .as_ref()
-            .unwrap()
-            .get()
-            .into_iter();
+        let mut args = get_attribute_args(attrib).into_iter();
         assert_eq!(args.next().map(|arg| arg.as_str()), Some("one"));
         assert_eq!(args.next().map(|arg| arg.as_str()), Some("two"));
         assert_eq!(args.next().map(|arg| arg.as_str()), None);
@@ -472,14 +436,7 @@ mod tests {
         assert_eq!(attrib.attribute.get().name.as_str(), "foo");
         assert!(attrib.attribute.get().args.is_some());
 
-        let mut args = attrib
-            .attribute
-            .get()
-            .args
-            .as_ref()
-            .unwrap()
-            .get()
-            .into_iter();
+        let mut args = get_attribute_args(attrib).into_iter();
         assert_eq!(args.next().map(|arg| arg.as_str()), Some("one"));
         assert_eq!(args.next().map(|arg| arg.as_str()), None);
 
@@ -487,14 +444,7 @@ mod tests {
         assert_eq!(attrib.attribute.get().name.as_str(), "baz");
         assert!(attrib.attribute.get().args.is_some());
 
-        let mut args = attrib
-            .attribute
-            .get()
-            .args
-            .as_ref()
-            .unwrap()
-            .get()
-            .into_iter();
+        let mut args = get_attribute_args(attrib).into_iter();
         assert_eq!(args.next().map(|arg| arg.as_str()), Some("two"));
         assert_eq!(args.next().map(|arg| arg.as_str()), Some("three"));
         assert_eq!(args.next().map(|arg| arg.as_str()), Some("four"));
@@ -531,14 +481,7 @@ mod tests {
             let attrib = f_sig.unwrap().0.attribute_list.get(0).unwrap();
             assert_eq!(attrib.attribute.get().name.as_str(), "foo");
             assert!(attrib.attribute.get().args.is_some());
-            let mut args = attrib
-                .attribute
-                .get()
-                .args
-                .as_ref()
-                .unwrap()
-                .get()
-                .into_iter();
+            let mut args = get_attribute_args(attrib).into_iter();
             assert_eq!(args.next().map(|arg| arg.as_str()), Some("one"));
             assert_eq!(args.next().map(|arg| arg.as_str()), None);
 
@@ -557,14 +500,7 @@ mod tests {
             let attrib = g_sig.unwrap().attribute_list.get(0).unwrap();
             assert_eq!(attrib.attribute.get().name.as_str(), "bar");
             assert!(attrib.attribute.get().args.is_some());
-            let mut args = attrib
-                .attribute
-                .get()
-                .args
-                .as_ref()
-                .unwrap()
-                .get()
-                .into_iter();
+            let mut args = get_attribute_args(attrib).into_iter();
             assert_eq!(args.next().map(|arg| arg.as_str()), Some("one"));
             assert_eq!(args.next().map(|arg| arg.as_str()), Some("two"));
             assert_eq!(args.next().map(|arg| arg.as_str()), Some("three"));
@@ -608,14 +544,7 @@ mod tests {
             let attrib = f_sig.unwrap().0.attribute_list.get(0).unwrap();
             assert_eq!(attrib.attribute.get().name.as_str(), "bar");
             assert!(attrib.attribute.get().args.is_some());
-            let mut args = attrib
-                .attribute
-                .get()
-                .args
-                .as_ref()
-                .unwrap()
-                .get()
-                .into_iter();
+            let mut args = get_attribute_args(attrib).into_iter();
             assert_eq!(args.next().map(|arg| arg.as_str()), Some("one"));
             assert_eq!(args.next().map(|arg| arg.as_str()), Some("two"));
             assert_eq!(args.next().map(|arg| arg.as_str()), Some("three"));
@@ -643,14 +572,7 @@ mod tests {
             let attrib = h_sig.unwrap().attribute_list.get(0).unwrap();
             assert_eq!(attrib.attribute.get().name.as_str(), "baz");
             assert!(attrib.attribute.get().args.is_some());
-            let mut args = attrib
-                .attribute
-                .get()
-                .args
-                .as_ref()
-                .unwrap()
-                .get()
-                .into_iter();
+            let mut args = get_attribute_args(attrib).into_iter();
             assert_eq!(args.next().map(|arg| arg.as_str()), Some("one"));
             assert_eq!(args.next().map(|arg| arg.as_str()), None);
 
@@ -681,14 +603,7 @@ mod tests {
             assert_eq!(attrib.attribute.get().name.as_str(), "doc");
             assert!(attrib.attribute.get().args.is_some());
 
-            let mut args = attrib
-                .attribute
-                .get()
-                .args
-                .as_ref()
-                .unwrap()
-                .get()
-                .into_iter();
+            let mut args = get_attribute_args(attrib).into_iter();
             assert_eq!(
                 args.next().map(|arg| arg.as_str()),
                 match i {

--- a/sway-parse/src/parser.rs
+++ b/sway-parse/src/parser.rs
@@ -3,7 +3,9 @@ use crate::{Parse, ParseError, ParseErrorKind, ParseToEnd, Peek};
 use core::marker::PhantomData;
 use sway_ast::keywords::Keyword;
 use sway_ast::literal::Literal;
-use sway_ast::token::{Delimiter, Group, Punct, PunctKind, Spacing, TokenStream, TokenTree};
+use sway_ast::token::{
+    Delimiter, DocComment, Group, Punct, PunctKind, Spacing, TokenStream, TokenTree,
+};
 use sway_ast::PubToken;
 use sway_types::{Ident, Span, Spanned};
 
@@ -231,6 +233,16 @@ impl<'a> Peeker<'a> {
             [TokenTree::Group(Group { delimiter, .. }), ..] => {
                 *self.num_tokens = 1;
                 Ok(*delimiter)
+            }
+            _ => Err(self),
+        }
+    }
+
+    pub fn peek_doc_comment(self) -> Result<&'a DocComment, Self> {
+        match self.token_trees {
+            [TokenTree::DocComment(doc_comment), ..] => {
+                *self.num_tokens = 1;
+                Ok(doc_comment)
             }
             _ => Err(self),
         }

--- a/sway-types/src/ident.rs
+++ b/sway-types/src/ident.rs
@@ -72,6 +72,14 @@ impl Ident {
         }
     }
 
+    pub fn new_no_trim(span: Span) -> Ident {
+        Ident {
+            name_override_opt: None,
+            span,
+            is_raw_ident: false,
+        }
+    }
+
     pub fn new_with_raw(span: Span, is_raw_ident: bool) -> Ident {
         let span = span.trim();
         Ident {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/main_should_not_have_args/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/main_should_not_have_args/Forc.lock
@@ -1,14 +1,4 @@
 [[package]]
-name = 'core'
-source = 'path+from-root-B4D60689AE851FD3'
-dependencies = []
-
-[[package]]
 name = 'main_should_not_have_args'
 source = 'root'
-dependencies = ['std']
-
-[[package]]
-name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.19.2#6808861389966f99887f71476918a562a9edd90e'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/main_should_not_have_args/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/main_should_not_have_args/Forc.toml
@@ -3,3 +3,4 @@ authors = ["Deniz Surmeli <denizsurmeli@icloud.com>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "main_should_not_have_args"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ec_recover_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ec_recover_test/src/main.sw
@@ -49,7 +49,7 @@ fn main() -> bool {
     };
 
     /////////////////////////////////////////
-    ///  Failure to recover
+    ////  Failure to recover
     /////////////////////////////////////////
 
     // using invalid data here to test the handling of failed pubkey/address recovery.

--- a/test/src/sdk-harness/test_artifacts/reentrancy_target_contract/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/reentrancy_target_contract/src/main.sw
@@ -28,7 +28,7 @@ impl Target for Contract {
             let id = id.value;
             let caller = abi(Attacker, id);
 
-            /// this call transfers control to the attacker contract, allowing it to execute arbitrary code.
+            // this call transfers control to the attacker contract, allowing it to execute arbitrary code.
             let return_value = caller.evil_callback_1();
             false
         }
@@ -43,7 +43,7 @@ impl Target for Contract {
         let id = id.value;
         let caller = abi(Attacker, id);
 
-        /// this call transfers control to the attacker contract, allowing it to execute arbitrary code.
+        // this call transfers control to the attacker contract, allowing it to execute arbitrary code.
         let return_value = caller.evil_callback_2();
     }
 
@@ -56,7 +56,7 @@ impl Target for Contract {
         let id = id.value;
         let caller = abi(Attacker, id);
 
-        /// this call transfers control to the attacker contract, allowing it to execute arbitrary code.
+        // this call transfers control to the attacker contract, allowing it to execute arbitrary code.
         let return_value = caller.evil_callback_3();
     }
 


### PR DESCRIPTION
This PR extends the parser so that the following:
```rs
/// This is a doc comment.
/// This is another doc comment.
fn f() -> bool {
    false
}
```
is basically parsed like:
```rs
#[doc( This is a doc comment.)]
#[doc( This is another doc comment.)]
fn f() -> bool {
    false
}
```

Notes:
- Corners were cut to unblock the rest of the work.
- Inner DocComment (`//!`) support was left for later. The lexer has commented out code for supporting these in the future.
- Enum and Struct fields (`TypeField`s) aren't annotated ATM so they can't have DocComments. Since we do have code that uses DocComments for these fields, we started getting errors. As a temporary solution I made the parser ignore these DocComments. When we start supporting annotations for `TypeField`s, we can remove the temp code and everything should work fine.
- There's some ugliness in the `DocComment` to `AttributeDecl` conversion code. Adding `Literal` support for `Attribute` args or having two types of attributes, `Normal` and `DocComment`, [like Rust](https://github.com/rust-lang/rust/blob/aeb5067967ef58e4a324b19dd0dba2f385d5959f/compiler/rustc_ast/src/ast.rs#L2551-L2560) could help.