### PR TITLE
Fix new clippy lints (with rust version 1.63)

### DIFF
--- a/scripts/mdbook-forc-documenter/src/formatter.rs
+++ b/scripts/mdbook-forc-documenter/src/formatter.rs
@@ -1,4 +1,4 @@
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum LineKind {
     SubHeader,
     Arg,

--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -90,7 +90,7 @@ impl ErrorContext {
     }
 }
 
-#[derive(Error, Debug, Clone, PartialEq, Hash)]
+#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ConvertParseTreeError {
     #[error("pub use imports are not supported")]
     PubUseNotSupported { span: Span },

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -191,7 +191,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Hint {
     msg: Option<String>,
 }
@@ -213,7 +213,7 @@ impl Display for Hint {
 
 // TODO: since moving to using Idents instead of strings the warning_content will usually contain a
 // duplicate of the span.
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CompileWarning {
     pub span: Span,
     pub warning_content: Warning,
@@ -258,7 +258,7 @@ impl From<(usize, usize)> for LineCol {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Warning {
     NonClassCaseStructName {
         struct_name: Ident,
@@ -447,7 +447,7 @@ impl fmt::Display for Warning {
 
 // TODO: since moving to using Idents instead of strings, there are a lot of redundant spans in
 // this type.
-#[derive(Error, Debug, Clone, PartialEq, Hash)]
+#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CompileError {
     #[error("Variable \"{var_name}\" does not exist in this scope.")]
     UnknownVariable { var_name: Ident },
@@ -1231,7 +1231,7 @@ impl CompileError {
     }
 }
 
-#[derive(Error, Debug, Clone, PartialEq, Hash)]
+#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TypeError {
     #[error(
         "Mismatched types.\n\

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -287,7 +287,7 @@ fn const_eval_typed_expr(
             let tag_value = Constant::new_uint(64, *tag as u64);
             let mut fields: Vec<Constant> = vec![tag_value];
             contents.iter().for_each(|subexpr| {
-                const_eval_typed_expr(lookup, known_consts, &*subexpr)
+                const_eval_typed_expr(lookup, known_consts, subexpr)
                     .into_iter()
                     .for_each(|enum_val| {
                         fields.push(enum_val);
@@ -300,7 +300,7 @@ fn const_eval_typed_expr(
             field_to_access,
             resolved_type_of_parent,
             ..
-        } => match const_eval_typed_expr(lookup, known_consts, &*prefix) {
+        } => match const_eval_typed_expr(lookup, known_consts, prefix) {
             Some(Constant {
                 value: ConstantValue::Struct(fields),
                 ..
@@ -320,7 +320,7 @@ fn const_eval_typed_expr(
             prefix,
             elem_to_access_num,
             ..
-        } => match const_eval_typed_expr(lookup, known_consts, &*prefix) {
+        } => match const_eval_typed_expr(lookup, known_consts, prefix) {
             Some(Constant {
                 value: ConstantValue::Struct(fields),
                 ..

--- a/sway-core/src/parse_tree/expression/mod.rs
+++ b/sway-core/src/parse_tree/expression/mod.rs
@@ -140,7 +140,7 @@ pub enum Expression {
     },
 }
 
-#[derive(Clone, Debug, PartialEq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum LazyOp {
     And,
     Or,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -220,8 +220,7 @@ impl TypedImplTrait {
                     prefix: expr1,
                     index: expr2,
                 } => {
-                    expr_contains_get_storage_index(&*expr1)
-                        || expr_contains_get_storage_index(&*expr2)
+                    expr_contains_get_storage_index(expr1) || expr_contains_get_storage_index(expr2)
                 }
                 TypedExpressionVariant::Tuple { fields: exprvec }
                 | TypedExpressionVariant::Array { contents: exprvec } => {
@@ -237,22 +236,22 @@ impl TypedImplTrait {
                     then,
                     r#else,
                 } => {
-                    expr_contains_get_storage_index(&*condition)
-                        || expr_contains_get_storage_index(&*then)
+                    expr_contains_get_storage_index(condition)
+                        || expr_contains_get_storage_index(then)
                         || r#else
                             .as_ref()
-                            .map_or(false, |r#else| expr_contains_get_storage_index(&*r#else))
+                            .map_or(false, |r#else| expr_contains_get_storage_index(r#else))
                 }
                 TypedExpressionVariant::StructFieldAccess { prefix: exp, .. }
                 | TypedExpressionVariant::TupleElemAccess { prefix: exp, .. }
                 | TypedExpressionVariant::AbiCast { address: exp, .. }
                 | TypedExpressionVariant::EnumTag { exp }
                 | TypedExpressionVariant::UnsafeDowncast { exp, .. } => {
-                    expr_contains_get_storage_index(&*exp)
+                    expr_contains_get_storage_index(exp)
                 }
                 TypedExpressionVariant::EnumInstantiation { contents, .. } => contents
                     .as_ref()
-                    .map_or(false, |f| expr_contains_get_storage_index(&*f)),
+                    .map_or(false, |f| expr_contains_get_storage_index(f)),
 
                 TypedExpressionVariant::IntrinsicFunction(TypedIntrinsicFunctionKind {
                     kind,

--- a/sway-core/src/semantic_analysis/ast_node/expression/struct_expr_field.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/struct_expr_field.rs
@@ -1,7 +1,7 @@
 use crate::Ident;
 use crate::{semantic_analysis::*, type_system::*};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypedStructExpressionField {
     pub name: Ident,
     pub value: TypedExpression,

--- a/sway-core/src/semantic_analysis/storage_only_types.rs
+++ b/sway-core/src/semantic_analysis/storage_only_types.rs
@@ -60,8 +60,8 @@ fn expr_validate(expr: &TypedExpression) -> CompileResult<()> {
             prefix: expr1,
             index: expr2,
         } => {
-            check!(expr_validate(&*expr1), (), warnings, errors);
-            check!(expr_validate(&*expr2), (), warnings, errors);
+            check!(expr_validate(expr1), (), warnings, errors);
+            check!(expr_validate(expr2), (), warnings, errors);
         }
         TypedExpressionVariant::IntrinsicFunction(TypedIntrinsicFunctionKind {
             arguments: exprvec,
@@ -91,10 +91,10 @@ fn expr_validate(expr: &TypedExpression) -> CompileResult<()> {
             then,
             r#else,
         } => {
-            check!(expr_validate(&*condition), (), warnings, errors);
-            check!(expr_validate(&*then), (), warnings, errors);
+            check!(expr_validate(condition), (), warnings, errors);
+            check!(expr_validate(then), (), warnings, errors);
             if let Some(r#else) = r#else {
-                check!(expr_validate(&*r#else), (), warnings, errors);
+                check!(expr_validate(r#else), (), warnings, errors);
             }
         }
         TypedExpressionVariant::StructFieldAccess { prefix: exp, .. }
@@ -102,11 +102,11 @@ fn expr_validate(expr: &TypedExpression) -> CompileResult<()> {
         | TypedExpressionVariant::AbiCast { address: exp, .. }
         | TypedExpressionVariant::EnumTag { exp }
         | TypedExpressionVariant::UnsafeDowncast { exp, .. } => {
-            check!(expr_validate(&*exp), (), warnings, errors)
+            check!(expr_validate(exp), (), warnings, errors)
         }
         TypedExpressionVariant::EnumInstantiation { contents, .. } => {
             if let Some(f) = contents {
-                check!(expr_validate(&*f), (), warnings, errors);
+                check!(expr_validate(f), (), warnings, errors);
             }
         }
     }

--- a/sway-core/src/type_system/type_info.rs
+++ b/sway-core/src/type_system/type_info.rs
@@ -11,7 +11,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-#[derive(Debug, Clone, Hash, PartialEq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum AbiName {
     Deferred,
     Known(CallPath),

--- a/sway-fmt-v2/src/config/lists.rs
+++ b/sway-fmt-v2/src/config/lists.rs
@@ -78,7 +78,7 @@ impl SeparatorTactic {
 }
 
 /// Where to put separator.
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub enum SeparatorPlace {
     Front,
     Back,

--- a/sway-fmt/src/code_line.rs
+++ b/sway-fmt/src/code_line.rs
@@ -117,7 +117,7 @@ impl CodeLine {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum CodeType {
     String,
     Default,

--- a/sway-ir/src/parser.rs
+++ b/sway-ir/src/parser.rs
@@ -372,7 +372,7 @@ mod ir_builder {
             rule str_char() -> u8
                 // Match any of the printable characters except '"' and '\'.
                 = c:$([' ' | '!' | '#'..='[' | ']'..='~']) {
-                    *c.as_bytes().get(0).unwrap()
+                    *c.as_bytes().first().unwrap()
                 }
                 / "\\x" h:hex_digit() l:hex_digit() {
                     (h << 4) | l
@@ -386,10 +386,10 @@ mod ir_builder {
             //  right offset.  Fiddly.
             rule hex_digit() -> u8
                 = d:$(['0'..='9']) {
-                    d.as_bytes().get(0).unwrap() - b'0'
+                    d.as_bytes().first().unwrap() - b'0'
                 }
                 / d:$(['a'..='f' | 'A'..='F']) {
-                    (d.as_bytes().get(0).unwrap() | 0x20) - b'a' + 10
+                    (d.as_bytes().first().unwrap() | 0x20) - b'a' + 10
                 }
 
             rule array_const() -> IrAstConstValue

--- a/sway-parse/src/error.rs
+++ b/sway-parse/src/error.rs
@@ -2,7 +2,7 @@ use sway_ast::token::PunctKind;
 use sway_types::{Ident, Span};
 use thiserror::Error;
 
-#[derive(Debug, Error, Clone, PartialEq, Hash)]
+#[derive(Debug, Error, Clone, PartialEq, Eq, Hash)]
 pub enum ParseErrorKind {
     #[error("Expected an import name, group of imports, or `*`.")]
     ExpectedImportNameGroupOrGlob,
@@ -74,7 +74,7 @@ pub enum ParseErrorKind {
     UnnecessaryVisibilityQualifier { visibility: Ident },
 }
 
-#[derive(Debug, Error, Clone, PartialEq, Hash)]
+#[derive(Debug, Error, Clone, PartialEq, Eq, Hash)]
 #[error("{}", kind)]
 pub struct ParseError {
     pub span: Span,

--- a/sway-parse/src/lib.rs
+++ b/sway-parse/src/lib.rs
@@ -31,7 +31,7 @@ use sway_ast::Module;
 use crate::priv_prelude::*;
 use std::{path::PathBuf, sync::Arc};
 
-#[derive(Debug, Clone, PartialEq, Hash, Error)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Error)]
 pub enum ParseFileError {
     #[error(transparent)]
     Lex(LexError),


### PR DESCRIPTION
With rust version 1.63 released, we have some new clippy warnings in our CI.