### PR TITLE
Update 'Sway toolchain' references to 'Fuel toolchain' where appropriate

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,7 +5,7 @@
 - [Introduction](./introduction/index.md)
   - [Installation](./introduction/installation.md)
   - [Getting Started](./introduction/overview.md)
-  - [The Sway Toolchain](./introduction/sway-toolchain.md)
+  - [The Fuel Toolchain](./introduction/fuel-toolchain.md)
   - [A Forc Project](./introduction/forc_project.md)
   - [Standard Library](./introduction/standard_library.md)
 - [Examples](./examples/index.md)

--- a/docs/src/introduction/fuel-toolchain.md
+++ b/docs/src/introduction/fuel-toolchain.md
@@ -26,4 +26,4 @@ The [Visual Studio Code plugin](https://marketplace.visualstudio.com/items?itemN
 
 ## Fuel Core (`fuel-core`)
 
-While not directly part of the Sway toolchain, an implementation of the Fuel protocol, [Fuel Core](https://github.com/FuelLabs/fuel-core), is provided. [The Rust SDK](https://github.com/FuelLabs/fuels-rs) will automatically start and stop an instance of the node during tests, so there is no need to manually run a node unless using Forc directly without the SDK.
+An implementation of the Fuel protocol, [Fuel Core](https://github.com/FuelLabs/fuel-core), is provided together with the _Sway toolchain_ to form the _Fuel toolchain_. [The Rust SDK](https://github.com/FuelLabs/fuels-rs) will automatically start and stop an instance of the node during tests, so there is no need to manually run a node unless using Forc directly without the SDK.

--- a/docs/src/introduction/index.md
+++ b/docs/src/introduction/index.md
@@ -1,9 +1,9 @@
 # Introduction
 
-To get started with Forc and Sway smart contract development, install the Sway toolchain and Fuel full node and set up your first project.
+To get started with Forc and Sway smart contract development, install the Fuel toolchain and Fuel full node and set up your first project.
 
 - [Installation](./installation.md)
 - [Getting Started](./overview.md)
-- [The Sway Toolchain](./sway-toolchain.md)
+- [The Fuel Toolchain](./fuel-toolchain.md)
 - [A Forc Project](./forc_project.md)
 - [Standard Library](./standard_library.md)

--- a/docs/src/introduction/installation.md
+++ b/docs/src/introduction/installation.md
@@ -1,12 +1,12 @@
 # Installation
 
-Note that if you want to run Sway smart contracts (e.g. for testing), a Fuel Core full node is required. Otherwise, the Sway toolchain is sufficient to compile Sway smart contracts.
+The _Sway toolchain_ is sufficient to compile Sway smart contracts. Otherwise, note that if you want to run Sway smart contracts (e.g. for testing), a Fuel Core full node is required, which is packaged together with the _Sway toolchain_ together as the _Fuel toolchain_.
 
 ## Installing from Pre-compiled Binaries
 
 Pre-compiled release binaries for Linux and macOS are available for the Sway toolchain. Native Windows is currently unsupported ([tracking issue for Windows support](https://github.com/FuelLabs/sway/issues/1526)). Windows Subsystem for Linux should work but is not officially supported.
 
-[`fuelup`](https://github.com/FuelLabs/fuelup) is the equivalent of Rust's `rustup` for the Sway toolchain. It enables easily downloading binary releases of the Sway toolchain.
+[`fuelup`](https://github.com/FuelLabs/fuelup) is the equivalent of Rust's `rustup` for the Fuel toolchain. It enables easily downloading binary releases of the Fuel toolchain.
 
 Start by installing `fuelup` with:
 
@@ -28,7 +28,7 @@ Once `fuelup` is installed, `fuelup-init` automatically runs the command below
 fuelup toolchain install latest
 ```
 
-to install the latest Sway toolchain.
+to install the latest Fuel toolchain.
 
 You can run the same command at a later time to update the toolchain.
 
@@ -45,7 +45,7 @@ rustup install stable
 
 Installing `fuel-core` may require installing additional system dependencies. See [here](https://github.com/FuelLabs/fuel-core#building) for instructions.
 
-The Sway toolchain is built and tested against the `stable` Rust toolchain version (<https://github.com/rust-lang/rust/releases/latest>).  There is no guarantee it will work with the `nightly` Rust toolchain, or with earlier `stable` versions, so ensure you are using `stable` with:
+The Sway toolchain is built and tested against the `stable` Rust toolchain version (<https://github.com/rust-lang/rust/releases/latest>). There is no guarantee it will work with the `nightly` Rust toolchain, or with earlier `stable` versions, so ensure you are using `stable` with:
 
 ```sh
 # Update installed Rust toolchain; can be used independently.

--- a/docs/src/introduction/overview.md
+++ b/docs/src/introduction/overview.md
@@ -30,7 +30,7 @@ See [the chapter on program types](../sway-program-types/index.md) for more info
 
 To deploy a wallet on Fuel, we will need to write a library, a contract, and a script in Sway.
 
-First, let's [install the Sway toolchain](./installation.md). Then with `forc` installed, let's create three different sibling projects:
+First, let's [install the Fuel toolchain](./installation.md). Then with `forc` installed, let's create three different sibling projects:
 
 ```sh
 forc new wallet_lib
@@ -220,7 +220,7 @@ Note that we are passing in the `wallet_contract` contract ID as a command-line 
 If the script is successfully run, it will output something that looks like:
 
 ```console
-$ forc run --pretty-print --contract <contract-id> 
+$ forc run --pretty-print --contract <contract-id>
   Compiled library "core".
   Compiled library "std".
   Compiled library "wallet_lib".

--- a/docs/src/introduction/sway-toolchain.md
+++ b/docs/src/introduction/sway-toolchain.md
@@ -1,6 +1,6 @@
-# The Sway Toolchain
+# The Fuel Toolchain
 
-The Sway toolchain consists of several components.
+The Fuel toolchain consists of several components.
 
 ## Forc (`forc`)
 


### PR DESCRIPTION
This PR updates several instances of references to the 'Sway toolchain' to the 'Fuel toolchain'.

For some context: created this PR as a result of working on `fuelup` and realizing that I started calling it the _Fuel toolchain_ there (to refer to `sway` + `fuel-core`), saw that in the Sway book it was the _Sway toolchain_ but this seems to be referring to `sway` alone.

Note that several instances were left untouched - places where the content was mostly talking about  `sway` only, I left the _Sway toolchain_ references alone; places where the content was mostly described in the context of working with both `sway` + `fuel-core`, I updated them to be _Fuel toolchain_ instead.

Very minor difference but I think it's worth the differentiation between the two, unless there's a better way to call `sway` instead of _the Sway toolchain_.