### PR TITLE
Break/continue expressions

### DIFF
--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -15,7 +15,7 @@ impl ControlFlowGraph {
         // do a depth first traversal and cover individual inner ast nodes
         let mut leaves = vec![];
         for ast_entrypoint in module_nodes {
-            let l_leaves = connect_node(ast_entrypoint, &mut graph, &leaves, None, None)?.0;
+            let l_leaves = connect_node(ast_entrypoint, &mut graph, &leaves)?.0;
             if let NodeConnection::NextStep(nodes) = l_leaves {
                 leaves = nodes;
             }
@@ -121,8 +121,6 @@ fn connect_node(
     node: &TypedAstNode,
     graph: &mut ControlFlowGraph,
     leaves: &[NodeIndex],
-    break_to_node: Option<NodeIndex>,
-    continue_to_node: Option<NodeIndex>,
 ) -> Result<(NodeConnection, ReturnStatementNodes), CompileError> {
     let span = node.span.clone();
     match &node.content {
@@ -155,13 +153,7 @@ fn connect_node(
 
             // We need to dig into the body of the while loop in case there is a break or a
             // continue at some level.
-            let (l_leaves, inner_returns) = depth_first_insertion_code_block(
-                body,
-                graph,
-                &leaves,
-                Some(while_loop_exit), // break_to_node
-                Some(entry),           // continue_to_node
-            )?;
+            let (l_leaves, inner_returns) = depth_first_insertion_code_block(body, graph, &leaves)?;
 
             // insert edges from end of block back to beginning of it
             for leaf in &l_leaves {
@@ -189,15 +181,7 @@ fn connect_node(
         }
         TypedAstNodeContent::SideEffect => Ok((NodeConnection::NextStep(leaves.to_vec()), vec![])),
         TypedAstNodeContent::Declaration(decl) => Ok((
-            NodeConnection::NextStep(connect_declaration(
-                node,
-                decl,
-                graph,
-                span,
-                leaves,
-                break_to_node,
-                continue_to_node,
-            )?),
+            NodeConnection::NextStep(connect_declaration(node, decl, graph, span, leaves)?),
             vec![],
         )),
     }
@@ -209,8 +193,6 @@ fn connect_declaration(
     graph: &mut ControlFlowGraph,
     span: Span,
     leaves: &[NodeIndex],
-    break_to_node: Option<NodeIndex>,
-    continue_to_node: Option<NodeIndex>,
 ) -> Result<Vec<NodeIndex>, CompileError> {
     use TypedDeclaration::*;
     match decl {
@@ -262,32 +244,6 @@ fn connect_declaration(
             Ok(leaves.to_vec())
         }
         ErrorRecovery => Ok(leaves.to_vec()),
-        Break { .. } => {
-            let entry_node = graph.add_node(node.into());
-            for leaf in leaves {
-                graph.add_edge(*leaf, entry_node, "".into());
-            }
-            match break_to_node {
-                Some(break_to_node) => {
-                    graph.add_edge(entry_node, break_to_node, "".into());
-                    Ok(vec![break_to_node])
-                }
-                None => Err(CompileError::BreakOutsideLoop { span }),
-            }
-        }
-        Continue { .. } => {
-            let entry_node = graph.add_node(node.into());
-            for leaf in leaves {
-                graph.add_edge(*leaf, entry_node, "".into());
-            }
-            match continue_to_node {
-                Some(continue_to_node) => {
-                    graph.add_edge(entry_node, continue_to_node, "".into());
-                    Ok(vec![continue_to_node])
-                }
-                None => Err(CompileError::ContinueOutsideLoop { span }),
-            }
-        }
     }
 }
 
@@ -342,8 +298,7 @@ fn connect_typed_fn_decl(
     _span: Span,
 ) -> Result<(), CompileError> {
     let fn_exit_node = graph.add_node(format!("\"{}\" fn exit", fn_decl.name.as_str()).into());
-    let return_nodes =
-        depth_first_insertion_code_block(&fn_decl.body, graph, &[entry_node], None, None)?.0;
+    let return_nodes = depth_first_insertion_code_block(&fn_decl.body, graph, &[entry_node])?.0;
     for node in return_nodes {
         graph.add_edge(node, fn_exit_node, "return".into());
     }
@@ -366,14 +321,11 @@ fn depth_first_insertion_code_block(
     node_content: &TypedCodeBlock,
     graph: &mut ControlFlowGraph,
     leaves: &[NodeIndex],
-    break_to_node: Option<NodeIndex>,
-    continue_to_node: Option<NodeIndex>,
 ) -> Result<(ReturnStatementNodes, Vec<NodeIndex>), CompileError> {
     let mut leaves = leaves.to_vec();
     let mut return_nodes = vec![];
     for node in node_content.contents.iter() {
-        let (this_node, inner_returns) =
-            connect_node(node, graph, &leaves, break_to_node, continue_to_node)?;
+        let (this_node, inner_returns) = connect_node(node, graph, &leaves)?;
         match this_node {
             NodeConnection::NextStep(nodes) => leaves = nodes,
             NodeConnection::Return(node) => {

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -1101,6 +1101,20 @@ fn connect_expression(
             }
             Ok(vec![while_loop_exit])
         }
+        Break => {
+            let break_node = graph.add_node("break".to_string().into());
+            for leaf in leaves {
+                graph.add_edge(*leaf, break_node, "".into());
+            }
+            Ok(vec![])
+        }
+        Continue => {
+            let continue_node = graph.add_node("continue".to_string().into());
+            for leaf in leaves {
+                graph.add_edge(*leaf, continue_node, "".into());
+            }
+            Ok(vec![])
+        }
     }
 }
 

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -397,7 +397,6 @@ fn connect_declaration(
             Ok(leaves.to_vec())
         }
         ErrorRecovery | GenericTypeForFunctionScope { .. } => Ok(leaves.to_vec()),
-        Break { .. } | Continue { .. } => Ok(vec![]),
     }
 }
 

--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -1914,25 +1914,11 @@ fn expr_to_expression(ec: &mut ErrorContext, expr: Expr) -> Result<Expression, E
             return Err(ec.error(error));
         }
         Expr::Break { .. } => Expression {
-            kind: ExpressionKind::CodeBlock(CodeBlock {
-                contents: vec![AstNode {
-                    content: AstNodeContent::Declaration(Declaration::Break { span: span.clone() }),
-                    span: span.clone(),
-                }],
-                whole_block_span: span.clone(),
-            }),
+            kind: ExpressionKind::Break,
             span,
         },
         Expr::Continue { .. } => Expression {
-            kind: ExpressionKind::CodeBlock(CodeBlock {
-                contents: vec![AstNode {
-                    content: AstNodeContent::Declaration(Declaration::Continue {
-                        span: span.clone(),
-                    }),
-                    span: span.clone(),
-                }],
-                whole_block_span: span.clone(),
-            }),
+            kind: ExpressionKind::Continue,
             span,
         },
     };

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -134,9 +134,7 @@ fn compile_declarations(
             | TypedDeclaration::AbiDeclaration(_)
             | TypedDeclaration::GenericTypeForFunctionScope { .. }
             | TypedDeclaration::StorageDeclaration(_)
-            | TypedDeclaration::ErrorRecovery
-            | TypedDeclaration::Break { .. }
-            | TypedDeclaration::Continue { .. } => (),
+            | TypedDeclaration::ErrorRecovery => (),
         }
     }
     Ok(())

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -339,6 +339,8 @@ fn const_eval_typed_expr(
         | TypedExpressionVariant::AbiName(_)
         | TypedExpressionVariant::EnumTag { .. }
         | TypedExpressionVariant::UnsafeDowncast { .. }
+        | TypedExpressionVariant::Break
+        | TypedExpressionVariant::Continue
         | TypedExpressionVariant::WhileLoop { .. } => None,
     }
 }

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -90,15 +90,7 @@ impl FnCompiler {
         ast_block: TypedCodeBlock,
     ) -> Result<Value, CompileError> {
         self.lexical_map.enter_scope();
-        let index_of_first_break_or_continue_decl =
-            ast_block.contents.clone().into_iter().position(|r| {
-                matches!(
-                    r.content,
-                    TypedAstNodeContent::Declaration(TypedDeclaration::Break { .. })
-                        | TypedAstNodeContent::Declaration(TypedDeclaration::Continue { .. })
-                )
-            });
-        let index_of_first_break_or_continue_expr = {
+        let index_of_first_break_or_continue = {
             ast_block.contents.iter().position(|r| {
                 matches!(
                     r.content,
@@ -109,14 +101,6 @@ impl FnCompiler {
                     })
                 )
             })
-        };
-        let index_of_first_break_or_continue = match (
-            index_of_first_break_or_continue_decl,
-            index_of_first_break_or_continue_expr,
-        ) {
-            (None, None) => None,
-            (Some(i), None) | (None, Some(i)) => Some(i),
-            (Some(i0), Some(i1)) => Some(std::cmp::min(i0, i1)),
         };
 
         // Filter out all ast nodes *after* a `break` statement. Those nodes are essentially dead.
@@ -204,30 +188,6 @@ impl FnCompiler {
                                 span: ast_node.span,
                             })
                         }
-                        TypedDeclaration::Break { .. } => match self.block_to_break_to {
-                            // If `self.block_to_break_to` is not None, then it has been set inside
-                            // a loop and the use of `break` here is legal, so create a branch
-                            // instruction. Error out otherwise.
-                            Some(block_to_break_to) => Ok(self
-                                .current_block
-                                .ins(context)
-                                .branch(block_to_break_to, None)),
-                            None => Err(CompileError::BreakOutsideLoop {
-                                span: ast_node.span,
-                            }),
-                        },
-                        TypedDeclaration::Continue { .. } => match self.block_to_continue_to {
-                            // If `self.block_to_continue_to` is not None, then it has been set inside
-                            // a loop and the use of `continue` here is legal, so create a branch
-                            // instruction. Error out otherwise.
-                            Some(block_to_continue_to) => Ok(self
-                                .current_block
-                                .ins(context)
-                                .branch(block_to_continue_to, None)),
-                            None => Err(CompileError::ContinueOutsideLoop {
-                                span: ast_node.span,
-                            }),
-                        },
                         TypedDeclaration::StorageDeclaration(_) => {
                             Err(CompileError::UnexpectedDeclaration {
                                 decl_type: "storage",

--- a/sway-core/src/parse_tree/declaration.rs
+++ b/sway-core/src/parse_tree/declaration.rs
@@ -33,6 +33,4 @@ pub enum Declaration {
     AbiDeclaration(AbiDeclaration),
     ConstantDeclaration(ConstantDeclaration),
     StorageDeclaration(StorageDeclaration),
-    Break { span: sway_types::Span },
-    Continue { span: sway_types::Span },
 }

--- a/sway-core/src/parse_tree/expression/mod.rs
+++ b/sway-core/src/parse_tree/expression/mod.rs
@@ -161,6 +161,8 @@ pub enum ExpressionKind {
     /// A control flow element which loops continually until some boolean expression evaluates as
     /// `false`.
     WhileLoop(WhileLoopExpression),
+    Break,
+    Continue,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -38,8 +38,6 @@ pub enum TypedDeclaration {
     ErrorRecovery,
     StorageDeclaration(TypedStorageDeclaration),
     StorageReassignment(TypeCheckedStorageReassignment),
-    Break { span: Span },
-    Continue { span: Span },
 }
 
 impl CopyTypes for TypedDeclaration {
@@ -61,9 +59,7 @@ impl CopyTypes for TypedDeclaration {
             | StorageDeclaration(..)
             | StorageReassignment(..)
             | GenericTypeForFunctionScope { .. }
-            | ErrorRecovery
-            | Break { .. }
-            | Continue { .. } => (),
+            | ErrorRecovery => (),
         }
     }
 }
@@ -89,7 +85,7 @@ impl Spanned for TypedDeclaration {
             ImplTrait(TypedImplTrait { span, .. }) => span.clone(),
             StorageDeclaration(decl) => decl.span(),
             StorageReassignment(decl) => decl.span(),
-            ErrorRecovery | GenericTypeForFunctionScope { .. } | Break { .. } | Continue { .. } => {
+            ErrorRecovery | GenericTypeForFunctionScope { .. } => {
                 unreachable!("No span exists for these ast node types")
             }
         }
@@ -208,9 +204,7 @@ impl UnresolvedTypeCheck for TypedDeclaration {
             | EnumDeclaration(_)
             | ImplTrait { .. }
             | AbiDeclaration(_)
-            | GenericTypeForFunctionScope { .. }
-            | Break { .. }
-            | Continue { .. } => vec![],
+            | GenericTypeForFunctionScope { .. } => vec![],
         }
     }
 }
@@ -323,8 +317,6 @@ impl TypedDeclaration {
             ErrorRecovery => "error",
             StorageDeclaration(_) => "contract storage declaration",
             StorageReassignment(_) => "contract storage reassignment",
-            Break { .. } => "break",
-            Continue { .. } => "continue",
         }
     }
 
@@ -374,9 +366,7 @@ impl TypedDeclaration {
             | StorageDeclaration { .. }
             | StorageReassignment { .. }
             | AbiDeclaration(..)
-            | ErrorRecovery
-            | Break { .. }
-            | Continue { .. } => Visibility::Public,
+            | ErrorRecovery => Visibility::Public,
             VariableDeclaration(TypedVariableDeclaration {
                 mutability: is_mutable,
                 ..

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -202,6 +202,8 @@ impl TypedImplTrait {
                 | TypedExpressionVariant::VariableExpression { .. }
                 | TypedExpressionVariant::FunctionParameter
                 | TypedExpressionVariant::AsmExpression { .. }
+                | TypedExpressionVariant::Break
+                | TypedExpressionVariant::Continue
                 | TypedExpressionVariant::StorageAccess(_)
                 | TypedExpressionVariant::AbiName(_) => false,
                 TypedExpressionVariant::FunctionApplication { arguments, .. } => arguments

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -284,9 +284,7 @@ impl TypedImplTrait {
                 | TypedDeclaration::GenericTypeForFunctionScope { .. }
                 | TypedDeclaration::ErrorRecovery
                 | TypedDeclaration::StorageDeclaration(_)
-                | TypedDeclaration::StorageReassignment(_)
-                | TypedDeclaration::Break { .. }
-                | TypedDeclaration::Continue { .. } => false,
+                | TypedDeclaration::StorageReassignment(_) => false,
             }
         }
         fn codeblock_contains_get_storage_index(cb: &semantic_analysis::TypedCodeBlock) -> bool {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -118,6 +118,8 @@ pub enum TypedExpressionVariant {
         condition: Box<TypedExpression>,
         body: TypedCodeBlock,
     },
+    Break,
+    Continue,
 }
 
 // NOTE: Hash and PartialEq must uphold the invariant:
@@ -451,6 +453,8 @@ impl CopyTypes for TypedExpressionVariant {
                 condition.copy_types(type_mapping);
                 body.copy_types(type_mapping);
             }
+            Break => (),
+            Continue => (),
         }
     }
 }
@@ -540,6 +544,8 @@ impl fmt::Display for TypedExpressionVariant {
             TypedExpressionVariant::WhileLoop { condition, .. } => {
                 format!("while loop on {}", condition)
             }
+            TypedExpressionVariant::Break => "break".to_string(),
+            TypedExpressionVariant::Continue => "continue".to_string(),
         };
         write!(f, "{}", s)
     }

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -433,8 +433,6 @@ impl TypedAstNode {
                             );
                             TypedDeclaration::StorageDeclaration(decl)
                         }
-                        Declaration::Break { span } => TypedDeclaration::Break { span },
-                        Declaration::Continue { span } => TypedDeclaration::Continue { span },
                     })
                 }
                 AstNodeContent::Expression(expr) => {

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -497,6 +497,8 @@ impl Dependencies {
             ExpressionKind::WhileLoop(WhileLoopExpression {
                 condition, body, ..
             }) => self.gather_from_expr(condition).gather_from_block(body),
+            ExpressionKind::Break => self,
+            ExpressionKind::Continue => self,
         }
     }
 

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -373,9 +373,6 @@ impl Dependencies {
                 .gather_from_iter(fields.iter(), |deps, StorageField { ref type_info, .. }| {
                     deps.gather_from_typeinfo(type_info)
                 }),
-            // Nothing to do for `break` and `continue`
-            Declaration::Break { .. } => self,
-            Declaration::Continue { .. } => self,
         }
     }
 
@@ -722,9 +719,6 @@ fn decl_name(decl: &Declaration) -> Option<DependentSymbol> {
         Declaration::Reassignment(_) => None,
         // Storage cannot be depended upon or exported
         Declaration::StorageDeclaration(_) => None,
-        // Nothing depends on a `break` and `continue`
-        Declaration::Break { .. } => None,
-        Declaration::Continue { .. } => None,
     }
 }
 

--- a/sway-core/src/semantic_analysis/storage_only_types.rs
+++ b/sway-core/src/semantic_analysis/storage_only_types.rs
@@ -108,6 +108,8 @@ fn expr_validate(expr: &TypedExpression) -> CompileResult<()> {
                 errors
             );
         }
+        TypedExpressionVariant::Break => (),
+        TypedExpressionVariant::Continue => (),
     }
     ok((), warnings, errors)
 }

--- a/sway-core/src/semantic_analysis/storage_only_types.rs
+++ b/sway-core/src/semantic_analysis/storage_only_types.rs
@@ -232,9 +232,7 @@ fn decl_validate(decl: &TypedDeclaration) -> CompileResult<()> {
         }
         TypedDeclaration::GenericTypeForFunctionScope { .. }
         | TypedDeclaration::ErrorRecovery
-        | TypedDeclaration::StorageReassignment(_)
-        | TypedDeclaration::Break { .. }
-        | TypedDeclaration::Continue { .. } => {}
+        | TypedDeclaration::StorageReassignment(_) => {}
     }
     ok((), warnings, errors)
 }

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -45,7 +45,6 @@ pub fn parsed_to_completion_kind(ast_token: &AstToken) -> Option<CompletionItemK
             | Declaration::AbiDeclaration(_)
             | Declaration::Reassignment(_)
             | Declaration::StorageDeclaration(_) => Some(CompletionItemKind::TEXT),
-            Declaration::Break { .. } | Declaration::Continue { .. } => None,
         },
         AstToken::Expression(exp) => match &exp.kind {
             ExpressionKind::Literal { .. } => Some(CompletionItemKind::VALUE),

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -55,9 +55,7 @@ fn parsed_to_symbol_kind(ast_token: &AstToken) -> SymbolKind {
                 // currently we return `variable` type as default
                 Declaration::Reassignment(_)
                 | Declaration::ImplSelf { .. }
-                | Declaration::StorageDeclaration(_)
-                | Declaration::Break { .. }
-                | Declaration::Continue { .. } => SymbolKind::VARIABLE,
+                | Declaration::StorageDeclaration(_) => SymbolKind::VARIABLE,
             }
         }
         AstToken::Expression(exp) => {
@@ -102,9 +100,7 @@ fn typed_to_symbol_kind(typed_ast_token: &TypedAstToken) -> SymbolKind {
                 TypedDeclaration::Reassignment(_)
                 | TypedDeclaration::ErrorRecovery
                 | TypedDeclaration::StorageDeclaration(_)
-                | TypedDeclaration::StorageReassignment(_)
-                | TypedDeclaration::Break { .. }
-                | TypedDeclaration::Continue { .. } => SymbolKind::VARIABLE,
+                | TypedDeclaration::StorageReassignment(_) => SymbolKind::VARIABLE,
             }
         }
         TypedAstToken::TypedExpression(exp) => {

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -522,6 +522,8 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
         ExpressionKind::WhileLoop(WhileLoopExpression {
             body, condition, ..
         }) => handle_while_loop(body, condition, tokens),
+        // TODO: collect these tokens as keywords once the compiler returns the span
+        ExpressionKind::Break | ExpressionKind::Continue => (),
     }
 }
 

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -290,8 +290,6 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                 handle_expression(&field.initializer, tokens);
             }
         }
-        // TODO: collect these tokens as keywords once the compiler returns the span
-        Declaration::Break { .. } | Declaration::Continue { .. } => {}
     }
 }
 

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -226,8 +226,6 @@ fn handle_declaration(declaration: &TypedDeclaration, tokens: &TokenMap) {
             }
             handle_expression(&storage_reassignment.rhs, tokens);
         }
-        TypedDeclaration::Break { .. } => {}
-        TypedDeclaration::Continue { .. } => {}
     }
 }
 

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -424,6 +424,8 @@ fn handle_expression(expression: &TypedExpression, tokens: &TokenMap) {
         TypedExpressionVariant::WhileLoop {
             body, condition, ..
         } => handle_while_loop(body, condition, tokens),
+        TypedExpressionVariant::Break => (),
+        TypedExpressionVariant::Continue => (),
     }
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_fail/illegal_break/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/illegal_break/test.toml
@@ -2,4 +2,10 @@ category = "fail"
 
 # check: $()fn main() {
 # nextln: $()break;
+# nextln: $()not assigned to anything
+
+# check: $()This code is unreachable
+
+# check: $()fn main() {
+# nextln: $()break;
 # nextln: $()"break" used outside of a loop

--- a/test/src/e2e_vm_tests/test_programs/should_fail/illegal_continue/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/illegal_continue/test.toml
@@ -2,4 +2,10 @@ category = "fail"
 
 # check: $()fn main() {
 # nextln: $()continue;
+# nextln: $()not assigned to anything
+
+# check: $()This code is unreachable
+
+# check: $()fn main() {
+# nextln: $()continue;
 # nextln: $()"continue" used outside of a loop


### PR DESCRIPTION
Make `break` and `continue` expressions rather than declarations in the compiler's internal representation of the AST.