### PR TITLE
Diagnose Unrecognized Annotations

### DIFF
--- a/sway-core/src/constants.rs
+++ b/sway-core/src/constants.rs
@@ -35,5 +35,5 @@ pub const STORAGE_PURITY_WRITE_NAME: &str = "write";
 /// The valid attribute strings related to documentation.
 pub const DOC_ATTRIBUTE_NAME: &str = "doc";
 
-/// The list of valid attributes
+/// The list of valid attributes.
 pub const VALID_ATTRIBUTE_NAMES: [&str; 2] = [STORAGE_PURITY_ATTRIBUTE_NAME, DOC_ATTRIBUTE_NAME];

--- a/sway-core/src/constants.rs
+++ b/sway-core/src/constants.rs
@@ -31,3 +31,6 @@ pub const MATCH_RETURN_VAR_NAME_PREFIX: &str = "__match_return_var_name_";
 pub const STORAGE_PURITY_ATTRIBUTE_NAME: &str = "storage";
 pub const STORAGE_PURITY_READ_NAME: &str = "read";
 pub const STORAGE_PURITY_WRITE_NAME: &str = "write";
+
+/// The valid attribute strings related to documentation.
+pub const DOC_ATTRIBUTE_NAME: &str = "doc";

--- a/sway-core/src/constants.rs
+++ b/sway-core/src/constants.rs
@@ -34,3 +34,6 @@ pub const STORAGE_PURITY_WRITE_NAME: &str = "write";
 
 /// The valid attribute strings related to documentation.
 pub const DOC_ATTRIBUTE_NAME: &str = "doc";
+
+/// The list of valid attributes
+pub const VALID_ATTRIBUTE_NAMES: [&str; 2] = [STORAGE_PURITY_ATTRIBUTE_NAME, DOC_ATTRIBUTE_NAME];

--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -8,8 +8,8 @@ use crate::{
 use {
     crate::{
         constants::{
-            DOC_ATTRIBUTE_NAME, STORAGE_PURITY_ATTRIBUTE_NAME, STORAGE_PURITY_READ_NAME,
-            STORAGE_PURITY_WRITE_NAME,
+            STORAGE_PURITY_ATTRIBUTE_NAME, STORAGE_PURITY_READ_NAME, STORAGE_PURITY_WRITE_NAME,
+            VALID_ATTRIBUTE_NAMES,
         },
         error::{err, ok, CompileError, CompileResult, CompileWarning, Warning},
         type_system::{insert_type, AbiName, IntegerBits},
@@ -403,7 +403,7 @@ fn item_attrs_to_map<'a>(
     for attr_decl in attribute_list {
         let attr = attr_decl.attribute.get();
         let name = attr.name.as_str();
-        if name != STORAGE_PURITY_ATTRIBUTE_NAME && name != DOC_ATTRIBUTE_NAME {
+        if !VALID_ATTRIBUTE_NAMES.contains(&name) {
             ec.warning(CompileWarning {
                 span: attr_decl.span().clone(),
                 warning_content: Warning::UnrecognizedAttribute {

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -318,6 +318,9 @@ pub enum Warning {
         unneeded_attrib: String,
     },
     MatchExpressionUnreachableArm,
+    UnrecognizedAttribute {
+        attrib_name: Ident,
+    },
 }
 
 impl fmt::Display for Warning {
@@ -441,6 +444,7 @@ impl fmt::Display for Warning {
                 and can be removed."
             ),
             MatchExpressionUnreachableArm => write!(f, "This match arm is unreachable."),
+            UnrecognizedAttribute {attrib_name} => write!(f, "Unknown attribute: \"{attrib_name}\"."),
         }
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/diagnose_unknown_annotations/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/diagnose_unknown_annotations/Forc.lock
@@ -1,0 +1,14 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-1C8151ABD9941A97'
+dependencies = []
+
+[[package]]
+name = 'diagnose_unknown_annotations'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-1C8151ABD9941A97'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/diagnose_unknown_annotations/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/diagnose_unknown_annotations/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "diagnose_unknown_annotations"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/diagnose_unknown_annotations/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/diagnose_unknown_annotations/src/main.sw
@@ -1,0 +1,28 @@
+contract;
+
+#[storage(read, write)]
+#[doc(test)]
+abi GoodAbi {
+    #[storage(read, write)]
+    #[doc(test)]
+    fn good_func() -> bool;
+
+    #[bad_attr(blah)]
+    fn bad_func() -> bool;
+}
+
+impl GoodAbi for Contract {
+    #[storage(read, write)]
+    #[doc(Test)]
+    fn good_func() -> bool {
+        true
+    }
+
+    #[bad_attr(blah)]
+    fn bad_func() -> bool {
+        true
+    }
+}
+
+#[bad_attr(blah)]
+struct BadStruct {}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/diagnose_unknown_annotations/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/diagnose_unknown_annotations/test.toml
@@ -1,0 +1,14 @@
+category = "compile"
+validate_abi = false
+
+# check: $()#[bad_attr(blah)]
+# nextln: $()Unknown attribute: "bad_attr".
+# nextln: $()fn bad_func() -> bool;
+
+# check: $()#[bad_attr(blah)]
+# nextln: $()Unknown attribute: "bad_attr".
+# nextln: $()fn bad_func() -> bool {
+
+# check: $()#[bad_attr(blah)]
+# nextln: $()Unknown attribute: "bad_attr".
+# nextln: $()struct BadStruct {}


### PR DESCRIPTION
This PR marks `doc` and `storage` as the only attributes we allow and generates a warning when others are used.