### PR TITLE
[simplify-cfg] Separate `remove_dead_blocks` from `merge_blocks`

### DIFF
--- a/sway-ir/src/optimize/simplify_cfg.rs
+++ b/sway-ir/src/optimize/simplify_cfg.rs
@@ -20,13 +20,13 @@ pub fn simplify_cfg(context: &mut Context, function: &Function) -> Result<bool, 
             modified = true;
             continue;
         }
-
+        break;
+    }
+    loop {
         if merge_blocks(context, function)? {
             modified = true;
             continue;
         }
-
-        // Other passes here... always continue to the top if pass returns true.
         break;
     }
     Ok(modified)


### PR DESCRIPTION
Currently dead block removal and block merging are both run in a loop. However, block merging cannot expose any new dead blocks (assuming dead blocks removal was run prior). So it doesn't make sense to try dead block removal again, interleaved with merge blocks.

Some performance numbers:
On a debug build, `forc build` of `test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage` takes about 14s without this change, and about 3.5s with this change (and the latter number is close to the compile time without having simplify-cfg).

On a release build, `forc build` of `test/src/e2e_vm_tests/test_programs/should_pass/stdlib/vec` takes about 25m with this change. Earlier, it was [reported](https://github.com/FuelLabs/sway/pull/2436#issue-1323901821) that this takes ~hours. @otrho  can you verify?