### PR TITLE
Speed improvements and bug fixes for `simplify-cfg`.

### DIFF
--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -465,6 +465,13 @@ pub(crate) fn compile_ast_to_ir_to_asm(
         errors
     );
 
+    check!(
+        simplify_cfg(&mut ir, &entry_point_functions),
+        return err(warnings, errors),
+        warnings,
+        errors
+    );
+
     if build_config.print_ir {
         tracing::info!("{}", ir);
     }
@@ -490,6 +497,21 @@ fn inline_function_calls(ir: &mut Context, functions: &[Function]) -> CompileRes
 fn combine_constants(ir: &mut Context, functions: &[Function]) -> CompileResult<()> {
     for function in functions {
         if let Err(ir_error) = sway_ir::optimize::combine_constants(ir, function) {
+            return err(
+                Vec::new(),
+                vec![CompileError::InternalOwned(
+                    ir_error.to_string(),
+                    span::Span::dummy(),
+                )],
+            );
+        }
+    }
+    ok((), Vec::new(), Vec::new())
+}
+
+fn simplify_cfg(ir: &mut Context, functions: &[Function]) -> CompileResult<()> {
+    for function in functions {
+        if let Err(ir_error) = sway_ir::optimize::simplify_cfg(ir, function) {
             return err(
                 Vec::new(),
                 vec![CompileError::InternalOwned(

--- a/sway-ir/src/block.rs
+++ b/sway-ir/src/block.rs
@@ -148,6 +148,8 @@ impl Block {
             }
         })
     }
+
+    /// Get the CFG successors of this block.
     pub(super) fn successors<'a>(&'a self, context: &'a Context) -> Vec<Block> {
         match self.get_terminator(context) {
             Some(Instruction::ConditionalBranch {

--- a/sway-ir/src/block.rs
+++ b/sway-ir/src/block.rs
@@ -148,6 +148,19 @@ impl Block {
             }
         })
     }
+    pub(super) fn successors<'a>(&'a self, context: &'a Context) -> Vec<Block> {
+        match self.get_terminator(context) {
+            Some(Instruction::ConditionalBranch {
+                true_block,
+                false_block,
+                ..
+            }) => vec![*true_block, *false_block],
+
+            Some(Instruction::Branch(block)) => vec![*block],
+
+            _otherwise => Vec::new(),
+        }
+    }
 
     /// Return whether this block is already terminated.  Checks if the final instruction, if it
     /// exists, is a terminator.
@@ -298,28 +311,6 @@ impl BlockContent {
 
     pub(super) fn num_predecessors(&self, context: &Context) -> usize {
         self.predecessors(context).count()
-    }
-
-    pub(super) fn successors<'a>(
-        &'a self,
-        context: &'a Context,
-    ) -> impl Iterator<Item = Block> + 'a {
-        self.function.block_iter(context).flat_map(|block| {
-            block
-                .get_terminator(context)
-                .map(|term_inst| match term_inst {
-                    Instruction::ConditionalBranch {
-                        true_block,
-                        false_block,
-                        ..
-                    } => vec![*true_block, *false_block],
-
-                    Instruction::Branch(block) => vec![*block],
-
-                    _otherwise => Vec::new(),
-                })
-                .unwrap_or_default()
-        })
     }
 }
 

--- a/sway-ir/src/function.rs
+++ b/sway-ir/src/function.rs
@@ -217,6 +217,21 @@ impl Function {
             .sum()
     }
 
+    /// Go through all blocks in the function and compute predecessor count for each.
+    pub fn count_predecessors(&self, context: &Context) -> HashMap<Block, usize> {
+        let mut pred_counts = HashMap::<Block, usize>::new();
+
+        for block in self.block_iter(context) {
+            for succ in block.successors(context) {
+                pred_counts
+                    .entry(succ)
+                    .and_modify(|counter| *counter += 1)
+                    .or_insert(1);
+            }
+        }
+        pred_counts
+    }
+
     /// Return the function name.
     pub fn get_name<'a>(&self, context: &'a Context) -> &'a str {
         &context.functions[self.0].name

--- a/sway-ir/src/optimize/simplify_cfg.rs
+++ b/sway-ir/src/optimize/simplify_cfg.rs
@@ -31,7 +31,7 @@ pub fn simplify_cfg(context: &mut Context, function: &Function) -> Result<bool, 
 }
 
 fn remove_dead_blocks(context: &mut Context, function: &Function) -> Result<bool, IrError> {
-    let mut worklist = std::vec::Vec::<Block>::new();
+    let mut worklist = Vec::<Block>::new();
     let mut reachable = std::collections::HashSet::<Block>::new();
 
     // The entry is always reachable. Let's begin with that.

--- a/sway-ir/src/optimize/simplify_cfg.rs
+++ b/sway-ir/src/optimize/simplify_cfg.rs
@@ -140,11 +140,12 @@ fn merge_blocks(
         // Replace the `phi` instruction in `to_block` with its singular element.
         let phi_val = to_block.get_phi(context);
         match &context.values[phi_val.0].value {
-            ValueDatum::Instruction(Instruction::Phi(els)) if els.len() == 1 => {
+            ValueDatum::Instruction(Instruction::Phi(els)) if els.len() <= 1 => {
                 // Replace all uses of the phi and then remove it so it isn't merged below.
-                let (_, ref_val) = els[0];
-                function.replace_value(context, phi_val, ref_val, None);
-                to_block.remove_instruction(context, phi_val);
+                if let Some((_, ref_val)) = els.get(0) {
+                    function.replace_value(context, phi_val, *ref_val, None);
+                    to_block.remove_instruction(context, phi_val);
+                }
             }
             _otherwise => return Err(IrError::InvalidPhi),
         };

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -3,7 +3,7 @@ use basic_storage_abi::{StoreU64, Quad};
 use std::assert::assert;
 
 fn main() -> u64 {
-    let addr = abi(StoreU64, 0x44e9394f2d3b9ce7ed4899f2bcf28478f1218ca0f310c7d0105d638b95fee171);
+    let addr = abi(StoreU64, 0x0b222d6eeb6602aa99c209bc43ddc214052f1ee8519d7f46a482f6e8d2b56df0);
     let key = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
@@ -7,7 +7,7 @@ fn main() -> bool {
     let zero = ~b256::min();
     let gas: u64 = 1000;
     let amount: u64 = 11;
-    let other_contract_id = ~ContractId::from(0x189a69c7ffc261ec84769563bdde047e592a33456acc079f189332c2837cba6b);
+    let other_contract_id = ~ContractId::from(0x18bf8e0d8f9ae71fe6448e18785f5aef719f40055e45672fa0e9e906f13eb289);
     let base_asset_id = BASE_ASSET_ID;
 
     let test_contract = abi(ContextTesting, other_contract_id.into());

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/get_storage_key_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/get_storage_key_caller/src/main.sw
@@ -3,7 +3,7 @@ use get_storage_key_abi::TestContract;
 use std::assert::assert;
 
 fn main() -> u64 {
-    let caller = abi(TestContract, 0x7c21d11cf8164675bb548e11a408b1ad3f2896d3ab6d108c9c66742f8a28d266);
+    let caller = abi(TestContract, 0xde1fc5ef591759ed30d7ec21256339b11937d3b8d84229ca12915cc3637acdf9);
 
     // Get the storage keys directly by calling the contract methods from_f1,
     // from_f2, from_f3, from_f4. The keys correspond to different entries in

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
@@ -3,7 +3,7 @@ use storage_access_abi::*;
 use std::{assert::assert, hash::sha256, revert::revert};
 
 fn main() -> bool {
-    let contract_id = 0x1c7c76380ef43c048596b4cda60eff2763d7c081b70d8662a3e1d18a9ee1dc2b;
+    let contract_id = 0xcda49fd4e5a7c02b771df294bddfcc8adfa339dcd98a5c659eaf87317823d94d;
     let caller = abi(StorageAccess, contract_id);
 
     // Test initializers

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/token_ops_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/token_ops_test/src/main.sw
@@ -17,7 +17,7 @@ fn main() -> bool {
     let default_gas = 1_000_000_000_000;
 
     // the deployed fuel_coin Contract_Id:
-    let fuelcoin_id = ~ContractId::from(0x018f59fe434b323a5054e7bb41de983f4926a3c5d3e4e1f9f33b5f0f0e611889);
+    let fuelcoin_id = ~ContractId::from(0xae7ffe3b9300b99d43119c289c2ca56cda96afb0f7c0438c06a98f596313708c);
 
     // contract ID for sway/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/balance_test_contract/
     let balance_test_id = ~ContractId::from(0x597e5ddb1a6bec92a96a73e4f0bc6f6e3e7b21f5e03e1c812cd63cffac480463);


### PR DESCRIPTION
#### Algorithmic changes
- New worklist based algorithm for `remove_dead_blocks`
- Cached predecessor counts for `merge_blocks`

#### Bugfix:
- `BlockContent::successors()` was incorrect. It was returning successors for all blocks in the function.
- Allow empty PHIs in `to_block` when merging blocks.

#### Performance
With this change, we now can compile the `stdlib/vec` test in about 35s (on my i7-7th-gen/32GB RAM laptop).
It was [previously taking](https://github.com/FuelLabs/sway/pull/2548#issue-1340432847) about 25m.

#### Testing
 The `stdlib/vec` test's bytecode with this change is identical to the one without this change. The existing regression tests for `simplify-cfg` pass.

I've also enabled `simplify-cfg` optimization pass by default now.