### PR TITLE
Add LSP tests back in.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3829,6 +3829,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4252,6 +4278,7 @@ dependencies = [
  "ropey",
  "serde",
  "serde_json",
+ "serial_test",
  "sway-core",
  "sway-types",
  "sway-utils",

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/FuelLabs/sway"
 description = "LSP server for Sway."
 
 [dependencies]
-dashmap = "5.3.4"
+dashmap = "5.4"
 forc-pkg = { version = "0.25.1", path = "../forc-pkg" }
 forc-util = { version = "0.25.1", path = "../forc-util" }
 ropey = "1.2"

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -26,5 +26,4 @@ tracing = "0.1"
 [dev-dependencies]
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
-serial_test = "0.9.0"
 tower = { version = "0.4.12", default-features = false, features = ["util"] }

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -26,4 +26,5 @@ tracing = "0.1"
 [dev-dependencies]
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+serial_test = "0.9.0"
 tower = { version = "0.4.12", default-features = false, features = ["util"] }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -702,7 +702,7 @@ mod tests {
         initialized_notification(service).await;
 
         // ignore the "window/logMessage" notification: "Initializing the Sway Language Server"
-        //let _ = messages.next().await;
+        let _ = messages.next().await;
 
         let (uri, sway_program) = load_sway_example(manifest_dir);
 
@@ -710,7 +710,7 @@ mod tests {
         did_open_notification(service, &uri, &sway_program).await;
 
         // ignore the "textDocument/publishDiagnostics" notification
-        //let _ = messages.next().await;
+        let _ = messages.next().await;
 
         uri
     }
@@ -751,7 +751,7 @@ mod tests {
                 initialized_notification(&mut service).await;
 
                 // ignore the "window/logMessage" notification: "Initializing the Sway Language Server"
-                //let _ = messages.next().await;
+                let _ = messages.next().await;
             })
         });
     }
@@ -771,7 +771,7 @@ mod tests {
                 initialized_notification(&mut service).await;
 
                 // ignore the "window/logMessage" notification: "Initializing the Sway Language Server"
-                //let _ = messages.next().await;
+                let _ = messages.next().await;
 
                 // send "initialize" request (again); should error
                 let response = service.ready().await.unwrap().call(initialize).await;
@@ -796,7 +796,7 @@ mod tests {
                 initialized_notification(&mut service).await;
 
                 // ignore the "window/logMessage" notification: "Initializing the Sway Language Server"
-                //let _ = messages.next().await;
+                let _ = messages.next().await;
 
                 // send "shutdown" request
                 let shutdown = shutdown_request(&mut service).await;
@@ -824,7 +824,7 @@ mod tests {
                 let _ = initialize_request(&mut service).await;
 
                 // ignore the "window/logMessage" notification: "Initializing the Sway Language Server"
-                //let _ = messages.next().await;
+                let _ = messages.next().await;
 
                 // send "shutdown" request
                 let shutdown = shutdown_request(&mut service).await;
@@ -902,7 +902,7 @@ mod tests {
                 let _ = did_change_request(&mut service, params).await;
 
                 // ignore the "textDocument/publishDiagnostics" notification
-                //let _ = messages.next().await;
+                let _ = messages.next().await;
 
                 shutdown_and_exit(&mut service).await;
             })

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -673,188 +673,152 @@ mod tests {
         exit_notification(service).await;
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn initialize() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
-            let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
+    async fn initialize() {
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
 
-            // send "initialize" request
-            let _ = initialize_request(&mut service).await;
-        });
-        rt.shutdown_background();
+        // send "initialize" request
+        let _ = initialize_request(&mut service).await;
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn initialized() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
-            let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
+    async fn initialized() {
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
 
-            // send "initialize" request
-            let _ = initialize_request(&mut service).await;
+        // send "initialize" request
+        let _ = initialize_request(&mut service).await;
 
-            // send "initialized" notification
-            initialized_notification(&mut service).await;
-        });
-        rt.shutdown_background();
+        // send "initialized" notification
+        initialized_notification(&mut service).await;
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn initializes_only_once() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
-            let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
+    async fn initializes_only_once() {
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
 
-            // send "initialize" request
-            let initialize = initialize_request(&mut service).await;
+        // send "initialize" request
+        let initialize = initialize_request(&mut service).await;
 
-            // send "initialized" notification
-            initialized_notification(&mut service).await;
+        // send "initialized" notification
+        initialized_notification(&mut service).await;
 
-            // send "initialize" request (again); should error
-            let response = call_request(&mut service, initialize).await;
+        // send "initialize" request (again); should error
+        let response = call_request(&mut service, initialize).await;
 
-            let err = Response::from_error(1.into(), jsonrpc::Error::invalid_request());
-            assert_eq!(response, Ok(Some(err)));
-        });
-        rt.shutdown_background();
+        let err = Response::from_error(1.into(), jsonrpc::Error::invalid_request());
+        assert_eq!(response, Ok(Some(err)));
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn shutdown() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
-            let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
+    async fn shutdown() {
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
 
-            // send "initialize" request
-            let _ = initialize_request(&mut service).await;
+        // send "initialize" request
+        let _ = initialize_request(&mut service).await;
 
-            // send "initialized" notification
-            initialized_notification(&mut service).await;
+        // send "initialized" notification
+        initialized_notification(&mut service).await;
 
-            // send "shutdown" request
-            let shutdown = shutdown_request(&mut service).await;
+        // send "shutdown" request
+        let shutdown = shutdown_request(&mut service).await;
 
-            // send "shutdown" request (again); should error
-            let response = call_request(&mut service, shutdown).await;
-            let err = Response::from_error(1.into(), jsonrpc::Error::invalid_request());
-            assert_eq!(response, Ok(Some(err)));
+        // send "shutdown" request (again); should error
+        let response = call_request(&mut service, shutdown).await;
+        let err = Response::from_error(1.into(), jsonrpc::Error::invalid_request());
+        assert_eq!(response, Ok(Some(err)));
 
-            // send "exit" request
-            exit_notification(&mut service).await;
-        });
-        rt.shutdown_background();
+        // send "exit" request
+        exit_notification(&mut service).await;
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn refuses_requests_after_shutdown() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
-            let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
+    async fn refuses_requests_after_shutdown() {
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
 
-            // send "initialize" request
-            let _ = initialize_request(&mut service).await;
+        // send "initialize" request
+        let _ = initialize_request(&mut service).await;
 
-            // send "shutdown" request
-            let shutdown = shutdown_request(&mut service).await;
+        // send "shutdown" request
+        let shutdown = shutdown_request(&mut service).await;
 
-            let response = call_request(&mut service, shutdown).await;
-            let err = Response::from_error(1.into(), jsonrpc::Error::invalid_request());
-            assert_eq!(response, Ok(Some(err)));
-        });
-        rt.shutdown_background();
+        let response = call_request(&mut service, shutdown).await;
+        let err = Response::from_error(1.into(), jsonrpc::Error::invalid_request());
+        assert_eq!(response, Ok(Some(err)));
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn did_open() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
-            let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
-            let _ = init_and_open(&mut service, e2e_test_dir()).await;
-            shutdown_and_exit(&mut service).await;
-        });
-        rt.shutdown_background();
+    async fn did_open() {
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
+        let _ = init_and_open(&mut service, e2e_test_dir()).await;
+        shutdown_and_exit(&mut service).await;
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn did_close() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
-            let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
-            let _ = init_and_open(&mut service, e2e_test_dir()).await;
+    async fn did_close() {
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
+        let _ = init_and_open(&mut service, e2e_test_dir()).await;
 
-            // send "textDocument/didClose" notification for `uri`
-            did_close_notification(&mut service).await;
+        // send "textDocument/didClose" notification for `uri`
+        did_close_notification(&mut service).await;
 
-            shutdown_and_exit(&mut service).await;
-        });
-        rt.shutdown_background();
+        shutdown_and_exit(&mut service).await;
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn did_change() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
-            let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
-            let uri = init_and_open(&mut service, e2e_test_dir()).await;
+    async fn did_change() {
+        let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
+        let uri = init_and_open(&mut service, e2e_test_dir()).await;
 
-            // send "textDocument/didChange" notification for `uri`
-            let params = json!({
-                "textDocument": {
-                    "uri": uri,
-                    "version": 1
-                },
-                "contentChanges": [
-                    {
-                        "range": {
-                            "start": {
-                                "line": 3,
-                                "character": 4
-                            },
-                            "end": {
-                                "line": 3,
-                                "character": 4
-                            }
+        // send "textDocument/didChange" notification for `uri`
+        let params = json!({
+            "textDocument": {
+                "uri": uri,
+                "version": 1
+            },
+            "contentChanges": [
+                {
+                    "range": {
+                        "start": {
+                            "line": 3,
+                            "character": 4
                         },
-                        "rangeLength": 0,
-                        "text": "let x = 0.0;",
-                    }
-                ]
-            });
-
-            let _ = did_change_request(&mut service, params).await;
-
-            shutdown_and_exit(&mut service).await;
+                        "end": {
+                            "line": 3,
+                            "character": 4
+                        }
+                    },
+                    "rangeLength": 0,
+                    "text": "let x = 0.0;",
+                }
+            ]
         });
-        rt.shutdown_background();
+
+        let _ = did_change_request(&mut service, params).await;
+
+        shutdown_and_exit(&mut service).await;
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn show_ast() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
-            let (mut service, _) = LspService::build(|client| Backend::new(client, config()))
-                .custom_method("sway/show_ast", Backend::show_ast)
-                .finish();
+    async fn show_ast() {
+        let (mut service, _) = LspService::build(|client| Backend::new(client, config()))
+            .custom_method("sway/show_ast", Backend::show_ast)
+            .finish();
 
-            let uri = init_and_open(&mut service, e2e_test_dir()).await;
+        let uri = init_and_open(&mut service, e2e_test_dir()).await;
 
-            // send "sway/show_typed_ast" request
-            let _ = show_ast_request(&mut service, &uri).await;
+        // send "sway/show_typed_ast" request
+        let _ = show_ast_request(&mut service, &uri).await;
 
-            shutdown_and_exit(&mut service).await;
-        });
-        rt.shutdown_background();
+        shutdown_and_exit(&mut service).await;
     }
 
     // This macro allows us to spin up a server / client for testing
@@ -864,57 +828,53 @@ mod tests {
     // The capability argument is an async function.
     macro_rules! test_lsp_capability {
         ($example_dir:expr, $capability:expr) => {{
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async {
-                let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
-                let uri = init_and_open(&mut service, $example_dir).await;
-                // Call the specific LSP capability function that was passed in.
-                let _ = $capability(&mut service, &uri).await;
+            let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
+            let uri = init_and_open(&mut service, $example_dir).await;
+            // Call the specific LSP capability function that was passed in.
+            let _ = $capability(&mut service, &uri).await;
 
-                shutdown_and_exit(&mut service).await;
-            });
-            rt.shutdown_background();
+            shutdown_and_exit(&mut service).await;
         }};
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn semantic_tokens() {
+    async fn semantic_tokens() {
         // send "textDocument/semanticTokens/full" request
         test_lsp_capability!(doc_comments_dir(), semantic_tokens_request);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn document_symbol() {
+    async fn document_symbol() {
         // send "textDocument/documentSymbol" request
         test_lsp_capability!(doc_comments_dir(), document_symbol_request);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn go_to_definition() {
+    async fn go_to_definition() {
         // send "textDocument/definition" request
         test_lsp_capability!(doc_comments_dir(), go_to_definition_request);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn format() {
+    async fn format() {
         // send "textDocument/formatting" request
         test_lsp_capability!(doc_comments_dir(), format_request);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn hover() {
+    async fn hover() {
         // send "textDocument/hover" request
         test_lsp_capability!(doc_comments_dir(), hover_request);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn highlight() {
+    async fn highlight() {
         // send "textDocument/documentHighlight" request
         test_lsp_capability!(doc_comments_dir(), highlight_request);
     }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -372,6 +372,7 @@ impl Backend {
 mod tests {
     use serde_json::json;
     use std::{env, fs, io::Read, path::PathBuf};
+    use futures::stream::StreamExt;
     use tower::{Service, ServiceExt};
 
     use super::*;

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -651,25 +651,15 @@ mod tests {
     }
 
     async fn init_and_open(service: &mut LspService<Backend>, manifest_dir: PathBuf) -> Url {
-        // send "initialize" request
         let _ = initialize_request(service).await;
-
-        // send "initialized" notification
         initialized_notification(service).await;
-
         let (uri, sway_program) = load_sway_example(manifest_dir);
-
-        // send "textDocument/didOpen" notification for `uri`
         did_open_notification(service, &uri, &sway_program).await;
-
         uri
     }
 
     async fn shutdown_and_exit(service: &mut LspService<Backend>) {
-        // send "shutdown" request
         let _ = shutdown_request(service).await;
-
-        // send "exit" request
         exit_notification(service).await;
     }
 
@@ -677,8 +667,6 @@ mod tests {
     #[serial]
     async fn initialize() {
         let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
-
-        // send "initialize" request
         let _ = initialize_request(&mut service).await;
     }
 
@@ -686,11 +674,7 @@ mod tests {
     #[serial]
     async fn initialized() {
         let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
-
-        // send "initialize" request
         let _ = initialize_request(&mut service).await;
-
-        // send "initialized" notification
         initialized_notification(&mut service).await;
     }
 
@@ -698,16 +682,9 @@ mod tests {
     #[serial]
     async fn initializes_only_once() {
         let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
-
-        // send "initialize" request
         let initialize = initialize_request(&mut service).await;
-
-        // send "initialized" notification
         initialized_notification(&mut service).await;
-
-        // send "initialize" request (again); should error
         let response = call_request(&mut service, initialize).await;
-
         let err = Response::from_error(1.into(), jsonrpc::Error::invalid_request());
         assert_eq!(response, Ok(Some(err)));
     }
@@ -716,22 +693,12 @@ mod tests {
     #[serial]
     async fn shutdown() {
         let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
-
-        // send "initialize" request
         let _ = initialize_request(&mut service).await;
-
-        // send "initialized" notification
         initialized_notification(&mut service).await;
-
-        // send "shutdown" request
         let shutdown = shutdown_request(&mut service).await;
-
-        // send "shutdown" request (again); should error
         let response = call_request(&mut service, shutdown).await;
         let err = Response::from_error(1.into(), jsonrpc::Error::invalid_request());
         assert_eq!(response, Ok(Some(err)));
-
-        // send "exit" request
         exit_notification(&mut service).await;
     }
 
@@ -739,13 +706,8 @@ mod tests {
     #[serial]
     async fn refuses_requests_after_shutdown() {
         let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
-
-        // send "initialize" request
         let _ = initialize_request(&mut service).await;
-
-        // send "shutdown" request
         let shutdown = shutdown_request(&mut service).await;
-
         let response = call_request(&mut service, shutdown).await;
         let err = Response::from_error(1.into(), jsonrpc::Error::invalid_request());
         assert_eq!(response, Ok(Some(err)));
@@ -764,10 +726,7 @@ mod tests {
     async fn did_close() {
         let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
         let _ = init_and_open(&mut service, e2e_test_dir()).await;
-
-        // send "textDocument/didClose" notification for `uri`
         did_close_notification(&mut service).await;
-
         shutdown_and_exit(&mut service).await;
     }
 
@@ -777,7 +736,6 @@ mod tests {
         let (mut service, _) = LspService::new(|client| Backend::new(client, config()));
         let uri = init_and_open(&mut service, e2e_test_dir()).await;
 
-        // send "textDocument/didChange" notification for `uri`
         let params = json!({
             "textDocument": {
                 "uri": uri,
@@ -802,7 +760,6 @@ mod tests {
         });
 
         let _ = did_change_request(&mut service, params).await;
-
         shutdown_and_exit(&mut service).await;
     }
 
@@ -814,10 +771,7 @@ mod tests {
             .finish();
 
         let uri = init_and_open(&mut service, e2e_test_dir()).await;
-
-        // send "sway/show_typed_ast" request
         let _ = show_ast_request(&mut service, &uri).await;
-
         shutdown_and_exit(&mut service).await;
     }
 
@@ -832,7 +786,6 @@ mod tests {
             let uri = init_and_open(&mut service, $example_dir).await;
             // Call the specific LSP capability function that was passed in.
             let _ = $capability(&mut service, &uri).await;
-
             shutdown_and_exit(&mut service).await;
         }};
     }
@@ -840,42 +793,36 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn semantic_tokens() {
-        // send "textDocument/semanticTokens/full" request
         test_lsp_capability!(doc_comments_dir(), semantic_tokens_request);
     }
 
     #[tokio::test]
     #[serial]
     async fn document_symbol() {
-        // send "textDocument/documentSymbol" request
         test_lsp_capability!(doc_comments_dir(), document_symbol_request);
     }
 
     #[tokio::test]
     #[serial]
     async fn go_to_definition() {
-        // send "textDocument/definition" request
         test_lsp_capability!(doc_comments_dir(), go_to_definition_request);
     }
 
     #[tokio::test]
     #[serial]
     async fn format() {
-        // send "textDocument/formatting" request
         test_lsp_capability!(doc_comments_dir(), format_request);
     }
 
     #[tokio::test]
     #[serial]
     async fn hover() {
-        // send "textDocument/hover" request
         test_lsp_capability!(doc_comments_dir(), hover_request);
     }
 
     #[tokio::test]
     #[serial]
     async fn highlight() {
-        // send "textDocument/documentHighlight" request
         test_lsp_capability!(doc_comments_dir(), highlight_request);
     }
 }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -34,16 +34,11 @@ impl Backend {
     }
 
     async fn parse_and_store_sway_files(&self) -> Result<(), DocumentError> {
-        let curr_dir = std::env::current_dir().unwrap();
-
-        if let Some(path) = find_manifest_dir(&curr_dir) {
-            let files = get_sway_files(path);
-            for file_path in files {
-                if let Some(path) = file_path.to_str() {
-                    // store the document
-                    let text_document = TextDocument::build_from_path(path)?;
-                    self.session.store_document(text_document)?;
-                }
+        if let Some(path) = find_manifest_dir(&std::env::current_dir().unwrap()) {
+            // Store the documents.
+            for path in get_sway_files(path).iter().filter_map(|fp| fp.to_str()) {
+                self.session
+                    .store_document(TextDocument::build_from_path(path)?)?;
             }
         }
 

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -724,6 +724,7 @@ mod tests {
             // send "initialize" request
             let _ = initialize_request(&mut service).await;
         });
+        rt.shutdown_background();
     }
 
     #[test]
@@ -739,6 +740,7 @@ mod tests {
             // send "initialized" notification
             initialized_notification(&mut service).await;
         });
+        rt.shutdown_background();
     }
 
     #[test]
@@ -759,6 +761,7 @@ mod tests {
             let err = Response::from_error(1.into(), jsonrpc::Error::invalid_request());
             assert_eq!(response, Ok(Some(err)));
         });
+        rt.shutdown_background();
     }
 
     #[test]
@@ -785,6 +788,7 @@ mod tests {
             // send "exit" request
             exit_notification(&mut service).await;
         });
+        rt.shutdown_background();
     }
 
     #[test]
@@ -804,6 +808,7 @@ mod tests {
             let err = Response::from_error(1.into(), jsonrpc::Error::invalid_request());
             assert_eq!(response, Ok(Some(err)));
         });
+        rt.shutdown_background();
     }
 
     #[test]
@@ -815,9 +820,11 @@ mod tests {
             let _ = init_and_open(&mut service, e2e_test_dir()).await;
             shutdown_and_exit(&mut service).await;
         });
+        rt.shutdown_background();
     }
 
     #[test]
+    #[serial]
     fn did_close() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
@@ -829,6 +836,7 @@ mod tests {
 
             shutdown_and_exit(&mut service).await;
         });
+        rt.shutdown_background();
     }
 
     #[test]
@@ -867,6 +875,7 @@ mod tests {
 
             shutdown_and_exit(&mut service).await;
         });
+        rt.shutdown_background();
     }
 
     #[test]
@@ -885,6 +894,7 @@ mod tests {
 
             shutdown_and_exit(&mut service).await;
         });
+        rt.shutdown_background();
     }
 
     // This macro allows us to spin up a server / client for testing
@@ -903,6 +913,7 @@ mod tests {
 
                 shutdown_and_exit(&mut service).await;
             });
+            rt.shutdown_background();
         }};
     }
 

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -150,21 +150,20 @@ impl LanguageServer for Backend {
 
     // Document Handlers
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
-        let uri = params.text_document.uri.clone();
-        self.session.handle_open_file(&uri);
-        self.parse_project(&uri).await;
+        let uri = &params.text_document.uri;
+        self.session.handle_open_file(uri);
+        self.parse_project(uri).await;
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
-        let uri = params.text_document.uri.clone();
+        let uri = &params.text_document.uri;
         self.session
-            .update_text_document(&uri, params.content_changes);
-        self.parse_project(&uri).await;
+            .update_text_document(uri, params.content_changes);
+        self.parse_project(uri).await;
     }
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
-        let uri = params.text_document.uri.clone();
-        self.parse_project(&uri).await;
+        self.parse_project(&params.text_document.uri).await;
     }
 
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -370,9 +370,9 @@ impl Backend {
 
 #[cfg(test)]
 mod tests {
+    use futures::stream::StreamExt;
     use serde_json::json;
     use std::{env, fs, io::Read, path::PathBuf};
-    use futures::stream::StreamExt;
     use tower::{Service, ServiceExt};
 
     use super::*;

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -365,7 +365,7 @@ impl Backend {
 #[cfg(test)]
 mod tests {
     use serde_json::json;
-    use std::{env, fs, io::Read, path::PathBuf};
+    use std::{borrow::Cow, env, fs, io::Read, path::PathBuf};
     use tower::{Service, ServiceExt};
 
     use super::*;
@@ -412,11 +412,11 @@ mod tests {
         (uri, sway_program)
     }
 
-    fn build_request_with_id<M, I>(method: M, params: serde_json::Value, id: I) -> Request
-    where
-        M: Into<std::borrow::Cow<'static, str>>,
-        I: Into<Id>,
-    {
+    fn build_request_with_id(
+        method: impl Into<Cow<'static, str>>,
+        params: serde_json::Value,
+        id: impl Into<Id>,
+    ) -> Request {
         Request::build(method).params(params).id(id).finish()
     }
 
@@ -784,39 +784,20 @@ mod tests {
         }};
     }
 
-    #[tokio::test]
-    #[serial]
-    async fn semantic_tokens() {
-        test_lsp_capability!(doc_comments_dir(), semantic_tokens_request);
+    macro_rules! lsp_capability_test {
+        ($test:ident, $capability:expr) => {
+            #[tokio::test]
+            #[serial]
+            async fn $test() {
+                test_lsp_capability!(doc_comments_dir(), $capability);
+            }
+        };
     }
 
-    #[tokio::test]
-    #[serial]
-    async fn document_symbol() {
-        test_lsp_capability!(doc_comments_dir(), document_symbol_request);
-    }
-
-    #[tokio::test]
-    #[serial]
-    async fn go_to_definition() {
-        test_lsp_capability!(doc_comments_dir(), go_to_definition_request);
-    }
-
-    #[tokio::test]
-    #[serial]
-    async fn format() {
-        test_lsp_capability!(doc_comments_dir(), format_request);
-    }
-
-    #[tokio::test]
-    #[serial]
-    async fn hover() {
-        test_lsp_capability!(doc_comments_dir(), hover_request);
-    }
-
-    #[tokio::test]
-    #[serial]
-    async fn highlight() {
-        test_lsp_capability!(doc_comments_dir(), highlight_request);
-    }
+    lsp_capability_test!(semantic_tokens, semantic_tokens_request);
+    lsp_capability_test!(document_symbol, document_symbol_request);
+    lsp_capability_test!(go_to_definition, go_to_definition_request);
+    lsp_capability_test!(format, format_request);
+    lsp_capability_test!(hover, hover_request);
+    lsp_capability_test!(highlight, highlight_request);
 }

--- a/sway-lsp/src/utils/token.rs
+++ b/sway-lsp/src/utils/token.rs
@@ -41,7 +41,7 @@ pub(crate) fn to_ident_key(ident: &Ident) -> (Ident, Span) {
 /// Uses the TypeId to find the associated TypedDeclaration in the TokenMap.
 pub(crate) fn declaration_of_type_id(type_id: &TypeId, tokens: &TokenMap) -> Option<TyDeclaration> {
     ident_of_type_id(type_id)
-        .and_then(|decl_ident| tokens.get(&to_ident_key(&decl_ident)))
+        .and_then(|decl_ident| tokens.try_get(&to_ident_key(&decl_ident)).try_unwrap())
         .map(|item| item.value().clone())
         .and_then(|token| token.typed)
         .and_then(|typed_token| match typed_token {


### PR DESCRIPTION
These were temporarily removed in #2519 as some tests were getting stuck in CI. 

Also adds tests for the following LSP capabilities. 

- documentHighlight
- hover
- formatting
- definition
- documentSymbol
- semanticTokens