### PR TITLE
Collect SymbolKind info and generate correct semantic tokens

### DIFF
--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -23,6 +23,6 @@ pub struct FunctionParameter {
     pub name: Ident,
     pub is_reference: bool,
     pub is_mutable: bool,
-    pub(crate) type_id: TypeId,
+    pub type_id: TypeId,
     pub type_span: Span,
 }

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -19,7 +19,7 @@ pub use integer_bits::*;
 pub(crate) use replace_self_type::*;
 pub(crate) use resolved_type::*;
 pub(crate) use trait_constraint::*;
-pub(crate) use type_argument::*;
+pub use type_argument::*;
 pub(crate) use type_binding::*;
 pub use type_engine::*;
 pub use type_id::*;

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -1,11 +1,5 @@
-use crate::core::token::{AstToken, SymbolKind, TokenMap, TypedAstToken};
+use crate::core::token::{SymbolKind, TokenMap};
 use crate::utils::token::is_initial_declaration;
-use sway_core::{
-    semantic_analysis::ast_node::{
-        expression::typed_expression_variant::TypedExpressionVariant, TypedDeclaration,
-    },
-    Declaration,
-};
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
 
 pub fn to_completion_items(token_map: &TokenMap) -> Vec<CompletionItem> {

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -23,7 +23,7 @@ pub fn to_completion_items(token_map: &TokenMap) -> Vec<CompletionItem> {
 pub(crate) fn completion_item_kind(symbol_kind: &SymbolKind) -> Option<CompletionItemKind> {
     match symbol_kind {
         SymbolKind::Field => Some(CompletionItemKind::FIELD),
-        SymbolKind::TypeParam => Some(CompletionItemKind::TYPE_PARAMETER),
+        SymbolKind::BuiltinType => Some(CompletionItemKind::TYPE_PARAMETER),
         SymbolKind::ValueParam => Some(CompletionItemKind::VALUE),
         SymbolKind::Function | SymbolKind::Method => Some(CompletionItemKind::FUNCTION),
         SymbolKind::Const => Some(CompletionItemKind::CONSTANT),

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -29,6 +29,7 @@ pub(crate) fn completion_item_kind(symbol_kind: &SymbolKind) -> Option<Completio
         SymbolKind::Const => Some(CompletionItemKind::CONSTANT),
         SymbolKind::Struct => Some(CompletionItemKind::STRUCT),
         SymbolKind::Trait => Some(CompletionItemKind::INTERFACE),
+        SymbolKind::Module => Some(CompletionItemKind::MODULE),
         SymbolKind::Enum => Some(CompletionItemKind::ENUM),
         SymbolKind::Variant => Some(CompletionItemKind::ENUM_MEMBER),
         SymbolKind::BoolLiteral

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -1,10 +1,10 @@
-use crate::core::token::{AstToken, TokenMap, TypedAstToken};
+use crate::core::token::{AstToken, SymbolKind, TokenMap, TypedAstToken};
 use crate::utils::token::is_initial_declaration;
 use sway_core::{
     semantic_analysis::ast_node::{
         expression::typed_expression_variant::TypedExpressionVariant, TypedDeclaration,
     },
-    Declaration, ExpressionKind,
+    Declaration,
 };
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
 
@@ -16,12 +16,7 @@ pub fn to_completion_items(token_map: &TokenMap) -> Vec<CompletionItem> {
         if is_initial_declaration(token) {
             let item = CompletionItem {
                 label: ident.as_str().to_string(),
-                kind: {
-                    match &token.typed {
-                        Some(typed_token) => typed_to_completion_kind(typed_token),
-                        None => parsed_to_completion_kind(&token.parsed),
-                    }
-                },
+                kind: completion_item_kind(&token.kind),
                 ..Default::default()
             };
             completion_items.push(item);
@@ -31,67 +26,23 @@ pub fn to_completion_items(token_map: &TokenMap) -> Vec<CompletionItem> {
     completion_items
 }
 
-pub fn parsed_to_completion_kind(ast_token: &AstToken) -> Option<CompletionItemKind> {
-    match ast_token {
-        AstToken::Declaration(dec) => match dec {
-            Declaration::VariableDeclaration(_) => Some(CompletionItemKind::VARIABLE),
-            Declaration::FunctionDeclaration(_) => Some(CompletionItemKind::FUNCTION),
-            Declaration::TraitDeclaration(_) => Some(CompletionItemKind::INTERFACE),
-            Declaration::StructDeclaration(_) => Some(CompletionItemKind::STRUCT),
-            Declaration::EnumDeclaration(_) => Some(CompletionItemKind::ENUM),
-            Declaration::ConstantDeclaration(_) => Some(CompletionItemKind::CONSTANT),
-            Declaration::ImplTrait { .. }
-            | Declaration::ImplSelf(_)
-            | Declaration::AbiDeclaration(_)
-            | Declaration::StorageDeclaration(_) => Some(CompletionItemKind::TEXT),
-        },
-        AstToken::Expression(exp) => match &exp.kind {
-            ExpressionKind::Literal { .. } => Some(CompletionItemKind::VALUE),
-            ExpressionKind::FunctionApplication { .. } => Some(CompletionItemKind::FUNCTION),
-            ExpressionKind::Variable { .. } => Some(CompletionItemKind::VARIABLE),
-            ExpressionKind::Struct { .. } => Some(CompletionItemKind::STRUCT),
-            _ => None,
-        },
-        AstToken::FunctionDeclaration(_) => Some(CompletionItemKind::FUNCTION),
-        AstToken::FunctionParameter(_) => Some(CompletionItemKind::TYPE_PARAMETER),
-        AstToken::StructField(_) => Some(CompletionItemKind::FIELD),
-        AstToken::EnumVariant(_) => Some(CompletionItemKind::ENUM_MEMBER),
-        AstToken::TraitFn(_) => Some(CompletionItemKind::FUNCTION),
-        AstToken::StorageField(_) => Some(CompletionItemKind::FIELD),
-        AstToken::Reassignment(_) => Some(CompletionItemKind::VARIABLE),
-    }
-}
-
-pub fn typed_to_completion_kind(typed_ast_token: &TypedAstToken) -> Option<CompletionItemKind> {
-    match typed_ast_token {
-        TypedAstToken::TypedDeclaration(dec) => match dec {
-            TypedDeclaration::VariableDeclaration(_) => Some(CompletionItemKind::VARIABLE),
-            TypedDeclaration::FunctionDeclaration(_) => Some(CompletionItemKind::FUNCTION),
-            TypedDeclaration::TraitDeclaration(_) => Some(CompletionItemKind::INTERFACE),
-            TypedDeclaration::StructDeclaration(_) => Some(CompletionItemKind::STRUCT),
-            TypedDeclaration::EnumDeclaration(_) => Some(CompletionItemKind::ENUM),
-            TypedDeclaration::ConstantDeclaration(_) => Some(CompletionItemKind::CONSTANT),
-            TypedDeclaration::ImplTrait { .. }
-            | TypedDeclaration::AbiDeclaration(_)
-            | TypedDeclaration::StorageDeclaration(_) => Some(CompletionItemKind::TEXT),
-            _ => None,
-        },
-        TypedAstToken::TypedExpression(exp) => match &exp.expression {
-            TypedExpressionVariant::Literal(_) => Some(CompletionItemKind::VALUE),
-            TypedExpressionVariant::FunctionApplication { .. } => {
-                Some(CompletionItemKind::FUNCTION)
-            }
-            TypedExpressionVariant::VariableExpression { .. } => Some(CompletionItemKind::VARIABLE),
-            TypedExpressionVariant::StructExpression { .. } => Some(CompletionItemKind::STRUCT),
-            _ => None,
-        },
-        TypedAstToken::TypedFunctionDeclaration(_) => Some(CompletionItemKind::FUNCTION),
-        TypedAstToken::TypedFunctionParameter(_) => Some(CompletionItemKind::TYPE_PARAMETER),
-        TypedAstToken::TypedStructField(_) => Some(CompletionItemKind::FIELD),
-        TypedAstToken::TypedEnumVariant(_) => Some(CompletionItemKind::ENUM_MEMBER),
-        TypedAstToken::TypedTraitFn(_) => Some(CompletionItemKind::FUNCTION),
-        TypedAstToken::TypedStorageField(_) => Some(CompletionItemKind::FIELD),
-        TypedAstToken::TypedReassignment(_) => Some(CompletionItemKind::VARIABLE),
-        TypedAstToken::TypeCheckedStorageReassignDescriptor(_) => None,
+pub(crate) fn completion_item_kind(symbol_kind: &SymbolKind) -> Option<CompletionItemKind> {
+    match symbol_kind {
+        SymbolKind::Field => Some(CompletionItemKind::FIELD),
+        SymbolKind::TypeParam => Some(CompletionItemKind::TYPE_PARAMETER),
+        SymbolKind::ValueParam => Some(CompletionItemKind::VALUE),
+        SymbolKind::Function | SymbolKind::Method => Some(CompletionItemKind::FUNCTION),
+        SymbolKind::Const => Some(CompletionItemKind::CONSTANT),
+        SymbolKind::Struct => Some(CompletionItemKind::STRUCT),
+        SymbolKind::Trait => Some(CompletionItemKind::INTERFACE),
+        SymbolKind::Enum => Some(CompletionItemKind::ENUM),
+        SymbolKind::Variant => Some(CompletionItemKind::ENUM_MEMBER),
+        SymbolKind::BoolLiteral
+        | SymbolKind::ByteLiteral
+        | SymbolKind::CharLiteral
+        | SymbolKind::StringLiteral
+        | SymbolKind::NumericLiteral => Some(CompletionItemKind::VALUE),
+        SymbolKind::Variable => Some(CompletionItemKind::VARIABLE),
+        SymbolKind::Unknown => None,
     }
 }

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -33,7 +33,6 @@ pub(crate) fn completion_item_kind(symbol_kind: &SymbolKind) -> Option<Completio
         SymbolKind::Variant => Some(CompletionItemKind::ENUM_MEMBER),
         SymbolKind::BoolLiteral
         | SymbolKind::ByteLiteral
-        | SymbolKind::CharLiteral
         | SymbolKind::StringLiteral
         | SymbolKind::NumericLiteral => Some(CompletionItemKind::VALUE),
         SymbolKind::Variable => Some(CompletionItemKind::VARIABLE),

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -37,6 +37,7 @@ pub(crate) fn symbol_kind(symbol_kind: &SymbolKind) -> lsp_types::SymbolKind {
         SymbolKind::Const => lsp_types::SymbolKind::CONSTANT,
         SymbolKind::Struct => lsp_types::SymbolKind::STRUCT,
         SymbolKind::Trait => lsp_types::SymbolKind::INTERFACE,
+        SymbolKind::Module => lsp_types::SymbolKind::MODULE,
         SymbolKind::Enum => lsp_types::SymbolKind::ENUM,
         SymbolKind::Variant => lsp_types::SymbolKind::ENUM_MEMBER,
         SymbolKind::BoolLiteral => lsp_types::SymbolKind::BOOLEAN,

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -32,7 +32,7 @@ fn symbol_info(ident: &Ident, token: &Token, url: Url) -> SymbolInformation {
 pub(crate) fn symbol_kind(symbol_kind: &SymbolKind) -> lsp_types::SymbolKind {
     match symbol_kind {
         SymbolKind::Field => lsp_types::SymbolKind::FIELD,
-        SymbolKind::TypeParam => lsp_types::SymbolKind::TYPE_PARAMETER,
+        SymbolKind::BuiltinType => lsp_types::SymbolKind::TYPE_PARAMETER,
         SymbolKind::Function | SymbolKind::Method => lsp_types::SymbolKind::FUNCTION,
         SymbolKind::Const => lsp_types::SymbolKind::CONSTANT,
         SymbolKind::Struct => lsp_types::SymbolKind::STRUCT,

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -40,7 +40,7 @@ pub(crate) fn symbol_kind(symbol_kind: &SymbolKind) -> lsp_types::SymbolKind {
         SymbolKind::Enum => lsp_types::SymbolKind::ENUM,
         SymbolKind::Variant => lsp_types::SymbolKind::ENUM_MEMBER,
         SymbolKind::BoolLiteral => lsp_types::SymbolKind::BOOLEAN,
-        SymbolKind::StringLiteral | SymbolKind::CharLiteral => lsp_types::SymbolKind::STRING,
+        SymbolKind::StringLiteral => lsp_types::SymbolKind::STRING,
         SymbolKind::NumericLiteral => lsp_types::SymbolKind::NUMBER,
         SymbolKind::ValueParam
         | SymbolKind::ByteLiteral

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -1,13 +1,7 @@
-use crate::core::token::{AstToken, Token, TokenMap, TypedAstToken};
+use crate::core::token::{SymbolKind, Token, TokenMap};
 use crate::utils::common::get_range_from_span;
-use sway_core::{
-    semantic_analysis::ast_node::{
-        expression::typed_expression_variant::TypedExpressionVariant, TypedDeclaration,
-    },
-    Declaration, ExpressionKind, Literal,
-};
 use sway_types::{Ident, Spanned};
-use tower_lsp::lsp_types::{Location, SymbolInformation, SymbolKind, Url};
+use tower_lsp::lsp_types::{self, Location, SymbolInformation, Url};
 
 pub fn to_symbol_information(token_map: &TokenMap, url: Url) -> Vec<SymbolInformation> {
     let mut symbols: Vec<SymbolInformation> = vec![];
@@ -27,12 +21,7 @@ fn symbol_info(ident: &Ident, token: &Token, url: Url) -> SymbolInformation {
     let range = get_range_from_span(&ident.span());
     SymbolInformation {
         name: ident.as_str().to_string(),
-        kind: {
-            match &token.typed {
-                Some(typed_token) => typed_to_symbol_kind(&typed_token),
-                None => parsed_to_symbol_kind(&token.parsed),
-            }
-        },
+        kind: symbol_kind(&token.kind),
         location: Location::new(url, range),
         tags: None,
         container_name: None,
@@ -40,91 +29,24 @@ fn symbol_info(ident: &Ident, token: &Token, url: Url) -> SymbolInformation {
     }
 }
 
-fn parsed_to_symbol_kind(ast_token: &AstToken) -> SymbolKind {
-    match ast_token {
-        AstToken::Declaration(dec) => {
-            match dec {
-                Declaration::VariableDeclaration(_) => SymbolKind::VARIABLE,
-                Declaration::FunctionDeclaration(_) => SymbolKind::FUNCTION,
-                Declaration::TraitDeclaration(_) => SymbolKind::INTERFACE,
-                Declaration::StructDeclaration(_) => SymbolKind::STRUCT,
-                Declaration::EnumDeclaration(_) => SymbolKind::ENUM,
-                Declaration::ConstantDeclaration(_) => SymbolKind::CONSTANT,
-                Declaration::ImplTrait { .. } => SymbolKind::INTERFACE,
-                Declaration::AbiDeclaration(_) => SymbolKind::INTERFACE,
-                // currently we return `variable` type as default
-                Declaration::ImplSelf { .. } | Declaration::StorageDeclaration(_) => {
-                    SymbolKind::VARIABLE
-                }
-            }
-        }
-        AstToken::Expression(exp) => {
-            match &exp.kind {
-                ExpressionKind::Literal(value) => match value {
-                    Literal::String(_) => SymbolKind::STRING,
-                    Literal::Boolean(_) => SymbolKind::BOOLEAN,
-                    _ => SymbolKind::NUMBER,
-                },
-                ExpressionKind::FunctionApplication(_) => SymbolKind::FUNCTION,
-                ExpressionKind::Variable(_) => SymbolKind::VARIABLE,
-                ExpressionKind::Array(_) => SymbolKind::ARRAY,
-                ExpressionKind::Struct(_) => SymbolKind::STRUCT,
-                // currently we return `variable` type as default
-                _ => SymbolKind::VARIABLE,
-            }
-        }
-        AstToken::FunctionDeclaration(_) => SymbolKind::FUNCTION,
-        AstToken::FunctionParameter(_) => SymbolKind::TYPE_PARAMETER,
-        AstToken::StructField(_) | AstToken::StructExpressionField(_) => SymbolKind::FIELD,
-        AstToken::EnumVariant(_) => SymbolKind::ENUM_MEMBER,
-        AstToken::TraitFn(_) => SymbolKind::FUNCTION,
-        AstToken::StorageField(_) => SymbolKind::FIELD,
-        AstToken::Reassignment(_) => SymbolKind::VARIABLE,
-    }
-}
-
-fn typed_to_symbol_kind(typed_ast_token: &TypedAstToken) -> SymbolKind {
-    match typed_ast_token {
-        TypedAstToken::TypedDeclaration(dec) => {
-            match dec {
-                TypedDeclaration::VariableDeclaration(_) => SymbolKind::VARIABLE,
-                TypedDeclaration::ConstantDeclaration(_) => SymbolKind::CONSTANT,
-                TypedDeclaration::FunctionDeclaration(_) => SymbolKind::FUNCTION,
-                TypedDeclaration::TraitDeclaration(_) => SymbolKind::INTERFACE,
-                TypedDeclaration::StructDeclaration(_) => SymbolKind::STRUCT,
-                TypedDeclaration::EnumDeclaration(_) => SymbolKind::ENUM,
-                TypedDeclaration::ImplTrait { .. } => SymbolKind::INTERFACE,
-                TypedDeclaration::AbiDeclaration(_) => SymbolKind::INTERFACE,
-                TypedDeclaration::GenericTypeForFunctionScope { .. } => SymbolKind::TYPE_PARAMETER,
-                // currently we return `variable` type as default
-                TypedDeclaration::ErrorRecovery | TypedDeclaration::StorageDeclaration(_) => {
-                    SymbolKind::VARIABLE
-                }
-            }
-        }
-        TypedAstToken::TypedExpression(exp) => {
-            match &exp.expression {
-                TypedExpressionVariant::Literal(lit) => match lit {
-                    Literal::String(_) => SymbolKind::STRING,
-                    Literal::Boolean(_) => SymbolKind::BOOLEAN,
-                    _ => SymbolKind::NUMBER,
-                },
-                TypedExpressionVariant::FunctionApplication { .. } => SymbolKind::FUNCTION,
-                TypedExpressionVariant::VariableExpression { .. } => SymbolKind::VARIABLE,
-                TypedExpressionVariant::Array { .. } => SymbolKind::ARRAY,
-                TypedExpressionVariant::StructExpression { .. } => SymbolKind::STRUCT,
-                TypedExpressionVariant::StructFieldAccess { .. } => SymbolKind::FIELD,
-                // currently we return `variable` type as default
-                _ => SymbolKind::VARIABLE,
-            }
-        }
-        TypedAstToken::TypedFunctionDeclaration(_) => SymbolKind::FUNCTION,
-        TypedAstToken::TypedFunctionParameter(_) => SymbolKind::TYPE_PARAMETER,
-        TypedAstToken::TypedStructField(_) => SymbolKind::FIELD,
-        TypedAstToken::TypedEnumVariant(_) => SymbolKind::ENUM_MEMBER,
-        TypedAstToken::TypedTraitFn(_) => SymbolKind::FUNCTION,
-        TypedAstToken::TypedStorageField(_) => SymbolKind::FIELD,
-        TypedAstToken::TypeCheckedStorageReassignDescriptor(_)
-        | TypedAstToken::TypedReassignment(_) => SymbolKind::VARIABLE,
+pub(crate) fn symbol_kind(symbol_kind: &SymbolKind) -> lsp_types::SymbolKind {
+    match symbol_kind {
+        SymbolKind::Field => lsp_types::SymbolKind::FIELD,
+        SymbolKind::TypeParam => lsp_types::SymbolKind::TYPE_PARAMETER,
+        SymbolKind::Function
+        | SymbolKind::Method => lsp_types::SymbolKind::FUNCTION,
+        SymbolKind::Const => lsp_types::SymbolKind::CONSTANT,
+        SymbolKind::Struct => lsp_types::SymbolKind::STRUCT,
+        SymbolKind::Trait => lsp_types::SymbolKind::INTERFACE,
+        SymbolKind::Enum => lsp_types::SymbolKind::ENUM,
+        SymbolKind::Variant => lsp_types::SymbolKind::ENUM_MEMBER,
+        SymbolKind::BoolLiteral => lsp_types::SymbolKind::BOOLEAN,
+        SymbolKind::StringLiteral
+        | SymbolKind::CharLiteral => lsp_types::SymbolKind::STRING,
+        SymbolKind::NumericLiteral => lsp_types::SymbolKind::NUMBER,
+        SymbolKind::ValueParam
+        | SymbolKind::ByteLiteral
+        | SymbolKind::Variable
+        | SymbolKind::Unknown => lsp_types::SymbolKind::VARIABLE,
     }
 }

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -75,7 +75,7 @@ fn parsed_to_symbol_kind(ast_token: &AstToken) -> SymbolKind {
         }
         AstToken::FunctionDeclaration(_) => SymbolKind::FUNCTION,
         AstToken::FunctionParameter(_) => SymbolKind::TYPE_PARAMETER,
-        AstToken::StructField(_) => SymbolKind::FIELD,
+        AstToken::StructField(_) | AstToken::StructExpressionField(_) => SymbolKind::FIELD,
         AstToken::EnumVariant(_) => SymbolKind::ENUM_MEMBER,
         AstToken::TraitFn(_) => SymbolKind::FUNCTION,
         AstToken::StorageField(_) => SymbolKind::FIELD,

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -33,16 +33,14 @@ pub(crate) fn symbol_kind(symbol_kind: &SymbolKind) -> lsp_types::SymbolKind {
     match symbol_kind {
         SymbolKind::Field => lsp_types::SymbolKind::FIELD,
         SymbolKind::TypeParam => lsp_types::SymbolKind::TYPE_PARAMETER,
-        SymbolKind::Function
-        | SymbolKind::Method => lsp_types::SymbolKind::FUNCTION,
+        SymbolKind::Function | SymbolKind::Method => lsp_types::SymbolKind::FUNCTION,
         SymbolKind::Const => lsp_types::SymbolKind::CONSTANT,
         SymbolKind::Struct => lsp_types::SymbolKind::STRUCT,
         SymbolKind::Trait => lsp_types::SymbolKind::INTERFACE,
         SymbolKind::Enum => lsp_types::SymbolKind::ENUM,
         SymbolKind::Variant => lsp_types::SymbolKind::ENUM_MEMBER,
         SymbolKind::BoolLiteral => lsp_types::SymbolKind::BOOLEAN,
-        SymbolKind::StringLiteral
-        | SymbolKind::CharLiteral => lsp_types::SymbolKind::STRING,
+        SymbolKind::StringLiteral | SymbolKind::CharLiteral => lsp_types::SymbolKind::STRING,
         SymbolKind::NumericLiteral => lsp_types::SymbolKind::NUMBER,
         SymbolKind::ValueParam
         | SymbolKind::ByteLiteral

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -15,7 +15,7 @@ pub fn semantic_tokens_full(session: &Session, url: &Url) -> Option<SemanticToke
     let tokens = session.tokens_for_file(url);
 
     // The tokens need sorting by thier span so each token is sequential
-    // If this is done then the bit offsets used for the lsp_types::SemanticToken are incorrect.
+    // If this step isn't done, then the bit offsets used for the lsp_types::SemanticToken are incorrect.
     let mut tokens_sorted: Vec<_> = tokens
         .iter()
         .map(|item| {

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -128,7 +128,7 @@ fn semantic_token_type(kind: &SymbolKind) -> SemanticTokenType {
         SymbolKind::Trait => SemanticTokenType::INTERFACE,
         SymbolKind::BoolLiteral => SemanticTokenType::new("boolean"),
         SymbolKind::ByteLiteral | SymbolKind::NumericLiteral => SemanticTokenType::NUMBER,
-        SymbolKind::CharLiteral | SymbolKind::StringLiteral => SemanticTokenType::STRING,
+        SymbolKind::StringLiteral => SemanticTokenType::STRING,
         SymbolKind::Unknown => SemanticTokenType::new("generic"),
     }
 }

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -93,9 +93,8 @@ impl SemanticTokensBuilder {
     }
 }
 
-static TOKEN_RESULT_COUNTER: AtomicU32 = AtomicU32::new(1);
-
 pub(crate) fn semantic_tokens(tokens_sorted: &[(Span, Token)]) -> SemanticTokens {
+    static TOKEN_RESULT_COUNTER: AtomicU32 = AtomicU32::new(1);
     let id = TOKEN_RESULT_COUNTER
         .fetch_add(1, Ordering::SeqCst)
         .to_string();

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -1,95 +1,39 @@
 use crate::core::{
     session::Session,
-    token::{AstToken, TokenMap},
+    token::{AstToken, SymbolKind, Token},
 };
 use crate::utils::common::get_range_from_span;
+use std::sync::atomic::{AtomicU32, Ordering};
 use sway_core::{Declaration, ExpressionKind, Literal};
 use sway_types::Span;
 use tower_lsp::lsp_types::{
-    SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
-    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions, SemanticTokensResult,
-    SemanticTokensServerCapabilities, Url,
+    Range, SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
+    SemanticTokensResult, Url,
 };
 
 // https://github.com/microsoft/vscode-extension-samples/blob/5ae1f7787122812dcc84e37427ca90af5ee09f14/semantic-tokens-sample/vscode.proposed.d.ts#L71
 pub fn semantic_tokens_full(session: &Session, url: &Url) -> Option<SemanticTokensResult> {
-    match session.semantic_tokens(url) {
-        Some(semantic_tokens) => {
-            if semantic_tokens.is_empty() {
-                return None;
-            }
+    let tokens = session.tokens_for_file(url);
 
-            Some(SemanticTokensResult::Tokens(SemanticTokens {
-                result_id: None,
-                data: semantic_tokens,
-            }))
-        }
-        _ => None,
-    }
-}
+    // The tokens need sorting by thier span so each token is sequential
+    // If this is done then the bit offsets used for the lsp_types::SemanticToken are incorrect.
+    let mut tokens_sorted: Vec<_> = tokens
+        .iter()
+        .map(|item| {
+            let ((_, span), token) = item.pair();
+            (span.clone(), token.clone())
+        })
+        .collect();
 
-pub fn to_semantic_tokens(token_map: &TokenMap) -> Vec<SemanticToken> {
-    let mut semantic_tokens: Vec<SemanticToken> = Vec::new();
+    tokens_sorted.sort_by(|(a_span, _), (b_span, _)| {
+        let a = (a_span.start(), a_span.end());
+        let b = (b_span.start(), b_span.end());
+        a.cmp(&b)
+    });
 
-    let mut prev_token_span = None;
-    for item in token_map.iter() {
-        let ((_, span), token) = item.pair();
-        let token_type_idx = type_idx(&token.parsed);
-        let semantic_token = semantic_token(token_type_idx, span, prev_token_span);
+    let semantic_tokens = semantic_tokens(&tokens_sorted);
 
-        semantic_tokens.push(semantic_token);
-        prev_token_span = Some(span.clone());
-    }
-
-    semantic_tokens
-}
-
-fn semantic_token(
-    token_type_idx: u32,
-    next_token_span: &Span,
-    prev_token_span: Option<Span>,
-) -> SemanticToken {
-    let next_token_range = get_range_from_span(next_token_span);
-    let next_token_line_start = next_token_range.start.line;
-
-    // TODO - improve with modifiers
-    let token_modifiers_bitset = 0;
-    let length = next_token_range.end.character - next_token_range.start.character;
-
-    let next_token_start_char = next_token_range.start.character;
-
-    let (delta_line, delta_start) = if let Some(prev_token_span) = prev_token_span {
-        let prev_token_range = get_range_from_span(&prev_token_span);
-        let prev_token_line_start = prev_token_range.start.line;
-        let delta_start = if next_token_line_start == prev_token_line_start {
-            next_token_start_char - prev_token_range.start.character
-        } else {
-            next_token_start_char
-        };
-        (next_token_line_start - prev_token_line_start, delta_start)
-    } else {
-        (next_token_line_start, next_token_start_char)
-    };
-
-    SemanticToken {
-        token_modifiers_bitset,
-        token_type: token_type_idx,
-        length,
-        delta_line,
-        delta_start,
-    }
-}
-
-/// these values should reflect indexes in `token_types`
-#[repr(u32)]
-enum TokenTypeIndex {
-    Function = 1,
-    Parameter = 5,
-    String = 6,
-    Variable = 9,
-    Enum = 10,
-    Struct = 11,
-    Interface = 12,
+    Some(semantic_tokens.into())
 }
 
 fn type_idx(ast_token: &AstToken) -> u32 {
@@ -125,50 +69,155 @@ fn type_idx(ast_token: &AstToken) -> u32 {
     }
 }
 
-pub fn semantic_tokens() -> Option<SemanticTokensServerCapabilities> {
-    let token_types = vec![
-        SemanticTokenType::CLASS,          // 0
-        SemanticTokenType::FUNCTION,       // 1
-        SemanticTokenType::KEYWORD,        // 2
-        SemanticTokenType::NAMESPACE,      // 3
-        SemanticTokenType::OPERATOR,       // 4
-        SemanticTokenType::PARAMETER,      // 5
-        SemanticTokenType::STRING,         // 6
-        SemanticTokenType::TYPE,           // 7
-        SemanticTokenType::TYPE_PARAMETER, // 8
-        SemanticTokenType::VARIABLE,       // 9
-        SemanticTokenType::ENUM,           // 10
-        SemanticTokenType::STRUCT,         // 11
-        SemanticTokenType::INTERFACE,      // 12
-    ];
-
-    let token_modifiers: Vec<SemanticTokenModifier> = vec![
-        // declaration of symbols
-        SemanticTokenModifier::DECLARATION,
-        // definition of symbols as in header files
-        SemanticTokenModifier::DEFINITION,
-        SemanticTokenModifier::READONLY,
-        SemanticTokenModifier::STATIC,
-        // for variable references where the variable is assigned to
-        SemanticTokenModifier::MODIFICATION,
-        SemanticTokenModifier::DOCUMENTATION,
-        // for symbols that are part of stdlib
-        SemanticTokenModifier::DEFAULT_LIBRARY,
-    ];
-
-    let legend = SemanticTokensLegend {
-        token_types,
-        token_modifiers,
-    };
-
-    let options = SemanticTokensOptions {
-        legend,
-        range: None,
-        full: Some(SemanticTokensFullOptions::Bool(true)),
-        ..Default::default()
-    };
-
-    Some(SemanticTokensServerCapabilities::SemanticTokensOptions(
-        options,
-    ))
+/// these values should reflect indexes in `token_types`
+#[repr(u32)]
+enum TokenTypeIndex {
+    Function = 1,
+    Parameter = 5,
+    String = 6,
+    Variable = 9,
+    Enum = 10,
+    Struct = 11,
+    Interface = 12,
 }
+
+//-------------------------------
+/// Tokens are encoded relative to each other.
+///
+/// This is taken from rust-analyzer which is also a direct port of <https://github.com/microsoft/vscode-languageserver-node/blob/f425af9de46a0187adb78ec8a46b9b2ce80c5412/server/src/sematicTokens.proposed.ts#L45>
+pub(crate) struct SemanticTokensBuilder {
+    id: String,
+    prev_line: u32,
+    prev_char: u32,
+    data: Vec<SemanticToken>,
+}
+
+impl SemanticTokensBuilder {
+    pub(crate) fn new(id: String) -> Self {
+        SemanticTokensBuilder {
+            id,
+            prev_line: 0,
+            prev_char: 0,
+            data: Default::default(),
+        }
+    }
+
+    /// Push a new token onto the builder
+    pub(crate) fn push(&mut self, range: Range, token_index: u32, modifier_bitset: u32) {
+        let mut push_line = range.start.line as u32;
+        let mut push_char = range.start.character as u32;
+
+        if !self.data.is_empty() {
+            push_line -= self.prev_line;
+            if push_line == 0 {
+                push_char -= self.prev_char;
+            }
+        }
+
+        // A token cannot be multiline
+        let token_len = range.end.character - range.start.character;
+
+        let token = SemanticToken {
+            delta_line: push_line,
+            delta_start: push_char,
+            length: token_len as u32,
+            token_type: token_index,
+            token_modifiers_bitset: modifier_bitset,
+        };
+
+        self.data.push(token);
+
+        self.prev_line = range.start.line as u32;
+        self.prev_char = range.start.character as u32;
+    }
+
+    pub(crate) fn build(self) -> SemanticTokens {
+        SemanticTokens {
+            result_id: Some(self.id),
+            data: self.data,
+        }
+    }
+}
+
+static TOKEN_RESULT_COUNTER: AtomicU32 = AtomicU32::new(1);
+
+pub(crate) fn semantic_tokens(tokens_sorted: &[(Span, Token)]) -> SemanticTokens {
+    let id = TOKEN_RESULT_COUNTER
+        .fetch_add(1, Ordering::SeqCst)
+        .to_string();
+    let mut builder = SemanticTokensBuilder::new(id);
+
+    for (span, token) in tokens_sorted.iter() {
+        let ty = semantic_token_type(&token.kind);
+        let token_index = type_index(ty);
+        // TODO - improve with modifiers
+        let modifier_bitset = 0;
+        let range = get_range_from_span(span);
+
+        builder.push(range, token_index, modifier_bitset);
+    }
+    builder.build()
+}
+
+fn semantic_token_type(kind: &SymbolKind) -> SemanticTokenType {
+    match kind {
+        SymbolKind::Field => SemanticTokenType::PROPERTY,
+        SymbolKind::TypeParam => SemanticTokenType::TYPE_PARAMETER,
+        SymbolKind::ValueParam => SemanticTokenType::PARAMETER,
+        SymbolKind::Variable => SemanticTokenType::VARIABLE,
+        SymbolKind::Function => SemanticTokenType::FUNCTION,
+        SymbolKind::Method => SemanticTokenType::METHOD,
+        SymbolKind::Const => SemanticTokenType::VARIABLE,
+        SymbolKind::Struct => SemanticTokenType::STRUCT,
+        SymbolKind::Enum => SemanticTokenType::ENUM,
+        SymbolKind::Variant => SemanticTokenType::ENUM_MEMBER,
+        SymbolKind::Trait => SemanticTokenType::INTERFACE,
+        SymbolKind::BoolLiteral => SemanticTokenType::new("boolean"),
+        SymbolKind::ByteLiteral | SymbolKind::NumericLiteral => SemanticTokenType::NUMBER,
+        SymbolKind::CharLiteral | SymbolKind::StringLiteral => SemanticTokenType::STRING,
+        SymbolKind::Unknown => SemanticTokenType::new("generic"),
+    }
+}
+
+pub(crate) fn type_index(ty: SemanticTokenType) -> u32 {
+    SUPPORTED_TYPES.iter().position(|it| *it == ty).unwrap() as u32
+}
+
+pub(crate) const SUPPORTED_TYPES: &[SemanticTokenType] = &[
+    //SemanticTokenType::COMMENT,
+    //SemanticTokenType::KEYWORD,
+    SemanticTokenType::STRING,
+    SemanticTokenType::NUMBER,
+    //SemanticTokenType::REGEXP,
+    //SemanticTokenType::OPERATOR,
+    SemanticTokenType::NAMESPACE,
+    SemanticTokenType::TYPE,
+    SemanticTokenType::STRUCT,
+    SemanticTokenType::CLASS,
+    SemanticTokenType::INTERFACE,
+    SemanticTokenType::ENUM,
+    SemanticTokenType::ENUM_MEMBER,
+    SemanticTokenType::TYPE_PARAMETER,
+    SemanticTokenType::FUNCTION,
+    SemanticTokenType::METHOD,
+    SemanticTokenType::PROPERTY,
+    //SemanticTokenType::MACRO,
+    SemanticTokenType::VARIABLE,
+    SemanticTokenType::PARAMETER,
+    SemanticTokenType::new("generic"),
+    SemanticTokenType::new("boolean"),
+];
+
+pub(crate) const SUPPORTED_MODIFIERS: &[SemanticTokenModifier] = &[
+    // declaration of symbols
+    SemanticTokenModifier::DECLARATION,
+    // definition of symbols as in header files
+    SemanticTokenModifier::DEFINITION,
+    SemanticTokenModifier::READONLY,
+    SemanticTokenModifier::STATIC,
+    // for variable references where the variable is assigned to
+    SemanticTokenModifier::MODIFICATION,
+    SemanticTokenModifier::DOCUMENTATION,
+    // for symbols that are part of stdlib
+    SemanticTokenModifier::DEFAULT_LIBRARY,
+];

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -129,6 +129,7 @@ fn semantic_token_type(kind: &SymbolKind) -> SemanticTokenType {
         SymbolKind::ByteLiteral | SymbolKind::NumericLiteral => SemanticTokenType::NUMBER,
         SymbolKind::StringLiteral => SemanticTokenType::STRING,
         SymbolKind::BuiltinType => SemanticTokenType::new("builtinType"),
+        SymbolKind::Module => SemanticTokenType::NAMESPACE,
         SymbolKind::Unknown => SemanticTokenType::new("generic"),
     }
 }

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -1,10 +1,9 @@
 use crate::core::{
     session::Session,
-    token::{AstToken, SymbolKind, Token},
+    token::{SymbolKind, Token},
 };
 use crate::utils::common::get_range_from_span;
 use std::sync::atomic::{AtomicU32, Ordering};
-use sway_core::{Declaration, ExpressionKind, Literal};
 use sway_types::Span;
 use tower_lsp::lsp_types::{
     Range, SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
@@ -34,51 +33,6 @@ pub fn semantic_tokens_full(session: &Session, url: &Url) -> Option<SemanticToke
     let semantic_tokens = semantic_tokens(&tokens_sorted);
 
     Some(semantic_tokens.into())
-}
-
-fn type_idx(ast_token: &AstToken) -> u32 {
-    match ast_token {
-        AstToken::Declaration(dec) => {
-            match dec {
-                Declaration::VariableDeclaration(_) => TokenTypeIndex::Variable as u32,
-                Declaration::FunctionDeclaration(_) => TokenTypeIndex::Function as u32,
-                Declaration::TraitDeclaration(_) | Declaration::ImplTrait { .. } => {
-                    TokenTypeIndex::Interface as u32
-                }
-                Declaration::StructDeclaration(_) => TokenTypeIndex::Struct as u32,
-                Declaration::EnumDeclaration(_) => TokenTypeIndex::Enum as u32,
-                // currently we return `variable` type as default
-                _ => TokenTypeIndex::Variable as u32,
-            }
-        }
-        AstToken::Expression(exp) => {
-            match &exp.kind {
-                ExpressionKind::Literal(Literal::String(_)) => TokenTypeIndex::String as u32,
-                ExpressionKind::FunctionApplication(_) => TokenTypeIndex::Function as u32,
-                ExpressionKind::Variable(_) => TokenTypeIndex::Variable as u32,
-                ExpressionKind::Struct(_) => TokenTypeIndex::Struct as u32,
-                // currently we return `variable` type as default
-                _ => TokenTypeIndex::Variable as u32,
-            }
-        }
-        AstToken::FunctionDeclaration(_) => TokenTypeIndex::Function as u32,
-        AstToken::FunctionParameter(_) => TokenTypeIndex::Parameter as u32,
-        AstToken::TraitFn(_) => TokenTypeIndex::Function as u32,
-        // currently we return `variable` type as default
-        _ => TokenTypeIndex::Variable as u32,
-    }
-}
-
-/// these values should reflect indexes in `token_types`
-#[repr(u32)]
-enum TokenTypeIndex {
-    Function = 1,
-    Parameter = 5,
-    String = 6,
-    Variable = 9,
-    Enum = 10,
-    Struct = 11,
-    Interface = 12,
 }
 
 //-------------------------------
@@ -184,12 +138,8 @@ pub(crate) fn type_index(ty: SemanticTokenType) -> u32 {
 }
 
 pub(crate) const SUPPORTED_TYPES: &[SemanticTokenType] = &[
-    //SemanticTokenType::COMMENT,
-    //SemanticTokenType::KEYWORD,
     SemanticTokenType::STRING,
     SemanticTokenType::NUMBER,
-    //SemanticTokenType::REGEXP,
-    //SemanticTokenType::OPERATOR,
     SemanticTokenType::NAMESPACE,
     SemanticTokenType::TYPE,
     SemanticTokenType::STRUCT,
@@ -201,7 +151,6 @@ pub(crate) const SUPPORTED_TYPES: &[SemanticTokenType] = &[
     SemanticTokenType::FUNCTION,
     SemanticTokenType::METHOD,
     SemanticTokenType::PROPERTY,
-    //SemanticTokenType::MACRO,
     SemanticTokenType::VARIABLE,
     SemanticTokenType::PARAMETER,
     SemanticTokenType::new("generic"),

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -116,7 +116,6 @@ pub(crate) fn semantic_tokens(tokens_sorted: &[(Span, Token)]) -> SemanticTokens
 fn semantic_token_type(kind: &SymbolKind) -> SemanticTokenType {
     match kind {
         SymbolKind::Field => SemanticTokenType::PROPERTY,
-        SymbolKind::TypeParam => SemanticTokenType::TYPE_PARAMETER,
         SymbolKind::ValueParam => SemanticTokenType::PARAMETER,
         SymbolKind::Variable => SemanticTokenType::VARIABLE,
         SymbolKind::Function => SemanticTokenType::FUNCTION,
@@ -129,6 +128,7 @@ fn semantic_token_type(kind: &SymbolKind) -> SemanticTokenType {
         SymbolKind::BoolLiteral => SemanticTokenType::new("boolean"),
         SymbolKind::ByteLiteral | SymbolKind::NumericLiteral => SemanticTokenType::NUMBER,
         SymbolKind::StringLiteral => SemanticTokenType::STRING,
+        SymbolKind::BuiltinType => SemanticTokenType::new("builtinType"),
         SymbolKind::Unknown => SemanticTokenType::new("generic"),
     }
 }
@@ -155,6 +155,7 @@ pub(crate) const SUPPORTED_TYPES: &[SemanticTokenType] = &[
     SemanticTokenType::PARAMETER,
     SemanticTokenType::new("generic"),
     SemanticTokenType::new("boolean"),
+    SemanticTokenType::new("builtinType"),
 ];
 
 pub(crate) const SUPPORTED_MODIFIERS: &[SemanticTokenModifier] = &[

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -187,7 +187,6 @@ impl Session {
                 Err(DocumentError::FailedToParse(diagnostics))
             }
             Some(parse_program) => {
-                eprintln!("{:#?}", &parse_program.root.tree.root_nodes);
                 for node in &parse_program.root.tree.root_nodes {
                     traverse_parse_tree::traverse_node(node, &self.token_map);
                 }

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -23,7 +23,7 @@ use sway_core::{CompileAstResult, CompileResult, ParseProgram, TypedProgram, Typ
 use sway_types::{Ident, Spanned};
 use tower_lsp::lsp_types::{
     CompletionItem, Diagnostic, GotoDefinitionParams, GotoDefinitionResponse, Location, Position,
-    Range, SemanticToken, SymbolInformation, TextDocumentContentChangeEvent, TextEdit, Url,
+    Range, SymbolInformation, TextDocumentContentChangeEvent, TextEdit, Url,
 };
 
 pub type Documents = DashMap<String, TextDocument>;

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -337,10 +337,10 @@ impl Session {
         ))
     }
 
-    pub fn semantic_tokens(&self, url: &Url) -> Option<Vec<SemanticToken>> {
-        let tokens = self.tokens_for_file(url);
-        Some(capabilities::semantic_tokens::to_semantic_tokens(&tokens))
-    }
+    // pub fn semantic_tokens(&self, url: &Url) -> Option<Vec<SemanticToken>> {
+    //     let tokens = self.tokens_for_file(url);
+    //     Some(capabilities::semantic_tokens::to_semantic_tokens(&tokens))
+    // }
 
     pub fn symbol_information(&self, url: &Url) -> Option<Vec<SymbolInformation>> {
         let tokens = self.tokens_for_file(url);

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -187,6 +187,7 @@ impl Session {
                 Err(DocumentError::FailedToParse(diagnostics))
             }
             Some(parse_program) => {
+                eprintln!("{:#?}", &parse_program.root.tree.root_nodes);
                 for node in &parse_program.root.tree.root_nodes {
                     traverse_parse_tree::traverse_node(node, &self.token_map);
                 }
@@ -336,11 +337,6 @@ impl Session {
             self.token_map(),
         ))
     }
-
-    // pub fn semantic_tokens(&self, url: &Url) -> Option<Vec<SemanticToken>> {
-    //     let tokens = self.tokens_for_file(url);
-    //     Some(capabilities::semantic_tokens::to_semantic_tokens(&tokens))
-    // }
 
     pub fn symbol_information(&self, url: &Url) -> Option<Vec<SymbolInformation>> {
         let tokens = self.tokens_for_file(url);

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -69,7 +69,6 @@ pub enum TypedAstToken {
 #[derive(Debug, Clone)]
 pub enum SymbolKind {
     Field,
-    TypeParam,
     ValueParam,
     Function,
     Method,
@@ -83,5 +82,6 @@ pub enum SymbolKind {
     StringLiteral,
     NumericLiteral,
     Variable,
+    BuiltinType,
     Unknown,
 }

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -7,7 +7,7 @@ use sway_core::{
     },
     type_system::TypeId,
     Declaration, EnumVariant, Expression, FunctionDeclaration, FunctionParameter,
-    ReassignmentExpression, StorageField, StructField, TraitFn,
+    ReassignmentExpression, StorageField, StructExpressionField, StructField, TraitFn,
 };
 use sway_types::{Ident, Span};
 
@@ -42,6 +42,7 @@ impl Token {
 pub enum AstToken {
     Declaration(Declaration),
     Expression(Expression),
+    StructExpressionField(StructExpressionField),
     FunctionDeclaration(FunctionDeclaration),
     FunctionParameter(FunctionParameter),
     StructField(StructField),

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -80,7 +80,6 @@ pub enum SymbolKind {
     Variant,
     BoolLiteral,
     ByteLiteral,
-    CharLiteral,
     StringLiteral,
     NumericLiteral,
     Variable,

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -83,5 +83,6 @@ pub enum SymbolKind {
     NumericLiteral,
     Variable,
     BuiltinType,
+    Module,
     Unknown,
 }

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -24,14 +24,16 @@ pub struct Token {
     pub parsed: AstToken,
     pub typed: Option<TypedAstToken>,
     pub type_def: Option<TypeDefinition>,
+    pub kind: SymbolKind,
 }
 
 impl Token {
-    pub fn from_parsed(token: AstToken) -> Self {
+    pub fn from_parsed(token: AstToken, kind: SymbolKind) -> Self {
         Self {
             parsed: token,
             typed: None,
             type_def: None,
+            kind,
         }
     }
 }
@@ -61,4 +63,25 @@ pub enum TypedAstToken {
     TypedStorageField(TypedStorageField),
     TypeCheckedStorageReassignDescriptor(TypeCheckedStorageReassignDescriptor),
     TypedReassignment(TypedReassignment),
+}
+
+#[derive(Debug, Clone)]
+pub enum SymbolKind {
+    Field,
+    TypeParam,
+    ValueParam,
+    Function,
+    Method,
+    Const,
+    Struct,
+    Trait,
+    Enum,
+    Variant,
+    BoolLiteral,
+    ByteLiteral,
+    CharLiteral,
+    StringLiteral,
+    NumericLiteral,
+    Variable,
+    Unknown,
 }

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -201,7 +201,7 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                 to_ident_key(&abi_decl.name),
                 Token::from_parsed(
                     AstToken::Declaration(declaration.clone()),
-                    SymbolKind::Unknown,
+                    SymbolKind::Trait,
                 ),
             );
             for trait_fn in &abi_decl.interface_surface {
@@ -283,7 +283,7 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                         to_ident_key(ident),
                         Token::from_parsed(
                             AstToken::Expression(expression.clone()),
-                            SymbolKind::Unknown,
+                            SymbolKind::Module,
                         ),
                     );
                 }
@@ -291,7 +291,7 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                     to_ident_key(&call_path_binding.inner.suffix),
                     Token::from_parsed(
                         AstToken::Expression(expression.clone()),
-                        SymbolKind::Unknown,
+                        SymbolKind::Function,
                     ),
                 );
             }
@@ -447,7 +447,7 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                     to_ident_key(&method_name_binding.inner.easy_name()),
                     Token::from_parsed(
                         AstToken::Expression(expression.clone()),
-                        SymbolKind::Unknown,
+                        SymbolKind::Struct,
                     ),
                 );
             }
@@ -486,17 +486,14 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
             for ident in &call_path_binding.inner.prefixes {
                 tokens.insert(
                     to_ident_key(ident),
-                    Token::from_parsed(
-                        AstToken::Expression(expression.clone()),
-                        SymbolKind::Unknown,
-                    ),
+                    Token::from_parsed(AstToken::Expression(expression.clone()), SymbolKind::Enum),
                 );
             }
             tokens.insert(
                 to_ident_key(&call_path_binding.inner.suffix),
                 Token::from_parsed(
                     AstToken::Expression(expression.clone()),
-                    SymbolKind::Unknown,
+                    SymbolKind::Variant,
                 ),
             );
 
@@ -511,16 +508,13 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                     to_ident_key(ident),
                     Token::from_parsed(
                         AstToken::Expression(expression.clone()),
-                        SymbolKind::Unknown,
+                        SymbolKind::Module,
                     ),
                 );
             }
             tokens.insert(
                 to_ident_key(&abi_name.suffix),
-                Token::from_parsed(
-                    AstToken::Expression(expression.clone()),
-                    SymbolKind::Unknown,
-                ),
+                Token::from_parsed(AstToken::Expression(expression.clone()), SymbolKind::Trait),
             );
             handle_expression(address, tokens);
         }

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -49,14 +49,19 @@ fn handle_function_declation(func: &FunctionDeclaration, tokens: &TokenMap) {
         collect_function_parameter(parameter, tokens);
     }
 
-    if let TypeInfo::Custom { name, .. } = &func.return_type {
-        tokens.insert(
-            to_ident_key(name),
-            Token::from_parsed(
-                AstToken::FunctionDeclaration(func.clone()),
-                SymbolKind::Struct,
-            ),
+    if let TypeInfo::Custom {
+        name,
+        type_arguments,
+    } = &func.return_type
+    {
+        let token = Token::from_parsed(
+            AstToken::FunctionDeclaration(func.clone()),
+            SymbolKind::Struct,
         );
+        tokens.insert(to_ident_key(name), token.clone());
+        if let Some(args) = type_arguments {
+            collect_type_args(args, &token, tokens);
+        }
     }
 }
 
@@ -169,14 +174,19 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
             }
         }
         Declaration::ImplSelf(impl_self) => {
-            if let TypeInfo::Custom { name, .. } = &impl_self.type_implementing_for {
-                tokens.insert(
-                    to_ident_key(name),
-                    Token::from_parsed(
-                        AstToken::Declaration(declaration.clone()),
-                        SymbolKind::Unknown,
-                    ),
+            if let TypeInfo::Custom {
+                name,
+                type_arguments,
+            } = &impl_self.type_implementing_for
+            {
+                let token = Token::from_parsed(
+                    AstToken::Declaration(declaration.clone()),
+                    SymbolKind::Unknown,
                 );
+                tokens.insert(to_ident_key(name), token.clone());
+                if let Some(args) = type_arguments {
+                    collect_type_args(args, &token, tokens);
+                }
             }
 
             for func_dec in &impl_self.functions {
@@ -201,11 +211,17 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                     collect_function_parameter(parameter, tokens);
                 }
 
-                if let TypeInfo::Custom { name, .. } = &trait_fn.return_type {
-                    tokens.insert(
-                        to_ident_key(name),
-                        Token::from_parsed(AstToken::TraitFn(trait_fn.clone()), SymbolKind::Struct),
-                    );
+                if let TypeInfo::Custom {
+                    name,
+                    type_arguments,
+                } = &trait_fn.return_type
+                {
+                    let token =
+                        Token::from_parsed(AstToken::TraitFn(trait_fn.clone()), SymbolKind::Struct);
+                    tokens.insert(to_ident_key(name), token.clone());
+                    if let Some(args) = type_arguments {
+                        collect_type_args(args, &token, tokens);
+                    }
                 }
             }
         }
@@ -327,14 +343,22 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                 );
             }
 
-            if let (TypeInfo::Custom { name, .. }, ..) = &call_path_binding.inner.suffix {
-                tokens.insert(
-                    to_ident_key(name),
-                    Token::from_parsed(
-                        AstToken::Expression(expression.clone()),
-                        SymbolKind::Struct,
-                    ),
+            if let (
+                TypeInfo::Custom {
+                    name,
+                    type_arguments,
+                },
+                ..,
+            ) = &call_path_binding.inner.suffix
+            {
+                let token = Token::from_parsed(
+                    AstToken::Expression(expression.clone()),
+                    SymbolKind::Struct,
                 );
+                tokens.insert(to_ident_key(name), token.clone());
+                if let Some(args) = type_arguments {
+                    collect_type_args(args, &token, tokens);
+                }
             }
 
             for field in fields {
@@ -395,14 +419,22 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                 call_path_binding, ..
             } = &method_name_binding.inner
             {
-                if let (TypeInfo::Custom { name, .. }, ..) = &call_path_binding.inner.suffix {
-                    tokens.insert(
-                        to_ident_key(name),
-                        Token::from_parsed(
-                            AstToken::Expression(expression.clone()),
-                            SymbolKind::Struct,
-                        ),
+                if let (
+                    TypeInfo::Custom {
+                        name,
+                        type_arguments,
+                    },
+                    ..,
+                ) = &call_path_binding.inner.suffix
+                {
+                    let token = Token::from_parsed(
+                        AstToken::Expression(expression.clone()),
+                        SymbolKind::Struct,
                     );
+                    tokens.insert(to_ident_key(name), token.clone());
+                    if let Some(args) = type_arguments {
+                        collect_type_args(args, &token, tokens);
+                    }
                 }
             }
 

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -159,7 +159,7 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                     to_ident_key(ident),
                     Token::from_parsed(
                         AstToken::Declaration(declaration.clone()),
-                        SymbolKind::Unknown,
+                        SymbolKind::Module,
                     ),
                 );
             }
@@ -168,7 +168,7 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                 to_ident_key(&impl_trait.trait_name.suffix),
                 Token::from_parsed(
                     AstToken::Declaration(declaration.clone()),
-                    SymbolKind::Unknown,
+                    SymbolKind::Trait,
                 ),
             );
 

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -367,8 +367,8 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                 tokens.insert(
                     to_ident_key(&field.name),
                     Token::from_parsed(
-                        AstToken::Expression(field.value.clone()),
-                        SymbolKind::Variable,
+                        AstToken::StructExpressionField(field.clone()),
+                        SymbolKind::Field,
                     ),
                 );
                 handle_expression(&field.value, tokens);

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -181,7 +181,7 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
             {
                 let token = Token::from_parsed(
                     AstToken::Declaration(declaration.clone()),
-                    SymbolKind::Unknown,
+                    SymbolKind::Struct,
                 );
                 tokens.insert(to_ident_key(name), token.clone());
                 if let Some(args) = type_arguments {

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -138,17 +138,31 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                 );
 
                 match &field.type_info {
-                    TypeInfo::UnsignedInteger(..)
-                    | TypeInfo::Boolean
+                    TypeInfo::UnsignedInteger(..) => {
+                        tokens.insert(
+                            to_ident_key(&Ident::new(field.type_span.clone())),
+                            Token::from_parsed(AstToken::StructField(field.clone()),
+                            SymbolKind::NumericLiteral),
+                        );
+                    }
+                    TypeInfo::Boolean => {
+                        tokens.insert(
+                            to_ident_key(&Ident::new(field.type_span.clone())),
+                            Token::from_parsed(AstToken::StructField(field.clone()),
+                            SymbolKind::BoolLiteral),
+                        );
+                    }
                     | TypeInfo::Byte
                     | TypeInfo::B256 => {
                         tokens.insert(
                             to_ident_key(&Ident::new(field.type_span.clone())),
-                            Token::from_parsed(AstToken::StructField(field.clone())),
+                            Token::from_parsed(AstToken::StructField(field.clone()),
+                            SymbolKind::ByteLiteral),
                         );
                     }
                     TypeInfo::Ref(type_id, span) => {
-                        let mut token = Token::from_parsed(AstToken::StructField(field.clone()));
+                        let mut token = Token::from_parsed(AstToken::StructField(field.clone()),
+                    SymbolKind::Unknown);
                         token.type_def = Some(TypeDefinition::TypeId(*type_id));
                         tokens.insert(to_ident_key(&Ident::new(span.clone())), token);
                     }
@@ -158,13 +172,16 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                     } => {
                         tokens.insert(
                             to_ident_key(name),
-                            Token::from_parsed(AstToken::StructField(field.clone())),
+                            Token::from_parsed(AstToken::StructField(field.clone()),
+                        SymbolKind::Struct),
                         );
 
                         if let Some(args) = type_arguments {
                             for arg in args {
+                                //TODO write a function that converts type_id to SymbolKind
                                 let mut token =
-                                    Token::from_parsed(AstToken::StructField(field.clone()));
+                                    Token::from_parsed(AstToken::StructField(field.clone()),
+                                    SymbolKind::Unknown);
                                 token.type_def = Some(TypeDefinition::TypeId(arg.type_id));
                                 tokens.insert(to_ident_key(&Ident::new(arg.span.clone())), token);
                             }
@@ -284,8 +301,10 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                 match &field.type_info {
                     TypeInfo::Tuple(args) => {
                         for arg in args {
+                            //TODO write a function that converts type_id to SymbolKind
                             let mut token =
-                                Token::from_parsed(AstToken::StorageField(field.clone()));
+                                Token::from_parsed(AstToken::StorageField(field.clone()),
+                            SymbolKind::Unknown);
                             token.type_def = Some(TypeDefinition::TypeId(arg.type_id));
                             tokens.insert(to_ident_key(&Ident::new(arg.span.clone())), token);
                         }
@@ -296,13 +315,16 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                     } => {
                         tokens.insert(
                             to_ident_key(name),
-                            Token::from_parsed(AstToken::StorageField(field.clone())),
+                            Token::from_parsed(AstToken::StorageField(field.clone()),
+                        SymbolKind::Struct),
                         );
 
                         if let Some(args) = type_arguments {
                             for arg in args {
+                                //TODO write a function that converts type_id to SymbolKind
                                 let mut token =
-                                    Token::from_parsed(AstToken::StorageField(field.clone()));
+                                    Token::from_parsed(AstToken::StorageField(field.clone()),
+                                    SymbolKind::Unknown);
                                 token.type_def = Some(TypeDefinition::TypeId(arg.type_id));
                                 tokens.insert(to_ident_key(&Ident::new(arg.span.clone())), token);
                             }

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -551,7 +551,10 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                     for ident in idents {
                         tokens.insert(
                             to_ident_key(ident),
-                            Token::from_parsed(AstToken::Reassignment(reassignment.clone()), SymbolKind::Field),
+                            Token::from_parsed(
+                                AstToken::Reassignment(reassignment.clone()),
+                                SymbolKind::Field,
+                            ),
                         );
                     }
                 }

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -88,7 +88,10 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                 if let Some(type_ascription_span) = &variable.type_ascription_span {
                     tokens.insert(
                         to_ident_key(&Ident::new(type_ascription_span.clone())),
-                        Token::from_parsed(AstToken::Declaration(declaration.clone())),
+                        Token::from_parsed(
+                            AstToken::Declaration(declaration.clone()),
+                            type_info_to_symbol_kind(&variable.type_ascription),
+                        ),
                     );
                 }
             }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -417,11 +417,11 @@ mod tests {
     }
 
     fn tmp_test_dir() -> PathBuf {
-        env::current_dir().unwrap().join("test_programs/enums")
+        env::current_dir().unwrap().join("test_programs/particle")
     }
 
     fn load_sway_example() -> (Url, String) {
-        let manifest_dir = e2e_test_dir();
+        let manifest_dir = tmp_test_dir();
         let src_path = manifest_dir.join("src/main.sw");
         let mut file = fs::File::open(&src_path).unwrap();
         let mut sway_program = String::new();
@@ -584,8 +584,8 @@ mod tests {
         assert_eq!(response, Ok(Some(err)));
     }
 
-    //#[tokio::test]
-    #[allow(dead_code)]
+    #[tokio::test]
+    //#[allow(dead_code)]
     async fn did_open() {
         let (mut service, mut messages) = LspService::new(|client| Backend::new(client, config()));
 

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -61,7 +61,6 @@ fn capabilities() -> ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Kind(
             TextDocumentSyncKind::INCREMENTAL,
         )),
-        // semantic_tokens_provider: capabilities::semantic_tokens::semantic_tokens(),
         semantic_tokens_provider: Some(
             SemanticTokensOptions {
                 legend: SemanticTokensLegend {
@@ -416,12 +415,8 @@ mod tests {
             .join("examples/storage_variables")
     }
 
-    fn tmp_test_dir() -> PathBuf {
-        env::current_dir().unwrap().join("test_programs/particle")
-    }
-
     fn load_sway_example() -> (Url, String) {
-        let manifest_dir = tmp_test_dir();
+        let manifest_dir = e2e_test_dir();
         let src_path = manifest_dir.join("src/main.sw");
         let mut file = fs::File::open(&src_path).unwrap();
         let mut sway_program = String::new();
@@ -584,8 +579,8 @@ mod tests {
         assert_eq!(response, Ok(Some(err)));
     }
 
-    #[tokio::test]
-    //#[allow(dead_code)]
+    //#[tokio::test]
+    #[allow(dead_code)]
     async fn did_open() {
         let (mut service, mut messages) = LspService::new(|client| Backend::new(client, config()));
 

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -61,7 +61,19 @@ fn capabilities() -> ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Kind(
             TextDocumentSyncKind::INCREMENTAL,
         )),
-        semantic_tokens_provider: capabilities::semantic_tokens::semantic_tokens(),
+        // semantic_tokens_provider: capabilities::semantic_tokens::semantic_tokens(),
+        semantic_tokens_provider: Some(
+            SemanticTokensOptions {
+                legend: SemanticTokensLegend {
+                    token_types: capabilities::semantic_tokens::SUPPORTED_TYPES.to_vec(),
+                    token_modifiers: capabilities::semantic_tokens::SUPPORTED_MODIFIERS.to_vec(),
+                },
+                full: Some(SemanticTokensFullOptions::Bool(true)),
+                range: None,
+                ..Default::default()
+            }
+            .into(),
+        ),
         document_symbol_provider: Some(OneOf::Left(true)),
         completion_provider: Some(CompletionOptions {
             resolve_provider: Some(false),
@@ -402,6 +414,10 @@ mod tests {
             .parent()
             .unwrap()
             .join("examples/storage_variables")
+    }
+
+    fn tmp_test_dir() -> PathBuf {
+        env::current_dir().unwrap().join("test_programs/enums")
     }
 
     fn load_sway_example() -> (Url, String) {

--- a/sway-lsp/src/utils/token.rs
+++ b/sway-lsp/src/utils/token.rs
@@ -1,4 +1,4 @@
-use crate::core::token::{AstToken, Token, TokenMap, TypedAstToken};
+use crate::core::token::{AstToken, SymbolKind, Token, TokenMap, TypedAstToken};
 use sway_core::semantic_analysis::ast_node::{
     declaration::TypedStructDeclaration, TypedDeclaration,
 };
@@ -75,6 +75,26 @@ pub(crate) fn ident_of_type_id(type_id: &TypeId) -> Option<Ident> {
         | TypeInfo::Struct { name, .. }
         | TypeInfo::Custom { name, .. } => Some(name),
         _ => None,
+    }
+}
+
+pub(crate) fn type_info_to_symbol_kind(type_info: &TypeInfo) -> SymbolKind {
+    match type_info {
+        TypeInfo::UnsignedInteger(..) | TypeInfo::Numeric => SymbolKind::NumericLiteral,
+        TypeInfo::Boolean => SymbolKind::BoolLiteral,
+        TypeInfo::Byte | TypeInfo::B256 => SymbolKind::ByteLiteral,
+        TypeInfo::Str(..) => SymbolKind::StringLiteral,
+        TypeInfo::Custom { .. } | TypeInfo::Struct { .. } => SymbolKind::Struct,
+        TypeInfo::Enum { .. } => SymbolKind::Enum,
+        TypeInfo::Ref(type_id, ..) => {
+            let type_info = sway_core::type_system::look_up_type_id(*type_id);
+            type_info_to_symbol_kind(&type_info)
+        }
+        TypeInfo::Array(type_id, ..) => {
+            let type_info = sway_core::type_system::look_up_type_id(*type_id);
+            type_info_to_symbol_kind(&type_info)
+        }
+        _ => SymbolKind::Unknown,
     }
 }
 

--- a/sway-lsp/src/utils/token.rs
+++ b/sway-lsp/src/utils/token.rs
@@ -80,10 +80,12 @@ pub(crate) fn ident_of_type_id(type_id: &TypeId) -> Option<Ident> {
 
 pub(crate) fn type_info_to_symbol_kind(type_info: &TypeInfo) -> SymbolKind {
     match type_info {
-        TypeInfo::UnsignedInteger(..) | TypeInfo::Numeric => SymbolKind::NumericLiteral,
-        TypeInfo::Boolean => SymbolKind::BoolLiteral,
-        TypeInfo::Byte | TypeInfo::B256 => SymbolKind::ByteLiteral,
-        TypeInfo::Str(..) => SymbolKind::StringLiteral,
+        TypeInfo::UnsignedInteger(..)
+        | TypeInfo::Boolean
+        | TypeInfo::Str(..)
+        | TypeInfo::B256
+        | TypeInfo::Byte => SymbolKind::BuiltinType,
+        TypeInfo::Numeric => SymbolKind::NumericLiteral,
         TypeInfo::Custom { .. } | TypeInfo::Struct { .. } => SymbolKind::Struct,
         TypeInfo::Enum { .. } => SymbolKind::Enum,
         TypeInfo::Ref(type_id, ..) => {


### PR DESCRIPTION
This PR introduces a new SymbolKind enum which is stored in the `Token` type. We are populating the kind of each token during the parse-tree traversal stage. This makes it a lot cleaner when going from our Token type to the various `lsp_types` enums such as `CompletionItemKind`, `SemanticTokenType` etc..

We are now providing accurate semantic token information to the client which is resulting in much nicer syntax highlighting for sway files. 
