### PR TITLE
Provide LSP extension for printing the parsed or typed AST in VS Code

### DIFF
--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -16,10 +16,8 @@ use dashmap::DashMap;
 use forc_pkg::{self as pkg};
 use serde_json::Value;
 use std::{
-    fs::File,
-    io::Write,
     path::PathBuf,
-    sync::{Arc, LockResult, RwLock}, fmt::write,
+    sync::{Arc, LockResult, RwLock},
 };
 use sway_core::{CompileAstResult, CompileResult, ParseProgram, TypedProgram, TypedProgramKind};
 use sway_types::{Ident, Spanned};

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -224,9 +224,6 @@ impl Session {
             } => {
                 if let TypedProgramKind::Script {
                     ref main_function, ..
-                }
-                | TypedProgramKind::Predicate {
-                    ref main_function, ..
                 } = typed_program.kind
                 {
                     let main_fn_location =

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -210,6 +210,9 @@ impl Session {
                 typed_program,
                 warnings,
             } => {
+                let typed_ast = format!("{:#?}", typed_program.root.all_nodes);
+                // println!("{}", typed_ast);
+
                 if let TypedProgramKind::Script {
                     ref main_function, ..
                 }

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -14,7 +14,7 @@ pub async fn start(config: DebugFlags) {
 
     let (service, socket) = LspService::build(|client| Backend::new(client, config))
         .custom_method("sway/runnables", Backend::runnables)
-        .custom_method("sway/show_typed_ast", Backend::show_typed_ast)
+        .custom_method("sway/show_ast", Backend::show_ast)
         .finish();
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -14,6 +14,7 @@ pub async fn start(config: DebugFlags) {
 
     let (service, socket) = LspService::build(|client| Backend::new(client, config))
         .custom_method("sway/runnables", Backend::runnables)
+        .custom_method("sway/show_typed_ast", Backend::show_typed_ast)
         .finish();
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -354,7 +354,7 @@ impl Backend {
                             _ => Ok(None),
                         }
                     }
-                    _ => unreachable!(),
+                    _ => Ok(None),
                 }
             }
             _ => Ok(None),
@@ -697,8 +697,6 @@ mod tests {
         messages.next().await.unwrap();
 
         let (uri, sway_program) = load_sway_example();
-
-        // let uri = Url::from_file_path("/Users/joshuabatty/Documents/rust/fuel/sway/examples/enums/src/enum_of_structs.sw").unwrap();
 
         // send "textDocument/didOpen" notification for `uri`
         did_open_notification(&mut service, &uri, &sway_program).await;

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -401,11 +401,11 @@ mod tests {
             .unwrap()
             .parent()
             .unwrap()
-            .join("examples/enums")
+            .join("examples/storage_variables")
     }
 
     fn load_sway_example() -> (Url, String) {
-        let manifest_dir = sway_example_dir();
+        let manifest_dir = e2e_test_dir();
         let src_path = manifest_dir.join("src/main.sw");
         let mut file = fs::File::open(&src_path).unwrap();
         let mut sway_program = String::new();
@@ -568,7 +568,7 @@ mod tests {
         assert_eq!(response, Ok(Some(err)));
     }
 
-    #[tokio::test]
+    //#[tokio::test]
     #[allow(dead_code)]
     async fn did_open() {
         let (mut service, mut messages) = LspService::new(|client| Backend::new(client, config()));


### PR DESCRIPTION
This provides a custom LSP extension method that the client can call when either a "show parsed ast" or a "show typed ast" command is executed from the command palette. 

For example, in VS Code if you executed a "show typed ast" command while working on a sway file, a second window will open up containing the formatted `TypedProgram` of the current file. 

Once #2487 happens we can update the VS Code plugin with options for pretty printing and verbosity levels etc.. 