### PR TITLE
Fixing the defaults for `forc new`

### DIFF
--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -101,7 +101,11 @@ abigen!(MyContract, "out/debug/"#,
 async fn get_contract_instance() -> (MyContract, ContractId) {
     // Launch a local network and deploy the contract
     let mut wallets = launch_custom_provider_and_get_wallets(
-        WalletsConfig::new(Some(1), Some(1000000), Some(1_000_000)),
+        WalletsConfig::new(
+            Some(1),             /* Single wallet */
+            Some(1),             /* Single coin (UTXO) */
+            Some(1_000_000_000), /* Amount per coin */
+        ),
         None,
     )
     .await;


### PR DESCRIPTION
Closes #2567

- Changing the number of coins to 1 so that the test doesn't hang while trying to create 1_000_000 coins.
- Adding comments to make it clear what `WalletsConfig` is doing.