### PR TITLE
Bump to `v0.20.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "forc-client"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "forc-explore"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "forc-fmt"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "forc-fmt-v2"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "forc-lsp"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "forc-pkg"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "forc-util",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "forc-util"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ast"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "extension-trait",
  "num-bigint",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "sway-core"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "clap 3.2.17",
  "derivative",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "sway-fmt"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "ropey",
  "sway-core",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "sway-fmt-v2"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "forc-util",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "filecheck",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "sway-lsp"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "sway-parse"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "assert_matches",
  "extension-trait",
@@ -3718,7 +3718,7 @@ dependencies = [
 
 [[package]]
 name = "sway-types"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "fuel-asm 0.6.0",
  "fuel-crypto",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "sway-utils"
-version = "0.20.1"
+version = "0.20.2"
 
 [[package]]
 name = "syn"

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-pkg"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,7 +10,7 @@ description = "Building, locking, fetching and updating Sway projects as Forc pa
 
 [dependencies]
 anyhow = "1"
-forc-util = { version = "0.20.1", path = "../forc-util" }
+forc-util = { version = "0.20.2", path = "../forc-util" }
 fuel-crypto = "0.5"
 fuel-tx = "0.13"
 git2 = { version = "0.14", features = ["vendored-libgit2", "vendored-openssl"] }
@@ -19,9 +19,9 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
 serde_json = "1.0"
-sway-core = { version = "0.20.1", path = "../sway-core" }
-sway-types = { version = "0.20.1", path = "../sway-types" }
-sway-utils = { version = "0.20.1", path = "../sway-utils" }
+sway-core = { version = "0.20.2", path = "../sway-core" }
+sway-types = { version = "0.20.2", path = "../sway-types" }
+sway-utils = { version = "0.20.2", path = "../sway-utils" }
 toml = "0.5"
 tracing = "0.1"
 url = { version = "2.2", features = ["serde"] }

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-client"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,8 +11,8 @@ description = "A `forc` plugin for interacting with a Fuel node."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive", "env"] }
-forc-pkg = { version = "0.20.1", path = "../../forc-pkg" }
-forc-util = { version = "0.20.1", path = "../../forc-util" }
+forc-pkg = { version = "0.20.2", path = "../../forc-pkg" }
+forc-util = { version = "0.20.2", path = "../../forc-util" }
 fuel-gql-client = { version = "0.9", default-features = false }
 fuel-tx = "0.13"
 fuel-vm = "0.12"
@@ -20,9 +20,9 @@ futures = "0.3"
 hex = "0.4.3"
 serde = { version = "1.0" }
 serde_json = "1.0.73"
-sway-core = { version = "0.20.1", path = "../../sway-core" }
-sway-types = { version = "0.20.1", path = "../../sway-types" }
-sway-utils = { version = "0.20.1", path = "../../sway-utils" }
+sway-core = { version = "0.20.2", path = "../../sway-core" }
+sway-types = { version = "0.20.2", path = "../../sway-types" }
+sway-utils = { version = "0.20.2", path = "../../sway-utils" }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "process"] }
 tracing = "0.1"
 

--- a/forc-plugins/forc-explore/Cargo.toml
+++ b/forc-plugins/forc-explore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-explore"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,7 +11,7 @@ description = "A `forc` plugin for running the fuel block explorer."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-forc-util = { version = "0.20.1", path = "../../forc-util" }
+forc-util = { version = "0.20.2", path = "../../forc-util" }
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 tar = "0.4"

--- a/forc-plugins/forc-fmt-v2/Cargo.toml
+++ b/forc-plugins/forc-fmt-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-fmt-v2"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,10 +12,10 @@ description = "A `forc` plugin for running the Sway code formatter."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-forc-util = { version = "0.20.1", path = "../../forc-util" }
+forc-util = { version = "0.20.2", path = "../../forc-util" }
 prettydiff = "0.5"
-sway-core = { version = "0.20.1", path = "../../sway-core" }
-sway-fmt-v2 = { version = "0.20.1", path = "../../sway-fmt-v2" }
-sway-utils = { version = "0.20.1", path = "../../sway-utils" }
+sway-core = { version = "0.20.2", path = "../../sway-core" }
+sway-fmt-v2 = { version = "0.20.2", path = "../../sway-fmt-v2" }
+sway-utils = { version = "0.20.2", path = "../../sway-utils" }
 taplo = "0.7"
 tracing = "0.1"

--- a/forc-plugins/forc-fmt/Cargo.toml
+++ b/forc-plugins/forc-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-fmt"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,10 +11,10 @@ description = "A `forc` plugin for running the Sway code formatter."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-forc-util = { version = "0.20.1", path = "../../forc-util" }
+forc-util = { version = "0.20.2", path = "../../forc-util" }
 prettydiff = "0.5"
-sway-core = { version = "0.20.1", path = "../../sway-core" }
-sway-fmt = { version = "0.20.1", path = "../../sway-fmt" }
-sway-utils = { version = "0.20.1", path = "../../sway-utils" }
+sway-core = { version = "0.20.2", path = "../../sway-core" }
+sway-fmt = { version = "0.20.2", path = "../../sway-fmt" }
+sway-utils = { version = "0.20.2", path = "../../sway-utils" }
 taplo = "0.7"
 tracing = "0.1"

--- a/forc-plugins/forc-lsp/Cargo.toml
+++ b/forc-plugins/forc-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-lsp"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,5 +11,5 @@ description = "A simple `forc` plugin for starting the sway language server."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-sway-lsp = { version = "0.20.1", path = "../../sway-lsp" }
+sway-lsp = { version = "0.20.2", path = "../../sway-lsp" }
 tokio = { version = "1.8" }

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-util"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,9 +12,9 @@ description = "Utility items shared between forc crates."
 annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1"
 dirs = "3.0.2"
-sway-core = { version = "0.20.1", path = "../sway-core" }
-sway-types = { version = "0.20.1", path = "../sway-types" }
-sway-utils = { version = "0.20.1", path = "../sway-utils" }
+sway-core = { version = "0.20.2", path = "../sway-core" }
+sway-types = { version = "0.20.2", path = "../sway-types" }
+sway-utils = { version = "0.20.2", path = "../sway-utils" }
 termcolor = "1.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -21,16 +21,16 @@ annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1.0.41"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 clap_complete = "3.1"
-forc-pkg = { version = "0.20.1", path = "../forc-pkg" }
-forc-util = { version = "0.20.1", path = "../forc-util" }
+forc-pkg = { version = "0.20.2", path = "../forc-pkg" }
+forc-util = { version = "0.20.2", path = "../forc-util" }
 fs_extra = "1.2"
 fuel-asm = "0.6"
 hex = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.73"
-sway-core = { version = "0.20.1", path = "../sway-core" }
-sway-types = { version = "0.20.1", path = "../sway-types" }
-sway-utils = { version = "0.20.1", path = "../sway-utils" }
+sway-core = { version = "0.20.2", path = "../sway-core" }
+sway-types = { version = "0.20.2", path = "../sway-types" }
+sway-utils = { version = "0.20.2", path = "../sway-utils" }
 term-table = "1.3"
 tokio = { version = "1.8.0", features = ["macros", "rt-multi-thread"] }
 toml = "0.5"

--- a/sway-ast/Cargo.toml
+++ b/sway-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ast"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,4 +12,4 @@ description = "Sway's parser"
 extension-trait = "1.0.1"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
-sway-types = { version = "0.20.1", path = "../sway-types" }
+sway-types = { version = "0.20.2", path = "../sway-types" }

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-core"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -27,11 +27,11 @@ prettydiff = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.9"
 smallvec = "1.7"
-sway-ast = { version = "0.20.1", path = "../sway-ast" }
-sway-ir = { version = "0.20.1", path = "../sway-ir" }
-sway-parse = { version = "0.20.1", path = "../sway-parse" }
-sway-types = { version = "0.20.1", path = "../sway-types" }
-sway-utils = { version = "0.20.1", path = "../sway-utils" }
+sway-ast = { version = "0.20.2", path = "../sway-ast" }
+sway-ir = { version = "0.20.2", path = "../sway-ir" }
+sway-parse = { version = "0.20.2", path = "../sway-parse" }
+sway-types = { version = "0.20.2", path = "../sway-types" }
+sway-utils = { version = "0.20.2", path = "../sway-utils" }
 thiserror = "1.0"
 tracing = "0.1"
 uint = "0.9"

--- a/sway-fmt-v2/Cargo.toml
+++ b/sway-fmt-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-fmt-v2"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,14 +11,14 @@ description = "Sway sway-fmt-v2."
 
 [dependencies]
 anyhow = "1"
-forc-util = { version = "0.20.1", path = "../forc-util" }
+forc-util = { version = "0.20.2", path = "../forc-util" }
 ropey = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
-sway-ast = { version = "0.20.1", path = "../sway-ast" }
-sway-core = { version = "0.20.1", path = "../sway-core" }
-sway-parse = { version = "0.20.1", path = "../sway-parse" }
-sway-types = { version = "0.20.1", path = "../sway-types" }
+sway-ast = { version = "0.20.2", path = "../sway-ast" }
+sway-core = { version = "0.20.2", path = "../sway-core" }
+sway-parse = { version = "0.20.2", path = "../sway-parse" }
+sway-types = { version = "0.20.2", path = "../sway-types" }
 thiserror = "1.0.30"
 toml = "0.5"
 

--- a/sway-fmt/Cargo.toml
+++ b/sway-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-fmt"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,6 +10,6 @@ description = "Sway sway-fmt."
 
 [dependencies]
 ropey = "1.2"
-sway-core = { version = "0.20.1", path = "../sway-core" }
-sway-types = { version = "0.20.1", path = "../sway-types" }
+sway-core = { version = "0.20.2", path = "../sway-core" }
+sway-types = { version = "0.20.2", path = "../sway-types" }
 

--- a/sway-ir/Cargo.toml
+++ b/sway-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ir"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -13,4 +13,4 @@ anyhow = "1.0"
 filecheck = "0.5"
 generational-arena = "0.2"
 peg = "0.7"
-sway-types = { version = "0.20.1", path = "../sway-types" }
+sway-types = { version = "0.20.2", path = "../sway-types" }

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-lsp"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,15 +10,15 @@ description = "LSP server for Sway."
 
 [dependencies]
 dashmap = "5.3.4"
-forc-pkg = { version = "0.20.1", path = "../forc-pkg" }
-forc-util = { version = "0.20.1", path = "../forc-util" }
+forc-pkg = { version = "0.20.2", path = "../forc-pkg" }
+forc-util = { version = "0.20.2", path = "../forc-util" }
 ropey = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.60"
-sway-core = { version = "0.20.1", path = "../sway-core" }
-sway-fmt = { version = "0.20.1", path = "../sway-fmt" }
-sway-types = { version = "0.20.1", path = "../sway-types" }
-sway-utils = { version = "0.20.1", path = "../sway-utils" }
+sway-core = { version = "0.20.2", path = "../sway-core" }
+sway-fmt = { version = "0.20.2", path = "../sway-fmt" }
+sway-types = { version = "0.20.2", path = "../sway-types" }
+sway-utils = { version = "0.20.2", path = "../sway-utils" }
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tower-lsp = "0.17"
 tracing = "0.1"

--- a/sway-parse/Cargo.toml
+++ b/sway-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-parse"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -13,8 +13,8 @@ extension-trait = "1.0.1"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 phf = { version = "0.10.1", features = ["macros"] }
-sway-ast = { version = "0.20.1", path = "../sway-ast" }
-sway-types = { version = "0.20.1", path = "../sway-types" }
+sway-ast = { version = "0.20.2", path = "../sway-ast" }
+sway-types = { version = "0.20.2", path = "../sway-types" }
 thiserror = "1.0"
 unicode-xid = "0.2.2"
 

--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-types"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/sway-utils/Cargo.toml
+++ b/sway-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-utils"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
Waiting on 
- [x] https://github.com/FuelLabs/sway/pull/2582

Assets for `v0.20.1` failed to generate unfortunately and the PR above fixes that. Trying again with `v0.20.2`.