### PR TITLE
feat: check for dependency program type in dependency manifest validation

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -479,15 +479,12 @@ fn validate_dep(
 }
 /// Part of dependency validation, any checks related to the depenency's manifest content.
 fn validate_dep_manifest(dep: &Pinned, dep_manifest: &ManifestFile) -> Result<()> {
-    // Check that the dependency is a library.
-    match dep_manifest.program_type()? {
-        TreeType::Library { .. } => {}
-        _ => {
-            bail!(
-                "\"{}\" is not a library! Depending on a non-library package is not supported.",
-                dep.name
-            );
-        }
+    // Ensure that the dependency is a library.
+    if !matches!(dep_manifest.program_type()?, TreeType::Library { .. }) {
+        bail!(
+            "\"{}\" is not a library! Depending on a non-library packages is not supported.",
+            dep.name
+        );
     }
 
     // Ensure the name matches the manifest project name.

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -479,6 +479,17 @@ fn validate_dep(
 }
 /// Part of dependency validation, any checks related to the depenency's manifest content.
 fn validate_dep_manifest(dep: &Pinned, dep_manifest: &ManifestFile) -> Result<()> {
+    // Check that the dependency is a library.
+    match dep_manifest.program_type()? {
+        TreeType::Library { .. } => {}
+        _ => {
+            bail!(
+                "\"{}\" is not a library! Depending on a non-library package is not supported.",
+                dep.name
+            );
+        }
+    }
+
     // Ensure the name matches the manifest project name.
     if dep.name != dep_manifest.project.name {
         bail!(

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -482,7 +482,7 @@ fn validate_dep_manifest(dep: &Pinned, dep_manifest: &ManifestFile) -> Result<()
     // Ensure that the dependency is a library.
     if !matches!(dep_manifest.program_type()?, TreeType::Library { .. }) {
         bail!(
-            "\"{}\" is not a library! Depending on a non-library packages is not supported.",
+            "\"{}\" is not a library! Depending on a non-library package is not supported.",
             dep.name
         );
     }


### PR DESCRIPTION
closes #1681.

This has happened couple of times and I think we should be providing a descriptive error. I believe packages should only depend on libraries but please correct me if I am wrong cc @mitchmindtree.


~Leaving this as a draft because I want to tweak something a little.~