### PR TITLE
Fix IR gen for explicit return of structs.

### DIFF
--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -618,7 +618,7 @@ impl FnCompiler {
         }
 
         let ret_value = self.compile_expression(context, md_mgr, ast_expr.clone())?;
-        match ret_value.get_type(context) {
+        match ret_value.get_stripped_ptr_type(context) {
             None => Err(CompileError::Internal(
                 "Unable to determine type for return statement expression.",
                 ast_expr.span,

--- a/test/src/ir_generation/tests/return_stmt_structs.sw
+++ b/test/src/ir_generation/tests/return_stmt_structs.sw
@@ -1,0 +1,30 @@
+script;
+
+pub struct MyStruct {
+    value: u64,
+}
+
+fn fn_implicit_ret_struct() -> MyStruct {
+    let s = MyStruct {
+        value: 0,
+    };
+    s
+}
+
+fn fn_explicit_ret_struct() -> MyStruct {
+    let s = MyStruct {
+        value: 0,
+    };
+    return s;
+}
+
+fn main() {
+    fn_implicit_ret_struct();
+    fn_explicit_ret_struct();
+}
+
+// check: fn fn_implicit_ret_struct_0() -> { u64 }
+// check: ret { u64 } $VAL
+
+// check: fn fn_explicit_ret_struct_1() -> { u64 }
+// check: ret { u64 } $VAL


### PR DESCRIPTION
This fixes IR gen for return statement.

After https://github.com/FuelLabs/sway/pull/2363, we were getting unexpected pointer return types, due to the return statement IR gen code looking at the type of the `get_ptr` instruction to figure out its own return type.

Fix this by stripping the pointer type before building the return statement type.

The following code now compiles again:

```
fn fn_explicit_ret_struct() -> MyStruct {
    let s = MyStruct {
        value: 0,
    };
    return s;
}
```

Closes https://github.com/FuelLabs/sway/issues/2600.