### PR TITLE
Add missing `gtf` support to compiler

### DIFF
--- a/sway-ast/src/expr/op_code.rs
+++ b/sway-ast/src/expr/op_code.rs
@@ -155,6 +155,12 @@ define_op_codes!(
     (Exp, ExpOpcode, "exp", (ret: reg, base: reg, power: reg)),
     (Expi, ExpiOpcode, "expi", (ret: reg, base: reg, power: imm)),
     (Gt, GtOpcode, "gt", (ret: reg, lhs: reg, rhs: reg)),
+    (
+        Gtf,
+        GtfOpcode,
+        "gtf",
+        (ret: reg, index: reg, tx_field_id: imm)
+    ),
     (Lt, LtOpcode, "lt", (ret: reg, lhs: reg, rhs: reg)),
     (Mlog, MlogOpcode, "mlog", (ret: reg, arg: reg, base: reg)),
     (Mod, ModOpcode, "mod", (ret: reg, lhs: reg, rhs: reg)),

--- a/sway-core/src/asm_lang/mod.rs
+++ b/sway-core/src/asm_lang/mod.rs
@@ -1347,7 +1347,7 @@ impl fmt::Display for Op {
                 EXP(a, b, c) => format!("exp {} {} {}", a, b, c),
                 EXPI(a, b, c) => format!("expi {} {} {}", a, b, c),
                 GT(a, b, c) => format!("gt {} {} {}", a, b, c),
-                GTF(a, b, c) => format!("gt {} {} {}", a, b, c),
+                GTF(a, b, c) => format!("gtf {} {} {}", a, b, c),
                 LT(a, b, c) => format!("lt {} {} {}", a, b, c),
                 MLOG(a, b, c) => format!("mlog {} {} {}", a, b, c),
                 MROO(a, b, c) => format!("mroo {} {} {}", a, b, c),

--- a/sway-parse/src/expr/op_code.rs
+++ b/sway-parse/src/expr/op_code.rs
@@ -33,6 +33,7 @@ define_op_codes!(
     (Exp, ExpOpcode, "exp", (ret, base, power)),
     (Expi, ExpiOpcode, "expi", (ret, base, power)),
     (Gt, GtOpcode, "gt", (ret, lhs, rhs)),
+    (Gtf, GtfOpcode, "gtf", (ret, index, tx_field_id)),
     (Lt, LtOpcode, "lt", (ret, lhs, rhs)),
     (Mlog, MlogOpcode, "mlog", (ret, arg, base)),
     (Mod, ModOpcode, "mod", (ret, lhs, rhs)),


### PR DESCRIPTION
Adds support for the `gtf` opcode in 2 files where it was previously missing, and fixes a typo in a third file.
I tested this with a new `forc` build generated from my local patched branch and it worked.