### PR TITLE
Make `ConcurrentSlab` more general.

### DIFF
--- a/sway-core/src/type_system/type_engine.rs
+++ b/sway-core/src/type_system/type_engine.rs
@@ -11,8 +11,8 @@ lazy_static! {
 
 #[derive(Debug, Default)]
 pub(crate) struct TypeEngine {
-    slab: ConcurrentSlab<TypeInfo>,
-    storage_only_types: ConcurrentSlab<TypeInfo>,
+    slab: ConcurrentSlab<TypeId, TypeInfo>,
+    storage_only_types: ConcurrentSlab<TypeId, TypeInfo>,
 }
 
 impl TypeEngine {

--- a/sway-core/src/type_system/type_id.rs
+++ b/sway-core/src/type_system/type_id.rs
@@ -6,7 +6,7 @@ use crate::types::*;
 use super::*;
 
 /// A identifier to uniquely refer to our type terms
-#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, Clone, Copy, Default)]
 pub struct TypeId(usize);
 
 impl std::ops::Deref for TypeId {


### PR DESCRIPTION
PR to make `ConcurrentSlab` more general so that it can be used in other situations.