### PR TITLE
Collect missing tokens in the language server

### DIFF
--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -797,7 +797,7 @@ pub(crate) fn item_const_to_constant_declaration(
             let type_ascription_span = if let Ty::Path(path_type) = &ty {
                 path_type.prefix.name.span()
             } else {
-                ty.span().clone()
+                ty.span()
             };
             (type_ascription, Some(type_ascription_span))
         }
@@ -1998,7 +1998,7 @@ fn storage_field_to_storage_field(
     let type_info_span = if let Ty::Path(path_type) = &storage_field.ty {
         path_type.prefix.name.span()
     } else {
-        storage_field.ty.span().clone()
+        storage_field.ty.span()
     };
     let storage_field = StorageField {
         name: storage_field.name,

--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -2770,7 +2770,7 @@ fn statement_let_to_ast_nodes(
                 let error = ConvertParseTreeError::ConstructorPatternsNotSupportedHere { span };
                 return Err(ec.error(error));
             }
-            Pattern::Struct { fields, .. } => {
+            Pattern::Struct { path, fields, .. } => {
                 let mut ast_nodes = Vec::new();
 
                 // Generate a deterministic name for the destructured struct
@@ -2784,7 +2784,7 @@ fn statement_let_to_ast_nodes(
                 COUNTER.fetch_add(1, Ordering::SeqCst);
                 let destructure_name = Ident::new_with_override(
                     Box::leak(destructured_name.into_boxed_str()),
-                    span.clone(),
+                    path.prefix.name.span(),
                 );
 
                 // Parse the type ascription and the type ascription span.

--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -1995,9 +1995,15 @@ fn storage_field_to_storage_field(
     ec: &mut ErrorContext,
     storage_field: sway_ast::StorageField,
 ) -> Result<StorageField, ErrorEmitted> {
+    let type_info_span = if let Ty::Path(path_type) = &storage_field.ty {
+        path_type.prefix.name.span()
+    } else {
+        storage_field.ty.span().clone()
+    };
     let storage_field = StorageField {
         name: storage_field.name,
         type_info: ty_to_type_info(ec, storage_field.ty)?,
+        type_info_span,
         initializer: expr_to_expression(ec, storage_field.initializer)?,
     };
     Ok(storage_field)

--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -930,9 +930,16 @@ fn type_field_to_enum_variant(
     tag: usize,
 ) -> Result<EnumVariant, ErrorEmitted> {
     let span = type_field.span();
+    let type_span = if let Ty::Path(path_type) = &type_field.ty {
+        path_type.prefix.name.span()
+    } else {
+        span.clone()
+    };
+
     let enum_variant = EnumVariant {
         name: type_field.name,
         type_info: ty_to_type_info(ec, type_field.ty)?,
+        type_span,
         tag,
         span,
     };

--- a/sway-core/src/parse_tree/declaration/constant.rs
+++ b/sway-core/src/parse_tree/declaration/constant.rs
@@ -3,12 +3,13 @@ use crate::{
     type_system::TypeInfo,
 };
 
-use sway_types::ident::Ident;
+use sway_types::{Ident, Span};
 
 #[derive(Debug, Clone)]
 pub struct ConstantDeclaration {
     pub name: Ident,
     pub type_ascription: TypeInfo,
+    pub type_ascription_span: Option<Span>,
     pub value: Expression,
     pub visibility: Visibility,
 }

--- a/sway-core/src/parse_tree/declaration/enum.rs
+++ b/sway-core/src/parse_tree/declaration/enum.rs
@@ -5,7 +5,7 @@ use sway_types::{ident::Ident, span::Span};
 #[derive(Debug, Clone)]
 pub struct EnumDeclaration {
     pub name: Ident,
-    pub(crate) type_parameters: Vec<TypeParameter>,
+    pub type_parameters: Vec<TypeParameter>,
     pub variants: Vec<EnumVariant>,
     pub(crate) span: Span,
     pub visibility: Visibility,

--- a/sway-core/src/parse_tree/declaration/enum.rs
+++ b/sway-core/src/parse_tree/declaration/enum.rs
@@ -14,7 +14,8 @@ pub struct EnumDeclaration {
 #[derive(Debug, Clone)]
 pub struct EnumVariant {
     pub name: Ident,
-    pub(crate) type_info: TypeInfo,
+    pub type_info: TypeInfo,
+    pub type_span: Span,
     pub(crate) tag: usize,
     pub(crate) span: Span,
 }

--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -15,7 +15,7 @@ pub struct FunctionDeclaration {
     pub span: Span,
     pub return_type: TypeInfo,
     pub(crate) type_parameters: Vec<TypeParameter>,
-    pub(crate) return_type_span: Span,
+    pub return_type_span: Span,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/sway-core/src/parse_tree/declaration/function.rs
+++ b/sway-core/src/parse_tree/declaration/function.rs
@@ -14,7 +14,7 @@ pub struct FunctionDeclaration {
     pub parameters: Vec<FunctionParameter>,
     pub span: Span,
     pub return_type: TypeInfo,
-    pub(crate) type_parameters: Vec<TypeParameter>,
+    pub type_parameters: Vec<TypeParameter>,
     pub return_type_span: Span,
 }
 

--- a/sway-core/src/parse_tree/declaration/impl_trait.rs
+++ b/sway-core/src/parse_tree/declaration/impl_trait.rs
@@ -11,7 +11,7 @@ pub struct ImplTrait {
     pub trait_name: CallPath,
     pub type_implementing_for: TypeInfo,
     pub type_implementing_for_span: Span,
-    pub(crate) type_parameters: Vec<TypeParameter>,
+    pub type_parameters: Vec<TypeParameter>,
     pub functions: Vec<FunctionDeclaration>,
     // the span of the whole impl trait and block
     pub(crate) block_span: Span,
@@ -23,7 +23,7 @@ pub struct ImplTrait {
 pub struct ImplSelf {
     pub type_implementing_for: TypeInfo,
     pub(crate) type_implementing_for_span: Span,
-    pub(crate) type_parameters: Vec<TypeParameter>,
+    pub type_parameters: Vec<TypeParameter>,
     pub functions: Vec<FunctionDeclaration>,
     // the span of the whole impl trait and block
     pub(crate) block_span: Span,

--- a/sway-core/src/parse_tree/declaration/impl_trait.rs
+++ b/sway-core/src/parse_tree/declaration/impl_trait.rs
@@ -9,8 +9,8 @@ use sway_types::span::Span;
 #[derive(Debug, Clone)]
 pub struct ImplTrait {
     pub trait_name: CallPath,
-    pub(crate) type_implementing_for: TypeInfo,
-    pub(crate) type_implementing_for_span: Span,
+    pub type_implementing_for: TypeInfo,
+    pub type_implementing_for_span: Span,
     pub(crate) type_parameters: Vec<TypeParameter>,
     pub functions: Vec<FunctionDeclaration>,
     // the span of the whole impl trait and block

--- a/sway-core/src/parse_tree/declaration/storage.rs
+++ b/sway-core/src/parse_tree/declaration/storage.rs
@@ -18,5 +18,6 @@ pub struct StorageDeclaration {
 pub struct StorageField {
     pub name: Ident,
     pub type_info: TypeInfo,
+    pub type_info_span: Span,
     pub initializer: Expression,
 }

--- a/sway-core/src/parse_tree/declaration/struct.rs
+++ b/sway-core/src/parse_tree/declaration/struct.rs
@@ -9,7 +9,7 @@ use sway_types::{ident::Ident, span::Span};
 pub struct StructDeclaration {
     pub name: Ident,
     pub fields: Vec<StructField>,
-    pub(crate) type_parameters: Vec<TypeParameter>,
+    pub type_parameters: Vec<TypeParameter>,
     pub visibility: Visibility,
     pub(crate) span: Span,
 }

--- a/sway-core/src/parse_tree/declaration/trait.rs
+++ b/sway-core/src/parse_tree/declaration/trait.rs
@@ -28,5 +28,5 @@ pub struct TraitFn {
     pub purity: Purity,
     pub parameters: Vec<FunctionParameter>,
     pub return_type: TypeInfo,
-    pub(crate) return_type_span: Span,
+    pub return_type_span: Span,
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -362,7 +362,7 @@ impl CopyTypes for TypedConstantDeclaration {
 pub struct TypedTraitFn {
     pub name: Ident,
     pub(crate) purity: Purity,
-    pub(crate) parameters: Vec<TypedFunctionParameter>,
+    pub parameters: Vec<TypedFunctionParameter>,
     pub return_type: TypeId,
     #[derivative(PartialEq = "ignore")]
     #[derivative(Eq(bound = ""))]

--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -15,7 +15,7 @@ use sway_types::{Ident, Property, Span, Spanned};
 #[derive(Clone, Debug, Eq)]
 pub struct TypedEnumDeclaration {
     pub name: Ident,
-    pub(crate) type_parameters: Vec<TypeParameter>,
+    pub type_parameters: Vec<TypeParameter>,
     pub variants: Vec<TypedEnumVariant>,
     pub(crate) span: Span,
     pub visibility: Visibility,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -150,6 +150,7 @@ pub struct TypedEnumVariant {
     pub name: Ident,
     pub type_id: TypeId,
     pub initial_type_id: TypeId,
+    pub type_span: Span,
     pub(crate) tag: usize,
     pub(crate) span: Span,
 }
@@ -228,6 +229,7 @@ impl TypedEnumVariant {
                 name: variant.name.clone(),
                 type_id: enum_variant_type,
                 initial_type_id,
+                type_span: variant.type_span.clone(),
                 tag: variant.tag,
                 span: variant.span,
             },

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -16,7 +16,7 @@ pub struct TypedFunctionDeclaration {
     pub span: Span,
     pub return_type: TypeId,
     pub initial_return_type: TypeId,
-    pub(crate) type_parameters: Vec<TypeParameter>,
+    pub type_parameters: Vec<TypeParameter>,
     /// Used for error messages -- the span pointing to the return type
     /// annotation of the function
     pub return_type_span: Span,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -24,6 +24,7 @@ pub struct TypedImplTrait {
     pub(crate) span: Span,
     pub methods: Vec<TypedFunctionDeclaration>,
     pub implementing_for_type_id: TypeId,
+    pub type_implementing_for_span: Span,
 }
 
 impl CopyTypes for TypedImplTrait {
@@ -121,6 +122,7 @@ impl TypedImplTrait {
                     span: block_span,
                     methods: functions_buf,
                     implementing_for_type_id,
+                    type_implementing_for_span: type_implementing_for_span.clone(),
                 };
                 let implementing_for_type_id = insert_type(
                     match resolve_type(implementing_for_type_id, &type_implementing_for_span) {
@@ -166,6 +168,7 @@ impl TypedImplTrait {
                     span: block_span,
                     methods: functions_buf,
                     implementing_for_type_id,
+                    type_implementing_for_span,
                 };
                 (impl_trait, implementing_for_type_id)
             }
@@ -389,6 +392,7 @@ impl TypedImplTrait {
             span: block_span,
             methods,
             implementing_for_type_id,
+            type_implementing_for_span,
         };
         ok(impl_trait, warnings, errors)
     }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
@@ -180,6 +180,7 @@ impl TypedStorageDeclaration {
 pub struct TypedStorageField {
     pub name: Ident,
     pub type_id: TypeId,
+    pub type_span: Span,
     pub initializer: TypedExpression,
     pub(crate) span: Span,
 }
@@ -196,10 +197,17 @@ impl PartialEq for TypedStorageField {
 }
 
 impl TypedStorageField {
-    pub fn new(name: Ident, r#type: TypeId, initializer: TypedExpression, span: Span) -> Self {
+    pub fn new(
+        name: Ident,
+        r#type: TypeId,
+        type_span: Span,
+        initializer: TypedExpression,
+        span: Span,
+    ) -> Self {
         TypedStorageField {
             name,
             type_id: r#type,
+            type_span,
             initializer,
             span,
         }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
@@ -6,7 +6,7 @@ use sway_types::{Ident, Property, Span, Spanned};
 pub struct TypedStructDeclaration {
     pub name: Ident,
     pub fields: Vec<TypedStructField>,
-    pub(crate) type_parameters: Vec<TypeParameter>,
+    pub type_parameters: Vec<TypeParameter>,
     pub visibility: Visibility,
     pub(crate) span: Span,
 }

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -379,7 +379,7 @@ impl TypedAstNode {
                                 name,
                                 type_info,
                                 initializer,
-                                ..
+                                type_info_span,
                             } in fields
                             {
                                 let type_id = check!(
@@ -404,6 +404,7 @@ impl TypedAstNode {
                                 fields_buf.push(TypedStorageField::new(
                                     name,
                                     type_id,
+                                    type_info_span,
                                     initializer,
                                     span.clone(),
                                 ));

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -379,6 +379,7 @@ impl TypedAstNode {
                                 name,
                                 type_info,
                                 initializer,
+                                ..
                             } in fields
                             {
                                 let type_id = check!(

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -257,6 +257,7 @@ impl TypedAstNode {
                             type_ascription,
                             value,
                             visibility,
+                            ..
                         }) => {
                             let result =
                                 type_check_ascribed_expr(ctx.by_ref(), type_ascription, value);

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -25,7 +25,7 @@ pub use type_engine::*;
 pub use type_id::*;
 pub use type_info::*;
 pub(crate) use type_mapping::*;
-pub(crate) use type_parameter::*;
+pub use type_parameter::*;
 pub(crate) use unresolved_type_check::*;
 
 use crate::error::*;

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -50,6 +50,7 @@ fn generic_enum_resolution() {
             name: Ident::new_with_override("T", sp.clone()),
         }),
         span: sp.clone(),
+        type_span: sp.clone(),
     }];
 
     let ty_1 = engine.insert_type(TypeInfo::Enum {
@@ -64,6 +65,7 @@ fn generic_enum_resolution() {
         type_id: engine.insert_type(TypeInfo::Boolean),
         initial_type_id: engine.insert_type(TypeInfo::Boolean),
         span: sp.clone(),
+        type_span: sp.clone(),
     }];
 
     let ty_2 = engine.insert_type(TypeInfo::Enum {

--- a/sway-core/src/type_system/type_parameter.rs
+++ b/sway-core/src/type_system/type_parameter.rs
@@ -14,9 +14,9 @@ use std::{
 
 #[derive(Debug, Clone, Eq)]
 pub struct TypeParameter {
-    pub(crate) type_id: TypeId,
+    pub type_id: TypeId,
     pub(crate) initial_type_id: TypeId,
-    pub(crate) name_ident: Ident,
+    pub name_ident: Ident,
     pub(crate) trait_constraints: Vec<TraitConstraint>,
 }
 

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -25,7 +25,7 @@ pub(crate) fn completion_item_kind(symbol_kind: &SymbolKind) -> Option<Completio
         SymbolKind::Field => Some(CompletionItemKind::FIELD),
         SymbolKind::BuiltinType => Some(CompletionItemKind::TYPE_PARAMETER),
         SymbolKind::ValueParam => Some(CompletionItemKind::VALUE),
-        SymbolKind::Function | SymbolKind::Method => Some(CompletionItemKind::FUNCTION),
+        SymbolKind::Function => Some(CompletionItemKind::FUNCTION),
         SymbolKind::Const => Some(CompletionItemKind::CONSTANT),
         SymbolKind::Struct => Some(CompletionItemKind::STRUCT),
         SymbolKind::Trait => Some(CompletionItemKind::INTERFACE),

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -32,6 +32,7 @@ pub(crate) fn completion_item_kind(symbol_kind: &SymbolKind) -> Option<Completio
         SymbolKind::Module => Some(CompletionItemKind::MODULE),
         SymbolKind::Enum => Some(CompletionItemKind::ENUM),
         SymbolKind::Variant => Some(CompletionItemKind::ENUM_MEMBER),
+        SymbolKind::TypeParameter => Some(CompletionItemKind::TYPE_PARAMETER),
         SymbolKind::BoolLiteral
         | SymbolKind::ByteLiteral
         | SymbolKind::StringLiteral

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -43,6 +43,7 @@ pub(crate) fn symbol_kind(symbol_kind: &SymbolKind) -> lsp_types::SymbolKind {
         SymbolKind::BoolLiteral => lsp_types::SymbolKind::BOOLEAN,
         SymbolKind::StringLiteral => lsp_types::SymbolKind::STRING,
         SymbolKind::NumericLiteral => lsp_types::SymbolKind::NUMBER,
+        SymbolKind::TypeParameter => lsp_types::SymbolKind::TYPE_PARAMETER,
         SymbolKind::ValueParam
         | SymbolKind::ByteLiteral
         | SymbolKind::Variable

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -33,7 +33,7 @@ pub(crate) fn symbol_kind(symbol_kind: &SymbolKind) -> lsp_types::SymbolKind {
     match symbol_kind {
         SymbolKind::Field => lsp_types::SymbolKind::FIELD,
         SymbolKind::BuiltinType => lsp_types::SymbolKind::TYPE_PARAMETER,
-        SymbolKind::Function | SymbolKind::Method => lsp_types::SymbolKind::FUNCTION,
+        SymbolKind::Function => lsp_types::SymbolKind::FUNCTION,
         SymbolKind::Const => lsp_types::SymbolKind::CONSTANT,
         SymbolKind::Struct => lsp_types::SymbolKind::STRUCT,
         SymbolKind::Trait => lsp_types::SymbolKind::INTERFACE,

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -118,7 +118,6 @@ fn semantic_token_type(kind: &SymbolKind) -> SemanticTokenType {
         SymbolKind::ValueParam => SemanticTokenType::PARAMETER,
         SymbolKind::Variable => SemanticTokenType::VARIABLE,
         SymbolKind::Function => SemanticTokenType::FUNCTION,
-        SymbolKind::Method => SemanticTokenType::METHOD,
         SymbolKind::Const => SemanticTokenType::VARIABLE,
         SymbolKind::Struct => SemanticTokenType::STRUCT,
         SymbolKind::Enum => SemanticTokenType::ENUM,

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -123,6 +123,7 @@ fn semantic_token_type(kind: &SymbolKind) -> SemanticTokenType {
         SymbolKind::Enum => SemanticTokenType::ENUM,
         SymbolKind::Variant => SemanticTokenType::ENUM_MEMBER,
         SymbolKind::Trait => SemanticTokenType::INTERFACE,
+        SymbolKind::TypeParameter => SemanticTokenType::TYPE_PARAMETER,
         SymbolKind::BoolLiteral => SemanticTokenType::new("boolean"),
         SymbolKind::ByteLiteral | SymbolKind::NumericLiteral => SemanticTokenType::NUMBER,
         SymbolKind::StringLiteral => SemanticTokenType::STRING,

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -72,7 +72,6 @@ pub enum SymbolKind {
     Field,
     ValueParam,
     Function,
-    Method,
     Const,
     Struct,
     Trait,

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -84,5 +84,6 @@ pub enum SymbolKind {
     Variable,
     BuiltinType,
     Module,
+    TypeParameter,
     Unknown,
 }

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -6,8 +6,8 @@ use sway_core::{
         TypedReassignment, TypedStorageField, TypedStructField, TypedTraitFn,
     },
     type_system::TypeId,
-    Declaration, EnumVariant, Expression, FunctionDeclaration, FunctionParameter, ReassignmentExpression,
-    Scrutinee, StorageField, StructExpressionField, StructField, TraitFn,
+    Declaration, EnumVariant, Expression, FunctionDeclaration, FunctionParameter,
+    ReassignmentExpression, Scrutinee, StorageField, StructExpressionField, StructField, TraitFn,
 };
 use sway_types::{Ident, Span};
 

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -6,8 +6,8 @@ use sway_core::{
         TypedReassignment, TypedStorageField, TypedStructField, TypedTraitFn,
     },
     type_system::TypeId,
-    Declaration, EnumVariant, Expression, FunctionDeclaration, FunctionParameter,
-    ReassignmentExpression, StorageField, StructExpressionField, StructField, TraitFn,
+    Declaration, EnumVariant, Expression, FunctionDeclaration, FunctionParameter, ReassignmentExpression,
+    Scrutinee, StorageField, StructExpressionField, StructField, TraitFn,
 };
 use sway_types::{Ident, Span};
 
@@ -50,6 +50,7 @@ pub enum AstToken {
     TraitFn(TraitFn),
     Reassignment(ReassignmentExpression),
     StorageField(StorageField),
+    Scrutinee(Scrutinee),
 }
 
 #[derive(Debug, Clone)]

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -406,23 +406,13 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                 call_path_binding, ..
             } = &method_name_binding.inner
             {
-                if let (
-                    TypeInfo::Custom {
-                        name,
-                        type_arguments,
-                    },
-                    ..,
-                ) = &call_path_binding.inner.suffix
-                {
-                    let token = Token::from_parsed(
-                        AstToken::Expression(expression.clone()),
-                        SymbolKind::Struct,
-                    );
-                    tokens.insert(to_ident_key(name), token.clone());
-                    if let Some(args) = type_arguments {
-                        collect_type_args(args, &token, tokens);
-                    }
-                }
+                let token = Token::from_parsed(
+                    AstToken::Expression(expression.clone()),
+                    SymbolKind::Struct,
+                );
+                let (type_info, span) = &call_path_binding.inner.suffix;
+
+                collect_type_info_token(tokens, &token, &type_info, Some(span.clone()));
             }
 
             // Don't collect applications of desugared operators due to mismatched ident lengths.

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -271,13 +271,15 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                         ),
                     );
                 }
-                tokens.insert(
-                    to_ident_key(&call_path_binding.inner.suffix),
-                    Token::from_parsed(
-                        AstToken::Expression(expression.clone()),
-                        SymbolKind::Function,
-                    ),
+
+                let token = Token::from_parsed(
+                    AstToken::Expression(expression.clone()),
+                    SymbolKind::Function,
                 );
+
+                tokens.insert(to_ident_key(&call_path_binding.inner.suffix), token.clone());
+
+                collect_type_args(&call_path_binding.type_arguments, &token, tokens);
             }
 
             for exp in arguments {
@@ -411,7 +413,6 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                     SymbolKind::Struct,
                 );
                 let (type_info, span) = &call_path_binding.inner.suffix;
-
                 collect_type_info_token(tokens, &token, &type_info, Some(span.clone()));
             }
 

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -67,21 +67,18 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                     .contains(MATCH_RETURN_VAR_NAME_PREFIX)
                 && !variable.name.as_str().contains(DESTRUCTURE_PREFIX)
             {
-                tokens.insert(
-                    to_ident_key(&variable.name),
-                    Token::from_parsed(
-                        AstToken::Declaration(declaration.clone()),
-                        SymbolKind::Variable,
-                    ),
+                let token = Token::from_parsed(
+                    AstToken::Declaration(declaration.clone()),
+                    SymbolKind::Variable,
                 );
+                tokens.insert(to_ident_key(&variable.name), token.clone());
 
                 if let Some(type_ascription_span) = &variable.type_ascription_span {
-                    tokens.insert(
-                        to_ident_key(&Ident::new(type_ascription_span.clone())),
-                        Token::from_parsed(
-                            AstToken::Declaration(declaration.clone()),
-                            type_info_to_symbol_kind(&variable.type_ascription),
-                        ),
+                    collect_type_info_token(
+                        tokens,
+                        &token,
+                        &variable.type_ascription,
+                        Some(type_ascription_span.clone()),
                     );
                 }
             }

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -681,7 +681,7 @@ fn collect_scrutinee(scrutinee: &Scrutinee, tokens: &TokenMap) {
                 Token::from_parsed(AstToken::Scrutinee(scrutinee.clone()), SymbolKind::Variant);
             tokens.insert(to_ident_key(&call_path.suffix), token);
 
-            collect_scrutinee(&*value, tokens);
+            collect_scrutinee(value, tokens);
         }
         Scrutinee::Tuple { elems, .. } => {
             for elem in elems {

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -618,7 +618,7 @@ fn collect_type_args(type_arguments: &Vec<TypeArgument>, token: &Token, tokens: 
     for arg in type_arguments {
         let mut token = token.clone();
         let type_info = sway_core::type_system::look_up_type_id(arg.type_id);
-        // TODO handle tuple and arrays in type_arguments
+        // TODO handle tuple and arrays in type_arguments - https://github.com/FuelLabs/sway/issues/2486
         if let TypeInfo::Tuple(_) | TypeInfo::Array(_, _, _) = type_info {
             continue;
         }

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -147,9 +147,15 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                 Token::from_parsed(AstToken::Declaration(declaration.clone()), SymbolKind::Enum),
             );
             for variant in &enum_decl.variants {
-                tokens.insert(
-                    to_ident_key(&variant.name),
-                    Token::from_parsed(AstToken::EnumVariant(variant.clone()), SymbolKind::Variant),
+                let token =
+                    Token::from_parsed(AstToken::EnumVariant(variant.clone()), SymbolKind::Variant);
+                tokens.insert(to_ident_key(&variant.name), token.clone());
+
+                collect_type_info_token(
+                    tokens,
+                    &token,
+                    &variant.type_info,
+                    Some(variant.type_span.clone()),
                 );
             }
         }

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -228,7 +228,12 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                     Token::from_parsed(AstToken::StorageField(field.clone()), SymbolKind::Field);
                 tokens.insert(to_ident_key(&field.name), token.clone());
 
-                collect_type_info_token(tokens, &token, &field.type_info, None);
+                collect_type_info_token(
+                    tokens,
+                    &token,
+                    &field.type_info,
+                    Some(field.type_info_span.clone()),
+                );
                 handle_expression(&field.initializer, tokens);
             }
         }
@@ -589,10 +594,8 @@ fn collect_scrutinee(scrutinee: &Scrutinee, tokens: &TokenMap) {
             tokens.insert(to_ident_key(&struct_name), token);
 
             for field in fields {
-                let token = Token::from_parsed(
-                    AstToken::Scrutinee(scrutinee.clone()),
-                    SymbolKind::Field,
-                );
+                let token =
+                    Token::from_parsed(AstToken::Scrutinee(scrutinee.clone()), SymbolKind::Field);
                 if let StructScrutineeField::Field {
                     field, scrutinee, ..
                 } = field
@@ -606,9 +609,7 @@ fn collect_scrutinee(scrutinee: &Scrutinee, tokens: &TokenMap) {
             }
         }
         Scrutinee::EnumScrutinee {
-            call_path,
-            value,
-            ..
+            call_path, value, ..
         } => {
             for ident in &call_path.prefixes {
                 let token =

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -6,7 +6,7 @@ use crate::{
 use sway_core::{
     constants::{DESTRUCTURE_PREFIX, MATCH_RETURN_VAR_NAME_PREFIX, TUPLE_NAME_PREFIX},
     parse_tree::{Literal, MethodName},
-    type_system::TypeArgument,
+    type_system::{TypeArgument, TypeParameter},
     AbiCastExpression, ArrayIndexExpression, AstNode, AstNodeContent, CodeBlock, Declaration,
     DelineatedPathExpression, Expression, ExpressionKind, FunctionApplicationExpression,
     FunctionDeclaration, FunctionParameter, IfExpression, IntrinsicFunctionExpression,
@@ -139,6 +139,15 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                 to_ident_key(&enum_decl.name),
                 Token::from_parsed(AstToken::Declaration(declaration.clone()), SymbolKind::Enum),
             );
+
+            for type_param in &enum_decl.type_parameters {
+                collect_type_parameter(
+                    &type_param,
+                    tokens,
+                    AstToken::Declaration(declaration.clone()),
+                );
+            }
+
             for variant in &enum_decl.variants {
                 let token =
                     Token::from_parsed(AstToken::EnumVariant(variant.clone()), SymbolKind::Variant);
@@ -709,5 +718,12 @@ fn collect_trait_fn(trait_fn: &TraitFn, tokens: &TokenMap) {
         &token,
         &trait_fn.return_type,
         Some(trait_fn.return_type_span.clone()),
+    );
+}
+
+fn collect_type_parameter(type_param: &TypeParameter, tokens: &TokenMap, token: AstToken) {
+    tokens.insert(
+        to_ident_key(&type_param.name_ident),
+        Token::from_parsed(token, SymbolKind::TypeParameter),
     );
 }

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -480,13 +480,18 @@ fn handle_expression(expression: &Expression, tokens: &TokenMap) {
                     Token::from_parsed(AstToken::Expression(expression.clone()), SymbolKind::Enum),
                 );
             }
+
+            let token = Token::from_parsed(
+                AstToken::Expression(expression.clone()),
+                SymbolKind::Variant,
+            );
+
             tokens.insert(
                 to_ident_key(&call_path_binding.inner.suffix),
-                Token::from_parsed(
-                    AstToken::Expression(expression.clone()),
-                    SymbolKind::Variant,
-                ),
+                token.clone(),
             );
+
+            collect_type_args(&call_path_binding.type_arguments, &token, tokens);
 
             for exp in args {
                 handle_expression(exp, tokens);

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -200,12 +200,17 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
             }
         }
         Declaration::ConstantDeclaration(const_decl) => {
-            tokens.insert(
-                to_ident_key(&const_decl.name),
-                Token::from_parsed(
-                    AstToken::Declaration(declaration.clone()),
-                    SymbolKind::Const,
-                ),
+            let token = Token::from_parsed(
+                AstToken::Declaration(declaration.clone()),
+                SymbolKind::Const,
+            );
+            tokens.insert(to_ident_key(&const_decl.name), token.clone());
+
+            collect_type_info_token(
+                tokens,
+                &token,
+                &const_decl.type_ascription,
+                const_decl.type_ascription_span.clone(),
             );
             handle_expression(&const_decl.value, tokens);
         }

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -162,6 +162,14 @@ fn handle_declaration(declaration: &Declaration, tokens: &TokenMap) {
                 ),
             );
 
+            tokens.insert(
+                to_ident_key(&Ident::new(impl_trait.type_implementing_for_span.clone())),
+                Token::from_parsed(
+                    AstToken::Declaration(declaration.clone()),
+                    type_info_to_symbol_kind(&impl_trait.type_implementing_for),
+                ),
+            );
+
             for func_dec in &impl_trait.functions {
                 handle_function_declation(func_dec, tokens);
             }

--- a/sway-lsp/src/core/traverse_parse_tree.rs
+++ b/sway-lsp/src/core/traverse_parse_tree.rs
@@ -549,6 +549,10 @@ fn collect_type_args(type_arguments: &Vec<TypeArgument>, token: &Token, tokens: 
     for arg in type_arguments {
         let mut token = token.clone();
         let type_info = sway_core::type_system::look_up_type_id(arg.type_id);
+        // TODO handle tuple and arrays in type_arguments
+        if let TypeInfo::Tuple(_) | TypeInfo::Array(_, _, _) = type_info {
+            continue;
+        }
         let symbol_kind = type_info_to_symbol_kind(&type_info);
         token.kind = symbol_kind;
         token.type_def = Some(TypeDefinition::TypeId(arg.type_id));
@@ -571,6 +575,9 @@ fn collect_type_info_token(
             if let Some(type_span) = type_span {
                 tokens.insert(to_ident_key(&Ident::new(type_span)), token);
             }
+        }
+        TypeInfo::Tuple(args) => {
+            collect_type_args(args, &token, tokens);
         }
         TypeInfo::Ref(type_id, span) => {
             token.type_def = Some(TypeDefinition::TypeId(*type_id));

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -116,6 +116,12 @@ fn handle_declaration(declaration: &TypedDeclaration, tokens: &TokenMap) {
             for variant in &enum_decl.variants {
                 if let Some(mut token) = tokens.get_mut(&to_ident_key(&variant.name)) {
                     token.typed = Some(TypedAstToken::TypedEnumVariant(variant.clone()));
+                    token.type_def = Some(TypeDefinition::TypeId(variant.type_id));
+                }
+
+                if let Some(mut token) = tokens.get_mut(&to_ident_key(&Ident::new(variant.type_span.clone()))) {
+                    token.typed = Some(TypedAstToken::TypedEnumVariant(variant.clone()));
+                    token.type_def = Some(TypeDefinition::TypeId(variant.type_id));
                 }
             }
         }

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -104,6 +104,13 @@ fn handle_declaration(declaration: &TypedDeclaration, tokens: &TokenMap) {
                 token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
             }
 
+            for type_param in &enum_decl.type_parameters {
+                if let Some(mut token) = tokens.get_mut(&to_ident_key(&type_param.name_ident)) {
+                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                    token.type_def = Some(TypeDefinition::TypeId(type_param.type_id));
+                }
+            }
+
             for variant in &enum_decl.variants {
                 if let Some(mut token) = tokens.get_mut(&to_ident_key(&variant.name)) {
                     token.typed = Some(TypedAstToken::TypedEnumVariant(variant.clone()));

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -176,6 +176,13 @@ fn handle_declaration(declaration: &TypedDeclaration, tokens: &TokenMap) {
                     token.type_def = Some(TypeDefinition::TypeId(field.type_id));
                 }
 
+                if let Some(mut token) =
+                    tokens.get_mut(&to_ident_key(&Ident::new(field.type_span.clone())))
+                {
+                    token.typed = Some(TypedAstToken::TypedStorageField(field.clone()));
+                    token.type_def = Some(TypeDefinition::TypeId(field.type_id));
+                }
+
                 handle_expression(&field.initializer, tokens);
             }
         }

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -136,7 +136,9 @@ fn handle_declaration(declaration: &TypedDeclaration, tokens: &TokenMap) {
                 token.type_def = Some(TypeDefinition::TypeId(*implementing_for_type_id));
             }
 
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&Ident::new(type_implementing_for_span.clone()))) {
+            if let Some(mut token) = tokens.get_mut(&to_ident_key(&Ident::new(
+                type_implementing_for_span.clone(),
+            ))) {
                 token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
                 token.type_def = Some(TypeDefinition::TypeId(*implementing_for_type_id));
             }

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -122,6 +122,7 @@ fn handle_declaration(declaration: &TypedDeclaration, tokens: &TokenMap) {
             trait_name,
             methods,
             implementing_for_type_id,
+            type_implementing_for_span,
             ..
         }) => {
             for ident in &trait_name.prefixes {
@@ -131,6 +132,11 @@ fn handle_declaration(declaration: &TypedDeclaration, tokens: &TokenMap) {
             }
 
             if let Some(mut token) = tokens.get_mut(&to_ident_key(&trait_name.suffix)) {
+                token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                token.type_def = Some(TypeDefinition::TypeId(*implementing_for_type_id));
+            }
+
+            if let Some(mut token) = tokens.get_mut(&to_ident_key(&Ident::new(type_implementing_for_span.clone()))) {
                 token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
                 token.type_def = Some(TypeDefinition::TypeId(*implementing_for_type_id));
             }


### PR DESCRIPTION
This PR collects most of the remaining tokens in the language server. 

I wrote a script that saved out the ASTs for the `sway_ast::Module`, `ParseProgram` and `TypedProgram` stages for each of the sway examples and all of the e2e/language/should pass examples. This made it quick to inspect what extra span information needed to be carried through in the compiler.

There are still a few tokens not being collected but they don't involve trivial changes to the compiler so I'll address them individually in separate PRs.