### PR TITLE
Use zero and one registers instead of 0/1 immediates

### DIFF
--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -1918,6 +1918,20 @@ impl<'ir> AsmBuilder<'ir> {
         constant: &Constant,
         span: Option<Span>,
     ) -> VirtualRegister {
+        let value_size = ir_type_size_in_bytes(self.context, &constant.ty);
+        if size_bytes_in_words!(value_size) == 1 {
+            match constant.value {
+                ConstantValue::Unit | ConstantValue::Bool(false) | ConstantValue::Uint(0) => {
+                    return VirtualRegister::Constant(ConstantRegister::Zero)
+                }
+
+                ConstantValue::Bool(true) | ConstantValue::Uint(1) => {
+                    return VirtualRegister::Constant(ConstantRegister::One)
+                }
+                _ => (),
+            }
+        }
+
         // Get the constant into the namespace.
         let lit = ir_constant_to_ast_literal(constant);
         let data_id = self.data_section.insert_data_value(&lit);

--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -880,6 +880,16 @@ impl<'ir> AsmBuilder<'ir> {
 
         // Index value is the array element index, not byte nor word offset.
         let index_reg = self.value_to_register(index_val);
+        let rel_offset_reg = match index_reg {
+            VirtualRegister::Virtual(_) => {
+                // We can reuse the register.
+                index_reg.clone()
+            }
+            VirtualRegister::Constant(_) => {
+                // We have a constant register, cannot reuse it.
+                self.reg_seqr.next()
+            }
+        };
 
         // We could put the OOB check here, though I'm now thinking it would be too wasteful.
         // See compile_bounds_assertion() in expression/array.rs (or look in Git history).
@@ -891,8 +901,8 @@ impl<'ir> AsmBuilder<'ir> {
         if elem_type.is_copy_type() {
             self.bytecode.push(Op {
                 opcode: Either::Left(VirtualOp::MULI(
-                    index_reg.clone(),
-                    index_reg.clone(),
+                    rel_offset_reg.clone(),
+                    index_reg,
                     VirtualImmediate12 { value: 8 },
                 )),
                 comment: "extract_element relative offset".into(),
@@ -900,7 +910,11 @@ impl<'ir> AsmBuilder<'ir> {
             });
             let elem_offs_reg = self.reg_seqr.next();
             self.bytecode.push(Op {
-                opcode: Either::Left(VirtualOp::ADD(elem_offs_reg.clone(), base_reg, index_reg)),
+                opcode: Either::Left(VirtualOp::ADD(
+                    elem_offs_reg.clone(),
+                    base_reg,
+                    rel_offset_reg,
+                )),
                 comment: "extract_element absolute offset".into(),
                 owning_span: owning_span.clone(),
             });
@@ -1173,6 +1187,16 @@ impl<'ir> AsmBuilder<'ir> {
 
         // Index value is the array element index, not byte nor word offset.
         let index_reg = self.value_to_register(index_val);
+        let rel_offset_reg = match index_reg {
+            VirtualRegister::Virtual(_) => {
+                // We can reuse the register.
+                index_reg.clone()
+            }
+            VirtualRegister::Constant(_) => {
+                // We have a constant register, cannot reuse it.
+                self.reg_seqr.next()
+            }
+        };
 
         let owning_span = self.md_mgr.val_to_span(self.context, *instr_val);
 
@@ -1181,8 +1205,8 @@ impl<'ir> AsmBuilder<'ir> {
         if elem_type.is_copy_type() {
             self.bytecode.push(Op {
                 opcode: Either::Left(VirtualOp::MULI(
-                    index_reg.clone(),
-                    index_reg.clone(),
+                    rel_offset_reg.clone(),
+                    index_reg,
                     VirtualImmediate12 { value: 8 },
                 )),
                 comment: "insert_element relative offset".into(),
@@ -1193,7 +1217,7 @@ impl<'ir> AsmBuilder<'ir> {
                 opcode: Either::Left(VirtualOp::ADD(
                     elem_offs_reg.clone(),
                     base_reg.clone(),
-                    index_reg,
+                    rel_offset_reg,
                 )),
                 comment: "insert_element absolute offset".into(),
                 owning_span: owning_span.clone(),

--- a/sway-core/tests/ir_to_asm/enum_struct_string.asm
+++ b/sway-core/tests/ir_to_asm/enum_struct_string.asm
@@ -9,42 +9,38 @@ move $r4 $sp                  ; save locals base register
 cfei i48                      ; allocate 48 bytes for all locals
 move $r3 $sp                  ; save register for temporary stack value
 cfei i56                      ; allocate 56 bytes for temporary struct
-lw   $r0 data_0               ; literal instantiation
-sw   $r3 $r0 i0               ; insert_value @ 0
+sw   $r3 $zero i0             ; insert_value @ 0
 move $r2 $sp                  ; save register for temporary stack value
 cfei i32                      ; allocate 32 bytes for temporary struct
-lw   $r1 data_1               ; literal instantiation
+lw   $r1 data_0               ; literal instantiation
 addi $r0 $r2 i0               ; get struct field(s) 0 offset
 mcpi $r0 $r1 i24              ; store struct field value
-lw   $r0 data_2               ; literal instantiation
+lw   $r0 data_1               ; literal instantiation
 sw   $r2 $r0 i3               ; insert_value @ 1
 move $r1 $sp                  ; save register for temporary stack value
 cfei i48                      ; allocate 48 bytes for temporary struct
 addi $r0 $r1 i0               ; get struct field(s) 0 offset
 mcpi $r0 $r2 i32              ; store struct field value
-lw   $r0 data_3               ; literal instantiation
+lw   $r0 data_2               ; literal instantiation
 sw   $r1 $r0 i4               ; insert_value @ 1
-lw   $r0 data_4               ; literal instantiation
-sw   $r1 $r0 i5               ; insert_value @ 2
+sw   $r1 $zero i5             ; insert_value @ 2
 addi $r0 $r3 i8               ; get struct field(s) 1 offset
 mcpi $r0 $r1 i48              ; store struct field value
-lw   $r1 $r3 i0               ; extract_value @ 0
-lw   $r0 data_0               ; literal instantiation
-eq   $r0 $r1 $r0
-jnzi $r0 i35
-ji   i42
+lw   $r0 $r3 i0               ; extract_value @ 0
+eq   $r0 $r0 $zero
+jnzi $r0 i32
+ji   i39
 addi $r1 $r3 i8               ; extract address
 addi $r0 $r4 i0               ; get offset reg for get_ptr
 addi $r0 $r4 i0               ; get store offset
 mcpi $r0 $r1 i48              ; store value
 addi $r0 $r4 i0               ; get offset reg for get_ptr
 lw   $r0 $r0 i4               ; extract_value @ 1
-ji   i43
-lw   $r0 data_0               ; literal instantiation
+ji   i40
+move $r0 $zero                ; branch to phi value
 ret  $r0
+noop                          ; word-alignment of data section
 .data:
-data_0 .u64 0x00
-data_1 .str " an odd length"
-data_2 .u64 0x14
-data_3 .u64 0x0a
-data_4 .bool 0x00
+data_0 .str " an odd length"
+data_1 .u64 0x14
+data_2 .u64 0x0a

--- a/sway-core/tests/ir_to_asm/if_expr.asm
+++ b/sway-core/tests/ir_to_asm/if_expr.asm
@@ -5,14 +5,13 @@ DATA_SECTION_OFFSET[0..32]
 DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
+jnzi $zero i8
+ji   i10
 lw   $r0 data_0               ; literal instantiation
-jnzi $r0 i9
 ji   i11
 lw   $r0 data_1               ; literal instantiation
-ji   i12
-lw   $r0 data_2               ; literal instantiation
 ret  $r0
+noop                          ; word-alignment of data section
 .data:
-data_0 .bool 0x00
-data_1 .u64 0xf4240
-data_2 .u64 0x2a
+data_0 .u64 0xf4240
+data_1 .u64 0x2a

--- a/sway-core/tests/ir_to_asm/lazy_binops.asm
+++ b/sway-core/tests/ir_to_asm/lazy_binops.asm
@@ -5,17 +5,13 @@ DATA_SECTION_OFFSET[0..32]
 DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
-lw   $r0 data_0               ; literal instantiation
-lw   $r1 data_0               ; literal instantiation
-lw   $r0 data_0               ; literal instantiation
-jnzi $r0 i11
-ji   i12
-lw   $r1 data_1               ; literal instantiation
-move $r0 $r1                  ; branch to phi value
-jnzi $r1 i15
-lw   $r1 data_1               ; literal instantiation
-ret  $r1
-noop                          ; word-alignment of data section
+move $r0 $zero                ; branch to phi value
+move $r0 $zero                ; branch to phi value
+jnzi $zero i10
+ji   i11
+move $r0 $one                 ; branch to phi value
+move $r1 $r0                  ; branch to phi value
+jnzi $r0 i14
+move $r0 $one                 ; branch to phi value
+ret  $r0
 .data:
-data_0 .bool 0x00
-data_1 .bool 0x01

--- a/sway-core/tests/ir_to_asm/let_reassign_while_loop.asm
+++ b/sway-core/tests/ir_to_asm/let_reassign_while_loop.asm
@@ -8,24 +8,20 @@ add  $$ds $$ds $is
 move $r2 $sp                  ; save locals base register
 cfei i8                       ; allocate 8 bytes for all locals
 addi $r0 $r2 i0               ; get offset reg for get_ptr
-lw   $r0 data_0               ; literal instantiation
-sw   $r2 $r0 i0               ; store value
+sw   $r2 $one i0              ; store value
 addi $r0 $r2 i0               ; get offset reg for get_ptr
 lw   $r0 $r2 i0               ; load value
-jnzi $r0 i15
-ji   i23
+jnzi $r0 i14
+ji   i22
 addi $r0 $r2 i0               ; get offset reg for get_ptr
-lw   $r0 $r2 i0               ; load value
-jnzi $r0 i19
-ji   i20
-lw   $r0 data_1               ; literal instantiation
-addi $r1 $r2 i0               ; get offset reg for get_ptr
-sw   $r2 $r0 i0               ; store value
-ji   i11
+lw   $r1 $r2 i0               ; load value
+jnzi $r1 i18
+ji   i19
+move $r1 $zero                ; branch to phi value
+addi $r0 $r2 i0               ; get offset reg for get_ptr
+sw   $r2 $r1 i0               ; store value
+ji   i10
 addi $r0 $r2 i0               ; get offset reg for get_ptr
 lw   $r0 $r2 i0               ; load value
 ret  $r0
-noop                          ; word-alignment of data section
 .data:
-data_0 .bool 0x01
-data_1 .bool 0x00

--- a/sway-core/tests/ir_to_asm/simple_array.asm
+++ b/sway-core/tests/ir_to_asm/simple_array.asm
@@ -5,38 +5,28 @@ DATA_SECTION_OFFSET[0..32]
 DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
-move $r3 $sp                  ; save locals base register
+move $r2 $sp                  ; save locals base register
 cfei i24                      ; allocate 24 bytes for all locals
-move $r2 $sp                  ; save register for temporary stack value
+move $r1 $sp                  ; save register for temporary stack value
 cfei i24                      ; allocate 24 bytes for temporary array
-lw   $r1 data_0               ; literal instantiation
-lw   $r0 data_1               ; literal instantiation
+muli $r0 $zero i8             ; insert_element relative offset
+add  $r0 $r1 $r0              ; insert_element absolute offset
+sw   $r0 $zero i0             ; insert_element
+muli $r0 $one i8              ; insert_element relative offset
+add  $r0 $r1 $r0              ; insert_element absolute offset
+sw   $r0 $one i0              ; insert_element
+lw   $r0 data_0               ; literal instantiation
 muli $r0 $r0 i8               ; insert_element relative offset
-add  $r0 $r2 $r0              ; insert_element absolute offset
-sw   $r0 $r1 i0               ; insert_element
-lw   $r1 data_2               ; literal instantiation
-lw   $r0 data_3               ; literal instantiation
-muli $r0 $r0 i8               ; insert_element relative offset
-add  $r0 $r2 $r0              ; insert_element absolute offset
-sw   $r0 $r1 i0               ; insert_element
-lw   $r1 data_0               ; literal instantiation
-lw   $r0 data_4               ; literal instantiation
-muli $r0 $r0 i8               ; insert_element relative offset
-add  $r0 $r2 $r0              ; insert_element absolute offset
-sw   $r0 $r1 i0               ; insert_element
-addi $r0 $r3 i0               ; get offset reg for get_ptr
-addi $r0 $r3 i0               ; get store offset
-mcpi $r0 $r2 i24              ; store value
-addi $r1 $r3 i0               ; get offset reg for get_ptr
-lw   $r0 data_3               ; literal instantiation
-muli $r0 $r0 i8               ; extract_element relative offset
+add  $r0 $r1 $r0              ; insert_element absolute offset
+sw   $r0 $zero i0             ; insert_element
+addi $r0 $r2 i0               ; get offset reg for get_ptr
+addi $r0 $r2 i0               ; get store offset
+mcpi $r0 $r1 i24              ; store value
+addi $r1 $r2 i0               ; get offset reg for get_ptr
+muli $r0 $one i8              ; extract_element relative offset
 add  $r0 $r1 $r0              ; extract_element absolute offset
 lw   $r0 $r0 i0               ; extract_element
 ret  $r0
 noop                          ; word-alignment of data section
 .data:
-data_0 .bool 0x00
-data_1 .u64 0x00
-data_2 .bool 0x01
-data_3 .u64 0x01
-data_4 .u64 0x02
+data_0 .u64 0x02

--- a/sway-core/tests/ir_to_asm/simple_contract_call.asm
+++ b/sway-core/tests/ir_to_asm/simple_contract_call.asm
@@ -5,9 +5,9 @@ DATA_SECTION_OFFSET[0..32]
 DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
-move $r4 $sp                  ; save locals base register
+move $r3 $sp                  ; save locals base register
 cfei i160                     ; allocate 160 bytes for all locals
-addi $r1 $r4 i80              ; get offset reg for get_ptr
+addi $r1 $r3 i80              ; get offset reg for get_ptr
 lw   $r0 data_0               ; literal instantiation
 sw   $r1 $r0 i0               ; insert_value @ 0
 move $r2 $sp                  ; save register for temporary stack value
@@ -17,71 +17,66 @@ addi $r0 $r2 i0               ; get struct field(s) 0 offset
 mcpi $r0 $r1 i32              ; store struct field value
 lw   $r0 data_2               ; literal instantiation
 sw   $r2 $r0 i4               ; insert_value @ 1
-addi $r0 $r4 i80              ; get offset reg for get_ptr
+addi $r0 $r3 i80              ; get offset reg for get_ptr
 sw   $r2 $r0 i5               ; insert_value @ 2
 lw   $r1 data_3               ; literal instantiation
 lw   $r0 data_4               ; literal instantiation
-lw   $r3 data_5               ; literal instantiation
-call $r2 $r1 $r0 $r3          ; call external contract
+call $r2 $zero $r1 $r0        ; call external contract
 move $r1 $ret
-addi $r0 $r4 i0               ; get offset reg for get_ptr
-sw   $r4 $r1 i0               ; store value
-addi $r0 $r4 i8               ; get offset reg for get_ptr
-lw   $r1 data_6               ; literal instantiation
+addi $r0 $r3 i0               ; get offset reg for get_ptr
+sw   $r3 $r1 i0               ; store value
+addi $r0 $r3 i8               ; get offset reg for get_ptr
+lw   $r1 data_5               ; literal instantiation
 addi $r0 $r0 i0               ; get struct field(s) 0 offset
 mcpi $r0 $r1 i32              ; store struct field value
-move $r3 $sp                  ; save register for temporary stack value
+move $r2 $sp                  ; save register for temporary stack value
 cfei i48                      ; allocate 48 bytes for temporary struct
 lw   $r1 data_1               ; literal instantiation
-addi $r0 $r3 i0               ; get struct field(s) 0 offset
+addi $r0 $r2 i0               ; get struct field(s) 0 offset
 mcpi $r0 $r1 i32              ; store struct field value
+lw   $r0 data_6               ; literal instantiation
+sw   $r2 $r0 i4               ; insert_value @ 1
+addi $r0 $r3 i8               ; get offset reg for get_ptr
+sw   $r2 $r0 i5               ; insert_value @ 2
+lw   $r1 data_3               ; literal instantiation
 lw   $r0 data_7               ; literal instantiation
-sw   $r3 $r0 i4               ; insert_value @ 1
-addi $r0 $r4 i8               ; get offset reg for get_ptr
-sw   $r3 $r0 i5               ; insert_value @ 2
-lw   $r2 data_3               ; literal instantiation
-lw   $r1 data_4               ; literal instantiation
-lw   $r0 data_8               ; literal instantiation
-call $r3 $r2 $r1 $r0          ; call external contract
+call $r2 $zero $r1 $r0        ; call external contract
 move $r1 $ret
-addi $r0 $r4 i88              ; get offset reg for get_ptr
-addi $r0 $r4 i88              ; get store offset
+addi $r0 $r3 i88              ; get offset reg for get_ptr
+addi $r0 $r3 i88              ; get store offset
 mcpi $r0 $r1 i32              ; store value
-addi $r2 $r4 i40              ; get offset reg for get_ptr
-lw   $r0 data_9               ; literal instantiation
+addi $r2 $r3 i40              ; get offset reg for get_ptr
+lw   $r0 data_8               ; literal instantiation
 sw   $r2 $r0 i0               ; insert_value @ 0
-lw   $r1 data_10              ; literal instantiation
+lw   $r1 data_9               ; literal instantiation
 addi $r0 $r2 i8               ; get struct field(s) 1 offset
 mcpi $r0 $r1 i32              ; store struct field value
-move $r3 $sp                  ; save register for temporary stack value
+move $r2 $sp                  ; save register for temporary stack value
 cfei i48                      ; allocate 48 bytes for temporary struct
 lw   $r1 data_1               ; literal instantiation
-addi $r0 $r3 i0               ; get struct field(s) 0 offset
+addi $r0 $r2 i0               ; get struct field(s) 0 offset
 mcpi $r0 $r1 i32              ; store struct field value
-lw   $r0 data_11              ; literal instantiation
-sw   $r3 $r0 i4               ; insert_value @ 1
-addi $r0 $r4 i40              ; get offset reg for get_ptr
-sw   $r3 $r0 i5               ; insert_value @ 2
-move $r2 $cgas                ; move register into abi function
-lw   $r1 data_3               ; literal instantiation
-lw   $r0 data_4               ; literal instantiation
-call $r3 $r1 $r0 $r2          ; call external contract
-move $r1 $ret
-addi $r0 $r4 i120             ; get offset reg for get_ptr
-addi $r0 $r4 i120             ; get store offset
-mcpi $r0 $r1 i40              ; store value
+lw   $r0 data_10              ; literal instantiation
+sw   $r2 $r0 i4               ; insert_value @ 1
+addi $r0 $r3 i40              ; get offset reg for get_ptr
+sw   $r2 $r0 i5               ; insert_value @ 2
+move $r1 $cgas                ; move register into abi function
 lw   $r0 data_3               ; literal instantiation
-ret  $r0
+call $r2 $zero $r0 $r1        ; call external contract
+move $r1 $ret
+addi $r0 $r3 i120             ; get offset reg for get_ptr
+addi $r0 $r3 i120             ; get store offset
+mcpi $r0 $r1 i40              ; store value
+ret  $zero
 .data:
 data_0 .u64 0x457
 data_1 .b256 0x0c1c50c2bf5ba4bb351b4249a2f5e7d86556fcb4a6ae90465ff6c86126eeb3c0
 data_2 .u64 0x9890aef4
-data_3 .u64 0x00
-data_4 .b256 0x0000000000000000000000000000000000000000000000000000000000000000
-data_5 .u64 0x2710
-data_6 .b256 0x3333333333333333333333333333333333333333333333333333333333333333
-data_7 .u64 0x42123b96
-data_8 .u64 0x4e20
-data_9 .u64 0x15b3
-data_10 .b256 0x5555555555555555555555555555555555555555555555555555555555555555
-data_11 .u64 0xfc62d029
+data_3 .b256 0x0000000000000000000000000000000000000000000000000000000000000000
+data_4 .u64 0x2710
+data_5 .b256 0x3333333333333333333333333333333333333333333333333333333333333333
+data_6 .u64 0x42123b96
+data_7 .u64 0x4e20
+data_8 .u64 0x15b3
+data_9 .b256 0x5555555555555555555555555555555555555555555555555555555555555555
+data_10 .u64 0xfc62d029

--- a/sway-core/tests/ir_to_asm/simple_enum.asm
+++ b/sway-core/tests/ir_to_asm/simple_enum.asm
@@ -9,20 +9,19 @@ move $r2 $sp                  ; save locals base register
 cfei i16                      ; allocate 16 bytes for all locals
 move $r1 $sp                  ; save register for temporary stack value
 cfei i16                      ; allocate 16 bytes for temporary struct
-lw   $r0 data_0               ; literal instantiation
-sw   $r1 $r0 i0               ; insert_value @ 0
+sw   $r1 $one i0              ; insert_value @ 0
 addi $r0 $r2 i0               ; get offset reg for get_ptr
 addi $r0 $r2 i0               ; get store offset
 mcpi $r0 $r1 i16              ; store value
 addi $r0 $r2 i0               ; get offset reg for get_ptr
 move $r1 $sp                  ; save register for temporary stack value
 cfei i16                      ; allocate 16 bytes for temporary struct
-lw   $r0 data_1               ; literal instantiation
+lw   $r0 data_0               ; literal instantiation
 sw   $r1 $r0 i0               ; insert_value @ 0
-lw   $r0 data_2               ; literal instantiation
+lw   $r0 data_1               ; literal instantiation
 sw   $r1 $r0 i1               ; insert_value @ 1
 ret  $zero                    ; returning unit as zero
+noop                          ; word-alignment of data section
 .data:
-data_0 .u64 0x01
-data_1 .u64 0x02
-data_2 .u64 0x03
+data_0 .u64 0x02
+data_1 .u64 0x03

--- a/sway-core/tests/ir_to_asm/simple_if_let.asm
+++ b/sway-core/tests/ir_to_asm/simple_if_let.asm
@@ -5,32 +5,27 @@ DATA_SECTION_OFFSET[0..32]
 DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
-move $r3 $sp                  ; save locals base register
+move $r2 $sp                  ; save locals base register
 cfei i24                      ; allocate 24 bytes for all locals
 move $r1 $sp                  ; save register for temporary stack value
 cfei i16                      ; allocate 16 bytes for temporary struct
-lw   $r0 data_0               ; literal instantiation
-sw   $r1 $r0 i0               ; insert_value @ 0
-lw   $r0 data_1               ; literal instantiation
-sw   $r1 $r0 i1               ; insert_value @ 1
-addi $r0 $r3 i8               ; get offset reg for get_ptr
-addi $r0 $r3 i8               ; get store offset
+sw   $r1 $zero i0             ; insert_value @ 0
+sw   $r1 $one i1              ; insert_value @ 1
+addi $r0 $r2 i8               ; get offset reg for get_ptr
+addi $r0 $r2 i8               ; get store offset
 mcpi $r0 $r1 i16              ; store value
-addi $r2 $r3 i8               ; get offset reg for get_ptr
-lw   $r1 $r2 i0               ; extract_value @ 0
-lw   $r0 data_2               ; literal instantiation
-eq   $r0 $r1 $r0
-jnzi $r0 i23
-ji   i29
-lw   $r1 $r2 i1               ; extract_value @ 1,1
-addi $r0 $r3 i0               ; get offset reg for get_ptr
-sw   $r3 $r1 i0               ; store value
-addi $r0 $r3 i0               ; get offset reg for get_ptr
-lw   $r0 $r3 i0               ; load value
-ji   i30
-lw   $r0 data_0               ; literal instantiation
+addi $r1 $r2 i8               ; get offset reg for get_ptr
+lw   $r0 $r1 i0               ; extract_value @ 0
+eq   $r0 $r0 $one
+jnzi $r0 i20
+ji   i26
+lw   $r1 $r1 i1               ; extract_value @ 1,1
+addi $r0 $r2 i0               ; get offset reg for get_ptr
+sw   $r2 $r1 i0               ; store value
+addi $r0 $r2 i0               ; get offset reg for get_ptr
+lw   $r0 $r2 i0               ; load value
+ji   i27
+move $r0 $zero                ; branch to phi value
 ret  $r0
+noop                          ; word-alignment of data section
 .data:
-data_0 .u64 0x00
-data_1 .bool 0x01
-data_2 .u64 0x01

--- a/sway-core/tests/ir_to_asm/storage_store.asm
+++ b/sway-core/tests/ir_to_asm/storage_store.asm
@@ -6,46 +6,43 @@ DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
 lw   $r1 $fp i73              ; load input function selector
-lw   $r0 data_4               ; load fn selector for comparison
+lw   $r0 data_3               ; load fn selector for comparison
 eq   $r0 $r1 $r0              ; function selector comparison
 jnzi $r0 i14                  ; jump to selected function
-lw   $r0 data_5               ; load fn selector for comparison
+lw   $r0 data_4               ; load fn selector for comparison
 eq   $r0 $r1 $r0              ; function selector comparison
-jnzi $r0 i28                  ; jump to selected function
+jnzi $r0 i26                  ; jump to selected function
 rvrt $zero                    ; revert if no selectors matched
 move $r2 $sp                  ; save locals base register
 cfei i40                      ; allocate 40 bytes for all locals
 addi $r0 $r2 i32              ; get offset reg for get_ptr
-lw   $r0 data_0               ; literal instantiation
-sw   $r2 $r0 i4               ; store value
+sw   $r2 $zero i4             ; store value
 addi $r0 $r2 i0               ; get offset reg for get_ptr
-lw   $r1 data_1               ; literal instantiation
+lw   $r1 data_0               ; literal instantiation
 addi $r0 $r2 i0               ; get store offset
 mcpi $r0 $r1 i32              ; store value
-lw   $r1 data_0               ; literal instantiation
 addi $r0 $r2 i0               ; get offset
-sww  $r0 $r1                  ; single word state access
+sww  $r0 $zero                ; single word state access
 ret  $zero                    ; returning unit as zero
-move $r1 $sp                  ; save locals base register
+move $r2 $sp                  ; save locals base register
 cfei i64                      ; allocate 64 bytes for all locals
-addi $r0 $r1 i32              ; get offset reg for get_ptr
-lw   $r2 data_2               ; literal instantiation
-addi $r0 $r1 i32              ; get store offset
-mcpi $r0 $r2 i32              ; store value
-addi $r0 $r1 i0               ; get offset reg for get_ptr
-lw   $r2 data_3               ; literal instantiation
-addi $r0 $r1 i0               ; get store offset
-mcpi $r0 $r2 i32              ; store value
-addi $r0 $r1 i32              ; get offset reg for get_ptr
-addi $r2 $r1 i32              ; get offset
-addi $r0 $r1 i0               ; get offset
-swwq $r0 $r2                  ; quad word state access
+addi $r0 $r2 i32              ; get offset reg for get_ptr
+lw   $r1 data_1               ; literal instantiation
+addi $r0 $r2 i32              ; get store offset
+mcpi $r0 $r1 i32              ; store value
+addi $r0 $r2 i0               ; get offset reg for get_ptr
+lw   $r1 data_2               ; literal instantiation
+addi $r0 $r2 i0               ; get store offset
+mcpi $r0 $r1 i32              ; store value
+addi $r0 $r2 i32              ; get offset reg for get_ptr
+addi $r1 $r2 i32              ; get offset
+addi $r0 $r2 i0               ; get offset
+swwq $r0 $r1                  ; quad word state access
 ret  $zero                    ; returning unit as zero
 noop                          ; word-alignment of data section
 .data:
-data_0 .u64 0x00
-data_1 .b256 0x7fbd1192666bfac3767b890bd4d048c940879d316071e20c7c8c81bce2ca41c5
-data_2 .b256 0x0000000000000000000000000000000000000000000000000000000000000000
-data_3 .b256 0xa15d6d36b54df993ed1fbe4544a45d4c4f70d81b4229861dfde0e20eb652202c
-data_4 .u32 0x1b9b478f
-data_5 .u32 0x858a3d18
+data_0 .b256 0x7fbd1192666bfac3767b890bd4d048c940879d316071e20c7c8c81bce2ca41c5
+data_1 .b256 0x0000000000000000000000000000000000000000000000000000000000000000
+data_2 .b256 0xa15d6d36b54df993ed1fbe4544a45d4c4f70d81b4229861dfde0e20eb652202c
+data_3 .u32 0x1b9b478f
+data_4 .u32 0x858a3d18

--- a/sway-core/tests/ir_to_asm/storage_store_load_intrinsics.asm
+++ b/sway-core/tests/ir_to_asm/storage_store_load_intrinsics.asm
@@ -6,7 +6,7 @@ DATA_SECTION_OFFSET[32..64]
 lw   $ds $is 1
 add  $$ds $$ds $is
 lw   $r1 $fp i73              ; load input function selector
-lw   $r0 data_15              ; load fn selector for comparison
+lw   $r0 data_13              ; load fn selector for comparison
 eq   $r0 $r1 $r0              ; function selector comparison
 jnzi $r0 i11                  ; jump to selected function
 rvrt $zero                    ; revert if no selectors matched
@@ -16,34 +16,33 @@ lw   $r0 data_0               ; literal instantiation
 addi $r1 $r4 i240             ; get offset reg for get_ptr
 addi $r1 $r4 i240             ; get store offset
 mcpi $r1 $r0 i32              ; store value
-lw   $r0 data_1               ; literal instantiation
-eq   $r0 $r0 $zero            ; asm block
-jnzi $r0 i22
-ji   i32
+eq   $r0 $zero $zero          ; asm block
+jnzi $r0 i21
+ji   i31
 addi $r0 $r4 i240             ; get offset reg for get_ptr
 addi $r3 $r4 i240             ; load address
-lw   $r1 data_2               ; literal instantiation
-lw   $r0 data_3               ; literal instantiation
+lw   $r1 data_1               ; literal instantiation
+lw   $r0 data_2               ; literal instantiation
 move $r2 $sp                  ; asm block
 cfei i8                       ; asm block
 sw   $r2 $r1 i0               ; asm block
 s256 $r3 $r2 $r0              ; asm block
 cfsi i8                       ; asm block
-ji   i41
+ji   i40
 addi $r0 $r4 i272             ; get offset reg for get_ptr
-lw   $r0 data_3               ; literal instantiation
+lw   $r0 data_2               ; literal instantiation
 sw   $r4 $r0 i34              ; store value
 addi $r0 $r4 i240             ; get offset reg for get_ptr
 addi $r3 $r4 i240             ; load address
 addi $r0 $r4 i272             ; get offset reg for get_ptr
 lw   $r1 $r4 i34              ; load value
-lw   $r0 data_2               ; literal instantiation
+lw   $r0 data_1               ; literal instantiation
 s256 $r3 $r0 $r1              ; asm block
 addi $r0 $r4 i0               ; get offset reg for get_ptr
 addi $r0 $r4 i0               ; get store offset
 mcpi $r0 $r3 i32              ; store value
 addi $r0 $r4 i280             ; get offset reg for get_ptr
-lw   $r0 data_4               ; literal instantiation
+lw   $r0 data_3               ; literal instantiation
 sw   $r4 $r0 i35              ; store value
 addi $r0 $r4 i0               ; get offset reg for get_ptr
 addi $r2 $r4 i0               ; load address
@@ -65,37 +64,36 @@ addi $r0 $r4 i280             ; get offset reg for get_ptr
 lw   $r0 $r4 i35              ; load value
 eq   $r0 $r1 $r0
 eq   $r0 $r0 $zero            ; asm block
-jnzi $r0 i69
-ji   i73
-lw   $r0 data_5               ; literal instantiation
-rvrt $r0                      ; asm block
-lw   $r0 data_5               ; literal instantiation
-ji   i74
-lw   $r0 data_5               ; literal instantiation
-lw   $r0 data_5               ; literal instantiation
+jnzi $r0 i68
+ji   i71
+rvrt $zero                    ; asm block
+move $r0 $zero                ; branch to phi value
+ji   i72
+move $r0 $zero                ; branch to phi value
+move $r0 $zero                ; branch to phi value
 addi $r0 $r4 i160             ; get offset reg for get_ptr
 move $r1 $sp                  ; save register for temporary stack value
 cfei i32                      ; allocate 32 bytes for temporary struct
-lw   $r0 data_6               ; literal instantiation for aggregate field
+lw   $r0 data_4               ; literal instantiation for aggregate field
 sw   $r1 $r0 i0               ; initialise aggregate field
-lw   $r0 data_7               ; literal instantiation for aggregate field
+lw   $r0 data_5               ; literal instantiation for aggregate field
 sw   $r1 $r0 i1               ; initialise aggregate field
-lw   $r0 data_8               ; literal instantiation for aggregate field
+lw   $r0 data_6               ; literal instantiation for aggregate field
 sw   $r1 $r0 i2               ; initialise aggregate field
-lw   $r0 data_9               ; literal instantiation for aggregate field
+lw   $r0 data_7               ; literal instantiation for aggregate field
 sw   $r1 $r0 i3               ; initialise aggregate field
 addi $r0 $r4 i160             ; get store offset
 mcpi $r0 $r1 i32              ; store value
 addi $r0 $r4 i200             ; get offset reg for get_ptr
 move $r1 $sp                  ; save register for temporary stack value
 cfei i32                      ; allocate 32 bytes for temporary struct
-lw   $r0 data_10              ; literal instantiation for aggregate field
+lw   $r0 data_8               ; literal instantiation for aggregate field
 sw   $r1 $r0 i0               ; initialise aggregate field
-lw   $r0 data_11              ; literal instantiation for aggregate field
+lw   $r0 data_9               ; literal instantiation for aggregate field
 sw   $r1 $r0 i1               ; initialise aggregate field
-lw   $r0 data_12              ; literal instantiation for aggregate field
+lw   $r0 data_10              ; literal instantiation for aggregate field
 sw   $r1 $r0 i2               ; initialise aggregate field
-lw   $r0 data_13              ; literal instantiation for aggregate field
+lw   $r0 data_11              ; literal instantiation for aggregate field
 sw   $r1 $r0 i3               ; initialise aggregate field
 addi $r0 $r4 i200             ; get store offset
 mcpi $r0 $r1 i32              ; store value
@@ -128,52 +126,50 @@ lw   $r1 $r0 i0               ; extract_value @ 0
 addi $r0 $r4 i200             ; get offset reg for get_ptr
 lw   $r0 $r0 i0               ; extract_value @ 0
 eq   $r0 $r1 $r0
-jnzi $r0 i132
-ji   i137
+jnzi $r0 i130
+ji   i135
 addi $r0 $r4 i160             ; get offset reg for get_ptr
 lw   $r1 $r0 i1               ; extract_value @ 1
 addi $r0 $r4 i200             ; get offset reg for get_ptr
 lw   $r0 $r0 i1               ; extract_value @ 1
 eq   $r0 $r1 $r0
-jnzi $r0 i139
-ji   i144
+jnzi $r0 i137
+ji   i142
 addi $r0 $r4 i160             ; get offset reg for get_ptr
 lw   $r1 $r0 i2               ; extract_value @ 2
 addi $r0 $r4 i200             ; get offset reg for get_ptr
 lw   $r0 $r0 i2               ; extract_value @ 2
 eq   $r0 $r1 $r0
-jnzi $r0 i146
-ji   i151
+jnzi $r0 i144
+ji   i149
 addi $r0 $r4 i160             ; get offset reg for get_ptr
 lw   $r1 $r0 i3               ; extract_value @ 3
 addi $r0 $r4 i200             ; get offset reg for get_ptr
 lw   $r0 $r0 i3               ; extract_value @ 3
 eq   $r0 $r1 $r0
 eq   $r0 $r0 $zero            ; asm block
-jnzi $r0 i154
-ji   i158
-lw   $r0 data_5               ; literal instantiation
-rvrt $r0                      ; asm block
-lw   $r0 data_5               ; literal instantiation
-ji   i159
-lw   $r0 data_5               ; literal instantiation
-lw   $r0 data_5               ; literal instantiation
-lw   $r0 data_14              ; literal instantiation
+jnzi $r0 i152
+ji   i155
+rvrt $zero                    ; asm block
+move $r0 $zero                ; branch to phi value
+ji   i156
+move $r0 $zero                ; branch to phi value
+move $r0 $zero                ; branch to phi value
+lw   $r0 data_12              ; literal instantiation
 ret  $r0
+noop                          ; word-alignment of data section
 .data:
 data_0 .b256 0x0000000000000000000000000000000000000000000000000000000000000000
-data_1 .bool 0x00
-data_2 .u64 0x16
-data_3 .u64 0x08
-data_4 .u64 0x6c
-data_5 .u64 0x00
-data_6 .u64 0x01
-data_7 .u64 0x02
-data_8 .u64 0x04
-data_9 .u64 0x64
-data_10 .u64 0x65
-data_11 .u64 0x79
-data_12 .u64 0xe0
-data_13 .u64 0x68
-data_14 .u64 0x80
-data_15 .u32 0xea1a0f91
+data_1 .u64 0x16
+data_2 .u64 0x08
+data_3 .u64 0x6c
+data_4 .u64 0x01
+data_5 .u64 0x02
+data_6 .u64 0x04
+data_7 .u64 0x64
+data_8 .u64 0x65
+data_9 .u64 0x79
+data_10 .u64 0xe0
+data_11 .u64 0x68
+data_12 .u64 0x80
+data_13 .u32 0xea1a0f91

--- a/sway-core/tests/ir_to_asm/struct_in_union.asm
+++ b/sway-core/tests/ir_to_asm/struct_in_union.asm
@@ -17,22 +17,19 @@ lw   $r1 data_1               ; literal instantiation for aggregate field
 sw   $r2 $r1 i0               ; initialise aggregate field
 addi $r1 $r2 i8               ; get struct field(s) 1 offset
 mcpi $r1 $r0 i8               ; store struct field value
-lw   $r1 $r2 i0               ; extract_value @ 0
-lw   $r0 data_1               ; literal instantiation
-eq   $r0 $r1 $r0
-jnzi $r0 i23
-ji   i30
-addi $r1 $r2 i8               ; extract address
-addi $r0 $r3 i0               ; get offset reg for get_ptr
-addi $r0 $r3 i0               ; get store offset
-mcpi $r0 $r1 i8               ; store value
+lw   $r0 $r2 i0               ; extract_value @ 0
+eq   $r0 $r0 $one
+jnzi $r0 i22
+ji   i29
+addi $r0 $r2 i8               ; extract address
+addi $r1 $r3 i0               ; get offset reg for get_ptr
+addi $r1 $r3 i0               ; get store offset
+mcpi $r1 $r0 i8               ; store value
 addi $r0 $r3 i0               ; get offset reg for get_ptr
 lw   $r0 $r0 i0               ; extract_value @ 0
-ji   i31
-lw   $r0 data_2               ; literal instantiation
+ji   i30
+move $r0 $zero                ; branch to phi value
 ret  $r0
-noop                          ; word-alignment of data section
 .data:
 data_0 .u64 0x2a
 data_1 .u64 0x01
-data_2 .u64 0x00

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
@@ -3,7 +3,7 @@ use array_of_structs_abi::{Id, TestContract, Wrapper};
 use std::{assert::assert, hash::sha256};
 
 fn main() -> u64 {
-    let addr = abi(TestContract, 0xa99f286587d192c092dcbdefeb22b3f86a54c1837a80bb05328241dc24a6ac8e);
+    let addr = abi(TestContract, 0x4c963e7006e41055f19915d5ac64bd68b971e05efee75ba85a23862b80837d7a);
 
     let input = [Wrapper {
         id: Id {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/src/main.sw
@@ -4,7 +4,7 @@ use abi_with_tuples::*;
 use std::assert::assert;
 
 fn main() -> bool {
-    let the_abi = abi(MyContract, 0x417e8ee99a538fb03b032862bedf70ccd28dcec4a0fb455c72700f5234467f48);
+    let the_abi = abi(MyContract, 0x32a5e5b389bda4bbf8edad1cdb3abe8e1e004bc947ebc6212e307ae7809b554f);
 
     let param1 = (
         Person {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -3,7 +3,7 @@ use basic_storage_abi::{StoreU64, Quad};
 use std::assert::assert;
 
 fn main() -> u64 {
-    let addr = abi(StoreU64, 0x57ba3df09ddb4efc3df2931eaa0b565d7100289f6317ec21277657eced7f3c39);
+    let addr = abi(StoreU64, 0xc46c8efaea3fa7566aa9d5723f360030a59c1fbba3cfbbc2b4141de10cff9886);
     let key = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 


### PR DESCRIPTION
This PR follows up on a [comment](https://github.com/FuelLabs/sway/pull/2615#issuecomment-1225722391) in #2615. 

Using `__eq` instead of
```
v34 = asm(r1: v33, r2) -> bool r2, !20 {
    eq     r2 r1 zero, !21
}
```
results in an extra instruction to load the immediate from the data area, causing code increase in some cases. So this PR fixes that.

Code size numbers on our e2e testsuite:
test | Prior to #2615 | #2615 | This PR (#2621) | Reduction Now | Net Reduction
-- | -- | -- | -- | -- | --
test/src/e2e_vm_tests/test_programs/should_pass/forc/dependency_package_field | 84 | 44 | 28 | 36.3636363636364 | 66.6666666666667
test/src/e2e_vm_tests/test_programs/should_pass/forc/dependency_patching | 44 | 44 | 28 | 36.3636363636364 | 36.3636363636364
test/src/e2e_vm_tests/test_programs/should_pass/language/basic_func_decl | 532 | 508 | 484 | 4.7244094488189 | 9.02255639097744
test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl_in_library | 156 | 116 | 84 | 27.5862068965517 | 46.1538461538462
test/src/e2e_vm_tests/test_programs/should_pass/language/dependencies | 168 | 168 | 152 | 9.52380952380952 | 9.52380952380952
test/src/e2e_vm_tests/test_programs/should_pass/language/generic-type-inference | 144 | 28 | 28 | 0 | 80.5555555555556
test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic | 140 | 172 | 124 | 27.906976744186 | 11.4285714285714
test/src/e2e_vm_tests/test_programs/should_pass/language/import_trailing_comma | 180 | 180 | 180 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/addrof_intrinsic | 884 | 700 | 628 | 10.2857142857143 | 28.9592760180996
test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_access | 140 | 140 | 140 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/array_generics | 540 | 540 | 428 | 20.7407407407407 | 20.7407407407407
test/src/e2e_vm_tests/test_programs/should_pass/language/is_prime | 3788 | 3476 | 2908 | 16.3406214039125 | 23.2312565997888
test/src/e2e_vm_tests/test_programs/should_pass/language/out_of_order_decl | 300 | 300 | 292 | 2.66666666666667 | 2.66666666666667
test/src/e2e_vm_tests/test_programs/should_pass/language/chained_if_let | 316 | 316 | 308 | 2.53164556962025 | 2.53164556962025
test/src/e2e_vm_tests/test_programs/should_pass/language/builtin_type_method_call | 100 | 100 | 84 | 16 | 16
test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_nested | 228 | 228 | 220 | 3.50877192982456 | 3.50877192982456
test/src/e2e_vm_tests/test_programs/should_pass/language/raw_identifiers | 636 | 636 | 468 | 26.4150943396226 | 26.4150943396226
test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_struct_assign | 116 | 116 | 116 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/generic_enum | 140 | 140 | 132 | 5.71428571428571 | 5.71428571428571
test/src/e2e_vm_tests/test_programs/should_pass/language/op_precedence | 100 | 100 | 92 | 8 | 8
test/src/e2e_vm_tests/test_programs/should_pass/language/retd_struct | 120 | 120 | 120 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/retd_small_array | 108 | 108 | 84 | 22.2222222222222 | 22.2222222222222
test/src/e2e_vm_tests/test_programs/should_pass/language/many_stack_variables | 96020 | 96020 | 79284 | 17.4297021453864 | 17.4297021453864
test/src/e2e_vm_tests/test_programs/should_pass/language/multi_item_import | 196 | 196 | 188 | 4.08163265306122 | 4.08163265306122
test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_struct | 108 | 108 | 108 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/inline_if_expr_const | 156 | 28 | 28 | 0 | 82.051282051282
test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_ret | 68 | 68 | 60 | 11.7647058823529 | 11.7647058823529
test/src/e2e_vm_tests/test_programs/should_pass/language/u64_ops | 3612 | 3852 | 3068 | 20.3530633437175 | 15.0609080841639
test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_in_struct | 940 | 996 | 868 | 12.85140562249 | 7.65957446808511
test/src/e2e_vm_tests/test_programs/should_pass/language/doc_comments | 140 | 140 | 140 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic_2 | 212 | 268 | 196 | 26.865671641791 | 7.54716981132076
test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_simple | 796 | 796 | 756 | 5.0251256281407 | 5.0251256281407
test/src/e2e_vm_tests/test_programs/should_pass/language/gtf_intrinsic | 100 | 100 | 76 | 24 | 24
test/src/e2e_vm_tests/test_programs/should_pass/language/modulo_uint_test | 676 | 716 | 604 | 15.6424581005587 | 10.6508875739645
test/src/e2e_vm_tests/test_programs/should_pass/language/ret_string_in_struct | 88 | 88 | 88 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/smo_opcode | 112 | 112 | 80 | 28.5714285714286 | 28.5714285714286
test/src/e2e_vm_tests/test_programs/should_pass/language/ret_small_string | 64 | 64 | 64 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest | 516 | 516 | 508 | 1.55038759689923 | 1.55038759689923
test/src/e2e_vm_tests/test_programs/should_pass/language/b256_bad_jumps | 144 | 112 | 96 | 14.2857142857143 | 33.3333333333333
test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_single_element | 196 | 204 | 172 | 15.6862745098039 | 12.2448979591837
test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_mismatched | 268 | 268 | 260 | 2.98507462686567 | 2.98507462686567
test/src/e2e_vm_tests/test_programs/should_pass/language/basic_predicate | 44 | 44 | 28 | 36.3636363636364 | 36.3636363636364
test/src/e2e_vm_tests/test_programs/should_pass/language/if_elseif_enum | 1188 | 1188 | 1188 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_return | 68 | 44 | 44 | 0 | 35.2941176470588
test/src/e2e_vm_tests/test_programs/should_pass/language/config_time_constants | 144 | 112 | 112 | 0 | 22.2222222222222
test/src/e2e_vm_tests/test_programs/should_pass/language/trait_override_bug | 100 | 100 | 100 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_with_self | 364 | 364 | 316 | 13.1868131868132 | 13.1868131868132
test/src/e2e_vm_tests/test_programs/should_pass/language/enum_type_inference | 192 | 192 | 192 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/abort_control_flow_good | 284 | 228 | 212 | 7.01754385964912 | 25.3521126760563
test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_structs | 372 | 372 | 348 | 6.45161290322581 | 6.45161290322581
test/src/e2e_vm_tests/test_programs/should_pass/language/funcs_with_generic_types | 44 | 44 | 28 | 36.3636363636364 | 36.3636363636364
test/src/e2e_vm_tests/test_programs/should_pass/language/bool_and_or | 180 | 116 | 92 | 20.6896551724138 | 48.8888888888889
test/src/e2e_vm_tests/test_programs/should_pass/language/eq_and_neq | 1964 | 1260 | 1076 | 14.6031746031746 | 45.213849287169
test/src/e2e_vm_tests/test_programs/should_pass/language/unit_type_variants | 68 | 68 | 68 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_call | 84 | 84 | 68 | 19.047619047619 | 19.047619047619
test/src/e2e_vm_tests/test_programs/should_pass/language/size_of | 564 | 284 | 284 | 0 | 49.645390070922
test/src/e2e_vm_tests/test_programs/should_pass/language/zero_field_types | 44 | 44 | 44 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/asm_without_return | 52 | 52 | 52 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/struct_destructuring | 268 | 268 | 268 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/is_reference_type | 956 | 196 | 156 | 20.4081632653061 | 83.6820083682008
test/src/e2e_vm_tests/test_programs/should_pass/language/reassignment_operators | 596 | 628 | 540 | 14.0127388535032 | 9.39597315436242
test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let_large_type | 420 | 420 | 404 | 3.80952380952381 | 3.80952380952381
test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_enums | 252 | 252 | 220 | 12.6984126984127 | 12.6984126984127
test/src/e2e_vm_tests/test_programs/should_pass/language/asm_expr_basic | 500 | 524 | 452 | 13.7404580152672 | 9.6
test/src/e2e_vm_tests/test_programs/should_pass/language/nested_structs | 2108 | 2228 | 1972 | 11.4901256732496 | 6.45161290322581
test/src/e2e_vm_tests/test_programs/should_pass/language/retd_b256 | 140 | 140 | 140 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/array_dynamic_oob | 220 | 220 | 196 | 10.9090909090909 | 10.9090909090909
test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_types | 196 | 196 | 180 | 8.16326530612245 | 8.16326530612245
test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let | 648 | 544 | 504 | 7.35294117647059 | 22.2222222222222
test/src/e2e_vm_tests/test_programs/should_pass/language/main_returns_unit | 28 | 28 | 28 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_indexing | 100 | 100 | 100 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_type | 44 | 44 | 44 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/eq_intrinsic | 1156 | 868 | 748 | 13.8248847926267 | 35.2941176470588
test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_reassignment | 176 | 176 | 176 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/generic_structs | 212 | 212 | 212 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/use_full_path_names | 172 | 172 | 172 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/retd_zero_len_array | 52 | 52 | 52 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/generic_functions | 188 | 188 | 172 | 8.51063829787234 | 8.51063829787234
test/src/e2e_vm_tests/test_programs/should_pass/language/b256_bitwise_ops | 130372 | 130956 | 127420 | 2.7001435596689 | 2.2642898781947
test/src/e2e_vm_tests/test_programs/should_pass/language/enum_in_fn_decl | 156 | 156 | 156 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/valid_impurity | 140 | 140 | 124 | 11.4285714285714 | 11.4285714285714
test/src/e2e_vm_tests/test_programs/should_pass/language/nested_while_and_if | 316 | 324 | 268 | 17.283950617284 | 15.1898734177215
test/src/e2e_vm_tests/test_programs/should_pass/language/supertraits | 5228 | 5476 | 4684 | 14.4631117604091 | 10.4055087987758
test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_field_reassignment | 1028 | 1028 | 1012 | 1.55642023346304 | 1.55642023346304
test/src/e2e_vm_tests/test_programs/should_pass/language/enum_destructuring | 172 | 172 | 156 | 9.30232558139535 | 9.30232558139535
test/src/e2e_vm_tests/test_programs/should_pass/language/xos_opcode | 44 | 44 | 36 | 18.1818181818182 | 18.1818181818182
test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_bool | 84 | 84 | 60 | 28.5714285714286 | 28.5714285714286
test/src/e2e_vm_tests/test_programs/should_pass/language/diagnose_unknown_annotations | 100 | 100 | 84 | 16 | 16
test/src/e2e_vm_tests/test_programs/should_pass/language/generic_struct | 116 | 116 | 116 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/primitive_type_argument | 200 | 200 | 200 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug | 300 | 300 | 172 | 42.6666666666667 | 42.6666666666667
test/src/e2e_vm_tests/test_programs/should_pass/language/fixing_generic_type | 828 | 516 | 452 | 12.4031007751938 | 45.4106280193237
test/src/e2e_vm_tests/test_programs/should_pass/language/import_method_from_other_file | 84 | 84 | 84 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/aliased_imports | 84 | 84 | 84 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/break_and_continue | 1260 | 1220 | 1060 | 13.1147540983607 | 15.8730158730159
test/src/e2e_vm_tests/test_programs/should_pass/language/empty_method_initializer | 452 | 460 | 404 | 12.1739130434783 | 10.6194690265487
test/src/e2e_vm_tests/test_programs/should_pass/language/const_inits | 2932 | 2524 | 2316 | 8.24088748019017 | 21.0095497953615
test/src/e2e_vm_tests/test_programs/should_pass/language/if_implicit_unit | 28 | 28 | 28 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/enum_init_fn_call | 636 | 620 | 572 | 7.74193548387097 | 10.062893081761
test/src/e2e_vm_tests/test_programs/should_pass/language/enum_padding | 124 | 124 | 124 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/method_on_empty_struct | 52 | 52 | 36 | 30.7692307692308 | 30.7692307692308
test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl | 84 | 84 | 68 | 19.047619047619 | 19.047619047619
test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_access | 552 | 552 | 552 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/impure_ifs | 1388 | 900 | 796 | 11.5555555555556 | 42.6512968299712
test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_u32 | 84 | 84 | 76 | 9.52380952380952 | 9.52380952380952
test/src/e2e_vm_tests/test_programs/should_pass/language/trait_import_with_star | 84 | 84 | 68 | 19.047619047619 | 19.047619047619
test/src/e2e_vm_tests/test_programs/should_pass/language/while_loops | 676 | 692 | 580 | 16.1849710982659 | 14.2011834319527
test/src/e2e_vm_tests/test_programs/should_pass/language/local_impl_for_ord | 44 | 44 | 28 | 36.3636363636364 | 36.3636363636364
test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_inside_generic_functions | 1732 | 1724 | 1564 | 9.28074245939675 | 9.69976905311778
test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants | 644 | 44 | 28 | 36.3636363636364 | 95.6521739130435
test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self | 1164 | 1100 | 1068 | 2.90909090909091 | 8.24742268041237
test/src/e2e_vm_tests/test_programs/should_pass/language/generic_inside_generic | 316 | 316 | 308 | 2.53164556962025 | 2.53164556962025
test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions | 380 | 380 | 364 | 4.21052631578947 | 4.21052631578947
test/src/e2e_vm_tests/test_programs/should_pass/language/self_impl_reassignment | 1324 | 1356 | 1236 | 8.84955752212389 | 6.64652567975831
test/src/e2e_vm_tests/test_programs/should_pass/language/b256_ops | 1296 | 1104 | 1056 | 4.34782608695652 | 18.5185185185185
test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self | 44 | 44 | 44 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics | 1492 | 1492 | 1292 | 13.4048257372654 | 13.4048257372654
test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_desugaring | 332 | 332 | 332 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/non_literal_const_decl | 60 | 60 | 60 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/redundant_return | 76 | 44 | 28 | 36.3636363636364 | 63.1578947368421
test/src/e2e_vm_tests/test_programs/should_pass/language/nested_struct_destructuring | 736 | 736 | 736 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/language/new_allocator_test | 892 | 804 | 700 | 12.9353233830846 | 21.52466367713
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/evm_ecr | 1376 | 1240 | 1192 | 3.87096774193548 | 13.3720930232558
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_div_test | 54508 | 54532 | 53844 | 1.26164453898628 | 1.21816980993616
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/mem | 3452 | 2372 | 2172 | 8.43170320404722 | 37.0799536500579
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/result | 604 | 620 | 548 | 11.6129032258065 | 9.27152317880795
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_mul_test | 5228 | 5196 | 4884 | 6.00461893764434 | 6.57995409334353
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/require | 924 | 520 | 472 | 9.23076923076923 | 48.9177489177489
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/address_test | 4440 | 2696 | 2360 | 12.4629080118694 | 46.8468468468469
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/alloc | 1060 | 1108 | 948 | 14.4404332129964 | 10.5660377358491
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_ops_test | 66900 | 67468 | 65732 | 2.57307167842533 | 1.74588938714499
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_test | 3964 | 4052 | 3660 | 9.67423494570583 | 7.66902119071645
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_test | 2772 | 2852 | 2476 | 13.1837307152875 | 10.6782106782107
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/option | 604 | 620 | 548 | 11.6129032258065 | 9.27152317880795
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/exponentiation_test | 2148 | 2300 | 1868 | 18.7826086956522 | 13.0353817504656
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/vec | 190064 | 178032 | 167016 | 6.18765165812888 | 12.126441619665
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/vec_swap | 38708 | 35060 | 32036 | 8.62521391899601 | 17.2367469257001
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_test | 412 | 172 | 108 | 37.2093023255814 | 73.7864077669903
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/intrinsics | 1500 | 516 | 468 | 9.30232558139535 | 68.8
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ge_test | 252 | 236 | 212 | 10.1694915254237 | 15.8730158730159
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_test | 9252 | 9396 | 8660 | 7.83312047679864 | 6.39861651534803
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ec_recover_test | 3028 | 2932 | 2732 | 6.82128240109141 | 9.77542932628798
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/contract_id_test | 288 | 304 | 256 | 15.7894736842105 | 11.1111111111111
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/contract_id_type | 492 | 372 | 316 | 15.0537634408602 | 35.7723577235772
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/block_height | 140 | 156 | 100 | 35.8974358974359 | 28.5714285714286
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_mul_test | 80316 | 80604 | 79020 | 1.965163019205 | 1.61362617660242
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_div_test | 4380 | 4340 | 4052 | 6.63594470046083 | 7.48858447488584
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/identity_eq | 8060 | 5884 | 5412 | 8.02175390890551 | 32.8535980148883
test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_struct_alignment | 340 | 340 | 308 | 9.41176470588235 | 9.41176470588235
test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/abi_fn_params | 116 | 116 | 116 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/dca/unused_struct | 28 | 28 | 28 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/dca/unused_free_fn | 28 | 28 | 28 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/dca/library/fn_params_free | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/dca/library/fn_params_impl | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/dca/library/unused_pub_free_fn | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/dca/library/fn_params_trait | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_decl_expr | 68 | 68 | 68 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples | 508 | 524 | 476 | 9.16030534351145 | 6.2992125984252
test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract | 444 | 452 | 412 | 8.84955752212389 | 7.20720720720721
test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode | 392 | 408 | 352 | 13.7254901960784 | 10.2040816326531
test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller | 1136 | 1044 | 948 | 9.19540229885057 | 16.5492957746479
test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/nested_struct_args_caller | 372 | 380 | 340 | 10.5263157894737 | 8.60215053763441
test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test | 780 | 804 | 724 | 9.95024875621891 | 7.17948717948718
test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller | 11084 | 11180 | 9924 | 11.2343470483005 | 10.4655359076146
test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test | 252 | 268 | 244 | 8.95522388059701 | 3.17460317460317
test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/get_storage_key_caller | 1668 | 1756 | 1564 | 10.9339407744875 | 6.23501199040767
test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage | 1344 | 1368 | 1304 | 4.67836257309942 | 2.97619047619048
test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/token_ops_test | 952 | 984 | 888 | 9.75609756097561 | 6.72268907563025
test/src/e2e_vm_tests/test_programs/should_pass/test_abis/get_storage_key_abi | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/test_abis/abi_with_tuples | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/test_abis/test_fuel_coin_abi | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/test_abis/context_testing_abi | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/test_abis/basic_storage_abi | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/test_abis/storage_access_abi | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/test_abis/auth_testing_abi | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/test_abis/increment_abi | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/test_abis/balance_test_abi | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/test_abis/array_of_structs_abi | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/test_abis/nested_struct_args_abi | 0 | 0 | 0 | #DIV/0! | #DIV/0!
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/context_testing_contract | 332 | 332 | 332 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage | 19732 | 11760 | 11552 | 1.7687074829932 | 41.4555037502534
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract | 5956 | 5956 | 5956 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/auth_testing_contract | 60 | 60 | 60 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/nested_struct_args_contract | 124 | 124 | 116 | 6.45161290322581 | 6.45161290322581
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_tuples_contract | 108 | 108 | 92 | 14.8148148148148 | 14.8148148148148
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/test_fuel_coin_contract | 148 | 148 | 148 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/array_of_structs_contract | 180 | 180 | 164 | 8.88888888888889 | 8.88888888888889
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_generic_types | 152 | 152 | 144 | 5.26315789473684 | 5.26315789473684
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/get_storage_key_contract | 452 | 452 | 452 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/balance_test_contract | 68 | 68 | 68 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/multiple_impl | 212 | 100 | 84 | 16 | 60.377358490566
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/issue_1512_repro | 564 | 564 | 564 | 0 | 0
test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/increment_contract | 256 | 256 | 256 | 0 | 0
