### PR TITLE
Add a monomorphization cache to the declaration engine.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -1,4 +1,5 @@
 use crate::{
+    declaration_engine::declaration_wrapper::DeclarationWrapper,
     error::*,
     parse_tree::*,
     semantic_analysis::*,
@@ -66,6 +67,10 @@ impl MonomorphizeHelper for TypedEnumDeclaration {
 
     fn name(&self) -> &Ident {
         &self.name
+    }
+
+    fn to_wrapper(&self) -> DeclarationWrapper {
+        DeclarationWrapper::Enum(self.clone())
     }
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -1,7 +1,10 @@
 mod function_parameter;
 pub use function_parameter::*;
 
-use crate::{error::*, parse_tree::*, semantic_analysis::*, style::*, type_system::*};
+use crate::{
+    declaration_engine::declaration_wrapper::DeclarationWrapper, error::*, parse_tree::*,
+    semantic_analysis::*, style::*, type_system::*,
+};
 use sha2::{Digest, Sha256};
 use sway_types::{Ident, JsonABIFunction, JsonTypeApplication, JsonTypeDeclaration, Span, Spanned};
 
@@ -78,6 +81,10 @@ impl MonomorphizeHelper for TypedFunctionDeclaration {
 
     fn name(&self) -> &Ident {
         &self.name
+    }
+
+    fn to_wrapper(&self) -> DeclarationWrapper {
+        DeclarationWrapper::Function(self.clone())
     }
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
@@ -1,4 +1,7 @@
-use crate::{error::*, parse_tree::*, semantic_analysis::*, type_system::*};
+use crate::{
+    declaration_engine::declaration_wrapper::DeclarationWrapper, error::*, parse_tree::*,
+    semantic_analysis::*, type_system::*,
+};
 use std::hash::{Hash, Hasher};
 use sway_types::{Ident, Span, Spanned};
 
@@ -57,6 +60,10 @@ impl MonomorphizeHelper for TypedStructDeclaration {
 
     fn name(&self) -> &Ident {
         &self.name
+    }
+
+    fn to_wrapper(&self) -> DeclarationWrapper {
+        DeclarationWrapper::Struct(self.clone())
     }
 }
 

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -7,7 +7,7 @@ mod resolved_type;
 mod trait_constraint;
 mod type_argument;
 mod type_binding;
-mod type_engine;
+pub(crate) mod type_engine;
 mod type_id;
 mod type_info;
 mod type_mapping;

--- a/sway-core/src/type_system/type_argument.rs
+++ b/sway-core/src/type_system/type_argument.rs
@@ -30,6 +30,12 @@ impl PartialEq for TypeArgument {
     }
 }
 
+impl PartialEq<TypeParameter> for TypeArgument {
+    fn eq(&self, other: &TypeParameter) -> bool {
+        self.type_id == other.type_id
+    }
+}
+
 impl Default for TypeArgument {
     fn default() -> Self {
         let initial_type_id = insert_type(TypeInfo::Unknown);

--- a/sway-core/src/type_system/type_engine.rs
+++ b/sway-core/src/type_system/type_engine.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::concurrent_slab::ConcurrentSlab;
+use crate::declaration_engine::declaration_wrapper::DeclarationWrapper;
 use crate::namespace::{Path, Root};
 use lazy_static::lazy_static;
 use sway_types::span::Span;
@@ -577,6 +578,7 @@ enum NumericCastCompatResult {
 pub(crate) trait MonomorphizeHelper {
     fn name(&self) -> &Ident;
     fn type_parameters(&self) -> &[TypeParameter];
+    fn to_wrapper(&self) -> DeclarationWrapper;
 }
 
 /// This type is used to denote if, during monomorphization, the compiler

--- a/sway-core/src/type_system/type_parameter.rs
+++ b/sway-core/src/type_system/type_parameter.rs
@@ -37,6 +37,12 @@ impl PartialEq for TypeParameter {
     }
 }
 
+impl PartialEq<TypeArgument> for TypeParameter {
+    fn eq(&self, other: &TypeArgument) -> bool {
+        self.type_id == other.type_id
+    }
+}
+
 impl CopyTypes for TypeParameter {
     fn copy_types(&mut self, type_mapping: &TypeMapping) {
         self.type_id = match look_up_type_id(self.type_id).matches_type_parameter(type_mapping) {


### PR DESCRIPTION
This introduces a cache to the declaration engine that keeps track of functions/structs that have been instantiated from a specific set of type parameters.

The approach here is relatively simple and relies on a linear search. I originally thought about having more maps to speed it up by keying on the type arguments, but since it adds a bit of complexity I opted for this for now. If it proves to be a bottleneck in the future we can always speed it up.

This was prototyped in https://github.com/tritao/declaration-engine-and-collection-context-demo/commit/c3aa5e718211ee1a88d7ebc51798280e8321e387, where these APIs where wired to the function application and struct expressions instantiation code.

However given the declaration engine is not hooked up yet here, this PR is just adding the APIs, and more proper testing will be added as we wire things up.

Closes https://github.com/FuelLabs/sway/issues/2636.