### PR TITLE
Fix warning regression when handling break and continue expressions.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -474,19 +474,24 @@ impl TypedAstNode {
         };
 
         if let TypedAstNode {
-            content: TypedAstNodeContent::Expression(TypedExpression { .. }),
+            content: TypedAstNodeContent::Expression(TypedExpression { ref expression, .. }),
             ..
         } = node
         {
-            let warning = Warning::UnusedReturnValue {
-                r#type: Box::new(node.type_info()),
-            };
-            assert_or_warn!(
-                node.type_info().is_unit() || node.type_info() == TypeInfo::ErrorRecovery,
-                warnings,
-                node.span.clone(),
-                warning
-            );
+            if !matches!(
+                expression,
+                TypedExpressionVariant::Break | TypedExpressionVariant::Continue,
+            ) {
+                let warning = Warning::UnusedReturnValue {
+                    r#type: Box::new(node.type_info()),
+                };
+                assert_or_warn!(
+                    node.type_info().is_unit() || node.type_info() == TypeInfo::ErrorRecovery,
+                    warnings,
+                    node.span.clone(),
+                    warning
+                );
+            }
         }
 
         ok(node, warnings, errors)

--- a/test/src/e2e_vm_tests/test_programs/should_fail/illegal_break/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/illegal_break/test.toml
@@ -1,9 +1,5 @@
 category = "fail"
 
-# check: $()fn main() {
-# nextln: $()break;
-# nextln: $()not assigned to anything
-
 # check: $()This code is unreachable
 
 # check: $()fn main() {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/illegal_continue/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/illegal_continue/test.toml
@@ -1,9 +1,5 @@
 category = "fail"
 
-# check: $()fn main() {
-# nextln: $()continue;
-# nextln: $()not assigned to anything
-
 # check: $()This code is unreachable
 
 # check: $()fn main() {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/break_and_continue_block_ret/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/break_and_continue_block_ret/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'break_and_continue_block_ret'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/break_and_continue_block_ret/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/break_and_continue_block_ret/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "break_and_continue_block_ret"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/break_and_continue_block_ret/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/break_and_continue_block_ret/src/main.sw
@@ -1,0 +1,15 @@
+script;
+
+fn main() {
+    while true {
+        if true {
+            break;
+        }
+    }
+
+    while true {
+        if true {
+            continue;
+        }
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/break_and_continue_block_ret/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/break_and_continue_block_ret/test.toml
@@ -1,0 +1,3 @@
+category = "compile"
+
+# not: $()This returns a value of type unknown, which is not assigned to anything and is ignored.


### PR DESCRIPTION
This fixes a recently introduced regression when checking for unused expression values inside blocks.

The following code:

```rust
script;

fn main() {
    while true {
        if true {
            break;
        }
    }
}
```

Would emit the following warning:

```
This returns a value of type unknown, which is not assigned to anything and is ignored.
```

The fix is pretty simple and just checks to make sure we are not handling either a break or return expresisons before issuing the warning.

Closes https://github.com/FuelLabs/sway/issues/2638.