### PR TITLE
Pass the `Declaration Engine` to IR gen

### DIFF
--- a/sway-core/src/declaration_engine/declaration_engine.rs
+++ b/sway-core/src/declaration_engine/declaration_engine.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{
     concurrent_slab::ConcurrentSlab,
     semantic_analysis::{
@@ -9,18 +11,19 @@ use crate::{
 use super::{declaration_id::DeclarationId, declaration_wrapper::DeclarationWrapper};
 
 /// Used inside of type inference to store declarations.
+#[derive(Debug)]
 pub struct DeclarationEngine {
     slab: ConcurrentSlab<DeclarationId, DeclarationWrapper>,
     // *declaration_id -> vec of monomorphized copies
     // where the declaration_id is the original declaration
-    monomorphized_copies: im::HashMap<usize, Vec<DeclarationId>>,
+    monomorphized_copies: HashMap<usize, Vec<DeclarationId>>,
 }
 
 impl DeclarationEngine {
     pub(crate) fn new() -> DeclarationEngine {
         DeclarationEngine {
             slab: ConcurrentSlab::default(),
-            monomorphized_copies: im::HashMap::new(),
+            monomorphized_copies: HashMap::new(),
         }
     }
 

--- a/sway-core/src/declaration_engine/declaration_wrapper.rs
+++ b/sway-core/src/declaration_engine/declaration_wrapper.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// The [DeclarationWrapper] type is used in the [DeclarationEngine]
 /// as a means of placing all declaration types into the same type.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum DeclarationWrapper {
     // no-op variant to fulfill the default trait
     Default,

--- a/sway-core/src/ir_generation.rs
+++ b/sway-core/src/ir_generation.rs
@@ -18,7 +18,12 @@ use sway_types::span::Span;
 pub(crate) use purity::PurityChecker;
 
 pub fn compile_program(program: TypedProgram) -> Result<Context, CompileError> {
-    let TypedProgram { kind, root, .. } = program;
+    let TypedProgram {
+        kind,
+        root,
+        declaration_engine,
+        ..
+    } = program;
 
     let mut ctx = Context::default();
     match kind {
@@ -31,11 +36,23 @@ pub fn compile_program(program: TypedProgram) -> Result<Context, CompileError> {
             declarations,
             // predicates and scripts have the same codegen, their only difference is static
             // type-check time checks.
-        } => compile::compile_script(&mut ctx, main_function, &root.namespace, declarations),
+        } => compile::compile_script(
+            &mut ctx,
+            main_function,
+            &root.namespace,
+            &declaration_engine,
+            declarations,
+        ),
         TypedProgramKind::Contract {
             abi_entries,
             declarations,
-        } => compile::compile_contract(&mut ctx, abi_entries, &root.namespace, declarations),
+        } => compile::compile_contract(
+            &mut ctx,
+            abi_entries,
+            &root.namespace,
+            &declaration_engine,
+            declarations,
+        ),
         TypedProgramKind::Library { .. } => unimplemented!("compile library to ir"),
     }?;
     ctx.verify()

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -1,4 +1,5 @@
 use crate::{
+    declaration_engine::declaration_engine,
     error::CompileError,
     metadata::MetadataManager,
     parse_tree::Visibility,
@@ -19,13 +20,21 @@ pub(super) fn compile_script(
     context: &mut Context,
     main_function: TypedFunctionDeclaration,
     namespace: &namespace::Module,
+    declaration_engine: &declaration_engine::DeclarationEngine,
     declarations: Vec<TypedDeclaration>,
 ) -> Result<Module, CompileError> {
     let module = Module::new(context, Kind::Script);
     let mut md_mgr = MetadataManager::default();
 
     compile_constants(context, &mut md_mgr, module, namespace)?;
-    compile_declarations(context, &mut md_mgr, module, namespace, declarations)?;
+    compile_declarations(
+        context,
+        &mut md_mgr,
+        module,
+        namespace,
+        declaration_engine,
+        declarations,
+    )?;
     compile_function(context, &mut md_mgr, module, main_function)?;
 
     Ok(module)
@@ -35,13 +44,21 @@ pub(super) fn compile_contract(
     context: &mut Context,
     abi_entries: Vec<TypedFunctionDeclaration>,
     namespace: &namespace::Module,
+    declaration_engine: &declaration_engine::DeclarationEngine,
     declarations: Vec<TypedDeclaration>,
 ) -> Result<Module, CompileError> {
     let module = Module::new(context, Kind::Contract);
     let mut md_mgr = MetadataManager::default();
 
     compile_constants(context, &mut md_mgr, module, namespace)?;
-    compile_declarations(context, &mut md_mgr, module, namespace, declarations)?;
+    compile_declarations(
+        context,
+        &mut md_mgr,
+        module,
+        namespace,
+        declaration_engine,
+        declarations,
+    )?;
     for decl in abi_entries {
         compile_abi_method(context, &mut md_mgr, module, decl)?;
     }
@@ -84,12 +101,12 @@ pub(crate) fn compile_constants(
 // And for structs and enums in particular, we must ignore those with embedded generic types as
 // they are monomorphised only at the instantation site.  We must ignore the generic declarations
 // altogether anyway.
-
 fn compile_declarations(
     context: &mut Context,
     md_mgr: &mut MetadataManager,
     module: Module,
     namespace: &namespace::Module,
+    _declaration_engine: &declaration_engine::DeclarationEngine,
     declarations: Vec<TypedDeclaration>,
 ) -> Result<(), CompileError> {
     for declaration in declarations {

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -240,13 +240,11 @@ pub fn parsed_to_ast(
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
 
-    let mut declaration_engine = DeclarationEngine::new();
-
     let CompileResult {
         value: typed_program_result,
         warnings: new_warnings,
         errors: new_errors,
-    } = TypedProgram::type_check(parse_program, initial_namespace, &mut declaration_engine);
+    } = TypedProgram::type_check(parse_program, initial_namespace, DeclarationEngine::new());
     warnings.extend(new_warnings);
     errors.extend(new_errors);
     let typed_program = match typed_program_result {


### PR DESCRIPTION
Skeleton code to pass the DE to IR gen. Also a switch from `im::HashMap` to `HashMap` per https://github.com/FuelLabs/sway/pull/2630#discussion_r956908535