### PR TITLE
Fixes consecutive `fn_sig` formatting

### DIFF
--- a/sway-fmt-v2/src/items/item_fn/mod.rs
+++ b/sway-fmt-v2/src/items/item_fn/mod.rs
@@ -103,9 +103,7 @@ impl Format for FnSignature {
         format_fn_sig(self, &mut fn_sig, &mut temp_formatter)?;
         format_fn_args(self.arguments.get(), &mut fn_args, &mut temp_formatter)?;
 
-        println!("{}", fn_sig);
         let fn_sig_width = fn_sig.chars().count() as usize + 2; // add two for opening brace + space
-        println!("{}", fn_args);
         let fn_args_width = fn_args.chars().count() as usize;
 
         formatter.shape.update_width(fn_sig_width);

--- a/sway-fmt-v2/src/items/item_fn/mod.rs
+++ b/sway-fmt-v2/src/items/item_fn/mod.rs
@@ -167,9 +167,7 @@ fn format_fn_args(
 ) -> Result<(), FormatterError> {
     match fn_args {
         FnArgs::Static(args) => {
-            if !args.value_separator_pairs.is_empty() || args.final_value_opt.is_some() {
-                args.format(formatted_code, formatter)?;
-            }
+            args.format(formatted_code, formatter)?;
         }
         FnArgs::NonStatic {
             self_token,

--- a/sway-fmt-v2/src/items/item_fn/mod.rs
+++ b/sway-fmt-v2/src/items/item_fn/mod.rs
@@ -103,17 +103,18 @@ impl Format for FnSignature {
         format_fn_sig(self, &mut fn_sig, &mut temp_formatter)?;
         format_fn_args(self.arguments.get(), &mut fn_args, &mut temp_formatter)?;
 
+        println!("{}", fn_sig);
         let fn_sig_width = fn_sig.chars().count() as usize + 2; // add two for opening brace + space
+        println!("{}", fn_args);
         let fn_args_width = fn_args.chars().count() as usize;
 
-        formatter.shape.add_width(fn_sig_width);
+        formatter.shape.update_width(fn_sig_width);
         formatter
             .shape
             .get_line_style(None, Some(fn_args_width), &formatter.config);
 
         format_fn_sig(self, formatted_code, formatter)?;
 
-        formatter.shape.sub_width(fn_sig_width);
         formatter.shape.update_line_settings(prev_state);
 
         Ok(())
@@ -168,7 +169,9 @@ fn format_fn_args(
 ) -> Result<(), FormatterError> {
     match fn_args {
         FnArgs::Static(args) => {
-            args.format(formatted_code, formatter)?;
+            if !args.value_separator_pairs.is_empty() || args.final_value_opt.is_some() {
+                args.format(formatted_code, formatter)?;
+            }
         }
         FnArgs::NonStatic {
             self_token,


### PR DESCRIPTION
Found while testing on Sway applications, consecutive fn signatures will take into account the width of the previous function. In order to stop this we replace the add and sub width methods with an update method instead.

Closes #2662 