### PR TITLE
fix: sway-fmt-v2 newline/comment handler makes duplicate searches

### DIFF
--- a/sway-fmt-v2/src/utils/map/comments.rs
+++ b/sway-fmt-v2/src/utils/map/comments.rs
@@ -159,21 +159,23 @@ fn get_comments_between_spans(
     unformatted_code: &Arc<str>,
 ) -> Vec<CommentWithContext> {
     let mut comments_with_context: Vec<CommentWithContext> = Vec::new();
-    for (index, (comment_span, comment)) in comment_map
-        .range((Included(from), Excluded(to)))
-        .enumerate()
-    {
-        let starting_position_for_context = if index == 0 {
-            // This is the first comment in the current range the context should be collected between from's end and comment's beginning
-            from.end
-        } else {
-            // There is a comment before this one, so we should get the context starting from the last comment's end to the beginning of the current comment
-            comments_with_context[index - 1].0.span.end()
-        };
-        comments_with_context.push((
-            comment.clone(),
-            unformatted_code[starting_position_for_context..comment_span.start].to_string(),
-        ));
+    if from < to {
+        for (index, (comment_span, comment)) in comment_map
+            .range((Included(from), Excluded(to)))
+            .enumerate()
+        {
+            let starting_position_for_context = if index == 0 {
+                // This is the first comment in the current range the context should be collected between from's end and comment's beginning
+                from.end
+            } else {
+                // There is a comment before this one, so we should get the context starting from the last comment's end to the beginning of the current comment
+                comments_with_context[index - 1].0.span.end()
+            };
+            comments_with_context.push((
+                comment.clone(),
+                unformatted_code[starting_position_for_context..comment_span.start].to_string(),
+            ));
+        }
     }
     comments_with_context
 }

--- a/sway-fmt-v2/src/utils/map/newline.rs
+++ b/sway-fmt-v2/src/utils/map/newline.rs
@@ -203,8 +203,10 @@ fn get_newline_sequences_between_spans(
     newline_map: &NewlineMap,
 ) -> Vec<NewlineSequence> {
     let mut newline_sequences: Vec<NewlineSequence> = Vec::new();
-    for (_, newline_sequence) in newline_map.range((Included(from), Excluded(to))) {
-        newline_sequences.push(newline_sequence.clone());
+    if from < to {
+        for (_, newline_sequence) in newline_map.range((Included(from), Excluded(to))) {
+            newline_sequences.push(newline_sequence.clone());
+        }
     }
     newline_sequences
 }


### PR DESCRIPTION
closes #2664.

This is blocking #2668