### PR TITLE
Bump to `fuels v0.22.0` and remove the "-flat" from the name of the JSON ABI file

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1847,7 +1847,7 @@ pub fn build_with_options(build_options: BuildOptions) -> Result<Compiled> {
         .with_extension("bin");
     fs::write(&bin_path, &compiled.bytecode)?;
     if !compiled.json_abi_program.functions.is_empty() {
-        let json_abi_program_stem = format!("{}-flat-abi", manifest.project.name);
+        let json_abi_program_stem = format!("{}-abi", manifest.project.name);
         let json_abi_program_path = output_dir
             .join(&json_abi_program_stem)
             .with_extension("json");

--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -30,7 +30,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = {{ version = "0.21", features = ["fuel-core-lib"] }}
+fuels = {{ version = "0.22", features = ["fuel-core-lib"] }}
 tokio = {{ version = "1.12", features = ["rt", "macros"] }}
 
 [[test]]
@@ -96,7 +96,7 @@ pub(crate) fn default_test_program(project_name: &str) -> String {
 // Load abi from json
 abigen!(MyContract, "out/debug/"#,
         project_name,
-        r#"-flat-abi.json");
+        r#"-abi.json");
 
 async fn get_contract_instance() -> (MyContract, ContractId) {
     // Launch a local network and deploy the contract

--- a/test/src/sdk-harness/Cargo.toml
+++ b/test/src/sdk-harness/Cargo.toml
@@ -11,7 +11,7 @@ fuel-core = { version = "0.10", default-features = false }
 fuel-gql-client = { version = "0.10", default-features = false }
 fuel-types = "0.5"
 fuel-vm = "0.15"
-fuels = { version = "0.21", features = ["fuel-core-lib"] }
+fuels = { version = "0.22", features = ["fuel-core-lib"] }
 hex = "0.4.3"
 rand = "0.8"
 sha2 = "0.10"

--- a/test/src/sdk-harness/test_projects/auth/mod.rs
+++ b/test/src/sdk-harness/test_projects/auth/mod.rs
@@ -2,11 +2,11 @@ use fuels::{prelude::*, tx::ContractId};
 
 abigen!(
     AuthContract,
-    "test_artifacts/auth_testing_contract/out/debug/auth_testing_contract-flat-abi.json"
+    "test_artifacts/auth_testing_contract/out/debug/auth_testing_contract-abi.json"
 );
 abigen!(
     AuthCallerContract,
-    "test_artifacts/auth_caller_contract/out/debug/auth_caller_contract-flat-abi.json"
+    "test_artifacts/auth_caller_contract/out/debug/auth_caller_contract-abi.json"
 );
 
 #[tokio::test]

--- a/test/src/sdk-harness/test_projects/call_frames/mod.rs
+++ b/test/src/sdk-harness/test_projects/call_frames/mod.rs
@@ -5,7 +5,7 @@ use sha2::{Digest, Sha256};
 
 abigen!(
     CallFramesTestContract,
-    "test_projects/call_frames/out/debug/call_frames-flat-abi.json"
+    "test_projects/call_frames/out/debug/call_frames-abi.json"
 );
 
 async fn get_call_frames_instance() -> (CallFramesTestContract, ContractId) {

--- a/test/src/sdk-harness/test_projects/context/mod.rs
+++ b/test/src/sdk-harness/test_projects/context/mod.rs
@@ -3,15 +3,15 @@ use fuels::{prelude::*, tx::ContractId};
 
 abigen!(
     TestContextContract,
-    "test_projects/context/out/debug/context-flat-abi.json",
+    "test_projects/context/out/debug/context-abi.json",
 );
 abigen!(
     TestContextCallerContract,
-    "test_artifacts/context_caller_contract/out/debug/context_caller_contract-flat-abi.json",
+    "test_artifacts/context_caller_contract/out/debug/context_caller_contract-abi.json",
 );
 abigen!(
     FuelCoin,
-    "test_projects/token_ops/out/debug/token_ops-flat-abi.json"
+    "test_projects/token_ops/out/debug/token_ops-abi.json"
 );
 
 async fn get_contracts() -> (

--- a/test/src/sdk-harness/test_projects/evm/mod.rs
+++ b/test/src/sdk-harness/test_projects/evm/mod.rs
@@ -1,6 +1,6 @@
 use fuels::{prelude::*, tx::ContractId};
 
-abigen!(EvmTestContract, "test_projects/evm/out/debug/evm-flat-abi.json");
+abigen!(EvmTestContract, "test_projects/evm/out/debug/evm-abi.json");
 
 async fn get_evm_test_instance() -> (EvmTestContract, ContractId) {
     let wallet = launch_provider_and_get_wallet().await;

--- a/test/src/sdk-harness/test_projects/exponentiation/mod.rs
+++ b/test/src/sdk-harness/test_projects/exponentiation/mod.rs
@@ -1,7 +1,7 @@
 use fuels::prelude::*;
 use fuels::tx::ContractId;
 
-abigen!(TestPowContract, "test_artifacts/pow/out/debug/pow-flat-abi.json");
+abigen!(TestPowContract, "test_artifacts/pow/out/debug/pow-abi.json");
 
 #[tokio::test]
 #[should_panic(expected = "ArithmeticOverflow")]

--- a/test/src/sdk-harness/test_projects/hashing/mod.rs
+++ b/test/src/sdk-harness/test_projects/hashing/mod.rs
@@ -4,7 +4,7 @@ use sha3::Keccak256;
 
 abigen!(
     HashingTestContract,
-    "test_projects/hashing/out/debug/hashing-flat-abi.json"
+    "test_projects/hashing/out/debug/hashing-abi.json"
 );
 
 enum Hash {

--- a/test/src/sdk-harness/test_projects/methods/mod.rs
+++ b/test/src/sdk-harness/test_projects/methods/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::*;
 
 abigen!(
     MethodsContract,
-    "test_artifacts/methods_contract/out/debug/methods_contract-flat-abi.json",
+    "test_artifacts/methods_contract/out/debug/methods_contract-abi.json",
 );
 
 #[tokio::test]

--- a/test/src/sdk-harness/test_projects/option_field_order/mod.rs
+++ b/test/src/sdk-harness/test_projects/option_field_order/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::*;
 
 abigen!(
     MyContract,
-    "test_projects/option_field_order/out/debug/option_field_order-flat-abi.json"
+    "test_projects/option_field_order/out/debug/option_field_order-abi.json"
 );
 
 #[tokio::test]

--- a/test/src/sdk-harness/test_projects/reentrancy/mod.rs
+++ b/test/src/sdk-harness/test_projects/reentrancy/mod.rs
@@ -3,12 +3,12 @@ use fuels::tx::ContractId;
 
 abigen!(
     AttackerContract,
-    "test_artifacts/reentrancy_attacker_contract/out/debug/reentrancy_attacker_contract-flat-abi.json",
+    "test_artifacts/reentrancy_attacker_contract/out/debug/reentrancy_attacker_contract-abi.json",
 );
 
 abigen!(
     TargetContract,
-    "test_artifacts/reentrancy_target_contract/out/debug/reentrancy_target_contract-flat-abi.json",
+    "test_artifacts/reentrancy_target_contract/out/debug/reentrancy_target_contract-abi.json",
 );
 
 #[tokio::test]

--- a/test/src/sdk-harness/test_projects/registers/mod.rs
+++ b/test/src/sdk-harness/test_projects/registers/mod.rs
@@ -3,7 +3,7 @@ use fuels::prelude::*;
 
 abigen!(
     TestRegistersContract,
-    "test_projects/registers/out/debug/registers-flat-abi.json",
+    "test_projects/registers/out/debug/registers-abi.json",
 );
 
 // Compile contract, create node and deploy contract, returning TestRegistersContract contract instance

--- a/test/src/sdk-harness/test_projects/storage/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::*;
 
 abigen!(
     TestStorageContract,
-    "test_projects/storage/out/debug/storage-flat-abi.json",
+    "test_projects/storage/out/debug/storage-abi.json",
 );
 
 async fn get_test_storage_instance() -> TestStorageContract {

--- a/test/src/sdk-harness/test_projects/storage_map/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_map/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::*;
 
 abigen!(
     TestStorageMapContract,
-    "test_projects/storage_map/out/debug/storage_map-flat-abi.json",
+    "test_projects/storage_map/out/debug/storage_map-abi.json",
 );
 
 async fn test_storage_map_instance() -> TestStorageMapContract {

--- a/test/src/sdk-harness/test_projects/storage_vec/array/utils.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/array/utils.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, tx::ContractId};
 // Load abi from json
 abigen!(
     MyContract,
-    "test_artifacts/storage_vec/svec_array/out/debug/svec_array-flat-abi.json"
+    "test_artifacts/storage_vec/svec_array/out/debug/svec_array-abi.json"
 );
 
 pub mod setup {

--- a/test/src/sdk-harness/test_projects/storage_vec/b256/utils.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/b256/utils.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, tx::ContractId};
 // Load abi from json
 abigen!(
     MyContract,
-    "test_artifacts/storage_vec/svec_b256/out/debug/svec_b256-flat-abi.json"
+    "test_artifacts/storage_vec/svec_b256/out/debug/svec_b256-abi.json"
 );
 
 pub mod setup {

--- a/test/src/sdk-harness/test_projects/storage_vec/bool/utils.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/bool/utils.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, tx::ContractId};
 // Load abi from json
 abigen!(
     MyContract,
-    "test_artifacts/storage_vec/svec_bool/out/debug/svec_bool-flat-abi.json"
+    "test_artifacts/storage_vec/svec_bool/out/debug/svec_bool-abi.json"
 );
 
 pub mod setup {

--- a/test/src/sdk-harness/test_projects/storage_vec/enum/utils.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/enum/utils.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, tx::ContractId};
 // Load abi from json
 abigen!(
     MyContract,
-    "test_artifacts/storage_vec/svec_enum/out/debug/svec_enum-flat-abi.json"
+    "test_artifacts/storage_vec/svec_enum/out/debug/svec_enum-abi.json"
 );
 
 pub mod setup {

--- a/test/src/sdk-harness/test_projects/storage_vec/str/utils.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/str/utils.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, tx::ContractId};
 // Load abi from json
 abigen!(
     MyContract,
-    "test_artifacts/storage_vec/svec_str/out/debug/svec_str-flat-abi.json"
+    "test_artifacts/storage_vec/svec_str/out/debug/svec_str-abi.json"
 );
 
 pub mod setup {

--- a/test/src/sdk-harness/test_projects/storage_vec/struct/utils.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/struct/utils.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, tx::ContractId};
 // Load abi from json
 abigen!(
     MyContract,
-    "test_artifacts/storage_vec/svec_struct/out/debug/svec_struct-flat-abi.json"
+    "test_artifacts/storage_vec/svec_struct/out/debug/svec_struct-abi.json"
 );
 
 pub mod setup {

--- a/test/src/sdk-harness/test_projects/storage_vec/tuple/utils.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/tuple/utils.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, tx::ContractId};
 // Load abi from json
 abigen!(
     MyContract,
-    "test_artifacts/storage_vec/svec_tuple/out/debug/svec_tuple-flat-abi.json"
+    "test_artifacts/storage_vec/svec_tuple/out/debug/svec_tuple-abi.json"
 );
 
 pub mod setup {

--- a/test/src/sdk-harness/test_projects/storage_vec/u16/utils.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/u16/utils.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, tx::ContractId};
 // Load abi from json
 abigen!(
     MyContract,
-    "test_artifacts/storage_vec/svec_u16/out/debug/svec_u16-flat-abi.json"
+    "test_artifacts/storage_vec/svec_u16/out/debug/svec_u16-abi.json"
 );
 
 pub mod setup {

--- a/test/src/sdk-harness/test_projects/storage_vec/u32/utils.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/u32/utils.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, tx::ContractId};
 // Load abi from json
 abigen!(
     MyContract,
-    "test_artifacts/storage_vec/svec_u32/out/debug/svec_u32-flat-abi.json"
+    "test_artifacts/storage_vec/svec_u32/out/debug/svec_u32-abi.json"
 );
 
 pub mod setup {

--- a/test/src/sdk-harness/test_projects/storage_vec/u64/utils.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/u64/utils.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, tx::ContractId};
 // Load abi from json
 abigen!(
     MyContract,
-    "test_artifacts/storage_vec/svec_u64/out/debug/svec_u64-flat-abi.json"
+    "test_artifacts/storage_vec/svec_u64/out/debug/svec_u64-abi.json"
 );
 
 pub mod setup {

--- a/test/src/sdk-harness/test_projects/storage_vec/u8/utils.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/u8/utils.rs
@@ -2,7 +2,7 @@ use fuels::{prelude::*, tx::ContractId};
 // Load abi from json
 abigen!(
     MyContract,
-    "test_artifacts/storage_vec/svec_u8/out/debug/svec_u8-flat-abi.json"
+    "test_artifacts/storage_vec/svec_u8/out/debug/svec_u8-abi.json"
 );
 
 pub mod setup {

--- a/test/src/sdk-harness/test_projects/token_ops/mod.rs
+++ b/test/src/sdk-harness/test_projects/token_ops/mod.rs
@@ -3,7 +3,7 @@ use fuels::tx::{AssetId, ContractId};
 
 abigen!(
     TestFuelCoinContract,
-    "test_projects/token_ops/out/debug/token_ops-flat-abi.json"
+    "test_projects/token_ops/out/debug/token_ops-abi.json"
 );
 
 #[tokio::test]

--- a/test/src/sdk-harness/test_projects/tx_fields/mod.rs
+++ b/test/src/sdk-harness/test_projects/tx_fields/mod.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 abigen!(
     TxContractTest,
-    "test_artifacts/tx_contract/out/debug/tx_contract-flat-abi.json",
+    "test_artifacts/tx_contract/out/debug/tx_contract-abi.json",
 );
 
 async fn get_contracts() -> (TxContractTest, ContractId, WalletUnlocked) {


### PR DESCRIPTION
Now that `fuels 0.22.0` supports the new JSON ABI format by default, there is no need to keep the `-flat` stem in the name of the JSON ABI file.