### PR TITLE
Fixes `Shape::width` bleed from file to file

### DIFF
--- a/swayfmt/src/formatter/mod.rs
+++ b/swayfmt/src/formatter/mod.rs
@@ -27,10 +27,6 @@ pub trait Format {
     ) -> Result<(), FormatterError>;
 }
 
-pub trait FormatInner {
-    fn format_inner<F>(&self, f: F);
-}
-
 impl Formatter {
     pub fn from_dir(dir: &Path) -> Result<Self, ConfigError> {
         let config = match Config::from_dir(dir) {

--- a/swayfmt/src/formatter/mod.rs
+++ b/swayfmt/src/formatter/mod.rs
@@ -27,6 +27,10 @@ pub trait Format {
     ) -> Result<(), FormatterError>;
 }
 
+pub trait FormatInner {
+    fn format_inner<F>(&self, f: F);
+}
+
 impl Formatter {
     pub fn from_dir(dir: &Path) -> Result<Self, ConfigError> {
         let config = match Config::from_dir(dir) {
@@ -89,6 +93,7 @@ impl Formatter {
         if !formatted_code.ends_with('\n') {
             writeln!(formatted_code)?;
         }
+        self.shape.reset_width(); // bandaid shape reset TODO:(#2495)
 
         Ok(formatted_code)
     }

--- a/swayfmt/src/items/item_fn/mod.rs
+++ b/swayfmt/src/items/item_fn/mod.rs
@@ -27,9 +27,14 @@ impl Format for ItemFn {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         self.fn_signature.format(formatted_code, formatter)?;
-        Self::open_curly_brace(formatted_code, formatter)?;
-        self.body.get().format(formatted_code, formatter)?;
-        Self::close_curly_brace(formatted_code, formatter)?;
+        let body = self.body.get();
+        if !body.statements.is_empty() || body.final_expr_opt.is_some() {
+            Self::open_curly_brace(formatted_code, formatter)?;
+            self.body.get().format(formatted_code, formatter)?;
+            Self::close_curly_brace(formatted_code, formatter)?;
+        } else {
+            write!(formatted_code, " {{}}")?;
+        }
 
         Ok(())
     }
@@ -74,12 +79,8 @@ impl CurlyBrace for ItemFn {
     ) -> Result<(), FormatterError> {
         // If shape is becoming left-most alligned or - indent just have the defualt shape
         formatter.shape.block_unindent(&formatter.config);
-        write!(
-            line,
-            "{}{}",
-            formatter.shape.indent.to_string(&formatter.config)?,
-            Delimiter::Brace.as_close_char()
-        )?;
+        println!("{:?}", formatter.shape);
+        write!(line, "{}", Delimiter::Brace.as_close_char())?;
 
         Ok(())
     }

--- a/swayfmt/src/items/item_fn/mod.rs
+++ b/swayfmt/src/items/item_fn/mod.rs
@@ -79,8 +79,12 @@ impl CurlyBrace for ItemFn {
     ) -> Result<(), FormatterError> {
         // If shape is becoming left-most alligned or - indent just have the defualt shape
         formatter.shape.block_unindent(&formatter.config);
-        println!("{:?}", formatter.shape);
-        write!(line, "{}", Delimiter::Brace.as_close_char())?;
+        write!(
+            line,
+            "{}{}",
+            formatter.shape.indent.to_string(&formatter.config)?,
+            Delimiter::Brace.as_close_char()
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
This is an artifact of shape state changes and this PR is a quick fix for the issue #2495 which I am currently tackling. This at least will solve the problem of files being incorrectly formatted when formatted as a group for the time being before a PR for the previously mentioned issue is ready.