### PR TITLE
Remove old, no-longer-necessary mdbook patch from workspace manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2520,8 +2520,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "mdbook"
-version = "0.4.20"
-source = "git+https://github.com/mitchmindtree/mdBook?branch=nightly-borrowcheck-err-workaround#13035baeae417e41ce98f49c072220de0e6e4075"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f3e133c6d515528745ffd3b9f0c7d975ae039f0b6abb099f2168daa2afb4f9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,3 @@ exclude = [
 
 [profile.dev.package.sway-lsp]
 debug = 2
-
-[patch.crates-io]
-# A workaround for a bug in mdbook `0.4.20` introduced by some breakage in rustc 1.64.0-nightly (62b272d25 2022-07-21).
-# This should be removed when either this PR https://github.com/rust-lang/mdBook/pull/1861 or a related fix is published.
-mdbook = { git = "https://github.com/mitchmindtree/mdBook", branch = "nightly-borrowcheck-err-workaround" }


### PR DESCRIPTION
Removes an old patch that was once required after a Rust update revealed some borrow-related soundness issues in mdbook.
https://github.com/rust-lang/mdBook/pull/1861