### PR TITLE
Fix bad refactor

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -165,13 +165,9 @@ impl ControlFlowGraph {
                                     decl_id,
                                 )),
                             ..
-                        }) => {
-                            let trait_decl = de_get_trait(decl_id.clone(), &decl_id.span())?;
-                            match trait_decl.visibility {
-                                Visibility::Private => true,
-                                Visibility::Public => false,
-                            }
-                        }
+                        }) => de_get_trait(decl_id.clone(), &decl_id.span())?
+                            .visibility
+                            .is_public(),
                         ControlFlowGraphNode::ProgramNode(TypedAstNode {
                             content:
                                 TypedAstNodeContent::Declaration(TypedDeclaration::StructDeclaration(


### PR DESCRIPTION
A previous PR needed to refactor this function, and flipped the boolean result. This PR changes this back to what it was before the incorrect change.