### PR TITLE
Add standard library prelude

### DIFF
--- a/forc-pkg/src/lib.rs
+++ b/forc-pkg/src/lib.rs
@@ -15,3 +15,4 @@ pub use pkg::*;
 
 const CORE: &str = "core";
 const STD: &str = "std";
+const PRELUDE: &str = "prelude";

--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -917,8 +917,6 @@ pub enum CompileError {
     ShadowsOtherSymbol { name: Ident },
     #[error("The name \"{name}\" is already used for a generic parameter in this scope.")]
     GenericShadowsGeneric { name: Ident },
-    #[error("The name \"{name}\" imported through `*` shadows another symbol with the same name.")]
-    StarImportShadowsOtherSymbol { name: Ident },
     #[error(
         "Match expression arm has mismatched types.\n\
          expected: {expected}\n\
@@ -1199,7 +1197,6 @@ impl Spanned for CompileError {
             ArrayOutOfBounds { span, .. } => span.clone(),
             ShadowsOtherSymbol { name } => name.span(),
             GenericShadowsGeneric { name } => name.span(),
-            StarImportShadowsOtherSymbol { name } => name.span(),
             MatchWrongType { span, .. } => span.clone(),
             MatchExpressionNonExhaustive { span, .. } => span.clone(),
             MatchStructPatternMissingFields { span, .. } => span.clone(),

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -13,15 +13,15 @@ use sway_types::{span::Span, Spanned};
 
 use std::sync::Arc;
 
-/// Is this a prelude import?
+/// Is this a glob (`use foo::*;`) import?
 #[derive(Clone, Copy, PartialEq, Debug)]
-pub(crate) enum PreludeImport {
+pub(crate) enum GlobImport {
     Yes,
     No,
 }
 
 pub(super) type SymbolMap = im::OrdMap<Ident, TypedDeclaration>;
-pub(super) type UseSynonyms = im::HashMap<Ident, (Vec<Ident>, PreludeImport)>;
+pub(super) type UseSynonyms = im::HashMap<Ident, (Vec<Ident>, GlobImport)>;
 pub(super) type UseAliases = im::HashMap<String, Ident>;
 
 /// The set of items that exist within some lexical scope via declaration or importing.

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -13,8 +13,15 @@ use sway_types::{span::Span, Spanned};
 
 use std::sync::Arc;
 
+/// Is this a prelude import?
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub(crate) enum PreludeImport {
+    Yes,
+    No,
+}
+
 pub(super) type SymbolMap = im::OrdMap<Ident, TypedDeclaration>;
-pub(super) type UseSynonyms = im::HashMap<Ident, Vec<Ident>>;
+pub(super) type UseSynonyms = im::HashMap<Ident, (Vec<Ident>, PreludeImport)>;
 pub(super) type UseAliases = im::HashMap<String, Ident>;
 
 /// The set of items that exist within some lexical scope via declaration or importing.
@@ -132,6 +139,7 @@ impl Items {
         let new_prefixes = if trait_name.prefixes.is_empty() {
             self.use_synonyms
                 .get(&trait_name.suffix)
+                .map(|us| &us.0)
                 .unwrap_or(&trait_name.prefixes)
                 .clone()
         } else {
@@ -155,7 +163,10 @@ impl Items {
     }
 
     pub(crate) fn get_canonical_path(&self, symbol: &Ident) -> &[Ident] {
-        self.use_synonyms.get(symbol).map(|v| &v[..]).unwrap_or(&[])
+        self.use_synonyms
+            .get(symbol)
+            .map(|v| &v.0[..])
+            .unwrap_or(&[])
     }
 
     pub(crate) fn has_storage_declared(&self) -> bool {

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -283,7 +283,7 @@ impl Module {
             // N.B. We had a path like `::bar::baz`, which makes the module `bar` "crate-relative".
             // Given that `bar`'s "crate" is `foo`, we'll need `foo::bar::baz` outside of it.
             //
-            // FIXME(Centril): Seems like the compiler has no way of
+            // FIXME(Centril, #2780): Seems like the compiler has no way of
             // distinguishing between external and crate-relative paths?
             let mut src = src[..1].to_vec();
             src.extend(mod_path);

--- a/sway-core/src/semantic_analysis/namespace/root.rs
+++ b/sway-core/src/semantic_analysis/namespace/root.rs
@@ -62,7 +62,7 @@ impl Root {
                 .get(symbol.as_str())
                 .unwrap_or(symbol);
             match module.use_synonyms.get(symbol) {
-                Some(src_path) if mod_path != src_path => {
+                Some((src_path, _)) if mod_path != src_path => {
                     self.resolve_symbol(src_path, true_symbol)
                 }
                 _ => CompileResult::from(module.check_symbol(true_symbol)),

--- a/sway-lib-std/src/lib.sw
+++ b/sway-lib-std/src/lib.sw
@@ -30,5 +30,6 @@ dep flags;
 dep u128;
 dep u256;
 dep vec;
+dep prelude;
 
 use core::*;

--- a/sway-lib-std/src/prelude.sw
+++ b/sway-lib-std/src/prelude.sw
@@ -1,0 +1,13 @@
+library prelude;
+
+//! Defines the Sway standard library prelude.
+//! The prelude consists of implicitly available items,
+//! for which `use` is not required.
+
+use ::address::Address;
+use ::contract_id::ContractId;
+use ::identity::Identity;
+use ::vec::Vec;
+use ::assert::assert;
+use ::revert::require;
+use ::revert::revert;

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/src/main.sw
@@ -8,7 +8,7 @@ use ::bar::{Bar1, Bar1 as Foo};
 // This is not okay because symbol `Foo` is already reserved
 use ::bar::Bar2 as Foo;
 
-// This is not okay 
+// This is not okay
 use ::bar::{Bar2, Bar2};
 
 // This not okay now because Bar1 and Bar2 have already been imported

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/src/main.sw
@@ -11,7 +11,7 @@ use ::bar::Bar2 as Foo;
 // This is not okay
 use ::bar::{Bar2, Bar2};
 
-// This not okay now because Bar1 and Bar2 have already been imported
+// This okay. Although Bar1 + Bar2 have already been imported, glob imports don't cause shadow errors.
 use ::bar::*;
 
 fn main() -> bool {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/test.toml
@@ -2,5 +2,3 @@ category = "fail"
 
 # check: $()The name "Foo" shadows another symbol with the same name.
 # check: $()The name "Bar2" shadows another symbol with the same name.
-# check: $()The name "Bar1" imported through `*` shadows another symbol with the same name.
-# check: $()The name "Bar2" imported through `*` shadows another symbol with the same name.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_expr_basic/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_expr_basic/src/main.sw
@@ -61,7 +61,7 @@ fn main() -> u32 {
     let bal = asm() { bal };
 
     let is = asm() { is };
-    
+
     let ret = asm() { ret };
 
     let retl = asm() { retl };

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/Forc.lock
@@ -1,0 +1,14 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-24E795B40E4736EB'
+dependencies = []
+
+[[package]]
+name = 'prelude_access'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-24E795B40E4736EB'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "prelude_access"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/json_abi_oracle.json
@@ -1,0 +1,22 @@
+{
+  "functions": [
+    {
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "types": [
+    {
+      "components": [],
+      "type": "()",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/src/main.sw
@@ -1,0 +1,8 @@
+script;
+
+struct A {
+    addr: Address,
+}
+
+fn main() {
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/src/main.sw
@@ -4,5 +4,8 @@ struct A {
     addr: Address,
 }
 
+// Ensure shadowing is allowed.
+use std::address::Address;
+
 fn main() {
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 0 }
+validate_abi = true

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access2/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access2/Forc.lock
@@ -1,0 +1,14 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-B3B7F7F1BCA7D931'
+dependencies = []
+
+[[package]]
+name = 'prelude_access2'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-B3B7F7F1BCA7D931'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access2/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access2/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "prelude_access2"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access2/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access2/json_abi_oracle.json
@@ -1,0 +1,22 @@
+{
+  "functions": [
+    {
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "types": [
+    {
+      "components": [],
+      "type": "()",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access2/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access2/src/main.sw
@@ -1,0 +1,17 @@
+script;
+
+struct A {
+    f1: Address,
+    f2: ContractId,
+    f3: Identity,
+    f4: Vec<u8>,
+}
+
+fn foo() {
+    assert(true);
+    require(true, 0);
+    revert(0);
+}
+
+fn main() {
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access2/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access2/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 0 }
+validate_abi = true


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway/issues/841.

This adds the standard library prelude with some initial suggested items as per https://github.com/FuelLabs/sway/issues/841#issuecomment-1242594164.

The approach is to have the module `std::prelude` which is then "glob re-exported" by the compiler into `init` in every module. Extending the prelude is then done in Sway and not in Rust.