### PR TITLE
feat: display long versions for forc crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,12 +1419,14 @@ dependencies = [
  "fs_extra",
  "fuel-asm",
  "hex",
+ "once_cell",
  "serde",
  "serde_json",
  "sway-core",
  "sway-types",
  "sway-utils",
  "term-table",
+ "time 0.3.14",
  "tokio",
  "toml",
  "toml_edit",
@@ -1452,6 +1454,7 @@ dependencies = [
  "fuels-types",
  "futures",
  "hex",
+ "once_cell",
  "serde",
  "serde_json",
  "sway-core",
@@ -1468,6 +1471,7 @@ dependencies = [
  "anyhow",
  "clap 3.2.20",
  "forc-util",
+ "once_cell",
  "reqwest",
  "serde",
  "tar",
@@ -1483,6 +1487,7 @@ dependencies = [
  "anyhow",
  "clap 3.2.20",
  "forc-util",
+ "once_cell",
  "prettydiff 0.5.1",
  "sway-core",
  "sway-utils",
@@ -1497,6 +1502,8 @@ version = "0.24.3"
 dependencies = [
  "anyhow",
  "clap 3.2.20",
+ "forc-util",
+ "once_cell",
  "sway-lsp",
  "tokio",
 ]
@@ -1532,10 +1539,12 @@ dependencies = [
  "annotate-snippets",
  "anyhow",
  "dirs 3.0.2",
+ "once_cell",
  "sway-core",
  "sway-types",
  "sway-utils",
  "termcolor",
+ "time 0.3.14",
  "tracing",
  "tracing-subscriber",
  "unicode-xid",
@@ -2666,6 +2675,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -4422,9 +4440,20 @@ dependencies = [
  "libc",
  "standback",
  "stdweb",
- "time-macros",
+ "time-macros 0.1.1",
  "version_check",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+dependencies = [
+ "libc",
+ "num_threads",
+ "time-macros 0.2.4",
 ]
 
 [[package]]
@@ -4436,6 +4465,12 @@ dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "time-macros-impl"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "countme"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1283,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,10 +1570,10 @@ dependencies = [
  "sway-types",
  "sway-utils",
  "termcolor",
- "time 0.3.14",
  "tracing",
  "tracing-subscriber",
  "unicode-xid",
+ "vergen",
 ]
 
 [[package]]
@@ -1917,6 +1943,18 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2636,6 +2674,15 @@ dependencies = [
  "lexical-core",
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -3502,6 +3549,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4249,6 +4302,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae2421f3e16b3afd4aa692d23b83d0ba42ee9b0081d5deeb7d21428d7195fb1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
 name = "tai64"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4440,7 +4507,7 @@ dependencies = [
  "libc",
  "standback",
  "stdweb",
- "time-macros 0.1.1",
+ "time-macros",
  "version_check",
  "winapi",
 ]
@@ -4451,9 +4518,9 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
+ "itoa 1.0.3",
  "libc",
  "num_threads",
- "time-macros 0.2.4",
 ]
 
 [[package]]
@@ -4465,12 +4532,6 @@ dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
 ]
-
-[[package]]
-name = "time-macros"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "time-macros-impl"
@@ -4963,6 +5024,24 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "vergen"
+version = "7.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ba753d713ec3844652ad2cb7eb56bc71e34213a14faddac7852a10ba88f61e"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "enum-iterator",
+ "getset",
+ "git2",
+ "rustc_version 0.4.0",
+ "rustversion",
+ "sysinfo",
+ "thiserror",
+ "time 0.3.14",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,7 +1452,6 @@ dependencies = [
  "sway-types",
  "sway-utils",
  "term-table",
- "time 0.3.14",
  "tokio",
  "toml",
  "toml_edit",

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -10,7 +10,7 @@ description = "A `forc` plugin for interacting with a Fuel node."
 
 [dependencies]
 anyhow = "1"
-clap = { version = "3", features = ["derive", "env", "cargo"] }
+clap = { version = "3", features = ["derive", "env"] }
 forc-pkg = { version = "0.24.3", path = "../../forc-pkg" }
 forc-util = { version = "0.24.3", path = "../../forc-util" }
 fuel-crypto = "0.6"

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -22,6 +22,7 @@ fuels-signers = "0.21"
 fuels-types = "0.21"
 futures = "0.3"
 hex = "0.4.3"
+once_cell = "1.14"
 serde = "1.0"
 serde_json = "1.0.73"
 sway-core = { version = "0.24.3", path = "../../sway-core" }

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -10,7 +10,7 @@ description = "A `forc` plugin for interacting with a Fuel node."
 
 [dependencies]
 anyhow = "1"
-clap = { version = "3", features = ["derive", "env"] }
+clap = { version = "3", features = ["derive", "env", "cargo"] }
 forc-pkg = { version = "0.24.3", path = "../../forc-pkg" }
 forc-util = { version = "0.24.3", path = "../../forc-util" }
 fuel-crypto = "0.6"

--- a/forc-plugins/forc-client/src/ops/deploy/cmd.rs
+++ b/forc-plugins/forc-client/src/ops/deploy/cmd.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use forc_util::long_version;
 use once_cell::sync::Lazy;
 
-static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()));
 
 fn long_version_static() -> &'static str {
     &LONG_VERSION

--- a/forc-plugins/forc-client/src/ops/deploy/cmd.rs
+++ b/forc-plugins/forc-client/src/ops/deploy/cmd.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use forc_util::long_version;
 use once_cell::sync::Lazy;
 
-static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()));
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(env!("CARGO_PKG_VERSION")));
 
 fn long_version_static() -> &'static str {
     &LONG_VERSION

--- a/forc-plugins/forc-client/src/ops/deploy/cmd.rs
+++ b/forc-plugins/forc-client/src/ops/deploy/cmd.rs
@@ -1,7 +1,15 @@
 use clap::Parser;
+use forc_util::long_version;
+use once_cell::sync::Lazy;
+
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
+
+fn long_version_static() -> &'static str {
+    &LONG_VERSION
+}
 
 #[derive(Debug, Default, Parser)]
-#[clap(bin_name = "forc deploy", version)]
+#[clap(bin_name = "forc deploy", version, long_version = long_version_static())]
 pub struct DeployCommand {
     /// Path to the project, if not specified, current working directory will be used.
     #[clap(short, long)]

--- a/forc-plugins/forc-client/src/ops/run/cmd.rs
+++ b/forc-plugins/forc-client/src/ops/run/cmd.rs
@@ -1,9 +1,17 @@
 use clap::Parser;
+use forc_util::long_version;
+use once_cell::sync::Lazy;
+
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
+
+fn long_version_static() -> &'static str {
+    &LONG_VERSION
+}
 
 /// Run script project.
 /// Crafts a script transaction then sends it to a running node.
 #[derive(Debug, Default, Parser)]
-#[clap(bin_name = "forc run", version)]
+#[clap(bin_name = "forc run", version, long_version = long_version_static())]
 pub struct RunCommand {
     /// Hex string of data to input to script.
     #[clap(short, long)]

--- a/forc-plugins/forc-client/src/ops/run/cmd.rs
+++ b/forc-plugins/forc-client/src/ops/run/cmd.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use forc_util::long_version;
 use once_cell::sync::Lazy;
 
-static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()));
 
 fn long_version_static() -> &'static str {
     &LONG_VERSION

--- a/forc-plugins/forc-client/src/ops/run/cmd.rs
+++ b/forc-plugins/forc-client/src/ops/run/cmd.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use forc_util::long_version;
 use once_cell::sync::Lazy;
 
-static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()));
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(env!("CARGO_PKG_VERSION")));
 
 fn long_version_static() -> &'static str {
     &LONG_VERSION

--- a/forc-plugins/forc-explore/Cargo.toml
+++ b/forc-plugins/forc-explore/Cargo.toml
@@ -10,7 +10,7 @@ description = "A `forc` plugin for running the fuel block explorer."
 
 [dependencies]
 anyhow = "1"
-clap = { version = "3", features = ["derive", "cargo"] }
+clap = { version = "3", features = ["derive"] }
 forc-util = { version = "0.24.3", path = "../../forc-util" }
 once_cell = "1.14"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }

--- a/forc-plugins/forc-explore/Cargo.toml
+++ b/forc-plugins/forc-explore/Cargo.toml
@@ -10,8 +10,9 @@ description = "A `forc` plugin for running the fuel block explorer."
 
 [dependencies]
 anyhow = "1"
-clap = { version = "3", features = ["derive"] }
+clap = { version = "3", features = ["derive", "cargo"] }
 forc-util = { version = "0.24.3", path = "../../forc-util" }
+once_cell = "1.14"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 tar = "0.4"

--- a/forc-plugins/forc-explore/src/main.rs
+++ b/forc-plugins/forc-explore/src/main.rs
@@ -17,7 +17,7 @@ use tar::Archive;
 use tracing::{error, info};
 use warp::Filter;
 
-static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()));
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(env!("CARGO_PKG_VERSION")));
 
 fn long_version_static() -> &'static str {
     &LONG_VERSION

--- a/forc-plugins/forc-explore/src/main.rs
+++ b/forc-plugins/forc-explore/src/main.rs
@@ -17,7 +17,7 @@ use tar::Archive;
 use tracing::{error, info};
 use warp::Filter;
 
-static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()));
 
 fn long_version_static() -> &'static str {
     &LONG_VERSION

--- a/forc-plugins/forc-explore/src/main.rs
+++ b/forc-plugins/forc-explore/src/main.rs
@@ -5,7 +5,9 @@
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use forc_util::init_tracing_subscriber;
+use forc_util::long_version;
 use forc_util::println_green;
+use once_cell::sync::Lazy;
 use serde::Deserialize;
 use std::{
     fs::{self, File},
@@ -15,11 +17,18 @@ use tar::Archive;
 use tracing::{error, info};
 use warp::Filter;
 
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
+
+fn long_version_static() -> &'static str {
+    &LONG_VERSION
+}
+
 #[derive(Debug, Parser)]
 #[clap(
     name = "forc-explore",
     about = "Forc plugin for running the Fuel Block Explorer.",
-    version
+    version,
+    long_version = long_version_static()
 )]
 struct App {
     /// The port number at which the explorer will run on localhost.

--- a/forc-plugins/forc-fmt/Cargo.toml
+++ b/forc-plugins/forc-fmt/Cargo.toml
@@ -10,7 +10,7 @@ description = "A `forc` plugin for running the Sway code formatter."
 
 [dependencies]
 anyhow = "1"
-clap = { version = "3", features = ["derive", "cargo"] }
+clap = { version = "3", features = ["derive"] }
 forc-util = { version = "0.24.3", path = "../../forc-util" }
 once_cell = "1.14"
 prettydiff = "0.5"

--- a/forc-plugins/forc-fmt/Cargo.toml
+++ b/forc-plugins/forc-fmt/Cargo.toml
@@ -10,8 +10,9 @@ description = "A `forc` plugin for running the Sway code formatter."
 
 [dependencies]
 anyhow = "1"
-clap = { version = "3", features = ["derive"] }
+clap = { version = "3", features = ["derive", "cargo"] }
 forc-util = { version = "0.24.3", path = "../../forc-util" }
+once_cell = "1.14"
 prettydiff = "0.5"
 sway-core = { version = "0.24.3", path = "../../sway-core" }
 sway-utils = { version = "0.24.3", path = "../../sway-utils" }

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -20,7 +20,7 @@ use sway_core::BuildConfig;
 use sway_utils::{constants, get_sway_files};
 use swayfmt::Formatter;
 
-static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()));
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(env!("CARGO_PKG_VERSION")));
 
 fn long_version_static() -> &'static str {
     &LONG_VERSION

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -20,7 +20,7 @@ use sway_core::BuildConfig;
 use sway_utils::{constants, get_sway_files};
 use swayfmt::Formatter;
 
-static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()));
 
 fn long_version_static() -> &'static str {
     &LONG_VERSION

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -12,16 +12,26 @@ use std::{
 use taplo::formatter as taplo_fmt;
 use tracing::{error, info};
 
-use forc_util::{find_manifest_dir, init_tracing_subscriber, println_green, println_red};
+use forc_util::{
+    find_manifest_dir, init_tracing_subscriber, long_version, println_green, println_red,
+};
+use once_cell::sync::Lazy;
 use sway_core::BuildConfig;
 use sway_utils::{constants, get_sway_files};
 use swayfmt::Formatter;
+
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
+
+fn long_version_static() -> &'static str {
+    &LONG_VERSION
+}
 
 #[derive(Debug, Parser)]
 #[clap(
     name = "forc-fmt",
     about = "Forc plugin for running the Sway code formatter.",
-    version
+    version,
+    long_version = long_version_static()
 )]
 pub struct App {
     /// Run in 'check' mode.

--- a/forc-plugins/forc-lsp/Cargo.toml
+++ b/forc-plugins/forc-lsp/Cargo.toml
@@ -10,6 +10,8 @@ description = "A simple `forc` plugin for starting the sway language server."
 
 [dependencies]
 anyhow = "1"
-clap = { version = "3", features = ["derive"] }
+clap = { version = "3", features = ["derive", "cargo"] }
+forc-util = { version = "0.24.3", path = "../../forc-util" }
+once_cell = "1.14"
 sway-lsp = { version = "0.24.3", path = "../../sway-lsp" }
 tokio = { version = "1.8" }

--- a/forc-plugins/forc-lsp/Cargo.toml
+++ b/forc-plugins/forc-lsp/Cargo.toml
@@ -10,7 +10,7 @@ description = "A simple `forc` plugin for starting the sway language server."
 
 [dependencies]
 anyhow = "1"
-clap = { version = "3", features = ["derive", "cargo"] }
+clap = { version = "3", features = ["derive"] }
 forc-util = { version = "0.24.3", path = "../../forc-util" }
 once_cell = "1.14"
 sway-lsp = { version = "0.24.3", path = "../../sway-lsp" }

--- a/forc-plugins/forc-lsp/src/main.rs
+++ b/forc-plugins/forc-lsp/src/main.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use forc_util::long_version;
 use once_cell::sync::Lazy;
 
-static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()));
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(env!("CARGO_PKG_VERSION")));
 
 fn long_version_static() -> &'static str {
     &LONG_VERSION

--- a/forc-plugins/forc-lsp/src/main.rs
+++ b/forc-plugins/forc-lsp/src/main.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use forc_util::long_version;
 use once_cell::sync::Lazy;
 
-static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()));
 
 fn long_version_static() -> &'static str {
     &LONG_VERSION

--- a/forc-plugins/forc-lsp/src/main.rs
+++ b/forc-plugins/forc-lsp/src/main.rs
@@ -2,13 +2,23 @@
 //!
 //! Once installed and available via `PATH`, can be executed via `forc lsp`.
 
+
 use clap::Parser;
+use once_cell::sync::Lazy;
+use forc_util::long_version;
+
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
+
+fn long_version_static() -> &'static str {
+    &LONG_VERSION
+}
 
 #[derive(Debug, Parser)]
 #[clap(
     name = "forc-lsp",
     about = "Forc plugin for the Sway LSP (Language Server Protocol) implementation.",
-    version
+    version,
+    long_version = long_version_static()
 )]
 struct App {
     /// Instructs the client to draw squiggly lines under all of the tokens that our server managed

--- a/forc-plugins/forc-lsp/src/main.rs
+++ b/forc-plugins/forc-lsp/src/main.rs
@@ -2,10 +2,9 @@
 //!
 //! Once installed and available via `PATH`, can be executed via `forc lsp`.
 
-
 use clap::Parser;
-use once_cell::sync::Lazy;
 use forc_util::long_version;
+use once_cell::sync::Lazy;
 
 static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
 

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -15,7 +15,9 @@ dirs = "3.0.2"
 sway-core = { version = "0.24.3", path = "../sway-core" }
 sway-types = { version = "0.24.3", path = "../sway-types" }
 sway-utils = { version = "0.24.3", path = "../sway-utils" }
+once_cell = "1.14"
 termcolor = "1.1"
+time = { version = "0.3", default_features = false, features = ["parsing", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }
 unicode-xid = "0.2.2"

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -17,7 +17,9 @@ sway-core = { version = "0.24.3", path = "../sway-core" }
 sway-types = { version = "0.24.3", path = "../sway-types" }
 sway-utils = { version = "0.24.3", path = "../sway-utils" }
 termcolor = "1.1"
-time = { version = "0.3", default_features = false, features = ["parsing", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }
 unicode-xid = "0.2.2"
+
+[build-dependencies]
+vergen = { version = "7", features = ["build", "git" ] }

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -12,10 +12,10 @@ description = "Utility items shared between forc crates."
 annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1"
 dirs = "3.0.2"
+once_cell = "1.14"
 sway-core = { version = "0.24.3", path = "../sway-core" }
 sway-types = { version = "0.24.3", path = "../sway-types" }
 sway-utils = { version = "0.24.3", path = "../sway-utils" }
-once_cell = "1.14"
 termcolor = "1.1"
 time = { version = "0.3", default_features = false, features = ["parsing", "macros"] }
 tracing = "0.1"

--- a/forc-util/build.rs
+++ b/forc-util/build.rs
@@ -6,5 +6,5 @@ fn main() {
     *config.git_mut().sha_kind_mut() = ShaKind::Short;
     *config.git_mut().commit_timestamp_mut() = true;
     *config.git_mut().commit_timestamp_kind_mut() = TimestampKind::DateOnly;
-    vergen(config).expect("Error executing vergen")
+    vergen(config).expect("Failed to configure vergen")
 }

--- a/forc-util/build.rs
+++ b/forc-util/build.rs
@@ -1,0 +1,10 @@
+use vergen::{vergen, Config, ShaKind, TimestampKind};
+
+fn main() {
+    let mut config = Config::default();
+
+    *config.git_mut().sha_kind_mut() = ShaKind::Short;
+    *config.git_mut().commit_timestamp_mut() = true;
+    *config.git_mut().commit_timestamp_kind_mut() = TimestampKind::DateOnly;
+    vergen(config).expect("Error executing vergen")
+}

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -442,11 +442,13 @@ pub fn init_tracing_subscriber() {
         .init();
 }
 
-pub fn long_version(clap_version: &str) -> String {
-    let commit_hash = env!("VERGEN_GIT_SHA_SHORT");
-    let commit_date = env!("VERGEN_GIT_COMMIT_DATE");
-
-    return format!("{} ({} {})", clap_version, commit_hash, commit_date);
+pub fn long_version(short_version: &str) -> String {
+    format!(
+        "{} ({} {})",
+        short_version,
+        env!("VERGEN_GIT_SHA_SHORT"),
+        env!("VERGEN_GIT_COMMIT_DATE")
+    )
 }
 
 #[cfg(all(feature = "uwu", any(target_arch = "x86", target_arch = "x86_64")))]

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -5,7 +5,6 @@ use annotate_snippets::{
     snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
 };
 use anyhow::{bail, Result};
-use once_cell::sync::OnceCell;
 use std::env;
 use std::ffi::OsStr;
 use std::io::Write;
@@ -21,7 +20,6 @@ use tracing_subscriber::filter::EnvFilter;
 pub mod restricted;
 
 pub const DEFAULT_OUTPUT_DIRECTORY: &str = "out";
-pub static LONG_VERSION: OnceCell<String> = OnceCell::new();
 
 /// Continually go up in the file tree until a specified file is found.
 #[allow(clippy::branches_sharing_code)]

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -14,7 +14,6 @@ use sway_core::{error::LineCol, CompileError, CompileWarning, TreeType};
 use sway_types::Spanned;
 use sway_utils::constants;
 use termcolor::{self, Color as TermColor, ColorChoice, ColorSpec, StandardStream, WriteColor};
-use time::{macros::format_description, Date};
 use tracing_subscriber::filter::EnvFilter;
 
 pub mod restricted;
@@ -444,17 +443,10 @@ pub fn init_tracing_subscriber() {
 }
 
 pub fn long_version(clap_version: &str) -> String {
-    if let (Some(commit_hash), Some(commit_date)) =
-        (option_env!("CI_COMMIT_HASH"), option_env!("CI_COMMIT_DATE"))
-    {
-        assert!(commit_hash.chars().all(|c| c.is_ascii_alphanumeric()));
+    let commit_hash = env!("VERGEN_GIT_SHA_SHORT");
+    let commit_date = env!("VERGEN_GIT_COMMIT_DATE");
 
-        if let Ok(date) = Date::parse(commit_date, format_description!("[year]-[month]-[day]")) {
-            return format!("{} ({} {})", clap_version, commit_hash, date);
-        };
-    }
-
-    clap_version.to_string()
+    return format!("{} ({} {})", clap_version, commit_hash, commit_date);
 }
 
 #[cfg(all(feature = "uwu", any(target_arch = "x86", target_arch = "x86_64")))]

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -23,9 +23,11 @@ clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 clap_complete = "3.1"
 forc-pkg = { version = "0.24.3", path = "../forc-pkg" }
 forc-util = { version = "0.24.3", path = "../forc-util" }
+time = { version = "0.3", features = ["parsing"] }
 fs_extra = "1.2"
 fuel-asm = "0.8"
 hex = "0.4.3"
+once_cell = "1.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.73"
 sway-core = { version = "0.24.3", path = "../sway-core" }

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -23,7 +23,6 @@ clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 clap_complete = "3.1"
 forc-pkg = { version = "0.24.3", path = "../forc-pkg" }
 forc-util = { version = "0.24.3", path = "../forc-util" }
-time = { version = "0.3", features = ["parsing"] }
 fs_extra = "1.2"
 fuel-asm = "0.8"
 hex = "0.4.3"
@@ -34,6 +33,7 @@ sway-core = { version = "0.24.3", path = "../sway-core" }
 sway-types = { version = "0.24.3", path = "../sway-types" }
 sway-utils = { version = "0.24.3", path = "../sway-utils" }
 term-table = "1.3"
+time = { version = "0.3", features = ["parsing"] }
 tokio = { version = "1.8.0", features = ["macros", "rt-multi-thread"] }
 toml = "0.5"
 toml_edit = "0.13"

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -33,7 +33,6 @@ sway-core = { version = "0.24.3", path = "../sway-core" }
 sway-types = { version = "0.24.3", path = "../sway-types" }
 sway-utils = { version = "0.24.3", path = "../sway-utils" }
 term-table = "1.3"
-time = { version = "0.3", features = ["parsing"] }
 tokio = { version = "1.8.0", features = ["macros", "rt-multi-thread"] }
 toml = "0.5"
 toml_edit = "0.13"

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -9,19 +9,18 @@ pub use check::Command as CheckCommand;
 use clap::Parser;
 pub use clean::Command as CleanCommand;
 pub use completions::Command as CompletionsCommand;
+use forc_util::long_version;
 pub use init::Command as InitCommand;
 pub use new::Command as NewCommand;
+use once_cell::sync::Lazy;
 use parse_bytecode::Command as ParseBytecodeCommand;
 pub use plugins::Command as PluginsCommand;
 pub use template::Command as TemplateCommand;
 use test::Command as TestCommand;
 pub use update::Command as UpdateCommand;
-use forc_util::long_version;
-use once_cell::sync::Lazy;
 
 mod commands;
 mod plugin;
-
 
 static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
 

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -16,12 +16,26 @@ pub use plugins::Command as PluginsCommand;
 pub use template::Command as TemplateCommand;
 use test::Command as TestCommand;
 pub use update::Command as UpdateCommand;
+use forc_util::long_version;
+use once_cell::sync::Lazy;
 
 mod commands;
 mod plugin;
 
+
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
+
+fn long_version_static() -> &'static str {
+    &LONG_VERSION
+}
+
 #[derive(Debug, Parser)]
-#[clap(name = "forc", about = "Fuel Orchestrator", version)]
+#[clap(
+    name = "forc",
+    about = "Fuel Orchestrator",
+    version,
+    long_version = long_version_static()
+)]
 struct Opt {
     /// the command to run
     #[clap(subcommand)]

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -22,7 +22,7 @@ pub use update::Command as UpdateCommand;
 mod commands;
 mod plugin;
 
-static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()).to_string());
+static LONG_VERSION: Lazy<String> = Lazy::new(|| long_version(clap::crate_version!()));
 
 fn long_version_static() -> &'static str {
     &LONG_VERSION


### PR DESCRIPTION
Related #2773 

Includes changes to show long versions for `forc` crates in the format `<name> <version> (<git_commit_hash> <date>)`

Certain commands of `fuelup` (eg. `show`, `check`) to support nightly toolchains require comparing dates. 

Currently a hacky way of doing this is implemented within the CI for publishing channels where we manually format the strings ([example of what is published](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-nightly.toml)). Downloading a toolchain will download the channel as well, which `fuelup` uses to compare versions. However, the actual version printed by the binaries do not change and makes it difficult to support the above commands, especially if we want to support a specific nightly version of a component in a custom toolchain.

~For this to work, we have to build with the options `CI_COMMIT_HASH` and `CI_COMMIT_DATE` in the release steps in the CI. Otherwise, the current format of versioning will be used.~

Instead of the above, we will be using [`vergen`](https://github.com/rustyhorde/vergen) to get the hash and date at build-time with `build.rs`.

Example:

![Screenshot 2022-09-13 at 11 25 32 AM](https://user-images.githubusercontent.com/25565268/189800769-c712e13f-d5c5-4cb9-ac74-eecedb85bacc.png)
