### PR TITLE
Fix publishing issue with the `sway-ir-macros` crate due to missing `derive(Debug)`

### DIFF
--- a/sway-ir/sway-ir-macros/Cargo.toml
+++ b/sway-ir/sway-ir-macros/Cargo.toml
@@ -15,4 +15,4 @@ proc-macro = true
 itertools = "0.10.3"
 proc-macro2 = "1.0.43"
 quote = "1.0.21"
-syn = { version = "1.0.99", features = ["derive"] }
+syn = { version = "1.0.99", features = ["derive", "extra-traits"] }


### PR DESCRIPTION
We were getting the following error when trying to publish the crate:
```console
error[E0277]: `Attribute` doesn't implement `Debug`
    --> src/lib.rs:185:14
     |
185  |             .expect("multiple #[in_context(..)] attributes on field")
     |              ^^^^^^ `Attribute` cannot be formatted using `{:?}` because it doesn't implement `Debug`
```
The fix here enables the `Debug` trait (and others) to be enabled for `Attribute`.

Tested this by running `cargo publish --dry-run --allow-dirty` locally with this change.