### PR TITLE
Make verbose flag a global option in forc

### DIFF
--- a/forc-plugins/forc-client/src/bin/deploy/main.rs
+++ b/forc-plugins/forc-client/src/bin/deploy/main.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 
 #[tokio::main]
 pub async fn main() {
-    init_tracing_subscriber();
+    init_tracing_subscriber(None);
     let command = DeployCommand::parse();
     if let Err(err) = deploy(command).await {
         eprintln!("Error: {:?}", err);

--- a/forc-plugins/forc-client/src/bin/run/main.rs
+++ b/forc-plugins/forc-client/src/bin/run/main.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 
 #[tokio::main]
 async fn main() {
-    init_tracing_subscriber();
+    init_tracing_subscriber(None);
     let command = RunCommand::parse();
     if let Err(err) = run(command).await {
         eprintln!("Error: {:?}", err);

--- a/forc-plugins/forc-explore/src/main.rs
+++ b/forc-plugins/forc-explore/src/main.rs
@@ -70,7 +70,7 @@ fn clean() -> Result<()> {
 }
 
 async fn run(app: App) -> Result<()> {
-    init_tracing_subscriber();
+    init_tracing_subscriber(None);
     let App { port, .. } = app;
     let releases = get_github_releases().await?;
     let release = releases

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -36,7 +36,7 @@ pub struct App {
 }
 
 fn main() {
-    init_tracing_subscriber();
+    init_tracing_subscriber(None);
     if let Err(err) = run() {
         error!("Error: {:?}", err);
         std::process::exit(1);

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -14,7 +14,10 @@ use sway_core::{error::LineCol, CompileError, CompileWarning, TreeType};
 use sway_types::Spanned;
 use sway_utils::constants;
 use tracing::{Level, Metadata};
-use tracing_subscriber::{filter::EnvFilter, fmt::MakeWriter};
+use tracing_subscriber::{
+    filter::{EnvFilter, LevelFilter},
+    fmt::MakeWriter,
+};
 
 pub mod restricted;
 
@@ -417,22 +420,34 @@ impl<'a> MakeWriter<'a> for StdioTracingWriter {
 /// A subscriber built from default `tracing_subscriber::fmt::SubscriberBuilder` such that it would match directly using `println!` throughout the repo.
 ///
 /// `RUST_LOG` environment variable can be used to set different minimum level for the subscriber, default is `INFO`.
-pub fn init_tracing_subscriber() {
-    let filter = match env::var_os(LOG_FILTER) {
+pub fn init_tracing_subscriber(verbosity: Option<u8>) {
+    let env_filter = match env::var_os(LOG_FILTER) {
         Some(_) => EnvFilter::try_from_default_env().expect("Invalid `RUST_LOG` provided"),
         None => EnvFilter::new("info"),
     };
 
-    tracing_subscriber::fmt::Subscriber::builder()
-        .with_env_filter(filter)
+    let level_filter = verbosity.and_then(|verbosity| match verbosity {
+        1 => Some(LevelFilter::DEBUG),
+        2 => Some(LevelFilter::TRACE),
+        _ => None,
+    });
+
+    let builder = tracing_subscriber::fmt::Subscriber::builder()
+        .with_env_filter(env_filter)
         .with_ansi(true)
         .with_level(false)
         .with_file(false)
         .with_line_number(false)
         .without_time()
         .with_target(false)
-        .with_writer(StdioTracingWriter)
-        .init();
+        .with_writer(StdioTracingWriter);
+
+    // If verbosity is set, it overrides the RUST_LOG setting
+    if let Some(level_filter) = level_filter {
+        builder.with_max_level(level_filter).init();
+    } else {
+        builder.init();
+    }
 }
 
 #[cfg(all(feature = "uwu", any(target_arch = "x86", target_arch = "x86_64")))]

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -427,8 +427,8 @@ pub fn init_tracing_subscriber(verbosity: Option<u8>) {
     };
 
     let level_filter = verbosity.and_then(|verbosity| match verbosity {
-        1 => Some(LevelFilter::DEBUG),
-        2 => Some(LevelFilter::TRACE),
+        1 => Some(LevelFilter::DEBUG), // matches --verbose or -v
+        2 => Some(LevelFilter::TRACE), // matches -vv
         _ => None,
     });
 

--- a/forc/src/cli/commands/init.rs
+++ b/forc/src/cli/commands/init.rs
@@ -20,9 +20,6 @@ pub struct Command {
     /// Create a package with a library target (src/lib.sw).
     #[clap(long)]
     pub library: bool,
-    /// Use verbose output.
-    #[clap(short = 'v', long)]
-    pub verbose: bool,
     /// Set the package name. Defaults to the directory name
     #[clap(long)]
     pub name: Option<String>,

--- a/forc/src/cli/commands/new.rs
+++ b/forc/src/cli/commands/new.rs
@@ -22,9 +22,6 @@ pub struct Command {
     /// Set the package name. Defaults to the directory name
     #[clap(long)]
     pub name: Option<String>,
-    /// Use verbose output.
-    #[clap(short = 'v', long)]
-    pub verbose: bool,
     /// The path at which the project directory will be created.
     pub path: String,
 }
@@ -39,7 +36,6 @@ pub(crate) fn exec(command: Command) -> Result<()> {
         predicate,
         library,
         name,
-        verbose,
         path,
     } = command;
 
@@ -61,7 +57,6 @@ pub(crate) fn exec(command: Command) -> Result<()> {
         script,
         predicate,
         library,
-        verbose,
         name,
     };
 

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -6,9 +6,10 @@ use addr2line::Command as Addr2LineCommand;
 use anyhow::{anyhow, Result};
 pub use build::Command as BuildCommand;
 pub use check::Command as CheckCommand;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 pub use clean::Command as CleanCommand;
 pub use completions::Command as CompletionsCommand;
+use forc_util::init_tracing_subscriber;
 pub use init::Command as InitCommand;
 pub use new::Command as NewCommand;
 use parse_bytecode::Command as ParseBytecodeCommand;
@@ -26,9 +27,12 @@ struct Opt {
     /// the command to run
     #[clap(subcommand)]
     command: Forc,
+    /// Use verbose output.
+    #[clap(short, long, parse(from_occurrences), global = true)]
+    verbose: u8,
 }
 
-#[derive(Debug, Parser)]
+#[derive(Subcommand, Debug)]
 enum Forc {
     #[clap(name = "addr2line")]
     Addr2Line(Addr2LineCommand),
@@ -59,6 +63,8 @@ enum Forc {
 
 pub async fn run_cli() -> Result<()> {
     let opt = Opt::parse();
+    init_tracing_subscriber(Some(opt.verbose));
+
     match opt.command {
         Forc::Addr2Line(command) => addr2line::exec(command),
         Forc::Build(command) => build::exec(command),

--- a/forc/src/main.rs
+++ b/forc/src/main.rs
@@ -1,9 +1,7 @@
-use forc_util::init_tracing_subscriber;
 use tracing::error;
 
 #[tokio::main]
 async fn main() {
-    init_tracing_subscriber();
     if let Err(err) = forc::cli::run_cli().await {
         error!("Error: {:?}", err);
         std::process::exit(1);

--- a/forc/src/ops/forc_init.rs
+++ b/forc/src/ops/forc_init.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use sway_utils::constants;
-use tracing::info;
+use tracing::{debug, info};
 
 fn print_welcome_message() {
     let read_the_docs = format!(
@@ -54,12 +54,10 @@ pub fn init(command: InitCommand) -> Result<()> {
         );
     }
 
-    if command.verbose {
-        info!(
-            "\nUsing project directory at {}",
-            project_dir.canonicalize()?.display()
-        );
-    }
+    debug!(
+        "\nUsing project directory at {}",
+        project_dir.canonicalize()?.display()
+    );
 
     let project_name = match command.name {
         Some(name) => name,
@@ -143,12 +141,10 @@ pub fn init(command: InitCommand) -> Result<()> {
     let harness_path = Path::new(&project_dir).join("tests").join("harness.rs");
     fs::write(&harness_path, defaults::default_test_program(&project_name))?;
 
-    if command.verbose {
-        info!(
-            "\nCreated test harness at {}",
-            harness_path.canonicalize()?.display()
-        );
-    }
+    debug!(
+        "\nCreated test harness at {}",
+        harness_path.canonicalize()?.display()
+    );
 
     // Ignore default `out` and `target` directories created by forc and cargo.
     let gitignore_path = Path::new(&project_dir).join(".gitignore");
@@ -160,16 +156,12 @@ pub fn init(command: InitCommand) -> Result<()> {
         .open(&gitignore_path)?;
     gitignore_file.write_all(defaults::default_gitignore().as_bytes())?;
 
-    if command.verbose {
-        info!(
-            "\nCreated .gitignore at {}",
-            gitignore_path.canonicalize()?.display()
-        );
-    }
+    debug!(
+        "\nCreated .gitignore at {}",
+        gitignore_path.canonicalize()?.display()
+    );
 
-    if command.verbose {
-        info!("\nSuccessfully created {program_type}: {project_name}",);
-    }
+    debug!("\nSuccessfully created {program_type}: {project_name}",);
 
     print_welcome_message();
 

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -40,7 +40,7 @@ struct TestDescription {
 }
 
 pub fn run(locked: bool, filter_regex: Option<&regex::Regex>) {
-    init_tracing_subscriber();
+    init_tracing_subscriber(None);
 
     let configured_tests = discover_test_configs().unwrap_or_else(|e| {
         panic!("Discovering tests {e}");


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway/issues/2305

Adds the `--verbose` flag to all forc commands and makes it so `tracing::debug` logs shows when `-v` or `--verbose` is used, and `tracing::trace` logs show when `-vv` is used.

If both `RUST_LOG` and the verbose flag are set, the verbose flag takes precedence.

Tested with permutations of:
```
cargo run -p forc -- clean --verbose
cargo run -p forc -- init -vv
```