### PR TITLE
Remove unwraps in the language server when calling into the declaration engine. 

### DIFF
--- a/sway-lsp/src/capabilities/hover.rs
+++ b/sway-lsp/src/capabilities/hover.rs
@@ -63,21 +63,28 @@ fn hover_format(token: &Token, ident: &Ident) -> Hover {
                 }
                 TypedDeclaration::FunctionDeclaration(func) => extract_fn_signature(&func.span()),
                 TypedDeclaration::StructDeclaration(decl_id) => {
-                    // TODO: do not use unwrap
-                    let struct_decl =
-                        declaration_engine::de_get_struct(decl_id.clone(), &decl.span()).unwrap();
-                    format_visibility_hover(struct_decl.visibility, decl.friendly_name())
+                    match declaration_engine::de_get_struct(decl_id.clone(), &decl.span()) {
+                        Ok(struct_decl) => {
+                            format_visibility_hover(struct_decl.visibility, decl.friendly_name())
+                        }
+                        Err(_) => token_name,
+                    }
                 }
                 TypedDeclaration::TraitDeclaration(ref decl_id) => {
-                    // TODO: do not use unwrap
-                    let trait_decl =
-                        declaration_engine::de_get_trait(decl_id.clone(), &decl_id.span()).unwrap();
-                    format_visibility_hover(trait_decl.visibility, decl.friendly_name())
+                    match declaration_engine::de_get_trait(decl_id.clone(), &decl.span()) {
+                        Ok(trait_decl) => {
+                            format_visibility_hover(trait_decl.visibility, decl.friendly_name())
+                        }
+                        Err(_) => token_name,
+                    }
                 }
                 TypedDeclaration::EnumDeclaration(decl_id) => {
-                    let enum_decl =
-                        declaration_engine::de_get_enum(decl_id.clone(), &decl_id.span()).unwrap();
-                    format_visibility_hover(enum_decl.visibility, decl.friendly_name())
+                    match declaration_engine::de_get_enum(decl_id.clone(), &decl.span()) {
+                        Ok(enum_decl) => {
+                            format_visibility_hover(enum_decl.visibility, decl.friendly_name())
+                        }
+                        Err(_) => token_name,
+                    }
                 }
                 _ => token_name,
             },

--- a/sway-lsp/src/capabilities/hover.rs
+++ b/sway-lsp/src/capabilities/hover.rs
@@ -63,28 +63,25 @@ fn hover_format(token: &Token, ident: &Ident) -> Hover {
                 }
                 TypedDeclaration::FunctionDeclaration(func) => extract_fn_signature(&func.span()),
                 TypedDeclaration::StructDeclaration(decl_id) => {
-                    match declaration_engine::de_get_struct(decl_id.clone(), &decl.span()) {
-                        Ok(struct_decl) => {
+                    declaration_engine::de_get_struct(decl_id.clone(), &decl.span())
+                        .map(|struct_decl| {
                             format_visibility_hover(struct_decl.visibility, decl.friendly_name())
-                        }
-                        Err(_) => token_name,
-                    }
+                        })
+                        .unwrap_or(token_name)
                 }
                 TypedDeclaration::TraitDeclaration(ref decl_id) => {
-                    match declaration_engine::de_get_trait(decl_id.clone(), &decl.span()) {
-                        Ok(trait_decl) => {
+                    declaration_engine::de_get_trait(decl_id.clone(), &decl.span())
+                        .map(|trait_decl| {
                             format_visibility_hover(trait_decl.visibility, decl.friendly_name())
-                        }
-                        Err(_) => token_name,
-                    }
+                        })
+                        .unwrap_or(token_name)
                 }
                 TypedDeclaration::EnumDeclaration(decl_id) => {
-                    match declaration_engine::de_get_enum(decl_id.clone(), &decl.span()) {
-                        Ok(enum_decl) => {
+                    declaration_engine::de_get_enum(decl_id.clone(), &decl.span())
+                        .map(|enum_decl| {
                             format_visibility_hover(enum_decl.visibility, decl.friendly_name())
-                        }
-                        Err(_) => token_name,
-                    }
+                        })
+                        .unwrap_or(token_name)
                 }
                 _ => token_name,
             },

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -47,128 +47,135 @@ fn handle_declaration(declaration: &TypedDeclaration, tokens: &TokenMap) {
             handle_expression(&variable.body, tokens);
         }
         TypedDeclaration::ConstantDeclaration(decl_id) => {
-            let const_decl =
-                declaration_engine::de_get_constant(decl_id.clone(), &decl_id.span()).unwrap();
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&const_decl.name)) {
-                token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+            if let Ok(const_decl) =
+                declaration_engine::de_get_constant(decl_id.clone(), &decl_id.span())
+            {
+                if let Some(mut token) = tokens.get_mut(&to_ident_key(&const_decl.name)) {
+                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                }
+                handle_expression(&const_decl.value, tokens);
             }
-            handle_expression(&const_decl.value, tokens);
         }
         TypedDeclaration::FunctionDeclaration(decl_id) => {
-            // TODO: do not use unwrap
-            let func_decl =
-                declaration_engine::de_get_function(decl_id.clone(), &decl_id.span()).unwrap();
-            collect_typed_fn_decl(&func_decl, tokens);
+            if let Ok(func_decl) =
+                declaration_engine::de_get_function(decl_id.clone(), &decl_id.span())
+            {
+                collect_typed_fn_decl(&func_decl, tokens);
+            }
         }
         TypedDeclaration::TraitDeclaration(decl_id) => {
-            // TODO: do not use unwrap
-            let trait_decl =
-                declaration_engine::de_get_trait(decl_id.clone(), &decl_id.span()).unwrap();
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&trait_decl.name)) {
-                token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-            }
+            if let Ok(trait_decl) =
+                declaration_engine::de_get_trait(decl_id.clone(), &decl_id.span())
+            {
+                if let Some(mut token) = tokens.get_mut(&to_ident_key(&trait_decl.name)) {
+                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                }
 
-            for trait_fn in &trait_decl.interface_surface {
-                collect_typed_trait_fn_token(trait_fn, tokens);
+                for trait_fn in &trait_decl.interface_surface {
+                    collect_typed_trait_fn_token(trait_fn, tokens);
+                }
             }
         }
         TypedDeclaration::StructDeclaration(decl_id) => {
-            // TODO: do not use unwrap
-            let struct_decl =
-                declaration_engine::de_get_struct(decl_id.clone(), &declaration.span()).unwrap();
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&struct_decl.name)) {
-                token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-            }
-
-            for field in &struct_decl.fields {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&field.name)) {
-                    token.typed = Some(TypedAstToken::TypedStructField(field.clone()));
-                    token.type_def = Some(TypeDefinition::TypeId(field.type_id));
-                }
-
-                if let Some(mut token) =
-                    tokens.get_mut(&to_ident_key(&Ident::new(field.type_span.clone())))
-                {
-                    token.typed = Some(TypedAstToken::TypedStructField(field.clone()));
-                    token.type_def = Some(TypeDefinition::TypeId(field.type_id));
-                }
-            }
-
-            for type_param in &struct_decl.type_parameters {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&type_param.name_ident)) {
+            if let Ok(struct_decl) =
+                declaration_engine::de_get_struct(decl_id.clone(), &declaration.span())
+            {
+                if let Some(mut token) = tokens.get_mut(&to_ident_key(&struct_decl.name)) {
                     token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-                    token.type_def = Some(TypeDefinition::TypeId(type_param.type_id));
+                }
+
+                for field in &struct_decl.fields {
+                    if let Some(mut token) = tokens.get_mut(&to_ident_key(&field.name)) {
+                        token.typed = Some(TypedAstToken::TypedStructField(field.clone()));
+                        token.type_def = Some(TypeDefinition::TypeId(field.type_id));
+                    }
+
+                    if let Some(mut token) =
+                        tokens.get_mut(&to_ident_key(&Ident::new(field.type_span.clone())))
+                    {
+                        token.typed = Some(TypedAstToken::TypedStructField(field.clone()));
+                        token.type_def = Some(TypeDefinition::TypeId(field.type_id));
+                    }
+                }
+
+                for type_param in &struct_decl.type_parameters {
+                    if let Some(mut token) = tokens.get_mut(&to_ident_key(&type_param.name_ident)) {
+                        token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                        token.type_def = Some(TypeDefinition::TypeId(type_param.type_id));
+                    }
                 }
             }
         }
         TypedDeclaration::EnumDeclaration(decl_id) => {
-            // TODO: do not use unwrap
-            let enum_decl =
-                declaration_engine::de_get_enum(decl_id.clone(), &decl_id.span()).unwrap();
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&enum_decl.name)) {
-                token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-            }
-
-            for type_param in &enum_decl.type_parameters {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&type_param.name_ident)) {
+            if let Ok(enum_decl) = declaration_engine::de_get_enum(decl_id.clone(), &decl_id.span())
+            {
+                if let Some(mut token) = tokens.get_mut(&to_ident_key(&enum_decl.name)) {
                     token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-                    token.type_def = Some(TypeDefinition::TypeId(type_param.type_id));
-                }
-            }
-
-            for variant in &enum_decl.variants {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&variant.name)) {
-                    token.typed = Some(TypedAstToken::TypedEnumVariant(variant.clone()));
-                    token.type_def = Some(TypeDefinition::TypeId(variant.type_id));
                 }
 
-                if let Some(mut token) =
-                    tokens.get_mut(&to_ident_key(&Ident::new(variant.type_span.clone())))
-                {
-                    token.typed = Some(TypedAstToken::TypedEnumVariant(variant.clone()));
-                    token.type_def = Some(TypeDefinition::TypeId(variant.type_id));
+                for type_param in &enum_decl.type_parameters {
+                    if let Some(mut token) = tokens.get_mut(&to_ident_key(&type_param.name_ident)) {
+                        token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                        token.type_def = Some(TypeDefinition::TypeId(type_param.type_id));
+                    }
+                }
+
+                for variant in &enum_decl.variants {
+                    if let Some(mut token) = tokens.get_mut(&to_ident_key(&variant.name)) {
+                        token.typed = Some(TypedAstToken::TypedEnumVariant(variant.clone()));
+                        token.type_def = Some(TypeDefinition::TypeId(variant.type_id));
+                    }
+
+                    if let Some(mut token) =
+                        tokens.get_mut(&to_ident_key(&Ident::new(variant.type_span.clone())))
+                    {
+                        token.typed = Some(TypedAstToken::TypedEnumVariant(variant.clone()));
+                        token.type_def = Some(TypeDefinition::TypeId(variant.type_id));
+                    }
                 }
             }
         }
         TypedDeclaration::ImplTrait(decl_id) => {
-            let TypedImplTrait {
+            if let Ok(TypedImplTrait {
                 trait_name,
                 methods,
                 implementing_for_type_id,
                 type_implementing_for_span,
                 ..
-            } = declaration_engine::de_get_impl_trait(decl_id.clone(), &decl_id.span()).unwrap();
-            for ident in &trait_name.prefixes {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(ident)) {
-                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-                }
-            }
-
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&trait_name.suffix)) {
-                token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-                token.type_def = Some(TypeDefinition::TypeId(implementing_for_type_id));
-            }
-
-            if let Some(mut token) =
-                tokens.get_mut(&to_ident_key(&Ident::new(type_implementing_for_span)))
+            }) = declaration_engine::de_get_impl_trait(decl_id.clone(), &decl_id.span())
             {
-                token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-                token.type_def = Some(TypeDefinition::TypeId(implementing_for_type_id));
-            }
+                for ident in &trait_name.prefixes {
+                    if let Some(mut token) = tokens.get_mut(&to_ident_key(ident)) {
+                        token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                    }
+                }
 
-            for method in methods {
-                collect_typed_fn_decl(&method, tokens);
+                if let Some(mut token) = tokens.get_mut(&to_ident_key(&trait_name.suffix)) {
+                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                    token.type_def = Some(TypeDefinition::TypeId(implementing_for_type_id));
+                }
+
+                if let Some(mut token) =
+                    tokens.get_mut(&to_ident_key(&Ident::new(type_implementing_for_span)))
+                {
+                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                    token.type_def = Some(TypeDefinition::TypeId(implementing_for_type_id));
+                }
+
+                for method in methods {
+                    collect_typed_fn_decl(&method, tokens);
+                }
             }
         }
         TypedDeclaration::AbiDeclaration(decl_id) => {
-            let abi_decl =
-                declaration_engine::de_get_abi(decl_id.clone(), &decl_id.span()).unwrap();
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&abi_decl.name)) {
-                token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-            }
+            if let Ok(abi_decl) = declaration_engine::de_get_abi(decl_id.clone(), &decl_id.span()) {
+                if let Some(mut token) = tokens.get_mut(&to_ident_key(&abi_decl.name)) {
+                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                }
 
-            for trait_fn in &abi_decl.interface_surface {
-                collect_typed_trait_fn_token(trait_fn, tokens);
+                for trait_fn in &abi_decl.interface_surface {
+                    collect_typed_trait_fn_token(trait_fn, tokens);
+                }
             }
         }
         TypedDeclaration::GenericTypeForFunctionScope { name, .. } => {
@@ -178,22 +185,24 @@ fn handle_declaration(declaration: &TypedDeclaration, tokens: &TokenMap) {
         }
         TypedDeclaration::ErrorRecovery => {}
         TypedDeclaration::StorageDeclaration(decl_id) => {
-            let storage_decl =
-                declaration_engine::de_get_storage(decl_id.clone(), &decl_id.span()).unwrap();
-            for field in &storage_decl.fields {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&field.name)) {
-                    token.typed = Some(TypedAstToken::TypedStorageField(field.clone()));
-                    token.type_def = Some(TypeDefinition::TypeId(field.type_id));
-                }
+            if let Ok(storage_decl) =
+                declaration_engine::de_get_storage(decl_id.clone(), &decl_id.span())
+            {
+                for field in &storage_decl.fields {
+                    if let Some(mut token) = tokens.get_mut(&to_ident_key(&field.name)) {
+                        token.typed = Some(TypedAstToken::TypedStorageField(field.clone()));
+                        token.type_def = Some(TypeDefinition::TypeId(field.type_id));
+                    }
 
-                if let Some(mut token) =
-                    tokens.get_mut(&to_ident_key(&Ident::new(field.type_span.clone())))
-                {
-                    token.typed = Some(TypedAstToken::TypedStorageField(field.clone()));
-                    token.type_def = Some(TypeDefinition::TypeId(field.type_id));
-                }
+                    if let Some(mut token) =
+                        tokens.get_mut(&to_ident_key(&Ident::new(field.type_span.clone())))
+                    {
+                        token.typed = Some(TypedAstToken::TypedStorageField(field.clone()));
+                        token.type_def = Some(TypeDefinition::TypeId(field.type_id));
+                    }
 
-                handle_expression(&field.initializer, tokens);
+                    handle_expression(&field.initializer, tokens);
+                }
             }
         }
     }

--- a/sway-lsp/src/utils/token.rs
+++ b/sway-lsp/src/utils/token.rs
@@ -63,7 +63,7 @@ pub(crate) fn struct_declaration_of_type_id(
 ) -> Option<TypedStructDeclaration> {
     declaration_of_type_id(type_id, tokens).and_then(|decl| match decl {
         TypedDeclaration::StructDeclaration(ref decl_id) => {
-            Some(declaration_engine::de_get_struct(decl_id.clone(), &decl.span()).unwrap())
+            declaration_engine::de_get_struct(decl_id.clone(), &decl_id.span()).ok()
         }
         _ => None,
     })
@@ -109,10 +109,9 @@ pub(crate) fn type_id(token_type: &Token) -> Option<TypeId> {
             TypedAstToken::TypedDeclaration(dec) => match dec {
                 TypedDeclaration::VariableDeclaration(var_decl) => Some(var_decl.type_ascription),
                 TypedDeclaration::ConstantDeclaration(decl_id) => {
-                    let const_decl =
-                        declaration_engine::de_get_constant(decl_id.clone(), &decl_id.span())
-                            .unwrap();
-                    Some(const_decl.value.return_type)
+                    declaration_engine::de_get_constant(decl_id.clone(), &decl_id.span())
+                        .ok()
+                        .and_then(|const_decl| Some(const_decl.value.return_type))
                 }
                 _ => None,
             },

--- a/sway-lsp/src/utils/token.rs
+++ b/sway-lsp/src/utils/token.rs
@@ -111,7 +111,7 @@ pub(crate) fn type_id(token_type: &Token) -> Option<TypeId> {
                 TypedDeclaration::ConstantDeclaration(decl_id) => {
                     declaration_engine::de_get_constant(decl_id.clone(), &decl_id.span())
                         .ok()
-                        .and_then(|const_decl| Some(const_decl.value.return_type))
+                        .map(|const_decl| const_decl.value.return_type)
                 }
                 _ => None,
             },


### PR DESCRIPTION
Removes the calls to `unwrap()` when getting types from the declaration engine and only continues if the result is `Ok`. 
