### PR TITLE
Publish error and warning diagnostics when the project cannot be parsed

### DIFF
--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -151,7 +151,6 @@ impl Session {
         if let Ok(manifest) = pkg::ManifestFile::from_dir(&manifest_dir) {
             if let Ok(plan) = pkg::BuildPlan::from_lock_and_manifest(&manifest, locked, offline) {
                 //we can then use them directly to convert them to a Vec<Diagnostic>
-<<<<<<< HEAD
                 if let Ok(CompileResult {
                     value,
                     warnings,
@@ -172,20 +171,6 @@ impl Session {
                     let res = self.parse_ast_to_typed_tokens(ast_res);
                     //self.test_typed_parse(ast_res);
                     return res;
-=======
-                match pkg::check(&plan, silent_mode) {
-                    Ok((parsed_res, ast_res)) => {
-                        // First, populate our token_map with un-typed ast nodes
-                        let _ = self.parse_ast_to_tokens(parsed_res);
-                        // Next, populate our token_map with typed ast nodes
-                        let res = self.parse_ast_to_typed_tokens(ast_res);
-                        //self.test_typed_parse(ast_res);
-                        return res;
-                    }
-                    Err(_err) => {
-                        //TODO get warnings and errors from the compiler here and publish them
-                    }
->>>>>>> ee5a60f62 (clippy)
                 }
             }
         }

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -151,6 +151,7 @@ impl Session {
         if let Ok(manifest) = pkg::ManifestFile::from_dir(&manifest_dir) {
             if let Ok(plan) = pkg::BuildPlan::from_lock_and_manifest(&manifest, locked, offline) {
                 //we can then use them directly to convert them to a Vec<Diagnostic>
+<<<<<<< HEAD
                 if let Ok(CompileResult {
                     value,
                     warnings,
@@ -171,6 +172,20 @@ impl Session {
                     let res = self.parse_ast_to_typed_tokens(ast_res);
                     //self.test_typed_parse(ast_res);
                     return res;
+=======
+                match pkg::check(&plan, silent_mode) {
+                    Ok((parsed_res, ast_res)) => {
+                        // First, populate our token_map with un-typed ast nodes
+                        let _ = self.parse_ast_to_tokens(parsed_res);
+                        // Next, populate our token_map with typed ast nodes
+                        let res = self.parse_ast_to_typed_tokens(ast_res);
+                        //self.test_typed_parse(ast_res);
+                        return res;
+                    }
+                    Err(_err) => {
+                        //TODO get warnings and errors from the compiler here and publish them
+                    }
+>>>>>>> ee5a60f62 (clippy)
                 }
             }
         }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -100,7 +100,7 @@ impl Backend {
     async fn publish_diagnostics(&self, uri: &Url, diagnostics: Vec<Diagnostic>) {
         match &self.config.collected_tokens_as_warnings {
             Some(s) => {
-                let token_map = self.session.tokens_for_file(&uri);
+                let token_map = self.session.tokens_for_file(uri);
 
                 // If collected_tokens_as_warnings is Some, take over the normal error and warning display behavior
                 // and instead show the either the parsed or typed tokens as warnings.

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -51,7 +51,7 @@ impl Backend {
     }
 
     async fn parse_project(&self, uri: &Url) {
-        let diagnostics = match self.session.parse_project(&uri) {
+        let diagnostics = match self.session.parse_project(uri) {
             Ok(diagnostics) => diagnostics,
             Err(err) => {
                 if let DocumentError::FailedToParse(diagnostics) = err {
@@ -61,7 +61,7 @@ impl Backend {
                 }
             }
         };
-        self.publish_diagnostics(&uri, diagnostics).await;
+        self.publish_diagnostics(uri, diagnostics).await;
     }
 }
 


### PR DESCRIPTION
~~waiting on #2724~~ 

LSP now displays errors and warnings to the user in the editor. 

<img width="943" alt="Screen Shot 2022-09-21 at 10 25 36 am" src="https://user-images.githubusercontent.com/1289413/191392654-69587e14-05f5-4e30-b88f-cddda32acf4f.png">
