### PR TITLE
ci: skip publishing/building forc-client crate/bin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           cargo install --debug --path ./forc-plugins/forc-fmt
           cargo install --debug --path ./forc-plugins/forc-lsp
           cargo install --debug --path ./forc-plugins/forc-explore
-          cargo install --debug --path ./forc-plugins/forc-client
+          cargo install --debug forc-client
       - name: Install mdbook-forc-documenter
         uses: actions-rs/cargo@v1
         with:
@@ -369,7 +369,6 @@ jobs:
         run: |
           cargo install toml-cli
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} forc/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} forc-plugins/forc-client/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} forc-plugins/forc-explore/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} forc-plugins/forc-fmt/Cargo.toml
           ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} forc-plugins/forc-lsp/Cargo.toml
@@ -610,12 +609,6 @@ jobs:
           command: install
           args: --profile=release --path ./forc-plugins/forc-explore
 
-      - name: Install Forc-Client
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --profile=release --path ./forc-plugins/forc-client
-
       - name: Prep Assets
         id: prep_assets
         env:
@@ -626,7 +619,7 @@ jobs:
           ZIP_FILE_NAME=forc-binaries-${{ env.PLATFORM_NAME }}_${{ env.ARCH }}.tar.gz
           echo "ZIP_FILE_NAME=$ZIP_FILE_NAME" >> $GITHUB_ENV
           mkdir -pv ./forc-binaries
-          for binary in forc forc-fmt forc-lsp forc-explore forc-deploy forc-run; do
+          for binary in forc forc-fmt forc-lsp forc-explore; do
             cp $(which ${binary}) ./forc-binaries
           done
           tar -czvf $ZIP_FILE_NAME ./forc-binaries

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,7 +28,7 @@ jobs:
           cargo install --debug --path ./forc-plugins/forc-fmt 
           cargo install --debug --path ./forc-plugins/forc-lsp 
           cargo install --debug --path ./forc-plugins/forc-explore
-          cargo install --debug --path ./forc-plugins/forc-client
+          cargo install --debug forc-client
       - name: Install mdbook-forc-documenter
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
related issue: #2608 
followup pr: #2806 

ideally should be done alongside a new release https://github.com/FuelLabs/forc-client/pull/17

Splitting deprecation of forc-client in 2 steps, first let's stop publishing the crate/releasing the `forc-client` binary from this repo.