### PR TITLE
Allow matching on constants in match expressions

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/usefulness.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/usefulness.rs
@@ -3,7 +3,7 @@ use sway_types::Span;
 use crate::{
     error::{err, ok},
     type_system::TypeId,
-    CompileError, CompileResult, Scrutinee,
+    CompileError, CompileResult, Namespace, Scrutinee,
 };
 
 use super::{
@@ -196,6 +196,7 @@ use super::{
 /// exhaustive if the imaginary additional wildcard pattern has an empty
 /// `WitnessReport`.
 pub(crate) fn check_match_expression_usefulness(
+    namespace: &Namespace,
     type_id: TypeId,
     scrutinees: Vec<Scrutinee>,
     span: Span,
@@ -212,7 +213,7 @@ pub(crate) fn check_match_expression_usefulness(
     );
     for scrutinee in scrutinees.iter() {
         let pat = check!(
-            Pattern::from_scrutinee(scrutinee.clone()),
+            Pattern::from_scrutinee(namespace, scrutinee.clone()),
             return err(warnings, errors),
             warnings,
             errors

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -632,6 +632,10 @@ impl TypedExpression {
         }
     }
 
+    pub(crate) fn extract_constant_literal_value(&self) -> Option<Literal> {
+        self.expression.extract_constant_literal_value()
+    }
+
     pub(crate) fn type_check(mut ctx: TypeCheckContext, expr: Expression) -> CompileResult<Self> {
         let expr_span = expr.span();
         let span = expr_span.clone();
@@ -1160,7 +1164,7 @@ impl TypedExpression {
 
         // check to see if the match expression is exhaustive and if all match arms are reachable
         let (witness_report, arms_reachability) = check!(
-            check_match_expression_usefulness(type_id, scrutinees, span.clone()),
+            check_match_expression_usefulness(ctx.namespace, type_id, scrutinees, span.clone()),
             return err(warnings, errors),
             warnings,
             errors

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression_variant.rs
@@ -583,6 +583,15 @@ impl fmt::Display for TypedExpressionVariant {
     }
 }
 
+impl TypedExpressionVariant {
+    pub(crate) fn extract_constant_literal_value(&self) -> Option<Literal> {
+        match self {
+            TypedExpressionVariant::Literal(value) => Some(value.clone()),
+            _ => None,
+        }
+    }
+}
+
 /// Describes the full storage access including all the subfields
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeCheckedStorageAccess {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_constants/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_constants/Forc.lock
@@ -1,0 +1,14 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-6679AAF5443CF293'
+dependencies = []
+
+[[package]]
+name = 'match_expressions_constants'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-6679AAF5443CF293'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_constants/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_constants/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "match_expressions_constants"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_constants/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_constants/json_abi_oracle.json
@@ -1,0 +1,22 @@
+{
+  "functions": [
+    {
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_constants/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_constants/src/main.sw
@@ -1,0 +1,16 @@
+script;
+
+const NUMBER_1: u64 = 7;
+const NUMBER_2: u64 = 14;
+const NUMBER_3: u64 = 5;
+
+fn main() -> u64 {
+    let a = 5;
+
+    match a {
+        NUMBER_1 => 1,
+        NUMBER_2 => 1,
+        NUMBER_3 => 42,
+        other => other,
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_constants/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_constants/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 42 }
+validate_abi = true


### PR DESCRIPTION
This PR allows constants to be on the LHS of a match expression such that a match expression can match on the value of the constant. However, its currently limited to constants with literal values only.

- closes #1816