### PR TITLE
Apply new clippy lints for Rust v1.64 

### DIFF
--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -68,10 +68,7 @@ impl ControlFlowGraph {
         let mut max_iterations = 50;
         while !rovers.is_empty() && rovers[0] != exit_point && max_iterations > 0 {
             max_iterations -= 1;
-            rovers = rovers
-                .into_iter()
-                .filter(|idx| *idx != exit_point)
-                .collect();
+            rovers.retain(|idx| *idx != exit_point);
             let mut next_rovers = vec![];
             let mut last_discovered_span;
             for rover in rovers {

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -143,14 +143,11 @@ impl<K: std::cmp::Eq + std::hash::Hash, V> MappedStack<K, V> {
         self.container.get(k).and_then(|val_vec| val_vec.last())
     }
     fn pop(&mut self, k: &K) {
-        match self.container.get_mut(k) {
-            Some(val_vec) => {
-                val_vec.pop();
-                if val_vec.is_empty() {
-                    self.container.remove(k);
-                }
+        if let Some(val_vec) = self.container.get_mut(k) {
+            val_vec.pop();
+            if val_vec.is_empty() {
+                self.container.remove(k);
             }
-            None => {}
         }
     }
 }

--- a/sway-core/src/type_system/type_id.rs
+++ b/sway-core/src/type_system/type_id.rs
@@ -137,10 +137,10 @@ impl TypeId {
         match look_up_type_id(*self) {
             TypeInfo::Enum {
                 type_parameters, ..
-            } => (!type_parameters.is_empty()).then(|| type_parameters),
+            } => (!type_parameters.is_empty()).then_some(type_parameters),
             TypeInfo::Struct {
                 type_parameters, ..
-            } => (!type_parameters.is_empty()).then(|| type_parameters),
+            } => (!type_parameters.is_empty()).then_some(type_parameters),
             _ => None,
         }
     }

--- a/sway-parse/src/parser.rs
+++ b/sway-parse/src/parser.rs
@@ -121,7 +121,7 @@ impl<'a, 'e> Parser<'a, 'e> {
 
     pub fn check_empty(&self) -> Option<ParserConsumed<'a>> {
         self.is_empty()
-            .then(|| ParserConsumed { _priv: PhantomData })
+            .then_some(ParserConsumed { _priv: PhantomData })
     }
 
     pub fn debug_tokens(&self) -> &[TokenTree] {


### PR DESCRIPTION
Rust v1.64 is [released](https://github.com/rust-lang/rust/releases/tag/1.64.0) and there seems to be some new clippy lints. 