### PR TITLE
Fix parse error when whitespace precedes comments

### DIFF
--- a/swayfmt/src/formatter/mod.rs
+++ b/swayfmt/src/formatter/mod.rs
@@ -1052,4 +1052,22 @@ library test_module_kind_with_comments;
         assert_eq!(correct_sway_code, formatted_sway_code);
         assert!(test_stability(formatted_sway_code, formatter));
     }
+    #[test]
+    fn newline_before_comments() {
+        let sway_code_to_format = r#"
+
+
+// something about module kind
+// something else about module kind
+library test_module_kind_with_comments;"#;
+        let correct_sway_code = r#"// something about module kind
+// something else about module kind
+library test_module_kind_with_comments;
+"#;
+        let mut formatter = Formatter::default();
+        let formatted_sway_code =
+            Formatter::format(&mut formatter, Arc::from(sway_code_to_format), None).unwrap();
+        assert_eq!(correct_sway_code, formatted_sway_code);
+        assert!(test_stability(formatted_sway_code, formatter));
+    }
 }

--- a/swayfmt/src/utils/map/comments.rs
+++ b/swayfmt/src/utils/map/comments.rs
@@ -45,17 +45,25 @@ impl CommentRange for CommentMap {
 
 /// Get the CommentedTokenStream and collect the spans -> Comment mapping for the input source
 /// code.
-pub fn comment_map_from_src(input: Arc<str>) -> Result<CommentMap, FormatterError> {
+pub fn comment_map_from_src(input: Arc<str>) -> Result<(CommentMap, usize), FormatterError> {
     let mut comment_map = BTreeMap::new();
 
     // pass the input through lexer
-    let commented_token_stream = lex_commented(&input, 0, input.len(), None)?;
+    let mut start = 0;
+    if input.starts_with('\n') {
+        let mut input_chars = input.chars().peekable();
+        while let Some('\n') = input_chars.next() {
+            start += 1
+        }
+    }
+    let commented_token_stream = lex_commented(&input, start, input.len(), None)?;
     let tts = commented_token_stream.token_trees().iter();
 
     for comment in tts {
         collect_comments_from_token_stream(comment, &mut comment_map);
     }
-    Ok(comment_map)
+
+    Ok((comment_map, start))
 }
 
 /// Collects `Comment`s from the token stream and insert it with its span to the `CommentMap`.
@@ -116,7 +124,7 @@ pub fn handle_comments(
 /// traversal. When `add_comments` is called we have already parsed the unformatted_code so there is no need
 /// to parse it again.
 fn add_comments(
-    comment_map: CommentMap,
+    comment_map: (CommentMap, usize),
     unformatted_module: &Module,
     formatted_module: &Module,
     formatted_code: &mut FormattedCode,
@@ -138,6 +146,7 @@ fn add_comments(
     // Since we are adding comments into formatted code, in the next iteration the spans we find for the formatted code needs to be offsetted
     // as the total length of comments we added in previous iterations.
     let mut offset = 0;
+    let (comment_map, start_offset) = comment_map;
 
     // We will definetly have a span in the collected span since for a source code to be parsed there should be some tokens present.
     let mut previous_unformatted_comment_span = unformatted_comment_spans
@@ -162,6 +171,7 @@ fn add_comments(
                 previous_formatted_comment_span,
                 comments_found,
                 offset,
+                start_offset,
                 formatted_code,
             )?;
         }
@@ -227,6 +237,7 @@ fn insert_after_span(
     from: &ByteSpan,
     comments_to_insert: Vec<CommentWithContext>,
     offset: usize,
+    start_offset: usize,
     formatted_code: &mut FormattedCode,
 ) -> Result<usize, FormatterError> {
     let iter = comments_to_insert.iter();
@@ -235,7 +246,7 @@ fn insert_after_span(
     let mut pre_module_comment = false;
     for comment_with_context in iter {
         let (comment_value, comment_context) = comment_with_context;
-        if comment_value.span.start() == 0 {
+        if comment_value.span.start() == from.start + start_offset {
             pre_module_comment = true;
         }
         write!(
@@ -245,16 +256,20 @@ fn insert_after_span(
             &format_comment(comment_value)
         )?;
     }
-    if pre_module_comment {
-        writeln!(comment_str)?;
-    }
     let mut src_rope = Rope::from_str(formatted_code);
     // If the position we are going to be inserting from + 1 is a \n we are moving that \n after
     // this comment so if that is the case we are inserting after the \n
     if formatted_code.chars().nth(from.end + offset + 1) == Some('\n') {
         offset += 1;
     }
-    src_rope.insert(from.end + offset, &comment_str);
+
+    if pre_module_comment {
+        writeln!(comment_str)?;
+
+        src_rope.insert(from.end + offset, &comment_str.trim_start().to_string());
+    } else {
+        src_rope.insert(from.end + offset, &comment_str);
+    }
     formatted_code.clear();
     formatted_code.push_str(&src_rope.to_string());
     Ok(comment_str.len())
@@ -285,7 +300,7 @@ mod tests {
             bar: i32,
         }
         "#;
-        let map = comment_map_from_src(Arc::from(input)).unwrap();
+        let (map, _) = comment_map_from_src(Arc::from(input)).unwrap();
         assert!(!map.is_empty());
         let range_start_span = ByteSpan { start: 0, end: 32 };
         let range_end_span = ByteSpan { start: 33, end: 34 };
@@ -307,7 +322,7 @@ mod tests {
             bar: i32,
         }
         "#;
-        let map = comment_map_from_src(Arc::from(input)).unwrap();
+        let (map, _) = comment_map_from_src(Arc::from(input)).unwrap();
         assert!(!map.is_empty());
         let range_start_span = ByteSpan { start: 40, end: 54 };
         let range_end_span = ByteSpan {
@@ -332,7 +347,7 @@ mod tests {
             bar: i32,
         }
         "#;
-        let map = comment_map_from_src(Arc::from(input)).unwrap();
+        let (map, _) = comment_map_from_src(Arc::from(input)).unwrap();
         assert!(!map.is_empty());
         let range_start_span = ByteSpan {
             start: 110,
@@ -357,7 +372,7 @@ mod tests {
         let range_end_span = ByteSpan { start: 8, end: 16 };
         let input = r#"// test
 contract;"#;
-        let map = comment_map_from_src(Arc::from(input)).unwrap();
+        let (map, _) = comment_map_from_src(Arc::from(input)).unwrap();
         assert!(!map.is_empty());
         let found_comments = map.comments_in_range(&range_start_span, &range_end_span);
         assert_eq!(found_comments[0].1.span.as_str(), "// test");


### PR DESCRIPTION
This should be the last piece of the puzzle for ensuring that comments before module kind will always work. As apposed to the newline map where we can just trim the start of the source code, we have to approach it a little differently since we are using functions that leave the source code in tact as an `Arc<str>`. We check if the src code starts with a newline, then we count the number of newlines, then we pass that offset to where we previously checked that the program started with a comment and add the offset to that logic. Finally we trim the comment string start to be sure the program start is the intended comment.