### PR TITLE
Better error message when fetching a git dependency failed

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1254,7 +1254,12 @@ where
     }
     repo.remote_anonymous(source.repo.as_str())?
         .fetch(&refspecs, Some(&mut fetch_opts), None)
-        .with_context(|| format!("failed to fetch `{}` Check your connection or run in `--offline` mode", &source.repo))?;
+        .with_context(|| {
+            format!(
+                "failed to fetch `{}` Check your connection or run in `--offline` mode",
+                &source.repo
+            )
+        })?;
 
     // Call the user function.
     let output = f(repo)?;

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1256,7 +1256,7 @@ where
         .fetch(&refspecs, Some(&mut fetch_opts), None)
         .with_context(|| {
             format!(
-                "failed to fetch `{}` Check your connection or run in `--offline` mode",
+                "failed to fetch `{}`. Check your connection or run in `--offline` mode",
                 &source.repo
             )
         })?;

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1254,7 +1254,7 @@ where
     }
     repo.remote_anonymous(source.repo.as_str())?
         .fetch(&refspecs, Some(&mut fetch_opts), None)
-        .with_context(|| format!("failed to fetch `{}`", &source.repo))?;
+        .with_context(|| format!("failed to fetch `{}` Check your connection or run in `--offline` mode", &source.repo))?;
 
     // Call the user function.
     let output = f(repo)?;


### PR DESCRIPTION
closes #895. 

And also with that `offline` support will be completly in place so I guess this also closes #2349 