### PR TITLE
Remove extra call to `resolve_type`

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -347,7 +347,6 @@ pub(crate) fn resolve_method_name(
                     type_id,
                     &type_info_prefix,
                     method_name,
-                    ctx.self_type(),
                     &arguments
                 ),
                 return err(warnings, errors),
@@ -371,7 +370,6 @@ pub(crate) fn resolve_method_name(
                     type_id,
                     &module_path,
                     &call_path.suffix,
-                    ctx.self_type(),
                     &arguments
                 ),
                 return err(warnings, errors),
@@ -391,13 +389,8 @@ pub(crate) fn resolve_method_name(
 
             // find the method
             check!(
-                ctx.namespace.find_method_for_type(
-                    type_id,
-                    &module_path,
-                    method_name,
-                    ctx.self_type(),
-                    &arguments
-                ),
+                ctx.namespace
+                    .find_method_for_type(type_id, &module_path, method_name, &arguments),
                 return err(warnings, errors),
                 warnings,
                 errors

--- a/sway-core/src/semantic_analysis/namespace/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace/namespace.rs
@@ -138,17 +138,10 @@ impl Namespace {
         r#type: TypeId,
         method_prefix: &Path,
         method_name: &Ident,
-        self_type: TypeId,
         args_buf: &VecDeque<TypedExpression>,
     ) -> CompileResult<TypedFunctionDeclaration> {
-        self.root.find_method_for_type(
-            &self.mod_path,
-            r#type,
-            method_prefix,
-            method_name,
-            self_type,
-            args_buf,
-        )
+        self.root
+            .find_method_for_type(&self.mod_path, r#type, method_prefix, method_name, args_buf)
     }
 
     /// Short-hand for performing a [Module::star_import] with `mod_path` as the destination.

--- a/sway-core/src/semantic_analysis/namespace/root.rs
+++ b/sway-core/src/semantic_analysis/namespace/root.rs
@@ -234,10 +234,9 @@ impl Root {
     pub(crate) fn find_method_for_type(
         &mut self,
         mod_path: &Path,
-        mut type_id: TypeId,
+        type_id: TypeId,
         method_prefix: &Path,
         method_name: &Ident,
-        self_type: TypeId,
         args_buf: &VecDeque<TypedExpression>,
     ) -> CompileResult<TypedFunctionDeclaration> {
         let mut warnings = vec![];
@@ -253,22 +252,6 @@ impl Root {
 
         // grab the local methods from the local module
         let local_methods = local_module.get_methods_for_type(type_id);
-
-        type_id.replace_self_type(self_type);
-
-        // resolve the type
-        let type_id = check!(
-            self.resolve_type(
-                type_id,
-                &method_name.span(),
-                EnforceTypeArguments::No,
-                None,
-                method_prefix
-            ),
-            insert_type(TypeInfo::ErrorRecovery),
-            warnings,
-            errors
-        );
 
         // grab the module where the type itself is declared
         let type_module = check!(

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/Forc.lock
@@ -6,4 +6,9 @@ dependencies = []
 [[package]]
 name = 'generic_impl_self'
 source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-DA3FEDB2AB26E552'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/Forc.toml
@@ -5,4 +5,4 @@ name = "generic_impl_self"
 entry = "main.sw"
 
 [dependencies]
-core = { path = "../../../../../../../sway-lib-core" }
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/src/main.sw
@@ -1,5 +1,7 @@
 script;
 
+use std::result::Result;
+
 struct Data<T> {
   value: T
 }
@@ -75,21 +77,6 @@ fn crazy<T, F>(x: T, y: F) -> F {
   foo.get_second()
 }
 
-enum Result<T> {
-  Ok: T,
-  Err: u8 // err code
-}
-
-impl<T> Result<T> {
-  fn ok(value: T) -> Self {
-    Result::Ok::<T>(value)
-  }
-
-  fn err(code: u8) -> Self {
-    Result::Err::<T>(code)
-  }
-}
-
 enum Option<T> {
   Some: T,
   None: ()
@@ -104,11 +91,11 @@ impl<T> Option<T> {
     Option::None::<T>(())
   }
 
-  fn to_result(self) -> Result<T> {
+  fn to_result(self) -> Result<T, u8> {
     if let Option::Some(value) = self {
-      ~Result::<T>::ok(value)
+      Result::Ok::<T, u8>(value)
     } else {
-      ~Result::<T>::err(99u8)
+      Result::Err::<T, u8>(99u8)
     }
   }
 }


### PR DESCRIPTION
This removes a no-op call to `resolve_type`.