### PR TITLE
Re-apply a PR that got written over in a merge conflict

### DIFF
--- a/sway-core/src/type_system/type_engine.rs
+++ b/sway-core/src/type_system/type_engine.rs
@@ -663,7 +663,7 @@ impl TypeEngine {
                 }
                 self.insert_type(TypeInfo::Tuple(type_arguments))
             }
-            o => insert_type(o),
+            _ => type_id,
         };
         ok(type_id, warnings, errors)
     }


### PR DESCRIPTION
This fix went in with  #2829 but then accidentally got written over by #2835.