### PR TITLE
Small fix to the IR verifier

### DIFF
--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -622,6 +622,7 @@ impl<'a> InstructionVerifier<'a> {
             .iter()
             .map(|(_, v)| v.get_type(self.context))
             .reduce(|a, b| if self.opt_ty_not_eq(&a, &b) { None } else { b })
+            .unwrap() // Safe to unwrap because `pairs` is *not* empty as this was checked earlier
             .is_none()
         {
             Err(IrError::VerifyPhiInconsistentTypes)


### PR DESCRIPTION
The result of the a `reduce` needs to be unwrapped first before checking its content. The `VerifyPhiInconsistentTypes` was never actually reached previously. I was seeing some inconsistent behavior while looking at https://github.com/FuelLabs/sway/issues/2876 and found this issue.