### PR TITLE
Add `append` macro

### DIFF
--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -29,6 +29,14 @@ macro_rules! check {
     }};
 }
 
+macro_rules! append {
+    ($fn_expr: expr, $warnings: ident, $errors: ident $(,)?) => {{
+        let (mut l, mut r) = $fn_expr;
+        $warnings.append(&mut l);
+        $errors.append(&mut r);
+    }};
+}
+
 macro_rules! assert_or_warn {
     ($bool_expr: expr, $warnings: ident, $span: expr, $warning: expr $(,)?) => {{
         if !$bool_expr {

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -73,9 +73,7 @@ impl TypedCodeBlock {
             })
             .unwrap_or_else(|| insert_type(TypeInfo::Tuple(Vec::new())));
 
-        let (new_warnings, new_errors) = ctx.unify_with_self(block_type, &span);
-        warnings.extend(new_warnings);
-        errors.extend(new_errors.into_iter().map(|type_error| type_error.into()));
+        append!(ctx.unify_with_self(block_type, &span), warnings, errors);
 
         let typed_code_block = TypedCodeBlock {
             contents: evaluated_contents,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -176,13 +176,16 @@ impl TypedFunctionDeclaration {
 
         // unify the types of the return statements with the function return type
         for stmt in return_statements {
-            let (mut new_warnings, new_errors) = ctx
-                .by_ref()
-                .with_type_annotation(return_type)
-                .with_help_text("Return statement must return the declared function return type.")
-                .unify_with_self(stmt.return_type, &stmt.span);
-            warnings.append(&mut new_warnings);
-            errors.append(&mut new_errors.into_iter().map(|x| x.into()).collect());
+            append!(
+                ctx.by_ref()
+                    .with_type_annotation(return_type)
+                    .with_help_text(
+                        "Return statement must return the declared function return type."
+                    )
+                    .unify_with_self(stmt.return_type, &stmt.span),
+                warnings,
+                errors
+            );
         }
 
         let function_decl = TypedFunctionDeclaration {

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
@@ -77,9 +77,7 @@ pub(crate) fn matcher(
     } = scrutinee;
 
     // unify the type of the scrutinee with the type of the expression
-    let (mut new_warnings, new_errors) = unify(type_id, exp.return_type, &span, "");
-    warnings.append(&mut new_warnings);
-    errors.append(&mut new_errors.into_iter().map(|x| x.into()).collect());
+    append!(unify(type_id, exp.return_type, &span, ""), warnings, errors);
 
     if !errors.is_empty() {
         return err(warnings, errors);

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
@@ -93,10 +93,11 @@ impl TypedMatchBranch {
 
         // unify the return type from the typed result with the type annotation
         if !typed_result.deterministically_aborts() {
-            let (mut new_warnings, new_errors) =
-                ctx.unify_with_self(typed_result.return_type, &typed_result.span);
-            warnings.append(&mut new_warnings);
-            errors.append(&mut new_errors.into_iter().map(|x| x.into()).collect());
+            append!(
+                ctx.unify_with_self(typed_result.return_type, &typed_result.span),
+                warnings,
+                errors
+            );
         }
 
         // if the typed branch result is a code block, then add the contents

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -819,10 +819,11 @@ impl TypedExpression {
         let mut errors = res.errors;
 
         // if the return type cannot be cast into the annotation type then it is a type error
-        let (mut new_warnings, new_errors) =
-            ctx.unify_with_self(typed_expression.return_type, &expr_span);
-        warnings.append(&mut new_warnings);
-        errors.append(&mut new_errors.into_iter().map(|x| x.into()).collect());
+        append!(
+            ctx.unify_with_self(typed_expression.return_type, &expr_span),
+            warnings,
+            errors
+        );
 
         // The annotation may result in a cast, which is handled in the type engine.
         typed_expression.return_type = check!(
@@ -1039,9 +1040,12 @@ impl TypedExpression {
             errors
         );
 
-        let (mut new_warnings, new_errors) = ctx.unify_with_self(block_return_type, &span);
-        warnings.append(&mut new_warnings);
-        errors.append(&mut new_errors.into_iter().map(|x| x.into()).collect());
+        append!(
+            ctx.unify_with_self(block_return_type, &span),
+            warnings,
+            errors
+        );
+
         let exp = TypedExpression {
             expression: TypedExpressionVariant::CodeBlock(TypedCodeBlock {
                 contents: typed_block.contents,
@@ -1810,14 +1814,14 @@ impl TypedExpression {
 
         let elem_type = typed_contents[0].return_type;
         for typed_elem in &typed_contents[1..] {
-            let (mut new_warnings, new_errors) = ctx
+            let (mut new_warnings, mut new_errors) = ctx
                 .by_ref()
                 .with_type_annotation(elem_type)
                 .unify_with_self(typed_elem.return_type, &typed_elem.span);
             let no_warnings = new_warnings.is_empty();
             let no_errors = new_errors.is_empty();
             warnings.append(&mut new_warnings);
-            errors.append(&mut new_errors.into_iter().map(|x| x.into()).collect());
+            errors.append(&mut new_errors);
             // In both cases, if there are warnings or errors then break here, since we don't
             // need to spam type errors for every element once we have one.
             if !no_warnings && !no_errors {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/if_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/if_expression.rs
@@ -24,15 +24,17 @@ pub(crate) fn instantiate_if_expression(
         } else {
             insert_type(TypeInfo::Tuple(vec![]))
         };
-        let (mut new_warnings, new_errors) = unify_with_self(
-            then.return_type,
-            ty_to_check,
-            self_type,
-            &then.span,
-            "`then` branch must return expected type.",
+        append!(
+            unify_with_self(
+                then.return_type,
+                ty_to_check,
+                self_type,
+                &then.span,
+                "`then` branch must return expected type.",
+            ),
+            warnings,
+            errors
         );
-        warnings.append(&mut new_warnings);
-        errors.append(&mut new_errors.into_iter().map(|x| x.into()).collect());
     }
     let mut else_deterministically_aborts = false;
     let r#else = r#else.map(|r#else| {
@@ -44,15 +46,17 @@ pub(crate) fn instantiate_if_expression(
         };
         if !else_deterministically_aborts {
             // if this does not deterministically_abort, check the block return type
-            let (mut new_warnings, new_errors) = unify_with_self(
-                r#else.return_type,
-                ty_to_check,
-                self_type,
-                &r#else.span,
-                "`else` branch must return expected type.",
+            append!(
+                unify_with_self(
+                    r#else.return_type,
+                    ty_to_check,
+                    self_type,
+                    &r#else.span,
+                    "`else` branch must return expected type.",
+                ),
+                warnings,
+                errors
             );
-            warnings.append(&mut new_warnings);
-            errors.append(&mut new_errors.into_iter().map(|x| x.into()).collect());
         }
         Box::new(r#else)
     });
@@ -63,7 +67,7 @@ pub(crate) fn instantiate_if_expression(
         .unwrap_or_else(|| insert_type(TypeInfo::Tuple(Vec::new())));
     // if there is a type annotation, then the else branch must exist
     if !else_deterministically_aborts && !then_deterministically_aborts {
-        let (mut new_warnings, new_errors) = unify_with_self(
+        let (mut new_warnings, mut new_errors) = unify_with_self(
             then.return_type,
             r#else_ret_ty,
             self_type,
@@ -79,7 +83,7 @@ pub(crate) fn instantiate_if_expression(
                 });
             }
         } else {
-            errors.append(&mut new_errors.into_iter().map(|x| x.into()).collect());
+            errors.append(&mut new_errors);
         }
     }
 

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -6,7 +6,7 @@ use crate::{
         insert_type, monomorphize, unify_with_self, CopyTypes, EnforceTypeArguments,
         MonomorphizeHelper, TypeArgument, TypeId, TypeInfo,
     },
-    CompileResult, CompileWarning, TypeError,
+    CompileError, CompileResult, CompileWarning,
 };
 use sway_types::{span::Span, Ident};
 
@@ -230,7 +230,7 @@ impl<'ns> TypeCheckContext<'ns> {
         &self,
         ty: TypeId,
         span: &Span,
-    ) -> (Vec<CompileWarning>, Vec<TypeError>) {
+    ) -> (Vec<CompileWarning>, Vec<CompileError>) {
         unify_with_self(
             ty,
             self.type_annotation(),

--- a/sway-core/src/type_system/type_engine.rs
+++ b/sway-core/src/type_system/type_engine.rs
@@ -248,14 +248,16 @@ impl TypeEngine {
                 let mut warnings = vec![];
                 let mut errors = vec![];
                 for (field_a, field_b) in fields_a.iter().zip(fields_b.iter()) {
-                    let (new_warnings, new_errors) = self.unify(
-                        field_a.type_id,
-                        field_b.type_id,
-                        &field_a.span,
-                        help_text.clone(),
+                    append!(
+                        self.unify(
+                            field_a.type_id,
+                            field_b.type_id,
+                            &field_a.span,
+                            help_text.clone(),
+                        ),
+                        warnings,
+                        errors
                     );
-                    warnings.extend(new_warnings);
-                    errors.extend(new_errors);
                 }
                 (warnings, errors)
             }
@@ -330,23 +332,26 @@ impl TypeEngine {
                     && a_parameters.len() == b_parameters.len()
                 {
                     a_fields.iter().zip(b_fields.iter()).for_each(|(a, b)| {
-                        let (new_warnings, new_errors) =
-                            self.unify(a.type_id, b.type_id, &a.span, help_text.clone());
-                        warnings.extend(new_warnings);
-                        errors.extend(new_errors);
+                        append!(
+                            self.unify(a.type_id, b.type_id, &a.span, help_text.clone()),
+                            warnings,
+                            errors
+                        );
                     });
                     a_parameters
                         .iter()
                         .zip(b_parameters.iter())
                         .for_each(|(a, b)| {
-                            let (new_warnings, new_errors) = self.unify(
-                                a.type_id,
-                                b.type_id,
-                                &a.name_ident.span(),
-                                help_text.clone(),
+                            append!(
+                                self.unify(
+                                    a.type_id,
+                                    b.type_id,
+                                    &a.name_ident.span(),
+                                    help_text.clone(),
+                                ),
+                                warnings,
+                                errors
                             );
-                            warnings.extend(new_warnings);
-                            errors.extend(new_errors);
                         });
                 } else {
                     errors.push(TypeError::MismatchedType {
@@ -377,23 +382,26 @@ impl TypeEngine {
                     && a_parameters.len() == b_parameters.len()
                 {
                     a_variants.iter().zip(b_variants.iter()).for_each(|(a, b)| {
-                        let (new_warnings, new_errors) =
-                            self.unify(a.type_id, b.type_id, &a.span, help_text.clone());
-                        warnings.extend(new_warnings);
-                        errors.extend(new_errors);
+                        append!(
+                            self.unify(a.type_id, b.type_id, &a.span, help_text.clone()),
+                            warnings,
+                            errors
+                        );
                     });
                     a_parameters
                         .iter()
                         .zip(b_parameters.iter())
                         .for_each(|(a, b)| {
-                            let (new_warnings, new_errors) = self.unify(
-                                a.type_id,
-                                b.type_id,
-                                &a.name_ident.span(),
-                                help_text.clone(),
+                            append!(
+                                self.unify(
+                                    a.type_id,
+                                    b.type_id,
+                                    &a.name_ident.span(),
+                                    help_text.clone(),
+                                ),
+                                warnings,
+                                errors
                             );
-                            warnings.extend(new_warnings);
-                            errors.extend(new_errors);
                         });
                 } else {
                     errors.push(TypeError::MismatchedType {
@@ -748,8 +756,12 @@ pub fn unify_with_self(
     self_type: TypeId,
     span: &Span,
     help_text: impl Into<String>,
-) -> (Vec<CompileWarning>, Vec<TypeError>) {
-    TYPE_ENGINE.unify_with_self(a, b, self_type, span, help_text)
+) -> (Vec<CompileWarning>, Vec<CompileError>) {
+    let (warnings, errors) = TYPE_ENGINE.unify_with_self(a, b, self_type, span, help_text);
+    (
+        warnings,
+        errors.into_iter().map(|error| error.into()).collect(),
+    )
 }
 
 pub(crate) fn unify(
@@ -757,8 +769,12 @@ pub(crate) fn unify(
     b: TypeId,
     span: &Span,
     help_text: impl Into<String>,
-) -> (Vec<CompileWarning>, Vec<TypeError>) {
-    TYPE_ENGINE.unify(a, b, span, help_text)
+) -> (Vec<CompileWarning>, Vec<CompileError>) {
+    let (warnings, errors) = TYPE_ENGINE.unify(a, b, span, help_text);
+    (
+        warnings,
+        errors.into_iter().map(|error| error.into()).collect(),
+    )
 }
 
 pub fn to_typeinfo(id: TypeId, error_span: &Span) -> Result<TypeInfo, TypeError> {

--- a/sway-core/src/type_system/type_mapping.rs
+++ b/sway-core/src/type_system/type_mapping.rs
@@ -317,14 +317,16 @@ impl TypeMapping {
         let mut warnings = vec![];
         let mut errors = vec![];
         for ((_, destination_type), type_arg) in self.mapping.iter().zip(type_arguments.iter()) {
-            let (mut new_warnings, new_errors) = unify(
-                *destination_type,
-                type_arg.type_id,
-                &type_arg.span,
-                "Type argument is not assignable to generic type parameter.",
+            append!(
+                unify(
+                    *destination_type,
+                    type_arg.type_id,
+                    &type_arg.span,
+                    "Type argument is not assignable to generic type parameter.",
+                ),
+                warnings,
+                errors
             );
-            warnings.append(&mut new_warnings);
-            errors.append(&mut new_errors.into_iter().map(|x| x.into()).collect());
         }
         ok((), warnings, errors)
     }


### PR DESCRIPTION
This macro takes an instance of `(Vec<T>, Vec<F>)` `&mut Vec<T>`, and `&mut Vec<F>`. It appends the `Vec<T>` to the `&mut Vec<T>`, and the `Vec<F>` to the `&mut Vec<F>`.