### PR TITLE
Change `storage::get()` in libstd to use the heap.

### DIFF
--- a/sway-lib-std/src/storage.sw
+++ b/sway-lib-std/src/storage.sw
@@ -2,7 +2,6 @@ library r#storage;
 
 use ::alloc::alloc;
 use ::assert::assert;
-use ::context::registers::stack_ptr;
 use ::hash::sha256;
 use ::option::Option;
 use ::result::Result;
@@ -42,7 +41,10 @@ pub fn store<T>(key: b256, value: T) {
     };
 }
 
-/// Load a stack variable from storage.
+/// Load a variable from storage.
+///
+/// If the value size is larger than 8 bytes it is read to a heap buffer which is leaked for the
+/// duration of the program.
 #[storage(read)]
 pub fn get<T>(key: b256) -> T {
     if !__is_reference_type::<T>() {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -3,7 +3,7 @@ use basic_storage_abi::{StoreU64, Quad};
 use std::assert::assert;
 
 fn main() -> u64 {
-    let addr = abi(StoreU64, 0xd992b1febc69f6102915ea1102fde7b88f3e484ec55a02b4539c91615dca84e7);
+    let addr = abi(StoreU64, 0x7b214549ede63a82bab44723a09c27f17cd8cecbcf127f11abab699eb3fc143e);
     let key = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 


### PR DESCRIPTION
Until now it read non-copy types to a leaked buffer on the stack.  This will interfere with function call frames which require stack use symmetry within functions.

It now uses the heap, although it still leaks.

OK, see my note below though.  I don't know why it's failing, maybe there's an off-by-one thing happening or something.  @AlicanC in particular, you might see what's going on here.  @vaivaswatha or @mohammadfawaz you might have some insights too.  Am I missing something obvious?