### PR TITLE
Enable a `StorageMap` test case that wasn't working before

### DIFF
--- a/test/src/sdk-harness/test_projects/storage_map/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_map/mod.rs
@@ -984,11 +984,16 @@ mod to_u64_map {
                 .value,
             val1
         );
-        // This assert currently fails. Not sure why yet
-        //    assert_eq!(
-        //        instance.get_from_enum_to_u64_map(key2).call().await.unwrap().value,
-        //        val2
-        //    );
+        assert_eq!(
+            instance
+                .methods()
+                .get_from_enum_to_u64_map(key2)
+                .call()
+                .await
+                .unwrap()
+                .value,
+            val2
+        );
         assert_eq!(
             instance
                 .methods()


### PR DESCRIPTION
I remember this not working when I first added the test. There was a problem with the data layout for enums but now that's fixed.