### PR TITLE
Rename `transfer_to_output` to `transfer_to_address`

### DIFF
--- a/examples/identity/src/main.sw
+++ b/examples/identity/src/main.sw
@@ -17,7 +17,7 @@ use std::{
     },
     token::{
         force_transfer_to_contract,
-        transfer_to_output,
+        transfer_to_address,
     },
 };
 
@@ -48,7 +48,7 @@ impl IdentityExample for Contract {
 
         // ANCHOR: different_executions
         match my_identity {
-            Identity::Address(identity) => transfer_to_output(amount, token_id, identity),
+            Identity::Address(identity) => transfer_to_address(amount, token_id, identity),
             Identity::ContractId(identity) => force_transfer_to_contract(amount, token_id, identity),
         };
         // ANCHOR_END: different_executions

--- a/examples/identity/src/main.sw
+++ b/examples/identity/src/main.sw
@@ -48,8 +48,8 @@ impl IdentityExample for Contract {
 
         // ANCHOR: different_executions
         match my_identity {
-            Identity::Address(identity) => transfer_to_address(amount, token_id, identity),
-            Identity::ContractId(identity) => force_transfer_to_contract(amount, token_id, identity),
+            Identity::Address(address) => transfer_to_address(amount, token_id, address),
+            Identity::ContractId(contract_id) => force_transfer_to_contract(amount, token_id, contract_id),
         };
         // ANCHOR_END: different_executions
     }

--- a/examples/liquidity_pool/src/main.sw
+++ b/examples/liquidity_pool/src/main.sw
@@ -8,7 +8,7 @@ use std::{
     context::msg_amount,
     token::{
         mint_to_address,
-        transfer_to_output,
+        transfer_to_address,
     },
 };
 
@@ -39,6 +39,6 @@ impl LiquidityPool for Contract {
         let amount_to_transfer = msg_amount() / 2;
 
         // Transfer base token to recipient.
-        transfer_to_output(amount_to_transfer, BASE_TOKEN, recipient);
+        transfer_to_address(amount_to_transfer, BASE_TOKEN, recipient);
     }
 }

--- a/examples/native_token/src/main.sw
+++ b/examples/native_token/src/main.sw
@@ -31,7 +31,7 @@ impl NativeAssetToken for Contract {
 
     /// Transfer coins to a transaction output to be spent later.
     fn transfer_coins_to_output(coins: u64, asset_id: ContractId, recipient: Address) {
-        transfer_to_output(coins, asset_id, recipient);
+        transfer_to_address(coins, asset_id, recipient);
     }
 
     /// Get the internal balance of a specific coin at a specific contract.

--- a/examples/wallet_smart_contract/src/main.sw
+++ b/examples/wallet_smart_contract/src/main.sw
@@ -11,7 +11,7 @@ use std::{
         call_frames::msg_asset_id,
         msg_amount,
     },
-    token::transfer_to_output,
+    token::transfer_to_address,
 };
 
 // ANCHOR: abi_import
@@ -50,10 +50,10 @@ impl Wallet for Contract {
 
         storage.balance = current_balance - amount_to_send;
 
-        // Note: `transfer_to_output()` is not a call and thus not an
+        // Note: `transfer_to_address()` is not a call and thus not an
         // interaction. Regardless, this code conforms to
         // checks-effects-interactions to avoid re-entrancy.
-        transfer_to_output(amount_to_send, BASE_ASSET_ID, recipient_address);
+        transfer_to_address(amount_to_send, BASE_ASSET_ID, recipient_address);
     }
 }
 // ANCHOR_END: abi_impl

--- a/sway-lib-std/src/token.sw
+++ b/sway-lib-std/src/token.sw
@@ -8,11 +8,11 @@ use ::identity::Identity;
 use ::revert::revert;
 use ::outputs::{Output, output_amount, output_count, output_type};
 
-const FAILED_TRANSFER_TO_OUTPUT_SIGNAL = 0xffff_ffff_ffff_0001;
+const FAILED_TRANSFER_TO_ADDRESS_SIGNAL = 0xffff_ffff_ffff_0001;
 
 /// Mint `amount` coins of the current contract's `asset_id` and transfer them
 /// to `to` by calling either force_transfer_to_contract() or
-/// transfer_to_output(), depending on the type of `Identity`.
+/// transfer_to_address(), depending on the type of `Identity`.
 pub fn mint_to(amount: u64, to: Identity) {
     mint(amount);
     transfer(amount, contract_id(), to);
@@ -35,7 +35,7 @@ pub fn mint_to_contract(amount: u64, to: ContractId) {
 /// the Address `to`.
 pub fn mint_to_address(amount: u64, to: Address) {
     mint(amount);
-    transfer_to_output(amount, contract_id(), to);
+    transfer_to_address(amount, contract_id(), to);
 }
 
 /// Mint `amount` coins of the current contract's `asset_id`.
@@ -54,7 +54,7 @@ pub fn burn(amount: u64) {
 
 /// Transfer `amount` coins of the current contract's `asset_id` and send them
 /// to `to` by calling either force_transfer_to_contract() or
-/// transfer_to_output(), depending on the type of `Identity`.
+/// transfer_to_address(), depending on the type of `Identity`.
 ///
 /// CAUTION !!!
 ///
@@ -63,7 +63,7 @@ pub fn burn(amount: u64) {
 /// to the PERMANENT LOSS OF COINS if not used with care.
 pub fn transfer(amount: u64, asset_id: ContractId, to: Identity) {
     match to {
-        Identity::Address(addr) => transfer_to_output(amount, asset_id, addr),
+        Identity::Address(addr) => transfer_to_address(amount, asset_id, addr),
         Identity::ContractId(id) => force_transfer_to_contract(amount, asset_id, id),
     };
 }
@@ -84,33 +84,24 @@ pub fn force_transfer_to_contract(amount: u64, asset_id: ContractId, to: Contrac
 
 /// Transfer `amount` coins of type `asset_id` and send them to
 /// the address `to`.
-pub fn transfer_to_output(amount: u64, asset_id: ContractId, to: Address) {
+pub fn transfer_to_address(amount: u64, asset_id: ContractId, to: Address) {
     // maintain a manual index as we only have `while` loops in sway atm:
     let mut index = 0;
-    let mut output_index = 0;
-    let mut output_found = false;
 
     // If an output of type `OutputVariable` is found, check if its `amount` is
     // zero. As one cannot transfer zero coins to an output without a panic, a
     // variable output with a value of zero is by definition unused.
-    let outputs = output_count();
-    while index < outputs {
-        let type_of_output = output_type(index);
-        if let Output::Variable = type_of_output {
+    while index < output_count() {
+        if let Output::Variable = output_type(index) {
             if output_amount(index) == 0 {
-                output_index = index;
-                output_found = true;
-                break; // break early and use the output we found
+                asm(r1: to.value, r2: index, r3: amount, r4: asset_id.value) {
+                    tro r1 r2 r3 r4;
+                };
+                return;
             }
         }
         index += 1;
     }
 
-    if !output_found {
-        revert(FAILED_TRANSFER_TO_OUTPUT_SIGNAL);
-    } else {
-        asm(r1: to.value, r2: output_index, r3: amount, r4: asset_id.value) {
-            tro r1 r2 r3 r4;
-        };
-    }
+    revert(FAILED_TRANSFER_TO_ADDRESS_SIGNAL);
 }

--- a/sway-lib-std/src/token.sw
+++ b/sway-lib-std/src/token.sw
@@ -91,7 +91,8 @@ pub fn transfer_to_address(amount: u64, asset_id: ContractId, to: Address) {
     // If an output of type `OutputVariable` is found, check if its `amount` is
     // zero. As one cannot transfer zero coins to an output without a panic, a
     // variable output with a value of zero is by definition unused.
-    while index < output_count() {
+    let number_of_outputs = output_count();
+    while index < number_of_outputs {
         if let Output::Variable = output_type(index) {
             if output_amount(index) == 0 {
                 asm(r1: to.value, r2: index, r3: amount, r4: asset_id.value) {

--- a/test/src/sdk-harness/test_projects/token_ops/src/main.sw
+++ b/test/src/sdk-harness/test_projects/token_ops/src/main.sw
@@ -9,7 +9,7 @@ abi TestFuelCoin {
     fn mint_coins(mint_amount: u64);
     fn burn_coins(burn_amount: u64);
     fn force_transfer_coins(coins: u64, asset_id: ContractId, target: ContractId);
-    fn transfer_coins_to_output(coins: u64, asset_id: ContractId, to: Address);
+    fn transfer_coins_to_address(coins: u64, asset_id: ContractId, to: Address);
     fn get_balance(target: ContractId, asset_id: ContractId) -> u64;
     fn mint_and_send_to_contract(amount: u64, to: ContractId);
     fn mint_and_send_to_address(amount: u64, to: Address);
@@ -30,8 +30,8 @@ impl TestFuelCoin for Contract {
         force_transfer_to_contract(coins, asset_id, target);
     }
 
-    fn transfer_coins_to_output(coins: u64, asset_id: ContractId, to: Address) {
-        transfer_to_output(coins, asset_id, to);
+    fn transfer_coins_to_address(coins: u64, asset_id: ContractId, to: Address) {
+        transfer_to_address(coins, asset_id, to);
     }
 
     fn get_balance(target: ContractId, asset_id: ContractId) -> u64 {


### PR DESCRIPTION
Closes #2912

Even though `transfer_to_output` is technically more correct, users really understand this as transferring to an address. Besides, the name `transfer_to_address` aligns better with the names of its parameters:

```rust
(amount: u64, asset_id: ContractId, to: Address)
```

And also with other functions in `token.rs` (such as `mint_to_address`).

I also did some minor refactoring of the function.