### PR TITLE
Correctly generate the `typeArguments` field for logged types

### DIFF
--- a/sway-core/src/type_system/type_id.rs
+++ b/sway-core/src/type_system/type_id.rs
@@ -387,6 +387,35 @@ impl TypeId {
                     })
                     .collect::<Vec<_>>()
             }),
+            TypeInfo::Enum {
+                type_parameters, ..
+            }
+            | TypeInfo::Struct {
+                type_parameters, ..
+            } => {
+                // Here, type_parameters.type_id should contain resolved types
+                let json_type_arguments = type_parameters
+                    .iter()
+                    .map(|v| JsonTypeDeclaration {
+                        type_id: *v.type_id,
+                        type_field: v.type_id.get_json_type_str(v.type_id),
+                        components: v.type_id.get_json_type_components(types, v.type_id),
+                        type_parameters: v.type_id.get_json_type_parameters(types, v.type_id),
+                    })
+                    .collect::<Vec<_>>();
+                types.extend(json_type_arguments);
+
+                Some(
+                    type_parameters
+                        .iter()
+                        .map(|arg| JsonTypeApplication {
+                            name: "".to_string(),
+                            type_id: *arg.type_id,
+                            type_arguments: arg.type_id.get_json_type_arguments(types, arg.type_id),
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            }
             _ => None,
         }
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/logging/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/logging/src/main.sw
@@ -4,15 +4,20 @@ fn log<T>(value: T) {
     __log::<T>(value);
 }
 
-struct TestStruct {
+struct TestStruct<T> {
     field_1: bool,
-    field_2: b256,
+    field_2: T,
     field_3: u64,
 }
 
 enum TestEnum {
     VariantOne: (),
     VariantTwo: (),
+}
+
+pub enum Option<T> {
+    None: (),
+    Some: T,
 }
 
 fn main() -> bool {
@@ -35,6 +40,11 @@ fn main() -> bool {
     __log(b);
     __log(test_struct);
     __log(test_enum);
+    __log(Option::Some(TestStruct {
+        field_1: true,
+        field_2: 42,
+        field_3: 42,
+    }));
 
     true
 }


### PR DESCRIPTION
Closes #2946

When logging a value, the `type_parameters` field for enums and structs will contains the required type arguments because types have to be resolved at that point. This is handled slightly differently for contract method arguments (i.e. the ABI) because the types there are explicit in the method signature.