### PR TITLE
Bump to `v0.25.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,7 +1419,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "forc-client"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "forc-explore"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "forc-fmt"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "forc-lsp"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "forc-pkg"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "forc-util",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "forc-util"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "annotate-snippets",
  "ansi_term",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ast"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "extension-trait",
  "num-bigint",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "sway-core"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "clap 3.2.22",
  "derivative",
@@ -4221,7 +4221,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "filecheck",
@@ -4233,7 +4233,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir-macros"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "sway-lsp"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -4265,7 +4265,7 @@ dependencies = [
 
 [[package]]
 name = "sway-parse"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "assert_matches",
  "extension-trait",
@@ -4280,7 +4280,7 @@ dependencies = [
 
 [[package]]
 name = "sway-types"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "fuel-asm 0.8.0",
  "fuel-crypto",
@@ -4291,11 +4291,11 @@ dependencies = [
 
 [[package]]
 name = "sway-utils"
-version = "0.25.1"
+version = "0.25.2"
 
 [[package]]
 name = "swayfmt"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "forc-util",

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-pkg"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,7 +10,7 @@ description = "Building, locking, fetching and updating Sway projects as Forc pa
 
 [dependencies]
 anyhow = "1"
-forc-util = { version = "0.25.1", path = "../forc-util" }
+forc-util = { version = "0.25.2", path = "../forc-util" }
 fuel-crypto = "0.6"
 fuel-tx = { version = "0.18", features = ["serde"] }
 git2 = { version = "0.14", features = ["vendored-libgit2", "vendored-openssl"] }
@@ -20,9 +20,9 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
 serde_json = "1.0"
-sway-core = { version = "0.25.1", path = "../sway-core" }
-sway-types = { version = "0.25.1", path = "../sway-types" }
-sway-utils = { version = "0.25.1", path = "../sway-utils" }
+sway-core = { version = "0.25.2", path = "../sway-core" }
+sway-types = { version = "0.25.2", path = "../sway-types" }
+sway-utils = { version = "0.25.2", path = "../sway-utils" }
 toml = "0.5"
 tracing = "0.1"
 url = { version = "2.2", features = ["serde"] }

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-client"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,8 +11,8 @@ description = "A `forc` plugin for interacting with a Fuel node."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive", "env"] }
-forc-pkg = { version = "0.25.1", path = "../../forc-pkg" }
-forc-util = { version = "0.25.1", path = "../../forc-util" }
+forc-pkg = { version = "0.25.2", path = "../../forc-pkg" }
+forc-util = { version = "0.25.2", path = "../../forc-util" }
 fuel-crypto = "0.6"
 fuel-gql-client = { version = "0.10", default-features = false }
 fuel-tx = "0.18"
@@ -24,9 +24,9 @@ futures = "0.3"
 hex = "0.4.3"
 serde = "1.0"
 serde_json = "1.0.73"
-sway-core = { version = "0.25.1", path = "../../sway-core" }
-sway-types = { version = "0.25.1", path = "../../sway-types" }
-sway-utils = { version = "0.25.1", path = "../../sway-utils" }
+sway-core = { version = "0.25.2", path = "../../sway-core" }
+sway-types = { version = "0.25.2", path = "../../sway-types" }
+sway-utils = { version = "0.25.2", path = "../../sway-utils" }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "process"] }
 tracing = "0.1"
 

--- a/forc-plugins/forc-explore/Cargo.toml
+++ b/forc-plugins/forc-explore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-explore"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,7 +11,7 @@ description = "A `forc` plugin for running the fuel block explorer."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-forc-util = { version = "0.25.1", path = "../../forc-util" }
+forc-util = { version = "0.25.2", path = "../../forc-util" }
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 tar = "0.4"

--- a/forc-plugins/forc-fmt/Cargo.toml
+++ b/forc-plugins/forc-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-fmt"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,10 +11,10 @@ description = "A `forc` plugin for running the Sway code formatter."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-forc-util = { version = "0.25.1", path = "../../forc-util" }
+forc-util = { version = "0.25.2", path = "../../forc-util" }
 prettydiff = "0.5"
-sway-core = { version = "0.25.1", path = "../../sway-core" }
-sway-utils = { version = "0.25.1", path = "../../sway-utils" }
-swayfmt = { version = "0.25.1", path = "../../swayfmt" }
+sway-core = { version = "0.25.2", path = "../../sway-core" }
+sway-utils = { version = "0.25.2", path = "../../sway-utils" }
+swayfmt = { version = "0.25.2", path = "../../swayfmt" }
 taplo = "0.7"
 tracing = "0.1"

--- a/forc-plugins/forc-lsp/Cargo.toml
+++ b/forc-plugins/forc-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-lsp"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,5 +11,5 @@ description = "A simple `forc` plugin for starting the sway language server."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-sway-lsp = { version = "0.25.1", path = "../../sway-lsp" }
+sway-lsp = { version = "0.25.2", path = "../../sway-lsp" }
 tokio = { version = "1.8" }

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-util"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -13,9 +13,9 @@ annotate-snippets = { version = "0.9", features = ["color"] }
 ansi_term = "0.12"
 anyhow = "1"
 dirs = "3.0.2"
-sway-core = { version = "0.25.1", path = "../sway-core" }
-sway-types = { version = "0.25.1", path = "../sway-types" }
-sway-utils = { version = "0.25.1", path = "../sway-utils" }
+sway-core = { version = "0.25.2", path = "../sway-core" }
+sway-types = { version = "0.25.2", path = "../sway-types" }
+sway-utils = { version = "0.25.2", path = "../sway-utils" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }
 unicode-xid = "0.2.2"

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -21,16 +21,16 @@ annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1.0.41"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 clap_complete = "3.1"
-forc-pkg = { version = "0.25.1", path = "../forc-pkg" }
-forc-util = { version = "0.25.1", path = "../forc-util" }
+forc-pkg = { version = "0.25.2", path = "../forc-pkg" }
+forc-util = { version = "0.25.2", path = "../forc-util" }
 fs_extra = "1.2"
 fuel-asm = "0.8"
 hex = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.73"
-sway-core = { version = "0.25.1", path = "../sway-core" }
-sway-types = { version = "0.25.1", path = "../sway-types" }
-sway-utils = { version = "0.25.1", path = "../sway-utils" }
+sway-core = { version = "0.25.2", path = "../sway-core" }
+sway-types = { version = "0.25.2", path = "../sway-types" }
+sway-utils = { version = "0.25.2", path = "../sway-utils" }
 term-table = "1.3"
 tokio = { version = "1.8.0", features = ["macros", "rt-multi-thread"] }
 toml = "0.5"

--- a/sway-ast/Cargo.toml
+++ b/sway-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ast"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,4 +12,4 @@ description = "Sway's parser"
 extension-trait = "1.0.1"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
-sway-types = { version = "0.25.1", path = "../sway-types" }
+sway-types = { version = "0.25.2", path = "../sway-types" }

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-core"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -27,11 +27,11 @@ prettydiff = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.9"
 smallvec = "1.7"
-sway-ast = { version = "0.25.1", path = "../sway-ast" }
-sway-ir = { version = "0.25.1", path = "../sway-ir" }
-sway-parse = { version = "0.25.1", path = "../sway-parse" }
-sway-types = { version = "0.25.1", path = "../sway-types" }
-sway-utils = { version = "0.25.1", path = "../sway-utils" }
+sway-ast = { version = "0.25.2", path = "../sway-ast" }
+sway-ir = { version = "0.25.2", path = "../sway-ir" }
+sway-parse = { version = "0.25.2", path = "../sway-parse" }
+sway-types = { version = "0.25.2", path = "../sway-types" }
+sway-utils = { version = "0.25.2", path = "../sway-utils" }
 thiserror = "1.0"
 tracing = "0.1"
 uint = "0.9"

--- a/sway-ir/Cargo.toml
+++ b/sway-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ir"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -13,5 +13,5 @@ anyhow = "1.0"
 filecheck = "0.5"
 generational-arena = "0.2"
 peg = "0.7"
-sway-ir-macros = { version = "0.25.1", path = "sway-ir-macros" }
-sway-types = { version = "0.25.1", path = "../sway-types" }
+sway-ir-macros = { version = "0.25.2", path = "sway-ir-macros" }
+sway-types = { version = "0.25.2", path = "../sway-types" }

--- a/sway-ir/sway-ir-macros/Cargo.toml
+++ b/sway-ir/sway-ir-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ir-macros"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-lsp"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,15 +10,15 @@ description = "LSP server for Sway."
 
 [dependencies]
 dashmap = "5.3.4"
-forc-pkg = { version = "0.25.1", path = "../forc-pkg" }
-forc-util = { version = "0.25.1", path = "../forc-util" }
+forc-pkg = { version = "0.25.2", path = "../forc-pkg" }
+forc-util = { version = "0.25.2", path = "../forc-util" }
 ropey = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.60"
-sway-core = { version = "0.25.1", path = "../sway-core" }
-sway-types = { version = "0.25.1", path = "../sway-types" }
-sway-utils = { version = "0.25.1", path = "../sway-utils" }
-swayfmt = { version = "0.25.1", path = "../swayfmt" }
+sway-core = { version = "0.25.2", path = "../sway-core" }
+sway-types = { version = "0.25.2", path = "../sway-types" }
+sway-utils = { version = "0.25.2", path = "../sway-utils" }
+swayfmt = { version = "0.25.2", path = "../swayfmt" }
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tower-lsp = "0.17"
 tracing = "0.1"

--- a/sway-parse/Cargo.toml
+++ b/sway-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-parse"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -13,8 +13,8 @@ extension-trait = "1.0.1"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 phf = { version = "0.10.1", features = ["macros"] }
-sway-ast = { version = "0.25.1", path = "../sway-ast" }
-sway-types = { version = "0.25.1", path = "../sway-types" }
+sway-ast = { version = "0.25.2", path = "../sway-ast" }
+sway-types = { version = "0.25.2", path = "../sway-types" }
 thiserror = "1.0"
 unicode-xid = "0.2.2"
 

--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-types"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/sway-utils/Cargo.toml
+++ b/sway-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-utils"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/swayfmt/Cargo.toml
+++ b/swayfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swayfmt"
-version = "0.25.1"
+version = "0.25.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,14 +10,14 @@ description = "Sway language formatter."
 
 [dependencies]
 anyhow = "1"
-forc-util = { version = "0.25.1", path = "../forc-util" }
+forc-util = { version = "0.25.2", path = "../forc-util" }
 ropey = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
-sway-ast = { version = "0.25.1", path = "../sway-ast" }
-sway-core = { version = "0.25.1", path = "../sway-core" }
-sway-parse = { version = "0.25.1", path = "../sway-parse" }
-sway-types = { version = "0.25.1", path = "../sway-types" }
+sway-ast = { version = "0.25.2", path = "../sway-ast" }
+sway-core = { version = "0.25.2", path = "../sway-core" }
+sway-parse = { version = "0.25.2", path = "../sway-parse" }
+sway-types = { version = "0.25.2", path = "../sway-types" }
 thiserror = "1.0.30"
 toml = "0.5"
 


### PR DESCRIPTION
Another quick release to publish https://github.com/FuelLabs/sway/pull/2972 to unblock the SDK team.
Pending
- [x] https://github.com/FuelLabs/sway/pull/2972