### PR TITLE
Add `#[test]` to list of known attributes in `sway-core`

### DIFF
--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -1945,17 +1945,15 @@ fn statement_to_ast_nodes(
         Statement::Let(statement_let) => statement_let_to_ast_nodes(ec, statement_let)?,
         Statement::Item(item) => {
             let nodes = item_to_ast_nodes(ec, item)?;
-            let mut err = None;
-            for node in &nodes {
+            nodes.iter().fold(Ok(()), |res, node| {
                 if ast_node_is_test_fn(node) {
                     let span = node.span.clone();
                     let error = ConvertParseTreeError::TestFnOnlyAllowedAtModuleLevel { span };
-                    err = Some(ec.error(error));
+                    Err(ec.error(error))
+                } else {
+                    res
                 }
-            }
-            if let Some(err) = err {
-                return Err(err);
-            }
+            })?;
             nodes
         }
         Statement::Expr { expr, .. } => vec![expr_to_ast_node(ec, expr, true)?],

--- a/sway-core/src/convert_parse_tree.rs
+++ b/sway-core/src/convert_parse_tree.rs
@@ -25,7 +25,7 @@ use sway_error::error::CompileError;
 use sway_types::constants::{
     DESTRUCTURE_PREFIX, DOC_ATTRIBUTE_NAME, MATCH_RETURN_VAR_NAME_PREFIX,
     STORAGE_PURITY_ATTRIBUTE_NAME, STORAGE_PURITY_READ_NAME, STORAGE_PURITY_WRITE_NAME,
-    TUPLE_NAME_PREFIX, VALID_ATTRIBUTE_NAMES,
+    TEST_ATTRIBUTE_NAME, TUPLE_NAME_PREFIX, VALID_ATTRIBUTE_NAMES,
 };
 use sway_types::{Ident, Span, Spanned};
 
@@ -247,6 +247,7 @@ pub struct Attribute {
 pub enum AttributeKind {
     Doc,
     Storage,
+    Test,
 }
 
 /// Stores the attributes associated with the type.
@@ -283,6 +284,7 @@ fn item_attrs_to_map(
         if let Some(attr_kind) = match name {
             DOC_ATTRIBUTE_NAME => Some(AttributeKind::Doc),
             STORAGE_PURITY_ATTRIBUTE_NAME => Some(AttributeKind::Storage),
+            TEST_ATTRIBUTE_NAME => Some(AttributeKind::Test),
             _ => None,
         } {
             match attrs_map.get_mut(&attr_kind) {

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -56,9 +56,13 @@ use language::parsed;
 /// # Panics
 /// Panics if the parser panics.
 pub fn parse(input: Arc<str>, config: Option<&BuildConfig>) -> CompileResult<parsed::ParseProgram> {
+    // Omit tests by default so that a test that fails to typecheck doesn't block the rest of the
+    // program (similar behaviour to rust). Later, we'll add a flag for including tests on
+    // invocations of `forc test` or `forc check --tests`. See #1832.
+    let include_test_fns = false;
     match config {
-        None => parse_in_memory(input),
-        Some(config) => parse_files(input, config),
+        None => parse_in_memory(input, include_test_fns),
+        Some(config) => parse_files(input, config, include_test_fns),
     }
 }
 
@@ -70,9 +74,9 @@ fn parse_file(src: Arc<str>, path: Option<Arc<PathBuf>>) -> CompileResult<sway_a
 }
 
 /// When no `BuildConfig` is given, we're assumed to be parsing in-memory with no submodules.
-fn parse_in_memory(src: Arc<str>) -> CompileResult<parsed::ParseProgram> {
+fn parse_in_memory(src: Arc<str>, include_test_fns: bool) -> CompileResult<parsed::ParseProgram> {
     parse_file(src, None).flat_map(|module| {
-        convert_parse_tree::convert_parse_tree(module).flat_map(|(kind, tree)| {
+        convert_parse_tree::convert_parse_tree(module, include_test_fns).flat_map(|(kind, tree)| {
             let submodules = Default::default();
             let root = parsed::ParseModule { tree, submodules };
             ok(parsed::ParseProgram { kind, root }, vec![], vec![])
@@ -82,9 +86,13 @@ fn parse_in_memory(src: Arc<str>) -> CompileResult<parsed::ParseProgram> {
 
 /// When a `BuildConfig` is given, the module source may declare `dep`s that must be parsed from
 /// other files.
-fn parse_files(src: Arc<str>, config: &BuildConfig) -> CompileResult<parsed::ParseProgram> {
+fn parse_files(
+    src: Arc<str>,
+    config: &BuildConfig,
+    include_test_fns: bool,
+) -> CompileResult<parsed::ParseProgram> {
     let root_mod_path = config.canonical_root_module();
-    parse_module_tree(src, root_mod_path).flat_map(|(kind, root)| {
+    parse_module_tree(src, root_mod_path, include_test_fns).flat_map(|(kind, root)| {
         let program = parsed::ParseProgram { kind, root };
         ok(program, vec![], vec![])
     })
@@ -94,6 +102,7 @@ fn parse_files(src: Arc<str>, config: &BuildConfig) -> CompileResult<parsed::Par
 fn parse_submodules(
     deps: &[Dependency],
     module_dir: &Path,
+    include_test_fns: bool,
 ) -> CompileResult<Vec<(Ident, parsed::ParseSubmodule)>> {
     let mut warnings = vec![];
     let mut errors = vec![];
@@ -116,7 +125,7 @@ fn parse_submodules(
             }
         };
 
-        let mt_res = parse_module_tree(dep_str.clone(), dep_path.clone());
+        let mt_res = parse_module_tree(dep_str.clone(), dep_path.clone(), include_test_fns);
         warnings.extend(mt_res.warnings);
         errors.extend(mt_res.errors);
 
@@ -150,18 +159,22 @@ fn parse_submodules(
 fn parse_module_tree(
     src: Arc<str>,
     path: Arc<PathBuf>,
+    include_test_fns: bool,
 ) -> CompileResult<(parsed::TreeType, parsed::ParseModule)> {
     // Parse this module first.
     parse_file(src, Some(path.clone())).flat_map(|module| {
         let module_dir = path.parent().expect("module file has no parent directory");
 
         // Parse all submodules before converting to the `ParseTree`.
-        let submodules_res = parse_submodules(&module.dependencies, module_dir);
+        let submodules_res = parse_submodules(&module.dependencies, module_dir, include_test_fns);
 
         // Convert from the raw parsed module to the `ParseTree` ready for type-check.
-        convert_parse_tree::convert_parse_tree(module).flat_map(|(prog_kind, tree)| {
-            submodules_res.map(|submodules| (prog_kind, parsed::ParseModule { tree, submodules }))
-        })
+        convert_parse_tree::convert_parse_tree(module, include_test_fns).flat_map(
+            |(prog_kind, tree)| {
+                submodules_res
+                    .map(|submodules| (prog_kind, parsed::ParseModule { tree, submodules }))
+            },
+        )
     })
 }
 
@@ -275,27 +288,6 @@ pub fn parsed_to_ast(
     )
 }
 
-/// Strips all functions decorated with the `#[test]` attribute from the module and its submodules.
-fn remove_test_fns(module: &mut parsed::ParseModule) {
-    module.tree.root_nodes.retain(|node| {
-        if let parsed::AstNodeContent::Declaration(parsed::Declaration::FunctionDeclaration(
-            ref decl,
-        )) = node.content
-        {
-            if decl
-                .attributes
-                .contains_key(&convert_parse_tree::AttributeKind::Test)
-            {
-                return false;
-            }
-        }
-        true
-    });
-    for (_, submodule) in &mut module.submodules {
-        remove_test_fns(&mut submodule.module);
-    }
-}
-
 pub fn compile_to_ast(
     input: Arc<str>,
     initial_namespace: namespace::Module,
@@ -307,15 +299,10 @@ pub fn compile_to_ast(
         mut warnings,
         mut errors,
     } = parse(input, build_config);
-    let mut parse_program = match parse_program_opt {
+    let parse_program = match parse_program_opt {
         Some(parse_program) => parse_program,
         None => return deduped_err(warnings, errors),
     };
-
-    // Omit tests by default so that a test that fails to typecheck doesn't block the rest of the
-    // program (similar behaviour to rust). Later, we'll add a flag for including tests on
-    // invocations of `forc test` or `forc check --tests`. See #1832.
-    remove_test_fns(&mut parse_program.root);
 
     // Type check (+ other static analysis) the CST to a typed AST.
     let generate_logged_types = build_config.map_or(false, |bc| bc.generate_logged_types);

--- a/sway-error/src/convert_parse_tree_error.rs
+++ b/sway-error/src/convert_parse_tree_error.rs
@@ -91,6 +91,8 @@ pub enum ConvertParseTreeError {
     DuplicateParameterIdentifier { name: Ident, span: Span },
     #[error("self parameter is not allowed for a free function")]
     SelfParameterNotAllowedForFreeFn { span: Span },
+    #[error("test functions are only allowed at module level")]
+    TestFnOnlyAllowedAtModuleLevel { span: Span },
 }
 
 impl Spanned for ConvertParseTreeError {
@@ -140,6 +142,7 @@ impl Spanned for ConvertParseTreeError {
             ConvertParseTreeError::DuplicateStructField { span, .. } => span.clone(),
             ConvertParseTreeError::DuplicateParameterIdentifier { span, .. } => span.clone(),
             ConvertParseTreeError::SelfParameterNotAllowedForFreeFn { span, .. } => span.clone(),
+            ConvertParseTreeError::TestFnOnlyAllowedAtModuleLevel { span } => span.clone(),
         }
     }
 }

--- a/sway-types/src/constants.rs
+++ b/sway-types/src/constants.rs
@@ -35,5 +35,12 @@ pub const STORAGE_PURITY_WRITE_NAME: &str = "write";
 /// The valid attribute strings related to documentation.
 pub const DOC_ATTRIBUTE_NAME: &str = "doc";
 
+/// The attribute used for Sway in-language unit tests.
+pub const TEST_ATTRIBUTE_NAME: &str = "test";
+
 /// The list of valid attributes.
-pub const VALID_ATTRIBUTE_NAMES: [&str; 2] = [STORAGE_PURITY_ATTRIBUTE_NAME, DOC_ATTRIBUTE_NAME];
+pub const VALID_ATTRIBUTE_NAMES: &[&str] = &[
+    STORAGE_PURITY_ATTRIBUTE_NAME,
+    DOC_ATTRIBUTE_NAME,
+    TEST_ATTRIBUTE_NAME,
+];

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/Forc.lock
@@ -1,0 +1,9 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-85D7AF51FC17C583'
+dependencies = []
+
+[[package]]
+name = 'test_attribute'
+source = 'root'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/Forc.lock
@@ -1,9 +1,4 @@
 [[package]]
-name = 'core'
-source = 'path+from-root-85D7AF51FC17C583'
-dependencies = []
-
-[[package]]
 name = 'test_attribute'
 source = 'root'
-dependencies = ['core']
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["mindtree"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "test_attribute"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/Forc.toml
@@ -3,6 +3,4 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "test_attribute"
-
-[dependencies]
-core = { path = "../../../../../../../sway-lib-core" }
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-authors = ["mindtree"]
+authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "test_attribute"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/src/main.sw
@@ -1,4 +1,4 @@
-library test_attributes;
+library test_attribute;
 
 #[test]
 fn foo() {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/src/main.sw
@@ -1,0 +1,5 @@
+library test_attributes;
+
+#[test]
+fn foo() {
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/test.toml
@@ -1,0 +1,3 @@
+category = "compile"
+
+# not: $()Unknown attribute: "test".

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/test_attribute/test.toml
@@ -1,3 +1,4 @@
 category = "compile"
 
 # not: $()Unknown attribute: "test".
+# not: $()This function is never called.


### PR DESCRIPTION
First steps of #1832, this adds basic awareness to the compiler for the new `#[test]` attribute.

For now, we omit test functions when constructing the `ParseTree` during regular compilation (i.e. `forc build` or `forc check`) so that:

1. Programs may continue to compile even if tests do not typecheck (like Rust).
2. We don't do extra work type-checking test functions when we don't have to.
3. We don't get a bunch of dead code warnings for `#[test]` fns.

Later on, I'll add an option to enable these during `forc test`, `forc check --tests`, etc.

This PR doesn't enable compilation or execution of test functions just yet. This will be addressed in a following PR (see #1832).

Adds a basic test that makes sure we don't provide any undesired warnings about unknown attributes or dead code.