### PR TITLE
Handler warnings + misc related simplifications

### DIFF
--- a/sway-core/src/error.rs
+++ b/sway-core/src/error.rs
@@ -2,6 +2,7 @@
 
 use crate::language::parsed::VariableDeclaration;
 use sway_error::error::CompileError;
+use sway_error::handler::Handler;
 use sway_error::warning::CompileWarning;
 
 macro_rules! check {
@@ -109,7 +110,7 @@ impl<T> CompileResult<T> {
     }
 
     pub fn is_ok_no_warn(&self) -> bool {
-        self.value.is_some() && self.warnings.is_empty() && self.errors.is_empty()
+        self.is_ok() && self.warnings.is_empty()
     }
 
     pub fn new(value: Option<T>, warnings: Vec<CompileWarning>, errors: Vec<CompileError>) -> Self {
@@ -118,6 +119,11 @@ impl<T> CompileResult<T> {
             warnings,
             errors,
         }
+    }
+
+    pub fn from_handler(value: Option<T>, handler: Handler) -> Self {
+        let (errors, warnings) = handler.consume();
+        Self::new(value, warnings, errors)
     }
 
     pub fn ok(

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -67,7 +67,7 @@ pub fn parse(input: Arc<str>, config: Option<&BuildConfig>) -> CompileResult<par
 fn parse_file(src: Arc<str>, path: Option<Arc<PathBuf>>) -> CompileResult<sway_ast::Module> {
     let handler = sway_error::handler::Handler::default();
     let res = sway_parse::parse_file(&handler, src, path);
-    CompileResult::new(res.ok(), vec![], handler.into_errors())
+    CompileResult::from_handler(res.ok(), handler)
 }
 
 /// When no `BuildConfig` is given, we're assumed to be parsing in-memory with no submodules.

--- a/sway-error/src/handler.rs
+++ b/sway-error/src/handler.rs
@@ -1,8 +1,8 @@
-use crate::error::CompileError;
+use crate::{error::CompileError, warning::CompileWarning};
 
 use core::cell::RefCell;
 
-/// A handler with which you can emit errors.
+/// A handler with which you can emit diagnostics.
 #[derive(Default)]
 pub struct Handler {
     /// The inner handler.
@@ -15,19 +15,27 @@ pub struct Handler {
 #[derive(Default)]
 struct HandlerInner {
     /// The sink through which errors will be emitted.
-    sink: Vec<CompileError>,
+    errors: Vec<CompileError>,
+    /// The sink through which warnings will be emitted.
+    warnings: Vec<CompileWarning>,
 }
 
 impl Handler {
     /// Emit the error `err`.
     pub fn emit_err(&self, err: CompileError) -> ErrorEmitted {
-        self.inner.borrow_mut().sink.push(err);
+        self.inner.borrow_mut().errors.push(err);
         ErrorEmitted { _priv: () }
     }
 
+    /// Emit the warning `warn`.
+    pub fn emit_warn(&self, warn: CompileWarning) {
+        self.inner.borrow_mut().warnings.push(warn);
+    }
+
     /// Extract all the errors from this handler.
-    pub fn into_errors(self) -> Vec<CompileError> {
-        self.inner.into_inner().sink
+    pub fn consume(self) -> (Vec<CompileError>, Vec<CompileWarning>) {
+        let inner = self.inner.into_inner();
+        (inner.errors, inner.warnings)
     }
 }
 

--- a/sway-parse/src/item/mod.rs
+++ b/sway-parse/src/item/mod.rs
@@ -160,24 +160,17 @@ impl Parse for FnSignature {
 
 #[cfg(test)]
 mod tests {
-    use sway_error::handler::Handler;
-
     use super::*;
     use std::sync::Arc;
     use sway_ast::{AttributeDecl, CommaToken, Item, Punctuated};
     use sway_types::Ident;
 
     fn parse_item(input: &str) -> Item {
-        let handler = Handler::default();
-        let token_stream =
-            crate::token::lex(&handler, &Arc::from(input), 0, input.len(), None).unwrap();
-        let mut parser = Parser::new(&handler, &token_stream);
-        match Item::parse(&mut parser) {
-            Ok(item) => item,
-            Err(_) => {
-                panic!("Parse error: {:?}", handler.into_errors());
-            }
-        }
+        let handler = <_>::default();
+        let ts = crate::token::lex(&handler, &Arc::from(input), 0, input.len(), None).unwrap();
+        Parser::new(&handler, &ts)
+            .parse()
+            .unwrap_or_else(|_| panic!("Parse error: {:?}", handler.consume().0))
     }
 
     fn get_attribute_args(attrib: &AttributeDecl) -> &Punctuated<Ident, CommaToken> {

--- a/sway-parse/src/lib.rs
+++ b/sway-parse/src/lib.rs
@@ -25,33 +25,15 @@ pub use crate::{
 };
 
 use sway_ast::Module;
-use sway_error::{
-    error::CompileError,
-    handler::{ErrorEmitted, Handler},
-};
+use sway_error::handler::{ErrorEmitted, Handler};
 
 use std::{path::PathBuf, sync::Arc};
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Error)]
-#[error("Unable to parse: {}", self.0.iter().map(|x| x.to_string()).collect::<Vec<String>>().join("\n"))]
-pub struct ParseFileError(pub Vec<CompileError>);
-
-pub fn parse_file_standalone(
-    src: Arc<str>,
-    path: Option<Arc<PathBuf>>,
-) -> Result<Module, ParseFileError> {
-    let handler = Handler::default();
-    parse_file(&handler, src, path).map_err(|_| ParseFileError(handler.into_errors()))
-}
 
 pub fn parse_file(
     handler: &Handler,
     src: Arc<str>,
     path: Option<Arc<PathBuf>>,
 ) -> Result<Module, ErrorEmitted> {
-    let token_stream = lex(handler, &src, 0, src.len(), path)?;
-    match Parser::new(handler, &token_stream).parse_to_end() {
-        Ok((module, _parser_consumed)) => Ok(module),
-        Err(error) => Err(error),
-    }
+    let ts = lex(handler, &src, 0, src.len(), path)?;
+    Parser::new(handler, &ts).parse_to_end().map(|(m, _)| m)
 }

--- a/sway-parse/src/token.rs
+++ b/sway-parse/src/token.rs
@@ -734,7 +734,7 @@ mod tests {
         let path = None;
         let handler = Handler::default();
         let stream = lex_commented(&handler, &Arc::from(input), start, end, &path).unwrap();
-        assert!(handler.into_errors().is_empty());
+        assert!(handler.consume().0.is_empty());
         let mut tts = stream.token_trees().iter();
         assert_eq!(tts.next().unwrap().span().as_str(), "//");
         assert_eq!(
@@ -776,7 +776,7 @@ mod tests {
         let path = None;
         let handler = Handler::default();
         let stream = lex_commented(&handler, &Arc::from(input), start, end, &path).unwrap();
-        assert!(handler.into_errors().is_empty());
+        assert!(handler.consume().0.is_empty());
         let mut tts = stream.token_trees().iter();
         assert_matches!(
             tts.next(),
@@ -831,7 +831,7 @@ mod tests {
         "#;
         let handler = Handler::default();
         let stream = lex(&handler, &Arc::from(input), 0, input.len(), None).unwrap();
-        assert!(handler.into_errors().is_empty());
+        assert!(handler.consume().0.is_empty());
         let mut tts = stream.token_trees().iter();
         assert_matches!(
             tts.next(),

--- a/swayfmt/src/error.rs
+++ b/swayfmt/src/error.rs
@@ -1,10 +1,15 @@
 use std::{io, path::PathBuf};
+use sway_error::error::CompileError;
 use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Error)]
+#[error("Unable to parse: {}", self.0.iter().map(|x| x.to_string()).collect::<Vec<String>>().join("\n"))]
+pub struct ParseFileError(pub Vec<CompileError>);
 
 #[derive(Debug, Error)]
 pub enum FormatterError {
     #[error("Error parsing file: {0}")]
-    ParseFileError(#[from] sway_parse::ParseFileError),
+    ParseFileError(#[from] ParseFileError),
     #[error("Error formatting a message into a stream: {0}")]
     FormatError(#[from] std::fmt::Error),
     #[error("Error while adding comments")]

--- a/swayfmt/src/formatter/mod.rs
+++ b/swayfmt/src/formatter/mod.rs
@@ -1,4 +1,5 @@
 use self::shape::Shape;
+use crate::parse::parse_file;
 use crate::utils::map::{
     comments::handle_comments, newline::handle_newlines, newline_style::apply_newline_style,
 };
@@ -61,7 +62,7 @@ impl Formatter {
         // which will reduce the number of reallocations
         let mut raw_formatted_code = String::with_capacity(src.len());
 
-        let module = sway_parse::parse_file_standalone(Arc::from(src), path.clone())?;
+        let module = parse_file(Arc::from(src), path.clone())?;
         module.format(&mut raw_formatted_code, self)?;
 
         let mut formatted_code = String::from(&raw_formatted_code);
@@ -901,8 +902,8 @@ trait Qux {
     fn is_baz_true(self) -> bool;
 }
 
-impl   Qux for 
-Foo 
+impl   Qux for
+Foo
 {fn is_baz_true(self) -> bool {
         self.baz
     }}"#;

--- a/swayfmt/src/items/item_enum/tests.rs
+++ b/swayfmt/src/items/item_enum/tests.rs
@@ -1,24 +1,6 @@
-use crate::{Format, Formatter};
 use forc_util::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
-use sway_ast::ItemEnum;
-use sway_error::handler::Handler;
-use sway_parse::*;
-
-fn format_code(input: &str) -> String {
-    let mut formatter: Formatter = Default::default();
-    let input_arc = std::sync::Arc::from(input);
-    let handler = Handler::default();
-    let token_stream = lex(&handler, &input_arc, 0, input.len(), None).unwrap();
-    let mut parser = Parser::new(&handler, &token_stream);
-    let expression: ItemEnum = parser.parse().unwrap();
-
-    let mut buf = Default::default();
-    expression.format(&mut buf, &mut formatter).unwrap();
-
-    buf
-}
 
 macro_rules! fmt_test {
     ($scope:ident $desired_output:expr, $($name:ident $y:expr),+) => {
@@ -39,7 +21,7 @@ macro_rules! fmt_test_inner {
         paste! {
             #[test]
             fn [<$scope _ $name>] () {
-                let formatted_code = format_code($y);
+                let formatted_code = crate::parse::parse_format::<sway_ast::ItemEnum>($y);
                 let changeset = diff_lines(&formatted_code, $desired_output);
                 let diff = changeset.diff();
                 let count_of_updates = diff.len();

--- a/swayfmt/src/items/item_fn/tests.rs
+++ b/swayfmt/src/items/item_fn/tests.rs
@@ -1,24 +1,6 @@
-use crate::{Format, Formatter};
 use forc_util::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
-use sway_ast::ItemFn;
-use sway_error::handler::Handler;
-use sway_parse::*;
-
-fn format_code(input: &str) -> String {
-    let mut formatter: Formatter = Default::default();
-    let input_arc = std::sync::Arc::from(input);
-    let handler = Handler::default();
-    let token_stream = lex(&handler, &input_arc, 0, input.len(), None).unwrap();
-    let mut parser = Parser::new(&handler, &token_stream);
-    let expression: ItemFn = parser.parse().unwrap();
-
-    let mut buf = Default::default();
-    expression.format(&mut buf, &mut formatter).unwrap();
-
-    buf
-}
 
 macro_rules! fmt_test {
     ($scope:ident $desired_output:expr, $($name:ident $y:expr),+) => {
@@ -39,7 +21,7 @@ macro_rules! fmt_test_inner {
         paste! {
             #[test]
             fn [<$scope _ $name>] () {
-                let formatted_code = format_code($y);
+                let formatted_code = crate::parse::parse_format::<sway_ast::ItemFn>($y);
                 let changeset = diff_lines(&formatted_code, $desired_output);
                 let diff = changeset.diff();
                 let count_of_updates = diff.len();

--- a/swayfmt/src/items/item_impl/tests.rs
+++ b/swayfmt/src/items/item_impl/tests.rs
@@ -1,24 +1,6 @@
-use crate::{Format, Formatter};
 use forc_util::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
-use sway_ast::ItemImpl;
-use sway_error::handler::Handler;
-use sway_parse::*;
-
-fn format_code(input: &str) -> String {
-    let mut formatter: Formatter = Default::default();
-    let input_arc = std::sync::Arc::from(input);
-    let handler = Handler::default();
-    let token_stream = lex(&handler, &input_arc, 0, input.len(), None).unwrap();
-    let mut parser = Parser::new(&handler, &token_stream);
-    let expression: ItemImpl = parser.parse().unwrap();
-
-    let mut buf = Default::default();
-    expression.format(&mut buf, &mut formatter).unwrap();
-
-    buf
-}
 
 macro_rules! fmt_test {
     ($scope:ident $desired_output:expr, $($name:ident $y:expr),+) => {
@@ -39,7 +21,7 @@ macro_rules! fmt_test_inner {
         paste! {
             #[test]
             fn [<$scope _ $name>] () {
-                let formatted_code = format_code($y);
+                let formatted_code = crate::parse::parse_format::<sway_ast::ItemImpl>($y);
                 let changeset = diff_lines(&formatted_code, $desired_output);
                 let diff = changeset.diff();
                 let count_of_updates = diff.len();

--- a/swayfmt/src/items/item_storage/tests.rs
+++ b/swayfmt/src/items/item_storage/tests.rs
@@ -1,24 +1,6 @@
-use crate::{Format, Formatter};
 use forc_util::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
-use sway_ast::ItemStorage;
-use sway_error::handler::Handler;
-use sway_parse::*;
-
-fn format_code(input: &str) -> String {
-    let mut formatter: Formatter = Default::default();
-    let input_arc = std::sync::Arc::from(input);
-    let handler = Handler::default();
-    let token_stream = lex(&handler, &input_arc, 0, input.len(), None).unwrap();
-    let mut parser = Parser::new(&handler, &token_stream);
-    let expression: ItemStorage = parser.parse().unwrap();
-
-    let mut buf = Default::default();
-    expression.format(&mut buf, &mut formatter).unwrap();
-
-    buf
-}
 
 macro_rules! fmt_test {
     ($scope:ident $desired_output:expr, $($name:ident $y:expr),+) => {
@@ -39,7 +21,7 @@ macro_rules! fmt_test_inner {
         paste! {
             #[test]
             fn [<$scope _ $name>] () {
-                let formatted_code = format_code($y);
+                let formatted_code = crate::parse::parse_format::<sway_ast::ItemStorage>($y);
                 let changeset = diff_lines(&formatted_code, $desired_output);
                 let diff = changeset.diff();
                 let count_of_updates = diff.len();

--- a/swayfmt/src/items/item_struct/tests.rs
+++ b/swayfmt/src/items/item_struct/tests.rs
@@ -1,24 +1,6 @@
-use crate::{Format, Formatter};
 use forc_util::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
-use sway_ast::ItemStruct;
-use sway_error::handler::Handler;
-use sway_parse::*;
-
-fn format_code(input: &str) -> String {
-    let mut formatter: Formatter = Default::default();
-    let input_arc = std::sync::Arc::from(input);
-    let handler = Handler::default();
-    let token_stream = lex(&handler, &input_arc, 0, input.len(), None).unwrap();
-    let mut parser = Parser::new(&handler, &token_stream);
-    let expression: ItemStruct = parser.parse().unwrap();
-
-    let mut buf = Default::default();
-    expression.format(&mut buf, &mut formatter).unwrap();
-
-    buf
-}
 
 macro_rules! fmt_test {
     ($scope:ident $desired_output:expr, $($name:ident $y:expr),+) => {
@@ -39,7 +21,7 @@ macro_rules! fmt_test_inner {
         paste! {
             #[test]
             fn [<$scope _ $name>] () {
-                let formatted_code = format_code($y);
+                let formatted_code = crate::parse::parse_format::<sway_ast::ItemStruct>($y);
                 let changeset = diff_lines(&formatted_code, $desired_output);
                 let diff = changeset.diff();
                 let count_of_updates = diff.len();

--- a/swayfmt/src/items/item_use/tests.rs
+++ b/swayfmt/src/items/item_use/tests.rs
@@ -1,24 +1,6 @@
-use crate::{Format, Formatter};
 use forc_util::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
-use sway_ast::ItemUse;
-use sway_error::handler::Handler;
-use sway_parse::*;
-
-fn format_code(input: &str) -> String {
-    let mut formatter: Formatter = Default::default();
-    let input_arc = std::sync::Arc::from(input);
-    let handler = Handler::default();
-    let token_stream = lex(&handler, &input_arc, 0, input.len(), None).unwrap();
-    let mut parser = Parser::new(&handler, &token_stream);
-    let expression: ItemUse = parser.parse().unwrap();
-
-    let mut buf = Default::default();
-    expression.format(&mut buf, &mut formatter).unwrap();
-
-    buf
-}
 
 macro_rules! fmt_test {
     ($scope:ident $desired_output:expr, $($name:ident $y:expr),+) => {
@@ -39,7 +21,7 @@ macro_rules! fmt_test_inner {
         paste! {
             #[test]
             fn [<$scope _ $name>] () {
-                let formatted_code = format_code($y);
+                let formatted_code = crate::parse::parse_format::<sway_ast::ItemUse>($y);
                 let changeset = diff_lines(&formatted_code, $desired_output);
                 let diff = changeset.diff();
                 let count_of_updates = diff.len();

--- a/swayfmt/src/lib.rs
+++ b/swayfmt/src/lib.rs
@@ -10,6 +10,7 @@ mod error;
 mod formatter;
 mod items;
 mod module;
+mod parse;
 mod utils;
 
 pub use crate::formatter::{Format, Formatter};

--- a/swayfmt/src/parse.rs
+++ b/swayfmt/src/parse.rs
@@ -1,0 +1,37 @@
+use crate::error::ParseFileError;
+use std::path::PathBuf;
+use std::sync::Arc;
+use sway_ast::{token::CommentedTokenStream, Module};
+use sway_error::handler::{ErrorEmitted, Handler};
+
+fn with_handler<T>(
+    run: impl FnOnce(&Handler) -> Result<T, ErrorEmitted>,
+) -> Result<T, ParseFileError> {
+    let handler = <_>::default();
+    let res = run(&handler);
+    let (errors, _warnings) = handler.consume();
+    res.ok()
+        .filter(|_| errors.is_empty())
+        .ok_or(ParseFileError(errors))
+}
+
+pub fn parse_file(src: Arc<str>, path: Option<Arc<PathBuf>>) -> Result<Module, ParseFileError> {
+    with_handler(|h| sway_parse::parse_file(h, src, path))
+}
+
+pub fn lex(input: &Arc<str>) -> Result<CommentedTokenStream, ParseFileError> {
+    with_handler(|h| sway_parse::lex_commented(h, input, 0, input.len(), &None))
+}
+
+#[cfg(test)]
+pub fn parse_format<P: sway_parse::Parse + crate::Format>(input: &str) -> String {
+    let parsed = with_handler(|handler| {
+        let token_stream = sway_parse::lex(handler, &input.into(), 0, input.len(), None)?;
+        sway_parse::Parser::new(handler, &token_stream).parse::<P>()
+    })
+    .unwrap();
+
+    let mut buf = <_>::default();
+    parsed.format(&mut buf, &mut <_>::default()).unwrap();
+    buf
+}

--- a/swayfmt/src/utils/language/expr/tests.rs
+++ b/swayfmt/src/utils/language/expr/tests.rs
@@ -1,26 +1,9 @@
 //! Specific tests for the expression module
 
-use crate::{Format, Formatter};
 use forc_util::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
-use sway_ast::Expr;
-use sway_error::handler::Handler;
-use sway_parse::*;
 
-fn format_code(input: &str) -> String {
-    let mut formatter: Formatter = Default::default();
-    let input_arc = std::sync::Arc::from(input);
-    let handler = Handler::default();
-    let token_stream = lex(&handler, &input_arc, 0, input.len(), None).unwrap();
-    let mut parser = Parser::new(&handler, &token_stream);
-    let expression: Expr = parser.parse().unwrap();
-
-    let mut buf = Default::default();
-    expression.format(&mut buf, &mut formatter).unwrap();
-
-    buf
-}
 /// convenience macro for generating test cases
 /// provide a known good, and then some named test cases that should evaluate to
 /// that known good. e.g.:
@@ -49,7 +32,7 @@ macro_rules! fmt_test_inner {
         paste! {
             #[test]
             fn [<$scope _ $name>] () {
-                let formatted_code = format_code($y);
+                let formatted_code = crate::parse::parse_format::<sway_ast::Expr>($y);
                 let changeset = diff_lines(&formatted_code, $desired_output);
                 let count_of_updates = changeset.diff().len();
                 if count_of_updates != 0 {

--- a/swayfmt/src/utils/map/newline.rs
+++ b/swayfmt/src/utils/map/newline.rs
@@ -11,6 +11,7 @@ use sway_ast::Module;
 
 use crate::{
     formatter::{FormattedCode, Formatter},
+    parse::parse_file,
     utils::map::byte_span::{ByteSpan, LeafSpans},
     FormatterError,
 };
@@ -93,7 +94,7 @@ pub fn handle_newlines(
     // formatting the code a second time will still produce the same result.
     let newline_map = newline_map_from_src(&unformatted_input)?;
     // After the formatting existing items should be the same (type of the item) but their spans will be changed since we applied formatting to them.
-    let formatted_module = sway_parse::parse_file_standalone(formatted_input, path)?;
+    let formatted_module = parse_file(formatted_input, path)?;
     // Actually find & insert the newline sequences
     add_newlines(
         newline_map,
@@ -271,7 +272,7 @@ fn main() {
         fuel_coin.mint        {
             gas:             default_gas
         }
-        
+
         (11);"#;
 
         let newline_map = newline_map_from_src(raw_src.trim_start()).unwrap();


### PR DESCRIPTION
After https://github.com/FuelLabs/sway/pull/2981, which this PR is based on, we can now add `fn emit_warn` to the `Handler`, which is what this PR does.

This PR also does some related refactoring, in particular in `swayfmt`.
This is work towards https://github.com/FuelLabs/sway/issues/2734.