### PR TITLE
Move `VariableMutability` to the `ty` module.

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -6,7 +6,7 @@ use crate::{
         ast_node::{
             TyAbiDeclaration, TyCodeBlock, TyConstantDeclaration, TyDeclaration, TyEnumDeclaration,
             TyFunctionDeclaration, TyStructDeclaration, TyStructExpressionField,
-            TyTraitDeclaration, TyVariableDeclaration, VariableMutability,
+            TyTraitDeclaration, TyVariableDeclaration,
         },
         TyAsmRegisterDeclaration, TyAstNode, TyAstNodeContent, TyImplTrait,
         TyIntrinsicFunctionKind, TyStorageDeclaration,
@@ -295,7 +295,7 @@ fn connect_declaration(
                 mutability: is_mutable,
                 ..
             } = &**var_decl;
-            if matches!(is_mutable, VariableMutability::ExportedConst) {
+            if matches!(is_mutable, ty::VariableMutability::ExportedConst) {
                 graph.namespace.insert_constant(name.clone(), entry_node);
                 Ok(leaves.to_vec())
             } else {

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -12,7 +12,7 @@ use crate::{
         ContractCallParams, ProjectionKind, TyAsmRegisterDeclaration, TyCodeBlock,
         TyEnumDeclaration, TyEnumVariant, TyIntrinsicFunctionKind, TyReassignment,
         TyReturnStatement, TyStorageReassignment, TyStructExpressionField, TyStructField,
-        TypeCheckedStorageAccess, VariableMutability,
+        TypeCheckedStorageAccess,
     },
     type_system::*,
     TyFunctionDeclaration,

--- a/sway-core/src/language/ty/mod.rs
+++ b/sway-core/src/language/ty/mod.rs
@@ -1,3 +1,5 @@
 mod expression;
+mod variable_mutability;
 
 pub use expression::*;
+pub use variable_mutability::*;

--- a/sway-core/src/language/ty/variable_mutability.rs
+++ b/sway-core/src/language/ty/variable_mutability.rs
@@ -18,7 +18,18 @@ impl Default for VariableMutability {
         VariableMutability::Immutable
     }
 }
+
 impl VariableMutability {
+    pub fn new_from_ref_mut(is_reference: bool, is_mutable: bool) -> VariableMutability {
+        if is_reference {
+            VariableMutability::RefMutable
+        } else if is_mutable {
+            VariableMutability::Mutable
+        } else {
+            VariableMutability::Immutable
+        }
+    }
+
     pub fn is_mutable(&self) -> bool {
         matches!(
             self,
@@ -35,18 +46,5 @@ impl VariableMutability {
 
     pub fn is_immutable(&self) -> bool {
         !self.is_mutable()
-    }
-}
-
-pub fn convert_to_variable_immutability(
-    is_reference: bool,
-    is_mutable: bool,
-) -> VariableMutability {
-    if is_reference {
-        VariableMutability::RefMutable
-    } else if is_mutable {
-        VariableMutability::Mutable
-    } else {
-        VariableMutability::Immutable
     }
 }

--- a/sway-core/src/language/ty/variable_mutability.rs
+++ b/sway-core/src/language/ty/variable_mutability.rs
@@ -1,0 +1,52 @@
+use crate::language::Visibility;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VariableMutability {
+    // private + mutable
+    Mutable,
+    // private + referenceable + mutable
+    RefMutable,
+    // private + immutable
+    Immutable,
+    // public + immutable
+    ExportedConst,
+    // public + mutable is invalid
+}
+
+impl Default for VariableMutability {
+    fn default() -> Self {
+        VariableMutability::Immutable
+    }
+}
+impl VariableMutability {
+    pub fn is_mutable(&self) -> bool {
+        matches!(
+            self,
+            VariableMutability::Mutable | VariableMutability::RefMutable
+        )
+    }
+
+    pub fn visibility(&self) -> Visibility {
+        match self {
+            VariableMutability::ExportedConst => Visibility::Public,
+            _ => Visibility::Private,
+        }
+    }
+
+    pub fn is_immutable(&self) -> bool {
+        !self.is_mutable()
+    }
+}
+
+pub fn convert_to_variable_immutability(
+    is_reference: bool,
+    is_mutable: bool,
+) -> VariableMutability {
+    if is_reference {
+        VariableMutability::RefMutable
+    } else if is_mutable {
+        VariableMutability::Mutable
+    } else {
+        VariableMutability::Immutable
+    }
+}

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -105,10 +105,10 @@ impl fmt::Display for TyDeclaration {
                     } = &**decl;
                     let mut builder = String::new();
                     match mutability {
-                        VariableMutability::Mutable => builder.push_str("mut"),
-                        VariableMutability::RefMutable => builder.push_str("ref mut"),
-                        VariableMutability::Immutable => {}
-                        VariableMutability::ExportedConst => builder.push_str("pub const"),
+                        ty::VariableMutability::Mutable => builder.push_str("mut"),
+                        ty::VariableMutability::RefMutable => builder.push_str("ref mut"),
+                        ty::VariableMutability::Immutable => {}
+                        ty::VariableMutability::ExportedConst => builder.push_str("pub const"),
                     }
                     builder.push_str(name.as_str());
                     builder.push_str(": ");

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
@@ -72,7 +72,7 @@ impl TyFunctionParameter {
             errors,
         );
 
-        let mutability = ty::convert_to_variable_immutability(is_reference, is_mutable);
+        let mutability = ty::VariableMutability::new_from_ref_mut(is_reference, is_mutable);
         if mutability == ty::VariableMutability::Mutable {
             errors.push(CompileError::MutableParameterNotSupported { param_name: name });
             return err(warnings, errors);
@@ -194,7 +194,7 @@ fn insert_into_namespace(ctx: TypeCheckContext, typed_parameter: &TyFunctionPara
                 is_constant: IsConstant::No,
                 span: typed_parameter.name.span(),
             },
-            mutability: ty::convert_to_variable_immutability(
+            mutability: ty::VariableMutability::new_from_ref_mut(
                 typed_parameter.is_reference,
                 typed_parameter.is_mutable,
             ),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
@@ -1,10 +1,7 @@
 use crate::{
     error::{err, ok},
     language::{parsed::FunctionParameter, ty},
-    semantic_analysis::{
-        convert_to_variable_immutability, IsConstant, TyVariableDeclaration, TypeCheckContext,
-        VariableMutability,
-    },
+    semantic_analysis::{IsConstant, TyVariableDeclaration, TypeCheckContext},
     type_system::*,
     CompileResult, Ident, Namespace, TyDeclaration,
 };
@@ -75,8 +72,8 @@ impl TyFunctionParameter {
             errors,
         );
 
-        let mutability = convert_to_variable_immutability(is_reference, is_mutable);
-        if mutability == VariableMutability::Mutable {
+        let mutability = ty::convert_to_variable_immutability(is_reference, is_mutable);
+        if mutability == ty::VariableMutability::Mutable {
             errors.push(CompileError::MutableParameterNotSupported { param_name: name });
             return err(warnings, errors);
         }
@@ -197,7 +194,7 @@ fn insert_into_namespace(ctx: TypeCheckContext, typed_parameter: &TyFunctionPara
                 is_constant: IsConstant::No,
                 span: typed_parameter.name.span(),
             },
-            mutability: convert_to_variable_immutability(
+            mutability: ty::convert_to_variable_immutability(
                 typed_parameter.is_reference,
                 typed_parameter.is_mutable,
             ),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
@@ -1,64 +1,11 @@
-use crate::{
-    language::{ty, Visibility},
-    type_system::*,
-    Ident,
-};
+use crate::{language::ty, type_system::*, Ident};
 use sway_types::Span;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum VariableMutability {
-    // private + mutable
-    Mutable,
-    // private + referenceable + mutable
-    RefMutable,
-    // private + immutable
-    Immutable,
-    // public + immutable
-    ExportedConst,
-    // public + mutable is invalid
-}
-
-impl Default for VariableMutability {
-    fn default() -> Self {
-        VariableMutability::Immutable
-    }
-}
-impl VariableMutability {
-    pub fn is_mutable(&self) -> bool {
-        matches!(
-            self,
-            VariableMutability::Mutable | VariableMutability::RefMutable
-        )
-    }
-    pub fn visibility(&self) -> Visibility {
-        match self {
-            VariableMutability::ExportedConst => Visibility::Public,
-            _ => Visibility::Private,
-        }
-    }
-    pub fn is_immutable(&self) -> bool {
-        !self.is_mutable()
-    }
-}
-
-pub fn convert_to_variable_immutability(
-    is_reference: bool,
-    is_mutable: bool,
-) -> VariableMutability {
-    if is_reference {
-        VariableMutability::RefMutable
-    } else if is_mutable {
-        VariableMutability::Mutable
-    } else {
-        VariableMutability::Immutable
-    }
-}
 
 #[derive(Clone, Debug, Eq)]
 pub struct TyVariableDeclaration {
     pub name: Ident,
     pub body: ty::TyExpression,
-    pub mutability: VariableMutability,
+    pub mutability: ty::VariableMutability,
     pub type_ascription: TypeId,
     pub type_ascription_span: Option<Span>,
 }

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
@@ -7,7 +7,7 @@ use crate::{
             instantiate_unsafe_downcast,
         },
         namespace::Namespace,
-        IsConstant, TyEnumVariant, VariableMutability,
+        IsConstant, TyEnumVariant,
     },
     type_system::unify,
     CompileResult, Ident, TypeId,
@@ -134,7 +134,7 @@ fn match_constant(
             expression: ty::TyExpressionVariant::VariableExpression {
                 name: scrutinee_name,
                 span: span.clone(),
-                mutability: VariableMutability::Immutable,
+                mutability: ty::VariableMutability::Immutable,
             },
             return_type: scrutinee_type_id,
             is_constant: IsConstant::Yes,

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
@@ -6,7 +6,6 @@ use crate::{
     semantic_analysis::{
         ast_node::expression::match_expression::typed::typed_scrutinee::TyScrutinee, IsConstant,
         TyAstNode, TyAstNodeContent, TyCodeBlock, TyVariableDeclaration, TypeCheckContext,
-        VariableMutability,
     },
     type_system::insert_type,
     types::DeterministicallyAborts,
@@ -67,7 +66,7 @@ impl TyMatchBranch {
             let var_decl = TyDeclaration::VariableDeclaration(Box::new(TyVariableDeclaration {
                 name: left_decl.clone(),
                 body: right_decl,
-                mutability: VariableMutability::Immutable,
+                mutability: ty::VariableMutability::Immutable,
                 type_ascription,
                 type_ascription_span: None,
             }));

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -187,10 +187,10 @@ impl ty::TyExpression {
     }
 
     /// gathers the mutability of the expressions within
-    pub(crate) fn gather_mutability(&self) -> VariableMutability {
+    pub(crate) fn gather_mutability(&self) -> ty::VariableMutability {
         match &self.expression {
             ty::TyExpressionVariant::VariableExpression { mutability, .. } => *mutability,
-            _ => VariableMutability::Immutable,
+            _ => ty::VariableMutability::Immutable,
         }
     }
 
@@ -493,7 +493,7 @@ impl ty::TyExpression {
                     expression: ty::TyExpressionVariant::VariableExpression {
                         name: decl_name,
                         span: name.span(),
-                        mutability: VariableMutability::Immutable,
+                        mutability: ty::VariableMutability::Immutable,
                     },
                     span,
                 }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -57,7 +57,7 @@ pub(crate) fn instantiate_function_application(
 
             // check for matching mutability
             let param_mutability =
-                ty::convert_to_variable_immutability(param.is_reference, param.is_mutable);
+                ty::VariableMutability::new_from_ref_mut(param.is_reference, param.is_mutable);
             if exp.gather_mutability().is_immutable() && param_mutability.is_mutable() {
                 errors.push(CompileError::ImmutableArgumentToMutableParameter { span: arg.span() });
             }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -57,7 +57,7 @@ pub(crate) fn instantiate_function_application(
 
             // check for matching mutability
             let param_mutability =
-                convert_to_variable_immutability(param.is_reference, param.is_mutable);
+                ty::convert_to_variable_immutability(param.is_reference, param.is_mutable);
             if exp.gather_mutability().is_immutable() && param_mutability.is_mutable() {
                 errors.push(CompileError::ImmutableArgumentToMutableParameter { span: arg.span() });
             }

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -263,7 +263,7 @@ impl TyAstNode {
                                 TyVariableDeclaration {
                                     name: name.clone(),
                                     body,
-                                    mutability: ty::convert_to_variable_immutability(
+                                    mutability: ty::VariableMutability::new_from_ref_mut(
                                         false, is_mutable,
                                     ),
                                     type_ascription,

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -263,7 +263,9 @@ impl TyAstNode {
                                 TyVariableDeclaration {
                                     name: name.clone(),
                                     body,
-                                    mutability: convert_to_variable_immutability(false, is_mutable),
+                                    mutability: ty::convert_to_variable_immutability(
+                                        false, is_mutable,
+                                    ),
                                     type_ascription,
                                     type_ascription_span,
                                 },

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -1,9 +1,8 @@
 use crate::{
     error::*,
-    language::{parsed::*, Visibility},
+    language::{parsed::*, ty, Visibility},
     semantic_analysis::{
         ast_node::{TyAstNode, TyAstNodeContent, TyVariableDeclaration},
-        declaration::VariableMutability,
         TypeCheckContext,
     },
     CompileResult, Ident, Namespace, TyDeclaration,
@@ -346,7 +345,7 @@ impl Module {
                     let TyVariableDeclaration {
                         mutability, name, ..
                     } = &**var_decl;
-                    if mutability == &VariableMutability::ExportedConst {
+                    if mutability == &ty::VariableMutability::ExportedConst {
                         self[dst]
                             .insert_symbol(alias.unwrap_or_else(|| name.clone()), decl.clone());
                         return ok((), warnings, errors);


### PR DESCRIPTION
This PR is one of several in a process to address https://github.com/FuelLabs/sway/issues/2951. This PR moves `VariableMutability` to the ty module. Currently, things are a little awkward organizationally, as the definitions and impl blocks are in different modules, but this is done in (quick) iterations to reduce merge conflicts overall.