### PR TITLE
Move `TyCodeBlock` to the ty module.

### DIFF
--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -311,7 +311,7 @@ fn connect_typed_fn_decl(
 type ReturnStatementNodes = Vec<NodeIndex>;
 
 fn depth_first_insertion_code_block(
-    node_content: &TyCodeBlock,
+    node_content: &ty::TyCodeBlock,
     graph: &mut ControlFlowGraph,
     leaves: &[NodeIndex],
 ) -> Result<(ReturnStatementNodes, Vec<NodeIndex>), CompileError> {

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -4,7 +4,7 @@ use crate::{
     language::{parsed::TreeType, ty, CallPath, Visibility},
     semantic_analysis::{
         ast_node::{
-            TyAbiDeclaration, TyCodeBlock, TyConstantDeclaration, TyDeclaration, TyEnumDeclaration,
+            TyAbiDeclaration, TyConstantDeclaration, TyDeclaration, TyEnumDeclaration,
             TyFunctionDeclaration, TyStructDeclaration, TyStructExpressionField,
             TyTraitDeclaration, TyVariableDeclaration, VariableMutability,
         },
@@ -606,7 +606,7 @@ fn connect_fn_params_struct_enums(
 }
 
 fn depth_first_insertion_code_block(
-    node_content: &TyCodeBlock,
+    node_content: &ty::TyCodeBlock,
     graph: &mut ControlFlowGraph,
     leaves: &[NodeIndex],
     exit_node: Option<NodeIndex>,
@@ -793,7 +793,7 @@ fn connect_expression(
 
             Ok([condition_expr, then_expr, else_expr].concat())
         }
-        CodeBlock(a @ TyCodeBlock { .. }) => {
+        CodeBlock(a @ ty::TyCodeBlock { .. }) => {
             connect_code_block(a, graph, leaves, exit_node, tree_type)
         }
         StructExpression {
@@ -1157,7 +1157,7 @@ fn connect_intrinsic_function(
 }
 
 fn connect_code_block(
-    block: &TyCodeBlock,
+    block: &ty::TyCodeBlock,
     graph: &mut ControlFlowGraph,
     leaves: &[NodeIndex],
     exit_node: Option<NodeIndex>,

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -73,7 +73,7 @@ impl FnCompiler {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_block: TyCodeBlock,
+        ast_block: ty::TyCodeBlock,
     ) -> Result<Value, CompileError> {
         self.compile_with_new_scope(|fn_compiler| {
             fn_compiler.compile_code_block_inner(context, md_mgr, ast_block)
@@ -84,7 +84,7 @@ impl FnCompiler {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_block: TyCodeBlock,
+        ast_block: ty::TyCodeBlock,
     ) -> Result<Value, CompileError> {
         self.lexical_map.enter_scope();
 
@@ -1172,7 +1172,7 @@ impl FnCompiler {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        body: TyCodeBlock,
+        body: ty::TyCodeBlock,
         condition: ty::TyExpression,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {

--- a/sway-core/src/language/ty/code_block.rs
+++ b/sway-core/src/language/ty/code_block.rs
@@ -1,0 +1,20 @@
+use crate::{semantic_analysis::TyAstNode, type_system::*, types::DeterministicallyAborts};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TyCodeBlock {
+    pub contents: Vec<TyAstNode>,
+}
+
+impl CopyTypes for TyCodeBlock {
+    fn copy_types(&mut self, type_mapping: &TypeMapping) {
+        self.contents
+            .iter_mut()
+            .for_each(|x| x.copy_types(type_mapping));
+    }
+}
+
+impl DeterministicallyAborts for TyCodeBlock {
+    fn deterministically_aborts(&self) -> bool {
+        self.contents.iter().any(|x| x.deterministically_aborts())
+    }
+}

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -9,10 +9,10 @@ use sway_types::{state::StateIndex, Ident, Span};
 use crate::{
     language::{ty::*, *},
     semantic_analysis::{
-        ContractCallParams, ProjectionKind, TyAsmRegisterDeclaration, TyCodeBlock,
-        TyEnumDeclaration, TyEnumVariant, TyIntrinsicFunctionKind, TyReassignment,
-        TyReturnStatement, TyStorageReassignment, TyStructExpressionField, TyStructField,
-        TypeCheckedStorageAccess, VariableMutability,
+        ContractCallParams, ProjectionKind, TyAsmRegisterDeclaration, TyEnumDeclaration,
+        TyEnumVariant, TyIntrinsicFunctionKind, TyReassignment, TyReturnStatement,
+        TyStorageReassignment, TyStructExpressionField, TyStructField, TypeCheckedStorageAccess,
+        VariableMutability,
     },
     type_system::*,
     TyFunctionDeclaration,

--- a/sway-core/src/language/ty/mod.rs
+++ b/sway-core/src/language/ty/mod.rs
@@ -1,3 +1,5 @@
+mod code_block;
 mod expression;
 
+pub use code_block::*;
 pub use expression::*;

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -1,26 +1,7 @@
 use super::*;
 use crate::language::{parsed::CodeBlock, ty};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TyCodeBlock {
-    pub contents: Vec<TyAstNode>,
-}
-
-impl CopyTypes for TyCodeBlock {
-    fn copy_types(&mut self, type_mapping: &TypeMapping) {
-        self.contents
-            .iter_mut()
-            .for_each(|x| x.copy_types(type_mapping));
-    }
-}
-
-impl DeterministicallyAborts for TyCodeBlock {
-    fn deterministically_aborts(&self) -> bool {
-        self.contents.iter().any(|x| x.deterministically_aborts())
-    }
-}
-
-impl TyCodeBlock {
+impl ty::TyCodeBlock {
     pub(crate) fn type_check(
         mut ctx: TypeCheckContext,
         code_block: CodeBlock,
@@ -75,7 +56,7 @@ impl TyCodeBlock {
 
         append!(ctx.unify_with_self(block_type, &span), warnings, errors);
 
-        let typed_code_block = TyCodeBlock {
+        let typed_code_block = ty::TyCodeBlock {
             contents: evaluated_contents,
         };
         ok((typed_code_block, block_type), warnings, errors)

--- a/sway-core/src/semantic_analysis/ast_node/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration.rs
@@ -522,7 +522,7 @@ impl TyTraitFn {
         TyFunctionDeclaration {
             purity: self.purity,
             name: self.name.clone(),
-            body: TyCodeBlock { contents: vec![] },
+            body: ty::TyCodeBlock { contents: vec![] },
             parameters: self.parameters.clone(),
             span: self.name.span(),
             attributes: self.attributes.clone(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -19,7 +19,7 @@ use sway_types::{
 #[derive(Clone, Debug, Eq)]
 pub struct TyFunctionDeclaration {
     pub name: Ident,
-    pub body: TyCodeBlock,
+    pub body: ty::TyCodeBlock,
     pub parameters: Vec<TyFunctionParameter>,
     pub span: Span,
     pub attributes: AttributesMap,
@@ -172,9 +172,9 @@ impl TyFunctionDeclaration {
                 .with_help_text("Function body's return type does not match up with its return type annotation.")
                 .with_type_annotation(return_type);
             check!(
-                TyCodeBlock::type_check(ctx, body),
+                ty::TyCodeBlock::type_check(ctx, body),
                 (
-                    TyCodeBlock { contents: vec![] },
+                    ty::TyCodeBlock { contents: vec![] },
                     insert_type(TypeInfo::ErrorRecovery)
                 ),
                 warnings,
@@ -354,7 +354,7 @@ fn test_function_selector_behavior() {
     let decl = TyFunctionDeclaration {
         purity: Default::default(),
         name: Ident::new_no_span("foo"),
-        body: TyCodeBlock { contents: vec![] },
+        body: ty::TyCodeBlock { contents: vec![] },
         parameters: vec![],
         span: Span::dummy(),
         attributes: Default::default(),
@@ -376,7 +376,7 @@ fn test_function_selector_behavior() {
     let decl = TyFunctionDeclaration {
         purity: Default::default(),
         name: Ident::new_with_override("bar", Span::dummy()),
-        body: TyCodeBlock { contents: vec![] },
+        body: ty::TyCodeBlock { contents: vec![] },
         parameters: vec![
             TyFunctionParameter {
                 name: Ident::new_no_span("foo"),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -208,7 +208,6 @@ impl TyImplTrait {
         methods: &[TyFunctionDeclaration],
         access_span: &Span,
     ) -> Result<(), CompileError> {
-        use crate::semantic_analysis;
         fn ast_node_contains_get_storage_index(
             x: &TyAstNodeContent,
             access_span: &Span,
@@ -355,7 +354,7 @@ impl TyImplTrait {
         }
 
         fn codeblock_contains_get_storage_index(
-            cb: &semantic_analysis::TyCodeBlock,
+            cb: &ty::TyCodeBlock,
             access_span: &Span,
         ) -> Result<bool, CompileError> {
             for content in cb.contents.iter() {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -5,10 +5,10 @@ use sway_types::{style::is_upper_camel_case, Ident, Spanned};
 use crate::{
     declaration_engine::declaration_engine::de_get_trait,
     error::{err, ok},
-    language::{parsed::*, CallPath, Visibility},
+    language::{parsed::*, ty, CallPath, Visibility},
     semantic_analysis::{
         ast_node::{type_check_interface_surface, type_check_trait_methods},
-        Mode, TyCodeBlock, TypeCheckContext,
+        Mode, TypeCheckContext,
     },
     type_system::{insert_type, CopyTypes, TypeMapping},
     CompileError, CompileResult, Namespace, TyDeclaration, TyFunctionDeclaration, TypeInfo,
@@ -229,7 +229,7 @@ fn convert_trait_methods_to_dummy_funcs(
         dummy_funcs.push(TyFunctionDeclaration {
             purity: Default::default(),
             name: name.clone(),
-            body: TyCodeBlock { contents: vec![] },
+            body: ty::TyCodeBlock { contents: vec![] },
             parameters: typed_parameters,
             attributes: method.attributes.clone(),
             span: name.span(),

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
@@ -5,8 +5,7 @@ use crate::{
     language::{parsed::MatchBranch, ty},
     semantic_analysis::{
         ast_node::expression::match_expression::typed::typed_scrutinee::TyScrutinee, IsConstant,
-        TyAstNode, TyAstNodeContent, TyCodeBlock, TyVariableDeclaration, TypeCheckContext,
-        VariableMutability,
+        TyAstNode, TyAstNodeContent, TyVariableDeclaration, TypeCheckContext, VariableMutability,
     },
     type_system::insert_type,
     types::DeterministicallyAborts,
@@ -111,7 +110,7 @@ impl TyMatchBranch {
             span: typed_result_span,
         } = typed_result;
         match typed_result_expression_variant {
-            ty::TyExpressionVariant::CodeBlock(TyCodeBlock { mut contents, .. }) => {
+            ty::TyExpressionVariant::CodeBlock(ty::TyCodeBlock { mut contents, .. }) => {
                 code_block_contents.append(&mut contents);
             }
             typed_result_expression_variant => {
@@ -130,7 +129,7 @@ impl TyMatchBranch {
         // assemble a new branch result that includes both the variable declarations
         // that we create and the typed result from the original untyped branch
         let new_result = ty::TyExpression {
-            expression: ty::TyExpressionVariant::CodeBlock(TyCodeBlock {
+            expression: ty::TyExpressionVariant::CodeBlock(ty::TyCodeBlock {
                 contents: code_block_contents,
             }),
             return_type: typed_result.return_type,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -94,7 +94,7 @@ impl ty::TyExpression {
                 }
                 buf
             }
-            ty::TyExpressionVariant::CodeBlock(TyCodeBlock { contents, .. }) => {
+            ty::TyExpressionVariant::CodeBlock(ty::TyCodeBlock { contents, .. }) => {
                 let mut buf = vec![];
                 for node in contents {
                     buf.append(&mut node.gather_return_statements())
@@ -594,9 +594,9 @@ impl ty::TyExpression {
         let mut warnings = vec![];
         let mut errors = vec![];
         let (typed_block, block_return_type) = check!(
-            TyCodeBlock::type_check(ctx.by_ref(), contents),
+            ty::TyCodeBlock::type_check(ctx.by_ref(), contents),
             (
-                TyCodeBlock { contents: vec![] },
+                ty::TyCodeBlock { contents: vec![] },
                 crate::type_system::insert_type(TypeInfo::Tuple(Vec::new()))
             ),
             warnings,
@@ -610,7 +610,7 @@ impl ty::TyExpression {
         );
 
         let exp = ty::TyExpression {
-            expression: ty::TyExpressionVariant::CodeBlock(TyCodeBlock {
+            expression: ty::TyExpressionVariant::CodeBlock(ty::TyCodeBlock {
                 contents: typed_block.contents,
             }),
             return_type: block_return_type,
@@ -1519,7 +1519,7 @@ impl ty::TyExpression {
                  instead.",
         );
         let (typed_body, _block_implicit_return) = check!(
-            TyCodeBlock::type_check(ctx, body),
+            ty::TyCodeBlock::type_check(ctx, body),
             return err(warnings, errors),
             warnings,
             errors

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -6,7 +6,6 @@ mod return_statement;
 
 use std::fmt;
 
-pub(crate) use code_block::*;
 pub use declaration::*;
 pub(crate) use expression::*;
 pub(crate) use mode::*;
@@ -668,7 +667,7 @@ fn type_check_trait_methods(
                 annotation.",
             );
         let (body, _code_block_implicit_return) = check!(
-            TyCodeBlock::type_check(ctx, body),
+            ty::TyCodeBlock::type_check(ctx, body),
             continue,
             warnings,
             errors
@@ -709,7 +708,7 @@ fn error_recovery_function_declaration(decl: FunctionDeclaration) -> TyFunctionD
     TyFunctionDeclaration {
         purity: Default::default(),
         name,
-        body: TyCodeBlock {
+        body: ty::TyCodeBlock {
             contents: Default::default(),
         },
         span,

--- a/sway-core/src/semantic_analysis/storage_only_types.rs
+++ b/sway-core/src/semantic_analysis/storage_only_types.rs
@@ -7,7 +7,7 @@ use crate::{
     error::*,
     language::ty,
     semantic_analysis::{
-        TyAstNodeContent, TyCodeBlock, TyConstantDeclaration, TyDeclaration, TyEnumDeclaration,
+        TyAstNodeContent, TyConstantDeclaration, TyDeclaration, TyEnumDeclaration,
         TyFunctionDeclaration, TyImplTrait, TyIntrinsicFunctionKind, TyReassignment,
         TyStorageDeclaration, TyStructDeclaration,
     },
@@ -300,7 +300,9 @@ pub fn validate_decls_for_storage_only_types_in_ast(ast_n: &TyAstNodeContent) ->
     ast_node_validate(ast_n)
 }
 
-pub fn validate_decls_for_storage_only_types_in_codeblock(cb: &TyCodeBlock) -> CompileResult<()> {
+pub fn validate_decls_for_storage_only_types_in_codeblock(
+    cb: &ty::TyCodeBlock,
+) -> CompileResult<()> {
     let mut warnings: Vec<CompileWarning> = vec![];
     let mut errors: Vec<CompileError> = vec![];
     for x in &cb.contents {

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -8,7 +8,6 @@ use sway_core::{
     declaration_engine,
     language::ty,
     semantic_analysis::ast_node::{
-        code_block::TyCodeBlock,
         expression::TyIntrinsicFunctionKind,
         ProjectionKind, TyFunctionDeclaration, TyFunctionParameter, TyImplTrait, TyTraitFn,
         {TyAstNode, TyAstNodeContent, TyDeclaration},
@@ -450,7 +449,7 @@ fn handle_intrinsic_function(
     }
 }
 
-fn handle_while_loop(body: &TyCodeBlock, condition: &ty::TyExpression, tokens: &TokenMap) {
+fn handle_while_loop(body: &ty::TyCodeBlock, condition: &ty::TyExpression, tokens: &TokenMap) {
     handle_expression(condition, tokens);
     for node in &body.contents {
         traverse_node(node, tokens);


### PR DESCRIPTION
This PR is one of several in a process to address https://github.com/FuelLabs/sway/issues/2951. This PR moves `TyCodeBlock` to the ty module. Currently, things are a little awkward organizationally, as the definitions and impl blocks are in different modules, but this is done in (quick) iterations to reduce merge conflicts overall.