### PR TITLE
LSP: Add Inlay Hints functionality for variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4468,6 +4468,7 @@ dependencies = [
  "futures",
  "notify",
  "notify-debouncer-mini",
+ "parking_lot 0.12.1",
  "ropey",
  "serde",
  "serde_json",

--- a/forc-plugins/forc-lsp/src/main.rs
+++ b/forc-plugins/forc-lsp/src/main.rs
@@ -10,18 +10,9 @@ use clap::Parser;
     about = "Forc plugin for the Sway LSP (Language Server Protocol) implementation.",
     version
 )]
-struct App {
-    /// Instructs the client to draw squiggly lines under all of the tokens that our server managed
-    /// to parse. Expects either "typed" or "parsed".
-    #[clap(long)]
-    pub collected_tokens_as_warnings: Option<String>,
-}
+struct App {}
 
 #[tokio::main]
 async fn main() {
-    let app = App::parse();
-    let dbg = sway_lsp::utils::debug::DebugFlags {
-        collected_tokens_as_warnings: app.collected_tokens_as_warnings,
-    };
-    sway_lsp::start(dbg).await
+    sway_lsp::start().await
 }

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -26,7 +26,7 @@ tempfile = "3"
 thiserror = "1.0.30"
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 toml_edit = "0.14.4"
-tower-lsp = "0.17"
+tower-lsp = { version = "0.17", features = ["proposed"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -14,6 +14,7 @@ dashmap = "5.4"
 forc-pkg = { version = "0.26.0", path = "../forc-pkg" }
 notify = "5.0.0"
 notify-debouncer-mini = { version = "0.2.0" }
+parking_lot = "0.12.1"
 ropey = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.60"

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -30,6 +30,10 @@ pub(crate) fn inlay_hints(
     // 4. Look up the type id for the remaining tokens
     // 5. Convert the type into a string
     let config = &session.config.read().inlay_hints;
+    if !config.type_hints {
+        return None;
+    }
+
     let hints: Vec<lsp_types::InlayHint> = session
         .tokens_for_file(uri)
         .iter()

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -25,7 +25,7 @@ pub(crate) fn inlay_hints(
     range: &Range,
 ) -> Option<Vec<lsp_types::InlayHint>> {
     // 1. Loop through all our tokens and filter out all tokens that aren't TypedVariableDeclaration tokens
-    // 2. Also filter out all tokens that have a span that fall outside of the provide range
+    // 2. Also filter out all tokens that have a span that fall outside of the provided range
     // 3. Filter out all variable tokens that have a type_ascription
     // 4. Look up the type id for the remaining tokens
     // 5. Convert the type into a string

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -1,0 +1,164 @@
+use crate::core::{
+    session::Session,
+    token::{SymbolKind, Token, TypedAstToken},
+};
+use sway_core::{
+    type_system::TypeInfo,
+    TypedDeclaration
+};
+use sway_types::Spanned;
+use tower_lsp::lsp_types::{
+    self, Range, InlayHintParams, Url,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InlayHintsConfig {
+    /// Whether to render leading colons for type hints, and trailing colons for parameter hints.
+    pub render_colons: bool,
+    /// Whether to show inlay type hints for variables.
+    pub type_hints: bool,
+    /// Maximum length for inlay hints. Set to null to have an unlimited length.
+    pub max_length: Option<usize>,
+}
+
+// Future PR's will add more kinds
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InlayKind {
+    TypeHint,
+}
+
+#[derive(Debug)]
+pub struct InlayHint {
+    pub range: Range,
+    pub kind: InlayKind,
+    pub label: String,
+}
+
+pub(crate) fn inlay_hints(session: &Session, uri: &Url, range: &Range, config: &InlayHintsConfig) -> Option<Vec<lsp_types::InlayHint>> {    
+    // 1. Loop through all our tokens and filter out all tokens that aren't TypedVariableDeclaration tokens
+    // 2. Also filter out all tokens that have a span that fall outside of the provide range
+    // 3. Filter out all variable tokens that have a type_ascription
+    // 4. Look up the type id for the remaining tokens
+    // 5. Convert the type into a string
+
+    let hints: Vec<lsp_types::InlayHint> = session.tokens_for_file(uri)
+        .iter()
+        .filter_map(|item| {
+            let token = item.value();
+            match &token.typed {
+                Some(t) => match t {
+                    TypedAstToken::TypedDeclaration(decl) => match decl {
+                        TypedDeclaration::VariableDeclaration(var_decl) => {
+                            match var_decl.type_ascription_span {
+                                Some(_) => None,
+                                None => {
+                                    let var_range = crate::utils::common::get_range_from_span(&var_decl.name.span());
+                                    if var_range.start >= range.start && var_range.end <= range.end {
+                                        Some(var_decl.clone())
+                                    } else {
+                                        None
+                                    }
+                                }
+                            }
+                        }
+                        _ => None,
+                    }
+                    _ => None,
+                }
+                None => None,
+            }
+        })
+        .filter_map(|var| {
+            let type_info = sway_core::type_system::look_up_type_id(var.type_ascription);
+            match type_info {
+                TypeInfo::Numeric | TypeInfo::Unknown | TypeInfo::UnknownGeneric { .. } => None,
+                _ => Some(var)
+            }
+        })
+        .map(|var| {
+            let range = crate::utils::common::get_range_from_span(&var.name.span());
+            let kind = InlayKind::TypeHint;
+            let label = format!("{}",var.type_ascription);
+            let inlay_hint = InlayHint {
+                range,
+                kind,
+                label,
+            };
+            self::inlay_hint(config.render_colons, inlay_hint)
+        }).collect();
+    
+    Some(hints)
+
+    // let v = document.get_token_map()
+    //     .iter()
+    //     .map(|((ident, span), token)| {
+    //         let range = crate::utils::common::get_range_from_span(span);
+    //         let kind = InlayKind::TypeHint;
+    //         //let label = "$$$$".to_string();
+
+    //         let label = match crate::core::traverse_typed_tree::get_type_id(token) {
+    //             Some(type_id) => {
+    //                 tracing::info!("type_id = {:#?}", type_id);
+
+    //                 // Use the TypeId to look up the actual type (I think there is a method in the type_engine for this)
+    //                 let type_info = sway_core::type_engine::look_up_type_id(type_id);
+    //                 tracing::info!("type_info = {:#?}", type_info);
+    //                 type_info.friendly_type_str()
+    //             }
+    //             None => "".to_string()
+    //         };
+    //         let inlay_hint = InlayHint {
+    //             range,
+    //             kind,
+    //             label,
+    //         };
+    //         self::inlay_hint(config.render_colons, inlay_hint)
+    // }).collect();
+
+    //return Ok(Some(v));
+    
+
+    // iter over all tokens in out token_map.
+    // filter_map? all tokens that are outside of the params.range 
+    // map the remaining tokens into an LSP InlayHint
+    // collect all these into a vector 
+    // return
+}
+
+pub(crate) fn inlay_hint(
+    render_colons: bool,
+    inlay_hint: InlayHint,
+) -> lsp_types::InlayHint {
+    lsp_types::InlayHint {
+        position: match inlay_hint.kind {
+            // after annotated thing
+            InlayKind::TypeHint => inlay_hint.range.end,
+        },
+        label: lsp_types::InlayHintLabel::String(match inlay_hint.kind {
+            InlayKind::TypeHint if render_colons => format!(": {}", inlay_hint.label),
+            _ => inlay_hint.label.to_string(),
+        }),
+        kind: match inlay_hint.kind {
+            InlayKind::TypeHint => Some(lsp_types::InlayHintKind::TYPE)
+        },
+        tooltip: None,
+        padding_left: Some(match inlay_hint.kind {
+            InlayKind::TypeHint => !render_colons,
+        }),
+        padding_right: Some(match inlay_hint.kind {
+            InlayKind::TypeHint => false,
+        }),
+        text_edits: None,
+        data: None,
+    }
+}
+
+impl Default for InlayHintsConfig {
+    fn default() -> Self {
+        Self {
+            render_colons: true,
+            type_hints: true,
+            max_length: Some(25),
+        }
+    }
+}

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -1,17 +1,7 @@
-use crate::core::{session::Session, token::TypedAstToken};
+use crate::core::{config::InlayHintsConfig, session::Session, token::TypedAstToken};
 use sway_core::{language::ty::TyDeclaration, type_system::TypeInfo};
 use sway_types::Spanned;
 use tower_lsp::lsp_types::{self, Range, Url};
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct InlayHintsConfig {
-    /// Whether to render leading colons for type hints, and trailing colons for parameter hints.
-    pub render_colons: bool,
-    /// Whether to show inlay type hints for variables.
-    pub type_hints: bool,
-    /// Maximum length for inlay hints. Set to null to have an unlimited length.
-    pub max_length: Option<usize>,
-}
 
 // Future PR's will add more kinds
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -101,15 +91,5 @@ pub(crate) fn inlay_hint(render_colons: bool, inlay_hint: InlayHint) -> lsp_type
         }),
         text_edits: None,
         data: None,
-    }
-}
-
-impl Default for InlayHintsConfig {
-    fn default() -> Self {
-        Self {
-            render_colons: true,
-            type_hints: true,
-            max_length: Some(25),
-        }
     }
 }

--- a/sway-lsp/src/capabilities/mod.rs
+++ b/sway-lsp/src/capabilities/mod.rs
@@ -4,6 +4,7 @@ pub mod document_symbol;
 pub mod formatting;
 pub mod highlight;
 pub mod hover;
+pub mod inlay_hints;
 pub mod rename;
 pub mod runnable;
 pub mod semantic_tokens;

--- a/sway-lsp/src/core/config.rs
+++ b/sway-lsp/src/core/config.rs
@@ -1,0 +1,86 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Config {
+    pub debug: Debug,
+    pub inlay_hints: InlayHintsConfig,
+    #[serde(skip_serializing)]
+    trace: Trace,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Default)]
+struct Trace {}
+
+// Options for debugging various parts of the server
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Debug {
+    pub show_collected_tokens_as_warnings: Warnings,
+}
+
+/// Instructs the client to draw squiggly lines
+/// under all of the tokens that our server managed to parse.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub enum Warnings {
+    Default,
+    Parsed,
+    Typed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InlayHintsConfig {
+    /// Whether to render leading colons for type hints, and trailing colons for parameter hints.
+    pub render_colons: bool,
+    /// Whether to show inlay type hints for variables.
+    pub type_hints: bool,
+    /// Maximum length for inlay hints. Set to null to have an unlimited length.
+    pub max_length: Option<usize>,
+}
+
+impl Default for Debug {
+    fn default() -> Self {
+        Self {
+            show_collected_tokens_as_warnings: Warnings::Default,
+        }
+    }
+}
+
+impl Default for InlayHintsConfig {
+    fn default() -> Self {
+        Self {
+            render_colons: true,
+            type_hints: true,
+            max_length: Some(25),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Warnings {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct WarningsVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for WarningsVisitor {
+            type Value = Warnings;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(formatter, "a string representing a Warnings")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, s: &str) -> Result<Warnings, E> {
+                Ok(match s {
+                    "off" => Warnings::Default,
+                    "parsed" => Warnings::Parsed,
+                    "typed" => Warnings::Typed,
+                    _ => return Err(E::invalid_value(serde::de::Unexpected::Str(s), &self)),
+                })
+            }
+        }
+
+        deserializer.deserialize_any(WarningsVisitor)
+    }
+}

--- a/sway-lsp/src/core/mod.rs
+++ b/sway-lsp/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod config;
 pub mod document;
 pub mod session;
 pub(crate) mod token;

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -52,7 +52,7 @@ impl Session {
             documents: DashMap::new(),
             token_map: DashMap::new(),
             runnables: DashMap::new(),
-            config: parking_lot::RwLock::new(Default::default()),
+            config: RwLock::new(Default::default()),
             compiled_program: RwLock::new(Default::default()),
             sync: SyncWorkspace::new(),
         }
@@ -285,7 +285,6 @@ impl Session {
         })
     }
 
-    // Token
     pub fn token_ranges(&self, url: &Url, position: Position) -> Option<Vec<Range>> {
         if let Some((_, token)) = self.token_at_position(url, position) {
             let token_ranges = self
@@ -346,10 +345,8 @@ impl Session {
 
 #[cfg(test)]
 mod tests {
-
-    use crate::test_utils::{get_absolute_path, get_url};
-
     use super::*;
+    use crate::test_utils::{get_absolute_path, get_url};
 
     #[test]
     fn store_document_returns_empty_tuple() {

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -5,6 +5,7 @@ use crate::{
         runnable::{Runnable, RunnableType},
     },
     core::{
+        config::Config,
         document::TextDocument,
         token::{Token, TokenMap, TypeDefinition},
         {traverse_parse_tree, traverse_typed_tree},
@@ -42,6 +43,7 @@ pub struct Session {
     pub documents: Documents,
     pub token_map: TokenMap,
     pub runnables: DashMap<RunnableType, Runnable>,
+    pub config: RwLock<Config>,
     pub compiled_program: RwLock<CompiledProgram>,
     pub sync: SyncWorkspace,
 }
@@ -52,6 +54,7 @@ impl Session {
             documents: DashMap::new(),
             token_map: DashMap::new(),
             runnables: DashMap::new(),
+            config: RwLock::new(Default::default()),
             compiled_program: RwLock::new(Default::default()),
             sync: SyncWorkspace::new(),
         }

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -15,10 +15,8 @@ use crate::{
 };
 use dashmap::DashMap;
 use forc_pkg::{self as pkg};
-use std::{
-    path::PathBuf,
-    sync::{Arc, LockResult, RwLock},
-};
+use parking_lot::RwLock;
+use std::{path::PathBuf, sync::Arc};
 use sway_core::{
     language::{parsed::ParseProgram, ty},
     CompileResult,
@@ -43,7 +41,7 @@ pub struct Session {
     pub documents: Documents,
     pub token_map: TokenMap,
     pub runnables: DashMap<RunnableType, Runnable>,
-    pub config: parking_lot::RwLock<Config>,
+    pub config: RwLock<Config>,
     pub compiled_program: RwLock<CompiledProgram>,
     pub sync: SyncWorkspace,
 }
@@ -210,7 +208,8 @@ impl Session {
             }
         }
 
-        if let LockResult::Ok(mut program) = self.compiled_program.write() {
+        {
+            let mut program = self.compiled_program.write();
             program.parsed = Some(parse_program);
         }
 
@@ -250,7 +249,8 @@ impl Session {
             .chain(sub_nodes)
             .for_each(|node| traverse_typed_tree::traverse_node(node, &self.token_map));
 
-        if let LockResult::Ok(mut program) = self.compiled_program.write() {
+        {
+            let mut program = self.compiled_program.write();
             program.typed = Some(typed_program);
         }
 

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -43,7 +43,7 @@ pub struct Session {
     pub documents: Documents,
     pub token_map: TokenMap,
     pub runnables: DashMap<RunnableType, Runnable>,
-    pub config: RwLock<Config>,
+    pub config: parking_lot::RwLock<Config>,
     pub compiled_program: RwLock<CompiledProgram>,
     pub sync: SyncWorkspace,
 }
@@ -54,7 +54,7 @@ impl Session {
             documents: DashMap::new(),
             token_map: DashMap::new(),
             runnables: DashMap::new(),
-            config: RwLock::new(Default::default()),
+            config: parking_lot::RwLock::new(Default::default()),
             compiled_program: RwLock::new(Default::default()),
             sync: SyncWorkspace::new(),
         }

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -68,7 +68,7 @@ pub enum TypedAstToken {
     TypedReassignment(ty::TyReassignment),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SymbolKind {
     Field,
     ValueParam,

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -68,7 +68,7 @@ pub enum TypedAstToken {
     TypedReassignment(ty::TyReassignment),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SymbolKind {
     Field,
     ValueParam,

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -8,13 +8,12 @@ mod server;
 pub mod test_utils;
 pub mod utils;
 use server::Backend;
-use utils::debug::DebugFlags;
 
-pub async fn start(config: DebugFlags) {
+pub async fn start() {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let (service, socket) = LspService::build(|client| Backend::new(client, config))
+    let (service, socket) = LspService::build(Backend::new)
         .custom_method("sway/runnables", Backend::runnables)
         .custom_method("sway/show_ast", Backend::show_ast)
         .custom_method("textDocument/inlayHint", Backend::inlay_hints)

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -17,6 +17,7 @@ pub async fn start(config: DebugFlags) {
     let (service, socket) = LspService::build(|client| Backend::new(client, config))
         .custom_method("sway/runnables", Backend::runnables)
         .custom_method("sway/show_ast", Backend::show_ast)
+        .custom_method("textDocument/inlayHint", Backend::inlay_hints)
         .finish();
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -414,11 +414,11 @@ impl Backend {
         &self,
         params: InlayHintParams,
     ) -> jsonrpc::Result<Option<Vec<InlayHint>>> {
-        Ok(capabilities::inlay_hints::inlay_hints(
-            &self.session,
-            &params.text_document.uri,
-            &params.range,
-        ))
+        self.session
+            .sync
+            .workspace_to_temp_url(&params.text_document.uri)
+            .map(|uri| capabilities::inlay_hints::inlay_hints(&self.session, &uri, &params.range))
+            .map_err(|_| jsonrpc::Error::invalid_params("invalid path"))
     }
 
     pub async fn runnables(

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -415,12 +415,10 @@ impl Backend {
         &self,
         params: InlayHintParams,
     ) -> jsonrpc::Result<Option<Vec<InlayHint>>> {
-        let config = crate::core::config::InlayHintsConfig::default();
         Ok(capabilities::inlay_hints::inlay_hints(
             &self.session,
             &params.text_document.uri,
             &params.range,
-            &config,
         ))
     }
 

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -125,6 +125,7 @@ fn capabilities() -> ServerCapabilities {
         }),
         document_formatting_provider: Some(OneOf::Left(true)),
         definition_provider: Some(OneOf::Left(true)),
+        inlay_hint_provider: Some(OneOf::Left(true)),
         ..ServerCapabilities::default()
     }
 }
@@ -170,6 +171,7 @@ impl LanguageServer for Backend {
         Ok(InitializeResult {
             server_info: None,
             capabilities: capabilities(),
+            ..InitializeResult::default()
         })
     }
 
@@ -410,6 +412,16 @@ pub struct ShowAstParams {
 
 // Custom LSP-Server Methods
 impl Backend {
+    pub async fn inlay_hints(&self, params: InlayHintParams) -> jsonrpc::Result<Option<Vec<InlayHint>>> {
+        let config = capabilities::inlay_hints::InlayHintsConfig::default();
+        Ok(capabilities::inlay_hints::inlay_hints(
+            &self.session,
+            &params.text_document.uri,
+            &params.range,
+            &config,
+        ))
+    }
+    
     pub async fn runnables(
         &self,
         _params: RunnableParams,

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -412,7 +412,10 @@ pub struct ShowAstParams {
 
 // Custom LSP-Server Methods
 impl Backend {
-    pub async fn inlay_hints(&self, params: InlayHintParams) -> jsonrpc::Result<Option<Vec<InlayHint>>> {
+    pub async fn inlay_hints(
+        &self,
+        params: InlayHintParams,
+    ) -> jsonrpc::Result<Option<Vec<InlayHint>>> {
         let config = capabilities::inlay_hints::InlayHintsConfig::default();
         Ok(capabilities::inlay_hints::inlay_hints(
             &self.session,
@@ -421,7 +424,7 @@ impl Backend {
             &config,
         ))
     }
-    
+
     pub async fn runnables(
         &self,
         _params: RunnableParams,

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -12,7 +12,7 @@ use std::{
     io::Write,
     ops::Deref,
     path::{Path, PathBuf},
-    sync::{Arc, LockResult},
+    sync::Arc,
 };
 use sway_types::Spanned;
 use sway_utils::helpers::get_sway_files;
@@ -472,57 +472,54 @@ impl Backend {
                 None
             };
 
-        match self.session.compiled_program.read() {
-            LockResult::Ok(program) => {
-                match params.ast_kind.as_str() {
-                    "parsed" => {
-                        match program.parsed {
-                            Some(ref parsed_program) => {
-                                // Initialize the string with the AST from the root
-                                let mut formatted_ast: String =
-                                    format!("{:#?}", parsed_program.root.tree.root_nodes);
+        {
+            let program = self.session.compiled_program.read();
+            match params.ast_kind.as_str() {
+                "parsed" => {
+                    match program.parsed {
+                        Some(ref parsed_program) => {
+                            // Initialize the string with the AST from the root
+                            let mut formatted_ast: String =
+                                format!("{:#?}", parsed_program.root.tree.root_nodes);
 
-                                for (ident, submodule) in &parsed_program.root.submodules {
-                                    // if the current path matches the path of a submodule
-                                    // overwrite the root AST with the submodule AST
-                                    if ident.span().path().map(|a| a.deref()) == path.as_ref() {
-                                        formatted_ast =
-                                            format!("{:#?}", submodule.module.tree.root_nodes);
-                                    }
+                            for (ident, submodule) in &parsed_program.root.submodules {
+                                // if the current path matches the path of a submodule
+                                // overwrite the root AST with the submodule AST
+                                if ident.span().path().map(|a| a.deref()) == path.as_ref() {
+                                    formatted_ast =
+                                        format!("{:#?}", submodule.module.tree.root_nodes);
                                 }
-
-                                let tmp_ast_path = Path::new("/tmp/parsed_ast.rs");
-                                Ok(write_ast_to_file(tmp_ast_path, &formatted_ast))
                             }
-                            _ => Ok(None),
-                        }
-                    }
-                    "typed" => {
-                        match program.typed {
-                            Some(ref typed_program) => {
-                                // Initialize the string with the AST from the root
-                                let mut formatted_ast: String =
-                                    format!("{:#?}", typed_program.root.all_nodes);
 
-                                for (ident, submodule) in &typed_program.root.submodules {
-                                    // if the current path matches the path of a submodule
-                                    // overwrite the root AST with the submodule AST
-                                    if ident.span().path().map(|a| a.deref()) == path.as_ref() {
-                                        formatted_ast =
-                                            format!("{:#?}", submodule.module.all_nodes);
-                                    }
-                                }
-
-                                let tmp_ast_path = Path::new("/tmp/typed_ast.rs");
-                                Ok(write_ast_to_file(tmp_ast_path, &formatted_ast))
-                            }
-                            _ => Ok(None),
+                            let tmp_ast_path = Path::new("/tmp/parsed_ast.rs");
+                            Ok(write_ast_to_file(tmp_ast_path, &formatted_ast))
                         }
+                        _ => Ok(None),
                     }
-                    _ => Ok(None),
                 }
+                "typed" => {
+                    match program.typed {
+                        Some(ref typed_program) => {
+                            // Initialize the string with the AST from the root
+                            let mut formatted_ast: String =
+                                format!("{:#?}", typed_program.root.all_nodes);
+
+                            for (ident, submodule) in &typed_program.root.submodules {
+                                // if the current path matches the path of a submodule
+                                // overwrite the root AST with the submodule AST
+                                if ident.span().path().map(|a| a.deref()) == path.as_ref() {
+                                    formatted_ast = format!("{:#?}", submodule.module.all_nodes);
+                                }
+                            }
+
+                            let tmp_ast_path = Path::new("/tmp/typed_ast.rs");
+                            Ok(write_ast_to_file(tmp_ast_path, &formatted_ast))
+                        }
+                        _ => Ok(None),
+                    }
+                }
+                _ => Ok(None),
             }
-            _ => Ok(None),
         }
     }
 }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -130,11 +130,10 @@ impl Backend {
         workspace_uri: &Url,
         diagnostics: Vec<Diagnostic>,
     ) {
-        let mut diagnostics_res = Vec::new();
-        {
+        let diagnostics_res = {
             let debug = &self.session.config.read().debug;
             let token_map = self.session.tokens_for_file(uri);
-            diagnostics_res = match debug.show_collected_tokens_as_warnings {
+            match debug.show_collected_tokens_as_warnings {
                 Warnings::Default => diagnostics,
                 // If collected_tokens_as_warnings is Parsed or Typed,
                 // take over the normal error and warning display behavior
@@ -142,8 +141,8 @@ impl Backend {
                 // This is useful for debugging the lsp parser.
                 Warnings::Parsed => debug::generate_warnings_for_parsed_tokens(&token_map),
                 Warnings::Typed => debug::generate_warnings_for_typed_tokens(&token_map),
-            };
-        }
+            }
+        };
 
         // Note: Even if the computed diagnostics vec is empty, we still have to push the empty Vec
         // in order to clear former diagnostics. Newly pushed diagnostics always replace previously pushed diagnostics.

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -814,14 +814,14 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn initialize() {
-        let (mut service, _) = LspService::new(|client| Backend::new(client));
+        let (mut service, _) = LspService::new(Backend::new);
         let _ = initialize_request(&mut service).await;
     }
 
     #[tokio::test]
     #[serial]
     async fn initialized() {
-        let (mut service, _) = LspService::new(|client| Backend::new(client));
+        let (mut service, _) = LspService::new(Backend::new);
         let _ = initialize_request(&mut service).await;
         initialized_notification(&mut service).await;
     }
@@ -829,7 +829,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn initializes_only_once() {
-        let (mut service, _) = LspService::new(|client| Backend::new(client));
+        let (mut service, _) = LspService::new(Backend::new);
         let initialize = initialize_request(&mut service).await;
         initialized_notification(&mut service).await;
         let response = call_request(&mut service, initialize).await;
@@ -840,7 +840,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn shutdown() {
-        let (mut service, _) = LspService::new(|client| Backend::new(client));
+        let (mut service, _) = LspService::new(Backend::new);
         let _ = initialize_request(&mut service).await;
         initialized_notification(&mut service).await;
         let shutdown = shutdown_request(&mut service).await;
@@ -853,7 +853,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn refuses_requests_after_shutdown() {
-        let (mut service, _) = LspService::new(|client| Backend::new(client));
+        let (mut service, _) = LspService::new(Backend::new);
         let _ = initialize_request(&mut service).await;
         let shutdown = shutdown_request(&mut service).await;
         let response = call_request(&mut service, shutdown).await;
@@ -864,7 +864,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn did_open() {
-        let (mut service, _) = LspService::new(|client| Backend::new(client));
+        let (mut service, _) = LspService::new(Backend::new);
         let _ = init_and_open(&mut service, e2e_test_dir()).await;
         shutdown_and_exit(&mut service).await;
     }
@@ -872,7 +872,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn did_close() {
-        let (mut service, _) = LspService::new(|client| Backend::new(client));
+        let (mut service, _) = LspService::new(Backend::new);
         let _ = init_and_open(&mut service, e2e_test_dir()).await;
         did_close_notification(&mut service).await;
         shutdown_and_exit(&mut service).await;
@@ -881,7 +881,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn did_change() {
-        let (mut service, _) = LspService::new(|client| Backend::new(client));
+        let (mut service, _) = LspService::new(Backend::new);
         let uri = init_and_open(&mut service, doc_comments_dir()).await;
         let _ = did_change_request(&mut service, &uri).await;
         shutdown_and_exit(&mut service).await;
@@ -890,7 +890,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn lsp_syncs_with_workspace_edits() {
-        let (mut service, _) = LspService::new(|client| Backend::new(client));
+        let (mut service, _) = LspService::new(Backend::new);
         let uri = init_and_open(&mut service, doc_comments_dir()).await;
         let _ = go_to_definition_request(&mut service, &uri, 44, 19, 1).await;
         let _ = did_change_request(&mut service, &uri).await;
@@ -901,7 +901,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn show_ast() {
-        let (mut service, _) = LspService::build(|client| Backend::new(client))
+        let (mut service, _) = LspService::build(Backend::new)
             .custom_method("sway/show_ast", Backend::show_ast)
             .finish();
 
@@ -913,7 +913,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn go_to_definition() {
-        let (mut service, _) = LspService::new(|client| Backend::new(client));
+        let (mut service, _) = LspService::new(Backend::new);
         let uri = init_and_open(&mut service, doc_comments_dir()).await;
         let _ = go_to_definition_request(&mut service, &uri, 44, 19, 1).await;
         shutdown_and_exit(&mut service).await;
@@ -926,7 +926,7 @@ mod tests {
     // The capability argument is an async function.
     macro_rules! test_lsp_capability {
         ($example_dir:expr, $capability:expr) => {{
-            let (mut service, _) = LspService::new(|client| Backend::new(client));
+            let (mut service, _) = LspService::new(Backend::new);
             let uri = init_and_open(&mut service, $example_dir).await;
             // Call the specific LSP capability function that was passed in.
             let _ = $capability(&mut service, &uri).await;

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -8,15 +8,6 @@ use sway_core::language::{
 use sway_types::{Ident, Spanned};
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
-// Flags for debugging various parts of the server
-#[derive(Debug, Default)]
-pub struct DebugFlags {
-    /// Instructs the client to draw squiggly lines
-    /// under all of the tokens that our server managed to parse.
-    /// String can be either "typed" or "parsed".
-    pub collected_tokens_as_warnings: Option<String>,
-}
-
 pub(crate) fn generate_warnings_non_typed_tokens(tokens: &TokenMap) -> Vec<Diagnostic> {
     let warnings = tokens
         .iter()


### PR DESCRIPTION
Provides inlay hints for variables that don't already have a type_ascription set by the user. 

<img width="617" alt="Screen Shot 2022-10-12 at 4 40 46 pm" src="https://user-images.githubusercontent.com/1289413/195259328-d224a4cb-90ac-4fe0-bc65-5b2ea4412e2f.png">

Also adds a new `Config` type that is deserialized from reading `InitializeParams::initialization_options` during the lsp initialize callback. 

closes #2853