### PR TITLE
Add `enum variant` attributes to `TyProgram`

### DIFF
--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -71,6 +71,7 @@ pub struct TyEnumVariant {
     pub type_span: Span,
     pub(crate) tag: usize,
     pub(crate) span: Span,
+    pub attributes: AttributesMap,
 }
 
 // NOTE: Hash and PartialEq must uphold the invariant:

--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -112,6 +112,7 @@ impl ty::TyEnumVariant {
                 type_span: variant.type_span.clone(),
                 tag: variant.tag,
                 span: variant.span,
+                attributes: variant.attributes,
             },
             vec![],
             errors,

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -34,7 +34,7 @@ use sway_types::{integer_bits::IntegerBits, Span};
 
 #[test]
 fn generic_enum_resolution() {
-    use crate::{language::ty, span::Span, Ident};
+    use crate::{language::ty, span::Span, AttributesMap, Ident};
     let engine = TypeEngine::default();
 
     let sp = Span::dummy();
@@ -50,6 +50,7 @@ fn generic_enum_resolution() {
         }),
         span: sp.clone(),
         type_span: sp.clone(),
+        attributes: AttributesMap::default(),
     }];
 
     let ty_1 = engine.insert_type(TypeInfo::Enum {
@@ -65,6 +66,7 @@ fn generic_enum_resolution() {
         initial_type_id: engine.insert_type(TypeInfo::Boolean),
         span: sp.clone(),
         type_span: sp.clone(),
+        attributes: AttributesMap::default(),
     }];
 
     let ty_2 = engine.insert_type(TypeInfo::Enum {


### PR DESCRIPTION
It seems we missed the enum variant attributes when merging in #2979 

Found while refactoring `forc doc`

Closes #3034 