### PR TITLE
Add the `sway-error` crate to the top level `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "scripts/mdbook-forc-documenter",
     "sway-ast",
     "sway-core",
+    "sway-error",
     "sway-ir",
     "sway-ir/sway-ir-macros",
     "sway-lsp",


### PR DESCRIPTION
Without this, [we're not able to publish `v0.26.0`](https://github.com/FuelLabs/sway/actions/runs/3244479334/jobs/5320968858).