### PR TITLE
Port `TypedExpressionVariant::FunctionApplication` to the declaration engine.

### DIFF
--- a/sway-core/src/declaration_engine/declaration_id.rs
+++ b/sway-core/src/declaration_engine/declaration_id.rs
@@ -4,7 +4,10 @@ use sway_types::{Span, Spanned};
 
 use crate::type_system::{CopyTypes, TypeMapping};
 
-use super::declaration_engine::{de_look_up_decl_id, de_replace_decl_id};
+use super::{
+    de_insert_function,
+    declaration_engine::{de_look_up_decl_id, de_replace_decl_id},
+};
 
 /// An ID used to refer to an item in the [DeclarationEngine](super::declaration_engine::DeclarationEngine)
 #[derive(Debug, Eq)]
@@ -62,5 +65,16 @@ impl CopyTypes for DeclarationId {
 impl DeclarationId {
     pub(super) fn new(index: usize, span: Span) -> DeclarationId {
         DeclarationId(index, span)
+    }
+
+    pub(crate) fn replace_id(&mut self, index: usize) {
+        self.0 = index;
+    }
+
+    pub(crate) fn copy_and_insert_new(&self, type_mapping: &TypeMapping) -> DeclarationId {
+        let mut decl = de_look_up_decl_id(self.clone());
+        decl.copy_types(type_mapping);
+        let function = decl.expect_function(&self.1).unwrap();
+        de_insert_function(function)
     }
 }

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -1,6 +1,8 @@
 use crate::{
-    declaration_engine::declaration_engine::de_get_constant, language::ty,
-    metadata::MetadataManager, semantic_analysis::*,
+    declaration_engine::{de_get_function, declaration_engine::de_get_constant},
+    language::ty,
+    metadata::MetadataManager,
+    semantic_analysis::*,
 };
 
 use super::{convert::convert_literal_to_constant, types::*};
@@ -163,7 +165,7 @@ fn const_eval_typed_expr(
         ty::TyExpressionVariant::Literal(l) => Some(convert_literal_to_constant(l)),
         ty::TyExpressionVariant::FunctionApplication {
             arguments,
-            function_decl,
+            function_decl_id,
             ..
         } => {
             let mut actuals_const: Vec<_> = vec![];
@@ -185,6 +187,7 @@ fn const_eval_typed_expr(
             }
 
             // TODO: Handle more than one statement in the block.
+            let function_decl = de_get_function(function_decl_id.clone(), &expr.span)?;
             if function_decl.body.contents.len() > 1 {
                 return Ok(None);
             }

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -15,6 +15,7 @@ use crate::{
     metadata::MetadataManager,
     type_system::{look_up_type_id, to_typeinfo, TypeId, TypeInfo},
 };
+use declaration_engine::de_get_function;
 use sway_ast::intrinsics::Intrinsic;
 use sway_error::error::{CompileError, Hint};
 use sway_ir::{Context, *};
@@ -209,7 +210,7 @@ impl FnCompiler {
                 call_path: name,
                 contract_call_params,
                 arguments,
-                function_decl,
+                function_decl_id,
                 self_state_idx,
                 selector,
             } => {
@@ -225,6 +226,7 @@ impl FnCompiler {
                         span_md_idx,
                     )
                 } else {
+                    let function_decl = de_get_function(function_decl_id, &ast_expr.span)?;
                     self.compile_fn_call(
                         context,
                         md_mgr,

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -7,6 +7,7 @@ use derivative::Derivative;
 use sway_types::{state::StateIndex, Ident, Span};
 
 use crate::{
+    declaration_engine::{de_get_function, DeclarationId},
     language::{ty::*, *},
     type_system::*,
 };
@@ -20,7 +21,7 @@ pub enum TyExpressionVariant {
         #[derivative(Eq(bound = ""))]
         contract_call_params: HashMap<String, TyExpression>,
         arguments: Vec<(Ident, TyExpression)>,
-        function_decl: TyFunctionDeclaration,
+        function_decl_id: DeclarationId,
         /// If this is `Some(val)` then `val` is the metadata. If this is `None`, then
         /// there is no selector.
         self_state_idx: Option<StateIndex>,
@@ -136,16 +137,20 @@ impl PartialEq for TyExpressionVariant {
                 Self::FunctionApplication {
                     call_path: l_name,
                     arguments: l_arguments,
-                    function_decl: l_function_decl,
+                    function_decl_id: l_function_decl_id,
                     ..
                 },
                 Self::FunctionApplication {
                     call_path: r_name,
                     arguments: r_arguments,
-                    function_decl: r_function_decl,
+                    function_decl_id: r_function_decl_id,
                     ..
                 },
             ) => {
+                let l_function_decl =
+                    de_get_function(l_function_decl_id.clone(), &Span::dummy()).unwrap();
+                let r_function_decl =
+                    de_get_function(r_function_decl_id.clone(), &Span::dummy()).unwrap();
                 l_name == r_name
                     && l_arguments == r_arguments
                     && l_function_decl.body == r_function_decl.body
@@ -360,7 +365,7 @@ impl CopyTypes for TyExpressionVariant {
             Literal(..) => (),
             FunctionApplication {
                 arguments,
-                function_decl,
+                ref mut function_decl_id,
                 ..
             } => {
                 arguments

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -366,7 +366,9 @@ impl CopyTypes for TyExpressionVariant {
                 arguments
                     .iter_mut()
                     .for_each(|(_ident, expr)| expr.copy_types(type_mapping));
-                function_decl.copy_types(type_mapping);
+
+                let new_decl_id = function_decl_id.clone().copy_and_insert_new(type_mapping);
+                function_decl_id.replace_id(*new_decl_id);
             }
             LazyOperator { lhs, rhs, .. } => {
                 (*lhs).copy_types(type_mapping);

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -90,6 +90,7 @@ pub(crate) fn instantiate_function_application(
         None,
         span,
     );
+
     ok(exp, warnings, errors)
 }
 
@@ -178,7 +179,7 @@ fn instantiate_function_application_inner(
             call_path,
             contract_call_params,
             arguments,
-            function_decl: function_decl.clone(),
+            function_decl_id: de_insert_function(function_decl.clone()),
             self_state_idx,
             selector,
         },


### PR DESCRIPTION
This ports the FunctionApplication expression variant to the declaration engine.

The first commit adds some error handling paths to the const evaluator that is used later for handling DE errors. Not 100% happy with removing the functional style code but couldn't really come up with a decent alternative that kept the existing style.

The next commit fixes a newly-exposed bug in the copy types implementation, special thanks to @emilyaherbert for her help in dealing with that. 

Closes https://github.com/FuelLabs/sway/issues/2786.