### PR TITLE
Return reference type values from calls.

### DIFF
--- a/sway-core/src/asm_generation/asm_builder.rs
+++ b/sway-core/src/asm_generation/asm_builder.rs
@@ -223,7 +223,7 @@ impl<'ir> AsmBuilder<'ir> {
                     if func_is_entry {
                         self.compile_ret_from_entry(instr_val, ret_val, ty)
                     } else {
-                        self.compile_ret_from_call(instr_val, ret_val, ty)
+                        self.compile_ret_from_call(instr_val, ret_val)
                     }
                 }
                 Instruction::Revert(revert_val) => self.compile_revert(instr_val, revert_val),

--- a/sway-core/src/asm_generation/asm_builder.rs
+++ b/sway-core/src/asm_generation/asm_builder.rs
@@ -6,7 +6,7 @@ use super::{
 };
 
 use crate::{
-    asm_lang::{virtual_register::*, Label, Op, VirtualImmediate12, VirtualOp},
+    asm_lang::{virtual_register::*, Label, Op, VirtualImmediate12, VirtualImmediate18, VirtualOp},
     error::*,
     metadata::MetadataManager,
     size_bytes_in_words, size_bytes_round_up_to_word_alignment,
@@ -212,6 +212,11 @@ impl<'ir> AsmBuilder<'ir> {
                     log_ty,
                     log_id,
                 } => self.compile_log(instr_val, log_val, log_ty, log_id),
+                Instruction::MemCopy {
+                    dst_val,
+                    src_val,
+                    byte_len,
+                } => self.compile_mem_copy(instr_val, dst_val, src_val, *byte_len),
                 Instruction::Nop => (),
                 Instruction::ReadRegister(reg) => self.compile_read_register(instr_val, reg),
                 Instruction::Ret(ret_val, ty) => {
@@ -1198,6 +1203,37 @@ impl<'ir> AsmBuilder<'ir> {
         }
         self.reg_map.insert(*instr_val, instr_reg);
         ok((), Vec::new(), Vec::new())
+    }
+
+    fn compile_mem_copy(
+        &mut self,
+        instr_val: &Value,
+        dst_val: &Value,
+        src_val: &Value,
+        byte_len: u64,
+    ) {
+        let owning_span = self.md_mgr.val_to_span(self.context, *instr_val);
+
+        let dst_reg = self.value_to_register(dst_val);
+        let src_reg = self.value_to_register(src_val);
+
+        let len_reg = self.reg_seqr.next();
+        self.cur_bytecode.push(Op {
+            opcode: Either::Left(VirtualOp::MOVI(
+                len_reg.clone(),
+                VirtualImmediate18 {
+                    value: byte_len as u32,
+                },
+            )),
+            comment: "get length for mcp".into(),
+            owning_span: owning_span.clone(),
+        });
+
+        self.cur_bytecode.push(Op {
+            opcode: Either::Left(VirtualOp::MCP(dst_reg, src_reg, len_reg)),
+            comment: "copy memory with mem_copy".into(),
+            owning_span,
+        });
     }
 
     fn compile_log(&mut self, instr_val: &Value, log_val: &Value, log_ty: &Type, log_id: &Value) {

--- a/sway-core/src/asm_generation/asm_builder/functions.rs
+++ b/sway-core/src/asm_generation/asm_builder/functions.rs
@@ -53,20 +53,6 @@ use either::Either;
 
 impl<'ir> AsmBuilder<'ir> {
     pub(super) fn compile_call(&mut self, instr_val: &Value, function: &Function, args: &[Value]) {
-        if !function.get_return_type(self.context).is_copy_type() {
-            // To implement non-copy type return values we will transform functions to return their
-            // value via an 'out' argument, either during IR generation or possibly with an IR
-            // transformation.
-            //
-            // This hasn't been done yet and will be addressed in a future change.  Until then we
-            // will enforce functions returning non-copy type values are always inlined, and so
-            // we will not see them at this stage of the compiler.
-            unimplemented!(
-                "Can't do reference type return values yet (and should've been inlined). {}",
-                function.get_name(self.context)
-            )
-        }
-
         // Put the args into the args registers.
         for (idx, arg_val) in args.iter().enumerate() {
             if idx < compiler_constants::NUM_ARG_REGISTERS as usize {
@@ -116,17 +102,7 @@ impl<'ir> AsmBuilder<'ir> {
         self.reg_map.insert(*instr_val, ret_reg);
     }
 
-    pub(super) fn compile_ret_from_call(
-        &mut self,
-        instr_val: &Value,
-        ret_val: &Value,
-        ret_type: &Type,
-    ) {
-        if !ret_type.is_copy_type() {
-            // See above in compile_call().
-            unimplemented!("Can't do reference type return values yet. {ret_type:?}")
-        }
-
+    pub(super) fn compile_ret_from_call(&mut self, instr_val: &Value, ret_val: &Value) {
         // Move the result into the return value register.
         let owning_span = self.md_mgr.val_to_span(self.context, *instr_val);
         let ret_reg = self.value_to_register(ret_val);

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -32,15 +32,21 @@ pub(super) struct FnCompiler {
     module: Module,
     pub(super) function: Function,
     pub(super) current_block: Block,
-    pub(super) block_to_break_to: Option<Block>,
-    pub(super) block_to_continue_to: Option<Block>,
-    pub(super) current_fn_param: Option<ty::TyFunctionParameter>,
+    block_to_break_to: Option<Block>,
+    block_to_continue_to: Option<Block>,
+    current_fn_param: Option<ty::TyFunctionParameter>,
+    returns_by_ref: bool,
     lexical_map: LexicalMap,
     recreated_fns: HashMap<(Span, Vec<TypeId>, Vec<TypeId>), Function>,
 }
 
 impl FnCompiler {
-    pub(super) fn new(context: &mut Context, module: Module, function: Function) -> Self {
+    pub(super) fn new(
+        context: &mut Context,
+        module: Module,
+        function: Function,
+        returns_by_ref: bool,
+    ) -> Self {
         let lexical_map = LexicalMap::from_iter(
             function
                 .args_iter(context)
@@ -53,6 +59,7 @@ impl FnCompiler {
             block_to_break_to: None,
             block_to_continue_to: None,
             lexical_map,
+            returns_by_ref,
             recreated_fns: HashMap::new(),
             current_fn_param: None,
         }
@@ -185,8 +192,7 @@ impl FnCompiler {
                 }
             }
             ty::TyAstNodeContent::ImplicitReturnExpression(te) => {
-                let value = self.compile_expression(context, md_mgr, te)?;
-                Ok(Some(value))
+                self.compile_expression(context, md_mgr, te).map(Some)
             }
             // a side effect can be () because it just impacts the type system/namespacing.
             // There should be no new IR generated.
@@ -672,23 +678,48 @@ impl FnCompiler {
         }
 
         let ret_value = self.compile_expression(context, md_mgr, ast_expr.clone())?;
+
         if ret_value.is_diverging(context) {
             return Ok(ret_value);
         }
+
+        let span_md_idx = md_mgr.span_to_md(context, &ast_expr.span);
+
+        if self.returns_by_ref {
+            // We need to copy the actual return value to the out parameter.
+            self.compile_copy_to_last_arg(context, ret_value, span_md_idx);
+        }
+
         match ret_value.get_stripped_ptr_type(context) {
             None => Err(CompileError::Internal(
                 "Unable to determine type for return statement expression.",
                 ast_expr.span,
             )),
-            Some(ret_ty) => {
-                let span_md_idx = md_mgr.span_to_md(context, &ast_expr.span);
-                Ok(self
-                    .current_block
-                    .ins(context)
-                    .ret(ret_value, ret_ty)
-                    .add_metadatum(context, span_md_idx))
-            }
+            Some(ret_ty) => Ok(self
+                .current_block
+                .ins(context)
+                .ret(ret_value, ret_ty)
+                .add_metadatum(context, span_md_idx)),
         }
+    }
+
+    pub(super) fn compile_copy_to_last_arg(
+        &mut self,
+        context: &mut Context,
+        ret_val: Value,
+        span_md_idx: Option<MetadataIndex>,
+    ) -> Value {
+        let dst_val = self.function.args_iter(context).last().unwrap().1;
+        let src_val = ret_val;
+        let byte_len =
+            ir_type_size_in_bytes(context, &src_val.get_stripped_ptr_type(context).unwrap());
+
+        self.current_block
+            .ins(context)
+            .mem_copy(dst_val, src_val, byte_len)
+            .add_metadatum(context, span_md_idx);
+
+        dst_val
     }
 
     fn compile_lazy_op(
@@ -1025,7 +1056,7 @@ impl FnCompiler {
         };
 
         // Now actually call the new function.
-        let args = {
+        let mut args = {
             let mut args = Vec::with_capacity(ast_args.len());
             for ((_, expr), param) in ast_args.into_iter().zip(callee.parameters.into_iter()) {
                 self.current_fn_param = Some(param);
@@ -1038,12 +1069,37 @@ impl FnCompiler {
             }
             args
         };
-        let state_idx_md_idx = match self_state_idx {
-            Some(self_state_idx) => {
-                md_mgr.storage_key_to_md(context, self_state_idx.to_usize() as u64)
+
+        // If there is an 'unexpected' extra arg in the callee and it's a pointer then we need to
+        // set up returning by reference.
+        if args.len() + 1 == new_callee.num_args(context) {
+            if let Some(Type::Pointer(ptr)) = new_callee
+                .args_iter(context)
+                .last()
+                .unwrap()
+                .1
+                .get_argument_type(context)
+            {
+                // Create a local to pass in as the 'out' parameter.
+                let ptr_type = *ptr.get_type(context);
+                let local_name = format!("__ret_val_{}", new_callee.get_name(context));
+                let local_ptr = self
+                    .function
+                    .new_unique_local_ptr(context, local_name, ptr_type, true, None);
+
+                // Pass it as the final arg.
+                args.push(
+                    self.current_block
+                        .ins(context)
+                        .get_ptr(local_ptr, ptr_type, 0),
+                );
             }
-            None => None,
-        };
+        }
+
+        let state_idx_md_idx = self_state_idx.and_then(|self_state_idx| {
+            md_mgr.storage_key_to_md(context, self_state_idx.to_usize() as u64)
+        });
+
         Ok(self
             .current_block
             .ins(context)

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -505,17 +505,15 @@ fn inline_function_calls(
 
     let inline_heuristic = |ctx: &Context, func: &Function, _call_site: &Value| {
         // For now, pending improvements to ASMgen for calls, we must inline any function which has
-        // a non-copy return type or has too many args.
-        if !func.get_return_type(ctx).is_copy_type()
-            || func.args_iter(ctx).count() as u8
-                > crate::asm_generation::compiler_constants::NUM_ARG_REGISTERS
+        // too many args.
+        if func.args_iter(ctx).count() as u8
+            > crate::asm_generation::compiler_constants::NUM_ARG_REGISTERS
         {
             return true;
         }
 
         // If the function is called only once then definitely inline it.
-        let call_count = call_counts.get(func).copied().unwrap_or(0);
-        if call_count == 1 {
+        if call_counts.get(func).copied().unwrap_or(0) == 1 {
             return true;
         }
 

--- a/sway-ir/src/constant.rs
+++ b/sway-ir/src/constant.rs
@@ -28,28 +28,6 @@ pub enum ConstantValue {
 }
 
 impl Constant {
-    pub fn new_undef(context: &Context, ty: Type) -> Self {
-        match ty {
-            Type::Array(aggregate) => {
-                let (elem_type, count) = context.aggregates[aggregate.0].array_type();
-                let elem_init = Self::new_undef(context, *elem_type);
-                Constant::new_array(&aggregate, vec![elem_init; *count as usize])
-            }
-            Type::Struct(aggregate) => {
-                let field_types = context.aggregates[aggregate.0].field_types().clone();
-                let field_inits = field_types
-                    .into_iter()
-                    .map(|field_type| Self::new_undef(context, field_type)) // Hrmm, recursive structures would break here.
-                    .collect();
-                Constant::new_struct(&aggregate, field_inits)
-            }
-            _otherwise => Constant {
-                ty,
-                value: ConstantValue::Undef,
-            },
-        }
-    }
-
     pub fn new_unit() -> Self {
         Constant {
             ty: Type::Unit,

--- a/sway-ir/src/error.rs
+++ b/sway-ir/src/error.rs
@@ -48,6 +48,7 @@ pub enum IrError {
     VerifyMismatchedReturnTypes(String),
     VerifyBlockArgMalformed,
     VerifyPtrCastFromNonPointer,
+    VerifyReturnRefTypeValue(String, String),
     VerifyStateKeyBadType,
     VerifyStateDestBadType(String),
     VerifyStoreMismatchedTypes,
@@ -265,6 +266,13 @@ impl fmt::Display for IrError {
                 write!(
                     f,
                     "Verification failed: Pointer cast from non pointer value."
+                )
+            }
+            IrError::VerifyReturnRefTypeValue(fn_str, ty_str) => {
+                write!(
+                    f,
+                    "Verification failed: Function {fn_str} must not return value with reference \
+                    type of {ty_str}.",
                 )
             }
             IrError::VerifyStateKeyBadType => {

--- a/sway-ir/src/function.rs
+++ b/sway-ir/src/function.rs
@@ -264,6 +264,11 @@ impl Function {
         context.functions[self.0].return_type
     }
 
+    /// Get the number of args.
+    pub fn num_args(&self, context: &Context) -> usize {
+        context.functions[self.0].arguments.len()
+    }
+
     /// Get an arg value by name, if found.
     pub fn get_arg(&self, context: &Context, name: &str) -> Option<Value> {
         context.functions[self.0]

--- a/sway-ir/src/instruction.rs
+++ b/sway-ir/src/instruction.rs
@@ -368,7 +368,12 @@ impl Instruction {
                 replace(log_val);
                 replace(log_id);
             }
-            Instruction::MemCopy { .. } => (),
+            Instruction::MemCopy {
+                dst_val, src_val, ..
+            } => {
+                replace(dst_val);
+                replace(src_val);
+            }
             Instruction::Nop => (),
             Instruction::ReadRegister { .. } => (),
             Instruction::Ret(ret_val, _) => replace(ret_val),

--- a/sway-ir/src/instruction.rs
+++ b/sway-ir/src/instruction.rs
@@ -109,6 +109,12 @@ pub enum Instruction {
         log_ty: Type,
         log_id: Value,
     },
+    /// Copy a specified number of bytes between pointers.
+    MemCopy {
+        dst_val: Value,
+        src_val: Value,
+        byte_len: u64,
+    },
     /// No-op, handy as a placeholder instruction.
     Nop,
     /// Reads a special register in the VM.
@@ -234,6 +240,7 @@ impl Instruction {
             Instruction::Ret(..) => None,
             Instruction::Revert(..) => None,
 
+            Instruction::MemCopy { .. } => Some(Type::Unit),
             Instruction::StateLoadQuadWord { .. } => Some(Type::Unit),
             Instruction::StateStoreQuadWord { .. } => Some(Type::Unit),
             Instruction::StateStoreWord { .. } => Some(Type::Unit),
@@ -361,6 +368,7 @@ impl Instruction {
                 replace(log_val);
                 replace(log_id);
             }
+            Instruction::MemCopy { .. } => (),
             Instruction::Nop => (),
             Instruction::ReadRegister { .. } => (),
             Instruction::Ret(ret_val, _) => replace(ret_val),
@@ -392,6 +400,7 @@ impl Instruction {
                 | Instruction::Call(..)
                 | Instruction::ContractCall { .. }
                 | Instruction::Log { .. }
+                | Instruction::MemCopy { .. }
                 | Instruction::StateLoadQuadWord { .. }
                 | Instruction::StateStoreQuadWord { .. }
                 | Instruction::StateStoreWord { .. }
@@ -691,6 +700,17 @@ impl<'a> InstructionInserter<'a> {
                 log_val,
                 log_ty,
                 log_id
+            }
+        )
+    }
+
+    pub fn mem_copy(self, dst_val: Value, src_val: Value, byte_len: u64) -> Value {
+        make_instruction!(
+            self,
+            Instruction::MemCopy {
+                dst_val,
+                src_val,
+                byte_len
             }
         )
     }

--- a/sway-ir/src/instruction.rs
+++ b/sway-ir/src/instruction.rs
@@ -473,6 +473,16 @@ pub struct InstructionInserter<'a> {
     block: Block,
 }
 
+macro_rules! make_instruction {
+    ($self: ident, $ctor: expr) => {{
+        let instruction_val = Value::new_instruction($self.context, $ctor);
+        $self.context.blocks[$self.block.0]
+            .instructions
+            .push(instruction_val);
+        instruction_val
+    }};
+}
+
 impl<'a> InstructionInserter<'a> {
     /// Return a new [`InstructionInserter`] context for `block`.
     pub fn new(context: &'a mut Context, block: Block) -> InstructionInserter<'a> {
@@ -481,8 +491,6 @@ impl<'a> InstructionInserter<'a> {
 
     //
     // XXX Maybe these should return result, in case they get bad args?
-    //
-    // XXX Also, these are all the same and could probably be created with a local macro.
     //
 
     /// Append a new [`Instruction::AsmBlock`] from `args` and a `body`.
@@ -504,42 +512,23 @@ impl<'a> InstructionInserter<'a> {
     }
 
     pub fn asm_block_from_asm(self, asm: AsmBlock, args: Vec<AsmArg>) -> Value {
-        let asm_val = Value::new_instruction(self.context, Instruction::AsmBlock(asm, args));
-        self.context.blocks[self.block.0].instructions.push(asm_val);
-        asm_val
+        make_instruction!(self, Instruction::AsmBlock(asm, args))
     }
 
     pub fn addr_of(self, value: Value) -> Value {
-        let addrof_val = Value::new_instruction(self.context, Instruction::AddrOf(value));
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(addrof_val);
-        addrof_val
+        make_instruction!(self, Instruction::AddrOf(value))
     }
 
     pub fn bitcast(self, value: Value, ty: Type) -> Value {
-        let bitcast_val = Value::new_instruction(self.context, Instruction::BitCast(value, ty));
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(bitcast_val);
-        bitcast_val
+        make_instruction!(self, Instruction::BitCast(value, ty))
     }
 
     pub fn binary_op(self, op: BinaryOpKind, arg1: Value, arg2: Value) -> Value {
-        let binop_val =
-            Value::new_instruction(self.context, Instruction::BinaryOp { op, arg1, arg2 });
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(binop_val);
-        binop_val
+        make_instruction!(self, Instruction::BinaryOp { op, arg1, arg2 })
     }
 
     pub fn int_to_ptr(self, value: Value, ty: Type) -> Value {
-        let int_to_ptr_val = Value::new_instruction(self.context, Instruction::IntToPtr(value, ty));
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(int_to_ptr_val);
-        int_to_ptr_val
+        make_instruction!(self, Instruction::IntToPtr(value, ty))
     }
 
     pub fn branch(self, to_block: Block, dest_params: Vec<Value>) -> Value {
@@ -556,19 +545,11 @@ impl<'a> InstructionInserter<'a> {
     }
 
     pub fn call(self, function: Function, args: &[Value]) -> Value {
-        let call_val =
-            Value::new_instruction(self.context, Instruction::Call(function, args.to_vec()));
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(call_val);
-        call_val
+        make_instruction!(self, Instruction::Call(function, args.to_vec()))
     }
 
     pub fn cmp(self, pred: Predicate, lhs_value: Value, rhs_value: Value) -> Value {
-        let cmp_val =
-            Value::new_instruction(self.context, Instruction::Cmp(pred, lhs_value, rhs_value));
-        self.context.blocks[self.block.0].instructions.push(cmp_val);
-        cmp_val
+        make_instruction!(self, Instruction::Cmp(pred, lhs_value, rhs_value))
     }
 
     pub fn conditional_branch(
@@ -608,8 +589,8 @@ impl<'a> InstructionInserter<'a> {
         asset_id: Value, // b256 asset ID of the coint being forwarded
         gas: Value,      // amount of gas to forward
     ) -> Value {
-        let contract_call_val = Value::new_instruction(
-            self.context,
+        make_instruction!(
+            self,
             Instruction::ContractCall {
                 return_type,
                 name,
@@ -617,72 +598,50 @@ impl<'a> InstructionInserter<'a> {
                 coins,
                 asset_id,
                 gas,
-            },
-        );
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(contract_call_val);
-        contract_call_val
+            }
+        )
     }
 
     pub fn extract_element(self, array: Value, ty: Aggregate, index_val: Value) -> Value {
-        let extract_element_val = Value::new_instruction(
-            self.context,
+        make_instruction!(
+            self,
             Instruction::ExtractElement {
                 array,
                 ty,
                 index_val,
-            },
-        );
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(extract_element_val);
-        extract_element_val
+            }
+        )
     }
 
     pub fn extract_value(self, aggregate: Value, ty: Aggregate, indices: Vec<u64>) -> Value {
-        let extract_value_val = Value::new_instruction(
-            self.context,
+        make_instruction!(
+            self,
             Instruction::ExtractValue {
                 aggregate,
                 ty,
                 indices,
-            },
-        );
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(extract_value_val);
-        extract_value_val
+            }
+        )
     }
 
     pub fn get_storage_key(self) -> Value {
-        let get_storage_key_val = Value::new_instruction(self.context, Instruction::GetStorageKey);
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(get_storage_key_val);
-        get_storage_key_val
+        make_instruction!(self, Instruction::GetStorageKey)
     }
 
     pub fn gtf(self, index: Value, tx_field_id: u64) -> Value {
-        let gtf_val = Value::new_instruction(self.context, Instruction::Gtf { index, tx_field_id });
-        self.context.blocks[self.block.0].instructions.push(gtf_val);
-        gtf_val
+        make_instruction!(self, Instruction::Gtf { index, tx_field_id })
     }
 
     pub fn get_ptr(self, base_ptr: Pointer, ptr_ty: Type, offset: u64) -> Value {
         let ptr = Pointer::new(self.context, ptr_ty, false, None);
-        let get_ptr_val = Value::new_instruction(
-            self.context,
+        make_instruction!(
+            self,
             Instruction::GetPointer {
                 base_ptr,
                 ptr_ty: ptr,
                 offset,
-            },
-        );
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(get_ptr_val);
-        get_ptr_val
+            }
+        )
     }
 
     pub fn insert_element(
@@ -692,19 +651,15 @@ impl<'a> InstructionInserter<'a> {
         value: Value,
         index_val: Value,
     ) -> Value {
-        let insert_val = Value::new_instruction(
-            self.context,
+        make_instruction!(
+            self,
             Instruction::InsertElement {
                 array,
                 ty,
                 value,
                 index_val,
-            },
-        );
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(insert_val);
-        insert_val
+            }
+        )
     }
 
     pub fn insert_value(
@@ -714,63 +669,42 @@ impl<'a> InstructionInserter<'a> {
         value: Value,
         indices: Vec<u64>,
     ) -> Value {
-        let insert_val = Value::new_instruction(
-            self.context,
+        make_instruction!(
+            self,
             Instruction::InsertValue {
                 aggregate,
                 ty,
                 value,
                 indices,
-            },
-        );
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(insert_val);
-        insert_val
+            }
+        )
     }
 
     pub fn load(self, src_val: Value) -> Value {
-        let load_val = Value::new_instruction(self.context, Instruction::Load(src_val));
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(load_val);
-        load_val
+        make_instruction!(self, Instruction::Load(src_val))
     }
 
     pub fn log(self, log_val: Value, log_ty: Type, log_id: Value) -> Value {
-        let log_instr_val = Value::new_instruction(
-            self.context,
+        make_instruction!(
+            self,
             Instruction::Log {
                 log_val,
                 log_ty,
-                log_id,
-            },
-        );
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(log_instr_val);
-        log_instr_val
+                log_id
+            }
+        )
     }
 
     pub fn nop(self) -> Value {
-        let nop_val = Value::new_instruction(self.context, Instruction::Nop);
-        self.context.blocks[self.block.0].instructions.push(nop_val);
-        nop_val
+        make_instruction!(self, Instruction::Nop)
     }
 
     pub fn read_register(self, reg: Register) -> Value {
-        let read_register_val =
-            Value::new_instruction(self.context, Instruction::ReadRegister(reg));
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(read_register_val);
-        read_register_val
+        make_instruction!(self, Instruction::ReadRegister(reg))
     }
 
     pub fn ret(self, value: Value, ty: Type) -> Value {
-        let ret_val = Value::new_instruction(self.context, Instruction::Ret(value, ty));
-        self.context.blocks[self.block.0].instructions.push(ret_val);
-        ret_val
+        make_instruction!(self, Instruction::Ret(value, ty))
     }
 
     pub fn revert(self, value: Value) -> Value {
@@ -782,57 +716,28 @@ impl<'a> InstructionInserter<'a> {
     }
 
     pub fn state_load_quad_word(self, load_val: Value, key: Value) -> Value {
-        let state_load_val = Value::new_instruction(
-            self.context,
-            Instruction::StateLoadQuadWord { load_val, key },
-        );
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(state_load_val);
-        state_load_val
+        make_instruction!(self, Instruction::StateLoadQuadWord { load_val, key })
     }
 
     pub fn state_load_word(self, key: Value) -> Value {
-        let state_load_val = Value::new_instruction(self.context, Instruction::StateLoadWord(key));
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(state_load_val);
-        state_load_val
+        make_instruction!(self, Instruction::StateLoadWord(key))
     }
 
     pub fn state_store_quad_word(self, stored_val: Value, key: Value) -> Value {
-        let state_store_val = Value::new_instruction(
-            self.context,
-            Instruction::StateStoreQuadWord { stored_val, key },
-        );
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(state_store_val);
-        state_store_val
+        make_instruction!(self, Instruction::StateStoreQuadWord { stored_val, key })
     }
 
     pub fn state_store_word(self, stored_val: Value, key: Value) -> Value {
-        let state_store_val = Value::new_instruction(
-            self.context,
-            Instruction::StateStoreWord { stored_val, key },
-        );
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(state_store_val);
-        state_store_val
+        make_instruction!(self, Instruction::StateStoreWord { stored_val, key })
     }
 
     pub fn store(self, dst_val: Value, stored_val: Value) -> Value {
-        let store_val = Value::new_instruction(
-            self.context,
+        make_instruction!(
+            self,
             Instruction::Store {
                 dst_val,
                 stored_val,
-            },
-        );
-        self.context.blocks[self.block.0]
-            .instructions
-            .push(store_val);
-        store_val
+            }
+        )
     }
 }

--- a/sway-ir/src/optimize/dce.rs
+++ b/sway-ir/src/optimize/dce.rs
@@ -89,6 +89,13 @@ pub fn dce(context: &mut Context, function: &Function) -> Result<bool, IrError> 
             Instruction::Log {
                 log_val, log_id, ..
             } => vec![*log_val, *log_id],
+            Instruction::MemCopy {
+                dst_val,
+                src_val,
+                byte_len: _,
+            } => {
+                vec![*dst_val, *src_val]
+            }
             Instruction::Nop => vec![],
             Instruction::ReadRegister(_) => vec![],
             Instruction::Ret(v, _) => vec![*v],

--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -414,6 +414,13 @@ fn inline_instruction(
             } => new_block
                 .ins(context)
                 .log(map_value(log_val), log_ty, map_value(log_id)),
+            Instruction::MemCopy {
+                dst_val,
+                src_val,
+                byte_len,
+            } => new_block
+                .ins(context)
+                .mem_copy(map_value(dst_val), map_value(src_val), byte_len),
             Instruction::Nop => new_block.ins(context).nop(),
             Instruction::ReadRegister(reg) => new_block.ins(context).read_register(reg),
             // We convert `ret` to `br post_block` and add the returned value as a phi value.

--- a/sway-ir/src/parser.rs
+++ b/sway-ir/src/parser.rs
@@ -150,6 +150,7 @@ mod ir_builder {
                 / op_int_to_ptr()
                 / op_load()
                 / op_log()
+                / op_mem_copy()
                 / op_nop()
                 / op_read_register()
                 / op_ret()
@@ -271,6 +272,11 @@ mod ir_builder {
             rule op_log() -> IrAstOperation
                 = "log" _ log_ty:ast_ty() log_val:id() comma() log_id:id() {
                     IrAstOperation::Log(log_ty, log_val, log_id)
+                }
+
+            rule op_mem_copy() -> IrAstOperation
+                = "mem_copy" _ dst_name:id() comma() src_name:id() comma() len:decimal() {
+                    IrAstOperation::MemCopy(dst_name, src_name, len)
                 }
 
             rule op_nop() -> IrAstOperation
@@ -443,6 +449,7 @@ mod ir_builder {
                 / array_ty()
                 / struct_ty()
                 / union_ty()
+                / mp:mut_ptr() ty:ast_ty() { IrAstTy::Pointer(Box::new(ty), mp) }
 
             rule array_ty() -> IrAstTy
                 = "[" _ ty:ast_ty() ";" _ c:decimal() "]" _ {
@@ -638,6 +645,7 @@ mod ir_builder {
         IntToPtr(String, IrAstTy),
         Load(String),
         Log(IrAstTy, String, String),
+        MemCopy(String, String, u64),
         Nop,
         ReadRegister(String),
         Ret(IrAstTy, String),
@@ -744,6 +752,7 @@ mod ir_builder {
         Array(Box<IrAstTy>, u64),
         Union(Vec<IrAstTy>),
         Struct(Vec<IrAstTy>),
+        Pointer(Box<IrAstTy>, bool),
     }
 
     impl IrAstTy {
@@ -757,6 +766,10 @@ mod ir_builder {
                 IrAstTy::Array(..) => Type::Array(self.to_ir_aggregate_type(context)),
                 IrAstTy::Union(_) => Type::Union(self.to_ir_aggregate_type(context)),
                 IrAstTy::Struct(_) => Type::Struct(self.to_ir_aggregate_type(context)),
+                IrAstTy::Pointer(ty, is_mut) => {
+                    let ty = ty.to_ir_type(context);
+                    Type::Pointer(Pointer::new(context, ty, *is_mut, None))
+                }
             }
         }
 
@@ -1151,6 +1164,14 @@ mod ir_builder {
                             )
                             .add_metadatum(context, opt_metadata)
                     }
+                    IrAstOperation::MemCopy(dst_name, src_name, len) => block
+                        .ins(context)
+                        .mem_copy(
+                            *val_map.get(&dst_name).unwrap(),
+                            *val_map.get(&src_name).unwrap(),
+                            len,
+                        )
+                        .add_metadatum(context, opt_metadata),
                     IrAstOperation::Nop => block.ins(context).nop(),
                     IrAstOperation::ReadRegister(reg_name) => block
                         .ins(context)

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -624,7 +624,7 @@ fn instruction_to_doc<'a>(
                 dst_val,
                 src_val,
                 byte_len,
-            } => Doc::line(
+            } => maybe_constant_to_doc(context, md_namer, namer, src_val).append(Doc::line(
                 Doc::text(format!(
                     "mem_copy {}, {}, {}",
                     namer.name(context, dst_val),
@@ -632,7 +632,7 @@ fn instruction_to_doc<'a>(
                     byte_len,
                 ))
                 .append(md_namer.md_idx_to_doc(context, metadata)),
-            ),
+            )),
             Instruction::Nop => Doc::line(
                 Doc::text(format!("{} = nop", namer.name(context, ins_value)))
                     .append(md_namer.md_idx_to_doc(context, metadata)),

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -620,6 +620,19 @@ fn instruction_to_doc<'a>(
                     ))
                     .append(md_namer.md_idx_to_doc(context, metadata)),
                 )),
+            Instruction::MemCopy {
+                dst_val,
+                src_val,
+                byte_len,
+            } => Doc::line(
+                Doc::text(format!(
+                    "mem_copy {}, {}, {}",
+                    namer.name(context, dst_val),
+                    namer.name(context, src_val),
+                    byte_len,
+                ))
+                .append(md_namer.md_idx_to_doc(context, metadata)),
+            ),
             Instruction::Nop => Doc::line(
                 Doc::text(format!("{} = nop", namer.name(context, ins_value)))
                     .append(md_namer.md_idx_to_doc(context, metadata)),

--- a/sway-ir/src/value.rs
+++ b/sway-ir/src/value.rs
@@ -12,6 +12,7 @@ use crate::{
     instruction::Instruction,
     irtype::Type,
     metadata::{combine, MetadataIndex},
+    pointer::Pointer,
     pretty::DebugWithContext,
     BlockArgument,
 };

--- a/sway-ir/src/value.rs
+++ b/sway-ir/src/value.rs
@@ -187,6 +187,26 @@ impl Value {
         }
     }
 
+    /// Get the pointer argument for this value if there is one.  I.e., where get_ptr is
+    /// essentially a Value wrapper around a Pointer, this function unwrap it.
+    pub fn get_pointer(&self, context: &Context) -> Option<Pointer> {
+        match &context.values[self.0].value {
+            ValueDatum::Instruction(Instruction::GetPointer { base_ptr, .. }) => Some(*base_ptr),
+
+            ValueDatum::Argument(BlockArgument {
+                ty: Type::Pointer(ptr),
+                ..
+            }) => Some(*ptr),
+
+            ValueDatum::Instruction(Instruction::InsertValue { aggregate, .. })
+            | ValueDatum::Instruction(Instruction::ExtractValue { aggregate, .. }) => {
+                aggregate.get_pointer(context)
+            }
+
+            _otherwise => None,
+        }
+    }
+
     /// Get the type for this value with any pointer stripped, if found.
     pub fn get_stripped_ptr_type(&self, context: &Context) -> Option<Type> {
         self.get_type(context).map(|f| f.strip_ptr_type(context))

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -196,9 +196,14 @@ impl<'a> InstructionVerifier<'a> {
                         log_ty,
                         log_id,
                     } => self.verify_log(log_val, log_ty, log_id)?,
+                    Instruction::MemCopy {
+                        dst_val,
+                        src_val,
+                        byte_len,
+                    } => self.verify_mem_copy(dst_val, src_val, byte_len)?,
                     Instruction::Nop => (),
                     Instruction::ReadRegister(_) => (),
-                    Instruction::Ret(val, ty) => self.verify_ret(self.cur_function, val, ty)?,
+                    Instruction::Ret(val, ty) => self.verify_ret(val, ty)?,
                     Instruction::Revert(val) => self.verify_revert(val)?,
                     Instruction::StateLoadWord(key) => self.verify_state_load_word(key)?,
                     Instruction::StateLoadQuadWord {
@@ -612,7 +617,7 @@ impl<'a> InstructionVerifier<'a> {
     }
 
     fn verify_load(&self, src_val: &Value) -> Result<(), IrError> {
-        let src_ptr = self.get_pointer(src_val);
+        let src_ptr = src_val.get_pointer(self.context);
         if src_ptr.is_none() {
             if !self.is_ptr_argument(src_val) {
                 Err(IrError::VerifyLoadFromNonPointer)
@@ -623,6 +628,7 @@ impl<'a> InstructionVerifier<'a> {
             Ok(())
         }
     }
+
     fn verify_log(&self, log_val: &Value, log_ty: &Type, log_id: &Value) -> Result<(), IrError> {
         if !matches!(log_id.get_type(self.context), Some(Type::Uint(64))) {
             return Err(IrError::VerifyLogId);
@@ -635,16 +641,52 @@ impl<'a> InstructionVerifier<'a> {
         Ok(())
     }
 
-    fn verify_ret(
+    fn verify_mem_copy(
         &self,
-        function: &FunctionContent,
-        val: &Value,
-        ty: &Type,
+        _dst_val: &Value,
+        _src_val: &Value,
+        _byte_len: &u64,
     ) -> Result<(), IrError> {
-        if !function.return_type.eq(self.context, ty)
-            || self.opt_ty_not_eq(&val.get_stripped_ptr_type(self.context), &Some(*ty))
+        // We should perhaps verify that the pointer types are the same size in bytes, or at least
+        // the dst is equal to or larger than the src.
+        //
+        //| XXX Pointers are broken, pending https://github.com/FuelLabs/sway/issues/2819
+        //| So here we may still get non-pointers, but still ref-types, passed as the source for
+        //| mem_copy, especially when dealing with constant b256s or similar.
+        //|if !dst_val.get_pointer(self.context).is_some()
+        //|    || !(src_val.get_pointer(self.context).is_some()
+        //|        || matches!(
+        //|            src_val.get_instruction(self.context),
+        //|            Some(Instruction::GetStorageKey) | Some(Instruction::IntToPtr(..))
+        //|        ))
+        //|{
+        //|    Err(IrError::VerifyGetNonExistentPointer)
+        //|} else {
+        //|    Ok(())
+        //|}
+        Ok(())
+    }
+
+    fn verify_ret(&self, val: &Value, ty: &Type) -> Result<(), IrError> {
+        //| XXX Also waiting for better pointers in https://github.com/FuelLabs/sway/issues/2819
+        //| We should disallow returning ref types, as we're using 'out' parameters for anything
+        //| that doesn't fit in a reg. So we should instead return pointers to those ref type
+        //| values.  But we need better support from a data section for constant ref-type values,
+        //| which is currently handled in ASMgen, but should be handled here in IR.
+        //|
+        //|if !self.cur_func_is_entry() && !ty.is_copy_type() {
+        //|    Err(IrError::VerifyReturnRefTypeValue(
+        //|        self.cur_function.name.clone(),
+        //|        ty.as_string(self.context),
+        //|    ))
+        //|} else
+        if !self.cur_function.return_type.eq(self.context, ty)
+            || (self.opt_ty_not_eq(&val.get_type(self.context), &Some(*ty))
+                && self.opt_ty_not_eq(&val.get_stripped_ptr_type(self.context), &Some(*ty)))
         {
-            Err(IrError::VerifyMismatchedReturnTypes(function.name.clone()))
+            Err(IrError::VerifyMismatchedReturnTypes(
+                self.cur_function.name.clone(),
+            ))
         } else {
             Ok(())
         }
@@ -707,17 +749,6 @@ impl<'a> InstructionVerifier<'a> {
         }
     }
 
-    fn get_pointer(&self, ptr_val: &Value) -> Option<Pointer> {
-        match &self.context.values[ptr_val.0].value {
-            ValueDatum::Instruction(Instruction::GetPointer { base_ptr, .. }) => Some(*base_ptr),
-            ValueDatum::Argument(BlockArgument {
-                ty: Type::Pointer(ptr),
-                ..
-            }) => Some(*ptr),
-            _otherwise => None,
-        }
-    }
-
     // This is a temporary workaround due to the fact that we don't support pointer arguments yet.
     // We do treat non-copy types as references anyways though so this is fine. Eventually, we
     // should allow function arguments to also be Pointer.
@@ -761,4 +792,13 @@ impl<'a> InstructionVerifier<'a> {
     fn opt_ty_not_eq(&self, l_ty: &Option<Type>, r_ty: &Option<Type>) -> bool {
         l_ty.is_none() || r_ty.is_none() || !l_ty.unwrap().eq(self.context, r_ty.as_ref().unwrap())
     }
+
+    //| XXX Will be used by verify_ret() when we have proper pointers fixed.
+    //|fn cur_func_is_entry(&self) -> bool {
+    //|    match self.cur_module.kind {
+    //|        Kind::Script | Kind::Predicate => self.cur_function.name == "main",
+    //|        Kind::Contract => self.cur_function.selector.is_some(),
+    //|        Kind::Library => false,
+    //|    }
+    //|}
 }

--- a/sway-ir/tests/inline/get_storage_key.ir
+++ b/sway-ir/tests/inline/get_storage_key.ir
@@ -4,41 +4,48 @@
 // regex: MD=!\d+
 // regex: LABEL=[[:alpha:]0-9_]+
 
-script {
-    fn return_storage_key_wrapper() -> b256 {
+contract {
+    fn test<58d7eb51>() -> b256, !1 {
+        local ptr {  } __anon_0
+        local mut ptr b256 __ret_val_f_0
+
         entry():
-        v0 = call return_storage_key(), !4
-        ret b256 v0
+        v0 = get_ptr ptr {  } __anon_0, ptr {  }, 0, !2
+        v1 = get_ptr mut ptr b256 __ret_val_f_0, ptr b256, 0
+        v2 = call f_0(v0, v1), !5
+        ret b256 v2
     }
 
-    fn return_storage_key() -> b256 {
-        entry():
-        v0 = get_storage_key, !2
-        ret b256 v0
-    }
-
-// check: fn main
-    fn main() -> b256 {
-        entry():
-        v0 = call return_storage_key_wrapper(), !5
-// check: $(arg0=$VAR) = get_storage_key, $(stk_md=$MD)
-// check: br $(lbl_block1=$LABEL)($arg0)
-// check: $(lbl_block1)($(arg1=$VAR): b256):
-// check: br $(lbl_block0=$LABEL)($arg1)
-// check: $(lbl_block0)($(arg2=$VAR): b256):
-// check: ret b256 $arg2
-        ret b256 v0
+    fn f_0(self !6: {  }, __ret_value !7: mut ptr b256) -> b256, !8 {
+        entry(self: {  }, __ret_value: mut ptr b256):
+        v0 = get_storage_key, !9
+        mem_copy __ret_value, v0, 32
+        ret b256 __ret_value
     }
 }
 
+!0 = "get_storage_key.sw"
+!1 = span !0 218 265
+!2 = span !0 254 255
+!3 = span !0 246 259
+!4 = state_index 42
+!5 = (!3 !4)
+!6 = span !0 42 46
+!7 = span !0 51 55
+!8 = span !0 37 91
+!9 = span !0 66 85
+
+// check: fn test<58d7eb51>() -> b256
+
+// not: call
+// check: $(stk_val=$VAR) = get_storage_key, $(stk_md=$MD)
+
+// check: mem_copy $(block_arg=$VAR), $VAR, 32
+// check: br $(ret_block=$LABEL)($block_arg)
+
+// check: $ret_block($(ret_val=$VAR): b256):
+// check: ret b256 $ret_val
+
 // check: $(si_md=$MD) = state_index 42
-
-// check: $(stk_md) = (
+// check: $stk_md = (
 // sameln: $si_md
-
-!0 = "proj/src/main.sw"
-!1 = span !0 381 425
-!2 = span !0 404 423
-!3 = state_index 42
-!4 = (!2 !3)
-!5 = (!1 !3)

--- a/sway-ir/tests/inline/int_to_ptr.ir
+++ b/sway-ir/tests/inline/int_to_ptr.ir
@@ -4,25 +4,33 @@
 // regex: LABEL=[[:alpha:]0-9_]+
 
 script {
-    fn a(b: u64) -> b256 {
-        entry(b: u64):
-        v1 = int_to_ptr b to b256
-        ret b256 v1
+    fn a(b: u64, __ret_value: mut ptr b256) -> b256 {
+        entry(b: u64, __ret_value: mut ptr b256):
+        v0 = int_to_ptr b to b256
+        mem_copy __ret_value, v0, 32
+        ret b256 __ret_value
     }
 
-// check: fn main
     fn main() -> b256 {
+// check: fn main
+        local mut ptr b256 __ret_val_a
+
         entry():
+        v0 = get_ptr mut ptr b256 __ret_val_a, ptr b256, 0
+        v1 = const u64 11
 
+// check: $(retv=$VAR) = get_ptr mut ptr b256 __ret_val_a, ptr b256, 0
 // check: $(arg0=$VAR) = const u64 11
-        v0 = const u64 11
-// check: $(arg1=$VAR) = int_to_ptr $arg0 to b256
-// not: call
-// check: br $(lbl0=$LABEL)($arg1)
-        v1 = call a(v0)
 
-// check: $(lbl0)($(arg2=$VAR): b256):
-// check: ret b256 $arg2
-        ret b256 v1
+        v2 = call a(v1, v0)
+// not: call
+
+// check: $(ret_ptr=$VAR) = int_to_ptr $arg0 to b256
+// check: mem_copy $retv, $ret_ptr, 32
+// check: br $(ret_block=$LABEL)($retv)
+
+        ret b256 v0
+// check: $ret_block($VAR: b256)
+// check: ret b256
     }
 }

--- a/sway-ir/tests/serialize/mem_copy.ir
+++ b/sway-ir/tests/serialize/mem_copy.ir
@@ -1,0 +1,14 @@
+script {
+// check: fn main
+    fn main() -> () {
+        local mut ptr b256 addr_a = const b256 0x1111111111111111111111111111111111111111111111111111111111111111
+        local mut ptr b256 addr_b
+
+        entry():
+        v0 = get_ptr ptr b256 addr_a, ptr b256, 0
+        v1 = get_ptr ptr b256 addr_b, ptr b256, 0
+        mem_copy v1, v0, 32
+        v0 = const unit ()
+        ret () v0
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -3,7 +3,7 @@ use basic_storage_abi::{StoreU64, Quad};
 use std::assert::assert;
 
 fn main() -> u64 {
-    let addr = abi(StoreU64, 0x06ee714ac67bc939377e34466b2461daaa0914eaf3f1390e54ede488a63114b8);
+    let addr = abi(StoreU64, 0x22abf712dc70ad97414a7147b3877a609f0f9715b3db54f1fc3261d6277ac68c);
     let key = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
@@ -5,9 +5,9 @@ use core::num::*;
 
 fn main() -> bool {
     let zero = ~b256::min();
-    let gas: u64 = 1000;
+    let gas: u64 = 1100;
     let amount: u64 = 11;
-    let other_contract_id = ~ContractId::from(0x84de7dc313a1f48a59148c8ff50c2ed59514d5ea21874ad0914c246420b5ecd9);
+    let other_contract_id = ~ContractId::from(0xdb6b5908388fd8e879fcb455050420cccbaeafda6c451009ea4dd1ca97b4640f);
     let base_asset_id = BASE_ASSET_ID;
 
     let test_contract = abi(ContextTesting, other_contract_id.into());

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/get_storage_key_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/get_storage_key_caller/src/main.sw
@@ -3,7 +3,7 @@ use get_storage_key_abi::TestContract;
 use std::assert::assert;
 
 fn main() -> u64 {
-    let caller = abi(TestContract, 0x18bd4f3ed949119c14c56a60367e1c06ee9afa88eb3a51f41a809b23b2dd8064);
+    let caller = abi(TestContract, 0xae09c61ade9ab646ca0a9762118b7a1498b4edecb52569bf4556e5abf084f9d3);
 
     // Get the storage keys directly by calling the contract methods from_f1,
     // from_f2, from_f3, from_f4. The keys correspond to different entries in

--- a/test/src/ir_generation/tests/fn_call_ret_by_ref_explicit.sw
+++ b/test/src/ir_generation/tests/fn_call_ret_by_ref_explicit.sw
@@ -1,0 +1,44 @@
+script;
+
+fn a(p: bool, x: u64, y: u64) -> (u64, u64, u64) {
+    if p {
+        return (x, x, x);
+    }
+
+    return (y, y, y);
+}
+
+fn main() -> u64 {
+    a(false, a(true, 11, 22).1, 33).2
+}
+
+// ::check-ir::
+
+// check: fn main() -> u64
+// check: local mut ptr { u64, u64, u64 } $(ret_for_call_0=$ID)
+// check: local mut ptr { u64, u64, u64 } $(ret_for_call_1=$ID)
+
+// check: $(ret_arg_0=$ID) = get_ptr mut ptr { u64, u64, u64 } $ret_for_call_0, ptr { u64, u64, u64 }, 0
+// check: $(ret_val_0=$ID) = call $(a_func=$ID)($ID, $ID, $ID, $ret_arg_0)
+// check: extract_value $ret_val_0, { u64, u64, u64 }, 1
+
+// check: $(ret_arg_1=$ID) = get_ptr mut ptr { u64, u64, u64 } $ret_for_call_1, ptr { u64, u64, u64 }, 0
+// check: $(ret_val_1=$ID) = call $a_func($ID, $ID, $ID, $ret_arg_1)
+// check extract_value $ret_val_1, { u64, u64, u64 }, 2
+
+// fn a()...
+//
+// check: fn $a_func($ID $MD: bool, $ID $MD: u64, $ID $MD: u64, __ret_value $MD: mut ptr { u64, u64, u64 }) -> { u64, u64, u64 }
+// check: cbr $ID, $(block_0=$ID)(), $(block_1=$ID)()
+
+// A single mem_copy for each explicit return:
+//
+// check: $block_0():
+// check: mem_copy __ret_value
+// not: mem_copy __ret_value
+// check: ret { u64, u64, u64 } $ID
+
+// check: $block_1():
+// check: mem_copy __ret_value
+// not: mem_copy __ret_value
+// check: ret { u64, u64, u64 } $ID

--- a/test/src/ir_generation/tests/fn_call_ret_by_ref_implicit.sw
+++ b/test/src/ir_generation/tests/fn_call_ret_by_ref_implicit.sw
@@ -1,0 +1,29 @@
+script;
+
+fn a(x: u64) -> (u64, u64, u64) {
+    (x, x, x)
+}
+
+fn main() -> u64 {
+    a(a(11).1).2
+}
+
+// ::check-ir::
+
+// check: fn main() -> u64
+// check: local mut ptr { u64, u64, u64 } $(ret_for_call_0=$ID)
+// check: local mut ptr { u64, u64, u64 } $(ret_for_call_1=$ID)
+
+// check: $(ret_arg_0=$ID) = get_ptr mut ptr { u64, u64, u64 } $ret_for_call_0, ptr { u64, u64, u64 }, 0
+// check: $(ret_val_0=$ID) = call $(a_func=$ID)($ID, $ret_arg_0)
+// check: extract_value $ret_val_0, { u64, u64, u64 }, 1
+
+// check: $(ret_arg_1=$ID) = get_ptr mut ptr { u64, u64, u64 } $ret_for_call_1, ptr { u64, u64, u64 }, 0
+// check: $(ret_val_1=$ID) = call $a_func($ID, $ret_arg_1)
+// check extract_value $ret_val_1, { u64, u64, u64 }, 2
+
+// check: fn $a_func($ID $MD: u64, __ret_value $MD: mut ptr { u64, u64, u64 }) -> { u64, u64, u64 }
+// check: mem_copy __ret_value
+// There should be only a single mem_copy
+// not: mem_copy __ret_value
+// check: ret { u64, u64, u64 }

--- a/test/src/ir_generation/tests/get_storage_key.sw
+++ b/test/src/ir_generation/tests/get_storage_key.sw
@@ -30,10 +30,11 @@ impl GetStorageKeyTest for Contract {
 // check: fn foo1<2994c98e>() -> b256
 // check: entry():
 // nextln: $(empty_struct_val=$VAL) = get_ptr ptr {  } $ID, ptr {  }, 0
-// nextln: $(res=$VAL) = call $(fn_name=$ID)($empty_struct_val)
-// nextln: ret b256 $res
+// nextln: $(retv=$VAL) = get_ptr mut ptr b256 $(local_ret_var=$ID), ptr b256, 0
+// nextln: call $(fn_name=$ID)($empty_struct_val, $retv)
 
-// check: fn $fn_name(self $MD: {  }) -> b256
-// nextln: entry(self: {  }):
+// check: fn $fn_name(self $MD: {  }, __ret_value $MD: mut ptr b256) -> b256
+// nextln: entry(self: {  }
 // nextln: $(key_val=$VAL) = get_storage_key
-// nextln: ret b256 $key_val
+// nextln: mem_copy __ret_value, $key_val, 32
+// nextln: ret b256 __ret_value

--- a/test/src/ir_generation/tests/return_stmt_structs.sw
+++ b/test/src/ir_generation/tests/return_stmt_structs.sw
@@ -23,8 +23,8 @@ fn main() {
     fn_explicit_ret_struct();
 }
 
-// check: fn fn_implicit_ret_struct_0() -> { u64 }
-// check: ret { u64 } $VAL
+// check: fn $ID(__ret_value $MD: mut ptr { u64 }) -> { u64 }
+// check:mem_copy __ret_value, $VAL, 8
 
-// check: fn fn_explicit_ret_struct_1() -> { u64 }
-// check: ret { u64 } $VAL
+// check: fn $ID(__ret_value $MD: mut ptr { u64 }) -> { u64 }
+// check:mem_copy __ret_value, $VAL, 8

--- a/test/src/ir_generation/tests/shadowed_struct_init.sw
+++ b/test/src/ir_generation/tests/shadowed_struct_init.sw
@@ -18,7 +18,7 @@ fn main() {
     new(true, false);
 }
 
-// check: fn $ID(a $MD: bool, b $MD: bool) -> { bool, bool }
+// check: fn $ID(a $MD: bool, b $MD: bool, __ret_value $MD: mut ptr { bool, bool }) -> { bool, bool }
 
 // check: local ptr bool a_
 // check: local ptr bool b_


### PR DESCRIPTION
Implement changes to call to allow returning reference-type values.

Uses an auxiliary 'out' parameter to receive the value, uses `mem_copy` to set it and then returns the pointer itself.
