### PR TITLE
Fix span calculations for errors at the end of a file with no final `\n`

### DIFF
--- a/sway-parse/src/parser.rs
+++ b/sway-parse/src/parser.rs
@@ -31,13 +31,19 @@ impl<'a, 'e> Parser<'a, 'e> {
         let span = match self.token_trees {
             [token_tree, ..] => token_tree.span(),
             _ => {
-                // Create a new span that points to _just_ after the last parsed item
+                // Create a new span that points to _just_ after the last parsed item or 1
+                // character before that if the last parsed item is the last item in the full span.
                 let num_trailing_spaces =
                     self.full_span.as_str().len() - self.full_span.as_str().trim_end().len();
+                let trim_offset = if num_trailing_spaces == 0 {
+                    1
+                } else {
+                    num_trailing_spaces
+                };
                 Span::new(
                     self.full_span.src().clone(),
-                    self.full_span.end() - num_trailing_spaces,
-                    self.full_span.end() - num_trailing_spaces + 1,
+                    self.full_span.end() - trim_offset,
+                    self.full_span.end() - trim_offset + 1,
                     self.full_span.path().cloned(),
                 )
             }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/no_newline/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/no_newline/Forc.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = 'no_newline'
+source = 'root'
+dependencies = []

--- a/test/src/e2e_vm_tests/test_programs/should_fail/no_newline/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/no_newline/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "no_newline"
+
+[dependencies]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/no_newline/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/no_newline/src/main.sw
@@ -1,0 +1,3 @@
+script;
+
+use std::

--- a/test/src/e2e_vm_tests/test_programs/should_fail/no_newline/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/no_newline/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: $()use std::
+# nextln: $()Expected an import name, group of imports, or `*`.


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway/issues/3052

Really the issue only shows up when the error is at the end of the file and the file has no `\n` at the end of it. Our current calculations don't take that into account. Just step back one more characters when creating the span.

This is somewhat of a follow up to https://github.com/FuelLabs/sway/pull/1973