### PR TITLE
LSP: code reorganize to support multiple projects simultaneously

### DIFF
--- a/sway-lsp/src/capabilities/highlight.rs
+++ b/sway-lsp/src/capabilities/highlight.rs
@@ -1,8 +1,9 @@
 use crate::core::session::Session;
+use std::sync::Arc;
 use tower_lsp::lsp_types::{DocumentHighlight, Position, Url};
 
 pub fn get_highlights(
-    session: &Session,
+    session: Arc<Session>,
     url: Url,
     position: Position,
 ) -> Option<Vec<DocumentHighlight>> {

--- a/sway-lsp/src/capabilities/hover.rs
+++ b/sway-lsp/src/capabilities/hover.rs
@@ -9,6 +9,7 @@ use crate::{
         token::to_ident_key,
     },
 };
+use std::sync::Arc;
 use sway_core::{
     declaration_engine,
     language::{parsed::Declaration, ty, Visibility},
@@ -16,7 +17,7 @@ use sway_core::{
 use sway_types::{Ident, Spanned};
 use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Position, Url};
 
-pub fn hover_data(session: &Session, url: Url, position: Position) -> Option<Hover> {
+pub fn hover_data(session: Arc<Session>, url: Url, position: Position) -> Option<Hover> {
     if let Some((_, token)) = session.token_at_position(&url, position) {
         if let Some(decl_ident) = session.declared_token_ident(&token) {
             if let Some(decl_token) = session

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{session::Session, token::TypedAstToken},
+    core::{config::InlayHintsConfig, session::Session, token::TypedAstToken},
     utils::common::get_range_from_span,
 };
 use sway_core::{language::ty::TyDeclaration, type_system::TypeInfo};
@@ -23,13 +23,13 @@ pub(crate) fn inlay_hints(
     session: &Session,
     uri: &Url,
     range: &Range,
+    config: &InlayHintsConfig,
 ) -> Option<Vec<lsp_types::InlayHint>> {
     // 1. Loop through all our tokens and filter out all tokens that aren't TypedVariableDeclaration tokens
     // 2. Also filter out all tokens that have a span that fall outside of the provided range
     // 3. Filter out all variable tokens that have a type_ascription
     // 4. Look up the type id for the remaining tokens
     // 5. Convert the type into a string
-    let config = &session.config.read().inlay_hints;
     if !config.type_hints {
         return None;
     }

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -2,6 +2,7 @@ use crate::{
     core::{config::InlayHintsConfig, session::Session, token::TypedAstToken},
     utils::common::get_range_from_span,
 };
+use std::sync::Arc;
 use sway_core::{language::ty::TyDeclaration, type_system::TypeInfo};
 use sway_types::Spanned;
 use tower_lsp::lsp_types::{self, Range, Url};
@@ -20,7 +21,7 @@ pub struct InlayHint {
 }
 
 pub(crate) fn inlay_hints(
-    session: &Session,
+    session: Arc<Session>,
     uri: &Url,
     range: &Range,
     config: &InlayHintsConfig,

--- a/sway-lsp/src/capabilities/rename.rs
+++ b/sway-lsp/src/capabilities/rename.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use sway_types::Spanned;
 use tower_lsp::lsp_types::{Position, PrepareRenameResponse, TextEdit, Url, WorkspaceEdit};
 
@@ -6,7 +7,7 @@ use crate::core::{session::Session, token::AstToken};
 use crate::utils::common::get_range_from_span;
 
 pub fn rename(
-    session: &Session,
+    session: Arc<Session>,
     new_name: String,
     url: Url,
     position: Position,
@@ -31,7 +32,7 @@ pub fn rename(
 }
 
 pub fn prepare_rename(
-    session: &Session,
+    session: Arc<Session>,
     url: Url,
     position: Position,
 ) -> Option<PrepareRenameResponse> {

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -3,7 +3,10 @@ use crate::core::{
     token::{SymbolKind, Token},
 };
 use crate::utils::common::get_range_from_span;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc,
+};
 use sway_types::Span;
 use tower_lsp::lsp_types::{
     Range, SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
@@ -11,7 +14,7 @@ use tower_lsp::lsp_types::{
 };
 
 // https://github.com/microsoft/vscode-extension-samples/blob/5ae1f7787122812dcc84e37427ca90af5ee09f14/semantic-tokens-sample/vscode.proposed.d.ts#L71
-pub fn semantic_tokens_full(session: &Session, url: &Url) -> Option<SemanticTokensResult> {
+pub fn semantic_tokens_full(session: Arc<Session>, url: &Url) -> Option<SemanticTokensResult> {
     let tokens = session.tokens_for_file(url);
 
     // The tokens need sorting by thier span so each token is sequential

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -76,6 +76,17 @@ impl Session {
         self.sync.manifest_dir()
     }
 
+    pub fn shutdown(&self) {
+        // shutdown the thread watching the manifest file
+        let handle = self.sync.notify_join_handle.read();
+        if let Some(join_handle) = &*handle {
+            join_handle.abort();
+        }
+        
+        // Delete the temporary directory.
+        self.sync.remove_temp_dir();
+    }
+
     /// Check if the code editor's cursor is currently over one of our collected tokens.
     pub fn token_at_position(&self, uri: &Url, position: Position) -> Option<(Ident, Token)> {
         let tokens = self.tokens_for_file(uri);

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -82,7 +82,7 @@ impl Session {
         if let Some(join_handle) = &*handle {
             join_handle.abort();
         }
-        
+
         // Delete the temporary directory.
         self.sync.remove_temp_dir();
     }

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -10,7 +10,10 @@ use crate::{
         {traverse_parse_tree, traverse_typed_tree},
     },
     error::{DocumentError, LanguageServerError},
-    utils::{self, sync::{SyncWorkspace, Directory}},
+    utils::{
+        self,
+        sync::{Directory, SyncWorkspace},
+    },
 };
 use dashmap::DashMap;
 use forc_pkg::{self as pkg};
@@ -61,8 +64,7 @@ impl Session {
         let manifest_dir = PathBuf::from(uri.path());
         // Create a new temp dir that clones the current workspace
         // and store manifest and temp paths
-        self.sync
-            .create_temp_dir_from_workspace(&manifest_dir)?;
+        self.sync.create_temp_dir_from_workspace(&manifest_dir)?;
 
         self.sync.clone_manifest_dir_to_temp()?;
 
@@ -71,7 +73,7 @@ impl Session {
 
         self.sync.watch_and_sync_manifest();
 
-        Ok(self.sync.manifest_dir()?)
+        self.sync.manifest_dir()
     }
 
     /// Check if the code editor's cursor is currently over one of our collected tokens.

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -5,13 +5,12 @@ use crate::{
         runnable::{Runnable, RunnableType},
     },
     core::{
-        config::Config,
         document::TextDocument,
         token::{Token, TokenMap, TypeDefinition},
         {traverse_parse_tree, traverse_typed_tree},
     },
     error::{DocumentError, LanguageServerError},
-    utils::{self, sync::SyncWorkspace},
+    utils::{self, sync::{SyncWorkspace, Directory}},
 };
 use dashmap::DashMap;
 use forc_pkg::{self as pkg};
@@ -22,6 +21,7 @@ use sway_core::{
     CompileResult,
 };
 use sway_types::{Ident, Spanned};
+use sway_utils::helpers::get_sway_files;
 use swayfmt::Formatter;
 use tower_lsp::lsp_types::{
     CompletionItem, Diagnostic, GotoDefinitionResponse, Location, Position, Range,
@@ -29,6 +29,7 @@ use tower_lsp::lsp_types::{
 };
 
 pub type Documents = DashMap<String, TextDocument>;
+pub type ProjectDirectory = PathBuf;
 
 #[derive(Default, Debug)]
 pub struct CompiledProgram {
@@ -41,7 +42,6 @@ pub struct Session {
     pub documents: Documents,
     pub token_map: TokenMap,
     pub runnables: DashMap<RunnableType, Runnable>,
-    pub config: RwLock<Config>,
     pub compiled_program: RwLock<CompiledProgram>,
     pub sync: SyncWorkspace,
 }
@@ -52,10 +52,26 @@ impl Session {
             documents: DashMap::new(),
             token_map: DashMap::new(),
             runnables: DashMap::new(),
-            config: RwLock::new(Default::default()),
             compiled_program: RwLock::new(Default::default()),
             sync: SyncWorkspace::new(),
         }
+    }
+
+    pub fn init(&self, uri: &Url) -> Result<ProjectDirectory, LanguageServerError> {
+        let manifest_dir = PathBuf::from(uri.path());
+        // Create a new temp dir that clones the current workspace
+        // and store manifest and temp paths
+        self.sync
+            .create_temp_dir_from_workspace(&manifest_dir)?;
+
+        self.sync.clone_manifest_dir_to_temp()?;
+
+        // iterate over the project dir, parse all sway files
+        let _ = self.parse_and_store_sway_files();
+
+        self.sync.watch_and_sync_manifest();
+
+        Ok(self.sync.manifest_dir()?)
     }
 
     /// Check if the code editor's cursor is currently over one of our collected tokens.
@@ -340,6 +356,22 @@ impl Session {
         } else {
             None
         }
+    }
+
+    pub fn parse_and_store_sway_files(&self) -> Result<(), DocumentError> {
+        if let Some(temp_dir) = self
+            .sync
+            .directories
+            .get(&Directory::Temp)
+            .map(|item| item.value().clone())
+        {
+            // Store the documents.
+            for path in get_sway_files(temp_dir).iter().filter_map(|fp| fp.to_str()) {
+                self.store_document(TextDocument::build_from_path(path)?)?;
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -5,29 +5,15 @@ use tower_lsp::lsp_types::Diagnostic;
 pub enum LanguageServerError {
     #[error(transparent)]
     DocumentError(#[from] DocumentError),
-    #[error(transparent)]
-    DirectoryError(#[from] DirectoryError),
-
+    // #[error(transparent)]
+    // DirectoryError(#[from] DirectoryError),
     #[error("Failed to create build plan. {0}")]
     BuildPlanFailed(anyhow::Error),
     #[error("Failed to compile. {0}")]
     FailedToCompile(anyhow::Error),
     #[error("Failed to parse document")]
     FailedToParse { diagnostics: Vec<Diagnostic> },
-}
 
-#[derive(Debug, Error, PartialEq, Eq)]
-pub enum DocumentError {
-    #[error("No document found at {:?}", path)]
-    DocumentNotFound { path: String },
-    #[error("Missing Forc.toml in {:?}", dir)]
-    ManifestFileNotFound { dir: String },
-    #[error("Document is already stored at {:?}", path)]
-    DocumentAlreadyStored { path: String },
-}
-
-#[derive(Debug, Error, PartialEq, Eq)]
-pub enum DirectoryError {
     #[error("Can't find temporary directory")]
     TempDirNotFound,
     #[error("Can't find manifest directory")]
@@ -45,3 +31,33 @@ pub enum DirectoryError {
     #[error("Unable to create Url from path {:?}", path)]
     UrlFromPathFailed { path: String },
 }
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DocumentError {
+    #[error("No document found at {:?}", path)]
+    DocumentNotFound { path: String },
+    #[error("Missing Forc.toml in {:?}", dir)]
+    ManifestFileNotFound { dir: String },
+    #[error("Document is already stored at {:?}", path)]
+    DocumentAlreadyStored { path: String },
+}
+
+// #[derive(Debug, Error, PartialEq, Eq)]
+// pub enum DirectoryError {
+//     #[error("Can't find temporary directory")]
+//     TempDirNotFound,
+//     #[error("Can't find manifest directory")]
+//     ManifestDirNotFound,
+//     #[error("Can't extract project name from {:?}", dir)]
+//     CantExtractProjectName { dir: String },
+//     #[error("Failed to create temp directory")]
+//     TempDirFailed,
+//     #[error("Failed to canonicalize path")]
+//     CanonicalizeFailed,
+//     #[error("Failed to copy workspace contents to temp directory")]
+//     CopyContentsFailed,
+//     #[error("Failed to create build plan. {0}")]
+//     StripPrefixError(std::path::StripPrefixError),
+//     #[error("Unable to create Url from path {:?}", path)]
+//     UrlFromPathFailed { path: String },
+// }

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -5,8 +5,6 @@ use tower_lsp::lsp_types::Diagnostic;
 pub enum LanguageServerError {
     #[error(transparent)]
     DocumentError(#[from] DocumentError),
-    // #[error(transparent)]
-    // DirectoryError(#[from] DirectoryError),
     #[error("Failed to create build plan. {0}")]
     BuildPlanFailed(anyhow::Error),
     #[error("Failed to compile. {0}")]
@@ -41,23 +39,3 @@ pub enum DocumentError {
     #[error("Document is already stored at {:?}", path)]
     DocumentAlreadyStored { path: String },
 }
-
-// #[derive(Debug, Error, PartialEq, Eq)]
-// pub enum DirectoryError {
-//     #[error("Can't find temporary directory")]
-//     TempDirNotFound,
-//     #[error("Can't find manifest directory")]
-//     ManifestDirNotFound,
-//     #[error("Can't extract project name from {:?}", dir)]
-//     CantExtractProjectName { dir: String },
-//     #[error("Failed to create temp directory")]
-//     TempDirFailed,
-//     #[error("Failed to canonicalize path")]
-//     CanonicalizeFailed,
-//     #[error("Failed to copy workspace contents to temp directory")]
-//     CopyContentsFailed,
-//     #[error("Failed to create build plan. {0}")]
-//     StripPrefixError(std::path::StripPrefixError),
-//     #[error("Unable to create Url from path {:?}", path)]
-//     UrlFromPathFailed { path: String },
-// }

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 use tower_lsp::{LspService, Server};
 
 mod capabilities;

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -129,7 +129,7 @@ impl Backend {
             .parent()
             .ok_or(LanguageServerError::ManifestDirNotFound)?
             .to_path_buf();
-        
+
         let session = match self.sessions.get(&manifest_dir) {
             Some(item) => item.value().clone(),
             None => {
@@ -150,7 +150,7 @@ impl Backend {
                     .expect("no session found even though it was just inserted into the map")
             }
         };
-        
+
         Ok(session)
     }
 

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -1,7 +1,10 @@
 pub use crate::error::DocumentError;
 use crate::{
     capabilities,
-    core::{config::{Config, Warnings}, document::TextDocument, session::Session},
+    core::{
+        config::{Config, Warnings},
+        session::Session,
+    },
     error::LanguageServerError,
     utils::{debug, sync},
 };
@@ -25,27 +28,38 @@ pub struct Backend {
     pub client: Client,
     pub config: RwLock<Config>,
 
-    session: Arc<Session>,
-
+    //session: Arc<Session>,
     sessions: DashMap<PathBuf, Arc<Session>>,
 }
 
 impl Backend {
     pub fn new(client: Client) -> Self {
-        let session = Arc::new(Session::new());
+        //let session = Arc::new(Session::new());
         let sessions = DashMap::new();
         let config = RwLock::new(Default::default());
 
-        Backend { client, config, session, sessions }
+        Backend {
+            client,
+            config,
+            //session,
+            sessions,
+        }
     }
 
     fn init(&self, uri: &Url) -> Result<(), LanguageServerError> {
-        let project_name = self.session.init(uri)?;
-
-        let mut session = Arc::new(Session::new());
+        let session = Arc::new(Session::new());
         let project_name = session.init(uri)?;
         self.sessions.insert(project_name, session);
         Ok(())
+    }
+
+    fn get_uri_and_session(
+        &self,
+        workspace_uri: &Url,
+    ) -> Result<(Url, Arc<Session>), LanguageServerError> {
+        let session = self.url_to_session(workspace_uri)?;
+        let uri = session.sync.workspace_to_temp_url(workspace_uri)?;
+        Ok((uri, session))
     }
 
     async fn log_info_message(&self, message: &str) {
@@ -56,9 +70,9 @@ impl Backend {
         self.client.log_message(MessageType::ERROR, message).await;
     }
 
-    async fn parse_project(&self, uri: Url, workspace_uri: Url) {
+    async fn parse_project(&self, uri: Url, workspace_uri: Url, session: Arc<Session>) {
         // pass in the temp Url into parse_project, we can now get the updated AST's back.
-        let diagnostics = match self.session.parse_project(&uri) {
+        let diagnostics = match session.parse_project(&uri) {
             Ok(diagnostics) => diagnostics,
             Err(err) => {
                 self.log_error_message(err.to_string().as_str()).await;
@@ -69,7 +83,7 @@ impl Backend {
                 }
             }
         };
-        self.publish_diagnostics(&uri, &workspace_uri, diagnostics)
+        self.publish_diagnostics(&uri, &workspace_uri, session, diagnostics)
             .await;
     }
 }
@@ -105,15 +119,45 @@ fn capabilities() -> ServerCapabilities {
 }
 
 impl Backend {
+    fn url_to_session(&self, uri: &Url) -> Result<Arc<Session>, LanguageServerError> {
+        let path = PathBuf::from(uri.path());
+        let manifest = PackageManifestFile::from_dir(&path).map_err(|_| {
+            DocumentError::ManifestFileNotFound {
+                dir: path.to_string_lossy().to_string(),
+            }
+        })?;
+
+        // strip Forc.toml from the path to get the manifest directory
+        let manifest_dir = manifest
+            .path()
+            .parent()
+            .ok_or(LanguageServerError::ManifestDirNotFound)?
+            .to_path_buf();
+
+        let session = match self.sessions.get(&manifest_dir) {
+            Some(item) => item.value().clone(),
+            None => {
+                // If no session can be found, then we need to call init and inserst a new session into the map
+                self.init(uri)?;
+                self.sessions
+                    .get(&manifest_dir) //
+                    .map(|item| item.value().clone())
+                    .expect("no session found even though it was just inserted into the map")
+            }
+        };
+        Ok(session)
+    }
+
     async fn publish_diagnostics(
         &self,
         uri: &Url,
         workspace_uri: &Url,
+        session: Arc<Session>,
         diagnostics: Vec<Diagnostic>,
     ) {
         let diagnostics_res = {
             let debug = &self.config.read().debug;
-            let token_map = self.session.tokens_for_file(uri);
+            let token_map = session.tokens_for_file(uri);
             match debug.show_collected_tokens_as_warnings {
                 Warnings::Default => diagnostics,
                 // If collected_tokens_as_warnings is Parsed or Typed,
@@ -165,226 +209,234 @@ impl LanguageServer for Backend {
         self.log_info_message("Shutting Down the Sway Language Server")
             .await;
 
-        // shutdown the thread watching the manifest file
-        if let std::sync::LockResult::Ok(handle) = self.session.sync.notify_join_handle.read() {
-            if let Some(join_handle) = &*handle {
-                join_handle.abort();
+        let _ = self.sessions.iter().map(|item| {
+            let session = item.value();
+            // shutdown the thread watching the manifest file
+            {
+                let handle = session.sync.notify_join_handle.read();
+                if let Some(join_handle) = &*handle {
+                    join_handle.abort();
+                }
             }
-        }
 
-        // Delete the temporary directory.
-        self.session.sync.remove_temp_dir();
+            // Delete the temporary directory.
+            session.sync.remove_temp_dir();
+        });
 
         Ok(())
     }
 
     // Document Handlers
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
-        eprintln!("params.text_document.uri = {:#?}", params.text_document.uri);
-        // The first time did_open gets called, we call init which sets up the temp directories
-        // to allow for synchronization between the users workspace and the temp workspacace.
-        // We then set InitializedState to Initialized so the function is never called again.
-        // Ideally we would call this in the `initialize` LSP function but we don't have access
-        // to the correct path of the project until this function.
-        if let std::sync::LockResult::Ok(mut init_state) = self.session.sync.init_state.write() {
-            if let sync::InitializedState::Uninitialized = *init_state {
-                match self.init(&params.text_document.uri) {
-                    Ok(()) => {
-                        *init_state = sync::InitializedState::Initialized;
-                    }
-                    Err(err) => {
-                        tracing::error!("{}", err.to_string().as_str());
-                    }
-                }
+        match self.get_uri_and_session(&params.text_document.uri) {
+            Ok((uri, session)) => {
+                session.handle_open_file(&uri);
+                self.parse_project(uri, params.text_document.uri, session.clone())
+                    .await;
             }
-        }
-
-        eprintln!("self.session.sync.manifest_dir() = {:#?}", self.session.sync.manifest_dir());
-
-        // convert the client Url to the temp uri
-        if let Ok(uri) = self
-            .session
-            .sync
-            .workspace_to_temp_url(&params.text_document.uri)
-        {
-            self.session.handle_open_file(&uri);
-            self.parse_project(uri, params.text_document.uri).await;
+            Err(err) => tracing::error!("{}", err.to_string()),
         }
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
-        if let Ok(uri) = self
-            .session
-            .sync
-            .workspace_to_temp_url(&params.text_document.uri)
-        {
-            // update this file with the new changes and write to disk
-            if let Some(src) = self
-                .session
-                .update_text_document(&uri, params.content_changes)
-            {
-                if let Ok(mut file) = File::create(uri.path()) {
-                    let _ = writeln!(&mut file, "{}", src);
+        match self.get_uri_and_session(&params.text_document.uri) {
+            Ok((uri, session)) => {
+                // update this file with the new changes and write to disk
+                if let Some(src) = session.update_text_document(&uri, params.content_changes) {
+                    if let Ok(mut file) = File::create(uri.path()) {
+                        let _ = writeln!(&mut file, "{}", src);
+                    }
                 }
+                self.parse_project(uri, params.text_document.uri, session.clone())
+                    .await;
             }
-            self.parse_project(uri, params.text_document.uri).await;
+            Err(err) => tracing::error!("{}", err.to_string()),
         }
     }
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
-        // overwrite the contents of the tmp/folder with everything in
-        // the current workspace. (resync)
-        if let Err(err) = self.session.sync.clone_manifest_dir_to_temp() {
-            tracing::error!("{}", err.to_string().as_str());
-        }
-
-        let _ = self
-            .session
-            .sync
-            .manifest_path()
-            .and_then(|manifest_path| PackageManifestFile::from_dir(&manifest_path).ok())
-            .map(|manifest| {
-                if let Some(temp_manifest_path) = &self.session.sync.temp_manifest_path() {
-                    sync::edit_manifest_dependency_paths(&manifest, temp_manifest_path)
+        match self.get_uri_and_session(&params.text_document.uri) {
+            Ok((uri, session)) => {
+                // overwrite the contents of the tmp/folder with everything in
+                // the current workspace. (resync)
+                if let Err(err) = session.sync.clone_manifest_dir_to_temp() {
+                    tracing::error!("{}", err.to_string().as_str());
                 }
-            });
 
-        if let Ok(uri) = self
-            .session
-            .sync
-            .workspace_to_temp_url(&params.text_document.uri)
-        {
-            self.parse_project(uri, params.text_document.uri).await;
+                let _ = session
+                    .sync
+                    .manifest_path()
+                    .and_then(|manifest_path| PackageManifestFile::from_dir(&manifest_path).ok())
+                    .map(|manifest| {
+                        if let Some(temp_manifest_path) = &session.sync.temp_manifest_path() {
+                            sync::edit_manifest_dependency_paths(&manifest, temp_manifest_path)
+                        }
+                    });
+                self.parse_project(uri, params.text_document.uri, session.clone())
+                    .await;
+            }
+            Err(err) => tracing::error!("{}", err.to_string()),
         }
     }
 
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
         for event in params.changes {
             if event.typ == FileChangeType::DELETED {
-                if let Ok(uri) = self.session.sync.workspace_to_temp_url(&event.uri) {
-                    let _ = self.session.remove_document(&uri);
+                match self.get_uri_and_session(&event.uri) {
+                    Ok((uri, session)) => {
+                        let _ = session.remove_document(&uri);
+                    }
+                    Err(err) => tracing::error!("{}", err.to_string()),
                 }
             }
         }
     }
 
     async fn hover(&self, params: HoverParams) -> jsonrpc::Result<Option<Hover>> {
-        self.session
-            .sync
-            .workspace_to_temp_url(&params.text_document_position_params.text_document.uri)
-            .map(|uri| {
+        match self.get_uri_and_session(&params.text_document_position_params.text_document.uri) {
+            Ok((uri, session)) => {
                 let position = params.text_document_position_params.position;
-                capabilities::hover::hover_data(&self.session, uri, position)
-            })
-            .map_err(|_| jsonrpc::Error::invalid_params("invalid path"))
+                Ok(capabilities::hover::hover_data(session, uri, position))
+            }
+            Err(err) => {
+                tracing::error!("{}", err.to_string());
+                Ok(None)
+            }
+        }
     }
 
     async fn completion(
         &self,
-        _params: CompletionParams,
+        params: CompletionParams,
     ) -> jsonrpc::Result<Option<CompletionResponse>> {
-        // TODO
-        // here we would also need to provide a list of builtin methods not just the ones from the document
-        Ok(self
-            .session
-            .completion_items()
-            .map(CompletionResponse::Array))
+        match self.get_uri_and_session(&params.text_document_position.text_document.uri) {
+            Ok((_, session)) => {
+                // TODO
+                // here we would also need to provide a list of builtin methods not just the ones from the document
+                Ok(session.completion_items().map(CompletionResponse::Array))
+            }
+            Err(err) => {
+                tracing::error!("{}", err.to_string());
+                Ok(None)
+            }
+        }
     }
 
     async fn document_symbol(
         &self,
         params: DocumentSymbolParams,
     ) -> jsonrpc::Result<Option<DocumentSymbolResponse>> {
-        self.session
-            .sync
-            .workspace_to_temp_url(&params.text_document.uri)
-            .map(|uri| {
-                self.session
-                    .symbol_information(&uri)
-                    .map(DocumentSymbolResponse::Flat)
-            })
-            .map_err(|_| jsonrpc::Error::invalid_params("invalid path"))
+        match self.get_uri_and_session(&params.text_document.uri) {
+            Ok((uri, session)) => Ok(session
+                .symbol_information(&uri)
+                .map(DocumentSymbolResponse::Flat)),
+            Err(err) => {
+                tracing::error!("{}", err.to_string());
+                Ok(None)
+            }
+        }
     }
 
     async fn semantic_tokens_full(
         &self,
         params: SemanticTokensParams,
     ) -> jsonrpc::Result<Option<SemanticTokensResult>> {
-        self.session
-            .sync
-            .workspace_to_temp_url(&params.text_document.uri)
-            .map(|uri| capabilities::semantic_tokens::semantic_tokens_full(&self.session, &uri))
-            .map_err(|_| jsonrpc::Error::invalid_params("invalid path"))
+        match self.get_uri_and_session(&params.text_document.uri) {
+            Ok((uri, session)) => Ok(capabilities::semantic_tokens::semantic_tokens_full(
+                session, &uri,
+            )),
+            Err(err) => {
+                tracing::error!("{}", err.to_string());
+                Ok(None)
+            }
+        }
     }
 
     async fn document_highlight(
         &self,
         params: DocumentHighlightParams,
     ) -> jsonrpc::Result<Option<Vec<DocumentHighlight>>> {
-        self.session
-            .sync
-            .workspace_to_temp_url(&params.text_document_position_params.text_document.uri)
-            .map(|uri| {
+        match self.get_uri_and_session(&params.text_document_position_params.text_document.uri) {
+            Ok((uri, session)) => {
                 let position = params.text_document_position_params.position;
-                capabilities::highlight::get_highlights(&self.session, uri, position)
-            })
-            .map_err(|_| jsonrpc::Error::invalid_params("invalid path"))
+                Ok(capabilities::highlight::get_highlights(
+                    session, uri, position,
+                ))
+            }
+            Err(err) => {
+                tracing::error!("{}", err.to_string());
+                Ok(None)
+            }
+        }
     }
 
     async fn goto_definition(
         &self,
         params: GotoDefinitionParams,
     ) -> jsonrpc::Result<Option<GotoDefinitionResponse>> {
-        self.session
-            .sync
-            .workspace_to_temp_url(&params.text_document_position_params.text_document.uri)
-            .map(|uri| {
+        match self.get_uri_and_session(&params.text_document_position_params.text_document.uri) {
+            Ok((uri, session)) => {
                 let position = params.text_document_position_params.position;
-                self.session.token_definition_response(uri, position)
-            })
-            .map_err(|_| jsonrpc::Error::invalid_params("invalid path"))
+                Ok(session.token_definition_response(uri, position))
+            }
+            Err(err) => {
+                tracing::error!("{}", err.to_string());
+                Ok(None)
+            }
+        }
     }
 
     async fn formatting(
         &self,
         params: DocumentFormattingParams,
     ) -> jsonrpc::Result<Option<Vec<TextEdit>>> {
-        self.session
-            .sync
-            .workspace_to_temp_url(&params.text_document.uri)
-            .map(|uri| self.session.format_text(&uri))
-            .map_err(|_| jsonrpc::Error::invalid_params("invalid path"))
+        match self.get_uri_and_session(&params.text_document.uri) {
+            Ok((uri, session)) => Ok(session.format_text(&uri)),
+            Err(err) => {
+                tracing::error!("{}", err.to_string());
+                Ok(None)
+            }
+        }
     }
 
     async fn rename(&self, params: RenameParams) -> jsonrpc::Result<Option<WorkspaceEdit>> {
-        self.session
-            .sync
-            .workspace_to_temp_url(&params.text_document_position.text_document.uri)
-            .map(|uri| {
+        match self.get_uri_and_session(&params.text_document_position.text_document.uri) {
+            Ok((uri, session)) => {
                 let new_name = params.new_name;
                 let position = params.text_document_position.position;
-                capabilities::rename::rename(&self.session, new_name, uri, position)
-            })
-            .map_err(|_| jsonrpc::Error::invalid_params("invalid path"))
+                Ok(capabilities::rename::rename(
+                    session, new_name, uri, position,
+                ))
+            }
+            Err(err) => {
+                tracing::error!("{}", err.to_string());
+                Ok(None)
+            }
+        }
     }
 
     async fn prepare_rename(
         &self,
         params: TextDocumentPositionParams,
     ) -> jsonrpc::Result<Option<PrepareRenameResponse>> {
-        self.session
-            .sync
-            .workspace_to_temp_url(&params.text_document.uri)
-            .map(|uri| {
+        match self.get_uri_and_session(&params.text_document.uri) {
+            Ok((uri, session)) => {
                 let position = params.position;
-                capabilities::rename::prepare_rename(&self.session, uri, position)
-            })
-            .map_err(|_| jsonrpc::Error::invalid_params("invalid path"))
+                Ok(capabilities::rename::prepare_rename(session, uri, position))
+            }
+            Err(err) => {
+                tracing::error!("{}", err.to_string());
+                Ok(None)
+            }
+        }
     }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct RunnableParams {}
+#[serde(rename_all = "camelCase")]
+pub struct RunnableParams {
+    pub text_document: TextDocumentIdentifier,
+}
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -399,30 +451,44 @@ impl Backend {
         &self,
         params: InlayHintParams,
     ) -> jsonrpc::Result<Option<Vec<InlayHint>>> {
-        self.session
-            .sync
-            .workspace_to_temp_url(&params.text_document.uri)
-            .map(|uri| {
+        match self.get_uri_and_session(&params.text_document.uri) {
+            Ok((uri, session)) => {
                 let config = &self.config.read().inlay_hints;
-                capabilities::inlay_hints::inlay_hints(&self.session, &uri, &params.range, config)
-            })
-            .map_err(|_| jsonrpc::Error::invalid_params("invalid path"))
+                Ok(capabilities::inlay_hints::inlay_hints(
+                    session,
+                    &uri,
+                    &params.range,
+                    config,
+                ))
+            }
+            Err(err) => {
+                tracing::error!("{}", err.to_string());
+                Ok(None)
+            }
+        }
     }
 
     pub async fn runnables(
         &self,
-        _params: RunnableParams,
+        params: RunnableParams,
     ) -> jsonrpc::Result<Option<Vec<(Range, String)>>> {
-        let ranges = self
-            .session
-            .runnables
-            .get(&capabilities::runnable::RunnableType::MainFn)
-            .map(|item| {
-                let runnable = item.value();
-                vec![(runnable.range, format!("{}", runnable.tree_type))]
-            });
+        match self.get_uri_and_session(&params.text_document.uri) {
+            Ok((_, session)) => {
+                let ranges = session
+                    .runnables
+                    .get(&capabilities::runnable::RunnableType::MainFn)
+                    .map(|item| {
+                        let runnable = item.value();
+                        vec![(runnable.range, format!("{}", runnable.tree_type))]
+                    });
 
-        Ok(ranges)
+                Ok(ranges)
+            }
+            Err(err) => {
+                tracing::error!("{}", err.to_string());
+                Ok(None)
+            }
+        }
     }
 
     /// This method is triggered by a command palette request in VScode
@@ -441,69 +507,78 @@ impl Backend {
         &self,
         params: ShowAstParams,
     ) -> jsonrpc::Result<Option<TextDocumentIdentifier>> {
-        let current_open_file = params.text_document.uri;
-        // Convert the Uri to a PathBuf
-        let path = current_open_file.to_file_path().ok();
+        match self.get_uri_and_session(&params.text_document.uri) {
+            Ok((_, session)) => {
+                let current_open_file = params.text_document.uri;
+                // Convert the Uri to a PathBuf
+                let path = current_open_file.to_file_path().ok();
 
-        let write_ast_to_file =
-            |path: &Path, ast_string: &String| -> Option<TextDocumentIdentifier> {
-                if let Ok(mut file) = File::create(path) {
-                    let _ = writeln!(&mut file, "{}", ast_string);
-                    if let Ok(uri) = Url::from_file_path(path) {
-                        // Return the tmp file path where the AST has been written to.
-                        return Some(TextDocumentIdentifier::new(uri));
-                    }
-                }
-                None
-            };
-
-        {
-            let program = self.session.compiled_program.read();
-            match params.ast_kind.as_str() {
-                "parsed" => {
-                    match program.parsed {
-                        Some(ref parsed_program) => {
-                            // Initialize the string with the AST from the root
-                            let mut formatted_ast: String =
-                                format!("{:#?}", parsed_program.root.tree.root_nodes);
-
-                            for (ident, submodule) in &parsed_program.root.submodules {
-                                // if the current path matches the path of a submodule
-                                // overwrite the root AST with the submodule AST
-                                if ident.span().path().map(|a| a.deref()) == path.as_ref() {
-                                    formatted_ast =
-                                        format!("{:#?}", submodule.module.tree.root_nodes);
-                                }
+                let write_ast_to_file =
+                    |path: &Path, ast_string: &String| -> Option<TextDocumentIdentifier> {
+                        if let Ok(mut file) = File::create(path) {
+                            let _ = writeln!(&mut file, "{}", ast_string);
+                            if let Ok(uri) = Url::from_file_path(path) {
+                                // Return the tmp file path where the AST has been written to.
+                                return Some(TextDocumentIdentifier::new(uri));
                             }
+                        }
+                        None
+                    };
 
-                            let tmp_ast_path = Path::new("/tmp/parsed_ast.rs");
-                            Ok(write_ast_to_file(tmp_ast_path, &formatted_ast))
+                {
+                    let program = session.compiled_program.read();
+                    match params.ast_kind.as_str() {
+                        "parsed" => {
+                            match program.parsed {
+                                Some(ref parsed_program) => {
+                                    // Initialize the string with the AST from the root
+                                    let mut formatted_ast: String =
+                                        format!("{:#?}", parsed_program.root.tree.root_nodes);
+
+                                    for (ident, submodule) in &parsed_program.root.submodules {
+                                        // if the current path matches the path of a submodule
+                                        // overwrite the root AST with the submodule AST
+                                        if ident.span().path().map(|a| a.deref()) == path.as_ref() {
+                                            formatted_ast =
+                                                format!("{:#?}", submodule.module.tree.root_nodes);
+                                        }
+                                    }
+
+                                    let tmp_ast_path = Path::new("/tmp/parsed_ast.rs");
+                                    Ok(write_ast_to_file(tmp_ast_path, &formatted_ast))
+                                }
+                                _ => Ok(None),
+                            }
+                        }
+                        "typed" => {
+                            match program.typed {
+                                Some(ref typed_program) => {
+                                    // Initialize the string with the AST from the root
+                                    let mut formatted_ast: String =
+                                        format!("{:#?}", typed_program.root.all_nodes);
+
+                                    for (ident, submodule) in &typed_program.root.submodules {
+                                        // if the current path matches the path of a submodule
+                                        // overwrite the root AST with the submodule AST
+                                        if ident.span().path().map(|a| a.deref()) == path.as_ref() {
+                                            formatted_ast =
+                                                format!("{:#?}", submodule.module.all_nodes);
+                                        }
+                                    }
+
+                                    let tmp_ast_path = Path::new("/tmp/typed_ast.rs");
+                                    Ok(write_ast_to_file(tmp_ast_path, &formatted_ast))
+                                }
+                                _ => Ok(None),
+                            }
                         }
                         _ => Ok(None),
                     }
                 }
-                "typed" => {
-                    match program.typed {
-                        Some(ref typed_program) => {
-                            // Initialize the string with the AST from the root
-                            let mut formatted_ast: String =
-                                format!("{:#?}", typed_program.root.all_nodes);
-
-                            for (ident, submodule) in &typed_program.root.submodules {
-                                // if the current path matches the path of a submodule
-                                // overwrite the root AST with the submodule AST
-                                if ident.span().path().map(|a| a.deref()) == path.as_ref() {
-                                    formatted_ast = format!("{:#?}", submodule.module.all_nodes);
-                                }
-                            }
-
-                            let tmp_ast_path = Path::new("/tmp/typed_ast.rs");
-                            Ok(write_ast_to_file(tmp_ast_path, &formatted_ast))
-                        }
-                        _ => Ok(None),
-                    }
-                }
-                _ => Ok(None),
+            }
+            Err(err) => {
+                tracing::error!("{}", err.to_string());
+                Ok(None)
             }
         }
     }
@@ -900,7 +975,7 @@ mod tests {
         let uri = init_and_open(&mut service, doc_comments_dir()).await;
         dbg!();
         let _ = go_to_definition_request(&mut service, &uri, 44, 19, 1).await;
-        
+
         let (uri, sway_program) = load_sway_example(sway_example_structs());
         did_open_notification(&mut service, &uri, &sway_program).await;
 

--- a/sway-lsp/src/test_utils.rs
+++ b/sway-lsp/src/test_utils.rs
@@ -20,10 +20,6 @@ pub(crate) fn sway_example_dir() -> PathBuf {
     sway_workspace_dir().join("examples/storage_variables")
 }
 
-pub(crate) fn sway_example_structs() -> PathBuf {
-    sway_workspace_dir().join("examples/structs")
-}
-
 pub(crate) fn doc_comments_dir() -> PathBuf {
     sway_workspace_dir()
         .join(e2e_language_dir())

--- a/sway-lsp/src/test_utils.rs
+++ b/sway-lsp/src/test_utils.rs
@@ -20,6 +20,10 @@ pub(crate) fn sway_example_dir() -> PathBuf {
     sway_workspace_dir().join("examples/storage_variables")
 }
 
+pub(crate) fn sway_example_structs() -> PathBuf {
+    sway_workspace_dir().join("examples/structs")
+}
+
 pub(crate) fn doc_comments_dir() -> PathBuf {
     sway_workspace_dir()
         .join(e2e_language_dir())

--- a/sway-lsp/src/utils/sync.rs
+++ b/sway-lsp/src/utils/sync.rs
@@ -183,7 +183,7 @@ impl SyncWorkspace {
             });
     }
 
-    fn manifest_dir(&self) -> Result<PathBuf, DirectoryError> {
+    pub(crate) fn manifest_dir(&self) -> Result<PathBuf, DirectoryError> {
         self.directories
             .get(&Directory::Manifest)
             .map(|item| item.value().clone())


### PR DESCRIPTION
The main change is instead of having a single `session: Arc<Session>`, we now have a `sessions: DashMap<PathBuf, Arc<Session>>,`. The `PathBuf` is the manifest directory of the sway project and the `Session` contains all the tokens, runnables etc.. for that project.

Although we are blocked currently to support multiple simultaneous projects, this PR fixes a current bug that now allows the users to jump between different projects in a workspace so long as they only have one window pane open. 

related: #3069 and #2063