### PR TITLE
Fixed testing-with-rust docs

### DIFF
--- a/docs/src/testing/testing-with-rust.md
+++ b/docs/src/testing/testing-with-rust.md
@@ -208,6 +208,7 @@ async fn initialize_and_increment() {
     // Now you have an instance of your contract you can use to test each function
 
     let result = contract_instance
+        .methods()
         .initialize_counter(42)
         .call()
         .await
@@ -217,6 +218,7 @@ async fn initialize_and_increment() {
 
     // Call `increment_counter()` method in our deployed contract.
     let result = contract_instance
+        .methods()
         .increment_counter(10)
         .call()
         .await


### PR DESCRIPTION
Docs outdated, added `.methods()` to contract calling

Before
```rust
contract
    .method_name()
    .call()
    .await
    .unwrap()
```

After
```rust
contract
    .methods()
    .method_name()
    .call()
    .await
    .unwrap()
```