### PR TITLE
Don't clone the whole graph on each trait impl connection during DCA

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -421,8 +421,7 @@ fn connect_impl_trait(
     entry_node: NodeIndex,
     tree_type: &TreeType,
 ) -> Result<(), CompileError> {
-    let graph_c = graph.clone();
-    let trait_decl_node = graph_c.namespace.find_trait(trait_name);
+    let trait_decl_node = graph.namespace.find_trait(trait_name).cloned();
     match trait_decl_node {
         None => {
             let node_ix = graph.add_node("External trait".into());
@@ -430,7 +429,7 @@ fn connect_impl_trait(
         }
         Some(trait_decl_node) => {
             graph.add_edge_from_entry(entry_node, "".into());
-            graph.add_edge(entry_node, *trait_decl_node, "".into());
+            graph.add_edge(entry_node, trait_decl_node, "".into());
         }
     };
     let mut methods_and_indexes = vec![];


### PR DESCRIPTION
Just spotted a quick performance win in kcachegrind, nothing major but makes quite a difference for a couple lines:

Before:

```console
     Running `target/release/forc build --time-phases --path ./examples/counter`
  Time elapsed to produce `sway_core::BuildConfig`: 3.21µs
  Time elapsed to compile to ast: 12.570709ms
  Time elapsed to generate JSON ABI program: 290ns
  Time elapsed to compile ast to asm: 37.54µs
  Time elapsed to compile asm to bytecode: 2.08µs
  Compiled library "core".
  Time elapsed to produce `sway_core::BuildConfig`: 1.32µs
  Time elapsed to compile to ast: 171.563552ms
  Time elapsed to generate JSON ABI program: 190ns
  Time elapsed to compile ast to asm: 385.504µs
  Time elapsed to compile asm to bytecode: 2.5µs
  Compiled library "std".
  Time elapsed to produce `sway_core::BuildConfig`: 1.84µs
  Time elapsed to compile to ast: 554.196µs
  Time elapsed to generate JSON ABI program: 4.21µs
  Time elapsed to compile ast to asm: 555.095µs
  Time elapsed to compile asm to bytecode: 17.061µs
  Compiled contract "counter".
```

After:

```console
     Running `target/release/forc build --time-phases --path ./examples/counter`
  Time elapsed to produce `sway_core::BuildConfig`: 3.08µs
  Time elapsed to compile to ast: 10.732561ms
  Time elapsed to generate JSON ABI program: 260ns
  Time elapsed to compile ast to asm: 46.27µs
  Time elapsed to compile asm to bytecode: 3.56µs
  Compiled library "core".
  Time elapsed to produce `sway_core::BuildConfig`: 1.39µs
  Time elapsed to compile to ast: 147.781186ms
  Time elapsed to generate JSON ABI program: 230ns
  Time elapsed to compile ast to asm: 429.884µs
  Time elapsed to compile asm to bytecode: 2.67µs
  Compiled library "std".
  Time elapsed to produce `sway_core::BuildConfig`: 2.06µs
  Time elapsed to compile to ast: 600.816µs
  Time elapsed to generate JSON ABI program: 3.97µs
  Time elapsed to compile ast to asm: 587.306µs
  Time elapsed to compile asm to bytecode: 17.93µs
  Compiled contract "counter".
  Bytecode size is 264 bytes.
```

The main difference is the 171ms -> 147ms in the std typecheck+cfa step. Still lots to be done!