### PR TITLE
Speedup bytecode-gen by applying an upper bound on `read_exact`

### DIFF
--- a/sway-core/src/asm_generation/finalized_asm.rs
+++ b/sway-core/src/asm_generation/finalized_asm.rs
@@ -131,7 +131,9 @@ fn to_bytecode_mut(
                     if let Some(span) = &span {
                         source_map.insert(half_word_ix, span);
                     }
-                    op.read_exact(&mut buf[half_word_ix * 4..])
+                    let read_range_upper_bound =
+                        core::cmp::min(half_word_ix * 4 + std::mem::size_of_val(&op), buf.len());
+                    op.read_exact(&mut buf[half_word_ix * 4..read_range_upper_bound])
                         .expect("Failed to write to in-memory buffer.");
                     half_word_ix += 1;
                 }


### PR DESCRIPTION
Tested with [the `amm` repo](https://github.com/sway-libs/amm):
Previously:
```console
❯ forc b --time-phases --silent
...
  Time elapsed to compile to ast: 4.9242855s
  Time elapsed to generate JSON ABI program: 49.625µs
  Time elapsed to compile ast to asm: 51.795523958s
  Time elapsed to compile asm to bytecode: 27.532206458s
```
With this change:
```console
❯ forc b --time-phases --silent
...
  Time elapsed to compile to ast: 4.970219875s
  Time elapsed to generate JSON ABI program: 48.375µs
  Time elapsed to compile ast to asm: 52.703999375s
  Time elapsed to compile asm to bytecode: 76.786833ms
```
Specifically looking at the last step which is ~360X faster.