### PR TITLE
Speedup `remove_redudant_moves()` by using a `HashSet` instead of a `BTreeSet`

### DIFF
--- a/sway-core/src/asm_generation/abstract_instruction_set.rs
+++ b/sway-core/src/asm_generation/abstract_instruction_set.rs
@@ -6,7 +6,7 @@ use crate::{
     },
 };
 
-use std::{collections::BTreeSet, fmt};
+use std::{collections::HashSet, fmt};
 
 use either::Either;
 
@@ -64,12 +64,13 @@ impl AbstractInstructionSet {
         //     MOVE t, a        MOVE b, a
         //     MOVE b, t   =>   USE  b
         //     USE  b
-
         loop {
             // Gather all the uses for each register.
-            let uses: BTreeSet<&VirtualRegister> =
-                self.ops.iter().fold(BTreeSet::new(), |mut acc, op| {
-                    acc.append(&mut op.use_registers());
+            let uses: HashSet<&VirtualRegister> =
+                self.ops.iter().fold(HashSet::new(), |mut acc, op| {
+                    for u in &op.use_registers() {
+                        acc.insert(u);
+                    }
                     acc
                 });
 


### PR DESCRIPTION
As we're not actually looping over the set of used registers, it can just be a `HashSet`. I did not try to optimized this further. 

Tested with [the `amm` repo](https://github.com/sway-libs/amm) (without https://github.com/FuelLabs/sway/pull/3096):
Previously:
```console
❯ forc b --time-phases --silent
...
  Time elapsed to compile to ast: 4.8512885s
  Time elapsed to generate JSON ABI program: 50.875µs
  Time elapsed to compile ast to asm: 53.342876291s
  Time elapsed to compile asm to bytecode: 27.719744166s
```
With this change:
```console
❯ forc b --time-phases --silent
...
  Time elapsed to compile to ast: 4.629979583s
  Time elapsed to generate JSON ABI program: 53.5µs
  Time elapsed to compile ast to asm: 6.345263583s
  Time elapsed to compile asm to bytecode: 28.130886833s
```
Specifically looking at the second to last step which is ~8.4X faster.