### PR TITLE
Speedup `simplify_cfg` by avoiding Vec alloc in hot loop

### DIFF
--- a/sway-ir/src/block.rs
+++ b/sway-ir/src/block.rs
@@ -296,7 +296,8 @@ impl Block {
     /// For every instruction within the block, any reference to `old_val` is replaced with
     /// `new_val`.
     pub fn replace_value(&self, context: &mut Context, old_val: Value, new_val: Value) {
-        for ins in context.blocks[self.0].instructions.clone() {
+        for ins_idx in 0..context.blocks[self.0].instructions.len() {
+            let ins = context.blocks[self.0].instructions[ins_idx];
             ins.replace_instruction_value(context, old_val, new_val);
         }
     }


### PR DESCRIPTION
Doing a bit of profiling with kcachegrind and spotted `Block::replace_value` showing up. Normally `Vec` allocations are pretty cheap, but In the `stdlib/vec` test alone `merge_blocks` gets called around 15K times which means we hit this function many more times than that, so this makes a bit of a difference.

Before:

```console
     Running `target/profiling/forc build --time-phases --path test/src/e2e_vm_tests/test_programs/should_pass/stdlib/vec`
  Time elapsed to produce `sway_core::BuildConfig`: 2µs
  Time elapsed to compile to ast: 9.573259ms
  Time elapsed to generate JSON ABI program: 160ns
  Compiled library "core".
  Time elapsed to produce `sway_core::BuildConfig`: 1.36µs
  Time elapsed to compile to ast: 55.706103ms
  Time elapsed to generate JSON ABI program: 200ns
  Compiled library "std".
  Time elapsed to produce `sway_core::BuildConfig`: 1.99µs
  Time elapsed to compile to ast: 955.793391ms
  Time elapsed to generate JSON ABI program: 4.01µs
  Time elapsed to compile ast to asm: 9.504405706s
  Time elapsed to compile asm to bytecode: 17.600861ms
  Compiled script "vec".
  Bytecode size is 278480 bytes.
  Script bytecode hash: 0x688afa937c946ce9c882bb535bfdfaec82cf8cd9a81a815c83aced37ca19ee6a
```

After:

```console
     Running `target/profiling/forc build --time-phases --path test/src/e2e_vm_tests/test_programs/should_pass/stdlib/vec`
  Time elapsed to produce `sway_core::BuildConfig`: 1.91µs
  Time elapsed to compile to ast: 9.538978ms
  Time elapsed to generate JSON ABI program: 150ns
  Compiled library "core".
  Time elapsed to produce `sway_core::BuildConfig`: 1.33µs
  Time elapsed to compile to ast: 53.719224ms
  Time elapsed to generate JSON ABI program: 450ns
  Compiled library "std".
  Time elapsed to produce `sway_core::BuildConfig`: 2.01µs
  Time elapsed to compile to ast: 939.993222ms
  Time elapsed to generate JSON ABI program: 3.76µs
  Time elapsed to compile ast to asm: 8.320020537s
  Time elapsed to compile asm to bytecode: 18.069617ms
  Compiled script "vec".
  Bytecode size is 278480 bytes.
  Script bytecode hash: 0x688afa937c946ce9c882bb535bfdfaec82cf8cd9a81a815c83aced37ca19ee6a
```

Overall we get a ~10% improvement coming from `ast_to_asm`.