### PR TITLE
refactor(forc): extract tracing utils from `forc-util` into dedicated `forc-tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,6 +1490,7 @@ dependencies = [
  "clap 3.2.22",
  "clap_complete",
  "forc-pkg",
+ "forc-tracing",
  "forc-util",
  "fs_extra",
  "fuel-asm 0.8.0",
@@ -1559,6 +1560,7 @@ version = "0.26.0"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
+ "forc-tracing",
  "forc-util",
  "prettydiff 0.5.1",
  "sway-core",
@@ -1583,6 +1585,7 @@ name = "forc-pkg"
 version = "0.26.0"
 dependencies = [
  "anyhow",
+ "forc-tracing",
  "forc-util",
  "fuel-crypto",
  "fuel-tx 0.18.0",
@@ -1621,6 +1624,7 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "dirs 3.0.2",
+ "forc-tracing",
  "sway-core",
  "sway-error",
  "sway-types",
@@ -4533,6 +4537,7 @@ name = "swayfmt"
 version = "0.26.0"
 dependencies = [
  "anyhow",
+ "forc-tracing",
  "forc-util",
  "paste",
  "prettydiff 0.6.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4480,7 +4480,7 @@ dependencies = [
  "async-trait",
  "dashmap",
  "forc-pkg",
- "forc-util",
+ "forc-tracing",
  "futures",
  "notify",
  "notify-debouncer-mini",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,7 +1518,7 @@ dependencies = [
  "async-trait",
  "clap 3.2.22",
  "forc-pkg",
- "forc-util",
+ "forc-tracing",
  "fuel-crypto",
  "fuel-gql-client",
  "fuel-tx 0.18.0",
@@ -1543,7 +1543,8 @@ version = "0.26.0"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
- "forc-util",
+ "dirs 3.0.2",
+ "forc-tracing",
  "reqwest",
  "serde",
  "tar",
@@ -1601,6 +1602,15 @@ dependencies = [
  "url",
  "vec1",
  "walkdir",
+]
+
+[[package]]
+name = "forc-tracing"
+version = "0.26.0"
+dependencies = [
+ "ansi_term",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4638,7 +4648,7 @@ dependencies = [
  "forc",
  "forc-client",
  "forc-pkg",
- "forc-util",
+ "forc-tracing",
  "fuel-asm 0.8.0",
  "fuel-tx 0.18.0",
  "fuel-vm 0.15.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "forc-plugins/forc-explore",
     "forc-plugins/forc-fmt",
     "forc-plugins/forc-lsp",
+    "forc-tracing",
     "forc-util",
     "scripts/examples-checker",
     "scripts/mdbook-forc-documenter",

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -10,6 +10,7 @@ description = "Building, locking, fetching and updating Sway projects as Forc pa
 
 [dependencies]
 anyhow = "1"
+forc-tracing = { version = "0.26.0", path = "../forc-tracing" }
 forc-util = { version = "0.26.0", path = "../forc-util" }
 fuel-crypto = "0.6"
 fuel-tx = { version = "0.18", features = ["serde"] }

--- a/forc-pkg/src/lock.rs
+++ b/forc-pkg/src/lock.rs
@@ -1,6 +1,6 @@
 use crate::pkg;
 use anyhow::{anyhow, Result};
-use forc_util::{println_green, println_red};
+use forc_tracing::{println_green, println_red};
 use petgraph::{visit::EdgeRef, Direction};
 use serde::{Deserialize, Serialize};
 use std::{

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -1,6 +1,7 @@
 use crate::pkg::{manifest_file_missing, parsing_failed, wrong_program_type};
 use anyhow::{anyhow, bail, Result};
-use forc_util::{find_manifest_dir, println_yellow_err, validate_name};
+use forc_tracing::println_yellow_err;
+use forc_util::{find_manifest_dir, validate_name};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1"
 async-trait = "0.1.58"
 clap = { version = "3", features = ["derive", "env"] }
 forc-pkg = { version = "0.26.0", path = "../../forc-pkg" }
-forc-util = { version = "0.26.0", path = "../../forc-util" }
+forc-tracing = { version = "0.26.0", path = "../../forc-tracing" }
 fuel-crypto = "0.6"
 fuel-gql-client = { version = "0.10", default-features = false }
 fuel-tx = { version = "0.18", features = ["builder"] }

--- a/forc-plugins/forc-client/src/bin/deploy/main.rs
+++ b/forc-plugins/forc-client/src/bin/deploy/main.rs
@@ -1,5 +1,5 @@
 use forc_client::ops::deploy::{cmd::DeployCommand, op::deploy};
-use forc_util::init_tracing_subscriber;
+use forc_tracing::init_tracing_subscriber;
 use std::process;
 
 use clap::Parser;

--- a/forc-plugins/forc-client/src/bin/run/main.rs
+++ b/forc-plugins/forc-client/src/bin/run/main.rs
@@ -1,5 +1,5 @@
 use forc_client::ops::run::{cmd::RunCommand, op::run};
-use forc_util::init_tracing_subscriber;
+use forc_tracing::init_tracing_subscriber;
 use std::process;
 
 use clap::Parser;

--- a/forc-plugins/forc-explore/Cargo.toml
+++ b/forc-plugins/forc-explore/Cargo.toml
@@ -11,7 +11,8 @@ description = "A `forc` plugin for running the fuel block explorer."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-forc-util = { version = "0.26.0", path = "../../forc-util" }
+dirs = "3.0.2"
+forc-tracing = { version = "0.26.0", path = "../../forc-tracing" }
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 tar = "0.4"

--- a/forc-plugins/forc-explore/src/main.rs
+++ b/forc-plugins/forc-explore/src/main.rs
@@ -4,8 +4,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
-use forc_util::init_tracing_subscriber;
-use forc_util::println_green;
+use forc_tracing::{init_tracing_subscriber, println_green};
 use serde::Deserialize;
 use std::{
     fs::{self, File},
@@ -159,7 +158,10 @@ pub(crate) mod path {
     use std::path::PathBuf;
 
     pub fn explorer_directory() -> PathBuf {
-        forc_util::user_forc_directory().join("explorer")
+        dirs::home_dir()
+            .expect("unable to find the user home directory")
+            .join(".forc")
+            .join("explorer")
     }
 
     pub fn web_app() -> PathBuf {

--- a/forc-plugins/forc-fmt/Cargo.toml
+++ b/forc-plugins/forc-fmt/Cargo.toml
@@ -11,6 +11,7 @@ description = "A `forc` plugin for running the Sway code formatter."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
+forc-tracing = { version = "0.26.0", path = "../../forc-tracing" }
 forc-util = { version = "0.26.0", path = "../../forc-util" }
 prettydiff = "0.5"
 sway-core = { version = "0.26.0", path = "../../sway-core" }

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -12,7 +12,8 @@ use std::{
 use taplo::formatter as taplo_fmt;
 use tracing::{error, info};
 
-use forc_util::{find_manifest_dir, init_tracing_subscriber, println_green, println_red};
+use forc_tracing::{init_tracing_subscriber, println_green, println_red};
+use forc_util::find_manifest_dir;
 use sway_core::BuildConfig;
 use sway_utils::{constants, get_sway_files};
 use swayfmt::Formatter;

--- a/forc-tracing/Cargo.toml
+++ b/forc-tracing/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "forc-tracing"
+version = "0.26.0"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+edition = "2021"
+homepage = "https://fuel.network/"
+license = "Apache-2.0"
+repository = "https://github.com/FuelLabs/sway"
+description = "Utility items shared between forc crates."
+
+[dependencies]
+ansi_term = "0.12"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }

--- a/forc-tracing/Cargo.toml
+++ b/forc-tracing/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/sway"
-description = "Utility items shared between forc crates."
+description = "Tracing utility shared between forc crates."
 
 [dependencies]
 ansi_term = "0.12"

--- a/forc-tracing/src/lib.rs
+++ b/forc-tracing/src/lib.rs
@@ -1,0 +1,118 @@
+//! Utility items shared between forc crates.
+
+use ansi_term::Colour;
+use std::str;
+use std::{env, io};
+use tracing::{Level, Metadata};
+use tracing_subscriber::{
+    filter::{EnvFilter, LevelFilter},
+    fmt::MakeWriter,
+};
+
+pub fn println_red(txt: &str) {
+    println_std_out(txt, Colour::Red);
+}
+
+pub fn println_green(txt: &str) {
+    println_std_out(txt, Colour::Green);
+}
+
+pub fn println_yellow_err(txt: &str) {
+    println_std_err(txt, Colour::Yellow);
+}
+
+pub fn println_red_err(txt: &str) {
+    println_std_err(txt, Colour::Red);
+}
+
+pub fn println_green_err(txt: &str) {
+    println_std_err(txt, Colour::Green);
+}
+
+fn println_std_out(txt: &str, color: Colour) {
+    tracing::info!("{}", color.paint(txt));
+}
+
+fn println_std_err(txt: &str, color: Colour) {
+    tracing::error!("{}", color.paint(txt));
+}
+
+const LOG_FILTER: &str = "RUST_LOG";
+
+// This allows us to write ERROR and WARN level logs to stderr and everything else to stdout.
+// https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
+struct StdioTracingWriter;
+impl<'a> MakeWriter<'a> for StdioTracingWriter {
+    type Writer = Box<dyn io::Write>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        // We must have an implementation of `make_writer` that makes
+        // a "default" writer without any configuring metadata. Let's
+        // just return stdout in that case.
+        Box::new(io::stdout())
+    }
+
+    fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
+        // Here's where we can implement our special behavior. We'll
+        // check if the metadata's verbosity level is WARN or ERROR,
+        // and return stderr in that case.
+        if meta.level() <= &Level::WARN {
+            return Box::new(io::stderr());
+        }
+
+        // Otherwise, we'll return stdout.
+        Box::new(io::stdout())
+    }
+}
+
+#[derive(Default)]
+pub struct TracingSubscriberOptions {
+    pub verbosity: Option<u8>,
+    pub silent: Option<bool>,
+    pub log_level: Option<LevelFilter>,
+}
+
+/// A subscriber built from default `tracing_subscriber::fmt::SubscriberBuilder` such that it would match directly using `println!` throughout the repo.
+///
+/// `RUST_LOG` environment variable can be used to set different minimum level for the subscriber, default is `INFO`.
+pub fn init_tracing_subscriber(options: TracingSubscriberOptions) {
+    let env_filter = match env::var_os(LOG_FILTER) {
+        Some(_) => EnvFilter::try_from_default_env().expect("Invalid `RUST_LOG` provided"),
+        None => EnvFilter::new("info"),
+    };
+
+    let level_filter = options
+        .log_level
+        .or_else(|| {
+            options.verbosity.and_then(|verbosity| {
+                match verbosity {
+                    1 => Some(LevelFilter::DEBUG), // matches --verbose or -v
+                    2 => Some(LevelFilter::TRACE), // matches -vv
+                    _ => None,
+                }
+            })
+        })
+        .or_else(|| {
+            options.silent.and_then(|silent| match silent {
+                true => Some(LevelFilter::OFF),
+                _ => None,
+            })
+        });
+
+    let builder = tracing_subscriber::fmt::Subscriber::builder()
+        .with_env_filter(env_filter)
+        .with_ansi(true)
+        .with_level(false)
+        .with_file(false)
+        .with_line_number(false)
+        .without_time()
+        .with_target(false)
+        .with_writer(StdioTracingWriter);
+
+    // If log level, verbosity, or silent mode is set, it overrides the RUST_LOG setting
+    if let Some(level_filter) = level_filter {
+        builder.with_max_level(level_filter).init();
+    } else {
+        builder.init();
+    }
+}

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -13,6 +13,7 @@ annotate-snippets = { version = "0.9", features = ["color"] }
 ansi_term = "0.12"
 anyhow = "1"
 dirs = "3.0.2"
+forc-tracing = { version = "0.26.0", path = "../forc-tracing" }
 sway-core = { version = "0.26.0", path = "../sway-core" }
 sway-error = { version = "0.26.0", path = "../sway-error" }
 sway-types = { version = "0.26.0", path = "../sway-types" }

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -4,22 +4,16 @@ use annotate_snippets::{
     display_list::{DisplayList, FormatOptions},
     snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
 };
-use ansi_term::Colour;
 use anyhow::{bail, Result};
+use forc_tracing::{println_green_err, println_red_err, println_yellow_err};
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::str;
-use std::{env, io};
 use sway_core::language::parsed::TreeType;
 use sway_error::error::CompileError;
 use sway_error::warning::CompileWarning;
 use sway_types::{LineCol, Spanned};
 use sway_utils::constants;
-use tracing::{Level, Metadata};
-use tracing_subscriber::{
-    filter::{EnvFilter, LevelFilter},
-    fmt::MakeWriter,
-};
 
 pub mod restricted;
 
@@ -201,34 +195,6 @@ pub fn print_on_failure(terse_mode: bool, warnings: &[CompileWarning], errors: &
     ));
 }
 
-pub fn println_red(txt: &str) {
-    println_std_out(txt, Colour::Red);
-}
-
-pub fn println_green(txt: &str) {
-    println_std_out(txt, Colour::Green);
-}
-
-pub fn println_yellow_err(txt: &str) {
-    println_std_err(txt, Colour::Yellow);
-}
-
-pub fn println_red_err(txt: &str) {
-    println_std_err(txt, Colour::Red);
-}
-
-pub fn println_green_err(txt: &str) {
-    println_std_err(txt, Colour::Green);
-}
-
-fn println_std_out(txt: &str, color: Colour) {
-    tracing::info!("{}", color.paint(txt));
-}
-
-fn println_std_err(txt: &str, color: Colour) {
-    tracing::error!("{}", color.paint(txt));
-}
-
 fn format_err(err: &CompileError) {
     let span = err.span();
     let input = span.input();
@@ -385,86 +351,6 @@ fn construct_window<'a>(
 
     start.line = lines_to_start_of_snippet;
     &input[calculated_start_ix..calculated_end_ix]
-}
-
-const LOG_FILTER: &str = "RUST_LOG";
-
-// This allows us to write ERROR and WARN level logs to stderr and everything else to stdout.
-// https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html
-struct StdioTracingWriter;
-impl<'a> MakeWriter<'a> for StdioTracingWriter {
-    type Writer = Box<dyn io::Write>;
-
-    fn make_writer(&'a self) -> Self::Writer {
-        // We must have an implementation of `make_writer` that makes
-        // a "default" writer without any configuring metadata. Let's
-        // just return stdout in that case.
-        Box::new(io::stdout())
-    }
-
-    fn make_writer_for(&'a self, meta: &Metadata<'_>) -> Self::Writer {
-        // Here's where we can implement our special behavior. We'll
-        // check if the metadata's verbosity level is WARN or ERROR,
-        // and return stderr in that case.
-        if meta.level() <= &Level::WARN {
-            return Box::new(io::stderr());
-        }
-
-        // Otherwise, we'll return stdout.
-        Box::new(io::stdout())
-    }
-}
-
-#[derive(Default)]
-pub struct TracingSubscriberOptions {
-    pub verbosity: Option<u8>,
-    pub silent: Option<bool>,
-    pub log_level: Option<LevelFilter>,
-}
-
-/// A subscriber built from default `tracing_subscriber::fmt::SubscriberBuilder` such that it would match directly using `println!` throughout the repo.
-///
-/// `RUST_LOG` environment variable can be used to set different minimum level for the subscriber, default is `INFO`.
-pub fn init_tracing_subscriber(options: TracingSubscriberOptions) {
-    let env_filter = match env::var_os(LOG_FILTER) {
-        Some(_) => EnvFilter::try_from_default_env().expect("Invalid `RUST_LOG` provided"),
-        None => EnvFilter::new("info"),
-    };
-
-    let level_filter = options
-        .log_level
-        .or_else(|| {
-            options.verbosity.and_then(|verbosity| {
-                match verbosity {
-                    1 => Some(LevelFilter::DEBUG), // matches --verbose or -v
-                    2 => Some(LevelFilter::TRACE), // matches -vv
-                    _ => None,
-                }
-            })
-        })
-        .or_else(|| {
-            options.silent.and_then(|silent| match silent {
-                true => Some(LevelFilter::OFF),
-                _ => None,
-            })
-        });
-
-    let builder = tracing_subscriber::fmt::Subscriber::builder()
-        .with_env_filter(env_filter)
-        .with_ansi(true)
-        .with_level(false)
-        .with_file(false)
-        .with_line_number(false)
-        .without_time()
-        .with_target(false)
-        .with_writer(StdioTracingWriter);
-
-    // If log level, verbosity, or silent mode is set, it overrides the RUST_LOG setting
-    if let Some(level_filter) = level_filter {
-        builder.with_max_level(level_filter).init();
-    } else {
-        builder.init();
-    }
 }
 
 #[cfg(all(feature = "uwu", any(target_arch = "x86", target_arch = "x86_64")))]

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1.0.41"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 clap_complete = "3.1"
 forc-pkg = { version = "0.26.0", path = "../forc-pkg" }
+forc-tracing = { version = "0.26.0", path = "../forc-tracing" }
 forc-util = { version = "0.26.0", path = "../forc-util" }
 fs_extra = "1.2"
 fuel-asm = "0.8"

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -11,7 +11,7 @@ pub use check::Command as CheckCommand;
 use clap::{Parser, Subcommand};
 pub use clean::Command as CleanCommand;
 pub use completions::Command as CompletionsCommand;
-use forc_util::{init_tracing_subscriber, TracingSubscriberOptions};
+use forc_tracing::{init_tracing_subscriber, TracingSubscriberOptions};
 pub use init::Command as InitCommand;
 pub use new::Command as NewCommand;
 use parse_bytecode::Command as ParseBytecodeCommand;

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -12,7 +12,7 @@ description = "LSP server for Sway."
 anyhow = "1.0.41"
 dashmap = "5.4"
 forc-pkg = { version = "0.27.0", path = "../forc-pkg" }
-forc-util = { version = "0.27.0", path = "../forc-util" }
+forc-tracing = { version = "0.27.0", path = "../forc-tracing" }
 notify = "5.0.0"
 notify-debouncer-mini = { version = "0.2.0" }
 parking_lot = "0.12.1"

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -1,6 +1,6 @@
 #![recursion_limit = "256"]
 
-use forc_util::{init_tracing_subscriber, TracingSubscriberOptions, TracingWriterMode};
+use forc_tracing::{init_tracing_subscriber, TracingSubscriberOptions, TracingWriterMode};
 use tower_lsp::{LspService, Server};
 
 mod capabilities;

--- a/swayfmt/Cargo.toml
+++ b/swayfmt/Cargo.toml
@@ -10,6 +10,7 @@ description = "Sway language formatter."
 
 [dependencies]
 anyhow = "1"
+forc-tracing = { version = "0.26.0", path = "../forc-tracing" }
 forc-util = { version = "0.26.0", path = "../forc-util" }
 ropey = "1.5"
 serde = { version = "1.0", features = ["derive"] }

--- a/swayfmt/src/config/manifest.rs
+++ b/swayfmt/src/config/manifest.rs
@@ -8,7 +8,8 @@ use crate::{
     constants::SWAY_FORMAT_FILE_NAME,
     error::ConfigError,
 };
-use forc_util::{find_parent_dir_with_file, println_yellow_err};
+use forc_tracing::println_yellow_err;
+use forc_util::find_parent_dir_with_file;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 

--- a/swayfmt/src/items/item_enum/tests.rs
+++ b/swayfmt/src/items/item_enum/tests.rs
@@ -1,4 +1,4 @@
-use forc_util::{println_green, println_red};
+use forc_tracing::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
 

--- a/swayfmt/src/items/item_fn/tests.rs
+++ b/swayfmt/src/items/item_fn/tests.rs
@@ -1,4 +1,4 @@
-use forc_util::{println_green, println_red};
+use forc_tracing::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
 

--- a/swayfmt/src/items/item_impl/tests.rs
+++ b/swayfmt/src/items/item_impl/tests.rs
@@ -1,4 +1,4 @@
-use forc_util::{println_green, println_red};
+use forc_tracing::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
 

--- a/swayfmt/src/items/item_storage/tests.rs
+++ b/swayfmt/src/items/item_storage/tests.rs
@@ -1,4 +1,4 @@
-use forc_util::{println_green, println_red};
+use forc_tracing::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
 

--- a/swayfmt/src/items/item_struct/tests.rs
+++ b/swayfmt/src/items/item_struct/tests.rs
@@ -1,4 +1,4 @@
-use forc_util::{println_green, println_red};
+use forc_tracing::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
 

--- a/swayfmt/src/items/item_use/tests.rs
+++ b/swayfmt/src/items/item_use/tests.rs
@@ -1,4 +1,4 @@
-use forc_util::{println_green, println_red};
+use forc_tracing::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
 

--- a/swayfmt/src/utils/language/expr/tests.rs
+++ b/swayfmt/src/utils/language/expr/tests.rs
@@ -1,6 +1,6 @@
 //! Specific tests for the expression module
 
-use forc_util::{println_green, println_red};
+use forc_tracing::{println_green, println_red};
 use paste::paste;
 use prettydiff::{basic::DiffOp, diff_lines};
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -12,7 +12,7 @@ filecheck = "0.5"
 forc = { path = "../forc", features = ["test"], default-features = false }
 forc-client = { path = "../forc-plugins/forc-client" }
 forc-pkg = { path = "../forc-pkg" }
-forc-util = { path = "../forc-util" }
+forc-tracing = { path = "../forc-tracing" }
 fuel-asm = "0.8"
 fuel-tx = { version = "0.18", features = ["builder"]}
 fuel-vm = { version = "0.15", features = ["random"] }

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -2,7 +2,7 @@
 
 mod harness;
 
-use forc_util::init_tracing_subscriber;
+use forc_tracing::init_tracing_subscriber;
 use fuel_vm::prelude::*;
 use regex::Regex;
 


### PR DESCRIPTION
closes #3107 

For the motivation for this PR, refer to the issue linked above.

This PR extracts all `tracing` related util functions from `forc-util` and puts them into a dedicated `forc-tracing` crate. There is a minor code change [here](https://github.com/FuelLabs/sway/pull/3108/files#diff-fb650e8292a5d6bc84d8a261393ff2cabe324b5162c40ee5cf23af57ff4dcf58R161-R164) because it is the only place that `forc-explore` uses `forc-util` (so we can eliminate the dependency entirely), but other than that this PR is mostly just moving code around and updating deps as required for crates dependent on the moved `tracing` utils.