### PR TITLE
bump rust SDK to v0.26

### DIFF
--- a/test/src/sdk-harness/Cargo.toml
+++ b/test/src/sdk-harness/Cargo.toml
@@ -11,7 +11,7 @@ fuel-core = { version = "0.10", default-features = false }
 fuel-gql-client = { version = "0.10", default-features = false }
 fuel-types = "0.5"
 fuel-vm = "0.15"
-fuels = { version = "0.25", features = ["fuel-core-lib"] }
+fuels = { version = "0.26", features = ["fuel-core-lib"] }
 hex = "0.4.3"
 rand = "0.8"
 sha2 = "0.10"


### PR DESCRIPTION
I also attempted (but was unable) to bump other deps in this manifest:
- fuel-gql-client
- fuel-vm
- fuel-core
THis is because the SDK doesn't yet use the latest `fuel-gql-client` version.