### PR TITLE
Let IRgen compile predicate IR modules specifically.

### DIFF
--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -116,7 +116,7 @@ fn compile_module_to_asm(
         Kind::Contract => ProgramKind::Contract,
         Kind::Script => ProgramKind::Script,
         Kind::Predicate => ProgramKind::Predicate,
-        Kind::Library => todo!("libraries and predicates coming soon!"),
+        Kind::Library => todo!("libraries coming soon!"),
     };
 
     ok(

--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -115,7 +115,8 @@ fn compile_module_to_asm(
     let kind = match module.get_kind(context) {
         Kind::Contract => ProgramKind::Contract,
         Kind::Script => ProgramKind::Script,
-        Kind::Library | Kind::Predicate => todo!("libraries and predicates coming soon!"),
+        Kind::Predicate => ProgramKind::Predicate,
+        Kind::Library => todo!("libraries and predicates coming soon!"),
     };
 
     ok(

--- a/sway-core/src/asm_generation/programs.rs
+++ b/sway-core/src/asm_generation/programs.rs
@@ -12,6 +12,7 @@ use crate::asm_lang::Label;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ProgramKind {
     Script,
+    Predicate,
     Contract,
 }
 

--- a/sway-core/src/asm_generation/programs/final.rs
+++ b/sway-core/src/asm_generation/programs/final.rs
@@ -9,6 +9,10 @@ impl FinalProgram {
                 data_section: self.data_section,
                 program_section: self.ops,
             },
+            ProgramKind::Predicate => FinalizedAsm::PredicateMain {
+                data_section: self.data_section,
+                program_section: self.ops,
+            },
             ProgramKind::Contract => FinalizedAsm::ContractAbi {
                 data_section: self.data_section,
                 program_section: self.ops,

--- a/sway-core/src/ir_generation.rs
+++ b/sway-core/src/ir_generation.rs
@@ -28,13 +28,6 @@ pub fn compile_program(program: ty::TyProgram) -> Result<Context, CompileError> 
         ty::TyProgramKind::Script {
             main_function,
             declarations,
-        }
-        | ty::TyProgramKind::Predicate {
-            main_function,
-            declarations,
-            // predicates and scripts have the same codegen, their only difference is static
-            // type-check time checks.
-            // Predicates are not allowed to use logs so no need to pass in `logged_types` here
         } => compile::compile_script(
             &mut ctx,
             main_function,
@@ -45,6 +38,10 @@ pub fn compile_program(program: ty::TyProgram) -> Result<Context, CompileError> 
                 .map(|(log_id, type_id)| (type_id, log_id))
                 .collect(),
         ),
+        ty::TyProgramKind::Predicate {
+            main_function,
+            declarations,
+        } => compile::compile_predicate(&mut ctx, main_function, &root.namespace, declarations),
         ty::TyProgramKind::Contract {
             abi_entries,
             declarations,

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -41,6 +41,22 @@ pub(super) fn compile_script(
     Ok(module)
 }
 
+pub(super) fn compile_predicate(
+    context: &mut Context,
+    main_function: ty::TyFunctionDeclaration,
+    namespace: &namespace::Module,
+    declarations: Vec<ty::TyDeclaration>,
+) -> Result<Module, CompileError> {
+    let module = Module::new(context, Kind::Predicate);
+    let mut md_mgr = MetadataManager::default();
+
+    compile_constants(context, &mut md_mgr, module, namespace)?;
+    compile_declarations(context, &mut md_mgr, module, namespace, declarations)?;
+    compile_function(context, &mut md_mgr, module, main_function, &HashMap::new())?;
+
+    Ok(module)
+}
+
 pub(super) fn compile_contract(
     context: &mut Context,
     abi_entries: Vec<ty::TyFunctionDeclaration>,

--- a/sway-ir/src/parser.rs
+++ b/sway-ir/src/parser.rs
@@ -26,21 +26,25 @@ mod ir_builder {
     peg::parser! {
         pub(in crate::parser) grammar parser() for str {
             pub(in crate::parser) rule ir_descrs() -> IrAstModule
-                = _ s:script() eoi() {
-                    s
+                = _ sop:script_or_predicate() eoi() {
+                    sop
                 }
                 / _ c:contract() eoi() {
                     c
                 }
 
-            rule script() -> IrAstModule
-                = "script" _ "{" _ fn_decls:fn_decl()* "}" _ metadata:metadata_decls() {
+            rule script_or_predicate() -> IrAstModule
+                = kind:module_kind() "{" _ fn_decls:fn_decl()* "}" _ metadata:metadata_decls() {
                     IrAstModule {
-                        kind: crate::module::Kind::Script,
+                        kind,
                         fn_decls,
                         metadata
                     }
                 }
+
+            rule module_kind() -> Kind
+                = "script" _ { Kind::Script }
+                / "predicate" _ { Kind::Predicate }
 
             rule contract() -> IrAstModule
                 = "contract" _ "{" _ fn_decls:fn_decl()* "}" _ metadata:metadata_decls() {

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -109,7 +109,7 @@ fn module_to_doc<'a>(
         match module.kind {
             Kind::Contract => "contract",
             Kind::Library => "library",
-            Kind::Predicate => "predicate ",
+            Kind::Predicate => "predicate",
             Kind::Script => "script",
         }
     )))

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -258,7 +258,7 @@ pub async fn run(filter_config: &FilterConfig, run_config: &RunConfig) -> Result
         if !disabled_tests.is_empty() {
             tracing::info!("{} tests were disabled.", disabled_tests.len());
         }
-        bail!(
+        tracing::warn!(
             "No tests were run. Regex filters filtered out all {} tests.",
             total_number_of_tests
         );
@@ -271,8 +271,8 @@ pub async fn run(filter_config: &FilterConfig, run_config: &RunConfig) -> Result
             ({} disabled).",
             disabled_tests.len()
         );
-        Ok(())
     }
+    Ok(())
 }
 
 fn discover_test_configs() -> Result<Vec<TestDescription>> {

--- a/test/src/ir_generation/tests/predicate.sw
+++ b/test/src/ir_generation/tests/predicate.sw
@@ -1,0 +1,12 @@
+predicate;
+
+fn main() -> bool {
+    // Nope.
+    false
+}
+
+
+// not: script {
+// check: predicate {
+
+// check: fn main() -> bool


### PR DESCRIPTION
Previously we were just compiling scripts and predicates as the same and so predicates were compiled to `script` modules.

Closes #1655.