### PR TITLE
Provide a way to detect type of manifest files and general refactor for workspace builds 

### DIFF
--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -13,6 +13,25 @@ use sway_core::{language::parsed::TreeType, parse};
 pub use sway_types::ConfigTimeConstant;
 use sway_utils::constants;
 
+pub enum ManifestFile {
+    Package(Box<PackageManifestFile>),
+    Workspace(WorkspaceManifestFile),
+}
+
+impl ManifestFile {
+    /// Returns a `PackageManifestFile` if the path is within a package directory, otherwise
+    /// returns a `WorkspaceManifestFile` if within a workspace directory.
+    pub fn from_dir(dir: &Path) -> Result<Self> {
+        if let Ok(package_manifest) = PackageManifestFile::from_dir(dir) {
+            Ok(ManifestFile::Package(Box::new(package_manifest)))
+        } else if let Ok(workspace_manifest) = WorkspaceManifestFile::from_dir(dir) {
+            Ok(ManifestFile::Workspace(workspace_manifest))
+        } else {
+            bail!("Cannot find a valid `Forc.toml` at {:?}", dir)
+        }
+    }
+}
+
 type PatchMap = BTreeMap<String, Dependency>;
 
 /// A [PackageManifest] that was deserialized from a file at a particular path.

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -278,7 +278,7 @@ impl PackageManifest {
     pub fn from_file(path: &Path) -> Result<Self> {
         // While creating a `ManifestFile` we need to check if the given path corresponds to a
         // package or a workspace. While doing so, we should be printing the warnings if the given
-        // parses so that we only see warnings for the correct type of manifest.
+        // file parses so that we only see warnings for the correct type of manifest.
         let mut warnings = vec![];
         let manifest_str = std::fs::read_to_string(path)
             .map_err(|e| anyhow!("failed to read manifest at {:?}: {}", path, e))?;
@@ -606,7 +606,7 @@ impl WorkspaceManifest {
     pub fn from_file(path: &Path) -> Result<Self> {
         // While creating a `ManifestFile` we need to check if the given path corresponds to a
         // package or a workspace. While doing so, we should be printing the warnings if the given
-        // parses so that we only see warnings for the correct type of manifest.
+        // file parses so that we only see warnings for the correct type of manifest.
         let mut warnings = vec![];
         let manifest_str = std::fs::read_to_string(path)
             .map_err(|e| anyhow!("failed to read manifest at {:?}: {}", path, e))?;

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -265,6 +265,9 @@ impl PackageManifest {
     /// implicitly. In this case, the git tag associated with the version of this crate is used to
     /// specify the pinned commit at which we fetch `std`.
     pub fn from_file(path: &Path) -> Result<Self> {
+        // While creating a `ManifestFile` we need to check if the given path corresponds to a
+        // package or a workspace. While doing so, we should be printing the warnings if the given
+        // parses so that we only see warnings for the correct type of manifest.
         let mut warnings = vec![];
         let manifest_str = std::fs::read_to_string(path)
             .map_err(|e| anyhow!("failed to read manifest at {:?}: {}", path, e))?;
@@ -590,6 +593,9 @@ impl WorkspaceManifestFile {
 impl WorkspaceManifest {
     /// Given a path to a `Forc.toml`, read it and construct a `WorkspaceManifest`.
     pub fn from_file(path: &Path) -> Result<Self> {
+        // While creating a `ManifestFile` we need to check if the given path corresponds to a
+        // package or a workspace. While doing so, we should be printing the warnings if the given
+        // parses so that we only see warnings for the correct type of manifest.
         let mut warnings = vec![];
         let manifest_str = std::fs::read_to_string(path)
             .map_err(|e| anyhow!("failed to read manifest at {:?}: {}", path, e))?;

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -21,14 +21,25 @@ pub enum ManifestFile {
 impl ManifestFile {
     /// Returns a `PackageManifestFile` if the path is within a package directory, otherwise
     /// returns a `WorkspaceManifestFile` if within a workspace directory.
-    pub fn from_path(dir: &Path) -> Result<Self> {
-        let path = dir.to_path_buf().join("Forc.toml");
-        if let Ok(package_manifest) = PackageManifestFile::from_file(path.clone()) {
+    pub fn from_dir(manifest_dir: &Path) -> Result<Self> {
+        if let Ok(package_manifest) = PackageManifestFile::from_dir(manifest_dir) {
             Ok(ManifestFile::Package(Box::new(package_manifest)))
-        } else if let Ok(workspace_manifest) = WorkspaceManifestFile::from_file(path) {
+        } else if let Ok(workspace_manifest) = WorkspaceManifestFile::from_dir(manifest_dir) {
             Ok(ManifestFile::Workspace(workspace_manifest))
         } else {
-            bail!("Cannot find a valid `Forc.toml` at {:?}", dir)
+            bail!("Cannot find a valid `Forc.toml` at {:?}", manifest_dir)
+        }
+    }
+
+    /// Returns a `PackageManifestFile` if the path is pointing to package manifest, otherwise
+    /// returns a `WorkspaceManifestFile` if it is pointing to a workspace manifest.
+    pub fn from_file(path: PathBuf) -> Result<Self> {
+        if let Ok(package_manifest) = PackageManifestFile::from_file(path.clone()) {
+            Ok(ManifestFile::Package(Box::new(package_manifest)))
+        } else if let Ok(workspace_manifest) = WorkspaceManifestFile::from_file(path.clone()) {
+            Ok(ManifestFile::Workspace(workspace_manifest))
+        } else {
+            bail!("Cannot find a valid `Forc.toml` at {:?}", path)
         }
     }
 }

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -21,10 +21,11 @@ pub enum ManifestFile {
 impl ManifestFile {
     /// Returns a `PackageManifestFile` if the path is within a package directory, otherwise
     /// returns a `WorkspaceManifestFile` if within a workspace directory.
-    pub fn from_dir(dir: &Path) -> Result<Self> {
-        if let Ok(package_manifest) = PackageManifestFile::from_dir(dir) {
+    pub fn from_path(dir: &Path) -> Result<Self> {
+        let path = dir.to_path_buf().join("Forc.toml");
+        if let Ok(package_manifest) = PackageManifestFile::from_file(path.clone()) {
             Ok(ManifestFile::Package(Box::new(package_manifest)))
-        } else if let Ok(workspace_manifest) = WorkspaceManifestFile::from_dir(dir) {
+        } else if let Ok(workspace_manifest) = WorkspaceManifestFile::from_file(path) {
             Ok(ManifestFile::Workspace(workspace_manifest))
         } else {
             bail!("Cannot find a valid `Forc.toml` at {:?}", dir)

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -264,14 +264,18 @@ impl PackageManifest {
     /// implicitly. In this case, the git tag associated with the version of this crate is used to
     /// specify the pinned commit at which we fetch `std`.
     pub fn from_file(path: &Path) -> Result<Self> {
+        let mut warnings = vec![];
         let manifest_str = std::fs::read_to_string(path)
             .map_err(|e| anyhow!("failed to read manifest at {:?}: {}", path, e))?;
         let toml_de = &mut toml::de::Deserializer::new(&manifest_str);
         let mut manifest: Self = serde_ignored::deserialize(toml_de, |path| {
             let warning = format!("  WARNING! unused manifest key: {}", path);
-            println_yellow_err(&warning);
+            warnings.push(warning);
         })
         .map_err(|e| anyhow!("failed to parse manifest: {}.", e))?;
+        for warning in warnings {
+            println_yellow_err(&warning);
+        }
         manifest.implicitly_include_std_if_missing();
         manifest.implicitly_include_default_build_profiles_if_missing();
         manifest.validate()?;
@@ -585,14 +589,18 @@ impl WorkspaceManifestFile {
 impl WorkspaceManifest {
     /// Given a path to a `Forc.toml`, read it and construct a `WorkspaceManifest`.
     pub fn from_file(path: &Path) -> Result<Self> {
+        let mut warnings = vec![];
         let manifest_str = std::fs::read_to_string(path)
             .map_err(|e| anyhow!("failed to read manifest at {:?}: {}", path, e))?;
         let toml_de = &mut toml::de::Deserializer::new(&manifest_str);
         let manifest: Self = serde_ignored::deserialize(toml_de, |path| {
             let warning = format!("  WARNING! unused manifest key: {}", path);
-            println_yellow_err(&warning);
+            warnings.push(warning);
         })
         .map_err(|e| anyhow!("failed to parse manifest: {}.", e))?;
+        for warning in warnings {
+            println_yellow_err(&warning);
+        }
         Ok(manifest)
     }
 

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2253,7 +2253,7 @@ pub fn build_with_options(build_options: BuildOptions) -> Result<Built> {
         std::env::current_dir()?
     };
 
-    let manifest_file = ManifestFile::from_path(&this_dir)?;
+    let manifest_file = ManifestFile::from_dir(&this_dir)?;
     match manifest_file {
         ManifestFile::Package(package_manifest) => {
             let built_package = build_package_with_options(&package_manifest, build_options)?;

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -71,7 +71,7 @@ pub struct PinnedId(u64);
 
 /// The result of successfully compiling a package.
 #[derive(Debug, Clone)]
-pub struct Compiled {
+pub struct BuiltPackage {
     pub json_abi_program: JsonABIProgram,
     pub storage_slots: Vec<StorageSlot>,
     pub bytecode: Vec<u8>,
@@ -1780,7 +1780,7 @@ pub fn sway_build_config(
 /// then the std prelude will also be added.
 pub fn dependency_namespace(
     lib_namespace_map: &HashMap<NodeIx, namespace::Module>,
-    compiled_contract_deps: &HashMap<NodeIx, Compiled>,
+    compiled_contract_deps: &HashMap<NodeIx, BuiltPackage>,
     graph: &Graph,
     node: NodeIx,
     constants: BTreeMap<String, ConfigTimeConstant>,
@@ -1932,7 +1932,7 @@ pub fn compile(
     build_profile: &BuildProfile,
     namespace: namespace::Module,
     source_map: &mut SourceMap,
-) -> Result<(Compiled, Option<namespace::Root>)> {
+) -> Result<(BuiltPackage, Option<namespace::Root>)> {
     // Time the given expression and print the result if `build_config.time_phases` is true.
     macro_rules! time_expr {
         ($description:expr, $expression:expr) => {{
@@ -1995,13 +1995,13 @@ pub fn compile(
             print_on_success_library(terse_mode, &pkg.name, &ast_res.warnings);
             let bytecode = vec![];
             let lib_namespace = typed_program.root.namespace.clone();
-            let compiled = Compiled {
+            let built_package = BuiltPackage {
                 json_abi_program,
                 storage_slots,
                 bytecode,
                 tree_type,
             };
-            return Ok((compiled, Some(lib_namespace.into())));
+            return Ok((built_package, Some(lib_namespace.into())));
         }
         // For all other program types, we'll compile the bytecode.
         TreeType::Contract | TreeType::Predicate | TreeType::Script => {}
@@ -2023,13 +2023,13 @@ pub fn compile(
         Some(BytecodeOrLib::Bytecode(bytes)) if bc_res.errors.is_empty() => {
             print_on_success(terse_mode, &pkg.name, &bc_res.warnings, &tree_type);
             let bytecode = bytes;
-            let compiled = Compiled {
+            let built_package = BuiltPackage {
                 json_abi_program,
                 storage_slots,
                 bytecode,
                 tree_type,
             };
-            Ok((compiled, None))
+            Ok((built_package, None))
         }
         Some(BytecodeOrLib::Bytecode(_)) | None => fail(&bc_res.warnings, &bc_res.errors),
     }
@@ -2085,17 +2085,17 @@ pub struct BuildOptions {
 }
 
 /// The suffix that helps identify the file which contains the hash of the binary file created when
-/// scripts are built.
+/// scripts are built_package.
 pub const SWAY_BIN_HASH_SUFFIX: &str = "-bin-hash";
 
 /// The suffix that helps identify the file which contains the root hash of the binary file created
-/// when predicates are built.
+/// when predicates are built_package.
 pub const SWAY_BIN_ROOT_SUFFIX: &str = "-bin-root";
 
 pub fn build_package_with_options(
     manifest: &PackageManifestFile,
     build_options: BuildOptions,
-) -> Result<Compiled> {
+) -> Result<BuiltPackage> {
     let key_debug: String = "debug".to_string();
     let key_release: String = "release".to_string();
 
@@ -2159,10 +2159,10 @@ pub fn build_package_with_options(
     let plan = BuildPlan::from_lock_and_manifest(manifest, locked, offline_mode)?;
 
     // Build it!
-    let (compiled, source_map) = build(&plan, &profile)?;
+    let (built_package, source_map) = build(&plan, &profile)?;
 
     if let Some(outfile) = binary_outfile {
-        fs::write(&outfile, &compiled.bytecode)?;
+        fs::write(&outfile, &built_package.bytecode)?;
     }
 
     if let Some(outfile) = debug_outfile {
@@ -2182,25 +2182,25 @@ pub fn build_package_with_options(
     let bin_path = output_dir
         .join(&manifest.project.name)
         .with_extension("bin");
-    fs::write(&bin_path, &compiled.bytecode)?;
-    if !compiled.json_abi_program.functions.is_empty() {
+    fs::write(&bin_path, &built_package.bytecode)?;
+    if !built_package.json_abi_program.functions.is_empty() {
         let json_abi_program_stem = format!("{}-abi", manifest.project.name);
         let json_abi_program_path = output_dir
             .join(&json_abi_program_stem)
             .with_extension("json");
         let file = File::create(json_abi_program_path)?;
         let res = if minify_json_abi {
-            serde_json::to_writer(&file, &compiled.json_abi_program)
+            serde_json::to_writer(&file, &built_package.json_abi_program)
         } else {
-            serde_json::to_writer_pretty(&file, &compiled.json_abi_program)
+            serde_json::to_writer_pretty(&file, &built_package.json_abi_program)
         };
         res?;
     }
 
-    info!("  Bytecode size is {} bytes.", compiled.bytecode.len());
+    info!("  Bytecode size is {} bytes.", built_package.bytecode.len());
 
     // Additional ops required depending on the program type
-    match compiled.tree_type {
+    match built_package.tree_type {
         TreeType::Contract => {
             // For contracts, emit a JSON file with all the initialized storage slots.
             let json_storage_slots_stem = format!("{}-storage_slots", manifest.project.name);
@@ -2209,16 +2209,16 @@ pub fn build_package_with_options(
                 .with_extension("json");
             let storage_slots_file = File::create(json_storage_slots_path)?;
             let res = if minify_json_storage_slots {
-                serde_json::to_writer(&storage_slots_file, &compiled.storage_slots)
+                serde_json::to_writer(&storage_slots_file, &built_package.storage_slots)
             } else {
-                serde_json::to_writer_pretty(&storage_slots_file, &compiled.storage_slots)
+                serde_json::to_writer_pretty(&storage_slots_file, &built_package.storage_slots)
             };
 
             res?;
         }
         TreeType::Predicate => {
             // get the root hash of the bytecode for predicates and store the result in a file in the output directory
-            let root = format!("0x{}", Contract::root_from_code(&compiled.bytecode));
+            let root = format!("0x{}", Contract::root_from_code(&built_package.bytecode));
             let root_file_name = format!("{}{}", &manifest.project.name, SWAY_BIN_ROOT_SUFFIX);
             let root_path = output_dir.join(root_file_name);
             fs::write(root_path, &root)?;
@@ -2226,7 +2226,7 @@ pub fn build_package_with_options(
         }
         TreeType::Script => {
             // hash the bytecode for scripts and store the result in a file in the output directory
-            let bytecode_hash = format!("0x{}", fuel_crypto::Hasher::hash(&compiled.bytecode));
+            let bytecode_hash = format!("0x{}", fuel_crypto::Hasher::hash(&built_package.bytecode));
             let hash_file_name = format!("{}{}", &manifest.project.name, SWAY_BIN_HASH_SUFFIX);
             let hash_path = output_dir.join(hash_file_name);
             fs::write(hash_path, &bytecode_hash)?;
@@ -2235,7 +2235,7 @@ pub fn build_package_with_options(
         _ => (),
     }
 
-    Ok(compiled)
+    Ok(built_package)
 }
 
 /// Builds a project with given BuildOptions
@@ -2259,23 +2259,23 @@ pub fn build_with_options(build_options: BuildOptions) -> Result<()> {
     Ok(())
 }
 
-/// Returns the ContractId of a compiled contract with specified `salt`.
-fn contract_id(compiled: &Compiled) -> ContractId {
+/// Returns the ContractId of a built_package contract with specified `salt`.
+fn contract_id(built_package: &BuiltPackage) -> ContractId {
     // Construct the contract ID
-    let contract = Contract::from(compiled.bytecode.clone());
+    let contract = Contract::from(built_package.bytecode.clone());
     let salt = fuel_tx::Salt::new([0; 32]);
-    let mut storage_slots = compiled.storage_slots.clone();
+    let mut storage_slots = built_package.storage_slots.clone();
     storage_slots.sort();
     let state_root = Contract::initial_state_root(storage_slots.iter());
     contract.id(&salt, &contract.root(), &state_root)
 }
 
-/// Build an entire forc package and return the compiled output.
+/// Build an entire forc package and return the built_package output.
 ///
 /// This compiles all packages (including dependencies) in the order specified by the `BuildPlan`.
 ///
 /// Also returns the resulting `sway_core::SourceMap` which may be useful for debugging purposes.
-pub fn build(plan: &BuildPlan, profile: &BuildProfile) -> anyhow::Result<(Compiled, SourceMap)> {
+pub fn build(plan: &BuildPlan, profile: &BuildProfile) -> anyhow::Result<(BuiltPackage, SourceMap)> {
     //TODO remove once type engine isn't global anymore.
     sway_core::clear_lazy_statics();
 
@@ -2308,30 +2308,30 @@ pub fn build(plan: &BuildPlan, profile: &BuildProfile) -> anyhow::Result<(Compil
             }
         };
         let res = compile(pkg, manifest, profile, dep_namespace, &mut source_map)?;
-        let (compiled, maybe_namespace) = res;
+        let (built_package, maybe_namespace) = res;
         // If the current node is a contract dependency, collect the contract_id
         if plan
             .graph()
             .edges_directed(node, Direction::Incoming)
             .any(|e| e.weight().kind == DepKind::Contract)
         {
-            compiled_contract_deps.insert(node, compiled.clone());
+            compiled_contract_deps.insert(node, built_package.clone());
         }
         if let Some(namespace) = maybe_namespace {
             lib_namespace_map.insert(node, namespace.into());
         }
         json_abi_program
             .types
-            .extend(compiled.json_abi_program.types);
+            .extend(built_package.json_abi_program.types);
         json_abi_program
             .functions
-            .extend(compiled.json_abi_program.functions);
+            .extend(built_package.json_abi_program.functions);
         json_abi_program
             .logged_types
-            .extend(compiled.json_abi_program.logged_types);
-        storage_slots.extend(compiled.storage_slots);
-        bytecode = compiled.bytecode;
-        tree_type = Some(compiled.tree_type);
+            .extend(built_package.json_abi_program.logged_types);
+        storage_slots.extend(built_package.storage_slots);
+        bytecode = built_package.bytecode;
+        tree_type = Some(built_package.tree_type);
         source_map.insert_dependency(manifest.dir());
     }
 
@@ -2339,13 +2339,13 @@ pub fn build(plan: &BuildPlan, profile: &BuildProfile) -> anyhow::Result<(Compil
 
     let tree_type =
         tree_type.ok_or_else(|| anyhow!("build plan must contain at least one package"))?;
-    let compiled = Compiled {
+    let built_package = BuiltPackage {
         bytecode,
         json_abi_program,
         storage_slots,
         tree_type,
     };
-    Ok((compiled, source_map))
+    Ok((built_package, source_map))
 }
 
 /// Standardize the JSON ABI data structure by eliminating duplicate types. This is an iterative

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2261,7 +2261,6 @@ pub fn build_with_options(build_options: BuildOptions) -> Result<Built> {
         }
         ManifestFile::Workspace(_) => bail!("Workspace building is not supported"),
     }
-
 }
 
 /// Returns the ContractId of a built_package contract with specified `salt`.
@@ -2280,7 +2279,10 @@ fn contract_id(built_package: &BuiltPackage) -> ContractId {
 /// This compiles all packages (including dependencies) in the order specified by the `BuildPlan`.
 ///
 /// Also returns the resulting `sway_core::SourceMap` which may be useful for debugging purposes.
-pub fn build(plan: &BuildPlan, profile: &BuildProfile) -> anyhow::Result<(BuiltPackage, SourceMap)> {
+pub fn build(
+    plan: &BuildPlan,
+    profile: &BuildProfile,
+) -> anyhow::Result<(BuiltPackage, SourceMap)> {
     //TODO remove once type engine isn't global anymore.
     sway_core::clear_lazy_statics();
 

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2248,7 +2248,7 @@ pub fn build_with_options(build_options: BuildOptions) -> Result<()> {
         std::env::current_dir()?
     };
 
-    let manifest_file = ManifestFile::from_dir(&this_dir)?;
+    let manifest_file = ManifestFile::from_path(&this_dir)?;
     match manifest_file {
         ManifestFile::Package(package_manifest) => {
             build_package_with_options(&package_manifest, build_options)?

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -78,6 +78,11 @@ pub struct BuiltPackage {
     pub tree_type: TreeType,
 }
 
+pub enum Built {
+    Package(BuiltPackage),
+    Workspace,
+}
+
 /// A package uniquely identified by name along with its source.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub struct Pkg {
@@ -2239,7 +2244,7 @@ pub fn build_package_with_options(
 }
 
 /// Builds a project with given BuildOptions
-pub fn build_with_options(build_options: BuildOptions) -> Result<()> {
+pub fn build_with_options(build_options: BuildOptions) -> Result<Built> {
     let path = &build_options.path;
 
     let this_dir = if let Some(ref path) = path {
@@ -2251,12 +2256,12 @@ pub fn build_with_options(build_options: BuildOptions) -> Result<()> {
     let manifest_file = ManifestFile::from_path(&this_dir)?;
     match manifest_file {
         ManifestFile::Package(package_manifest) => {
-            build_package_with_options(&package_manifest, build_options)?
+            let built_package = build_package_with_options(&package_manifest, build_options)?;
+            Ok(Built::Package(built_package))
         }
         ManifestFile::Workspace(_) => bail!("Workspace building is not supported"),
-    };
+    }
 
-    Ok(())
 }
 
 /// Returns the ContractId of a built_package contract with specified `salt`.

--- a/forc-plugins/forc-client/src/ops/deploy/op.rs
+++ b/forc-plugins/forc-client/src/ops/deploy/op.rs
@@ -46,7 +46,7 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
         release: command.release,
         time_phases: command.time_phases,
     };
-    let compiled = forc_pkg::build_with_options(build_options)?;
+    let compiled = forc_pkg::build_package_with_options(&manifest, build_options)?;
 
     let bytecode = compiled.bytecode.clone().into();
     let salt = Salt::new([0; 32]);

--- a/forc-plugins/forc-client/src/ops/run/op.rs
+++ b/forc-plugins/forc-client/src/ops/run/op.rs
@@ -50,7 +50,7 @@ pub async fn run(command: RunCommand) -> Result<Vec<fuel_tx::Receipt>> {
         release: false,
         time_phases: command.time_phases,
     };
-    let compiled = forc_pkg::build_with_options(build_options)?;
+    let compiled = forc_pkg::build_package_with_options(&manifest, build_options)?;
 
     let contract_ids: Vec<ContractId> = command
         .contract

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -2,7 +2,7 @@ use crate::cli::BuildCommand;
 use anyhow::Result;
 use forc_pkg::{self as pkg};
 
-pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
+pub fn build(command: BuildCommand) -> Result<()> {
     let build_options = pkg::BuildOptions {
         path: command.path,
         print_ast: command.print_ast,
@@ -21,6 +21,6 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
         time_phases: command.time_phases,
         print_intermediate_asm: command.print_intermediate_asm,
     };
-    let compiled = pkg::build_with_options(build_options)?;
-    Ok(compiled)
+    pkg::build_with_options(build_options)?;
+    Ok(())
 }

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -2,7 +2,7 @@ use crate::cli::BuildCommand;
 use anyhow::Result;
 use forc_pkg::{self as pkg};
 
-pub fn build(command: BuildCommand) -> Result<()> {
+pub fn build(command: BuildCommand) -> Result<pkg::Built> {
     let build_options = pkg::BuildOptions {
         path: command.path,
         print_ast: command.print_ast,
@@ -21,6 +21,6 @@ pub fn build(command: BuildCommand) -> Result<()> {
         time_phases: command.time_phases,
         print_intermediate_asm: command.print_intermediate_asm,
     };
-    pkg::build_with_options(build_options)?;
-    Ok(())
+    let built = pkg::build_with_options(build_options)?;
+    Ok(built)
 }

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -3,7 +3,7 @@ use forc_client::ops::{
     deploy::{cmd::DeployCommand, op::deploy},
     run::{cmd::RunCommand, op::run},
 };
-use forc_pkg::{Compiled, PackageManifestFile};
+use forc_pkg::{BuiltPackage, PackageManifestFile};
 use fuel_tx::TransactionBuilder;
 use fuel_vm::interpreter::Interpreter;
 use fuel_vm::prelude::*;
@@ -68,9 +68,9 @@ pub(crate) async fn runs_on_node(
 /// Very basic check that code does indeed run in the VM.
 /// `true` if it does, `false` if not.
 pub(crate) fn runs_in_vm(
-    script: Compiled,
+    script: BuiltPackage,
     script_data: Option<Vec<u8>>,
-) -> (ProgramState, Compiled) {
+) -> (ProgramState, BuiltPackage) {
     let storage = MemoryStorage::default();
 
     let rng = &mut StdRng::seed_from_u64(2322u64);
@@ -100,7 +100,7 @@ pub(crate) fn compile_to_bytes(
     file_name: &str,
     run_config: &RunConfig,
     capture_output: bool,
-) -> (Result<Compiled>, String) {
+) -> (Result<BuiltPackage>, String) {
     tracing::info!(" Compiling {}", file_name);
 
     let mut buf_stdout: Option<gag::BufferRedirect> = None;
@@ -154,8 +154,8 @@ pub(crate) fn compile_to_bytes(
     (result, output)
 }
 
-pub(crate) fn test_json_abi(file_name: &str, compiled: &Compiled) -> Result<()> {
-    emit_json_abi(file_name, compiled)?;
+pub(crate) fn test_json_abi(file_name: &str, built_package: &BuiltPackage) -> Result<()> {
+    emit_json_abi(file_name, built_package)?;
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let oracle_path = format!(
         "{}/src/e2e_vm_tests/test_programs/{}/{}",
@@ -181,9 +181,9 @@ pub(crate) fn test_json_abi(file_name: &str, compiled: &Compiled) -> Result<()> 
     Ok(())
 }
 
-fn emit_json_abi(file_name: &str, compiled: &Compiled) -> Result<()> {
+fn emit_json_abi(file_name: &str, built_package: &BuiltPackage) -> Result<()> {
     tracing::info!("   ABI gen {}", file_name);
-    let json_abi = serde_json::json!(compiled.json_abi_program);
+    let json_abi = serde_json::json!(built_package.json_abi_program);
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let file = std::fs::File::create(format!(
         "{}/src/e2e_vm_tests/test_programs/{}/{}",
@@ -194,8 +194,8 @@ fn emit_json_abi(file_name: &str, compiled: &Compiled) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn test_json_storage_slots(file_name: &str, compiled: &Compiled) -> Result<()> {
-    emit_json_storage_slots(file_name, compiled)?;
+pub(crate) fn test_json_storage_slots(file_name: &str, built_package: &BuiltPackage) -> Result<()> {
+    emit_json_storage_slots(file_name, built_package)?;
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let oracle_path = format!(
         "{}/src/e2e_vm_tests/test_programs/{}/{}",
@@ -221,9 +221,9 @@ pub(crate) fn test_json_storage_slots(file_name: &str, compiled: &Compiled) -> R
     Ok(())
 }
 
-fn emit_json_storage_slots(file_name: &str, compiled: &Compiled) -> Result<()> {
+fn emit_json_storage_slots(file_name: &str, built_package: &BuiltPackage) -> Result<()> {
     tracing::info!("   storage slots JSON gen {}", file_name);
-    let json_storage_slots = serde_json::json!(compiled.storage_slots);
+    let json_storage_slots = serde_json::json!(built_package.storage_slots);
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let file = std::fs::File::create(format!(
         "{}/src/e2e_vm_tests/test_programs/{}/{}",


### PR DESCRIPTION
closes #3127.

This sets the stage up for upcoming workspace building feature by providing a way of detecting manifest file type and general refactor around `forc-pkg` so that we can split the logic for workspace and single package