### PR TITLE
Remove `raw_ptr::addr()`

### DIFF
--- a/sway-lib-core/src/raw_ptr.sw
+++ b/sway-lib-core/src/raw_ptr.sw
@@ -7,11 +7,6 @@ impl raw_ptr {
         __eq(addr, 0)
     }
 
-    /// Gets the address of the pointer.
-    pub fn addr(self) -> u64 {
-        asm(ptr: self) { ptr: u64 }
-    }
-
     /// Calculates the offset from the pointer.
     pub fn add(self, count: u64) -> raw_ptr {
         let addr = asm(ptr: self) { ptr: u64 };

--- a/test/src/sdk-harness/test_artifacts/tx_contract/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/tx_contract/src/main.sw
@@ -72,7 +72,7 @@ impl TxContractTest for Contract {
         tx_receipts_root()
     }
     fn get_tx_script_start_pointer() -> u64 {
-        tx_script_start_pointer().addr()
+        asm(ptr: tx_script_start_pointer()) { ptr: u64 }
     }
     fn get_tx_script_bytecode_hash() -> b256 {
         tx_script_bytecode_hash()

--- a/test/src/sdk-harness/test_projects/registers/src/main.sw
+++ b/test/src/sdk-harness/test_projects/registers/src/main.sw
@@ -25,23 +25,23 @@ impl Registers for Contract {
     }
 
     fn get_program_counter() -> u64 {
-        program_counter().addr()
+        asm(ptr: program_counter()) { ptr: u64 }
     }
 
     fn get_stack_start_ptr() -> u64 {
-        stack_start_ptr().addr()
+        asm(ptr: stack_start_ptr()) { ptr: u64 }
     }
 
     fn get_stack_ptr() -> u64 {
-        stack_ptr().addr()
+        asm(ptr: stack_ptr()) { ptr: u64 }
     }
 
     fn get_frame_ptr() -> u64 {
-        frame_ptr().addr()
+        asm(ptr: frame_ptr()) { ptr: u64 }
     }
 
     fn get_heap_ptr() -> u64 {
-        heap_ptr().addr()
+        asm(ptr: heap_ptr()) { ptr: u64 }
     }
 
     fn get_error() -> u64 {
@@ -61,7 +61,7 @@ impl Registers for Contract {
     }
 
     fn get_instrs_start() -> u64 {
-        instrs_start().addr()
+        asm(ptr: instrs_start()) { ptr: u64 }
     }
 
     fn get_return_value() -> u64 {


### PR DESCRIPTION
With this change, `core` and `std` should stop providing a convenient way to access pointers as `u64`s.

While this might seem limiting, with `alloc()` returning `raw_ptr`s that have `add()` and `sub()`, all usages of `.addr()` could be refactored. (If not there's still `asm(r1: ptr) { r1: u64 }` of course.)