### PR TITLE
Enable printing contract-id and accept Bech32 address in `forc-deploy`

### DIFF
--- a/forc-plugins/forc-client/src/ops/deploy/op.rs
+++ b/forc-plugins/forc-client/src/ops/deploy/op.rs
@@ -56,6 +56,7 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
     let root = contract.root();
     let state_root = Contract::initial_state_root(storage_slots.iter());
     let contract_id = contract.id(&salt, &root, &state_root);
+    info!("Contract id: 0x{}", hex::encode(contract_id));
     let tx = TransactionBuilder::create(bytecode, salt, storage_slots.clone())
         .params(TxParameters::new(command.gas_limit, command.gas_price))
         .add_output(Output::contract_created(contract_id, state_root))

--- a/forc-plugins/forc-client/src/ops/tx_util.rs
+++ b/forc-plugins/forc-client/src/ops/tx_util.rs
@@ -10,12 +10,12 @@ use fuels_core::constants::BASE_ASSET_ID;
 use fuels_signers::{provider::Provider, Wallet};
 use fuels_types::bech32::Bech32Address;
 
-fn prompt_address() -> Result<Address> {
+fn prompt_address() -> Result<Bech32Address> {
     print!("Please provide the address of the wallet you are going to sign this transaction with:");
     std::io::stdout().flush()?;
     let mut buf = String::new();
     std::io::stdin().read_line(&mut buf)?;
-    Address::from_str(buf.trim()).map_err(Error::msg)
+    Bech32Address::from_str(buf.trim()).map_err(Error::msg)
 }
 
 fn prompt_signature(message: Message) -> Result<Signature> {
@@ -122,7 +122,7 @@ impl TransactionBuilderExt for TransactionBuilder {
         let inputs = wallet
             .get_asset_inputs_for_amount(asset_id, amount, signature_witness_index)
             .await?;
-        let output = Output::change(address, 0, asset_id);
+        let output = Output::change(wallet.address().into(), 0, asset_id);
 
         self.add_inputs(inputs).add_output(output);
 
@@ -140,7 +140,7 @@ impl TransactionBuilderExt for TransactionBuilder {
             let address = if let Some(signing_key) = signing_key {
                 Address::from(*signing_key.public_key().hash())
             } else {
-                prompt_address()?
+                Address::from(prompt_address()?)
             };
 
             // Insert dummy witness for signature


### PR DESCRIPTION
closes #3137.

I re-added the contract id prompt and also introduced a small fix where input from the user is expected to be in `Bech32` format so that `forc-wallet list` output can be directly used. This is tested with forc-client v0.10.1, and it can sign a deployment transaction with that version. But it seems like there are some changes in the newer versions that breaks the signing process, I guess to address that we will have to bump versions to the latest. I think we might be short of some releases for that but I will have a deeper look into that after this one. 