### PR TITLE
Add a `--tests` flag to `forc build` (and sway-core) in preparation for building unit tests

### DIFF
--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -92,6 +92,7 @@ pub struct BuildProfile {
     pub print_intermediate_asm: bool,
     pub terse: bool,
     pub time_phases: bool,
+    pub include_tests: bool,
 }
 
 impl Dependency {
@@ -433,6 +434,7 @@ impl BuildProfile {
             print_intermediate_asm: false,
             terse: false,
             time_phases: false,
+            include_tests: false,
         }
     }
 
@@ -444,6 +446,7 @@ impl BuildProfile {
             print_intermediate_asm: false,
             terse: false,
             time_phases: false,
+            include_tests: false,
         }
     }
 }

--- a/forc-plugins/forc-client/src/ops/deploy/op.rs
+++ b/forc-plugins/forc-client/src/ops/deploy/op.rs
@@ -45,6 +45,7 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
         build_profile: command.build_profile,
         release: command.release,
         time_phases: command.time_phases,
+        tests: false,
     };
     let compiled = forc_pkg::build_with_options(build_options)?;
 

--- a/forc-plugins/forc-client/src/ops/run/op.rs
+++ b/forc-plugins/forc-client/src/ops/run/op.rs
@@ -49,6 +49,7 @@ pub async fn run(command: RunCommand) -> Result<Vec<fuel_tx::Receipt>> {
         build_profile: None,
         release: false,
         time_phases: command.time_phases,
+        tests: false,
     };
     let compiled = forc_pkg::build_with_options(build_options)?;
 

--- a/forc/src/cli/commands/build.rs
+++ b/forc/src/cli/commands/build.rs
@@ -80,6 +80,9 @@ pub struct Command {
     /// Output the time elapsed over each part of the compilation process.
     #[clap(long)]
     pub time_phases: bool,
+    /// Also build all tests within the project.
+    #[clap(long)]
+    pub tests: bool,
 }
 
 pub(crate) fn exec(command: Command) -> Result<()> {

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -20,6 +20,7 @@ pub fn build(command: BuildCommand) -> Result<pkg::Compiled> {
         release: command.release,
         time_phases: command.time_phases,
         print_intermediate_asm: command.print_intermediate_asm,
+        tests: command.tests,
     };
     let compiled = pkg::build_with_options(build_options)?;
     Ok(compiled)

--- a/sway-core/src/build_config.rs
+++ b/sway-core/src/build_config.rs
@@ -9,6 +9,7 @@ pub struct BuildConfig {
     pub(crate) print_intermediate_asm: bool,
     pub(crate) print_finalized_asm: bool,
     pub(crate) print_ir: bool,
+    pub(crate) include_tests: bool,
 }
 
 impl BuildConfig {
@@ -46,6 +47,7 @@ impl BuildConfig {
             print_intermediate_asm: false,
             print_finalized_asm: false,
             print_ir: false,
+            include_tests: false,
         }
     }
 
@@ -66,6 +68,18 @@ impl BuildConfig {
     pub fn print_ir(self, a: bool) -> Self {
         Self {
             print_ir: a,
+            ..self
+        }
+    }
+
+    /// Whether or not to include test functions in parsing, type-checking and codegen.
+    ///
+    /// This should be set to `true` by invocations like `forc test` or `forc check --tests`.
+    ///
+    /// Default: `false`
+    pub fn include_tests(self, include_tests: bool) -> Self {
+        Self {
+            include_tests,
             ..self
         }
     }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -59,18 +59,18 @@ pub fn parse(input: Arc<str>, config: Option<&BuildConfig>) -> CompileResult<par
         None => parse_in_memory(h, input),
         // When a `BuildConfig` is given,
         // the module source may declare `dep`s that must be parsed from other files.
-        Some(config) => {
-            parse_module_tree(h, input, config.canonical_root_module(), config.include_tests)
-                .map(|(kind, root)| parsed::ParseProgram { kind, root })
-        }
+        Some(config) => parse_module_tree(
+            h,
+            input,
+            config.canonical_root_module(),
+            config.include_tests,
+        )
+        .map(|(kind, root)| parsed::ParseProgram { kind, root }),
     })
 }
 
 /// When no `BuildConfig` is given, we're assumed to be parsing in-memory with no submodules.
-fn parse_in_memory(
-    handler: &Handler,
-    src: Arc<str>,
-) -> Result<parsed::ParseProgram, ErrorEmitted> {
+fn parse_in_memory(handler: &Handler, src: Arc<str>) -> Result<parsed::ParseProgram, ErrorEmitted> {
     // Omit tests by default so that a test that fails to typecheck doesn't block the rest of the
     // program (similar behaviour to rust). To include test functions, specify the `include_tests`
     // flag in the `BuildConfig` passed to `parse`.

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -165,20 +165,10 @@ fn module_path(parent_module_dir: &Path, dep: &sway_ast::Dependency) -> PathBuf 
         .with_extension(sway_types::constants::DEFAULT_FILE_EXTENSION)
 }
 
-/// Either finalized ASM or a library.
-pub enum AsmOrLib {
-    Asm(FinalizedAsm),
-    Library {
-        name: Ident,
-        namespace: Box<namespace::Root>,
-    },
-}
+pub struct CompiledAsm(pub FinalizedAsm);
 
-/// Either compiled bytecode in byte form or a library.
-pub enum BytecodeOrLib {
-    Bytecode(Vec<u8>),
-    Library,
-}
+/// The bytecode for a sway program.
+pub struct CompiledBytecode(pub Vec<u8>);
 
 pub fn parsed_to_ast(
     parse_program: &parsed::ParseProgram,
@@ -296,49 +286,36 @@ pub fn compile_to_ast(
 }
 
 /// Given input Sway source code,
-/// try compiling to a `AsmOrLib`,
+/// try compiling to a `CompiledAsm`,
 /// containing the asm in opcode form (not raw bytes/bytecode).
 pub fn compile_to_asm(
     input: Arc<str>,
     initial_namespace: namespace::Module,
     build_config: BuildConfig,
-) -> CompileResult<AsmOrLib> {
+) -> CompileResult<CompiledAsm> {
     let ast_res = compile_to_ast(input, initial_namespace, Some(&build_config));
     ast_to_asm(ast_res, &build_config)
 }
 
 /// Given an AST compilation result,
-/// try compiling to a `AsmOrLib`,
+/// try compiling to a `CompiledAsm`,
 /// containing the asm in opcode form (not raw bytes/bytecode).
 pub fn ast_to_asm(
     ast_res: CompileResult<ty::TyProgram>,
     build_config: &BuildConfig,
-) -> CompileResult<AsmOrLib> {
+) -> CompileResult<CompiledAsm> {
     match ast_res.value {
         None => err(ast_res.warnings, ast_res.errors),
         Some(typed_program) => {
             let mut errors = ast_res.errors;
             let mut warnings = ast_res.warnings;
-
-            let tree_type = typed_program.kind.tree_type();
-            match tree_type {
-                parsed::TreeType::Contract
-                | parsed::TreeType::Script
-                | parsed::TreeType::Predicate => {
-                    let asm = check!(
-                        compile_ast_to_ir_to_asm(typed_program, build_config),
-                        return deduped_err(warnings, errors),
-                        warnings,
-                        errors
-                    );
-                    ok(AsmOrLib::Asm(asm), warnings, errors)
-                }
-                parsed::TreeType::Library { name } => {
-                    let namespace = Box::new(typed_program.root.namespace.into());
-                    let lib = AsmOrLib::Library { name, namespace };
-                    ok(lib, warnings, errors)
-                }
-            }
+            let asm = check!(
+                compile_ast_to_ir_to_asm(typed_program, build_config),
+                return deduped_err(warnings, errors),
+                warnings,
+                errors
+            );
+            ok(CompiledAsm(asm), warnings, errors)
         }
     }
 }
@@ -582,39 +559,38 @@ fn simplify_cfg(
     Ok(())
 }
 
-/// Given input Sway source code, compile to a [BytecodeOrLib], containing the asm in bytecode form.
+/// Given input Sway source code, compile to [CompiledBytecode], containing the asm in bytecode form.
 pub fn compile_to_bytecode(
     input: Arc<str>,
     initial_namespace: namespace::Module,
     build_config: BuildConfig,
     source_map: &mut SourceMap,
-) -> CompileResult<BytecodeOrLib> {
+) -> CompileResult<CompiledBytecode> {
     let asm_res = compile_to_asm(input, initial_namespace, build_config);
     let result = asm_to_bytecode(asm_res, source_map);
     clear_lazy_statics();
     result
 }
 
-/// Given the assembly (opcodes), compile to a [BytecodeOrLib], containing the asm in bytecode form.
+/// Given the assembly (opcodes), compile to [CompiledBytecode], containing the asm in bytecode form.
 pub fn asm_to_bytecode(
     CompileResult {
         value,
         mut warnings,
         mut errors,
-    }: CompileResult<AsmOrLib>,
+    }: CompileResult<CompiledAsm>,
     source_map: &mut SourceMap,
-) -> CompileResult<BytecodeOrLib> {
+) -> CompileResult<CompiledBytecode> {
     match value {
-        Some(AsmOrLib::Asm(mut asm)) => {
+        Some(CompiledAsm(mut asm)) => {
             let bytes = check!(
                 asm.to_bytecode_mut(source_map),
                 return err(warnings, errors),
                 warnings,
                 errors,
             );
-            ok(BytecodeOrLib::Bytecode(bytes), warnings, errors)
+            ok(CompiledBytecode(bytes), warnings, errors)
         }
-        Some(AsmOrLib::Library { .. }) => ok(BytecodeOrLib::Library, warnings, errors),
         None => err(warnings, errors),
     }
 }


### PR DESCRIPTION
This strips out a couple commits from #2985 and aims to land them independently!

Specifically, this enables calling `forc build --tests` which will (once #2985 lands) build the current project along with all its tests. Eventually we'll also want `forc check --tests` and `forc test` itself, but landing this command early is particularly useful for testing the new in-progress unit testing feature.

This PR also removes the old `AsmOrLib` and `BytecodeOrLib` types in favour of new `CompiledAsm` and `CompiledBytecode` types. This is in preparation for #2985 in which libraries will begin to generate bytecode when tests are enabled.