### PR TITLE
Include `#[test]` functions as entry points during dead code analysis

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -2,14 +2,13 @@ use super::*;
 use crate::{
     declaration_engine::declaration_engine::*,
     language::{parsed::TreeType, ty, CallPath, Visibility},
-    transform::AttributeKind,
     type_system::{to_typeinfo, TypeInfo},
 };
 use petgraph::{prelude::NodeIndex, visit::Dfs};
 use std::collections::BTreeSet;
 use sway_error::error::CompileError;
 use sway_error::warning::{CompileWarning, Warning};
-use sway_types::{constants::DEFAULT_ENTRY_POINT_FN_NAME, span::Span, Ident, Spanned};
+use sway_types::{span::Span, Ident, Spanned};
 
 impl ControlFlowGraph {
     pub(crate) fn find_dead_code(&self) -> Vec<CompileWarning> {
@@ -135,9 +134,7 @@ fn entry_points(
                         ..
                     }) => {
                         let decl = de_get_function(decl_id.clone(), span)?;
-                        let is_entry = decl.name.as_str() == DEFAULT_ENTRY_POINT_FN_NAME
-                            || decl.attributes.contains_key(&AttributeKind::Test);
-                        if !is_entry {
+                        if !decl.is_entry() {
                             continue;
                         }
                     }
@@ -158,8 +155,7 @@ fn entry_points(
                         ..
                     }) => {
                         let decl = de_get_function(decl_id.clone(), &decl_id.span())?;
-                        decl.visibility == Visibility::Public
-                            || decl.attributes.contains_key(&AttributeKind::Test)
+                        decl.visibility == Visibility::Public || decl.is_test()
                     }
                     ControlFlowGraphNode::ProgramNode(ty::TyAstNode {
                         content:

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -253,6 +253,24 @@ impl TyFunctionDeclaration {
             },
         }
     }
+
+    /// Whether or not this function is the default entry point.
+    pub fn is_main_entry(&self) -> bool {
+        // NOTE: We may want to make this check more sophisticated or customisable in the future,
+        // but for now this assumption is baked in throughout the compiler.
+        self.name.as_str() == sway_types::constants::DEFAULT_ENTRY_POINT_FN_NAME
+    }
+
+    /// Whether or not this function is a unit test, i.e. decorated with `#[test]`.
+    pub fn is_test(&self) -> bool {
+        self.attributes
+            .contains_key(&transform::AttributeKind::Test)
+    }
+
+    /// Whether or not this function describes a program entry point.
+    pub fn is_entry(&self) -> bool {
+        self.is_main_entry() || self.is_test()
+    }
 }
 
 #[derive(Debug, Clone, Eq)]


### PR DESCRIPTION
Refactors the collection of flow graph entry points into a function, and includes functions decorated with the `#[test]` attribute.

Short-hand methods have been added to `TyFunctionDeclaration` for checking if the function is `main`, a unit test or if it is an entry point.

This is another step towards #2985.