### PR TITLE
Add method to `TyProgram` for retrieving all `#[test]` functions

### DIFF
--- a/sway-core/src/language/ty/module.rs
+++ b/sway-core/src/language/ty/module.rs
@@ -1,6 +1,9 @@
 use sway_types::Ident;
 
-use crate::{language::ty::*, language::DepName, semantic_analysis::namespace};
+use crate::{
+    declaration_engine::de_get_function, language::ty::*, language::DepName,
+    semantic_analysis::namespace,
+};
 
 #[derive(Clone, Debug)]
 pub struct TyModule {
@@ -13,4 +16,57 @@ pub struct TyModule {
 pub struct TySubmodule {
     pub library_name: Ident,
     pub module: TyModule,
+}
+
+/// Iterator type for iterating over submodules.
+///
+/// Used rather than `impl Iterator` to enable recursive submodule iteration.
+pub struct SubmodulesRecursive<'module> {
+    submods: std::slice::Iter<'module, (DepName, TySubmodule)>,
+    current: Option<Box<SubmodulesRecursive<'module>>>,
+}
+
+impl TyModule {
+    /// An iterator yielding all submodules recursively, depth-first.
+    pub fn submodules_recursive(&self) -> SubmodulesRecursive {
+        let mut submods = self.submodules.iter();
+        let current = submods
+            .next()
+            .map(|(_, submod)| Box::new(submod.module.submodules_recursive()));
+        SubmodulesRecursive { submods, current }
+    }
+
+    /// All test functions within this module.
+    pub fn test_fns(&self) -> impl Iterator<Item = TyFunctionDeclaration> + '_ {
+        self.all_nodes.iter().filter_map(|node| {
+            if let TyAstNodeContent::Declaration(TyDeclaration::FunctionDeclaration(ref decl_id)) =
+                node.content
+            {
+                let fn_decl = de_get_function(decl_id.clone(), &node.span)
+                    .expect("no function declaration for ID");
+                if fn_decl.is_test() {
+                    return Some(fn_decl);
+                }
+            }
+            None
+        })
+    }
+}
+
+impl<'module> Iterator for SubmodulesRecursive<'module> {
+    type Item = &'module (DepName, TySubmodule);
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            self.current = match self.current.as_mut() {
+                None => match self.submods.next() {
+                    None => return None,
+                    Some((_, submod)) => Some(Box::new(submod.module.submodules_recursive())),
+                },
+                Some(submod) => match submod.next() {
+                    Some(submod) => return Some(submod),
+                    None => continue,
+                },
+            }
+        }
+    }
 }

--- a/sway-core/src/language/ty/module.rs
+++ b/sway-core/src/language/ty/module.rs
@@ -29,15 +29,14 @@ pub struct SubmodulesRecursive<'module> {
 impl TyModule {
     /// An iterator yielding all submodules recursively, depth-first.
     pub fn submodules_recursive(&self) -> SubmodulesRecursive {
-        let mut submods = self.submodules.iter();
-        let current = submods
-            .next()
-            .map(|(_, submod)| Box::new(submod.module.submodules_recursive()));
-        SubmodulesRecursive { submods, current }
+        SubmodulesRecursive {
+            submods: self.submodules.iter(),
+            current: None,
+        }
     }
 
     /// All test functions within this module.
-    pub fn test_fns(&self) -> impl Iterator<Item = TyFunctionDeclaration> + '_ {
+    pub fn test_fns(&self) -> impl '_ + Iterator<Item = TyFunctionDeclaration> {
         self.all_nodes.iter().filter_map(|node| {
             if let TyAstNodeContent::Declaration(TyDeclaration::FunctionDeclaration(ref decl_id)) =
                 node.content
@@ -64,7 +63,10 @@ impl<'module> Iterator for SubmodulesRecursive<'module> {
                 },
                 Some(submod) => match submod.next() {
                     Some(submod) => return Some(submod),
-                    None => continue,
+                    None => {
+                        self.current = None;
+                        continue;
+                    }
                 },
             }
         }

--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -377,6 +377,14 @@ impl TyProgram {
             })
             .collect()
     }
+
+    /// All test function declarations within the program.
+    pub fn test_fns(&self) -> impl Iterator<Item = TyFunctionDeclaration> + '_ {
+        self.root
+            .submodules_recursive()
+            .flat_map(|(_, submod)| submod.module.test_fns())
+            .chain(self.root.test_fns())
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -379,7 +379,7 @@ impl TyProgram {
     }
 
     /// All test function declarations within the program.
-    pub fn test_fns(&self) -> impl Iterator<Item = TyFunctionDeclaration> + '_ {
+    pub fn test_fns(&self) -> impl '_ + Iterator<Item = TyFunctionDeclaration> {
         self.root
             .submodules_recursive()
             .flat_map(|(_, submod)| submod.module.test_fns())


### PR DESCRIPTION
~*This PR is based on #3151, and will be rebased on `master` once it lands.*~

Adds a method for producing an iterator that yields all test function declarations throughout the program.

This is another step towards #2985.