### PR TITLE
Refactor `forc_pkg::BuildOptions` into its parts

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -231,6 +231,74 @@ pub struct GitSourceIndex {
     pub head_with_time: HeadWithTime,
 }
 
+#[derive(Default)]
+pub struct PkgOpts {
+    /// Path to the project, if not specified, current working directory will be used.
+    pub path: Option<String>,
+    /// Offline mode, prevents Forc from using the network when managing dependencies.
+    /// Meaning it will only try to use previously downloaded dependencies.
+    pub offline: bool,
+    /// Terse mode. Limited warning and error output.
+    pub terse: bool,
+    /// Requires that the Forc.lock file is up-to-date. If the lock file is missing, or it
+    /// needs to be updated, Forc will exit with an error
+    pub locked: bool,
+    /// The directory in which the sway compiler output artifacts are placed.
+    ///
+    /// By default, this is `<project-root>/out`.
+    pub output_directory: Option<String>,
+}
+
+#[derive(Default)]
+pub struct PrintOpts {
+    /// Print the generated Sway AST (Abstract Syntax Tree).
+    pub ast: bool,
+    /// Print the finalized ASM.
+    ///
+    /// This is the state of the ASM with registers allocated and optimisations applied.
+    pub finalized_asm: bool,
+    /// Print the generated ASM.
+    ///
+    /// This is the state of the ASM prior to performing register allocation and other ASM
+    /// optimisations.
+    pub intermediate_asm: bool,
+    /// Print the generated Sway IR (Intermediate Representation).
+    pub ir: bool,
+}
+
+#[derive(Default)]
+pub struct MinifyOpts {
+    /// By default the JSON for ABIs is formatted for human readability. By using this option JSON
+    /// output will be "minified", i.e. all on one line without whitespace.
+    pub json_abi: bool,
+    /// By default the JSON for initial storage slots is formatted for human readability. By using
+    /// this option JSON output will be "minified", i.e. all on one line without whitespace.
+    pub json_storage_slots: bool,
+}
+
+/// The set of options provided to the `build` functions.
+#[derive(Default)]
+pub struct BuildOpts {
+    pub pkg: PkgOpts,
+    pub print: PrintOpts,
+    pub minify: MinifyOpts,
+    /// If set, outputs a binary file representing the script bytes.
+    pub binary_outfile: Option<String>,
+    /// If set, outputs source file mapping in JSON format
+    pub debug_outfile: Option<String>,
+    /// Name of the build profile to use.
+    /// If it is not specified, forc will use debug build profile.
+    pub build_profile: Option<String>,
+    /// Use release build plan. If a custom release plan is not specified, it is implicitly added to the manifest file.
+    ///
+    ///  If --build-profile is also provided, forc omits this flag and uses provided build-profile.
+    pub release: bool,
+    /// Output the time elapsed over each part of the compilation process.
+    pub time_phases: bool,
+    /// Include all test functions within the build.
+    pub tests: bool,
+}
+
 impl GitSourceIndex {
     pub fn new(time: i64, git_reference: GitReference, commit_hash: String) -> GitSourceIndex {
         GitSourceIndex {
@@ -2038,58 +2106,6 @@ pub fn compile(
     }
 }
 
-#[derive(Default)]
-pub struct BuildOptions {
-    /// Path to the project, if not specified, current working directory will be used.
-    pub path: Option<String>,
-    /// Print the generated Sway AST (Abstract Syntax Tree).
-    pub print_ast: bool,
-    /// Print the finalized ASM.
-    ///
-    /// This is the state of the ASM with registers allocated and optimisations applied.
-    pub print_finalized_asm: bool,
-    /// Print the generated ASM.
-    ///
-    /// This is the state of the ASM prior to performing register allocation and other ASM
-    /// optimisations.
-    pub print_intermediate_asm: bool,
-    /// Print the generated Sway IR (Intermediate Representation).
-    pub print_ir: bool,
-    /// If set, outputs a binary file representing the script bytes.
-    pub binary_outfile: Option<String>,
-    /// If set, outputs source file mapping in JSON format
-    pub debug_outfile: Option<String>,
-    /// Offline mode, prevents Forc from using the network when managing dependencies.
-    /// Meaning it will only try to use previously downloaded dependencies.
-    pub offline_mode: bool,
-    /// Terse mode. Limited warning and error output.
-    pub terse_mode: bool,
-    /// The directory in which the sway compiler output artifacts are placed.
-    ///
-    /// By default, this is `<project-root>/out`.
-    pub output_directory: Option<String>,
-    /// By default the JSON for ABIs is formatted for human readability. By using this option JSON
-    /// output will be "minified", i.e. all on one line without whitespace.
-    pub minify_json_abi: bool,
-    /// By default the JSON for initial storage slots is formatted for human readability. By using
-    /// this option JSON output will be "minified", i.e. all on one line without whitespace.
-    pub minify_json_storage_slots: bool,
-    /// Requires that the Forc.lock file is up-to-date. If the lock file is missing, or it
-    /// needs to be updated, Forc will exit with an error
-    pub locked: bool,
-    /// Name of the build profile to use.
-    /// If it is not specified, forc will use debug build profile.
-    pub build_profile: Option<String>,
-    /// Use release build plan. If a custom release plan is not specified, it is implicitly added to the manifest file.
-    ///
-    ///  If --build-profile is also provided, forc omits this flag and uses provided build-profile.
-    pub release: bool,
-    /// Output the time elapsed over each part of the compilation process.
-    pub time_phases: bool,
-    /// Include all test functions within the build.
-    pub tests: bool,
-}
-
 /// The suffix that helps identify the file which contains the hash of the binary file created when
 /// scripts are built_package.
 pub const SWAY_BIN_HASH_SUFFIX: &str = "-bin-hash";
@@ -2100,25 +2116,17 @@ pub const SWAY_BIN_ROOT_SUFFIX: &str = "-bin-root";
 
 pub fn build_package_with_options(
     manifest: &PackageManifestFile,
-    build_options: BuildOptions,
+    build_options: BuildOpts,
 ) -> Result<BuiltPackage> {
     let key_debug: String = "debug".to_string();
     let key_release: String = "release".to_string();
 
-    let BuildOptions {
-        path: _,
+    let BuildOpts {
+        pkg,
+        print,
+        minify,
         binary_outfile,
         debug_outfile,
-        print_ast,
-        print_finalized_asm,
-        print_intermediate_asm,
-        print_ir,
-        offline_mode,
-        terse_mode,
-        output_directory,
-        minify_json_abi,
-        minify_json_storage_slots,
-        locked,
         build_profile,
         release,
         time_phases,
@@ -2156,15 +2164,15 @@ pub fn build_package_with_options(
             );
             Default::default()
         });
-    profile.print_ast |= print_ast;
-    profile.print_ir |= print_ir;
-    profile.print_finalized_asm |= print_finalized_asm;
-    profile.print_intermediate_asm |= print_intermediate_asm;
-    profile.terse |= terse_mode;
+    profile.print_ast |= print.ast;
+    profile.print_ir |= print.ir;
+    profile.print_finalized_asm |= print.finalized_asm;
+    profile.print_intermediate_asm |= print.intermediate_asm;
+    profile.terse |= pkg.terse;
     profile.time_phases |= time_phases;
     profile.include_tests |= tests;
 
-    let plan = BuildPlan::from_lock_and_manifest(manifest, locked, offline_mode)?;
+    let plan = BuildPlan::from_lock_and_manifest(manifest, pkg.locked, pkg.offline)?;
 
     // Build it!
     let (built_package, source_map) = build(&plan, &profile)?;
@@ -2179,7 +2187,8 @@ pub fn build_package_with_options(
     }
 
     // Create the output directory for build artifacts.
-    let output_dir = output_directory
+    let output_dir = pkg
+        .output_directory
         .map(PathBuf::from)
         .unwrap_or_else(|| default_output_directory(manifest.dir()).join(selected_build_profile));
     if !output_dir.exists() {
@@ -2197,7 +2206,7 @@ pub fn build_package_with_options(
             .join(&json_abi_program_stem)
             .with_extension("json");
         let file = File::create(json_abi_program_path)?;
-        let res = if minify_json_abi {
+        let res = if minify.json_abi {
             serde_json::to_writer(&file, &built_package.json_abi_program)
         } else {
             serde_json::to_writer_pretty(&file, &built_package.json_abi_program)
@@ -2216,7 +2225,7 @@ pub fn build_package_with_options(
                 .join(&json_storage_slots_stem)
                 .with_extension("json");
             let storage_slots_file = File::create(json_storage_slots_path)?;
-            let res = if minify_json_storage_slots {
+            let res = if minify.json_storage_slots {
                 serde_json::to_writer(&storage_slots_file, &built_package.storage_slots)
             } else {
                 serde_json::to_writer_pretty(&storage_slots_file, &built_package.storage_slots)
@@ -2247,8 +2256,8 @@ pub fn build_package_with_options(
 }
 
 /// Builds a project with given BuildOptions
-pub fn build_with_options(build_options: BuildOptions) -> Result<Built> {
-    let path = &build_options.path;
+pub fn build_with_options(build_options: BuildOpts) -> Result<Built> {
+    let path = &build_options.pkg.path;
 
     let this_dir = if let Some(ref path) = path {
         PathBuf::from(path)

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -19,7 +19,7 @@ fuel-crypto = "0.6"
 fuel-gql-client = { version = "0.10", default-features = false }
 fuel-tx = { version = "0.18", features = ["builder"] }
 fuel-vm = "0.15"
-fuels-core = "0.24" 
+fuels-core = "0.24"
 fuels-signers = "0.24"
 fuels-types = "0.24"
 futures = "0.3"
@@ -31,7 +31,6 @@ sway-types = { version = "0.28.1", path = "../../sway-types" }
 sway-utils = { version = "0.28.1", path = "../../sway-utils" }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "process"] }
 tracing = "0.1"
-
 
 [[bin]]
 name = "forc-deploy"

--- a/forc-plugins/forc-client/src/ops/run/cmd.rs
+++ b/forc-plugins/forc-client/src/ops/run/cmd.rs
@@ -92,6 +92,17 @@ pub struct RunCommand {
     #[clap(long)]
     pub minify_json_storage_slots: bool,
 
+    /// Name of the build profile to use.
+    /// If it is not specified, forc will use debug build profile.
+    #[clap(long)]
+    pub build_profile: Option<String>,
+
+    /// Use release build plan. If a custom release plan is not specified, it is implicitly added to the manifest file.
+    ///
+    /// If --build-profile is also provided, forc omits this flag and uses provided build-profile.
+    #[clap(long)]
+    pub release: bool,
+
     /// Set the transaction gas limit. Defaults to the maximum gas limit.
     #[clap(long)]
     pub gas_limit: Option<u64>,

--- a/forc/src/cli/commands/build.rs
+++ b/forc/src/cli/commands/build.rs
@@ -1,4 +1,4 @@
-use crate::ops::forc_build;
+use crate::{cli, ops::forc_build};
 use anyhow::Result;
 use clap::Parser;
 
@@ -18,68 +18,8 @@ use clap::Parser;
 /// `<project-name>-abi.json`.
 #[derive(Debug, Default, Parser)]
 pub struct Command {
-    /// Path to the project, if not specified, current working directory will be used.
-    #[clap(short, long)]
-    pub path: Option<String>,
-    /// Print the generated Sway AST (Abstract Syntax Tree).
-    #[clap(long)]
-    pub print_ast: bool,
-    /// Print the finalized ASM.
-    ///
-    /// This is the state of the ASM with registers allocated and optimisations applied.
-    #[clap(long)]
-    pub print_finalized_asm: bool,
-    /// Print the generated ASM.
-    ///
-    /// This is the state of the ASM prior to performing register allocation and other ASM
-    /// optimisations.
-    #[clap(long)]
-    pub print_intermediate_asm: bool,
-    /// Print the generated Sway IR (Intermediate Representation).
-    #[clap(long)]
-    pub print_ir: bool,
-    /// If set, outputs a binary file representing the script bytes.
-    #[clap(short = 'o')]
-    pub binary_outfile: Option<String>,
-    /// If set, outputs source file mapping in JSON format
-    #[clap(short = 'g', long)]
-    pub debug_outfile: Option<String>,
-    /// Offline mode, prevents Forc from using the network when managing dependencies.
-    /// Meaning it will only try to use previously downloaded dependencies.
-    #[clap(long = "offline")]
-    pub offline_mode: bool,
-    /// Terse mode. Limited warning and error output.
-    #[clap(long = "terse", short = 't')]
-    pub terse_mode: bool,
-    /// The directory in which the sway compiler output artifacts are placed.
-    ///
-    /// By default, this is `<project-root>/out`.
-    #[clap(long)]
-    pub output_directory: Option<String>,
-    /// By default the JSON for ABIs is formatted for human readability. By using this option JSON
-    /// output will be "minified", i.e. all on one line without whitespace.
-    #[clap(long)]
-    pub minify_json_abi: bool,
-    /// By default the JSON for initial storage slots is formatted for human readability. By using
-    /// this option JSON output will be "minified", i.e. all on one line without whitespace.
-    #[clap(long)]
-    pub minify_json_storage_slots: bool,
-    /// Requires that the Forc.lock file is up-to-date. If the lock file is missing, or it
-    /// needs to be updated, Forc will exit with an error
-    #[clap(long)]
-    pub locked: bool,
-    /// Name of the build profile to use.
-    /// If it is not specified, forc will use debug build profile.
-    #[clap(long)]
-    pub build_profile: Option<String>,
-    /// Use release build plan. If a custom release plan is not specified, it is implicitly added to the manifest file.
-    ///
-    ///  If --build-profile is also provided, forc omits this flag and uses provided build-profile.
-    #[clap(long)]
-    pub release: bool,
-    /// Output the time elapsed over each part of the compilation process.
-    #[clap(long)]
-    pub time_phases: bool,
+    #[clap(flatten)]
+    pub build: cli::shared::Build,
     /// Also build all tests within the project.
     #[clap(long)]
     pub tests: bool,

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use crate::cli;
 use clap::Parser;
 
 /// Run the Sway unit tests for the current project.
@@ -11,22 +11,32 @@ use clap::Parser;
 /// the behaviour to support unit testing can be found at the following link:
 /// https://github.com/FuelLabs/sway/issues/1833
 ///
-/// Sway unit tests are functions decorated with the `#[test_script]` attribute. Each test is
-/// compiled as an independent `script` program and has access to the namespace of the module in
-/// which it is declared. Unit tests declared within `contract` projects may also call directly
-/// into their associated contract's ABI.
+/// Sway unit tests are functions decorated with the `#[test]` attribute. Each test is compiled as
+/// a unique entry point for a single program and has access to the namespace of the module in
+/// which it is declared.
+///
+/// Unit tests decorated with the `#[test(script)]` attribute that are declared within `contract`
+/// projects may also call directly into their associated contract's ABI.
 ///
 /// Upon successful compilation, test scripts are executed to their completion. A test is
 /// considered a failure in the case that a revert (`rvrt`) instruction is encountered during
 /// execution. Otherwise, it is considered a success.
 #[derive(Debug, Parser)]
-pub(crate) struct Command {
+pub struct Command {
+    #[clap(flatten)]
+    pub build: cli::shared::Build,
+    /// Enable the incomplete, unstable unit testing support. Warning: May create a black hole!
+    ///
+    /// This is purely for Sway devs to test the unit testing functionality until it stabilises,
+    /// and will be removed upon stabilisation of the command.
+    #[clap(long)]
+    pub unstable: bool,
     /// When specified, only tests containing the given string will be executed.
     pub filter: Option<String>,
 }
 
-pub(crate) fn exec(_command: Command) -> Result<()> {
-    bail!(
+pub(crate) fn exec(_cmd: Command) -> anyhow::Result<()> {
+    anyhow::bail!(
         r#"
 Sway unit testing is not yet implemented. Track progress at the following link:
 

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -17,12 +17,13 @@ pub use new::Command as NewCommand;
 use parse_bytecode::Command as ParseBytecodeCommand;
 pub use plugins::Command as PluginsCommand;
 pub use template::Command as TemplateCommand;
-use test::Command as TestCommand;
+pub use test::Command as TestCommand;
 use tracing::metadata::LevelFilter;
 pub use update::Command as UpdateCommand;
 
 mod commands;
 mod plugin;
+pub mod shared;
 
 #[derive(Debug, Parser)]
 #[clap(name = "forc", about = "Fuel Orchestrator", version)]

--- a/forc/src/cli/shared.rs
+++ b/forc/src/cli/shared.rs
@@ -1,0 +1,71 @@
+//! Sets of arguments that are shared between commands.
+
+use clap::Parser;
+
+/// Args that can be shared between all commands that `build` a package. E.g. `build`, `test`,
+/// `deploy`.
+#[derive(Debug, Default, Parser)]
+pub struct Build {
+    /// Path to the project, if not specified, current working directory will be used.
+    #[clap(short, long)]
+    pub path: Option<String>,
+    /// Print the generated Sway AST (Abstract Syntax Tree).
+    #[clap(long)]
+    pub print_ast: bool,
+    /// Print the finalized ASM.
+    ///
+    /// This is the state of the ASM with registers allocated and optimisations applied.
+    #[clap(long)]
+    pub print_finalized_asm: bool,
+    /// Print the generated ASM.
+    ///
+    /// This is the state of the ASM prior to performing register allocation and other ASM
+    /// optimisations.
+    #[clap(long)]
+    pub print_intermediate_asm: bool,
+    /// Print the generated Sway IR (Intermediate Representation).
+    #[clap(long)]
+    pub print_ir: bool,
+    /// Offline mode, prevents Forc from using the network when managing dependencies.
+    /// Meaning it will only try to use previously downloaded dependencies.
+    #[clap(long = "offline")]
+    pub offline_mode: bool,
+    /// Terse mode. Limited warning and error output.
+    #[clap(long = "terse", short = 't')]
+    pub terse_mode: bool,
+    /// The directory in which the sway compiler output artifacts are placed.
+    ///
+    /// By default, this is `<project-root>/out`.
+    #[clap(long)]
+    pub output_directory: Option<String>,
+    /// By default the JSON for ABIs is formatted for human readability. By using this option JSON
+    /// output will be "minified", i.e. all on one line without whitespace.
+    #[clap(long)]
+    pub minify_json_abi: bool,
+    /// By default the JSON for initial storage slots is formatted for human readability. By using
+    /// this option JSON output will be "minified", i.e. all on one line without whitespace.
+    #[clap(long)]
+    pub minify_json_storage_slots: bool,
+    /// Requires that the Forc.lock file is up-to-date. If the lock file is missing, or it
+    /// needs to be updated, Forc will exit with an error
+    #[clap(long)]
+    pub locked: bool,
+    /// Name of the build profile to use.
+    /// If it is not specified, forc will use debug build profile.
+    #[clap(long)]
+    pub build_profile: Option<String>,
+    /// Use release build plan. If a custom release plan is not specified, it is implicitly added to the manifest file.
+    ///
+    ///  If --build-profile is also provided, forc omits this flag and uses provided build-profile.
+    #[clap(long)]
+    pub release: bool,
+    /// Output the time elapsed over each part of the compilation process.
+    #[clap(long)]
+    pub time_phases: bool,
+    /// If set, outputs a binary file representing the script bytes.
+    #[clap(short = 'o')]
+    pub binary_outfile: Option<String>,
+    /// If set, outputs source file mapping in JSON format
+    #[clap(short = 'g', long)]
+    pub debug_outfile: Option<String>,
+}

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -1,27 +1,37 @@
 use crate::cli::BuildCommand;
 use anyhow::Result;
-use forc_pkg::{self as pkg};
+use forc_pkg as pkg;
 
-pub fn build(command: BuildCommand) -> Result<pkg::Built> {
-    let build_options = pkg::BuildOptions {
-        path: command.path,
-        print_ast: command.print_ast,
-        print_finalized_asm: command.print_finalized_asm,
-        print_ir: command.print_ir,
-        binary_outfile: command.binary_outfile,
-        debug_outfile: command.debug_outfile,
-        offline_mode: command.offline_mode,
-        terse_mode: command.terse_mode,
-        output_directory: command.output_directory,
-        minify_json_abi: command.minify_json_abi,
-        minify_json_storage_slots: command.minify_json_storage_slots,
-        locked: command.locked,
-        build_profile: command.build_profile,
-        release: command.release,
-        time_phases: command.time_phases,
-        print_intermediate_asm: command.print_intermediate_asm,
-        tests: command.tests,
-    };
-    let built = pkg::build_with_options(build_options)?;
+pub fn build(cmd: BuildCommand) -> Result<pkg::Built> {
+    let opts = opts_from_cmd(cmd);
+    let built = pkg::build_with_options(opts)?;
     Ok(built)
+}
+
+fn opts_from_cmd(cmd: BuildCommand) -> pkg::BuildOpts {
+    pkg::BuildOpts {
+        pkg: pkg::PkgOpts {
+            path: cmd.build.path,
+            offline: cmd.build.offline_mode,
+            terse: cmd.build.terse_mode,
+            locked: cmd.build.locked,
+            output_directory: cmd.build.output_directory,
+        },
+        print: pkg::PrintOpts {
+            ast: cmd.build.print_ast,
+            finalized_asm: cmd.build.print_finalized_asm,
+            intermediate_asm: cmd.build.print_intermediate_asm,
+            ir: cmd.build.print_ir,
+        },
+        minify: pkg::MinifyOpts {
+            json_abi: cmd.build.minify_json_abi,
+            json_storage_slots: cmd.build.minify_json_storage_slots,
+        },
+        build_profile: cmd.build.build_profile,
+        release: cmd.build.release,
+        time_phases: cmd.build.time_phases,
+        binary_outfile: cmd.build.binary_outfile,
+        debug_outfile: cmd.build.debug_outfile,
+        tests: cmd.tests,
+    }
 }

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -119,13 +119,16 @@ pub(crate) fn compile_to_bytes(
     let manifest = PackageManifestFile::from_dir(&PathBuf::from(path)).unwrap();
     let result = forc_pkg::build_package_with_options(
         &manifest,
-        forc_pkg::BuildOptions {
-            path: Some(format!(
-                "{}/src/e2e_vm_tests/test_programs/{}",
-                manifest_dir, file_name
-            )),
-            locked: run_config.locked,
-            terse_mode: !(capture_output || run_config.verbose),
+        forc_pkg::BuildOpts {
+            pkg: forc_pkg::PkgOpts {
+                path: Some(format!(
+                    "{}/src/e2e_vm_tests/test_programs/{}",
+                    manifest_dir, file_name
+                )),
+                locked: run_config.locked,
+                terse: !(capture_output || run_config.verbose),
+                ..Default::default()
+            },
             ..Default::default()
         },
     );


### PR DESCRIPTION
This is in anticipation of introducing a new `forc-test` library crate that will contain the logic for building and executing tests. It will expose a similar `TestOpts` type that shares some of these parts, but not all.

Also splits up the forc `BuildCommand` for easier sharing between sets of clap arguments (using the `clap` `flatten` attribute) that require building a project (e.g. build, test).

Also adds two missing args to the `RunCommand` (`release` and `build-profile`).