### PR TITLE
Initialize tracing based on user setting

### DIFF
--- a/sway-lsp/src/core/config.rs
+++ b/sway-lsp/src/core/config.rs
@@ -39,6 +39,7 @@ impl Default for LoggingConfig {
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "lowercase")]
 #[serde(remote = "LevelFilter")]
+#[allow(clippy::upper_case_acronyms)]
 enum LevelFilterDef {
     OFF,
     ERROR,

--- a/sway-lsp/src/core/config.rs
+++ b/sway-lsp/src/core/config.rs
@@ -1,22 +1,51 @@
 use serde::{Deserialize, Serialize};
+use tracing::metadata::LevelFilter;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Config {
-    pub debug: Debug,
+    pub debug: DebugConfig,
+    pub logging: LoggingConfig,
     pub inlay_hints: InlayHintsConfig,
     #[serde(skip_serializing)]
-    trace: Trace,
+    trace: TraceConfig,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Default)]
-struct Trace {}
+struct TraceConfig {}
 
 // Options for debugging various parts of the server
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Debug {
+pub struct DebugConfig {
     pub show_collected_tokens_as_warnings: Warnings,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoggingConfig {
+    #[serde(with = "LevelFilterDef")]
+    pub level: LevelFilter,
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            level: LevelFilter::OFF,
+        }
+    }
+}
+
+// This allows us to deserialize the enum that is defined in another crate.
+#[derive(Deserialize, Serialize, Clone)]
+#[serde(rename_all = "lowercase")]
+#[serde(remote = "LevelFilter")]
+enum LevelFilterDef {
+    OFF,
+    ERROR,
+    WARN,
+    INFO,
+    DEBUG,
+    TRACE,
 }
 
 /// Instructs the client to draw squiggly lines
@@ -39,7 +68,7 @@ pub struct InlayHintsConfig {
     pub max_length: Option<usize>,
 }
 
-impl Default for Debug {
+impl Default for DebugConfig {
     fn default() -> Self {
         Self {
             show_collected_tokens_as_warnings: Warnings::Default,

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -1,6 +1,5 @@
 #![recursion_limit = "256"]
 
-use forc_tracing::{init_tracing_subscriber, TracingSubscriberOptions, TracingWriterMode};
 use tower_lsp::{LspService, Server};
 
 mod capabilities;
@@ -11,16 +10,8 @@ mod server;
 pub mod test_utils;
 pub mod utils;
 use server::Backend;
-use tracing::metadata::LevelFilter;
 
 pub async fn start() {
-    let tracing_options = TracingSubscriberOptions {
-        log_level: Some(LevelFilter::DEBUG), // TODO: Set this based on IDE config
-        writer_mode: Some(TracingWriterMode::Stderr),
-        ..Default::default()
-    };
-    init_tracing_subscriber(tracing_options);
-
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -191,7 +191,7 @@ impl LanguageServer for Backend {
         // Initalizing tracing library based on the user's config
         let config = self.config.read();
         let tracing_options = TracingSubscriberOptions {
-            log_level: Some(config.logging.level.clone()),
+            log_level: Some(config.logging.level),
             writer_mode: Some(TracingWriterMode::Stderr),
             ..Default::default()
         };

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -23,6 +23,7 @@ use std::{
 use sway_types::Spanned;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{jsonrpc, Client, LanguageServer};
+use tracing::metadata::LevelFilter;
 
 #[derive(Debug)]
 pub struct Backend {
@@ -190,12 +191,14 @@ impl LanguageServer for Backend {
 
         // Initalizing tracing library based on the user's config
         let config = self.config.read();
-        let tracing_options = TracingSubscriberOptions {
-            log_level: Some(config.logging.level),
-            writer_mode: Some(TracingWriterMode::Stderr),
-            ..Default::default()
-        };
-        init_tracing_subscriber(tracing_options);
+        if config.logging.level != LevelFilter::OFF {
+            let tracing_options = TracingSubscriberOptions {
+                log_level: Some(config.logging.level),
+                writer_mode: Some(TracingWriterMode::Stderr),
+                ..Default::default()
+            };
+            init_tracing_subscriber(tracing_options);
+        }
 
         tracing::info!("Initializing the Sway Language Server");
 

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use dashmap::DashMap;
 use forc_pkg::manifest::PackageManifestFile;
+use forc_tracing::{init_tracing_subscriber, TracingSubscriberOptions, TracingWriterMode};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -178,14 +179,23 @@ impl Backend {
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> jsonrpc::Result<InitializeResult> {
-        tracing::info!("Initializing the Sway Language Server");
-
         if let Some(initialization_options) = &params.initialization_options {
             let mut config = self.config.write();
             *config = serde_json::from_value(initialization_options.clone())
                 .ok()
                 .unwrap_or_default();
         }
+
+        // Initalizing tracing library based on the user's config
+        let config = self.config.read();
+        let tracing_options = TracingSubscriberOptions {
+            log_level: Some(config.logging.level.clone()),
+            writer_mode: Some(TracingWriterMode::Stderr),
+            ..Default::default()
+        };
+        init_tracing_subscriber(tracing_options);
+
+        tracing::info!("Initializing the Sway Language Server");
 
         Ok(InitializeResult {
             server_info: None,


### PR DESCRIPTION
- initializes trace _after_ the server has started and the user's settings from the IDE have been written to `config`
- uses the log level from the config to initialize tracing

Tested this change manually and confirmed that the user's setting is passed to the server and that the correct logs are shown in the output console.

Related https://github.com/FuelLabs/sway/pull/2925 
plugin PR: https://github.com/FuelLabs/sway-vscode-plugin/pull/100