### PR TITLE
Revert changes to the `token_ops` test made in #2922

### DIFF
--- a/test/src/sdk-harness/test_projects/token_ops/mod.rs
+++ b/test/src/sdk-harness/test_projects/token_ops/mod.rs
@@ -372,7 +372,7 @@ async fn can_send_message_output_with_data() {
 
     let call_response = fuelcoin_instance
         .methods()
-        .send_message_with_data(Bits256(*recipient_address), amount)
+        .send_message(Bits256(*recipient_address), vec![100, 75, 50], amount)
         .append_message_outputs(1)
         .call()
         .await
@@ -415,7 +415,7 @@ async fn can_send_message_output_without_data() {
 
     let call_response = fuelcoin_instance
         .methods()
-        .send_message_without_data(Bits256(*recipient_address), amount)
+        .send_message(Bits256(*recipient_address), Vec::<u64>::new(), amount)
         .append_message_outputs(1)
         .call()
         .await

--- a/test/src/sdk-harness/test_projects/token_ops/src/main.sw
+++ b/test/src/sdk-harness/test_projects/token_ops/src/main.sw
@@ -12,8 +12,7 @@ abi TestFuelCoin {
     fn mint_and_send_to_address(amount: u64, to: Address);
     fn generic_mint_to(amount: u64, to: Identity);
     fn generic_transfer(amount: u64, asset_id: ContractId, to: Identity);
-    fn send_message_without_data(recipient: b256, coins: u64);
-    fn send_message_with_data(recipient: b256, coins: u64);
+    fn send_message(recipient: b256, msg_data: Vec<u64>, coins: u64);
 }
 
 impl TestFuelCoin for Contract {
@@ -53,16 +52,7 @@ impl TestFuelCoin for Contract {
         transfer(amount, asset_id, to)
     }
 
-    fn send_message_without_data(recipient: b256, coins: u64) {
-        let vec: Vec<u64> = ~Vec::new();
-        send_message(recipient, vec, coins);
-    }
-
-    fn send_message_with_data(recipient: b256, coins: u64) {
-        let mut vec: Vec<u64> = ~Vec::new();
-        vec.push(100);
-        vec.push(75);
-        vec.push(50);
-        send_message(recipient, vec, coins);
+    fn send_message(recipient: b256, msg_data: Vec<u64>, coins: u64) {
+        send_message(recipient, msg_data, coins);
     }
 }


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway/issues/3122

The new version of `fuels` supports `raw_ptr` so we can re-enable this test now.