### PR TITLE
Update section title

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,7 +4,7 @@
 
 - [Introduction](./introduction/index.md)
   - [Installation](./introduction/installation.md)
-  - [Getting Started](./introduction/overview.md)
+  - [Sway Quickstart](./introduction/overview.md)
   - [The Fuel Toolchain](./introduction/fuel-toolchain.md)
   - [A Forc Project](./introduction/forc_project.md)
   - [Standard Library](./introduction/standard_library.md)

--- a/docs/src/introduction/overview.md
+++ b/docs/src/introduction/overview.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Sway Quickstart
 
 Follow this guide to write, test, and deploy a simple smart contract in Sway.
 


### PR DESCRIPTION
Change title on navigation from Getting Started to Sway Quickstart to make it clear to developers that is the tab to navigate to to start building with Sway. This https://github.com/FuelLabs/sway/pull/3198 PR updates that section to include links to the developer quickstart, a note on the difference between deploying to a local Fuel node vs testnet, and removes old links