### PR TITLE
Do not reuse registers for insert/extract element, they may be live

### DIFF
--- a/sway-core/src/asm_generation/asm_builder.rs
+++ b/sway-core/src/asm_generation/asm_builder.rs
@@ -607,16 +607,7 @@ impl<'ir> AsmBuilder<'ir> {
 
         // Index value is the array element index, not byte nor word offset.
         let index_reg = self.value_to_register(index_val);
-        let rel_offset_reg = match index_reg {
-            VirtualRegister::Virtual(_) => {
-                // We can reuse the register.
-                index_reg.clone()
-            }
-            VirtualRegister::Constant(_) => {
-                // We have a constant register, cannot reuse it.
-                self.reg_seqr.next()
-            }
-        };
+        let rel_offset_reg = self.reg_seqr.next();
 
         // We could put the OOB check here, though I'm now thinking it would be too wasteful.
         // See compile_bounds_assertion() in expression/array.rs (or look in Git history).
@@ -915,16 +906,7 @@ impl<'ir> AsmBuilder<'ir> {
 
         // Index value is the array element index, not byte nor word offset.
         let index_reg = self.value_to_register(index_val);
-        let rel_offset_reg = match index_reg {
-            VirtualRegister::Virtual(_) => {
-                // We can reuse the register.
-                index_reg.clone()
-            }
-            VirtualRegister::Constant(_) => {
-                // We have a constant register, cannot reuse it.
-                self.reg_seqr.next()
-            }
-        };
+        let rel_offset_reg = self.reg_seqr.next();
 
         let owning_span = self.md_mgr.val_to_span(self.context, *instr_val);
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-8E2171C2F6D30B77'
+
+[[package]]
+name = 'insert_element_reg_reuse'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-8E2171C2F6D30B77'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "insert_element_reg_reuse"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/json_abi_oracle.json
@@ -1,0 +1,22 @@
+{
+  "functions": [
+    {
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/src/main.sw
@@ -1,0 +1,64 @@
+script;
+
+impl core::ops::Eq for [u64; 2] {
+    fn eq(self, other: Self) -> bool {
+        let mut i = 0;
+        while i < 2 {
+            if self[i] != other[i] {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+}
+
+impl core::ops::Eq for Vec<[u64; 2]> {
+    fn eq(self, other: Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+        let mut i = 0;
+        while i < self.len() {
+            if self.get(i).unwrap() != other.get(i).unwrap() {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+}
+
+fn tester1(arg: Vec<[u64; 2]>) {
+    let mut expected = ~Vec::new();
+    expected.push([0, 1]);
+    expected.push([0, 1]);
+
+    assert(arg == expected);
+}
+
+fn tester2(arg: Vec<[u64; 2]>) {
+    let mut expected = ~Vec::new();
+    expected.push([0, 1]);
+    expected.push([0, 1]);
+
+    assert(arg != expected);
+}
+
+fn main() -> u64 {
+
+  let mut arg1 = ~Vec::new();
+  arg1.push([0, 1]);
+  arg1.push([0, 1]);
+  tester1(arg1);
+
+  let mut arg2 = ~Vec::new();
+  arg2.push([0, 1]);
+  arg2.push([0, 2]);
+  tester2(arg2);
+
+  arg1.push([0, 1]);
+  tester2(arg1);
+
+  1
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+validate_abi = true


### PR DESCRIPTION
Previously, values would be reloaded from memory, thus even if it was live and clobbered, it wouldn't matter because it would be reloaded. But now (with `mem2reg`, expectedly), a live register cannot be clobbered.

Closes #3188

