### PR TITLE
Detect and disallow multiple methods with the same name.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -776,6 +776,7 @@ fn type_check_trait_implementation(
             self_type_id,
             functions_buf.clone(),
             block_span,
+            false,
         ),
         return err(warnings, errors),
         warnings,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -100,6 +100,7 @@ impl ty::TyTraitDeclaration {
                     .map(|x| x.to_dummy_func(Mode::NonAbi))
                     .collect(),
                 &span,
+                false
             ),
             return err(warnings, errors),
             warnings,
@@ -189,6 +190,7 @@ fn handle_supertraits(mut ctx: TypeCheckContext, supertraits: &[Supertrait]) -> 
                         .map(|x| x.to_dummy_func(Mode::NonAbi))
                         .collect(),
                     &supertrait.name.span(),
+                    false,
                 );
 
                 // insert dummy versions of the methods of all of the supertraits
@@ -206,6 +208,7 @@ fn handle_supertraits(mut ctx: TypeCheckContext, supertraits: &[Supertrait]) -> 
                     self_type,
                     dummy_funcs,
                     &supertrait.name.span(),
+                    false,
                 );
 
                 // Recurse to insert dummy versions of interfaces and methods of the *super*

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1243,6 +1243,7 @@ impl ty::TyExpression {
                 return_type,
                 functions_buf,
                 &span,
+                false
             ),
             return err(warnings, errors),
             warnings,

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -218,6 +218,7 @@ impl ty::TyAstNode {
                                     impl_trait.implementing_for_type_id,
                                     methods,
                                     &impl_trait.span,
+                                    false
                                 ),
                                 return err(warnings, errors),
                                 warnings,
@@ -242,12 +243,18 @@ impl ty::TyAstNode {
                             // specifically dont check for conflicting trait definitions
                             // because its totally ok to defined multiple impl selfs for
                             // the same type
-                            ctx.namespace.insert_trait_implementation(
-                                impl_trait.trait_name.clone(),
-                                impl_trait.trait_type_arguments.clone(),
-                                impl_trait.implementing_for_type_id,
-                                methods,
-                                &impl_trait.span,
+                            check!(
+                                ctx.namespace.insert_trait_implementation(
+                                    impl_trait.trait_name.clone(),
+                                    impl_trait.trait_type_arguments.clone(),
+                                    impl_trait.implementing_for_type_id,
+                                    methods,
+                                    &impl_trait.span,
+                                    true
+                                ),
+                                return err(warnings, errors),
+                                warnings,
+                                errors
                             );
                             ty::TyDeclaration::ImplTrait(de_insert_impl_trait(impl_trait))
                         }

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -240,9 +240,6 @@ impl ty::TyAstNode {
                                     Err(err) => errors.push(err),
                                 }
                             }
-                            // specifically dont check for conflicting trait definitions
-                            // because its totally ok to defined multiple impl selfs for
-                            // the same type
                             check!(
                                 ctx.namespace.insert_trait_implementation(
                                     impl_trait.trait_name.clone(),

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -140,6 +140,7 @@ impl Items {
         type_id: TypeId,
         methods: Vec<ty::TyFunctionDeclaration>,
         impl_span: &Span,
+        is_impl_self: bool,
     ) -> CompileResult<()> {
         let new_prefixes = if trait_name.prefixes.is_empty() {
             self.use_synonyms
@@ -155,8 +156,14 @@ impl Items {
             suffix: trait_name.suffix,
             is_absolute: trait_name.is_absolute,
         };
-        self.implemented_traits
-            .insert(trait_name, trait_type_args, type_id, methods, impl_span)
+        self.implemented_traits.insert(
+            trait_name,
+            trait_type_args,
+            type_id,
+            methods,
+            impl_span,
+            is_impl_self,
+        )
     }
 
     pub(crate) fn insert_trait_implementation_for_type(&mut self, type_id: TypeId) {

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -445,6 +445,12 @@ pub enum CompileError {
         type_implementing_for: String,
         second_impl_span: Span,
     },
+    #[error("Duplicate definitions for the method \"{func_name}\" for type \"{type_implementing_for}\".")]
+    DuplicateMethodsDefinedForType {
+        func_name: String,
+        type_implementing_for: String,
+        span: Span,
+    },
     #[error("The function \"{fn_name}\" in {interface_name} is defined with {num_parameters} parameters, but the provided implementation has {provided_parameters} parameters.")]
     IncorrectNumberOfInterfaceSurfaceFunctionParameters {
         fn_name: Ident,
@@ -773,6 +779,7 @@ impl Spanned for CompileError {
             ConflictingImplsForTraitAndType {
                 second_impl_span, ..
             } => second_impl_span.clone(),
+            DuplicateMethodsDefinedForType { span, .. } => span.clone(),
             IncorrectNumberOfInterfaceSurfaceFunctionParameters { span, .. } => span.clone(),
             ArgumentParameterTypeMismatch { span, .. } => span.clone(),
             RecursiveCall { span, .. } => span.clone(),

--- a/sway-lib-core/src/ops.sw
+++ b/sway-lib-core/src/ops.sw
@@ -320,17 +320,6 @@ impl Ord for b256 {
     }
 }
 
-impl b256 {
-    fn neq(self, other: Self) -> bool {
-        // Both self and other are addresses of the values, so we can use MEQ.
-        asm(r1: self, r2: other, r3, r4) {
-            addi r3 zero i32;
-            meq r4 r1 r2 r3;
-            r4: bool
-        }.not()
-    }
-}
-
 pub trait BitwiseAnd {
     fn binary_and(self, other: Self) -> Self;
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/multiple_methods_with_the_same_name/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/multiple_methods_with_the_same_name/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-C42B3A5463177F2D'
+
+[[package]]
+name = 'multiple_methods_with_the_same_name'
+source = 'root'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/multiple_methods_with_the_same_name/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/multiple_methods_with_the_same_name/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "multiple_methods_with_the_same_name"
+entry = "main.sw"
+implicit-std = false
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/multiple_methods_with_the_same_name/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/multiple_methods_with_the_same_name/json_abi_oracle.json
@@ -1,0 +1,15 @@
+[
+  {
+    "inputs": [],
+    "name": "main",
+    "outputs": [
+      {
+        "components": null,
+        "name": "",
+        "type": "u32",
+        "typeArguments": null
+      }
+    ],
+    "type": "function"
+  }
+]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/multiple_methods_with_the_same_name/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/multiple_methods_with_the_same_name/src/main.sw
@@ -1,0 +1,67 @@
+script;
+
+// We should definitely implement something like the "fully qualified syntax",
+// but until then, multiple methods with the same name is undefined behavior.
+// https://doc.rust-lang.org/rust-by-example/trait/disambiguating.html
+
+struct Data<T> {
+    value: T
+}
+
+trait MyAdd {
+    fn my_add(self, other: Self) -> Self;
+}
+
+impl<T> MyAdd for Data<T> {
+    fn my_add(self, other: Self) -> Self {
+        other
+    }
+}
+
+impl<T> Data<T> {
+    // duplicate definition
+    fn my_add(self, other: Self) -> Self {
+        other
+    }
+}
+
+impl Data<u64> {
+    fn get_value(self) -> u64 {
+        self.value
+    }
+}
+
+impl Data<u64> {
+    // duplicate definition
+    fn get_value(self) -> u64 {
+        self.value
+    }
+}
+
+impl Data<u64> {
+    // duplicate definition
+    fn my_add(self, other: Self) -> Self {
+        Data {
+            value: self.value + other.value
+        }
+    }
+}
+
+impl Data<u32> {
+    // duplicate definition
+    fn my_add(self, other: Self) -> Self {
+        Data {
+            value: self.value + other.value
+        }
+    }
+}
+
+impl Data<u8> {
+    fn get_value(self) -> u8 {
+        self.value
+    }
+}
+
+fn main() {
+
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/multiple_methods_with_the_same_name/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/multiple_methods_with_the_same_name/test.toml
@@ -1,0 +1,13 @@
+category = "fail"
+
+# check: $()fn my_add(self, other: Self) -> Self {
+# check: $()Duplicate definitions for the method "my_add" for type "Data<T>".
+
+# check: $()fn get_value(self) -> u64 {
+# check: $()Duplicate definitions for the method "get_value" for type "Data<u64>".
+
+# check: $()fn my_add(self, other: Self) -> Self {
+# check: $()Duplicate definitions for the method "my_add" for type "Data<u64>".
+
+# check: $()fn my_add(self, other: Self) -> Self {
+# check: $()Duplicate definitions for the method "my_add" for type "Data<u32>".

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_traits/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_traits/src/main.sw
@@ -1,5 +1,9 @@
 script;
 
+// We should definitely implement something like the "fully qualified syntax",
+// but until then, multiple methods with the same name is undefined behavior.
+// https://doc.rust-lang.org/rust-by-example/trait/disambiguating.html
+
 dep my_double;
 dep my_point;
 dep my_triple;
@@ -37,11 +41,11 @@ trait MyAdd<T> {
     fn my_add(self, a: T, b: T) -> T;
 }
 
-impl<T> MyAdd<u8> for FooBarData<T> {
-    fn my_add(self, a: u8, b: u8) -> u8 {
-        a + b
-    }
-}
+// impl<T> MyAdd<u8> for FooBarData<T> {
+//     fn my_add(self, a: u8, b: u8) -> u8 {
+//         a + b
+//     }
+// }
 
 impl<T> MyAdd<u64> for FooBarData<T> {
     fn my_add(self, a: u64, b: u64) -> u64 {
@@ -53,15 +57,15 @@ trait MySub<T> {
     fn my_sub(a: T, b: T) -> T;
 }
 
-impl<T> MySub<u8> for FooBarData<T> {
-    fn my_sub(a: u8, b: u8) -> u8 {
-        if a >= b {
-            a - b
-        } else {
-            b - a
-        }
-    }
-}
+// impl<T> MySub<u8> for FooBarData<T> {
+//     fn my_sub(a: u8, b: u8) -> u8 {
+//         if a >= b {
+//             a - b
+//         } else {
+//             b - a
+//         }
+//     }
+// }
 
 impl<T> MySub<u64> for FooBarData<T> {
     fn my_sub(a: u64, b: u64) -> u64 {
@@ -78,11 +82,11 @@ struct OtherData<T> {
     b: T,
 }
 
-impl<T> MyAdd<u8> for OtherData<T> {
-    fn my_add(self, a: u8, b: u8) -> u8 {
-        a + b
-    }
-}
+// impl<T> MyAdd<u8> for OtherData<T> {
+//     fn my_add(self, a: u8, b: u8) -> u8 {
+//         a + b
+//     }
+// }
 
 impl<T> MyAdd<u64> for OtherData<T> {
     fn my_add(self, a: u64, b: u64) -> u64 {
@@ -90,15 +94,15 @@ impl<T> MyAdd<u64> for OtherData<T> {
     }
 }
 
-impl<T> MySub<u8> for OtherData<T> {
-    fn my_sub(a: u8, b: u8) -> u8 {
-        if a >= b {
-            a - b
-        } else {
-            b - a
-        }
-    }
-}
+// impl<T> MySub<u8> for OtherData<T> {
+//     fn my_sub(a: u8, b: u8) -> u8 {
+//         if a >= b {
+//             a - b
+//         } else {
+//             b - a
+//         }
+//     }
+// }
 
 impl<T> MySub<u64> for OtherData<T> {
     fn my_sub(a: u64, b: u64) -> u64 {


### PR DESCRIPTION
This PR:
1. detects and disallows multiple methods with the same name
2. removes a duplicate definition for `neq` on `b256`

Eventually we should remove the ban on # 1 by adding a version of "fully qualified trait name syntax", but until then writing multiple methods with the same name was undefined behavior. See: https://doc.rust-lang.org/rust-by-example/trait/disambiguating.html