### PR TITLE
Fix bug which created dead and incorrectly typed blocks into IR, triggering a verification failure.

### DIFF
--- a/sway-ir/src/constant.rs
+++ b/sway-ir/src/constant.rs
@@ -77,6 +77,13 @@ impl Constant {
         }
     }
 
+    pub fn get_undef(ty: Type) -> Self {
+        Constant {
+            ty,
+            value: ConstantValue::Undef,
+        }
+    }
+
     pub fn get_unit(context: &mut Context) -> Value {
         Value::new_constant(context, Constant::new_unit())
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_explicit_rets/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_explicit_rets/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_explicit_rets/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_explicit_rets/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-3F456608F1F32854'
+
+[[package]]
+name = 'match_expressions_explicit_rets'
+source = 'root'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_explicit_rets/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_explicit_rets/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "match_expressions_explicit_rets"
+implicit-std = false
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_explicit_rets/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_explicit_rets/src/main.sw
@@ -1,0 +1,15 @@
+script;
+
+// Explicit returns from each arm of a match expression.  Was causing mistyped dead IR to be
+// generated.
+
+fn main() -> bool {
+    match true {
+        true => {
+            return true;
+        },
+        false => {
+            return false;
+        }
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_explicit_rets/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_explicit_rets/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+validate_abi = false


### PR DESCRIPTION
If both arms of an `if` (or all arms of a `match` which are converted to `if`s) were terminated with `return` then we still created a merge block with an unknown arg, which ended up being dead code and incorrectly typed.

Closes #3205