### PR TITLE
Adds error for doc comment before Dependency.

### DIFF
--- a/sway-error/src/parser_error.rs
+++ b/sway-error/src/parser_error.rs
@@ -8,6 +8,8 @@ pub enum ParseErrorKind {
     ExpectedImportNameGroupOrGlob,
     #[error("Expected an item.")]
     ExpectedAnItem,
+    #[error("Cannot doc comment a dependency.")]
+    CannotDocCommentDepToken,
     #[error("Expected a comma or closing parenthesis in function arguments.")]
     ExpectedCommaOrCloseParenInFnArgs,
     #[error("Unrecognized op code.")]

--- a/sway-parse/src/parser.rs
+++ b/sway-parse/src/parser.rs
@@ -136,6 +136,14 @@ impl<'a, 'e> Parser<'a, 'e> {
         &self.token_trees[..len]
     }
 
+    pub(crate) fn token_trees(&self) -> &'a [TokenTree] {
+        &self.token_trees
+    }
+
+    pub(crate) fn set_token_trees(&mut self, token_trees: &'a [TokenTree]) {
+        self.token_trees = token_trees;
+    }
+
     /// Errors given `Some(PubToken)`.
     pub fn ban_visibility_qualifier(&mut self, vis: &Option<PubToken>) -> ParseResult<()> {
         if let Some(token) = vis {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-137BEA77671D03C2'
+
+[[package]]
+name = 'dep_doc_comment'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-137BEA77671D03C2'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+name = "dep_doc_comment"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+
+[dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/src/bar.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/src/bar.sw
@@ -1,0 +1,3 @@
+library foo;
+
+fn foo() -> bool { true }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/src/baz.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/src/baz.sw
@@ -1,0 +1,4 @@
+library foo;
+
+fn foo() -> bool { true }
+

--- a/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/src/foo.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/src/foo.sw
@@ -1,0 +1,3 @@
+library foo;
+
+fn foo() -> bool { true } 

--- a/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/src/main.sw
@@ -1,0 +1,12 @@
+contract;
+
+dep foo;
+
+/// This doc comment
+/// should return a parser error
+dep bar;
+
+dep baz;
+
+fn a() -> bool { true }
+

--- a/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/dep_doc_comment/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Cannot doc comment a dependency.


### PR DESCRIPTION
Before this fix the error message for doc comments before was out of place and was "Expected an item."

This was fixed by 'pre-parsing' each `Dependency` and checking if there is a `DocComment` before. The 'pre-parsing' stores a clone of `parser.token_trees` and restores it later to avoid consuming any `DocComment` that is consumed later while parsing `Annotated<ItemKind>`.

Closes #3116