### PR TITLE
Fixed "Cannot infer type" error to point to call site span.

### DIFF
--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -132,7 +132,7 @@ impl CollectTypesMetadata for TyExpression {
             StructExpression { fields, span, .. } => {
                 if let TypeInfo::Struct {
                     type_parameters, ..
-                } = look_up_type_id(self.return_type.clone())
+                } = look_up_type_id(self.return_type)
                 {
                     for type_parameter in type_parameters {
                         ctx.call_site_insert(type_parameter.type_id, span.clone());

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use sway_types::Span;
+use sway_types::{Span, Spanned};
 
 use crate::{
     declaration_engine::{de_get_function, DeclMapping, ReplaceDecls},
@@ -76,8 +76,10 @@ impl CollectTypesMetadata for TyExpression {
             FunctionApplication {
                 arguments,
                 function_decl_id,
+                call_path,
                 ..
             } => {
+                ctx.set_call_site_span(Some(call_path.span()));
                 for arg in arguments.iter() {
                     res.append(&mut check!(
                         arg.1.collect_types_metadata(ctx),
@@ -98,6 +100,7 @@ impl CollectTypesMetadata for TyExpression {
                         errors
                     ));
                 }
+                ctx.set_call_site_span(None);
             }
             Tuple { fields } => {
                 for field in fields.iter() {
@@ -244,8 +247,10 @@ impl CollectTypesMetadata for TyExpression {
             EnumInstantiation {
                 enum_decl,
                 contents,
+                enum_instantiation_span,
                 ..
             } => {
+                ctx.set_call_site_span(Some(enum_instantiation_span.clone()));
                 if let Some(contents) = contents {
                     res.append(&mut check!(
                         contents.collect_types_metadata(ctx),
@@ -270,6 +275,7 @@ impl CollectTypesMetadata for TyExpression {
                         errors
                     ));
                 }
+                ctx.set_call_site_span(None);
             }
             AbiCast { address, .. } => {
                 res.append(&mut check!(

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -232,10 +232,12 @@ pub fn parsed_to_ast(
 
     // All unresolved types lead to compile errors.
     errors.extend(types_metadata.iter().filter_map(|m| match m {
-        TypeMetadata::UnresolvedType(name) => Some(CompileError::UnableToInferGeneric {
-            ty: name.as_str().to_string(),
-            span: name.span(),
-        }),
+        TypeMetadata::UnresolvedType(name, call_site_span_opt) => {
+            Some(CompileError::UnableToInferGeneric {
+                ty: name.as_str().to_string(),
+                span: call_site_span_opt.clone().unwrap_or_else(|| name.span()),
+            })
+        }
         _ => None,
     }));
 

--- a/sway-core/src/type_system/collect_types_metadata.rs
+++ b/sway-core/src/type_system/collect_types_metadata.rs
@@ -4,7 +4,7 @@
 //! that is not the case.
 
 use crate::{type_system::TypeId, CompileResult};
-use sway_types::Ident;
+use sway_types::{Ident, Span};
 
 /// If any types contained by this node are unresolved or have yet to be inferred, throw an
 /// error to signal to the user that more type information is needed.
@@ -26,7 +26,8 @@ impl LogId {
 }
 
 pub enum TypeMetadata {
-    UnresolvedType(Ident),
+    // UnresolvedType receives the Ident of the type and a call site span.
+    UnresolvedType(Ident, Option<Span>),
     // A log with a unique log ID and the type ID of the type of the value being logged
     LoggedType(LogId, TypeId),
 }
@@ -36,6 +37,8 @@ pub struct CollectTypesMetadataContext {
     // Consume this and update it via the methods implemented for CollectTypesMetadataContext to
     // obtain a unique ID for a given log instance.
     log_id_counter: usize,
+
+    call_site_span: Option<Span>,
 }
 
 impl CollectTypesMetadataContext {
@@ -47,8 +50,19 @@ impl CollectTypesMetadataContext {
         &mut self.log_id_counter
     }
 
+    pub fn call_site_span(&self) -> Option<Span> {
+        self.call_site_span.clone()
+    }
+
+    pub fn set_call_site_span(&mut self, span: Option<Span>) {
+        self.call_site_span = span;
+    }
+
     pub fn new() -> Self {
-        Self { log_id_counter: 0 }
+        Self {
+            log_id_counter: 0,
+            call_site_span: None,
+        }
     }
 }
 

--- a/sway-core/src/type_system/collect_types_metadata.rs
+++ b/sway-core/src/type_system/collect_types_metadata.rs
@@ -73,7 +73,7 @@ impl CollectTypesMetadataContext {
 
     pub fn call_site_get(&mut self, type_id: &TypeId) -> Option<Span> {
         for lock in self.call_site_spans.iter() {
-            if let Some(hash_map) = lock.lock().ok() {
+            if let Ok(hash_map) = lock.lock() {
                 let opt = hash_map.get(type_id).cloned();
                 if opt.is_some() {
                     return opt;

--- a/sway-core/src/type_system/type_id.rs
+++ b/sway-core/src/type_system/type_id.rs
@@ -38,7 +38,7 @@ impl CollectTypesMetadata for TypeId {
     ) -> CompileResult<Vec<TypeMetadata>> {
         let res = match look_up_type_id(*self) {
             TypeInfo::UnknownGeneric { name } => {
-                vec![TypeMetadata::UnresolvedType(name, ctx.call_site_span())]
+                vec![TypeMetadata::UnresolvedType(name, ctx.call_site_get(self))]
             }
             _ => vec![],
         };

--- a/sway-core/src/type_system/type_id.rs
+++ b/sway-core/src/type_system/type_id.rs
@@ -34,10 +34,12 @@ impl From<usize> for TypeId {
 impl CollectTypesMetadata for TypeId {
     fn collect_types_metadata(
         &self,
-        _ctx: &mut CollectTypesMetadataContext,
+        ctx: &mut CollectTypesMetadataContext,
     ) -> CompileResult<Vec<TypeMetadata>> {
         let res = match look_up_type_id(*self) {
-            TypeInfo::UnknownGeneric { name } => vec![TypeMetadata::UnresolvedType(name)],
+            TypeInfo::UnknownGeneric { name } => {
+                vec![TypeMetadata::UnresolvedType(name, ctx.call_site_span())]
+            }
             _ => vec![],
         };
         ok(res, vec![], vec![])

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info/test.toml
@@ -1,4 +1,4 @@
 category = "fail"
 
-# check: fn foo<T>() {
+# check: foo()
 # nextln: $()Cannot infer type for type parameter "T". Insufficient type information provided. Try annotating its type.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_enum/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_enum/Forc.lock
@@ -4,7 +4,7 @@ source = 'path+from-root-517D42DD06E1D0DC'
 
 [[package]]
 name = 'insufficient_type_info_enum'
-source = 'root'
+source = 'member'
 dependencies = ['std']
 
 [[package]]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_enum/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_enum/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-517D42DD06E1D0DC'
+
+[[package]]
+name = 'insufficient_type_info_enum'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-517D42DD06E1D0DC'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_enum/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_enum/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "insufficient_type_info_enum"
+
+[dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_enum/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_enum/src/main.sw
@@ -1,0 +1,6 @@
+script;
+
+fn main() -> bool {
+    let o = Option::None();
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_enum/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_enum/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: Option::None()
+# nextln: $()Cannot infer type for type parameter "T". Insufficient type information provided. Try annotating its type.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_struct/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-125BF2A2DA112749'
+
+[[package]]
+name = 'insufficient_type_info_struct'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-125BF2A2DA112749'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_struct/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_struct/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "insufficient_type_info_struct"
+
+[dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_struct/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_struct/src/main.sw
@@ -1,0 +1,15 @@
+script;
+
+struct S<T> {
+}
+
+impl<T> S<T> {
+    fn foo(self) -> u64 {
+        __size_of::<T>()
+    }
+}
+
+fn main() -> u64 {
+    let s = S {};
+    s.foo()
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_struct/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info_struct/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: let s = S {};
+# nextln: $()Cannot infer type for type parameter "T". Insufficient type information provided. Try annotating its type.


### PR DESCRIPTION
`CompileError::UnableToInferGeneric` was using as span the span of the type_id. This causes the error to point to where the type is declared instead of to where it should be annotated.

The solution was to store a call site span in `CollectTypesMetadataContext` and pass it to `TypeInfo::UnknownGeneric` so when we convert it to the actual error we can use the call site span which points to the place that is missing a type annotation.

Closes #3192