### PR TITLE
[WIP] Allow returning and receiving `Vec`s in scripts

### DIFF
--- a/sway-core/src/asm_generation/asm_builder/functions.rs
+++ b/sway-core/src/asm_generation/asm_builder/functions.rs
@@ -446,6 +446,10 @@ impl<'ir> AsmBuilder<'ir> {
                         self.ptr_map.insert(*ptr, Storage::Stack(stack_base));
                         stack_base += 1;
                     }
+                    Type::Slice => {
+                        self.ptr_map.insert(*ptr, Storage::Stack(stack_base));
+                        stack_base += 2;
+                    }
                     Type::B256 => {
                         // XXX Like strings, should we just reserve space for a pointer?
                         self.ptr_map.insert(*ptr, Storage::Stack(stack_base));

--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -161,6 +161,7 @@ pub enum StateAccessType {
 pub(crate) fn ir_type_size_in_bytes(context: &Context, ty: &Type) -> u64 {
     match ty {
         Type::Unit | Type::Bool | Type::Uint(_) | Type::Pointer(_) => 8,
+        Type::Slice => 16,
         Type::B256 => 32,
         Type::String(n) => size_bytes_round_up_to_word_alignment!(n),
         Type::Array(aggregate) => {

--- a/sway-core/src/ir_generation/convert.rs
+++ b/sway-core/src/ir_generation/convert.rs
@@ -116,6 +116,7 @@ fn convert_resolved_type(
             }
         }
         TypeInfo::RawUntypedPtr => Type::Uint(64),
+        TypeInfo::RawUntypedSlice => Type::Slice,
 
         // Unsupported types which shouldn't exist in the AST after type checking and
         // monomorphisation.

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -2164,6 +2164,10 @@ impl FnCompiler {
                         "Pointers in storage have not been implemented yet.",
                         Span::dummy(),
                     )),
+                    Type::Slice => Err(CompileError::Internal(
+                        "Slices in storage have not been implemented yet.",
+                        Span::dummy(),
+                    )),
                     Type::B256 => self.compile_b256_storage_read(
                         context,
                         ix,
@@ -2280,6 +2284,10 @@ impl FnCompiler {
                     )),
                     Type::Pointer(_) => Err(CompileError::Internal(
                         "Pointers in storage have not been implemented yet.",
+                        Span::dummy(),
+                    )),
+                    Type::Slice => Err(CompileError::Internal(
+                        "Slices in storage have not been implemented yet.",
                         Span::dummy(),
                     )),
                     Type::B256 => self.compile_b256_storage_write(

--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -180,7 +180,7 @@ impl TyProgram {
                         name: mains.last().unwrap().name.clone(),
                     });
                 }
-                // A script must not return a `raw_ptr`
+                // A script must not return a `raw_ptr` or any type containing a `raw_slice`.
                 let main_func = mains.remove(0);
                 let nested_types = check!(
                     look_up_type_id(main_func.return_type)
@@ -194,6 +194,17 @@ impl TyProgram {
                     .any(|ty| matches!(ty, TypeInfo::RawUntypedPtr))
                 {
                     errors.push(CompileError::PointerReturnNotAllowedInMain {
+                        span: main_func.return_type_span.clone(),
+                    });
+                }
+                if !matches!(
+                    look_up_type_id(main_func.return_type),
+                    TypeInfo::RawUntypedSlice
+                ) && nested_types
+                    .iter()
+                    .any(|ty| matches!(ty, TypeInfo::RawUntypedSlice))
+                {
+                    errors.push(CompileError::NestedSliceReturnNotAllowedInMain {
                         span: main_func.return_type_span.clone(),
                     });
                 }

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -519,6 +519,7 @@ fn are_equal_minus_dynamic_types(left: TypeId, right: TypeId) -> bool {
         (TypeInfo::Str(l), TypeInfo::Str(r)) => l == r,
         (TypeInfo::UnsignedInteger(l), TypeInfo::UnsignedInteger(r)) => l == r,
         (TypeInfo::RawUntypedPtr, TypeInfo::RawUntypedPtr) => true,
+        (TypeInfo::RawUntypedSlice, TypeInfo::RawUntypedSlice) => true,
 
         // these cases may contain dynamic types
         (

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -769,6 +769,7 @@ fn type_info_name(type_info: &TypeInfo) -> String {
         TypeInfo::Array(..) => "array",
         TypeInfo::Storage { .. } => "contract storage",
         TypeInfo::RawUntypedPtr => "raw untyped ptr",
+        TypeInfo::RawUntypedSlice => "raw untyped slice",
     }
     .to_string()
 }

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -858,6 +858,7 @@ pub(crate) fn type_name_to_type_info_opt(name: &Ident) -> Option<TypeInfo> {
         "unit" => Some(TypeInfo::Tuple(Vec::new())),
         "b256" => Some(TypeInfo::B256),
         "raw_ptr" => Some(TypeInfo::RawUntypedPtr),
+        "raw_slice" => Some(TypeInfo::RawUntypedSlice),
         "Self" | "self" => Some(TypeInfo::SelfType),
         "Contract" => Some(TypeInfo::Contract),
         _other => None,

--- a/sway-core/src/type_system/type_id.rs
+++ b/sway-core/src/type_system/type_id.rs
@@ -103,6 +103,7 @@ impl ReplaceSelfType for TypeId {
             | TypeInfo::B256
             | TypeInfo::Numeric
             | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
             | TypeInfo::Contract
             | TypeInfo::ErrorRecovery => {}
         }

--- a/sway-core/src/type_system/type_info.rs
+++ b/sway-core/src/type_system/type_info.rs
@@ -93,6 +93,7 @@ pub enum TypeInfo {
     /// which can create pointers by (eg.) reading logically-pointer-valued registers, using the
     /// gtf instruction, or manipulating u64s.
     RawUntypedPtr,
+    RawUntypedSlice,
 }
 
 // NOTE: Hash and PartialEq must uphold the invariant:
@@ -187,6 +188,9 @@ impl Hash for TypeInfo {
             TypeInfo::RawUntypedPtr => {
                 state.write_u8(18);
             }
+            TypeInfo::RawUntypedSlice => {
+                state.write_u8(19);
+            }
         }
     }
 }
@@ -267,6 +271,7 @@ impl PartialEq for TypeInfo {
                 l_fields == r_fields
             }
             (TypeInfo::RawUntypedPtr, TypeInfo::RawUntypedPtr) => true,
+            (TypeInfo::RawUntypedSlice, TypeInfo::RawUntypedSlice) => true,
             _ => false,
         }
     }
@@ -337,6 +342,7 @@ impl fmt::Display for TypeInfo {
             Array(elem_ty, count, _) => format!("[{}; {}]", elem_ty, count),
             Storage { .. } => "contract storage".into(),
             RawUntypedPtr => "raw untyped ptr".into(),
+            RawUntypedSlice => "raw untyped slice".into(),
         };
         write!(f, "{}", s)
     }
@@ -419,6 +425,7 @@ impl UnconstrainedTypeParameters for TypeInfo {
             | TypeInfo::Contract
             | TypeInfo::ErrorRecovery
             | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
             | TypeInfo::Storage { .. } => false,
         }
     }
@@ -464,6 +471,7 @@ impl TypeInfo {
             Array(elem_ty, count, _) => format!("[{}; {}]", elem_ty.json_abi_str(), count),
             Storage { .. } => "contract storage".into(),
             RawUntypedPtr => "raw untyped ptr".into(),
+            RawUntypedSlice => "raw untyped slice".into(),
         }
     }
 
@@ -625,6 +633,7 @@ impl TypeInfo {
                 format!("a[{};{}]", name, size)
             }
             RawUntypedPtr => "rawptr".to_string(),
+            RawUntypedSlice => "rawslice".to_string(),
             _ => {
                 return err(
                     vec![],
@@ -777,6 +786,7 @@ impl TypeInfo {
             | TypeInfo::B256
             | TypeInfo::Numeric
             | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
             | TypeInfo::Contract
             | TypeInfo::ErrorRecovery
             | TypeInfo::Array(_, _, _)
@@ -856,6 +866,7 @@ impl TypeInfo {
                 | TypeInfo::B256
                 | TypeInfo::Numeric
                 | TypeInfo::RawUntypedPtr
+                | TypeInfo::RawUntypedSlice
                 | TypeInfo::Contract => {
                     inner_types.insert(type_id);
                 }
@@ -921,6 +932,7 @@ impl TypeInfo {
             | TypeInfo::Numeric
             | TypeInfo::Contract
             | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
             | TypeInfo::ErrorRecovery => {}
         }
         inner_types
@@ -945,6 +957,7 @@ impl TypeInfo {
             | TypeInfo::Numeric => ok((), warnings, errors),
             TypeInfo::Unknown
             | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
             | TypeInfo::ContractCaller { .. }
             | TypeInfo::Custom { .. }
             | TypeInfo::SelfType
@@ -975,6 +988,7 @@ impl TypeInfo {
             | TypeInfo::Tuple(_)
             | TypeInfo::B256
             | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
             | TypeInfo::Custom { .. }
             | TypeInfo::Str(_)
             | TypeInfo::Array(_, _, _)
@@ -1090,6 +1104,7 @@ impl TypeInfo {
             | TypeInfo::B256
             | TypeInfo::Numeric
             | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
             | TypeInfo::Contract
             | TypeInfo::ErrorRecovery => {}
             TypeInfo::Custom { .. } | TypeInfo::SelfType => {
@@ -1378,6 +1393,7 @@ impl TypeInfo {
             | TypeInfo::Boolean
             | TypeInfo::B256
             | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
             | TypeInfo::ErrorRecovery => false,
             TypeInfo::Unknown
             | TypeInfo::UnknownGeneric { .. }

--- a/sway-core/src/type_system/type_mapping.rs
+++ b/sway-core/src/type_system/type_mapping.rs
@@ -383,6 +383,7 @@ impl TypeMapping {
             | TypeInfo::B256
             | TypeInfo::Numeric
             | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
             | TypeInfo::Contract
             | TypeInfo::ErrorRecovery => None,
         }

--- a/sway-core/src/type_system/unify.rs
+++ b/sway-core/src/type_system/unify.rs
@@ -41,6 +41,7 @@ pub(super) fn unify(
         (Numeric, Numeric) => (vec![], vec![]),
         (Contract, Contract) => (vec![], vec![]),
         (RawUntypedPtr, RawUntypedPtr) => (vec![], vec![]),
+        (RawUntypedSlice, RawUntypedSlice) => (vec![], vec![]),
         (Str(l), Str(r)) => unify::unify_strs(
             received,
             expected,
@@ -292,6 +293,7 @@ pub(super) fn unify_right(
         (Numeric, Numeric) => (vec![], vec![]),
         (Contract, Contract) => (vec![], vec![]),
         (RawUntypedPtr, RawUntypedPtr) => (vec![], vec![]),
+        (RawUntypedSlice, RawUntypedSlice) => (vec![], vec![]),
         (Str(l), Str(r)) => unify::unify_strs(received, expected, span, help_text, l, r, false),
         (Tuple(rfs), Tuple(efs)) if rfs.len() == efs.len() => {
             unify::unify_tuples(help_text, rfs, efs, curried)

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -668,8 +668,13 @@ pub enum CompileError {
     ConfigTimeConstantNotALiteral { span: Span },
     #[error("ref mut parameter not allowed for main()")]
     RefMutableNotAllowedInMain { param_name: Ident },
-    #[error("returning a `raw_ptr` from `main()` is not allowed")]
+    #[error("Returning a `raw_ptr` from `main()` is not allowed.")]
     PointerReturnNotAllowedInMain { span: Span },
+    #[error(
+        "Returning a type containing `raw_slice` from `main()` is not allowed. \
+            Consider converting it into a flat `raw_slice` instead."
+    )]
+    NestedSliceReturnNotAllowedInMain { span: Span },
     #[error(
         "Register \"{name}\" is initialized and later reassigned which is not allowed. \
             Consider assigning to a different register inside the ASM block."
@@ -856,6 +861,7 @@ impl Spanned for CompileError {
             ConfigTimeConstantNotALiteral { span } => span.clone(),
             RefMutableNotAllowedInMain { param_name } => param_name.span(),
             PointerReturnNotAllowedInMain { span } => span.clone(),
+            NestedSliceReturnNotAllowedInMain { span } => span.clone(),
             InitializedRegisterReassignment { span, .. } => span.clone(),
         }
     }

--- a/sway-ir/src/irtype.rs
+++ b/sway-ir/src/irtype.rs
@@ -22,6 +22,7 @@ pub enum Type {
     Union(Aggregate),
     Struct(Aggregate),
     Pointer(Pointer),
+    Slice,
 }
 
 impl Type {
@@ -63,6 +64,7 @@ impl Type {
                 format!("{{ {} }}", sep_types_str(agg_content, ", "))
             }
             Type::Pointer(ptr) => ptr.as_string(context, None),
+            Type::Slice => "slice".into(),
         }
     }
 
@@ -88,6 +90,7 @@ impl Type {
                 .any(|field_ty| r.eq(context, field_ty)),
 
             (Type::Pointer(l), Type::Pointer(r)) => l.is_equivalent(context, r),
+            (Type::Slice, Type::Slice) => true,
             _ => false,
         }
     }

--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -95,7 +95,8 @@ pub fn is_small_fn(
             | Type::Uint(_)
             | Type::B256
             | Type::String(_)
-            | Type::Pointer(_) => 1,
+            | Type::Pointer(_)
+            | Type::Slice => 1,
             Type::Array(aggregate) => {
                 let (ty, sz) = context.aggregates[aggregate.0].array_type();
                 count_type_elements(context, ty) * *sz as usize

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -270,7 +270,8 @@ impl<'a> InstructionVerifier<'a> {
             | Type::Array(_)
             | Type::Union(_)
             | Type::Struct(_)
-            | Type::Pointer(_) => false,
+            | Type::Pointer(_)
+            | Type::Slice => false,
         };
         if !is_valid {
             Err(IrError::VerifyBitcastBetweenInvalidTypes(

--- a/sway-lib-core/src/lib.sw
+++ b/sway-lib-core/src/lib.sw
@@ -2,5 +2,6 @@ library core;
 
 dep num;
 dep raw_ptr;
+dep raw_slice;
 dep ops;
 dep prelude;

--- a/sway-lib-core/src/ops.sw
+++ b/sway-lib-core/src/ops.sw
@@ -219,6 +219,14 @@ impl Eq for raw_ptr {
     }
 }
 
+impl Eq for raw_slice {
+    fn eq(self, other: Self) -> bool {
+        let _self = asm(ptr: self) { ptr: (raw_ptr, u64) };
+        let _other = asm(ptr: other) { ptr: (raw_ptr, u64) };
+        __eq(_self.0, _other.0) && __eq(_self.1, _other.1)
+    }
+}
+
 pub trait Ord {
     fn gt(self, other: Self) -> bool;
     fn lt(self, other: Self) -> bool;

--- a/sway-lib-core/src/prelude.sw
+++ b/sway-lib-core/src/prelude.sw
@@ -5,3 +5,4 @@ library prelude;
 //! for which `use` is not required.
 use ::num::*;
 use ::raw_ptr::*;
+use ::raw_slice::*;

--- a/sway-lib-core/src/raw_slice.sw
+++ b/sway-lib-core/src/raw_slice.sw
@@ -1,0 +1,54 @@
+library raw_slice;
+
+dep raw_ptr;
+
+use ::raw_ptr::*;
+
+pub trait AsRawSlice {
+    fn as_slice(self) -> raw_slice;
+}
+
+fn to_parts(slice: raw_slice) -> (raw_ptr, u64) {
+    asm(ptr: slice) { ptr: (raw_ptr, u64) }
+}
+
+fn from_parts(parts: (raw_ptr, u64)) -> raw_slice {
+    asm(ptr: parts) { ptr: raw_slice }
+}
+
+impl raw_slice {
+    /// Forms a slice from a pointer and a length.
+    pub fn from_raw_parts(ptr: raw_ptr, len: u64) -> Self {
+        from_parts((ptr, len))
+    }
+
+    /// Returns the pointer to the slice.
+    pub fn ptr(self) -> raw_ptr {
+        to_parts(self).0
+    }
+
+    /// Returns the number of elements in the slice.
+    pub fn len<T>(self) -> u64 {
+        __div(to_parts(self).1, __size_of::<T>())
+    }
+
+    /// Calculates the offset from the pointer without modifying the length.
+    pub fn add<T>(self, count: u64) -> raw_slice {
+        let _self = to_parts(self);
+        from_parts((__ptr_add::<T>(_self.0, count), _self.1))
+    }
+
+    /// Calculates the offset from the pointer without modifying the length.
+    pub fn sub<T>(self, count: u64) -> raw_slice {
+        let _self = to_parts(self);
+        from_parts((__ptr_sub::<T>(_self.0, count), _self.1))
+    }
+
+    /// Copies all bytes from `self` to `dst`.
+    /// SAFETY: Length of `dst` will not be checked.
+    pub fn copy_to<T>(self, dst: raw_slice) {
+        let _self = to_parts(self);
+        let _dst = to_parts(dst);
+        _self.0.copy_to::<T>(_dst.0, __div(_self.1, __size_of::<T>()));
+    }
+}

--- a/sway-lib-std/src/alloc.sw
+++ b/sway-lib-std/src/alloc.sw
@@ -11,7 +11,7 @@ library alloc;
 /// ... 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 |
 ///                                               $hp^  ^VM_MAX_RAM
 ///
-/// After allocating with `let ptr = alloc(8)`:
+/// After allocating with `let ptr = alloc::<u64>(1)`:
 /// ... 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 |
 ///                       $hp^  ^ptr                    ^VM_MAX_RAM
 ///
@@ -21,25 +21,28 @@ library alloc;
 ///
 /// See: https://fuellabs.github.io/fuel-specs/master/vm#vm-initialization
 /// See: https://fuellabs.github.io/fuel-specs/master/vm/instruction_set.html#aloc-allocate-memory
-pub fn alloc<T>(count: u64) -> raw_ptr {
-    asm(size: __size_of::<T>() * count, ptr) {
+pub fn alloc<T>(count: u64) -> raw_slice {
+    let size = __size_of::<T>() * count;
+    let ptr = asm(size: size, ptr) {
         aloc size;
         // `$hp` points to unallocated space and heap grows downward so
         // our newly allocated space will be right after it
         addi ptr hp i1;
         ptr: raw_ptr
-    }
+    };
+    raw_slice::from_raw_parts(ptr, size)
 }
 
 /// Reallocates the given area of memory
-pub fn realloc<T>(ptr: raw_ptr, count: u64, new_count: u64) -> raw_ptr {
+pub fn realloc<T>(buf: raw_slice, new_count: u64) -> raw_slice {
+    let count = buf.len::<T>();
     if new_count > count {
-        let new_ptr = alloc::<T>(new_count);
+        let new_buf = alloc::<T>(new_count);
         if count > 0 {
-            ptr.copy_to::<T>(new_ptr, count);
+            buf.copy_to::<T>(new_buf);
         }
-        new_ptr
+        new_buf
     } else {
-        ptr
+        buf
     }
 }

--- a/sway-lib-std/src/message.sw
+++ b/sway-lib-std/src/message.sw
@@ -22,10 +22,10 @@ pub fn send_message(recipient: b256, msg_data: Vec<u64>, coins: u64) {
     // data and recipient values there
     if !msg_data.is_empty() {
         size = msg_data.len();
-        recipient_heap_buffer = alloc::<u64>(4 + size);
+        recipient_heap_buffer = alloc::<u64>(4 + size).ptr();
         recipient_heap_buffer.write(recipient);
         let data_heap_buffer = recipient_heap_buffer.add::<b256>(1);
-        msg_data.buf.ptr.copy_to::<u64>(data_heap_buffer, size);
+        msg_data.as_slice().ptr().copy_to::<u64>(data_heap_buffer, size);
     };
 
     let mut index = 0;

--- a/sway-lib-std/src/storage.sw
+++ b/sway-lib-std/src/storage.sw
@@ -59,7 +59,7 @@ pub fn get<T>(key: b256) -> T {
 
         // Allocate a buffer for the result.  It needs to be a multiple of 32 bytes so we can make
         // 'quad' storage reads without overflowing.
-        let result_ptr = alloc::<u64>(((size_left + 31) & 0xffffffe0) / 8);
+        let result_ptr = alloc::<u64>(((size_left + 31) & 0xffffffe0) / 8).ptr();
 
         let mut current_pointer = result_ptr;
         while size_left > 32 {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/raw_ptr/raw_ptr_ret/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/raw_ptr/raw_ptr_ret/test.toml
@@ -1,4 +1,4 @@
 category = "fail"
 
 # check: fn main() -> raw_ptr {
-# nextln: $()returning a `raw_ptr` from `main()` is not allowed
+# nextln: $()Returning a `raw_ptr` from `main()` is not allowed.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/raw_ptr/vec_ret/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/raw_ptr/vec_ret/test.toml
@@ -1,4 +1,4 @@
 category = "fail"
 
 # check: fn main() -> Vec<u64> {
-# nextln: $()returning a `raw_ptr` from `main()` is not allowed
+# nextln: $()Returning a type containing `raw_slice` from `main()` is not allowed. Consider converting it into a flat `raw_slice` instead.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/alloc/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/alloc/src/main.sw
@@ -28,37 +28,37 @@ fn heap_ptr() -> raw_ptr {
 fn main() -> bool {
     // Allocate zero
     let hp = heap_ptr();
-    let ptr = alloc::<u64>(0);
-    assert(ptr == hp);
+    let buf = alloc::<u64>(0);
+    assert(buf.ptr() == hp);
     assert(heap_ptr() == hp);
 
     // Allocate some memory
     let hp = heap_ptr();
-    let ptr = alloc::<u64>(1);
-    assert(ptr == hp.sub::<u64>(1));
+    let buf = alloc::<u64>(1);
+    assert(buf.ptr() == hp.sub::<u64>(1));
     assert(heap_ptr() == hp.sub::<u64>(1));
 
     // Read from it
-    let val = lw(ptr);
+    let val = lw(buf.ptr());
     assert(val == 0);
 
     // Write to it
     let val = u64::max();
-    sw(ptr, val);
-    assert(lw(ptr) == val);
+    sw(buf.ptr(), val);
+    assert(lw(buf.ptr()) == val);
 
     // Grow it
     let hp = heap_ptr();
-    let ptr = realloc::<u64>(ptr, 1, 2);
-    assert(ptr == hp.sub::<u64>(2));
+    let buf = realloc::<u64>(buf, 2);
+    assert(buf.ptr() == hp.sub::<u64>(2));
     assert(heap_ptr() == hp.sub::<u64>(2));
 
     // Make sure that reallocating an old allocation of size 0 does not cause a
     // panic.
     let hp = heap_ptr();
-    let ptr = alloc::<u64>(0);
-    let ptr = realloc::<u64>(ptr, 0, 2);
-    assert(ptr == hp.sub::<u64>(2));
+    let buf = alloc::<u64>(0);
+    let buf = realloc::<u64>(buf, 2);
+    assert(buf.ptr() == hp.sub::<u64>(2));
     assert(heap_ptr() == hp.sub::<u64>(2));
 
     true

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_ptr/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_ptr/src/main.sw
@@ -32,7 +32,7 @@ fn main() -> bool {
     assert(foo_ptr_2 == foo_ptr);
 
     // Copy the struct into a buffer
-    let buf_ptr = alloc::<u64>(2);
+    let buf_ptr = alloc::<u64>(2).ptr();
     foo_ptr.copy_to::<u64>(buf_ptr, 2);
     assert(asm(r1: buf_ptr, r2: foo_ptr, r3: foo_len, res) {
         meq res r1 r2 r3;
@@ -53,7 +53,7 @@ fn main() -> bool {
     assert(boo == true);
 
     // Write values into a buffer
-    let buf_ptr = alloc::<u64>(2);
+    let buf_ptr = alloc::<u64>(2).ptr();
     buf_ptr.write(true);
     buf_ptr.add::<bool>(1).write(42);
     let foo: TestStruct = buf_ptr.read();
@@ -61,7 +61,7 @@ fn main() -> bool {
     assert(foo.uwu == 42);
 
     // Write structs into a buffer
-    let buf_ptr = alloc::<u64>(4);
+    let buf_ptr = alloc::<u64>(4).ptr();
     buf_ptr.write(foo);
     buf_ptr.add::<TestStruct>(1).write(foo);
     let bar: ExtendedTestStruct = buf_ptr.read();
@@ -72,7 +72,7 @@ fn main() -> bool {
 
     // Make sure that reading a memory location into a variable and then
     // overriding the same memory location does not change the variable read.
-    let buf_ptr = alloc::<u64>(1);
+    let buf_ptr = alloc::<u64>(1).ptr();
     let small_string_1 = "fuel";
     let small_string_2 = "labs";
     buf_ptr.write(small_string_1);
@@ -82,7 +82,7 @@ fn main() -> bool {
     assert(sha256(small_string_1) == sha256(read_small_string_1));
     assert(sha256(small_string_2) == sha256(read_small_string_2));
 
-    let buf_ptr = alloc::<u64>(2);
+    let buf_ptr = alloc::<u64>(2).ptr();
     let large_string_1 = "fuelfuelfuel";
     let large_string_2 = "labslabslabs";
     buf_ptr.write(large_string_1);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_slice/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_slice/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-8175BA0DBE650EFE'
+
+[[package]]
+name = 'raw_slice'
+source = 'root'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-8175BA0DBE650EFE'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_slice/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_slice/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "raw_slice"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_slice/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_slice/json_abi_oracle.json
@@ -1,0 +1,22 @@
+{
+  "functions": [
+    {
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "raw untyped slice",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_slice/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_slice/src/main.sw
@@ -1,0 +1,50 @@
+script;
+
+use std::{
+    alloc::alloc,
+    assert::assert,
+    hash::sha256,
+    intrinsics::{
+        size_of,
+        size_of_val,
+    },
+    logging::log,
+    tx::{
+        tx_script_data,
+    },
+};
+
+struct TestStruct {
+    boo: bool,
+    uwu: u64,
+}
+
+fn main() -> raw_slice {
+    // Create a struct
+    let foo = TestStruct {
+        boo: true,
+        uwu: 42,
+    };
+    let foo_len = size_of_val(foo);
+    assert(foo_len == 16);
+
+    // Get a slice to it
+    let foo_buf = raw_slice::from_raw_parts(__addr_of(foo), size_of_val(foo));
+    assert(foo_buf.ptr() == asm(r1: foo) { r1: raw_ptr });
+    assert(foo_buf.len::<u64>() == 2);
+
+    // Get another slice to it and compare
+    let foo_buf_2 = raw_slice::from_raw_parts(__addr_of(foo), size_of_val(foo));
+    assert(foo_buf_2 == foo_buf);
+
+    // Copy the struct into a buffer
+    let buf = alloc::<TestStruct>(1);
+    foo_buf.copy_to::<TestStruct>(buf);
+    assert(asm(r1: buf.ptr(), r2: foo_buf.ptr(), r3: 16, res) {
+        meq res r1 r2 r3;
+        res: bool
+    });
+
+    // Return
+    foo_buf
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_slice/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_slice/test.toml
@@ -1,0 +1,4 @@
+category = "run"
+script_data = "000000000000000000000000000000100000000000000001000000000000002a"
+expected_result = { action = "return_data", value = "0000000000000001000000000000002a" }
+validate_abi = true


### PR DESCRIPTION
This PR is a WIP.

This draft contains an attempt to solve the [issue](https://github.com/FuelLabs/sway/issues/2900) by generalizing the problem into "supporting dynamically sized types" and implementing a raw DST `raw_slice` as detailed on https://github.com/FuelLabs/sway/issues/3086.

ATM the code is messy but it should be good enough to ask for an initial review to see if I have a green light to proceed.

`raw_slice` aims to be just a pointer and a length that together represent a range of bytes, without a concept of unfilled capacity like `Vec`, or a hard-coded growth logic like `RawVec`. It should be roughly equivalent to `&[u8]` in Rust and it could be later evolved into `ref [T]` here in Sway.

This PR, even in this state, would unblock a [fuels-ts issue](https://github.com/FuelLabs/fuels-ts/issues/467#issuecomment-1285871841) which is blocked by the lack of `RETD`. While we could reintroduce `RETD`, it is only necessary for returning ASM-crafted DSTs so adding a native DST and support for returning it also unblocks the issue. For this reason, we could consider releasing this rather sooner and leave detailing to a follow-up PR.

Currently, this PR:
- Adds `raw_slice`, which is like `raw_ptr`, but:
  - It's a `(u64, u64)` instead of just a `u64`.
  - In IR, it doesn't use the previously available types, but has its own type `Type::Slice`.
  - If they are flat, meaning not aggregated in another type, they can be returned from scripts. (So you can't return a `Vec` which contains a `raw_slice`, but you can return `vec.as_slice()`. Implicitly calling something like `IntoSlice::as_slice` is TODO.)
  - Scripts receiving `raw_slices` in `main()` args is TODO. This is already possible and the lack shouldn't block anything though.
  - Intrinsic support for `add`, `sub`, etc. is TODO.
- Uses `raw_slice` in different parts of `std`, mainly `std::{alloc,vec}`. This allows us to remove size args from certain APIs.

If it seems like this PR is on the right direction, I'd like to proceed and:
- Check and implement what's left to unblock [fuels-ts issue](https://github.com/FuelLabs/fuels-ts/issues/467#issuecomment-1285871841).
- Clean the code up and request a merge.
- Keep following-up with PRs to support receiving slices in `main()` args and such.