### PR TITLE
Workaround clippy::result_large_err error with Rust 1.65.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features --all-targets -- -D warnings --allow clippy::result_large_err
+          args: --all-features --all-targets -- -D warnings
 
   cargo-toml-fmt-check:
     runs-on: ubuntu-latest

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+large-error-threshold = 256


### PR DESCRIPTION
This configures the default threshold of Clippy for this error so it works fine with the Sway codebase.