### PR TITLE
Adds more opcodes to check_invalid_opcodes for predicates.

### DIFF
--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -497,6 +497,8 @@ pub enum CompileError {
     BurnFromExternalContext { span: Span },
     #[error("Contract storage cannot be used in an external context.")]
     ContractStorageFromExternalContext { span: Span },
+    #[error("The {opcode} opcode cannot be used in a predicate.")]
+    InvalidOpcodeFromPredicate { opcode: String, span: Span },
     #[error("Array index out of bounds; the length is {count} but the index is {index}.")]
     ArrayOutOfBounds { index: u64, count: u64, span: Span },
     #[error("Tuple index out of bounds; the arity is {count} but the index is {index}.")]
@@ -797,6 +799,7 @@ impl Spanned for CompileError {
             MintFromExternalContext { span, .. } => span.clone(),
             BurnFromExternalContext { span, .. } => span.clone(),
             ContractStorageFromExternalContext { span, .. } => span.clone(),
+            InvalidOpcodeFromPredicate { span, .. } => span.clone(),
             ArrayOutOfBounds { span, .. } => span.clone(),
             ShadowsOtherSymbol { name } => name.span(),
             GenericShadowsGeneric { name } => name.span(),


### PR DESCRIPTION
All the contract specific opcodes now throw an error if used within a predicate. Except for RVRT which is used currently in tests.

Closes #2550