### PR TITLE
Add initial unit testing documentation to the Sway book

### DIFF
--- a/docs/src/testing/index.md
+++ b/docs/src/testing/index.md
@@ -11,4 +11,5 @@ issue](https://github.com/FuelLabs/sway/issues/1832).
 within some wider application. You can add integration testing to your Sway+Rust
 projects today using the cargo generate template and Rust SDK.
 
+- [Unit Testing](./unit-testing.md)
 - [Testing with Rust](./testing-with-rust.md)

--- a/docs/src/testing/unit-testing.md
+++ b/docs/src/testing/unit-testing.md
@@ -1,0 +1,53 @@
+# Unit Testing
+
+Forc provides built-in support for building and executing tests for a package.
+
+Tests are written as free functions with the `#[test]` attribute. For example:
+
+```sway
+#[test]
+fn test_meaning_of_life() {
+    assert(6 * 7 == 42);
+}
+```
+
+Each test function is ran as if it were the entry point for a
+[script](../sway-program-types/scripts.md). Tests "pass" if they return
+successfully, and "fail" if they revert.
+
+## Building and Running Tests
+
+We can build and execute all tests within a package with the following:
+
+```console
+forc test
+```
+
+The output should look similar to this:
+
+```console
+  Compiled library "core".
+  Compiled library "std".
+  Compiled library "lib_single_test".
+  Bytecode size is 92 bytes.
+   Running 1 tests
+      test test_meaning_of_life ... ok (170.652µs)
+   Result: OK. 1 passed. 0 failed. Finished in 1.564996ms.
+```
+
+Visit the [`forc test`](../forc/commands/forc_test.md) command reference to find
+the options available for `forc test`.
+
+## Testing Failure
+
+***Coming Soon***
+
+*Track progress on `#[test(should_revert)]`
+[here](https://github.com/FuelLabs/sway/issues/3260).*
+
+## Calling Contracts
+
+***Coming Soon***
+
+*Track progress on constract calls in tests
+[here](https://github.com/FuelLabs/sway/issues/3262)*

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -7,9 +7,6 @@ use tracing::info;
 
 /// Run the Sway unit tests for the current project.
 ///
-/// NOTE: This feature is not yet implemented. Track progress at the following link:
-/// https://github.com/FuelLabs/sway/issues/1832
-///
 /// NOTE: Previously this command was used to support Rust integration testing, however the
 /// provided behaviour served no benefit over running `cargo test` directly. The proposal to change
 /// the behaviour to support unit testing can be found at the following link:


### PR DESCRIPTION
This is a minimal start at documenting the Sway unit testing feature provided via `forc test`.

We should continue to extend this as we land new features like contract calling, dev-dependencies, `#[test(should_revert)]`, etc.