### PR TITLE
Port `EnumInstantation` to the declaration engine.

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -743,13 +743,15 @@ fn connect_expression(
         }
         EnumInstantiation {
             enum_decl,
+            enum_instantiation_span,
             variant_name,
             contents,
             ..
         } => {
             // connect this particular instantiation to its variants declaration
+            let enum_decl = de_get_enum(enum_decl.clone(), enum_instantiation_span).unwrap();
             connect_enum_instantiation(
-                enum_decl,
+                &enum_decl,
                 contents,
                 variant_name,
                 graph,

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -1,5 +1,5 @@
 use crate::{
-    declaration_engine::{de_get_function, declaration_engine::de_get_constant},
+    declaration_engine::{de_get_constant, de_get_enum, de_get_function},
     language::ty,
     metadata::MetadataManager,
     semantic_analysis::*,
@@ -239,11 +239,13 @@ fn const_eval_typed_expr(
         }
         ty::TyExpressionVariant::EnumInstantiation {
             enum_decl,
+            enum_instantiation_span,
             tag,
             contents,
             ..
         } => {
-            let aggregate = create_enum_aggregate(lookup.context, enum_decl.variants.clone());
+            let enum_decl = de_get_enum(enum_decl.clone(), enum_instantiation_span).unwrap();
+            let aggregate = create_enum_aggregate(lookup.context, enum_decl.variants);
             if let Ok(aggregate) = aggregate {
                 let tag_value = Constant::new_uint(64, *tag as u64);
                 let mut fields: Vec<Constant> = vec![tag_value];

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -16,7 +16,7 @@ use crate::{
     metadata::MetadataManager,
     type_system::{look_up_type_id, to_typeinfo, LogId, TypeId, TypeInfo},
 };
-use declaration_engine::de_get_function;
+use declaration_engine::{de_get_enum, de_get_function};
 use sway_ast::intrinsics::Intrinsic;
 use sway_error::error::{CompileError, Hint};
 use sway_ir::{Context, *};
@@ -307,10 +307,14 @@ impl FnCompiler {
             }
             ty::TyExpressionVariant::EnumInstantiation {
                 enum_decl,
+                enum_instantiation_span,
                 tag,
                 contents,
                 ..
-            } => self.compile_enum_expr(context, md_mgr, enum_decl, tag, contents),
+            } => {
+                let enum_decl = de_get_enum(enum_decl, &enum_instantiation_span).unwrap();
+                self.compile_enum_expr(context, md_mgr, enum_decl, tag, contents)
+            }
             ty::TyExpressionVariant::Tuple { fields } => {
                 self.compile_tuple_expr(context, md_mgr, fields, span_md_idx)
             }

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -27,6 +27,24 @@ pub enum TyDeclaration {
     StorageDeclaration(DeclarationId),
 }
 
+impl GetDeclId for TyDeclaration {
+    fn get_decl_id(&self) -> Option<DeclarationId> {
+        match self {
+            TyDeclaration::VariableDeclaration(_) => None,
+            TyDeclaration::ConstantDeclaration(decl_id) => Some(decl_id.clone()),
+            TyDeclaration::FunctionDeclaration(decl_id) => Some(decl_id.clone()),
+            TyDeclaration::TraitDeclaration(decl_id) => Some(decl_id.clone()),
+            TyDeclaration::StructDeclaration(decl_id) => Some(decl_id.clone()),
+            TyDeclaration::EnumDeclaration(decl_id) => Some(decl_id.clone()),
+            TyDeclaration::ImplTrait(decl_id) => Some(decl_id.clone()),
+            TyDeclaration::AbiDeclaration(decl_id) => Some(decl_id.clone()),
+            TyDeclaration::GenericTypeForFunctionScope { .. } => None,
+            TyDeclaration::ErrorRecovery => None,
+            TyDeclaration::StorageDeclaration(decl_id) => Some(decl_id.clone()),
+        }
+    }
+}
+
 impl CopyTypes for TyDeclaration {
     fn copy_types_inner(&mut self, type_mapping: &TypeMapping) {
         use TyDeclaration::*;

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use sway_types::{Span, Spanned};
 
 use crate::{
-    declaration_engine::{de_get_function, DeclMapping, ReplaceDecls},
+    declaration_engine::{de_get_enum, de_get_function, DeclMapping, ReplaceDecls},
     error::*,
     language::{ty::*, Literal},
     type_system::*,
@@ -258,11 +258,12 @@ impl CollectTypesMetadata for TyExpression {
                 ));
             }
             EnumInstantiation {
-                enum_decl,
-                contents,
+                enum_decl: enum_decl_id,
                 enum_instantiation_span,
+                contents,
                 ..
             } => {
+                let enum_decl = de_get_enum(enum_decl_id.clone(), enum_instantiation_span).unwrap();
                 for type_param in enum_decl.type_parameters.iter() {
                     ctx.call_site_insert(type_param.type_id, enum_instantiation_span.clone())
                 }

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -7,7 +7,7 @@ use derivative::Derivative;
 use sway_types::{state::StateIndex, Ident, Span};
 
 use crate::{
-    declaration_engine::{de_get_function, DeclMapping, DeclarationId, ReplaceDecls},
+    declaration_engine::{de_get_enum, de_get_function, DeclMapping, DeclarationId, ReplaceDecls},
     language::{ty::*, *},
     type_system::*,
 };
@@ -84,7 +84,7 @@ pub enum TyExpressionVariant {
     },
     EnumInstantiation {
         /// for printing
-        enum_decl: TyEnumDeclaration,
+        enum_decl: DeclarationId,
         /// for printing
         variant_name: Ident,
         tag: usize,
@@ -744,8 +744,10 @@ impl fmt::Display for TyExpressionVariant {
                 tag,
                 enum_decl,
                 variant_name,
+                enum_instantiation_span,
                 ..
             } => {
+                let enum_decl = de_get_enum(enum_decl.clone(), enum_instantiation_span).unwrap();
                 format!(
                     "{}::{} enum instantiation (tag: {})",
                     enum_decl.name.as_str(),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -18,7 +18,11 @@ use crate::{
     asm_lang::{virtual_ops::VirtualOp, virtual_register::VirtualRegister},
     declaration_engine::declaration_engine::*,
     error::*,
-    language::{parsed::*, ty, *},
+    language::{
+        parsed::*,
+        ty::{self, GetDeclId},
+        *,
+    },
     semantic_analysis::*,
     transform::to_parsed_lang::type_name_to_type_info_opt,
     type_system::*,
@@ -1186,9 +1190,8 @@ impl ty::TyExpression {
                 span: call_path_binding.span,
             };
             TypeBinding::type_check_with_ident(&mut call_path_binding, ctx.by_ref())
-                .flat_map(|unknown_decl| unknown_decl.expect_enum(&call_path_binding.span()))
                 .ok(&mut enum_probe_warnings, &mut enum_probe_errors)
-                .map(|enum_decl| (enum_decl, enum_name, variant_name))
+                .map(|enum_decl| (enum_decl.get_decl_id().unwrap(), enum_name, variant_name))
         };
 
         // Check if this could be a constant

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -152,22 +152,22 @@ impl ty::TyAstNode {
                             typed_const_decl
                         }
                         Declaration::EnumDeclaration(decl) => {
+                            let decl_name = decl.name.clone();
                             let enum_decl = check!(
                                 ty::TyEnumDeclaration::type_check(ctx.by_ref(), decl),
                                 return err(warnings, errors),
                                 warnings,
                                 errors
                             );
-                            let name = enum_decl.name.clone();
-                            let decl =
+                            let ty_decl =
                                 ty::TyDeclaration::EnumDeclaration(de_insert_enum(enum_decl));
                             check!(
-                                ctx.namespace.insert_symbol(name, decl.clone()),
+                                ctx.namespace.insert_symbol(decl_name, ty_decl.clone()),
                                 return err(warnings, errors),
                                 warnings,
                                 errors
                             );
-                            decl
+                            ty_decl
                         }
                         Declaration::FunctionDeclaration(fn_decl) => {
                             let mut ctx = ctx.with_type_annotation(insert_type(TypeInfo::Unknown));

--- a/sway-lsp/src/core/traverse_typed_tree.rs
+++ b/sway-lsp/src/core/traverse_typed_tree.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::token::{struct_declaration_of_type_id, to_ident_key},
 };
 use sway_core::{
-    declaration_engine::{self, de_get_function},
+    declaration_engine::{self, de_get_enum, de_get_function},
     language::ty,
 };
 use sway_types::{ident::Ident, Spanned};
@@ -368,7 +368,8 @@ fn handle_expression(expression: &ty::TyExpression, tokens: &TokenMap) {
                 tokens.get_mut(&to_ident_key(&Ident::new(enum_instantiation_span.clone())))
             {
                 token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
-                token.type_def = Some(TypeDefinition::Ident(enum_decl.name.clone()));
+                let enum_decl = de_get_enum(enum_decl.clone(), enum_instantiation_span).unwrap();
+                token.type_def = Some(TypeDefinition::Ident(enum_decl.name));
             }
 
             if let Some(mut token) = tokens.get_mut(&to_ident_key(&Ident::new(


### PR DESCRIPTION
This ports `EnumInstantation` to use declaration ids, which fixes the enum instantiation code to directly use the declaration id we previously inserted for the enum in the declaration engine, instead of converting it to a declaration, and then re-inserting it to the declaration engine, causing the declaration engine to end up with duplicates.