### PR TITLE
don't exhaustively match on transaction status in forc deploy

### DIFF
--- a/forc-plugins/forc-client/src/ops/deploy/op.rs
+++ b/forc-plugins/forc-client/src/ops/deploy/op.rs
@@ -65,11 +65,11 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
                 info!("contract {} deployed in block {}", &contract_id, &block_id);
                 Ok(contract_id)
             }
-            TransactionStatus::Failure { reason, .. } => {
+            e => {
                 bail!(
                     "contract {} failed to deploy due to an error: {}",
                     &contract_id,
-                    reason
+                    e
                 )
             }
         },

--- a/forc-plugins/forc-client/src/ops/deploy/op.rs
+++ b/forc-plugins/forc-client/src/ops/deploy/op.rs
@@ -67,7 +67,7 @@ pub async fn deploy(command: DeployCommand) -> Result<fuel_tx::ContractId> {
             }
             e => {
                 bail!(
-                    "contract {} failed to deploy due to an error: {}",
+                    "contract {} failed to deploy due to an error: {:?}",
                     &contract_id,
                     e
                 )


### PR DESCRIPTION
Allow for new TransactionStatus variants to be added in a non-breaking way. This is blocking the release of fuel-core v0.14.1.