### PR TITLE
Fixes method Eq not found when used with where clause.

### DIFF
--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -651,7 +651,6 @@ fn are_equal_minus_dynamic_types(left: TypeId, right: TypeId) -> bool {
         (TypeInfo::Unknown, TypeInfo::Unknown) => false,
         (TypeInfo::SelfType, TypeInfo::SelfType) => false,
         (TypeInfo::Numeric, TypeInfo::Numeric) => false,
-        (TypeInfo::UnknownGeneric { .. }, TypeInfo::UnknownGeneric { .. }) => false,
         (TypeInfo::Contract, TypeInfo::Contract) => false,
         (TypeInfo::Storage { .. }, TypeInfo::Storage { .. }) => false,
 
@@ -663,6 +662,10 @@ fn are_equal_minus_dynamic_types(left: TypeId, right: TypeId) -> bool {
         (TypeInfo::UnsignedInteger(l), TypeInfo::UnsignedInteger(r)) => l == r,
         (TypeInfo::RawUntypedPtr, TypeInfo::RawUntypedPtr) => true,
         (TypeInfo::RawUntypedSlice, TypeInfo::RawUntypedSlice) => true,
+        (
+            TypeInfo::UnknownGeneric { name: rname, .. },
+            TypeInfo::UnknownGeneric { name: lname, .. },
+        ) => rname.eq_origin(lname),
 
         // these cases may contain dynamic types
         (

--- a/sway-types/src/ident.rs
+++ b/sway-types/src/ident.rs
@@ -104,4 +104,12 @@ impl Ident {
             is_raw_ident: false,
         }
     }
+
+    pub fn eq_origin(&self, other: Self) -> bool {
+        if self.name_override_opt.is_some() || other.name_override_opt.is_some() {
+            false
+        } else {
+            self.span == other.span
+        }
+    }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-D8A8CF23B4069FF9'
+
+[[package]]
+name = 'eq_generic'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-D8A8CF23B4069FF9'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "eq_generic"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/json_abi_oracle.json
@@ -1,0 +1,22 @@
+{
+  "functions": [
+    {
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "types": [
+    {
+      "components": [],
+      "type": "()",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/src/main.sw
@@ -1,0 +1,21 @@
+script;
+
+use core::ops::*;
+
+impl<T> Option<T> {
+    pub fn ok_or<E>(self, err: E) -> Result<T, E> {
+        match self {
+            Option::Some(v) => Result::Ok(v),
+            Option::None => Result::Err(err),
+        }
+    }
+}
+
+fn test_ok_or<T, E>(val: T, val2: T, default: E) where T: Eq {
+    match Option::Some(val).ok_or(default) {
+        Result::Ok(inner) => assert(inner == val),
+        Result::Err(_) => revert(0),
+    };
+}
+
+fn main() {}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 0 }
+validate_abi = true


### PR DESCRIPTION
Solution was to change how `TypeInfo::UnknownGeneric` are compared in `are_equal_minus_dynamic_types`. It now compares the span of the name which is unique in the source code. If the span is equal then it assumes it is safe to consider the TypeIds refer to the same generic parameter and that using the methods of one another is also safe.

Closes #3324