### PR TITLE
add option to preserve lazy statics on compilation

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2681,9 +2681,15 @@ type ParseAndTypedPrograms = CompileResult<(ParseProgram, Option<ty::TyProgram>)
 /// Compile the entire forc package and return the parse and typed programs
 /// of the dependancies and project.
 /// The final item in the returned vector is the project.
-pub fn check(plan: &BuildPlan, terse_mode: bool) -> anyhow::Result<Vec<ParseAndTypedPrograms>> {
+pub fn check(
+    plan: &BuildPlan,
+    terse_mode: bool,
+    preserve_statics: bool,
+) -> anyhow::Result<Vec<ParseAndTypedPrograms>> {
     //TODO remove once type engine isn't global anymore.
-    sway_core::clear_lazy_statics();
+    if !preserve_statics {
+        sway_core::clear_lazy_statics();
+    }
     let mut lib_namespace_map = Default::default();
     let mut source_map = SourceMap::new();
     // During `check`, we don't compile so this stays empty.

--- a/forc-plugins/forc-doc/src/main.rs
+++ b/forc-plugins/forc-doc/src/main.rs
@@ -54,7 +54,7 @@ pub fn main() -> Result<()> {
     let lock_path = manifest.lock_path()?;
     let plan =
         pkg::BuildPlan::from_lock_and_manifests(&lock_path, &member_manifests, locked, offline)?;
-    let compilation = pkg::check(&plan, silent)?
+    let compilation = pkg::check(&plan, silent, false)?
         .pop()
         .expect("there is guaranteed to be at least one elem in the vector");
     let raw_docs: Documentation = Document::from_ty_program(&compilation, no_deps)?;

--- a/forc/src/cli/commands/check.rs
+++ b/forc/src/cli/commands/check.rs
@@ -22,6 +22,12 @@ pub struct Command {
     /// Terse mode. Limited warning and error output.
     #[clap(long = "terse", short = 't')]
     pub terse_mode: bool,
+    /// TODO remove this when we remove lazy statics from the compiler.
+    /// This is just an implementation detail for improving LSP performance
+    /// we let the lazy statics continually leak in order to allow for parallel
+    /// project compilation
+    #[clap(hide = true, long = "preserve-statics")]
+    pub preserve_statics: bool,
 }
 
 pub(crate) fn exec(command: Command) -> Result<()> {

--- a/forc/src/ops/forc_check.rs
+++ b/forc/src/ops/forc_check.rs
@@ -11,6 +11,7 @@ pub fn check(command: CheckCommand) -> Result<CompileResult<ty::TyProgram>> {
         offline_mode: offline,
         terse_mode,
         locked,
+        preserve_statics,
     } = command;
 
     let this_dir = if let Some(ref path) = path {
@@ -24,7 +25,7 @@ pub fn check(command: CheckCommand) -> Result<CompileResult<ty::TyProgram>> {
     let plan =
         pkg::BuildPlan::from_lock_and_manifests(&lock_path, &member_manifests, locked, offline)?;
 
-    let mut v = pkg::check(&plan, terse_mode)?;
+    let mut v = pkg::check(&plan, terse_mode, preserve_statics)?;
     let res = v
         .pop()
         .expect("there is guaranteed to be at least one elem in the vector")

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -219,7 +219,8 @@ impl Session {
                 .map_err(LanguageServerError::BuildPlanFailed)?;
 
         let mut diagnostics = Vec::new();
-        let results = pkg::check(&plan, true).map_err(LanguageServerError::FailedToCompile)?;
+        let results =
+            pkg::check(&plan, true, true).map_err(LanguageServerError::FailedToCompile)?;
         let results_len = results.len();
         for (i, res) in results.into_iter().enumerate() {
             // We can convert these destructured elements to a Vec<Diagnostic> later on.

--- a/test/src/ir_generation/mod.rs
+++ b/test/src/ir_generation/mod.rs
@@ -292,6 +292,7 @@ fn compile_core() -> namespace::Module {
         offline_mode: true,
         terse_mode: true,
         locked: false,
+        preserve_statics: false,
     };
 
     let res = forc::test::forc_check::check(check_cmd)


### PR DESCRIPTION
It has been made clear to me that the LSP can't be adopted by app devs until it can run multiple projects without crashing. @mitchmindtree suggested we just preserve the lazy statics if it is coming from the LSP so the type ids and decl ids remain valid.

Since @emilyaherbert recently reduced the number of type ids we generate significantly, this is probably a good enough workaround until we actually remove the lazy statics. Perhaps the devs can get a couple of hours out of this before the engine overflows. 😅 

This is totally just a hacky workaround and should be removed when we remove lazy statics.