### PR TITLE
Add forc-index plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,8 +299,8 @@ dependencies = [
  "futures-core",
  "futures-io",
  "rustls 0.18.1",
- "webpki",
- "webpki-roots",
+ "webpki 0.21.4",
+ "webpki-roots 0.20.0",
 ]
 
 [[package]]
@@ -1114,7 +1114,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
 dependencies = [
- "sct",
+ "sct 0.6.1",
 ]
 
 [[package]]
@@ -1469,6 +1469,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "entities"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,7 +1553,7 @@ checksum = "9146112ee3ce031aa5aebe3e049e10b1d353b9c7630cc6be488c2c62cc5d9c42"
 dependencies = [
  "futures",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.22.1",
  "hyper-timeout",
  "log",
  "pin-project",
@@ -1747,6 +1756,29 @@ dependencies = [
  "sway-utils",
  "swayfmt",
  "taplo",
+ "tracing",
+]
+
+[[package]]
+name = "forc-index"
+version = "0.1.4"
+dependencies = [
+ "anyhow",
+ "clap 3.2.23",
+ "forc-tracing",
+ "forc-util",
+ "fuel-tx",
+ "fuels-types",
+ "hex",
+ "hyper-rustls 0.23.1",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sway-core",
+ "sway-types",
+ "sway-utils",
+ "tokio",
  "tracing",
 ]
 
@@ -2516,10 +2548,25 @@ dependencies = [
  "hyper",
  "log",
  "rustls 0.19.1",
- "rustls-native-certs",
+ "rustls-native-certs 0.5.0",
  "tokio",
- "tokio-rustls",
- "webpki",
+ "tokio-rustls 0.22.0",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls 0.20.7",
+ "rustls-native-certs 0.6.2",
+ "tokio",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -2638,6 +2685,12 @@ name = "io-lifetimes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+
+[[package]]
+name = "ipnet"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "itertools"
@@ -3760,6 +3813,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls 0.23.1",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.20.7",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls 0.23.4",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.22.5",
+ "winreg",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3876,8 +3969,8 @@ dependencies = [
  "base64 0.12.3",
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.6.1",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -3889,8 +3982,20 @@ dependencies = [
  "base64 0.13.1",
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+dependencies = [
+ "log",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -3903,6 +4008,27 @@ dependencies = [
  "rustls 0.19.1",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -3976,6 +4102,16 @@ name = "sct"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -4133,6 +4269,18 @@ dependencies = [
  "itoa 1.0.4",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -5021,7 +5169,18 @@ checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls 0.19.1",
  "tokio",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.7",
+ "tokio",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -5538,12 +5697,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
 dependencies = [
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+dependencies = [
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -5696,6 +5874,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "xdg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,16 @@
 [workspace]
 resolver = "2"
 members = [
-    "forc",
     "forc-pkg",
     "forc-plugins/forc-client",
     "forc-plugins/forc-doc",
     "forc-plugins/forc-fmt",
+    "forc-plugins/forc-index",
     "forc-plugins/forc-lsp",
     "forc-test",
     "forc-tracing",
     "forc-util",
+    "forc",
     "scripts/examples-checker",
     "scripts/mdbook-forc-documenter",
     "sway-ast",

--- a/docs/src/forc/plugins/forc_index.md
+++ b/docs/src/forc/plugins/forc_index.md
@@ -1,0 +1,1 @@
+# forc index

--- a/forc-plugins/forc-index/Cargo.toml
+++ b/forc-plugins/forc-index/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "forc-index"
+version = "0.1.4"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+edition = "2021"
+homepage = "https://fuel.network/"
+license = "Apache-2.0"
+repository = "https://github.com/FuelLabs/sway"
+description = "A `forc` plugin for basic Fuel Indexer interaction."
+
+[dependencies]
+anyhow = "1"
+clap = { version = "3", features = ["derive", "env"] }
+forc-tracing = { version = "0.31.1", path = "../../forc-tracing" }
+forc-util = { version = "0.31.1", path = "../../forc-util" }
+fuel-tx = { version = "0.23", features = ["builder"] }
+fuels-types = "0.31"
+hex = "0.4.3"
+hyper-rustls = { version = "0.23", features = ["http2"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls", "multipart", "blocking"] }
+serde = "1.0"
+serde_json = "1.0.73"
+serde_yaml = "0.8"
+sway-core = { version = "0.31.1", path = "../../sway-core" }
+sway-types = { version = "0.31.1", path = "../../sway-types" }
+sway-utils = { version = "0.31.1", path = "../../sway-utils" }
+tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "process"] }
+tracing = "0.1"
+
+[[bin]]
+name = "forc-index"
+path = "src/bin/forc-index.rs"
+
+[lib]
+path = "src/lib.rs"

--- a/forc-plugins/forc-index/README.md
+++ b/forc-plugins/forc-index/README.md
@@ -1,0 +1,37 @@
+# forc-index
+
+A `forc` plugin for basic Fuel Indexer interaction.
+
+## Commands
+
+### `forc index init`
+
+Create a new index project at the provided path. If no path is provided the current working directory will be used.
+
+```bash
+forc index init --namespace fuel
+```
+
+### `forc index new`
+
+Create new index project at the provided path.
+
+```bash
+forc index new --namespace fuel --path /home/fuel/projects
+```
+
+### `forc index start`
+
+Start a local Fuel Indexer service.
+
+```bash
+forc index start --background
+```
+
+### `forc index deploy`
+
+Deploy a given index project to a particular endpoint
+
+```bash
+forc index deploy --url https://index.swaysway.io --manifest my-index.manifest.yaml
+```

--- a/forc-plugins/forc-index/src/bin/forc-index.rs
+++ b/forc-plugins/forc-index/src/bin/forc-index.rs
@@ -1,0 +1,9 @@
+use tracing::error;
+
+#[tokio::main]
+async fn main() {
+    if let Err(err) = forc_index::cli::run_cli().await {
+        error!("Error: {:?}", err);
+        std::process::exit(1);
+    }
+}

--- a/forc-plugins/forc-index/src/cli.rs
+++ b/forc-plugins/forc-index/src/cli.rs
@@ -1,0 +1,38 @@
+pub(crate) use crate::commands::{
+    deploy::Command as DeployCommand, init::Command as InitCommand, new::Command as NewCommand,
+    start::Command as StartCommand,
+};
+use clap::{Parser, Subcommand};
+use forc_tracing::{init_tracing_subscriber, TracingSubscriberOptions};
+
+#[derive(Debug, Parser)]
+#[clap(name = "forc index", about = "Fuel Index Orchestrator", version)]
+struct Opt {
+    /// The command to run
+    #[clap(subcommand)]
+    command: ForcIndex,
+}
+
+#[derive(Subcommand, Debug)]
+enum ForcIndex {
+    Init(InitCommand),
+    New(NewCommand),
+    Deploy(DeployCommand),
+    Start(StartCommand),
+}
+
+pub async fn run_cli() -> Result<(), anyhow::Error> {
+    let opt = Opt::parse();
+    let tracing_options = TracingSubscriberOptions {
+        ..Default::default()
+    };
+
+    init_tracing_subscriber(tracing_options);
+
+    match opt.command {
+        ForcIndex::Init(command) => crate::commands::init::exec(command),
+        ForcIndex::New(command) => crate::commands::new::exec(command),
+        ForcIndex::Deploy(command) => crate::commands::deploy::exec(command),
+        ForcIndex::Start(command) => crate::commands::start::exec(command),
+    }
+}

--- a/forc-plugins/forc-index/src/commands/deploy.rs
+++ b/forc-plugins/forc-index/src/commands/deploy.rs
@@ -1,0 +1,25 @@
+use crate::{ops::forc_index_deploy, utils::defaults};
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Create a new Forc project in an existing directory.
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// URL at which to upload index assets
+    #[clap(long, default_value = defaults::DEFAULT_INDEXER_URL, help = "URL at which to upload index assets.")]
+    pub url: String,
+
+    /// Path of the index manifest to upload
+    #[clap(long, help = "Path of the index manifest to upload.")]
+    pub manifest: PathBuf,
+
+    /// Authentication header value
+    #[clap(long, help = "Authentication header value.")]
+    pub auth: Option<String>,
+}
+
+pub fn exec(command: Command) -> Result<()> {
+    forc_index_deploy::init(command)?;
+    Ok(())
+}

--- a/forc-plugins/forc-index/src/commands/init.rs
+++ b/forc-plugins/forc-index/src/commands/init.rs
@@ -1,0 +1,30 @@
+use crate::ops::forc_index_init;
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Create a new Forc project in the current directory.
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// Name of index
+    #[clap(long, help = "Name of index.")]
+    pub name: Option<String>,
+
+    /// Path at which to create index
+    #[clap(
+        short,
+        long,
+        parse(from_os_str),
+        help = "Path at which to create index."
+    )]
+    pub path: Option<PathBuf>,
+
+    /// Name of the index namespace
+    #[clap(long, help = "Namespace in which index belongs.")]
+    pub namespace: Option<String>,
+}
+
+pub fn exec(command: Command) -> Result<()> {
+    forc_index_init::init(command)?;
+    Ok(())
+}

--- a/forc-plugins/forc-index/src/commands/mod.rs
+++ b/forc-plugins/forc-index/src/commands/mod.rs
@@ -1,0 +1,4 @@
+pub mod deploy;
+pub mod init;
+pub mod new;
+pub mod start;

--- a/forc-plugins/forc-index/src/commands/new.rs
+++ b/forc-plugins/forc-index/src/commands/new.rs
@@ -1,0 +1,24 @@
+use crate::ops::forc_index_new;
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Create a new Forc project in an existing directory.
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// Name of index
+    #[clap(long, help = "Name of index.")]
+    pub name: Option<String>,
+
+    /// Path at which to create index
+    pub path: PathBuf,
+
+    /// Name of the index namespace
+    #[clap(long, help = "Namespace in which index belongs.")]
+    pub namespace: Option<String>,
+}
+
+pub fn exec(command: Command) -> Result<()> {
+    forc_index_new::init(command)?;
+    Ok(())
+}

--- a/forc-plugins/forc-index/src/commands/start.rs
+++ b/forc-plugins/forc-index/src/commands/start.rs
@@ -1,0 +1,29 @@
+use crate::ops::forc_index_start;
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Create a new Forc project in an existing directory.
+#[derive(Debug, Parser)]
+pub struct Command {
+    /// Log level passed to the Fuel Indexer service.
+    #[clap(long, default_value = "info", value_parser(["info", "debug", "error", "warn"]), help = "Log level passed to the Fuel Indexer service.")]
+    pub log_level: String,
+
+    /// Path to the config file used to start the Fuel Indexer.
+    #[clap(long, help = "Path to the config file used to start the Fuel Indexer.")]
+    pub config: Option<PathBuf>,
+
+    /// Path to the fuel-indexer binary.
+    #[clap(long, help = "Path to the fuel-indexer binary.")]
+    pub bin: Option<PathBuf>,
+
+    /// Whether to run the Fuel Indexer in the background.
+    #[clap(long, help = "Whether to run the Fuel Indexer in the background.")]
+    pub background: bool,
+}
+
+pub fn exec(command: Command) -> Result<()> {
+    forc_index_start::init(command)?;
+    Ok(())
+}

--- a/forc-plugins/forc-index/src/lib.rs
+++ b/forc-plugins/forc-index/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod cli;
+pub(crate) mod commands;
+pub(crate) mod ops;
+pub(crate) mod utils;

--- a/forc-plugins/forc-index/src/ops/forc_index_deploy.rs
+++ b/forc-plugins/forc-index/src/ops/forc_index_deploy.rs
@@ -1,0 +1,117 @@
+use crate::cli::DeployCommand;
+use reqwest::{
+    blocking::{multipart::Form, Client},
+    header::{HeaderMap, AUTHORIZATION},
+    StatusCode,
+};
+use serde_json::{to_string_pretty, value::Value, Map};
+use std::fs;
+use std::io::{BufReader, Read};
+use std::path::Path;
+use tracing::{error, info};
+
+fn extract_manifest_fields(
+    manifest: serde_yaml::Value,
+) -> anyhow::Result<(String, String, String, String)> {
+    let namespace: String = manifest
+        .get(&serde_yaml::Value::String("namespace".into()))
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+    let identifier: String = manifest
+        .get(&serde_yaml::Value::String("identifier".into()))
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+    let graphql_schema: String = manifest
+        .get(&serde_yaml::Value::String("graphql_schema".into()))
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+    let module: serde_yaml::Value = manifest
+        .get(&serde_yaml::Value::String("module".into()))
+        .unwrap()
+        .to_owned();
+    let module_path: String = module
+        .get(&serde_yaml::Value::String("wasm".into()))
+        .unwrap_or_else(|| {
+            module
+                .get(&serde_yaml::Value::String("native".into()))
+                .unwrap()
+        })
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    Ok((namespace, identifier, graphql_schema, module_path))
+}
+
+pub fn init(command: DeployCommand) -> anyhow::Result<()> {
+    let mut manifest_file = fs::File::open(&command.manifest).unwrap_or_else(|_| {
+        panic!(
+            "Index manifest file at '{}' does not exist",
+            command.manifest.display()
+        )
+    });
+    let mut manifest_contents = String::new();
+    manifest_file.read_to_string(&mut manifest_contents)?;
+    let manifest: serde_yaml::Value = serde_yaml::from_str(&manifest_contents)?;
+
+    let (namespace, identifier, graphql_schema, module_path) = extract_manifest_fields(manifest)?;
+
+    let mut manifest_buff = Vec::new();
+    let mut manifest_reader = BufReader::new(manifest_file);
+    manifest_reader.read_to_end(&mut manifest_buff)?;
+
+    let form = Form::new()
+        .file("manifest", Path::new(&command.manifest))?
+        .file("schema", Path::new(&graphql_schema))?
+        .file("wasm", Path::new(&module_path))?;
+
+    let target = format!("{}/api/index/{}/{}", &command.url, &namespace, &identifier);
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        command.auth.unwrap_or_else(|| "fuel".into()).parse()?,
+    );
+
+    info!(
+        "\n🚀 Deploying index at {} to {}",
+        &command.manifest.display(),
+        &target
+    );
+
+    let res = Client::new()
+        .post(&target)
+        .multipart(form)
+        .headers(headers)
+        .send()
+        .expect("Failed to deploy index.");
+
+    if res.status() != StatusCode::OK {
+        error!(
+            "\n❌ {} returned a non-200 response code: {:?}",
+            &target,
+            res.status()
+        );
+        return Ok(());
+    }
+
+    let res_json = res
+        .json::<Map<String, Value>>()
+        .expect("Failed to read JSON response.");
+
+    println!("\n{}", to_string_pretty(&res_json)?);
+
+    info!(
+        "\n✅ Successfully deployed index at {} to {} \n",
+        &command.manifest.display(),
+        &target
+    );
+
+    Ok(())
+}

--- a/forc-plugins/forc-index/src/ops/forc_index_init.rs
+++ b/forc-plugins/forc-index/src/ops/forc_index_init.rs
@@ -1,0 +1,145 @@
+use crate::{cli::InitCommand, utils::defaults};
+use anyhow::Context;
+use forc_util::validate_name;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+use tracing::{debug, info};
+
+fn print_welcome_message() {
+    let read_the_docs = format!(
+        "Read the Docs:\n- {}\n- {}\n- {}\n- {}\n",
+        "Fuel Indexer: https://github.com/FuelLabs/fuel-indexer",
+        "Fuel Indexer Book: https://fuellabs.github.io/fuel-indexer/latest",
+        "Sway Book: https://fuellabs.github.io/sway/latest",
+        "Rust SDK Book: https://fuellabs.github.io/fuels-rs/latest",
+    );
+
+    let join_the_community = format!(
+        "Join the Community:\n- Follow us {}
+- Ask questions in dev-chat on {}",
+        "@SwayLang: https://twitter.com/fuellabs_", "Discord: https://discord.com/invite/xfpK4Pe"
+    );
+
+    let report_bugs = format!(
+        "Report Bugs:\n- {}",
+        "Fuel Indexer Issues: https://github.com/FuelLabs/fuel-indexer/issues/new"
+    );
+
+    let ascii_tag = r#"
+███████ ██    ██ ███████ ██          ██ ███    ██ ██████  ███████ ██   ██ ███████ ██████  
+██      ██    ██ ██      ██          ██ ████   ██ ██   ██ ██       ██ ██  ██      ██   ██ 
+█████   ██    ██ █████   ██          ██ ██ ██  ██ ██   ██ █████     ███   █████   ██████  
+██      ██    ██ ██      ██          ██ ██  ██ ██ ██   ██ ██       ██ ██  ██      ██   ██ 
+██       ██████  ███████ ███████     ██ ██   ████ ██████  ███████ ██   ██ ███████ ██   ██ 
+                                                                                          
+
+An easy-to-use, flexible indexing service built to go fast. 🚗💨
+    "#;
+
+    info!(
+        "\n{}\n\n----\n\n{}\n\n{}\n\n{}\n\n",
+        ascii_tag, read_the_docs, join_the_community, report_bugs
+    );
+}
+
+pub fn init(command: InitCommand) -> anyhow::Result<()> {
+    let project_dir = match &command.path {
+        Some(p) => PathBuf::from(p),
+        None => std::env::current_dir()
+            .context("❌ Failed to get current directory for forc index init.")?,
+    };
+
+    if !project_dir.is_dir() {
+        anyhow::bail!("❌ '{}' is not a valid directory.", project_dir.display());
+    }
+
+    if project_dir
+        .join(defaults::CARGO_MANIFEST_FILE_NAME)
+        .exists()
+    {
+        anyhow::bail!(
+            "❌ '{}' already includes a Cargo.toml file.",
+            project_dir.display()
+        );
+    }
+
+    debug!(
+        "\nUsing project directory at {}",
+        project_dir.canonicalize()?.display()
+    );
+
+    let project_name = match command.name {
+        Some(name) => name,
+        None => project_dir
+            .file_stem()
+            .context("❌ Failed to infer project name from directory name.")?
+            .to_string_lossy()
+            .into_owned(),
+    };
+
+    validate_name(&project_name, "project name")?;
+
+    // Make a new directory for the project
+    fs::create_dir_all(Path::new(&project_dir).join("src"))?;
+
+    // Write index Cargo manifest
+    let namespace = command
+        .namespace
+        .unwrap_or_else(|| defaults::DEFAULT_NAMESPACE.into());
+    fs::write(
+        Path::new(&project_dir).join(defaults::CARGO_MANIFEST_FILE_NAME),
+        defaults::default_index_cargo_toml(&project_name),
+    )
+    .unwrap();
+
+    // Write index manifest
+    let manifest_filename = format!("{}.manifest.yaml", project_name);
+    fs::write(
+        Path::new(&project_dir).join(&manifest_filename),
+        defaults::default_index_manifest(
+            &namespace,
+            &project_name,
+            fs::canonicalize(Path::new(&project_dir))?.to_str().unwrap(),
+        ),
+    )
+    .unwrap();
+
+    // Write index schema
+    let schema_filename = format!("{}.schema.graphql", &project_name);
+    fs::create_dir_all(Path::new(&project_dir).join("schema"))?;
+    fs::write(
+        Path::new(&project_dir).join("schema").join(schema_filename),
+        defaults::default_index_schema(),
+    )
+    .unwrap();
+
+    // Write lib file
+    fs::write(
+        Path::new(&project_dir)
+            .join("src")
+            .join(defaults::INDEX_LIB_FILENAME),
+        defaults::default_index_lib(
+            &project_name,
+            &manifest_filename,
+            fs::canonicalize(Path::new(&project_dir))?.to_str().unwrap(),
+        ),
+    )
+    .unwrap();
+
+    // Write cargo config with WASM target
+    fs::create_dir_all(Path::new(&project_dir).join(defaults::CARGO_CONFIG_DIR_NAME))?;
+    let _ = fs::write(
+        Path::new(&project_dir)
+            .join(defaults::CARGO_CONFIG_DIR_NAME)
+            .join(defaults::CARGO_CONFIG_FILENAME),
+        defaults::default_cargo_config(),
+    );
+
+    debug!("\n✅ nSuccessfully created index {project_name}");
+
+    print_welcome_message();
+
+    Ok(())
+}

--- a/forc-plugins/forc-index/src/ops/forc_index_new.rs
+++ b/forc-plugins/forc-index/src/ops/forc_index_new.rs
@@ -1,0 +1,31 @@
+use crate::cli::{InitCommand, NewCommand};
+use crate::commands::init;
+use std::path::Path;
+
+pub fn init(command: NewCommand) -> anyhow::Result<()> {
+    let NewCommand {
+        name,
+        namespace,
+        path,
+    } = command;
+
+    let dir_path = Path::new(&path);
+    if dir_path.exists() {
+        anyhow::bail!(
+            "❌ Directory \"{}\" already exists.\nIf you wish to initialise an index project inside \
+            this directory, consider using `forc index init --path {}`",
+            dir_path.canonicalize()?.display(),
+            dir_path.display(),
+        );
+    } else {
+        std::fs::create_dir_all(dir_path)?;
+    }
+
+    let _ = init::exec(InitCommand {
+        name,
+        namespace,
+        path: Some(dir_path.to_path_buf()),
+    });
+
+    Ok(())
+}

--- a/forc-plugins/forc-index/src/ops/forc_index_start.rs
+++ b/forc-plugins/forc-index/src/ops/forc_index_start.rs
@@ -1,0 +1,47 @@
+use crate::cli::StartCommand;
+use std::path::PathBuf;
+use std::process::Command;
+use tracing::info;
+
+pub fn init(command: StartCommand) -> anyhow::Result<()> {
+    // If the user has a binary path they'd prefer to use, they can specify
+    // it, else just use whichever indexer is in the path - whether that be
+    // ia fuelup or some other means.
+    let binary_path = command.bin.unwrap_or_else(|| {
+        PathBuf::from(
+            String::from_utf8(
+                Command::new("which")
+                    .arg("fuel-indexer")
+                    .output()
+                    .expect("❌ Failed to detect fuel-indexer binary.")
+                    .stdout,
+            )
+            .unwrap(),
+        )
+    });
+
+    let mut cmd = Command::new(&binary_path);
+
+    if let Some(c) = &command.config {
+        cmd.arg("--config").arg(c);
+    }
+
+    let mut proc = cmd
+        .spawn()
+        .expect("❌ Failed to spawn fuel-indexer child process.");
+
+    // Starting the service in the background allows the user to
+    // go and and continue interacting with the service (e.g., forc index deploy)
+    // without having to switch terminals
+    if !command.background {
+        let ecode = proc
+            .wait()
+            .expect("❌ Failed to wait on fuel-indexer process.");
+
+        assert!(ecode.success());
+    }
+
+    info!("\n✅ Successfully started the indexer service.");
+
+    Ok(())
+}

--- a/forc-plugins/forc-index/src/ops/mod.rs
+++ b/forc-plugins/forc-index/src/ops/mod.rs
@@ -1,0 +1,4 @@
+pub mod forc_index_deploy;
+pub mod forc_index_init;
+pub mod forc_index_new;
+pub mod forc_index_start;

--- a/forc-plugins/forc-index/src/utils/defaults.rs
+++ b/forc-plugins/forc-index/src/utils/defaults.rs
@@ -1,0 +1,89 @@
+pub const CARGO_MANIFEST_FILE_NAME: &str = "Cargo.toml";
+pub const INDEX_LIB_FILENAME: &str = "lib.rs";
+pub const DEFAULT_NAMESPACE: &str = "fuel";
+pub const CARGO_CONFIG_DIR_NAME: &str = ".cargo";
+pub const CARGO_CONFIG_FILENAME: &str = "config";
+pub const DEFAULT_INDEXER_URL: &str = "http://127.0.0.1:29987";
+
+pub fn default_index_cargo_toml(index_name: &str) -> String {
+    format!(
+        r#"[package]
+name = "{index_name}"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ['cdylib']
+
+[dependencies]
+fuel-indexer-macros = {{ version = "0.1", default-features = false }}
+fuel-indexer-plugin = {{ version = "0.1" }}
+fuel-indexer-schema = {{ version = "0.1", default-features = false }}
+fuel-tx = "0.23"
+fuels-core = "0.30"
+fuels-types = "0.30"
+getrandom = {{ version = "0.2", features = ["js"] }}
+serde = {{ version = "1.0", default-features = false, features = ["derive"] }}
+"#
+    )
+}
+
+pub fn default_index_manifest(namespace: &str, index_name: &str, project_path: &str) -> String {
+    format!(
+        r#"namespace: {namespace}
+identifier: {index_name}
+# abi: /path/to/your/contract-abi.json
+graphql_schema: {project_path}/schema/{index_name}.schema.graphql
+module:
+  wasm: /path/to/your/index_wasm_module.wasm
+"#
+    )
+}
+
+pub fn default_index_lib(index_name: &str, manifest_filename: &str, path: &str) -> String {
+    format!(
+        r#"extern crate alloc;
+use fuel_indexer_macros::indexer;
+
+#[indexer(manifest = "{path}/{manifest_filename}")]
+pub mod {index_name}_index_mod {{
+
+    fn {index_name}_handler(block: BlockData) {{
+        Logger::info("Processing a block. (>'.')>");
+        for tx in block.transactions.iter() {{
+            let msg = format!("Processing transaction: {{}}", tx.id);
+            Logger::info(&msg);
+        }}
+    }}
+}}
+"#
+    )
+}
+
+pub fn default_index_schema() -> String {
+    r#"schema {
+    query: QueryRoot
+}
+
+type QueryRoot {
+    account: Account
+}
+
+type Account {
+    id: ID!
+    address: Address! @indexed
+    first_seen: UInt8!
+    last_seen: UInt8!
+}
+
+"#
+    .to_string()
+}
+
+pub fn default_cargo_config() -> String {
+    r#"[build]
+target = "wasm32-unknown-unknown"
+"#
+    .to_string()
+}

--- a/forc-plugins/forc-index/src/utils/mod.rs
+++ b/forc-plugins/forc-index/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod defaults;


### PR DESCRIPTION
### Description
- This PR adds the long-awaited Forc Indexer plugin that is invoked via `forc index`
- `forc index` is pretty much based on forc in terms of structure
- There may have been a few things that I left out (it's been a minute since I've committed to forc)
- I'm not really sure how to "hook this in" to forc -- so I just built the binary `cargo build --release -p forc-index` and manually added it to my `~/.fuelup/bin`

### Testings steps
- [ ] I would recommend you pull down the https://github.com/FuelLabs/fuel-indexer/ project
- [ ] And build a `fuel-indexer` binary via `cargo build --release -p fuel-indexer`
  - This will help with the `forc index start` and `forc index deploy` commands
  - This `fuel-indexer` binary has been merged into `fuelup` but haven't had a chance to use it yet 
- [ ] Then maybe just start playing around by following [the `forc index` README](https://github.com/FuelLabs/sway/pull/3408/files#diff-f2a224153badb56732262b7d0bcbf0ab38ea97660a497b02be28408310918dd1)