### PR TITLE
Add a check in codegen to ensure all registers are initialised before use.

### DIFF
--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -41,7 +41,12 @@ pub fn compile_ir_to_asm(
         println!("{abstract_program}\n");
     }
 
-    let allocated_program = abstract_program.into_allocated_program();
+    let allocated_program = check!(
+        CompileResult::from(abstract_program.into_allocated_program()),
+        return err(warnings, errors),
+        warnings,
+        errors
+    );
 
     if build_config
         .map(|cfg| cfg.print_intermediate_asm)

--- a/sway-core/src/asm_generation/programs/abstract.rs
+++ b/sway-core/src/asm_generation/programs/abstract.rs
@@ -12,6 +12,8 @@ use crate::{
     },
 };
 
+use sway_error::error::CompileError;
+
 use either::Either;
 
 impl AbstractProgram {
@@ -31,7 +33,7 @@ impl AbstractProgram {
         }
     }
 
-    pub(crate) fn into_allocated_program(mut self) -> AllocatedProgram {
+    pub(crate) fn into_allocated_program(mut self) -> Result<AllocatedProgram, CompileError> {
         // Build our bytecode prologue which has a preamble and for contracts is the switch based on
         // function selector.
         let mut prologue = self.build_preamble();
@@ -47,26 +49,32 @@ impl AbstractProgram {
             .map(|entry| (entry.selector, entry.label, entry.name.clone()))
             .collect();
 
-        // Allocate the registers for each function.
-        let functions: Vec<_> = self
+        // Gather all the functions together, optimise and then verify the instructions.
+        let abstract_functions = self
             .entries
             .into_iter()
             .map(|entry| entry.ops)
             .chain(self.non_entries.into_iter())
             .map(AbstractInstructionSet::optimize)
+            .map(AbstractInstructionSet::verify)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Allocate the registers for each function.
+        let functions = abstract_functions
+            .into_iter()
             .map(|fn_ops| fn_ops.allocate_registers(&mut self.reg_seqr))
             .map(AllocatedAbstractInstructionSet::emit_pusha_popa)
-            .collect();
+            .collect::<Vec<_>>();
 
         // XXX need to verify that the stack use for each function is balanced.
 
-        AllocatedProgram {
+        Ok(AllocatedProgram {
             kind: self.kind,
             data_section: self.data_section,
             prologue,
             functions,
             entries,
-        }
+        })
     }
 
     /// Builds the asm preamble, which includes metadata and a jump past the metadata.


### PR DESCRIPTION
It isn't really possible to add tests, at least not easily, as we need to get the IR -> ASM code to generate bad code deliberately.

Closes #2272