### PR TITLE
Update the E2E test runner to report shell exit code on failure

### DIFF
--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -421,7 +421,11 @@ pub async fn run(filter_config: &FilterConfig, run_config: &RunConfig) -> Result
             disabled_tests.len()
         );
     }
-    Ok(())
+    if number_of_tests_failed != 0 {
+        Err(anyhow::Error::msg("Failed tests"))
+    } else {
+        Ok(())
+    }
 }
 
 fn discover_test_configs() -> Result<Vec<TestDescription>> {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_invalid_opcodes/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_invalid_opcodes/src/main.sw
@@ -1,7 +1,7 @@
 predicate;
 
 fn main() -> bool {
-  asm(r1, r2, r3) {
+  asm(r1, r2: 0, r3: 0) {
     bal r1 r2 r3;
   };
 
@@ -9,31 +9,31 @@ fn main() -> bool {
     bhei r1;
   };
 
-  asm(r1, r2) {
+  asm(r1: 0, r2: 0) {
     bhsh r1 r2;
   };
 
-  asm(r1) {
+  asm(r1: 0) {
     burn r1;
   };
 
-  asm(r1, r2, r3, r4) {
+  asm(r1: 0, r2: 0, r3: 0, r4: 0) {
     call r1 r2 r3 r4;
   };
 
-  asm(r1) {
+  asm(r1: 0) {
     cb r1;
   };
 
-  asm(r1, r2, r3, r4) {
+  asm(r1: 0, r2: 0, r3: 0, r4: 0) {
     ccp r1 r2 r3 r4;
   };
 
-  asm(r1, r2) {
+  asm(r1: 0, r2: 0) {
     croo r1 r2;
   };
 
-  asm(r1, r2) {
+  asm(r1, r2: 0) {
     csiz r1 r2;
   };
 
@@ -50,54 +50,58 @@ fn main() -> bool {
     gm r1 i3;
   };
 
-  asm(r1, r2, r3) {
+  asm(r1: 0, r2: 0, r3: 0) {
     ldc r1 r2 r3;
   }
 
-  asm(r1, r2, r3, r4) {
+  asm(r1: 0, r2: 0, r3: 0, r4: 0) {
     log r1 r2 r3 r4;
   }
 
-  asm(r1, r2, r3, r4) {
+  asm(r1: 0, r2: 0, r3: 0, r4: 0) {
     logd r1 r2 r3 r4;
   }
 
-  asm(r1) {
+  asm(r1: 0) {
     mint r1;
   }
 
   // retd: There is no way of testing
   // rvrt: It is allowed and used to abort predicates.
 
-  asm(r1, r2, r3, r4) {
+  asm(r1: 0, r2: 0, r3: 0, r4: 0) {
     smo r1 r2 r3 r4;
   }
 
-  asm(r1, r2, r3) {
+  // cannot test storage opcodes due to needing to annotate main
+  // with #[storage(read, write)] which is not allowed for predicates
+  /*
+  asm(r1: 0, r2: 0, r3) {
     srw r1 r2 r3;
   }
 
-  asm(r1, r2, r3, r4) {
+  asm(r1: 0, r2: 0, r3: 0, r4: 0) {
     srwq r1 r2 r3 r4;
   }
 
-  asm(r1, r2, r3) {
+  asm(r1: 0, r2: 0, r3) {
     sww r1 r2 r3;
   }
 
-  asm(r1, r2, r3, r4) {
+  asm(r1: 0, r2: 0, r3: 0, r4: 0) {
     swwq r1 r2 r3 r4;
   }
+  */
 
-  asm(r1, r2) {
+  asm(r1, r2: 0) {
     time r1 r2;
   }
 
-  asm(r1, r2, r3) {
+  asm(r1: 0, r2: 0, r3: 0) {
     tr r1 r2 r3;
   }
 
-  asm(r1, r2, r3, r4) {
+  asm(r1: 0, r2: 0, r3: 0, r4: 0) {
     tro r1 r2 r3 r4;
   }
 

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_invalid_opcodes/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_invalid_opcodes/test.toml
@@ -1,7 +1,5 @@
 category = "fail"
 
-# check: $()This function performs a storage read & write but does not have the required attribute(s).
-
 # check: bal r1 r2 r3;
 # nextln: $()The BAL opcode cannot be used in a predicate.
 
@@ -51,18 +49,6 @@ category = "fail"
 
 # check: smo r1 r2 r3 r4;
 # nextln: $()The SMO opcode cannot be used in a predicate.
-
-# check: srw r1 r2 r3;
-# nextln: $()The SRW opcode cannot be used in a predicate.
-
-# check: srwq r1 r2 r3 r4;
-# nextln: $()The SRWQ opcode cannot be used in a predicate.
-
-# check: sww r1 r2 r3;
-# nextln: $()The SWW opcode cannot be used in a predicate.
-
-# check: swwq r1 r2 r3 r4;
-# nextln: $()The SWWQ opcode cannot be used in a predicate.
 
 # check: time r1 r2;
 # nextln: $()The TIME opcode cannot be used in a predicate.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/storage_annotations_unused_read/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/storage_annotations_unused_read/test.toml
@@ -1,3 +1,3 @@
 category = "compile"
 
-# check: $()This function's storage attributes declaration does not match this function's actual storage access pattern: 'read' attribute(s) can be removed.
+# check: $()This function's storage attributes declaration does not match its actual storage access pattern: 'read' attribute(s) can be removed.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/storage_annotations_unused_read_and_write/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/storage_annotations_unused_read_and_write/test.toml
@@ -1,3 +1,3 @@
 category = "compile"
 
-# check: $()This function's storage attributes declaration does not match this function's actual storage access pattern: 'read, write' attribute(s) can be removed.
+# check: $()This function's storage attributes declaration does not match its actual storage access pattern: 'read, write' attribute(s) can be removed.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/storage_annotations_unused_write/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/storage_annotations_unused_write/test.toml
@@ -1,3 +1,3 @@
 category = "compile"
 
-# check: $()This function's storage attributes declaration does not match this function's actual storage access pattern: 'write' attribute(s) can be removed.
+# check: $()This function's storage attributes declaration does not match its actual storage access pattern: 'write' attribute(s) can be removed.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/src/main.sw
@@ -2,15 +2,6 @@ script;
 
 use core::ops::*;
 
-impl<T> Option<T> {
-    pub fn ok_or<E>(self, err: E) -> Result<T, E> {
-        match self {
-            Option::Some(v) => Result::Ok(v),
-            Option::None => Result::Err(err),
-        }
-    }
-}
-
 fn test_ok_or<T, E>(val: T, default: E) where T: Eq {
     match Option::Some(val).ok_or(default) {
         Result::Ok(inner) => assert(inner == val),

--- a/test/src/ir_generation/mod.rs
+++ b/test/src/ir_generation/mod.rs
@@ -266,6 +266,7 @@ pub(super) async fn run(filter_regex: Option<&regex::Regex>) -> Result<()> {
             total_test_count - run_test_count
         );
     }
+    // TODO: Make this return an Err once the panics above are converted to an error
     Ok(())
 }
 


### PR DESCRIPTION
This updates the E2E test runner to report shell exit code on failure, which it never did before but is now required due to the whole testing process not panicking anymore.

Unfortunately this broke the E2E tests step in CI, which means we have not been correctly reporting tests failures on PRs since https://github.com/FuelLabs/sway/commit/4fe5a388ed894aca00e4a3995e085d63bdab169c landed. :hear_no_evil: 

Some test failures have been introduced to master since, thankfully nothing major, which this also fixes.