### PR TITLE
Revert changes to while loop handling in analyze_return_paths

### DIFF
--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -138,46 +138,20 @@ fn connect_node(
             for leaf_ix in leaves {
                 graph.add_edge(*leaf_ix, this_index, "".into());
             }
-            Ok((NodeConnection::Return(this_index), vec![]))
+            Ok((NodeConnection::Return(this_index), vec![this_index]))
         }
         ty::TyAstNodeContent::Expression(ty::TyExpression {
-            expression: ty::TyExpressionVariant::WhileLoop { body, .. },
+            expression: ty::TyExpressionVariant::WhileLoop { .. },
             ..
         }) => {
-            // This is very similar to the dead code analysis for a while loop.
-            let entry = graph.add_node(node.into());
-            let while_loop_exit = graph.add_node("while loop exit".to_string().into());
+            // An abridged version of the dead code analysis for a while loop
+            // since we don't really care about what the loop body contains when detecting
+            // divergent paths
+            let node = graph.add_node(node.into());
             for leaf in leaves {
-                graph.add_edge(*leaf, entry, "".into());
+                graph.add_edge(*leaf, node, "while loop entry".into());
             }
-            // it is possible for a whole while loop to be skipped so add edge from
-            // beginning of while loop straight to exit
-            graph.add_edge(
-                entry,
-                while_loop_exit,
-                "condition is initially false".into(),
-            );
-            let mut leaves = vec![entry];
-
-            // We need to dig into the body of the while loop in case there is a break or a
-            // continue at some level.
-            let (l_leaves, inner_returns) =
-                depth_first_insertion_code_block(type_engine, body, graph, &leaves)?;
-
-            // insert edges from end of block back to beginning of it
-            for leaf in &l_leaves {
-                graph.add_edge(*leaf, entry, "loop repeats".into());
-            }
-
-            leaves = l_leaves;
-            for leaf in leaves {
-                graph.add_edge(leaf, while_loop_exit, "".into());
-            }
-
-            Ok((
-                NodeConnection::NextStep(vec![while_loop_exit]),
-                inner_returns,
-            ))
+            Ok((NodeConnection::NextStep(vec![node]), vec![]))
         }
         ty::TyAstNodeContent::Expression(ty::TyExpression { .. }) => {
             let entry = graph.add_node(node.into());
@@ -318,7 +292,7 @@ fn connect_typed_fn_decl(
 ) -> Result<(), CompileError> {
     let fn_exit_node = graph.add_node(format!("\"{}\" fn exit", fn_decl.name.as_str()).into());
     let return_nodes =
-        depth_first_insertion_code_block(type_engine, &fn_decl.body, graph, &[entry_node])?.0;
+        depth_first_insertion_code_block(type_engine, &fn_decl.body, graph, &[entry_node])?;
     for node in return_nodes {
         graph.add_edge(node, fn_exit_node, "return".into());
     }
@@ -343,7 +317,7 @@ fn depth_first_insertion_code_block(
     node_content: &ty::TyCodeBlock,
     graph: &mut ControlFlowGraph,
     leaves: &[NodeIndex],
-) -> Result<(ReturnStatementNodes, Vec<NodeIndex>), CompileError> {
+) -> Result<ReturnStatementNodes, CompileError> {
     let mut leaves = leaves.to_vec();
     let mut return_nodes = vec![];
     for node in node_content.contents.iter() {
@@ -356,5 +330,5 @@ fn depth_first_insertion_code_block(
         }
         return_nodes.extend(inner_returns);
     }
-    Ok((return_nodes, leaves))
+    Ok(return_nodes)
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_1/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_1/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'while_explicit_ret_1'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_1/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_1/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "while_explicit_ret_1"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_1/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_1/src/main.sw
@@ -1,0 +1,7 @@
+script;
+
+fn main() -> u64 {
+    while true {
+        return 0;
+    };
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_1/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_1/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()This path must return a value of type "u64" from function "main", but it does not.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_2/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_2/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'while_explicit_ret_2'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_2/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_2/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "while_explicit_ret_2"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_2/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_2/src/main.sw
@@ -1,0 +1,8 @@
+script;
+
+fn main() -> u64 {
+    while true {
+        if true {        }
+        return 0;
+    };
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_2/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/while_explicit_ret_2/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()This path must return a value of type "u64" from function "main", but it does not.


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway/issues/3426 and https://github.com/FuelLabs/sway/issues/3386

Really all I did was revert the changes made in https://github.com/FuelLabs/sway/pull/2112. Those were made to handle `break` and `continue` which are now handled somewhere else anyways so the coded I added to dig into the while loop is no longer needed, and that code was a bit buggy anyways.