### PR TITLE
feat: add no-span-debug feature for omitting span for debug purposes

### DIFF
--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -14,3 +14,6 @@ fuel-crypto = "0.6"
 fuel-tx = "0.23"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] }
+
+[features]
+no-span-debug = []

--- a/sway-types/src/span.rs
+++ b/sway-types/src/span.rs
@@ -191,6 +191,7 @@ impl Span {
 }
 
 impl fmt::Debug for Span {
+    #[cfg(not(feature = "no-span-debug"))]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("Span")
             .field("src (ptr)", &self.src.as_ptr())
@@ -199,6 +200,10 @@ impl fmt::Debug for Span {
             .field("end", &self.end)
             .field("as_str()", &self.as_str())
             .finish()
+    }
+    #[cfg(feature = "no-span-debug")]
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "")
     }
 }
 


### PR DESCRIPTION
closes #3422.

Building the workspace with `cargo build` and trying to print a debug declaration:
```console
[ConstantDeclaration(DeclarationId(6403, Span { src (ptr): 0x600001fe81c0, path: Some("/Users/kayagokalp/fuel/test_projects/test_debug_library/src/lib.sw"), start: 111, end: 121, as_str(): "test_const" }))]
```

After building the workspace with `cargo build --features sway-types/no-span-debug` and trying to do the same thing:

```console
[ConstantDeclaration(DeclarationId(6403, ))]
```

This is fairly limited as it is completely removing all the span but it is enough for my limited debugging around the compiler. If some flexibility (like keeping the as_str field etc with a different feature) is needed I can also introduce it with this PR.