### PR TITLE
Add a struct test for CEI pattern analysis

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_struct/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'cei_pattern_violation_in_struct'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+source = 'path+from-root-DC10F9EB95613970'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-DC10F9EB95613970'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_struct/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_struct/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "cei_pattern_violation_in_struct"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_struct/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_struct/src/main.sw
@@ -15,8 +15,8 @@ struct S {
 impl TestAbi for Contract {
     #[storage(write)]
     fn deposit(amount: u64) {
-    // 1st tuple component is a code block with interaction
-    // 2nd tuple component is a code block with effect
+    // 1st struct field is a code block with interaction
+    // 2nd struct field is a code block with effect
         let s = S {
             field1:  {
                 // interaction

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_struct/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_struct/src/main.sw
@@ -1,0 +1,34 @@
+contract;
+
+use std::storage::store;
+
+abi TestAbi {
+    #[storage(write)]
+    fn deposit(amount: u64);
+}
+
+struct S {
+    field1: u64,
+    field2: u64,
+}
+
+impl TestAbi for Contract {
+    #[storage(write)]
+    fn deposit(amount: u64) {
+    // 1st tuple component is a code block with interaction
+    // 2nd tuple component is a code block with effect
+        let s = S {
+            field1:  {
+                // interaction
+                abi(TestAbi, 0x3dba0a4455b598b7655a7fb430883d96c9527ef275b49739e7b0ad12f8280eae).deposit(amount);
+                42
+            },
+            field2:  {
+                // effect -- therefore violation of CEI where effect should go before interaction
+                // (assuming left-to-right struct fields evaluation)
+                store(0x3dba0a4455b598b7655a7fb430883d96c9527ef275b49739e7b0ad12f8280eae, ());
+                43
+            },
+        };
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_struct/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_struct/test.toml
@@ -1,0 +1,3 @@
+category = "compile"
+
+# check: $()Storage modification after external contract interaction in function or method "deposit". Consider making all storage writes before calling another contract


### PR DESCRIPTION
We already check the CEI pattern analysis treats _tuples_ correctly (assuming left-to-right evaluation order, which we also test), this commit also adds an explicit test for _struct_ fields evaluation which follows the following pattern:

```
let s = S {
    field1: /* interaction */,
    field2: /* effect */,
}
```

close #3462