### PR TITLE
ci: use cross to fix arm64 release step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,8 +541,8 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
 
-  install-and-upload-forc-binaries:
-    name: Install and upload forc binaries to release
+  build-and-release-forc-binaries:
+    name: Build and upload forc binaries to release
     runs-on: ${{ matrix.job.os }}
     if: github.event_name == 'release' && github.event.action == 'published'
     needs: publish
@@ -584,48 +584,17 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
+          key: "${{ matrix.job.target }}"
 
-      - name: Apple M1 setup
-        if: ${{ matrix.job.target == 'aarch64-apple-darwin' }}
+      - name: Use Cross
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cross
+          cache-key: "${{ matrix.job.target }}"
+
+      - name: Build forc binaries 
         run: |
-          echo "SDKROOT=$(xcrun -sdk macosx --show-sdk-path)" >> $GITHUB_ENV
-          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx --show-sdk-platform-version)" >> $GITHUB_ENV
-      - name: Linux ARM setup
-        if: ${{ matrix.job.target == 'aarch64-unknown-linux-gnu' }}
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-
-      - name: Install Forc
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --profile=release --path ./forc
-
-      - name: Install Forc-Fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --profile=release --path ./forc-plugins/forc-fmt
-
-      - name: Install Forc-LSP
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --profile=release --path ./forc-plugins/forc-lsp
-
-      - name: Install Forc-Client
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --profile=release --path ./forc-plugins/forc-client
-
-      - name: Install forc-doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --profile=release --path ./forc-plugins/forc-doc
+          cross build --profile=release --target ${{ matrix.job.target }} --bins
 
       - name: Prep Assets
         id: prep_assets
@@ -637,8 +606,8 @@ jobs:
           ZIP_FILE_NAME=forc-binaries-${{ env.PLATFORM_NAME }}_${{ env.ARCH }}.tar.gz
           echo "ZIP_FILE_NAME=$ZIP_FILE_NAME" >> $GITHUB_ENV
           mkdir -pv ./forc-binaries
-          for binary in forc forc-fmt forc-lsp forc-deploy forc-run forc-doc; do
-            cp $(which ${binary}) ./forc-binaries
+          for BINARY in forc forc-fmt forc-lsp forc-deploy forc-run forc-doc; do
+            cp "target/${{ matrix.job.target }}/release/$BINARY" ./forc-binaries
           done
           tar -czvf $ZIP_FILE_NAME ./forc-binaries
 


### PR DESCRIPTION
Closes #2726 

The issue was with the `cargo install` step, which resulted in the binaries being built and compiled on the `macos:latest` GitHub runner (which is on x86-apple-darwin ([source](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources))). This is why our "arm64" binaries were actually still in "amd64" format.

A direct fix would be to update the step to use `cargo build --target ${{ matrix.job.os }}` instead, but I opted to go for an indirect fix which is to use `cross` for 2 reasons: 1) standardization, since we're using that for all other repos anyway, and 2) this allows us to skip some of the setup steps as well.

I have a personal repo setup specifically to test this and the releases are here (albeit with older binary versions because I haven't yet pulled changes there): https://github.com/bingcicle/sway/releases/tag/nightly-2022-11-30. 

Output of `file forc` for each of the tarballs:

amd64 Linux:
`forc: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, BuildID[sha1]=3f51b5c41c1c915d117cb12214808a417d695dd7, with debug_info, not stripped`

arm64 Linux:
`forc: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, BuildID[sha1]=44bc7da687b369f5bf6bc8890ea97b31c6c4023a, with debug_info, not stripped`

amd64 Darwin:
`forc: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>`

arm64 Darwin:
`forc: Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>`
