### PR TITLE
Fixes compiler picking wrong trait implementation for tuples.

### DIFF
--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -887,9 +887,13 @@ fn are_equal_minus_dynamic_types(type_engine: &TypeEngine, left: TypeId, right: 
                 )
         }
         (TypeInfo::Tuple(l), TypeInfo::Tuple(r)) => {
-            l.iter().zip(r.iter()).fold(true, |acc, (left, right)| {
-                acc && are_equal_minus_dynamic_types(type_engine, left.type_id, right.type_id)
-            })
+            if l.len() != r.len() {
+                false
+            } else {
+                l.iter().zip(r.iter()).fold(true, |acc, (left, right)| {
+                    acc && are_equal_minus_dynamic_types(type_engine, left.type_id, right.type_id)
+                })
+            }
         }
         (
             TypeInfo::ContractCaller {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_trait/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_trait/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-8222DC735DC134D4'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-8222DC735DC134D4'
+dependencies = ['core']
+
+[[package]]
+name = 'tuple_types'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_trait/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_trait/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "tuple_types"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_trait/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_trait/json_abi_oracle.json
@@ -1,0 +1,22 @@
+{
+  "functions": [
+    {
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "bool",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_trait/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_trait/src/main.sw
@@ -1,0 +1,22 @@
+script;
+
+use core::ops::*;
+
+impl Eq for (u64, u64, u64) {
+    fn eq(self, other: Self) -> bool {
+        self.0 == other.0 && self.1 == other.1 && self.2 == other.2
+    }
+}
+
+impl Eq for (u64, u64) {
+    fn eq(self, other: Self) -> bool {
+        self.0 == other.0 && self.1 == other.1
+    }
+}
+
+fn main() -> bool {
+    let t = (42, 43);
+    assert(t == t);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_trait/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_trait/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+validate_abi = true


### PR DESCRIPTION
Tuples with same fields types but different lengths were consider equal by `are_equal_minus_dynamic_types` and an error was thrown later on when the number of fields didn't match.

The solution was to fix `are_equal_minus_dynamic_types` to check tuple length before doing a zip of the field iterators.

Closes #3485