### PR TITLE
Fixes error when dependency variable is used as function parameter.

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/contract_dependencies/contract_a/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/contract_dependencies/contract_a/src/main.sw
@@ -10,8 +10,7 @@ abi MyContract {
 impl MyContract for Contract {
     fn test_function() {
         let CONTRACT_B = CONTRACT_B_ID;
-        let CONTRACT_C = CONTRACT_C_ID;
         let contract_b_id = ContractId::from(CONTRACT_B);
-        let contract_c_id = ContractId::from(CONTRACT_C);
+        let contract_c_id = ContractId::from(contract_c::CONTRACT_ID);
     }
 }


### PR DESCRIPTION
When a dependency variable was passed into a function as first parameter such as `ContractId::from(contract_c::CONTRACT_ID);` an error was thrown by `type_check_method_application` while it tried to resolve the variable as a local one.

The solution was to only resolve the variable if the function is expecting a mutable parameter.

Closes #3406