### PR TITLE
Use borrowed types instead of owned types so that `TyProgram` is not consumed after IR generation

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2327,7 +2327,7 @@ pub fn compile(
 
     let asm_res = time_expr!(
         "compile ast to asm",
-        sway_core::ast_to_asm(type_engine, ast_res, &sway_build_config)
+        sway_core::ast_to_asm(type_engine, &ast_res, &sway_build_config)
     );
     let entries = asm_res
         .value

--- a/sway-core/src/ir_generation.rs
+++ b/sway-core/src/ir_generation.rs
@@ -16,7 +16,7 @@ pub(crate) use purity::{check_function_purity, PurityEnv};
 use crate::{language::ty, TypeEngine};
 
 pub fn compile_program(
-    program: ty::TyProgram,
+    program: &ty::TyProgram,
     include_tests: bool,
     type_engine: &TypeEngine,
 ) -> Result<Context, CompileError> {
@@ -35,7 +35,7 @@ pub fn compile_program(
 
     let logged_types = logged_types
         .into_iter()
-        .map(|(log_id, type_id)| (type_id, log_id))
+        .map(|(log_id, type_id)| (*type_id, *log_id))
         .collect();
 
     let mut ctx = Context::default();
@@ -49,7 +49,7 @@ pub fn compile_program(
             &root.namespace,
             declarations,
             &logged_types,
-            test_fns,
+            &test_fns,
         ),
         ty::TyProgramKind::Predicate { main_function } => compile::compile_predicate(
             type_engine,
@@ -58,7 +58,7 @@ pub fn compile_program(
             &root.namespace,
             declarations,
             &logged_types,
-            test_fns,
+            &test_fns,
         ),
         ty::TyProgramKind::Contract { abi_entries } => compile::compile_contract(
             &mut ctx,
@@ -66,7 +66,7 @@ pub fn compile_program(
             &root.namespace,
             declarations,
             &logged_types,
-            test_fns,
+            &test_fns,
             type_engine,
         ),
         ty::TyProgramKind::Library { .. } => compile::compile_library(
@@ -75,7 +75,7 @@ pub fn compile_program(
             &root.namespace,
             declarations,
             &logged_types,
-            test_fns,
+            &test_fns,
         ),
     }?;
     ctx.verify()

--- a/sway-core/src/ir_generation.rs
+++ b/sway-core/src/ir_generation.rs
@@ -34,7 +34,7 @@ pub fn compile_program(
     } = program;
 
     let logged_types = logged_types
-        .into_iter()
+        .iter()
         .map(|(log_id, type_id)| (*type_id, *log_id))
         .collect();
 

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -336,7 +336,7 @@ pub(super) fn compile_tests(
     test_fns: &[ty::TyFunctionDeclaration],
 ) -> Result<Vec<Function>, CompileError> {
     test_fns
-        .into_iter()
+        .iter()
         .map(|ast_fn_decl| {
             compile_entry_function(
                 type_engine,
@@ -397,7 +397,7 @@ fn compile_fn_with_args(
         .map(|(name, ty, span)| (name, ty, md_mgr.span_to_md(context, &span)))
         .collect::<Vec<_>>();
 
-    let ret_type = convert_resolved_typeid(type_engine, context, &return_type, &return_type_span)?;
+    let ret_type = convert_resolved_typeid(type_engine, context, return_type, return_type_span)?;
 
     let returns_by_ref = !is_entry && !ret_type.is_copy_type();
     if returns_by_ref {
@@ -405,11 +405,11 @@ fn compile_fn_with_args(
         args.push((
             "__ret_value".to_owned(),
             Type::Pointer(Pointer::new(context, ret_type, true, None)),
-            md_mgr.span_to_md(context, &return_type_span),
+            md_mgr.span_to_md(context, return_type_span),
         ));
     }
 
-    let span_md_idx = md_mgr.span_to_md(context, &span);
+    let span_md_idx = md_mgr.span_to_md(context, span);
     let storage_md_idx = md_mgr.purity_to_md(context, *purity);
     let mut metadata = md_combine(context, &span_md_idx, &storage_md_idx);
 

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -22,11 +22,11 @@ use std::collections::HashMap;
 pub(super) fn compile_script(
     type_engine: &TypeEngine,
     context: &mut Context,
-    main_function: ty::TyFunctionDeclaration,
+    main_function: &ty::TyFunctionDeclaration,
     namespace: &namespace::Module,
-    declarations: Vec<ty::TyDeclaration>,
+    declarations: &[ty::TyDeclaration],
     logged_types_map: &HashMap<TypeId, LogId>,
-    test_fns: Vec<ty::TyFunctionDeclaration>,
+    test_fns: &[ty::TyFunctionDeclaration],
 ) -> Result<Module, CompileError> {
     let module = Module::new(context, Kind::Script);
     let mut md_mgr = MetadataManager::default();
@@ -63,11 +63,11 @@ pub(super) fn compile_script(
 pub(super) fn compile_predicate(
     type_engine: &TypeEngine,
     context: &mut Context,
-    main_function: ty::TyFunctionDeclaration,
+    main_function: &ty::TyFunctionDeclaration,
     namespace: &namespace::Module,
-    declarations: Vec<ty::TyDeclaration>,
+    declarations: &[ty::TyDeclaration],
     logged_types: &HashMap<TypeId, LogId>,
-    test_fns: Vec<ty::TyFunctionDeclaration>,
+    test_fns: &[ty::TyFunctionDeclaration],
 ) -> Result<Module, CompileError> {
     let module = Module::new(context, Kind::Predicate);
     let mut md_mgr = MetadataManager::default();
@@ -103,11 +103,11 @@ pub(super) fn compile_predicate(
 
 pub(super) fn compile_contract(
     context: &mut Context,
-    abi_entries: Vec<ty::TyFunctionDeclaration>,
+    abi_entries: &[ty::TyFunctionDeclaration],
     namespace: &namespace::Module,
-    declarations: Vec<ty::TyDeclaration>,
+    declarations: &[ty::TyDeclaration],
     logged_types_map: &HashMap<TypeId, LogId>,
-    test_fns: Vec<ty::TyFunctionDeclaration>,
+    test_fns: &[ty::TyFunctionDeclaration],
     type_engine: &TypeEngine,
 ) -> Result<Module, CompileError> {
     let module = Module::new(context, Kind::Contract);
@@ -148,9 +148,9 @@ pub(super) fn compile_library(
     type_engine: &TypeEngine,
     context: &mut Context,
     namespace: &namespace::Module,
-    declarations: Vec<ty::TyDeclaration>,
+    declarations: &[ty::TyDeclaration],
     logged_types_map: &HashMap<TypeId, LogId>,
-    test_fns: Vec<ty::TyFunctionDeclaration>,
+    test_fns: &[ty::TyFunctionDeclaration],
 ) -> Result<Module, CompileError> {
     let module = Module::new(context, Kind::Library);
     let mut md_mgr = MetadataManager::default();
@@ -220,7 +220,7 @@ fn compile_declarations(
     md_mgr: &mut MetadataManager,
     module: Module,
     namespace: &namespace::Module,
-    declarations: Vec<ty::TyDeclaration>,
+    declarations: &[ty::TyDeclaration],
 ) -> Result<(), CompileError> {
     for declaration in declarations {
         match declaration {
@@ -276,7 +276,7 @@ pub(super) fn compile_function(
     context: &mut Context,
     md_mgr: &mut MetadataManager,
     module: Module,
-    ast_fn_decl: ty::TyFunctionDeclaration,
+    ast_fn_decl: &ty::TyFunctionDeclaration,
     logged_types_map: &HashMap<TypeId, LogId>,
     is_entry: bool,
 ) -> Result<Option<Function>, CompileError> {
@@ -311,7 +311,7 @@ pub(super) fn compile_entry_function(
     context: &mut Context,
     md_mgr: &mut MetadataManager,
     module: Module,
-    ast_fn_decl: ty::TyFunctionDeclaration,
+    ast_fn_decl: &ty::TyFunctionDeclaration,
     logged_types_map: &HashMap<TypeId, LogId>,
 ) -> Result<Function, CompileError> {
     let is_entry = true;
@@ -333,7 +333,7 @@ pub(super) fn compile_tests(
     md_mgr: &mut MetadataManager,
     module: Module,
     logged_types_map: &HashMap<TypeId, LogId>,
-    test_fns: Vec<ty::TyFunctionDeclaration>,
+    test_fns: &[ty::TyFunctionDeclaration],
 ) -> Result<Vec<Function>, CompileError> {
     test_fns
         .into_iter()
@@ -374,7 +374,7 @@ fn compile_fn_with_args(
     context: &mut Context,
     md_mgr: &mut MetadataManager,
     module: Module,
-    ast_fn_decl: ty::TyFunctionDeclaration,
+    ast_fn_decl: &ty::TyFunctionDeclaration,
     is_entry: bool,
     args: Vec<(String, Type, Span)>,
     selector: Option<[u8; 4]>,
@@ -410,7 +410,7 @@ fn compile_fn_with_args(
     }
 
     let span_md_idx = md_mgr.span_to_md(context, &span);
-    let storage_md_idx = md_mgr.purity_to_md(context, purity);
+    let storage_md_idx = md_mgr.purity_to_md(context, *purity);
     let mut metadata = md_combine(context, &span_md_idx, &storage_md_idx);
 
     if let Some(inline) = inline_opt {
@@ -425,7 +425,7 @@ fn compile_fn_with_args(
         args,
         ret_type,
         selector,
-        visibility == Visibility::Public,
+        *visibility == Visibility::Public,
         is_entry,
         metadata,
     );
@@ -513,7 +513,7 @@ fn compile_abi_method(
     context: &mut Context,
     md_mgr: &mut MetadataManager,
     module: Module,
-    ast_fn_decl: ty::TyFunctionDeclaration,
+    ast_fn_decl: &ty::TyFunctionDeclaration,
     logged_types_map: &HashMap<TypeId, LogId>,
     type_engine: &TypeEngine,
 ) -> Result<Function, CompileError> {

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -317,7 +317,7 @@ fn const_eval_typed_expr(
             let aggregate = create_enum_aggregate(
                 lookup.type_engine,
                 lookup.context,
-                enum_decl.variants.clone(),
+                &enum_decl.variants,
             );
             if let Ok(aggregate) = aggregate {
                 let tag_value = Constant::new_uint(64, *tag as u64);

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -314,11 +314,8 @@ fn const_eval_typed_expr(
             contents,
             ..
         } => {
-            let aggregate = create_enum_aggregate(
-                lookup.type_engine,
-                lookup.context,
-                &enum_decl.variants,
-            );
+            let aggregate =
+                create_enum_aggregate(lookup.type_engine, lookup.context, &enum_decl.variants);
             if let Ok(aggregate) = aggregate {
                 let tag_value = Constant::new_uint(64, *tag as u64);
                 let mut fields: Vec<Constant> = vec![tag_value];

--- a/sway-core/src/ir_generation/convert.rs
+++ b/sway-core/src/ir_generation/convert.rs
@@ -105,7 +105,7 @@ fn convert_resolved_type(
         )
         .map(Type::Struct)?,
         TypeInfo::Enum { variant_types, .. } => {
-            create_enum_aggregate(type_engine, context, variant_types.clone()).map(Type::Struct)?
+            create_enum_aggregate(type_engine, context, variant_types).map(Type::Struct)?
         }
         TypeInfo::Array(elem_type_id, count, _) => {
             let elem_type = convert_resolved_typeid(type_engine, context, elem_type_id, span)?;

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -92,7 +92,7 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_block: ty::TyCodeBlock,
+        ast_block: &ty::TyCodeBlock,
     ) -> Result<Value, CompileError> {
         self.compile_with_new_scope(|fn_compiler| {
             fn_compiler.compile_code_block_inner(context, md_mgr, ast_block)
@@ -103,17 +103,17 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_block: ty::TyCodeBlock,
+        ast_block: &ty::TyCodeBlock,
     ) -> Result<Value, CompileError> {
         self.lexical_map.enter_scope();
 
-        let mut ast_nodes = ast_block.contents.into_iter();
+        let mut ast_nodes = ast_block.contents.iter();
         let value_res = loop {
             let ast_node = match ast_nodes.next() {
                 Some(ast_node) => ast_node,
                 None => break Ok(Constant::get_unit(context)),
             };
-            match self.compile_ast_node(context, md_mgr, ast_node) {
+            match self.compile_ast_node(context, md_mgr, &ast_node) {
                 Ok(Some(val)) => break Ok(val),
                 Ok(None) => (),
                 Err(err) => break Err(err),
@@ -128,40 +128,40 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_node: ty::TyAstNode,
+        ast_node: &ty::TyAstNode,
     ) -> Result<Option<Value>, CompileError> {
         let span_md_idx = md_mgr.span_to_md(context, &ast_node.span);
-        match ast_node.content {
+        match &ast_node.content {
             ty::TyAstNodeContent::Declaration(td) => match td {
                 ty::TyDeclaration::VariableDeclaration(tvd) => {
-                    self.compile_var_decl(context, md_mgr, *tvd, span_md_idx)
+                    self.compile_var_decl(context, md_mgr, tvd, span_md_idx)
                 }
                 ty::TyDeclaration::ConstantDeclaration(decl_id) => {
-                    let tcd = declaration_engine::de_get_constant(decl_id, &ast_node.span)?;
+                    let tcd = declaration_engine::de_get_constant(decl_id.clone(), &ast_node.span)?;
                     self.compile_const_decl(context, md_mgr, tcd, span_md_idx)?;
                     Ok(None)
                 }
                 ty::TyDeclaration::FunctionDeclaration(_) => {
                     Err(CompileError::UnexpectedDeclaration {
                         decl_type: "function",
-                        span: ast_node.span,
+                        span: ast_node.span.clone(),
                     })
                 }
                 ty::TyDeclaration::TraitDeclaration(_) => {
                     Err(CompileError::UnexpectedDeclaration {
                         decl_type: "trait",
-                        span: ast_node.span,
+                        span: ast_node.span.clone(),
                     })
                 }
                 ty::TyDeclaration::StructDeclaration(_) => {
                     Err(CompileError::UnexpectedDeclaration {
                         decl_type: "struct",
-                        span: ast_node.span,
+                        span: ast_node.span.clone(),
                     })
                 }
                 ty::TyDeclaration::EnumDeclaration(decl_id) => {
-                    let ted = declaration_engine::de_get_enum(decl_id, &ast_node.span)?;
-                    create_enum_aggregate(self.type_engine, context, ted.variants).map(|_| ())?;
+                    let ted = declaration_engine::de_get_enum(decl_id.clone(), &ast_node.span)?;
+                    create_enum_aggregate(self.type_engine, context, &ted.variants).map(|_| ())?;
                     Ok(None)
                 }
                 ty::TyDeclaration::ImplTrait(_) => {
@@ -174,24 +174,24 @@ impl<'te> FnCompiler<'te> {
                 }
                 ty::TyDeclaration::AbiDeclaration(_) => Err(CompileError::UnexpectedDeclaration {
                     decl_type: "abi",
-                    span: ast_node.span,
+                    span: ast_node.span.clone(),
                 }),
                 ty::TyDeclaration::GenericTypeForFunctionScope { .. } => {
                     Err(CompileError::UnexpectedDeclaration {
                         decl_type: "abi",
-                        span: ast_node.span,
+                        span: ast_node.span.clone(),
                     })
                 }
                 ty::TyDeclaration::ErrorRecovery { .. } => {
                     Err(CompileError::UnexpectedDeclaration {
                         decl_type: "error recovery",
-                        span: ast_node.span,
+                        span: ast_node.span.clone(),
                     })
                 }
                 ty::TyDeclaration::StorageDeclaration(_) => {
                     Err(CompileError::UnexpectedDeclaration {
                         decl_type: "storage",
-                        span: ast_node.span,
+                        span: ast_node.span.clone(),
                     })
                 }
             },
@@ -217,12 +217,12 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_expr: ty::TyExpression,
+        ast_expr: &ty::TyExpression,
     ) -> Result<Value, CompileError> {
         let span_md_idx = md_mgr.span_to_md(context, &ast_expr.span);
-        match ast_expr.expression {
+        match &ast_expr.expression {
             ty::TyExpressionVariant::Literal(l) => {
-                Ok(convert_literal_to_value(context, &l).add_metadatum(context, span_md_idx))
+                Ok(convert_literal_to_value(context, l).add_metadatum(context, span_md_idx))
             }
             ty::TyExpressionVariant::FunctionApplication {
                 call_path: name,
@@ -236,27 +236,27 @@ impl<'te> FnCompiler<'te> {
                     self.compile_contract_call(
                         context,
                         md_mgr,
-                        &metadata,
-                        &contract_call_params,
+                        metadata,
+                        contract_call_params,
                         name.suffix.as_str(),
                         arguments,
                         ast_expr.return_type,
                         span_md_idx,
                     )
                 } else {
-                    let function_decl = de_get_function(function_decl_id, &ast_expr.span)?;
+                    let function_decl = de_get_function(function_decl_id.clone(), &ast_expr.span)?;
                     self.compile_fn_call(
                         context,
                         md_mgr,
                         arguments,
-                        function_decl,
-                        self_state_idx,
+                        &function_decl,
+                        *self_state_idx,
                         span_md_idx,
                     )
                 }
             }
             ty::TyExpressionVariant::LazyOperator { op, lhs, rhs } => {
-                self.compile_lazy_op(context, md_mgr, op, *lhs, *rhs, span_md_idx)
+                self.compile_lazy_op(context, md_mgr, op, lhs, rhs, span_md_idx)
             }
             ty::TyExpressionVariant::VariableExpression { name, .. } => {
                 self.compile_var_expr(context, name.as_str(), span_md_idx)
@@ -265,7 +265,7 @@ impl<'te> FnCompiler<'te> {
                 self.compile_array_expr(context, md_mgr, contents, span_md_idx)
             }
             ty::TyExpressionVariant::ArrayIndex { prefix, index } => {
-                self.compile_array_index(context, md_mgr, *prefix, *index, span_md_idx)
+                self.compile_array_index(context, md_mgr, prefix, index, span_md_idx)
             }
             ty::TyExpressionVariant::StructExpression { fields, .. } => {
                 self.compile_struct_expr(context, md_mgr, fields, span_md_idx)
@@ -273,27 +273,27 @@ impl<'te> FnCompiler<'te> {
             ty::TyExpressionVariant::CodeBlock(cb) => self.compile_code_block(context, md_mgr, cb),
             ty::TyExpressionVariant::FunctionParameter => Err(CompileError::Internal(
                 "Unexpected function parameter declaration.",
-                ast_expr.span,
+                ast_expr.span.clone(),
             )),
             ty::TyExpressionVariant::IfExp {
                 condition,
                 then,
                 r#else,
-            } => self.compile_if(context, md_mgr, *condition, *then, r#else),
+            } => self.compile_if(context, md_mgr, condition, then, r#else.clone()),
             ty::TyExpressionVariant::AsmExpression {
                 registers,
                 body,
                 returns,
                 whole_block_span,
             } => {
-                let span_md_idx = md_mgr.span_to_md(context, &whole_block_span);
+                let span_md_idx = md_mgr.span_to_md(context, whole_block_span);
                 self.compile_asm_expr(
                     context,
                     md_mgr,
                     registers,
                     body,
                     ast_expr.return_type,
-                    returns,
+                    returns.as_ref(),
                     span_md_idx,
                 )
             }
@@ -307,8 +307,8 @@ impl<'te> FnCompiler<'te> {
                 self.compile_struct_field_expr(
                     context,
                     md_mgr,
-                    *prefix,
-                    resolved_type_of_parent,
+                    prefix,
+                    *resolved_type_of_parent,
                     field_to_access,
                     span_md_idx,
                 )
@@ -318,7 +318,7 @@ impl<'te> FnCompiler<'te> {
                 tag,
                 contents,
                 ..
-            } => self.compile_enum_expr(context, md_mgr, enum_decl, tag, contents),
+            } => self.compile_enum_expr(context, md_mgr, enum_decl, *tag, contents.clone()),
             ty::TyExpressionVariant::Tuple { fields } => {
                 self.compile_tuple_expr(context, md_mgr, fields, span_md_idx)
             }
@@ -327,9 +327,9 @@ impl<'te> FnCompiler<'te> {
                 elem_to_access_num: idx,
                 elem_to_access_span: span,
                 resolved_type_of_parent: tuple_type,
-            } => self.compile_tuple_elem_expr(context, md_mgr, *prefix, tuple_type, idx, span),
+            } => self.compile_tuple_elem_expr(context, md_mgr, prefix, *tuple_type, *idx, span.clone()),
             ty::TyExpressionVariant::AbiCast { span, .. } => {
-                let span_md_idx = md_mgr.span_to_md(context, &span);
+                let span_md_idx = md_mgr.span_to_md(context, span);
                 Ok(Constant::get_unit(context).add_metadatum(context, span_md_idx))
             }
             ty::TyExpressionVariant::StorageAccess(access) => {
@@ -343,22 +343,22 @@ impl<'te> FnCompiler<'te> {
                 )
             }
             ty::TyExpressionVariant::IntrinsicFunction(kind) => {
-                self.compile_intrinsic_function(context, md_mgr, kind, ast_expr.span)
+                self.compile_intrinsic_function(context, md_mgr, kind, ast_expr.span.clone())
             }
             ty::TyExpressionVariant::AbiName(_) => {
                 Ok(Value::new_constant(context, Constant::new_unit()))
             }
             ty::TyExpressionVariant::UnsafeDowncast { exp, variant } => {
-                self.compile_unsafe_downcast(context, md_mgr, exp, variant)
+                self.compile_unsafe_downcast(context, md_mgr, exp.to_owned(), variant)
             }
-            ty::TyExpressionVariant::EnumTag { exp } => self.compile_enum_tag(context, md_mgr, exp),
+            ty::TyExpressionVariant::EnumTag { exp } => self.compile_enum_tag(context, md_mgr, exp.to_owned()),
             ty::TyExpressionVariant::WhileLoop { body, condition } => self.compile_while_loop(
                 context,
                 md_mgr,
                 body,
-                *condition,
+                condition,
                 span_md_idx,
-                ast_expr.span,
+                ast_expr.span.clone(),
             ),
             ty::TyExpressionVariant::Break => {
                 match self.block_to_break_to {
@@ -370,7 +370,7 @@ impl<'te> FnCompiler<'te> {
                         .ins(context)
                         .branch(block_to_break_to, vec![])),
                     None => Err(CompileError::BreakOutsideLoop {
-                        span: ast_expr.span,
+                        span: ast_expr.span.clone(),
                     }),
                 }
             }
@@ -383,11 +383,11 @@ impl<'te> FnCompiler<'te> {
                     .ins(context)
                     .branch(block_to_continue_to, vec![])),
                 None => Err(CompileError::ContinueOutsideLoop {
-                    span: ast_expr.span,
+                    span: ast_expr.span.clone(),
                 }),
             },
             ty::TyExpressionVariant::Reassignment(reassignment) => {
-                self.compile_reassignment(context, md_mgr, *reassignment, span_md_idx)
+                self.compile_reassignment(context, md_mgr, reassignment, span_md_idx)
             }
             ty::TyExpressionVariant::StorageReassignment(storage_reassignment) => self
                 .compile_storage_reassignment(
@@ -399,7 +399,7 @@ impl<'te> FnCompiler<'te> {
                     span_md_idx,
                 ),
             ty::TyExpressionVariant::Return(exp) => {
-                self.compile_return_statement(context, md_mgr, *exp)
+                self.compile_return_statement(context, md_mgr, exp)
             }
         }
     }
@@ -413,7 +413,7 @@ impl<'te> FnCompiler<'te> {
             arguments,
             type_arguments,
             span: _,
-        }: ty::TyIntrinsicFunctionKind,
+        }: &ty::TyIntrinsicFunctionKind,
         span: Span,
     ) -> Result<Value, CompileError> {
         fn store_key_in_local_mem(
@@ -455,7 +455,7 @@ impl<'te> FnCompiler<'te> {
         // because the type-checker ensures that the arguments are all there.
         match kind {
             Intrinsic::SizeOfVal => {
-                let exp = arguments[0].clone();
+                let exp = &arguments[0];
                 // Compile the expression in case of side-effects but ignore its value.
                 let ir_type = convert_resolved_typeid(
                     self.type_engine,
@@ -495,8 +495,8 @@ impl<'te> FnCompiler<'te> {
                     .add_metadatum(context, span_md_idx))
             }
             Intrinsic::Eq => {
-                let lhs = arguments[0].clone();
-                let rhs = arguments[1].clone();
+                let lhs = &arguments[0];
+                let rhs = &arguments[1];
                 let lhs_value = self.compile_expression(context, md_mgr, lhs)?;
                 let rhs_value = self.compile_expression(context, md_mgr, rhs)?;
                 Ok(self
@@ -506,7 +506,7 @@ impl<'te> FnCompiler<'te> {
             }
             Intrinsic::Gtf => {
                 // The index is just a Value
-                let index = self.compile_expression(context, md_mgr, arguments[0].clone())?;
+                let index = self.compile_expression(context, md_mgr, &arguments[0])?;
 
                 // The tx field ID has to be a compile-time constant because it becomes an
                 // immediate
@@ -561,7 +561,7 @@ impl<'te> FnCompiler<'te> {
                 }
             }
             Intrinsic::AddrOf => {
-                let exp = arguments[0].clone();
+                let exp = &arguments[0];
                 let value = self.compile_expression(context, md_mgr, exp)?;
                 let span_md_idx = md_mgr.span_to_md(context, &span);
                 Ok(self
@@ -571,7 +571,7 @@ impl<'te> FnCompiler<'te> {
                     .add_metadatum(context, span_md_idx))
             }
             Intrinsic::StateLoadWord => {
-                let exp = arguments[0].clone();
+                let exp = &arguments[0];
                 let value = self.compile_expression(context, md_mgr, exp)?;
                 let span_md_idx = md_mgr.span_to_md(context, &span);
                 let key_ptr_val = store_key_in_local_mem(self, context, value, span_md_idx)?;
@@ -582,8 +582,8 @@ impl<'te> FnCompiler<'te> {
                     .add_metadatum(context, span_md_idx))
             }
             Intrinsic::StateStoreWord => {
-                let key_exp = arguments[0].clone();
-                let val_exp = arguments[1].clone();
+                let key_exp = &arguments[0];
+                let val_exp = &arguments[1];
                 // Validate that the val_exp is of the right type. We couldn't do it
                 // earlier during type checking as the type arguments may not have been resolved.
                 let val_ty = self.type_engine.to_typeinfo(val_exp.return_type, &span)?;
@@ -605,8 +605,8 @@ impl<'te> FnCompiler<'te> {
                     .add_metadatum(context, span_md_idx))
             }
             Intrinsic::StateLoadQuad | Intrinsic::StateStoreQuad => {
-                let key_exp = arguments[0].clone();
-                let val_exp = arguments[1].clone();
+                let key_exp = &arguments[0];
+                let val_exp = &arguments[1];
                 // Validate that the val_exp is of the right type. We couldn't do it
                 // earlier during type checking as the type arguments may not have been resolved.
                 let val_ty = self.type_engine.to_typeinfo(val_exp.return_type, &span)?;
@@ -643,7 +643,7 @@ impl<'te> FnCompiler<'te> {
             }
             Intrinsic::Log => {
                 // The log value and the log ID are just Value.
-                let log_val = self.compile_expression(context, md_mgr, arguments[0].clone())?;
+                let log_val = self.compile_expression(context, md_mgr, &arguments[0])?;
                 let log_id = match self.logged_types_map.get(&arguments[0].return_type) {
                     None => {
                         return Err(CompileError::Internal(
@@ -681,8 +681,8 @@ impl<'te> FnCompiler<'te> {
                     Intrinsic::Div => BinaryOpKind::Div,
                     _ => unreachable!(),
                 };
-                let lhs = arguments[0].clone();
-                let rhs = arguments[1].clone();
+                let lhs = &arguments[0];
+                let rhs = &arguments[1];
                 let lhs_value = self.compile_expression(context, md_mgr, lhs)?;
                 let rhs_value = self.compile_expression(context, md_mgr, rhs)?;
                 Ok(self
@@ -692,7 +692,7 @@ impl<'te> FnCompiler<'te> {
             }
             Intrinsic::Revert => {
                 let revert_code_val =
-                    self.compile_expression(context, md_mgr, arguments[0].clone())?;
+                    self.compile_expression(context, md_mgr, &arguments[0])?;
 
                 // The `revert` instruction
                 let span_md_idx = md_mgr.span_to_md(context, &span);
@@ -715,8 +715,8 @@ impl<'te> FnCompiler<'te> {
                 let len_value =
                     Constant::get_uint(context, 64, ir_type_size_in_bytes(context, &ir_type));
 
-                let lhs = arguments[0].clone();
-                let count = arguments[1].clone();
+                let lhs = &arguments[0];
+                let count = &arguments[1];
                 let lhs_value = self.compile_expression(context, md_mgr, lhs)?;
                 let count_value = self.compile_expression(context, md_mgr, count)?;
                 let rhs_value = self.current_block.ins(context).binary_op(
@@ -736,14 +736,14 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_expr: ty::TyExpression,
+        ast_expr: &ty::TyExpression,
     ) -> Result<Value, CompileError> {
         // Nothing to do if the current block already has a terminator
         if self.current_block.is_terminated(context) {
             return Ok(Constant::get_unit(context));
         }
 
-        let ret_value = self.compile_expression(context, md_mgr, ast_expr.clone())?;
+        let ret_value = self.compile_expression(context, md_mgr, ast_expr)?;
 
         if ret_value.is_diverging(context) {
             return Ok(ret_value);
@@ -759,7 +759,7 @@ impl<'te> FnCompiler<'te> {
         match ret_value.get_stripped_ptr_type(context) {
             None => Err(CompileError::Internal(
                 "Unable to determine type for return statement expression.",
-                ast_expr.span,
+                ast_expr.span.clone(),
             )),
             Some(ret_ty) => Ok(self
                 .current_block
@@ -792,9 +792,9 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_op: LazyOp,
-        ast_lhs: ty::TyExpression,
-        ast_rhs: ty::TyExpression,
+        ast_op: &LazyOp,
+        ast_lhs: &ty::TyExpression,
+        ast_rhs: &ty::TyExpression,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
         // Short-circuit: if LHS is true for AND we still must eval the RHS block; for OR we can
@@ -854,13 +854,13 @@ impl<'te> FnCompiler<'te> {
         call_params: &ty::ContractCallParams,
         contract_call_parameters: &HashMap<String, ty::TyExpression>,
         ast_name: &str,
-        ast_args: Vec<(Ident, ty::TyExpression)>,
+        ast_args: &[(Ident, ty::TyExpression)],
         return_type: TypeId,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
         // Compile each user argument
         let compiled_args = ast_args
-            .into_iter()
+            .iter()
             .map(|(_, expr)| self.compile_expression(context, md_mgr, expr))
             .collect::<Result<Vec<Value>, CompileError>>()?;
 
@@ -987,7 +987,7 @@ impl<'te> FnCompiler<'te> {
 
         // Insert the contract address
         let addr =
-            self.compile_expression(context, md_mgr, *call_params.contract_address.clone())?;
+            self.compile_expression(context, md_mgr, &call_params.contract_address)?;
         ra_struct_val = self
             .current_block
             .ins(context)
@@ -1020,7 +1020,7 @@ impl<'te> FnCompiler<'te> {
         let coins = match contract_call_parameters
             .get(&constants::CONTRACT_CALL_COINS_PARAMETER_NAME.to_string())
         {
-            Some(coins_expr) => self.compile_expression(context, md_mgr, coins_expr.clone())?,
+            Some(coins_expr) => self.compile_expression(context, md_mgr, coins_expr)?,
             None => convert_literal_to_value(
                 context,
                 &Literal::U64(constants::CONTRACT_CALL_COINS_PARAMETER_DEFAULT_VALUE),
@@ -1032,7 +1032,7 @@ impl<'te> FnCompiler<'te> {
             .get(&constants::CONTRACT_CALL_ASSET_ID_PARAMETER_NAME.to_string())
         {
             Some(asset_id_expr) => {
-                self.compile_expression(context, md_mgr, asset_id_expr.clone())?
+                self.compile_expression(context, md_mgr, asset_id_expr)?
             }
             None => convert_literal_to_value(
                 context,
@@ -1044,7 +1044,7 @@ impl<'te> FnCompiler<'te> {
         let gas = match contract_call_parameters
             .get(&constants::CONTRACT_CALL_GAS_PARAMETER_NAME.to_string())
         {
-            Some(gas_expr) => self.compile_expression(context, md_mgr, gas_expr.clone())?,
+            Some(gas_expr) => self.compile_expression(context, md_mgr, gas_expr)?,
             None => self
                 .current_block
                 .ins(context)
@@ -1074,8 +1074,8 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_args: Vec<(Ident, ty::TyExpression)>,
-        callee: ty::TyFunctionDeclaration,
+        ast_args: &[(Ident, ty::TyExpression)],
+        callee: &ty::TyFunctionDeclaration,
         self_state_idx: Option<StateIndex>,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
@@ -1112,7 +1112,7 @@ impl<'te> FnCompiler<'te> {
                         context.get_unique_id()
                     ))),
                     parameters: callee.parameters.clone(),
-                    ..callee
+                    ..callee.clone()
                 };
                 let is_entry = false;
                 let new_func = compile_function(
@@ -1120,7 +1120,7 @@ impl<'te> FnCompiler<'te> {
                     context,
                     md_mgr,
                     self.module,
-                    callee_fn_decl,
+                    &callee_fn_decl,
                     &self.logged_types_map,
                     is_entry,
                 )?
@@ -1133,7 +1133,7 @@ impl<'te> FnCompiler<'te> {
         // Now actually call the new function.
         let mut args = {
             let mut args = Vec::with_capacity(ast_args.len());
-            for ((_, expr), param) in ast_args.into_iter().zip(callee.parameters.into_iter()) {
+            for ((_, expr), param) in ast_args.iter().zip(callee.parameters.clone().into_iter()) {
                 self.current_fn_param = Some(param);
                 let arg = self.compile_expression(context, md_mgr, expr)?;
                 if arg.is_diverging(context) {
@@ -1187,8 +1187,8 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_condition: ty::TyExpression,
-        ast_then: ty::TyExpression,
+        ast_condition: &ty::TyExpression,
+        ast_then: &ty::TyExpression,
         ast_else: Option<Box<ty::TyExpression>>,
     ) -> Result<Value, CompileError> {
         // Compile the condition expression in the entry block.  Then save the current block so we
@@ -1222,7 +1222,7 @@ impl<'te> FnCompiler<'te> {
         self.current_block = false_block_begin;
         let false_value = match ast_else {
             None => Constant::get_unit(context),
-            Some(expr) => self.compile_expression(context, md_mgr, *expr)?,
+            Some(expr) => self.compile_expression(context, md_mgr, &expr)?,
         };
         let false_block_end = self.current_block;
 
@@ -1265,7 +1265,7 @@ impl<'te> FnCompiler<'te> {
         context: &mut Context,
         md_mgr: &mut MetadataManager,
         exp: Box<ty::TyExpression>,
-        variant: ty::TyEnumVariant,
+        variant: &ty::TyEnumVariant,
     ) -> Result<Value, CompileError> {
         // retrieve the aggregate info for the enum
         let enum_aggregate = match convert_resolved_typeid(
@@ -1283,7 +1283,7 @@ impl<'te> FnCompiler<'te> {
             }
         };
         // compile the expression to asm
-        let compiled_value = self.compile_expression(context, md_mgr, *exp)?;
+        let compiled_value = self.compile_expression(context, md_mgr, &exp)?;
         // retrieve the value minus the tag
         Ok(self.current_block.ins(context).extract_value(
             compiled_value,
@@ -1310,7 +1310,7 @@ impl<'te> FnCompiler<'te> {
                 return Err(CompileError::Internal("Expected enum type here.", exp.span));
             }
         };
-        let exp = self.compile_expression(context, md_mgr, *exp)?;
+        let exp = self.compile_expression(context, md_mgr, &exp)?;
         Ok(self
             .current_block
             .ins(context)
@@ -1322,8 +1322,8 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        body: ty::TyCodeBlock,
-        condition: ty::TyExpression,
+        body: &ty::TyCodeBlock,
+        condition: &ty::TyExpression,
         span_md_idx: Option<MetadataIndex>,
         span: Span,
     ) -> Result<Value, CompileError> {
@@ -1459,7 +1459,7 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_var_decl: ty::TyVariableDeclaration,
+        ast_var_decl: &ty::TyVariableDeclaration,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Option<Value>, CompileError> {
         let ty::TyVariableDeclaration {
@@ -1576,7 +1576,7 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_reassignment: ty::TyReassignment,
+        ast_reassignment: &ty::TyReassignment,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
         let name = self
@@ -1608,7 +1608,7 @@ impl<'te> FnCompiler<'te> {
             }
         };
 
-        let reassign_val = self.compile_expression(context, md_mgr, ast_reassignment.rhs)?;
+        let reassign_val = self.compile_expression(context, md_mgr, &ast_reassignment.rhs)?;
         if reassign_val.is_diverging(context) {
             return Ok(reassign_val);
         }
@@ -1626,7 +1626,7 @@ impl<'te> FnCompiler<'te> {
         {
             let it = &mut ast_reassignment.lhs_indices.iter().peekable();
             while let Some(ProjectionKind::ArrayIndex { index, .. }) = it.next() {
-                let index_val = self.compile_expression(context, md_mgr, *index.clone())?;
+                let index_val = self.compile_expression(context, md_mgr, index)?;
                 if index_val.is_diverging(context) {
                     return Ok(index_val);
                 }
@@ -1709,7 +1709,7 @@ impl<'te> FnCompiler<'te> {
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
         // Compile the RHS into a value
-        let rhs = self.compile_expression(context, md_mgr, rhs.clone())?;
+        let rhs = self.compile_expression(context, md_mgr, rhs)?;
         if rhs.is_diverging(context) {
             return Ok(rhs);
         }
@@ -1744,7 +1744,7 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        contents: Vec<ty::TyExpression>,
+        contents: &[ty::TyExpression],
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
         let elem_type = if contents.is_empty() {
@@ -1770,7 +1770,7 @@ impl<'te> FnCompiler<'te> {
             .get_ptr(array_ptr, array_ptr_ty, 0)
             .add_metadatum(context, span_md_idx);
 
-        for (idx, elem_expr) in contents.into_iter().enumerate() {
+        for (idx, elem_expr) in contents.iter().enumerate() {
             let elem_value = self.compile_expression(context, md_mgr, elem_expr)?;
             if elem_value.is_diverging(context) {
                 return Ok(elem_value);
@@ -1790,8 +1790,8 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        array_expr: ty::TyExpression,
-        index_expr: ty::TyExpression,
+        array_expr: &ty::TyExpression,
+        index_expr: &ty::TyExpression,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
         let array_expr_span = array_expr.span.clone();
@@ -1838,7 +1838,7 @@ impl<'te> FnCompiler<'te> {
             self.module,
             None,
             Some(self),
-            &index_expr,
+            index_expr,
         ) {
             let (_, count) = aggregate.get_content(context).array_type();
             if constant_value >= *count {
@@ -1866,7 +1866,7 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        fields: Vec<ty::TyStructExpressionField>,
+        fields: &[ty::TyStructExpressionField],
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
         // NOTE: This is a struct instantiation with initialisers for each field of a named struct.
@@ -1879,9 +1879,9 @@ impl<'te> FnCompiler<'te> {
 
         let mut inserted_values_indices = Vec::with_capacity(fields.len());
         let mut field_types = Vec::with_capacity(fields.len());
-        for (insert_idx, struct_field) in fields.into_iter().enumerate() {
+        for (insert_idx, struct_field) in fields.iter().enumerate() {
             let field_ty = struct_field.value.return_type;
-            let insert_val = self.compile_expression(context, md_mgr, struct_field.value)?;
+            let insert_val = self.compile_expression(context, md_mgr, &struct_field.value)?;
             if insert_val.is_diverging(context) {
                 return Ok(insert_val);
             }
@@ -1918,9 +1918,9 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_struct_expr: ty::TyExpression,
+        ast_struct_expr: &ty::TyExpression,
         struct_type_id: TypeId,
-        ast_field: ty::TyStructField,
+        ast_field: &ty::TyStructField,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
         let ast_struct_expr_span = ast_struct_expr.span.clone();
@@ -1956,7 +1956,7 @@ impl<'te> FnCompiler<'te> {
         ) {
             None => Err(CompileError::Internal(
                 "Unknown struct in field expression.",
-                ast_field.span,
+                ast_field.span.clone(),
             )),
             Some((struct_name, field_idx_and_type_opt)) => match field_idx_and_type_opt {
                 None => Err(CompileError::InternalOwned(
@@ -1964,7 +1964,7 @@ impl<'te> FnCompiler<'te> {
                         "Unknown field name '{}' for struct '{struct_name}' in field expression.",
                         ast_field.name
                     ),
-                    ast_field.span,
+                    ast_field.span.clone(),
                 )),
                 Some((field_idx, _field_type)) => Ok(field_idx),
             },
@@ -1981,7 +1981,7 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        enum_decl: ty::TyEnumDeclaration,
+        enum_decl: &ty::TyEnumDeclaration,
         tag: usize,
         contents: Option<Box<ty::TyExpression>>,
     ) -> Result<Value, CompileError> {
@@ -1992,7 +1992,7 @@ impl<'te> FnCompiler<'te> {
         // we could potentially use the wrong aggregate with the same name, different module...
         // dunno.
         let span_md_idx = md_mgr.span_to_md(context, &enum_decl.span);
-        let aggregate = create_enum_aggregate(self.type_engine, context, enum_decl.variants)?;
+        let aggregate = create_enum_aggregate(self.type_engine, context, &enum_decl.variants)?;
         let tag_value =
             Constant::get_uint(context, 64, tag as u64).add_metadatum(context, span_md_idx);
 
@@ -2022,11 +2022,11 @@ impl<'te> FnCompiler<'te> {
                 Ok(if field_tys.len() == 1 {
                     agg_value
                 } else {
-                    match contents {
+                    match &contents {
                         None => agg_value,
                         Some(te) => {
                             // Insert the value too.
-                            let contents_value = self.compile_expression(context, md_mgr, *te)?;
+                            let contents_value = self.compile_expression(context, md_mgr, te)?;
                             self.current_block
                                 .ins(context)
                                 .insert_value(agg_value, aggregate, contents_value, vec![1])
@@ -2043,7 +2043,7 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        fields: Vec<ty::TyExpression>,
+        fields: &[ty::TyExpression],
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
         if fields.is_empty() {
@@ -2098,7 +2098,7 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        tuple: ty::TyExpression,
+        tuple: &ty::TyExpression,
         tuple_type: TypeId,
         idx: usize,
         span: Span,
@@ -2152,32 +2152,32 @@ impl<'te> FnCompiler<'te> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        registers: Vec<ty::TyAsmRegisterDeclaration>,
-        body: Vec<AsmOp>,
+        registers: &[ty::TyAsmRegisterDeclaration],
+        body: &[AsmOp],
         return_type: TypeId,
-        returns: Option<(AsmRegister, Span)>,
+        returns: Option<&(AsmRegister, Span)>,
         whole_block_span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
         let registers = registers
-            .into_iter()
+            .iter()
             .map(
                 |ty::TyAsmRegisterDeclaration {
                      initializer, name, ..
                  }| {
                     // Take the optional initialiser, map it to an Option<Result<Value>>,
                     // transpose that to Result<Option<Value>> and map that to an AsmArg.
-                    initializer
-                        .map(|init_expr| self.compile_expression(context, md_mgr, init_expr))
+                    initializer.
+                        as_ref().map(|init_expr| self.compile_expression(context, md_mgr, init_expr))
                         .transpose()
                         .map(|init| AsmArg {
-                            name,
+                            name: name.clone(),
                             initializer: init,
                         })
                 },
             )
             .collect::<Result<Vec<AsmArg>, CompileError>>()?;
         let body = body
-            .into_iter()
+            .iter()
             .map(
                 |AsmOp {
                      op_name,
@@ -2185,10 +2185,10 @@ impl<'te> FnCompiler<'te> {
                      immediate,
                      span,
                  }| AsmInstruction {
-                    name: op_name,
-                    args: op_args,
-                    immediate,
-                    metadata: md_mgr.span_to_md(context, &span),
+                    name: op_name.clone(),
+                    args: op_args.clone(),
+                    immediate: immediate.clone(),
+                    metadata: md_mgr.span_to_md(context, span),
                 },
             )
             .collect();

--- a/sway-core/src/ir_generation/types.rs
+++ b/sway-core/src/ir_generation/types.rs
@@ -18,7 +18,7 @@ pub(super) fn create_enum_aggregate(
     // Create the enum aggregate first.  NOTE: single variant enums don't need an aggregate but are
     // getting one here anyway.  They don't need to be a tagged union either.
     let field_types: Vec<_> = variants
-        .into_iter()
+        .iter()
         .map(|tev| convert_resolved_typeid_no_span(type_engine, context, &tev.type_id))
         .collect::<Result<Vec<_>, CompileError>>()?;
 

--- a/sway-core/src/ir_generation/types.rs
+++ b/sway-core/src/ir_generation/types.rs
@@ -13,7 +13,7 @@ use sway_types::span::Spanned;
 pub(super) fn create_enum_aggregate(
     type_engine: &TypeEngine,
     context: &mut Context,
-    variants: Vec<ty::TyEnumVariant>,
+    variants: &[ty::TyEnumVariant],
 ) -> Result<Aggregate, CompileError> {
     // Create the enum aggregate first.  NOTE: single variant enums don't need an aggregate but are
     // getting one here anyway.  They don't need to be a tagged union either.

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -319,7 +319,7 @@ pub fn compile_to_asm(
     build_config: BuildConfig,
 ) -> CompileResult<CompiledAsm> {
     let ast_res = compile_to_ast(type_engine, input, initial_namespace, Some(&build_config));
-    ast_to_asm(type_engine, ast_res, &build_config)
+    ast_to_asm(type_engine, &ast_res, &build_config)
 }
 
 /// Given an AST compilation result,
@@ -327,14 +327,14 @@ pub fn compile_to_asm(
 /// containing the asm in opcode form (not raw bytes/bytecode).
 pub fn ast_to_asm(
     type_engine: &TypeEngine,
-    ast_res: CompileResult<ty::TyProgram>,
+    ast_res: &CompileResult<ty::TyProgram>,
     build_config: &BuildConfig,
 ) -> CompileResult<CompiledAsm> {
-    match ast_res.value {
-        None => err(ast_res.warnings, ast_res.errors),
+    match &ast_res.value {
+        None => err(ast_res.warnings.clone(), ast_res.errors.clone()),
         Some(typed_program) => {
-            let mut errors = ast_res.errors;
-            let mut warnings = ast_res.warnings;
+            let mut errors = ast_res.errors.clone();
+            let mut warnings = ast_res.warnings.clone();
             let asm = check!(
                 compile_ast_to_ir_to_asm(type_engine, typed_program, build_config),
                 return deduped_err(warnings, errors),
@@ -348,7 +348,7 @@ pub fn ast_to_asm(
 
 pub(crate) fn compile_ast_to_ir_to_asm(
     type_engine: &TypeEngine,
-    program: ty::TyProgram,
+    program: &ty::TyProgram,
     build_config: &BuildConfig,
 ) -> CompileResult<FinalizedAsm> {
     let mut warnings = Vec::new();

--- a/test/src/ir_generation/mod.rs
+++ b/test/src/ir_generation/mod.rs
@@ -142,7 +142,7 @@ pub(super) async fn run(filter_regex: Option<&regex::Regex>) -> Result<()> {
 
                 // Compile to IR.
                 let include_tests = false;
-                let mut ir = compile_program(typed_program, include_tests, &type_engine)
+                let mut ir = compile_program(&typed_program, include_tests, &type_engine)
                     .unwrap_or_else(|e| {
                         panic!("Failed to compile test {}:\n{e}", path.display());
                     })


### PR DESCRIPTION
closes #3492.