### PR TITLE
`U128` and `U256` division optimisation

### DIFF
--- a/sway-lib-std/src/u128.sw
+++ b/sway-lib-std/src/u128.sw
@@ -329,6 +329,10 @@ impl core::ops::Divide for U128 {
 
         assert(divisor != zero);
 
+        if self.upper == 0 && divisor.upper == 0 {
+            return U128::from((0, self.lower / divisor.lower));
+        }
+
         let mut quotient = U128::new();
         let mut remainder = U128::new();
         let mut i = 128 - 1;

--- a/sway-lib-std/src/u256.sw
+++ b/sway-lib-std/src/u256.sw
@@ -468,6 +468,11 @@ impl core::ops::Divide for U256 {
 
         assert(divisor != zero);
 
+        if self.a == 0 && self.b == 0 && divisor.a == 0 && divisor.b == 0 {
+            let res = U128::from((self.c, self.d)) / U128::from((divisor.c, divisor.d));
+            return U256::from((0, 0, res.upper, res.lower));
+        }
+
         let mut quotient = U256::from((0, 0, 0, 0));
         let mut remainder = U256::from((0, 0, 0, 0));
 


### PR DESCRIPTION
Not completely representative, as these optimisations help only in part of cases, but

division takes 2 times less gas for `U128`
division takes 2.6 times less gas for `U256`
square root takes almost 87 times less gas