### PR TITLE
Fix DCA warnings for struct field access prefix expressions.

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -902,10 +902,23 @@ fn connect_expression(
             Ok(vec![exit])
         }
         StructFieldAccess {
+            prefix,
             field_to_access,
             resolved_type_of_parent,
+            field_instantiation_span,
             ..
         } => {
+            connect_expression(
+                type_engine,
+                &prefix.expression,
+                graph,
+                leaves,
+                exit_node,
+                label,
+                tree_type,
+                field_instantiation_span.clone(),
+            )?;
+
             let resolved_type_of_parent = type_engine
                 .to_typeinfo(*resolved_type_of_parent, &field_to_access.span)
                 .unwrap_or_else(|_| TypeInfo::Tuple(Vec::new()));

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_struct/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'constant_struct'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_struct/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_struct/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "constant_struct"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_struct/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_struct/src/main.sw
@@ -1,0 +1,15 @@
+script;
+
+struct A {
+   a : u64
+}
+
+fn foo(a : u64) -> A {
+  A { a }
+}
+
+const B : A = foo(32);
+
+fn main() -> u64 {
+    B.a
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_struct/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_struct/test.toml
@@ -1,0 +1,4 @@
+category = "compile"
+
+# not: $()const B : A = foo(32);
+# not: $()This declaration is never used.


### PR DESCRIPTION
This now connects the prefix expression of a struct field access this making sure the constant declaration is properly connected to other expression nodes.

Closes https://github.com/FuelLabs/sway/issues/2054.