### PR TITLE
Fix DCA warnings for expressions reachable from while loop conditions.

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -1114,13 +1114,16 @@ fn connect_expression(
             tree_type,
             exp.span.clone(),
         ),
-        WhileLoop { body, .. } => {
+        WhileLoop {
+            body, condition, ..
+        } => {
             // a while loop can loop back to the beginning,
             // or it can terminate.
             // so we connect the _end_ of the while loop _both_ to its beginning and the next node.
             // the loop could also be entirely skipped
 
             let entry = leaves[0];
+
             let while_loop_exit = graph.add_node("while loop exit".to_string().into());
 
             // it is possible for a whole while loop to be skipped so add edge from
@@ -1131,6 +1134,19 @@ fn connect_expression(
                 "condition is initially false".into(),
             );
             let mut leaves = vec![entry];
+
+            // handle the condition of the loop
+            connect_expression(
+                type_engine,
+                &condition.expression,
+                graph,
+                &leaves,
+                exit_node,
+                label,
+                tree_type,
+                Span::dummy(),
+            )?;
+
             let (l_leaves, _l_exit_node) = depth_first_insertion_code_block(
                 type_engine,
                 body,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_while/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_while/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'constant_decl_expr'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_while/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_while/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "constant_decl_expr"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_while/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_while/src/main.sw
@@ -1,0 +1,7 @@
+script;
+
+const COND = false;
+
+fn main() {
+    while COND { }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_while/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/constant_while/test.toml
@@ -1,0 +1,4 @@
+category = "compile"
+
+# not: $()const COND = false;
+# not: $()This declaration is never used.


### PR DESCRIPTION
This connects the edges from expressions in while loop conditions to the entry node of the while loop.

Closes https://github.com/FuelLabs/sway/issues/3425.