### PR TITLE
ci: pin linux release steps to ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,12 +566,12 @@ jobs:
     strategy:
       matrix:
         job:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             platform: linux
             target: x86_64-unknown-linux-gnu
             arch: amd64
             svm_target_platform: linux-amd64
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             platform: linux
             target: aarch64-unknown-linux-gnu
             arch: arm64


### PR DESCRIPTION
Recently Github Actions began [migrating `ubuntu-latest` from `ubuntu-20.04` to `ubuntu-22.04`](https://github.com/actions/runner-images/issues/6399) on a rolling basis. To prevent issues with libc and to keep our binaries as backward compatible as possible, let's pin the release steps to use `ubuntu-20.04` instead.