### PR TITLE
Add a DCA test for unused private functions in a library.

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/library/unused_priv_free_fn/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/library/unused_priv_free_fn/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'unused_priv_free_fn'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/library/unused_priv_free_fn/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/library/unused_priv_free_fn/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "unused_priv_free_fn"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/library/unused_priv_free_fn/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/library/unused_priv_free_fn/src/main.sw
@@ -1,0 +1,5 @@
+library foo;
+
+fn private_fn(x: u64) -> u64 {
+    x
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/library/unused_priv_free_fn/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/library/unused_priv_free_fn/test.toml
@@ -1,0 +1,4 @@
+category = "compile"
+
+# check: $()This function is never called.
+


### PR DESCRIPTION
This was previously reported to output an unreachable code warning inside the function, but seems to work as expected now.

Add a test for it to make sure it continues to work as expected.

Closes https://github.com/FuelLabs/sway/issues/1914.