### PR TITLE
Add favicon to `forc doc`

### DIFF
--- a/forc-plugins/forc-doc/src/render.rs
+++ b/forc-plugins/forc-doc/src/render.rs
@@ -170,9 +170,11 @@ fn html_head(
     decl_name: String,
 ) -> Box<dyn RenderBox> {
     let prefix = module_depth_to_path_prefix(module_depth);
+    let mut favicon = prefix.clone();
     let mut normalize = prefix.clone();
     let mut swaydoc = prefix.clone();
     let mut ayu = prefix;
+    favicon.push_str("assets/sway-logo.svg");
     normalize.push_str("assets/normalize.css");
     swaydoc.push_str("assets/swaydoc.css");
     ayu.push_str("assets/ayu.css");
@@ -187,6 +189,7 @@ fn html_head(
                 content=format!("API documentation for the Sway `{decl_name}` {decl_ty} in `{location}`.")
             );
             meta(name="keywords", content=format!("sway, swaylang, sway-lang, {decl_name}"));
+            link(rel="icon", href=favicon);
             title: format!("{decl_name} in {location} - Sway");
             link(rel="stylesheet", type="text/css", href=normalize);
             link(rel="stylesheet", type="text/css", href=swaydoc, id="mainThemeStyle");
@@ -328,6 +331,7 @@ fn all_items(crate_name: String, all_doc: &AllDoc) -> Box<dyn RenderBox> {
                 content="List of all items in this crate"
             );
             meta(name="keywords", content="sway, swaylang, sway-lang");
+            link(rel="icon", href="assets/sway-logo.svg");
             title: "List of all items in this crate";
             link(rel="stylesheet", type="text/css", href="assets/normalize.css");
             link(rel="stylesheet", type="text/css", href="assets/swaydoc.css", id="mainThemeStyle");


### PR DESCRIPTION
Uses the `sway-logo.svg` as the favicon for docs produced by `forc doc`

Outcome:
<img width="98" alt="Screen Shot 2022-12-07 at 2 28 23 PM" src="https://user-images.githubusercontent.com/57543709/206288671-7407045c-0c64-49b5-9af5-d9cfd0d85804.png">

Closes #3481 