### PR TITLE
Fix span for unknown enum variant error

### DIFF
--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -94,7 +94,7 @@ impl TyEnumDeclaration {
                 errors.push(CompileError::UnknownEnumVariant {
                     enum_name: self.name.clone(),
                     variant_name: variant_name.clone(),
-                    span: self.span.clone(),
+                    span: variant_name.span(),
                 });
                 err(warnings, errors)
             }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unknown_enum_variant/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unknown_enum_variant/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'unknown_enum_variant'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unknown_enum_variant/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unknown_enum_variant/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "unknown_enum_variant"
+
+[dependencies]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unknown_enum_variant/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unknown_enum_variant/src/main.sw
@@ -1,0 +1,11 @@
+script;
+
+enum MyEnum {
+    A: (),
+    B: (),
+}
+
+fn main() {
+    let e = MyEnum::C;
+}
+

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unknown_enum_variant/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unknown_enum_variant/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check:  $()let e = MyEnum::C;
+# nextln: $()Variant "C" does not exist on enum "MyEnum"


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway/issues/3543

The new span now points to the actual enum instantiation where the error is, as opposed to the enum declaration.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/59666792/206610516-54fa34bb-6ca4-4a33-a671-51ba31189bad.png">
