### PR TITLE
Fix DCA warnings for unused struct fields in contracts.

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'unused_struct_field'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "unused_struct_field"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field/src/main.sw
@@ -1,0 +1,15 @@
+contract;
+
+struct S {
+    x: u64,
+}
+
+abi MyContract {
+    fn foo(s: S) -> S;
+}
+
+impl MyContract for Contract {
+    fn foo(s: S) -> S {
+        s
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field/test.toml
@@ -1,0 +1,3 @@
+category = "compile"
+
+# not: $()This struct field is never accessed.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_array/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_array/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'unused_struct_field_array'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_array/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_array/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "unused_struct_field_array"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_array/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_array/src/main.sw
@@ -1,0 +1,15 @@
+contract;
+
+struct S {
+    x: u64,
+}
+
+abi MyContract {
+    fn foo(s: S) -> [S; 1];
+}
+
+impl MyContract for Contract {
+    fn foo(s: S) -> [S; 1] {
+        [s]
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_array/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_array/test.toml
@@ -1,0 +1,3 @@
+category = "compile"
+
+# not: $()This struct field is never accessed.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_enum/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_enum/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'unused_struct_field_enum'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_enum/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_enum/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "unused_struct_field_enum"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_enum/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_enum/src/main.sw
@@ -1,0 +1,19 @@
+contract;
+
+struct S {
+    x: u64,
+}
+
+enum E {
+    A: S,
+}
+
+abi MyContract {
+    fn foo(s: S) -> E;
+}
+
+impl MyContract for Contract {
+    fn foo(s: S) -> E {
+        E::A(s)
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_enum/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_enum/test.toml
@@ -1,0 +1,3 @@
+category = "compile"
+
+# not: $()This struct field is never accessed.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_tuple/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_tuple/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'unused_struct_field_tuple'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_tuple/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_tuple/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "unused_struct_field_tuple"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_tuple/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_tuple/src/main.sw
@@ -1,0 +1,15 @@
+contract;
+
+struct S {
+    x: u64,
+}
+
+abi MyContract {
+    fn foo(s: S) -> (S);
+}
+
+impl MyContract for Contract {
+    fn foo(s: S) -> (S) {
+        (s)
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_tuple/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/contract/unused_struct_field_tuple/test.toml
@@ -1,0 +1,3 @@
+category = "compile"
+
+# not: $()This struct field is never accessed.


### PR DESCRIPTION
If a struct type is used as a return type in the interface surface of the contract, then assume that any fields inside the struct can be used outside of the contract.

Closes https://github.com/FuelLabs/sway/issues/1305.