### PR TITLE
Checks around `ref` and `mut` params of ABIs and Traits

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -43,7 +43,7 @@ impl ty::TyAbiDeclaration {
                 errors
             );
             for param in &method.parameters {
-                if param.is_reference && param.is_mutable {
+                if param.is_reference || param.is_mutable {
                     errors.push(CompileError::RefMutableNotAllowedInContractAbi {
                         param_name: param.name.clone(),
                     })
@@ -62,7 +62,7 @@ impl ty::TyAbiDeclaration {
                 errors
             );
             for param in &method.parameters {
-                if param.is_reference && param.is_mutable {
+                if param.is_reference || param.is_mutable {
                     errors.push(CompileError::RefMutableNotAllowedInContractAbi {
                         param_name: param.name.clone(),
                     })

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -700,7 +700,6 @@ fn type_check_trait_implementation(
         {
             // TODO use trait constraints as part of the type here to
             // implement trait constraint solver */
-
             // Check if we have a non-ref mutable argument. That's not allowed.
             if impl_method_signature_param.is_mutable && !impl_method_signature_param.is_reference {
                 errors.push(CompileError::MutableParameterNotSupported {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -700,17 +700,19 @@ fn type_check_trait_implementation(
         {
             // TODO use trait constraints as part of the type here to
             // implement trait constraint solver */
-            // check if the mutability of the parameters is incompatible
-            if impl_method_param.is_mutable != impl_method_signature_param.is_mutable {
-                errors.push(CompileError::ParameterMutabilityMismatch {
-                    span: impl_method_param.mutability_span.clone(),
-                });
+
+            // Check if we have a non-ref mutable argument. That's not allowed.
+            if impl_method_signature_param.is_mutable && !impl_method_signature_param.is_reference {
+                errors.push(CompileError::MutableParameterNotSupported {
+                    param_name: impl_method_signature.name.clone(),
+                })
             }
 
-            if (impl_method_param.is_reference || impl_method_signature_param.is_reference)
-                && is_contract
+            // check if reference / mutability of the parameters is incompatible
+            if impl_method_param.is_mutable != impl_method_signature_param.is_mutable
+                || impl_method_param.is_reference != impl_method_signature_param.is_reference
             {
-                errors.push(CompileError::RefMutParameterInContract {
+                errors.push(CompileError::ParameterRefMutabilityMismatch {
                     span: impl_method_param.mutability_span.clone(),
                 });
             }

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -131,7 +131,7 @@ pub enum CompileError {
     MutableParameterNotSupported { param_name: Ident },
     #[error("Cannot pass immutable argument to mutable parameter.")]
     ImmutableArgumentToMutableParameter { span: Span },
-    #[error("ref mut parameter is not allowed for contract ABI function.")]
+    #[error("ref mut or mut parameter is not allowed for contract ABI function.")]
     RefMutableNotAllowedInContractAbi { param_name: Ident },
     #[error(
         "Cannot call associated function \"{fn_name}\" as a method. Use associated function \
@@ -583,11 +583,9 @@ pub enum CompileError {
         span: Span,
     },
     #[error(
-        "Parameter mutability mismatch between the trait function declaration and its implementation."
+        "Parameter reference type or mutability mismatch between the trait function declaration and its implementation."
     )]
-    ParameterMutabilityMismatch { span: Span },
-    #[error("Ref mutable parameter is not supported for contract ABI function.")]
-    RefMutParameterInContract { span: Span },
+    ParameterRefMutabilityMismatch { span: Span },
     #[error("Literal value is too large for type {ty}.")]
     IntegerTooLarge { span: Span, ty: String },
     #[error("Literal value underflows type {ty}.")]
@@ -841,8 +839,7 @@ impl Spanned for CompileError {
             DeclIsNotAConstant { span, .. } => span.clone(),
             ImpureInNonContract { span, .. } => span.clone(),
             ImpureInPureContext { span, .. } => span.clone(),
-            ParameterMutabilityMismatch { span, .. } => span.clone(),
-            RefMutParameterInContract { span, .. } => span.clone(),
+            ParameterRefMutabilityMismatch { span, .. } => span.clone(),
             IntegerTooLarge { span, .. } => span.clone(),
             IntegerTooSmall { span, .. } => span.clone(),
             IntegerContainsInvalidDigit { span, .. } => span.clone(),

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_ref_mut/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_ref_mut/src/main.sw
@@ -1,11 +1,65 @@
 contract;
 
 abi MyContract {
-    fn test_function(p: u64);
+    fn test_function1(p1: u64);
+    fn test_function2(mut p2: u64);
+    fn test_function3(ref mut p3: u64);
+    fn test_function4(ref p4: u64);
+    fn test_function5(p5: u64);
+    fn test_function6(p6: u64);
 }
 
 impl MyContract for Contract {
-    fn test_function(ref mut p: u64) {
+    fn test_function1(ref mut p1: u64) {
+
+    }
+    fn test_function2(mut p2: u64) {
+
+    }
+    fn test_function3(ref mut p3: u64) {
+
+    }
+    fn test_function4(ref p4: u64) {
+
+    }
+    fn test_function5(ref p5: u64) {
+
+    }
+    fn test_function6(mut p6: u64) {
+
+    }
+}
+
+trait MyTrait {
+    fn check_function1(q1: u64);
+    fn check_function2(mut q2: u64);
+    fn check_function3(ref mut q3: u64);
+    fn check_function4(ref q4: u64);
+    fn check_function5(q5: u64);
+    fn check_function6(q6: u64);
+}
+
+struct S {
+
+}
+
+impl MyTrait for S {
+    fn check_function1(ref mut q1: u64) {
+
+    }
+    fn check_function2(mut q2: u64) {
+
+    }
+    fn check_function3(ref mut q3: u64) {
+
+    }
+    fn check_function4(ref q4: u64) {
+
+    }
+    fn check_function5(ref q5: u64) {
+
+    }
+    fn check_function6(mut q6: u64) {
 
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abi_ref_mut/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abi_ref_mut/test.toml
@@ -1,3 +1,46 @@
 category = "fail"
 
-# check: $()Ref mutable parameter is not supported for contract ABI function.
+# ABI
+
+# check: $()error
+# check: $()fn test_function2(mut p2: u64);
+# nextln: $()ref mut or mut parameter is not allowed for contract ABI function
+
+# check: $()error
+# check: $()fn test_function3(ref mut p3: u64);
+# nextln: $()ref mut or mut parameter is not allowed for contract ABI function
+
+# check: $()error
+# check: $()fn test_function4(ref p4: u64);
+# nextln: $()ref mut or mut parameter is not allowed for contract ABI function
+
+# check: $()error
+# check: $()fn test_function1(ref mut p1: u64) {
+# nextln: $()Parameter reference type or mutability mismatch between the trait function declaration and its implementation
+
+# check: $()error
+# check: $()fn test_function5(ref p5: u64) {
+# nextln: $()Parameter reference type or mutability mismatch between the trait function declaration and its implementation
+
+# check: $()error
+# check: $()fn test_function6(mut p6: u64) {
+# nextln: $()Parameter reference type or mutability mismatch between the trait function declaration and its implementation
+
+#### Trait
+
+# check: $()error
+# check: $()fn check_function1(ref mut q1: u64) {
+# nextln: $()Parameter reference type or mutability mismatch between the trait function declaration and its implementation
+
+# check: $()error
+# check: $()fn check_function2(mut q2: u64);
+# nextln: $()This parameter was declared as mutable, which is not supported yet, did you mean to use ref mut?
+
+# check: $()error
+# check: $()fn check_function5(ref q5: u64) {
+# nextln: $()Parameter reference type or mutability mismatch between the trait function declaration and its implementation
+
+# check: $()error
+# check: $()fn check_function6(mut q6: u64) {
+# nextln: $()Parameter reference type or mutability mismatch between the trait function declaration and its implementation
+

--- a/test/src/e2e_vm_tests/test_programs/should_fail/ref_mut_contract_abi/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/ref_mut_contract_abi/test.toml
@@ -1,4 +1,4 @@
 category = "fail"
 
 # check: $()fn foo(ref mut x: u64);
-# nextln: $()ref mut parameter is not allowed for contract ABI function.
+# nextln: $()ref mut or mut parameter is not allowed for contract ABI function.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_method_signature_mismatch/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_method_signature_mismatch/test.toml
@@ -11,7 +11,7 @@ category = "fail"
 # nextln: $()The definition of this function must match the one in the trait "Foo" declaration.
 
 # check: fn bar(ref mut variable: u64) -> bool {
-# check: $()Parameter mutability mismatch between the trait function declaration and its implementation.
+# check: $()Parameter reference type or mutability mismatch between the trait function declaration and its implementation.
 
 # check: fn baz() -> u64 {
 # nextln: $()expected: u32


### PR DESCRIPTION
Fixes #3570