### PR TITLE
ci: bump fuel-core to v0.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       fuel-core:
-        image: ghcr.io/fuellabs/fuel-core:v0.14.1
+        image: ghcr.io/fuellabs/fuel-core:v0.15.0
         ports:
           - 4000:4000
     steps:


### PR DESCRIPTION
fuelup passed the same e2e tests within the [CI](https://github.com/FuelLabs/fuelup/actions/runs/3661645487) in advance and has published the [latest channel](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-latest.toml), so this should be a safe change to make. 