### PR TITLE
Fix CI failure by running `cargo update` and bumping `fuel-core`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       fuel-core:
-        image: ghcr.io/fuellabs/fuel-core:v0.14.1
+        image: ghcr.io/fuellabs/fuel-core:v0.15.0
         ports:
           - 4000:4000
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,68 +19,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aead"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
-dependencies = [
- "generic-array 0.14.6",
-]
-
-[[package]]
-name = "aes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
-dependencies = [
- "aes-soft",
- "aesni",
- "cipher 0.2.5",
-]
-
-[[package]]
 name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.3.0",
+ "cipher",
  "cpufeatures",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
-dependencies = [
- "aead",
- "aes 0.6.0",
- "cipher 0.2.5",
- "ctr 0.6.0",
- "ghash",
- "subtle",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
-dependencies = [
- "cipher 0.2.5",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aesni"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
-dependencies = [
- "cipher 0.2.5",
  "opaque-debug 0.3.0",
 ]
 
@@ -108,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -174,151 +120,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "async-channel"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
-dependencies = [
- "concurrent-queue 1.2.4",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
-name = "async-dup"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7427a12b8dc09291528cfb1da2447059adb4a257388c2acd6497a79d55cf6f7c"
-dependencies = [
- "futures-io",
- "simple-mutex",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
-dependencies = [
- "async-lock",
- "async-task",
- "concurrent-queue 2.0.0",
- "fastrand",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-h1"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8101020758a4fc3a7c326cb42aa99e9fa77cbfb76987c128ad956406fe1f70a7"
-dependencies = [
- "async-channel",
- "async-dup",
- "async-std",
- "futures-core",
- "http-types",
- "httparse",
- "log",
- "pin-project",
-]
-
-[[package]]
-name = "async-io"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
-dependencies = [
- "async-lock",
- "autocfg",
- "concurrent-queue 1.2.4",
- "futures-lite",
- "libc",
- "log",
- "parking",
- "polling",
- "slab",
- "socket2",
- "waker-fn",
- "winapi",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
-dependencies = [
- "event-listener",
- "futures-lite",
-]
-
-[[package]]
-name = "async-std"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
-dependencies = [
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
-
-[[package]]
-name = "async-tls"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85a97c4a0ecce878efd3f945f119c78a646d8975340bca0398f9bb05c30cc52"
-dependencies = [
- "futures-core",
- "futures-io",
- "rustls 0.18.1",
- "webpki",
- "webpki-roots",
-]
-
-[[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -326,18 +131,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -359,12 +158,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base16ct"
@@ -475,11 +268,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
+checksum = "b12e5fd123190ce1c2e559308a94c9bacad77907d4c6005d9e58fe1a0689e55e"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -540,20 +333,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
-name = "blocking"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
-dependencies = [
- "async-channel",
- "async-task",
- "atomic-waker",
- "fastrand",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "borrown"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,24 +376,18 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "cache-padded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
-
-[[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 dependencies = [
  "jobserver",
 ]
@@ -633,26 +406,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.44",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
-]
-
-[[package]]
-name = "cipher"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
-dependencies = [
- "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -698,14 +462,14 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.22"
+version = "4.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b9970d7505127a162fdaa9b96428d28a479ba78c9ec7550a63a5d9863db682"
+checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive 4.0.21",
  "clap_lex 0.3.0",
+ "is-terminal",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
@@ -784,7 +548,7 @@ dependencies = [
  "bincode",
  "bs58",
  "coins-core",
- "digest 0.10.5",
+ "digest 0.10.6",
  "getrandom 0.2.8",
  "hmac 0.12.1",
  "k256",
@@ -806,7 +570,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.6",
  "thiserror",
 ]
@@ -821,7 +585,7 @@ dependencies = [
  "base64 0.12.3",
  "bech32 0.7.3",
  "blake2",
- "digest 0.10.5",
+ "digest 0.10.6",
  "generic-array 0.14.6",
  "hex",
  "ripemd",
@@ -872,7 +636,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11e55664fcff7f4d37cc2adf3a1996913692f037312f4ab0909047fdd2bf962"
 dependencies = [
- "clap 4.0.22",
+ "clap 4.0.29",
  "entities",
  "memchr",
  "once_cell",
@@ -887,35 +651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
-dependencies = [
- "cache-padded",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "config"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
-dependencies = [
- "lazy_static",
- "nom",
- "serde",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,15 +658,9 @@ checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "const-oid"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
-
-[[package]]
-name = "const_fn"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "constant_time_eq"
@@ -944,23 +673,6 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "cookie"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
-dependencies = [
- "aes-gcm",
- "base64 0.13.1",
- "hkdf",
- "hmac 0.10.1",
- "percent-encoding",
- "rand 0.8.5",
- "sha2 0.9.9",
- "time 0.2.27",
- "version_check",
-]
 
 [[package]]
 name = "core-foundation"
@@ -979,6 +691,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "counter"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d458e66999348f56fd3ffcfbb7f7951542075ca8359687c703de6500c1ddccd"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "countme"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,12 +713,6 @@ checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "cpuid-bool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "crc32fast"
@@ -1019,20 +734,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1050,7 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array 0.14.6",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -1062,7 +767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array 0.14.6",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -1075,16 +780,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.6",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
-dependencies = [
- "generic-array 0.14.6",
- "subtle",
 ]
 
 [[package]]
@@ -1125,26 +820,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
 dependencies = [
- "sct",
-]
-
-[[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "ctr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
-dependencies = [
- "cipher 0.2.5",
+ "sct 0.6.1",
 ]
 
 [[package]]
@@ -1153,14 +829,14 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
 dependencies = [
- "cipher 0.3.0",
+ "cipher",
 ]
 
 [[package]]
 name = "cxx"
-version = "1.0.81"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
+checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1170,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.81"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
+checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1185,15 +861,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.81"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
+checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.81"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
+checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1202,28 +878,28 @@ dependencies = [
 
 [[package]]
 name = "cynic"
-version = "1.0.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a086fdece2d6206e52894d978a09b09efca1e61ac59d69a934eab74d8d9ee40"
+checksum = "07097754f62237ba04e4c3315d50c0f6e85e6b2b95d57256941c3ec88b03be73"
 dependencies = [
  "cynic-proc-macros",
- "json-decode",
+ "reqwest",
  "serde",
  "serde_json",
- "surf",
+ "static_assertions",
  "thiserror",
 ]
 
 [[package]]
 name = "cynic-codegen"
-version = "1.0.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd9f0852fe3d3637d4dccb4b69e5a8f881214fc38907a528385ff71cd7b15c3e"
+checksum = "738b5c475d60eb95d83af1234aba8014f3f934fd166c752339011ac05165457f"
 dependencies = [
- "Inflector",
+ "counter",
  "darling",
  "graphql-parser",
- "lazy_static",
+ "once_cell",
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
@@ -1232,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "cynic-proc-macros"
-version = "1.0.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cabdef46a6ff3c06e337a9c0c6b7d2f71aefae4ab582ed319a0d454ea1085f9"
+checksum = "aa32c5bf6c87846b0332ca4b912881b28c91f8945c972cedeae3fd18eaf65751"
 dependencies = [
  "cynic-codegen",
  "syn",
@@ -1285,21 +961,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.4",
-]
-
-[[package]]
-name = "deadpool"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d126179d86aee4556e54f5f3c6bf6d9884e7cc52cef82f77ee6f90a7747616d"
-dependencies = [
- "async-trait",
- "config",
- "crossbeam-queue",
- "num_cpus",
- "serde",
- "tokio",
+ "parking_lot_core 0.9.5",
 ]
 
 [[package]]
@@ -1313,11 +975,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid 0.9.0",
+ "const-oid 0.9.1",
  "zeroize",
 ]
 
@@ -1341,7 +1003,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
+ "rustc_version",
  "syn",
 ]
 
@@ -1365,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -1415,18 +1077,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-
-[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der 0.6.0",
+ "der 0.6.1",
  "elliptic-curve 0.12.3",
  "rfc6979",
  "signature",
@@ -1448,7 +1104,7 @@ dependencies = [
  "crypto-bigint 0.3.2",
  "der 0.5.1",
  "generic-array 0.14.6",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -1461,13 +1117,13 @@ checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint 0.4.9",
- "der 0.6.0",
- "digest 0.10.5",
+ "der 0.6.1",
+ "digest 0.10.6",
  "ff",
  "generic-array 0.14.6",
  "group",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -1478,6 +1134,15 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "entities"
@@ -1525,13 +1190,13 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d47d900a7dea08593d398104f8288e37858b0ad714c8d08cd03fdb86563e6402"
 dependencies = [
- "aes 0.7.5",
- "ctr 0.7.0",
+ "aes",
+ "ctr",
  "digest 0.9.0",
  "hex",
  "hmac 0.11.0",
  "pbkdf2 0.8.0",
- "rand 0.8.5",
+ "rand",
  "scrypt",
  "serde",
  "serde_json",
@@ -1542,12 +1207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
 name = "eventsource-client"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,7 +1214,7 @@ checksum = "9146112ee3ce031aa5aebe3e049e10b1d353b9c7630cc6be488c2c62cc5d9c42"
 dependencies = [
  "futures",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.22.1",
  "hyper-timeout",
  "log",
  "pin-project",
@@ -1612,7 +1271,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1639,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
+checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1657,9 +1316,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1734,7 +1393,7 @@ name = "forc-doc"
 version = "0.31.3"
 dependencies = [
  "anyhow",
- "clap 4.0.22",
+ "clap 4.0.29",
  "comrak",
  "forc-pkg",
  "forc-util",
@@ -1785,7 +1444,7 @@ dependencies = [
  "git2",
  "hex",
  "petgraph",
- "semver 1.0.14",
+ "semver",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -1808,7 +1467,7 @@ dependencies = [
  "forc-pkg",
  "fuel-tx",
  "fuel-vm",
- "rand 0.8.5",
+ "rand",
  "sway-core",
  "sway-types",
 ]
@@ -1876,17 +1535,16 @@ dependencies = [
 
 [[package]]
 name = "fuel-chain-config"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56056dc76e152c92f82d35a5ed2354f6d0f1a306daf5ec26d970a72879edbce"
+checksum = "7c13c149a457eab4ad624051a470f2fc948c2ec5ff79fd1afc0fc7658904a47d"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
  "fuel-poa-coordinator",
  "hex",
  "itertools",
- "rand 0.8.5",
- "ron",
+ "rand",
  "serde",
  "serde_json",
  "serde_with",
@@ -1895,15 +1553,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-interfaces"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9a3b068c3990cbae13131ac8fa53aaea91a8bd22e3c46463d5c9022e885dd7"
+checksum = "0e7344b09d85494abed84d94930691cfb38fac88a75cf27d72b530d55b09fbe9"
 dependencies = [
  "anyhow",
  "async-trait",
  "derive_more",
  "fuel-vm",
- "futures",
  "lazy_static",
  "parking_lot 0.12.1",
  "secrecy",
@@ -1925,7 +1582,7 @@ dependencies = [
  "coins-bip39",
  "fuel-types",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "secp256k1",
  "serde",
  "sha2 0.10.6",
@@ -1934,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-gql-client"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c4c4a52e2dee7e026307877d79b0bdacbb02cb155a01c2da2e56dc7838459a"
+checksum = "313ae2b6405d5c8c1cc0011cf84e1b6259069e71d5f3838730b11921f6582bbc"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -1945,12 +1602,12 @@ dependencies = [
  "eventsource-client",
  "fuel-vm",
  "futures",
- "futures-timer",
  "hex",
+ "hyper-rustls 0.22.1",
  "itertools",
+ "reqwest",
  "serde",
  "serde_json",
- "surf",
  "tai64",
  "thiserror",
 ]
@@ -1961,7 +1618,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12e56cc8be0a2ea7cfb30ae4696bf5f658a9447df1b32af699b6273a11fdcfa3"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
  "fuel-storage",
  "hashbrown 0.12.3",
  "hex",
@@ -1971,11 +1628,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-poa-coordinator"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49262d99abab91616534a9ef2bab5d55b72c9076f1c8555c93cfdba293a14a23"
+checksum = "c837866f277c5d6ce0412f072618f107f3d2eefdc5fb2b876b00ed983418fcbd"
 dependencies = [
  "anyhow",
+ "async-trait",
  "fuel-core-interfaces",
  "humantime-serde",
  "parking_lot 0.12.1",
@@ -2004,7 +1662,7 @@ dependencies = [
  "fuel-types",
  "itertools",
  "num-integer",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
 ]
@@ -2015,7 +1673,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403dcac5f0788a8fbdb6cfa0e5690dd4fe4278648da674d7e430711abf90b570"
 dependencies = [
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -2032,7 +1690,7 @@ dependencies = [
  "fuel-tx",
  "fuel-types",
  "itertools",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha3 0.10.6",
  "tai64",
@@ -2042,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f87fa1c3616aa001152cc0286e0fb34df229c0779b85f6d04daeec4646c7c"
+checksum = "ce2349a66d10d6e9f214a78572a4470b9fc2e805e49327c3c1ac6870951020b9"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -2056,7 +1714,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "rand 0.8.5",
+ "rand",
  "regex",
  "serde",
  "serde_json",
@@ -2069,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-signers"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637db0375aee4950b6bbcec908789c3383cd5f17872d7dc30dc2435aa4ebde3d"
+checksum = "07d6769758c5718026d03bf55557c1cea78ab6672e4c5d8efcfef853d6162cdb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2084,7 +1742,8 @@ dependencies = [
  "fuels-core",
  "fuels-types",
  "hex",
- "rand 0.8.5",
+ "itertools",
+ "rand",
  "serde",
  "sha2 0.9.9",
  "thiserror",
@@ -2093,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-types"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c81ff2f34949edbdeb097aa4567e6f46d44069376eb2b9bc61d66050fe9042"
+checksum = "6c6b7ec28dbf349bbc097e7e45ee711046088fe0365261f16105c842a4db354d"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -2165,21 +1824,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
-name = "futures-lite"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,12 +1845,6 @@ name = "futures-task"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -2289,20 +1927,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghash"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
-dependencies = [
- "opaque-debug 0.3.0",
- "polyval",
-]
-
-[[package]]
 name = "git2"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
 dependencies = [
  "bitflags",
  "libc",
@@ -2320,22 +1948,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "graphql-parser"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1abd4ce5247dfc04a03ccde70f87a048458c9356c7e41d21ad8c407b3dde6f2"
+checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
  "combine 3.8.1",
  "thiserror",
@@ -2348,7 +1964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -2434,6 +2050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2443,32 +2068,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "hkdf"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
-dependencies = [
- "digest 0.9.0",
- "hmac 0.10.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
-dependencies = [
- "crypto-mac 0.10.1",
- "digest 0.9.0",
-]
-
-[[package]]
 name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
- "crypto-mac 0.11.1",
+ "crypto-mac",
  "digest 0.9.0",
 ]
 
@@ -2478,7 +2083,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2507,47 +2112,6 @@ dependencies = [
  "bytes",
  "http",
  "pin-project-lite",
-]
-
-[[package]]
-name = "http-client"
-version = "6.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1947510dc91e2bf586ea5ffb412caad7673264e14bb39fb9078da114a94ce1a5"
-dependencies = [
- "async-h1",
- "async-std",
- "async-tls",
- "async-trait",
- "cfg-if 1.0.0",
- "dashmap",
- "deadpool",
- "futures",
- "http-types",
- "log",
- "rustls 0.18.1",
-]
-
-[[package]]
-name = "http-types"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
-dependencies = [
- "anyhow",
- "async-channel",
- "async-std",
- "base64 0.13.1",
- "cookie",
- "futures-lite",
- "infer",
- "pin-project-lite",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url",
 ]
 
 [[package]]
@@ -2615,8 +2179,22 @@ dependencies = [
  "rustls 0.19.1",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
- "webpki",
+ "tokio-rustls 0.22.0",
+ "webpki 0.21.4",
+ "webpki-roots 0.21.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls 0.20.7",
+ "tokio",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -2678,7 +2256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
  "bitmaps",
- "rand_core 0.6.4",
+ "rand_core",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -2706,19 +2284,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
 ]
-
-[[package]]
-name = "infer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "inotify"
@@ -2751,9 +2323,31 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.5"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "itertools"
@@ -2795,17 +2389,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json-decode"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd72139ade93da4f8a437afe8654a4a3cf1d858dc195fc6691e6e932fa1b6ee"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "k256"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,9 +2402,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "kqueue"
@@ -2844,44 +2430,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.4+1.4.2"
+version = "0.14.0+1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
 dependencies = [
  "cc",
  "libc",
@@ -2943,9 +2507,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.46"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
 name = "lock_api"
@@ -2964,7 +2528,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
- "value-bag",
 ]
 
 [[package]]
@@ -3014,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "mdbook"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f3e133c6d515528745ffd3b9f0c7d975ae039f0b6abb099f2168daa2afb4f9"
+checksum = "6b61566b406cbd75d81c634763d6c90779ca9db80202921c884348d172ada70d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3024,9 +2587,9 @@ dependencies = [
  "clap_complete",
  "env_logger",
  "handlebars",
- "lazy_static",
  "log",
  "memchr",
+ "once_cell",
  "opener",
  "pulldown-cmark",
  "regex",
@@ -3045,7 +2608,7 @@ dependencies = [
  "anyhow",
  "clap 3.2.23",
  "mdbook",
- "semver 1.0.14",
+ "semver",
  "serde",
  "serde_json",
  "toml",
@@ -3073,20 +2636,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -3101,17 +2654,6 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -3188,7 +2730,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -3259,9 +2801,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
 dependencies = [
  "autocfg",
  "cc",
@@ -3273,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.1"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "overload"
@@ -3290,12 +2832,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
-name = "parking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
-
-[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,7 +2839,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.5",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
@@ -3313,14 +2849,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.4",
+ "parking_lot_core 0.9.5",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -3332,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -3350,7 +2886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e0b28ace46c5a396546bcf443bf422b57049617433d8854227352a4a9b24e7"
 dependencies = [
  "base64ct",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -3361,15 +2897,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "cf1c2c742266c2f1041c914ba65355a83ae8747b05f208319784083583494b4b"
 
 [[package]]
 name = "pbkdf2"
@@ -3378,7 +2914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
 dependencies = [
  "base64ct",
- "crypto-mac 0.11.1",
+ "crypto-mac",
  "hmac 0.11.0",
  "password-hash 0.2.3",
  "sha2 0.9.9",
@@ -3390,7 +2926,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
  "hmac 0.12.1",
  "password-hash 0.4.2",
  "sha2 0.10.6",
@@ -3431,9 +2967,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.4.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
+checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3441,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.4.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fd9bc6500181952d34bd0b2b0163a54d794227b498be0b7afa7698d0a7b18f"
+checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3451,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.4.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2610d5ac5156217b4ff8e46ddcef7cdf44b273da2ac5bca2ecbfa86a330e7c4"
+checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3464,13 +3000,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.4.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824749bf7e21dd66b36fbe26b3f45c713879cccd4a009a917ab8e045ca8246fe"
+checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
 dependencies = [
  "once_cell",
  "pest",
- "sha1 0.10.5",
+ "sha1",
 ]
 
 [[package]]
@@ -3503,7 +3039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -3567,7 +3103,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der 0.6.0",
+ "der 0.6.1",
  "spki",
 ]
 
@@ -3589,31 +3125,6 @@ dependencies = [
  "serde",
  "time 0.3.17",
  "xml-rs",
-]
-
-[[package]]
-name = "polling"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
-dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
- "libc",
- "log",
- "wepoll-ffi",
- "winapi",
-]
-
-[[package]]
-name = "polyval"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
-dependencies = [
- "cpuid-bool",
- "opaque-debug 0.3.0",
- "universal-hash",
 ]
 
 [[package]]
@@ -3725,36 +3236,13 @@ checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -3764,16 +3252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -3786,21 +3265,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3876,6 +3346,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls 0.23.2",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.20.7",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls 0.23.4",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.22.6",
+ "winreg",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3907,18 +3416,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.5",
-]
-
-[[package]]
-name = "ron"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff"
-dependencies = [
- "base64 0.13.1",
- "bitflags",
- "serde",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -3964,27 +3462,18 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.14",
+ "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.35.13"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",
@@ -3996,19 +3485,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
-dependencies = [
- "base64 0.12.3",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
@@ -4016,8 +3492,20 @@ dependencies = [
  "base64 0.13.1",
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+dependencies = [
+ "log",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -4030,6 +3518,15 @@ dependencies = [
  "rustls 0.19.1",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -4050,7 +3547,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
 dependencies = [
- "cipher 0.3.0",
+ "cipher",
 ]
 
 [[package]]
@@ -4109,13 +3606,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct",
- "der 0.6.0",
+ "der 0.6.1",
  "generic-array 0.14.6",
  "pkcs8",
  "subtle",
@@ -4124,11 +3631,11 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
+checksum = "d9512ffd81e3a3503ed401f79c33168b9148c75038956039166cd750eaa037c3"
 dependencies = [
- "rand 0.8.5",
+ "rand",
  "secp256k1-sys",
 ]
 
@@ -4175,15 +3682,6 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
@@ -4192,25 +3690,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4228,24 +3720,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa 1.0.4",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -4321,29 +3802,14 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -4378,7 +3844,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -4399,7 +3865,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
  "keccak",
 ]
 
@@ -4439,17 +3905,8 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.10.5",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "simple-mutex"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38aabbeafa6f6dead8cebf246fe9fae1f9215c8d29b3a69f93bd62a9e4a3dcd6"
-dependencies = [
- "event-listener",
+ "digest 0.10.6",
+ "rand_core",
 ]
 
 [[package]]
@@ -4512,16 +3969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der 0.6.0",
-]
-
-[[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
+ "der 0.6.1",
 ]
 
 [[package]]
@@ -4529,55 +3977,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1 0.6.1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "str_indices"
@@ -4644,28 +4043,6 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
-
-[[package]]
-name = "surf"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718b1ae6b50351982dedff021db0def601677f2120938b070eadb10ba4038dd7"
-dependencies = [
- "async-std",
- "async-trait",
- "cfg-if 1.0.0",
- "futures-util",
- "getrandom 0.2.8",
- "http-client",
- "http-types",
- "log",
- "mime_guess",
- "once_cell",
- "pin-project-lite",
- "rustls 0.18.1",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "sway-ast"
@@ -4830,9 +4207,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4895,7 +4272,7 @@ dependencies = [
  "logos",
  "regex",
  "rowan",
- "semver 1.0.14",
+ "semver",
  "smallvec",
  "toml",
  "wasm-bindgen",
@@ -4948,9 +4325,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ca90c434fd12083d1a6bdcbe9f92a14f96c8a1ba600ba451734ac334521f7a"
+checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
 dependencies = [
  "rustix",
  "windows-sys 0.42.0",
@@ -4962,7 +4339,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "clap 4.0.22",
+ "clap 4.0.29",
  "colored",
  "filecheck",
  "forc",
@@ -4975,7 +4352,7 @@ dependencies = [
  "gag",
  "hex",
  "prettydiff 0.6.1",
- "rand 0.8.5",
+ "rand",
  "regex",
  "serde_json",
  "sway-core",
@@ -5043,27 +4420,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros 0.1.1",
- "version_check",
  "winapi",
 ]
 
@@ -5076,7 +4438,7 @@ dependencies = [
  "itoa 1.0.4",
  "serde",
  "time-core",
- "time-macros 0.2.6",
+ "time-macros",
 ]
 
 [[package]]
@@ -5087,34 +4449,11 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
 ]
 
 [[package]]
@@ -5134,9 +4473,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
  "autocfg",
  "bytes",
@@ -5149,7 +4488,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5164,9 +4503,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5181,7 +4520,18 @@ checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls 0.19.1",
  "tokio",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.7",
+ "tokio",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -5373,9 +4723,9 @@ checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
@@ -5385,9 +4735,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "uint"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -5460,16 +4810,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
-name = "universal-hash"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
-dependencies = [
- "generic-array 0.14.6",
- "subtle",
-]
-
-[[package]]
 name = "unreachable"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5525,16 +4865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "value-bag"
-version = "1.0.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
-dependencies = [
- "ctor",
- "version_check",
-]
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5563,12 +4893,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -5698,21 +5022,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.20.0"
+name = "webpki"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
- "webpki",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
-name = "wepoll-ffi"
-version = "0.1.2"
+name = "webpki-roots"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
- "cc",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -5858,6 +5192,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "xdg"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5901,9 +5244,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.15.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
 dependencies = [
  "bitflags",
  "libc",
@@ -2443,9 +2443,9 @@ checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.0+1.5.0"
+version = "0.13.4+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
+checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
 dependencies = [
  "cc",
  "libc",

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1"
 forc-tracing = { version = "0.31.3", path = "../forc-tracing" }
 forc-util = { version = "0.31.3", path = "../forc-util" }
 fuels-types = "0.32" 
-git2 = { version = "0.14", features = ["vendored-libgit2", "vendored-openssl"] }
+git2 = { version = "0.15", features = ["vendored-libgit2", "vendored-openssl"] }
 hex = "0.4.3"
 petgraph = { version = "0.6", features = ["serde-1"] }
 semver = { version = "1.0", features = ["serde"] }

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1"
 forc-tracing = { version = "0.31.3", path = "../forc-tracing" }
 forc-util = { version = "0.31.3", path = "../forc-util" }
 fuels-types = "0.32" 
-git2 = { version = "0.15", features = ["vendored-libgit2", "vendored-openssl"] }
+git2 = { version = "0.14", features = ["vendored-libgit2", "vendored-openssl"] }
 hex = "0.4.3"
 petgraph = { version = "0.6", features = ["serde-1"] }
 semver = { version = "1.0", features = ["serde"] }

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "3", features = ["derive", "env"] }
 forc-pkg = { version = "0.31.3", path = "../../forc-pkg" }
 forc-tracing = { version = "0.31.3", path = "../../forc-tracing" }
 forc-util = { version = "0.31.3", path = "../../forc-util" }
-fuel-gql-client = { version = "0.14", default-features = false }
+fuel-gql-client = { version = "0.15", default-features = false }
 fuel-tx = { version = "0.23", features = ["builder"] }
 fuels-core = "0.32"
 fuels-signers = "0.32"

--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -374,6 +374,7 @@ impl TyProgram {
                     types: types.to_vec(),
                     functions,
                     logged_types: Some(logged_types),
+                    messages_types: None,
                 }
             }
             TyProgramKind::Script { main_function, .. }
@@ -384,12 +385,14 @@ impl TyProgram {
                     types: types.to_vec(),
                     functions,
                     logged_types: Some(logged_types),
+                    messages_types: None,
                 }
             }
             _ => fuels_types::ProgramABI {
                 types: vec![],
                 functions: vec![],
                 logged_types: None,
+                messages_types: None,
             },
         }
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/dependency_package_field/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/dependency_package_field/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/abort_control_flow_good/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/abort_control_flow_good/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/addrof_intrinsic/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/addrof_intrinsic/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/aliased_imports/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/aliased_imports/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array_generics/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array_generics/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_expr_basic/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_expr_basic/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_without_return/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/asm_without_return/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_bad_jumps/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_bad_jumps/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_bitwise_ops/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_bitwise_ops/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_ops/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/b256_ops/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/basic_func_decl/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/basic_func_decl/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/binary_and_hex_literals/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/binary_and_hex_literals/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/binop_intrinsics/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/binop_intrinsics/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/bitwise_not/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/bitwise_not/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/bool_and_or/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/bool_and_or/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/break_and_continue/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/break_and_continue/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/builtin_type_method_call/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/builtin_type_method_call/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/chained_if_let/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/chained_if_let/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/config_time_constants/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/config_time_constants/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl_and_use_in_library/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl_and_use_in_library/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl_in_library/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl_in_library/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl_with_call_path/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_decl_with_call_path/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_global_shadow/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_global_shadow/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_inits/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_inits/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_ret/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_as_ret/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/dependencies/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/dependencies/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/diverging_exprs/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/diverging_exprs/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/empty_method_initializer/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/empty_method_initializer/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_destructuring/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_destructuring/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let_large_type/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_if_let_large_type/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_in_fn_decl/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_in_fn_decl/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_init_fn_call/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_init_fn_call/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_padding/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_padding/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_type_inference/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_type_inference/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/eq_and_neq/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/eq_and_neq/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/eq_intrinsic/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/eq_intrinsic/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/funcs_with_generic_types/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/funcs_with_generic_types/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_enum/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_enum/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_functions/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_functions/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_inside_generic/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_inside_generic/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_struct/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_struct/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_structs/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_structs/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_traits/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_traits/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_type_inference/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_type_inference/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/gtf_intrinsic/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/gtf_intrinsic/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/if_elseif_enum/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/if_elseif_enum/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/if_implicit_unit/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/if_implicit_unit/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_return/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_return/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_method_from_other_file/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_method_from_other_file/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_trailing_comma/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_trailing_comma/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/impure_ifs/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/impure_ifs/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/inline_if_expr_const/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/inline_if_expr_const/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/insert_element_reg_reuse/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/integer_type_inference/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/integer_type_inference/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/is_prime/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/is_prime/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/is_reference_type/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/is_reference_type/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/left_to_right_func_args_evaluation/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/left_to_right_func_args_evaluation/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/local_impl_for_ord/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/local_impl_for_ord/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/logging/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/logging/json_abi_oracle.json
@@ -110,6 +110,7 @@
       }
     }
   ],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_copy/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_copy/json_abi_oracle.json
@@ -17,6 +17,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_copy_copy/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_copy_copy/json_abi_oracle.json
@@ -22,6 +22,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_empty/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_empty/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_predicate/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_predicate/json_abi_oracle.json
@@ -22,6 +22,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_ref/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_ref/json_abi_oracle.json
@@ -17,6 +17,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_ref_copy/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_ref_copy/json_abi_oracle.json
@@ -22,6 +22,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_ref_ref/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_ref_ref/json_abi_oracle.json
@@ -22,6 +22,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_various_types/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_various_types/json_abi_oracle.json
@@ -17,6 +17,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_returns_unit/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_returns_unit/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/many_stack_variables/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/many_stack_variables/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_constants/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_constants/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_enums/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_enums/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_inside_generic_functions/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_inside_generic_functions/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_mismatched/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_mismatched/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_nested/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_nested/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_rest/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_simple/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_simple/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_structs/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_structs/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_with_self/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_with_self/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/method_on_empty_struct/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/method_on_empty_struct/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/modulo_uint_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/modulo_uint_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_item_import/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_item_import/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/nested_struct_destructuring/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/nested_struct_destructuring/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/nested_structs/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/nested_structs/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/nested_while_and_if/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/nested_while_and_if/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/new_allocator_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/new_allocator_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/non_literal_const_decl/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/non_literal_const_decl/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/op_precedence/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/op_precedence/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/out_of_order_decl/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/out_of_order_decl/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access2/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/prelude_access2/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/primitive_type_argument/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/primitive_type_argument/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/raw_identifiers/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/raw_identifiers/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/reassignment_operators/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/reassignment_operators/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/redundant_return/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/redundant_return/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_bool/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_bool/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_call/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_call/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_struct/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_struct/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_struct_assign/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_struct_assign/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_u32/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/ref_mutable_fn_args_u32/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/ret_small_string/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/ret_small_string/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/ret_string_in_struct/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/ret_string_in_struct/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_b256/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_b256/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_small_array/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_small_array/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_struct/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_struct/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_zero_len_array/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/retd_zero_len_array/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/self_impl_reassignment/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/self_impl_reassignment/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/size_of/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/size_of/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_destructuring/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_destructuring/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_access/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_access/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_reassignment/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_field_reassignment/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/supertraits/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/supertraits/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/supertraits_with_trait_methods/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/supertraits_with_trait_methods/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_import_with_star/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_import_with_star/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_override_bug/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_override_bug/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_access/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_access/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_desugaring/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_desugaring/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_field_reassignment/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_field_reassignment/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_in_struct/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_in_struct/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_indexing/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_indexing/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_single_element/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_single_element/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_trait/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_trait/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_types/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_types/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/u64_ops/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/u64_ops/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic_2/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/unary_not_basic_2/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/unit_type_variants/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/unit_type_variants/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/use_full_path_names/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/use_full_path_names/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/valid_impurity/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/valid_impurity/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_functions/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_functions/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/while_loops/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/while_loops/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/zero_field_types/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/zero_field_types/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/address_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/address_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/alloc/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/alloc/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_struct_alignment/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_struct_alignment/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/block_height/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/block_height/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/contract_id_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/contract_id_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/contract_id_type/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/contract_id_type/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_custom_type/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_custom_type/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/eq_generic/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/exponentiation_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/exponentiation_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ge_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ge_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/identity_eq/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/identity_eq/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/intrinsics/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/intrinsics/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/logarithmic_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/logarithmic_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/option/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/option/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_ptr/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_ptr/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_slice/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/raw_slice/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/require/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/require/json_abi_oracle.json
@@ -60,6 +60,7 @@
       }
     }
   ],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/result/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/result/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_div_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_div_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_log_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_log_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_mul_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_mul_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_root_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_root_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_div_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_div_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_mul_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_mul_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_ops_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_ops_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_test/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_test/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/vec/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/vec/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_generic_types/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_generic_types/json_abi_oracle.json
@@ -106,6 +106,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_tuples_contract/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_tuples_contract/json_abi_oracle.json
@@ -32,6 +32,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/array_of_structs_contract/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/array_of_structs_contract/json_abi_oracle.json
@@ -47,6 +47,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/auth_testing_contract/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/auth_testing_contract/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/balance_test_contract/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/balance_test_contract/json_abi_oracle.json
@@ -11,6 +11,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/json_abi_oracle.json
@@ -116,6 +116,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/context_testing_contract/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/context_testing_contract/json_abi_oracle.json
@@ -82,6 +82,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/get_storage_key_contract/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/get_storage_key_contract/json_abi_oracle.json
@@ -47,6 +47,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/increment_contract/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/increment_contract/json_abi_oracle.json
@@ -26,6 +26,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": null,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/issue_1512_repro/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/issue_1512_repro/json_abi_oracle.json
@@ -22,6 +22,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/multiple_impl/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/multiple_impl/json_abi_oracle.json
@@ -28,6 +28,7 @@
       }
     }
   ],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/nested_struct_args_contract/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/nested_struct_args_contract/json_abi_oracle.json
@@ -22,6 +22,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/json_abi_oracle.json
@@ -581,6 +581,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/test_fuel_coin_contract/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/test_fuel_coin_contract/json_abi_oracle.json
@@ -57,6 +57,7 @@
     }
   ],
   "loggedTypes": [],
+  "messagesTypes": null,
   "types": [
     {
       "components": [],

--- a/test/src/sdk-harness/Cargo.toml
+++ b/test/src/sdk-harness/Cargo.toml
@@ -7,8 +7,8 @@ version = "0.0.0"
 
 [dependencies]
 assert_matches = "1.5.0"
-fuel-core = { version = "0.14", default-features = false }
-fuel-gql-client = { version = "0.14", default-features = false }
+fuel-core = { version = "0.15", default-features = false }
+fuel-gql-client = { version = "0.15", default-features = false }
 fuel-types = "0.5"
 fuel-vm = "0.22"
 fuels = { version = "0.32", features = ["fuel-core-lib"] }


### PR DESCRIPTION
This unfortunately happened because I made a non-breaking release in `fuels-rs` that was in fact breaking. The breaking was non-breaking from the point of view of the user, but it was breaking from the point of view of the sway repo. 
- Had to run `cargo update` to update the `fuels-rs` version
- Had to bump `fuel-core` to `0.15` due to some transitive dependencies and conflicting types.