### PR TITLE
Remove duplicate gas from std

### DIFF
--- a/sway-lib-std/src/context.sw
+++ b/sway-lib-std/src/context.sw
@@ -18,11 +18,6 @@ pub fn balance_of(asset_id: ContractId, target: ContractId) -> u64 {
     }
 }
 
-/// Get the remaining gas in the context.
-pub fn gas() -> u64 {
-    asm() { cgas: u64 }
-}
-
 /// Get the amount of units of `call_frames::msg_asset_id()` being sent.
 pub fn msg_amount() -> u64 {
     balance()

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/context_testing_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/context_testing_contract/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::{call_frames::{contract_id, msg_asset_id}, context::{balance_of, gas, msg_amount, this_balance}, contract_id::ContractId, registers::global_gas};
+use std::{call_frames::{contract_id, msg_asset_id}, context::{balance_of, msg_amount, this_balance}, contract_id::ContractId, registers::{global_gas, context_gas}};
 use context_testing_abi::*;
 
 impl ContextTesting for Contract {
@@ -25,7 +25,7 @@ impl ContextTesting for Contract {
     }
 
     fn get_gas() -> u64 {
-        gas()
+        context_gas()
     }
 
     fn get_global_gas() -> u64 {

--- a/test/src/sdk-harness/test_artifacts/reentrancy_target_contract/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/reentrancy_target_contract/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::{auth::*, call_frames::contract_id, context::gas, reentrancy::*};
+use std::{auth::*, call_frames::contract_id, reentrancy::*};
 
 use reentrancy_attacker_abi::Attacker;
 use reentrancy_target_abi::Target;

--- a/test/src/sdk-harness/test_projects/context/src/main.sw
+++ b/test/src/sdk-harness/test_projects/context/src/main.sw
@@ -25,7 +25,7 @@ impl ContextTesting for Contract {
     }
 
     fn get_gas() -> u64 {
-        gas()
+        context_gas()
     }
 
     fn get_global_gas() -> u64 {


### PR DESCRIPTION
Removed `gas` function in favor of `context_gas`.

Resolves #2464 