### PR TITLE
Add types for the traversal stages so we can store `TypeEngine` and `TokenMap`

### DIFF
--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -167,7 +167,8 @@ impl Session {
                 // Next, create runnables and populate our token_map with typed ast nodes.
                 self.create_runnables(typed_program);
                 self.parse_ast_to_typed_tokens(typed_program, |an, tm| {
-                    traverse::typed_tree::traverse_node(type_engine, an, tm)
+                    let typed_tree = traverse::typed_tree::TypedTree::new(type_engine, tm);
+                    typed_tree.traverse_node(an)
                 });
 
                 self.save_parse_program(parse_program.to_owned().clone());

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -297,7 +297,7 @@ impl Session {
             .iter()
             .flat_map(|(_, submodule)| &submodule.module.tree.root_nodes);
 
-        root_nodes.chain(sub_nodes).for_each(|node| f(node));
+        root_nodes.chain(sub_nodes).for_each(f);
     }
 
     /// Parse the [ty::TyProgram] AST to populate the [TokenMap] with typed AST nodes.
@@ -309,7 +309,7 @@ impl Session {
             .iter()
             .flat_map(|(_, submodule)| &submodule.module.all_nodes);
 
-        root_nodes.chain(sub_nodes).for_each(|node| f(node));
+        root_nodes.chain(sub_nodes).for_each(f);
     }
 
     /// Get a reference to the [ParseProgram] AST.

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -9,7 +9,7 @@ use crate::{
         token_map::TokenMap,
     },
     error::{DocumentError, LanguageServerError},
-    traverse::{self, parsed_tree::ParsedTree, typed_tree::TypedTree},
+    traverse::{dependency::Dependency, parsed_tree::ParsedTree, typed_tree::TypedTree},
 };
 use dashmap::DashMap;
 use forc_pkg::{self as pkg};
@@ -160,17 +160,14 @@ impl Session {
             // The final element in the results is the main program.
             if i == results_len - 1 {
                 // First, populate our token_map with un-typed ast nodes.
-                self.parse_ast_to_tokens(parse_program, |an, tm| {
-                    let parsed_tree = ParsedTree::new(type_engine, tm);
-                    parsed_tree.traverse_node(an)
-                });
+                let parsed_tree = ParsedTree::new(type_engine, &self.token_map);
+                self.parse_ast_to_tokens(parse_program, |an| parsed_tree.traverse_node(an));
 
                 // Next, create runnables and populate our token_map with typed ast nodes.
                 self.create_runnables(typed_program);
-                self.parse_ast_to_typed_tokens(typed_program, |an, tm| {
-                    let typed_tree = TypedTree::new(type_engine, tm);
-                    typed_tree.traverse_node(an)
-                });
+
+                let typed_tree = TypedTree::new(type_engine, &self.token_map);
+                self.parse_ast_to_typed_tokens(typed_program, |an| typed_tree.traverse_node(an));
 
                 self.save_parse_program(parse_program.to_owned().clone());
                 self.save_typed_program(typed_program.to_owned().clone());
@@ -179,15 +176,14 @@ impl Session {
                     capabilities::diagnostic::get_diagnostics(&ast_res.warnings, &ast_res.errors);
             } else {
                 // Collect tokens from dependencies and the standard library prelude.
-                self.parse_ast_to_tokens(
-                    parse_program,
-                    traverse::dependency::collect_parsed_declaration,
-                );
+                let dependency = Dependency::new(&self.token_map);
+                self.parse_ast_to_tokens(parse_program, |an| {
+                    dependency.collect_parsed_declaration(an)
+                });
 
-                self.parse_ast_to_typed_tokens(
-                    typed_program,
-                    traverse::dependency::collect_typed_declaration,
-                );
+                self.parse_ast_to_typed_tokens(typed_program, |an| {
+                    dependency.collect_typed_declaration(an)
+                });
             }
         }
         Ok(diagnostics)
@@ -293,7 +289,7 @@ impl Session {
     }
 
     /// Parse the [ParseProgram] AST to populate the [TokenMap] with parsed AST nodes.
-    fn parse_ast_to_tokens(&self, parse_program: &ParseProgram, f: impl Fn(&AstNode, &TokenMap)) {
+    fn parse_ast_to_tokens(&self, parse_program: &ParseProgram, f: impl Fn(&AstNode)) {
         let root_nodes = parse_program.root.tree.root_nodes.iter();
         let sub_nodes = parse_program
             .root
@@ -301,17 +297,11 @@ impl Session {
             .iter()
             .flat_map(|(_, submodule)| &submodule.module.tree.root_nodes);
 
-        root_nodes
-            .chain(sub_nodes)
-            .for_each(|node| f(node, &self.token_map));
+        root_nodes.chain(sub_nodes).for_each(|node| f(node));
     }
 
     /// Parse the [ty::TyProgram] AST to populate the [TokenMap] with typed AST nodes.
-    fn parse_ast_to_typed_tokens(
-        &self,
-        typed_program: &ty::TyProgram,
-        f: impl Fn(&ty::TyAstNode, &TokenMap),
-    ) {
+    fn parse_ast_to_typed_tokens(&self, typed_program: &ty::TyProgram, f: impl Fn(&ty::TyAstNode)) {
         let root_nodes = typed_program.root.all_nodes.iter();
         let sub_nodes = typed_program
             .root
@@ -319,9 +309,7 @@ impl Session {
             .iter()
             .flat_map(|(_, submodule)| &submodule.module.all_nodes);
 
-        root_nodes
-            .chain(sub_nodes)
-            .for_each(|node| f(node, &self.token_map));
+        root_nodes.chain(sub_nodes).for_each(|node| f(node));
     }
 
     /// Get a reference to the [ParseProgram] AST.

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -9,7 +9,7 @@ use crate::{
         token_map::TokenMap,
     },
     error::{DocumentError, LanguageServerError},
-    traverse,
+    traverse::{self, parsed_tree::ParsedTree, typed_tree::TypedTree},
 };
 use dashmap::DashMap;
 use forc_pkg::{self as pkg};
@@ -161,13 +161,14 @@ impl Session {
             if i == results_len - 1 {
                 // First, populate our token_map with un-typed ast nodes.
                 self.parse_ast_to_tokens(parse_program, |an, tm| {
-                    traverse::parsed_tree::traverse_node(type_engine, an, tm)
+                    let parsed_tree = ParsedTree::new(type_engine, tm);
+                    parsed_tree.traverse_node(an)
                 });
 
                 // Next, create runnables and populate our token_map with typed ast nodes.
                 self.create_runnables(typed_program);
                 self.parse_ast_to_typed_tokens(typed_program, |an, tm| {
-                    let typed_tree = traverse::typed_tree::TypedTree::new(type_engine, tm);
+                    let typed_tree = TypedTree::new(type_engine, tm);
                     typed_tree.traverse_node(an)
                 });
 

--- a/sway-lsp/src/traverse/dependency.rs
+++ b/sway-lsp/src/traverse/dependency.rs
@@ -11,57 +11,67 @@ use sway_core::{
 };
 use sway_types::Spanned;
 
-/// Insert Declaration tokens into the TokenMap.
-pub fn collect_parsed_declaration(node: &AstNode, tokens: &TokenMap) {
-    if let AstNodeContent::Declaration(declaration) = &node.content {
-        let parsed_token = AstToken::Declaration(declaration.clone());
-
-        let (ident, symbol_kind) = match declaration {
-            Declaration::VariableDeclaration(variable) => {
-                (variable.name.clone(), SymbolKind::Variable)
-            }
-            Declaration::StructDeclaration(decl) => (decl.name.clone(), SymbolKind::Struct),
-            Declaration::TraitDeclaration(decl) => (decl.name.clone(), SymbolKind::Trait),
-            Declaration::FunctionDeclaration(decl) => (decl.name.clone(), SymbolKind::Function),
-            Declaration::ConstantDeclaration(decl) => (decl.name.clone(), SymbolKind::Const),
-            Declaration::EnumDeclaration(decl) => (decl.name.clone(), SymbolKind::Enum),
-            _ => return,
-        };
-
-        let key = token::to_ident_key(&ident);
-        let token = Token::from_parsed(parsed_token, symbol_kind);
-        tokens.insert(key, token);
-    }
+pub struct Dependency<'a> {
+    tokens: &'a TokenMap,
 }
 
-/// Insert TypedDeclaration tokens into the TokenMap.
-pub fn collect_typed_declaration(node: &ty::TyAstNode, tokens: &TokenMap) {
-    if let ty::TyAstNodeContent::Declaration(declaration) = &node.content {
-        let typed_token = TypedAstToken::TypedDeclaration(declaration.clone());
+impl<'a> Dependency<'a> {
+    pub fn new(tokens: &'a TokenMap) -> Self {
+        Self { tokens }
+    }
 
-        if let Ok(ident) = match declaration {
-            ty::TyDeclaration::VariableDeclaration(variable) => Ok(variable.name.clone()),
-            ty::TyDeclaration::StructDeclaration(decl_id) => {
-                de::de_get_struct(decl_id.clone(), &declaration.span()).map(|decl| decl.name)
-            }
-            ty::TyDeclaration::TraitDeclaration(decl_id) => {
-                de::de_get_trait(decl_id.clone(), &declaration.span()).map(|decl| decl.name)
-            }
-            ty::TyDeclaration::FunctionDeclaration(decl_id) => {
-                de::de_get_function(decl_id.clone(), &declaration.span()).map(|decl| decl.name)
-            }
-            ty::TyDeclaration::ConstantDeclaration(decl_id) => {
-                de::de_get_constant(decl_id.clone(), &declaration.span()).map(|decl| decl.name)
-            }
-            ty::TyDeclaration::EnumDeclaration(decl_id) => {
-                de::de_get_enum(decl_id.clone(), &declaration.span()).map(|decl| decl.name)
-            }
-            _ => return,
-        } {
-            let ident = token::to_ident_key(&ident);
-            if let Some(mut token) = tokens.get_mut(&ident) {
-                token.typed = Some(typed_token);
-                token.type_def = Some(TypeDefinition::Ident(ident.0));
+    /// Insert Declaration tokens into the TokenMap.
+    pub fn collect_parsed_declaration(&self, node: &AstNode) {
+        if let AstNodeContent::Declaration(declaration) = &node.content {
+            let parsed_token = AstToken::Declaration(declaration.clone());
+
+            let (ident, symbol_kind) = match declaration {
+                Declaration::VariableDeclaration(variable) => {
+                    (variable.name.clone(), SymbolKind::Variable)
+                }
+                Declaration::StructDeclaration(decl) => (decl.name.clone(), SymbolKind::Struct),
+                Declaration::TraitDeclaration(decl) => (decl.name.clone(), SymbolKind::Trait),
+                Declaration::FunctionDeclaration(decl) => (decl.name.clone(), SymbolKind::Function),
+                Declaration::ConstantDeclaration(decl) => (decl.name.clone(), SymbolKind::Const),
+                Declaration::EnumDeclaration(decl) => (decl.name.clone(), SymbolKind::Enum),
+                _ => return,
+            };
+
+            let key = token::to_ident_key(&ident);
+            let token = Token::from_parsed(parsed_token, symbol_kind);
+            self.tokens.insert(key, token);
+        }
+    }
+
+    /// Insert TypedDeclaration tokens into the TokenMap.
+    pub fn collect_typed_declaration(&self, node: &ty::TyAstNode) {
+        if let ty::TyAstNodeContent::Declaration(declaration) = &node.content {
+            let typed_token = TypedAstToken::TypedDeclaration(declaration.clone());
+
+            if let Ok(ident) = match declaration {
+                ty::TyDeclaration::VariableDeclaration(variable) => Ok(variable.name.clone()),
+                ty::TyDeclaration::StructDeclaration(decl_id) => {
+                    de::de_get_struct(decl_id.clone(), &declaration.span()).map(|decl| decl.name)
+                }
+                ty::TyDeclaration::TraitDeclaration(decl_id) => {
+                    de::de_get_trait(decl_id.clone(), &declaration.span()).map(|decl| decl.name)
+                }
+                ty::TyDeclaration::FunctionDeclaration(decl_id) => {
+                    de::de_get_function(decl_id.clone(), &declaration.span()).map(|decl| decl.name)
+                }
+                ty::TyDeclaration::ConstantDeclaration(decl_id) => {
+                    de::de_get_constant(decl_id.clone(), &declaration.span()).map(|decl| decl.name)
+                }
+                ty::TyDeclaration::EnumDeclaration(decl_id) => {
+                    de::de_get_enum(decl_id.clone(), &declaration.span()).map(|decl| decl.name)
+                }
+                _ => return,
+            } {
+                let ident = token::to_ident_key(&ident);
+                if let Some(mut token) = self.tokens.get_mut(&ident) {
+                    token.typed = Some(typed_token);
+                    token.type_def = Some(TypeDefinition::Ident(ident.0));
+                }
             }
         }
     }

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -27,328 +27,581 @@ use sway_core::{
 use sway_types::constants::{DESTRUCTURE_PREFIX, MATCH_RETURN_VAR_NAME_PREFIX, TUPLE_NAME_PREFIX};
 use sway_types::{Ident, Span, Spanned};
 
-pub fn traverse_node(type_engine: &TypeEngine, node: &AstNode, tokens: &TokenMap) {
-    match &node.content {
-        AstNodeContent::Declaration(declaration) => {
-            handle_declaration(type_engine, declaration, tokens)
-        }
-        AstNodeContent::Expression(expression) => {
-            handle_expression(type_engine, expression, tokens)
-        }
-        AstNodeContent::ImplicitReturnExpression(expression) => {
-            handle_expression(type_engine, expression, tokens)
-        }
-
-        // TODO
-        // handle other content types
-        _ => {}
-    };
+pub struct ParsedTree<'a> {
+    type_engine: &'a TypeEngine,
+    tokens: &'a TokenMap,
 }
 
-fn handle_function_declation(
-    type_engine: &TypeEngine,
-    func: &FunctionDeclaration,
-    tokens: &TokenMap,
-) {
-    let token = Token::from_parsed(
-        AstToken::FunctionDeclaration(func.clone()),
-        SymbolKind::Function,
-    );
-    tokens.insert(to_ident_key(&func.name), token.clone());
-    for node in &func.body.contents {
-        traverse_node(type_engine, node, tokens);
-    }
-
-    for parameter in &func.parameters {
-        collect_function_parameter(type_engine, parameter, tokens);
-    }
-
-    for type_param in &func.type_parameters {
-        collect_type_parameter(
-            type_param,
+impl<'a> ParsedTree<'a> {
+    pub fn new(type_engine: &'a TypeEngine, tokens: &'a TokenMap) -> Self {
+        Self {
+            type_engine,
             tokens,
+        }
+    }
+
+    pub fn traverse_node(&self, node: &AstNode) {
+        match &node.content {
+            AstNodeContent::Declaration(declaration) => self.handle_declaration(declaration),
+            AstNodeContent::Expression(expression)
+            | AstNodeContent::ImplicitReturnExpression(expression) => {
+                self.handle_expression(expression)
+            }
+            // TODO
+            // handle other content types
+            _ => {}
+        };
+    }
+
+    fn handle_function_declation(&self, func: &FunctionDeclaration) {
+        let token = Token::from_parsed(
             AstToken::FunctionDeclaration(func.clone()),
+            SymbolKind::Function,
+        );
+        self.tokens.insert(to_ident_key(&func.name), token.clone());
+        for node in &func.body.contents {
+            self.traverse_node(node);
+        }
+
+        for parameter in &func.parameters {
+            self.collect_function_parameter(parameter);
+        }
+
+        for type_param in &func.type_parameters {
+            self.collect_type_parameter(type_param, AstToken::FunctionDeclaration(func.clone()));
+        }
+
+        self.collect_type_info_token(
+            &token,
+            &func.return_type,
+            Some(func.return_type_span.clone()),
+            None,
         );
     }
 
-    collect_type_info_token(
-        type_engine,
-        tokens,
-        &token,
-        &func.return_type,
-        Some(func.return_type_span.clone()),
-        None,
-    );
-}
+    fn handle_declaration(&self, declaration: &Declaration) {
+        match declaration {
+            Declaration::VariableDeclaration(variable) => {
+                // Don't collect tokens if the ident's name contains __tuple_ || __match_return_var_name_
+                // The individual elements are handled in the subsequent VariableDeclaration's
+                if !variable.name.as_str().contains(TUPLE_NAME_PREFIX)
+                    && !variable
+                        .name
+                        .as_str()
+                        .contains(MATCH_RETURN_VAR_NAME_PREFIX)
+                {
+                    let symbol_kind = if variable.name.as_str().contains(DESTRUCTURE_PREFIX) {
+                        SymbolKind::Struct
+                    } else {
+                        SymbolKind::Variable
+                    };
 
-fn handle_declaration(type_engine: &TypeEngine, declaration: &Declaration, tokens: &TokenMap) {
-    match declaration {
-        Declaration::VariableDeclaration(variable) => {
-            // Don't collect tokens if the ident's name contains __tuple_ || __match_return_var_name_
-            // The individual elements are handled in the subsequent VariableDeclaration's
-            if !variable.name.as_str().contains(TUPLE_NAME_PREFIX)
-                && !variable
-                    .name
-                    .as_str()
-                    .contains(MATCH_RETURN_VAR_NAME_PREFIX)
-            {
-                let symbol_kind = if variable.name.as_str().contains(DESTRUCTURE_PREFIX) {
-                    SymbolKind::Struct
-                } else {
-                    SymbolKind::Variable
-                };
+                    let token =
+                        Token::from_parsed(AstToken::Declaration(declaration.clone()), symbol_kind);
+                    // We want to use the span from variable.name to construct a
+                    // new Ident as the name_override_opt can be set to one of the
+                    // const prefixes and not the actual token name.
+                    self.tokens.insert(
+                        to_ident_key(&Ident::new(variable.name.span())),
+                        token.clone(),
+                    );
 
-                let token =
-                    Token::from_parsed(AstToken::Declaration(declaration.clone()), symbol_kind);
-                // We want to use the span from variable.name to construct a
-                // new Ident as the name_override_opt can be set to one of the
-                // const prefixes and not the actual token name.
-                tokens.insert(
-                    to_ident_key(&Ident::new(variable.name.span())),
-                    token.clone(),
+                    if let Some(type_ascription_span) = &variable.type_ascription_span {
+                        self.collect_type_info_token(
+                            &token,
+                            &variable.type_ascription,
+                            Some(type_ascription_span.clone()),
+                            None,
+                        );
+                    }
+                }
+                self.handle_expression(&variable.body);
+            }
+            Declaration::FunctionDeclaration(func) => {
+                self.handle_function_declation(func);
+            }
+            Declaration::TraitDeclaration(trait_decl) => {
+                self.tokens.insert(
+                    to_ident_key(&trait_decl.name),
+                    Token::from_parsed(
+                        AstToken::Declaration(declaration.clone()),
+                        SymbolKind::Trait,
+                    ),
                 );
 
-                if let Some(type_ascription_span) = &variable.type_ascription_span {
-                    collect_type_info_token(
-                        type_engine,
-                        tokens,
+                for trait_fn in &trait_decl.interface_surface {
+                    self.collect_trait_fn(trait_fn);
+                }
+
+                for func_dec in &trait_decl.methods {
+                    self.handle_function_declation(func_dec);
+                }
+            }
+            Declaration::StructDeclaration(struct_dec) => {
+                self.tokens.insert(
+                    to_ident_key(&struct_dec.name),
+                    Token::from_parsed(
+                        AstToken::Declaration(declaration.clone()),
+                        SymbolKind::Struct,
+                    ),
+                );
+                for field in &struct_dec.fields {
+                    let token =
+                        Token::from_parsed(AstToken::StructField(field.clone()), SymbolKind::Field);
+                    self.tokens.insert(to_ident_key(&field.name), token.clone());
+
+                    self.collect_type_info_token(
                         &token,
-                        &variable.type_ascription,
-                        Some(type_ascription_span.clone()),
+                        &field.type_info,
+                        Some(field.type_span.clone()),
                         None,
                     );
                 }
-            }
-            handle_expression(type_engine, &variable.body, tokens);
-        }
-        Declaration::FunctionDeclaration(func) => {
-            handle_function_declation(type_engine, func, tokens);
-        }
-        Declaration::TraitDeclaration(trait_decl) => {
-            tokens.insert(
-                to_ident_key(&trait_decl.name),
-                Token::from_parsed(
-                    AstToken::Declaration(declaration.clone()),
-                    SymbolKind::Trait,
-                ),
-            );
 
-            for trait_fn in &trait_decl.interface_surface {
-                collect_trait_fn(type_engine, trait_fn, tokens);
-            }
-
-            for func_dec in &trait_decl.methods {
-                handle_function_declation(type_engine, func_dec, tokens);
-            }
-        }
-        Declaration::StructDeclaration(struct_dec) => {
-            tokens.insert(
-                to_ident_key(&struct_dec.name),
-                Token::from_parsed(
-                    AstToken::Declaration(declaration.clone()),
-                    SymbolKind::Struct,
-                ),
-            );
-            for field in &struct_dec.fields {
-                let token =
-                    Token::from_parsed(AstToken::StructField(field.clone()), SymbolKind::Field);
-                tokens.insert(to_ident_key(&field.name), token.clone());
-
-                collect_type_info_token(
-                    type_engine,
-                    tokens,
-                    &token,
-                    &field.type_info,
-                    Some(field.type_span.clone()),
-                    None,
-                );
-            }
-
-            for type_param in &struct_dec.type_parameters {
-                collect_type_parameter(
-                    type_param,
-                    tokens,
-                    AstToken::Declaration(declaration.clone()),
-                );
-            }
-        }
-        Declaration::EnumDeclaration(enum_decl) => {
-            tokens.insert(
-                to_ident_key(&enum_decl.name),
-                Token::from_parsed(AstToken::Declaration(declaration.clone()), SymbolKind::Enum),
-            );
-
-            for type_param in &enum_decl.type_parameters {
-                collect_type_parameter(
-                    type_param,
-                    tokens,
-                    AstToken::Declaration(declaration.clone()),
-                );
-            }
-
-            for variant in &enum_decl.variants {
-                let token =
-                    Token::from_parsed(AstToken::EnumVariant(variant.clone()), SymbolKind::Variant);
-                tokens.insert(to_ident_key(&variant.name), token.clone());
-
-                collect_type_info_token(
-                    type_engine,
-                    tokens,
-                    &token,
-                    &variant.type_info,
-                    Some(variant.type_span.clone()),
-                    Some(SymbolKind::Variant),
-                );
-            }
-        }
-        Declaration::ImplTrait(impl_trait) => {
-            for ident in &impl_trait.trait_name.prefixes {
-                tokens.insert(
-                    to_ident_key(ident),
-                    Token::from_parsed(
+                for type_param in &struct_dec.type_parameters {
+                    self.collect_type_parameter(
+                        type_param,
                         AstToken::Declaration(declaration.clone()),
-                        SymbolKind::Module,
-                    ),
-                );
-            }
-
-            tokens.insert(
-                to_ident_key(&impl_trait.trait_name.suffix),
-                Token::from_parsed(
-                    AstToken::Declaration(declaration.clone()),
-                    SymbolKind::Trait,
-                ),
-            );
-
-            let token = Token::from_parsed(
-                AstToken::Declaration(declaration.clone()),
-                type_info_to_symbol_kind(type_engine, &impl_trait.type_implementing_for),
-            );
-
-            collect_type_info_token(
-                type_engine,
-                tokens,
-                &token,
-                &impl_trait.type_implementing_for,
-                Some(impl_trait.type_implementing_for_span.clone()),
-                Some(SymbolKind::Variant),
-            );
-
-            for type_param in &impl_trait.impl_type_parameters {
-                collect_type_parameter(
-                    type_param,
-                    tokens,
-                    AstToken::Declaration(declaration.clone()),
-                );
-            }
-
-            for func_dec in &impl_trait.functions {
-                handle_function_declation(type_engine, func_dec, tokens);
-            }
-        }
-        Declaration::ImplSelf(impl_self) => {
-            if let TypeInfo::Custom {
-                name,
-                type_arguments,
-            } = &impl_self.type_implementing_for
-            {
-                let token = Token::from_parsed(
-                    AstToken::Declaration(declaration.clone()),
-                    SymbolKind::Struct,
-                );
-                tokens.insert(to_ident_key(name), token.clone());
-                if let Some(type_arguments) = type_arguments {
-                    for type_arg in type_arguments {
-                        collect_type_arg(type_engine, type_arg, &token, tokens);
-                    }
+                    );
                 }
             }
-
-            for type_param in &impl_self.impl_type_parameters {
-                collect_type_parameter(
-                    type_param,
-                    tokens,
-                    AstToken::Declaration(declaration.clone()),
+            Declaration::EnumDeclaration(enum_decl) => {
+                self.tokens.insert(
+                    to_ident_key(&enum_decl.name),
+                    Token::from_parsed(
+                        AstToken::Declaration(declaration.clone()),
+                        SymbolKind::Enum,
+                    ),
                 );
-            }
 
-            for func_dec in &impl_self.functions {
-                handle_function_declation(type_engine, func_dec, tokens);
+                for type_param in &enum_decl.type_parameters {
+                    self.collect_type_parameter(
+                        type_param,
+                        AstToken::Declaration(declaration.clone()),
+                    );
+                }
+
+                for variant in &enum_decl.variants {
+                    let token = Token::from_parsed(
+                        AstToken::EnumVariant(variant.clone()),
+                        SymbolKind::Variant,
+                    );
+                    self.tokens
+                        .insert(to_ident_key(&variant.name), token.clone());
+
+                    self.collect_type_info_token(
+                        &token,
+                        &variant.type_info,
+                        Some(variant.type_span.clone()),
+                        Some(SymbolKind::Variant),
+                    );
+                }
             }
-        }
-        Declaration::AbiDeclaration(abi_decl) => {
-            tokens.insert(
-                to_ident_key(&abi_decl.name),
-                Token::from_parsed(
+            Declaration::ImplTrait(impl_trait) => {
+                for ident in &impl_trait.trait_name.prefixes {
+                    self.tokens.insert(
+                        to_ident_key(ident),
+                        Token::from_parsed(
+                            AstToken::Declaration(declaration.clone()),
+                            SymbolKind::Module,
+                        ),
+                    );
+                }
+
+                self.tokens.insert(
+                    to_ident_key(&impl_trait.trait_name.suffix),
+                    Token::from_parsed(
+                        AstToken::Declaration(declaration.clone()),
+                        SymbolKind::Trait,
+                    ),
+                );
+
+                let token = Token::from_parsed(
                     AstToken::Declaration(declaration.clone()),
-                    SymbolKind::Trait,
-                ),
-            );
+                    type_info_to_symbol_kind(self.type_engine, &impl_trait.type_implementing_for),
+                );
 
-            for trait_fn in &abi_decl.interface_surface {
-                collect_trait_fn(type_engine, trait_fn, tokens);
-            }
-        }
-        Declaration::ConstantDeclaration(const_decl) => {
-            let token = Token::from_parsed(
-                AstToken::Declaration(declaration.clone()),
-                SymbolKind::Const,
-            );
-            tokens.insert(to_ident_key(&const_decl.name), token.clone());
-
-            collect_type_info_token(
-                type_engine,
-                tokens,
-                &token,
-                &const_decl.type_ascription,
-                const_decl.type_ascription_span.clone(),
-                None,
-            );
-            handle_expression(type_engine, &const_decl.value, tokens);
-        }
-        Declaration::StorageDeclaration(storage_decl) => {
-            for field in &storage_decl.fields {
-                let token =
-                    Token::from_parsed(AstToken::StorageField(field.clone()), SymbolKind::Field);
-                tokens.insert(to_ident_key(&field.name), token.clone());
-
-                collect_type_info_token(
-                    type_engine,
-                    tokens,
+                self.collect_type_info_token(
                     &token,
-                    &field.type_info,
-                    Some(field.type_info_span.clone()),
+                    &impl_trait.type_implementing_for,
+                    Some(impl_trait.type_implementing_for_span.clone()),
+                    Some(SymbolKind::Variant),
+                );
+
+                for type_param in &impl_trait.impl_type_parameters {
+                    self.collect_type_parameter(
+                        type_param,
+                        AstToken::Declaration(declaration.clone()),
+                    );
+                }
+
+                for func_dec in &impl_trait.functions {
+                    self.handle_function_declation(func_dec);
+                }
+            }
+            Declaration::ImplSelf(impl_self) => {
+                if let TypeInfo::Custom {
+                    name,
+                    type_arguments,
+                } = &impl_self.type_implementing_for
+                {
+                    let token = Token::from_parsed(
+                        AstToken::Declaration(declaration.clone()),
+                        SymbolKind::Struct,
+                    );
+                    self.tokens.insert(to_ident_key(name), token.clone());
+                    if let Some(type_arguments) = type_arguments {
+                        for type_arg in type_arguments {
+                            self.collect_type_arg(type_arg, &token);
+                        }
+                    }
+                }
+
+                for type_param in &impl_self.impl_type_parameters {
+                    self.collect_type_parameter(
+                        type_param,
+                        AstToken::Declaration(declaration.clone()),
+                    );
+                }
+
+                for func_dec in &impl_self.functions {
+                    self.handle_function_declation(func_dec);
+                }
+            }
+            Declaration::AbiDeclaration(abi_decl) => {
+                self.tokens.insert(
+                    to_ident_key(&abi_decl.name),
+                    Token::from_parsed(
+                        AstToken::Declaration(declaration.clone()),
+                        SymbolKind::Trait,
+                    ),
+                );
+
+                for trait_fn in &abi_decl.interface_surface {
+                    self.collect_trait_fn(trait_fn);
+                }
+            }
+            Declaration::ConstantDeclaration(const_decl) => {
+                let token = Token::from_parsed(
+                    AstToken::Declaration(declaration.clone()),
+                    SymbolKind::Const,
+                );
+                self.tokens
+                    .insert(to_ident_key(&const_decl.name), token.clone());
+
+                self.collect_type_info_token(
+                    &token,
+                    &const_decl.type_ascription,
+                    const_decl.type_ascription_span.clone(),
                     None,
                 );
-                handle_expression(type_engine, &field.initializer, tokens);
+                self.handle_expression(&const_decl.value);
+            }
+            Declaration::StorageDeclaration(storage_decl) => {
+                for field in &storage_decl.fields {
+                    let token = Token::from_parsed(
+                        AstToken::StorageField(field.clone()),
+                        SymbolKind::Field,
+                    );
+                    self.tokens.insert(to_ident_key(&field.name), token.clone());
+
+                    self.collect_type_info_token(
+                        &token,
+                        &field.type_info,
+                        Some(field.type_info_span.clone()),
+                        None,
+                    );
+                    self.handle_expression(&field.initializer);
+                }
             }
         }
     }
-}
 
-fn handle_expression(type_engine: &TypeEngine, expression: &Expression, tokens: &TokenMap) {
-    let span = &expression.span;
-    match &expression.kind {
-        ExpressionKind::Error(_part_spans) => {
-            // FIXME(Centril): Left for @JoshuaBatty to use.
-        }
-        ExpressionKind::Literal(value) => {
-            let symbol_kind = literal_to_symbol_kind(value);
+    fn handle_expression(&self, expression: &Expression) {
+        let span = &expression.span;
+        match &expression.kind {
+            ExpressionKind::Error(_part_spans) => {
+                // FIXME(Centril): Left for @JoshuaBatty to use.
+            }
+            ExpressionKind::Literal(value) => {
+                let symbol_kind = literal_to_symbol_kind(value);
 
-            tokens.insert(
-                to_ident_key(&Ident::new(span.clone())),
-                Token::from_parsed(AstToken::Expression(expression.clone()), symbol_kind),
-            );
-        }
-        ExpressionKind::FunctionApplication(function_application_expression) => {
-            let FunctionApplicationExpression {
-                call_path_binding,
-                arguments,
-            } = &**function_application_expression;
-            // Don't collect applications of desugared operators due to mismatched ident lengths.
-            if !desugared_op(&call_path_binding.inner.prefixes) {
+                self.tokens.insert(
+                    to_ident_key(&Ident::new(span.clone())),
+                    Token::from_parsed(AstToken::Expression(expression.clone()), symbol_kind),
+                );
+            }
+            ExpressionKind::FunctionApplication(function_application_expression) => {
+                let FunctionApplicationExpression {
+                    call_path_binding,
+                    arguments,
+                } = &**function_application_expression;
+                // Don't collect applications of desugared operators due to mismatched ident lengths.
+                if !desugared_op(&call_path_binding.inner.prefixes) {
+                    for ident in &call_path_binding.inner.prefixes {
+                        self.tokens.insert(
+                            to_ident_key(ident),
+                            Token::from_parsed(
+                                AstToken::Expression(expression.clone()),
+                                SymbolKind::Module,
+                            ),
+                        );
+                    }
+
+                    let token = Token::from_parsed(
+                        AstToken::Expression(expression.clone()),
+                        SymbolKind::Function,
+                    );
+
+                    self.tokens
+                        .insert(to_ident_key(&call_path_binding.inner.suffix), token.clone());
+
+                    for type_arg in &call_path_binding.type_arguments {
+                        self.collect_type_arg(type_arg, &token);
+                    }
+                }
+
+                for exp in arguments {
+                    self.handle_expression(exp);
+                }
+            }
+            ExpressionKind::LazyOperator(LazyOperatorExpression { lhs, rhs, .. }) => {
+                self.handle_expression(lhs);
+                self.handle_expression(rhs);
+            }
+            ExpressionKind::Variable(name) => {
+                if !name.as_str().contains(TUPLE_NAME_PREFIX)
+                    && !name.as_str().contains(MATCH_RETURN_VAR_NAME_PREFIX)
+                {
+                    let symbol_kind = if name.as_str().contains(DESTRUCTURE_PREFIX) {
+                        SymbolKind::Struct
+                    } else {
+                        SymbolKind::Variable
+                    };
+
+                    self.tokens.insert(
+                        to_ident_key(name),
+                        Token::from_parsed(AstToken::Expression(expression.clone()), symbol_kind),
+                    );
+                }
+            }
+            ExpressionKind::Tuple(fields) => {
+                for exp in fields {
+                    self.handle_expression(exp);
+                }
+            }
+            ExpressionKind::TupleIndex(TupleIndexExpression { prefix, .. }) => {
+                self.handle_expression(prefix);
+            }
+            ExpressionKind::Array(contents) => {
+                for exp in contents {
+                    self.handle_expression(exp);
+                }
+            }
+            ExpressionKind::Struct(struct_expression) => {
+                let StructExpression {
+                    call_path_binding,
+                    fields,
+                } = &**struct_expression;
                 for ident in &call_path_binding.inner.prefixes {
-                    tokens.insert(
+                    self.tokens.insert(
+                        to_ident_key(ident),
+                        Token::from_parsed(
+                            AstToken::Expression(expression.clone()),
+                            SymbolKind::Struct,
+                        ),
+                    );
+                }
+
+                let name = &call_path_binding.inner.suffix;
+                let type_arguments = &call_path_binding.type_arguments;
+
+                let token = Token::from_parsed(
+                    AstToken::Expression(expression.clone()),
+                    SymbolKind::Struct,
+                );
+                self.tokens.insert(to_ident_key(name), token.clone());
+                for type_arg in type_arguments {
+                    self.collect_type_arg(type_arg, &token);
+                }
+
+                for field in fields {
+                    self.tokens.insert(
+                        to_ident_key(&field.name),
+                        Token::from_parsed(
+                            AstToken::StructExpressionField(field.clone()),
+                            SymbolKind::Field,
+                        ),
+                    );
+                    self.handle_expression(&field.value);
+                }
+            }
+            ExpressionKind::CodeBlock(contents) => {
+                for node in &contents.contents {
+                    self.traverse_node(node);
+                }
+            }
+            ExpressionKind::If(IfExpression {
+                condition,
+                then,
+                r#else,
+                ..
+            }) => {
+                self.handle_expression(condition);
+                self.handle_expression(then);
+                if let Some(r#else) = r#else {
+                    self.handle_expression(r#else);
+                }
+            }
+            ExpressionKind::Match(MatchExpression {
+                value, branches, ..
+            }) => {
+                self.handle_expression(value);
+                for branch in branches {
+                    self.collect_scrutinee(&branch.scrutinee);
+                    self.handle_expression(&branch.result);
+                }
+            }
+            ExpressionKind::Asm(_) => {
+                //TODO handle asm expressions
+            }
+            ExpressionKind::MethodApplication(method_application_expression) => {
+                let MethodApplicationExpression {
+                    method_name_binding,
+                    arguments,
+                    contract_call_params,
+                } = &**method_application_expression;
+                let prefixes = match &method_name_binding.inner {
+                    MethodName::FromType {
+                        call_path_binding, ..
+                    } => call_path_binding.inner.prefixes.clone(),
+                    MethodName::FromTrait { call_path, .. } => call_path.prefixes.clone(),
+                    _ => vec![],
+                };
+
+                if let MethodName::FromType {
+                    call_path_binding, ..
+                } = &method_name_binding.inner
+                {
+                    let token = Token::from_parsed(
+                        AstToken::Expression(expression.clone()),
+                        SymbolKind::Struct,
+                    );
+                    let (type_info, span) = &call_path_binding.inner.suffix;
+                    self.collect_type_info_token(&token, type_info, Some(span.clone()), None);
+                }
+
+                // Don't collect applications of desugared operators due to mismatched ident lengths.
+                if !desugared_op(&prefixes) {
+                    self.tokens.insert(
+                        to_ident_key(&method_name_binding.inner.easy_name()),
+                        Token::from_parsed(
+                            AstToken::Expression(expression.clone()),
+                            SymbolKind::Struct,
+                        ),
+                    );
+                }
+
+                for exp in arguments {
+                    self.handle_expression(exp);
+                }
+
+                for field in contract_call_params {
+                    self.tokens.insert(
+                        to_ident_key(&field.name),
+                        Token::from_parsed(
+                            AstToken::Expression(field.value.clone()),
+                            SymbolKind::Field,
+                        ),
+                    );
+                    self.handle_expression(&field.value);
+                }
+            }
+            ExpressionKind::Subfield(SubfieldExpression {
+                prefix,
+                field_to_access,
+                ..
+            }) => {
+                self.tokens.insert(
+                    to_ident_key(field_to_access),
+                    Token::from_parsed(AstToken::Expression(expression.clone()), SymbolKind::Field),
+                );
+                self.handle_expression(prefix);
+            }
+            ExpressionKind::AmbiguousPathExpression(path_expr) => {
+                let AmbiguousPathExpression {
+                    call_path_binding,
+                    args,
+                } = &**path_expr;
+
+                for ident in call_path_binding
+                    .inner
+                    .prefixes
+                    .iter()
+                    .chain(iter::once(&call_path_binding.inner.suffix.before.inner))
+                {
+                    self.tokens.insert(
+                        to_ident_key(ident),
+                        Token::from_parsed(
+                            AstToken::Expression(expression.clone()),
+                            SymbolKind::Enum,
+                        ),
+                    );
+                }
+
+                let token = Token::from_parsed(
+                    AstToken::Expression(expression.clone()),
+                    SymbolKind::Variant,
+                );
+
+                self.tokens.insert(
+                    to_ident_key(&call_path_binding.inner.suffix.suffix),
+                    token.clone(),
+                );
+
+                for type_arg in &call_path_binding.type_arguments {
+                    self.collect_type_arg(type_arg, &token);
+                }
+
+                for exp in args {
+                    self.handle_expression(exp);
+                }
+            }
+            ExpressionKind::DelineatedPath(delineated_path_expression) => {
+                let DelineatedPathExpression {
+                    call_path_binding,
+                    args,
+                } = &**delineated_path_expression;
+                for ident in &call_path_binding.inner.prefixes {
+                    self.tokens.insert(
+                        to_ident_key(ident),
+                        Token::from_parsed(
+                            AstToken::Expression(expression.clone()),
+                            SymbolKind::Enum,
+                        ),
+                    );
+                }
+
+                let token = Token::from_parsed(
+                    AstToken::Expression(expression.clone()),
+                    SymbolKind::Variant,
+                );
+
+                self.tokens
+                    .insert(to_ident_key(&call_path_binding.inner.suffix), token.clone());
+
+                for type_arg in &call_path_binding.type_arguments {
+                    self.collect_type_arg(type_arg, &token);
+                }
+
+                for exp in args {
+                    self.handle_expression(exp);
+                }
+            }
+            ExpressionKind::AbiCast(abi_cast_expression) => {
+                let AbiCastExpression { abi_name, address } = &**abi_cast_expression;
+                for ident in &abi_name.prefixes {
+                    self.tokens.insert(
                         to_ident_key(ident),
                         Token::from_parsed(
                             AstToken::Expression(expression.clone()),
@@ -356,326 +609,252 @@ fn handle_expression(type_engine: &TypeEngine, expression: &Expression, tokens: 
                         ),
                     );
                 }
-
-                let token = Token::from_parsed(
-                    AstToken::Expression(expression.clone()),
-                    SymbolKind::Function,
+                self.tokens.insert(
+                    to_ident_key(&abi_name.suffix),
+                    Token::from_parsed(AstToken::Expression(expression.clone()), SymbolKind::Trait),
                 );
-
-                tokens.insert(to_ident_key(&call_path_binding.inner.suffix), token.clone());
-
-                for type_arg in &call_path_binding.type_arguments {
-                    collect_type_arg(type_engine, type_arg, &token, tokens);
+                self.handle_expression(address);
+            }
+            ExpressionKind::ArrayIndex(ArrayIndexExpression { prefix, index, .. }) => {
+                self.handle_expression(prefix);
+                self.handle_expression(index);
+            }
+            ExpressionKind::StorageAccess(StorageAccessExpression { field_names, .. }) => {
+                for field in field_names {
+                    self.tokens.insert(
+                        to_ident_key(field),
+                        Token::from_parsed(
+                            AstToken::Expression(expression.clone()),
+                            SymbolKind::Field,
+                        ),
+                    );
                 }
             }
-
-            for exp in arguments {
-                handle_expression(type_engine, exp, tokens);
-            }
-        }
-        ExpressionKind::LazyOperator(LazyOperatorExpression { lhs, rhs, .. }) => {
-            handle_expression(type_engine, lhs, tokens);
-            handle_expression(type_engine, rhs, tokens);
-        }
-        ExpressionKind::Variable(name) => {
-            if !name.as_str().contains(TUPLE_NAME_PREFIX)
-                && !name.as_str().contains(MATCH_RETURN_VAR_NAME_PREFIX)
-            {
-                let symbol_kind = if name.as_str().contains(DESTRUCTURE_PREFIX) {
-                    SymbolKind::Struct
-                } else {
-                    SymbolKind::Variable
-                };
-
-                tokens.insert(
-                    to_ident_key(name),
-                    Token::from_parsed(AstToken::Expression(expression.clone()), symbol_kind),
-                );
-            }
-        }
-        ExpressionKind::Tuple(fields) => {
-            for exp in fields {
-                handle_expression(type_engine, exp, tokens);
-            }
-        }
-        ExpressionKind::TupleIndex(TupleIndexExpression { prefix, .. }) => {
-            handle_expression(type_engine, prefix, tokens);
-        }
-        ExpressionKind::Array(contents) => {
-            for exp in contents {
-                handle_expression(type_engine, exp, tokens);
-            }
-        }
-        ExpressionKind::Struct(struct_expression) => {
-            let StructExpression {
-                call_path_binding,
-                fields,
-            } = &**struct_expression;
-            for ident in &call_path_binding.inner.prefixes {
-                tokens.insert(
-                    to_ident_key(ident),
-                    Token::from_parsed(
-                        AstToken::Expression(expression.clone()),
-                        SymbolKind::Struct,
-                    ),
-                );
-            }
-
-            let name = &call_path_binding.inner.suffix;
-            let type_arguments = &call_path_binding.type_arguments;
-
-            let token =
-                Token::from_parsed(AstToken::Expression(expression.clone()), SymbolKind::Struct);
-            tokens.insert(to_ident_key(name), token.clone());
-            for type_arg in type_arguments {
-                collect_type_arg(type_engine, type_arg, &token, tokens);
-            }
-
-            for field in fields {
-                tokens.insert(
-                    to_ident_key(&field.name),
-                    Token::from_parsed(
-                        AstToken::StructExpressionField(field.clone()),
-                        SymbolKind::Field,
-                    ),
-                );
-                handle_expression(type_engine, &field.value, tokens);
-            }
-        }
-        ExpressionKind::CodeBlock(contents) => {
-            for node in &contents.contents {
-                traverse_node(type_engine, node, tokens);
-            }
-        }
-        ExpressionKind::If(IfExpression {
-            condition,
-            then,
-            r#else,
-            ..
-        }) => {
-            handle_expression(type_engine, condition, tokens);
-            handle_expression(type_engine, then, tokens);
-            if let Some(r#else) = r#else {
-                handle_expression(type_engine, r#else, tokens);
-            }
-        }
-        ExpressionKind::Match(MatchExpression {
-            value, branches, ..
-        }) => {
-            handle_expression(type_engine, value, tokens);
-            for branch in branches {
-                collect_scrutinee(&branch.scrutinee, tokens);
-                handle_expression(type_engine, &branch.result, tokens);
-            }
-        }
-        ExpressionKind::Asm(_) => {
-            //TODO handle asm expressions
-        }
-        ExpressionKind::MethodApplication(method_application_expression) => {
-            let MethodApplicationExpression {
-                method_name_binding,
-                arguments,
-                contract_call_params,
-            } = &**method_application_expression;
-            let prefixes = match &method_name_binding.inner {
-                MethodName::FromType {
-                    call_path_binding, ..
-                } => call_path_binding.inner.prefixes.clone(),
-                MethodName::FromTrait { call_path, .. } => call_path.prefixes.clone(),
-                _ => vec![],
-            };
-
-            if let MethodName::FromType {
-                call_path_binding, ..
-            } = &method_name_binding.inner
-            {
-                let token = Token::from_parsed(
-                    AstToken::Expression(expression.clone()),
-                    SymbolKind::Struct,
-                );
-                let (type_info, span) = &call_path_binding.inner.suffix;
-                collect_type_info_token(
-                    type_engine,
-                    tokens,
-                    &token,
-                    type_info,
-                    Some(span.clone()),
-                    None,
-                );
-            }
-
-            // Don't collect applications of desugared operators due to mismatched ident lengths.
-            if !desugared_op(&prefixes) {
-                tokens.insert(
-                    to_ident_key(&method_name_binding.inner.easy_name()),
-                    Token::from_parsed(
-                        AstToken::Expression(expression.clone()),
-                        SymbolKind::Struct,
-                    ),
-                );
-            }
-
-            for exp in arguments {
-                handle_expression(type_engine, exp, tokens);
-            }
-
-            for field in contract_call_params {
-                tokens.insert(
-                    to_ident_key(&field.name),
-                    Token::from_parsed(
-                        AstToken::Expression(field.value.clone()),
-                        SymbolKind::Field,
-                    ),
-                );
-                handle_expression(type_engine, &field.value, tokens);
-            }
-        }
-        ExpressionKind::Subfield(SubfieldExpression {
-            prefix,
-            field_to_access,
-            ..
-        }) => {
-            tokens.insert(
-                to_ident_key(field_to_access),
-                Token::from_parsed(AstToken::Expression(expression.clone()), SymbolKind::Field),
-            );
-            handle_expression(type_engine, prefix, tokens);
-        }
-        ExpressionKind::AmbiguousPathExpression(path_expr) => {
-            let AmbiguousPathExpression {
-                call_path_binding,
-                args,
-            } = &**path_expr;
-
-            for ident in call_path_binding
-                .inner
-                .prefixes
-                .iter()
-                .chain(iter::once(&call_path_binding.inner.suffix.before.inner))
-            {
-                tokens.insert(
-                    to_ident_key(ident),
-                    Token::from_parsed(AstToken::Expression(expression.clone()), SymbolKind::Enum),
-                );
-            }
-
-            let token = Token::from_parsed(
-                AstToken::Expression(expression.clone()),
-                SymbolKind::Variant,
-            );
-
-            tokens.insert(
-                to_ident_key(&call_path_binding.inner.suffix.suffix),
-                token.clone(),
-            );
-
-            for type_arg in &call_path_binding.type_arguments {
-                collect_type_arg(type_engine, type_arg, &token, tokens);
-            }
-
-            for exp in args {
-                handle_expression(type_engine, exp, tokens);
-            }
-        }
-        ExpressionKind::DelineatedPath(delineated_path_expression) => {
-            let DelineatedPathExpression {
-                call_path_binding,
-                args,
-            } = &**delineated_path_expression;
-            for ident in &call_path_binding.inner.prefixes {
-                tokens.insert(
-                    to_ident_key(ident),
-                    Token::from_parsed(AstToken::Expression(expression.clone()), SymbolKind::Enum),
-                );
-            }
-
-            let token = Token::from_parsed(
-                AstToken::Expression(expression.clone()),
-                SymbolKind::Variant,
-            );
-
-            tokens.insert(to_ident_key(&call_path_binding.inner.suffix), token.clone());
-
-            for type_arg in &call_path_binding.type_arguments {
-                collect_type_arg(type_engine, type_arg, &token, tokens);
-            }
-
-            for exp in args {
-                handle_expression(type_engine, exp, tokens);
-            }
-        }
-        ExpressionKind::AbiCast(abi_cast_expression) => {
-            let AbiCastExpression { abi_name, address } = &**abi_cast_expression;
-            for ident in &abi_name.prefixes {
-                tokens.insert(
-                    to_ident_key(ident),
-                    Token::from_parsed(
-                        AstToken::Expression(expression.clone()),
-                        SymbolKind::Module,
-                    ),
-                );
-            }
-            tokens.insert(
-                to_ident_key(&abi_name.suffix),
-                Token::from_parsed(AstToken::Expression(expression.clone()), SymbolKind::Trait),
-            );
-            handle_expression(type_engine, address, tokens);
-        }
-        ExpressionKind::ArrayIndex(ArrayIndexExpression { prefix, index, .. }) => {
-            handle_expression(type_engine, prefix, tokens);
-            handle_expression(type_engine, index, tokens);
-        }
-        ExpressionKind::StorageAccess(StorageAccessExpression { field_names, .. }) => {
-            for field in field_names {
-                tokens.insert(
-                    to_ident_key(field),
-                    Token::from_parsed(AstToken::Expression(expression.clone()), SymbolKind::Field),
-                );
-            }
-        }
-        ExpressionKind::IntrinsicFunction(IntrinsicFunctionExpression { arguments, .. }) => {
-            for argument in arguments {
-                handle_expression(type_engine, argument, tokens);
-            }
-        }
-        ExpressionKind::WhileLoop(WhileLoopExpression {
-            body, condition, ..
-        }) => handle_while_loop(type_engine, body, condition, tokens),
-        // TODO: collect these tokens as keywords once the compiler returns the span
-        ExpressionKind::Break | ExpressionKind::Continue => {}
-        ExpressionKind::Reassignment(reassignment) => {
-            handle_expression(type_engine, &reassignment.rhs, tokens);
-
-            match &reassignment.lhs {
-                ReassignmentTarget::VariableExpression(exp) => {
-                    handle_expression(type_engine, exp, tokens);
+            ExpressionKind::IntrinsicFunction(IntrinsicFunctionExpression {
+                arguments, ..
+            }) => {
+                for argument in arguments {
+                    self.handle_expression(argument);
                 }
-                ReassignmentTarget::StorageField(idents) => {
-                    for ident in idents {
-                        tokens.insert(
-                            to_ident_key(ident),
-                            Token::from_parsed(
-                                AstToken::Reassignment(reassignment.clone()),
-                                SymbolKind::Field,
-                            ),
-                        );
+            }
+            ExpressionKind::WhileLoop(WhileLoopExpression {
+                body, condition, ..
+            }) => self.handle_while_loop(body, condition),
+            // TODO: collect these tokens as keywords once the compiler returns the span
+            ExpressionKind::Break | ExpressionKind::Continue => {}
+            ExpressionKind::Reassignment(reassignment) => {
+                self.handle_expression(&reassignment.rhs);
+
+                match &reassignment.lhs {
+                    ReassignmentTarget::VariableExpression(exp) => {
+                        self.handle_expression(exp);
+                    }
+                    ReassignmentTarget::StorageField(idents) => {
+                        for ident in idents {
+                            self.tokens.insert(
+                                to_ident_key(ident),
+                                Token::from_parsed(
+                                    AstToken::Reassignment(reassignment.clone()),
+                                    SymbolKind::Field,
+                                ),
+                            );
+                        }
                     }
                 }
             }
+            ExpressionKind::Return(expr) => self.handle_expression(expr),
         }
-        ExpressionKind::Return(expr) => handle_expression(type_engine, expr, tokens),
     }
-}
 
-fn handle_while_loop(
-    type_engine: &TypeEngine,
-    body: &CodeBlock,
-    condition: &Expression,
-    tokens: &TokenMap,
-) {
-    handle_expression(type_engine, condition, tokens);
-    for node in &body.contents {
-        traverse_node(type_engine, node, tokens);
+    fn handle_while_loop(&self, body: &CodeBlock, condition: &Expression) {
+        self.handle_expression(condition);
+        for node in &body.contents {
+            self.traverse_node(node);
+        }
+    }
+
+    fn collect_type_arg(&self, type_argument: &TypeArgument, token: &Token) {
+        let mut token = token.clone();
+        let type_info = self.type_engine.look_up_type_id(type_argument.type_id);
+        match &type_info {
+            TypeInfo::Array(type_arg, length) => {
+                token.kind = SymbolKind::NumericLiteral;
+                self.tokens
+                    .insert(to_ident_key(&Ident::new(length.span())), token.clone());
+                self.collect_type_arg(type_arg, &token);
+            }
+            TypeInfo::Tuple(type_arguments) => {
+                for type_arg in type_arguments {
+                    self.collect_type_arg(type_arg, &token);
+                }
+            }
+            _ => {
+                let symbol_kind = type_info_to_symbol_kind(self.type_engine, &type_info);
+                token.kind = symbol_kind;
+                token.type_def = Some(TypeDefinition::TypeId(type_argument.type_id));
+                self.tokens
+                    .insert(to_ident_key(&Ident::new(type_argument.span.clone())), token);
+            }
+        }
+    }
+
+    fn collect_scrutinee(&self, scrutinee: &Scrutinee) {
+        match scrutinee {
+            Scrutinee::CatchAll { .. } => (),
+            Scrutinee::Literal { ref value, span } => {
+                let token = Token::from_parsed(
+                    AstToken::Scrutinee(scrutinee.clone()),
+                    literal_to_symbol_kind(value),
+                );
+                self.tokens
+                    .insert(to_ident_key(&Ident::new(span.clone())), token);
+            }
+            Scrutinee::Variable { name, .. } => {
+                let token = Token::from_parsed(
+                    AstToken::Scrutinee(scrutinee.clone()),
+                    SymbolKind::Variable,
+                );
+                self.tokens.insert(to_ident_key(name), token);
+            }
+            Scrutinee::StructScrutinee {
+                struct_name,
+                fields,
+                ..
+            } => {
+                let token =
+                    Token::from_parsed(AstToken::Scrutinee(scrutinee.clone()), SymbolKind::Struct);
+                self.tokens.insert(to_ident_key(struct_name), token);
+
+                for field in fields {
+                    let token = Token::from_parsed(
+                        AstToken::Scrutinee(scrutinee.clone()),
+                        SymbolKind::Field,
+                    );
+                    if let StructScrutineeField::Field {
+                        field, scrutinee, ..
+                    } = field
+                    {
+                        self.tokens.insert(to_ident_key(field), token);
+
+                        if let Some(scrutinee) = scrutinee {
+                            self.collect_scrutinee(scrutinee);
+                        }
+                    }
+                }
+            }
+            Scrutinee::EnumScrutinee {
+                call_path, value, ..
+            } => {
+                for ident in &call_path.prefixes {
+                    let token = Token::from_parsed(
+                        AstToken::Scrutinee(scrutinee.clone()),
+                        SymbolKind::Enum,
+                    );
+                    self.tokens.insert(to_ident_key(ident), token);
+                }
+
+                let token =
+                    Token::from_parsed(AstToken::Scrutinee(scrutinee.clone()), SymbolKind::Variant);
+                self.tokens.insert(to_ident_key(&call_path.suffix), token);
+
+                self.collect_scrutinee(value);
+            }
+            Scrutinee::Tuple { elems, .. } => {
+                for elem in elems {
+                    self.collect_scrutinee(elem);
+                }
+            }
+        }
+    }
+
+    fn collect_type_info_token(
+        &self,
+        token: &Token,
+        type_info: &TypeInfo,
+        type_span: Option<Span>,
+        symbol_kind: Option<SymbolKind>,
+    ) {
+        let mut token = token.clone();
+        match symbol_kind {
+            Some(kind) => token.kind = kind,
+            None => token.kind = type_info_to_symbol_kind(self.type_engine, type_info),
+        }
+
+        match type_info {
+            TypeInfo::Str(length) => {
+                self.tokens
+                    .insert(to_ident_key(&Ident::new(length.span())), token);
+            }
+            TypeInfo::Array(type_arg, length) => {
+                token.kind = SymbolKind::NumericLiteral;
+                self.tokens
+                    .insert(to_ident_key(&Ident::new(length.span())), token.clone());
+                self.collect_type_arg(type_arg, &token);
+            }
+            TypeInfo::Tuple(type_arguments) => {
+                for type_arg in type_arguments {
+                    self.collect_type_arg(type_arg, &token);
+                }
+            }
+            TypeInfo::Custom {
+                name,
+                type_arguments,
+            } => {
+                token.type_def = Some(TypeDefinition::Ident(name.clone()));
+                self.tokens.insert(to_ident_key(name), token.clone());
+                if let Some(type_arguments) = type_arguments {
+                    for type_arg in type_arguments {
+                        self.collect_type_arg(type_arg, &token);
+                    }
+                }
+            }
+            _ => {
+                if let Some(type_span) = type_span {
+                    self.tokens
+                        .insert(to_ident_key(&Ident::new(type_span)), token);
+                }
+            }
+        }
+    }
+
+    fn collect_function_parameter(&self, parameter: &FunctionParameter) {
+        let token = Token::from_parsed(
+            AstToken::FunctionParameter(parameter.clone()),
+            SymbolKind::ValueParam,
+        );
+        self.tokens
+            .insert(to_ident_key(&parameter.name), token.clone());
+
+        self.collect_type_info_token(
+            &token,
+            &parameter.type_info,
+            Some(parameter.type_span.clone()),
+            None,
+        );
+    }
+
+    fn collect_trait_fn(&self, trait_fn: &TraitFn) {
+        let token = Token::from_parsed(AstToken::TraitFn(trait_fn.clone()), SymbolKind::Function);
+        self.tokens
+            .insert(to_ident_key(&trait_fn.name), token.clone());
+
+        for parameter in &trait_fn.parameters {
+            self.collect_function_parameter(parameter);
+        }
+
+        self.collect_type_info_token(
+            &token,
+            &trait_fn.return_type,
+            Some(trait_fn.return_type_span.clone()),
+            None,
+        );
+    }
+
+    fn collect_type_parameter(&self, type_param: &TypeParameter, token: AstToken) {
+        self.tokens.insert(
+            to_ident_key(&type_param.name_ident),
+            Token::from_parsed(token, SymbolKind::TypeParameter),
+        );
     }
 }
 
@@ -690,188 +869,4 @@ fn literal_to_symbol_kind(value: &Literal) -> SymbolKind {
         Literal::B256(..) => SymbolKind::ByteLiteral,
         Literal::Boolean(..) => SymbolKind::BoolLiteral,
     }
-}
-
-fn collect_type_arg(
-    type_engine: &TypeEngine,
-    type_argument: &TypeArgument,
-    token: &Token,
-    tokens: &TokenMap,
-) {
-    let mut token = token.clone();
-    let type_info = type_engine.look_up_type_id(type_argument.type_id);
-    match &type_info {
-        TypeInfo::Array(type_arg, length) => {
-            token.kind = SymbolKind::NumericLiteral;
-            tokens.insert(to_ident_key(&Ident::new(length.span())), token.clone());
-            collect_type_arg(type_engine, type_arg, &token, tokens);
-        }
-        TypeInfo::Tuple(type_arguments) => {
-            for type_arg in type_arguments {
-                collect_type_arg(type_engine, type_arg, &token, tokens);
-            }
-        }
-        _ => {
-            let symbol_kind = type_info_to_symbol_kind(type_engine, &type_info);
-            token.kind = symbol_kind;
-            token.type_def = Some(TypeDefinition::TypeId(type_argument.type_id));
-            tokens.insert(to_ident_key(&Ident::new(type_argument.span.clone())), token);
-        }
-    }
-}
-
-fn collect_scrutinee(scrutinee: &Scrutinee, tokens: &TokenMap) {
-    match scrutinee {
-        Scrutinee::CatchAll { .. } => (),
-        Scrutinee::Literal { ref value, span } => {
-            let token = Token::from_parsed(
-                AstToken::Scrutinee(scrutinee.clone()),
-                literal_to_symbol_kind(value),
-            );
-            tokens.insert(to_ident_key(&Ident::new(span.clone())), token);
-        }
-        Scrutinee::Variable { name, .. } => {
-            let token =
-                Token::from_parsed(AstToken::Scrutinee(scrutinee.clone()), SymbolKind::Variable);
-            tokens.insert(to_ident_key(name), token);
-        }
-        Scrutinee::StructScrutinee {
-            struct_name,
-            fields,
-            ..
-        } => {
-            let token =
-                Token::from_parsed(AstToken::Scrutinee(scrutinee.clone()), SymbolKind::Struct);
-            tokens.insert(to_ident_key(struct_name), token);
-
-            for field in fields {
-                let token =
-                    Token::from_parsed(AstToken::Scrutinee(scrutinee.clone()), SymbolKind::Field);
-                if let StructScrutineeField::Field {
-                    field, scrutinee, ..
-                } = field
-                {
-                    tokens.insert(to_ident_key(field), token);
-
-                    if let Some(scrutinee) = scrutinee {
-                        collect_scrutinee(scrutinee, tokens);
-                    }
-                }
-            }
-        }
-        Scrutinee::EnumScrutinee {
-            call_path, value, ..
-        } => {
-            for ident in &call_path.prefixes {
-                let token =
-                    Token::from_parsed(AstToken::Scrutinee(scrutinee.clone()), SymbolKind::Enum);
-                tokens.insert(to_ident_key(ident), token);
-            }
-
-            let token =
-                Token::from_parsed(AstToken::Scrutinee(scrutinee.clone()), SymbolKind::Variant);
-            tokens.insert(to_ident_key(&call_path.suffix), token);
-
-            collect_scrutinee(value, tokens);
-        }
-        Scrutinee::Tuple { elems, .. } => {
-            for elem in elems {
-                collect_scrutinee(elem, tokens);
-            }
-        }
-    }
-}
-
-fn collect_type_info_token(
-    type_engine: &TypeEngine,
-    tokens: &TokenMap,
-    token: &Token,
-    type_info: &TypeInfo,
-    type_span: Option<Span>,
-    symbol_kind: Option<SymbolKind>,
-) {
-    let mut token = token.clone();
-    match symbol_kind {
-        Some(kind) => token.kind = kind,
-        None => token.kind = type_info_to_symbol_kind(type_engine, type_info),
-    }
-
-    match type_info {
-        TypeInfo::Str(length) => {
-            tokens.insert(to_ident_key(&Ident::new(length.span())), token);
-        }
-        TypeInfo::Array(type_arg, length) => {
-            token.kind = SymbolKind::NumericLiteral;
-            tokens.insert(to_ident_key(&Ident::new(length.span())), token.clone());
-            collect_type_arg(type_engine, type_arg, &token, tokens);
-        }
-        TypeInfo::Tuple(type_arguments) => {
-            for type_arg in type_arguments {
-                collect_type_arg(type_engine, type_arg, &token, tokens);
-            }
-        }
-        TypeInfo::Custom {
-            name,
-            type_arguments,
-        } => {
-            token.type_def = Some(TypeDefinition::Ident(name.clone()));
-            tokens.insert(to_ident_key(name), token.clone());
-            if let Some(type_arguments) = type_arguments {
-                for type_arg in type_arguments {
-                    collect_type_arg(type_engine, type_arg, &token, tokens);
-                }
-            }
-        }
-        _ => {
-            if let Some(type_span) = type_span {
-                tokens.insert(to_ident_key(&Ident::new(type_span)), token);
-            }
-        }
-    }
-}
-
-fn collect_function_parameter(
-    type_engine: &TypeEngine,
-    parameter: &FunctionParameter,
-    tokens: &TokenMap,
-) {
-    let token = Token::from_parsed(
-        AstToken::FunctionParameter(parameter.clone()),
-        SymbolKind::ValueParam,
-    );
-    tokens.insert(to_ident_key(&parameter.name), token.clone());
-
-    collect_type_info_token(
-        type_engine,
-        tokens,
-        &token,
-        &parameter.type_info,
-        Some(parameter.type_span.clone()),
-        None,
-    );
-}
-
-fn collect_trait_fn(type_engine: &TypeEngine, trait_fn: &TraitFn, tokens: &TokenMap) {
-    let token = Token::from_parsed(AstToken::TraitFn(trait_fn.clone()), SymbolKind::Function);
-    tokens.insert(to_ident_key(&trait_fn.name), token.clone());
-
-    for parameter in &trait_fn.parameters {
-        collect_function_parameter(type_engine, parameter, tokens);
-    }
-
-    collect_type_info_token(
-        type_engine,
-        tokens,
-        &token,
-        &trait_fn.return_type,
-        Some(trait_fn.return_type_span.clone()),
-        None,
-    );
-}
-
-fn collect_type_parameter(type_param: &TypeParameter, tokens: &TokenMap, token: AstToken) {
-    tokens.insert(
-        to_ident_key(&type_param.name_ident),
-        Token::from_parsed(token, SymbolKind::TypeParameter),
-    );
 }

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -14,711 +14,680 @@ use sway_core::{
 };
 use sway_types::{Ident, Span, Spanned};
 
-pub fn traverse_node(type_engine: &TypeEngine, node: &ty::TyAstNode, tokens: &TokenMap) {
-    match &node.content {
-        ty::TyAstNodeContent::Declaration(declaration) => {
-            handle_declaration(type_engine, declaration, tokens)
-        }
-        ty::TyAstNodeContent::Expression(expression) => {
-            handle_expression(type_engine, expression, tokens)
-        }
-        ty::TyAstNodeContent::ImplicitReturnExpression(expression) => {
-            handle_expression(type_engine, expression, tokens)
-        }
-        ty::TyAstNodeContent::SideEffect => (),
-    };
+pub struct TypedTree<'a> {
+    type_engine: &'a TypeEngine,
+    tokens: &'a TokenMap,
 }
 
-fn handle_declaration(
-    type_engine: &TypeEngine,
-    declaration: &ty::TyDeclaration,
-    tokens: &TokenMap,
-) {
-    match declaration {
-        ty::TyDeclaration::VariableDeclaration(variable) => {
-            let typed_token = TypedAstToken::TypedDeclaration(declaration.clone());
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&variable.name)) {
-                token.typed = Some(typed_token.clone());
-                token.type_def = Some(TypeDefinition::Ident(variable.name.clone()));
-            }
-            if let Some(type_ascription_span) = &variable.type_ascription_span {
-                collect_type_id(
-                    type_engine,
-                    variable.type_ascription,
-                    &typed_token,
-                    tokens,
-                    type_ascription_span.clone(),
-                );
-            }
-
-            handle_expression(type_engine, &variable.body, tokens);
+impl<'a> TypedTree<'a> {
+    pub fn new(type_engine: &'a TypeEngine, tokens: &'a TokenMap) -> Self {
+        Self {
+            type_engine,
+            tokens,
         }
-        ty::TyDeclaration::ConstantDeclaration(decl_id) => {
-            if let Ok(const_decl) =
-                declaration_engine::de_get_constant(decl_id.clone(), &decl_id.span())
-            {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&const_decl.name)) {
-                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-                    token.type_def = Some(TypeDefinition::Ident(const_decl.name.clone()));
-                }
-                handle_expression(type_engine, &const_decl.value, tokens);
-            }
-        }
-        ty::TyDeclaration::FunctionDeclaration(decl_id) => {
-            if let Ok(func_decl) =
-                declaration_engine::de_get_function(decl_id.clone(), &decl_id.span())
-            {
-                collect_typed_fn_decl(type_engine, &func_decl, tokens);
-            }
-        }
-        ty::TyDeclaration::TraitDeclaration(decl_id) => {
-            if let Ok(trait_decl) =
-                declaration_engine::de_get_trait(decl_id.clone(), &decl_id.span())
-            {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&trait_decl.name)) {
-                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-                    token.type_def = Some(TypeDefinition::Ident(trait_decl.name.clone()));
-                }
+    }
 
-                for trait_fn_decl_id in &trait_decl.interface_surface {
-                    if let Ok(trait_fn) = declaration_engine::de_get_trait_fn(
-                        trait_fn_decl_id.clone(),
-                        &trait_fn_decl_id.span(),
-                    ) {
-                        collect_typed_trait_fn_token(type_engine, &trait_fn, tokens);
-                    }
-                }
+    pub fn traverse_node(&self, node: &ty::TyAstNode) {
+        match &node.content {
+            ty::TyAstNodeContent::Declaration(declaration) => self.handle_declaration(declaration),
+            ty::TyAstNodeContent::Expression(expression)
+            | ty::TyAstNodeContent::ImplicitReturnExpression(expression) => {
+                self.handle_expression(expression)
             }
-        }
-        ty::TyDeclaration::StructDeclaration(decl_id) => {
-            if let Ok(struct_decl) =
-                declaration_engine::de_get_struct(decl_id.clone(), &declaration.span())
-            {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&struct_decl.name)) {
-                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-                    token.type_def = Some(TypeDefinition::Ident(struct_decl.name));
-                }
+            ty::TyAstNodeContent::SideEffect => (),
+        };
+    }
 
-                for field in &struct_decl.fields {
-                    collect_ty_struct_field(type_engine, field, tokens);
+    fn handle_declaration(&self, declaration: &ty::TyDeclaration) {
+        match declaration {
+            ty::TyDeclaration::VariableDeclaration(variable) => {
+                let typed_token = TypedAstToken::TypedDeclaration(declaration.clone());
+                if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&variable.name)) {
+                    token.typed = Some(typed_token.clone());
+                    token.type_def = Some(TypeDefinition::Ident(variable.name.clone()));
                 }
-
-                for type_param in &struct_decl.type_parameters {
-                    if let Some(mut token) = tokens.get_mut(&to_ident_key(&type_param.name_ident)) {
-                        token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-                        token.type_def = Some(TypeDefinition::TypeId(type_param.type_id));
-                    }
-                }
-            }
-        }
-        ty::TyDeclaration::EnumDeclaration(decl_id) => {
-            if let Ok(enum_decl) = declaration_engine::de_get_enum(decl_id.clone(), &decl_id.span())
-            {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&enum_decl.name)) {
-                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-                    token.type_def = Some(TypeDefinition::Ident(enum_decl.name.clone()));
-                }
-
-                for type_param in &enum_decl.type_parameters {
-                    if let Some(mut token) = tokens.get_mut(&to_ident_key(&type_param.name_ident)) {
-                        token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-                        token.type_def = Some(TypeDefinition::TypeId(type_param.type_id));
-                    }
-                }
-
-                for variant in &enum_decl.variants {
-                    collect_ty_enum_variant(type_engine, variant, tokens);
-                }
-            }
-        }
-        ty::TyDeclaration::ImplTrait(decl_id) => {
-            if let Ok(ty::TyImplTrait {
-                impl_type_parameters,
-                trait_name,
-                trait_type_arguments,
-                methods,
-                implementing_for_type_id,
-                type_implementing_for_span,
-                ..
-            }) = declaration_engine::de_get_impl_trait(decl_id.clone(), &decl_id.span())
-            {
-                for param in impl_type_parameters {
-                    collect_type_id(
-                        type_engine,
-                        param.type_id,
-                        &TypedAstToken::TypedParameter(param.clone()),
-                        tokens,
-                        param.name_ident.span().clone(),
+                if let Some(type_ascription_span) = &variable.type_ascription_span {
+                    self.collect_type_id(
+                        variable.type_ascription,
+                        &typed_token,
+                        type_ascription_span.clone(),
                     );
                 }
 
-                for ident in &trait_name.prefixes {
-                    if let Some(mut token) = tokens.get_mut(&to_ident_key(ident)) {
+                self.handle_expression(&variable.body);
+            }
+            ty::TyDeclaration::ConstantDeclaration(decl_id) => {
+                if let Ok(const_decl) =
+                    declaration_engine::de_get_constant(decl_id.clone(), &decl_id.span())
+                {
+                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&const_decl.name)) {
                         token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                        token.type_def = Some(TypeDefinition::Ident(const_decl.name.clone()));
+                    }
+                    self.handle_expression(&const_decl.value);
+                }
+            }
+            ty::TyDeclaration::FunctionDeclaration(decl_id) => {
+                if let Ok(func_decl) =
+                    declaration_engine::de_get_function(decl_id.clone(), &decl_id.span())
+                {
+                    self.collect_typed_fn_decl(&func_decl);
+                }
+            }
+            ty::TyDeclaration::TraitDeclaration(decl_id) => {
+                if let Ok(trait_decl) =
+                    declaration_engine::de_get_trait(decl_id.clone(), &decl_id.span())
+                {
+                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&trait_decl.name)) {
+                        token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                        token.type_def = Some(TypeDefinition::Ident(trait_decl.name.clone()));
+                    }
+
+                    for trait_fn_decl_id in &trait_decl.interface_surface {
+                        if let Ok(trait_fn) = declaration_engine::de_get_trait_fn(
+                            trait_fn_decl_id.clone(),
+                            &trait_fn_decl_id.span(),
+                        ) {
+                            self.collect_typed_trait_fn_token(&trait_fn);
+                        }
                     }
                 }
+            }
+            ty::TyDeclaration::StructDeclaration(decl_id) => {
+                if let Ok(struct_decl) =
+                    declaration_engine::de_get_struct(decl_id.clone(), &declaration.span())
+                {
+                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&struct_decl.name)) {
+                        token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                        token.type_def = Some(TypeDefinition::Ident(struct_decl.name));
+                    }
 
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&trait_name.suffix)) {
-                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-                    token.type_def = Some(TypeDefinition::TypeId(implementing_for_type_id));
-                }
+                    for field in &struct_decl.fields {
+                        self.collect_ty_struct_field(field);
+                    }
 
-                for type_arg in trait_type_arguments {
-                    collect_type_id(
-                        type_engine,
-                        type_arg.type_id,
-                        &TypedAstToken::TypedArgument(type_arg.clone()),
-                        tokens,
-                        type_arg.span().clone(),
-                    );
-                }
-
-                for method_id in methods {
-                    if let Ok(method) =
-                        declaration_engine::de_get_function(method_id.clone(), &decl_id.span())
-                    {
-                        collect_typed_fn_decl(type_engine, &method, tokens);
+                    for type_param in &struct_decl.type_parameters {
+                        if let Some(mut token) =
+                            self.tokens.get_mut(&to_ident_key(&type_param.name_ident))
+                        {
+                            token.typed =
+                                Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                            token.type_def = Some(TypeDefinition::TypeId(type_param.type_id));
+                        }
                     }
                 }
+            }
+            ty::TyDeclaration::EnumDeclaration(decl_id) => {
+                if let Ok(enum_decl) =
+                    declaration_engine::de_get_enum(decl_id.clone(), &decl_id.span())
+                {
+                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&enum_decl.name)) {
+                        token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                        token.type_def = Some(TypeDefinition::Ident(enum_decl.name.clone()));
+                    }
 
-                collect_type_id(
-                    type_engine,
+                    for type_param in &enum_decl.type_parameters {
+                        if let Some(mut token) =
+                            self.tokens.get_mut(&to_ident_key(&type_param.name_ident))
+                        {
+                            token.typed =
+                                Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                            token.type_def = Some(TypeDefinition::TypeId(type_param.type_id));
+                        }
+                    }
+
+                    for variant in &enum_decl.variants {
+                        self.collect_ty_enum_variant(variant);
+                    }
+                }
+            }
+            ty::TyDeclaration::ImplTrait(decl_id) => {
+                if let Ok(ty::TyImplTrait {
+                    impl_type_parameters,
+                    trait_name,
+                    trait_type_arguments,
+                    methods,
                     implementing_for_type_id,
-                    &TypedAstToken::TypedDeclaration(declaration.clone()),
-                    tokens,
                     type_implementing_for_span,
-                );
-            }
-        }
-        ty::TyDeclaration::AbiDeclaration(decl_id) => {
-            if let Ok(abi_decl) = declaration_engine::de_get_abi(decl_id.clone(), &decl_id.span()) {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&abi_decl.name)) {
-                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-                    token.type_def = Some(TypeDefinition::Ident(abi_decl.name.clone()));
-                }
-
-                for trait_fn_decl_id in &abi_decl.interface_surface {
-                    if let Ok(trait_fn) = declaration_engine::de_get_trait_fn(
-                        trait_fn_decl_id.clone(),
-                        &trait_fn_decl_id.span(),
-                    ) {
-                        collect_typed_trait_fn_token(type_engine, &trait_fn, tokens);
-                    }
-                }
-            }
-        }
-        ty::TyDeclaration::GenericTypeForFunctionScope { name, .. } => {
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(name)) {
-                token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
-            }
-        }
-        ty::TyDeclaration::ErrorRecovery(_) => {}
-        ty::TyDeclaration::StorageDeclaration(decl_id) => {
-            if let Ok(storage_decl) =
-                declaration_engine::de_get_storage(decl_id.clone(), &decl_id.span())
-            {
-                for field in &storage_decl.fields {
-                    if let Some(mut token) = tokens.get_mut(&to_ident_key(&field.name)) {
-                        token.typed = Some(TypedAstToken::TypedStorageField(field.clone()));
-                        token.type_def = Some(TypeDefinition::TypeId(field.type_id));
+                    ..
+                }) = declaration_engine::de_get_impl_trait(decl_id.clone(), &decl_id.span())
+                {
+                    for param in impl_type_parameters {
+                        self.collect_type_id(
+                            param.type_id,
+                            &TypedAstToken::TypedParameter(param.clone()),
+                            param.name_ident.span().clone(),
+                        );
                     }
 
-                    if let Some(mut token) =
-                        tokens.get_mut(&to_ident_key(&Ident::new(field.type_span.clone())))
+                    for ident in &trait_name.prefixes {
+                        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(ident)) {
+                            token.typed =
+                                Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                        }
+                    }
+
+                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&trait_name.suffix))
                     {
-                        token.typed = Some(TypedAstToken::TypedStorageField(field.clone()));
-                        token.type_def = Some(TypeDefinition::TypeId(field.type_id));
+                        token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                        token.type_def = Some(TypeDefinition::TypeId(implementing_for_type_id));
                     }
 
-                    handle_expression(type_engine, &field.initializer, tokens);
+                    for type_arg in trait_type_arguments {
+                        self.collect_type_id(
+                            type_arg.type_id,
+                            &TypedAstToken::TypedArgument(type_arg.clone()),
+                            type_arg.span().clone(),
+                        );
+                    }
+
+                    for method_id in methods {
+                        if let Ok(method) =
+                            declaration_engine::de_get_function(method_id.clone(), &decl_id.span())
+                        {
+                            self.collect_typed_fn_decl(&method);
+                        }
+                    }
+
+                    self.collect_type_id(
+                        implementing_for_type_id,
+                        &TypedAstToken::TypedDeclaration(declaration.clone()),
+                        type_implementing_for_span,
+                    );
+                }
+            }
+            ty::TyDeclaration::AbiDeclaration(decl_id) => {
+                if let Ok(abi_decl) =
+                    declaration_engine::de_get_abi(decl_id.clone(), &decl_id.span())
+                {
+                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&abi_decl.name)) {
+                        token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                        token.type_def = Some(TypeDefinition::Ident(abi_decl.name.clone()));
+                    }
+
+                    for trait_fn_decl_id in &abi_decl.interface_surface {
+                        if let Ok(trait_fn) = declaration_engine::de_get_trait_fn(
+                            trait_fn_decl_id.clone(),
+                            &trait_fn_decl_id.span(),
+                        ) {
+                            self.collect_typed_trait_fn_token(&trait_fn);
+                        }
+                    }
+                }
+            }
+            ty::TyDeclaration::GenericTypeForFunctionScope { name, .. } => {
+                if let Some(mut token) = self.tokens.get_mut(&to_ident_key(name)) {
+                    token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                }
+            }
+            ty::TyDeclaration::ErrorRecovery(_) => {}
+            ty::TyDeclaration::StorageDeclaration(decl_id) => {
+                if let Ok(storage_decl) =
+                    declaration_engine::de_get_storage(decl_id.clone(), &decl_id.span())
+                {
+                    for field in &storage_decl.fields {
+                        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&field.name)) {
+                            token.typed = Some(TypedAstToken::TypedStorageField(field.clone()));
+                            token.type_def = Some(TypeDefinition::TypeId(field.type_id));
+                        }
+
+                        if let Some(mut token) = self
+                            .tokens
+                            .get_mut(&to_ident_key(&Ident::new(field.type_span.clone())))
+                        {
+                            token.typed = Some(TypedAstToken::TypedStorageField(field.clone()));
+                            token.type_def = Some(TypeDefinition::TypeId(field.type_id));
+                        }
+
+                        self.handle_expression(&field.initializer);
+                    }
                 }
             }
         }
     }
-}
 
-fn handle_expression(type_engine: &TypeEngine, expression: &ty::TyExpression, tokens: &TokenMap) {
-    match &expression.expression {
-        ty::TyExpressionVariant::Literal { .. } => {
-            if let Some(mut token) =
-                tokens.get_mut(&to_ident_key(&Ident::new(expression.span.clone())))
-            {
-                token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
-            }
-        }
-        ty::TyExpressionVariant::FunctionApplication {
-            call_path,
-            contract_call_params,
-            arguments,
-            function_decl_id,
-            ..
-        } => {
-            for ident in &call_path.prefixes {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(ident)) {
+    fn handle_expression(&self, expression: &ty::TyExpression) {
+        match &expression.expression {
+            ty::TyExpressionVariant::Literal { .. } => {
+                if let Some(mut token) = self
+                    .tokens
+                    .get_mut(&to_ident_key(&Ident::new(expression.span.clone())))
+                {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
-                    token.type_def = Some(TypeDefinition::TypeId(expression.return_type));
                 }
             }
+            ty::TyExpressionVariant::FunctionApplication {
+                call_path,
+                contract_call_params,
+                arguments,
+                function_decl_id,
+                ..
+            } => {
+                for ident in &call_path.prefixes {
+                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(ident)) {
+                        token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                        token.type_def = Some(TypeDefinition::TypeId(expression.return_type));
+                    }
+                }
 
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&call_path.suffix)) {
-                token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&call_path.suffix)) {
+                    token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                    if let Ok(function_decl) =
+                        de_get_function(function_decl_id.clone(), &call_path.span())
+                    {
+                        token.type_def = Some(TypeDefinition::Ident(function_decl.name));
+                    }
+                }
+
+                for exp in contract_call_params.values() {
+                    self.handle_expression(exp);
+                }
+
+                for (ident, exp) in arguments {
+                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(ident)) {
+                        token.typed = Some(TypedAstToken::TypedExpression(exp.clone()));
+                    }
+                    self.handle_expression(exp);
+                }
+
                 if let Ok(function_decl) =
                     de_get_function(function_decl_id.clone(), &call_path.span())
                 {
-                    token.type_def = Some(TypeDefinition::Ident(function_decl.name));
-                }
-            }
-
-            for exp in contract_call_params.values() {
-                handle_expression(type_engine, exp, tokens);
-            }
-
-            for (ident, exp) in arguments {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(ident)) {
-                    token.typed = Some(TypedAstToken::TypedExpression(exp.clone()));
-                }
-                handle_expression(type_engine, exp, tokens);
-            }
-
-            if let Ok(function_decl) = de_get_function(function_decl_id.clone(), &call_path.span())
-            {
-                for node in &function_decl.body.contents {
-                    traverse_node(type_engine, node, tokens);
-                }
-            }
-        }
-        ty::TyExpressionVariant::LazyOperator { lhs, rhs, .. } => {
-            handle_expression(type_engine, lhs, tokens);
-            handle_expression(type_engine, rhs, tokens);
-        }
-        ty::TyExpressionVariant::VariableExpression {
-            ref name, ref span, ..
-        } => {
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&Ident::new(span.clone()))) {
-                token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
-                token.type_def = Some(TypeDefinition::Ident(name.clone()));
-            }
-        }
-        ty::TyExpressionVariant::Tuple { fields } => {
-            for exp in fields {
-                handle_expression(type_engine, exp, tokens);
-            }
-        }
-        ty::TyExpressionVariant::Array { contents } => {
-            for exp in contents {
-                handle_expression(type_engine, exp, tokens);
-            }
-        }
-        ty::TyExpressionVariant::ArrayIndex { prefix, index } => {
-            handle_expression(type_engine, prefix, tokens);
-            handle_expression(type_engine, index, tokens);
-        }
-        ty::TyExpressionVariant::StructExpression { fields, span, .. } => {
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&Ident::new(span.clone()))) {
-                token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
-                token.type_def = Some(TypeDefinition::TypeId(expression.return_type));
-            }
-
-            for field in fields {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&field.name)) {
-                    token.typed = Some(TypedAstToken::TypedExpression(field.value.clone()));
-
-                    if let Some(struct_decl) =
-                        &tokens.struct_declaration_of_type_id(type_engine, &expression.return_type)
-                    {
-                        for decl_field in &struct_decl.fields {
-                            if decl_field.name == field.name {
-                                token.type_def =
-                                    Some(TypeDefinition::Ident(decl_field.name.clone()));
-                            }
-                        }
+                    for node in &function_decl.body.contents {
+                        self.traverse_node(node);
                     }
                 }
-                handle_expression(type_engine, &field.value, tokens);
             }
-        }
-        ty::TyExpressionVariant::CodeBlock(code_block) => {
-            for node in &code_block.contents {
-                traverse_node(type_engine, node, tokens);
+            ty::TyExpressionVariant::LazyOperator { lhs, rhs, .. } => {
+                self.handle_expression(lhs);
+                self.handle_expression(rhs);
             }
-        }
-        ty::TyExpressionVariant::FunctionParameter { .. } => {}
-        ty::TyExpressionVariant::IfExp {
-            condition,
-            then,
-            r#else,
-        } => {
-            handle_expression(type_engine, condition, tokens);
-            handle_expression(type_engine, then, tokens);
-            if let Some(r#else) = r#else {
-                handle_expression(type_engine, r#else, tokens);
-            }
-        }
-        ty::TyExpressionVariant::AsmExpression { .. } => {}
-        ty::TyExpressionVariant::StructFieldAccess {
-            prefix,
-            field_to_access,
-            field_instantiation_span,
-            ..
-        } => {
-            handle_expression(type_engine, prefix, tokens);
-
-            if let Some(mut token) =
-                tokens.get_mut(&to_ident_key(&Ident::new(field_instantiation_span.clone())))
-            {
-                token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
-                token.type_def = Some(TypeDefinition::Ident(field_to_access.name.clone()));
-            }
-        }
-        ty::TyExpressionVariant::TupleElemAccess { prefix, .. } => {
-            handle_expression(type_engine, prefix, tokens);
-        }
-        ty::TyExpressionVariant::EnumInstantiation {
-            variant_name,
-            variant_instantiation_span,
-            enum_decl,
-            enum_instantiation_span,
-            contents,
-            ..
-        } => {
-            if let Some(mut token) =
-                tokens.get_mut(&to_ident_key(&Ident::new(enum_instantiation_span.clone())))
-            {
-                token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
-                token.type_def = Some(TypeDefinition::Ident(enum_decl.name.clone()));
-            }
-
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&Ident::new(
-                variant_instantiation_span.clone(),
-            ))) {
-                token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
-                token.type_def = Some(TypeDefinition::Ident(variant_name.clone()));
-            }
-
-            if let Some(contents) = contents.as_deref() {
-                handle_expression(type_engine, contents, tokens);
-            }
-        }
-        ty::TyExpressionVariant::AbiCast {
-            abi_name, address, ..
-        } => {
-            for ident in &abi_name.prefixes {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(ident)) {
+            ty::TyExpressionVariant::VariableExpression {
+                ref name, ref span, ..
+            } => {
+                if let Some(mut token) = self
+                    .tokens
+                    .get_mut(&to_ident_key(&Ident::new(span.clone())))
+                {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                    token.type_def = Some(TypeDefinition::Ident(name.clone()));
                 }
             }
-
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&abi_name.suffix)) {
-                token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
-            }
-
-            handle_expression(type_engine, address, tokens);
-        }
-        ty::TyExpressionVariant::StorageAccess(storage_access) => {
-            for field in &storage_access.fields {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&field.name)) {
-                    token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+            ty::TyExpressionVariant::Tuple { fields } => {
+                for exp in fields {
+                    self.handle_expression(exp);
                 }
             }
-        }
-        ty::TyExpressionVariant::IntrinsicFunction(kind) => {
-            handle_intrinsic_function(type_engine, kind, tokens);
-        }
-        ty::TyExpressionVariant::AbiName { .. } => {}
-        ty::TyExpressionVariant::EnumTag { exp } => {
-            handle_expression(type_engine, exp, tokens);
-        }
-        ty::TyExpressionVariant::UnsafeDowncast { exp, variant } => {
-            handle_expression(type_engine, exp, tokens);
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&variant.name)) {
-                token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+            ty::TyExpressionVariant::Array { contents } => {
+                for exp in contents {
+                    self.handle_expression(exp);
+                }
             }
-        }
-        ty::TyExpressionVariant::WhileLoop {
-            body, condition, ..
-        } => handle_while_loop(type_engine, body, condition, tokens),
-        ty::TyExpressionVariant::Break => (),
-        ty::TyExpressionVariant::Continue => (),
-        ty::TyExpressionVariant::Reassignment(reassignment) => {
-            handle_expression(type_engine, &reassignment.rhs, tokens);
-
-            if let Some(mut token) = tokens.get_mut(&to_ident_key(&reassignment.lhs_base_name)) {
-                token.typed = Some(TypedAstToken::TypedReassignment((**reassignment).clone()));
+            ty::TyExpressionVariant::ArrayIndex { prefix, index } => {
+                self.handle_expression(prefix);
+                self.handle_expression(index);
             }
+            ty::TyExpressionVariant::StructExpression { fields, span, .. } => {
+                if let Some(mut token) = self
+                    .tokens
+                    .get_mut(&to_ident_key(&Ident::new(span.clone())))
+                {
+                    token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                    token.type_def = Some(TypeDefinition::TypeId(expression.return_type));
+                }
 
-            for proj_kind in &reassignment.lhs_indices {
-                if let ty::ProjectionKind::StructField { name } = proj_kind {
-                    if let Some(mut token) = tokens.get_mut(&to_ident_key(name)) {
-                        token.typed =
-                            Some(TypedAstToken::TypedReassignment((**reassignment).clone()));
-                        if let Some(struct_decl) = &tokens
-                            .struct_declaration_of_type_id(type_engine, &reassignment.lhs_type)
-                        {
+                for field in fields {
+                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&field.name)) {
+                        token.typed = Some(TypedAstToken::TypedExpression(field.value.clone()));
+
+                        if let Some(struct_decl) = &self.tokens.struct_declaration_of_type_id(
+                            self.type_engine,
+                            &expression.return_type,
+                        ) {
                             for decl_field in &struct_decl.fields {
-                                if &decl_field.name == name {
+                                if decl_field.name == field.name {
                                     token.type_def =
                                         Some(TypeDefinition::Ident(decl_field.name.clone()));
                                 }
                             }
                         }
                     }
+                    self.handle_expression(&field.value);
                 }
             }
-        }
-        ty::TyExpressionVariant::StorageReassignment(storage_reassignment) => {
-            for field in &storage_reassignment.fields {
-                if let Some(mut token) = tokens.get_mut(&to_ident_key(&field.name)) {
-                    token.typed = Some(TypedAstToken::TypeCheckedStorageReassignDescriptor(
-                        field.clone(),
-                    ));
+            ty::TyExpressionVariant::CodeBlock(code_block) => {
+                for node in &code_block.contents {
+                    self.traverse_node(node);
                 }
             }
-            handle_expression(type_engine, &storage_reassignment.rhs, tokens);
+            ty::TyExpressionVariant::FunctionParameter { .. } => {}
+            ty::TyExpressionVariant::IfExp {
+                condition,
+                then,
+                r#else,
+            } => {
+                self.handle_expression(condition);
+                self.handle_expression(then);
+                if let Some(r#else) = r#else {
+                    self.handle_expression(r#else);
+                }
+            }
+            ty::TyExpressionVariant::AsmExpression { .. } => {}
+            ty::TyExpressionVariant::StructFieldAccess {
+                prefix,
+                field_to_access,
+                field_instantiation_span,
+                ..
+            } => {
+                self.handle_expression(prefix);
+
+                if let Some(mut token) = self
+                    .tokens
+                    .get_mut(&to_ident_key(&Ident::new(field_instantiation_span.clone())))
+                {
+                    token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                    token.type_def = Some(TypeDefinition::Ident(field_to_access.name.clone()));
+                }
+            }
+            ty::TyExpressionVariant::TupleElemAccess { prefix, .. } => {
+                self.handle_expression(prefix);
+            }
+            ty::TyExpressionVariant::EnumInstantiation {
+                variant_name,
+                variant_instantiation_span,
+                enum_decl,
+                enum_instantiation_span,
+                contents,
+                ..
+            } => {
+                if let Some(mut token) = self
+                    .tokens
+                    .get_mut(&to_ident_key(&Ident::new(enum_instantiation_span.clone())))
+                {
+                    token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                    token.type_def = Some(TypeDefinition::Ident(enum_decl.name.clone()));
+                }
+
+                if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&Ident::new(
+                    variant_instantiation_span.clone(),
+                ))) {
+                    token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                    token.type_def = Some(TypeDefinition::Ident(variant_name.clone()));
+                }
+
+                if let Some(contents) = contents.as_deref() {
+                    self.handle_expression(contents);
+                }
+            }
+            ty::TyExpressionVariant::AbiCast {
+                abi_name, address, ..
+            } => {
+                for ident in &abi_name.prefixes {
+                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(ident)) {
+                        token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                    }
+                }
+
+                if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&abi_name.suffix)) {
+                    token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                }
+
+                self.handle_expression(address);
+            }
+            ty::TyExpressionVariant::StorageAccess(storage_access) => {
+                for field in &storage_access.fields {
+                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&field.name)) {
+                        token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                    }
+                }
+            }
+            ty::TyExpressionVariant::IntrinsicFunction(kind) => {
+                self.handle_intrinsic_function(kind);
+            }
+            ty::TyExpressionVariant::AbiName { .. } => {}
+            ty::TyExpressionVariant::EnumTag { exp } => {
+                self.handle_expression(exp);
+            }
+            ty::TyExpressionVariant::UnsafeDowncast { exp, variant } => {
+                self.handle_expression(exp);
+                if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&variant.name)) {
+                    token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                }
+            }
+            ty::TyExpressionVariant::WhileLoop {
+                body, condition, ..
+            } => self.handle_while_loop(body, condition),
+            ty::TyExpressionVariant::Break => (),
+            ty::TyExpressionVariant::Continue => (),
+            ty::TyExpressionVariant::Reassignment(reassignment) => {
+                self.handle_expression(&reassignment.rhs);
+
+                if let Some(mut token) = self
+                    .tokens
+                    .get_mut(&to_ident_key(&reassignment.lhs_base_name))
+                {
+                    token.typed = Some(TypedAstToken::TypedReassignment((**reassignment).clone()));
+                }
+
+                for proj_kind in &reassignment.lhs_indices {
+                    if let ty::ProjectionKind::StructField { name } = proj_kind {
+                        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(name)) {
+                            token.typed =
+                                Some(TypedAstToken::TypedReassignment((**reassignment).clone()));
+                            if let Some(struct_decl) = &self.tokens.struct_declaration_of_type_id(
+                                self.type_engine,
+                                &reassignment.lhs_type,
+                            ) {
+                                for decl_field in &struct_decl.fields {
+                                    if &decl_field.name == name {
+                                        token.type_def =
+                                            Some(TypeDefinition::Ident(decl_field.name.clone()));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            ty::TyExpressionVariant::StorageReassignment(storage_reassignment) => {
+                for field in &storage_reassignment.fields {
+                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&field.name)) {
+                        token.typed = Some(TypedAstToken::TypeCheckedStorageReassignDescriptor(
+                            field.clone(),
+                        ));
+                    }
+                }
+                self.handle_expression(&storage_reassignment.rhs);
+            }
+            ty::TyExpressionVariant::Return(exp) => self.handle_expression(exp),
         }
-        ty::TyExpressionVariant::Return(exp) => handle_expression(type_engine, exp, tokens),
-    }
-}
-
-fn handle_intrinsic_function(
-    type_engine: &TypeEngine,
-    ty::TyIntrinsicFunctionKind { arguments, .. }: &ty::TyIntrinsicFunctionKind,
-    tokens: &TokenMap,
-) {
-    for arg in arguments {
-        handle_expression(type_engine, arg, tokens);
-    }
-}
-
-fn handle_while_loop(
-    type_engine: &TypeEngine,
-    body: &ty::TyCodeBlock,
-    condition: &ty::TyExpression,
-    tokens: &TokenMap,
-) {
-    handle_expression(type_engine, condition, tokens);
-    for node in &body.contents {
-        traverse_node(type_engine, node, tokens);
-    }
-}
-
-fn collect_typed_trait_fn_token(
-    type_engine: &TypeEngine,
-    trait_fn: &ty::TyTraitFn,
-    tokens: &TokenMap,
-) {
-    if let Some(mut token) = tokens.get_mut(&to_ident_key(&trait_fn.name)) {
-        token.typed = Some(TypedAstToken::TypedTraitFn(trait_fn.clone()));
-        token.type_def = Some(TypeDefinition::Ident(trait_fn.name.clone()));
     }
 
-    for parameter in &trait_fn.parameters {
-        collect_typed_fn_param_token(type_engine, parameter, tokens);
-    }
-
-    let return_ident = Ident::new(trait_fn.return_type_span.clone());
-    if let Some(mut token) = tokens.get_mut(&to_ident_key(&return_ident)) {
-        token.typed = Some(TypedAstToken::TypedTraitFn(trait_fn.clone()));
-        token.type_def = Some(TypeDefinition::TypeId(trait_fn.return_type));
-    }
-}
-
-fn collect_typed_fn_param_token(
-    type_engine: &TypeEngine,
-    param: &ty::TyFunctionParameter,
-    tokens: &TokenMap,
-) {
-    let typed_token = TypedAstToken::TypedFunctionParameter(param.clone());
-    if let Some(mut token) = tokens.get_mut(&to_ident_key(&param.name)) {
-        token.typed = Some(typed_token.clone());
-        token.type_def = Some(TypeDefinition::TypeId(param.type_id));
-    }
-
-    collect_type_id(
-        type_engine,
-        param.type_id,
-        &typed_token,
-        tokens,
-        param.type_span.clone(),
-    );
-}
-
-fn collect_type_id(
-    type_engine: &TypeEngine,
-    type_id: TypeId,
-    typed_token: &TypedAstToken,
-    tokens: &TokenMap,
-    type_span: Span,
-) {
-    let type_info = type_engine.look_up_type_id(type_id);
-    let symbol_kind = type_info_to_symbol_kind(type_engine, &type_info);
-    match &type_info {
-        TypeInfo::Array(type_arg, ..) => {
-            collect_type_id(
-                type_engine,
-                type_arg.type_id,
-                &TypedAstToken::TypedArgument(type_arg.clone()),
-                tokens,
-                type_arg.span(),
-            );
+    fn handle_intrinsic_function(
+        &self,
+        ty::TyIntrinsicFunctionKind { arguments, .. }: &ty::TyIntrinsicFunctionKind,
+    ) {
+        for arg in arguments {
+            self.handle_expression(arg);
         }
-        TypeInfo::Tuple(type_arguments) => {
-            for type_arg in type_arguments {
-                collect_type_id(
-                    type_engine,
+    }
+
+    fn handle_while_loop(&self, body: &ty::TyCodeBlock, condition: &ty::TyExpression) {
+        self.handle_expression(condition);
+        for node in &body.contents {
+            self.traverse_node(node);
+        }
+    }
+
+    fn collect_typed_trait_fn_token(&self, trait_fn: &ty::TyTraitFn) {
+        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&trait_fn.name)) {
+            token.typed = Some(TypedAstToken::TypedTraitFn(trait_fn.clone()));
+            token.type_def = Some(TypeDefinition::Ident(trait_fn.name.clone()));
+        }
+
+        for parameter in &trait_fn.parameters {
+            self.collect_typed_fn_param_token(parameter);
+        }
+
+        let return_ident = Ident::new(trait_fn.return_type_span.clone());
+        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&return_ident)) {
+            token.typed = Some(TypedAstToken::TypedTraitFn(trait_fn.clone()));
+            token.type_def = Some(TypeDefinition::TypeId(trait_fn.return_type));
+        }
+    }
+
+    fn collect_typed_fn_param_token(&self, param: &ty::TyFunctionParameter) {
+        let typed_token = TypedAstToken::TypedFunctionParameter(param.clone());
+        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&param.name)) {
+            token.typed = Some(typed_token.clone());
+            token.type_def = Some(TypeDefinition::TypeId(param.type_id));
+        }
+
+        self.collect_type_id(param.type_id, &typed_token, param.type_span.clone());
+    }
+
+    fn collect_type_id(&self, type_id: TypeId, typed_token: &TypedAstToken, type_span: Span) {
+        let type_info = self.type_engine.look_up_type_id(type_id);
+        let symbol_kind = type_info_to_symbol_kind(self.type_engine, &type_info);
+        match &type_info {
+            TypeInfo::Array(type_arg, ..) => {
+                self.collect_type_id(
                     type_arg.type_id,
                     &TypedAstToken::TypedArgument(type_arg.clone()),
-                    tokens,
-                    type_arg.span().clone(),
+                    type_arg.span(),
                 );
             }
-        }
-        TypeInfo::Enum {
-            type_parameters,
-            variant_types,
-            ..
-        } => {
-            if let Some(token) = tokens.get_mut(&to_ident_key(&Ident::new(type_span))) {
-                assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
-            }
-
-            for param in type_parameters {
-                collect_type_id(
-                    type_engine,
-                    param.type_id,
-                    &TypedAstToken::TypedParameter(param.clone()),
-                    tokens,
-                    param.name_ident.span().clone(),
-                );
-            }
-
-            for variant in variant_types {
-                collect_ty_enum_variant(type_engine, variant, tokens);
-            }
-        }
-        TypeInfo::Struct {
-            type_parameters,
-            fields,
-            ..
-        } => {
-            if let Some(token) = tokens.get_mut(&to_ident_key(&Ident::new(type_span))) {
-                assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
-            }
-
-            for param in type_parameters {
-                collect_type_id(
-                    type_engine,
-                    param.type_id,
-                    &TypedAstToken::TypedParameter(param.clone()),
-                    tokens,
-                    param.name_ident.span().clone(),
-                );
-            }
-
-            for field in fields {
-                collect_ty_struct_field(type_engine, field, tokens);
-            }
-        }
-        TypeInfo::Custom { type_arguments, .. } => {
-            if let Some(token) = tokens.get_mut(&to_ident_key(&Ident::new(type_span))) {
-                assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
-            }
-
-            if let Some(type_arguments) = type_arguments {
+            TypeInfo::Tuple(type_arguments) => {
                 for type_arg in type_arguments {
-                    collect_type_id(
-                        type_engine,
+                    self.collect_type_id(
                         type_arg.type_id,
                         &TypedAstToken::TypedArgument(type_arg.clone()),
-                        tokens,
                         type_arg.span().clone(),
                     );
                 }
             }
-        }
-        TypeInfo::Storage { fields } => {
-            for field in fields {
-                collect_ty_struct_field(type_engine, field, tokens);
+            TypeInfo::Enum {
+                type_parameters,
+                variant_types,
+                ..
+            } => {
+                if let Some(token) = self.tokens.get_mut(&to_ident_key(&Ident::new(type_span))) {
+                    assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
+                }
+
+                for param in type_parameters {
+                    self.collect_type_id(
+                        param.type_id,
+                        &TypedAstToken::TypedParameter(param.clone()),
+                        param.name_ident.span().clone(),
+                    );
+                }
+
+                for variant in variant_types {
+                    self.collect_ty_enum_variant(variant);
+                }
+            }
+            TypeInfo::Struct {
+                type_parameters,
+                fields,
+                ..
+            } => {
+                if let Some(token) = self.tokens.get_mut(&to_ident_key(&Ident::new(type_span))) {
+                    assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
+                }
+
+                for param in type_parameters {
+                    self.collect_type_id(
+                        param.type_id,
+                        &TypedAstToken::TypedParameter(param.clone()),
+                        param.name_ident.span().clone(),
+                    );
+                }
+
+                for field in fields {
+                    self.collect_ty_struct_field(field);
+                }
+            }
+            TypeInfo::Custom { type_arguments, .. } => {
+                if let Some(token) = self.tokens.get_mut(&to_ident_key(&Ident::new(type_span))) {
+                    assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
+                }
+
+                if let Some(type_arguments) = type_arguments {
+                    for type_arg in type_arguments {
+                        self.collect_type_id(
+                            type_arg.type_id,
+                            &TypedAstToken::TypedArgument(type_arg.clone()),
+                            type_arg.span().clone(),
+                        );
+                    }
+                }
+            }
+            TypeInfo::Storage { fields } => {
+                for field in fields {
+                    self.collect_ty_struct_field(field);
+                }
+            }
+            _ => {
+                if let Some(token) = self.tokens.get_mut(&to_ident_key(&Ident::new(type_span))) {
+                    assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
+                }
             }
         }
-        _ => {
-            if let Some(token) = tokens.get_mut(&to_ident_key(&Ident::new(type_span))) {
-                assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
-            }
+    }
+
+    fn collect_typed_fn_decl(&self, func_decl: &ty::TyFunctionDeclaration) {
+        let typed_token = TypedAstToken::TypedFunctionDeclaration(func_decl.clone());
+        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&func_decl.name)) {
+            token.typed = Some(typed_token.clone());
+            token.type_def = Some(TypeDefinition::Ident(func_decl.name.clone()));
         }
-    }
-}
 
-fn collect_typed_fn_decl(
-    type_engine: &TypeEngine,
-    func_decl: &ty::TyFunctionDeclaration,
-    tokens: &TokenMap,
-) {
-    let typed_token = TypedAstToken::TypedFunctionDeclaration(func_decl.clone());
-    if let Some(mut token) = tokens.get_mut(&to_ident_key(&func_decl.name)) {
-        token.typed = Some(typed_token.clone());
-        token.type_def = Some(TypeDefinition::Ident(func_decl.name.clone()));
-    }
+        for node in &func_decl.body.contents {
+            self.traverse_node(node);
+        }
+        for parameter in &func_decl.parameters {
+            self.collect_typed_fn_param_token(parameter);
+        }
 
-    for node in &func_decl.body.contents {
-        traverse_node(type_engine, node, tokens);
-    }
-    for parameter in &func_decl.parameters {
-        collect_typed_fn_param_token(type_engine, parameter, tokens);
-    }
+        for type_param in &func_decl.type_parameters {
+            self.collect_type_id(
+                type_param.type_id,
+                &typed_token,
+                type_param.name_ident.span().clone(),
+            );
+        }
 
-    for type_param in &func_decl.type_parameters {
-        collect_type_id(
-            type_engine,
-            type_param.type_id,
+        self.collect_type_id(
+            func_decl.return_type,
             &typed_token,
-            tokens,
-            type_param.name_ident.span().clone(),
+            func_decl.return_type_span.clone(),
         );
     }
 
-    collect_type_id(
-        type_engine,
-        func_decl.return_type,
-        &typed_token,
-        tokens,
-        func_decl.return_type_span.clone(),
-    );
-}
+    fn collect_ty_enum_variant(&self, enum_variant: &TyEnumVariant) {
+        let typed_token = TypedAstToken::TypedEnumVariant(enum_variant.clone());
+        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&enum_variant.name)) {
+            token.typed = Some(typed_token.clone());
+            token.type_def = Some(TypeDefinition::TypeId(enum_variant.type_id));
+        }
 
-fn collect_ty_enum_variant(
-    type_engine: &TypeEngine,
-    enum_variant: &TyEnumVariant,
-    tokens: &TokenMap,
-) {
-    let typed_token = TypedAstToken::TypedEnumVariant(enum_variant.clone());
-    if let Some(mut token) = tokens.get_mut(&to_ident_key(&enum_variant.name)) {
-        token.typed = Some(typed_token.clone());
-        token.type_def = Some(TypeDefinition::TypeId(enum_variant.type_id));
+        self.collect_type_id(
+            enum_variant.type_id,
+            &typed_token,
+            enum_variant.type_span.clone(),
+        );
     }
 
-    collect_type_id(
-        type_engine,
-        enum_variant.type_id,
-        &typed_token,
-        tokens,
-        enum_variant.type_span.clone(),
-    );
-}
+    fn collect_ty_struct_field(&self, field: &ty::TyStructField) {
+        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&field.name)) {
+            token.typed = Some(TypedAstToken::TypedStructField(field.clone()));
+            token.type_def = Some(TypeDefinition::TypeId(field.type_id));
+        }
 
-fn collect_ty_struct_field(type_engine: &TypeEngine, field: &ty::TyStructField, tokens: &TokenMap) {
-    if let Some(mut token) = tokens.get_mut(&to_ident_key(&field.name)) {
-        token.typed = Some(TypedAstToken::TypedStructField(field.clone()));
-        token.type_def = Some(TypeDefinition::TypeId(field.type_id));
+        let typed_token = TypedAstToken::TypedStructField(field.clone());
+        self.collect_type_id(field.type_id, &typed_token, field.type_span.clone());
     }
-
-    let typed_token = TypedAstToken::TypedStructField(field.clone());
-    collect_type_id(
-        type_engine,
-        field.type_id,
-        &typed_token,
-        tokens,
-        field.type_span.clone(),
-    );
 }
 
 fn assign_type_to_token(


### PR DESCRIPTION
This PR simply creates types for the parsed and typed modules. The motivation is to then store a reference to the `TypeEngine` and `TokenMap` types so they don't need to be passed in through the function signature.

Now, instead of calling into the function like so `traverse::typed_tree::traverse_node(type_engine, an, tm)`

We are able to create a new instance of the type and call the traverse_node method.

```rust
let typed_tree = TypedTree::new(type_engine, tm);
typed_tree.traverse_node(an)
```

It looks like a large diff but it's just because all the functions are now enclosed within the new types.

closes #3590