### PR TITLE
Remove a forward slash in `Cargo.toml` for `forc-test`

### DIFF
--- a/forc-test/Cargo.toml
+++ b/forc-test/Cargo.toml
@@ -15,4 +15,4 @@ fuel-tx = { version = "0.23", features = ["builder"] }
 fuel-vm = { version = "0.22", features = ["random"] }
 rand = "0.8"
 sway-core = { version = "0.31.3", path = "../sway-core" }
-sway-types = { version = "0.31.3", path = "../sway-types/" }
+sway-types = { version = "0.31.3", path = "../sway-types" }


### PR DESCRIPTION
This is causing the publishing stage of a release to fail https://github.com/FuelLabs/sway/actions/runs/3699005204/jobs/6266046839