### PR TITLE
Update location of `sway.js` in `forc-doc`

### DIFF
--- a/forc-plugins/forc-doc/src/assets/sway.js
+++ b/forc-plugins/forc-doc/src/assets/sway.js
@@ -1,0 +1,185 @@
+/*
+Language: Sway
+Author: Fuel Labs contact@fuel.sh
+Contributors: Fuel Labs <contact@fuel.sh>,
+Website: https://fuel.sh
+Category: smart contracts, layer 2, blockchain,
+*/
+
+import * as regex from '../lib/regex.js';
+
+/** @type LanguageFn */
+export default function(hljs) {
+  const FUNCTION_INVOKE = {
+    className: "title.function.invoke",
+    relevance: 0,
+    begin: regex.concat(
+      /\b/,
+      /(?!let\b)/,
+      hljs.IDENT_RE,
+      regex.lookahead(/\s*\(/))
+  };
+  const NUMBER_SUFFIX = '([u](8|16|32|64))\?';
+
+  const KEYWORDS = [
+    "abi",
+    "as",
+    "asm",
+    "break",
+    "const",
+    "continue",
+    "contract",
+    "dep",
+    "deref",
+    "else",
+    "enum",
+    "fn",
+    "for",
+    "if",
+    "impl",
+    "let",
+    "library",
+    "match",
+    "mut",
+    "predicate",
+    "pub",
+    "ref",
+    "return",
+    "script",
+    "Self",
+    "self",
+    "storage",
+    "str",
+    "struct",
+    "trait",
+    "use",
+    "where",
+    "while",
+  ];
+  const LITERALS = [
+    "true",
+    "false",
+    "Some",
+    "None",
+    "Ok",
+    "Err",
+  ];
+  const BUILTINS = [
+    
+  ];
+  const TYPES = [
+    "bool", "char", "u8", "u16", "u32", "u64", "b256", "str", "Self"
+  ];
+  return {
+    name: 'Sway',
+    aliases: [ 'sw' ],
+    keywords: {
+      $pattern: hljs.IDENT_RE + '!?',
+      keyword: KEYWORDS,
+      literal: LITERALS,
+      built_in: TYPES
+    },
+    illegal: '</',
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.COMMENT('/\\*', '\\*/', {
+        contains: [ 'self' ]
+      }),
+      hljs.inherit(hljs.QUOTE_STRING_MODE, {
+        begin: /b?"/,
+        illegal: null
+      }),
+      {
+        className: 'string',
+        variants: [
+          {
+            begin: /b?r(#*)"(.|\n)*?"\1(?!#)/
+          },
+          {
+            begin: /b?'\\?(x\w{2}|u\w{4}|U\w{8}|.)'/
+          }
+        ]
+      },
+      {
+        className: 'symbol',
+        begin: /'[a-zA-Z_][a-zA-Z0-9_]*/
+      },
+      {
+        className: 'number',
+        variants: [
+          {
+            begin: '\\b0b([01_]+)' + NUMBER_SUFFIX
+          },
+          {
+            begin: '\\b0o([0-7_]+)' + NUMBER_SUFFIX
+          },
+          {
+            begin: '\\b0x([A-Fa-f0-9_]+)' + NUMBER_SUFFIX
+          },
+          {
+            begin: '\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)' +
+                   NUMBER_SUFFIX
+          }
+        ],
+        relevance: 0
+      },
+      {
+        begin: [
+          /fn/,
+          /\s+/,
+          hljs.UNDERSCORE_IDENT_RE
+        ],
+        className: {
+          1: "keyword",
+          3: "title.function"
+        }
+      },
+      {
+        begin: [
+          /(let|const)/, /\s+/,
+          /(?:mut\s+)?/,
+          hljs.UNDERSCORE_IDENT_RE
+        ],
+        className: {
+          1: "keyword",
+          3: "keyword",
+          4: "variable"
+        }
+      },
+      {
+        begin: [
+          /type/,
+          /\s+/,
+          hljs.UNDERSCORE_IDENT_RE
+        ],
+        className: {
+          1: "keyword",
+          3: "title.class"
+        }
+      },
+      {
+        begin: [
+          /(?:trait|enum|struct|impl|for|library|abi)/,
+          /\s+/,
+          hljs.UNDERSCORE_IDENT_RE
+        ],
+        className: {
+          1: "keyword",
+          3: "title.class"
+        }
+      },
+      {
+        begin: hljs.IDENT_RE + '::',
+        keywords: {
+          keyword: "Self",
+          built_in: BUILTINS
+        }
+      },
+      {
+        className: "punctuation",
+        begin: '->'
+      },
+      FUNCTION_INVOKE
+    ]
+  };
+}

--- a/forc-plugins/forc-doc/src/main.rs
+++ b/forc-plugins/forc-doc/src/main.rs
@@ -89,7 +89,7 @@ pub fn main() -> Result<()> {
     }
     // Sway syntax highlighting file
     const SWAY_HJS_FILENAME: &str = "sway.js";
-    let sway_hjs = std::include_bytes!("../../../scripts/highlightjs/sway.js");
+    let sway_hjs = std::include_bytes!("assets/sway.js");
     fs::write(assets_path.join(SWAY_HJS_FILENAME), sway_hjs)?;
 
     // check if the user wants to open the doc in the browser


### PR DESCRIPTION
Looks like `cargo publish` requires that `sway.js` live inside the `forc-doc` directory. Otherwise, the file is not found. I'm simply moving `sway.js` to `forc-doc/src/assets` and updating the code to point to that location instead.