### PR TITLE
Bump to `v0.32.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,7 +1332,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "annotate-snippets",
  "ansi_term",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "forc-client"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "forc-doc"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "clap 4.0.29",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "forc-fmt"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "forc-lsp"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "forc-pkg"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "forc-tracing",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "forc-test"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "forc-pkg",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "forc-tracing"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "ansi_term",
  "tracing",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "forc-util"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "annotate-snippets",
  "ansi_term",
@@ -4047,7 +4047,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "sway-ast"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "extension-trait",
  "num-bigint",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "sway-core"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "clap 3.2.23",
  "derivative",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "sway-error"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "extension-trait",
  "num-bigint",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "filecheck",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir-macros"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "sway-lsp"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "sway-parse"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "assert_matches",
  "extension-trait",
@@ -4172,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "sway-types"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "fuel-asm",
  "fuel-crypto",
@@ -4183,11 +4183,11 @@ dependencies = [
 
 [[package]]
 name = "sway-utils"
-version = "0.32.0"
+version = "0.32.1"
 
 [[package]]
 name = "swayfmt"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "forc-tracing",

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-pkg"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,8 +10,8 @@ description = "Building, locking, fetching and updating Sway projects as Forc pa
 
 [dependencies]
 anyhow = "1"
-forc-tracing = { version = "0.32.0", path = "../forc-tracing" }
-forc-util = { version = "0.32.0", path = "../forc-util" }
+forc-tracing = { version = "0.32.1", path = "../forc-tracing" }
+forc-util = { version = "0.32.1", path = "../forc-util" }
 fuels-types = "0.32" 
 git2 = { version = "0.14", features = ["vendored-libgit2", "vendored-openssl"] }
 hex = "0.4.3"
@@ -20,10 +20,10 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
 serde_json = "1.0"
-sway-core = { version = "0.32.0", path = "../sway-core" }
-sway-error = { version = "0.32.0", path = "../sway-error" }
-sway-types = { version = "0.32.0", path = "../sway-types" }
-sway-utils = { version = "0.32.0", path = "../sway-utils" }
+sway-core = { version = "0.32.1", path = "../sway-core" }
+sway-error = { version = "0.32.1", path = "../sway-error" }
+sway-types = { version = "0.32.1", path = "../sway-types" }
+sway-utils = { version = "0.32.1", path = "../sway-utils" }
 toml = "0.5"
 tracing = "0.1"
 url = { version = "2.2", features = ["serde"] }

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-client"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,9 +12,9 @@ description = "A `forc` plugin for interacting with a Fuel node."
 anyhow = "1"
 async-trait = "0.1.58"
 clap = { version = "3", features = ["derive", "env"] }
-forc-pkg = { version = "0.32.0", path = "../../forc-pkg" }
-forc-tracing = { version = "0.32.0", path = "../../forc-tracing" }
-forc-util = { version = "0.32.0", path = "../../forc-util" }
+forc-pkg = { version = "0.32.1", path = "../../forc-pkg" }
+forc-tracing = { version = "0.32.1", path = "../../forc-tracing" }
+forc-util = { version = "0.32.1", path = "../../forc-util" }
 fuel-gql-client = { version = "0.15", default-features = false }
 fuel-tx = { version = "0.23", features = ["builder"] }
 fuels-core = "0.32"
@@ -24,9 +24,9 @@ futures = "0.3"
 hex = "0.4.3"
 serde = "1.0"
 serde_json = "1.0.73"
-sway-core = { version = "0.32.0", path = "../../sway-core" }
-sway-types = { version = "0.32.0", path = "../../sway-types" }
-sway-utils = { version = "0.32.0", path = "../../sway-utils" }
+sway-core = { version = "0.32.1", path = "../../sway-core" }
+sway-types = { version = "0.32.1", path = "../../sway-types" }
+sway-utils = { version = "0.32.1", path = "../../sway-utils" }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "process"] }
 tracing = "0.1"
 

--- a/forc-plugins/forc-doc/Cargo.toml
+++ b/forc-plugins/forc-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-doc"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,13 +12,13 @@ description = "Build the documentation for the local package and all dependencie
 anyhow = "1.0.65"
 clap = { version = "4.0.18", features = ["derive"] }
 comrak = "0.15"
-forc-pkg = { version = "0.32.0", path = "../../forc-pkg" }
-forc-util = { version = "0.32.0", path = "../../forc-util"}
+forc-pkg = { version = "0.32.1", path = "../../forc-pkg" }
+forc-util = { version = "0.32.1", path = "../../forc-util"}
 horrorshow = "0.8.4"
 include_dir = "0.7.3"
 opener = "0.5.0"
-sway-ast = { version = "0.32.0", path = "../../sway-ast" }
-sway-core = { version = "0.32.0", path = "../../sway-core" }
-sway-lsp = { version = "0.32.0", path = "../../sway-lsp" }
-sway-types = { version = "0.32.0", path = "../../sway-types" }
-swayfmt = { version = "0.32.0", path = "../../swayfmt" }
+sway-ast = { version = "0.32.1", path = "../../sway-ast" }
+sway-core = { version = "0.32.1", path = "../../sway-core" }
+sway-lsp = { version = "0.32.1", path = "../../sway-lsp" }
+sway-types = { version = "0.32.1", path = "../../sway-types" }
+swayfmt = { version = "0.32.1", path = "../../swayfmt" }

--- a/forc-plugins/forc-fmt/Cargo.toml
+++ b/forc-plugins/forc-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-fmt"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,11 +11,11 @@ description = "A `forc` plugin for running the Sway code formatter."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-forc-tracing = { version = "0.32.0", path = "../../forc-tracing" }
-forc-util = { version = "0.32.0", path = "../../forc-util" }
+forc-tracing = { version = "0.32.1", path = "../../forc-tracing" }
+forc-util = { version = "0.32.1", path = "../../forc-util" }
 prettydiff = "0.5"
-sway-core = { version = "0.32.0", path = "../../sway-core" }
-sway-utils = { version = "0.32.0", path = "../../sway-utils" }
-swayfmt = { version = "0.32.0", path = "../../swayfmt" }
+sway-core = { version = "0.32.1", path = "../../sway-core" }
+sway-utils = { version = "0.32.1", path = "../../sway-utils" }
+swayfmt = { version = "0.32.1", path = "../../swayfmt" }
 taplo = "0.7"
 tracing = "0.1"

--- a/forc-plugins/forc-lsp/Cargo.toml
+++ b/forc-plugins/forc-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-lsp"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,5 +11,5 @@ description = "A simple `forc` plugin for starting the sway language server."
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-sway-lsp = { version = "0.32.0", path = "../../sway-lsp" }
+sway-lsp = { version = "0.32.1", path = "../../sway-lsp" }
 tokio = { version = "1.8" }

--- a/forc-test/Cargo.toml
+++ b/forc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-test"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,9 +10,9 @@ description = "A library for building and running Sway unit tests within Forc pa
 
 [dependencies]
 anyhow = "1"
-forc-pkg = { version = "0.32.0", path = "../forc-pkg" }
+forc-pkg = { version = "0.32.1", path = "../forc-pkg" }
 fuel-tx = { version = "0.23", features = ["builder"] }
 fuel-vm = { version = "0.22", features = ["random"] }
 rand = "0.8"
-sway-core = { version = "0.32.0", path = "../sway-core" }
-sway-types = { version = "0.32.0", path = "../sway-types" }
+sway-core = { version = "0.32.1", path = "../sway-core" }
+sway-types = { version = "0.32.1", path = "../sway-types" }

--- a/forc-tracing/Cargo.toml
+++ b/forc-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-tracing"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-util"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -13,11 +13,11 @@ annotate-snippets = { version = "0.9", features = ["color"] }
 ansi_term = "0.12"
 anyhow = "1"
 dirs = "3.0.2"
-forc-tracing = { version = "0.32.0", path = "../forc-tracing" }
-sway-core = { version = "0.32.0", path = "../sway-core" }
-sway-error = { version = "0.32.0", path = "../sway-error" }
-sway-types = { version = "0.32.0", path = "../sway-types" }
-sway-utils = { version = "0.32.0", path = "../sway-utils" }
+forc-tracing = { version = "0.32.1", path = "../forc-tracing" }
+sway-core = { version = "0.32.1", path = "../sway-core" }
+sway-error = { version = "0.32.1", path = "../sway-error" }
+sway-types = { version = "0.32.1", path = "../sway-types" }
+sway-utils = { version = "0.32.1", path = "../sway-utils" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }
 unicode-xid = "0.2.2"

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -22,18 +22,18 @@ ansi_term = "0.12"
 anyhow = "1.0.41"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 clap_complete = "3.1"
-forc-pkg = { version = "0.32.0", path = "../forc-pkg" }
-forc-test = { version = "0.32.0", path = "../forc-test" }
-forc-tracing = { version = "0.32.0", path = "../forc-tracing" }
-forc-util = { version = "0.32.0", path = "../forc-util" }
+forc-pkg = { version = "0.32.1", path = "../forc-pkg" }
+forc-test = { version = "0.32.1", path = "../forc-test" }
+forc-tracing = { version = "0.32.1", path = "../forc-tracing" }
+forc-util = { version = "0.32.1", path = "../forc-util" }
 fs_extra = "1.2"
 fuel-asm = "0.10"
 hex = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.73"
-sway-core = { version = "0.32.0", path = "../sway-core" }
-sway-types = { version = "0.32.0", path = "../sway-types" }
-sway-utils = { version = "0.32.0", path = "../sway-utils" }
+sway-core = { version = "0.32.1", path = "../sway-core" }
+sway-types = { version = "0.32.1", path = "../sway-types" }
+sway-utils = { version = "0.32.1", path = "../sway-utils" }
 term-table = "1.3"
 tokio = { version = "1.8.0", features = ["macros", "rt-multi-thread"] }
 toml = "0.5"

--- a/sway-ast/Cargo.toml
+++ b/sway-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ast"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,4 +12,4 @@ description = "Sway's parser"
 extension-trait = "1.0.1"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
-sway-types = { version = "0.32.0", path = "../sway-types" }
+sway-types = { version = "0.32.1", path = "../sway-types" }

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-core"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -25,12 +25,12 @@ rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.9"
 smallvec = "1.7"
-sway-ast = { version = "0.32.0", path = "../sway-ast" }
-sway-error = { version = "0.32.0", path = "../sway-error" }
-sway-ir = { version = "0.32.0", path = "../sway-ir" }
-sway-parse = { version = "0.32.0", path = "../sway-parse" }
-sway-types = { version = "0.32.0", path = "../sway-types" }
-sway-utils = { version = "0.32.0", path = "../sway-utils" }
+sway-ast = { version = "0.32.1", path = "../sway-ast" }
+sway-error = { version = "0.32.1", path = "../sway-error" }
+sway-ir = { version = "0.32.1", path = "../sway-ir" }
+sway-parse = { version = "0.32.1", path = "../sway-parse" }
+sway-types = { version = "0.32.1", path = "../sway-types" }
+sway-utils = { version = "0.32.1", path = "../sway-utils" }
 thiserror = "1.0"
 tracing = "0.1"
 uint = "0.9"

--- a/sway-error/Cargo.toml
+++ b/sway-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-error"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,6 +12,6 @@ description = "Sway's error handling"
 extension-trait = "1.0.1"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
-sway-ast = { version = "0.32.0", path = "../sway-ast" }
-sway-types = { version = "0.32.0", path = "../sway-types" }
+sway-ast = { version = "0.32.1", path = "../sway-ast" }
+sway-types = { version = "0.32.1", path = "../sway-types" }
 thiserror = "1.0"

--- a/sway-ir/Cargo.toml
+++ b/sway-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ir"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -14,6 +14,6 @@ filecheck = "0.5"
 generational-arena = "0.2"
 peg = "0.7"
 rustc-hash = "1.1.0"
-sway-ir-macros = { version = "0.32.0", path = "sway-ir-macros" }
-sway-types = { version = "0.32.0", path = "../sway-types" }
-sway-utils = { version = "0.32.0", path = "../sway-utils" }
+sway-ir-macros = { version = "0.32.1", path = "sway-ir-macros" }
+sway-types = { version = "0.32.1", path = "../sway-types" }
+sway-utils = { version = "0.32.1", path = "../sway-utils" }

--- a/sway-ir/sway-ir-macros/Cargo.toml
+++ b/sway-ir/sway-ir-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ir-macros"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-lsp"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,19 +11,19 @@ description = "LSP server for Sway."
 [dependencies]
 anyhow = "1.0.41"
 dashmap = "5.4"
-forc-pkg = { version = "0.32.0", path = "../forc-pkg" }
-forc-tracing = { version = "0.32.0", path = "../forc-tracing" }
+forc-pkg = { version = "0.32.1", path = "../forc-pkg" }
+forc-tracing = { version = "0.32.1", path = "../forc-tracing" }
 notify = "5.0.0"
 notify-debouncer-mini = { version = "0.2.0" }
 parking_lot = "0.12.1"
 ropey = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.60"
-sway-core = { version = "0.32.0", path = "../sway-core" }
-sway-error = { version = "0.32.0", path = "../sway-error" }
-sway-types = { version = "0.32.0", path = "../sway-types" }
-sway-utils = { version = "0.32.0", path = "../sway-utils" }
-swayfmt = { version = "0.32.0", path = "../swayfmt" }
+sway-core = { version = "0.32.1", path = "../sway-core" }
+sway-error = { version = "0.32.1", path = "../sway-error" }
+sway-types = { version = "0.32.1", path = "../sway-types" }
+sway-utils = { version = "0.32.1", path = "../sway-utils" }
+swayfmt = { version = "0.32.1", path = "../swayfmt" }
 tempfile = "3"
 thiserror = "1.0.30"
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }

--- a/sway-parse/Cargo.toml
+++ b/sway-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-parse"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -13,9 +13,9 @@ extension-trait = "1.0.1"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 phf = { version = "0.10.1", features = ["macros"] }
-sway-ast = { version = "0.32.0", path = "../sway-ast" }
-sway-error = { version = "0.32.0", path = "../sway-error" }
-sway-types = { version = "0.32.0", path = "../sway-types" }
+sway-ast = { version = "0.32.1", path = "../sway-ast" }
+sway-error = { version = "0.32.1", path = "../sway-error" }
+sway-types = { version = "0.32.1", path = "../sway-types" }
 thiserror = "1.0"
 unicode-xid = "0.2.2"
 

--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-types"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/sway-utils/Cargo.toml
+++ b/sway-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-utils"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/swayfmt/Cargo.toml
+++ b/swayfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swayfmt"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -10,16 +10,16 @@ description = "Sway language formatter."
 
 [dependencies]
 anyhow = "1"
-forc-tracing = { version = "0.32.0", path = "../forc-tracing" }
-forc-util = { version = "0.32.0", path = "../forc-util" }
+forc-tracing = { version = "0.32.1", path = "../forc-tracing" }
+forc-util = { version = "0.32.1", path = "../forc-util" }
 ropey = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
-sway-ast = { version = "0.32.0", path = "../sway-ast" }
-sway-core = { version = "0.32.0", path = "../sway-core" }
-sway-error = { version = "0.32.0", path = "../sway-error" }
-sway-parse = { version = "0.32.0", path = "../sway-parse" }
-sway-types = { version = "0.32.0", path = "../sway-types" }
+sway-ast = { version = "0.32.1", path = "../sway-ast" }
+sway-core = { version = "0.32.1", path = "../sway-core" }
+sway-error = { version = "0.32.1", path = "../sway-error" }
+sway-parse = { version = "0.32.1", path = "../sway-parse" }
+sway-types = { version = "0.32.1", path = "../sway-types" }
 thiserror = "1.0.30"
 toml = "0.5"
 


### PR DESCRIPTION
Mainly to include https://github.com/FuelLabs/sway/pull/3605 so that we can publish correctly.