### PR TITLE
Use `try_get` methods on `DashMap` to avoid potential deadlocks

### DIFF
--- a/sway-lsp/src/capabilities/hover.rs
+++ b/sway-lsp/src/capabilities/hover.rs
@@ -22,7 +22,8 @@ pub fn hover_data(session: Arc<Session>, url: Url, position: Position) -> Option
         Some(decl_ident) => {
             let decl_token = session
                 .token_map()
-                .get(&to_ident_key(&decl_ident))
+                .try_get(&to_ident_key(&decl_ident))
+                .try_unwrap()
                 .map(|item| item.value().clone())?;
             (decl_ident, decl_token)
         }

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -235,12 +235,13 @@ impl Session {
     }
 
     pub fn format_text(&self, url: &Url) -> Result<Vec<TextEdit>, LanguageServerError> {
-        let document =
-            self.documents
-                .get(url.path())
-                .ok_or_else(|| DocumentError::DocumentNotFound {
-                    path: url.path().to_string(),
-                })?;
+        let document = self
+            .documents
+            .try_get(url.path())
+            .try_unwrap()
+            .ok_or_else(|| DocumentError::DocumentNotFound {
+                path: url.path().to_string(),
+            })?;
 
         get_page_text_edit(Arc::from(document.get_text()), &mut <_>::default())
             .map(|page_text_edit| vec![page_text_edit])
@@ -260,12 +261,15 @@ impl Session {
         url: &Url,
         changes: Vec<TextDocumentContentChangeEvent>,
     ) -> Option<String> {
-        self.documents.get_mut(url.path()).map(|mut document| {
-            changes.iter().for_each(|change| {
-                document.apply_change(change);
-            });
-            document.get_text()
-        })
+        self.documents
+            .try_get_mut(url.path())
+            .try_unwrap()
+            .map(|mut document| {
+                changes.iter().for_each(|change| {
+                    document.apply_change(change);
+                });
+                document.get_text()
+            })
     }
 
     /// Remove the text document from the session.

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -177,7 +177,8 @@ impl SyncWorkspace {
     /// Return the path to the projects manifest directory.
     pub(crate) fn manifest_dir(&self) -> Result<PathBuf, DirectoryError> {
         self.directories
-            .get(&Directory::Manifest)
+            .try_get(&Directory::Manifest)
+            .try_unwrap()
             .map(|item| item.value().clone())
             .ok_or(DirectoryError::ManifestDirNotFound)
     }
@@ -185,7 +186,8 @@ impl SyncWorkspace {
     /// Return the path to the temporary directory that was created for the current session.
     pub(crate) fn temp_dir(&self) -> Result<PathBuf, DirectoryError> {
         self.directories
-            .get(&Directory::Temp)
+            .try_get(&Directory::Temp)
+            .try_unwrap()
             .map(|item| item.value().clone())
             .ok_or(DirectoryError::TempDirNotFound)
     }

--- a/sway-lsp/src/core/token_map.rs
+++ b/sway-lsp/src/core/token_map.rs
@@ -75,13 +75,14 @@ impl TokenMap {
     /// Check if the code editor's cursor is currently over one of our collected tokens.
     pub fn token_at_position(&self, uri: &Url, position: Position) -> Option<(Ident, Token)> {
         let tokens = self.tokens_for_file(uri);
-        match self.ident_at_position(position, tokens) {
-            Some(ident) => self.get(&token::to_ident_key(&ident)).map(|item| {
-                let ((ident, _), token) = item.pair();
-                (ident.clone(), token.clone())
-            }),
-            None => None,
-        }
+        self.ident_at_position(position, tokens).and_then(|ident| {
+            self.try_get(&token::to_ident_key(&ident))
+                .try_unwrap()
+                .map(|item| {
+                    let ((ident, _), token) = item.pair();
+                    (ident.clone(), token.clone())
+                })
+        })
     }
 
     /// Uses the [TypeId] to find the associated [ty::TyDeclaration] in the TokenMap.

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -123,7 +123,7 @@ impl Backend {
             .ok_or(DirectoryError::ManifestDirNotFound)?
             .to_path_buf();
 
-        let session = match self.sessions.get(&manifest_dir) {
+        let session = match self.sessions.try_get(&manifest_dir).try_unwrap() {
             Some(item) => item.value().clone(),
             None => {
                 // TODO, remove this once the type engine no longer uses global memory: https://github.com/FuelLabs/sway/issues/2063
@@ -139,7 +139,8 @@ impl Backend {
                 // If no session can be found, then we need to call init and inserst a new session into the map
                 self.init(uri)?;
                 self.sessions
-                    .get(&manifest_dir)
+                    .try_get(&manifest_dir)
+                    .try_unwrap()
                     .map(|item| item.value().clone())
                     .expect("no session found even though it was just inserted into the map")
             }
@@ -472,7 +473,8 @@ impl Backend {
             Ok((_, session)) => {
                 let ranges = session
                     .runnables
-                    .get(&capabilities::runnable::RunnableType::MainFn)
+                    .try_get(&capabilities::runnable::RunnableType::MainFn)
+                    .try_unwrap()
                     .map(|item| {
                         let runnable = item.value();
                         vec![(runnable.range, format!("{}", runnable.tree_type))]

--- a/sway-lsp/src/traverse/dependency.rs
+++ b/sway-lsp/src/traverse/dependency.rs
@@ -68,7 +68,7 @@ impl<'a> Dependency<'a> {
                 _ => return,
             } {
                 let ident = token::to_ident_key(&ident);
-                if let Some(mut token) = self.tokens.get_mut(&ident) {
+                if let Some(mut token) = self.tokens.try_get_mut(&ident).try_unwrap() {
                     token.typed = Some(typed_token);
                     token.type_def = Some(TypeDefinition::Ident(ident.0));
                 }

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -42,7 +42,11 @@ impl<'a> TypedTree<'a> {
         match declaration {
             ty::TyDeclaration::VariableDeclaration(variable) => {
                 let typed_token = TypedAstToken::TypedDeclaration(declaration.clone());
-                if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&variable.name)) {
+                if let Some(mut token) = self
+                    .tokens
+                    .try_get_mut(&to_ident_key(&variable.name))
+                    .try_unwrap()
+                {
                     token.typed = Some(typed_token.clone());
                     token.type_def = Some(TypeDefinition::Ident(variable.name.clone()));
                 }
@@ -60,7 +64,11 @@ impl<'a> TypedTree<'a> {
                 if let Ok(const_decl) =
                     declaration_engine::de_get_constant(decl_id.clone(), &decl_id.span())
                 {
-                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&const_decl.name)) {
+                    if let Some(mut token) = self
+                        .tokens
+                        .try_get_mut(&to_ident_key(&const_decl.name))
+                        .try_unwrap()
+                    {
                         token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
                         token.type_def = Some(TypeDefinition::Ident(const_decl.name.clone()));
                     }
@@ -78,7 +86,11 @@ impl<'a> TypedTree<'a> {
                 if let Ok(trait_decl) =
                     declaration_engine::de_get_trait(decl_id.clone(), &decl_id.span())
                 {
-                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&trait_decl.name)) {
+                    if let Some(mut token) = self
+                        .tokens
+                        .try_get_mut(&to_ident_key(&trait_decl.name))
+                        .try_unwrap()
+                    {
                         token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
                         token.type_def = Some(TypeDefinition::Ident(trait_decl.name.clone()));
                     }
@@ -97,7 +109,11 @@ impl<'a> TypedTree<'a> {
                 if let Ok(struct_decl) =
                     declaration_engine::de_get_struct(decl_id.clone(), &declaration.span())
                 {
-                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&struct_decl.name)) {
+                    if let Some(mut token) = self
+                        .tokens
+                        .try_get_mut(&to_ident_key(&struct_decl.name))
+                        .try_unwrap()
+                    {
                         token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
                         token.type_def = Some(TypeDefinition::Ident(struct_decl.name));
                     }
@@ -107,8 +123,10 @@ impl<'a> TypedTree<'a> {
                     }
 
                     for type_param in &struct_decl.type_parameters {
-                        if let Some(mut token) =
-                            self.tokens.get_mut(&to_ident_key(&type_param.name_ident))
+                        if let Some(mut token) = self
+                            .tokens
+                            .try_get_mut(&to_ident_key(&type_param.name_ident))
+                            .try_unwrap()
                         {
                             token.typed =
                                 Some(TypedAstToken::TypedDeclaration(declaration.clone()));
@@ -121,14 +139,20 @@ impl<'a> TypedTree<'a> {
                 if let Ok(enum_decl) =
                     declaration_engine::de_get_enum(decl_id.clone(), &decl_id.span())
                 {
-                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&enum_decl.name)) {
+                    if let Some(mut token) = self
+                        .tokens
+                        .try_get_mut(&to_ident_key(&enum_decl.name))
+                        .try_unwrap()
+                    {
                         token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
                         token.type_def = Some(TypeDefinition::Ident(enum_decl.name.clone()));
                     }
 
                     for type_param in &enum_decl.type_parameters {
-                        if let Some(mut token) =
-                            self.tokens.get_mut(&to_ident_key(&type_param.name_ident))
+                        if let Some(mut token) = self
+                            .tokens
+                            .try_get_mut(&to_ident_key(&type_param.name_ident))
+                            .try_unwrap()
                         {
                             token.typed =
                                 Some(TypedAstToken::TypedDeclaration(declaration.clone()));
@@ -161,13 +185,18 @@ impl<'a> TypedTree<'a> {
                     }
 
                     for ident in &trait_name.prefixes {
-                        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(ident)) {
+                        if let Some(mut token) =
+                            self.tokens.try_get_mut(&to_ident_key(ident)).try_unwrap()
+                        {
                             token.typed =
                                 Some(TypedAstToken::TypedDeclaration(declaration.clone()));
                         }
                     }
 
-                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&trait_name.suffix))
+                    if let Some(mut token) = self
+                        .tokens
+                        .try_get_mut(&to_ident_key(&trait_name.suffix))
+                        .try_unwrap()
                     {
                         token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
                         token.type_def = Some(TypeDefinition::TypeId(implementing_for_type_id));
@@ -200,7 +229,11 @@ impl<'a> TypedTree<'a> {
                 if let Ok(abi_decl) =
                     declaration_engine::de_get_abi(decl_id.clone(), &decl_id.span())
                 {
-                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&abi_decl.name)) {
+                    if let Some(mut token) = self
+                        .tokens
+                        .try_get_mut(&to_ident_key(&abi_decl.name))
+                        .try_unwrap()
+                    {
                         token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
                         token.type_def = Some(TypeDefinition::Ident(abi_decl.name.clone()));
                     }
@@ -216,7 +249,7 @@ impl<'a> TypedTree<'a> {
                 }
             }
             ty::TyDeclaration::GenericTypeForFunctionScope { name, .. } => {
-                if let Some(mut token) = self.tokens.get_mut(&to_ident_key(name)) {
+                if let Some(mut token) = self.tokens.try_get_mut(&to_ident_key(name)).try_unwrap() {
                     token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
                 }
             }
@@ -226,14 +259,19 @@ impl<'a> TypedTree<'a> {
                     declaration_engine::de_get_storage(decl_id.clone(), &decl_id.span())
                 {
                     for field in &storage_decl.fields {
-                        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&field.name)) {
+                        if let Some(mut token) = self
+                            .tokens
+                            .try_get_mut(&to_ident_key(&field.name))
+                            .try_unwrap()
+                        {
                             token.typed = Some(TypedAstToken::TypedStorageField(field.clone()));
                             token.type_def = Some(TypeDefinition::TypeId(field.type_id));
                         }
 
                         if let Some(mut token) = self
                             .tokens
-                            .get_mut(&to_ident_key(&Ident::new(field.type_span.clone())))
+                            .try_get_mut(&to_ident_key(&Ident::new(field.type_span.clone())))
+                            .try_unwrap()
                         {
                             token.typed = Some(TypedAstToken::TypedStorageField(field.clone()));
                             token.type_def = Some(TypeDefinition::TypeId(field.type_id));
@@ -251,7 +289,8 @@ impl<'a> TypedTree<'a> {
             ty::TyExpressionVariant::Literal { .. } => {
                 if let Some(mut token) = self
                     .tokens
-                    .get_mut(&to_ident_key(&Ident::new(expression.span.clone())))
+                    .try_get_mut(&to_ident_key(&Ident::new(expression.span.clone())))
+                    .try_unwrap()
                 {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                 }
@@ -264,13 +303,19 @@ impl<'a> TypedTree<'a> {
                 ..
             } => {
                 for ident in &call_path.prefixes {
-                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(ident)) {
+                    if let Some(mut token) =
+                        self.tokens.try_get_mut(&to_ident_key(ident)).try_unwrap()
+                    {
                         token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                         token.type_def = Some(TypeDefinition::TypeId(expression.return_type));
                     }
                 }
 
-                if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&call_path.suffix)) {
+                if let Some(mut token) = self
+                    .tokens
+                    .try_get_mut(&to_ident_key(&call_path.suffix))
+                    .try_unwrap()
+                {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                     if let Ok(function_decl) =
                         de_get_function(function_decl_id.clone(), &call_path.span())
@@ -284,7 +329,9 @@ impl<'a> TypedTree<'a> {
                 }
 
                 for (ident, exp) in arguments {
-                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(ident)) {
+                    if let Some(mut token) =
+                        self.tokens.try_get_mut(&to_ident_key(ident)).try_unwrap()
+                    {
                         token.typed = Some(TypedAstToken::TypedExpression(exp.clone()));
                     }
                     self.handle_expression(exp);
@@ -307,7 +354,8 @@ impl<'a> TypedTree<'a> {
             } => {
                 if let Some(mut token) = self
                     .tokens
-                    .get_mut(&to_ident_key(&Ident::new(span.clone())))
+                    .try_get_mut(&to_ident_key(&Ident::new(span.clone())))
+                    .try_unwrap()
                 {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                     token.type_def = Some(TypeDefinition::Ident(name.clone()));
@@ -330,14 +378,19 @@ impl<'a> TypedTree<'a> {
             ty::TyExpressionVariant::StructExpression { fields, span, .. } => {
                 if let Some(mut token) = self
                     .tokens
-                    .get_mut(&to_ident_key(&Ident::new(span.clone())))
+                    .try_get_mut(&to_ident_key(&Ident::new(span.clone())))
+                    .try_unwrap()
                 {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                     token.type_def = Some(TypeDefinition::TypeId(expression.return_type));
                 }
 
                 for field in fields {
-                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&field.name)) {
+                    if let Some(mut token) = self
+                        .tokens
+                        .try_get_mut(&to_ident_key(&field.name))
+                        .try_unwrap()
+                    {
                         token.typed = Some(TypedAstToken::TypedExpression(field.value.clone()));
 
                         if let Some(struct_decl) = &self.tokens.struct_declaration_of_type_id(
@@ -383,7 +436,8 @@ impl<'a> TypedTree<'a> {
 
                 if let Some(mut token) = self
                     .tokens
-                    .get_mut(&to_ident_key(&Ident::new(field_instantiation_span.clone())))
+                    .try_get_mut(&to_ident_key(&Ident::new(field_instantiation_span.clone())))
+                    .try_unwrap()
                 {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                     token.type_def = Some(TypeDefinition::Ident(field_to_access.name.clone()));
@@ -402,15 +456,20 @@ impl<'a> TypedTree<'a> {
             } => {
                 if let Some(mut token) = self
                     .tokens
-                    .get_mut(&to_ident_key(&Ident::new(enum_instantiation_span.clone())))
+                    .try_get_mut(&to_ident_key(&Ident::new(enum_instantiation_span.clone())))
+                    .try_unwrap()
                 {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                     token.type_def = Some(TypeDefinition::Ident(enum_decl.name.clone()));
                 }
 
-                if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&Ident::new(
-                    variant_instantiation_span.clone(),
-                ))) {
+                if let Some(mut token) = self
+                    .tokens
+                    .try_get_mut(&to_ident_key(&Ident::new(
+                        variant_instantiation_span.clone(),
+                    )))
+                    .try_unwrap()
+                {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                     token.type_def = Some(TypeDefinition::Ident(variant_name.clone()));
                 }
@@ -423,12 +482,18 @@ impl<'a> TypedTree<'a> {
                 abi_name, address, ..
             } => {
                 for ident in &abi_name.prefixes {
-                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(ident)) {
+                    if let Some(mut token) =
+                        self.tokens.try_get_mut(&to_ident_key(ident)).try_unwrap()
+                    {
                         token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                     }
                 }
 
-                if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&abi_name.suffix)) {
+                if let Some(mut token) = self
+                    .tokens
+                    .try_get_mut(&to_ident_key(&abi_name.suffix))
+                    .try_unwrap()
+                {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                 }
 
@@ -436,7 +501,11 @@ impl<'a> TypedTree<'a> {
             }
             ty::TyExpressionVariant::StorageAccess(storage_access) => {
                 for field in &storage_access.fields {
-                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&field.name)) {
+                    if let Some(mut token) = self
+                        .tokens
+                        .try_get_mut(&to_ident_key(&field.name))
+                        .try_unwrap()
+                    {
                         token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                     }
                 }
@@ -450,7 +519,11 @@ impl<'a> TypedTree<'a> {
             }
             ty::TyExpressionVariant::UnsafeDowncast { exp, variant } => {
                 self.handle_expression(exp);
-                if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&variant.name)) {
+                if let Some(mut token) = self
+                    .tokens
+                    .try_get_mut(&to_ident_key(&variant.name))
+                    .try_unwrap()
+                {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                 }
             }
@@ -464,14 +537,17 @@ impl<'a> TypedTree<'a> {
 
                 if let Some(mut token) = self
                     .tokens
-                    .get_mut(&to_ident_key(&reassignment.lhs_base_name))
+                    .try_get_mut(&to_ident_key(&reassignment.lhs_base_name))
+                    .try_unwrap()
                 {
                     token.typed = Some(TypedAstToken::TypedReassignment((**reassignment).clone()));
                 }
 
                 for proj_kind in &reassignment.lhs_indices {
                     if let ty::ProjectionKind::StructField { name } = proj_kind {
-                        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(name)) {
+                        if let Some(mut token) =
+                            self.tokens.try_get_mut(&to_ident_key(name)).try_unwrap()
+                        {
                             token.typed =
                                 Some(TypedAstToken::TypedReassignment((**reassignment).clone()));
                             if let Some(struct_decl) = &self.tokens.struct_declaration_of_type_id(
@@ -491,7 +567,11 @@ impl<'a> TypedTree<'a> {
             }
             ty::TyExpressionVariant::StorageReassignment(storage_reassignment) => {
                 for field in &storage_reassignment.fields {
-                    if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&field.name)) {
+                    if let Some(mut token) = self
+                        .tokens
+                        .try_get_mut(&to_ident_key(&field.name))
+                        .try_unwrap()
+                    {
                         token.typed = Some(TypedAstToken::TypeCheckedStorageReassignDescriptor(
                             field.clone(),
                         ));
@@ -520,7 +600,11 @@ impl<'a> TypedTree<'a> {
     }
 
     fn collect_typed_trait_fn_token(&self, trait_fn: &ty::TyTraitFn) {
-        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&trait_fn.name)) {
+        if let Some(mut token) = self
+            .tokens
+            .try_get_mut(&to_ident_key(&trait_fn.name))
+            .try_unwrap()
+        {
             token.typed = Some(TypedAstToken::TypedTraitFn(trait_fn.clone()));
             token.type_def = Some(TypeDefinition::Ident(trait_fn.name.clone()));
         }
@@ -530,7 +614,11 @@ impl<'a> TypedTree<'a> {
         }
 
         let return_ident = Ident::new(trait_fn.return_type_span.clone());
-        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&return_ident)) {
+        if let Some(mut token) = self
+            .tokens
+            .try_get_mut(&to_ident_key(&return_ident))
+            .try_unwrap()
+        {
             token.typed = Some(TypedAstToken::TypedTraitFn(trait_fn.clone()));
             token.type_def = Some(TypeDefinition::TypeId(trait_fn.return_type));
         }
@@ -538,7 +626,11 @@ impl<'a> TypedTree<'a> {
 
     fn collect_typed_fn_param_token(&self, param: &ty::TyFunctionParameter) {
         let typed_token = TypedAstToken::TypedFunctionParameter(param.clone());
-        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&param.name)) {
+        if let Some(mut token) = self
+            .tokens
+            .try_get_mut(&to_ident_key(&param.name))
+            .try_unwrap()
+        {
             token.typed = Some(typed_token.clone());
             token.type_def = Some(TypeDefinition::TypeId(param.type_id));
         }
@@ -571,7 +663,11 @@ impl<'a> TypedTree<'a> {
                 variant_types,
                 ..
             } => {
-                if let Some(token) = self.tokens.get_mut(&to_ident_key(&Ident::new(type_span))) {
+                if let Some(token) = self
+                    .tokens
+                    .try_get_mut(&to_ident_key(&Ident::new(type_span)))
+                    .try_unwrap()
+                {
                     assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
                 }
 
@@ -592,7 +688,11 @@ impl<'a> TypedTree<'a> {
                 fields,
                 ..
             } => {
-                if let Some(token) = self.tokens.get_mut(&to_ident_key(&Ident::new(type_span))) {
+                if let Some(token) = self
+                    .tokens
+                    .try_get_mut(&to_ident_key(&Ident::new(type_span)))
+                    .try_unwrap()
+                {
                     assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
                 }
 
@@ -609,7 +709,11 @@ impl<'a> TypedTree<'a> {
                 }
             }
             TypeInfo::Custom { type_arguments, .. } => {
-                if let Some(token) = self.tokens.get_mut(&to_ident_key(&Ident::new(type_span))) {
+                if let Some(token) = self
+                    .tokens
+                    .try_get_mut(&to_ident_key(&Ident::new(type_span)))
+                    .try_unwrap()
+                {
                     assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
                 }
 
@@ -629,7 +733,11 @@ impl<'a> TypedTree<'a> {
                 }
             }
             _ => {
-                if let Some(token) = self.tokens.get_mut(&to_ident_key(&Ident::new(type_span))) {
+                if let Some(token) = self
+                    .tokens
+                    .try_get_mut(&to_ident_key(&Ident::new(type_span)))
+                    .try_unwrap()
+                {
                     assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
                 }
             }
@@ -638,7 +746,11 @@ impl<'a> TypedTree<'a> {
 
     fn collect_typed_fn_decl(&self, func_decl: &ty::TyFunctionDeclaration) {
         let typed_token = TypedAstToken::TypedFunctionDeclaration(func_decl.clone());
-        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&func_decl.name)) {
+        if let Some(mut token) = self
+            .tokens
+            .try_get_mut(&to_ident_key(&func_decl.name))
+            .try_unwrap()
+        {
             token.typed = Some(typed_token.clone());
             token.type_def = Some(TypeDefinition::Ident(func_decl.name.clone()));
         }
@@ -667,7 +779,11 @@ impl<'a> TypedTree<'a> {
 
     fn collect_ty_enum_variant(&self, enum_variant: &TyEnumVariant) {
         let typed_token = TypedAstToken::TypedEnumVariant(enum_variant.clone());
-        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&enum_variant.name)) {
+        if let Some(mut token) = self
+            .tokens
+            .try_get_mut(&to_ident_key(&enum_variant.name))
+            .try_unwrap()
+        {
             token.typed = Some(typed_token.clone());
             token.type_def = Some(TypeDefinition::TypeId(enum_variant.type_id));
         }
@@ -680,7 +796,11 @@ impl<'a> TypedTree<'a> {
     }
 
     fn collect_ty_struct_field(&self, field: &ty::TyStructField) {
-        if let Some(mut token) = self.tokens.get_mut(&to_ident_key(&field.name)) {
+        if let Some(mut token) = self
+            .tokens
+            .try_get_mut(&to_ident_key(&field.name))
+            .try_unwrap()
+        {
             token.typed = Some(TypedAstToken::TypedStructField(field.clone()));
             token.type_def = Some(TypeDefinition::TypeId(field.type_id));
         }


### PR DESCRIPTION
This PR simply changes calling `.get` to `.try_get` and `.get_mut` to `.try_get_mut` on types that use a `DashMap` in the language server. These functions ensure that a result is only returned if the shard is not locked. 

There was an issue where an LSP test was hanging in CI only rarely a while ago and it was because an internal lock wasn't getting released in `DashMap`. This PR makes sure we are handling this situation in all places we are calling these methods in the server. 