### PR TITLE
Reorder block creation for `while` loops.

### DIFF
--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -1461,23 +1461,25 @@ impl<'te> FnCompiler<'te> {
         // We're dancing around a bit here to make the blocks sit in the right order.  Ideally we
         // have the cond block, followed by the body block which may contain other blocks, and the
         // final block comes after any body block(s).
+        //
+        // NOTE: This is currently very important!  There is a limitation in the register allocator
+        // which requires that all value uses are after the value definitions, where 'after' means
+        // later in the list of instructions, as opposed to in the control flow sense.
+        //
+        // Hence the need for a 'break' block which does nothing more than jump to the final block,
+        // as we need to construct the final block after the body block, but we need somewhere to
+        // break to during the body block construction.
 
         // Jump to the while cond block.
         let cond_block = self.function.create_block(context, Some("while".into()));
-
         if !self.current_block.is_terminated(context) {
             self.current_block.ins(context).branch(cond_block, vec![]);
         }
 
-        // Fill in the body block now, jump unconditionally to the cond block at its end.
-        let body_block = self
+        // Create the break block.
+        let break_block = self
             .function
-            .create_block(context, Some("while_body".into()));
-
-        // Create the final block after we're finished with the body.
-        let final_block = self
-            .function
-            .create_block(context, Some("end_while".into()));
+            .create_block(context, Some("while_break".into()));
 
         // Keep track of the previous blocks we have to jump to in case of a break or a continue.
         // This should be `None` if we're not in a loop already or the previous break or continue
@@ -1486,11 +1488,13 @@ impl<'te> FnCompiler<'te> {
         let prev_block_to_continue_to = self.block_to_continue_to;
 
         // Keep track of the current blocks to jump to in case of a break or continue.
-        self.block_to_break_to = Some(final_block);
+        self.block_to_break_to = Some(break_block);
         self.block_to_continue_to = Some(cond_block);
 
-        // Compile the body and a branch to the condition block if no branch is already present in
-        // the body block
+        // Fill in the body block now, jump unconditionally to the cond block at its end.
+        let body_block = self
+            .function
+            .create_block(context, Some("while_body".into()));
         self.current_block = body_block;
         self.compile_code_block(context, md_mgr, body)?;
         if !self.current_block.is_terminated(context) {
@@ -1501,7 +1505,16 @@ impl<'te> FnCompiler<'te> {
         self.block_to_break_to = prev_block_to_break_to;
         self.block_to_continue_to = prev_block_to_continue_to;
 
-        // Add the conditional which jumps into the body or out to the final block.
+        // Create the final block now we're finished with the body.
+        let final_block = self
+            .function
+            .create_block(context, Some("end_while".into()));
+
+        // Add an unconditional jump from the break block to the final block.
+        break_block.ins(context).branch(final_block, vec![]);
+
+        // Add the conditional in the cond block which jumps into the body or out to the final
+        // block.
         self.current_block = cond_block;
         let cond_value = self.compile_expression(context, md_mgr, condition)?;
         if !self.current_block.is_terminated(context) {

--- a/sway-ir/src/error.rs
+++ b/sway-ir/src/error.rs
@@ -45,6 +45,7 @@ pub enum IrError {
     VerifyIntToPtrToCopyType(String),
     VerifyIntToPtrUnknownSourceType,
     VerifyLoadFromNonPointer,
+    VerifyMemcopyNonExistentPointer,
     VerifyMismatchedReturnTypes(String),
     VerifyBlockArgMalformed,
     VerifyPtrCastFromNonPointer,
@@ -252,6 +253,12 @@ impl fmt::Display for IrError {
             ),
             IrError::VerifyLoadFromNonPointer => {
                 write!(f, "Verification failed: Load must be from a pointer.")
+            }
+            IrError::VerifyMemcopyNonExistentPointer => {
+                write!(
+                    f,
+                    "Verification failed: Attempt to use non pointer with `mem_copy`."
+                )
             }
             IrError::VerifyMismatchedReturnTypes(fn_str) => write!(
                 f,

--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -180,7 +180,7 @@ pub fn inline_function_call(
         context,
         call_site,
         post_block.get_arg(context, 0).unwrap(),
-        Some(post_block),
+        None,
     );
 
     // Take the locals from the inlined function and add them to this function.  `value_map` is a

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -652,7 +652,7 @@ impl<'a> InstructionVerifier<'a> {
 
     fn verify_mem_copy(
         &self,
-        _dst_val: &Value,
+        dst_val: &Value,
         _src_val: &Value,
         _byte_len: &u64,
     ) -> Result<(), IrError> {
@@ -662,18 +662,17 @@ impl<'a> InstructionVerifier<'a> {
         //| XXX Pointers are broken, pending https://github.com/FuelLabs/sway/issues/2819
         //| So here we may still get non-pointers, but still ref-types, passed as the source for
         //| mem_copy, especially when dealing with constant b256s or similar.
-        //|if !dst_val.get_pointer(self.context).is_some()
+        if dst_val.get_pointer(self.context).is_none()
         //|    || !(src_val.get_pointer(self.context).is_some()
         //|        || matches!(
         //|            src_val.get_instruction(self.context),
         //|            Some(Instruction::GetStorageKey) | Some(Instruction::IntToPtr(..))
         //|        ))
-        //|{
-        //|    Err(IrError::VerifyGetNonExistentPointer)
-        //|} else {
-        //|    Ok(())
-        //|}
-        Ok(())
+        {
+            Err(IrError::VerifyMemcopyNonExistentPointer)
+        } else {
+            Ok(())
+        }
     }
 
     fn verify_ret(&self, val: &Value, ty: &Type) -> Result<(), IrError> {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -3,7 +3,7 @@ use basic_storage_abi::{Quad, StoreU64};
 use std::assert::assert;
 
 fn main() -> u64 {
-    let addr = abi(StoreU64, 0x3b4a1dcf91b22eb138d14dd4aab4b0727f9c6fa855617860e59b8ba7d0fc8a07);
+    let addr = abi(StoreU64, 0x8384cd87cb862d1c4e16943c6cd7c72892ce81e0ead639fd7b71bb45236d7228);
     let key = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/basic_storage_abi/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/basic_storage_abi/Forc.lock
@@ -1,9 +1,8 @@
 [[package]]
 name = 'basic_storage_abi'
-source = 'root'
+source = 'member'
 dependencies = ['core']
 
 [[package]]
 name = 'core'
 source = 'path+from-root-3777C332FD2E3D7A'
-dependencies = []

--- a/test/src/ir_generation/tests/continue.sw
+++ b/test/src/ir_generation/tests/continue.sw
@@ -13,40 +13,46 @@ fn main() {
 }
 
 
-// check: br $(while=$ID)()
+// OUTER LOOP
+// check: br $(outer_while_cond=$ID)()
 
-// OUTER LOOP: while / while_body / end_while
-// Jump to first inner loop in body, return when done.
+// check: $outer_while_cond():
+// check: cbr $VAL, $(outer_while_body=$ID)(), $(outer_while_end=$ID)()
 
-// check: $while():
-// check: cbr $VAL, $(while_body=$ID)(), $(end_while=$ID)()
+// check: $(outer_while_break=$ID)():
+// check: br $outer_while_end()
 
-// check: $while_body():
-// check: br $(while0=$ID)
+// check: $outer_while_body():
+// check: br $(inner1_while_cond=$ID)()
 
-// check: $end_while():
+
+// FIRST INNER LOOP
+// check: $inner1_while_cond():
+// check: cbr $VAL, $(inner1_while_body=$ID)(), $(inner1_while_end=$ID)()
+
+// check: $(inner1_while_break=$ID)():
+// check: br $inner1_while_end()
+
+// check: $inner1_while_body():
+// check: br $inner1_while_cond()
+
+// check: $inner1_while_end():
+// check: br $(inner2_while_cond=$ID)()
+
+
+// SECOND INNER LOOP
+// check: $inner2_while_cond():
+// check: cbr $VAL, $(inner_while_body=$ID)(), $(inner2_while_end=$ID)()
+
+// check: $(inner2_while_break=$ID)():
+// check: br $inner2_while_end()
+
+// check: $inner_while_body():
+// check: br $inner2_while_cond()
+
+// check: $inner2_while_end():
+// check: br $outer_while_cond()
+
+
+// check: $outer_while_end():
 // check: ret () $VAL
-
-// FIRST INNER LOOP: while0 / while_body1 / end_while2
-// `continue` forces jump to `while0` in body, branch to second inner loop when done.
-
-// check: $while0():
-// check: cbr $VAL, $(while_body1=$ID)(), $(end_while2=$ID)()
-
-// check: $while_body1():
-// check: br $while0()
-
-// check: $end_while2():
-// check: br $(while3=$ID)
-
-// SECOND INNER LOOP: while3 / while_body4 / end_while5
-// `continue` forces jump to `while3` in body, branch to outer loop when done.
-
-// check: $while3():
-// check: cbr $VAL, $(while_body4=$ID)(), $(end_while5=$ID)()
-
-// check: $while_body4():
-// check: br $while3()
-
-// check: $end_while5():
-// check: br $while()

--- a/test/src/ir_generation/tests/let_reassign_while_loop.sw
+++ b/test/src/ir_generation/tests/let_reassign_while_loop.sw
@@ -13,13 +13,16 @@ fn main() -> bool {
 // check: $while():
 // check: cbr $VAL, $(while_body=$ID)(), $(end_while=$ID)()
 
+// check: $(while_break=$ID)():
+// check: br $end_while()
+
 // check: $while_body():
 // check: cbr $VAL, $(block0=$ID)(), $(block1=$ID)($VAL)
 
-// check: $end_while():
-
 // check: $block0():
-// check: br $(block1=$ID)
+// check: br $(block1=$ID)($VAL)
 
 // check: $block1($VAL: bool):
 // check: br $while
+
+// check: $end_while():


### PR DESCRIPTION
Closes #3580.

Unfortunately the register allocator is a little bit fragile and requires all register uses are listed after their definitions, regardless of topological order.  When compiling `while` loops we have put the 'end' block before the body which could cause these sort of out of order definitions.  This change ensures `while` bodies are between the conditional and end blocks.

Improving the allocator (perhaps including the ability for spilling) should be done after we refactor the ASM generation, in particular after we introduce SSA and basic blocks to the abstract program.  Performing a true topological traversal of the ASM without BBs would be much, much harder otherwise.  The ASM gen refactor is mostly covered in #2505.