### PR TITLE
Only parse project if the changes could be written to disk

### DIFF
--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -15,7 +15,7 @@ use dashmap::DashMap;
 use forc_pkg::{self as pkg};
 use parking_lot::RwLock;
 use pkg::manifest::ManifestFile;
-use std::{path::PathBuf, sync::Arc};
+use std::{fs::File, io::Write, path::PathBuf, sync::Arc};
 use sway_core::{
     language::{
         parsed::{AstNode, ParseProgram},
@@ -252,6 +252,30 @@ impl Session {
                 let _ = self.store_document(text_document);
             }
         }
+    }
+
+    /// Writes the changes to the file and updates the document.
+    pub fn write_changes_to_file(
+        &self,
+        uri: &Url,
+        changes: Vec<TextDocumentContentChangeEvent>,
+    ) -> Result<(), LanguageServerError> {
+        let src = self.update_text_document(uri, changes).ok_or_else(|| {
+            DocumentError::DocumentNotFound {
+                path: uri.path().to_string(),
+            }
+        })?;
+
+        let mut file =
+            File::create(uri.path()).map_err(|err| DocumentError::UnableToCreateFile {
+                err: err.to_string(),
+            })?;
+
+        writeln!(&mut file, "{}", src).map_err(|err| DocumentError::UnableToWriteFile {
+            err: err.to_string(),
+        })?;
+
+        Ok(())
     }
 
     /// Update the document at the given [Url] with the Vec of changes returned by the client.

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -267,9 +267,11 @@ impl Session {
         })?;
         let mut file =
             File::create(uri.path()).map_err(|err| DocumentError::UnableToCreateFile {
+                path: uri.path().to_string(),
                 err: err.to_string(),
             })?;
         writeln!(&mut file, "{}", src).map_err(|err| DocumentError::UnableToWriteFile {
+            path: uri.path().to_string(),
             err: err.to_string(),
         })?;
         Ok(())

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -265,16 +265,13 @@ impl Session {
                 path: uri.path().to_string(),
             }
         })?;
-
         let mut file =
             File::create(uri.path()).map_err(|err| DocumentError::UnableToCreateFile {
                 err: err.to_string(),
             })?;
-
         writeln!(&mut file, "{}", src).map_err(|err| DocumentError::UnableToWriteFile {
             err: err.to_string(),
         })?;
-
         Ok(())
     }
 

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -33,6 +33,10 @@ pub enum DocumentError {
     ManifestsLockPathFailed { dir: String },
     #[error("Document is already stored at {:?}", path)]
     DocumentAlreadyStored { path: String },
+    #[error("File wasn't able to be created: {:?}", err)]
+    UnableToCreateFile { err: String },
+    #[error("Unable to write string to file: {:?}", err)]
+    UnableToWriteFile { err: String },
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -33,10 +33,10 @@ pub enum DocumentError {
     ManifestsLockPathFailed { dir: String },
     #[error("Document is already stored at {:?}", path)]
     DocumentAlreadyStored { path: String },
-    #[error("File wasn't able to be created: {:?}", err)]
-    UnableToCreateFile { err: String },
-    #[error("Unable to write string to file: {:?}", err)]
-    UnableToWriteFile { err: String },
+    #[error("File wasn't able to be created at path {:?} : {:?}", path, err)]
+    UnableToCreateFile { path: String, err: String },
+    #[error("Unable to write string to file at {:?} : {:?}", path, err)]
+    UnableToWriteFile { path: String, err: String },
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -239,13 +239,13 @@ impl LanguageServer for Backend {
         match self.get_uri_and_session(&params.text_document.uri) {
             Ok((uri, session)) => {
                 // update this file with the new changes and write to disk
-                if let Some(src) = session.update_text_document(&uri, params.content_changes) {
-                    if let Ok(mut file) = File::create(uri.path()) {
-                        let _ = writeln!(&mut file, "{}", src);
+                match session.write_changes_to_file(&uri, params.content_changes) {
+                    Ok(_) => {
+                        self.parse_project(uri, params.text_document.uri, session.clone())
+                            .await;
                     }
+                    Err(err) => tracing::error!("{}", err.to_string()),
                 }
-                self.parse_project(uri, params.text_document.uri, session.clone())
-                    .await;
             }
             Err(err) => tracing::error!("{}", err.to_string()),
         }


### PR DESCRIPTION
There was a [CI failure earlier](https://github.com/FuelLabs/sway/actions/runs/3704653621/jobs/6277535455) on one of the LSP tests.

On further investigation, we seemed to reparse the project on `did_change` events, even if the changes were unable to be written to disk. This PR updates the logic so this can't happen. 
  
should hopefully solve #3609