### PR TITLE
Fixes impl self methods with where clause.

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2207,6 +2207,8 @@ pub fn dependency_namespace(
                 namespace::Module::default_with_constants(engines, constants)?
             }
         };
+        let node_idx = &graph[node];
+        namespace.name = node_idx.name.clone();
         namespace.insert_submodule(dep_name, dep_namespace);
         let dep = &graph[dep_node];
         if dep.name == CORE {

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2289,11 +2289,18 @@ pub fn compile_ast(
     manifest: &PackageManifestFile,
     build_profile: &BuildProfile,
     namespace: namespace::Module,
+    pkg_name: Option<String>,
 ) -> Result<CompileResult<ty::TyProgram>> {
     let source = manifest.entry_string()?;
     let sway_build_config =
         sway_build_config(manifest.dir(), &manifest.entry_path(), build_profile)?;
-    let ast_res = sway_core::compile_to_ast(engines, source, namespace, Some(&sway_build_config));
+    let ast_res = sway_core::compile_to_ast(
+        engines,
+        source,
+        namespace,
+        Some(&sway_build_config),
+        pkg_name,
+    );
     Ok(ast_res)
 }
 
@@ -2355,7 +2362,13 @@ pub fn compile(
     // First, compile to an AST. We'll update the namespace and check for JSON ABI output.
     let ast_res = time_expr!(
         "compile to ast",
-        compile_ast(engines, manifest, build_profile, namespace)?
+        compile_ast(
+            engines,
+            manifest,
+            build_profile,
+            namespace,
+            Some(pkg.name.clone())
+        )?
     );
     let typed_program = match ast_res.value.as_ref() {
         None => return fail(&ast_res.warnings, &ast_res.errors),
@@ -2843,7 +2856,13 @@ pub fn check(
             Some(program) => program,
         };
 
-        let ast_result = sway_core::parsed_to_ast(engines, &parse_program, dep_namespace, None);
+        let ast_result = sway_core::parsed_to_ast(
+            engines,
+            &parse_program,
+            dep_namespace,
+            None,
+            Some(pkg.name.clone()),
+        );
         warnings.extend(ast_result.warnings);
         errors.extend(ast_result.errors);
 

--- a/sway-core/src/declaration_engine/decl_mapping.rs
+++ b/sway-core/src/declaration_engine/decl_mapping.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, fmt};
 
-use sway_types::IdentUnique;
+use sway_types::{Ident, IdentUnique};
 
 use super::DeclarationId;
 
@@ -47,7 +47,20 @@ impl DeclMapping {
     }
 
     pub(crate) fn from_original_and_new_decl_ids(
-        original_decl_ids: BTreeMap<IdentUnique, DeclarationId>,
+        original_decl_ids: BTreeMap<Ident, DeclarationId>,
+        new_decl_ids: BTreeMap<Ident, DeclarationId>,
+    ) -> DeclMapping {
+        let mut mapping = vec![];
+        for (original_decl_name, original_decl_id) in original_decl_ids.into_iter() {
+            if let Some(new_decl_id) = new_decl_ids.get(&original_decl_name) {
+                mapping.push((original_decl_id, new_decl_id.clone()));
+            }
+        }
+        DeclMapping { mapping }
+    }
+
+    pub(crate) fn from_original_and_new_decl_ids_unique(
+        original_decl_ids: BTreeMap<Ident, DeclarationId>,
         new_decl_ids: BTreeMap<IdentUnique, DeclarationId>,
     ) -> DeclMapping {
         let mut mapping = vec![];

--- a/sway-core/src/declaration_engine/decl_mapping.rs
+++ b/sway-core/src/declaration_engine/decl_mapping.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, fmt};
 
-use sway_types::Ident;
+use sway_types::IdentUnique;
 
 use super::DeclarationId;
 
@@ -10,7 +10,7 @@ type DestinationDecl = DeclarationId;
 /// The [DeclMapping] is used to create a mapping between a [SourceDecl] (LHS)
 /// and a [DestinationDecl] (RHS).
 pub(crate) struct DeclMapping {
-    mapping: Vec<(SourceDecl, DestinationDecl)>,
+    pub(crate) mapping: Vec<(SourceDecl, DestinationDecl)>,
 }
 
 impl fmt::Display for DeclMapping {
@@ -47,13 +47,16 @@ impl DeclMapping {
     }
 
     pub(crate) fn from_original_and_new_decl_ids(
-        original_decl_ids: BTreeMap<Ident, DeclarationId>,
-        new_decl_ids: BTreeMap<Ident, DeclarationId>,
+        original_decl_ids: BTreeMap<IdentUnique, DeclarationId>,
+        new_decl_ids: BTreeMap<IdentUnique, DeclarationId>,
     ) -> DeclMapping {
         let mut mapping = vec![];
         for (original_decl_name, original_decl_id) in original_decl_ids.into_iter() {
-            if let Some(new_decl_id) = new_decl_ids.get(&original_decl_name) {
-                mapping.push((original_decl_id, new_decl_id.clone()));
+            for (new_decl_name, new_decl_id) in new_decl_ids.iter() {
+                if new_decl_name.as_str() != original_decl_name.as_str() {
+                    continue;
+                }
+                mapping.push((original_decl_id.clone(), new_decl_id.clone()));
             }
         }
         DeclMapping { mapping }

--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::Ident;
+use crate::{Ident, Namespace};
 
 use sway_types::{span::Span, Spanned};
 
@@ -45,7 +45,11 @@ impl<T: Spanned> Spanned for CallPath<T> {
         if self.prefixes.is_empty() {
             self.suffix.span()
         } else {
-            let prefixes_spans = self.prefixes.iter().map(|x| x.span());
+            let prefixes_spans = self
+                .prefixes
+                .iter()
+                .map(|x| x.span())
+                .filter(|x| x.path() == self.suffix.span().path());
             Span::join(Span::join_all(prefixes_spans), self.suffix.span())
         }
     }
@@ -64,5 +68,40 @@ impl CallPath {
                 is_absolute: self.is_absolute,
             }
         }
+    }
+
+    pub fn to_fullpath(&self, namespace: &mut Namespace) -> CallPath {
+        let mut full_trait_name = self.clone();
+        if self.prefixes.is_empty() {
+            let mut synonym_prefixes = vec![];
+            if let Some(use_synonym) = namespace.use_synonyms.get(&self.suffix) {
+                synonym_prefixes = use_synonym.0.clone();
+                for mod_path in namespace.mod_path() {
+                    if synonym_prefixes[0].as_str() == mod_path.as_str() {
+                        synonym_prefixes.drain(0..1);
+                    } else {
+                        synonym_prefixes = use_synonym.0.clone();
+                        break;
+                    }
+                }
+            }
+
+            let mut prefixes: Vec<Ident> = match &namespace.root().pkg_name {
+                Some(pkg_name) if synonym_prefixes.is_empty() => vec![pkg_name.clone()],
+                _ => vec![],
+            };
+
+            for mod_path in namespace.mod_path() {
+                prefixes.push(mod_path.clone());
+            }
+            prefixes.extend(synonym_prefixes);
+
+            full_trait_name = CallPath {
+                prefixes,
+                suffix: self.suffix.clone(),
+                is_absolute: false,
+            }
+        }
+        full_trait_name
     }
 }

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -636,11 +636,11 @@ impl ReplaceDecls for TyExpressionVariant {
                         if fn_decl.parameters.len() != arguments.len() {
                             continue;
                         }
-                        for i in 0..arguments.len() {
-                            if !engines.te().are_equal_minus_dynamic_types(
-                                arguments[i].1.return_type,
-                                fn_decl.parameters[i].type_id,
-                            ) {
+                        for (arg, param) in arguments.iter().zip(fn_decl.parameters) {
+                            if !engines
+                                .te()
+                                .are_equal_minus_dynamic_types(arg.1.return_type, param.type_id)
+                            {
                                 continue 'decls;
                             }
                         }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -702,18 +702,17 @@ fn type_check_trait_implementation(
         }
 
         // remove this function from the "checklist"
-        let mut impl_method_signature =
-            match method_checklist.remove(&impl_method.name.clone().into()) {
-                Some(trait_fn) => trait_fn,
-                None => {
-                    errors.push(CompileError::FunctionNotAPartOfInterfaceSurface {
-                        name: impl_method.name.clone(),
-                        interface_name: interface_name(),
-                        span: impl_method.name.span(),
-                    });
-                    continue;
-                }
-            };
+        let mut impl_method_signature = match method_checklist.remove(&impl_method.name.clone()) {
+            Some(trait_fn) => trait_fn,
+            None => {
+                errors.push(CompileError::FunctionNotAPartOfInterfaceSurface {
+                    name: impl_method.name.clone(),
+                    interface_name: interface_name(),
+                    span: impl_method.name.span(),
+                });
+                continue;
+            }
+        };
 
         // replace instances of `TypeInfo::SelfType` with a fresh
         // `TypeInfo::SelfType` to avoid replacing types in the original trait

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use sway_error::error::CompileError;
-use sway_types::{Ident, Span, Spanned};
+use sway_types::{Ident, IdentUnique, Span, Spanned};
 
 use crate::{
     declaration_engine::{declaration_engine::*, DeclMapping, DeclarationId, ReplaceDecls},
@@ -658,11 +658,11 @@ fn type_check_trait_implementation(
 
     // This map keeps track of the original declaration id's of the original
     // interface surface.
-    let mut original_method_ids: BTreeMap<Ident, DeclarationId> = BTreeMap::new();
+    let mut original_method_ids: BTreeMap<IdentUnique, DeclarationId> = BTreeMap::new();
 
     // This map keeps track of the new declaration ids of the implemented
     // interface surface.
-    let mut impld_method_ids: BTreeMap<Ident, DeclarationId> = BTreeMap::new();
+    let mut impld_method_ids: BTreeMap<IdentUnique, DeclarationId> = BTreeMap::new();
 
     for decl_id in trait_interface_surface.iter() {
         let method = check!(
@@ -673,7 +673,7 @@ fn type_check_trait_implementation(
         );
         let name = method.name.clone();
         method_checklist.insert(name.clone(), method);
-        original_method_ids.insert(name, decl_id.clone());
+        original_method_ids.insert(name.into(), decl_id.clone());
     }
 
     for impl_method in impl_methods {
@@ -691,7 +691,10 @@ fn type_check_trait_implementation(
         );
 
         // Ensure that there aren't multiple definitions of this function impl'd
-        if impld_method_ids.contains_key(&impl_method.name.clone()) {
+        if impld_method_ids
+            .keys()
+            .any(|k| k.as_str() == impl_method.name.clone().as_str())
+        {
             errors.push(CompileError::MultipleDefinitionsOfFunction {
                 name: impl_method.name.clone(),
             });
@@ -699,17 +702,18 @@ fn type_check_trait_implementation(
         }
 
         // remove this function from the "checklist"
-        let mut impl_method_signature = match method_checklist.remove(&impl_method.name) {
-            Some(trait_fn) => trait_fn,
-            None => {
-                errors.push(CompileError::FunctionNotAPartOfInterfaceSurface {
-                    name: impl_method.name.clone(),
-                    interface_name: interface_name(),
-                    span: impl_method.name.span(),
-                });
-                continue;
-            }
-        };
+        let mut impl_method_signature =
+            match method_checklist.remove(&impl_method.name.clone().into()) {
+                Some(trait_fn) => trait_fn,
+                None => {
+                    errors.push(CompileError::FunctionNotAPartOfInterfaceSurface {
+                        name: impl_method.name.clone(),
+                        interface_name: interface_name(),
+                        span: impl_method.name.span(),
+                    });
+                    continue;
+                }
+            };
 
         // replace instances of `TypeInfo::SelfType` with a fresh
         // `TypeInfo::SelfType` to avoid replacing types in the original trait
@@ -884,7 +888,7 @@ fn type_check_trait_implementation(
 
         let name = impl_method.name.clone();
         let decl_id = declaration_engine.insert_function(impl_method);
-        impld_method_ids.insert(name, decl_id);
+        impld_method_ids.insert(name.into(), decl_id);
     }
 
     let mut all_method_ids: Vec<DeclarationId> = impld_method_ids.values().cloned().collect();
@@ -1047,16 +1051,16 @@ fn handle_supertraits(
     mut ctx: TypeCheckContext,
     supertraits: &[Supertrait],
 ) -> CompileResult<(
-    BTreeMap<Ident, DeclarationId>,
-    BTreeMap<Ident, DeclarationId>,
+    BTreeMap<IdentUnique, DeclarationId>,
+    BTreeMap<IdentUnique, DeclarationId>,
 )> {
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
 
     let declaration_engine = ctx.declaration_engine;
 
-    let mut interface_surface_methods_ids: BTreeMap<Ident, DeclarationId> = BTreeMap::new();
-    let mut impld_method_ids: BTreeMap<Ident, DeclarationId> = BTreeMap::new();
+    let mut interface_surface_methods_ids: BTreeMap<IdentUnique, DeclarationId> = BTreeMap::new();
+    let mut impld_method_ids: BTreeMap<IdentUnique, DeclarationId> = BTreeMap::new();
     let self_type = ctx.self_type();
 
     for supertrait in supertraits.iter() {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use sway_error::warning::{CompileWarning, Warning};
-use sway_types::{style::is_upper_camel_case, Ident, Spanned};
+use sway_types::{style::is_upper_camel_case, IdentUnique, Spanned};
 
 use crate::{
     declaration_engine::*,
@@ -11,7 +11,7 @@ use crate::{
     type_system::*,
 };
 
-type MethodMap = BTreeMap<Ident, DeclarationId>;
+type MethodMap = BTreeMap<IdentUnique, DeclarationId>;
 
 impl ty::TyTraitDeclaration {
     pub(crate) fn type_check(
@@ -165,7 +165,7 @@ impl ty::TyTraitDeclaration {
                 warnings,
                 errors
             );
-            interface_surface_method_ids.insert(method.name, decl_id.clone());
+            interface_surface_method_ids.insert(method.name.into(), decl_id.clone());
         }
 
         // Retrieve the implemented methods for this type.
@@ -180,7 +180,7 @@ impl ty::TyTraitDeclaration {
                 warnings,
                 errors
             );
-            impld_method_ids.insert(method.name, decl_id);
+            impld_method_ids.insert(method.name.into(), decl_id);
         }
 
         ok(
@@ -226,7 +226,7 @@ impl ty::TyTraitDeclaration {
                 warnings,
                 errors
             );
-            interface_surface_method_ids.insert(method.name, decl_id.clone());
+            interface_surface_method_ids.insert(method.name.into(), decl_id.clone());
         }
 
         // Retrieve the trait methods for this trait.
@@ -239,7 +239,7 @@ impl ty::TyTraitDeclaration {
                 warnings,
                 errors
             );
-            method_ids.insert(method.name, decl_id.clone());
+            method_ids.insert(method.name.into(), decl_id.clone());
         }
 
         // Retrieve the implemented methods for this type.
@@ -268,7 +268,7 @@ impl ty::TyTraitDeclaration {
             );
             method.copy_types(&type_mapping, engines);
             impld_method_ids.insert(
-                method.name.clone(),
+                method.name.clone().into(),
                 declaration_engine
                     .insert_function(method)
                     .with_parent(declaration_engine, decl_id),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use sway_error::warning::{CompileWarning, Warning};
-use sway_types::{style::is_upper_camel_case, IdentUnique, Spanned};
+use sway_types::{style::is_upper_camel_case, Ident, Spanned};
 
 use crate::{
     declaration_engine::*,
@@ -11,7 +11,7 @@ use crate::{
     type_system::*,
 };
 
-type MethodMap = BTreeMap<IdentUnique, DeclarationId>;
+type MethodMap = BTreeMap<Ident, DeclarationId>;
 
 impl ty::TyTraitDeclaration {
     pub(crate) fn type_check(
@@ -165,7 +165,7 @@ impl ty::TyTraitDeclaration {
                 warnings,
                 errors
             );
-            interface_surface_method_ids.insert(method.name.into(), decl_id.clone());
+            interface_surface_method_ids.insert(method.name, decl_id.clone());
         }
 
         // Retrieve the implemented methods for this type.
@@ -180,7 +180,7 @@ impl ty::TyTraitDeclaration {
                 warnings,
                 errors
             );
-            impld_method_ids.insert(method.name.into(), decl_id);
+            impld_method_ids.insert(method.name, decl_id);
         }
 
         ok(
@@ -226,7 +226,7 @@ impl ty::TyTraitDeclaration {
                 warnings,
                 errors
             );
-            interface_surface_method_ids.insert(method.name.into(), decl_id.clone());
+            interface_surface_method_ids.insert(method.name, decl_id.clone());
         }
 
         // Retrieve the trait methods for this trait.
@@ -239,7 +239,7 @@ impl ty::TyTraitDeclaration {
                 warnings,
                 errors
             );
-            method_ids.insert(method.name.into(), decl_id.clone());
+            method_ids.insert(method.name, decl_id.clone());
         }
 
         // Retrieve the implemented methods for this type.
@@ -268,7 +268,7 @@ impl ty::TyTraitDeclaration {
             );
             method.copy_types(&type_mapping, engines);
             impld_method_ids.insert(
-                method.name.clone().into(),
+                method.name.clone(),
                 declaration_engine
                     .insert_function(method)
                     .with_parent(declaration_engine, decl_id),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1999,7 +1999,7 @@ mod tests {
         expr: Expression,
         type_annotation: TypeId,
     ) -> CompileResult<ty::TyExpression> {
-        let mut namespace = Namespace::init_root(namespace::Module::default());
+        let mut namespace = Namespace::init_root(namespace::Module::default(), None);
         let ctx = TypeCheckContext::from_root(&mut namespace, engines)
             .with_type_annotation(type_annotation);
         ty::TyExpression::type_check(ctx, expr)

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -1,5 +1,5 @@
 use crate::{
-    declaration_engine::DeclarationId,
+    declaration_engine::{DeclarationId, ReplaceDecls},
     error::*,
     language::{parsed::*, ty, *},
     semantic_analysis::*,
@@ -49,7 +49,7 @@ pub(crate) fn type_check_method_application(
         warnings,
         errors
     );
-    let method = check!(
+    let mut method = check!(
         CompileResult::from(
             declaration_engine.get_function(decl_id.clone(), &method_name_binding.span())
         ),
@@ -296,7 +296,7 @@ pub(crate) fn type_check_method_application(
                 _ => {
                     errors.push(CompileError::Internal(
                         "Attempted to find contract address of non-contract-call.",
-                        span.clone(),
+                        span,
                     ));
                     None
                 }
@@ -364,16 +364,38 @@ pub(crate) fn type_check_method_application(
         .map(|(param, arg)| (param.name.clone(), arg))
         .collect::<Vec<(_, _)>>();
 
+    // Handle the trait constraints. This includes checking to see if the trait
+    // constraints are satisfied and replacing old decl ids based on the
+    // constraint with new decl ids based on the new type.
+    let decl_mapping = check!(
+        TypeParameter::gather_decl_mapping_from_trait_constraints(
+            ctx.by_ref(),
+            &method.type_parameters,
+            &call_path.span()
+        ),
+        return err(warnings, errors),
+        warnings,
+        errors
+    );
+    method.replace_decls(&decl_mapping, ctx.engines());
+    let return_type = method.return_type;
+    let span = method.span.clone();
+    let new_decl_id = if decl_mapping.is_empty() {
+        decl_id
+    } else {
+        ctx.declaration_engine.insert_function(method)
+    };
+
     let exp = ty::TyExpression {
         expression: ty::TyExpressionVariant::FunctionApplication {
             call_path,
             contract_call_params: contract_call_params_map,
             arguments: args_and_names,
-            function_decl_id: decl_id,
+            function_decl_id: new_decl_id,
             self_state_idx,
             selector,
         },
-        return_type: method.return_type,
+        return_type,
         span,
     };
 

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -2,7 +2,7 @@ use crate::{
     declaration_engine::{declaration_id::DeclarationId, DeclarationEngine},
     engine_threading::Engines,
     error::*,
-    language::{ty, CallPath},
+    language::ty,
     namespace::*,
     type_system::*,
 };
@@ -141,42 +141,6 @@ impl Items {
             .ok_or_else(|| CompileError::SymbolNotFound { name: name.clone() })
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn insert_trait_implementation<'a>(
-        &mut self,
-        trait_name: CallPath,
-        trait_type_args: Vec<TypeArgument>,
-        type_id: TypeId,
-        methods: &[DeclarationId],
-        impl_span: &Span,
-        is_impl_self: bool,
-        engines: Engines<'a>,
-    ) -> CompileResult<()> {
-        let new_prefixes = if trait_name.prefixes.is_empty() {
-            self.use_synonyms
-                .get(&trait_name.suffix)
-                .map(|us| &us.0)
-                .unwrap_or(&trait_name.prefixes)
-                .clone()
-        } else {
-            trait_name.prefixes
-        };
-        let trait_name = CallPath {
-            prefixes: new_prefixes,
-            suffix: trait_name.suffix,
-            is_absolute: trait_name.is_absolute,
-        };
-        self.implemented_traits.insert(
-            trait_name,
-            trait_type_args,
-            type_id,
-            methods,
-            impl_span,
-            is_impl_self,
-            engines,
-        )
-    }
-
     pub(crate) fn insert_trait_implementation_for_type(
         &mut self,
         engines: Engines<'_>,
@@ -192,16 +156,6 @@ impl Items {
     ) -> Vec<DeclarationId> {
         self.implemented_traits
             .get_methods_for_type(engines, type_id)
-    }
-
-    pub(crate) fn get_methods_for_type_and_trait_name(
-        &self,
-        engines: Engines<'_>,
-        type_id: TypeId,
-        trait_name: &CallPath,
-    ) -> Vec<DeclarationId> {
-        self.implemented_traits
-            .get_methods_for_type_and_trait_name(engines, type_id, trait_name)
     }
 
     pub(crate) fn has_storage_declared(&self) -> bool {

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -111,7 +111,7 @@ impl Module {
                 content: AstNodeContent::Declaration(Declaration::ConstantDeclaration(const_decl)),
                 span: const_item_span.clone(),
             };
-            let mut ns = Namespace::init_root(Default::default());
+            let mut ns = Namespace::init_root(Default::default(), None);
             let type_check_ctx = TypeCheckContext::from_root(&mut ns, engines);
             let typed_node = ty::TyAstNode::type_check(type_check_ctx, ast_node)
                 .unwrap(&mut vec![], &mut vec![]);

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -41,6 +41,8 @@ pub struct Module {
     pub(crate) submodules: im::OrdMap<ModuleName, Module>,
     /// The set of symbols, implementations, synonyms and aliases present within this module.
     items: Items,
+    /// Name of the module, package name for root module, dependency name for other modules
+    pub name: String,
 }
 
 impl Module {
@@ -144,6 +146,8 @@ impl Module {
 
     /// Insert a submodule into this `Module`.
     pub fn insert_submodule(&mut self, name: String, submodule: Module) {
+        let mut submodule = submodule;
+        submodule.name = name.clone();
         self.submodules.insert(name, submodule);
     }
 

--- a/sway-core/src/semantic_analysis/namespace/root.rs
+++ b/sway-core/src/semantic_analysis/namespace/root.rs
@@ -16,6 +16,7 @@ use super::{module::Module, namespace::Namespace, Path};
 #[derive(Clone, Debug)]
 pub struct Root {
     pub(crate) module: Module,
+    pub(crate) pkg_name: Option<Ident>,
 }
 
 impl Root {
@@ -76,7 +77,10 @@ impl std::ops::DerefMut for Root {
 
 impl From<Module> for Root {
     fn from(module: Module) -> Self {
-        Root { module }
+        Root {
+            module,
+            pkg_name: None,
+        }
     }
 }
 

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -659,7 +659,7 @@ impl TraitMap {
             return methods;
         }
         for entry in self.trait_impls.iter() {
-            if are_equal_minus_dynamic_types(type_engine, type_id, entry.key.type_id) {
+            if type_engine.are_equal_minus_dynamic_types(type_id, entry.key.type_id) {
                 let mut trait_methods = entry
                     .value
                     .values()
@@ -704,7 +704,7 @@ impl TraitMap {
                 is_absolute: e.key.name.is_absolute,
             };
             if &map_trait_name == trait_name
-                && are_equal_minus_dynamic_types(type_engine, type_id, e.key.type_id)
+                && type_engine.are_equal_minus_dynamic_types(type_id, e.key.type_id)
             {
                 let mut trait_methods = e.value.values().cloned().into_iter().collect::<Vec<_>>();
                 methods.append(&mut trait_methods);
@@ -763,12 +763,9 @@ impl TraitMap {
                         },
                     },
                 );
-                if are_equal_minus_dynamic_types(type_engine, type_id, key.type_id)
-                    && are_equal_minus_dynamic_types(
-                        type_engine,
-                        constraint_type_id,
-                        map_trait_type_id,
-                    )
+                if type_engine.are_equal_minus_dynamic_types(type_id, key.type_id)
+                    && type_engine
+                        .are_equal_minus_dynamic_types(constraint_type_id, map_trait_type_id)
                 {
                     found_traits.insert(constraint_trait_name.suffix.clone());
                 }
@@ -789,170 +786,5 @@ impl TraitMap {
         } else {
             err(warnings, errors)
         }
-    }
-}
-
-fn are_equal_minus_dynamic_types(type_engine: &TypeEngine, left: TypeId, right: TypeId) -> bool {
-    if left.index() == right.index() {
-        return true;
-    }
-    match (
-        type_engine.look_up_type_id(left),
-        type_engine.look_up_type_id(right),
-    ) {
-        // these cases are false because, unless left and right have the same
-        // TypeId, they may later resolve to be different types in the type
-        // engine
-        (TypeInfo::Unknown, TypeInfo::Unknown) => false,
-        (TypeInfo::SelfType, TypeInfo::SelfType) => false,
-        (TypeInfo::Numeric, TypeInfo::Numeric) => false,
-        (TypeInfo::Contract, TypeInfo::Contract) => false,
-        (TypeInfo::Storage { .. }, TypeInfo::Storage { .. }) => false,
-
-        // these cases are able to be directly compared
-        (TypeInfo::Boolean, TypeInfo::Boolean) => true,
-        (TypeInfo::B256, TypeInfo::B256) => true,
-        (TypeInfo::ErrorRecovery, TypeInfo::ErrorRecovery) => true,
-        (TypeInfo::Str(l), TypeInfo::Str(r)) => l.val() == r.val(),
-        (TypeInfo::UnsignedInteger(l), TypeInfo::UnsignedInteger(r)) => l == r,
-        (TypeInfo::RawUntypedPtr, TypeInfo::RawUntypedPtr) => true,
-        (TypeInfo::RawUntypedSlice, TypeInfo::RawUntypedSlice) => true,
-        (TypeInfo::UnknownGeneric { .. }, TypeInfo::UnknownGeneric { .. }) => {
-            // return true if left and right were unified previously
-            type_engine.get_unified_types(left).contains(&right)
-                || type_engine.get_unified_types(right).contains(&left)
-        }
-
-        // these cases may contain dynamic types
-        (
-            TypeInfo::Custom {
-                name: l_name,
-                type_arguments: l_type_args,
-            },
-            TypeInfo::Custom {
-                name: r_name,
-                type_arguments: r_type_args,
-            },
-        ) => {
-            l_name == r_name
-                && l_type_args
-                    .unwrap_or_default()
-                    .iter()
-                    .zip(r_type_args.unwrap_or_default().iter())
-                    .fold(true, |acc, (left, right)| {
-                        acc && are_equal_minus_dynamic_types(
-                            type_engine,
-                            left.type_id,
-                            right.type_id,
-                        )
-                    })
-        }
-        (
-            TypeInfo::Enum {
-                name: l_name,
-                variant_types: l_variant_types,
-                type_parameters: l_type_parameters,
-            },
-            TypeInfo::Enum {
-                name: r_name,
-                variant_types: r_variant_types,
-                type_parameters: r_type_parameters,
-            },
-        ) => {
-            l_name == r_name
-                && l_variant_types.iter().zip(r_variant_types.iter()).fold(
-                    true,
-                    |acc, (left, right)| {
-                        acc && left.name == right.name
-                            && are_equal_minus_dynamic_types(
-                                type_engine,
-                                left.type_id,
-                                right.type_id,
-                            )
-                    },
-                )
-                && l_type_parameters.iter().zip(r_type_parameters.iter()).fold(
-                    true,
-                    |acc, (left, right)| {
-                        acc && left.name_ident == right.name_ident
-                            && are_equal_minus_dynamic_types(
-                                type_engine,
-                                left.type_id,
-                                right.type_id,
-                            )
-                    },
-                )
-        }
-        (
-            TypeInfo::Struct {
-                name: l_name,
-                fields: l_fields,
-                type_parameters: l_type_parameters,
-            },
-            TypeInfo::Struct {
-                name: r_name,
-                fields: r_fields,
-                type_parameters: r_type_parameters,
-            },
-        ) => {
-            l_name == r_name
-                && l_fields
-                    .iter()
-                    .zip(r_fields.iter())
-                    .fold(true, |acc, (left, right)| {
-                        acc && left.name == right.name
-                            && are_equal_minus_dynamic_types(
-                                type_engine,
-                                left.type_id,
-                                right.type_id,
-                            )
-                    })
-                && l_type_parameters.iter().zip(r_type_parameters.iter()).fold(
-                    true,
-                    |acc, (left, right)| {
-                        acc && left.name_ident == right.name_ident
-                            && are_equal_minus_dynamic_types(
-                                type_engine,
-                                left.type_id,
-                                right.type_id,
-                            )
-                    },
-                )
-        }
-        (TypeInfo::Tuple(l), TypeInfo::Tuple(r)) => {
-            if l.len() != r.len() {
-                false
-            } else {
-                l.iter().zip(r.iter()).fold(true, |acc, (left, right)| {
-                    acc && are_equal_minus_dynamic_types(type_engine, left.type_id, right.type_id)
-                })
-            }
-        }
-        (
-            TypeInfo::ContractCaller {
-                abi_name: l_abi_name,
-                address: l_address,
-            },
-            TypeInfo::ContractCaller {
-                abi_name: r_abi_name,
-                address: r_address,
-            },
-        ) => {
-            l_abi_name == r_abi_name
-                && Option::zip(l_address, r_address)
-                    .map(|(l_address, r_address)| {
-                        are_equal_minus_dynamic_types(
-                            type_engine,
-                            l_address.return_type,
-                            r_address.return_type,
-                        )
-                    })
-                    .unwrap_or(true)
-        }
-        (TypeInfo::Array(l0, l1), TypeInfo::Array(r0, r1)) => {
-            l1.val() == r1.val()
-                && are_equal_minus_dynamic_types(type_engine, l0.type_id, r0.type_id)
-        }
-        _ => false,
     }
 }

--- a/sway-core/src/semantic_analysis/program.rs
+++ b/sway-core/src/semantic_analysis/program.rs
@@ -20,8 +20,9 @@ impl ty::TyProgram {
         engines: Engines<'_>,
         parsed: &ParseProgram,
         initial_namespace: namespace::Module,
+        pkg_name_opt: Option<String>,
     ) -> CompileResult<Self> {
-        let mut namespace = Namespace::init_root(initial_namespace);
+        let mut namespace = Namespace::init_root(initial_namespace, pkg_name_opt);
         let ctx =
             TypeCheckContext::from_root(&mut namespace, engines).with_kind(parsed.kind.clone());
         let ParseProgram { root, kind } = parsed;

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -69,6 +69,7 @@ fn generic_enum_resolution() {
             name_ident: Ident::new_no_span("T"),
             trait_constraints: vec![],
             trait_constraints_span: Span::dummy(),
+            is_from_parent: false,
         }],
     });
 
@@ -91,6 +92,7 @@ fn generic_enum_resolution() {
             name_ident: Ident::new_no_span("T"),
             trait_constraints: vec![],
             trait_constraints_span: Span::dummy(),
+            is_from_parent: false,
         }],
     });
 

--- a/sway-core/src/type_system/type_parameter.rs
+++ b/sway-core/src/type_system/type_parameter.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 use sway_error::error::CompileError;
-use sway_types::{ident::Ident, span::Span, Spanned};
+use sway_types::{ident::Ident, span::Span, IdentUnique, Spanned};
 
 use std::{
     collections::BTreeMap,
@@ -221,8 +221,8 @@ impl TypeParameter {
         let mut warnings = vec![];
         let mut errors = vec![];
 
-        let mut original_method_ids: BTreeMap<Ident, DeclarationId> = BTreeMap::new();
-        let mut impld_method_ids: BTreeMap<Ident, DeclarationId> = BTreeMap::new();
+        let mut original_method_ids: BTreeMap<IdentUnique, DeclarationId> = BTreeMap::new();
+        let mut impld_method_ids: BTreeMap<IdentUnique, DeclarationId> = BTreeMap::new();
 
         for type_param in type_parameters.iter() {
             let TypeParameter {
@@ -279,16 +279,16 @@ fn handle_trait(
     trait_name: &CallPath,
     type_arguments: &[TypeArgument],
 ) -> CompileResult<(
-    BTreeMap<Ident, DeclarationId>,
-    BTreeMap<Ident, DeclarationId>,
+    BTreeMap<IdentUnique, DeclarationId>,
+    BTreeMap<IdentUnique, DeclarationId>,
 )> {
     let mut warnings = vec![];
     let mut errors = vec![];
 
     let declaration_engine = ctx.declaration_engine;
 
-    let mut original_method_ids: BTreeMap<Ident, DeclarationId> = BTreeMap::new();
-    let mut impld_method_ids: BTreeMap<Ident, DeclarationId> = BTreeMap::new();
+    let mut original_method_ids: BTreeMap<IdentUnique, DeclarationId> = BTreeMap::new();
+    let mut impld_method_ids: BTreeMap<IdentUnique, DeclarationId> = BTreeMap::new();
 
     match ctx
         .namespace

--- a/sway-core/src/type_system/type_parameter.rs
+++ b/sway-core/src/type_system/type_parameter.rs
@@ -221,7 +221,7 @@ impl TypeParameter {
         let mut warnings = vec![];
         let mut errors = vec![];
 
-        let mut original_method_ids: BTreeMap<IdentUnique, DeclarationId> = BTreeMap::new();
+        let mut original_method_ids: BTreeMap<Ident, DeclarationId> = BTreeMap::new();
         let mut impld_method_ids: BTreeMap<IdentUnique, DeclarationId> = BTreeMap::new();
 
         for type_param in type_parameters.iter() {
@@ -259,13 +259,17 @@ impl TypeParameter {
                     errors
                 );
                 original_method_ids.extend(trait_original_method_ids);
-                impld_method_ids.extend(trait_impld_method_ids);
+                for (key, value) in trait_impld_method_ids {
+                    impld_method_ids.insert(key.into(), value);
+                }
             }
         }
 
         if errors.is_empty() {
-            let decl_mapping =
-                DeclMapping::from_original_and_new_decl_ids(original_method_ids, impld_method_ids);
+            let decl_mapping = DeclMapping::from_original_and_new_decl_ids_unique(
+                original_method_ids,
+                impld_method_ids,
+            );
             ok(decl_mapping, warnings, errors)
         } else {
             err(warnings, errors)
@@ -279,16 +283,16 @@ fn handle_trait(
     trait_name: &CallPath,
     type_arguments: &[TypeArgument],
 ) -> CompileResult<(
-    BTreeMap<IdentUnique, DeclarationId>,
-    BTreeMap<IdentUnique, DeclarationId>,
+    BTreeMap<Ident, DeclarationId>,
+    BTreeMap<Ident, DeclarationId>,
 )> {
     let mut warnings = vec![];
     let mut errors = vec![];
 
     let declaration_engine = ctx.declaration_engine;
 
-    let mut original_method_ids: BTreeMap<IdentUnique, DeclarationId> = BTreeMap::new();
-    let mut impld_method_ids: BTreeMap<IdentUnique, DeclarationId> = BTreeMap::new();
+    let mut original_method_ids: BTreeMap<Ident, DeclarationId> = BTreeMap::new();
+    let mut impld_method_ids: BTreeMap<Ident, DeclarationId> = BTreeMap::new();
 
     match ctx
         .namespace

--- a/sway-core/src/type_system/unify.rs
+++ b/sway-core/src/type_system/unify.rs
@@ -251,6 +251,8 @@ pub(super) fn unify(
             (vec![], vec![])
         }
         (ref r @ UnknownGeneric { .. }, e) => {
+            type_engine.insert_unified_type(received, expected);
+            type_engine.insert_unified_type(expected, received);
             match type_engine.slab.replace(received, r, e, engines) {
                 None => (vec![], vec![]),
                 Some(_) => unify(
@@ -264,6 +266,8 @@ pub(super) fn unify(
             }
         }
         (r, ref e @ UnknownGeneric { .. }) => {
+            type_engine.insert_unified_type(received, expected);
+            type_engine.insert_unified_type(expected, received);
             match type_engine.slab.replace(expected, e, r, engines) {
                 None => (vec![], vec![]),
                 Some(_) => unify(

--- a/sway-types/src/ident.rs
+++ b/sway-types/src/ident.rs
@@ -119,6 +119,14 @@ impl fmt::Display for Ident {
 #[derive(Debug, Clone)]
 pub struct IdentUnique(BaseIdent);
 
+impl IdentUnique {
+    pub fn as_str(&self) -> &str {
+        self.0
+            .name_override_opt
+            .unwrap_or_else(|| self.0.span.as_str())
+    }
+}
+
 impl From<Ident> for IdentUnique {
     fn from(item: Ident) -> Self {
         IdentUnique(item)

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-701263CC2F33CD43'
+
+[[package]]
+name = 'generic_impl_self_where'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-701263CC2F33CD43'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "generic_impl_self_where"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/json_abi_oracle.json
@@ -1,0 +1,23 @@
+{
+  "functions": [
+    {
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": [],
+      "type": "()",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/json_abi_oracle.json
@@ -1,6 +1,7 @@
 {
   "functions": [
     {
+      "attributes": null,
       "inputs": [],
       "name": "main",
       "output": {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/folder/nested_traits.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/folder/nested_traits.sw
@@ -1,0 +1,11 @@
+library nested_traits;
+
+pub trait MyEq2 {
+    fn my_eq2(self, other: Self) -> bool;
+}
+
+impl MyEq2 for u64 {
+    fn my_eq2(self, other: Self) -> bool {
+        self == other
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/folder/traits.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/folder/traits.sw
@@ -1,0 +1,15 @@
+library traits;
+
+dep nested_traits;
+
+use nested_traits::*;
+
+pub trait MyEq {
+    fn my_eq(self, other: Self) -> bool;
+}
+
+impl MyEq for u64 {
+    fn my_eq(self, other: Self) -> bool {
+        self == other
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/folder/traits.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/folder/traits.sw
@@ -13,3 +13,9 @@ impl MyEq for u64 {
         self == other
     }
 }
+
+impl MyEq for bool {
+    fn my_eq(self, other: Self) -> bool {
+        self == other
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/main.sw
@@ -1,7 +1,11 @@
 script;
 
+dep folder/traits;
+
 use core::ops::*;
 use std::assert::assert;
+use traits::*;
+use traits::nested_traits::*;
 
 struct Data<T> {
   x: T
@@ -13,8 +17,65 @@ impl<T> Data<T> {
   }
 }
 
+struct Data2<T, K> {
+  x: T,
+  y: K
+}
+
+impl<T,K> Data2<T,K> {
+  fn contains(self, other: Self) -> bool where T: Eq, K: Eq  {
+    self.x == other.x && self.y == other.y
+  }
+  fn contains2(self, other: Self) -> bool where T: Eq, K: Eq  {
+    self.x == other.x && self.y == other.y
+  }
+}
+
+impl<T,K> Data2<T,K> {
+  fn contains3(self, other: Self) -> bool where T: Eq, K: Eq  {
+    self.x == other.x && self.y == other.y
+  }
+
+  fn contains4(first: Self, second: Self) -> bool where T: Eq, K: Eq  {
+    first.x == second.x && first.y == second.y
+  }
+
+  fn contains5(self, other: Self) -> bool where T: MyEq, K: MyEq  {
+    self.x.my_eq(other.x) && self.y.my_eq(other.y)
+  }
+
+  fn contains6(self, other: Self) -> bool where T: MyEq2, K: MyEq2  {
+    self.x.my_eq2(other.x) && self.y.my_eq2(other.y)
+  }
+}
+
 fn main() {
   let s = Data { x: 42 };
   assert(s.contains(42));
   assert(!s.contains(41));
+
+  let d = Data2 { x: 42, y: 42 };
+  assert(d.contains(Data2 { x: 42, y: 42 }));
+  assert(!d.contains(Data2 { x: 42, y: 41 }));
+  assert(!d.contains(Data2 { x: 41, y: 42 }));
+
+  assert(d.contains2(Data2 { x: 42, y: 42 }));
+  assert(!d.contains2(Data2 { x: 42, y: 41 }));
+  assert(!d.contains2(Data2 { x: 41, y: 42 }));
+
+  assert(d.contains3(Data2 { x: 42, y: 42 }));
+  assert(!d.contains3(Data2 { x: 42, y: 41 }));
+  assert(!d.contains3(Data2 { x: 41, y: 42 }));
+
+  assert(Data2::contains4(d, Data2 { x: 42, y: 42 }));
+  assert(!Data2::contains4(d, Data2 { x: 42, y: 41 }));
+  assert(!Data2::contains4(d, Data2 { x: 41, y: 42 }));
+
+  assert(d.contains5(Data2 { x: 42, y: 42 }));
+  assert(!d.contains5(Data2 { x: 42, y: 41 }));
+  assert(!d.contains5(Data2 { x: 41, y: 42 }));
+
+  assert(d.contains6(Data2 { x: 42, y: 42 }));
+  assert(!d.contains6(Data2 { x: 42, y: 41 }));
+  assert(!d.contains6(Data2 { x: 41, y: 42 }));
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/main.sw
@@ -49,6 +49,22 @@ impl<T,K> Data2<T,K> {
   }
 }
 
+struct Data3 {
+  x: u64
+}
+
+impl Eq for Data3 {
+  fn eq(self, other: Self) -> bool {
+    self.x == other.x
+  }
+}
+
+impl MyEq for Data3 {
+  fn my_eq(self, other: Self) -> bool {
+    self.x == other.x
+  }
+}
+
 fn main() {
   let s = Data { x: 42 };
   assert(s.contains(42));
@@ -78,4 +94,18 @@ fn main() {
   assert(d.contains6(Data2 { x: 42, y: 42 }));
   assert(!d.contains6(Data2 { x: 42, y: 41 }));
   assert(!d.contains6(Data2 { x: 41, y: 42 }));
+
+  let d2 = Data2 { x: 42, y: true };
+  assert(d2.contains5(Data2 { x: 42, y: true }));
+  assert(!d2.contains5(Data2 { x: 42, y: false }));
+  assert(!d2.contains5(Data2 { x: 41, y: true }));
+
+  let d3 = Data { x: Data3 { x: 42 }};
+  assert(d3.contains(Data3 { x: 42 }));
+  assert(!d3.contains(Data3 { x: 41 }));
+
+  let d4 = Data2 { x: 42, y: Data3 { x: 42 } };
+  assert(d4.contains5(Data2 { x: 42, y: Data3 { x: 42 } }));
+  assert(!d4.contains5(Data2 { x: 42, y: Data3 { x: 41 } }));
+  assert(!d4.contains5(Data2 { x: 41, y: Data3 { x: 42 } }));
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/main.sw
@@ -1,0 +1,20 @@
+script;
+
+use core::ops::*;
+use std::assert::assert;
+
+struct Data<T> {
+  x: T
+}
+
+impl<T> Data<T> {
+  fn contains(self, other: T) -> bool where T: Eq {
+    self.x == other
+  }
+}
+
+fn main() {
+  let s = Data { x: 42 };
+  assert(s.contains(42));
+  assert(!s.contains(41));
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 0 }
+validate_abi = true

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_result_method/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_result_method/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-D54DA94A05F8FCF5'
+
+[[package]]
+name = 'generic_result_method'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-D54DA94A05F8FCF5'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_result_method/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_result_method/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "generic_result_method"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_result_method/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_result_method/json_abi_oracle.json
@@ -1,0 +1,24 @@
+{
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "bool",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_result_method/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_result_method/src/main.sw
@@ -1,0 +1,33 @@
+script;
+
+use core::ops::*;
+use std::assert::*;
+
+enum Result2<T, E> {
+    Ok: T,
+    Err: E,
+}
+
+impl<T, E> Result2<T, E> {
+    pub fn unwrap_or(self, default: T) -> T {
+        match self {
+            Result2::Ok(inner_value) => inner_value,
+            Result2::Err(_) => default,
+        }
+    }
+}
+
+pub fn test_unwrap_or<T>(val: T, default: T)
+where
+    T: Eq
+{
+    assert(Result2::Ok::<T, T>(val).unwrap_or(default) == val);
+    assert(Result2::Err::<T, T>(val).unwrap_or(default) == default);
+}
+
+fn main() -> bool {
+  test_unwrap_or(true, true);
+  test_unwrap_or(true, false);
+
+  true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_result_method/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_result_method/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+validate_abi = true

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_functions/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_functions/src/main.sw
@@ -218,6 +218,7 @@ fn main() -> u64 {
     assert(m.y == 20u64);
 
     test_ok_or(true, 0);
+    test_ok_or(0, true);
 
     42
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-415990365485FD0B'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-415990365485FD0B'
+dependencies = ['core']
+
+[[package]]
+name = 'where_clause_methods'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+name = "where_clause_methods"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/json_abi_oracle.json
@@ -1,6 +1,7 @@
 {
   "functions": [
     {
+      "attributes": null,
       "inputs": [],
       "name": "main",
       "output": {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/json_abi_oracle.json
@@ -1,0 +1,23 @@
+{
+  "functions": [
+    {
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/src/main.sw
@@ -58,10 +58,6 @@ impl<T> MyPoint<T> {
     }
 }
 
-trait MyMul {
-    fn my_mul(self, other: Self) -> Self;
-}
-
 impl MyMul for u8 {
     fn my_mul(self, other: Self) -> Self {
         self * other

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/src/main.sw
@@ -1,0 +1,207 @@
+script;
+
+use std::{
+    assert::assert,
+    logging::log,
+};
+
+trait MyAdd {
+    fn my_add(self, other: Self) -> Self;
+}
+
+trait MyMul {
+    fn my_mul(self, other: Self) -> Self;
+}
+
+impl MyAdd for u8 {
+    fn my_add(self, other: Self) -> Self {
+        self + other
+    }
+}
+
+impl MyAdd for u16 {
+    fn my_add(self, other: Self) -> Self {
+        self + other
+    }
+}
+
+impl MyAdd for u32 {
+    fn my_add(self, other: Self) -> Self {
+        self + other
+    }
+}
+
+impl MyAdd for u64 {
+    fn my_add(self, other: Self) -> Self {
+        self + other
+    }
+}
+
+struct MyPoint<T> {
+    x: T,
+    y: T,
+}
+
+impl<T> MyPoint<T> {
+    fn add_points(self, b: MyPoint<T>) -> MyPoint<T> where T: MyAdd {
+        MyPoint {
+            x: self.x.my_add(b.x),
+            y: self.y.my_add(b.y),
+        }
+    }
+
+    fn add_points2<F>(self, b: MyPoint<F>) -> MyPoint<F> where T: MyAdd, F: MyAdd {
+        MyPoint {
+            x: b.x.my_add(b.x),
+            y: b.y.my_add(b.y),
+        }
+    }
+}
+
+trait MyMul {
+    fn my_mul(self, other: Self) -> Self;
+}
+
+impl MyMul for u8 {
+    fn my_mul(self, other: Self) -> Self {
+        self * other
+    }
+}
+
+impl MyMul for u16 {
+    fn my_mul(self, other: Self) -> Self {
+        self * other
+    }
+}
+
+impl MyMul for u32 {
+    fn my_mul(self, other: Self) -> Self {
+        self * other
+    }
+}
+
+impl MyMul for u64 {
+    fn my_mul(self, other: Self) -> Self {
+        self * other
+    }
+}
+
+impl<T> MyPoint<T> {
+    fn mul_points(self, b: MyPoint<T>) -> MyPoint<T> where T: MyMul {
+        MyPoint {
+            x: self.x.my_mul(b.x),
+            y: self.y.my_mul(b.y),
+        }
+    }
+
+    fn mul_points2<F>(self, b: MyPoint<F>) -> MyPoint<F> where T: MyMul, F: MyMul {
+        MyPoint {
+            x: b.x.my_mul(b.x),
+            y: b.y.my_mul(b.y),
+        }
+    }
+
+    fn do_math(self, b: MyPoint<T>) -> MyPoint<T> where T: MyAdd + MyMul {
+        MyPoint {
+            x: self.x.my_add(b.x),
+            y: self.y.my_mul(b.y),
+        }
+    }
+
+    fn do_math2<F>(self, b: MyPoint<F>) -> MyPoint<F> where T: MyAdd + MyMul, F: MyMul + MyAdd {
+        MyPoint {
+            x: b.x.my_add(b.x),
+            y: b.y.my_mul(b.y),
+        }
+    }
+}
+trait MyMath: MyAdd + MyMul {
+
+} {
+    fn my_double(self) -> Self {
+        self.my_add(self)
+    }
+
+    fn my_pow_2(self) -> Self {
+        self.my_mul(self)
+    }
+}
+
+impl MyMath for u8 {}
+
+impl MyMath for u16 {}
+
+impl MyMath for u32 {}
+
+impl MyMath for u64 {}
+
+impl<T> MyPoint<T> {
+    fn do_math3(self, b: MyPoint<T>) -> MyPoint<T> where T: MyMath {
+        MyPoint {
+            x: self.x.my_double().my_mul(b.x.my_double()),
+            y: self.y.my_pow_2().my_add(b.y.my_pow_2()),
+        }
+    }
+}
+
+fn main() -> u64 {
+    let a = MyPoint {
+        x: 1u64,
+        y: 2u64,
+    };
+    assert(a.x == 1u64);
+    assert(a.y == 2u64);
+
+    let b = MyPoint {
+        x: 3u64,
+        y: 4u64,
+    };
+    assert(b.x == 3u64);
+    assert(b.y == 4u64);
+
+    let c = a.add_points(b);
+    assert(c.x == 4u64);
+    assert(c.y == 6u64);
+
+    let d = MyPoint {
+        x: 99u16,
+        y: 99u16,
+    };
+    let e = MyPoint {
+        x: 5u8,
+        y: 10u8
+    };
+    let f = d.add_points2(e);
+    assert(f.x == 10u8);
+    assert(f.y == 20u8);
+
+    let g = a.mul_points(b);
+    assert(g.x == 3u64);
+    assert(g.y == 8u64);
+
+    let h = d.mul_points2(e);
+    assert(h.x == 25u8);
+    assert(h.y == 100u8);
+
+    let i = MyPoint {
+        x: 3u16,
+        y: 6u16,
+    };
+    let j = MyPoint {
+        x: 9u16,
+        y: 12u16,
+    };
+    let k = i.do_math(j);
+    assert(k.x == 12u16);
+    assert(k.y == 72u16);
+
+    let l = i.do_math2(j);
+    assert(l.x == 18u16);
+    assert(l.y == 144u16);
+
+    let m = a.do_math3(b);
+    assert(m.x == 12u64);
+    assert(m.y == 20u64);
+
+    42
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 42 }
+validate_abi = true

--- a/test/src/ir_generation/mod.rs
+++ b/test/src/ir_generation/mod.rs
@@ -122,6 +122,7 @@ pub(super) async fn run(filter_regex: Option<&regex::Regex>) -> Result<()> {
                     Arc::from(sway_str),
                     core_lib.clone(),
                     Some(&bld_cfg),
+                    None,
                 );
                 if !typed_res.errors.is_empty() {
                     panic!(


### PR DESCRIPTION
When where clauses were used in impl self methods with a generic parameter from impl<T> an error was thrown saying `cannot find type "T" in this scope`

This fix includes multiple changes:
  - Parent type parameters that are used in method where clauses are now added to `FunctionDeclaration.type_parameters`
  - `type_check_method_application` now replaces decls from trait constraints.
  - `insert_trait_implementation` and `get_methods_for_type_and_trait_name` now use a new method `trait_name.to_fullpath` this improves consistency between inserting and getting by using a full path representation in stored trait implementations.
  - `Namespace::init_root` now receives a pkg_name, this was required by the previous change.

Closes #3333

Another issue this solves is related to #3325 where multiple trait constraints were used for same method but with different types an error would occur as the replace of the declaration would pick only one trait method implementation for both constraints.

The solution was to use IdentUnique while collecting traits implemented methods in `gather_decl_mapping_from_trait_constraints`. This allows to create `DeclMapping` mappings from one trait original method to multiple trait implementations. For instance eq method original method to both bool and u64 trait implementations.

The other step of the solution was to verify while replacing decls if the current function application beeing replaced matches the argument types of one decl mapping specifically.

This changes also fix #3623, added test case `generic_result_method`.
Closes #3623