### PR TITLE
Add `--stdlib` option to `forc new` and `forc init`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,10 +167,8 @@ jobs:
         with:
           command: install
           args: --debug --path ./forc
-      - name: Initialize test project
-        run: forc new test-proj
-      - name: Update project forc manifest to use local sway-lib-std
-        run: echo "std = { path = \"../sway-lib-std/\" }" >> test-proj/Forc.toml
+      - name: Initialize test project (use local sway-lib-std)
+        run: forc new test-proj --stdlib sway-lib-std
       - name: Build test project
         run: forc build --path test-proj
       # TODO: Re-add this upon landing unit test support: #1832

--- a/docs/book/src/introduction/standard_library.md
+++ b/docs/book/src/introduction/standard_library.md
@@ -10,6 +10,14 @@ The entire Sway standard library is a Forc project called `std`, and is availabl
 
 The standard library is made implicitly available to all Forc projects created using [`forc new`](../forc/commands/forc_new.md). In other words, it is not required to manually specify `std` as an explicit dependency. Forc will automatically use the version of `std` that matches its version.
 
+There is a command-line option to override the path to the standard library at the time of project creation:
+
+```shell
+forc new <project-name> --stdlib path-to-sway-lib-std
+```
+
+If the path is relative, `forc new` makes it relative w.r.t. the project directory, otherwise, if it is absolute, `forc new` uses it as is.
+
 Importing items from the standard library can be done using the `use` keyword, just as importing items from any Sway project. For example:
 
 ```sway

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -19,6 +19,12 @@ pub mod restricted;
 
 pub const DEFAULT_OUTPUT_DIRECTORY: &str = "out";
 
+pub enum StdlibPath {
+    Dir(String),
+    Git(String),
+    Unspecified,
+}
+
 /// Continually go up in the file tree until a specified file is found.
 #[allow(clippy::branches_sharing_code)]
 pub fn find_parent_dir_with_file(starter_path: &Path, file_name: &str) -> Option<PathBuf> {

--- a/forc/src/cli/commands/init.rs
+++ b/forc/src/cli/commands/init.rs
@@ -23,11 +23,11 @@ pub struct Command {
     /// Adding this flag creates an empty workspace.
     #[clap(long)]
     pub workspace: bool,
-    /// The path at which the standard library is located.
+    /// The local directory path or URL at which the standard library is located.
     /// If unspecified, the std will be implicitly included as a git dependency
     /// via the git tag that matches `forc`'s version.
-    /// If the path is relative, forc makes it relative w.r.t. the project directory.
-    /// If the path is absolute, forc uses it as is.
+    /// `forc` uses absolute directory paths and URLs as is.
+    /// Relative directory paths are made relative w.r.t. the project directory.
     #[clap(long)]
     pub stdlib: Option<String>,
     /// Set the package name. Defaults to the directory name

--- a/forc/src/cli/commands/init.rs
+++ b/forc/src/cli/commands/init.rs
@@ -24,7 +24,8 @@ pub struct Command {
     #[clap(long)]
     pub workspace: bool,
     /// The path at which the standard library is located.
-    /// Does not override the std dependency if missing.
+    /// If unspecified, the std will be implicitly included as a git dependency
+    /// via the git tag that matches `forc`'s version.
     /// If the path is relative, forc makes it relative w.r.t. the project directory.
     /// If the path is absolute, forc uses it as is.
     #[clap(long)]

--- a/forc/src/cli/commands/init.rs
+++ b/forc/src/cli/commands/init.rs
@@ -23,6 +23,12 @@ pub struct Command {
     /// Adding this flag creates an empty workspace.
     #[clap(long)]
     pub workspace: bool,
+    /// The path at which the standard library is located.
+    /// Does not override the std dependency if missing.
+    /// If the path is relative, forc makes it relative w.r.t. the project directory.
+    /// If the path is absolute, forc uses it as is.
+    #[clap(long)]
+    pub stdlib: Option<String>,
     /// Set the package name. Defaults to the directory name
     #[clap(long)]
     pub name: Option<String>,

--- a/forc/src/cli/commands/new.rs
+++ b/forc/src/cli/commands/new.rs
@@ -23,9 +23,15 @@ pub struct Command {
     /// Adding this flag creates an empty workspace.
     #[clap(long)]
     pub workspace: bool,
-    /// Set the package name. Defaults to the directory name
+    /// Set the package name. Defaults to the directory name.
     #[clap(long)]
     pub name: Option<String>,
+    /// The path at which the standard library is located.
+    /// Does not override the std dependency if missing.
+    /// If the path is relative, forc makes it relative w.r.t. the project directory.
+    /// If the path is absolute, forc uses it as is.
+    #[clap(long)]
+    pub stdlib: Option<String>,
     /// The path at which the project directory will be created.
     pub path: String,
 }
@@ -41,6 +47,7 @@ pub(crate) fn exec(command: Command) -> Result<()> {
         library,
         workspace,
         name,
+        stdlib,
         path,
     } = command;
 
@@ -77,6 +84,7 @@ pub(crate) fn exec(command: Command) -> Result<()> {
         predicate,
         library,
         workspace,
+        stdlib,
         name,
     };
 

--- a/forc/src/cli/commands/new.rs
+++ b/forc/src/cli/commands/new.rs
@@ -27,7 +27,8 @@ pub struct Command {
     #[clap(long)]
     pub name: Option<String>,
     /// The path at which the standard library is located.
-    /// Does not override the std dependency if missing.
+    /// If unspecified, the std will be implicitly included as a git dependency
+    /// via the git tag that matches `forc`'s version.
     /// If the path is relative, forc makes it relative w.r.t. the project directory.
     /// If the path is absolute, forc uses it as is.
     #[clap(long)]

--- a/forc/src/cli/commands/new.rs
+++ b/forc/src/cli/commands/new.rs
@@ -26,11 +26,11 @@ pub struct Command {
     /// Set the package name. Defaults to the directory name.
     #[clap(long)]
     pub name: Option<String>,
-    /// The path at which the standard library is located.
+    /// The local directory path or URL at which the standard library is located.
     /// If unspecified, the std will be implicitly included as a git dependency
     /// via the git tag that matches `forc`'s version.
-    /// If the path is relative, forc makes it relative w.r.t. the project directory.
-    /// If the path is absolute, forc uses it as is.
+    /// `forc` uses absolute directory paths and URLs as is.
+    /// Relative directory paths are made relative w.r.t. the project directory.
     #[clap(long)]
     pub stdlib: Option<String>,
     /// The path at which the project directory will be created.

--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -1,7 +1,15 @@
 /// We intentionally don't construct this using [serde]'s default deserialization so we get
 /// the chance to insert some helpful comments and nicer formatting.
-pub(crate) fn default_pkg_manifest(project_name: &str, entry_type: &str) -> String {
+pub(crate) fn default_pkg_manifest(
+    project_name: &str,
+    entry_type: &str,
+    stdlib: &Option<String>,
+) -> String {
     let author = get_author();
+    let stdlib_override = match stdlib {
+        Some(stdlib) => format!("std = {{ path = \"{stdlib}\" }}\n"),
+        None => String::new(),
+    };
 
     format!(
         r#"[project]
@@ -11,7 +19,7 @@ license = "Apache-2.0"
 name = "{project_name}"
 
 [dependencies]
-"#
+{stdlib_override}"#
     )
 }
 
@@ -82,8 +90,12 @@ fn parse_default_pkg_manifest() {
     use sway_utils::constants::MAIN_ENTRY;
     tracing::info!(
         "{:#?}",
-        toml::from_str::<forc_pkg::PackageManifest>(&default_pkg_manifest("test_proj", MAIN_ENTRY))
-            .unwrap()
+        toml::from_str::<forc_pkg::PackageManifest>(&default_pkg_manifest(
+            "test_proj",
+            MAIN_ENTRY,
+            &None
+        ))
+        .unwrap()
     )
 }
 #[test]

--- a/forc/src/utils/defaults.rs
+++ b/forc/src/utils/defaults.rs
@@ -1,14 +1,17 @@
+use forc_util::StdlibPath;
+
 /// We intentionally don't construct this using [serde]'s default deserialization so we get
 /// the chance to insert some helpful comments and nicer formatting.
 pub(crate) fn default_pkg_manifest(
     project_name: &str,
     entry_type: &str,
-    stdlib: &Option<String>,
+    stdlib: &StdlibPath,
 ) -> String {
     let author = get_author();
     let stdlib_override = match stdlib {
-        Some(stdlib) => format!("std = {{ path = \"{stdlib}\" }}\n"),
-        None => String::new(),
+        StdlibPath::Dir(stdlib) => format!("std = {{ path = \"{stdlib}\" }}\n"),
+        StdlibPath::Git(stdlib) => format!("std = {{ git = \"{stdlib}\" }}\n"),
+        StdlibPath::Unspecified => String::new(),
     };
 
     format!(
@@ -93,7 +96,7 @@ fn parse_default_pkg_manifest() {
         toml::from_str::<forc_pkg::PackageManifest>(&default_pkg_manifest(
             "test_proj",
             MAIN_ENTRY,
-            &None
+            &StdlibPath::Unspecified
         ))
         .unwrap()
     )


### PR DESCRIPTION
It lets the user to specify the path to the standard library. If the path to stdlib is relative, `forc` makes it relative w.r.t. the project directory. If the path is absolute, forc uses it as is.

close #3627