### PR TITLE
Bump to `fuels 0.33`

### DIFF
--- a/templates/sway-test-rs/template/Cargo.toml
+++ b/templates/sway-test-rs/template/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["{{authors}}"]
 license = "Apache-2.0"
 
 [dev-dependencies]
-fuels = { version = "0.32", features = ["fuel-core-lib"] }
+fuels = { version = "0.33", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/test/src/sdk-harness/Cargo.toml
+++ b/test/src/sdk-harness/Cargo.toml
@@ -11,7 +11,7 @@ fuel-core = { version = "0.15", default-features = false }
 fuel-gql-client = { version = "0.15", default-features = false }
 fuel-types = "0.5"
 fuel-vm = "0.22"
-fuels = { version = "0.32", features = ["fuel-core-lib"] }
+fuels = { version = "0.33", features = ["fuel-core-lib"] }
 hex = "0.4.3"
 rand = "0.8"
 sha2 = "0.10"


### PR DESCRIPTION
This was partially done in https://github.com/FuelLabs/sway/commit/211667cde8ed10cbb0c6547ee0096bfb26d89e95