### PR TITLE
Extract FuelVM-specific instructions to umbrella instruction

### DIFF
--- a/sway-core/src/asm_generation/asm_builder.rs
+++ b/sway-core/src/asm_generation/asm_builder.rs
@@ -183,22 +183,81 @@ impl<'ir> AsmBuilder<'ir> {
                 Instruction::ExtractValue {
                     aggregate, indices, ..
                 } => self.compile_extract_value(instr_val, aggregate, indices),
-                Instruction::GetStorageKey => {
-                    check!(
-                        self.compile_get_storage_key(instr_val),
+                Instruction::FuelVm(fuel_vm_instr) => match fuel_vm_instr {
+                    FuelVmInstruction::GetStorageKey => {
+                        check!(
+                            self.compile_get_storage_key(instr_val),
+                            return err(warnings, errors),
+                            warnings,
+                            errors
+                        )
+                    }
+                    FuelVmInstruction::Gtf { index, tx_field_id } => {
+                        self.compile_gtf(instr_val, index, *tx_field_id)
+                    }
+                    FuelVmInstruction::Log {
+                        log_val,
+                        log_ty,
+                        log_id,
+                    } => self.compile_log(instr_val, log_val, log_ty, log_id),
+                    FuelVmInstruction::ReadRegister(reg) => {
+                        self.compile_read_register(instr_val, reg)
+                    }
+                    FuelVmInstruction::Revert(revert_val) => {
+                        self.compile_revert(instr_val, revert_val)
+                    }
+                    FuelVmInstruction::Smo {
+                        recipient_and_message,
+                        message_size,
+                        output_index,
+                        coins,
+                    } => self.compile_smo(
+                        instr_val,
+                        recipient_and_message,
+                        message_size,
+                        output_index,
+                        coins,
+                    ),
+                    FuelVmInstruction::StateLoadQuadWord { load_val, key } => check!(
+                        self.compile_state_access_quad_word(
+                            instr_val,
+                            load_val,
+                            key,
+                            StateAccessType::Read
+                        ),
                         return err(warnings, errors),
                         warnings,
                         errors
-                    )
-                }
+                    ),
+                    FuelVmInstruction::StateLoadWord(key) => check!(
+                        self.compile_state_load_word(instr_val, key),
+                        return err(warnings, errors),
+                        warnings,
+                        errors
+                    ),
+                    FuelVmInstruction::StateStoreQuadWord { stored_val, key } => check!(
+                        self.compile_state_access_quad_word(
+                            instr_val,
+                            stored_val,
+                            key,
+                            StateAccessType::Write
+                        ),
+                        return err(warnings, errors),
+                        warnings,
+                        errors
+                    ),
+                    FuelVmInstruction::StateStoreWord { stored_val, key } => check!(
+                        self.compile_state_store_word(instr_val, stored_val, key),
+                        return err(warnings, errors),
+                        warnings,
+                        errors
+                    ),
+                },
                 Instruction::GetPointer {
                     base_ptr,
                     ptr_ty,
                     offset,
                 } => self.compile_get_pointer(instr_val, base_ptr, ptr_ty, *offset),
-                Instruction::Gtf { index, tx_field_id } => {
-                    self.compile_gtf(instr_val, index, *tx_field_id)
-                }
                 Instruction::InsertElement {
                     array,
                     ty,
@@ -218,18 +277,12 @@ impl<'ir> AsmBuilder<'ir> {
                     warnings,
                     errors
                 ),
-                Instruction::Log {
-                    log_val,
-                    log_ty,
-                    log_id,
-                } => self.compile_log(instr_val, log_val, log_ty, log_id),
                 Instruction::MemCopy {
                     dst_val,
                     src_val,
                     byte_len,
                 } => self.compile_mem_copy(instr_val, dst_val, src_val, *byte_len),
                 Instruction::Nop => (),
-                Instruction::ReadRegister(reg) => self.compile_read_register(instr_val, reg),
                 Instruction::Ret(ret_val, ty) => {
                     if func_is_entry {
                         self.compile_ret_from_entry(instr_val, ret_val, ty)
@@ -237,53 +290,6 @@ impl<'ir> AsmBuilder<'ir> {
                         self.compile_ret_from_call(instr_val, ret_val)
                     }
                 }
-                Instruction::Revert(revert_val) => self.compile_revert(instr_val, revert_val),
-                Instruction::Smo {
-                    recipient_and_message,
-                    message_size,
-                    output_index,
-                    coins,
-                } => self.compile_smo(
-                    instr_val,
-                    recipient_and_message,
-                    message_size,
-                    output_index,
-                    coins,
-                ),
-                Instruction::StateLoadQuadWord { load_val, key } => check!(
-                    self.compile_state_access_quad_word(
-                        instr_val,
-                        load_val,
-                        key,
-                        StateAccessType::Read
-                    ),
-                    return err(warnings, errors),
-                    warnings,
-                    errors
-                ),
-                Instruction::StateLoadWord(key) => check!(
-                    self.compile_state_load_word(instr_val, key),
-                    return err(warnings, errors),
-                    warnings,
-                    errors
-                ),
-                Instruction::StateStoreQuadWord { stored_val, key } => check!(
-                    self.compile_state_access_quad_word(
-                        instr_val,
-                        stored_val,
-                        key,
-                        StateAccessType::Write
-                    ),
-                    return err(warnings, errors),
-                    warnings,
-                    errors
-                ),
-                Instruction::StateStoreWord { stored_val, key } => check!(
-                    self.compile_state_store_word(instr_val, stored_val, key),
-                    return err(warnings, errors),
-                    warnings,
-                    errors
-                ),
                 Instruction::Store {
                     dst_val,
                     stored_val,

--- a/sway-core/src/ir_generation/purity.rs
+++ b/sway-core/src/ir_generation/purity.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use sway_error::warning::{CompileWarning, Warning};
 use sway_error::{error::CompileError, handler::Handler};
-use sway_ir::{Context, Function, Instruction};
+use sway_ir::{Context, FuelVmInstruction, Function, Instruction};
 use sway_types::span::Span;
 
 use std::collections::HashMap;
@@ -43,12 +43,15 @@ pub(crate) fn check_function_purity(
                 .get_instruction(context)
                 .map(|instruction| {
                     match instruction {
-                        Instruction::StateLoadQuadWord { .. } | Instruction::StateLoadWord(_) => {
+                        Instruction::FuelVm(FuelVmInstruction::StateLoadQuadWord { .. })
+                        | Instruction::FuelVm(FuelVmInstruction::StateLoadWord(_)) => {
                             (true, writes)
                         }
 
-                        Instruction::StateStoreQuadWord { .. }
-                        | Instruction::StateStoreWord { .. } => (reads, true),
+                        Instruction::FuelVm(FuelVmInstruction::StateStoreQuadWord { .. })
+                        | Instruction::FuelVm(FuelVmInstruction::StateStoreWord { .. }) => {
+                            (reads, true)
+                        }
 
                         // Iterate for and check each instruction in the ASM block.
                         Instruction::AsmBlock(asm_block, _args) => {

--- a/sway-ir/src/block.rs
+++ b/sway-ir/src/block.rs
@@ -16,7 +16,7 @@ use crate::{
     context::Context,
     error::IrError,
     function::Function,
-    instruction::{Instruction, InstructionInserter, InstructionIterator},
+    instruction::{FuelVmInstruction, Instruction, InstructionInserter, InstructionIterator},
     pretty::DebugWithContext,
     value::{Value, ValueDatum},
     BranchToWithArgs, Type,
@@ -312,7 +312,10 @@ impl Block {
     /// Return whether this block is already terminated specifically by a Ret instruction.
     pub fn is_terminated_by_ret_or_revert(&self, context: &Context) -> bool {
         self.get_terminator(context).map_or(false, |i| {
-            matches!(i, Instruction::Ret(..) | Instruction::Revert(..))
+            matches!(
+                i,
+                Instruction::Ret(..) | Instruction::FuelVm(FuelVmInstruction::Revert(..))
+            )
         })
     }
 

--- a/sway-ir/src/instruction.rs
+++ b/sway-ir/src/instruction.rs
@@ -74,12 +74,8 @@ pub enum Instruction {
         ty: Aggregate,
         indices: Vec<u64>,
     },
-    /// Generate a unique integer value
-    GetStorageKey,
-    Gtf {
-        index: Value,
-        tx_field_id: u64,
-    },
+    /// Umbrella instruction variant for FuelVM-specific instructions
+    FuelVm(FuelVmInstruction),
     /// Return a pointer as a value.
     GetPointer {
         base_ptr: Pointer,
@@ -104,12 +100,6 @@ pub enum Instruction {
     IntToPtr(Value, Type),
     /// Read a value from a memory pointer.
     Load(Value),
-    /// Logs a value along with an identifier.
-    Log {
-        log_val: Value,
-        log_ty: Type,
-        log_id: Value,
-    },
     /// Copy a specified number of bytes between pointers.
     MemCopy {
         dst_val: Value,
@@ -118,10 +108,28 @@ pub enum Instruction {
     },
     /// No-op, handy as a placeholder instruction.
     Nop,
-    /// Reads a special register in the VM.
-    ReadRegister(Register),
     /// Return from a function.
     Ret(Value, Type),
+    /// Write a value to a memory pointer.
+    Store { dst_val: Value, stored_val: Value },
+}
+
+#[derive(Debug, Clone, DebugWithContext)]
+pub enum FuelVmInstruction {
+    /// Generate a unique integer value
+    GetStorageKey,
+    Gtf {
+        index: Value,
+        tx_field_id: u64,
+    },
+    /// Logs a value along with an identifier.
+    Log {
+        log_val: Value,
+        log_ty: Type,
+        log_id: Value,
+    },
+    /// Reads a special register in the VM.
+    ReadRegister(Register),
     /// Revert VM execution.
     Revert(Value),
     /// - Sends a message to an output via the `smo` FuelVM instruction. The first operand must be
@@ -153,11 +161,6 @@ pub enum Instruction {
     StateStoreWord {
         stored_val: Value,
         key: Value,
-    },
-    /// Write a value to a memory pointer.
-    Store {
-        dst_val: Value,
-        stored_val: Value,
     },
 }
 
@@ -225,8 +228,11 @@ impl Instruction {
             Instruction::ContractCall { return_type, .. } => Some(*return_type),
             Instruction::ExtractElement { ty, .. } => ty.get_elem_type(context),
             Instruction::ExtractValue { ty, indices, .. } => ty.get_field_type(context, indices),
-            Instruction::GetStorageKey => Some(Type::B256),
-            Instruction::Gtf { .. } => Some(Type::Uint(64)),
+            Instruction::FuelVm(FuelVmInstruction::GetStorageKey) => Some(Type::B256),
+            Instruction::FuelVm(FuelVmInstruction::Gtf { .. }) => Some(Type::Uint(64)),
+            Instruction::FuelVm(FuelVmInstruction::Log { .. }) => Some(Type::Unit),
+            Instruction::FuelVm(FuelVmInstruction::ReadRegister(_)) => Some(Type::Uint(64)),
+            Instruction::FuelVm(FuelVmInstruction::StateLoadWord(_)) => Some(Type::Uint(64)),
             Instruction::InsertElement { array, .. } => array.get_type(context),
             Instruction::InsertValue { aggregate, .. } => aggregate.get_type(context),
             Instruction::Load(ptr_val) => match &context.values[ptr_val.0].value {
@@ -236,9 +242,6 @@ impl Instruction {
                     ins.get_type(context).map(|f| f.strip_ptr_type(context))
                 }
             },
-            Instruction::Log { .. } => Some(Type::Unit),
-            Instruction::ReadRegister(_) => Some(Type::Uint(64)),
-            Instruction::StateLoadWord(_) => Some(Type::Uint(64)),
 
             // These can be recursed to via Load, so we return the pointer type.
             Instruction::GetPointer { ptr_ty, .. } => Some(Type::Pointer(*ptr_ty)),
@@ -249,14 +252,14 @@ impl Instruction {
             // These are all terminators which don't return, essentially.  No type.
             Instruction::Branch(_) => None,
             Instruction::ConditionalBranch { .. } => None,
+            Instruction::FuelVm(FuelVmInstruction::Revert(..)) => None,
             Instruction::Ret(..) => None,
-            Instruction::Revert(..) => None,
 
+            Instruction::FuelVm(FuelVmInstruction::Smo { .. }) => Some(Type::Unit),
+            Instruction::FuelVm(FuelVmInstruction::StateLoadQuadWord { .. }) => Some(Type::Unit),
+            Instruction::FuelVm(FuelVmInstruction::StateStoreQuadWord { .. }) => Some(Type::Unit),
+            Instruction::FuelVm(FuelVmInstruction::StateStoreWord { .. }) => Some(Type::Unit),
             Instruction::MemCopy { .. } => Some(Type::Unit),
-            Instruction::Smo { .. } => Some(Type::Unit),
-            Instruction::StateLoadQuadWord { .. } => Some(Type::Unit),
-            Instruction::StateStoreQuadWord { .. } => Some(Type::Unit),
-            Instruction::StateStoreWord { .. } => Some(Type::Unit),
             Instruction::Store { .. } => Some(Type::Unit),
 
             // No-op is also no-type.
@@ -342,11 +345,30 @@ impl Instruction {
                 ty: _,
                 indices: _,
             } => vec![*aggregate],
-            Instruction::GetStorageKey => vec![],
-            Instruction::Gtf {
-                index,
-                tx_field_id: _,
-            } => vec![*index],
+            Instruction::FuelVm(fuel_vm_instr) => match fuel_vm_instr {
+                FuelVmInstruction::GetStorageKey => vec![],
+                FuelVmInstruction::Gtf {
+                    index,
+                    tx_field_id: _,
+                } => vec![*index],
+                FuelVmInstruction::Log {
+                    log_val, log_id, ..
+                } => vec![*log_val, *log_id],
+                FuelVmInstruction::ReadRegister(_) => vec![],
+                FuelVmInstruction::Revert(v) => vec![*v],
+                FuelVmInstruction::Smo {
+                    recipient_and_message,
+                    message_size,
+                    output_index,
+                    coins,
+                } => vec![*recipient_and_message, *message_size, *output_index, *coins],
+                FuelVmInstruction::StateLoadQuadWord { load_val, key } => vec![*load_val, *key],
+                FuelVmInstruction::StateLoadWord(key) => vec![*key],
+                FuelVmInstruction::StateStoreQuadWord { stored_val, key } => {
+                    vec![*stored_val, *key]
+                }
+                FuelVmInstruction::StateStoreWord { stored_val, key } => vec![*stored_val, *key],
+            },
             Instruction::GetPointer {
                 base_ptr: _,
                 ptr_ty: _,
@@ -370,23 +392,8 @@ impl Instruction {
             } => vec![*aggregate, *value],
             Instruction::IntToPtr(v, _) => vec![*v],
             Instruction::Load(v) => vec![*v],
-            Instruction::Log {
-                log_val, log_id, ..
-            } => vec![*log_val, *log_id],
             Instruction::Nop => vec![],
-            Instruction::ReadRegister(_) => vec![],
             Instruction::Ret(v, _) => vec![*v],
-            Instruction::Revert(v) => vec![*v],
-            Instruction::Smo {
-                recipient_and_message,
-                message_size,
-                output_index,
-                coins,
-            } => vec![*recipient_and_message, *message_size, *output_index, *coins],
-            Instruction::StateLoadQuadWord { load_val, key } => vec![*load_val, *key],
-            Instruction::StateLoadWord(key) => vec![*key],
-            Instruction::StateStoreQuadWord { stored_val, key } => vec![*stored_val, *key],
-            Instruction::StateStoreWord { stored_val, key } => vec![*stored_val, *key],
             Instruction::Store {
                 dst_val,
                 stored_val,
@@ -469,16 +476,46 @@ impl Instruction {
                 replace(index_val);
             }
             Instruction::ExtractValue { aggregate, .. } => replace(aggregate),
-            Instruction::GetStorageKey => (),
-            Instruction::Gtf { index, .. } => replace(index),
+            Instruction::FuelVm(fuel_vm_instr) => match fuel_vm_instr {
+                FuelVmInstruction::GetStorageKey => (),
+                FuelVmInstruction::Gtf { index, .. } => replace(index),
+                FuelVmInstruction::Log {
+                    log_val, log_id, ..
+                } => {
+                    replace(log_val);
+                    replace(log_id);
+                }
+                FuelVmInstruction::ReadRegister { .. } => (),
+                FuelVmInstruction::Revert(revert_val) => replace(revert_val),
+                FuelVmInstruction::Smo {
+                    recipient_and_message,
+                    message_size,
+                    output_index,
+                    coins,
+                } => {
+                    replace(recipient_and_message);
+                    replace(message_size);
+                    replace(output_index);
+                    replace(coins);
+                }
+                FuelVmInstruction::StateLoadQuadWord { load_val, key } => {
+                    replace(load_val);
+                    replace(key);
+                }
+                FuelVmInstruction::StateLoadWord(key) => {
+                    replace(key);
+                }
+                FuelVmInstruction::StateStoreQuadWord { stored_val, key } => {
+                    replace(key);
+                    replace(stored_val);
+                }
+                FuelVmInstruction::StateStoreWord { stored_val, key } => {
+                    replace(key);
+                    replace(stored_val);
+                }
+            },
             Instruction::IntToPtr(value, _) => replace(value),
             Instruction::Load(_) => (),
-            Instruction::Log {
-                log_val, log_id, ..
-            } => {
-                replace(log_val);
-                replace(log_id);
-            }
             Instruction::MemCopy {
                 dst_val, src_val, ..
             } => {
@@ -486,35 +523,7 @@ impl Instruction {
                 replace(src_val);
             }
             Instruction::Nop => (),
-            Instruction::ReadRegister { .. } => (),
             Instruction::Ret(ret_val, _) => replace(ret_val),
-            Instruction::Revert(revert_val) => replace(revert_val),
-            Instruction::Smo {
-                recipient_and_message,
-                message_size,
-                output_index,
-                coins,
-            } => {
-                replace(recipient_and_message);
-                replace(message_size);
-                replace(output_index);
-                replace(coins);
-            }
-            Instruction::StateLoadQuadWord { load_val, key } => {
-                replace(load_val);
-                replace(key);
-            }
-            Instruction::StateLoadWord(key) => {
-                replace(key);
-            }
-            Instruction::StateStoreQuadWord { stored_val, key } => {
-                replace(key);
-                replace(stored_val);
-            }
-            Instruction::StateStoreWord { stored_val, key } => {
-                replace(key);
-                replace(stored_val);
-            }
             Instruction::Store { stored_val, .. } => {
                 replace(stored_val);
             }
@@ -526,12 +535,12 @@ impl Instruction {
             Instruction::AsmBlock(_, _)
                 | Instruction::Call(..)
                 | Instruction::ContractCall { .. }
-                | Instruction::Log { .. }
+                | Instruction::FuelVm(FuelVmInstruction::Log { .. })
+                | Instruction::FuelVm(FuelVmInstruction::Smo { .. })
+                | Instruction::FuelVm(FuelVmInstruction::StateLoadQuadWord { .. })
+                | Instruction::FuelVm(FuelVmInstruction::StateStoreQuadWord { .. })
+                | Instruction::FuelVm(FuelVmInstruction::StateStoreWord { .. })
                 | Instruction::MemCopy { .. }
-                | Instruction::Smo { .. }
-                | Instruction::StateLoadQuadWord { .. }
-                | Instruction::StateStoreQuadWord { .. }
-                | Instruction::StateStoreWord { .. }
                 | Instruction::Store { .. }
                 // Insert(Element/Value), unlike those in LLVM
                 // do not have SSA semantics. They are like stores.
@@ -543,17 +552,17 @@ impl Instruction {
                 | Instruction::Cmp(..)
                 | Instruction::ExtractElement {  .. }
                 | Instruction::ExtractValue { .. }
-                | Instruction::GetStorageKey
-                | Instruction::Gtf { .. }
+                | Instruction::FuelVm(FuelVmInstruction::GetStorageKey)
+                | Instruction::FuelVm(FuelVmInstruction::Gtf { .. })
+                | Instruction::FuelVm(FuelVmInstruction::ReadRegister(_))
+                | Instruction::FuelVm(FuelVmInstruction::Revert(..))
+                | Instruction::FuelVm(FuelVmInstruction::StateLoadWord(_))
                 | Instruction::Load(_)
-                | Instruction::ReadRegister(_)
-                | Instruction::StateLoadWord(_)
                 | Instruction::GetPointer { .. }
                 | Instruction::IntToPtr(..)
                 | Instruction::Branch(_)
                 | Instruction::ConditionalBranch { .. }
                 | Instruction::Ret(..)
-                | Instruction::Revert(..)
                 | Instruction::Nop => false,
         }
     }
@@ -564,7 +573,7 @@ impl Instruction {
             Instruction::Branch(_)
                 | Instruction::ConditionalBranch { .. }
                 | Instruction::Ret(..)
-                | Instruction::Revert(..)
+                | Instruction::FuelVm(FuelVmInstruction::Revert(..))
         )
     }
 }
@@ -776,11 +785,14 @@ impl<'a> InstructionInserter<'a> {
     }
 
     pub fn get_storage_key(self) -> Value {
-        make_instruction!(self, Instruction::GetStorageKey)
+        make_instruction!(self, Instruction::FuelVm(FuelVmInstruction::GetStorageKey))
     }
 
     pub fn gtf(self, index: Value, tx_field_id: u64) -> Value {
-        make_instruction!(self, Instruction::Gtf { index, tx_field_id })
+        make_instruction!(
+            self,
+            Instruction::FuelVm(FuelVmInstruction::Gtf { index, tx_field_id })
+        )
     }
 
     pub fn get_ptr(self, base_ptr: Pointer, ptr_ty: Type, offset: u64) -> Value {
@@ -838,11 +850,11 @@ impl<'a> InstructionInserter<'a> {
     pub fn log(self, log_val: Value, log_ty: Type, log_id: Value) -> Value {
         make_instruction!(
             self,
-            Instruction::Log {
+            Instruction::FuelVm(FuelVmInstruction::Log {
                 log_val,
                 log_ty,
                 log_id
-            }
+            })
         )
     }
 
@@ -862,7 +874,10 @@ impl<'a> InstructionInserter<'a> {
     }
 
     pub fn read_register(self, reg: Register) -> Value {
-        make_instruction!(self, Instruction::ReadRegister(reg))
+        make_instruction!(
+            self,
+            Instruction::FuelVm(FuelVmInstruction::ReadRegister(reg))
+        )
     }
 
     pub fn ret(self, value: Value, ty: Type) -> Value {
@@ -870,7 +885,10 @@ impl<'a> InstructionInserter<'a> {
     }
 
     pub fn revert(self, value: Value) -> Value {
-        let revert_val = Value::new_instruction(self.context, Instruction::Revert(value));
+        let revert_val = Value::new_instruction(
+            self.context,
+            Instruction::FuelVm(FuelVmInstruction::Revert(value)),
+        );
         self.context.blocks[self.block.0]
             .instructions
             .push(revert_val);
@@ -886,29 +904,41 @@ impl<'a> InstructionInserter<'a> {
     ) -> Value {
         make_instruction!(
             self,
-            Instruction::Smo {
+            Instruction::FuelVm(FuelVmInstruction::Smo {
                 recipient_and_message,
                 message_size,
                 output_index,
                 coins,
-            }
+            })
         )
     }
 
     pub fn state_load_quad_word(self, load_val: Value, key: Value) -> Value {
-        make_instruction!(self, Instruction::StateLoadQuadWord { load_val, key })
+        make_instruction!(
+            self,
+            Instruction::FuelVm(FuelVmInstruction::StateLoadQuadWord { load_val, key })
+        )
     }
 
     pub fn state_load_word(self, key: Value) -> Value {
-        make_instruction!(self, Instruction::StateLoadWord(key))
+        make_instruction!(
+            self,
+            Instruction::FuelVm(FuelVmInstruction::StateLoadWord(key))
+        )
     }
 
     pub fn state_store_quad_word(self, stored_val: Value, key: Value) -> Value {
-        make_instruction!(self, Instruction::StateStoreQuadWord { stored_val, key })
+        make_instruction!(
+            self,
+            Instruction::FuelVm(FuelVmInstruction::StateStoreQuadWord { stored_val, key })
+        )
     }
 
     pub fn state_store_word(self, stored_val: Value, key: Value) -> Value {
-        make_instruction!(self, Instruction::StateStoreWord { stored_val, key })
+        make_instruction!(
+            self,
+            Instruction::FuelVm(FuelVmInstruction::StateStoreWord { stored_val, key })
+        )
     }
 
     pub fn store(self, dst_val: Value, stored_val: Value) -> Value {

--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -12,7 +12,7 @@ use crate::{
     context::Context,
     error::IrError,
     function::Function,
-    instruction::Instruction,
+    instruction::{FuelVmInstruction, Instruction},
     irtype::Type,
     metadata::{combine, MetadataIndex},
     pointer::Pointer,
@@ -387,7 +387,44 @@ fn inline_instruction(
             } => new_block
                 .ins(context)
                 .extract_value(map_value(aggregate), ty, indices),
-            Instruction::GetStorageKey => new_block.ins(context).get_storage_key(),
+            Instruction::FuelVm(fuel_vm_instr) => match fuel_vm_instr {
+                FuelVmInstruction::GetStorageKey => new_block.ins(context).get_storage_key(),
+                FuelVmInstruction::Gtf { index, tx_field_id } => {
+                    new_block.ins(context).gtf(map_value(index), tx_field_id)
+                }
+                FuelVmInstruction::Log {
+                    log_val,
+                    log_ty,
+                    log_id,
+                } => new_block
+                    .ins(context)
+                    .log(map_value(log_val), log_ty, map_value(log_id)),
+                FuelVmInstruction::ReadRegister(reg) => new_block.ins(context).read_register(reg),
+                FuelVmInstruction::Revert(val) => new_block.ins(context).revert(map_value(val)),
+                FuelVmInstruction::Smo {
+                    recipient_and_message,
+                    message_size,
+                    output_index,
+                    coins,
+                } => new_block.ins(context).smo(
+                    map_value(recipient_and_message),
+                    map_value(message_size),
+                    map_value(output_index),
+                    map_value(coins),
+                ),
+                FuelVmInstruction::StateLoadQuadWord { load_val, key } => new_block
+                    .ins(context)
+                    .state_load_quad_word(map_value(load_val), map_value(key)),
+                FuelVmInstruction::StateLoadWord(key) => {
+                    new_block.ins(context).state_load_word(map_value(key))
+                }
+                FuelVmInstruction::StateStoreQuadWord { stored_val, key } => new_block
+                    .ins(context)
+                    .state_store_quad_word(map_value(stored_val), map_value(key)),
+                FuelVmInstruction::StateStoreWord { stored_val, key } => new_block
+                    .ins(context)
+                    .state_store_word(map_value(stored_val), map_value(key)),
+            },
             Instruction::GetPointer {
                 base_ptr,
                 ptr_ty,
@@ -397,9 +434,6 @@ fn inline_instruction(
                 new_block
                     .ins(context)
                     .get_ptr(map_ptr(base_ptr), ty, offset)
-            }
-            Instruction::Gtf { index, tx_field_id } => {
-                new_block.ins(context).gtf(map_value(index), tx_field_id)
             }
             Instruction::InsertElement {
                 array,
@@ -427,13 +461,6 @@ fn inline_instruction(
                 new_block.ins(context).int_to_ptr(map_value(value), ty)
             }
             Instruction::Load(src_val) => new_block.ins(context).load(map_value(src_val)),
-            Instruction::Log {
-                log_val,
-                log_ty,
-                log_id,
-            } => new_block
-                .ins(context)
-                .log(map_value(log_val), log_ty, map_value(log_id)),
             Instruction::MemCopy {
                 dst_val,
                 src_val,
@@ -442,35 +469,10 @@ fn inline_instruction(
                 .ins(context)
                 .mem_copy(map_value(dst_val), map_value(src_val), byte_len),
             Instruction::Nop => new_block.ins(context).nop(),
-            Instruction::ReadRegister(reg) => new_block.ins(context).read_register(reg),
             // We convert `ret` to `br post_block` and add the returned value as a phi value.
             Instruction::Ret(val, _) => new_block
                 .ins(context)
                 .branch(*post_block, vec![map_value(val)]),
-            Instruction::Revert(val) => new_block.ins(context).revert(map_value(val)),
-            Instruction::Smo {
-                recipient_and_message,
-                message_size,
-                output_index,
-                coins,
-            } => new_block.ins(context).smo(
-                map_value(recipient_and_message),
-                map_value(message_size),
-                map_value(output_index),
-                map_value(coins),
-            ),
-            Instruction::StateLoadQuadWord { load_val, key } => new_block
-                .ins(context)
-                .state_load_quad_word(map_value(load_val), map_value(key)),
-            Instruction::StateLoadWord(key) => {
-                new_block.ins(context).state_load_word(map_value(key))
-            }
-            Instruction::StateStoreQuadWord { stored_val, key } => new_block
-                .ins(context)
-                .state_store_quad_word(map_value(stored_val), map_value(key)),
-            Instruction::StateStoreWord { stored_val, key } => new_block
-                .ins(context)
-                .state_store_word(map_value(stored_val), map_value(key)),
             Instruction::Store {
                 dst_val,
                 stored_val,

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -12,7 +12,7 @@ use crate::{
     constant::{Constant, ConstantValue},
     context::Context,
     function::{Function, FunctionContent},
-    instruction::{Instruction, Predicate, Register},
+    instruction::{FuelVmInstruction, Instruction, Predicate, Register},
     irtype::Type,
     metadata::{MetadataIndex, Metadatum},
     module::{Kind, ModuleContent},
@@ -504,24 +504,132 @@ fn instruction_to_doc<'a>(
                 ))
                 .append(md_namer.md_idx_to_doc(context, metadata)),
             )),
-            Instruction::GetStorageKey => Doc::line(
-                Doc::text(format!(
-                    "{} = get_storage_key",
-                    namer.name(context, ins_value),
-                ))
-                .append(md_namer.md_idx_to_doc(context, metadata)),
-            ),
-            Instruction::Gtf { index, tx_field_id } => {
-                maybe_constant_to_doc(context, md_namer, namer, index).append(Doc::line(
+            Instruction::FuelVm(fuel_vm_instr) => match fuel_vm_instr {
+                FuelVmInstruction::GetStorageKey => Doc::line(
                     Doc::text(format!(
-                        "{} = gtf {}, {}",
+                        "{} = get_storage_key",
                         namer.name(context, ins_value),
-                        namer.name(context, index),
-                        tx_field_id,
                     ))
                     .append(md_namer.md_idx_to_doc(context, metadata)),
-                ))
-            }
+                ),
+                FuelVmInstruction::Gtf { index, tx_field_id } => {
+                    maybe_constant_to_doc(context, md_namer, namer, index).append(Doc::line(
+                        Doc::text(format!(
+                            "{} = gtf {}, {}",
+                            namer.name(context, ins_value),
+                            namer.name(context, index),
+                            tx_field_id,
+                        ))
+                        .append(md_namer.md_idx_to_doc(context, metadata)),
+                    ))
+                }
+                FuelVmInstruction::Log {
+                    log_val,
+                    log_ty,
+                    log_id,
+                } => maybe_constant_to_doc(context, md_namer, namer, log_val)
+                    .append(maybe_constant_to_doc(context, md_namer, namer, log_id))
+                    .append(Doc::line(
+                        Doc::text(format!(
+                            "log {} {}, {}",
+                            log_ty.as_string(context),
+                            namer.name(context, log_val),
+                            namer.name(context, log_id),
+                        ))
+                        .append(md_namer.md_idx_to_doc(context, metadata)),
+                    )),
+                FuelVmInstruction::ReadRegister(reg) => Doc::line(
+                    Doc::text(format!(
+                        "{} = read_register {}",
+                        namer.name(context, ins_value),
+                        match reg {
+                            Register::Of => "of",
+                            Register::Pc => "pc",
+                            Register::Ssp => "ssp",
+                            Register::Sp => "sp",
+                            Register::Fp => "fp",
+                            Register::Hp => "hp",
+                            Register::Error => "err",
+                            Register::Ggas => "ggas",
+                            Register::Cgas => "cgas",
+                            Register::Bal => "bal",
+                            Register::Is => "is",
+                            Register::Ret => "ret",
+                            Register::Retl => "retl",
+                            Register::Flag => "flag",
+                        },
+                    ))
+                    .append(md_namer.md_idx_to_doc(context, metadata)),
+                ),
+                FuelVmInstruction::Revert(v) => maybe_constant_to_doc(context, md_namer, namer, v)
+                    .append(Doc::line(
+                        Doc::text(format!("revert {}", namer.name(context, v),))
+                            .append(md_namer.md_idx_to_doc(context, metadata)),
+                    )),
+                FuelVmInstruction::Smo {
+                    recipient_and_message,
+                    message_size,
+                    output_index,
+                    coins,
+                } => maybe_constant_to_doc(context, md_namer, namer, recipient_and_message)
+                    .append(maybe_constant_to_doc(
+                        context,
+                        md_namer,
+                        namer,
+                        message_size,
+                    ))
+                    .append(maybe_constant_to_doc(
+                        context,
+                        md_namer,
+                        namer,
+                        output_index,
+                    ))
+                    .append(maybe_constant_to_doc(context, md_namer, namer, coins))
+                    .append(Doc::line(
+                        Doc::text(format!(
+                            "smo {}, {}, {}, {}",
+                            namer.name(context, recipient_and_message),
+                            namer.name(context, message_size),
+                            namer.name(context, output_index),
+                            namer.name(context, coins),
+                        ))
+                        .append(md_namer.md_idx_to_doc(context, metadata)),
+                    )),
+                FuelVmInstruction::StateLoadQuadWord { load_val, key } => Doc::line(
+                    Doc::text(format!(
+                        "state_load_quad_word ptr {}, key ptr {}",
+                        namer.name(context, load_val),
+                        namer.name(context, key),
+                    ))
+                    .append(md_namer.md_idx_to_doc(context, metadata)),
+                ),
+                FuelVmInstruction::StateLoadWord(key) => Doc::line(
+                    Doc::text(format!(
+                        "{} = state_load_word key ptr {}",
+                        namer.name(context, ins_value),
+                        namer.name(context, key),
+                    ))
+                    .append(md_namer.md_idx_to_doc(context, metadata)),
+                ),
+                FuelVmInstruction::StateStoreQuadWord { stored_val, key } => Doc::line(
+                    Doc::text(format!(
+                        "state_store_quad_word ptr {}, key ptr {}",
+                        namer.name(context, stored_val),
+                        namer.name(context, key),
+                    ))
+                    .append(md_namer.md_idx_to_doc(context, metadata)),
+                ),
+                FuelVmInstruction::StateStoreWord { stored_val, key } => {
+                    maybe_constant_to_doc(context, md_namer, namer, stored_val).append(Doc::line(
+                        Doc::text(format!(
+                            "state_store_word {}, key ptr {}",
+                            namer.name(context, stored_val),
+                            namer.name(context, key),
+                        ))
+                        .append(md_namer.md_idx_to_doc(context, metadata)),
+                    ))
+                }
+            },
             Instruction::GetPointer {
                 base_ptr,
                 ptr_ty,
@@ -604,21 +712,6 @@ fn instruction_to_doc<'a>(
                 ))
                 .append(md_namer.md_idx_to_doc(context, metadata)),
             ),
-            Instruction::Log {
-                log_val,
-                log_ty,
-                log_id,
-            } => maybe_constant_to_doc(context, md_namer, namer, log_val)
-                .append(maybe_constant_to_doc(context, md_namer, namer, log_id))
-                .append(Doc::line(
-                    Doc::text(format!(
-                        "log {} {}, {}",
-                        log_ty.as_string(context),
-                        namer.name(context, log_val),
-                        namer.name(context, log_id),
-                    ))
-                    .append(md_namer.md_idx_to_doc(context, metadata)),
-                )),
             Instruction::MemCopy {
                 dst_val,
                 src_val,
@@ -636,104 +729,12 @@ fn instruction_to_doc<'a>(
                 Doc::text(format!("{} = nop", namer.name(context, ins_value)))
                     .append(md_namer.md_idx_to_doc(context, metadata)),
             ),
-            Instruction::ReadRegister(reg) => Doc::line(
-                Doc::text(format!(
-                    "{} = read_register {}",
-                    namer.name(context, ins_value),
-                    match reg {
-                        Register::Of => "of",
-                        Register::Pc => "pc",
-                        Register::Ssp => "ssp",
-                        Register::Sp => "sp",
-                        Register::Fp => "fp",
-                        Register::Hp => "hp",
-                        Register::Error => "err",
-                        Register::Ggas => "ggas",
-                        Register::Cgas => "cgas",
-                        Register::Bal => "bal",
-                        Register::Is => "is",
-                        Register::Ret => "ret",
-                        Register::Retl => "retl",
-                        Register::Flag => "flag",
-                    },
-                ))
-                .append(md_namer.md_idx_to_doc(context, metadata)),
-            ),
             Instruction::Ret(v, t) => {
                 maybe_constant_to_doc(context, md_namer, namer, v).append(Doc::line(
                     Doc::text(format!(
                         "ret {} {}",
                         t.as_string(context),
                         namer.name(context, v),
-                    ))
-                    .append(md_namer.md_idx_to_doc(context, metadata)),
-                ))
-            }
-            Instruction::Revert(v) => {
-                maybe_constant_to_doc(context, md_namer, namer, v).append(Doc::line(
-                    Doc::text(format!("revert {}", namer.name(context, v),))
-                        .append(md_namer.md_idx_to_doc(context, metadata)),
-                ))
-            }
-            Instruction::Smo {
-                recipient_and_message,
-                message_size,
-                output_index,
-                coins,
-            } => maybe_constant_to_doc(context, md_namer, namer, recipient_and_message)
-                .append(maybe_constant_to_doc(
-                    context,
-                    md_namer,
-                    namer,
-                    message_size,
-                ))
-                .append(maybe_constant_to_doc(
-                    context,
-                    md_namer,
-                    namer,
-                    output_index,
-                ))
-                .append(maybe_constant_to_doc(context, md_namer, namer, coins))
-                .append(Doc::line(
-                    Doc::text(format!(
-                        "smo {}, {}, {}, {}",
-                        namer.name(context, recipient_and_message),
-                        namer.name(context, message_size),
-                        namer.name(context, output_index),
-                        namer.name(context, coins),
-                    ))
-                    .append(md_namer.md_idx_to_doc(context, metadata)),
-                )),
-            Instruction::StateLoadQuadWord { load_val, key } => Doc::line(
-                Doc::text(format!(
-                    "state_load_quad_word ptr {}, key ptr {}",
-                    namer.name(context, load_val),
-                    namer.name(context, key),
-                ))
-                .append(md_namer.md_idx_to_doc(context, metadata)),
-            ),
-            Instruction::StateLoadWord(key) => Doc::line(
-                Doc::text(format!(
-                    "{} = state_load_word key ptr {}",
-                    namer.name(context, ins_value),
-                    namer.name(context, key),
-                ))
-                .append(md_namer.md_idx_to_doc(context, metadata)),
-            ),
-            Instruction::StateStoreQuadWord { stored_val, key } => Doc::line(
-                Doc::text(format!(
-                    "state_store_quad_word ptr {}, key ptr {}",
-                    namer.name(context, stored_val),
-                    namer.name(context, key),
-                ))
-                .append(md_namer.md_idx_to_doc(context, metadata)),
-            ),
-            Instruction::StateStoreWord { stored_val, key } => {
-                maybe_constant_to_doc(context, md_namer, namer, stored_val).append(Doc::line(
-                    Doc::text(format!(
-                        "state_store_word {}, key ptr {}",
-                        namer.name(context, stored_val),
-                        namer.name(context, key),
                     ))
                     .append(md_namer.md_idx_to_doc(context, metadata)),
                 ))

--- a/sway-ir/src/value.rs
+++ b/sway-ir/src/value.rs
@@ -11,7 +11,7 @@ use rustc_hash::FxHashMap;
 use crate::{
     constant::Constant,
     context::Context,
-    instruction::Instruction,
+    instruction::{FuelVmInstruction, Instruction},
     irtype::Type,
     metadata::{combine, MetadataIndex},
     pointer::Pointer,
@@ -104,7 +104,7 @@ impl Value {
                 Instruction::Branch(_)
                     | Instruction::ConditionalBranch { .. }
                     | Instruction::Ret(_, _)
-                    | Instruction::Revert(_)
+                    | Instruction::FuelVm(FuelVmInstruction::Revert(_))
             ),
             _ => false,
         }
@@ -117,7 +117,7 @@ impl Value {
                 Instruction::Branch(..)
                     | Instruction::ConditionalBranch { .. }
                     | Instruction::Ret(..)
-                    | Instruction::Revert(..)
+                    | Instruction::FuelVm(FuelVmInstruction::Revert(..))
             ),
             ValueDatum::Argument(..) | ValueDatum::Constant(..) => false,
         }

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -8,7 +8,7 @@ use crate::{
     context::Context,
     error::IrError,
     function::{Function, FunctionContent},
-    instruction::{Instruction, Predicate},
+    instruction::{FuelVmInstruction, Instruction, Predicate},
     irtype::{Aggregate, Type},
     metadata::{MetadataIndex, Metadatum},
     module::ModuleContent,
@@ -168,15 +168,50 @@ impl<'a> InstructionVerifier<'a> {
                         ty,
                         indices,
                     } => self.verify_extract_value(aggregate, ty, indices)?,
-                    Instruction::GetStorageKey => (),
+                    Instruction::FuelVm(fuel_vm_instr) => match fuel_vm_instr {
+                        FuelVmInstruction::GetStorageKey => (),
+                        FuelVmInstruction::Gtf { index, tx_field_id } => {
+                            self.verify_gtf(index, tx_field_id)?
+                        }
+                        FuelVmInstruction::Log {
+                            log_val,
+                            log_ty,
+                            log_id,
+                        } => self.verify_log(log_val, log_ty, log_id)?,
+                        FuelVmInstruction::ReadRegister(_) => (),
+                        FuelVmInstruction::Revert(val) => self.verify_revert(val)?,
+                        FuelVmInstruction::Smo {
+                            recipient_and_message,
+                            message_size,
+                            output_index,
+                            coins,
+                        } => self.verify_smo(
+                            recipient_and_message,
+                            message_size,
+                            output_index,
+                            coins,
+                        )?,
+                        FuelVmInstruction::StateLoadWord(key) => {
+                            self.verify_state_load_word(key)?
+                        }
+                        FuelVmInstruction::StateLoadQuadWord {
+                            load_val: dst_val,
+                            key,
+                        }
+                        | FuelVmInstruction::StateStoreQuadWord {
+                            stored_val: dst_val,
+                            key,
+                        } => self.verify_state_load_store(dst_val, &Type::B256, key)?,
+                        FuelVmInstruction::StateStoreWord {
+                            stored_val: dst_val,
+                            key,
+                        } => self.verify_state_store_word(dst_val, key)?,
+                    },
                     Instruction::GetPointer {
                         base_ptr,
                         ptr_ty,
                         offset,
                     } => self.verify_get_ptr(base_ptr, ptr_ty, offset)?,
-                    Instruction::Gtf { index, tx_field_id } => {
-                        self.verify_gtf(index, tx_field_id)?
-                    }
                     Instruction::InsertElement {
                         array,
                         ty,
@@ -191,41 +226,13 @@ impl<'a> InstructionVerifier<'a> {
                     } => self.verify_insert_value(aggregate, ty, value, indices)?,
                     Instruction::IntToPtr(value, ty) => self.verify_int_to_ptr(value, ty)?,
                     Instruction::Load(ptr) => self.verify_load(ptr)?,
-                    Instruction::Log {
-                        log_val,
-                        log_ty,
-                        log_id,
-                    } => self.verify_log(log_val, log_ty, log_id)?,
                     Instruction::MemCopy {
                         dst_val,
                         src_val,
                         byte_len,
                     } => self.verify_mem_copy(dst_val, src_val, byte_len)?,
                     Instruction::Nop => (),
-                    Instruction::ReadRegister(_) => (),
                     Instruction::Ret(val, ty) => self.verify_ret(val, ty)?,
-                    Instruction::Revert(val) => self.verify_revert(val)?,
-                    Instruction::Smo {
-                        recipient_and_message,
-                        message_size,
-                        output_index,
-                        coins,
-                    } => {
-                        self.verify_smo(recipient_and_message, message_size, output_index, coins)?
-                    }
-                    Instruction::StateLoadWord(key) => self.verify_state_load_word(key)?,
-                    Instruction::StateLoadQuadWord {
-                        load_val: dst_val,
-                        key,
-                    }
-                    | Instruction::StateStoreQuadWord {
-                        stored_val: dst_val,
-                        key,
-                    } => self.verify_state_load_store(dst_val, &Type::B256, key)?,
-                    Instruction::StateStoreWord {
-                        stored_val: dst_val,
-                        key,
-                    } => self.verify_state_store_word(dst_val, key)?,
                     Instruction::Store {
                         dst_val,
                         stored_val,


### PR DESCRIPTION
This PR fixes #3071. I’ve extracted the following IR instructions:

- `Instruction::GetStorageKey`
- `Instruction::Gtf`
- `Instruction::Log`
- `Instruction::ReadRegister`
- `Instruction::Revert`
- `Instruction::Smo`
- `Instruction::StateLoadQuadWord`
- `Instruction::StateLoadWord`
- `Instruction::StateStoreQuadWord`
- `Instruction::StateStoreWord`

Each of these instructions has been moved to a new `FuelVmInstruction` enum. The main `Instruction` enum now has a new `FuelVm` variant, which contains a single `FuelVmInstruction` instance.

I’ve named these `FuelVm` instead of `FuelVM` to [follow the Rust API Guidelines / RFC 430](https://rust-lang.github.io/api-guidelines/naming.html#c-case) – let me know if I should change this to `FuelVM` though :)

I’ve tried to maintain the existing alphabetical ordering of `Instruction` variants, so apologies for the confusing diff 😅