### PR TITLE
Rename `Forc.toml` to `forc.toml` and `Forc.lock` to `forc.lock`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Initialize test project
         run: forc new test-proj
       - name: Update project forc manifest to use local sway-lib-std
-        run: echo "std = { path = \"../sway-lib-std/\" }" >> test-proj/Forc.toml
+        run: echo "std = { path = \"../sway-lib-std/\" }" >> test-proj/forc.toml
       - name: Build test project
         run: forc build --path test-proj
       # TODO: Re-add this upon landing unit test support: #1832

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -1,7 +1,7 @@
 use crate::pkg::{manifest_file_missing, parsing_failed, wrong_program_type};
 use anyhow::{anyhow, bail, Context, Result};
 use forc_tracing::println_yellow_err;
-use forc_util::{find_manifest_dir, validate_name};
+use forc_util::{find_manifest_file, validate_name};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -244,10 +244,8 @@ impl PackageManifestFile {
     ///
     /// This is short for `PackageManifest::from_file`, but takes care of constructing the path to the
     /// file.
-    pub fn from_dir(manifest_dir: &Path) -> Result<Self> {
-        let dir = forc_util::find_manifest_dir(manifest_dir)
-            .ok_or_else(|| manifest_file_missing(manifest_dir))?;
-        let path = dir.join(constants::MANIFEST_FILE_NAME);
+    pub fn from_dir(dir: &Path) -> Result<Self> {
+        let path = find_manifest_file(dir).ok_or_else(|| manifest_file_missing(dir))?;
         Self::from_file(path)
     }
 
@@ -444,8 +442,7 @@ impl PackageManifest {
     /// This is short for `PackageManifest::from_file`, but takes care of constructing the path to the
     /// file.
     pub fn from_dir(dir: &Path) -> Result<Self> {
-        let manifest_dir = find_manifest_dir(dir).ok_or_else(|| manifest_file_missing(dir))?;
-        let file_path = manifest_dir.join(constants::MANIFEST_FILE_NAME);
+        let file_path = find_manifest_file(dir).ok_or_else(|| manifest_file_missing(dir))?;
         Self::from_file(&file_path)
     }
 
@@ -721,10 +718,8 @@ impl WorkspaceManifestFile {
     ///
     /// This is short for `PackageManifest::from_file`, but takes care of constructing the path to the
     /// file.
-    pub fn from_dir(manifest_dir: &Path) -> Result<Self> {
-        let dir = forc_util::find_manifest_dir(manifest_dir)
-            .ok_or_else(|| manifest_file_missing(manifest_dir))?;
-        let path = dir.join(constants::MANIFEST_FILE_NAME);
+    pub fn from_dir(dir: &Path) -> Result<Self> {
+        let path = find_manifest_file(dir).ok_or_else(|| manifest_file_missing(dir))?;
         Self::from_file(path)
     }
 

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2507,16 +2507,17 @@ pub fn build_with_options(build_options: BuildOpts) -> Result<Built> {
     } = &build_options;
 
     let manifest_file = ManifestFile::from_dir(&this_dir)?;
+    let lock_path = manifest_file.lock_path()?;
+
     forc_util::warn_if_old_manifest_name(manifest_file.path());
+    forc_util::rename_lock_file_if_old(&lock_path)?;
+
     let member_manifests = manifest_file.member_manifests()?;
     // Check if we have members to build so that we are not trying to build an empty workspace.
     if member_manifests.is_empty() {
         bail!("No member found to build")
     }
 
-    todo!("Check for old lock file and rename it");
-
-    let lock_path = manifest_file.lock_path()?;
     let build_plan = BuildPlan::from_lock_and_manifests(
         &lock_path,
         &member_manifests,

--- a/forc/src/ops/forc_check.rs
+++ b/forc/src/ops/forc_check.rs
@@ -22,6 +22,7 @@ pub fn check(
         std::env::current_dir()?
     };
     let manifest_file = ManifestFile::from_dir(&this_dir)?;
+    forc_util::warn_if_old_manifest_name(manifest_file.path());
     let member_manifests = manifest_file.member_manifests()?;
     let lock_path = manifest_file.lock_path()?;
     let plan =

--- a/forc/src/ops/forc_check.rs
+++ b/forc/src/ops/forc_check.rs
@@ -22,9 +22,10 @@ pub fn check(
         std::env::current_dir()?
     };
     let manifest_file = ManifestFile::from_dir(&this_dir)?;
-    forc_util::warn_if_old_manifest_name(manifest_file.path());
-    let member_manifests = manifest_file.member_manifests()?;
     let lock_path = manifest_file.lock_path()?;
+    forc_util::warn_if_old_manifest_name(manifest_file.path());
+    forc_util::rename_lock_file_if_old(&lock_path)?;
+    let member_manifests = manifest_file.member_manifests()?;
     let plan =
         pkg::BuildPlan::from_lock_and_manifests(&lock_path, &member_manifests, locked, offline)?;
 

--- a/forc/src/ops/forc_clean.rs
+++ b/forc/src/ops/forc_clean.rs
@@ -29,7 +29,7 @@ pub fn clean(command: CleanCommand) -> Result<()> {
     let manifest_dir = manifest_path
         .parent()
         .expect("manifest file has no parent directory");
-    let out_dir = default_output_directory(&manifest_dir);
+    let out_dir = default_output_directory(manifest_dir);
     let _ = std::fs::remove_dir_all(out_dir);
 
     Ok(())

--- a/forc/src/ops/forc_clean.rs
+++ b/forc/src/ops/forc_clean.rs
@@ -1,6 +1,6 @@
 use crate::cli::CleanCommand;
 use anyhow::{anyhow, bail, Result};
-use forc_util::{default_output_directory, find_manifest_dir};
+use forc_util::{default_output_directory, find_manifest_file};
 use std::path::PathBuf;
 use sway_utils::MANIFEST_FILE_NAME;
 
@@ -13,8 +13,8 @@ pub fn clean(command: CleanCommand) -> Result<()> {
     } else {
         std::env::current_dir().map_err(|e| anyhow!("{:?}", e))?
     };
-    let manifest_dir = match find_manifest_dir(&this_dir) {
-        Some(dir) => dir,
+    let manifest_path = match find_manifest_file(&this_dir) {
+        Some(path) => path,
         None => {
             bail!(
                 "could not find `{}` in `{}` or any parent directory",
@@ -26,6 +26,9 @@ pub fn clean(command: CleanCommand) -> Result<()> {
 
     // Clear `<project>/out` directory.
     // Ignore I/O errors telling us `out_dir` isn't there.
+    let manifest_dir = manifest_path
+        .parent()
+        .expect("manifest file has no parent directory");
     let out_dir = default_output_directory(&manifest_dir);
     let _ = std::fs::remove_dir_all(out_dir);
 

--- a/forc/src/ops/forc_update.rs
+++ b/forc/src/ops/forc_update.rs
@@ -34,6 +34,7 @@ pub async fn update(command: UpdateCommand) -> Result<()> {
     };
 
     let manifest = ManifestFile::from_dir(&this_dir)?;
+    forc_util::warn_if_old_manifest_name(manifest.path());
     let lock_path = lock_path(manifest.dir());
     let old_lock = Lock::from_path(&lock_path).ok().unwrap_or_default();
     let offline = false;

--- a/forc/src/ops/forc_update.rs
+++ b/forc/src/ops/forc_update.rs
@@ -1,7 +1,6 @@
 use crate::cli::UpdateCommand;
 use anyhow::{anyhow, Result};
 use forc_pkg::{self as pkg, lock, Lock};
-use forc_util::lock_path;
 use pkg::manifest::ManifestFile;
 use std::{fs, path::PathBuf};
 use tracing::info;
@@ -34,8 +33,9 @@ pub async fn update(command: UpdateCommand) -> Result<()> {
     };
 
     let manifest = ManifestFile::from_dir(&this_dir)?;
+    let lock_path = manifest.lock_path()?;
     forc_util::warn_if_old_manifest_name(manifest.path());
-    let lock_path = lock_path(manifest.dir());
+    forc_util::rename_lock_file_if_old(&lock_path)?;
     let old_lock = Lock::from_path(&lock_path).ok().unwrap_or_default();
     let offline = false;
     let member_manifests = manifest.member_manifests()?;

--- a/sway-utils/src/constants.rs
+++ b/sway-utils/src/constants.rs
@@ -1,5 +1,7 @@
-pub const MANIFEST_FILE_NAME: &str = "Forc.toml";
-pub const LOCK_FILE_NAME: &str = "Forc.lock";
+pub const MANIFEST_FILE_NAME: &str = "forc.toml";
+pub const LOCK_FILE_NAME: &str = "forc.lock";
+pub const OLD_MANIFEST_FILE_NAME: &str = "Forc.toml";
+pub const OLD_LOCK_FILE_NAME: &str = "Forc.lock";
 pub const TEST_MANIFEST_FILE_NAME: &str = "Cargo.toml";
 pub const TEST_DIRECTORY: &str = "tests";
 pub const SWAY_EXTENSION: &str = "sw";


### PR DESCRIPTION
This is a WIP implementation of #3438.

TODO:

- [x] Handle old `Forc.lock` loading, automatically rename to `forc.lock`.
- [ ] (optional) Add a command for auto-renaming manifests and locks for a package/workspace? Or should we auto-update it? Might cause confusion as, unlike `Forc.lock`, the user might have the original file open in an editor? Might cause git noise?
- [ ] Update all comments and docs.
- [ ] Update all examples and tests.