### PR TITLE
Disable `self` parameters for ABI methods

### DIFF
--- a/sway-error/src/convert_parse_tree_error.rs
+++ b/sway-error/src/convert_parse_tree_error.rs
@@ -85,8 +85,8 @@ pub enum ConvertParseTreeError {
     DuplicateStructField { name: Ident, span: Span },
     #[error("identifier \"{name}\" bound more than once in this parameter list")]
     DuplicateParameterIdentifier { name: Ident, span: Span },
-    #[error("self parameter is not allowed for a free function")]
-    SelfParameterNotAllowedForFreeFn { span: Span },
+    #[error("self parameter is not allowed for {fn_kind}")]
+    SelfParameterNotAllowedForFn { fn_kind: String, span: Span },
     #[error("test functions are only allowed at module level")]
     TestFnOnlyAllowedAtModuleLevel { span: Span },
     #[error("`impl Self` for contracts is not supported")]
@@ -143,7 +143,7 @@ impl Spanned for ConvertParseTreeError {
             ConvertParseTreeError::DuplicateStorageField { span, .. } => span.clone(),
             ConvertParseTreeError::DuplicateStructField { span, .. } => span.clone(),
             ConvertParseTreeError::DuplicateParameterIdentifier { span, .. } => span.clone(),
-            ConvertParseTreeError::SelfParameterNotAllowedForFreeFn { span, .. } => span.clone(),
+            ConvertParseTreeError::SelfParameterNotAllowedForFn { span, .. } => span.clone(),
             ConvertParseTreeError::TestFnOnlyAllowedAtModuleLevel { span } => span.clone(),
             ConvertParseTreeError::SelfImplForContract { span, .. } => span.clone(),
             ConvertParseTreeError::CannotDocCommentDependency { span } => span.clone(),

--- a/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_abi_method_signature/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_abi_method_signature/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'no_self_in_abi_method_signature'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_abi_method_signature/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_abi_method_signature/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "no_self_in_abi_method_signature"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_abi_method_signature/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_abi_method_signature/src/main.sw
@@ -1,0 +1,6 @@
+contract;
+
+abi MyContract {
+    fn foo(self);
+}
+

--- a/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_abi_method_signature/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_abi_method_signature/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()self parameter is not allowed for an ABI method signature

--- a/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_method_provided_by_abi/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_method_provided_by_abi/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'no_self_in_method_provided_by_abi'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_method_provided_by_abi/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_method_provided_by_abi/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "no_self_in_method_provided_by_abi"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_method_provided_by_abi/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_method_provided_by_abi/src/main.sw
@@ -1,0 +1,9 @@
+contract;
+
+abi MyContract {
+    fn foo();
+} {
+    fn bar(self) {
+    }
+}
+

--- a/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_method_provided_by_abi/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/no_self_in_method_provided_by_abi/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()self parameter is not allowed for a method provided by ABI


### PR DESCRIPTION
ref #2397

Disable those both in ABI method signatures and methods provided by ABIs