### PR TITLE
Small fixes for incorrect rebasing in 3411

### DIFF
--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -11,19 +11,19 @@ description = "LSP server for Sway."
 [dependencies]
 anyhow = "1.0.41"
 dashmap = "5.4"
-forc-pkg = { version = "0.32.1", path = "../forc-pkg" }
-forc-tracing = { version = "0.32.1", path = "../forc-tracing" }
+forc-pkg = { version = "0.32.2", path = "../forc-pkg" }
+forc-tracing = { version = "0.32.2", path = "../forc-tracing" }
 notify = "5.0.0"
 notify-debouncer-mini = { version = "0.2.0" }
 parking_lot = "0.12.1"
 ropey = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.60"
-sway-core = { version = "0.32.1", path = "../sway-core" }
-sway-error = { version = "0.32.1", path = "../sway-error" }
-sway-types = { version = "0.32.1", path = "../sway-types" }
-sway-utils = { version = "0.32.1", path = "../sway-utils" }
-swayfmt = { version = "0.32.1", path = "../swayfmt" }
+sway-core = { version = "0.32.2", path = "../sway-core" }
+sway-error = { version = "0.32.2", path = "../sway-error" }
+sway-types = { version = "0.32.2", path = "../sway-types" }
+sway-utils = { version = "0.32.2", path = "../sway-utils" }
+swayfmt = { version = "0.32.2", path = "../swayfmt" }
 tempfile = "3"
 thiserror = "1.0.30"
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -15,7 +15,7 @@ use dashmap::DashMap;
 use forc_pkg::{self as pkg};
 use parking_lot::RwLock;
 use pkg::manifest::ManifestFile;
-use std::{path::PathBuf, sync::Arc};
+use std::{fs::File, io::Write, path::PathBuf, sync::Arc};
 use sway_core::{
     declaration_engine::DeclarationEngine,
     language::{
@@ -260,6 +260,29 @@ impl Session {
                 let _ = self.store_document(text_document);
             }
         }
+    }
+
+    /// Writes the changes to the file and updates the document.
+    pub fn write_changes_to_file(
+        &self,
+        uri: &Url,
+        changes: Vec<TextDocumentContentChangeEvent>,
+    ) -> Result<(), LanguageServerError> {
+        let src = self.update_text_document(uri, changes).ok_or_else(|| {
+            DocumentError::DocumentNotFound {
+                path: uri.path().to_string(),
+            }
+        })?;
+        let mut file =
+            File::create(uri.path()).map_err(|err| DocumentError::UnableToCreateFile {
+                path: uri.path().to_string(),
+                err: err.to_string(),
+            })?;
+        writeln!(&mut file, "{}", src).map_err(|err| DocumentError::UnableToWriteFile {
+            path: uri.path().to_string(),
+            err: err.to_string(),
+        })?;
+        Ok(())
     }
 
     /// Update the document at the given [Url] with the Vec of changes returned by the client.

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -33,6 +33,10 @@ pub enum DocumentError {
     ManifestsLockPathFailed { dir: String },
     #[error("Document is already stored at {:?}", path)]
     DocumentAlreadyStored { path: String },
+    #[error("File wasn't able to be created at path {:?} : {:?}", path, err)]
+    UnableToCreateFile { path: String, err: String },
+    #[error("Unable to write string to file at {:?} : {:?}", path, err)]
+    UnableToWriteFile { path: String, err: String },
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -241,13 +241,13 @@ impl LanguageServer for Backend {
         match self.get_uri_and_session(&params.text_document.uri) {
             Ok((uri, session)) => {
                 // update this file with the new changes and write to disk
-                if let Some(src) = session.update_text_document(&uri, params.content_changes) {
-                    if let Ok(mut file) = File::create(uri.path()) {
-                        let _ = writeln!(&mut file, "{}", src);
+                match session.write_changes_to_file(&uri, params.content_changes) {
+                    Ok(_) => {
+                        self.parse_project(uri, params.text_document.uri, session.clone())
+                            .await;
                     }
+                    Err(err) => tracing::error!("{}", err.to_string()),
                 }
-                self.parse_project(uri, params.text_document.uri, session.clone())
-                    .await;
             }
             Err(err) => tracing::error!("{}", err.to_string()),
         }


### PR DESCRIPTION
Small fixes to a few things that got reverted in the language server while merging #3411 into master.

Specifically, versions were downgraded from 0.32.2 to 0.32.1. And the changes introduced in #3620 were omitted.  