### PR TITLE
Enable LSP to work with multiple projects simultaneously

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,32 +3788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial_test"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
-dependencies = [
- "dashmap",
- "futures",
- "lazy_static",
- "log",
- "parking_lot 0.12.1",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4151,7 +4125,6 @@ dependencies = [
  "ropey",
  "serde",
  "serde_json",
- "serial_test",
  "sway-core",
  "sway-error",
  "sway-types",

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -34,5 +34,4 @@ tracing = "0.1"
 [dev-dependencies]
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
-serial_test = "0.9.0"
 tower = { version = "0.4.12", default-features = false, features = ["util"] }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -127,16 +127,6 @@ impl Backend {
         let session = match self.sessions.try_get(&manifest_dir).try_unwrap() {
             Some(item) => item.value().clone(),
             None => {
-                // TODO, remove this once the type engine no longer uses global memory: https://github.com/FuelLabs/sway/issues/2063
-                // Until then, we clear the current project and init with the new project.
-                // At least allows the user to switch between projects within a workspace but only if they
-                // have one pane open.
-                let _ = self.sessions.iter().map(|item| {
-                    let session = item.value();
-                    session.shutdown();
-                });
-                self.sessions.clear();
-
                 // If no session can be found, then we need to call init and inserst a new session into the map
                 self.init(uri)?;
                 self.sessions
@@ -606,7 +596,6 @@ mod tests {
     use super::*;
     use crate::utils::test::{doc_comments_dir, e2e_test_dir};
     use serde_json::json;
-    use serial_test::serial;
     use std::{borrow::Cow, fs, io::Read, path::PathBuf};
     use tower::{Service, ServiceExt};
     use tower_lsp::{
@@ -893,14 +882,12 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn initialize() {
         let (mut service, _) = LspService::new(Backend::new);
         let _ = initialize_request(&mut service).await;
     }
 
     #[tokio::test]
-    #[serial]
     async fn initialized() {
         let (mut service, _) = LspService::new(Backend::new);
         let _ = initialize_request(&mut service).await;
@@ -908,7 +895,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn initializes_only_once() {
         let (mut service, _) = LspService::new(Backend::new);
         let initialize = initialize_request(&mut service).await;
@@ -919,7 +905,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn shutdown() {
         let (mut service, _) = LspService::new(Backend::new);
         let _ = initialize_request(&mut service).await;
@@ -932,7 +917,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn refuses_requests_after_shutdown() {
         let (mut service, _) = LspService::new(Backend::new);
         let _ = initialize_request(&mut service).await;
@@ -943,7 +927,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn did_open() {
         let (mut service, _) = LspService::new(Backend::new);
         let _ = init_and_open(&mut service, e2e_test_dir()).await;
@@ -951,7 +934,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn did_close() {
         let (mut service, _) = LspService::new(Backend::new);
         let _ = init_and_open(&mut service, e2e_test_dir()).await;
@@ -960,7 +942,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn did_change() {
         let (mut service, _) = LspService::new(Backend::new);
         let uri = init_and_open(&mut service, doc_comments_dir()).await;
@@ -969,7 +950,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn lsp_syncs_with_workspace_edits() {
         let (mut service, _) = LspService::new(Backend::new);
         let uri = init_and_open(&mut service, doc_comments_dir()).await;
@@ -980,7 +960,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn show_ast() {
         let (mut service, _) = LspService::build(Backend::new)
             .custom_method("sway/show_ast", Backend::show_ast)
@@ -992,7 +971,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn go_to_definition() {
         let (mut service, _) = LspService::new(Backend::new);
         let uri = init_and_open(&mut service, doc_comments_dir()).await;
@@ -1018,7 +996,7 @@ mod tests {
     macro_rules! lsp_capability_test {
         ($test:ident, $capability:expr) => {
             #[tokio::test]
-            #[serial]
+
             async fn $test() {
                 test_lsp_capability!(doc_comments_dir(), $capability);
             }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -996,7 +996,6 @@ mod tests {
     macro_rules! lsp_capability_test {
         ($test:ident, $capability:expr) => {
             #[tokio::test]
-
             async fn $test() {
                 test_lsp_capability!(doc_comments_dir(), $capability);
             }


### PR DESCRIPTION
Now that the `lazy_statics` have been removed from the type and declaration engines, the language server can finally support providing LSP capabilities for multiple simultaneous projects within the same editor! 🥳 

This allows the LSP tests to be run in parallel, and also allows for unique projects to be opened in multiple windows within the editor. 

Very excited to get this in. Should finally allow the language server to work with non-trivial sway projects. cc @FuelLabs/application-dev 

closes #3372 
solves the issues outlined in #3069