### PR TITLE
Return the lexing stage produced by `sway_parse` from `forc-pkg::check()`

### DIFF
--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -21,7 +21,6 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
 serde_json = "1.0"
-sway-ast = { version = "0.32.2", path = "../sway-ast" }
 sway-core = { version = "0.32.2", path = "../sway-core" }
 sway-error = { version = "0.32.2", path = "../sway-error" }
 sway-types = { version = "0.32.2", path = "../sway-types" }

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -21,6 +21,7 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
 serde_json = "1.0"
+sway-ast = { version = "0.32.2", path = "../sway-ast" }
 sway-core = { version = "0.32.2", path = "../sway-core" }
 sway-error = { version = "0.32.2", path = "../sway-error" }
 sway-types = { version = "0.32.2", path = "../sway-types" }

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2818,7 +2818,7 @@ impl Programs {
     }
 }
 
-/// Compile the entire forc package and return the parse and typed programs
+/// Compile the entire forc package and return the lexed, parsed and typed programs
 /// of the dependancies and project.
 /// The final item in the returned vector is the project.
 pub fn check(

--- a/forc-plugins/forc-doc/src/main.rs
+++ b/forc-plugins/forc-doc/src/main.rs
@@ -64,7 +64,7 @@ pub fn main() -> Result<()> {
     let typed_program = match pkg::check(&plan, silent, engines)?
         .pop()
         .and_then(|compilation| compilation.value)
-        .and_then(|stage| stage.typed_program)
+        .and_then(|programs| programs.typed)
     {
         Some(typed_program) => typed_program,
         _ => bail!("CompileResult returned None"),

--- a/forc-plugins/forc-doc/src/main.rs
+++ b/forc-plugins/forc-doc/src/main.rs
@@ -64,8 +64,9 @@ pub fn main() -> Result<()> {
     let typed_program = match pkg::check(&plan, silent, engines)?
         .pop()
         .and_then(|compilation| compilation.value)
+        .and_then(|stage| stage.typed_program)
     {
-        Some((_, Some(typed_program))) => typed_program,
+        Some(typed_program) => typed_program,
         _ => bail!("CompileResult returned None"),
     };
     let raw_docs: Documentation = Document::from_ty_program(

--- a/forc/src/ops/forc_check.rs
+++ b/forc/src/ops/forc_check.rs
@@ -28,6 +28,6 @@ pub fn check(command: CheckCommand, engines: Engines<'_>) -> Result<CompileResul
     let res = v
         .pop()
         .expect("there is guaranteed to be at least one elem in the vector")
-        .flat_map(|(_, tp)| CompileResult::new(tp, vec![], vec![]));
+        .flat_map(|stage| CompileResult::new(stage.typed_program, vec![], vec![]));
     Ok(res)
 }

--- a/forc/src/ops/forc_check.rs
+++ b/forc/src/ops/forc_check.rs
@@ -28,6 +28,6 @@ pub fn check(command: CheckCommand, engines: Engines<'_>) -> Result<CompileResul
     let res = v
         .pop()
         .expect("there is guaranteed to be at least one elem in the vector")
-        .flat_map(|stage| CompileResult::new(stage.typed_program, vec![], vec![]));
+        .flat_map(|programs| CompileResult::new(programs.typed, vec![], vec![]));
     Ok(res)
 }

--- a/sway-ast/src/module.rs
+++ b/sway-ast/src/module.rs
@@ -1,5 +1,6 @@
 use crate::priv_prelude::*;
 
+#[derive(Clone, Debug)]
 pub struct Module {
     pub kind: ModuleKind,
     pub semicolon_token: SemicolonToken,
@@ -30,6 +31,7 @@ impl Spanned for Module {
     }
 }
 
+#[derive(Clone, Debug)]
 pub enum ModuleKind {
     Script {
         script_token: ScriptToken,

--- a/sway-core/src/language/lexed/mod.rs
+++ b/sway-core/src/language/lexed/mod.rs
@@ -8,7 +8,7 @@ use sway_types::Ident;
 /// A module and its submodules in the form of a tree.
 #[derive(Debug, Clone)]
 pub struct LexedModule {
-    /// The content of this module in the form of a `ParseTree`.
+    /// The content of this module in the form of a [Module].
     pub module: Module,
     /// Submodules introduced within this module using the `dep` syntax in order of declaration.
     pub submodules: Vec<(DepName, LexedSubmodule)>,

--- a/sway-core/src/language/lexed/mod.rs
+++ b/sway-core/src/language/lexed/mod.rs
@@ -1,0 +1,25 @@
+mod program;
+
+use crate::language::DepName;
+pub use program::LexedProgram;
+use sway_ast::Module;
+use sway_types::Ident;
+
+/// A module and its submodules in the form of a tree.
+#[derive(Debug, Clone)]
+pub struct LexedModule {
+    /// The content of this module in the form of a `ParseTree`.
+    pub module: Module,
+    /// Submodules introduced within this module using the `dep` syntax in order of declaration.
+    pub submodules: Vec<(DepName, LexedSubmodule)>,
+}
+
+/// A library module that was declared as a `dep` of another module.
+///
+/// Only submodules are guaranteed to be a `library` and have a `library_name`.
+#[derive(Debug, Clone)]
+pub struct LexedSubmodule {
+    /// The name of a submodule, parsed from the `library` declaration within the module itself.
+    pub library_name: Ident,
+    pub module: LexedModule,
+}

--- a/sway-core/src/language/lexed/program.rs
+++ b/sway-core/src/language/lexed/program.rs
@@ -1,0 +1,17 @@
+use super::LexedModule;
+use crate::language::parsed::TreeType;
+
+/// A parsed, but not yet type-checked, Sway program.
+///
+/// Includes all modules in the form of a `ParseModule` tree accessed via the `root`.
+#[derive(Debug, Clone)]
+pub struct LexedProgram {
+    pub kind: TreeType,
+    pub root: LexedModule,
+}
+
+impl LexedProgram {
+    pub fn new(kind: TreeType, root: LexedModule) -> LexedProgram {
+        LexedProgram { kind, root }
+    }
+}

--- a/sway-core/src/language/lexed/program.rs
+++ b/sway-core/src/language/lexed/program.rs
@@ -1,9 +1,9 @@
 use super::LexedModule;
 use crate::language::parsed::TreeType;
 
-/// A parsed, but not yet type-checked, Sway program.
+/// A lexed, but not yet parsed or type-checked, Sway program.
 ///
-/// Includes all modules in the form of a `ParseModule` tree accessed via the `root`.
+/// Includes all modules in the form of a [LexedModule] tree accessed via the `root`.
 #[derive(Debug, Clone)]
 pub struct LexedProgram {
     pub kind: TreeType,

--- a/sway-core/src/language/mod.rs
+++ b/sway-core/src/language/mod.rs
@@ -2,6 +2,7 @@ mod asm;
 mod call_path;
 mod inline;
 mod lazy_op;
+pub mod lexed;
 mod literal;
 mod module;
 pub mod parsed;

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -49,7 +49,7 @@ pub mod fuel_prelude {
 
 pub use engine_threading::Engines;
 
-/// Given an input `Arc<str>` and an optional [BuildConfig], parse the input into a [SwayParseTree].
+/// Given an input `Arc<str>` and an optional [BuildConfig], parse the input into a [lexed::LexedProgram] and [parsed::ParseProgram].
 ///
 /// # Example
 /// ```ignore
@@ -113,6 +113,7 @@ fn parse_in_memory(
     Ok((lexed_program, parsed::ParseProgram { kind, root }))
 }
 
+/// Contains the lexed and parsed submodules 'deps' of a module.
 struct Submodules {
     lexed: Vec<(Ident, lexed::LexedSubmodule)>,
     parsed: Vec<(Ident, parsed::ParseSubmodule)>,

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -14,7 +14,7 @@ use crate::{
 use dashmap::DashMap;
 use forc_pkg::{self as pkg};
 use parking_lot::RwLock;
-use pkg::manifest::ManifestFile;
+use pkg::{manifest::ManifestFile, CompilationStage};
 use std::{fs::File, io::Write, path::PathBuf, sync::Arc};
 use sway_core::{
     declaration_engine::DeclarationEngine,
@@ -151,14 +151,16 @@ impl Session {
                 errors,
             } = res;
 
-            // FIXME(Centril): Refactor parse_ast_to_tokens + parse_ast_to_typed_tokens
-            // due to the new API.g
-            let (parsed, typed) = match value {
-                None => (None, None),
-                Some((pp, tp)) => (Some(pp), tp),
+            let (modules, parsed, typed) = match value {
+                Some(CompilationStage {
+                    modules,
+                    parse_program,
+                    typed_program,
+                }) => (modules, parse_program, typed_program),
+                None => continue,
             };
 
-            let parsed_res = CompileResult::new(parsed, warnings.clone(), errors.clone());
+            let parsed_res = CompileResult::new(Some(parsed), warnings.clone(), errors.clone());
             let ast_res = CompileResult::new(typed, warnings, errors);
 
             let parse_program = self.compile_res_to_parse_program(&parsed_res)?;

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -151,16 +151,14 @@ impl Session {
                 errors,
             } = res;
 
-            let (modules, parsed, typed) = match value {
+            let (lexed, parsed, typed) = match value {
                 Some(CompilationStage {
-                    modules,
+                    lexed_program,
                     parse_program,
                     typed_program,
-                }) => (modules, parse_program, typed_program),
+                }) => (lexed_program, parse_program, typed_program),
                 None => continue,
             };
-
-            eprintln!("modules: {:#?}", modules.len());
 
             let parsed_res = CompileResult::new(Some(parsed), warnings.clone(), errors.clone());
             let ast_res = CompileResult::new(typed, warnings, errors);
@@ -170,6 +168,7 @@ impl Session {
 
             // The final element in the results is the main program.
             if i == results_len - 1 {
+                eprintln!("lexed: {:#?}", lexed);
                 // First, populate our token_map with un-typed ast nodes.
                 let parsed_tree = ParsedTree::new(type_engine, &self.token_map);
                 self.parse_ast_to_tokens(parse_program, |an| parsed_tree.traverse_node(an));

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -160,6 +160,8 @@ impl Session {
                 None => continue,
             };
 
+            eprintln!("modules: {:#?}", modules.len());
+
             let parsed_res = CompileResult::new(Some(parsed), warnings.clone(), errors.clone());
             let ast_res = CompileResult::new(typed, warnings, errors);
 


### PR DESCRIPTION
Previous to this PR, `forc_pkg::check()` would only return the `ParseProgram` and `TyProgram` AST's. In the language server, we now also need access to the initial lexing stage produced by `sway_parse` in order to get access to the sway keyword tokens. 

This PR now returns the lexing stage of a program along with the parsed and typed stages. 

closes #3524 