### PR TITLE
Add an error message about nested function definitions.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -1,7 +1,10 @@
 mod function_parameter;
 
 pub use function_parameter::*;
-use sway_error::warning::{CompileWarning, Warning};
+use sway_error::{
+    error::CompileError,
+    warning::{CompileWarning, Warning},
+};
 
 use crate::{
     error::*,
@@ -38,6 +41,15 @@ impl ty::TyFunctionDeclaration {
         let declaration_engine = ctx.declaration_engine;
         let engines = ctx.engines();
 
+        // If functions aren't allowed in this location, return an error.
+        if ctx.functions_disallowed() {
+            errors.push(CompileError::Unimplemented(
+                "Nested function definitions are not allowed at this time.",
+                span,
+            ));
+            return err(warnings, errors);
+        }
+
         // Warn against non-snake case function names.
         if !is_snake_case(name.as_str()) {
             warnings.push(CompileWarning {
@@ -48,7 +60,11 @@ impl ty::TyFunctionDeclaration {
 
         // create a namespace for the function
         let mut fn_namespace = ctx.namespace.clone();
-        let mut fn_ctx = ctx.by_ref().scoped(&mut fn_namespace).with_purity(purity);
+        let mut fn_ctx = ctx
+            .by_ref()
+            .scoped(&mut fn_namespace)
+            .with_purity(purity)
+            .disallow_functions();
 
         // type check the type parameters, which will also insert them into the namespace
         let mut new_type_parameters = vec![];

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -36,7 +36,7 @@ impl ty::TyImplTrait {
 
         // create a namespace for the impl
         let mut impl_namespace = ctx.namespace.clone();
-        let mut ctx = ctx.by_ref().scoped(&mut impl_namespace);
+        let mut ctx = ctx.by_ref().scoped(&mut impl_namespace).allow_functions();
 
         // type check the type parameters which also inserts them into the namespace
         let mut new_impl_type_parameters = vec![];
@@ -458,7 +458,7 @@ impl ty::TyImplTrait {
 
         // create the namespace for the impl
         let mut impl_namespace = ctx.namespace.clone();
-        let mut ctx = ctx.scoped(&mut impl_namespace);
+        let mut ctx = ctx.scoped(&mut impl_namespace).allow_functions();
 
         // create the trait name
         let trait_name = CallPath {

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -57,6 +57,11 @@ pub struct TypeCheckContext<'a> {
     /// Provides the kind of the module.
     /// This is useful for example to throw an error when while loops are present in predicates.
     kind: TreeType,
+
+    /// Indicates when semantic analysis should disallow functions. (i.e.
+    /// disallowing functions from being defined inside of another function
+    /// body).
+    disallow_functions: bool,
 }
 
 impl<'a> TypeCheckContext<'a> {
@@ -85,6 +90,7 @@ impl<'a> TypeCheckContext<'a> {
             mode: Mode::NonAbi,
             purity: Purity::default(),
             kind: TreeType::Contract,
+            disallow_functions: false,
         }
     }
 
@@ -107,6 +113,7 @@ impl<'a> TypeCheckContext<'a> {
             kind: self.kind.clone(),
             type_engine: self.type_engine,
             declaration_engine: self.declaration_engine,
+            disallow_functions: self.disallow_functions,
         }
     }
 
@@ -122,6 +129,7 @@ impl<'a> TypeCheckContext<'a> {
             kind: self.kind,
             type_engine: self.type_engine,
             declaration_engine: self.declaration_engine,
+            disallow_functions: self.disallow_functions,
         }
     }
 
@@ -179,6 +187,24 @@ impl<'a> TypeCheckContext<'a> {
         Self { self_type, ..self }
     }
 
+    /// Map this `TypeCheckContext` instance to a new one with
+    /// `disallow_functions` set to `true`.
+    pub(crate) fn disallow_functions(self) -> Self {
+        Self {
+            disallow_functions: true,
+            ..self
+        }
+    }
+
+    /// Map this `TypeCheckContext` instance to a new one with
+    /// `disallow_functions` set to `false`.
+    pub(crate) fn allow_functions(self) -> Self {
+        Self {
+            disallow_functions: false,
+            ..self
+        }
+    }
+
     // A set of accessor methods. We do this rather than making the fields `pub` in order to ensure
     // that these are only updated via the `with_*` methods that produce a new `TypeCheckContext`.
 
@@ -204,6 +230,10 @@ impl<'a> TypeCheckContext<'a> {
 
     pub(crate) fn self_type(&self) -> TypeId {
         self.self_type
+    }
+
+    pub(crate) fn functions_disallowed(&self) -> bool {
+        self.disallow_functions
     }
 
     // Provide some convenience functions around the inner context.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/nested_functions/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/nested_functions/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'nested_functions'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_fail/nested_functions/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/nested_functions/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "nested_functions"
+entry = "main.sw"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/nested_functions/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/nested_functions/src/main.sw
@@ -1,0 +1,19 @@
+script;
+
+struct Data {
+    value: u64
+}
+
+impl Data {
+    fn the_value(self) -> u64 {
+        fn double(n: u64) -> u64 {
+            n // + n
+        }
+
+        double(self.value)
+    }
+}
+
+fn main() {
+    fn bla() { }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/nested_functions/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/nested_functions/test.toml
@@ -1,0 +1,11 @@
+category = "fail"
+
+# check: $()error
+# check: main.sw:9:9
+# check: $()fn double(n: u64) -> u64 {
+# check: $()Unimplemented feature: Nested function definitions are not allowed at this time.
+
+# check: $()error
+# check: main.sw:18:5
+# check: $()fn bla() { }
+# nextln: $()Unimplemented feature: Nested function definitions are not allowed at this time.


### PR DESCRIPTION
This PR finds cases of nested function definitions like:

```rust
script;

fn main() {
    fn bla() { }
}
```

and gives an "unimplemented" error. (as opposed to an ICE).

Closes #3097