### PR TITLE
Fixes nested generic type inference errors.

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_transpose/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_transpose/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-15FB35F23D5E4698'
+
+[[package]]
+name = 'generic_transpose'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-15FB35F23D5E4698'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_transpose/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_transpose/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "generic_transpose"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_transpose/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_transpose/json_abi_oracle.json
@@ -1,0 +1,24 @@
+{
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "bool",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_transpose/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_transpose/src/main.sw
@@ -1,0 +1,34 @@
+script;
+
+struct GenericStruct<T> {
+    x:T
+}
+
+impl<T, E> Option<Result<T, E>> {
+    pub fn transpose(self) -> Result<Option<T>, E> {
+      match self {
+          Option::Some(Result::Ok(x)) => Result::Ok(Option::Some(x)),
+          Option::Some(Result::Err(e)) => Result::Err(e),
+          Option::None => Result::Ok(Option::None),
+      }
+    }
+}
+
+impl<T> GenericStruct<Option<T>> {
+    pub fn transpose(self) -> Option<GenericStruct<T>> {
+      match self {
+          GenericStruct{x:Option::Some(y)} => Option::Some(GenericStruct{ x: y}),
+          GenericStruct{x:Option::None} => Option::None,
+      }
+    }
+}
+
+fn main() -> bool {
+    let y: Option<Result<u64, u8>> = Option::Some(Result::Ok(5));
+    assert(y.transpose().unwrap().unwrap() == 5);
+
+    let y: GenericStruct<Option<u64>> = GenericStruct{ x: Option::Some(5)};
+    assert(y.transpose().unwrap().x == 5);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_transpose/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_transpose/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+validate_abi = true


### PR DESCRIPTION
The issue was that `TraitMap::filter_by_type_inner` monomorphization was not working properly for nested generic types, some type_ids were not properly replaced thus we would get type inference errors.

The solution was to fix `TypeMapping::from_superset_and_subset` to be recursive.

Closes #3321