### PR TITLE
Fix enum variant unit type span in `convert_parse_tree`

### DIFF
--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -845,7 +845,7 @@ fn type_field_to_enum_variant(
     let type_span = if let Ty::Path(path_type) = &type_field.ty {
         path_type.prefix.name.span()
     } else {
-        span.clone()
+        type_field.ty.span()
     };
 
     let enum_variant = EnumVariant {


### PR DESCRIPTION
Closes #3634 

Before: 
![Screen Shot 2023-01-09 at 7 26 05 PM](https://user-images.githubusercontent.com/57543709/211441217-c525c7d9-49db-40b9-8e74-2f21b3bd4c43.png)
After: 
![Screen Shot 2023-01-09 at 7 26 17 PM](https://user-images.githubusercontent.com/57543709/211441245-e9ea357b-e1c7-45de-9142-69712604b193.png)

This was originally to be closed in #3644 due to their similarity, but I came to realize how we handle implicit returns for function signatures will require some significant refactoring.