### PR TITLE
Allow LSP to start with partial config

### DIFF
--- a/sway-lsp/src/config.rs
+++ b/sway-lsp/src/config.rs
@@ -4,10 +4,13 @@ use tracing::metadata::LevelFilter;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Config {
+    #[serde(default)]
     pub debug: DebugConfig,
+    #[serde(default)]
     pub logging: LoggingConfig,
+    #[serde(default)]
     pub inlay_hints: InlayHintsConfig,
-    #[serde(skip_serializing)]
+    #[serde(default, skip_serializing)]
     trace: TraceConfig,
 }
 


### PR DESCRIPTION
Closes https://github.com/FuelLabs/sway.vim/issues/6

Makes it so the LSP will use partial config when provided, and defaults otherwise.

Confirmed it's working using partial config:
```
       init_options = {
         logging = { level = 'trace' },
         --inlayHints = { maxLength = 25, renderColons = true, typeHints = true },
         -- trace = {},
         --trace = { extension = true, server = 'messages' },
         -- debug = { showCollectedTokensAsWarnings = 'off' }
       },
```

