### PR TITLE
Optionally store the length span of array expressions 

### DIFF
--- a/sway-core/src/language/parsed/expression/mod.rs
+++ b/sway-core/src/language/parsed/expression/mod.rs
@@ -42,6 +42,12 @@ pub struct TupleIndexExpression {
 }
 
 #[derive(Debug, Clone)]
+pub struct ArrayExpression {
+    pub contents: Vec<Expression>,
+    pub length_span: Option<Span>,
+}
+
+#[derive(Debug, Clone)]
 pub struct StructExpression {
     pub call_path_binding: TypeBinding<CallPath>,
     pub fields: Vec<StructExpressionField>,
@@ -157,7 +163,7 @@ pub enum ExpressionKind {
     Variable(Ident),
     Tuple(Vec<Expression>),
     TupleIndex(TupleIndexExpression),
-    Array(Vec<Expression>),
+    Array(ArrayExpression),
     Struct(Box<StructExpression>),
     CodeBlock(CodeBlock),
     If(IfExpression),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -220,7 +220,9 @@ impl ty::TyExpression {
                 let AbiCastExpression { abi_name, address } = *abi_cast_expression;
                 Self::type_check_abi_cast(ctx.by_ref(), abi_name, *address, span)
             }
-            ExpressionKind::Array(contents) => Self::type_check_array(ctx.by_ref(), contents, span),
+            ExpressionKind::Array(array_expression) => {
+                Self::type_check_array(ctx.by_ref(), array_expression.contents, span)
+            }
             ExpressionKind::ArrayIndex(ArrayIndexExpression { prefix, index }) => {
                 let ctx = ctx
                     .by_ref()

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1894,16 +1894,19 @@ mod tests {
     fn test_array_type_check_non_homogeneous_0() {
         // [true, 0] -- first element is correct, assumes type is [bool; 2].
         let expr = Expression {
-            kind: ExpressionKind::Array(vec![
-                Expression {
-                    kind: ExpressionKind::Literal(Literal::Boolean(true)),
-                    span: Span::dummy(),
-                },
-                Expression {
-                    kind: ExpressionKind::Literal(Literal::U64(0)),
-                    span: Span::dummy(),
-                },
-            ]),
+            kind: ExpressionKind::Array(ArrayExpression {
+                contents: vec![
+                    Expression {
+                        kind: ExpressionKind::Literal(Literal::Boolean(true)),
+                        span: Span::dummy(),
+                    },
+                    Expression {
+                        kind: ExpressionKind::Literal(Literal::U64(0)),
+                        span: Span::dummy(),
+                    },
+                ],
+                length_span: None,
+            }),
             span: Span::dummy(),
         };
 
@@ -1922,16 +1925,19 @@ mod tests {
     fn test_array_type_check_non_homogeneous_1() {
         // [0, false] -- first element is incorrect, assumes type is [u64; 2].
         let expr = Expression {
-            kind: ExpressionKind::Array(vec![
-                Expression {
-                    kind: ExpressionKind::Literal(Literal::U64(0)),
-                    span: Span::dummy(),
-                },
-                Expression {
-                    kind: ExpressionKind::Literal(Literal::Boolean(true)),
-                    span: Span::dummy(),
-                },
-            ]),
+            kind: ExpressionKind::Array(ArrayExpression {
+                contents: vec![
+                    Expression {
+                        kind: ExpressionKind::Literal(Literal::U64(0)),
+                        span: Span::dummy(),
+                    },
+                    Expression {
+                        kind: ExpressionKind::Literal(Literal::Boolean(true)),
+                        span: Span::dummy(),
+                    },
+                ],
+                length_span: None,
+            }),
             span: Span::dummy(),
         };
 
@@ -1957,20 +1963,23 @@ mod tests {
     fn test_array_type_check_bad_count() {
         // [0, false] -- first element is incorrect, assumes type is [u64; 2].
         let expr = Expression {
-            kind: ExpressionKind::Array(vec![
-                Expression {
-                    kind: ExpressionKind::Literal(Literal::Boolean(true)),
-                    span: Span::dummy(),
-                },
-                Expression {
-                    kind: ExpressionKind::Literal(Literal::Boolean(true)),
-                    span: Span::dummy(),
-                },
-                Expression {
-                    kind: ExpressionKind::Literal(Literal::Boolean(true)),
-                    span: Span::dummy(),
-                },
-            ]),
+            kind: ExpressionKind::Array(ArrayExpression {
+                contents: vec![
+                    Expression {
+                        kind: ExpressionKind::Literal(Literal::Boolean(true)),
+                        span: Span::dummy(),
+                    },
+                    Expression {
+                        kind: ExpressionKind::Literal(Literal::Boolean(true)),
+                        span: Span::dummy(),
+                    },
+                    Expression {
+                        kind: ExpressionKind::Literal(Literal::Boolean(true)),
+                        span: Span::dummy(),
+                    },
+                ],
+                length_span: None,
+            }),
             span: Span::dummy(),
         };
 
@@ -1988,7 +1997,10 @@ mod tests {
     #[test]
     fn test_array_type_check_empty() {
         let expr = Expression {
-            kind: ExpressionKind::Array(Vec::new()),
+            kind: ExpressionKind::Array(ArrayExpression {
+                contents: Vec::new(),
+                length_span: None,
+            }),
             span: Span::dummy(),
         };
 

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -445,8 +445,8 @@ impl Dependencies {
                     deps.gather_from_match_branch(type_engine, branch)
                 }),
             ExpressionKind::CodeBlock(contents) => self.gather_from_block(type_engine, contents),
-            ExpressionKind::Array(contents) => self
-                .gather_from_iter(contents.iter(), |deps, expr| {
+            ExpressionKind::Array(array_expression) => self
+                .gather_from_iter(array_expression.contents.iter(), |deps, expr| {
                     deps.gather_from_expr(type_engine, expr)
                 }),
             ExpressionKind::ArrayIndex(ArrayIndexExpression { prefix, index, .. }) => self

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -1383,19 +1383,28 @@ fn expr_to_expression(
                         .into_iter()
                         .map(|expr| expr_to_expression(handler, engines, expr))
                         .collect::<Result<_, _>>()?;
+                    let array_expression = ArrayExpression {
+                        contents,
+                        length_span: None,
+                    };
                     Expression {
-                        kind: ExpressionKind::Array(contents),
+                        kind: ExpressionKind::Array(array_expression),
                         span,
                     }
                 }
                 ExprArrayDescriptor::Repeat { value, length, .. } => {
                     let expression = expr_to_expression(handler, engines, *value)?;
+                    let length_span = length.span();
                     let length = expr_to_usize(handler, *length)?;
                     let contents = iter::repeat_with(|| expression.clone())
                         .take(length)
                         .collect();
+                    let array_expression = ArrayExpression {
+                        contents,
+                        length_span: Some(length_span),
+                    };
                     Expression {
-                        kind: ExpressionKind::Array(contents),
+                        kind: ExpressionKind::Array(array_expression),
                         span,
                     }
                 }

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -403,9 +403,19 @@ impl<'a> ParsedTree<'a> {
                     ),
                 );
             }
-            ExpressionKind::Array(contents) => {
-                for exp in contents {
+            ExpressionKind::Array(array_expression) => {
+                for exp in &array_expression.contents {
                     self.handle_expression(exp);
+                }
+
+                if let Some(length_span) = &array_expression.length_span {
+                    self.tokens.insert(
+                        to_ident_key(&Ident::new(length_span.clone())),
+                        Token::from_parsed(
+                            AstToken::Expression(expression.clone()),
+                            SymbolKind::NumericLiteral,
+                        ),
+                    );
                 }
             }
             ExpressionKind::Struct(struct_expression) => {


### PR DESCRIPTION
We only do this if the `ExprArrayDescriptor` is of the `Repeat` variant. 

closes #3717