### PR TITLE
LSP: Collect supertraits from the `ParseProgram`

### DIFF
--- a/sway-core/src/language/parsed/declaration/trait.rs
+++ b/sway-core/src/language/parsed/declaration/trait.rs
@@ -10,7 +10,7 @@ pub struct TraitDeclaration {
     pub attributes: transform::AttributesMap,
     pub interface_surface: Vec<TraitFn>,
     pub methods: Vec<FunctionDeclaration>,
-    pub(crate) supertraits: Vec<Supertrait>,
+    pub supertraits: Vec<Supertrait>,
     pub visibility: Visibility,
     pub span: Span,
 }

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -136,6 +136,16 @@ impl<'a> ParsedTree<'a> {
                 for func_dec in &trait_decl.methods {
                     self.handle_function_declation(func_dec);
                 }
+
+                for supertrait in &trait_decl.supertraits {
+                    self.tokens.insert(
+                        to_ident_key(&supertrait.name.suffix),
+                        Token::from_parsed(
+                            AstToken::Declaration(declaration.clone()),
+                            SymbolKind::Trait,
+                        ),
+                    );
+                }
             }
             Declaration::StructDeclaration(struct_dec) => {
                 self.tokens.insert(


### PR DESCRIPTION
partially addresses #3723

This allows us to collect supertrait tokens and assign correct semantic token definitions to them, but we still are unable to assign type_info to them.