### PR TITLE
use sdk for call-data

### DIFF
--- a/test/src/sdk-harness/test_projects/low_level_call/mod.rs
+++ b/test/src/sdk-harness/test_projects/low_level_call/mod.rs
@@ -98,7 +98,6 @@ async fn get_contract_instance() -> (TestContract, ContractId, WalletUnlocked) {
 
 #[tokio::test]
 async fn can_call_with_one_word_arg() {
-    Tokenizable::into_token(10u64);
     let (instance, id, wallet) = get_contract_instance().await;
 
     let function_selector = fn_selector!(set_value(u64)).to_vec();

--- a/test/src/sdk-harness/test_projects/low_level_call/mod.rs
+++ b/test/src/sdk-harness/test_projects/low_level_call/mod.rs
@@ -100,7 +100,7 @@ async fn get_contract_instance() -> (TestContract, ContractId, WalletUnlocked) {
 async fn can_call_with_one_word_arg() {
     let (instance, id, wallet) = get_contract_instance().await;
 
-    let function_selector = fn_selector!(set_value(u64)).to_vec();
+    let function_selector = fn_selector!(set_value(u64));
 
     let calldata = calldata!(42u64);
 


### PR DESCRIPTION
A suggestion to make tests more robust until we figure out low-level-call support in the SDK. 