### PR TITLE
LSP: Collect type_ascription from `TyConstantDeclaration`

### DIFF
--- a/sway-core/src/language/ty/declaration/constant.rs
+++ b/sway-core/src/language/ty/declaration/constant.rs
@@ -14,6 +14,7 @@ pub struct TyConstantDeclaration {
     pub visibility: Visibility,
     pub return_type: TypeId,
     pub attributes: transform::AttributesMap,
+    pub type_ascription_span: Option<Span>,
     pub span: Span,
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -76,11 +76,11 @@ impl ty::TyDeclaration {
             parsed::Declaration::ConstantDeclaration(parsed::ConstantDeclaration {
                 name,
                 type_ascription,
+                type_ascription_span,
                 value,
                 visibility,
                 attributes,
                 span,
-                ..
             }) => {
                 let type_ascription = check!(
                     ctx.resolve_type_with_self(
@@ -132,6 +132,7 @@ impl ty::TyDeclaration {
                     visibility,
                     return_type,
                     attributes,
+                    type_ascription_span,
                     span,
                 };
                 let typed_const_decl = ty::TyDeclaration::ConstantDeclaration(

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -69,6 +69,18 @@ impl<'a> TypedTree<'a> {
                         token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
                         token.type_def = Some(TypeDefinition::Ident(const_decl.name.clone()));
                     }
+
+                    if let Some(type_ascription_span) = &const_decl.type_ascription_span {
+                        if let Some(mut token) = self
+                            .tokens
+                            .try_get_mut(&to_ident_key(&Ident::new(type_ascription_span.clone())))
+                            .try_unwrap()
+                        {
+                            token.typed =
+                                Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+                            token.type_def = Some(TypeDefinition::TypeId(const_decl.return_type));
+                        }
+                    };
                     self.handle_expression(&const_decl.value);
                 }
             }


### PR DESCRIPTION
Pretty simple fix, just need to pass through the type_ascription from the `parsed::ConstantDeclaration` to the `ty::TyConstantDeclaration`.

closes #3615