### PR TITLE
Typed AST for struct instantiation must have fields ordered correctly.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -138,27 +138,23 @@ fn type_check_field_arguments(
 
     let mut typed_fields = vec![];
 
-    for field in fields.iter() {
-        let ctx = ctx
-            .by_ref()
-            .with_help_text("")
-            .with_type_annotation(type_engine.insert_type(declaration_engine, TypeInfo::Unknown));
-        let value = check!(
-            ty::TyExpression::type_check(ctx, field.value.clone()),
-            continue,
-            warnings,
-            errors
-        );
-        typed_fields.push(ty::TyStructExpressionField {
-            value,
-            name: field.name.clone(),
-        });
-    }
-
     for struct_field in struct_fields.iter_mut() {
         match fields.iter().find(|x| x.name == struct_field.name) {
-            Some(typed_field) => {
-                struct_field.span = typed_field.value.span.clone();
+            Some(field) => {
+                let ctx = ctx.by_ref().with_help_text("").with_type_annotation(
+                    type_engine.insert_type(declaration_engine, TypeInfo::Unknown),
+                );
+                let value = check!(
+                    ty::TyExpression::type_check(ctx, field.value.clone()),
+                    continue,
+                    warnings,
+                    errors
+                );
+                typed_fields.push(ty::TyStructExpressionField {
+                    value,
+                    name: field.name.clone(),
+                });
+                struct_field.span = field.value.span.clone();
             }
             None => {
                 errors.push(CompileError::StructMissingField {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_init_reorder/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_init_reorder/Forc.lock
@@ -1,0 +1,16 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-320F50F2CB619270'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-320F50F2CB619270'
+dependencies = ['core']
+
+[[package]]
+name = 'struct_init_reorder'
+source = 'member'
+dependencies = [
+    'core',
+    'std',
+]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_init_reorder/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_init_reorder/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "struct_init_reorder"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_init_reorder/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_init_reorder/src/main.sw
@@ -1,0 +1,32 @@
+script;
+
+use std::logging::log;
+
+pub struct MyInnerStruct {
+    x: u64,
+    y: u64,
+}
+
+pub struct MyStruct {
+      value: MyInnerStruct,
+}
+
+pub enum MyEnum {
+    V1: u8,
+    V2: u64,
+}
+
+pub struct Foo {
+    f1: MyEnum,
+    f2: MyStruct,
+}
+
+fn main() {
+    let f1 : MyEnum = MyEnum::V1(0u8);
+    let f2 : MyStruct = MyStruct { value: MyInnerStruct { x: 0, y: 0 } };
+    // f1 and f2 are instantiated in the wrong order below. that shouldn't matter.
+    log(Foo {
+        f2,
+        f1
+    });
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_init_reorder/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/struct_init_reorder/test.toml
@@ -1,0 +1,2 @@
+category = "compile"
+


### PR DESCRIPTION
The IR generator [relies](https://github.com/FuelLabs/sway/blob/2930f4843a9d655758d1c310e92b40a7884e5149/sway-core/src/ir_generation/function.rs#L2003) on this assumption.

Closes #3727