### PR TITLE
fix: forc checks validity of parent manifests before assuming it is a workspace manifest

### DIFF
--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -722,8 +722,13 @@ impl WorkspaceManifestFile {
     /// This is short for `PackageManifest::from_file`, but takes care of constructing the path to the
     /// file.
     pub fn from_dir(manifest_dir: &Path) -> Result<Self> {
-        let dir = forc_util::find_manifest_dir(manifest_dir)
-            .ok_or_else(|| manifest_file_missing(manifest_dir))?;
+        let dir = forc_util::find_manifest_dir_with_check(manifest_dir, |possible_manifest_dir| {
+            // Check if the found manifest file is a workspace manifest file or a standalone
+            // package manifest file.
+            let possible_path = possible_manifest_dir.join(constants::MANIFEST_FILE_NAME);
+            Self::from_file(possible_path).is_ok()
+        })
+        .ok_or_else(|| manifest_file_missing(manifest_dir))?;
         let path = dir.join(constants::MANIFEST_FILE_NAME);
         Self::from_file(path)
     }

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -41,6 +41,24 @@ pub fn find_manifest_dir(starter_path: &Path) -> Option<PathBuf> {
     find_parent_dir_with_file(starter_path, constants::MANIFEST_FILE_NAME)
 }
 
+/// Continually go up in the file tree until a Forc manifest file is found and given predicate
+/// returns true.
+pub fn find_manifest_dir_with_check<F>(starter_path: &Path, f: F) -> Option<PathBuf>
+where
+    F: Fn(&Path) -> bool,
+{
+    find_manifest_dir(starter_path).and_then(|manifest_dir| {
+        // If given check satisifies return current dir otherwise start searching from the parent.
+        if f(&manifest_dir) {
+            Some(manifest_dir)
+        } else if let Some(parent_dir) = manifest_dir.parent() {
+            find_manifest_dir_with_check(parent_dir, f)
+        } else {
+            None
+        }
+    })
+}
+
 pub fn is_sway_file(file: &Path) -> bool {
     let res = file.extension();
     Some(OsStr::new(constants::SWAY_EXTENSION)) == res

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "contract_a"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/contract_a/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/contract_a/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/contract_a/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/contract_a/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'contract_a'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/contract_a/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/contract_a/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "contract_a"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/contract_a/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/contract_a/src/main.sw
@@ -1,0 +1,11 @@
+contract;
+
+abi MyContract {
+    fn test_function() -> bool;
+}
+
+impl MyContract for Contract {
+    fn test_function() -> bool {
+        true
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/contract_a/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/contract_a/test.toml
@@ -1,0 +1,1 @@
+category = "compile" 


### PR DESCRIPTION
I ended-up implementing the 3rd option discussed in the relevant issue: non workspace manifests residing at a parent directory:

> Silently ignore parent manifests that are not workspaces with a members set containing the current package.

There is one catch though, if we filter the ones that does not declare the current package as a member we are also losing a valuable error message which states the workspace manifest file does not list the current package as a member. Should we do that? cc @mitchmindtree.

Currently this fixes the situation where there is a pkg manifest in some parent directory, just like the cause of the original issue of @segfault-magnet.

again this would be a little bit clearer if we had https://github.com/FuelLabs/sway/issues/3283 so might refactor after that
closes #3535 