### PR TITLE
Pretty print `Vec<TyAstNode>` 

### DIFF
--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -586,13 +586,17 @@ impl Backend {
                         "typed" => {
                             Ok(program.typed.as_ref().and_then(|typed_program| {
                                 // Initialize the string with the AST from the root
-                                let mut formatted_ast =
-                                    format!("{:#?}", typed_program.root.all_nodes);
+                                let mut formatted_ast = debug::print_decl_engine_types(
+                                    &typed_program.root.all_nodes,
+                                    &session.decl_engine.read(),
+                                );
                                 for (ident, submodule) in &typed_program.root.submodules {
                                     if path_is_submodule(ident, &path) {
                                         // overwrite the root AST with the submodule AST
-                                        formatted_ast =
-                                            format!("{:#?}", submodule.module.all_nodes);
+                                        formatted_ast = debug::print_decl_engine_types(
+                                            &submodule.module.all_nodes,
+                                            &session.decl_engine.read(),
+                                        );
                                     }
                                 }
                                 let tmp_ast_path = Path::new("/tmp/typed_ast.rs");

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -1,6 +1,9 @@
 #![allow(dead_code)]
 use crate::core::token::{get_range_from_span, Token};
-use sway_core::language::Literal;
+use sway_core::{
+    decl_engine::DeclEngine,
+    language::{ty, Literal},
+};
 use sway_types::{Ident, Spanned};
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
@@ -53,4 +56,69 @@ fn literal_to_string(literal: &Literal) -> String {
         Literal::Boolean(_) => "bool".into(),
         Literal::B256(_) => "b256".into(),
     }
+}
+
+/// Print the AST nodes in a human readable format
+/// by getting the types from the declaration engine
+/// and formatting them into a String.
+pub(crate) fn print_decl_engine_types(
+    all_nodes: &[ty::TyAstNode],
+    decl_engine: &DeclEngine,
+) -> String {
+    all_nodes
+        .iter()
+        .map(|n| match &n.content {
+            ty::TyAstNodeContent::Declaration(declaration) => match declaration {
+                ty::TyDeclaration::ConstantDeclaration(decl_id) => {
+                    let const_decl = decl_engine
+                        .get_constant(decl_id.clone(), &decl_id.span())
+                        .unwrap();
+                    format!("{:#?}", const_decl)
+                }
+                ty::TyDeclaration::FunctionDeclaration(decl_id) => {
+                    let func_decl = decl_engine
+                        .get_function(decl_id.clone(), &decl_id.span())
+                        .unwrap();
+                    format!("{:#?}", func_decl)
+                }
+                ty::TyDeclaration::TraitDeclaration(decl_id) => {
+                    let trait_decl = decl_engine
+                        .get_trait(decl_id.clone(), &decl_id.span())
+                        .unwrap();
+                    format!("{:#?}", trait_decl)
+                }
+                ty::TyDeclaration::StructDeclaration(decl_id) => {
+                    let struct_decl = decl_engine
+                        .get_struct(decl_id.clone(), &decl_id.span())
+                        .unwrap();
+                    format!("{:#?}", struct_decl)
+                }
+                ty::TyDeclaration::EnumDeclaration(decl_id) => {
+                    let enum_decl = decl_engine
+                        .get_enum(decl_id.clone(), &decl_id.span())
+                        .unwrap();
+                    format!("{:#?}", enum_decl)
+                }
+                ty::TyDeclaration::AbiDeclaration(decl_id) => {
+                    let abi_decl = decl_engine
+                        .get_abi(decl_id.clone(), &decl_id.span())
+                        .unwrap();
+                    format!("{:#?}", abi_decl)
+                }
+                ty::TyDeclaration::StorageDeclaration(decl_id) => {
+                    let storage_decl = decl_engine
+                        .get_storage(decl_id.clone(), &decl_id.span())
+                        .unwrap();
+                    format!("{:#?}", storage_decl)
+                }
+                _ => format!("{:#?}", declaration),
+            },
+            ty::TyAstNodeContent::Expression(expression)
+            | ty::TyAstNodeContent::ImplicitReturnExpression(expression) => {
+                format!("{:#?}", expression)
+            }
+            ty::TyAstNodeContent::SideEffect => "".to_string(),
+        })
+        .map(|s| format!("{}\n", s))
+        .collect()
 }


### PR DESCRIPTION
We have a command in VScode called "Sway: Show typed AST". When executed, it opens a 2nd window containing the typed AST for the currently open sway file. This used to work but stopped behaving as intended when the declaration engine was introduced. 

Instead of showing the types, it just shows the declaration IDs of the decl_engine. This PR just iterates over the `&[TyAstNode]` and looks up the types in decl_engine and pretty prints them in order to return the original functionality. 