### PR TITLE
Update rustdoc comments to reflect the new `DeclEngine` names

### DIFF
--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -61,10 +61,10 @@ impl DeclEngine {
         DeclId::new(self.slab.insert(decl_wrapper), span)
     }
 
-    /// Given a [DeclarationId] `index`, finds all the parents of `index` and
-    /// all the recursive parents of those parents, and so on. Does not perform
-    /// duplicated computation---if the parents of a [DeclarationId] have
-    /// already been found, we do not find them again.
+    /// Given a [DeclId] `index`, finds all the parents of `index` and all the
+    /// recursive parents of those parents, and so on. Does not perform
+    /// duplicated computation---if the parents of a [DeclId] have already been
+    /// found, we do not find them again.
     #[allow(clippy::map_entry)]
     pub(crate) fn find_all_parents(&self, engines: Engines<'_>, index: DeclId) -> Vec<DeclId> {
         let parents = self.parents.read().unwrap();

--- a/sway-core/src/decl_engine/wrapper.rs
+++ b/sway-core/src/decl_engine/wrapper.rs
@@ -12,8 +12,8 @@ use crate::{
 
 use super::{DeclMapping, ReplaceDecls, ReplaceFunctionImplementingType};
 
-/// The [DeclarationWrapper] type is used in the [DeclarationEngine]
-/// as a means of placing all declaration types into the same type.
+/// The [DeclEngine] type is used in the [DeclarationEngine] as a means of
+/// placing all declaration types into the same type.
 #[derive(Clone, Debug)]
 pub enum DeclWrapper {
     // no-op variant to fulfill the default trait


### PR DESCRIPTION
Simple updates to rustdoc comments.

Closes #3759