### PR TITLE
Fix command for updating 'forc' from cargo

### DIFF
--- a/docs/book/src/introduction/installation.md
+++ b/docs/book/src/introduction/installation.md
@@ -45,7 +45,7 @@ cargo install forc fuel-core
 You can update the toolchain from source with Cargo with:
 
 ```sh
-cargo install forc fuel-core
+cargo update forc fuel-core
 ```
 
 #### Installing `forc` Plugins from Cargo


### PR DESCRIPTION
The **Update 'forc' from cargo** section in the installation docs currently lists the following incorrect command:
`cargo install forc fuel-core`

Instead, it should be as follows:
`cargo update forc fuel-core`

This PR replaces `install` with `update` to add the correct command for updating 'forc' using cargo.