### PR TITLE
Remove `VariableMutability::ExportedConst`

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -331,28 +331,18 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
     let decl_engine = engines.de();
     match decl {
         VariableDeclaration(var_decl) => {
-            let ty::TyVariableDeclaration {
-                name,
-                body,
-                mutability: is_mutable,
-                ..
-            } = &**var_decl;
-            if matches!(is_mutable, ty::VariableMutability::ExportedConst) {
-                graph.namespace.insert_constant(name.clone(), entry_node);
-                Ok(leaves.to_vec())
-            } else {
-                connect_expression(
-                    engines,
-                    &body.expression,
-                    graph,
-                    &[entry_node],
-                    exit_node,
-                    "variable instantiation",
-                    tree_type,
-                    body.clone().span,
-                    options,
-                )
-            }
+            let ty::TyVariableDeclaration { body, .. } = &**var_decl;
+            connect_expression(
+                engines,
+                &body.expression,
+                graph,
+                &[entry_node],
+                exit_node,
+                "variable instantiation",
+                tree_type,
+                body.clone().span,
+                options,
+            )
         }
         ConstantDeclaration(decl_id) => {
             let ty::TyConstantDeclaration { name, value, .. } =

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -138,7 +138,6 @@ impl DisplayWithEngines for TyDeclaration {
                         VariableMutability::Mutable => builder.push_str("mut"),
                         VariableMutability::RefMutable => builder.push_str("ref mut"),
                         VariableMutability::Immutable => {}
-                        VariableMutability::ExportedConst => builder.push_str("pub const"),
                     }
                     builder.push_str(name.as_str());
                     builder.push_str(": ");

--- a/sway-core/src/language/ty/variable_mutability.rs
+++ b/sway-core/src/language/ty/variable_mutability.rs
@@ -2,15 +2,12 @@ use crate::language::Visibility;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VariableMutability {
-    // private + mutable
+    // mutable
     Mutable,
-    // private + referenceable + mutable
+    // referenceable + mutable
     RefMutable,
-    // private + immutable
+    // immutable
     Immutable,
-    // public + immutable
-    ExportedConst,
-    // public + mutable is invalid
 }
 
 impl Default for VariableMutability {
@@ -38,10 +35,7 @@ impl VariableMutability {
     }
 
     pub fn visibility(&self) -> Visibility {
-        match self {
-            VariableMutability::ExportedConst => Visibility::Public,
-            _ => Visibility::Private,
-        }
+        Visibility::Private
     }
 
     pub fn is_immutable(&self) -> bool {

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -345,17 +345,6 @@ impl Module {
                 if visibility != Visibility::Public {
                     errors.push(CompileError::ImportPrivateSymbol { name: item.clone() });
                 }
-                // if this is a const, insert it into the local namespace directly
-                if let ty::TyDeclaration::VariableDeclaration(ref var_decl) = decl {
-                    let ty::TyVariableDeclaration {
-                        mutability, name, ..
-                    } = &**var_decl;
-                    if mutability == &ty::VariableMutability::ExportedConst {
-                        self[dst]
-                            .insert_symbol(alias.unwrap_or_else(|| name.clone()), decl.clone());
-                        return ok((), warnings, errors);
-                    }
-                }
                 let type_id = decl.return_type(engines, &item.span()).value;
                 //  if this is an enum or struct or function, import its implementations
                 if let Some(type_id) = type_id {


### PR DESCRIPTION
Constant declaration is no longer handled by `VariableDeclaration` but `ConstantDeclaration`.

Closes #3768