### PR TITLE
Fix order of logs such that they are printed after tested function name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,7 +1642,6 @@ version = "0.33.1"
 dependencies = [
  "anyhow",
  "forc-pkg",
- "forc-util",
  "fuel-tx",
  "fuel-vm",
  "rand",

--- a/forc-test/Cargo.toml
+++ b/forc-test/Cargo.toml
@@ -11,7 +11,6 @@ description = "A library for building and running Sway unit tests within Forc pa
 [dependencies]
 anyhow = "1"
 forc-pkg = { version = "0.33.1", path = "../forc-pkg" }
-forc-util = { version = "0.33.1", path = "../forc-util" }
 fuel-tx = { version = "0.23", features = ["builder"] }
 fuel-vm = { version = "0.22", features = ["random"] }
 rand = "0.8"

--- a/forc-test/src/lib.rs
+++ b/forc-test/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashSet, fs, path::PathBuf, sync::Arc};
 
 use forc_pkg as pkg;
-use forc_util::format_log_receipts;
 use fuel_tx as tx;
 use fuel_vm::{self as vm, prelude::Opcode};
 use pkg::{Built, BuiltPackage};
@@ -47,6 +46,8 @@ pub struct TestResult {
     pub state: vm::state::ProgramState,
     /// The required state of the VM for this test to pass.
     pub condition: TestPassCondition,
+    /// Emitted `Recipt`s during the execution of the test.
+    pub logs: Vec<fuel_tx::Receipt>,
 }
 
 /// The possible conditions for a test result to be considered "passing".
@@ -192,10 +193,7 @@ impl<'a> PackageTests {
     }
 
     /// Run all tests for this package and collect their results.
-    pub(crate) fn run_tests(
-        &self,
-        test_print_opts: &TestPrintOpts,
-    ) -> anyhow::Result<TestedPackage> {
+    pub(crate) fn run_tests(&self) -> anyhow::Result<TestedPackage> {
         let pkg_with_tests = self.built_pkg_with_tests();
         // TODO: We can easily parallelise this, but let's wait until testing is stable first.
         let tests = pkg_with_tests
@@ -207,12 +205,18 @@ impl<'a> PackageTests {
                     u32::try_from(entry.imm).expect("test instruction offset out of range");
                 let name = entry.fn_name.clone();
                 let test_setup = self.setup()?;
-                let (state, duration) = exec_test(
-                    &pkg_with_tests.bytecode,
-                    offset,
-                    test_setup,
-                    test_print_opts,
-                );
+                let (state, duration, receipts) =
+                    exec_test(&pkg_with_tests.bytecode, offset, test_setup);
+
+                // Only retain `Log` and `LogData` receipts.
+                let logs = receipts
+                    .into_iter()
+                    .filter(|receipt| {
+                        matches!(receipt, fuel_tx::Receipt::Log { .. })
+                            || matches!(receipt, fuel_tx::Receipt::LogData { .. })
+                    })
+                    .collect();
+
                 let test_decl_id = entry
                     .test_decl_id
                     .clone()
@@ -229,6 +233,7 @@ impl<'a> PackageTests {
                     span,
                     state,
                     condition,
+                    logs,
                 })
             })
             .collect::<anyhow::Result<_>>()?;
@@ -357,8 +362,8 @@ impl BuiltTests {
     }
 
     /// Run all built tests, return the result.
-    pub fn run(self, test_print_opts: &TestPrintOpts) -> anyhow::Result<Tested> {
-        run_tests(self, test_print_opts)
+    pub fn run(self) -> anyhow::Result<Tested> {
+        run_tests(self)
     }
 }
 
@@ -440,16 +445,16 @@ fn test_pass_condition(
 }
 
 /// Build the given package and run its tests, returning the results.
-fn run_tests(built: BuiltTests, test_print_opts: &TestPrintOpts) -> anyhow::Result<Tested> {
+fn run_tests(built: BuiltTests) -> anyhow::Result<Tested> {
     match built {
         BuiltTests::Package(pkg) => {
-            let tested_pkg = pkg.run_tests(test_print_opts)?;
+            let tested_pkg = pkg.run_tests()?;
             Ok(Tested::Package(Box::new(tested_pkg)))
         }
         BuiltTests::Workspace(workspace) => {
             let tested_pkgs = workspace
                 .into_iter()
-                .map(|pkg| pkg.run_tests(test_print_opts))
+                .map(|pkg| pkg.run_tests())
                 .collect::<anyhow::Result<Vec<TestedPackage>>>()?;
             Ok(Tested::Workspace(tested_pkgs))
         }
@@ -498,8 +503,11 @@ fn exec_test(
     bytecode: &[u8],
     test_offset: u32,
     test_setup: TestSetup,
-    test_print_opts: &TestPrintOpts,
-) -> (vm::state::ProgramState, std::time::Duration) {
+) -> (
+    vm::state::ProgramState,
+    std::time::Duration,
+    Vec<fuel_tx::Receipt>,
+) {
     let storage = test_setup.storage;
     let contract_id = test_setup.contract_id;
 
@@ -546,20 +554,7 @@ fn exec_test(
     let transition = interpreter.transact(tx).unwrap();
     let duration = start.elapsed();
     let state = *transition.state();
+    let receipts = transition.receipts().to_vec();
 
-    if test_print_opts.print_logs {
-        let receipts: Vec<_> = transition
-            .receipts()
-            .iter()
-            .cloned()
-            .filter(|receipt| {
-                matches!(receipt, tx::Receipt::LogData { .. })
-                    || matches!(receipt, tx::Receipt::Log { .. })
-            })
-            .collect();
-        let formatted_receipts = format_log_receipts(&receipts, test_print_opts.pretty_print)
-            .expect("cannot format log receipts for the test");
-        println!("{}", formatted_receipts);
-    }
-    (state, duration)
+    (state, duration, receipts)
 }

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -226,8 +226,7 @@ pub(crate) async fn compile_and_run_unit_tests(
             },
             ..Default::default()
         })?;
-        let test_print_opts = forc_test::TestPrintOpts::default();
-        let tested = built_tests.run(&test_print_opts)?;
+        let tested = built_tests.run()?;
 
         match tested {
             forc_test::Tested::Package(tested_pkg) => Ok(vec![*tested_pkg]),


### PR DESCRIPTION
closes #3824.


With this PR, different tests are emitting logs separately as pointed out by @mitchmindtree in #3808. 

(Github code block indentations are showing up weird)

## Before this PR
```console
fuel/test_projects/deploy [⏱ 4s]
❯ mforc test --logs
  Compiled library "core".
  Compiled library "std".
  Compiled library "deploy".
  Bytecode size is 52 bytes.
   Running 2 tests
[{"Log":{"id":"0000000000000000000000000000000000000000000000000000000000000000","is":10344,"pc":10368,"ra":1,"rb":0,"rc":0,"rd":0}}]
[{"Log":{"id":"0000000000000000000000000000000000000000000000000000000000000000","is":10344,"pc":10380,"ra":2,"rb":1,"rc":0,"rd":0}}]
      test my_test ... ok (393.833µs)
      test my_test2 ... ok (371.833µs)
   Result: OK. 2 passed. 0 failed. Finished in 765.666µs.
```


## After this PR
```console
fuel/test_projects/deploy [⏱ 4s]
❯ mforc test --logs
  Compiled library "core".
  Compiled library "std".
  Compiled library "deploy".
  Bytecode size is 52 bytes.
   Running 2 tests
      test my_test ... ok (608.041µs)
[{"Log":{"id":"0000000000000000000000000000000000000000000000000000000000000000","is":10344,"pc":10368,"ra":1,"rb":0,"rc":0,"rd":0}}]
      test my_test2 ... ok (360.041µs)
[{"Log":{"id":"0000000000000000000000000000000000000000000000000000000000000000","is":10344,"pc":10380,"ra":2,"rb":1,"rc":0,"rd":0}}]
   Result: OK. 2 passed. 0 failed. Finished in 968.082µs.
```