### PR TITLE
Adds support for where clauses in impl self methods.

### DIFF
--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -110,29 +110,28 @@ impl CallPath {
             // combination of the package name in which the symbol is defined and the path to the
             // current submodule.
             let mut synonym_prefixes = vec![];
-            let mut submodule_name_in_synonym_prefixes = false;
+            let mut is_external = false;
 
             if let Some(use_synonym) = namespace.use_synonyms.get(&self.suffix) {
                 synonym_prefixes = use_synonym.0.clone();
                 let submodule = namespace.submodule(&[use_synonym.0[0].clone()]);
                 if let Some(submodule) = submodule {
-                    if let Some(submodule_name) = submodule.name.clone() {
-                        submodule_name_in_synonym_prefixes =
-                            submodule_name.as_str() == synonym_prefixes[0].as_str();
-                    }
+                    is_external = submodule.is_external;
                 }
             }
 
             let mut prefixes: Vec<Ident> = vec![];
 
-            if synonym_prefixes.is_empty() || !submodule_name_in_synonym_prefixes {
+            if !is_external {
                 if let Some(pkg_name) = &namespace.root().module.name {
                     prefixes.push(pkg_name.clone());
                 }
+
                 for mod_path in namespace.mod_path() {
                     prefixes.push(mod_path.clone());
                 }
             }
+
             prefixes.extend(synonym_prefixes);
 
             CallPath {

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -50,6 +50,7 @@ impl ty::TyScrutinee {
                     name_ident: BaseIdent::new_with_override("_".into(), span.clone()),
                     trait_constraints: vec![],
                     trait_constraints_span: Span::dummy(),
+                    is_from_parent: false,
                 };
                 let typed_scrutinee = ty::TyScrutinee {
                     variant: ty::TyScrutineeVariant::CatchAll,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -1,5 +1,5 @@
 use crate::{
-    decl_engine::{DeclEngineInsert, DeclRefFunction, UpdateConstantExpression},
+    decl_engine::{DeclEngineInsert, DeclRefFunction, ReplaceDecls, UpdateConstantExpression},
     error::*,
     language::{parsed::*, ty, *},
     semantic_analysis::*,
@@ -49,7 +49,7 @@ pub(crate) fn type_check_method_application(
         warnings,
         errors
     );
-    let method = decl_engine.get_function(&decl_ref);
+    let mut method = decl_engine.get_function(&decl_ref);
 
     // check the method visibility
     if span.path() != method.span.path() && method.visibility.is_private() {
@@ -312,17 +312,36 @@ pub(crate) fn type_check_method_application(
     ctx.namespace
         .insert_trait_implementation_for_type(engines, method.return_type.type_id);
 
+    // Handle the trait constraints. This includes checking to see if the trait
+    // constraints are satisfied and replacing old decl ids based on the
+    // constraint with new decl ids based on the new type.
+    let decl_mapping = check!(
+        TypeParameter::gather_decl_mapping_from_trait_constraints(
+            ctx.by_ref(),
+            &method.type_parameters,
+            &call_path.span()
+        ),
+        return err(warnings, errors),
+        warnings,
+        errors
+    );
+    method.replace_decls(&decl_mapping, ctx.engines());
+    let return_type = method.return_type.type_id;
+    let new_decl_ref = decl_engine
+        .insert(method)
+        .with_parent(decl_engine, (*decl_ref.id()).into());
+
     let exp = ty::TyExpression {
         expression: ty::TyExpressionVariant::FunctionApplication {
             call_path,
             contract_call_params: contract_call_params_map,
             arguments: typed_arguments_with_names,
-            fn_ref: decl_ref,
+            fn_ref: new_decl_ref,
             selector,
             type_binding: Some(method_name_binding.strip_inner()),
             call_path_typeid: Some(call_path_typeid),
         },
-        return_type: method.return_type.type_id,
+        return_type,
         span,
     };
 

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -168,8 +168,9 @@ fn item_to_ast_nodes(
             item_enum_to_enum_declaration(context, handler, engines, item_enum, attributes)?,
         )),
         ItemKind::Fn(item_fn) => {
-            let function_declaration =
-                item_fn_to_function_declaration(context, handler, engines, item_fn, attributes)?;
+            let function_declaration = item_fn_to_function_declaration(
+                context, handler, engines, item_fn, attributes, None,
+            )?;
             error_if_self_param_is_not_allowed(
                 context,
                 handler,
@@ -461,6 +462,7 @@ fn item_fn_to_function_declaration(
     engines: Engines<'_>,
     item_fn: ItemFn,
     attributes: AttributesMap,
+    parent_generic_params_opt: Option<GenericParams>,
 ) -> Result<FunctionDeclaration, ErrorEmitted> {
     let span = item_fn.span();
     let return_type = match item_fn.fn_signature.return_type_opt {
@@ -491,11 +493,12 @@ fn item_fn_to_function_declaration(
         )?,
         span,
         return_type,
-        type_parameters: generic_params_opt_to_type_parameters(
+        type_parameters: generic_params_opt_to_type_parameters_with_parent(
             context,
             handler,
             engines,
             item_fn.fn_signature.generics,
+            parent_generic_params_opt,
             item_fn.fn_signature.where_clause_opt.clone(),
         )?,
         where_clause: item_fn
@@ -573,7 +576,7 @@ fn item_trait_to_trait_declaration(
         context,
         handler,
         engines,
-        item_trait.generics,
+        item_trait.generics.clone(),
         item_trait.where_clause_opt,
     )?;
     let interface_surface = item_trait
@@ -614,6 +617,7 @@ fn item_trait_to_trait_declaration(
                     engines,
                     item_fn.value,
                     attributes,
+                    item_trait.generics.clone(),
                 )?))
             })
             .filter_map_ok(|fn_decl| fn_decl)
@@ -654,10 +658,15 @@ fn item_impl_to_declaration(
                 return Ok(None);
             }
             Ok(Some(match item.value {
-                sway_ast::ItemImplItem::Fn(fn_item) => {
-                    item_fn_to_function_declaration(context, handler, engines, fn_item, attributes)
-                        .map(ImplItem::Fn)
-                }
+                sway_ast::ItemImplItem::Fn(fn_item) => item_fn_to_function_declaration(
+                    context,
+                    handler,
+                    engines,
+                    fn_item,
+                    attributes,
+                    item_impl.generic_params_opt.clone(),
+                )
+                .map(ImplItem::Fn),
                 sway_ast::ItemImplItem::Const(const_item) => item_const_to_constant_declaration(
                     context, handler, engines, const_item, attributes, true,
                 )
@@ -798,6 +807,7 @@ fn item_abi_to_abi_declaration(
                         engines,
                         item_fn.value,
                         attributes,
+                        None,
                     )?;
                     error_if_self_param_is_not_allowed(
                         context,
@@ -1014,6 +1024,24 @@ fn generic_params_opt_to_type_parameters(
     generic_params_opt: Option<GenericParams>,
     where_clause_opt: Option<WhereClause>,
 ) -> Result<Vec<TypeParameter>, ErrorEmitted> {
+    generic_params_opt_to_type_parameters_with_parent(
+        context,
+        handler,
+        engines,
+        generic_params_opt,
+        None,
+        where_clause_opt,
+    )
+}
+
+fn generic_params_opt_to_type_parameters_with_parent(
+    context: &mut Context,
+    handler: &Handler,
+    engines: Engines<'_>,
+    generic_params_opt: Option<GenericParams>,
+    parent_generic_params_opt: Option<GenericParams>,
+    where_clause_opt: Option<WhereClause>,
+) -> Result<Vec<TypeParameter>, ErrorEmitted> {
     let type_engine = engines.te();
     let decl_engine = engines.de();
 
@@ -1026,7 +1054,8 @@ fn generic_params_opt_to_type_parameters(
         None => Vec::new(),
     };
 
-    let mut params = match generic_params_opt {
+    let generics_to_params = |generics: Option<GenericParams>, is_from_parent: bool| match generics
+    {
         Some(generic_params) => generic_params
             .parameters
             .into_inner()
@@ -1045,26 +1074,35 @@ fn generic_params_opt_to_type_parameters(
                     name_ident: ident,
                     trait_constraints: Vec::new(),
                     trait_constraints_span: Span::dummy(),
+                    is_from_parent,
                 }
             })
             .collect::<Vec<_>>(),
         None => Vec::new(),
     };
 
+    let mut params = generics_to_params(generic_params_opt, false);
+    let parent_params = generics_to_params(parent_generic_params_opt, true);
+
     let mut errors = Vec::new();
     for (ty_name, bounds) in trait_constraints.into_iter() {
-        let param_to_edit = match params
+        let param_to_edit = if let Some(o) = params
             .iter_mut()
             .find(|TypeParameter { name_ident, .. }| name_ident.as_str() == ty_name.as_str())
         {
-            Some(o) => o,
-            None => {
-                errors.push(ConvertParseTreeError::ConstrainedNonExistentType {
-                    ty_name: ty_name.clone(),
-                    span: ty_name.span().clone(),
-                });
-                continue;
-            }
+            o
+        } else if let Some(o2) = parent_params
+            .iter()
+            .find(|TypeParameter { name_ident, .. }| name_ident.as_str() == ty_name.as_str())
+        {
+            params.push(o2.clone());
+            params.last_mut().unwrap()
+        } else {
+            errors.push(ConvertParseTreeError::ConstrainedNonExistentType {
+                ty_name: ty_name.clone(),
+                span: ty_name.span().clone(),
+            });
+            continue;
         };
 
         param_to_edit.trait_constraints_span = Span::join(ty_name.span(), bounds.span());
@@ -3247,6 +3285,7 @@ fn statement_let_to_ast_nodes(
                                         ),
                                         trait_constraints: vec![],
                                         trait_constraints_span: Span::dummy(),
+                                        is_from_parent: false,
                                     };
                                     let initial_type_id = engines.te().insert(
                                         engines.de(),
@@ -3537,6 +3576,7 @@ fn ty_to_type_parameter(
                 name_ident: underscore_token.into(),
                 trait_constraints: Default::default(),
                 trait_constraints_span: Span::dummy(),
+                is_from_parent: false,
             });
         }
         Ty::Tuple(..) => panic!("tuple types are not allowed in this position"),
@@ -3556,6 +3596,7 @@ fn ty_to_type_parameter(
         name_ident,
         trait_constraints: Vec::new(),
         trait_constraints_span: Span::dummy(),
+        is_from_parent: false,
     })
 }
 

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -45,6 +45,7 @@ fn generic_enum_resolution() {
             name_ident: generic_name.clone(),
             trait_constraints: vec![],
             trait_constraints_span: sp.clone(),
+            is_from_parent: false,
         }),
     );
     let placeholder_type_param = TypeParameter {
@@ -53,6 +54,7 @@ fn generic_enum_resolution() {
         name_ident: generic_name.clone(),
         trait_constraints: vec![],
         trait_constraints_span: sp.clone(),
+        is_from_parent: false,
     };
     let variant_types = vec![ty::TyEnumVariant {
         name: a_name.clone(),
@@ -101,6 +103,7 @@ fn generic_enum_resolution() {
         name_ident: generic_name,
         trait_constraints: vec![],
         trait_constraints_span: sp.clone(),
+        is_from_parent: false,
     };
     let decl_ref_2 = decl_engine.insert(TyEnumDecl {
         call_path: result_name.into(),

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-701263CC2F33CD43'
+
+[[package]]
+name = 'generic_impl_self_where'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-701263CC2F33CD43'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "generic_impl_self_where"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/main.sw
@@ -1,0 +1,120 @@
+script;
+
+mod traits;
+
+use core::ops::*;
+use std::assert::assert;
+use traits::*;
+use traits::nested_traits::*;
+
+struct Data<T> {
+  x: T
+}
+
+impl<T> Data<T> {
+  fn contains(self, other: T) -> bool where T: Eq {
+    self.x == other
+  }
+}
+
+struct Data2<T, K> {
+  x: T,
+  y: K
+}
+
+impl<T,K> Data2<T,K> {
+  fn contains(self, other: Self) -> bool where T: Eq, K: Eq  {
+    self.x == other.x && self.y == other.y
+  }
+  fn contains2(self, other: Self) -> bool where T: Eq, K: Eq  {
+    self.x == other.x && self.y == other.y
+  }
+}
+
+impl<T,K> Data2<T,K> {
+  fn contains3(self, other: Self) -> bool where T: Eq, K: Eq  {
+    self.x == other.x && self.y == other.y
+  }
+
+  fn contains4(first: Self, second: Self) -> bool where T: Eq, K: Eq  {
+    first.x == second.x && first.y == second.y
+  }
+
+  fn contains5(self, other: Self) -> bool where T: MyEq, K: MyEq  {
+    self.x.my_eq(other.x) && self.y.my_eq(other.y)
+  }
+
+  fn contains6(self, other: Self) -> bool where T: MyEq2, K: MyEq2  {
+    self.x.my_eq2(other.x) && self.y.my_eq2(other.y)
+  }
+}
+
+struct Data3 {
+  x: u64
+}
+
+impl Eq for Data3 {
+  fn eq(self, other: Self) -> bool {
+    self.x == other.x
+  }
+}
+
+impl MyEq for Data3 {
+  fn my_eq(self, other: Self) -> bool {
+    self.x == other.x
+  }
+}
+
+fn main() -> u64 {
+  let s = Data { x: 42 };
+  assert(s.contains(42));
+  assert(!s.contains(41));
+
+
+  let d = Data2 { x: 42, y: 42 };
+  assert(d.contains(Data2 { x: 42, y: 42 }));
+  assert(!d.contains(Data2 { x: 42, y: 41 }));
+  assert(!d.contains(Data2 { x: 41, y: 42 }));
+
+  assert(d.contains2(Data2 { x: 42, y: 42 }));
+  assert(!d.contains2(Data2 { x: 42, y: 41 }));
+  assert(!d.contains2(Data2 { x: 41, y: 42 }));
+
+  assert(d.contains3(Data2 { x: 42, y: 42 }));
+  assert(!d.contains3(Data2 { x: 42, y: 41 }));
+  assert(!d.contains3(Data2 { x: 41, y: 42 }));
+
+  assert(Data2::contains4(d, Data2 { x: 42, y: 42 }));
+  assert(!Data2::contains4(d, Data2 { x: 42, y: 41 }));
+  assert(!Data2::contains4(d, Data2 { x: 41, y: 42 }));
+
+  assert(d.contains5(Data2 { x: 42, y: 42 }));
+  assert(!d.contains5(Data2 { x: 42, y: 41 }));
+  assert(!d.contains5(Data2 { x: 41, y: 42 }));
+
+  assert(d.contains6(Data2 { x: 42, y: 42 }));
+  assert(!d.contains6(Data2 { x: 42, y: 41 }));
+  assert(!d.contains6(Data2 { x: 41, y: 42 }));
+
+// TODO (Esdrubal): activate test once #3818 is merged.
+/*
+  let d2 = Data2 { x: 42, y: true };
+  assert(d2.contains5(Data2 { x: 42, y: true }));
+  assert(!d2.contains5(Data2 { x: 42, y: false }));
+  assert(!d2.contains5(Data2 { x: 41, y: true }));
+*/
+
+  let d3 = Data { x: Data3 { x: 42 }};
+  assert(d3.contains(Data3 { x: 42 }));
+  assert(!d3.contains(Data3 { x: 41 }));
+
+// TODO (Esdrubal): activate test once #3818 is merged.
+/*
+  let d4 = Data2 { x: 42, y: Data3 { x: 42 } };
+  assert(d4.contains5(Data2 { x: 42, y: Data3 { x: 42 } }));
+  assert(!d4.contains5(Data2 { x: 42, y: Data3 { x: 41 } }));
+  assert(!d4.contains5(Data2 { x: 41, y: Data3 { x: 42 } }));
+  */
+
+  10
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/traits.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/traits.sw
@@ -1,0 +1,21 @@
+library;
+
+mod nested_traits;
+
+use nested_traits::*;
+
+pub trait MyEq {
+    fn my_eq(self, other: Self) -> bool;
+}
+
+impl MyEq for u64 {
+    fn my_eq(self, other: Self) -> bool {
+        self == other
+    }
+}
+
+impl MyEq for bool {
+    fn my_eq(self, other: Self) -> bool {
+        self == other
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/traits/nested_traits.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/src/traits/nested_traits.sw
@@ -1,0 +1,11 @@
+library;
+
+pub trait MyEq2 {
+    fn my_eq2(self, other: Self) -> bool;
+}
+
+impl MyEq2 for u64 {
+    fn my_eq2(self, other: Self) -> bool {
+        self == other
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self_where/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 10 }
+validate_abi = true

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-415990365485FD0B'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-415990365485FD0B'
+dependencies = ['core']
+
+[[package]]
+name = 'where_clause_methods'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+name = "where_clause_methods"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/src/main.sw
@@ -1,0 +1,203 @@
+script;
+
+use std::{
+    assert::assert,
+    logging::log,
+};
+
+trait MyAdd {
+    fn my_add(self, other: Self) -> Self;
+}
+
+trait MyMul {
+    fn my_mul(self, other: Self) -> Self;
+}
+
+impl MyAdd for u8 {
+    fn my_add(self, other: Self) -> Self {
+        self + other
+    }
+}
+
+impl MyAdd for u16 {
+    fn my_add(self, other: Self) -> Self {
+        self + other
+    }
+}
+
+impl MyAdd for u32 {
+    fn my_add(self, other: Self) -> Self {
+        self + other
+    }
+}
+
+impl MyAdd for u64 {
+    fn my_add(self, other: Self) -> Self {
+        self + other
+    }
+}
+
+struct MyPoint<T> {
+    x: T,
+    y: T,
+}
+
+impl<T> MyPoint<T> {
+    fn add_points(self, b: MyPoint<T>) -> MyPoint<T> where T: MyAdd {
+        MyPoint {
+            x: self.x.my_add(b.x),
+            y: self.y.my_add(b.y),
+        }
+    }
+
+    fn add_points2<F>(self, b: MyPoint<F>) -> MyPoint<F> where T: MyAdd, F: MyAdd {
+        MyPoint {
+            x: b.x.my_add(b.x),
+            y: b.y.my_add(b.y),
+        }
+    }
+}
+
+impl MyMul for u8 {
+    fn my_mul(self, other: Self) -> Self {
+        self * other
+    }
+}
+
+impl MyMul for u16 {
+    fn my_mul(self, other: Self) -> Self {
+        self * other
+    }
+}
+
+impl MyMul for u32 {
+    fn my_mul(self, other: Self) -> Self {
+        self * other
+    }
+}
+
+impl MyMul for u64 {
+    fn my_mul(self, other: Self) -> Self {
+        self * other
+    }
+}
+
+impl<T> MyPoint<T> {
+    fn mul_points(self, b: MyPoint<T>) -> MyPoint<T> where T: MyMul {
+        MyPoint {
+            x: self.x.my_mul(b.x),
+            y: self.y.my_mul(b.y),
+        }
+    }
+
+    fn mul_points2<F>(self, b: MyPoint<F>) -> MyPoint<F> where T: MyMul, F: MyMul {
+        MyPoint {
+            x: b.x.my_mul(b.x),
+            y: b.y.my_mul(b.y),
+        }
+    }
+
+    fn do_math(self, b: MyPoint<T>) -> MyPoint<T> where T: MyAdd + MyMul {
+        MyPoint {
+            x: self.x.my_add(b.x),
+            y: self.y.my_mul(b.y),
+        }
+    }
+
+    fn do_math2<F>(self, b: MyPoint<F>) -> MyPoint<F> where T: MyAdd + MyMul, F: MyMul + MyAdd {
+        MyPoint {
+            x: b.x.my_add(b.x),
+            y: b.y.my_mul(b.y),
+        }
+    }
+}
+trait MyMath: MyAdd + MyMul {
+
+} {
+    fn my_double(self) -> Self {
+        self.my_add(self)
+    }
+
+    fn my_pow_2(self) -> Self {
+        self.my_mul(self)
+    }
+}
+
+impl MyMath for u8 {}
+
+impl MyMath for u16 {}
+
+impl MyMath for u32 {}
+
+impl MyMath for u64 {}
+
+impl<T> MyPoint<T> {
+    fn do_math3(self, b: MyPoint<T>) -> MyPoint<T> where T: MyMath {
+        MyPoint {
+            x: self.x.my_double().my_mul(b.x.my_double()),
+            y: self.y.my_pow_2().my_add(b.y.my_pow_2()),
+        }
+    }
+}
+
+fn main() -> u64 {
+    let a = MyPoint {
+        x: 1u64,
+        y: 2u64,
+    };
+    assert(a.x == 1u64);
+    assert(a.y == 2u64);
+
+    let b = MyPoint {
+        x: 3u64,
+        y: 4u64,
+    };
+    assert(b.x == 3u64);
+    assert(b.y == 4u64);
+
+    let c = a.add_points(b);
+    assert(c.x == 4u64);
+    assert(c.y == 6u64);
+
+    let d = MyPoint {
+        x: 99u16,
+        y: 99u16,
+    };
+    let e = MyPoint {
+        x: 5u8,
+        y: 10u8
+    };
+    let f = d.add_points2(e);
+    assert(f.x == 10u8);
+    assert(f.y == 20u8);
+
+    let g = a.mul_points(b);
+    assert(g.x == 3u64);
+    assert(g.y == 8u64);
+
+    let h = d.mul_points2(e);
+    assert(h.x == 25u8);
+    assert(h.y == 100u8);
+
+    let i = MyPoint {
+        x: 3u16,
+        y: 6u16,
+    };
+    let j = MyPoint {
+        x: 9u16,
+        y: 12u16,
+    };
+    let k = i.do_math(j);
+    assert(k.x == 12u16);
+    assert(k.y == 72u16);
+
+    let l = i.do_math2(j);
+    assert(l.x == 18u16);
+    assert(l.y == 144u16);
+
+    let m = a.do_math3(b);
+    assert(m.x == 12u64);
+    assert(m.y == 20u64);
+
+    42
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/test.toml
@@ -1,0 +1,5 @@
+category = "run"
+expected_result = { action = "return", value = 42 }
+validate_abi = true
+
+expected_warnings = 8


### PR DESCRIPTION
When where clauses were used in impl self methods with a generic parameter from
 impl<T> an error was thrown saying `cannot find type "T" in this scope`

Parent type parameters that are used in method where clauses are now added to `FunctionDeclaration.type_parameters`.
This is needed for `TypeParameter::gather_decl_mapping_from_trait_constraints` to work properly as we need to have a type parameter with constraints. The generated decl_mapping is used by `type_check_method_application` to replace decls from trait constraints.

Closes #3333