### PR TITLE
Add StorageMapVec example to common collections

### DIFF
--- a/docs/book/src/common-collections/storage_map.md
+++ b/docs/book/src/common-collections/storage_map.md
@@ -88,33 +88,7 @@ storage.w.map1.insert(..);
 It is currently not possible to use somthing like StorageMap<K, StorageVec> directly in Sway. The workaround for this is to use a Sway reference library called [StorageMapVec](https://github.com/FuelLabs/sway-libs/tree/master/libs/storagemapvec) such as below:
 
 ```sway
-use storagemapvec::StorageMapVec;
-
-storage {
-    mapvec: StorageMapVec<u64, u64> = StorageMapVec {},
-}
-
-abi MyContract {
-    #[storage(read, write)]
-    fn push(key: u64, value: u64);
-
-    #[storage(read)]
-    fn get(key: u64, index: u64);
-}
-
-impl MyContract for Contract {
-    #[storage(read, write)]
-    fn push(key: u64, value: u64) {
-        // this will push the value to the vec, which is accessible with the key
-        storage.mapvec.push(key, value);
-    }
-
-    #[storage(read)]
-    fn get(key: u64, index: u64) {
-        // this will retrieve the vec at given key, and then retrieve the value at given index from that vec
-        storage.mapvec.get(key, index)
-    }
-}
+{{#include ../../../../examples/storagemapvec/src/main.sw}}
 ```
 
 Please note that the [StorageMapVec](https://github.com/FuelLabs/sway-libs/tree/master/libs/storagemapvec) is a temporary workaround for using complex storage variants and will be deprecated once the desired functionality is supported directly in Sway.


### PR DESCRIPTION
Made the following changes:
- Moved the `Storage maps with multiple keys` section as a sub-section under `Limitations`.
- Added a sub-section for `Storage maps within storage maps` under `Limitations` with example.