### PR TITLE
Refactor and fix `collect_types_metadata` for `TyProgram`

### DIFF
--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -89,7 +89,7 @@ impl TyProgram {
                 TyAstNodeContent::Declaration(TyDeclaration::ConstantDeclaration(decl_id)) => {
                     match decl_engine.get_constant(decl_id.clone(), &node.span) {
                         Ok(config_decl) if config_decl.is_configurable => {
-                            configurables.push(config_decl);
+                            configurables.push(config_decl)
                         }
                         _ => {}
                     }
@@ -312,98 +312,129 @@ impl TyProgram {
         let metadata = match &self.kind {
             TyProgramKind::Library { .. } => {
                 let mut ret = vec![];
-                for node in self.root.all_nodes.iter() {
-                    let public = check!(
-                        node.is_public(decl_engine),
-                        return err(warnings, errors),
-                        warnings,
-                        errors
-                    );
-                    let is_test = check!(
-                        node.is_test_function(decl_engine),
-                        return err(warnings, errors),
-                        warnings,
-                        errors
-                    );
-                    if public || is_test {
-                        ret.append(&mut check!(
-                            node.collect_types_metadata(ctx),
+                // Look through `root` and all of its submodules
+                for module in std::iter::once(&self.root).chain(
+                    self.root
+                        .submodules_recursive()
+                        .into_iter()
+                        .map(|(_, submod)| &submod.module),
+                ) {
+                    for node in module.all_nodes.iter() {
+                        let public = check!(
+                            node.is_public(decl_engine),
                             return err(warnings, errors),
                             warnings,
                             errors
-                        ));
+                        );
+                        let is_test = check!(
+                            node.is_test_function(decl_engine),
+                            return err(warnings, errors),
+                            warnings,
+                            errors
+                        );
+                        if public || is_test {
+                            ret.append(&mut check!(
+                                node.collect_types_metadata(ctx),
+                                return err(warnings, errors),
+                                warnings,
+                                errors
+                            ));
+                        }
                     }
                 }
+
+
                 ret
             }
             TyProgramKind::Script { .. } => {
                 let mut data = vec![];
-                for node in self.root.all_nodes.iter() {
-                    let is_main = check!(
-                        node.is_main_function(decl_engine, parsed::TreeType::Script),
-                        return err(warnings, errors),
-                        warnings,
-                        errors
-                    );
-                    let is_test = check!(
-                        node.is_test_function(decl_engine),
-                        return err(warnings, errors),
-                        warnings,
-                        errors
-                    );
-                    if is_main || is_test {
-                        data.append(&mut check!(
-                            node.collect_types_metadata(ctx),
+                for module in std::iter::once(&self.root).chain(
+                    self.root
+                        .submodules_recursive()
+                        .into_iter()
+                        .map(|(_, submod)| &submod.module),
+                ) {
+                    for node in module.all_nodes.iter() {
+                        let is_main = check!(
+                            node.is_main_function(decl_engine, parsed::TreeType::Script),
                             return err(warnings, errors),
                             warnings,
                             errors
-                        ));
+                        );
+                        let is_test = check!(
+                            node.is_test_function(decl_engine),
+                            return err(warnings, errors),
+                            warnings,
+                            errors
+                        );
+                        if is_main || is_test {
+                            data.append(&mut check!(
+                                node.collect_types_metadata(ctx),
+                                return err(warnings, errors),
+                                warnings,
+                                errors
+                            ));
+                        }
                     }
                 }
                 data
             }
             TyProgramKind::Predicate { .. } => {
                 let mut data = vec![];
-                for node in self.root.all_nodes.iter() {
-                    let is_main = check!(
-                        node.is_main_function(decl_engine, parsed::TreeType::Predicate),
-                        return err(warnings, errors),
-                        warnings,
-                        errors
-                    );
-                    let is_test = check!(
-                        node.is_test_function(decl_engine),
-                        return err(warnings, errors),
-                        warnings,
-                        errors
-                    );
-                    if is_main || is_test {
-                        data.append(&mut check!(
-                            node.collect_types_metadata(ctx),
+                for module in std::iter::once(&self.root).chain(
+                    self.root
+                        .submodules_recursive()
+                        .into_iter()
+                        .map(|(_, submod)| &submod.module),
+                ) {
+                    for node in module.all_nodes.iter() {
+                        let is_main = check!(
+                            node.is_main_function(decl_engine, parsed::TreeType::Predicate),
                             return err(warnings, errors),
                             warnings,
                             errors
-                        ));
+                        );
+                        let is_test = check!(
+                            node.is_test_function(decl_engine),
+                            return err(warnings, errors),
+                            warnings,
+                            errors
+                        );
+                        if is_main || is_test {
+                            data.append(&mut check!(
+                                node.collect_types_metadata(ctx),
+                                return err(warnings, errors),
+                                warnings,
+                                errors
+                            ));
+                        }
                     }
                 }
                 data
             }
             TyProgramKind::Contract { abi_entries, .. } => {
                 let mut data = vec![];
-                for node in self.root.all_nodes.iter() {
-                    let is_test = check!(
-                        node.is_test_function(decl_engine),
-                        return err(warnings, errors),
-                        warnings,
-                        errors
-                    );
-                    if is_test {
-                        data.append(&mut check!(
-                            node.collect_types_metadata(ctx),
+                for module in std::iter::once(&self.root).chain(
+                    self.root
+                        .submodules_recursive()
+                        .into_iter()
+                        .map(|(_, submod)| &submod.module),
+                ) {
+                    for node in module.all_nodes.iter() {
+                        let is_test = check!(
+                            node.is_test_function(decl_engine),
                             return err(warnings, errors),
                             warnings,
                             errors
-                        ));
+                        );
+                        if is_test {
+                            data.append(&mut check!(
+                                node.collect_types_metadata(ctx),
+                                return err(warnings, errors),
+                                warnings,
+                                errors
+                            ));
+                        }
                     }
                 }
                 for entry in abi_entries.iter() {

--- a/sway-core/src/type_system/collect_types_metadata.rs
+++ b/sway-core/src/type_system/collect_types_metadata.rs
@@ -47,6 +47,7 @@ impl MessageId {
 }
 
 #[allow(clippy::enum_variant_names)]
+#[derive(Debug, Clone)]
 pub enum TypeMetadata {
     // UnresolvedType receives the Ident of the type and a call site span.
     UnresolvedType(Ident, Option<Span>),

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/contract_with_nested_libs/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/contract_with_nested_libs/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-53DBC6786CED201E'
+
+[[package]]
+name = 'script_with_nested_libs'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-53DBC6786CED201E'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/contract_with_nested_libs/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/contract_with_nested_libs/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "script_with_nested_libs"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/contract_with_nested_libs/src/inner.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/contract_with_nested_libs/src/inner.sw
@@ -1,0 +1,14 @@
+library inner;
+
+dep inner2;
+
+#[test]
+fn test_meaning_of_life_inner() {
+    let meaning = 6 * 7;
+    assert(meaning == 42);
+}
+
+#[test]
+fn log_test_inner() {
+    std::logging::log(1u16);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/contract_with_nested_libs/src/inner2.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/contract_with_nested_libs/src/inner2.sw
@@ -1,0 +1,12 @@
+library inner2;
+
+#[test]
+fn test_meaning_of_life_inner2() {
+    let meaning = 6 * 7;
+    assert(meaning == 42);
+}
+
+#[test]
+fn log_test_inner2() {
+    std::logging::log(1u8);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/contract_with_nested_libs/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/contract_with_nested_libs/src/main.sw
@@ -1,6 +1,15 @@
-library lib;
+contract;
 
 dep inner;
+
+abi MyContract {
+    fn foo();
+}
+
+impl MyContract for Contract {
+    fn foo() { }
+}
+
 
 #[test]
 fn test_meaning_of_life() {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/contract_with_nested_libs/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/contract_with_nested_libs/test.toml
@@ -1,0 +1,1 @@
+category = "unit_tests_pass"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/nested_libs/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/nested_libs/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-6E8361428B3F8FCA'
+
+[[package]]
+name = 'nested_libs'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-6E8361428B3F8FCA'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/nested_libs/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/nested_libs/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "lib.sw"
+license = "Apache-2.0"
+name = "nested_libs"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/nested_libs/src/inner.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/nested_libs/src/inner.sw
@@ -1,0 +1,14 @@
+library inner;
+
+dep inner2;
+
+#[test]
+fn test_meaning_of_life_inner() {
+    let meaning = 6 * 7;
+    assert(meaning == 42);
+}
+
+#[test]
+fn log_test_inner() {
+    std::logging::log(1u16);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/nested_libs/src/inner2.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/nested_libs/src/inner2.sw
@@ -1,0 +1,12 @@
+library inner2;
+
+#[test]
+fn test_meaning_of_life_inner2() {
+    let meaning = 6 * 7;
+    assert(meaning == 42);
+}
+
+#[test]
+fn log_test_inner2() {
+    std::logging::log(1u8);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/nested_libs/src/lib.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/nested_libs/src/lib.sw
@@ -1,0 +1,14 @@
+library lib;
+
+dep inner;
+
+#[test]
+fn test_meaning_of_life() {
+    let meaning = 6 * 7;
+    assert(meaning == 42);
+}
+
+#[test]
+fn test_meaning_of_life() {
+    std::logging::log(1u32);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/nested_libs/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/nested_libs/test.toml
@@ -1,0 +1,1 @@
+category = "unit_tests_pass"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/predicate_with_nested_libs/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/predicate_with_nested_libs/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-53DBC6786CED201E'
+
+[[package]]
+name = 'script_with_nested_libs'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-53DBC6786CED201E'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/predicate_with_nested_libs/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/predicate_with_nested_libs/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "predicate_with_nested_libs"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/predicate_with_nested_libs/src/inner.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/predicate_with_nested_libs/src/inner.sw
@@ -1,0 +1,14 @@
+library inner;
+
+dep inner2;
+
+#[test]
+fn test_meaning_of_life_inner() {
+    let meaning = 6 * 7;
+    assert(meaning == 42);
+}
+
+#[test]
+fn log_test_inner() {
+    std::logging::log(1u16);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/predicate_with_nested_libs/src/inner2.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/predicate_with_nested_libs/src/inner2.sw
@@ -1,0 +1,12 @@
+library inner2;
+
+#[test]
+fn test_meaning_of_life_inner2() {
+    let meaning = 6 * 7;
+    assert(meaning == 42);
+}
+
+#[test]
+fn log_test_inner2() {
+    std::logging::log(1u8);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/predicate_with_nested_libs/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/predicate_with_nested_libs/src/main.sw
@@ -1,6 +1,8 @@
-library lib;
+predicate;
 
 dep inner;
+
+fn main() { }
 
 #[test]
 fn test_meaning_of_life() {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/predicate_with_nested_libs/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/predicate_with_nested_libs/test.toml
@@ -1,0 +1,1 @@
+category = "unit_tests_pass"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_with_nested_libs/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_with_nested_libs/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-53DBC6786CED201E'
+
+[[package]]
+name = 'script_with_nested_libs'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-53DBC6786CED201E'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_with_nested_libs/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_with_nested_libs/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "script_with_nested_libs"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_with_nested_libs/src/inner.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_with_nested_libs/src/inner.sw
@@ -1,0 +1,14 @@
+library inner;
+
+dep inner2;
+
+#[test]
+fn test_meaning_of_life_inner() {
+    let meaning = 6 * 7;
+    assert(meaning == 42);
+}
+
+#[test]
+fn log_test_inner() {
+    std::logging::log(1u16);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_with_nested_libs/src/inner2.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_with_nested_libs/src/inner2.sw
@@ -1,0 +1,12 @@
+library inner2;
+
+#[test]
+fn test_meaning_of_life_inner2() {
+    let meaning = 6 * 7;
+    assert(meaning == 42);
+}
+
+#[test]
+fn log_test_inner2() {
+    std::logging::log(1u8);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_with_nested_libs/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_with_nested_libs/src/main.sw
@@ -1,6 +1,8 @@
-library lib;
+script;
 
 dep inner;
+
+fn main() { }
 
 #[test]
 fn test_meaning_of_life() {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_with_nested_libs/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_with_nested_libs/test.toml
@@ -1,0 +1,1 @@
+category = "unit_tests_pass"


### PR DESCRIPTION
Closes #3812

This is a bit of a refactor of `collect_types_metadata` for `TyProgram` that solves a few issues. We now correctly handle all entry points for each possible program type. In particular:
- Unit tests are entry points regardless of the program type.
- For scripts and predicates, `fn main()` is the only other entry point.
- For contract, ABI methods are the only other entry points.
- For libraries, all `pub` functions/methods are entry points in the root of the library as well as in all it submodules.