### PR TITLE
Add missing tokens inside turbofish

### DIFF
--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -236,6 +236,7 @@ impl<'eng> FnCompiler<'eng> {
                 function_decl_id,
                 self_state_idx,
                 selector,
+                type_binding: _,
             } => {
                 if let Some(metadata) = selector {
                     self.compile_contract_call(

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -24,6 +24,8 @@ pub enum TyExpressionVariant {
         /// there is no selector.
         self_state_idx: Option<StateIndex>,
         selector: Option<ContractCallParams>,
+        /// optional binding information for the LSP
+        type_binding: Option<TypeBinding<()>>,
     },
     LazyOperator {
         op: LazyOp,
@@ -90,6 +92,7 @@ pub enum TyExpressionVariant {
         /// They are also used in the language server.
         enum_instantiation_span: Span,
         variant_instantiation_span: Span,
+        type_binding: TypeBinding<()>,
     },
     AbiCast {
         abi_name: CallPath,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -17,6 +17,7 @@ pub(crate) fn instantiate_enum(
     enum_name: Ident,
     enum_variant_name: Ident,
     args_opt: Option<Vec<Expression>>,
+    mut type_binding: TypeBinding<()>,
     span: &Span,
 ) -> CompileResult<ty::TyExpression> {
     let mut warnings = vec![];
@@ -46,6 +47,17 @@ pub(crate) fn instantiate_enum(
     }
     let args = args_opt.unwrap_or_default();
 
+    // Update type binding with the correct type information from the enum decl
+    for (type_arg, type_param) in type_binding
+        .type_arguments
+        .iter_mut()
+        .zip(enum_decl.type_parameters.iter())
+    {
+        type_arg.type_id = type_param.type_id;
+        type_arg.initial_type_id = type_param.initial_type_id;
+        // keep the type_arg span so the LSP knows where we are
+    }
+
     // If there is an instantiator, it must match up with the type. If there is not an
     // instantiator, then the type of the enum is necessarily the unit type.
 
@@ -60,6 +72,7 @@ pub(crate) fn instantiate_enum(
                     variant_name: enum_variant.name,
                     enum_instantiation_span: enum_name.span(),
                     variant_instantiation_span: enum_variant_name.span(),
+                    type_binding,
                 },
                 span: enum_variant_name.span(),
             },
@@ -105,6 +118,7 @@ pub(crate) fn instantiate_enum(
                         variant_name: enum_variant.name,
                         enum_instantiation_span: enum_name.span(),
                         variant_instantiation_span: enum_variant_name.span(),
+                        type_binding,
                     },
                     span: enum_variant_name.span(),
                 },

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -10,12 +10,12 @@ use std::collections::{HashMap, VecDeque};
 use sway_error::error::CompileError;
 use sway_types::{constants, integer_bits::IntegerBits};
 use sway_types::{constants::CONTRACT_CALL_COINS_PARAMETER_NAME, Spanned};
-use sway_types::{state::StateIndex, Span};
+use sway_types::{state::StateIndex, Ident, Span};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn type_check_method_application(
     mut ctx: TypeCheckContext,
-    method_name_binding: TypeBinding<MethodName>,
+    mut method_name_binding: TypeBinding<MethodName>,
     contract_call_params: Vec<StructExpressionField>,
     arguments: Vec<Expression>,
     span: Span,
@@ -44,7 +44,7 @@ pub(crate) fn type_check_method_application(
 
     // resolve the method name to a typed function declaration and type_check
     let decl_id = check!(
-        resolve_method_name(ctx.by_ref(), &method_name_binding, args_buf.clone()),
+        resolve_method_name(ctx.by_ref(), &mut method_name_binding, args_buf.clone()),
         return err(warnings, errors),
         warnings,
         errors
@@ -261,7 +261,7 @@ pub(crate) fn type_check_method_application(
     }
 
     // retrieve the function call path
-    let call_path = match method_name_binding.inner {
+    let call_path = match method_name_binding.inner.clone() {
         MethodName::FromType {
             call_path_binding,
             method_name,
@@ -335,20 +335,12 @@ pub(crate) fn type_check_method_application(
     );
 
     // unify the types of the arguments with the types of the parameters from the function declaration
-    check!(
-        unify_arguments_and_parameters(ctx.by_ref(), &args_buf, &method.parameters),
+    let typed_arguments_with_names = check!(
+        unify_arguments_and_parameters(ctx.by_ref(), args_buf, &method.parameters),
         return err(warnings, errors),
         warnings,
         errors
     );
-
-    // Map the names of the parameters to the typed arguments.
-    let args_and_names = method
-        .parameters
-        .iter()
-        .zip(args_buf.into_iter())
-        .map(|(param, arg)| (param.name.clone(), arg))
-        .collect::<Vec<(_, _)>>();
 
     // Retrieve the implemented traits for the type of the return type and
     // insert them in the broader namespace.
@@ -359,10 +351,11 @@ pub(crate) fn type_check_method_application(
         expression: ty::TyExpressionVariant::FunctionApplication {
             call_path,
             contract_call_params: contract_call_params_map,
-            arguments: args_and_names,
+            arguments: typed_arguments_with_names,
             function_decl_id: decl_id,
             self_state_idx,
             selector,
+            type_binding: Some(method_name_binding.strip_inner()),
         },
         return_type: method.return_type,
         span,
@@ -371,21 +364,22 @@ pub(crate) fn type_check_method_application(
     ok(exp, warnings, errors)
 }
 
-/// Unifies the types of the arguments with the types of the parameters from the
-/// function declaration.
+/// Unifies the types of the arguments with the types of the parameters. Returns
+/// a list of the arguments with the names of the corresponding parameters.
 fn unify_arguments_and_parameters(
     ctx: TypeCheckContext,
-    arguments: &VecDeque<ty::TyExpression>,
+    arguments: VecDeque<ty::TyExpression>,
     parameters: &[ty::TyFunctionParameter],
-) -> CompileResult<()> {
+) -> CompileResult<Vec<(Ident, ty::TyExpression)>> {
     let mut warnings = vec![];
     let mut errors = vec![];
 
     let type_engine = ctx.type_engine;
     let decl_engine = ctx.decl_engine;
     let engines = ctx.engines();
+    let mut typed_arguments_and_names = vec![];
 
-    for (arg, param) in arguments.iter().zip(parameters.iter()) {
+    for (arg, param) in arguments.into_iter().zip(parameters.iter()) {
         // unify the type of the argument with the type of the param
         check!(
             CompileResult::from(type_engine.unify_with_self(
@@ -405,10 +399,12 @@ fn unify_arguments_and_parameters(
             warnings,
             errors
         );
+
+        typed_arguments_and_names.push((param.name.clone(), arg));
     }
 
     if errors.is_empty() {
-        ok((), warnings, errors)
+        ok(typed_arguments_and_names, warnings, errors)
     } else {
         err(warnings, errors)
     }
@@ -416,7 +412,7 @@ fn unify_arguments_and_parameters(
 
 pub(crate) fn resolve_method_name(
     mut ctx: TypeCheckContext,
-    method_name: &TypeBinding<MethodName>,
+    method_name: &mut TypeBinding<MethodName>,
     arguments: VecDeque<ty::TyExpression>,
 ) -> CompileResult<DeclId> {
     let mut warnings = vec![];
@@ -526,12 +522,13 @@ pub(crate) fn resolve_method_name(
     );
 
     // monomorphize the function declaration
+    let method_name_span = method_name.span();
     check!(
         ctx.monomorphize(
             &mut func_decl,
-            &mut method_name.type_arguments.clone(),
+            &mut method_name.type_arguments,
             EnforceTypeArguments::No,
-            &method_name.span()
+            &method_name_span,
         ),
         return err(warnings, errors),
         warnings,

--- a/sway-core/src/type_system/binding.rs
+++ b/sway-core/src/type_system/binding.rs
@@ -82,6 +82,16 @@ impl<T> Spanned for TypeBinding<T> {
     }
 }
 
+impl<T> TypeBinding<T> {
+    pub fn strip_inner(self) -> TypeBinding<()> {
+        TypeBinding {
+            inner: (),
+            type_arguments: self.type_arguments,
+            span: self.span,
+        }
+    }
+}
+
 impl TypeBinding<CallPath<(TypeInfo, Span)>> {
     pub(crate) fn type_check_with_type_info(
         &self,

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -542,15 +542,19 @@ impl<'a> ParsedTree<'a> {
                     self.collect_type_info_token(&token, type_info, Some(span.clone()), None);
                 }
 
+                let token = Token::from_parsed(
+                    AstToken::Expression(expression.clone()),
+                    SymbolKind::Struct,
+                );
+
+                for type_arg in &method_name_binding.type_arguments {
+                    self.collect_type_arg(type_arg, &token);
+                }
+
                 // Don't collect applications of desugared operators due to mismatched ident lengths.
                 if !desugared_op(&prefixes) {
-                    self.tokens.insert(
-                        to_ident_key(&method_name_binding.inner.easy_name()),
-                        Token::from_parsed(
-                            AstToken::Expression(expression.clone()),
-                            SymbolKind::Struct,
-                        ),
-                    );
+                    self.tokens
+                        .insert(to_ident_key(&method_name_binding.inner.easy_name()), token);
                 }
 
                 for exp in arguments {

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -297,6 +297,7 @@ impl<'a> TypedTree<'a> {
                 contract_call_params,
                 arguments,
                 function_decl_id,
+                type_binding,
                 ..
             } => {
                 for ident in &call_path.prefixes {
@@ -305,6 +306,16 @@ impl<'a> TypedTree<'a> {
                     {
                         token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                         token.type_def = Some(TypeDefinition::TypeId(expression.return_type));
+                    }
+                }
+
+                if let Some(type_binding) = type_binding {
+                    for type_arg in &type_binding.type_arguments {
+                        self.collect_type_id(
+                            type_arg.type_id,
+                            &TypedAstToken::TypedArgument(type_arg.clone()),
+                            type_arg.span(),
+                        );
                     }
                 }
 
@@ -461,6 +472,7 @@ impl<'a> TypedTree<'a> {
                 enum_decl,
                 enum_instantiation_span,
                 contents,
+                type_binding,
                 ..
             } => {
                 if let Some(mut token) = self
@@ -470,6 +482,14 @@ impl<'a> TypedTree<'a> {
                 {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
                     token.type_def = Some(TypeDefinition::Ident(enum_decl.name.clone()));
+                }
+
+                for type_arg in &type_binding.type_arguments {
+                    self.collect_type_id(
+                        type_arg.type_id,
+                        &TypedAstToken::TypedArgument(type_arg.clone()),
+                        type_arg.span(),
+                    );
                 }
 
                 if let Some(mut token) = self

--- a/sway-lsp/test/fixtures/tokens/turbofish/.gitignore
+++ b/sway-lsp/test/fixtures/tokens/turbofish/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/sway-lsp/test/fixtures/tokens/turbofish/Forc.lock
+++ b/sway-lsp/test/fixtures/tokens/turbofish/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-C35A83477D5B662F'
+
+[[package]]
+name = 'turbofish'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-C35A83477D5B662F'
+dependencies = ['core']

--- a/sway-lsp/test/fixtures/tokens/turbofish/Forc.toml
+++ b/sway-lsp/test/fixtures/tokens/turbofish/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "turbofish"
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/test/fixtures/tokens/turbofish/src/main.sw
+++ b/sway-lsp/test/fixtures/tokens/turbofish/src/main.sw
@@ -1,0 +1,19 @@
+contract;
+
+struct A {
+    b: u32
+}
+
+impl A {
+    pub fn method<T>(self, a: T){}
+}
+
+#[storage(read)]
+pub fn g(amount: u64, to: Identity) {
+    let s = A{b: 0};
+    fun::<Option<u32>>(Option::None);
+    s.method::<Option<u32>>(Option::None);
+    let a = Option::None::<Option<u32>>;
+}
+
+fn fun<T>(t: T){}


### PR DESCRIPTION
Expose type arguments inside turbofish for function application, method application and enum instantiation by populating the typed AST with relevant instances of TypeBinding and having the LSP collect them.

All three of the following lines will now generate proper tokens that point to real type definitions inside turbofish:

```sway
fun::<Option<u32>>(Option::None);
s.meth::<Option<u32>>(Option::None);
let a = Option::None::<Option<u32>>;
```

Fix #3612