### PR TITLE
Add StorageMapVec example to common collections

### DIFF
--- a/examples/storage_map_vec/.gitignore
+++ b/examples/storage_map_vec/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/examples/storage_map_vec/Forc.toml
+++ b/examples/storage_map_vec/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Vishwa Mehta"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "storage_map_vec"
+
+[dependencies]

--- a/examples/storage_map_vec/src/main.sw
+++ b/examples/storage_map_vec/src/main.sw
@@ -1,0 +1,24 @@
+contract;
+
+use storagemapvec::StorageMapVec;
+storage {
+    mapvec: StorageMapVec<u64, u64> = StorageMapVec {},
+}
+abi MyContract {
+    #[storage(read, write)]
+    fn push(key: u64, value: u64);
+    #[storage(read)]
+    fn get(key: u64, index: u64);
+}
+impl MyContract for Contract {
+    #[storage(read, write)]
+    fn push(key: u64, value: u64) {
+        // this will push the value to the vec, which is accessible with the key
+        storage.mapvec.push(key, value);
+    }
+    #[storage(read)]
+    fn get(key: u64, index: u64) {
+        // this will retrieve the vec at given key, and then retrieve the value at given index from that vec
+        storage.mapvec.get(key, index)
+    }
+}


### PR DESCRIPTION
Made the following changes:

* Moved the `Storage maps with multiple keys` section as a sub-section under `Limitations`.
* Added a sub-section for `Storage maps within storage maps` under `Limitations` with example.
* Add an example for `StorageMapVec` library inside the `Examples` folder.