### PR TITLE
Fix the bug regarding methods not being found for types.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -39,7 +39,6 @@ impl ty::TyFunctionDeclaration {
 
         let type_engine = ctx.type_engine;
         let decl_engine = ctx.decl_engine;
-        let engines = ctx.engines();
 
         // If functions aren't allowed in this location, return an error.
         if ctx.functions_disallowed() {
@@ -168,20 +167,6 @@ impl ty::TyFunctionDeclaration {
             is_contract_call,
             purity,
         };
-
-        // // Retrieve the implemented traits for the type of the return type and
-        // // insert them in the broader namespace. We don't want to include any
-        // // type parameters, so we filter them out.
-        // let mut return_type_namespace = fn_ctx
-        //     .namespace
-        //     .implemented_traits
-        //     .filter_by_type(function_decl.return_type, fn_ctx.engines());
-        // for type_param in function_decl.type_parameters.iter() {
-        //     return_type_namespace.filter_against_type(engines, type_param.type_id);
-        // }
-        // ctx.namespace
-        //     .implemented_traits
-        //     .extend(return_type_namespace, engines);
 
         ok(function_decl, warnings, errors)
     }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -60,7 +60,7 @@ impl ty::TyFunctionDeclaration {
 
         // create a namespace for the function
         let mut fn_namespace = ctx.namespace.clone();
-        let mut fn_ctx = ctx
+        let mut ctx = ctx
             .by_ref()
             .scoped(&mut fn_namespace)
             .with_purity(purity)
@@ -70,7 +70,7 @@ impl ty::TyFunctionDeclaration {
         let mut new_type_parameters = vec![];
         for type_parameter in type_parameters.into_iter() {
             new_type_parameters.push(check!(
-                TypeParameter::type_check(fn_ctx.by_ref(), type_parameter),
+                TypeParameter::type_check(ctx.by_ref(), type_parameter),
                 continue,
                 warnings,
                 errors
@@ -84,7 +84,7 @@ impl ty::TyFunctionDeclaration {
         let mut new_parameters = vec![];
         for parameter in parameters.into_iter() {
             new_parameters.push(check!(
-                ty::TyFunctionParameter::type_check(fn_ctx.by_ref(), parameter, is_method),
+                ty::TyFunctionParameter::type_check(ctx.by_ref(), parameter, is_method),
                 continue,
                 warnings,
                 errors
@@ -97,7 +97,7 @@ impl ty::TyFunctionDeclaration {
         // type check the return type
         let initial_return_type = type_engine.insert(decl_engine, return_type);
         let return_type = check!(
-            fn_ctx.resolve_type_with_self(
+            ctx.resolve_type_with_self(
                 initial_return_type,
                 &return_type_span,
                 EnforceTypeArguments::Yes,
@@ -113,7 +113,7 @@ impl ty::TyFunctionDeclaration {
         // If there are no implicit block returns, then we do not want to type check them, so we
         // stifle the errors. If there _are_ implicit block returns, we want to type_check them.
         let (body, _implicit_block_return) = {
-            let fn_ctx = fn_ctx
+            let fn_ctx = ctx
                 .by_ref()
                 .with_purity(purity)
                 .with_help_text("Function body's return type does not match up with its return type annotation.")
@@ -137,7 +137,7 @@ impl ty::TyFunctionDeclaration {
             .collect();
 
         check!(
-            unify_return_statements(fn_ctx.by_ref(), &return_statements, return_type),
+            unify_return_statements(ctx.by_ref(), &return_statements, return_type),
             return err(warnings, errors),
             warnings,
             errors
@@ -150,7 +150,7 @@ impl ty::TyFunctionDeclaration {
                 (Visibility::Public, false)
             }
         } else {
-            (visibility, fn_ctx.mode() == Mode::ImplAbiFn)
+            (visibility, ctx.mode() == Mode::ImplAbiFn)
         };
 
         let function_decl = ty::TyFunctionDeclaration {
@@ -169,19 +169,19 @@ impl ty::TyFunctionDeclaration {
             purity,
         };
 
-        // Retrieve the implemented traits for the type of the return type and
-        // insert them in the broader namespace. We don't want to include any
-        // type parameters, so we filter them out.
-        let mut return_type_namespace = fn_ctx
-            .namespace
-            .implemented_traits
-            .filter_by_type(function_decl.return_type, fn_ctx.engines());
-        for type_param in function_decl.type_parameters.iter() {
-            return_type_namespace.filter_against_type(engines, type_param.type_id);
-        }
-        ctx.namespace
-            .implemented_traits
-            .extend(return_type_namespace, engines);
+        // // Retrieve the implemented traits for the type of the return type and
+        // // insert them in the broader namespace. We don't want to include any
+        // // type parameters, so we filter them out.
+        // let mut return_type_namespace = fn_ctx
+        //     .namespace
+        //     .implemented_traits
+        //     .filter_by_type(function_decl.return_type, fn_ctx.engines());
+        // for type_param in function_decl.type_parameters.iter() {
+        //     return_type_namespace.filter_against_type(engines, type_param.type_id);
+        // }
+        // ctx.namespace
+        //     .implemented_traits
+        //     .extend(return_type_namespace, engines);
 
         ok(function_decl, warnings, errors)
     }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
@@ -69,11 +69,8 @@ impl ty::TyTraitFn {
 
         // Retrieve the implemented traits for the type of the return type and
         // insert them in the broader namespace.
-        let trait_map = fn_ctx
-            .namespace
-            .implemented_traits
-            .filter_by_type(trait_fn.return_type, engines);
-        ctx.namespace.implemented_traits.extend(trait_map, engines);
+        ctx.namespace
+            .insert_trait_implementation_for_type(engines, trait_fn.return_type);
 
         ok(trait_fn, warnings, errors)
     }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -61,6 +61,14 @@ pub(crate) fn instantiate_function_application(
         errors
     );
 
+    // Retrieve the implemented traits for the type of the return type and
+    // insert them in the broader namespace.
+    let trait_map = ctx
+        .namespace
+        .implemented_traits
+        .filter_by_type(function_decl.return_type, engines);
+    ctx.namespace.implemented_traits.extend(trait_map, engines);
+
     // Handle the trait constraints. This includes checking to see if the trait
     // constraints are satisfied and replacing old decl ids based on the
     // constraint with new decl ids based on the new type.

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -63,11 +63,8 @@ pub(crate) fn instantiate_function_application(
 
     // Retrieve the implemented traits for the type of the return type and
     // insert them in the broader namespace.
-    let trait_map = ctx
-        .namespace
-        .implemented_traits
-        .filter_by_type(function_decl.return_type, engines);
-    ctx.namespace.implemented_traits.extend(trait_map, engines);
+    ctx.namespace
+        .insert_trait_implementation_for_type(engines, function_decl.return_type);
 
     // Handle the trait constraints. This includes checking to see if the trait
     // constraints are satisfied and replacing old decl ids based on the

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -350,6 +350,14 @@ pub(crate) fn type_check_method_application(
         .map(|(param, arg)| (param.name.clone(), arg))
         .collect::<Vec<(_, _)>>();
 
+    // Retrieve the implemented traits for the type of the return type and
+    // insert them in the broader namespace.
+    let trait_map = ctx
+        .namespace
+        .implemented_traits
+        .filter_by_type(method.return_type, engines);
+    ctx.namespace.implemented_traits.extend(trait_map, engines);
+
     let exp = ty::TyExpression {
         expression: ty::TyExpressionVariant::FunctionApplication {
             call_path,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -352,11 +352,8 @@ pub(crate) fn type_check_method_application(
 
     // Retrieve the implemented traits for the type of the return type and
     // insert them in the broader namespace.
-    let trait_map = ctx
-        .namespace
-        .implemented_traits
-        .filter_by_type(method.return_type, engines);
-    ctx.namespace.implemented_traits.extend(trait_map, engines);
+    ctx.namespace
+        .insert_trait_implementation_for_type(engines, method.return_type);
 
     let exp = ty::TyExpression {
         expression: ty::TyExpressionVariant::FunctionApplication {

--- a/sway-core/src/semantic_analysis/namespace/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace/namespace.rs
@@ -225,10 +225,6 @@ impl Namespace {
                 errors
             );
             if &method.name == method_name {
-                // // if we find the method that we are looking for, we also need
-                // // to retrieve the impl definitions for the return type so that
-                // // the user can string together method calls
-                // self.insert_trait_implementation_for_type(engines, method.return_type);
                 return ok(decl_id, warnings, errors);
             }
         }

--- a/sway-core/src/semantic_analysis/namespace/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace/namespace.rs
@@ -225,10 +225,10 @@ impl Namespace {
                 errors
             );
             if &method.name == method_name {
-                // if we find the method that we are looking for, we also need
-                // to retrieve the impl definitions for the return type so that
-                // the user can string together method calls
-                self.insert_trait_implementation_for_type(engines, method.return_type);
+                // // if we find the method that we are looking for, we also need
+                // // to retrieve the impl definitions for the return type so that
+                // // the user can string together method calls
+                // self.insert_trait_implementation_for_type(engines, method.return_type);
                 return ok(decl_id, warnings, errors);
             }
         }

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -807,7 +807,6 @@ fn are_equal_minus_dynamic_types(engines: Engines<'_>, left: TypeId, right: Type
                 trait_constraints: etc,
             },
         ) => rn.as_str() == en.as_str() && rtc.eq(&etc, engines),
-        // (TypeInfo::UnknownGeneric { .. }, TypeInfo::UnknownGeneric { .. }) => false,
         (TypeInfo::Placeholder(_), TypeInfo::Placeholder(_)) => false,
 
         // these cases may contain dynamic types

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -619,19 +619,6 @@ impl TraitMap {
         trait_map
     }
 
-    /// Filters the contents of `self` to exclude elements that are superset
-    /// types of the given `type_id`. This function is used when handling trait
-    /// constraints and is coupled with `filter_by_type` and
-    /// `filter_by_type_item_import`.
-    pub(crate) fn filter_against_type(&mut self, engines: Engines<'_>, type_id: TypeId) {
-        let type_engine = engines.te();
-        self.trait_impls.retain(|e| {
-            !type_engine
-                .get(type_id)
-                .is_subset_of(&type_engine.get(e.key.type_id), engines)
-        });
-    }
-
     /// Find the entries in `self` that are equivalent to `type_id`.
     ///
     /// Notes:

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -22,7 +22,6 @@ pub struct TypeEngine {
     pub(super) slab: ConcurrentSlab<TypeInfo>,
     storage_only_types: ConcurrentSlab<TypeInfo>,
     id_map: RwLock<HashMap<TypeInfo, TypeId>>,
-    unify_map: RwLock<HashMap<TypeId, Vec<TypeId>>>,
 }
 
 fn make_hasher<'a: 'b, 'b, K>(
@@ -58,40 +57,6 @@ impl TypeEngine {
                 let type_id = TypeId::new(self.slab.insert(ty.clone()));
                 v.insert_with_hasher(ty_hash, ty, type_id, make_hasher(&hash_builder, self));
                 type_id
-            }
-        }
-    }
-
-    pub(crate) fn insert_unified_type(&self, received: TypeId, expected: TypeId) {
-        let mut unify_map = self.unify_map.write().unwrap();
-        if let Some(type_ids) = unify_map.get(&received) {
-            if type_ids.contains(&expected) {
-                return;
-            }
-            let mut type_ids = type_ids.clone();
-            type_ids.push(expected);
-            unify_map.insert(received, type_ids);
-            return;
-        }
-
-        unify_map.insert(received, vec![expected]);
-    }
-
-    pub(crate) fn get_unified_types(&self, type_id: TypeId) -> Vec<TypeId> {
-        let mut final_unify_ids: Vec<TypeId> = vec![];
-        self.get_unified_types_rec(type_id, &mut final_unify_ids);
-        final_unify_ids
-    }
-
-    fn get_unified_types_rec(&self, type_id: TypeId, final_unify_ids: &mut Vec<TypeId>) {
-        let unify_map = self.unify_map.read().unwrap();
-        if let Some(unify_ids) = unify_map.get(&type_id) {
-            for unify_id in unify_ids {
-                if final_unify_ids.contains(unify_id) {
-                    continue;
-                }
-                final_unify_ids.push(*unify_id);
-                self.get_unified_types_rec(*unify_id, final_unify_ids);
             }
         }
     }

--- a/sway-core/src/type_system/unify.rs
+++ b/sway-core/src/type_system/unify.rs
@@ -225,17 +225,11 @@ impl<'a> Unifier<'a> {
                     name: en,
                     trait_constraints: etc,
                 },
-            ) if rn.as_str() == en.as_str() && rtc.eq(&etc, self.engines) => {
-                self.engines.te().insert_unified_type(received, expected);
-                self.engines.te().insert_unified_type(expected, received);
-                (vec![], vec![])
-            }
+            ) if rn.as_str() == en.as_str() && rtc.eq(&etc, self.engines) => (vec![], vec![]),
             (r @ UnknownGeneric { .. }, e) if !self.occurs_check(r.clone(), &e, span) => {
-                self.engines.te().insert_unified_type(expected, received);
                 self.replace_received_with_expected(received, expected, &r, e, span)
             }
             (r, e @ UnknownGeneric { .. }) if !self.occurs_check(e.clone(), &r, span) => {
-                self.engines.te().insert_unified_type(received, expected);
                 self.replace_expected_with_received(received, expected, r, &e, span)
             }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_type_inference/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_type_inference/src/main.sw
@@ -42,10 +42,15 @@ fn complex_vec_test() {
     assert(exp_vec_in_a_vec_in_a_struct_in_a_vec.get(0).unwrap().a.get(0).unwrap().get(2).unwrap() == 2);
 }
 
+fn simple_option_generics_test() {
+    assert(get_an_option::<u64>().is_none());
+}
+
 fn main() {
     sell_product();
     simple_vec_test();
     complex_vec_test();
+    simple_option_generics_test();
 }
 
 fn sell_product() -> MyResult<bool, CustomType> {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_type_inference/src/utils.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_type_inference/src/utils.sw
@@ -7,3 +7,7 @@ pub fn vec_from(vals: [u32; 3]) -> Vec<u32> {
     vec.push(vals[2]);
     vec
 }
+
+pub fn get_an_option<T>() -> Option<T> {
+    Option::None
+}


### PR DESCRIPTION
This PR fixes #3864 by changing the way that trait impls are re-exported to the greater namespace. Previously they we reexported somewhat at random, with one place being at function declaration sites. They _were not_ reexported at function call sites and method call sites. This PR changes this so to standardize the re-export locations to include function call sites and method call sites and to exclude function declaration sites.

This PR serves as an alternate fix to  #3324, as the bug with this issue involved re-exporting traits. Take this Sway example:

```rust
script;

use core::ops::*;

impl<T> Option<T> {
    pub fn ok_or<E>(self, err: E) -> Result<T, E> {
        match self {
            Option::Some(v) => Result::Ok(v),
            Option::None => Result::Err(err),
        }
    }
}

fn test_ok_or<T, E>(val: T, default: E) where T: Eq {
    match Option::Some(val).ok_or(default) {
        Result::Ok(inner) => assert(inner == val),
        Result::Err(_) => revert(0),
    }
}

fn main() {}
```

This PR better serves to re-export the trait constraint `T: Eq` to the usable namespace inside of the function body for `ok_or`. So, this PR also removes the `unify_map` abstraction which was added to the `TypeEngine` in #3348.

Closes #3864