### PR TITLE
Fix bug in "Advanced Calls" section in Sway book

### DIFF
--- a/docs/book/src/blockchain-development/calling_contracts.md
+++ b/docs/book/src/blockchain-development/calling_contracts.md
@@ -55,7 +55,7 @@ impl ContractB for Contract {
 
 All calls forward a gas stipend, and may additionally forward one native asset with the call.
 
-Here is an example of how to specify the amount of gas (`gas`), the asset ID of the native asset (`asset_id`), and the amount of the native asset (`amount`) to forward:
+Here is an example of how to specify the amount of gas (`gas`), the asset ID of the native asset (`asset_id`), and the amount of the native asset (`coins`) to forward:
 
 ```sway
 script;
@@ -68,7 +68,7 @@ fn main() {
     let x = abi(MyContract, 0x79fa8779bed2f36c3581d01c79df8da45eee09fac1fd76a5a656e16326317ef0);
     let asset_id = 0x7777_7777_7777_7777_7777_7777_7777_7777_7777_7777_7777_7777_7777_7777_7777_7777;
     x.foo {
-        gas: 5000, asset_id: asset_id, amount: 5000
+        gas: 5000, asset_id: asset_id, coins: 5000
     }
     (true, 3);
 }


### PR DESCRIPTION
Bug:
The example script in the [Advanced Calls](https://fuellabs.github.io/sway/v0.33.1/book/blockchain-development/calling_contracts.html#advanced-calls) section of the Sway Book uses `amount` to specify the asset amount to send with the function call.

Error:
`Unrecognized contract ABI method parameter "amount". The only available parameters are "gas", "coins", and "asset_id"`

Solution:
Replaced keyword `amount` with the expected keyword `coins`.

Fixes issue #3834