### PR TITLE
docs: update swayfmt contributing

### DIFF
--- a/swayfmt/CONTRIBUTING.md
+++ b/swayfmt/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Before you make changes, let's ensure that the test suite runs fine:
 cd swayfmt && cargo test
 ```
 
-`swayfmt` has an extensive test suite that should pass both locally and within the CI to ensure reliability. This is used 
+`swayfmt` has an extensive test suite that should pass both locally and within the CI to ensure reliability. This is used
 to ensure that there isn't regression introduced along with new changes. If your changes include fixing bugs or adding
 a new feature, please also include new tests accompanying your PR where possible. You may look at [formatter/mod.rs](https://github.com/FuelLabs/sway/blob/master/swayfmt/src/formatter/mod.rs)
 for examples on how you may test your changes.

--- a/swayfmt/CONTRIBUTING.md
+++ b/swayfmt/CONTRIBUTING.md
@@ -30,7 +30,21 @@ cargo build --path ~/sway/forc-plugins/forc-fmt/Cargo.toml && mv ~/sway/target/d
 
 ## Testing
 
-Be sure to have `forc` installed then move into a Sway project directory and execute the binary:
+You should test your changes both using the test suite as well as manually.
+
+Before you make changes, lets ensure that the test suite runs fine:
+
+```sh
+# from the root
+cd swayfmt && cargo test
+```
+
+`swayfmt` has an extensive test suite that should pass both locally and within the CI to ensure reliability. This is used 
+to ensure that there isn't regression introduced along with new changes. If your changes include fixing bugs or adding
+a new feature, please also include new tests accompanying your PR where possible. You may look at [formatter/mod.rs](https://github.com/FuelLabs/sway/blob/master/swayfmt/src/formatter/mod.rs)
+for examples on how you may test your changes.
+
+To manually test the formatter, Be sure to have `forc` installed then move into a Sway project directory and execute the binary:
 
 ```sh
 forc fmt

--- a/swayfmt/CONTRIBUTING.md
+++ b/swayfmt/CONTRIBUTING.md
@@ -32,7 +32,7 @@ cargo build --path ~/sway/forc-plugins/forc-fmt/Cargo.toml && mv ~/sway/target/d
 
 You should test your changes both using the test suite as well as manually.
 
-Before you make changes, lets ensure that the test suite runs fine:
+Before you make changes, let's ensure that the test suite runs fine:
 
 ```sh
 # from the root
@@ -44,7 +44,7 @@ to ensure that there isn't regression introduced along with new changes. If your
 a new feature, please also include new tests accompanying your PR where possible. You may look at [formatter/mod.rs](https://github.com/FuelLabs/sway/blob/master/swayfmt/src/formatter/mod.rs)
 for examples on how you may test your changes.
 
-To manually test the formatter, Be sure to have `forc` installed then move into a Sway project directory and execute the binary:
+To manually test the formatter, be sure to have `forc` installed then move into a Sway project directory and execute the binary:
 
 ```sh
 forc fmt


### PR DESCRIPTION
prompts the contributor within the `swayfmt` contributing guide to run the test suite as well as use the test suite as a guide on how to write tests.