### PR TITLE
Temporarily remove `assert_eq` from the standard library

### DIFF
--- a/sway-lib-std/src/assert.sw
+++ b/sway-lib-std/src/assert.sw
@@ -32,6 +32,8 @@ pub fn assert(condition: bool) {
     }
 }
 
+// NOTE: temporarily disabled until https://github.com/FuelLabs/sway/issues/3946 is fixed
+/*
 /// Asserts that the given values `v1` & `v2` will always be equal during runtime.
 ///
 /// ### Arguments
@@ -58,4 +60,4 @@ pub fn assert_eq<T>(v1: T, v2: T) where T: Eq {
         log(v2);
         revert(FAILED_ASSERT_EQ_SIGNAL);
     }
-}
+}*/

--- a/sway-lib-std/src/prelude.sw
+++ b/sway-lib-std/src/prelude.sw
@@ -13,7 +13,7 @@ use ::storage::StorageMap;
 use ::vec::Vec;
 
 // Error handling
-use ::assert::{assert, assert_eq};
+use ::assert::assert;
 use ::option::Option;
 use ::result::Result;
 use ::revert::{require, revert};

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_type_inference/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_type_inference/json_abi_oracle.json
@@ -12,36 +12,13 @@
       }
     }
   ],
-  "loggedTypes": [
-    {
-      "logId": 0,
-      "loggedType": {
-        "name": "",
-        "type": 1,
-        "typeArguments": null
-      }
-    },
-    {
-      "logId": 1,
-      "loggedType": {
-        "name": "",
-        "type": 1,
-        "typeArguments": null
-      }
-    }
-  ],
+  "loggedTypes": [],
   "messagesTypes": [],
   "types": [
     {
       "components": [],
       "type": "()",
       "typeId": 0,
-      "typeParameters": null
-    },
-    {
-      "components": null,
-      "type": "u64",
-      "typeId": 1,
       "typeParameters": null
     }
   ]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_type_inference/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_type_inference/src/main.sw
@@ -44,11 +44,12 @@ fn simple_option_generics_test() {
     assert(get_an_option::<u64>().is_none());
 }
 
-fn test_assert_eq_u64() {
+// Disabled until https://github.com/FuelLabs/sway/issues/3946 is resolved
+/*fn test_assert_eq_u64() {
     let a = 42;
     let b = 40 + 2;
     assert_eq(a, b);
-}
+}*/
 
 fn test_try_from() {
     let x = u64::try_from(7);
@@ -60,7 +61,7 @@ fn main() {
     simple_vec_test();
     complex_vec_test();
     simple_option_generics_test();
-    test_assert_eq_u64();
+    // test_assert_eq_u64();
     test_try_from();
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_eq/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_eq/test.toml
@@ -1,3 +1,3 @@
-category = "run"
+category = "disabled"
 expected_result = { action = "return", value = 1 }
 validate_abi = true


### PR DESCRIPTION
Basically until https://github.com/FuelLabs/sway/issues/3946 is resolved.