### PR TITLE
Collect tokens for dep and library names

### DIFF
--- a/sway-core/src/language/parsed/module.rs
+++ b/sway-core/src/language/parsed/module.rs
@@ -1,7 +1,7 @@
 use crate::language::DepName;
 
 use super::ParseTree;
-use sway_types::Ident;
+use sway_types::{Ident, Span};
 
 /// A module and its submodules in the form of a tree.
 #[derive(Debug, Clone)]
@@ -20,4 +20,5 @@ pub struct ParseSubmodule {
     /// The name of a submodule, parsed from the `library` declaration within the module itself.
     pub library_name: Ident,
     pub module: ParseModule,
+    pub dependency_path_span: Span,
 }

--- a/sway-core/src/language/ty/module.rs
+++ b/sway-core/src/language/ty/module.rs
@@ -1,4 +1,4 @@
-use sway_types::Ident;
+use sway_types::{Ident, Span};
 
 use crate::{
     decl_engine::{DeclEngine, DeclId},
@@ -18,6 +18,7 @@ pub struct TyModule {
 pub struct TySubmodule {
     pub library_name: Ident,
     pub module: TyModule,
+    pub dependency_path_span: Span,
 }
 
 /// Iterator type for iterating over submodules.

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -171,6 +171,7 @@ fn parse_submodules(
             let parse_submodule = parsed::ParseSubmodule {
                 library_name: library_name.clone(),
                 module: parse_module,
+                dependency_path_span: dep.path.span(),
             };
             let lexed_submodule = lexed::LexedSubmodule {
                 library_name,

--- a/sway-core/src/semantic_analysis/module.rs
+++ b/sway-core/src/semantic_analysis/module.rs
@@ -65,12 +65,14 @@ impl ty::TySubmodule {
         let ParseSubmodule {
             library_name,
             module,
+            dependency_path_span,
         } = submodule;
         parent_ctx.enter_submodule(dep_name, |submod_ctx| {
             let module_res = ty::TyModule::type_check(submod_ctx, module);
             module_res.map(|module| ty::TySubmodule {
                 library_name: library_name.clone(),
                 module,
+                dependency_path_span: dependency_path_span.clone(),
             })
         })
     }

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -181,12 +181,14 @@ impl Session {
 
                 // Next, populate our token_map with un-typed yet parsed ast nodes.
                 let parsed_tree = ParsedTree::new(type_engine, &self.token_map);
+                parsed_tree.collect_module_spans(&parsed);
                 self.parse_ast_to_tokens(&parsed, |an| parsed_tree.traverse_node(an));
 
                 // Finally, create runnables and populate our token_map with typed ast nodes.
                 self.create_runnables(typed_program);
 
                 let typed_tree = TypedTree::new(engines, &self.token_map);
+                typed_tree.collect_module_spans(typed_program);
                 self.parse_ast_to_typed_tokens(typed_program, |node, namespace| {
                     typed_tree.traverse_node(node, namespace)
                 });

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -4,7 +4,7 @@ use sway_core::{
         parsed::{
             Declaration, EnumVariant, Expression, FunctionDeclaration, FunctionParameter,
             ReassignmentExpression, Scrutinee, StorageField, StructExpressionField, StructField,
-            Supertrait, TraitFn,
+            Supertrait, TraitFn, TreeType,
         },
         ty,
     },
@@ -35,6 +35,8 @@ pub enum AstToken {
     Keyword(Ident),
     Intrinsic(Intrinsic),
     Attribute(Attribute),
+    TreeType(TreeType),
+    IncludeStatement,
 }
 
 /// The `TypedAstToken` holds the types produced by the [sway_core::language::ty::TyProgram].
@@ -53,6 +55,9 @@ pub enum TypedAstToken {
     TypedReassignment(ty::TyReassignment),
     TypedArgument(TypeArgument),
     TypedParameter(TypeParameter),
+    TypedProgramKind(ty::TyProgramKind),
+    TypedLibraryName(Ident),
+    TypedIncludeStatement,
 }
 
 /// These variants are used to represent the semantic type of the [Token].

--- a/sway-lsp/test/fixtures/tokens/modules/.gitignore
+++ b/sway-lsp/test/fixtures/tokens/modules/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/sway-lsp/test/fixtures/tokens/modules/Forc.lock
+++ b/sway-lsp/test/fixtures/tokens/modules/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-70DB58A2053CC06C'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-70DB58A2053CC06C'
+dependencies = ['core']
+
+[[package]]
+name = 'modules'
+source = 'member'
+dependencies = ['std']

--- a/sway-lsp/test/fixtures/tokens/modules/Forc.toml
+++ b/sway-lsp/test/fixtures/tokens/modules/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "lib.sw"
+license = "Apache-2.0"
+name = "turbofish"
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/test/fixtures/tokens/modules/src/dir_mod/mod.sw
+++ b/sway-lsp/test/fixtures/tokens/modules/src/dir_mod/mod.sw
@@ -1,0 +1,1 @@
+library dir_mod;

--- a/sway-lsp/test/fixtures/tokens/modules/src/lib.sw
+++ b/sway-lsp/test/fixtures/tokens/modules/src/lib.sw
@@ -1,0 +1,4 @@
+library modules;
+
+dep test_mod;
+dep dir_mod/mod;

--- a/sway-lsp/test/fixtures/tokens/modules/src/test_mod.sw
+++ b/sway-lsp/test/fixtures/tokens/modules/src/test_mod.sw
@@ -1,0 +1,1 @@
+library test_mod;


### PR DESCRIPTION
## Description

Add proper tokens for library type identifiers and `dep` imports that point to the correct library module declaration.

Fix #3718
Fix #3716

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
