### PR TITLE
Add tokens for import statements

### DIFF
--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -164,7 +164,7 @@ fn connect_node<'eng: 'cfg, 'cfg>(
             }
             Ok(NodeConnection::NextStep(vec![entry]))
         }
-        ty::TyAstNodeContent::SideEffect => Ok(NodeConnection::NextStep(leaves.to_vec())),
+        ty::TyAstNodeContent::SideEffect(_) => Ok(NodeConnection::NextStep(leaves.to_vec())),
         ty::TyAstNodeContent::Declaration(decl) => Ok(NodeConnection::NextStep(
             connect_declaration(engines, node, decl, graph, span, leaves)?,
         )),

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -323,7 +323,7 @@ fn connect_node<'eng: 'cfg, 'cfg>(
                 exit_node,
             )
         }
-        ty::TyAstNodeContent::SideEffect => (leaves.to_vec(), exit_node),
+        ty::TyAstNodeContent::SideEffect(_) => (leaves.to_vec(), exit_node),
         ty::TyAstNodeContent::Declaration(decl) => {
             // all leaves connect to this node, then this node is the singular leaf
             let cfg_node: ControlFlowGraphNode = node.into();
@@ -1748,7 +1748,7 @@ fn construct_dead_code_warning_from_node(
             content:
                 ty::TyAstNodeContent::ImplicitReturnExpression(_)
                 | ty::TyAstNodeContent::Expression(_)
-                | ty::TyAstNodeContent::SideEffect,
+                | ty::TyAstNodeContent::SideEffect(_),
         } => CompileWarning {
             span: span.clone(),
             warning_content: Warning::UnreachableCode,

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -458,6 +458,6 @@ fn const_eval_typed_ast_node(
         ty::TyAstNodeContent::Expression(e) | ty::TyAstNodeContent::ImplicitReturnExpression(e) => {
             const_eval_typed_expr(lookup, known_consts, e)
         }
-        ty::TyAstNodeContent::SideEffect => Ok(None),
+        ty::TyAstNodeContent::SideEffect(_) => Ok(None),
     }
 }

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -214,7 +214,7 @@ impl<'eng> FnCompiler<'eng> {
             }
             // a side effect can be () because it just impacts the type system/namespacing.
             // There should be no new IR generated.
-            ty::TyAstNodeContent::SideEffect => Ok(None),
+            ty::TyAstNodeContent::SideEffect(_) => Ok(None),
         }
     }
 

--- a/sway-core/src/language/parsed/use_statement.rs
+++ b/sway-core/src/language/parsed/use_statement.rs
@@ -1,19 +1,20 @@
+use crate::parsed::Span;
 use sway_types::ident::Ident;
 
 #[derive(Debug, Clone)]
 pub enum ImportType {
     Star,
-    SelfImport,
+    SelfImport(Span),
     Item(Ident),
 }
 
 /// A [UseStatement] is a statement that imports something from a module into the local namespace.
 #[derive(Debug, Clone)]
 pub struct UseStatement {
-    pub(crate) call_path: Vec<Ident>,
-    pub(crate) import_type: ImportType,
+    pub call_path: Vec<Ident>,
+    pub import_type: ImportType,
     // If `is_absolute` is true, then this use statement is an absolute path from
     // the project root namespace. If not, then it is relative to the current namespace.
-    pub(crate) is_absolute: bool,
-    pub(crate) alias: Option<Ident>,
+    pub is_absolute: bool,
+    pub alias: Option<Ident>,
 }

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -31,7 +31,7 @@ impl DisplayWithEngines for TyAstNode {
             Declaration(typed_decl) => DisplayWithEngines::fmt(typed_decl, f, engines),
             Expression(exp) => DisplayWithEngines::fmt(exp, f, engines),
             ImplicitReturnExpression(exp) => write!(f, "return {}", engines.help_out(exp)),
-            SideEffect => f.write_str(""),
+            SideEffect(_) => f.write_str(""),
         }
     }
 }
@@ -44,7 +44,7 @@ impl SubstTypes for TyAstNode {
             }
             TyAstNodeContent::Declaration(ref mut decl) => decl.subst(type_mapping, engines),
             TyAstNodeContent::Expression(ref mut expr) => expr.subst(type_mapping, engines),
-            TyAstNodeContent::SideEffect => (),
+            TyAstNodeContent::SideEffect(_) => (),
         }
     }
 }
@@ -61,7 +61,7 @@ impl ReplaceSelfType for TyAstNode {
             TyAstNodeContent::Expression(ref mut expr) => {
                 expr.replace_self_type(engines, self_type)
             }
-            TyAstNodeContent::SideEffect => (),
+            TyAstNodeContent::SideEffect(_) => (),
         }
     }
 }
@@ -74,7 +74,7 @@ impl ReplaceDecls for TyAstNode {
             }
             TyAstNodeContent::Declaration(_) => {}
             TyAstNodeContent::Expression(ref mut expr) => expr.replace_decls(decl_mapping, engines),
-            TyAstNodeContent::SideEffect => (),
+            TyAstNodeContent::SideEffect(_) => (),
         }
     }
 }
@@ -96,7 +96,7 @@ impl DeterministicallyAborts for TyAstNode {
             Expression(exp) | ImplicitReturnExpression(exp) => {
                 exp.deterministically_aborts(decl_engine, check_call_body)
             }
-            SideEffect => false,
+            SideEffect(_) => false,
         }
     }
 }
@@ -120,7 +120,7 @@ impl TyAstNode {
                 decl.body.gather_return_statements()
             }
             TyAstNodeContent::Expression(exp) => exp.gather_return_statements(),
-            TyAstNodeContent::SideEffect | TyAstNodeContent::Declaration(_) => vec![],
+            TyAstNodeContent::SideEffect(_) | TyAstNodeContent::Declaration(_) => vec![],
         }
     }
 
@@ -139,7 +139,7 @@ impl TyAstNode {
                 visibility.is_public()
             }
             TyAstNodeContent::Expression(_)
-            | TyAstNodeContent::SideEffect
+            | TyAstNodeContent::SideEffect(_)
             | TyAstNodeContent::ImplicitReturnExpression(_) => false,
         };
         ok(public, warnings, errors)
@@ -205,7 +205,7 @@ impl TyAstNode {
             TyAstNodeContent::ImplicitReturnExpression(TyExpression { return_type, .. }) => {
                 type_engine.get(*return_type)
             }
-            TyAstNodeContent::SideEffect => TypeInfo::Tuple(Vec::new()),
+            TyAstNodeContent::SideEffect(_) => TypeInfo::Tuple(Vec::new()),
         }
     }
 }
@@ -216,7 +216,7 @@ pub enum TyAstNodeContent {
     Expression(TyExpression),
     ImplicitReturnExpression(TyExpression),
     // a no-op node used for something that just issues a side effect, like an import statement.
-    SideEffect,
+    SideEffect(TySideEffect),
 }
 
 impl EqWithEngines for TyAstNodeContent {}
@@ -228,7 +228,7 @@ impl PartialEqWithEngines for TyAstNodeContent {
             (Self::ImplicitReturnExpression(x), Self::ImplicitReturnExpression(y)) => {
                 x.eq(y, engines)
             }
-            (Self::SideEffect, Self::SideEffect) => true,
+            (Self::SideEffect(_), Self::SideEffect(_)) => true,
             _ => false,
         }
     }
@@ -244,7 +244,7 @@ impl CollectTypesMetadata for TyAstNodeContent {
             Declaration(decl) => decl.collect_types_metadata(ctx),
             Expression(expr) => expr.collect_types_metadata(ctx),
             ImplicitReturnExpression(expr) => expr.collect_types_metadata(ctx),
-            SideEffect => ok(vec![], vec![], vec![]),
+            SideEffect(_) => ok(vec![], vec![], vec![]),
         }
     }
 }
@@ -255,7 +255,7 @@ impl GetDeclIdent for TyAstNodeContent {
             TyAstNodeContent::Declaration(decl) => decl.get_decl_ident(decl_engine),
             TyAstNodeContent::Expression(_expr) => None, //expr.get_decl_ident(),
             TyAstNodeContent::ImplicitReturnExpression(_expr) => None, //expr.get_decl_ident(),
-            TyAstNodeContent::SideEffect => None,
+            TyAstNodeContent::SideEffect(_) => None,
         }
     }
 }

--- a/sway-core/src/language/ty/mod.rs
+++ b/sway-core/src/language/ty/mod.rs
@@ -4,6 +4,7 @@ mod declaration;
 mod expression;
 mod module;
 mod program;
+mod side_effect;
 mod variable_mutability;
 
 pub use ast_node::*;
@@ -12,4 +13,5 @@ pub use declaration::*;
 pub use expression::*;
 pub use module::*;
 pub use program::*;
+pub use side_effect::*;
 pub use variable_mutability::*;

--- a/sway-core/src/language/ty/side_effect/mod.rs
+++ b/sway-core/src/language/ty/side_effect/mod.rs
@@ -1,0 +1,6 @@
+#[allow(clippy::module_inception)]
+mod side_effect;
+mod use_statement;
+
+pub use side_effect::*;
+pub use use_statement::*;

--- a/sway-core/src/language/ty/side_effect/side_effect.rs
+++ b/sway-core/src/language/ty/side_effect/side_effect.rs
@@ -1,0 +1,12 @@
+use super::TyUseStatement;
+
+#[derive(Clone, Debug)]
+pub struct TySideEffect {
+    pub side_effect: TySideEffectVariant,
+}
+
+#[derive(Clone, Debug)]
+pub enum TySideEffectVariant {
+    IncludeStatement,
+    UseStatement(TyUseStatement),
+}

--- a/sway-core/src/language/ty/side_effect/use_statement.rs
+++ b/sway-core/src/language/ty/side_effect/use_statement.rs
@@ -1,0 +1,12 @@
+use crate::language::parsed;
+use sway_types::ident::Ident;
+
+#[derive(Clone, Debug)]
+pub struct TyUseStatement {
+    pub call_path: Vec<Ident>,
+    pub import_type: parsed::ImportType,
+    // If `is_absolute` is true, then this use statement is an absolute path from
+    // the project root namespace. If not, then it is relative to the current namespace.
+    pub is_absolute: bool,
+    pub alias: Option<Ident>,
+}

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -250,7 +250,7 @@ impl ty::TyImplTrait {
                 ty::TyAstNodeContent::Declaration(decl) => {
                     decl_contains_get_storage_index(decl_engine, decl, access_span)
                 }
-                ty::TyAstNodeContent::SideEffect => Ok(false),
+                ty::TyAstNodeContent::SideEffect(_) => Ok(false),
             }
         }
 

--- a/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
+++ b/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
@@ -183,7 +183,7 @@ fn analyze_code_block_entry(
         | ty::TyAstNodeContent::ImplicitReturnExpression(expr) => {
             analyze_expression(engines, expr, block_name, warnings)
         }
-        ty::TyAstNodeContent::SideEffect => HashSet::new(),
+        ty::TyAstNodeContent::SideEffect(_) => HashSet::new(),
     }
 }
 
@@ -488,7 +488,7 @@ fn effects_of_codeblock_entry(engines: Engines<'_>, ast_node: &ty::TyAstNode) ->
         | ty::TyAstNodeContent::ImplicitReturnExpression(expr) => {
             effects_of_expression(engines, expr)
         }
-        ty::TyAstNodeContent::SideEffect => HashSet::new(),
+        ty::TyAstNodeContent::SideEffect(_) => HashSet::new(),
     }
 }
 

--- a/sway-core/src/semantic_analysis/storage_only_types.rs
+++ b/sway-core/src/semantic_analysis/storage_only_types.rs
@@ -11,7 +11,7 @@ fn ast_node_validate(engines: Engines<'_>, x: &ty::TyAstNodeContent) -> CompileR
         ty::TyAstNodeContent::Expression(expr)
         | ty::TyAstNodeContent::ImplicitReturnExpression(expr) => expr_validate(engines, expr),
         ty::TyAstNodeContent::Declaration(decl) => decl_validate(engines, decl),
-        ty::TyAstNodeContent::SideEffect => ok((), warnings, errors),
+        ty::TyAstNodeContent::SideEffect(_) => ok((), warnings, errors),
     }
 }
 

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -251,7 +251,7 @@ fn use_tree_to_use_statements(
         }
         UseTree::Name { name } => {
             let import_type = if name.as_str() == "self" {
-                ImportType::SelfImport
+                ImportType::SelfImport(name.span())
             } else {
                 ImportType::Item(name)
             };
@@ -264,7 +264,7 @@ fn use_tree_to_use_statements(
         }
         UseTree::Rename { name, alias, .. } => {
             let import_type = if name.as_str() == "self" {
-                ImportType::SelfImport
+                ImportType::SelfImport(name.span())
             } else {
                 ImportType::Item(name)
             };

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -4,7 +4,7 @@ use sway_core::{
         parsed::{
             Declaration, EnumVariant, Expression, FunctionDeclaration, FunctionParameter,
             ReassignmentExpression, Scrutinee, StorageField, StructExpressionField, StructField,
-            Supertrait, TraitFn, TreeType,
+            Supertrait, TraitFn, TreeType, UseStatement,
         },
         ty,
     },
@@ -37,6 +37,7 @@ pub enum AstToken {
     Attribute(Attribute),
     TreeType(TreeType),
     IncludeStatement,
+    UseStatement(UseStatement),
 }
 
 /// The `TypedAstToken` holds the types produced by the [sway_core::language::ty::TyProgram].
@@ -58,6 +59,7 @@ pub enum TypedAstToken {
     TypedProgramKind(ty::TyProgramKind),
     TypedLibraryName(Ident),
     TypedIncludeStatement,
+    TypedUseStatement(ty::TyUseStatement),
 }
 
 /// These variants are used to represent the semantic type of the [Token].

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -1372,7 +1372,7 @@ mod tests {
 
         let mut go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 8,
+            req_line: 10,
             req_char: 13,
             def_line: 0,
             def_start_char: 8,
@@ -1381,13 +1381,14 @@ mod tests {
         };
         // std
         let _ = definition_check(&mut service, &go_to, 1).await;
-        definition_check_with_req_offset(&mut service, &mut go_to, 10, 14, 2).await;
-        definition_check_with_req_offset(&mut service, &mut go_to, 16, 5, 3).await;
-        definition_check_with_req_offset(&mut service, &mut go_to, 22, 13, 4).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 12, 14, 2).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 18, 5, 3).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 24, 13, 4).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 7, 5, 5).await;
 
         let go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 8,
+            req_line: 10,
             req_char: 19,
             def_line: 74,
             def_start_char: 8,
@@ -1395,11 +1396,11 @@ mod tests {
             def_path: "sway-lib-std/src/option.sw",
         };
         // option
-        let _ = definition_check(&mut service, &go_to, 5).await;
+        let _ = definition_check(&mut service, &go_to, 6).await;
 
         let mut go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 8,
+            req_line: 10,
             req_char: 27,
             def_line: 80,
             def_start_char: 9,
@@ -1407,12 +1408,12 @@ mod tests {
             def_path: "sway-lib-std/src/option.sw",
         };
         // Option
-        let _ = definition_check(&mut service, &go_to, 6).await;
-        definition_check_with_req_offset(&mut service, &mut go_to, 9, 14, 7).await;
+        let _ = definition_check(&mut service, &go_to, 7).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 11, 14, 8).await;
 
         let go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 10,
+            req_line: 12,
             req_char: 17,
             def_line: 0,
             def_start_char: 8,
@@ -1420,11 +1421,11 @@ mod tests {
             def_path: "sway-lib-std/src/vm/mod.sw",
         };
         // vm
-        let _ = definition_check(&mut service, &go_to, 8).await;
+        let _ = definition_check(&mut service, &go_to, 9).await;
 
         let go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 10,
+            req_line: 12,
             req_char: 22,
             def_line: 0,
             def_start_char: 8,
@@ -1432,11 +1433,11 @@ mod tests {
             def_path: "sway-lib-std/src/vm/evm/mod.sw",
         };
         // evm
-        let _ = definition_check(&mut service, &go_to, 9).await;
+        let _ = definition_check(&mut service, &go_to, 10).await;
 
         let go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 10,
+            req_line: 12,
             req_char: 27,
             def_line: 1,
             def_start_char: 8,
@@ -1444,11 +1445,11 @@ mod tests {
             def_path: "sway-lib-std/src/vm/evm/evm_address.sw",
         };
         // evm_address
-        let _ = definition_check(&mut service, &go_to, 10).await;
+        let _ = definition_check(&mut service, &go_to, 11).await;
 
         let go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 10,
+            req_line: 12,
             req_char: 42,
             def_line: 7,
             def_start_char: 11,
@@ -1456,11 +1457,11 @@ mod tests {
             def_path: "sway-lib-std/src/vm/evm/evm_address.sw",
         };
         // EvmAddress
-        let _ = definition_check(&mut service, &go_to, 11).await;
+        let _ = definition_check(&mut service, &go_to, 12).await;
 
         let mut go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 14,
+            req_line: 16,
             req_char: 6,
             def_line: 0,
             def_start_char: 8,
@@ -1468,12 +1469,13 @@ mod tests {
             def_path: "sway-lsp/test/fixtures/tokens/paths/src/test_mod.sw",
         };
         // test_mod
-        let _ = definition_check(&mut service, &go_to, 12).await;
-        definition_check_with_req_offset(&mut service, &mut go_to, 20, 7, 13).await;
+        let _ = definition_check(&mut service, &go_to, 13).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 22, 7, 14).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 5, 5, 15).await;
 
         let go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 14,
+            req_line: 16,
             req_char: 16,
             def_line: 2,
             def_start_char: 7,
@@ -1481,11 +1483,11 @@ mod tests {
             def_path: "sway-lsp/test/fixtures/tokens/paths/src/test_mod.sw",
         };
         // test_fun
-        let _ = definition_check(&mut service, &go_to, 14).await;
+        let _ = definition_check(&mut service, &go_to, 16).await;
 
-        let go_to = GotoDefintion {
+        let mut go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 15,
+            req_line: 17,
             req_char: 8,
             def_line: 0,
             def_start_char: 8,
@@ -1493,11 +1495,12 @@ mod tests {
             def_path: "sway-lsp/test/fixtures/tokens/paths/src/deep_mod.sw",
         };
         // deep_mod
-        let _ = definition_check(&mut service, &go_to, 15).await;
+        let _ = definition_check(&mut service, &go_to, 17).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 6, 6, 18).await;
 
-        let go_to = GotoDefintion {
+        let mut go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 15,
+            req_line: 17,
             req_char: 18,
             def_line: 0,
             def_start_char: 8,
@@ -1505,11 +1508,12 @@ mod tests {
             def_path: "sway-lsp/test/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
         };
         // deeper_mod
-        let _ = definition_check(&mut service, &go_to, 16).await;
+        let _ = definition_check(&mut service, &go_to, 19).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 6, 16, 20).await;
 
-        let go_to = GotoDefintion {
+        let mut go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 15,
+            req_line: 17,
             req_char: 29,
             def_line: 2,
             def_start_char: 7,
@@ -1517,11 +1521,12 @@ mod tests {
             def_path: "sway-lsp/test/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
         };
         // deep_fun
-        let _ = definition_check(&mut service, &go_to, 17).await;
+        let _ = definition_check(&mut service, &go_to, 21).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 6, 28, 22).await;
 
         let go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 16,
+            req_line: 18,
             req_char: 11,
             def_line: 0,
             def_start_char: 8,
@@ -1529,11 +1534,11 @@ mod tests {
             def_path: "sway-lib-std/src/assert.sw",
         };
         // assert
-        let _ = definition_check(&mut service, &go_to, 18).await;
+        let _ = definition_check(&mut service, &go_to, 23).await;
 
         let go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 17,
+            req_line: 19,
             req_char: 13,
             def_line: 0,
             def_start_char: 8,
@@ -1541,11 +1546,11 @@ mod tests {
             def_path: "sway-lib-core/src/lib.sw",
         };
         // core
-        let _ = definition_check(&mut service, &go_to, 19).await;
+        let _ = definition_check(&mut service, &go_to, 24).await;
 
         let mut go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 17,
+            req_line: 19,
             req_char: 21,
             def_line: 0,
             def_start_char: 8,
@@ -1553,25 +1558,37 @@ mod tests {
             def_path: "sway-lib-core/src/primitives.sw",
         };
         // primitives
-        let _ = definition_check(&mut service, &go_to, 20).await;
-        definition_check_with_req_offset(&mut service, &mut go_to, 23, 20, 21).await;
+        let _ = definition_check(&mut service, &go_to, 25).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 25, 20, 26).await;
+
+        let go_to = GotoDefintion {
+            req_uri: &uri,
+            req_line: 5,
+            req_char: 14,
+            def_line: 4,
+            def_start_char: 11,
+            def_end_char: 12,
+            def_path: "sway-lsp/test/fixtures/tokens/paths/src/test_mod.sw",
+        };
+        // A def
+        let _ = definition_check(&mut service, &go_to, 27).await;
 
         let mut go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 19,
+            req_line: 21,
             req_char: 4,
             def_line: 6,
             def_start_char: 5,
             def_end_char: 6,
             def_path: "sway-lsp/test/fixtures/tokens/paths/src/test_mod.sw",
         };
-        // A
-        let _ = definition_check(&mut service, &go_to, 22).await;
-        definition_check_with_req_offset(&mut service, &mut go_to, 20, 14, 23).await;
+        // A impl
+        let _ = definition_check(&mut service, &go_to, 28).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 22, 14, 29).await;
 
         let mut go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 19,
+            req_line: 21,
             req_char: 7,
             def_line: 7,
             def_start_char: 11,
@@ -1579,12 +1596,12 @@ mod tests {
             def_path: "sway-lsp/test/fixtures/tokens/paths/src/test_mod.sw",
         };
         // fun
-        let _ = definition_check(&mut service, &go_to, 24).await;
-        definition_check_with_req_offset(&mut service, &mut go_to, 20, 18, 25).await;
+        let _ = definition_check(&mut service, &go_to, 30).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 22, 18, 31).await;
 
-        let go_to = GotoDefintion {
+        let mut go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 22,
+            req_line: 24,
             req_char: 20,
             def_line: 0,
             def_start_char: 8,
@@ -1592,11 +1609,13 @@ mod tests {
             def_path: "sway-lib-std/src/constants.sw",
         };
         // constants
-        let _ = definition_check(&mut service, &go_to, 26).await;
+        let _ = definition_check(&mut service, &go_to, 32).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 7, 11, 33).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 7, 23, 34).await;
 
-        let go_to = GotoDefintion {
+        let mut go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 22,
+            req_line: 24,
             req_char: 31,
             def_line: 5,
             def_start_char: 10,
@@ -1604,11 +1623,12 @@ mod tests {
             def_path: "sway-lib-std/src/constants.sw",
         };
         // ZERO_B256
-        let _ = definition_check(&mut service, &go_to, 27).await;
+        let _ = definition_check(&mut service, &go_to, 35).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 7, 31, 36).await;
 
         let go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 17,
+            req_line: 19,
             req_char: 31,
             def_line: 2,
             def_start_char: 5,
@@ -1616,11 +1636,11 @@ mod tests {
             def_path: "sway-lib-core/src/primitives.sw",
         };
         // u64
-        let _ = definition_check(&mut service, &go_to, 28).await;
+        let _ = definition_check(&mut service, &go_to, 37).await;
 
         let mut go_to = GotoDefintion {
             req_uri: &uri,
-            req_line: 11,
+            req_line: 13,
             req_char: 17,
             def_line: 74,
             def_start_char: 5,
@@ -1628,8 +1648,20 @@ mod tests {
             def_path: "sway-lib-core/src/primitives.sw",
         };
         // b256
-        let _ = definition_check(&mut service, &go_to, 29).await;
-        definition_check_with_req_offset(&mut service, &mut go_to, 23, 31, 30).await;
+        let _ = definition_check(&mut service, &go_to, 38).await;
+        definition_check_with_req_offset(&mut service, &mut go_to, 25, 31, 39).await;
+
+        let go_to = GotoDefintion {
+            req_uri: &uri,
+            req_line: 6,
+            req_char: 39,
+            def_line: 6,
+            def_start_char: 38,
+            def_end_char: 42,
+            def_path: "sway-lsp/test/fixtures/tokens/paths/src/main.sw",
+        };
+        // dfun
+        let _ = definition_check(&mut service, &go_to, 40).await;
 
         shutdown_and_exit(&mut service).await;
     }

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -10,7 +10,7 @@ use dashmap::mapref::one::RefMut;
 use sway_core::{
     decl_engine::DeclId,
     language::{
-        parsed::Supertrait,
+        parsed::{ImportType, Supertrait},
         ty::{self, GetDeclIdent, TyEnumVariant, TyModule, TyProgram, TyProgramKind, TySubmodule},
         CallPath,
     },
@@ -39,7 +39,9 @@ impl<'a> TypedTree<'a> {
             | ty::TyAstNodeContent::ImplicitReturnExpression(expression) => {
                 self.handle_expression(expression, namespace)
             }
-            ty::TyAstNodeContent::SideEffect => (),
+            ty::TyAstNodeContent::SideEffect(side_effect) => {
+                self.handle_side_effect(side_effect, namespace)
+            }
         };
     }
 
@@ -351,6 +353,84 @@ impl<'a> TypedTree<'a> {
                     }
                 }
             }
+        }
+    }
+
+    fn handle_side_effect(&self, side_effect: &ty::TySideEffect, namespace: &namespace::Module) {
+        use ty::TySideEffectVariant::*;
+        match &side_effect.side_effect {
+            UseStatement(
+                use_statement @ ty::TyUseStatement {
+                    call_path,
+                    import_type,
+                    alias,
+                    is_absolute: _,
+                },
+            ) => {
+                if let Some(alias) = alias {
+                    if let Some(mut token) =
+                        self.tokens.try_get_mut(&to_ident_key(alias)).try_unwrap()
+                    {
+                        token.typed = Some(TypedAstToken::TypedUseStatement(use_statement.clone()));
+                        token.type_def = Some(TypeDefinition::Ident(alias.clone()));
+                    }
+                }
+
+                for (mod_path, ident) in iter_prefixes(call_path).zip(call_path) {
+                    if let Some(mut token) =
+                        self.tokens.try_get_mut(&to_ident_key(ident)).try_unwrap()
+                    {
+                        token.typed = Some(TypedAstToken::TypedUseStatement(use_statement.clone()));
+
+                        if let Some(name) = namespace
+                            .submodule(mod_path)
+                            .and_then(|tgt_submod| tgt_submod.name.clone())
+                        {
+                            token.type_def = Some(TypeDefinition::Ident(name));
+                        }
+                    }
+                }
+
+                match &import_type {
+                    ImportType::Item(item) => {
+                        if let Some(mut token) =
+                            self.tokens.try_get_mut(&to_ident_key(item)).try_unwrap()
+                        {
+                            token.typed =
+                                Some(TypedAstToken::TypedUseStatement(use_statement.clone()));
+
+                            let decl_engine = self.engines.de();
+
+                            if let Some(decl_ident) = namespace
+                                .submodule(call_path)
+                                .and_then(|module| module.symbols().get(item))
+                                .and_then(|decl| decl.get_decl_ident(decl_engine))
+                            {
+                                token.type_def = Some(TypeDefinition::Ident(decl_ident));
+                            }
+                        }
+                    }
+                    ImportType::SelfImport(span) => {
+                        if let Some(mut token) = self
+                            .tokens
+                            .try_get_mut(&to_ident_key(&Ident::new(span.clone())))
+                            .try_unwrap()
+                        {
+                            token.typed =
+                                Some(TypedAstToken::TypedUseStatement(use_statement.clone()));
+
+                            if let Some(name) = namespace
+                                .submodule(call_path)
+                                .and_then(|tgt_submod| tgt_submod.name.clone())
+                            {
+                                token.type_def = Some(TypeDefinition::Ident(name));
+                            }
+                        }
+                    }
+                    ImportType::Star => {}
+                }
+            }
+            IncludeStatement => {}
         }
     }
 
@@ -753,10 +833,6 @@ impl<'a> TypedTree<'a> {
             .and_then(|function_decl| function_decl.implementing_type)
             .and_then(|impl_type| impl_type.get_decl_ident(decl_engine));
 
-        pub fn iter_prefixes<T>(slice: &[T]) -> impl Iterator<Item = &[T]> + DoubleEndedIterator {
-            (1..=slice.len()).map(move |len| &slice[..len])
-        }
-
         let prefixes = if let Some(impl_type_name) = implementing_type_name {
             // the last prefix of the call path is not a module but a type
             if let Some((last, prefixes)) = call_path.prefixes.split_last() {
@@ -1084,4 +1160,8 @@ fn assign_type_to_token(
     token.kind = symbol_kind;
     token.typed = Some(typed_token);
     token.type_def = Some(TypeDefinition::TypeId(type_id));
+}
+
+fn iter_prefixes<T>(slice: &[T]) -> impl Iterator<Item = &[T]> + DoubleEndedIterator {
+    (1..=slice.len()).map(move |len| &slice[..len])
 }

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -117,7 +117,7 @@ pub(crate) fn print_decl_engine_types(
             | ty::TyAstNodeContent::ImplicitReturnExpression(expression) => {
                 format!("{expression:#?}")
             }
-            ty::TyAstNodeContent::SideEffect => "".to_string(),
+            ty::TyAstNodeContent::SideEffect(side_effect) => format!("{side_effect:#?}"),
         })
         .map(|s| format!("{s}\n"))
         .collect()

--- a/sway-lsp/test/fixtures/tokens/paths/src/main.sw
+++ b/sway-lsp/test/fixtures/tokens/paths/src/main.sw
@@ -4,6 +4,8 @@ dep test_mod;
 dep deep_mod;
 
 use test_mod::A;
+use deep_mod::deeper_mod::deep_fun as dfun;
+use std::constants::{self, ZERO_B256};
 
 pub fn fun() {
     let _ = std::option::Option::None;


### PR DESCRIPTION
## Description

Add tokens and definitions for use statements' full call paths and imported items including `self`.

Fix #3713
Fix #3719

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
