### PR TITLE
Suppress dead code warnings for blocks with errors

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -1735,6 +1735,11 @@ fn construct_dead_code_warning_from_node(
             content: ty::TyAstNodeContent::Declaration(ty::TyDeclaration::StorageDeclaration { .. }),
             ..
         } => return None,
+        // If there is already an error for the declaration, we don't need to emit a dead code warning.
+        ty::TyAstNode {
+            content: ty::TyAstNodeContent::Declaration(ty::TyDeclaration::ErrorRecovery(..)),
+            ..
+        } => return None,
         ty::TyAstNode {
             content: ty::TyAstNodeContent::Declaration(..),
             span,


### PR DESCRIPTION
## Description

Closes https://github.com/FuelLabs/sway/issues/4000 and https://github.com/FuelLabs/sway/issues/3803

Before:

<img width="461" alt="image" src="https://user-images.githubusercontent.com/47993817/217112557-ff19f56c-a708-4542-9156-b703a7df44c3.png">


After: 

<img width="467" alt="image" src="https://user-images.githubusercontent.com/47993817/217112380-894cee1a-2980-439f-b2c1-d9eea1aa5f2c.png">


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
