### PR TITLE
Remove unused configurables from the JSON ABI

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2571,8 +2571,13 @@ pub fn compile(
             print_on_success(terse_mode, &pkg.name, &bc_res.warnings, &tree_type);
 
             if let ProgramABI::Fuel(ref mut json_abi_program) = json_abi_program {
-                for (config, offset) in config_offsets {
-                    if let Some(ref mut configurables) = json_abi_program.configurables {
+                if let Some(ref mut configurables) = json_abi_program.configurables {
+                    // Filter out all dead configurables (i.e. ones without offsets in the
+                    // bytecode)
+                    configurables.retain(|c| config_offsets.contains_key(&c.name));
+
+                    // Set the actual offsets in the JSON object
+                    for (config, offset) in config_offsets {
                         if let Some(idx) = configurables.iter().position(|c| c.name == config) {
                             configurables[idx].offset = offset
                         }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/src/main.sw
@@ -31,6 +31,7 @@ configurable {
     C5: MyEnum = MyEnum::B(true),
     C6: str[4] = "fuel",
     C7: [u64; 4] = [1, 2, 3, 4],
+    C8: u64 = 0, // Unused - should not show up in the JSON file
 }
 
 #[inline(never)]


### PR DESCRIPTION
## Description
Closes #3680

Simply filter out any configurables without offsets in `forc-pkg` before finalizing the JSON ABI object.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] (N/A) I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] (N/A) I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
