### PR TITLE
Remove branch based fuel-core dep for sdk-harness

### DIFF
--- a/test/src/sdk-harness/Cargo.toml
+++ b/test/src/sdk-harness/Cargo.toml
@@ -12,7 +12,6 @@ fuel-core-client = { version = "0.17", default-features = false }
 fuel-types = "0.26"
 fuel-vm = "0.26"
 fuels = { version = "0.36", features = ["fuel-core-lib"] }
-# fuels = { git = "https://github.com/FuelLabs/fuels-rs", branch = "Voxelot/fuel-core-0.16", features = ["fuel-core-lib"] }
 hex = "0.4.3"
 rand = "0.8"
 sha2 = "0.10"

--- a/test/src/sdk-harness/Cargo.toml
+++ b/test/src/sdk-harness/Cargo.toml
@@ -7,13 +7,12 @@ version = "0.0.0"
 
 [dependencies]
 assert_matches = "1.5.0"
-fuel-core = { version = "0.16", default-features = false }
-fuel-core-client = { version = "0.16", default-features = false }
-fuel-types = "0.25"
-fuel-vm = "0.25"
-# TODO: Return back `0.35` after merge of the https://github.com/FuelLabs/fuels-rs/pull/813
-# fuels = { version = "0.35", features = ["fuel-core-lib"] }
-fuels = { git = "https://github.com/FuelLabs/fuels-rs", branch = "Voxelot/fuel-core-0.16", features = ["fuel-core-lib"] }
+fuel-core = { version = "0.17", default-features = false }
+fuel-core-client = { version = "0.17", default-features = false }
+fuel-types = "0.26"
+fuel-vm = "0.26"
+fuels = { version = "0.36", features = ["fuel-core-lib"] }
+# fuels = { git = "https://github.com/FuelLabs/fuels-rs", branch = "Voxelot/fuel-core-0.16", features = ["fuel-core-lib"] }
 hex = "0.4.3"
 rand = "0.8"
 sha2 = "0.10"

--- a/test/src/sdk-harness/test_projects/predicate_data_simple/mod.rs
+++ b/test/src/sdk-harness/test_projects/predicate_data_simple/mod.rs
@@ -1,4 +1,4 @@
-use fuel_vm::{consts::*, prelude::Opcode};
+use fuel_vm::fuel_asm::{op, RegId};
 use fuels::{
     core::abi_encoder::ABIEncoder,
     prelude::*,
@@ -60,7 +60,7 @@ async fn create_predicate(
         1,
         1000000,
         0,
-        Opcode::RET(REG_ONE).to_bytes().to_vec(),
+        op::ret(RegId::ONE).to_bytes().to_vec(),
         vec![],
         wallet_coins,
         vec![output_coin, output_change],

--- a/test/src/sdk-harness/test_projects/predicate_data_struct/mod.rs
+++ b/test/src/sdk-harness/test_projects/predicate_data_struct/mod.rs
@@ -1,4 +1,4 @@
-use fuel_vm::{consts::*, prelude::Opcode};
+use fuel_vm::fuel_asm::{op, RegId};
 use fuels::{
     core::abi_encoder::ABIEncoder,
     prelude::*,
@@ -60,7 +60,7 @@ async fn create_predicate(
         1,
         1000000,
         0,
-        Opcode::RET(REG_ONE).to_bytes().to_vec(),
+        op::ret(RegId::ONE).to_bytes().to_vec(),
         vec![],
         wallet_coins,
         vec![output_coin, output_change],

--- a/test/src/sdk-harness/test_projects/tx_fields/mod.rs
+++ b/test/src/sdk-harness/test_projects/tx_fields/mod.rs
@@ -451,6 +451,7 @@ mod inputs {
                     .methods()
                     .get_tx_input_predicate_data_pointer(0)
                     .call_params(call_params)
+                    .unwrap()
                     .call()
                     .await
                     .unwrap();


### PR DESCRIPTION
## Description

Ensures the sdk-harness is running on the latest versions.

This is a CI blocker for sway as the branch sdk-harness was depending on no longer exists.