### PR TITLE
Add tokens for match scrutinees

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -984,6 +984,17 @@ fn connect_expression<'eng: 'cfg, 'cfg>(
                 options,
             )
         }
+        MatchExp { desugared, .. } => connect_expression(
+            engines,
+            &desugared.expression,
+            graph,
+            leaves,
+            exit_node,
+            label,
+            tree_type,
+            expression_span,
+            options,
+        ),
         IfExp {
             condition,
             then,

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -425,6 +425,9 @@ fn const_eval_typed_expr(
             _ => None,
         },
         ty::TyExpressionVariant::Return(exp) => const_eval_typed_expr(lookup, known_consts, exp)?,
+        ty::TyExpressionVariant::MatchExp { desugared, .. } => {
+            const_eval_typed_expr(lookup, known_consts, desugared)?
+        }
         ty::TyExpressionVariant::ArrayIndex { .. }
         | ty::TyExpressionVariant::IntrinsicFunction(_)
         | ty::TyExpressionVariant::CodeBlock(_)

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -283,6 +283,9 @@ impl<'eng> FnCompiler<'eng> {
                 "Unexpected function parameter declaration.",
                 ast_expr.span.clone(),
             )),
+            ty::TyExpressionVariant::MatchExp { desugared, .. } => {
+                self.compile_expression(context, md_mgr, desugared)
+            }
             ty::TyExpressionVariant::IfExp {
                 condition,
                 then,

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -214,6 +214,12 @@ impl CollectTypesMetadata for TyExpression {
                     ));
                 }
             }
+            MatchExp { desugared, .. } => res.append(&mut check!(
+                desugared.collect_types_metadata(ctx),
+                return err(warnings, errors),
+                warnings,
+                errors
+            )),
             IfExp {
                 condition,
                 then,
@@ -469,6 +475,9 @@ impl DeterministicallyAborts for TyExpression {
                     .map(|x| x.deterministically_aborts(decl_engine, check_call_body))
                     .unwrap_or(false)
             }),
+            MatchExp { desugared, .. } => {
+                desugared.deterministically_aborts(decl_engine, check_call_body)
+            }
             IfExp {
                 condition,
                 then,

--- a/sway-core/src/language/ty/expression/mod.rs
+++ b/sway-core/src/language/ty/expression/mod.rs
@@ -17,6 +17,6 @@ pub use expression_variant::*;
 pub use intrinsic_function::*;
 pub(crate) use match_expression::*;
 pub use reassignment::*;
-pub(crate) use scrutinee::*;
+pub use scrutinee::*;
 pub use storage::*;
 pub use struct_exp_field::*;

--- a/sway-core/src/language/ty/expression/scrutinee.rs
+++ b/sway-core/src/language/ty/expression/scrutinee.rs
@@ -6,31 +6,37 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-pub(crate) struct TyScrutinee {
-    pub(crate) variant: TyScrutineeVariant,
-    pub(crate) type_id: TypeId,
-    pub(crate) span: Span,
+pub struct TyScrutinee {
+    pub variant: TyScrutineeVariant,
+    pub type_id: TypeId,
+    pub span: Span,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum TyScrutineeVariant {
+pub enum TyScrutineeVariant {
     CatchAll,
     Literal(Literal),
     Variable(Ident),
-    Constant(Ident, Literal, TypeId),
-    StructScrutinee(Ident, Vec<TyStructScrutineeField>),
+    Constant(Ident, Literal, TyConstantDeclaration),
+    StructScrutinee {
+        struct_name: Ident,
+        decl_name: Ident,
+        fields: Vec<TyStructScrutineeField>,
+    },
     #[allow(dead_code)]
     EnumScrutinee {
         call_path: CallPath,
-        variant: TyEnumVariant,
+        variant: Box<TyEnumVariant>,
+        decl_name: Ident,
         value: Box<TyScrutinee>,
     },
     Tuple(Vec<TyScrutinee>),
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct TyStructScrutineeField {
-    pub(crate) field: Ident,
-    pub(crate) scrutinee: Option<TyScrutinee>,
-    pub(crate) span: Span,
+pub struct TyStructScrutineeField {
+    pub field: Ident,
+    pub scrutinee: Option<TyScrutinee>,
+    pub span: Span,
+    pub field_def_name: Ident,
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -313,6 +313,9 @@ impl ty::TyImplTrait {
                 ty::TyExpressionVariant::CodeBlock(cb) => {
                     codeblock_contains_get_storage_index(decl_engine, cb, access_span)?
                 }
+                ty::TyExpressionVariant::MatchExp { desugared, .. } => {
+                    expr_contains_get_storage_index(decl_engine, desugared, access_span)?
+                }
                 ty::TyExpressionVariant::IfExp {
                     condition,
                     then,

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
@@ -120,7 +120,11 @@ impl Pattern {
             ty::TyScrutineeVariant::Variable(_) => Pattern::Wildcard,
             ty::TyScrutineeVariant::Literal(value) => Pattern::from_literal(value),
             ty::TyScrutineeVariant::Constant(_, value, _) => Pattern::from_literal(value),
-            ty::TyScrutineeVariant::StructScrutinee(struct_name, fields) => {
+            ty::TyScrutineeVariant::StructScrutinee {
+                struct_name,
+                fields,
+                ..
+            } => {
                 let mut new_fields = vec![];
                 for field in fields.into_iter() {
                     let f = match field.scrutinee {

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
@@ -95,12 +95,12 @@ pub(crate) fn matcher(
         ty::TyScrutineeVariant::CatchAll => ok((vec![], vec![]), warnings, errors),
         ty::TyScrutineeVariant::Literal(value) => match_literal(exp, value, span),
         ty::TyScrutineeVariant::Variable(name) => match_variable(exp, name),
-        ty::TyScrutineeVariant::Constant(name, _, type_id) => {
-            match_constant(exp, name, type_id, span)
+        ty::TyScrutineeVariant::Constant(name, _, const_decl) => {
+            match_constant(exp, name, const_decl.value.return_type, span)
         }
-        ty::TyScrutineeVariant::StructScrutinee(_, fields) => match_struct(ctx, exp, fields),
+        ty::TyScrutineeVariant::StructScrutinee { fields, .. } => match_struct(ctx, exp, fields),
         ty::TyScrutineeVariant::EnumScrutinee { value, variant, .. } => {
-            match_enum(ctx, exp, variant, *value, span)
+            match_enum(ctx, exp, *variant, *value, span)
         }
         ty::TyScrutineeVariant::Tuple(elems) => match_tuple(ctx, exp, elems, span),
     }
@@ -167,6 +167,7 @@ fn match_struct(
         field,
         scrutinee,
         span: field_span,
+        field_def_name: _,
     } in fields.into_iter()
     {
         let subfield = check!(

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -88,12 +88,8 @@ fn type_check_variable(
                 }
             };
             ty::TyScrutinee {
-                variant: ty::TyScrutineeVariant::Constant(
-                    name,
-                    value,
-                    constant_decl.value.return_type,
-                ),
                 type_id: constant_decl.value.return_type,
+                variant: ty::TyScrutineeVariant::Constant(name, value, constant_decl),
                 span,
             }
         }
@@ -158,7 +154,7 @@ fn type_check_struct(
                 span,
             } => {
                 // ensure that the struct definition has this field
-                let _ = check!(
+                let struct_field = check!(
                     struct_decl.expect_field(&field),
                     return err(warnings, errors),
                     warnings,
@@ -178,6 +174,7 @@ fn type_check_struct(
                     field,
                     scrutinee: typed_scrutinee,
                     span,
+                    field_def_name: struct_field.name.clone(),
                 });
             }
         }
@@ -201,12 +198,13 @@ fn type_check_struct(
     }
 
     let typed_scrutinee = ty::TyScrutinee {
-        variant: ty::TyScrutineeVariant::StructScrutinee(
-            struct_decl.call_path.suffix.clone(),
-            typed_fields,
-        ),
         type_id: struct_decl.create_type_id(ctx.engines()),
         span,
+        variant: ty::TyScrutineeVariant::StructScrutinee {
+            struct_name,
+            decl_name: struct_decl.call_path.suffix,
+            fields: typed_fields,
+        },
     };
 
     ok(typed_scrutinee, warnings, errors)
@@ -282,7 +280,8 @@ fn type_check_enum(
     let typed_scrutinee = ty::TyScrutinee {
         variant: ty::TyScrutineeVariant::EnumScrutinee {
             call_path,
-            variant,
+            decl_name: enum_decl.call_path.suffix,
+            variant: Box::new(variant),
             value: Box::new(typed_value),
         },
         type_id: enum_type_id,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -683,7 +683,12 @@ impl ty::TyExpression {
 
         // check to see if the match expression is exhaustive and if all match arms are reachable
         let (witness_report, arms_reachability) = check!(
-            check_match_expression_usefulness(engines, type_id, typed_scrutinees, span.clone()),
+            check_match_expression_usefulness(
+                engines,
+                type_id,
+                typed_scrutinees.clone(),
+                span.clone()
+            ),
             return err(warnings, errors),
             warnings,
             errors
@@ -712,7 +717,16 @@ impl ty::TyExpression {
             errors
         );
 
-        ok(typed_if_exp, warnings, errors)
+        let match_exp = ty::TyExpression {
+            span: typed_if_exp.span.clone(),
+            return_type: typed_if_exp.return_type,
+            expression: ty::TyExpressionVariant::MatchExp {
+                desugared: Box::new(typed_if_exp),
+                scrutinees: typed_scrutinees,
+            },
+        };
+
+        ok(match_exp, warnings, errors)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
+++ b/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
@@ -325,6 +325,7 @@ fn analyze_expression(
             Some(expr) => analyze_expression(engines, expr, block_name, warnings),
             None => HashSet::new(),
         },
+        MatchExp { desugared, .. } => analyze_expression(engines, desugared, block_name, warnings),
         IfExp {
             condition,
             then,
@@ -546,6 +547,7 @@ fn effects_of_expression(engines: Engines<'_>, expr: &ty::TyExpression) -> HashS
         }
         StructExpression { fields, .. } => effects_of_struct_expressions(engines, fields),
         CodeBlock(codeblock) => effects_of_codeblock(engines, codeblock),
+        MatchExp { desugared, .. } => effects_of_expression(engines, desugared),
         IfExp {
             condition,
             then,

--- a/sway-core/src/semantic_analysis/coins_analysis.rs
+++ b/sway-core/src/semantic_analysis/coins_analysis.rs
@@ -49,6 +49,7 @@ pub fn possibly_nonzero_u64_expression(
         FunctionApplication { .. }
         | ArrayIndex { .. }
         | CodeBlock(_)
+        | MatchExp { .. }
         | IfExp { .. }
         | AsmExpression { .. }
         | StructFieldAccess { .. }

--- a/sway-core/src/semantic_analysis/storage_only_types.rs
+++ b/sway-core/src/semantic_analysis/storage_only_types.rs
@@ -65,6 +65,9 @@ fn expr_validate(engines: Engines<'_>, expr: &ty::TyExpression) -> CompileResult
                 errors
             );
         }
+        ty::TyExpressionVariant::MatchExp { desugared, .. } => {
+            check!(expr_validate(engines, desugared), (), warnings, errors)
+        }
         ty::TyExpressionVariant::IfExp {
             condition,
             then,

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -45,6 +45,7 @@ pub enum AstToken {
 pub enum TypedAstToken {
     TypedDeclaration(ty::TyDeclaration),
     TypedExpression(ty::TyExpression),
+    TypedScrutinee(ty::TyScrutinee),
     TypedFunctionDeclaration(ty::TyFunctionDeclaration),
     TypedFunctionParameter(ty::TyFunctionParameter),
     TypedStructField(ty::TyStructField),

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -893,20 +893,28 @@ impl<'a> ParsedTree<'a> {
                     .insert(to_ident_key(&Ident::new(span.clone())), token);
             }
             Scrutinee::Variable { name, .. } => {
-                let token = Token::from_parsed(
-                    AstToken::Scrutinee(scrutinee.clone()),
-                    SymbolKind::Variable,
+                self.tokens.insert(
+                    to_ident_key(name),
+                    // it could either be a variable or a constant
+                    Token::from_parsed(AstToken::Scrutinee(scrutinee.clone()), SymbolKind::Unknown),
                 );
-                self.tokens.insert(to_ident_key(name), token);
             }
             Scrutinee::StructScrutinee {
                 struct_name,
                 fields,
                 ..
             } => {
-                let token =
-                    Token::from_parsed(AstToken::Scrutinee(scrutinee.clone()), SymbolKind::Struct);
-                self.tokens.insert(to_ident_key(&struct_name.suffix), token);
+                for ident in &struct_name.prefixes {
+                    let token = Token::from_parsed(
+                        AstToken::Scrutinee(scrutinee.clone()),
+                        SymbolKind::Struct,
+                    );
+                    self.tokens.insert(to_ident_key(ident), token);
+                }
+                self.tokens.insert(
+                    to_ident_key(&struct_name.suffix),
+                    Token::from_parsed(AstToken::Scrutinee(scrutinee.clone()), SymbolKind::Struct),
+                );
 
                 for field in fields {
                     let token = Token::from_parsed(

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -8,11 +8,9 @@ use crate::core::{
 };
 use dashmap::mapref::one::RefMut;
 use sway_core::{
-    decl_engine::DeclId,
     language::{
         parsed::{ImportType, Supertrait},
         ty::{self, GetDeclIdent, TyEnumVariant, TyModule, TyProgram, TyProgramKind, TySubmodule},
-        CallPath,
     },
     namespace,
     type_system::TypeArgument,
@@ -458,10 +456,31 @@ impl<'a> TypedTree<'a> {
                     }
                 }
 
+                let implementing_type_name = decl_engine
+                    .get_function(function_decl_id.clone(), &call_path.span())
+                    .ok()
+                    .and_then(|function_decl| function_decl.implementing_type)
+                    .and_then(|impl_type| impl_type.get_decl_ident());
+
+                let prefixes = if let Some(impl_type_name) = implementing_type_name {
+                    // the last prefix of the call path is not a module but a type
+                    if let Some((last, prefixes)) = call_path.prefixes.split_last() {
+                        if let Some(mut token) =
+                            self.tokens.try_get_mut(&to_ident_key(last)).try_unwrap()
+                        {
+                            token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                            token.type_def = Some(TypeDefinition::Ident(impl_type_name));
+                        }
+                        prefixes
+                    } else {
+                        &call_path.prefixes
+                    }
+                } else {
+                    &call_path.prefixes
+                };
                 self.collect_call_path_prefixes(
-                    call_path,
-                    expression,
-                    Some(function_decl_id),
+                    prefixes,
+                    TypedAstToken::TypedExpression(expression.clone()),
                     namespace,
                 );
 
@@ -510,7 +529,11 @@ impl<'a> TypedTree<'a> {
                 ..
             } => {
                 if let Some(call_path) = call_path {
-                    self.collect_call_path_prefixes(call_path, expression, None, namespace);
+                    self.collect_call_path_prefixes(
+                        &call_path.prefixes,
+                        TypedAstToken::TypedExpression(expression.clone()),
+                        namespace,
+                    );
                 }
 
                 let span = if let Some(call_path) = call_path {
@@ -562,9 +585,8 @@ impl<'a> TypedTree<'a> {
                 }
 
                 self.collect_call_path_prefixes(
-                    &call_path_binding.inner,
-                    expression,
-                    None,
+                    &call_path_binding.inner.prefixes,
+                    TypedAstToken::TypedExpression(expression.clone()),
                     namespace,
                 );
 
@@ -597,6 +619,18 @@ impl<'a> TypedTree<'a> {
                 }
             }
             ty::TyExpressionVariant::FunctionParameter { .. } => {}
+            ty::TyExpressionVariant::MatchExp {
+                desugared,
+                scrutinees,
+            } => {
+                // Order is important here, the expression must be processed first otherwise the
+                // scrutinee information will get overwritten by processing the underlying tree of
+                // conditions
+                self.handle_expression(desugared, namespace);
+                for s in scrutinees {
+                    self.handle_scrutinee(s, namespace);
+                }
+            }
             ty::TyExpressionVariant::IfExp {
                 condition,
                 then,
@@ -665,9 +699,8 @@ impl<'a> TypedTree<'a> {
                 }
 
                 self.collect_call_path_prefixes(
-                    &call_path_binding.inner,
-                    expression,
-                    None,
+                    &call_path_binding.inner.prefixes,
+                    TypedAstToken::TypedExpression(expression.clone()),
                     namespace,
                 );
 
@@ -790,6 +823,102 @@ impl<'a> TypedTree<'a> {
             ty::TyExpressionVariant::Return(exp) => self.handle_expression(exp, namespace),
         }
     }
+    fn handle_scrutinee(&self, scrutinee: &ty::TyScrutinee, namespace: &namespace::Module) {
+        use ty::TyScrutineeVariant::*;
+        match &scrutinee.variant {
+            CatchAll => {}
+            Constant(name, _, const_decl) => {
+                if let Some(mut token) = self.tokens.try_get_mut(&to_ident_key(name)).try_unwrap() {
+                    token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));
+                    token.type_def = Some(TypeDefinition::Ident(const_decl.name.clone()));
+                }
+            }
+            Literal(_) => {
+                if let Some(mut token) = self
+                    .tokens
+                    .try_get_mut(&to_ident_key(&Ident::new(scrutinee.span.clone())))
+                    .try_unwrap()
+                {
+                    token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));
+                }
+            }
+            Variable(ident) => {
+                if let Some(mut token) = self.tokens.try_get_mut(&to_ident_key(ident)).try_unwrap()
+                {
+                    token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));
+                }
+            }
+            StructScrutinee {
+                struct_name,
+                decl_name,
+                fields,
+            } => {
+                if let Some(mut token) = self
+                    .tokens
+                    .try_get_mut(&to_ident_key(struct_name))
+                    .try_unwrap()
+                {
+                    token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));
+                    token.type_def = Some(TypeDefinition::Ident(decl_name.clone()));
+                }
+
+                for field in fields {
+                    if let Some(mut token) = self
+                        .tokens
+                        .try_get_mut(&to_ident_key(&field.field))
+                        .try_unwrap()
+                    {
+                        token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));
+                        token.type_def = Some(TypeDefinition::Ident(field.field_def_name.clone()));
+                    }
+
+                    if let Some(scrutinee) = &field.scrutinee {
+                        self.handle_scrutinee(scrutinee, namespace);
+                    }
+                }
+            }
+            EnumScrutinee {
+                call_path,
+                decl_name,
+                variant,
+                value,
+            } => {
+                let prefixes = if let Some((last, prefixes)) = call_path.prefixes.split_last() {
+                    // the last prefix of the call path is not a module but a type
+                    if let Some(mut token) =
+                        self.tokens.try_get_mut(&to_ident_key(last)).try_unwrap()
+                    {
+                        token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));
+                        token.type_def = Some(TypeDefinition::Ident(decl_name.clone()));
+                    }
+                    prefixes
+                } else {
+                    &call_path.prefixes
+                };
+                self.collect_call_path_prefixes(
+                    prefixes,
+                    TypedAstToken::TypedScrutinee(scrutinee.clone()),
+                    namespace,
+                );
+
+                if let Some(mut token) = self
+                    .tokens
+                    .try_get_mut(&to_ident_key(&call_path.suffix))
+                    .try_unwrap()
+                {
+                    token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));
+                    token.type_def = Some(TypeDefinition::Ident(variant.name.clone()));
+                }
+
+                self.handle_scrutinee(value, namespace);
+            }
+            Tuple(scrutinees) => {
+                for s in scrutinees {
+                    self.handle_scrutinee(s, namespace);
+                }
+            }
+        }
+    }
 
     fn handle_intrinsic_function(
         &self,
@@ -815,40 +944,13 @@ impl<'a> TypedTree<'a> {
 
     fn collect_call_path_prefixes(
         &self,
-        call_path: &CallPath,
-        expression: &ty::TyExpression,
-        function_decl_id: Option<&DeclId>,
+        prefixes: &[Ident],
+        typed: TypedAstToken,
         namespace: &namespace::Module,
     ) {
-        let decl_engine = self.engines.de();
-
-        let implementing_type_name = function_decl_id
-            .and_then(|decl_id| {
-                decl_engine
-                    .get_function(decl_id.clone(), &call_path.span())
-                    .ok()
-            })
-            .and_then(|function_decl| function_decl.implementing_type)
-            .and_then(|impl_type| impl_type.get_decl_ident());
-
-        let prefixes = if let Some(impl_type_name) = implementing_type_name {
-            // the last prefix of the call path is not a module but a type
-            if let Some((last, prefixes)) = call_path.prefixes.split_last() {
-                if let Some(mut token) = self.tokens.try_get_mut(&to_ident_key(last)).try_unwrap() {
-                    token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
-                    token.type_def = Some(TypeDefinition::Ident(impl_type_name));
-                }
-                prefixes
-            } else {
-                &call_path.prefixes
-            }
-        } else {
-            &call_path.prefixes
-        };
-
         for (mod_path, ident) in iter_prefixes(prefixes).zip(prefixes) {
             if let Some(mut token) = self.tokens.try_get_mut(&to_ident_key(ident)).try_unwrap() {
-                token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
+                token.typed = Some(typed.clone());
 
                 if let Some(name) = namespace
                     .submodule(mod_path)

--- a/sway-lsp/tests/fixtures/tokens/matches/.gitignore
+++ b/sway-lsp/tests/fixtures/tokens/matches/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/sway-lsp/tests/fixtures/tokens/matches/Forc.lock
+++ b/sway-lsp/tests/fixtures/tokens/matches/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-B6ED335A8DAEB4A7'
+
+[[package]]
+name = 'matches'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-B6ED335A8DAEB4A7'
+dependencies = ['core']

--- a/sway-lsp/tests/fixtures/tokens/matches/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/matches/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "matches"
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/tests/fixtures/tokens/matches/src/main.sw
+++ b/sway-lsp/tests/fixtures/tokens/matches/src/main.sw
@@ -1,0 +1,37 @@
+script;
+
+struct ExampleStruct {
+    variable: u32,
+}
+
+enum ExampleEnum {
+    Variants: u32,
+}
+
+const EXAMPLE_CONST = 0;
+
+fn main() {
+    let _ = match 0 {
+        EXAMPLE_CONST => 1,
+        a => a + 1,
+        _ => 0,
+    };
+
+    match EXAMPLE_CONST {
+        _ => {}
+    }
+    if let EXAMPLE_CONST = EXAMPLE_CONST {}
+    if EXAMPLE_CONST == EXAMPLE_CONST {}
+
+    let _ = match Option::Some(Option::Some(EXAMPLE_CONST)) {
+        Option::None => 1,
+        Option::Some(Option::None) => 2,
+        Option::Some(Option::Some(EXAMPLE_CONST)) => 2,
+        _ => 4,
+    };
+
+    let a = ExampleStruct { variable: 0 };
+    let _ = match a {
+        ExampleStruct { variable } => 0,
+    };
+}

--- a/sway-lsp/tests/integration/lsp.rs
+++ b/sway-lsp/tests/integration/lsp.rs
@@ -14,7 +14,7 @@ use tower_lsp::{
 
 use sway_lsp::server::{self, Backend};
 
-use crate::{GotoDefintion, HoverDocumentation};
+use crate::{GotoDefinition, HoverDocumentation};
 
 pub(crate) fn build_request_with_id(
     method: impl Into<Cow<'static, str>>,
@@ -380,10 +380,15 @@ pub(crate) async fn code_lens_request(service: &mut LspService<Backend>, uri: &U
 
 pub(crate) async fn definition_check<'a>(
     service: &mut LspService<Backend>,
-    go_to: &'a GotoDefintion<'a>,
-    id: i64,
+    go_to: &'a GotoDefinition<'a>,
+    ids: &mut impl Iterator<Item = i64>,
 ) -> Request {
-    let definition = definition_request(go_to.req_uri, go_to.req_line, go_to.req_char, id);
+    let definition = definition_request(
+        go_to.req_uri,
+        go_to.req_line,
+        go_to.req_char,
+        ids.next().unwrap(),
+    );
     let response = call_request(service, definition.clone())
         .await
         .unwrap()

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -15,7 +15,7 @@ use tower_lsp::{
 };
 
 /// Holds the information needed to check the response of a goto definition request.
-pub(crate) struct GotoDefintion<'a> {
+pub(crate) struct GotoDefinition<'a> {
     req_uri: &'a Url,
     req_line: i32,
     req_char: i32,
@@ -170,7 +170,8 @@ async fn did_change() {
 async fn lsp_syncs_with_workspace_edits() {
     let (mut service, _) = LspService::new(Backend::new);
     let uri = init_and_open(&mut service, doc_comments_dir().join("src/main.sw")).await;
-    let mut go_to = GotoDefintion {
+    let mut i = 0..;
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 44,
         req_char: 24,
@@ -179,10 +180,10 @@ async fn lsp_syncs_with_workspace_edits() {
         def_end_char: 11,
         def_path: uri.as_str(),
     };
-    let _ = lsp::definition_check(&mut service, &go_to, 1).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
     let _ = lsp::did_change_request(&mut service, &uri).await;
     go_to.def_line = 20;
-    definition_check_with_req_offset(&mut service, &mut go_to, 45, 24, 2).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 45, 24, &mut i).await;
     shutdown_and_exit(&mut service).await;
 }
 
@@ -203,7 +204,8 @@ async fn show_ast() {
 async fn go_to_definition() {
     let (mut service, _) = LspService::new(Backend::new);
     let uri = init_and_open(&mut service, doc_comments_dir().join("src/main.sw")).await;
-    let go_to = GotoDefintion {
+    let mut i = 0..;
+    let go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 44,
         req_char: 24,
@@ -212,20 +214,20 @@ async fn go_to_definition() {
         def_end_char: 11,
         def_path: uri.as_str(),
     };
-    let _ = lsp::definition_check(&mut service, &go_to, 1).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
     shutdown_and_exit(&mut service).await;
 }
 
 async fn definition_check_with_req_offset<'a>(
     service: &mut LspService<Backend>,
-    go_to: &mut GotoDefintion<'a>,
+    go_to: &mut GotoDefinition<'a>,
     req_line: i32,
     req_char: i32,
-    id: i64,
+    ids: &mut impl Iterator<Item = i64>,
 ) {
     go_to.req_line = req_line;
     go_to.req_char = req_char;
-    let _ = lsp::definition_check(service, go_to, id).await;
+    let _ = lsp::definition_check(service, go_to, ids).await;
 }
 
 #[tokio::test]
@@ -236,8 +238,9 @@ async fn go_to_definition_inside_turbofish() {
         test_fixtures_dir().join("tokens/turbofish/src/main.sw"),
     )
     .await;
+    let mut i = 0..;
 
-    let mut opt_go_to = GotoDefintion {
+    let mut opt_go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 15,
         req_char: 12,
@@ -247,16 +250,16 @@ async fn go_to_definition_inside_turbofish() {
         def_path: "sway-lib-std/src/option.sw",
     };
     // option.sw
-    let _ = lsp::definition_check(&mut service, &opt_go_to, 1).await;
-    definition_check_with_req_offset(&mut service, &mut opt_go_to, 16, 17, 2).await;
-    definition_check_with_req_offset(&mut service, &mut opt_go_to, 17, 29, 3).await;
-    definition_check_with_req_offset(&mut service, &mut opt_go_to, 18, 19, 4).await;
-    definition_check_with_req_offset(&mut service, &mut opt_go_to, 20, 13, 5).await;
-    definition_check_with_req_offset(&mut service, &mut opt_go_to, 21, 19, 6).await;
-    definition_check_with_req_offset(&mut service, &mut opt_go_to, 22, 29, 7).await;
-    definition_check_with_req_offset(&mut service, &mut opt_go_to, 23, 18, 8).await;
+    let _ = lsp::definition_check(&mut service, &opt_go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut opt_go_to, 16, 17, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut opt_go_to, 17, 29, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut opt_go_to, 18, 19, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut opt_go_to, 20, 13, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut opt_go_to, 21, 19, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut opt_go_to, 22, 29, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut opt_go_to, 23, 18, &mut i).await;
 
-    let mut res_go_to = GotoDefintion {
+    let mut res_go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 20,
         req_char: 19,
@@ -266,10 +269,122 @@ async fn go_to_definition_inside_turbofish() {
         def_path: "sway-lib-std/src/result.sw",
     };
     // result.sw
-    let _ = lsp::definition_check(&mut service, &res_go_to, 9).await;
-    definition_check_with_req_offset(&mut service, &mut res_go_to, 21, 25, 10).await;
-    definition_check_with_req_offset(&mut service, &mut res_go_to, 22, 36, 11).await;
-    definition_check_with_req_offset(&mut service, &mut res_go_to, 23, 27, 12).await;
+    let _ = lsp::definition_check(&mut service, &res_go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut res_go_to, 21, 25, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut res_go_to, 22, 36, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut res_go_to, 23, 27, &mut i).await;
+
+    shutdown_and_exit(&mut service).await;
+}
+
+#[tokio::test]
+async fn go_to_definition_for_matches() {
+    let (mut service, _) = LspService::new(Backend::new);
+    let uri = init_and_open(
+        &mut service,
+        test_fixtures_dir().join("tokens/matches/src/main.sw"),
+    )
+    .await;
+    let mut i = 0..;
+
+    let mut go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 14,
+        req_char: 10,
+        def_line: 10,
+        def_start_char: 6,
+        def_end_char: 19,
+        def_path: "sway-lsp/tests/fixtures/tokens/matches/src/main.sw",
+    };
+    // EXAMPLE_CONST
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 19, 18, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 22, 18, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 22, 30, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 23, 16, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 28, 38, &mut i).await;
+
+    let go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 15,
+        req_char: 13,
+        def_line: 15,
+        def_start_char: 8,
+        def_end_char: 9,
+        def_path: "sway-lsp/tests/fixtures/tokens/matches/src/main.sw",
+    };
+    // a => a + 1
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+
+    let mut go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 25,
+        req_char: 19,
+        def_line: 80,
+        def_start_char: 9,
+        def_end_char: 15,
+        def_path: "sway-lib-std/src/option.sw",
+    };
+    // Option
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 25, 33, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 26, 11, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 27, 11, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 27, 22, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 28, 11, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 28, 22, &mut i).await;
+
+    let mut go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 25,
+        req_char: 27,
+        def_line: 84,
+        def_start_char: 4,
+        def_end_char: 8,
+        def_path: "sway-lib-std/src/option.sw",
+    };
+    // Some
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 27, 17, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 28, 17, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 28, 30, &mut i).await;
+
+    let mut go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 26,
+        req_char: 17,
+        def_line: 82,
+        def_start_char: 4,
+        def_end_char: 8,
+        def_path: "sway-lib-std/src/option.sw",
+    };
+    // None
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 27, 30, &mut i).await;
+
+    let go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 34,
+        req_char: 11,
+        def_line: 2,
+        def_start_char: 7,
+        def_end_char: 20,
+        def_path: "sway-lsp/tests/fixtures/tokens/matches/src/main.sw",
+    };
+    // ExampleStruct
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+
+    let go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 34,
+        req_char: 26,
+        def_line: 3,
+        def_start_char: 4,
+        def_end_char: 12,
+        def_path: "sway-lsp/tests/fixtures/tokens/matches/src/main.sw",
+    };
+    // ExampleStruct.variable
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
     shutdown_and_exit(&mut service).await;
 }
@@ -282,8 +397,9 @@ async fn go_to_definition_for_modules() {
         test_fixtures_dir().join("tokens/modules/src/lib.sw"),
     )
     .await;
+    let mut i = 0..;
 
-    let opt_go_to = GotoDefintion {
+    let opt_go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 2,
         req_char: 6,
@@ -293,9 +409,9 @@ async fn go_to_definition_for_modules() {
         def_path: "sway-lsp/tests/fixtures/tokens/modules/src/test_mod.sw",
     };
     // dep test_mod;
-    let _ = lsp::definition_check(&mut service, &opt_go_to, 2).await;
+    let _ = lsp::definition_check(&mut service, &opt_go_to, &mut i).await;
 
-    let opt_go_to = GotoDefintion {
+    let opt_go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 3,
         req_char: 6,
@@ -305,7 +421,7 @@ async fn go_to_definition_for_modules() {
         def_path: "sway-lsp/tests/fixtures/tokens/modules/src/dir_mod/mod.sw",
     };
     // dep dir_mod/mod;
-    let _ = lsp::definition_check(&mut service, &opt_go_to, 3).await;
+    let _ = lsp::definition_check(&mut service, &opt_go_to, &mut i).await;
 
     shutdown_and_exit(&mut service).await;
 }
@@ -318,8 +434,9 @@ async fn go_to_definition_for_paths() {
         test_fixtures_dir().join("tokens/paths/src/main.sw"),
     )
     .await;
+    let mut i = 0..;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 10,
         req_char: 13,
@@ -329,13 +446,13 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/lib.sw",
     };
     // std
-    let _ = lsp::definition_check(&mut service, &go_to, 1).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 12, 14, 2).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 18, 5, 3).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 24, 13, 4).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 7, 5, 5).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 12, 14, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 18, 5, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 24, 13, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 7, 5, &mut i).await;
 
-    let go_to = GotoDefintion {
+    let go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 10,
         req_char: 19,
@@ -345,9 +462,9 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/option.sw",
     };
     // option
-    let _ = lsp::definition_check(&mut service, &go_to, 6).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 10,
         req_char: 27,
@@ -357,10 +474,10 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/option.sw",
     };
     // Option
-    let _ = lsp::definition_check(&mut service, &go_to, 7).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 11, 14, 8).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 11, 14, &mut i).await;
 
-    let go_to = GotoDefintion {
+    let go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 12,
         req_char: 17,
@@ -370,9 +487,9 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/vm/mod.sw",
     };
     // vm
-    let _ = lsp::definition_check(&mut service, &go_to, 9).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
-    let go_to = GotoDefintion {
+    let go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 12,
         req_char: 22,
@@ -382,9 +499,9 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/vm/evm/mod.sw",
     };
     // evm
-    let _ = lsp::definition_check(&mut service, &go_to, 10).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
-    let go_to = GotoDefintion {
+    let go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 12,
         req_char: 27,
@@ -394,9 +511,9 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/vm/evm/evm_address.sw",
     };
     // evm_address
-    let _ = lsp::definition_check(&mut service, &go_to, 11).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
-    let go_to = GotoDefintion {
+    let go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 12,
         req_char: 42,
@@ -406,9 +523,9 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/vm/evm/evm_address.sw",
     };
     // EvmAddress
-    let _ = lsp::definition_check(&mut service, &go_to, 12).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 16,
         req_char: 6,
@@ -418,11 +535,11 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
     };
     // test_mod
-    let _ = lsp::definition_check(&mut service, &go_to, 13).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 22, 7, 14).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 5, 5, 15).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 22, 7, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 5, 5, &mut i).await;
 
-    let go_to = GotoDefintion {
+    let go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 16,
         req_char: 16,
@@ -432,9 +549,9 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
     };
     // test_fun
-    let _ = lsp::definition_check(&mut service, &go_to, 16).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 17,
         req_char: 8,
@@ -444,10 +561,10 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod.sw",
     };
     // deep_mod
-    let _ = lsp::definition_check(&mut service, &go_to, 17).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 6, 6, 18).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 6, 6, &mut i).await;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 17,
         req_char: 18,
@@ -457,10 +574,10 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
     };
     // deeper_mod
-    let _ = lsp::definition_check(&mut service, &go_to, 19).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 6, 16, 20).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 6, 16, &mut i).await;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 17,
         req_char: 29,
@@ -470,10 +587,10 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
     };
     // deep_fun
-    let _ = lsp::definition_check(&mut service, &go_to, 21).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 6, 28, 22).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 6, 28, &mut i).await;
 
-    let go_to = GotoDefintion {
+    let go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 18,
         req_char: 11,
@@ -483,9 +600,9 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/assert.sw",
     };
     // assert
-    let _ = lsp::definition_check(&mut service, &go_to, 23).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
-    let go_to = GotoDefintion {
+    let go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 19,
         req_char: 13,
@@ -495,9 +612,9 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-core/src/lib.sw",
     };
     // core
-    let _ = lsp::definition_check(&mut service, &go_to, 24).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 19,
         req_char: 21,
@@ -507,10 +624,10 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-core/src/primitives.sw",
     };
     // primitives
-    let _ = lsp::definition_check(&mut service, &go_to, 25).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 25, 20, 26).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 25, 20, &mut i).await;
 
-    let go_to = GotoDefintion {
+    let go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 5,
         req_char: 14,
@@ -520,9 +637,9 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
     };
     // A def
-    let _ = lsp::definition_check(&mut service, &go_to, 27).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 21,
         req_char: 4,
@@ -532,10 +649,10 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
     };
     // A impl
-    let _ = lsp::definition_check(&mut service, &go_to, 28).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 22, 14, 29).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 22, 14, &mut i).await;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 21,
         req_char: 7,
@@ -545,10 +662,10 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
     };
     // fun
-    let _ = lsp::definition_check(&mut service, &go_to, 30).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 22, 18, 31).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 22, 18, &mut i).await;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 24,
         req_char: 20,
@@ -558,11 +675,11 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/constants.sw",
     };
     // constants
-    let _ = lsp::definition_check(&mut service, &go_to, 32).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 7, 11, 33).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 7, 23, 34).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 7, 11, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 7, 23, &mut i).await;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 24,
         req_char: 31,
@@ -572,10 +689,10 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/constants.sw",
     };
     // ZERO_B256
-    let _ = lsp::definition_check(&mut service, &go_to, 35).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 7, 31, 36).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 7, 31, &mut i).await;
 
-    let go_to = GotoDefintion {
+    let go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 19,
         req_char: 31,
@@ -585,9 +702,9 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-core/src/primitives.sw",
     };
     // u64
-    let _ = lsp::definition_check(&mut service, &go_to, 37).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 13,
         req_char: 17,
@@ -597,10 +714,10 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-core/src/primitives.sw",
     };
     // b256
-    let _ = lsp::definition_check(&mut service, &go_to, 38).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 25, 31, 39).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 25, 31, &mut i).await;
 
-    let go_to = GotoDefintion {
+    let go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 6,
         req_char: 39,
@@ -610,7 +727,7 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/main.sw",
     };
     // dfun
-    let _ = lsp::definition_check(&mut service, &go_to, 40).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
     shutdown_and_exit(&mut service).await;
 }
@@ -623,8 +740,9 @@ async fn go_to_definition_for_traits() {
         test_fixtures_dir().join("tokens/traits/src/main.sw"),
     )
     .await;
+    let mut i = 0..;
 
-    let mut trait_go_to = GotoDefintion {
+    let mut trait_go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 6,
         req_char: 10,
@@ -634,13 +752,21 @@ async fn go_to_definition_for_traits() {
         def_path: "sway-lsp/tests/fixtures/tokens/traits/src/traits.sw",
     };
 
-    let _ = lsp::definition_check(&mut service, &trait_go_to, 1).await;
-    definition_check_with_req_offset(&mut service, &mut trait_go_to, 7, 10, 2).await;
-    definition_check_with_req_offset(&mut service, &mut trait_go_to, 10, 6, 3).await;
+    let _ = lsp::definition_check(&mut service, &trait_go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut trait_go_to, 7, 10, &mut i).await;
+    definition_check_with_req_offset(
+        &mut service,
+        &mut trait_go_to,
+        10,
+        6,
+        // don't increment id for next check
+        &mut i.clone(),
+    )
+    .await;
     trait_go_to.req_line = 7;
     trait_go_to.req_char = 20;
     trait_go_to.def_line = 3;
-    let _ = lsp::definition_check(&mut service, &trait_go_to, 3).await;
+    let _ = lsp::definition_check(&mut service, &trait_go_to, &mut i).await;
 
     shutdown_and_exit(&mut service).await;
 }
@@ -653,8 +779,9 @@ async fn go_to_definition_for_variables() {
         test_fixtures_dir().join("tokens/variables/src/main.sw"),
     )
     .await;
+    let mut i = 0..;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 23,
         req_char: 26,
@@ -664,51 +791,51 @@ async fn go_to_definition_for_variables() {
         def_path: uri.as_str(),
     };
     // Variable expressions
-    let _ = lsp::definition_check(&mut service, &go_to, 1).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
     // Function arguments
     go_to.def_line = 23;
-    definition_check_with_req_offset(&mut service, &mut go_to, 28, 35, 2).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 28, 35, &mut i).await;
 
     // Struct fields
     go_to.def_line = 22;
-    definition_check_with_req_offset(&mut service, &mut go_to, 31, 45, 3).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 31, 45, &mut i).await;
 
     // Enum fields
     go_to.def_line = 22;
-    definition_check_with_req_offset(&mut service, &mut go_to, 34, 39, 4).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 34, 39, &mut i).await;
 
     // Tuple elements
     go_to.def_line = 24;
-    definition_check_with_req_offset(&mut service, &mut go_to, 37, 20, 5).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 37, 20, &mut i).await;
 
     // Array elements
     go_to.def_line = 25;
-    definition_check_with_req_offset(&mut service, &mut go_to, 40, 20, 6).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 40, 20, &mut i).await;
 
     // Scoped declarations
     go_to.def_line = 44;
     go_to.def_start_char = 12;
     go_to.def_end_char = 21;
-    definition_check_with_req_offset(&mut service, &mut go_to, 45, 13, 7).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 45, 13, &mut i).await;
 
     // If let scopes
     go_to.def_line = 50;
     go_to.def_start_char = 38;
     go_to.def_end_char = 39;
-    definition_check_with_req_offset(&mut service, &mut go_to, 50, 47, 8).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 50, 47, &mut i).await;
 
     // Shadowing
     go_to.def_line = 50;
     go_to.def_start_char = 8;
     go_to.def_end_char = 17;
-    definition_check_with_req_offset(&mut service, &mut go_to, 53, 29, 9).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 53, 29, &mut i).await;
 
     // Variable type ascriptions
     go_to.def_line = 6;
     go_to.def_start_char = 5;
     go_to.def_end_char = 16;
-    definition_check_with_req_offset(&mut service, &mut go_to, 56, 21, 10).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 56, 21, &mut i).await;
 
     shutdown_and_exit(&mut service).await;
 }
@@ -721,9 +848,10 @@ async fn go_to_definition_for_consts() {
         test_fixtures_dir().join("tokens/consts/src/main.sw"),
     )
     .await;
+    let mut i = 0..;
 
     // value: TyExpression
-    let mut contract_go_to = GotoDefintion {
+    let mut contract_go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 9,
         req_char: 24,
@@ -732,16 +860,16 @@ async fn go_to_definition_for_consts() {
         def_end_char: 9,
         def_path: "sway-lib-std/src/contract_id.sw",
     };
-    let _ = lsp::definition_check(&mut service, &contract_go_to, 1).await;
+    let _ = lsp::definition_check(&mut service, &contract_go_to, &mut i).await;
 
     contract_go_to.req_char = 34;
     contract_go_to.def_line = 19;
     contract_go_to.def_start_char = 7;
     contract_go_to.def_end_char = 11;
-    let _ = lsp::definition_check(&mut service, &contract_go_to, 2).await;
+    let _ = lsp::definition_check(&mut service, &contract_go_to, &mut i).await;
 
     // Constants defined in the same module
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 19,
         req_char: 34,
@@ -750,13 +878,13 @@ async fn go_to_definition_for_consts() {
         def_end_char: 16,
         def_path: uri.as_str(),
     };
-    let _ = lsp::definition_check(&mut service, &contract_go_to, 3).await;
+    let _ = lsp::definition_check(&mut service, &contract_go_to, &mut i).await;
 
     go_to.def_line = 9;
-    definition_check_with_req_offset(&mut service, &mut go_to, 20, 29, 4).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 20, 29, &mut i).await;
 
     // Constants defined in a different module
-    go_to = GotoDefintion {
+    go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 23,
         req_char: 73,
@@ -765,18 +893,18 @@ async fn go_to_definition_for_consts() {
         def_end_char: 20,
         def_path: "consts/src/more_consts.sw",
     };
-    let _ = lsp::definition_check(&mut service, &go_to, 5).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
     go_to.def_line = 13;
     go_to.def_start_char = 10;
     go_to.def_end_char = 18;
-    definition_check_with_req_offset(&mut service, &mut go_to, 24, 31, 6).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 24, 31, &mut i).await;
 
     // Constants with type ascriptions
     go_to.def_line = 6;
     go_to.def_start_char = 5;
     go_to.def_end_char = 9;
-    definition_check_with_req_offset(&mut service, &mut go_to, 10, 17, 7).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 10, 17, &mut i).await;
 }
 
 #[tokio::test]
@@ -787,8 +915,9 @@ async fn go_to_definition_for_functions() {
         test_fixtures_dir().join("tokens/functions/src/main.sw"),
     )
     .await;
+    let mut i = 0..;
 
-    let mut go_to = GotoDefintion {
+    let mut go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 8,
         req_char: 14,
@@ -798,12 +927,12 @@ async fn go_to_definition_for_functions() {
         def_path: uri.as_str(),
     };
     // Return type
-    let _ = lsp::definition_check(&mut service, &go_to, 1).await;
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
     // TODO: @IGI-111 add test for generic return type
 
     // Function parameter
-    definition_check_with_req_offset(&mut service, &mut go_to, 13, 16, 2).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 13, 16, &mut i).await;
 
     // TODO: @IGI-111 add test for generic function parameter
 
@@ -811,7 +940,7 @@ async fn go_to_definition_for_functions() {
     go_to.def_line = 8;
     go_to.def_start_char = 3;
     go_to.def_end_char = 6;
-    definition_check_with_req_offset(&mut service, &mut go_to, 19, 13, 3).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 19, 13, &mut i).await;
 }
 
 //------------------- HOVER DOCUMENTATION -------------------//


### PR DESCRIPTION
## Description
Produce proper LSP tokens for scrutinees inside match or if-let expressions, adds a new `TyExpressionVariant::MatchExp` to store the scrutinee metadata over the desugared conditional in the typed AST.

This also refactors the LSP tests to auto-increment query ids and simplify future edits.

Fix #3614

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
