### PR TITLE
Fix suffix token handling for enum and struct

### DIFF
--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -285,11 +285,11 @@ impl CollectTypesMetadata for TyExpression {
             EnumInstantiation {
                 enum_decl,
                 contents,
-                enum_instantiation_span,
+                call_path_binding,
                 ..
             } => {
                 for type_param in enum_decl.type_parameters.iter() {
-                    ctx.call_site_insert(type_param.type_id, enum_instantiation_span.clone())
+                    ctx.call_site_insert(type_param.type_id, call_path_binding.inner.suffix.span())
                 }
                 if let Some(contents) = contents {
                     res.append(&mut check!(

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -97,7 +97,6 @@ pub enum TyExpressionVariant {
         /// If there is an error regarding this instantiation of the enum,
         /// use these spans as it points to the call site and not the declaration.
         /// They are also used in the language server.
-        enum_instantiation_span: Span,
         variant_instantiation_span: Span,
         call_path_binding: TypeBinding<CallPath>,
     },
@@ -514,7 +513,6 @@ impl HashWithEngines for TyExpressionVariant {
                 contents,
                 // these fields are not hashed because they aren't relevant/a
                 // reliable source of obj v. obj distinction
-                enum_instantiation_span: _,
                 variant_instantiation_span: _,
                 call_path_binding: _,
             } => {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1128,7 +1128,6 @@ impl ty::TyExpression {
         let mut enum_probe_errors = vec![];
         let maybe_enum = {
             let call_path_binding = unknown_call_path_binding.clone();
-            let enum_name = call_path_binding.inner.prefixes[0].clone();
             let variant_name = call_path_binding.inner.suffix.clone();
             let enum_call_path = call_path_binding.inner.rshift();
 
@@ -1142,7 +1141,7 @@ impl ty::TyExpression {
                     unknown_decl.expect_enum(decl_engine, &call_path_binding.span())
                 })
                 .ok(&mut enum_probe_warnings, &mut enum_probe_errors)
-                .map(|enum_decl| (enum_decl, enum_name, variant_name, call_path_binding))
+                .map(|enum_decl| (enum_decl, variant_name, call_path_binding))
         };
 
         // Check if this could be a constant
@@ -1160,19 +1159,11 @@ impl ty::TyExpression {
 
         // compare the results of the checks
         let exp = match (is_module, maybe_function, maybe_enum, maybe_const) {
-            (false, None, Some((enum_decl, enum_name, variant_name, call_path_binding)), None) => {
+            (false, None, Some((enum_decl, variant_name, call_path_binding)), None) => {
                 warnings.append(&mut enum_probe_warnings);
                 errors.append(&mut enum_probe_errors);
                 check!(
-                    instantiate_enum(
-                        ctx,
-                        enum_decl,
-                        enum_name,
-                        variant_name,
-                        args,
-                        call_path_binding,
-                        &span
-                    ),
+                    instantiate_enum(ctx, enum_decl, variant_name, args, call_path_binding, &span),
                     return err(warnings, errors),
                     warnings,
                     errors

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -14,7 +14,6 @@ use sway_types::{Ident, Span, Spanned};
 pub(crate) fn instantiate_enum(
     ctx: TypeCheckContext,
     enum_decl: ty::TyEnumDeclaration,
-    enum_name: Ident,
     enum_variant_name: Ident,
     args_opt: Option<Vec<Expression>>,
     call_path_binding: TypeBinding<CallPath>,
@@ -59,7 +58,6 @@ pub(crate) fn instantiate_enum(
                     contents: None,
                     enum_decl,
                     variant_name: enum_variant.name,
-                    enum_instantiation_span: call_path_binding.inner.suffix.span(),
                     variant_instantiation_span: enum_variant_name.span(),
                     call_path_binding,
                 },
@@ -105,7 +103,6 @@ pub(crate) fn instantiate_enum(
                         contents: Some(Box::new(typed_expr)),
                         enum_decl,
                         variant_name: enum_variant.name,
-                        enum_instantiation_span: enum_name.span(),
                         variant_instantiation_span: enum_variant_name.span(),
                         call_path_binding,
                     },

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -552,13 +552,12 @@ impl<'a> TypedTree<'a> {
             }
             ty::TyExpressionVariant::StructExpression {
                 fields,
-                span,
                 call_path_binding,
                 ..
             } => {
                 if let Some(mut token) = self
                     .tokens
-                    .try_get_mut(&to_ident_key(&Ident::new(span.clone())))
+                    .try_get_mut(&to_ident_key(&call_path_binding.inner.suffix))
                     .try_unwrap()
                 {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));
@@ -664,14 +663,13 @@ impl<'a> TypedTree<'a> {
                 variant_name,
                 variant_instantiation_span,
                 enum_decl,
-                enum_instantiation_span,
                 contents,
                 call_path_binding,
                 ..
             } => {
                 if let Some(mut token) = self
                     .tokens
-                    .try_get_mut(&to_ident_key(&Ident::new(enum_instantiation_span.clone())))
+                    .try_get_mut(&to_ident_key(&call_path_binding.inner.suffix))
                     .try_unwrap()
                 {
                     token.typed = Some(TypedAstToken::TypedExpression(expression.clone()));

--- a/sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw
+++ b/sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw
@@ -1,3 +1,12 @@
 library deeper_mod;
 
 pub fn deep_fun(){}
+
+pub enum DeepEnum {
+    Variant: (),
+    Number: u32,
+}
+
+pub struct DeepStruct<T> {
+    field: T,
+}

--- a/sway-lsp/tests/fixtures/tokens/paths/src/main.sw
+++ b/sway-lsp/tests/fixtures/tokens/paths/src/main.sw
@@ -24,4 +24,12 @@ pub fn fun() {
 
     let _ = std::constants::ZERO_B256;
     let _ = core::primitives::b256::min();
+
+    let _ = ::deep_mod::deeper_mod::DeepEnum::Variant;
+    let _ = deep_mod::deeper_mod::DeepEnum::Variant;
+    let _ = ::deep_mod::deeper_mod::DeepEnum::Number(0);
+    let _ = deep_mod::deeper_mod::DeepEnum::Number(0);
+
+    let _ = ::deep_mod::deeper_mod::DeepStruct::<u64> { field: 0 };
+    let _ = deep_mod::deeper_mod::DeepStruct::<u64> { field: 0 };
 }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -563,6 +563,12 @@ async fn go_to_definition_for_paths() {
     // deep_mod
     let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
     definition_check_with_req_offset(&mut service, &mut go_to, 6, 6, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 27, 16, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 28, 16, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 29, 16, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 30, 16, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 32, 16, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 33, 16, &mut i).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -576,6 +582,66 @@ async fn go_to_definition_for_paths() {
     // deeper_mod
     let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
     definition_check_with_req_offset(&mut service, &mut go_to, 6, 16, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 27, 28, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 28, 28, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 29, 28, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 30, 28, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 32, 28, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 33, 28, &mut i).await;
+
+    let mut go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 27,
+        req_char: 38,
+        def_line: 4,
+        def_start_char: 9,
+        def_end_char: 17,
+        def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
+    };
+    // DeepEnum
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 28, 38, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 29, 38, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 30, 38, &mut i).await;
+
+    let mut go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 32,
+        req_char: 37,
+        def_line: 9,
+        def_start_char: 11,
+        def_end_char: 21,
+        def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
+    };
+    // DeepStruct
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 33, 37, &mut i).await;
+
+    let mut go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 27,
+        req_char: 48,
+        def_line: 5,
+        def_start_char: 4,
+        def_end_char: 11,
+        def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
+    };
+    // DeepEnum::Variant
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 28, 48, &mut i).await;
+
+    let mut go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 29,
+        req_char: 48,
+        def_line: 6,
+        def_start_char: 4,
+        def_end_char: 10,
+        def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
+    };
+    // DeepEnum::Number
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 30, 48, &mut i).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,


### PR DESCRIPTION

## Description
Properly handle suffix tokens for struct and enum instantiation in some edge cases by using call_path suffixes instead of spans.

Remove duplicate logic of `enum_instantiation_span` and use `call_path`'s suffix instead.

Fix #4055


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
