### PR TITLE
fix: add span based filter for `forc-test` test counts

### DIFF
--- a/forc-test/src/lib.rs
+++ b/forc-test/src/lib.rs
@@ -310,7 +310,7 @@ impl BuiltTests {
     pub fn test_count(&self) -> usize {
         // TODO: Remove this once https://github.com/FuelLabs/sway/issues/3947 is solved.
         let mut visited_tests = HashSet::new();
-        
+
         let pkgs: Vec<&PackageTests> = match self {
             BuiltTests::Package(pkg) => vec![pkg],
             BuiltTests::Workspace(workspace) => workspace.iter().collect(),

--- a/forc-test/src/lib.rs
+++ b/forc-test/src/lib.rs
@@ -308,6 +308,9 @@ impl TestResult {
 impl BuiltTests {
     /// The total number of tests.
     pub fn test_count(&self) -> usize {
+        // TODO: Remove this once https://github.com/FuelLabs/sway/issues/3947 is solved.
+        let mut visited_tests = HashSet::new();
+        
         let pkgs: Vec<&PackageTests> = match self {
             BuiltTests::Package(pkg) => vec![pkg],
             BuiltTests::Workspace(workspace) => workspace.iter().collect(),
@@ -317,7 +320,8 @@ impl BuiltTests {
                 pkg.built_pkg_with_tests()
                     .entries
                     .iter()
-                    .filter(|e| e.is_test())
+                    .filter_map(|entry| entry.kind.test().map(|test| (entry, test)))
+                    .filter(|(_, test_entry)| visited_tests.insert(&test_entry.span))
                     .count()
             })
             .sum()


### PR DESCRIPTION
## Description
closes #4034.

This is a hot-fix until #3947 is fixed. This PR adds a filter to test count to filter out duplicate test entries caused by duplicate dep declarations.

related to #3988.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
