### PR TITLE
Support inner doc attributes with `#!` & `//!` syntax

### DIFF
--- a/sway-ast/src/attribute.rs
+++ b/sway-ast/src/attribute.rs
@@ -15,14 +15,41 @@ pub struct Annotated<T> {
 
 #[derive(Clone, Debug)]
 pub struct AttributeDecl {
-    pub hash_token: HashToken,
+    pub hash_kind: AttributeHashKind,
     pub attribute: SquareBrackets<Punctuated<Attribute, CommaToken>>,
 }
 
 impl Spanned for AttributeDecl {
     fn span(&self) -> Span {
-        Span::join(self.hash_token.span(), self.attribute.span())
+        let hash_span = match &self.hash_kind {
+            AttributeHashKind::Inner(hash_bang_token) => hash_bang_token.span(),
+            AttributeHashKind::Outer(hash_token) => hash_token.span(),
+        };
+        Span::join(hash_span, self.attribute.span())
     }
+}
+
+/// Denotes the target direction of an [AttributeDecl] and
+/// the hash token kind associated.
+///
+/// Example:
+/// ```sway
+/// // outer (after), written as `///`
+/// #[doc("a Sway struct")]
+/// struct Foo {}
+///
+/// // inner (before), written as `//!`
+/// enum Bar {}
+/// #![doc("a Sway enum")]
+/// ```
+#[derive(Clone, Debug)]
+pub enum AttributeHashKind {
+    /// Inner specifies that the attribute belongs to
+    /// the item before it.
+    Inner(HashBangToken),
+    /// Outer specifies that the attribute belongs to
+    /// the item after it.
+    Outer(HashToken),
 }
 
 #[derive(Clone, Debug)]

--- a/sway-ast/src/keywords.rs
+++ b/sway-ast/src/keywords.rs
@@ -220,3 +220,4 @@ define_token!(
 define_token!(DoublePipeToken, "`||`", [Pipe, Pipe], [Pipe]);
 define_token!(UnderscoreToken, "`_`", [Underscore], [Underscore]);
 define_token!(HashToken, "`#`", [Sharp], []);
+define_token!(HashBangToken, "`#!`", [Sharp, Bang], []);

--- a/sway-core/src/language/parsed/module.rs
+++ b/sway-core/src/language/parsed/module.rs
@@ -10,7 +10,7 @@ pub struct ParseModule {
     pub tree: ParseTree,
     /// Submodules introduced within this module using the `dep` syntax in order of declaration.
     pub submodules: Vec<(DepName, ParseSubmodule)>,
-    // pub attributes: transform::AttributesMap,
+    // pub attributes: crate::transform::AttributesMap,
 }
 
 /// A library module that was declared as a `dep` of another module.

--- a/sway-core/src/language/parsed/module.rs
+++ b/sway-core/src/language/parsed/module.rs
@@ -10,6 +10,7 @@ pub struct ParseModule {
     pub tree: ParseTree,
     /// Submodules introduced within this module using the `dep` syntax in order of declaration.
     pub submodules: Vec<(DepName, ParseSubmodule)>,
+    // pub attributes: transform::AttributesMap,
 }
 
 /// A library module that was declared as a `dep` of another module.

--- a/sway-core/src/language/parsed/module.rs
+++ b/sway-core/src/language/parsed/module.rs
@@ -1,4 +1,4 @@
-use crate::language::DepName;
+use crate::{language::DepName, transform};
 
 use super::ParseTree;
 use sway_types::{Ident, Span};
@@ -10,7 +10,7 @@ pub struct ParseModule {
     pub tree: ParseTree,
     /// Submodules introduced within this module using the `dep` syntax in order of declaration.
     pub submodules: Vec<(DepName, ParseSubmodule)>,
-    // pub attributes: crate::transform::AttributesMap,
+    pub attributes: transform::AttributesMap,
 }
 
 /// A library module that was declared as a `dep` of another module.

--- a/sway-core/src/language/ty/module.rs
+++ b/sway-core/src/language/ty/module.rs
@@ -5,6 +5,7 @@ use crate::{
     language::ty::*,
     language::DepName,
     semantic_analysis::namespace,
+    transform,
 };
 
 #[derive(Clone, Debug)]
@@ -12,7 +13,7 @@ pub struct TyModule {
     pub submodules: Vec<(DepName, TySubmodule)>,
     pub namespace: namespace::Module,
     pub all_nodes: Vec<TyAstNode>,
-    // pub attributes: transform::AttributesMap,
+    pub attributes: transform::AttributesMap,
 }
 
 #[derive(Clone, Debug)]

--- a/sway-core/src/language/ty/module.rs
+++ b/sway-core/src/language/ty/module.rs
@@ -12,6 +12,7 @@ pub struct TyModule {
     pub submodules: Vec<(DepName, TySubmodule)>,
     pub namespace: namespace::Module,
     pub all_nodes: Vec<TyAstNode>,
+    // pub attributes: transform::AttributesMap,
 }
 
 #[derive(Clone, Debug)]

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -136,14 +136,7 @@ fn module_attrs_to_map(
                 DOC_COMMENT_ATTRIBUTE_NAME => Some(AttributeKind::DocComment),
                 _ => None,
             } {
-                match attrs_map.get_mut(&attr_kind) {
-                    Some(old_args) => {
-                        old_args.push(attribute);
-                    }
-                    None => {
-                        attrs_map.insert(attr_kind, vec![attribute]);
-                    }
-                }
+                attrs_map.entry(attr_kind).or_default().push(attribute);
             }
         }
     }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -114,7 +114,11 @@ fn parse_in_memory(
         module.clone(),
     )?;
     let submodules = Default::default();
-    let root = parsed::ParseModule { tree, submodules };
+    let root = parsed::ParseModule {
+        tree,
+        submodules,
+        // attributes,
+    };
     let lexed_program = lexed::LexedProgram::new(
         kind.clone(),
         lexed::LexedModule {
@@ -225,6 +229,7 @@ fn parse_module_tree(
     let parsed = parsed::ParseModule {
         tree,
         submodules: submodules.parsed,
+        // attributes,
     };
     Ok((kind, lexed, parsed))
 }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -102,6 +102,8 @@ pub fn parse_tree_type(input: Arc<str>) -> CompileResult<parsed::TreeType> {
         sway_parse::parse_module_kind(h, input, None).map(|kind| convert_module_kind(&kind))
     })
 }
+
+/// Convert attributes from `Annotated<Module>` to an [AttributesMap].
 fn module_attrs_to_map(
     handler: &Handler,
     attribute_list: &[AttributeDecl],

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -111,7 +111,7 @@ fn parse_in_memory(
         &mut to_parsed_lang::Context::default(),
         handler,
         engines,
-        module.clone(),
+        module.value.clone(),
     )?;
     let submodules = Default::default();
     let root = parsed::ParseModule {
@@ -122,7 +122,7 @@ fn parse_in_memory(
     let lexed_program = lexed::LexedProgram::new(
         kind.clone(),
         lexed::LexedModule {
-            tree: module,
+            tree: module.value,
             submodules: Default::default(),
         },
     );
@@ -212,18 +212,18 @@ fn parse_module_tree(
 
     // Parse all submodules before converting to the `ParseTree`.
     // This always recovers on parse errors for the file itself by skipping that file.
-    let submodules = parse_submodules(handler, engines, &module, module_dir);
+    let submodules = parse_submodules(handler, engines, &module.value, module_dir);
 
     // Convert from the raw parsed module to the `ParseTree` ready for type-check.
     let (kind, tree) = to_parsed_lang::convert_parse_tree(
         &mut to_parsed_lang::Context::default(),
         handler,
         engines,
-        module.clone(),
+        module.value.clone(),
     )?;
 
     let lexed = lexed::LexedModule {
-        tree: module,
+        tree: module.value,
         submodules: submodules.lexed,
     };
     let parsed = parsed::ParseModule {

--- a/sway-core/src/semantic_analysis/module.rs
+++ b/sway-core/src/semantic_analysis/module.rs
@@ -9,7 +9,11 @@ impl ty::TyModule {
     ///
     /// Recursively type-checks submodules first.
     pub fn type_check(mut ctx: TypeCheckContext, parsed: &ParseModule) -> CompileResult<Self> {
-        let ParseModule { submodules, tree } = parsed;
+        let ParseModule {
+            submodules,
+            tree,
+            attributes,
+        } = parsed;
 
         // Type-check submodules first in order of declaration.
         let mut submodules_res = ok(vec![], vec![], vec![]);
@@ -37,6 +41,7 @@ impl ty::TyModule {
                 submodules,
                 namespace: ctx.namespace.module().clone(),
                 all_nodes,
+                attributes: attributes.clone(),
             })
         })
     }

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -340,6 +340,10 @@ pub enum CompileError {
     #[error("Expected block to implicitly return a value.")]
     ExpectedImplicitReturnFromBlock { span: Span },
     #[error(
+        "Expected Module level doc comment. All other attributes are unsupported at this level."
+    )]
+    ExpectedModuleDocComment { span: Span },
+    #[error(
         "This register was not initialized in the initialization section of the ASM expression. \
          Initialized registers are: {initialized_registers}"
     )]
@@ -799,6 +803,7 @@ impl Spanned for CompileError {
             PathDoesNotReturn { span, .. } => span.clone(),
             ExpectedImplicitReturnFromBlockWithType { span, .. } => span.clone(),
             ExpectedImplicitReturnFromBlock { span, .. } => span.clone(),
+            ExpectedModuleDocComment { span } => span.clone(),
             UnknownRegister { span, .. } => span.clone(),
             MissingImmediate { span, .. } => span.clone(),
             InvalidImmediateValue { span, .. } => span.clone(),

--- a/sway-error/src/parser_error.rs
+++ b/sway-error/src/parser_error.rs
@@ -74,6 +74,8 @@ pub enum ParseErrorKind {
     UnnecessaryVisibilityQualifier { visibility: Ident },
     #[error("Expected a doc comment.")]
     ExpectedDocComment,
+    #[error("Top of file doc comments are reserved for module level documentation.\nTry using the `//!` syntax.")]
+    ExpectedModuleDocComment,
     #[error("Use the `struct` keyword to define records, instead of `class`.")]
     UnexpectedClass,
     #[error("Field projections, e.g., `foo.bar` cannot have type arguments.")]

--- a/sway-parse/src/item/mod.rs
+++ b/sway-parse/src/item/mod.rs
@@ -206,9 +206,9 @@ mod tests {
         let item = parse_item(
             r#"
             // I will be ignored.
-            //! I will be ignored.
+            //! I can't feel the way I did before
             /// This is a doc comment.
-            //! I will be ignored.
+            //! Don't turn your back on me, I won't be ignored.
             // I will be ignored.
             fn f() -> bool {
                 false
@@ -218,7 +218,17 @@ mod tests {
         assert!(matches!(item.value, ItemKind::Fn(_)));
         assert_eq!(
             attributes(&item.attribute_list),
-            vec![[("doc-comment", Some(vec![" This is a doc comment."]))]]
+            vec![
+                [(
+                    "doc-comment",
+                    Some(vec![" I can't feel the way I did before"])
+                )],
+                [("doc-comment", Some(vec![" This is a doc comment."]))],
+                [(
+                    "doc-comment",
+                    Some(vec![" Don't turn your back on me, I won't be ignored."])
+                )]
+            ]
         );
     }
 
@@ -227,15 +237,15 @@ mod tests {
         let item = parse_item(
             r#"
             // I will be ignored.
-            //! I will be ignored.
+            //! I can't feel the way I did before
             /// This is a doc comment.
-            //! I will be ignored.
+            //! Don't turn your back on me, I won't be ignored.
             // I will be ignored.
             struct MyStruct {
                 // I will be ignored.
-                //! I will be ignored.
+                //! Time won't heal this damage anymore
                 /// This is a doc comment.
-                //! I will be ignored.
+                //! Don't turn your back on me, I won't be ignored.
                 // I will be ignored.
                 a: bool,
             }
@@ -246,7 +256,17 @@ mod tests {
         assert!(matches!(item.value, ItemKind::Struct(_)));
         assert_eq!(
             attributes(&item.attribute_list),
-            vec![[("doc-comment", Some(vec![" This is a doc comment."]))]]
+            vec![
+                [(
+                    "doc-comment",
+                    Some(vec![" I can't feel the way I did before"])
+                )],
+                [("doc-comment", Some(vec![" This is a doc comment."]))],
+                [(
+                    "doc-comment",
+                    Some(vec![" Don't turn your back on me, I won't be ignored."])
+                )]
+            ]
         );
 
         /* struct field annotations */
@@ -257,7 +277,17 @@ mod tests {
 
         assert_eq!(
             attributes(&item.attribute_list),
-            vec![[("doc-comment", Some(vec![" This is a doc comment."]))]]
+            vec![
+                [(
+                    "doc-comment",
+                    Some(vec![" Time won't heal this damage anymore"])
+                )],
+                [("doc-comment", Some(vec![" This is a doc comment."]))],
+                [(
+                    "doc-comment",
+                    Some(vec![" Don't turn your back on me, I won't be ignored."])
+                )]
+            ]
         );
     }
 

--- a/sway-parse/src/keywords.rs
+++ b/sway-parse/src/keywords.rs
@@ -147,7 +147,8 @@ token_impls! {
     DoubleAmpersandToken,
     DoublePipeToken,
     UnderscoreToken,
-    HashToken
+    HashToken,
+    HashBangToken
 }
 
 // Keep this in sync with the list in `sway-ast/keywords.rs` defined by define_keyword!

--- a/sway-parse/src/lib.rs
+++ b/sway-parse/src/lib.rs
@@ -25,7 +25,7 @@ pub use crate::{
     token::{lex, lex_commented},
 };
 
-use sway_ast::{Module, ModuleKind};
+use sway_ast::{attribute::Annotated, Module, ModuleKind};
 use sway_error::handler::{ErrorEmitted, Handler};
 
 use std::{path::PathBuf, sync::Arc};
@@ -34,7 +34,7 @@ pub fn parse_file(
     handler: &Handler,
     src: Arc<str>,
     path: Option<Arc<PathBuf>>,
-) -> Result<Module, ErrorEmitted> {
+) -> Result<Annotated<Module>, ErrorEmitted> {
     let ts = lex(handler, &src, 0, src.len(), path)?;
     Parser::new(handler, &ts).parse_to_end().map(|(m, _)| m)
 }

--- a/sway-parse/src/module.rs
+++ b/sway-parse/src/module.rs
@@ -1,7 +1,14 @@
 use crate::{Parse, ParseResult, ParseToEnd, Parser, ParserConsumed};
 
-use sway_ast::{Module, ModuleKind};
+use sway_ast::{
+    attribute::{Annotated, Attribute, AttributeHashKind},
+    brackets::SquareBrackets,
+    keywords::{HashBangToken, Token},
+    token::{DocComment, DocStyle},
+    AttributeDecl, Module, ModuleKind, Parens, Punctuated,
+};
 use sway_error::parser_error::ParseErrorKind;
+use sway_types::{constants::DOC_COMMENT_ATTRIBUTE_NAME, Ident};
 
 impl Parse for ModuleKind {
     fn parse(parser: &mut Parser) -> ParseResult<Self> {
@@ -23,16 +30,50 @@ impl Parse for ModuleKind {
     }
 }
 
-impl ParseToEnd for Module {
+impl ParseToEnd for Annotated<Module> {
     fn parse_to_end<'a, 'e>(mut parser: Parser<'a, '_>) -> ParseResult<(Self, ParserConsumed<'a>)> {
+        // Parse the attribute list.
+        let mut attribute_list = Vec::new();
+        while let Some(DocComment { .. }) = parser.peek() {
+            let doc_comment = parser.parse::<DocComment>()?;
+            // TODO: Use a Literal instead of an Ident when Attribute args
+            // start supporting them and remove `Ident::new_no_trim`.
+            let value = Ident::new_no_trim(doc_comment.content_span.clone());
+            let hash_kind = match &doc_comment.doc_style {
+                DocStyle::Inner => Ok(AttributeHashKind::Inner(HashBangToken::new(
+                    doc_comment.span.clone(),
+                ))),
+                DocStyle::Outer => Err(parser.emit_error(ParseErrorKind::ExpectedModuleDocComment)),
+            }
+            .unwrap();
+            attribute_list.push(AttributeDecl {
+                hash_kind,
+                attribute: SquareBrackets::new(
+                    Punctuated::single(Attribute {
+                        name: Ident::new_with_override(
+                            DOC_COMMENT_ATTRIBUTE_NAME,
+                            doc_comment.span.clone(),
+                        ),
+                        args: Some(Parens::new(
+                            Punctuated::single(value),
+                            doc_comment.content_span,
+                        )),
+                    }),
+                    doc_comment.span,
+                ),
+            });
+        }
         let (kind, semicolon_token) = parser.parse()?;
 
         let (items, consumed) = parser.parse_to_end()?;
 
-        let module = Self {
-            kind,
-            semicolon_token,
-            items,
+        let module = Annotated {
+            attribute_list,
+            value: Module {
+                kind,
+                semicolon_token,
+                items,
+            },
         };
         Ok((module, consumed))
     }

--- a/sway-parse/src/token.rs
+++ b/sway-parse/src/token.rs
@@ -298,11 +298,7 @@ fn lex_line_comment(l: &mut Lexer<'_>, end: usize, index: usize) -> CommentedTok
 
     let doc_style = match (sp.as_str().chars().nth(2), sp.as_str().chars().nth(3)) {
         // `//!` is an inner line doc comment.
-        (Some('!'), _) => {
-            // TODO: Add support for inner line doc comments.
-            // Some(DocStyle::Inner)
-            None
-        }
+        (Some('!'), _) => Some(DocStyle::Inner),
         // `////` (more than 3 slashes) is not considered a doc comment.
         (Some('/'), Some('/')) => None,
         // `///` is an outer line doc comment.
@@ -767,6 +763,7 @@ mod tests {
         //none
         ////none
         //!inner
+        //! inner
         ///outer
         /// outer
         "#;
@@ -789,20 +786,21 @@ mod tests {
                 span
             })) if span.as_str() ==  "////none"
         );
-        // TODO: Add support for inner line doc comments.
-        // assert_matches!(
-        //     tts.next(),
-        //     Some(CommentedTokenTree::Tree(CommentedTree::DocComment(DocComment {
-        //         doc_style: DocStyle::Inner,
-        //         span,
-        //         content_span,
-        //     }))) if span.as_str() ==  "//!inner" && content_span.as_str() == "inner"
-        // );
         assert_matches!(
             tts.next(),
-            Some(CommentedTokenTree::Comment(Comment {
-                span
-            })) if span.as_str() ==  "//!inner"
+            Some(CommentedTokenTree::Tree(CommentedTree::DocComment(DocComment {
+                doc_style: DocStyle::Inner,
+                span,
+                content_span,
+            }))) if span.as_str() ==  "//!inner" && content_span.as_str() == "inner"
+        );
+        assert_matches!(
+            tts.next(),
+            Some(CommentedTokenTree::Tree(CommentedTree::DocComment(DocComment {
+                doc_style: DocStyle::Inner,
+                span,
+                content_span,
+            }))) if span.as_str() ==  "//! inner" && content_span.as_str() == " inner"
         );
         assert_matches!(
             tts.next(),

--- a/swayfmt/src/error.rs
+++ b/swayfmt/src/error.rs
@@ -16,6 +16,8 @@ pub enum FormatterError {
     CommentError,
     #[error("Error while formatting newline sequences")]
     NewlineSequenceError,
+    #[error("Cannot format raw hashbang attribute,\nIf this is intended to be a doc comment try using the `//!` syntax instead")]
+    HashBangAttributeError,
 }
 
 #[derive(Debug, Error)]

--- a/swayfmt/src/formatter/mod.rs
+++ b/swayfmt/src/formatter/mod.rs
@@ -67,7 +67,7 @@ impl Formatter {
         // Collect Span -> Comment mapping from unformatted input.
         self.comment_map = CommentMap::from_src(Arc::from(src))?;
 
-        let module = parse_file(Arc::from(src), path.clone())?;
+        let module = parse_file(Arc::from(src), path.clone())?.value;
         module.format(&mut raw_formatted_code, self)?;
 
         let mut formatted_code = String::from(&raw_formatted_code);

--- a/swayfmt/src/parse.rs
+++ b/swayfmt/src/parse.rs
@@ -1,7 +1,7 @@
 use crate::error::ParseFileError;
 use std::path::PathBuf;
 use std::sync::Arc;
-use sway_ast::{token::CommentedTokenStream, Module};
+use sway_ast::{attribute::Annotated, token::CommentedTokenStream, Module};
 use sway_error::handler::{ErrorEmitted, Handler};
 
 fn with_handler<T>(
@@ -15,7 +15,10 @@ fn with_handler<T>(
         .ok_or(ParseFileError(errors))
 }
 
-pub fn parse_file(src: Arc<str>, path: Option<Arc<PathBuf>>) -> Result<Module, ParseFileError> {
+pub fn parse_file(
+    src: Arc<str>,
+    path: Option<Arc<PathBuf>>,
+) -> Result<Annotated<Module>, ParseFileError> {
     with_handler(|h| sway_parse::parse_file(h, src, path))
 }
 

--- a/swayfmt/src/utils/map/comments.rs
+++ b/swayfmt/src/utils/map/comments.rs
@@ -126,7 +126,7 @@ pub fn handle_comments(
     comment_map: &mut CommentMap,
 ) -> Result<(), FormatterError> {
     // After the formatting existing items should be the same (type of the item) but their spans will be changed since we applied formatting to them.
-    let formatted_module = parse_file(formatted_input, path)?;
+    let formatted_module = parse_file(formatted_input, path)?.value;
 
     // Actually find & insert the comments.
     add_comments(

--- a/swayfmt/src/utils/map/newline.rs
+++ b/swayfmt/src/utils/map/newline.rs
@@ -94,7 +94,7 @@ pub fn handle_newlines(
     // formatting the code a second time will still produce the same result.
     let newline_map = newline_map_from_src(&unformatted_input)?;
     // After the formatting existing items should be the same (type of the item) but their spans will be changed since we applied formatting to them.
-    let formatted_module = parse_file(formatted_input, path)?;
+    let formatted_module = parse_file(formatted_input, path)?.value;
     // Actually find & insert the newline sequences
     add_newlines(
         newline_map,

--- a/swayfmt/tests/mod.rs
+++ b/swayfmt/tests/mod.rs
@@ -840,7 +840,33 @@ fn main() {
 }
 
 #[test]
-fn doc_comments() {
+fn inner_doc_comments() {
+    check(
+        r#"script;
+
+enum Color {
+//! Color is a Sway enum
+    blue: (),
+    red: ()
+}
+
+fn main() {
+}"#,
+        r#"script;
+
+enum Color {
+    //! Color is a Sway enum
+    blue: (),
+    red: (),
+}
+
+fn main() {}
+"#,
+    );
+}
+
+#[test]
+fn outer_doc_comments() {
     check(
         r#"script;
 


### PR DESCRIPTION
## Description
This adds the `HashBangToken` (`#!`) which will support nested module doc comments as well as inner doc comments for annotated items.

- [x] Add `HashBangToken`
- [x] Differentiate hash tokens on `AttributeDecl`
- [ ] Fix directional attribute parsing for `Inner` & `Outer` doc comments ( This is optional, the only downside of not implementing this right away is that inner and outer docs are treated equally )
- [x] Add attributes to `Module`
- [x] Complete support for module level attributes

## Checklist

- [x] I have linked to any relevant issues. Closes #3171 
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant. @mohammadfawaz 
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
