### PR TITLE
`forc-tx`: Improve error handling using `thiserror`. Fix `panic!`ing version/help output.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,6 +1764,7 @@ dependencies = [
  "fuel-tx",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/forc-plugins/forc-tx/Cargo.toml
+++ b/forc-plugins/forc-tx/Cargo.toml
@@ -22,3 +22,4 @@ devault = "0.1"
 fuel-tx = { workspace = true, features = ["serde"] }
 serde = "1.0"
 serde_json = { version = "1" }
+thiserror = "1"

--- a/forc-plugins/forc-tx/src/lib.rs
+++ b/forc-plugins/forc-tx/src/lib.rs
@@ -377,19 +377,19 @@ pub enum ConvertScriptTxError {
 /// Errors that can occur during transaction input conversion.
 #[derive(Debug, Error)]
 pub enum ConvertInputError {
-    #[error("failed to read message data from {path:?}")]
+    #[error("failed to read `--msg-data` from {path:?}")]
     MessageDataRead {
         path: PathBuf,
         #[source]
         err: std::io::Error,
     },
-    #[error("failed to read predicate from {path:?}")]
+    #[error("failed to read `--predicate` from {path:?}")]
     PredicateRead {
         path: PathBuf,
         #[source]
         err: std::io::Error,
     },
-    #[error("failed to read predicate data from {path:?}")]
+    #[error("failed to read `--predicate-data` from {path:?}")]
     PredicateDataRead {
         path: PathBuf,
         #[source]

--- a/forc-plugins/forc-tx/src/lib.rs
+++ b/forc-plugins/forc-tx/src/lib.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 /// The top-level `forc tx` command.
 #[derive(Debug, Parser, Deserialize, Serialize)]
-#[clap(about, version)]
+#[clap(about, version, after_help = EXAMPLES)]
 pub struct Command {
     #[clap(long, short = 'o')]
     pub output_path: Option<PathBuf>,
@@ -398,6 +398,68 @@ pub enum ConvertInputError {
     #[error("input accepts either witness index or predicate, not both")]
     WitnessPredicateMismatch,
 }
+
+const EXAMPLES: &str = r#"EXAMPLES:
+    # An example constructing a `create` transaction.
+    forc tx create \
+        --bytecode ./my-contract/out/debug/my-contract.bin \
+        --storage-slots ./my-contract/out/debug/my-contract-storage_slots.json \
+        --gas-limit 100 \
+        --gas-price 0 \
+        --maturity 0 \
+        --witness ADFD \
+        --witness DFDA \
+        input coin \
+            --utxo-id 0 \
+            --output-ix 0 \
+            --owner 0x0000000000000000000000000000000000000000000000000000000000000000 \
+            --amount 100 \
+            --asset-id 0x0000000000000000000000000000000000000000000000000000000000000000 \
+            --tx-ptr 89ACBDEFBDEF \
+            --witness-ix 0 \
+            --maturity 0 \
+            --predicate ./my-predicate/out/debug/my-predicate.bin \
+            --predicate-data ./my-predicate.dat \
+        input contract \
+            --utxo-id 1 \
+            --output-ix 1 \
+            --balance-root 0x0000000000000000000000000000000000000000000000000000000000000000 \
+            --state-root 0x0000000000000000000000000000000000000000000000000000000000000000 \
+            --tx-ptr 89ACBDEFBDEF \
+            --contract-id 0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC \
+        input message \
+            --msg-id 0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB \
+            --sender 0x1111111111111111111111111111111111111111111111111111111111111111 \
+            --recipient 0x2222222222222222222222222222222222222222222222222222222222222222 \
+            --amount 1 \
+            --nonce 1234 \
+            --witness-ix 1 \
+            --msg-data ./message.dat \
+            --predicate ./my-predicate2/out/debug/my-predicate2.bin \
+            --predicate-data ./my-predicate2.dat \
+        output coin \
+            --to 0x2222222222222222222222222222222222222222222222222222222222222222 \
+            --amount 100 \
+            --asset-id 0x0000000000000000000000000000000000000000000000000000000000000000 \
+        output contract \
+            --input-ix 1 \
+            --balance-root 0x0000000000000000000000000000000000000000000000000000000000000000 \
+            --state-root 0x0000000000000000000000000000000000000000000000000000000000000000 \
+        output message \
+            --recipient 0x2222222222222222222222222222222222222222222222222222222222222222 \
+            --amount 100 \
+        output change \
+            --to 0x2222222222222222222222222222222222222222222222222222222222222222 \
+            --amount 100 \
+            --asset-id 0x0000000000000000000000000000000000000000000000000000000000000000 \
+        output variable \
+            --to 0x2222222222222222222222222222222222222222222222222222222222222222 \
+            --amount 100 \
+            --asset-id 0x0000000000000000000000000000000000000000000000000000000000000000 \
+        output contract-created \
+            --contract-id 0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC \
+            --state-root 0x0000000000000000000000000000000000000000000000000000000000000000
+"#;
 
 impl ParseError {
     /// Print the error with clap's fancy formatting.

--- a/forc-plugins/forc-tx/src/main.rs
+++ b/forc-plugins/forc-tx/src/main.rs
@@ -1,15 +1,16 @@
-fn main() {
-    let cmd = forc_tx::Command::try_parse().unwrap();
-    let tx = fuel_tx::Transaction::try_from(cmd.tx).unwrap();
+fn main() -> anyhow::Result<()> {
+    let cmd = forc_tx::Command::parse();
+    let tx = fuel_tx::Transaction::try_from(cmd.tx)?;
     match cmd.output_path {
         None => {
-            let string = serde_json::to_string_pretty(&tx).unwrap();
+            let string = serde_json::to_string_pretty(&tx)?;
             println!("{string}");
         }
         Some(path) => {
-            let file = std::fs::File::create(path).unwrap();
+            let file = std::fs::File::create(path)?;
             let writer = std::io::BufWriter::new(file);
-            serde_json::to_writer_pretty(writer, &tx).unwrap();
+            serde_json::to_writer_pretty(writer, &tx)?;
         }
     }
+    Ok(())
 }


### PR DESCRIPTION
## Description

This introduces a `Command::parse` constructor that emulates the behaviour of the `clap` parse constructor in order to provide a more consistent clap-like CLI experience. For context, we cannot use the generated `parse` command due to limitations in clap's ability to handle trailing subcommands as mentioned in #3804.

We switch to using `thiserror` in the library in order to allow for handling error cases (necessary for the new `parse` constructor) and to provide cleaner, more detailed error cause traces.

The help and version output no longer panic, and now behave like regular clap applications. Closes #3886.

Also adds an example command invocation to the end of the `--help` output.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
