### PR TITLE
Update expected revert string in `storage_vec` tests to fix CI failure

### DIFF
--- a/test/src/sdk-harness/test_projects/storage_bytes/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_bytes/mod.rs
@@ -29,9 +29,17 @@ async fn stores_byte() {
 
     assert_eq!(instance.methods().len().call().await.unwrap().value, 0);
 
-    instance.methods().store_bytes(input.clone()).call().await.unwrap();
+    instance
+        .methods()
+        .store_bytes(input.clone())
+        .call()
+        .await
+        .unwrap();
 
-    assert_eq!(instance.methods().len().call().await.unwrap().value, input.len() as u64);
+    assert_eq!(
+        instance.methods().len().call().await.unwrap().value,
+        input.len() as u64
+    );
 
     instance
         .methods()
@@ -49,11 +57,24 @@ async fn stores_8_bytes() {
 
     assert_eq!(instance.methods().len().call().await.unwrap().value, 0);
 
-    instance.methods().store_bytes(input.clone()).call().await.unwrap();
+    instance
+        .methods()
+        .store_bytes(input.clone())
+        .call()
+        .await
+        .unwrap();
 
-    assert_eq!(instance.methods().len().call().await.unwrap().value, input.len() as u64);
+    assert_eq!(
+        instance.methods().len().call().await.unwrap().value,
+        input.len() as u64
+    );
 
-    instance.methods().assert_stored_bytes(input).call().await.unwrap();
+    instance
+        .methods()
+        .assert_stored_bytes(input)
+        .call()
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -67,11 +88,24 @@ async fn stores_32_bytes() {
 
     assert_eq!(instance.methods().len().call().await.unwrap().value, 0);
 
-    instance.methods().store_bytes(input.clone()).call().await.unwrap();
+    instance
+        .methods()
+        .store_bytes(input.clone())
+        .call()
+        .await
+        .unwrap();
 
-    assert_eq!(instance.methods().len().call().await.unwrap().value, input.len() as u64);
+    assert_eq!(
+        instance.methods().len().call().await.unwrap().value,
+        input.len() as u64
+    );
 
-    instance.methods().assert_stored_bytes(input).call().await.unwrap();
+    instance
+        .methods()
+        .assert_stored_bytes(input)
+        .call()
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/test/src/sdk-harness/test_projects/storage_vec/array/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/array/mod.rs
@@ -255,7 +255,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -263,7 +263,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_swap_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -271,7 +271,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_insert() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -279,7 +279,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_set() {
         let (instance, _id) = get_contract_instance().await;
 

--- a/test/src/sdk-harness/test_projects/storage_vec/b256/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/b256/mod.rs
@@ -261,7 +261,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -269,7 +269,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_swap_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -277,7 +277,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_insert() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -285,7 +285,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_set() {
         let (instance, _id) = get_contract_instance().await;
 

--- a/test/src/sdk-harness/test_projects/storage_vec/bool/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/bool/mod.rs
@@ -255,7 +255,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -263,7 +263,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_swap_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -271,7 +271,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_insert() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -279,7 +279,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_set() {
         let (instance, _id) = get_contract_instance().await;
 

--- a/test/src/sdk-harness/test_projects/storage_vec/enum/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/enum/mod.rs
@@ -262,7 +262,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -270,7 +270,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_swap_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -278,7 +278,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_insert() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -286,7 +286,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_set() {
         let (instance, _id) = get_contract_instance().await;
 

--- a/test/src/sdk-harness/test_projects/storage_vec/str/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/str/mod.rs
@@ -255,7 +255,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -263,7 +263,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_swap_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -271,7 +271,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_insert() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -279,7 +279,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_set() {
         let (instance, _id) = get_contract_instance().await;
 

--- a/test/src/sdk-harness/test_projects/storage_vec/struct/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/struct/mod.rs
@@ -262,7 +262,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -270,7 +270,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_swap_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -278,7 +278,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_insert() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -286,7 +286,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_set() {
         let (instance, _id) = get_contract_instance().await;
 

--- a/test/src/sdk-harness/test_projects/storage_vec/tuple/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/tuple/mod.rs
@@ -261,7 +261,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -269,7 +269,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_swap_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -277,7 +277,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_insert() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -285,7 +285,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_set() {
         let (instance, _id) = get_contract_instance().await;
 

--- a/test/src/sdk-harness/test_projects/storage_vec/u16/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/u16/mod.rs
@@ -255,7 +255,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -263,7 +263,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_swap_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -271,7 +271,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_insert() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -279,7 +279,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_set() {
         let (instance, _id) = get_contract_instance().await;
 

--- a/test/src/sdk-harness/test_projects/storage_vec/u32/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/u32/mod.rs
@@ -255,7 +255,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -263,7 +263,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_swap_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -271,7 +271,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_insert() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -279,7 +279,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_set() {
         let (instance, _id) = get_contract_instance().await;
 

--- a/test/src/sdk-harness/test_projects/storage_vec/u64/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/u64/mod.rs
@@ -255,7 +255,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -263,7 +263,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_swap_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -271,7 +271,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_insert() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -279,7 +279,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_set() {
         let (instance, _id) = get_contract_instance().await;
 

--- a/test/src/sdk-harness/test_projects/storage_vec/u8/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/u8/mod.rs
@@ -255,7 +255,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -263,7 +263,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_swap_remove() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -271,7 +271,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_insert() {
         let (instance, _id) = get_contract_instance().await;
 
@@ -279,7 +279,7 @@ mod failure {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486084)")]
+    #[should_panic(expected = "revert_id: 18446744073709486084")]
     async fn cant_set() {
         let (instance, _id) = get_contract_instance().await;
 


### PR DESCRIPTION
Seems that the format of the revert receipts is now different in the newest versions of `fuel-core` and `fuels-rs`.

Also ran `cargo fmt` just as I'm passing by :) 