### PR TITLE
Support for configurable blocks in the formatter

### DIFF
--- a/swayfmt/src/items/item_configurable/tests.rs
+++ b/swayfmt/src/items/item_configurable/tests.rs
@@ -1,0 +1,93 @@
+use forc_tracing::{println_green, println_red};
+use paste::paste;
+use prettydiff::{basic::DiffOp, diff_lines};
+
+macro_rules! fmt_test {
+    ($scope:ident $desired_output:expr, $($name:ident $y:expr),+) => {
+        fmt_test_inner!($scope $desired_output,
+                                $($name $y)+
+                                ,
+                                remove_trailing_whitespace format!("{} \n\n\t ", $desired_output).as_str(),
+                                remove_beginning_whitespace format!("  \n\t{}", $desired_output).as_str(),
+                                identity $desired_output, /* test return is valid */
+                                remove_beginning_and_trailing_whitespace format!("  \n\t  {} \n\t   ", $desired_output).as_str()
+                       );
+    };
+}
+
+macro_rules! fmt_test_inner {
+    ($scope:ident $desired_output:expr, $($name:ident $y:expr),+) => {
+        $(
+        paste! {
+            #[test]
+            fn [<$scope _ $name>] () {
+                let formatted_code = crate::parse::parse_format::<sway_ast::ItemConfigurable>($y);
+                let changeset = diff_lines(&formatted_code, $desired_output);
+                let diff = changeset.diff();
+                let count_of_updates = diff.len();
+                if count_of_updates != 0 {
+                    println!("FAILED: {count_of_updates} diff items.");
+                }
+                for diff in diff {
+                    match diff {
+                        DiffOp::Equal(old) => {
+                            for o in old {
+                                println!("{}", o)
+                            }
+                        }
+                        DiffOp::Insert(new) => {
+                            for n in new {
+                                println_green(&format!("+{}", n));
+                            }
+                        }
+                        DiffOp::Remove(old) => {
+                            for o in old {
+                                println_red(&format!("-{}", o));
+                            }
+                        }
+                        DiffOp::Replace(old, new) => {
+                            for o in old {
+                                println_red(&format!("-{}", o));
+                            }
+                            for n in new {
+                                println_green(&format!("+{}", n));
+                            }
+                        }
+                    }
+                }
+                assert_eq!(&formatted_code, $desired_output)
+            }
+        }
+    )+
+}
+}
+
+fmt_test!( configurables
+"configurable {
+    C0: bool = true,
+    C1: u64 = 42,
+    C2: b256 = 0x1111111111111111111111111111111111111111111111111111111111111111,
+    C3: MyStruct = MyStruct { x: 42, y: true },
+    C4: MyEnum = MyEnum::A(42),
+    C5: MyEnum = MyEnum::B(true),
+    C6: str[4] = \"fuel\",
+    C7: [u64; 4] = [1, 2, 3, 4],
+    C8: u64 = 0,
+}",
+            wrong_new_lines
+"configurable {
+    C0: bool = true, C1: u64 = 42,
+        C2:     b256   = 
+
+        0x1111111111111111111111111111111111111111111111111111111111111111,
+    C3: MyStruct = 
+    MyStruct { x: 42, 
+    y: true },
+    C4: MyEnum 
+    = MyEnum::A(42),
+    C5: MyEnum = MyEnum::B(true),
+    C6: str[4] = \"fuel\",
+    C7: [u64; 4] = [1, 2, 
+    3, 4], C8: u64 = 0,
+}"
+);

--- a/swayfmt/src/items/mod.rs
+++ b/swayfmt/src/items/mod.rs
@@ -1,4 +1,5 @@
 mod item_abi;
+mod item_configurable;
 mod item_const;
 mod item_enum;
 mod item_fn;

--- a/swayfmt/src/module/item.rs
+++ b/swayfmt/src/module/item.rs
@@ -21,7 +21,7 @@ impl Format for ItemKind {
             Abi(item_abi) => item_abi.format(formatted_code, formatter),
             Const(item_const) => item_const.format(formatted_code, formatter),
             Storage(item_storage) => item_storage.format(formatted_code, formatter),
-            Configurable(_item_configurable) => todo!(),
+            Configurable(item_configurable) => item_configurable.format(formatted_code, formatter),
         }
     }
 }
@@ -39,7 +39,7 @@ impl LeafSpans for ItemKind {
             Trait(item_trait) => item_trait.leaf_spans(),
             Impl(item_impl) => item_impl.leaf_spans(),
             Use(item_use) => item_use.leaf_spans(),
-            Configurable(_item_configurable) => todo!(),
+            Configurable(item_configurable) => item_configurable.leaf_spans(),
         }
     }
 }

--- a/swayfmt/src/utils/language/punctuated.rs
+++ b/swayfmt/src/utils/language/punctuated.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 use std::fmt::Write;
 use sway_ast::{
-    keywords::CommaToken, punctuated::Punctuated, token::PunctKind, StorageField, TypeField,
+    keywords::CommaToken, punctuated::Punctuated, token::PunctKind, ConfigurableField,
+    StorageField, TypeField,
 };
 use sway_types::{Ident, Spanned};
 
@@ -146,6 +147,34 @@ impl Format for TypeField {
             self.colon_token.span().as_str(),
         )?;
         self.ty.format(formatted_code, formatter)?;
+
+        Ok(())
+    }
+}
+
+impl Format for ConfigurableField {
+    fn format(
+        &self,
+        formatted_code: &mut FormattedCode,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
+        formatter.with_shape(
+            formatter.shape.with_default_code_line(),
+            |formatter| -> Result<(), FormatterError> {
+                write!(
+                    formatted_code,
+                    "{}{} ",
+                    self.name.span().as_str(),
+                    self.colon_token.span().as_str(),
+                )?;
+                self.ty.format(formatted_code, formatter)?;
+                write!(formatted_code, " {} ", self.eq_token.span().as_str())?;
+
+                Ok(())
+            },
+        )?;
+
+        self.initializer.format(formatted_code, formatter)?;
 
         Ok(())
     }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_immutable/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_immutable/Forc.toml
@@ -1,6 +1,6 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
-license = "Apache-2.0"
-implicit-std = false
-name = "configurables_are_immutable"
 entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "configurables_are_immutable"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_immutable/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_immutable/src/main.sw
@@ -1,7 +1,7 @@
 script;
 
 configurable {
-    C1:u64 = 5,
+    C1: u64 = 5,
 }
 
 fn main() -> u64 {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_immutable/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_immutable/test.toml
@@ -1,4 +1,4 @@
 category = "fail"
 
-#check: $()C1:u64 = 5,
+#check: $()C1: u64 = 5,
 #nextln: $()This is a constant, not a variable.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/configurables_in_lib/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/configurables_in_lib/Forc.toml
@@ -1,6 +1,6 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
-license = "Apache-2.0"
-implicit-std = false
-name = "configurables_in_lib"
 entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "configurables_in_lib"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/configurables_in_lib/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/configurables_in_lib/src/main.sw
@@ -5,5 +5,5 @@ dep lib;
 use lib::*;
 
 fn main() -> (bool, u64, b256) {
-    (C0, C1, C2) 
+    (C0, C1, C2)
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/repeated_configurable/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/repeated_configurable/src/main.sw
@@ -5,7 +5,4 @@ configurable {
     X: u64 = 42,
 }
 
-fn main() {
-}
-
-
+fn main() {}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/Forc.toml
@@ -1,8 +1,8 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
 license = "Apache-2.0"
 name = "configurable_consts"
-entry = "main.sw"
 
 [dependencies]
 std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/src/main.sw
@@ -3,8 +3,8 @@ script;
 use std::hash::sha256;
 
 struct MyStruct {
-    x: u64, 
-    y: bool
+    x: u64,
+    y: bool,
 }
 
 enum MyEnum {
@@ -15,8 +15,8 @@ enum MyEnum {
 impl core::ops::Eq for MyEnum {
     fn eq(self, other: MyEnum) -> bool {
         match (self, other) {
-            (MyEnum::A(inner1), MyEnum::A(inner2))  => inner1 == inner2,
-            (MyEnum::B(inner1), MyEnum::B(inner2))  => inner1 == inner2,
+            (MyEnum::A(inner1), MyEnum::A(inner2)) => inner1 == inner2,
+            (MyEnum::B(inner1), MyEnum::B(inner2)) => inner1 == inner2,
             _ => false,
         }
     }


### PR DESCRIPTION
## Description
Closes #3679

This is based on how `storage` blocks are handled.. Most of the code is copied from `item_storage`. We should probably consider making as much as that code common between the two because `storage` and `configurable` blocks look pretty much the same.

Making this change now so that the formatter does not panic when we add an example using `configurable` under `sway/examples`.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
