### PR TITLE
Add `mut` keyword to `append()` in the `Bytes` type

### DIFF
--- a/sway-lib-std/src/bytes.sw
+++ b/sway-lib-std/src/bytes.sw
@@ -636,7 +636,7 @@ impl Bytes {
     /// assert(bytes.len() == first_length + second_length);
     /// assert(bytes.capacity() == first_length + first_length);
     /// ```
-    pub fn append(ref mut self, ref other: self) {
+    pub fn append(ref mut self, ref mut other: self) {
         if other.len == 0 {
             return
         };


### PR DESCRIPTION
## Description

Added the `mut` keyword to `append()` in the `Bytes` type in the standard library. This causes an internal compiler error for the [`String`](https://github.com/FuelLabs/sway-libs/tree/master/libs/string) type. https://github.com/FuelLabs/sway/issues/4109 should disallow both the syntax and resolve the internal compiler error.

Closes #4108 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
