### PR TITLE
Limit inner doc comment attributes to `Module`

### DIFF
--- a/sway-parse/src/attribute.rs
+++ b/sway-parse/src/attribute.rs
@@ -29,21 +29,17 @@ impl<T: Parse> Parse for Annotated<T> {
     fn parse(parser: &mut Parser) -> ParseResult<Self> {
         // Parse the attribute list.
         let mut attribute_list = Vec::new();
-        while let Some(DocComment { .. }) = parser.peek() {
+        while let Some(DocComment {
+            doc_style: DocStyle::Outer,
+            ..
+        }) = parser.peek()
+        {
             let doc_comment = parser.parse::<DocComment>()?;
             // TODO: Use a Literal instead of an Ident when Attribute args
             // start supporting them and remove `Ident::new_no_trim`.
             let value = Ident::new_no_trim(doc_comment.content_span.clone());
-            let hash_kind = match &doc_comment.doc_style {
-                DocStyle::Inner => {
-                    AttributeHashKind::Inner(HashBangToken::new(doc_comment.span.clone()))
-                }
-                DocStyle::Outer => {
-                    AttributeHashKind::Outer(HashToken::new(doc_comment.span.clone()))
-                }
-            };
             attribute_list.push(AttributeDecl {
-                hash_kind,
+                hash_kind: AttributeHashKind::Outer(HashToken::new(doc_comment.span.clone())),
                 attribute: SquareBrackets::new(
                     Punctuated::single(Attribute {
                         name: Ident::new_with_override(

--- a/sway-parse/src/item/mod.rs
+++ b/sway-parse/src/item/mod.rs
@@ -206,9 +206,9 @@ mod tests {
         let item = parse_item(
             r#"
             // I will be ignored.
-            //! I can't feel the way I did before
+            //! I will be ignored.
             /// This is a doc comment.
-            //! Don't turn your back on me, I won't be ignored.
+            //! I will be ignored.
             // I will be ignored.
             fn f() -> bool {
                 false
@@ -218,17 +218,7 @@ mod tests {
         assert!(matches!(item.value, ItemKind::Fn(_)));
         assert_eq!(
             attributes(&item.attribute_list),
-            vec![
-                [(
-                    "doc-comment",
-                    Some(vec![" I can't feel the way I did before"])
-                )],
-                [("doc-comment", Some(vec![" This is a doc comment."]))],
-                [(
-                    "doc-comment",
-                    Some(vec![" Don't turn your back on me, I won't be ignored."])
-                )]
-            ]
+            vec![[("doc-comment", Some(vec![" This is a doc comment."]))]]
         );
     }
 
@@ -237,15 +227,15 @@ mod tests {
         let item = parse_item(
             r#"
             // I will be ignored.
-            //! I can't feel the way I did before
+            //! I will be ignored. 
             /// This is a doc comment.
-            //! Don't turn your back on me, I won't be ignored.
+            //! I will be ignored.
             // I will be ignored.
             struct MyStruct {
                 // I will be ignored.
-                //! Time won't heal this damage anymore
+                //! I will be ignored.
                 /// This is a doc comment.
-                //! Don't turn your back on me, I won't be ignored.
+                //! I will be ignored.
                 // I will be ignored.
                 a: bool,
             }
@@ -256,17 +246,7 @@ mod tests {
         assert!(matches!(item.value, ItemKind::Struct(_)));
         assert_eq!(
             attributes(&item.attribute_list),
-            vec![
-                [(
-                    "doc-comment",
-                    Some(vec![" I can't feel the way I did before"])
-                )],
-                [("doc-comment", Some(vec![" This is a doc comment."]))],
-                [(
-                    "doc-comment",
-                    Some(vec![" Don't turn your back on me, I won't be ignored."])
-                )]
-            ]
+            vec![[("doc-comment", Some(vec![" This is a doc comment."]))]]
         );
 
         /* struct field annotations */
@@ -277,17 +257,7 @@ mod tests {
 
         assert_eq!(
             attributes(&item.attribute_list),
-            vec![
-                [(
-                    "doc-comment",
-                    Some(vec![" Time won't heal this damage anymore"])
-                )],
-                [("doc-comment", Some(vec![" This is a doc comment."]))],
-                [(
-                    "doc-comment",
-                    Some(vec![" Don't turn your back on me, I won't be ignored."])
-                )]
-            ]
+            vec![[("doc-comment", Some(vec![" This is a doc comment."]))]]
         );
     }
 

--- a/sway-parse/src/token.rs
+++ b/sway-parse/src/token.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use sway_ast::literal::{LitChar, LitInt, LitIntType, LitString, Literal};
 use sway_ast::token::{
     Comment, CommentedGroup, CommentedTokenStream, CommentedTokenTree, Delimiter, DocComment,
-    DocStyle, Punct, PunctKind, Spacing, TokenStream,
+    DocStyle, GenericTokenTree, Punct, PunctKind, Spacing, TokenStream,
 };
 use sway_error::error::CompileError;
 use sway_error::handler::{ErrorEmitted, Handler};
@@ -120,17 +120,34 @@ pub fn lex_commented(
         path,
         stream,
     };
+    let mut gather_module_docs = false;
+    let mut file_start_offset: usize = 0;
 
     let mut parent_token_trees = Vec::new();
     let mut token_trees = Vec::new();
     while let Some((mut index, mut character)) = l.stream.next() {
         if character.is_whitespace() {
+            // if the beginning of a file starts with whitespace
+            // we must keep track to ensure that the module level docs
+            // will get inserted into the tree correctly
+            if index - file_start_offset == 0 {
+                file_start_offset += character.len_utf8();
+            }
             continue;
         }
         if character == '/' {
             match l.stream.peek() {
                 Some((_, '/')) => {
-                    token_trees.push(lex_line_comment(&mut l, end, index));
+                    let ctt =
+                        lex_line_comment(&mut l, end, index, file_start_offset, gather_module_docs);
+                    if let CommentedTokenTree::Tree(GenericTokenTree::DocComment(DocComment {
+                        doc_style: DocStyle::Inner,
+                        ..
+                    })) = &ctt
+                    {
+                        gather_module_docs = true;
+                    }
+                    token_trees.push(ctt);
                     continue;
                 }
                 Some((_, '*')) => {
@@ -141,7 +158,10 @@ pub fn lex_commented(
                 }
                 Some(_) | None => {}
             }
+        } else {
+            gather_module_docs = false;
         }
+
         if character.is_xid_start() || character == '_' {
             // Raw identifier, e.g., `r#foo`? Then mark as such, stripping the prefix `r#`.
             let is_raw_ident = character == 'r' && matches!(l.stream.peek(), Some((_, '#')));
@@ -286,7 +306,13 @@ fn lex_close_delimiter(
     parent
 }
 
-fn lex_line_comment(l: &mut Lexer<'_>, end: usize, index: usize) -> CommentedTokenTree {
+fn lex_line_comment(
+    l: &mut Lexer<'_>,
+    end: usize,
+    index: usize,
+    offset: usize,
+    gather_module_docs: bool,
+) -> CommentedTokenTree {
     let _ = l.stream.next();
 
     // Find end; either at EOF or at `\n`.
@@ -299,7 +325,7 @@ fn lex_line_comment(l: &mut Lexer<'_>, end: usize, index: usize) -> CommentedTok
     let doc_style = match (sp.as_str().chars().nth(2), sp.as_str().chars().nth(3)) {
         // `//!` is an inner line doc comment.
         (Some('!'), _) => {
-            if index == 0 {
+            if index - offset == 0 || gather_module_docs {
                 // TODO(#4112): remove this conditional block to enable
                 // inner doc comment attributes for all items
                 Some(DocStyle::Inner)

--- a/sway-parse/src/token.rs
+++ b/sway-parse/src/token.rs
@@ -300,8 +300,8 @@ fn lex_line_comment(l: &mut Lexer<'_>, end: usize, index: usize) -> CommentedTok
         // `//!` is an inner line doc comment.
         (Some('!'), _) => {
             if index == 0 {
-                // remove conditional block to enable
-                // item inner doc comment attributes
+                // TODO(#4112): remove this conditional block to enable
+                // inner doc comment attributes for all items
                 Some(DocStyle::Inner)
             } else {
                 None
@@ -796,19 +796,15 @@ mod tests {
         );
         assert_matches!(
             tts.next(),
-            Some(CommentedTokenTree::Tree(CommentedTree::DocComment(DocComment {
-                doc_style: DocStyle::Inner,
+            Some(CommentedTokenTree::Comment(Comment {
                 span,
-                content_span,
-            }))) if span.as_str() ==  "//!inner" && content_span.as_str() == "inner"
+            })) if span.as_str() ==  "//!inner"
         );
         assert_matches!(
             tts.next(),
-            Some(CommentedTokenTree::Tree(CommentedTree::DocComment(DocComment {
-                doc_style: DocStyle::Inner,
+            Some(CommentedTokenTree::Comment(Comment {
                 span,
-                content_span,
-            }))) if span.as_str() ==  "//! inner" && content_span.as_str() == " inner"
+            })) if span.as_str() ==  "//! inner"
         );
         assert_matches!(
             tts.next(),

--- a/sway-parse/src/token.rs
+++ b/sway-parse/src/token.rs
@@ -298,7 +298,15 @@ fn lex_line_comment(l: &mut Lexer<'_>, end: usize, index: usize) -> CommentedTok
 
     let doc_style = match (sp.as_str().chars().nth(2), sp.as_str().chars().nth(3)) {
         // `//!` is an inner line doc comment.
-        (Some('!'), _) => Some(DocStyle::Inner),
+        (Some('!'), _) => {
+            if index == 0 {
+                // remove conditional block to enable
+                // item inner doc comment attributes
+                Some(DocStyle::Inner)
+            } else {
+                None
+            }
+        }
         // `////` (more than 3 slashes) is not considered a doc comment.
         (Some('/'), Some('/')) => None,
         // `///` is an outer line doc comment.

--- a/swayfmt/tests/mod.rs
+++ b/swayfmt/tests/mod.rs
@@ -845,7 +845,7 @@ fn inner_doc_comments() {
         r#"script;
 
 enum Color {
-//! Color is a Sway enum
+    //! Color is a Sway enum
     blue: (),
     red: ()
 }


### PR DESCRIPTION
## Description
Ran on test branch & working as intended. Only beginning of file `//!` is collected as `DocComment` with `DocStyle::Inner` which is only parsed at the beginning of the `Module` parsing stage. This ensures that any `//!` found after the module docs will be treated as normal comments for now. Ref #4112 for tracking further progress in allowing inner doc comments for `Item`.

## Checklist

- [x] I have linked to any relevant issues. Closes #4097 
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
