### PR TITLE
add missing go to def tests for structs

### DIFF
--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -1141,13 +1141,29 @@ async fn go_to_definition_for_structs() {
     definition_check_with_req_offset(&mut service, &mut go_to, 14, 9, &mut i).await;
     definition_check_with_req_offset(&mut service, &mut go_to, 15, 16, &mut i).await;
     definition_check_with_req_offset(&mut service, &mut go_to, 15, 23, &mut i).await;
-    // TODO: check `o: Option<Identity>`
+    go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 16,
+        req_char: 11,
+        def_line: 80,
+        def_start_char: 9,
+        def_end_char: 15,
+        def_path: "sway-lib-std/src/option.sw",
+    };
+    // Type Params
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
     // Call Path
-    go_to.def_line = 19;
-    go_to.def_start_char = 7;
-    go_to.def_end_char = 13;
-    definition_check_with_req_offset(&mut service, &mut go_to, 24, 16, &mut i).await;
+    go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 24,
+        req_char: 16,
+        def_line: 19,
+        def_start_char: 7,
+        def_end_char: 13,
+        def_path: uri.as_str(),
+    };
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description
just adding a missing go to test for structs.

works towards #3989

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
