### PR TITLE
Check for storage types in impl method params

### DIFF
--- a/sway-core/src/semantic_analysis/storage_only_types.rs
+++ b/sway-core/src/semantic_analysis/storage_only_types.rs
@@ -268,7 +268,7 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
                             errors
                         );
                         for param in method.parameters {
-                            if param.name.as_str() != "self" {
+                            if !param.is_self() {
                                 check!(
                                     check_type(
                                         engines,

--- a/sway-core/src/semantic_analysis/storage_only_types.rs
+++ b/sway-core/src/semantic_analysis/storage_only_types.rs
@@ -267,6 +267,21 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
                             warnings,
                             errors
                         );
+                        for param in method.parameters {
+                            if param.name.as_str() != "self" {
+                                check!(
+                                    check_type(
+                                        engines,
+                                        param.type_argument.type_id,
+                                        param.type_argument.span.clone(),
+                                        false
+                                    ),
+                                    continue,
+                                    warnings,
+                                    errors
+                                );
+                            }
+                        }
                         check!(
                             check_type(
                                 engines,

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_types/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_types/src/main.sw
@@ -63,3 +63,24 @@ fn insert(mapping: StorageMap<u64, u64>) {
 fn return_storage_vec_standalone_fn() -> StorageVec<u64> {
     storage.v
 }
+
+pub struct MyStruct { }
+
+impl MyStruct {
+    #[storage(read, write)]
+    pub fn takes_storage_struct_in_impl(self, my_struct: StorageVec<u64>) {
+        my_struct.push(5);
+    }
+}
+
+pub trait MyTrait {
+    #[storage(read, write)]
+    fn takes_storage_struct_in_trait_impl(self, my_struct: StorageVec<u64>);
+}
+
+impl MyTrait for MyStruct {
+    #[storage(read, write)]
+    fn takes_storage_struct_in_trait_impl(self, my_struct: StorageVec<u64>) {
+        my_struct.push(5);
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/storage_types/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/storage_types/test.toml
@@ -54,5 +54,13 @@ category = "fail"
 # nextln: $()Type StorageVec<u64> can only be declared directly as a storage field
 
 # check: $()error
+# check: $()pub fn takes_storage_struct_in_impl(self, my_struct: StorageVec<u64>) {
+# nextln: $()Type StorageVec<u64> can only be declared directly as a storage field
+
+# check: $()error
+# check: $()fn takes_storage_struct_in_trait_impl(self, my_struct: StorageVec<u64>) {
+# nextln: $()Type StorageVec<u64> can only be declared directly as a storage field
+
+# check: $()error
 # check: $()bad_type: StorageVec<Vec<bool>> = StorageVec {},
 # nextln: $()The type "StorageVec<Vec<bool>>" is not allowed in storage.


### PR DESCRIPTION
## Description
Fixes #4040 

There is an exception for `self` parameters, to avoid the error being thrown for impl of the actual storage types (in storage.sw). I'm not sure if that's the best way to add that exception. Reviewers please advice. [Edit: This is fixed, thanks @anton-trunov ]

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
