### PR TITLE
docs: updated docs with missing supported workspace commands

### DIFF
--- a/docs/book/src/forc/workspaces.md
+++ b/docs/book/src/forc/workspaces.md
@@ -29,5 +29,8 @@ Packages that are located within a workspace directory but are *not* contained w
 
 * `forc build` - Builds an entire workspace.
 * `forc deploy` - Builds and deploys all deployable members (i.e, contracts) of the workspace in the correct order.
+* `forc run` - Builds and runs all scripts of the workspace.
 * `forc check` - Checks all members of the workspace.
 * `forc update` - Checks and updates workspace level `Forc.lock` file that is shared between workspace members.
+* `forc clean` - Cleans all output artifacts for each member of the workspace.
+* `forc fmt` - Formats all members of a workspace.


### PR DESCRIPTION
## Description
closes #4102.

Tiny doc PR adding missing essential commands that now supports workspaces

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
