### PR TITLE
feat: disallow duplicate submodule declaration

### DIFF
--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod semantic_analysis;
 pub mod source_map;
 pub mod transform;
 pub mod type_system;
+mod submodules;
 
 use crate::ir_generation::check_function_purity;
 use crate::language::parsed::TreeType;
@@ -35,6 +36,7 @@ use sway_ir::{
     create_inline_in_non_predicate_pass, create_inline_in_predicate_pass, create_mem2reg_pass,
     create_simplify_cfg_pass, Context, Kind, Module, PassManager, PassManagerConfig,
 };
+use submodules::dependency_graph::SubmodulePlan;
 
 pub use semantic_analysis::namespace::{self, Namespace};
 pub mod types;
@@ -266,6 +268,10 @@ pub fn parsed_to_ast(
         Some(types_metadata) => types_metadata,
         None => return deduped_err(warnings, errors),
     };
+
+    // Create submodule graph
+    let submodule_plan = SubmodulePlan::from_ty_program(&typed_program);
+    println!("submodule plan validity: {}", submodule_plan.check_validity());
 
     typed_program
         .logged_types

--- a/sway-core/src/submodules/dependency_graph.rs
+++ b/sway-core/src/submodules/dependency_graph.rs
@@ -1,0 +1,87 @@
+use std::collections::HashMap;
+
+use petgraph::{stable_graph::StableGraph, Directed};
+use sway_types::Span;
+
+use crate::language::{ty::TyProgram, DepName};
+
+type GraphIx = u32;
+type NodeIx = petgraph::graph::NodeIndex<GraphIx>;
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+pub(crate) struct Node {
+    pub(crate) dep_decls: Vec<NodeIx>,
+    pub(crate) dep_name: DepName
+}
+
+pub(crate) type DepGraph = StableGraph<Node, (), Directed, GraphIx>;
+
+#[derive(Debug)]
+pub(crate) struct SubmodulePlan {
+    pub(crate) graph: DepGraph,
+}
+
+impl SubmodulePlan {
+    /// Constructs a new `SubmodulePlan` from given `TyProgram`.
+    pub(crate) fn from_ty_program(ty_program: &TyProgram) -> Self {
+        let root = &ty_program.root;
+        let mut graph = DepGraph::new();
+        let mut node_indices = HashMap::new();
+
+        // Add non-root nodes to the graph.
+        for (dep_name, submodule) in root.submodules_recursive() {
+            let dep_decls = &submodule.module.submodules;
+            let dep_decls: Vec<NodeIx> = dep_decls.iter().map(|(dep_decl, _)| node_indices[dep_decl]).collect();
+            let node = Node::new(dep_name.clone(), dep_decls);
+            node_indices.entry(dep_name).or_insert_with(|| {
+                graph.add_node(node.clone())
+            });
+        }
+
+        // Create the root node.
+        let root_node_name = DepName::new(Span::dummy());
+        let root_node_dep_decls = root.submodules.iter().filter_map(|(dep_name, _)| graph.node_indices().find(|node| graph[*node].dep_name == *dep_name)).collect();
+        let root_node = Node::new(root_node_name.clone(), root_node_dep_decls);
+
+        // Add root node.
+        let root_ix = graph.add_node(root_node);
+        node_indices.insert(&root_node_name, root_ix);
+
+        // Add edges to the graph.
+        for node_ix in node_indices.values() {
+            let node_neighbors = graph[*node_ix].dep_decls.clone();
+            for neighbor in node_neighbors {
+                graph.add_edge(*node_ix, neighbor, ());
+            }
+        }
+
+        Self {
+            graph,
+        }
+    }
+
+    /// Checks validity of this `SubmodulePlan`. If there are more nodes that has more than 1
+    /// incoming edge to it, the plan is marked as invalid. This prevents duplicate module
+    /// declarations both directly and transitively. 
+    pub(crate) fn check_validity(self) -> bool {
+        let graph = self.graph;
+        for node in graph.node_indices() {
+            let incoming_edges_count = graph.edges_directed(node, petgraph::Direction::Incoming).count();
+            if incoming_edges_count > 1 {
+                return false;
+            }
+        }
+        true
+    }
+
+}
+
+impl Node {
+    /// Construct a new `Node` from given `TyModule`.
+    fn new(dep_name: DepName, dep_decls: Vec<NodeIx>) -> Self {
+        Self {
+            dep_decls,
+            dep_name,
+        }
+    }
+}

--- a/sway-core/src/submodules/mod.rs
+++ b/sway-core/src/submodules/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod dependency_graph;


### PR DESCRIPTION
## Description

This PR is heavily WIP, I am opening to discuss both the problem and solution. 
closes #3947.
closes #3988.

## TODO

- [ ] Generate an actual compilation error
- [ ] Remove filters added to `forc-test`
- [ ] Fix this situation in standard library
- [ ] Tests
- [ ] Documentation

## Problem

Duplicate `dep` declarations lead to duplicate entry points in the `FinalizedProgram` with different `imm` values and same `Span`. This was causing test entries to get duplicated. I guess this wasn't a problem until addition of unit testing, as other than test functions there is only the main function as an entry point(?). Also duplicate main declaration is something already checked. 

So basically duplicate submodule declarations (through dependencies) are causing tests to be duplicated in the top level module. An example can be seen below:

```mermaid
graph TD;
    A-->B;
    A-->C;
    B-->C;
```
A, B and C are separate modules where in with A we have following declarations:

```rust
dep B;
dep C;
```

and in B there is:

```rust
dep C;
```

In a scenario like this entry points of `C` are duplicated in `A`. So any tests that are placed in `C`, is duplicated in the top most level `A`. This caused #3813. To solve that I added a hot-fix (#3986  and #4069) but in a small discussion over slack, sezna mentioned that this is something that should be a compiler error.

## Solution

I constructed a graph from `dep` declarations. Such as the example given in the problem section and checked if any given node has more than 1 incoming edge. If there is one I am marking this `dep` declarations invalid and (will be) producing a compile error.

edit: I realized I need to add one more check as only checking incoming edge number also forbids the following pattern (which is perfectly fine):

```mermaid
graph TD;
    A-->C;
    B-->C;
```
I wonder if converting the graph into undirected graph and check for cycles is enough

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
