### PR TITLE
Collect `Expression` from asm register decls

### DIFF
--- a/sway-core/src/language/parsed/expression/asm.rs
+++ b/sway-core/src/language/parsed/expression/asm.rs
@@ -7,7 +7,7 @@ use sway_types::{ident::Ident, span::Span};
 
 #[derive(Debug, Clone)]
 pub struct AsmExpression {
-    pub(crate) registers: Vec<AsmRegisterDeclaration>,
+    pub registers: Vec<AsmRegisterDeclaration>,
     pub(crate) body: Vec<AsmOp>,
     pub(crate) returns: Option<(AsmRegister, Span)>,
     pub(crate) return_type: TypeInfo,
@@ -15,7 +15,7 @@ pub struct AsmExpression {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct AsmRegisterDeclaration {
+pub struct AsmRegisterDeclaration {
     pub(crate) name: Ident,
-    pub(crate) initializer: Option<Expression>,
+    pub initializer: Option<Expression>,
 }

--- a/sway-core/src/language/ty/expression/asm.rs
+++ b/sway-core/src/language/ty/expression/asm.rs
@@ -6,7 +6,7 @@ use crate::{engine_threading::*, language::ty::*, type_system::*};
 
 #[derive(Clone, Debug)]
 pub struct TyAsmRegisterDeclaration {
-    pub(crate) initializer: Option<TyExpression>,
+    pub initializer: Option<TyExpression>,
     pub(crate) name: Ident,
 }
 

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -775,7 +775,7 @@ impl<'a> ParsedTree<'a> {
                     to_ident_key(name),
                     Token::from_parsed(
                         AstToken::Intrinsic(kind_binding.inner.clone()),
-                        SymbolKind::Intrinsic,
+                        SymbolKind::Function,
                     ),
                 );
 

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -588,8 +588,12 @@ impl<'a> ParsedTree<'a> {
                     self.handle_expression(&branch.result);
                 }
             }
-            ExpressionKind::Asm(_) => {
-                //TODO handle asm expressions
+            ExpressionKind::Asm(asm) => {
+                for register in &asm.registers {
+                    if let Some(initializer) = &register.initializer {
+                        self.handle_expression(initializer);
+                    }
+                }
             }
             ExpressionKind::MethodApplication(method_application_expression) => {
                 let MethodApplicationExpression {
@@ -771,7 +775,7 @@ impl<'a> ParsedTree<'a> {
                     to_ident_key(name),
                     Token::from_parsed(
                         AstToken::Intrinsic(kind_binding.inner.clone()),
-                        SymbolKind::Function,
+                        SymbolKind::Intrinsic,
                     ),
                 );
 

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -642,7 +642,13 @@ impl<'a> TypedTree<'a> {
                     self.handle_expression(r#else, namespace);
                 }
             }
-            ty::TyExpressionVariant::AsmExpression { .. } => {}
+            ty::TyExpressionVariant::AsmExpression { registers, .. } => {
+                for register in registers {
+                    if let Some(initializer) = &register.initializer {
+                        self.handle_expression(initializer, namespace);
+                    }
+                }
+            }
             ty::TyExpressionVariant::StructFieldAccess {
                 prefix,
                 field_to_access,


### PR DESCRIPTION
## Description
Collects `Expression` variants in `AsmRegisterDeclaration` and `TyAsmRegisterDeclaration` if there are any. 

Closes #3715

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
