### PR TITLE
Fixes struct and enum call path comparison to use suffix.

### DIFF
--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -264,7 +264,7 @@ impl PartialEqWithEngines for TypeInfo {
                     type_parameters: r_type_parameters,
                 },
             ) => {
-                l_name == r_name
+                l_name.suffix == r_name.suffix
                     && l_variant_types.eq(r_variant_types, engines)
                     && l_type_parameters.eq(r_type_parameters, engines)
             }
@@ -280,7 +280,7 @@ impl PartialEqWithEngines for TypeInfo {
                     type_parameters: r_type_parameters,
                 },
             ) => {
-                l_name == r_name
+                l_name.suffix == r_name.suffix
                     && l_fields.eq(r_fields, engines)
                     && l_type_parameters.eq(r_type_parameters, engines)
             }

--- a/sway-core/src/type_system/unify_check.rs
+++ b/sway-core/src/type_system/unify_check.rs
@@ -167,7 +167,7 @@ impl<'a> UnifyCheck<'a> {
                     .iter()
                     .map(|x| x.type_id)
                     .collect::<Vec<_>>();
-                l_name == r_name && self.check_multiple(&l_types, &r_types)
+                l_name.suffix == r_name.suffix && self.check_multiple(&l_types, &r_types)
             }
             // Let empty enums to coerce to any other type. This is useful for Never enum.
             (

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-B1BD953F42F45255'
+
+[[package]]
+name = 'return_struct'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-B1BD953F42F45255'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "return_struct"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/json_abi_oracle.json
@@ -1,0 +1,69 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": [
+        {
+          "arguments": [
+            "read"
+          ],
+          "name": "storage"
+        }
+      ],
+      "inputs": [],
+      "name": "test_function",
+      "output": {
+        "name": "",
+        "type": 1,
+        "typeArguments": [
+          {
+            "name": "",
+            "type": 3,
+            "typeArguments": null
+          }
+        ]
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": [],
+      "type": "()",
+      "typeId": 0,
+      "typeParameters": null
+    },
+    {
+      "components": [
+        {
+          "name": "None",
+          "type": 0,
+          "typeArguments": null
+        },
+        {
+          "name": "Some",
+          "type": 2,
+          "typeArguments": null
+        }
+      ],
+      "type": "enum Option",
+      "typeId": 1,
+      "typeParameters": [
+        2
+      ]
+    },
+    {
+      "components": null,
+      "type": "generic T",
+      "typeId": 2,
+      "typeParameters": null
+    },
+    {
+      "components": [],
+      "type": "struct MyStruct",
+      "typeId": 3,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/src/data_structures.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/src/data_structures.sw
@@ -1,0 +1,3 @@
+library data_structures;
+
+pub struct MyStruct {}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/src/interface.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/src/interface.sw
@@ -1,0 +1,10 @@
+library interface;
+
+dep data_structures;
+
+use data_structures::MyStruct;
+
+abi MyContract {
+    #[storage(read)]
+    fn test_function() -> Option<MyStruct>;
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/src/main.sw
@@ -1,0 +1,18 @@
+contract;
+
+dep interface;
+dep data_structures;
+
+use interface::MyContract;
+use data_structures::MyStruct;
+
+storage {
+    a: StorageMap<u64, MyStruct> = StorageMap {}
+}
+
+impl MyContract for Contract {
+    #[storage(read)]
+    fn test_function() -> Option<MyStruct> {
+        storage.a.get(1)
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/test.toml
@@ -1,0 +1,2 @@
+category = "compile"
+validate_abi = true


### PR DESCRIPTION
## Description
The issue is that currently call paths of structs and enums are based on module path which can differ depending on the order of imports.

The solution was to revert to the old behavior of comparing only the type name contained in the suffix.

Closes #4125

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
