### PR TITLE
fix(fmt): forc-fmt check

### DIFF
--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -206,7 +206,7 @@ fn format_workspace_at_dir(app: &App, workspace: &WorkspaceManifestFile, dir: &P
 
     // Finally, format the root manifest using taplo formatter
     if let Ok(edited) = format_manifest(app, manifest_file) {
-        contains_edits = edited;
+        contains_edits = contains_edits || edited;
     }
 
     if app.check && contains_edits {
@@ -263,7 +263,7 @@ fn format_pkg_at_dir(app: &App, dir: &Path, formatter: &mut Formatter) -> Result
 
             for file in files {
                 if let Ok(edited) = format_file(app, file, Some(manifest_file.clone()), formatter) {
-                    contains_edits = edited;
+                    contains_edits = contains_edits || edited;
                 };
             }
             // format manifest using taplo formatter

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -206,7 +206,7 @@ fn format_workspace_at_dir(app: &App, workspace: &WorkspaceManifestFile, dir: &P
 
     // Finally, format the root manifest using taplo formatter
     if let Ok(edited) = format_manifest(app, manifest_file) {
-        contains_edits = contains_edits || edited;
+        contains_edits |= edited;
     }
 
     if app.check && contains_edits {
@@ -263,12 +263,12 @@ fn format_pkg_at_dir(app: &App, dir: &Path, formatter: &mut Formatter) -> Result
 
             for file in files {
                 if let Ok(edited) = format_file(app, file, Some(manifest_file.clone()), formatter) {
-                    contains_edits = contains_edits || edited;
+                    contains_edits |= edited;
                 };
             }
             // format manifest using taplo formatter
             if let Ok(edited) = format_manifest(app, manifest_file) {
-                contains_edits = contains_edits || edited;
+                contains_edits |= edited;
             }
 
             if app.check && contains_edits {


### PR DESCRIPTION
## Description

Fixes the same issue found here: https://github.com/FuelLabs/sway/pull/4038#discussion_r1105153934, but missed out in other locations. This has caused new PRs to not fail on `forc-fmt --check` even if they contained formatting violations, see: https://github.com/FuelLabs/sway/pull/4129

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
