### PR TITLE
fix imports

### DIFF
--- a/test/src/sdk-harness/test_projects/storage_vec/testgen.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/testgen.rs
@@ -223,6 +223,7 @@ macro_rules! testgen {
 
             pub mod success {
                 use super::{
+                    *,
                     setup::get_contract_instance,
                     wrappers::*,
                 };
@@ -527,6 +528,7 @@ macro_rules! testgen {
 
             pub mod failure {
                 use super::{
+                    *,
                     setup::get_contract_instance,
                     wrappers::*,
                 };


### PR DESCRIPTION
imports for the abigen-generated types were missing in success and failure modules.