### PR TITLE
Add LSP tests for `TyAbiDeclaration`

### DIFF
--- a/sway-lsp/src/capabilities/hover.rs
+++ b/sway-lsp/src/capabilities/hover.rs
@@ -169,7 +169,10 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
                         )
                     })
                     .ok(),
-                _ => Some(format!("{} {}", decl.friendly_type_name(), &token_name)),
+                ty::TyDeclaration::AbiDeclaration { .. } => {
+                    Some(format!("{} {}", decl.friendly_type_name(), &token_name))
+                }
+                _ => None,
             },
             TypedAstToken::TypedFunctionDeclaration(func) => {
                 Some(extract_fn_signature(&func.span()))

--- a/sway-lsp/src/capabilities/hover.rs
+++ b/sway-lsp/src/capabilities/hover.rs
@@ -169,7 +169,7 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
                         )
                     })
                     .ok(),
-                _ => None,
+                _ => Some(format!("{} {}", decl.friendly_type_name(), &token_name)),
             },
             TypedAstToken::TypedFunctionDeclaration(func) => {
                 Some(extract_fn_signature(&func.span()))

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -27,7 +27,7 @@ use sway_core::{
         parsed::{AstNode, ParseProgram},
         ty,
     },
-    namespace, BuildTarget, CompileResult, Engines, TypeEngine,
+    BuildTarget, CompileResult, Engines, TypeEngine,
 };
 use sway_types::{Span, Spanned};
 use sway_utils::helpers::get_sway_files;

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -363,14 +363,14 @@ impl Session {
 
     /// Parse the [ty::TyProgram] AST to populate the [TokenMap] with typed AST nodes.
     fn parse_ast_to_typed_tokens(&self, typed_program: &ty::TyProgram, f: impl Fn(&ty::TyAstNode)) {
-        let root_nodes = typed_program.root.all_nodes.iter().map(|node| node);
+        let root_nodes = typed_program.root.all_nodes.iter();
         let sub_nodes = typed_program
             .root
             .submodules
             .iter()
-            .flat_map(|(_, submodule)| submodule.module.all_nodes.iter().map(|node| node));
+            .flat_map(|(_, submodule)| submodule.module.all_nodes.iter());
 
-        root_nodes.chain(sub_nodes).for_each(|node| f(node));
+        root_nodes.chain(sub_nodes).for_each(f);
     }
 
     /// Get a reference to the [ty::TyProgram] AST.

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -187,7 +187,8 @@ impl Session {
                 // Finally, create runnables and populate our token_map with typed ast nodes.
                 self.create_runnables(typed_program);
 
-                let typed_tree = TypedTree::new(engines, &self.token_map, &typed_program.root.namespace);
+                let typed_tree =
+                    TypedTree::new(engines, &self.token_map, &typed_program.root.namespace);
                 typed_tree.collect_module_spans(typed_program);
                 self.parse_ast_to_typed_tokens(typed_program, |node| {
                     typed_tree.traverse_node(node)
@@ -361,31 +362,15 @@ impl Session {
     }
 
     /// Parse the [ty::TyProgram] AST to populate the [TokenMap] with typed AST nodes.
-    fn parse_ast_to_typed_tokens(
-        &self,
-        typed_program: &ty::TyProgram,
-        f: impl Fn(&ty::TyAstNode),
-    ) {
-        let root_nodes = typed_program
-            .root
-            .all_nodes
-            .iter()
-            .map(|node| node);
+    fn parse_ast_to_typed_tokens(&self, typed_program: &ty::TyProgram, f: impl Fn(&ty::TyAstNode)) {
+        let root_nodes = typed_program.root.all_nodes.iter().map(|node| node);
         let sub_nodes = typed_program
             .root
             .submodules
             .iter()
-            .flat_map(|(_, submodule)| {
-                submodule
-                    .module
-                    .all_nodes
-                    .iter()
-                    .map(|node| node)
-            });
+            .flat_map(|(_, submodule)| submodule.module.all_nodes.iter().map(|node| node));
 
-        root_nodes
-            .chain(sub_nodes)
-            .for_each(|node| f(node));
+        root_nodes.chain(sub_nodes).for_each(|node| f(node));
     }
 
     /// Get a reference to the [ty::TyProgram] AST.

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -175,7 +175,9 @@ pub fn type_info_to_symbol_kind(type_engine: &TypeEngine, type_info: &TypeInfo) 
             SymbolKind::BuiltinType
         }
         TypeInfo::Numeric | TypeInfo::Str(..) => SymbolKind::NumericLiteral,
-        TypeInfo::Custom { .. } | TypeInfo::Struct { .. } => SymbolKind::Struct,
+        TypeInfo::Custom { .. } | TypeInfo::Struct { .. } | TypeInfo::Contract => {
+            SymbolKind::Struct
+        }
         TypeInfo::Enum { .. } => SymbolKind::Enum,
         TypeInfo::Array(elem_ty, ..) => {
             let type_info = type_engine.get(elem_ty.type_id);

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -222,11 +222,6 @@ impl<'a> TypedTree<'a> {
             ty::TyDeclaration::ImplTrait {
                 decl_id, decl_span, ..
             } => {
-                eprintln!(
-                    "impl trait decl: {:#?}",
-                    decl_engine.get_impl_trait(decl_id, decl_span)
-                );
-
                 if let Ok(ty::TyImplTrait {
                     impl_type_parameters,
                     trait_name,
@@ -312,9 +307,6 @@ impl<'a> TypedTree<'a> {
                 decl_id, decl_span, ..
             } => {
                 if let Ok(abi_decl) = decl_engine.get_abi(decl_id, decl_span) {
-                    eprintln!("abi decl: {:#?}", abi_decl);
-                    eprintln!("");
-
                     if let Some(mut token) = self
                         .tokens
                         .try_get_mut(&to_ident_key(&abi_decl.name))
@@ -330,9 +322,6 @@ impl<'a> TypedTree<'a> {
                                 if let Ok(trait_fn) = decl_engine
                                     .get_trait_fn(trait_fn_decl_ref, &trait_fn_decl_ref.span())
                                 {
-                                    eprintln!("abi trait fn: {:#?}", trait_fn);
-                                    eprintln!("");
-
                                     self.collect_typed_trait_fn_token(&trait_fn);
                                 }
                             }
@@ -1077,7 +1066,6 @@ impl<'a> TypedTree<'a> {
     }
 
     fn collect_type_argument(&self, type_arg: &TypeArgument) {
-        eprintln!("collect_type_argument: {:#?}", type_arg);
         if let Some(call_path_tree) = &type_arg.call_path_tree {
             self.collect_call_path_tree(call_path_tree, type_arg);
         } else {
@@ -1273,11 +1261,7 @@ impl<'a> TypedTree<'a> {
         }
     }
 
-    fn collect_typed_fn_decl(
-        &self,
-        func_decl: &ty::TyFunctionDeclaration,
-    ) {
-        eprintln!("collect_typed_fn_decl: {:#?}", func_decl);
+    fn collect_typed_fn_decl(&self, func_decl: &ty::TyFunctionDeclaration) {
         let typed_token = TypedAstToken::TypedFunctionDeclaration(func_decl.clone());
         if let Some(mut token) = self
             .tokens

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -217,6 +217,8 @@ impl<'a> TypedTree<'a> {
             ty::TyDeclaration::ImplTrait {
                 decl_id, decl_span, ..
             } => {
+                eprintln!("impl trait decl: {:#?}", decl_engine.get_impl_trait(decl_id, decl_span));
+
                 if let Ok(ty::TyImplTrait {
                     impl_type_parameters,
                     trait_name,
@@ -251,9 +253,12 @@ impl<'a> TypedTree<'a> {
                         .try_unwrap()
                     {
                         token.typed = Some(TypedAstToken::TypedDeclaration(declaration.clone()));
+            
                         token.type_def = if let Some(decl_ref) = &trait_decl_ref {
                             if let Ok(trait_decl) = decl_engine.get_trait(decl_ref, decl_span) {
                                 Some(TypeDefinition::Ident(trait_decl.name))
+                            } else if let Ok(abi_decl) = decl_engine.get_abi(decl_ref, decl_span) {
+                                Some(TypeDefinition::Ident(abi_decl.name))
                             } else {
                                 Some(TypeDefinition::TypeId(implementing_for.type_id))
                             }
@@ -302,6 +307,9 @@ impl<'a> TypedTree<'a> {
                 decl_id, decl_span, ..
             } => {
                 if let Ok(abi_decl) = decl_engine.get_abi(decl_id, decl_span) {
+                    eprintln!("abi decl: {:#?}", abi_decl);
+                    eprintln!("");
+
                     if let Some(mut token) = self
                         .tokens
                         .try_get_mut(&to_ident_key(&abi_decl.name))
@@ -317,6 +325,9 @@ impl<'a> TypedTree<'a> {
                                 if let Ok(trait_fn) = decl_engine
                                     .get_trait_fn(trait_fn_decl_ref, &trait_fn_decl_ref.span())
                                 {
+                                    eprintln!("abi trait fn: {:#?}", trait_fn);
+                                    eprintln!("");
+                    
                                     self.collect_typed_trait_fn_token(&trait_fn, namespace);
                                 }
                             }

--- a/sway-lsp/src/utils/attributes.rs
+++ b/sway-lsp/src/utils/attributes.rs
@@ -10,6 +10,7 @@ pub fn attributes_map(token: &Token) -> Option<&transform::AttributesMap> {
             Declaration::StructDeclaration(decl) => Some(&decl.attributes),
             Declaration::ConstantDeclaration(decl) => Some(&decl.attributes),
             Declaration::StorageDeclaration(decl) => Some(&decl.attributes),
+            Declaration::AbiDeclaration(decl) => Some(&decl.attributes),
             _ => None,
         },
         AstToken::ConstantDeclaration(decl) => Some(&decl.attributes),

--- a/sway-lsp/tests/fixtures/tokens/abi/.gitignore
+++ b/sway-lsp/tests/fixtures/tokens/abi/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/sway-lsp/tests/fixtures/tokens/abi/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/abi/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "abi"
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/tests/fixtures/tokens/abi/src/main.sw
+++ b/sway-lsp/tests/fixtures/tokens/abi/src/main.sw
@@ -12,6 +12,6 @@ impl MyContract for Contract {
     }
 }
 
-// fn caller(address: ContractId) -> ContractCaller<_> {
-//     abi(MyContract, address.value)
-// }
+fn caller(address: ContractId) -> ContractCaller<_> {
+    abi(MyContract, address.value)
+}

--- a/sway-lsp/tests/fixtures/tokens/abi/src/main.sw
+++ b/sway-lsp/tests/fixtures/tokens/abi/src/main.sw
@@ -2,6 +2,7 @@ contract;
 
 struct Empty{}
 
+/// Docs for MyContract
 abi MyContract {
     fn test_function() -> Empty;
 }

--- a/sway-lsp/tests/fixtures/tokens/abi/src/main.sw
+++ b/sway-lsp/tests/fixtures/tokens/abi/src/main.sw
@@ -1,0 +1,17 @@
+contract;
+
+struct Empty{}
+
+abi MyContract {
+    fn test_function() -> Empty;
+}
+
+impl MyContract for Contract {
+    fn test_function() -> Empty {
+        Empty{}
+    }
+}
+
+// fn caller(address: ContractId) -> ContractCaller<_> {
+//     abi(MyContract, address.value)
+// }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -1310,6 +1310,35 @@ async fn go_to_definition_for_enums() {
     definition_check_with_req_offset(&mut service, &mut go_to, 25, 23, &mut i).await;
 }
 
+#[tokio::test]
+async fn go_to_definition_for_abi() {
+    let (mut service, _) = LspService::new(Backend::new);
+    let uri = init_and_open(
+        &mut service,
+        test_fixtures_dir().join("tokens/abi/src/main.sw"),
+    )
+    .await;
+    let mut i = 0..;
+
+    let mut go_to = GotoDefinition {
+        req_uri: &uri,
+        req_line: 5,
+        req_char: 29,
+        def_line: 2,
+        def_start_char: 7,
+        def_end_char: 12,
+        def_path: uri.as_str(),
+    };
+    // Return type
+    let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
+
+    // Abi name
+    go_to.def_line = 4;
+    go_to.def_start_char = 4;
+    go_to.def_end_char = 14;
+    definition_check_with_req_offset(&mut service, &mut go_to, 15, 15, &mut i).await;
+}
+
 //------------------- HOVER DOCUMENTATION -------------------//
 
 #[tokio::test]

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -1336,6 +1336,7 @@ async fn go_to_definition_for_abi() {
     go_to.def_line = 4;
     go_to.def_start_char = 4;
     go_to.def_end_char = 14;
+    definition_check_with_req_offset(&mut service, &mut go_to, 8, 11, &mut i).await;
     definition_check_with_req_offset(&mut service, &mut go_to, 15, 15, &mut i).await;
 }
 

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -1322,7 +1322,7 @@ async fn go_to_definition_for_abi() {
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
-        req_line: 5,
+        req_line: 6,
         req_char: 29,
         def_line: 2,
         def_start_char: 7,
@@ -1333,11 +1333,11 @@ async fn go_to_definition_for_abi() {
     let _ = lsp::definition_check(&mut service, &go_to, &mut i).await;
 
     // Abi name
-    go_to.def_line = 4;
+    go_to.def_line = 5;
     go_to.def_start_char = 4;
     go_to.def_end_char = 14;
-    definition_check_with_req_offset(&mut service, &mut go_to, 8, 11, &mut i).await;
-    definition_check_with_req_offset(&mut service, &mut go_to, 15, 15, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 9, 11, &mut i).await;
+    definition_check_with_req_offset(&mut service, &mut go_to, 16, 15, &mut i).await;
 }
 
 //------------------- HOVER DOCUMENTATION -------------------//
@@ -1448,6 +1448,27 @@ async fn hover_docs_for_enums() {
     hover.documentation = " Docs for variants";
     let _ = lsp::hover_request(&mut service, &hover, &mut i).await;
 }
+
+// #[tokio::test]
+// async fn hover_docs_for_abis() {
+//     let (mut service, _) = LspService::new(Backend::new);
+//     let uri = init_and_open(
+//         &mut service,
+//         test_fixtures_dir().join("tokens/abi/src/main.sw"),
+//     )
+//     .await;
+
+//     let mut i = 0..;
+//     let mut hover = HoverDocumentation {
+//         req_uri: &uri,
+//         req_line: 16,
+//         req_char: 19,
+//         documentation: "```sway\nstruct TestStruct\n```\n---\n Docs for MyContract",
+//     };
+//     let _ = lsp::hover_request(&mut service, &hover, &mut i).await;
+// }
+
+
 #[tokio::test]
 async fn hover_docs_with_code_examples() {
     let (mut service, _) = LspService::new(Backend::new);

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -1449,25 +1449,24 @@ async fn hover_docs_for_enums() {
     let _ = lsp::hover_request(&mut service, &hover, &mut i).await;
 }
 
-// #[tokio::test]
-// async fn hover_docs_for_abis() {
-//     let (mut service, _) = LspService::new(Backend::new);
-//     let uri = init_and_open(
-//         &mut service,
-//         test_fixtures_dir().join("tokens/abi/src/main.sw"),
-//     )
-//     .await;
+#[tokio::test]
+async fn hover_docs_for_abis() {
+    let (mut service, _) = LspService::new(Backend::new);
+    let uri = init_and_open(
+        &mut service,
+        test_fixtures_dir().join("tokens/abi/src/main.sw"),
+    )
+    .await;
 
-//     let mut i = 0..;
-//     let mut hover = HoverDocumentation {
-//         req_uri: &uri,
-//         req_line: 16,
-//         req_char: 19,
-//         documentation: "```sway\nstruct TestStruct\n```\n---\n Docs for MyContract",
-//     };
-//     let _ = lsp::hover_request(&mut service, &hover, &mut i).await;
-// }
-
+    let mut i = 0..;
+    let hover = HoverDocumentation {
+        req_uri: &uri,
+        req_line: 16,
+        req_char: 14,
+        documentation: "```sway\nabi MyContract\n```\n---\n Docs for MyContract",
+    };
+    let _ = lsp::hover_request(&mut service, &hover, &mut i).await;
+}
 
 #[tokio::test]
 async fn hover_docs_with_code_examples() {


### PR DESCRIPTION
## Description
Adds goto and hover tests for ABI's. Also cleaned up the typed_tree module by storing a ref to namespace in the type instead of passing it around everywhere. 

Found a bug where we weren't collecting attributes for `AbiDeclaration`. Hover docs now works on these types.

works towards #3989 
closes #4065 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
