### PR TITLE
feat: display gas used for unit tests

### DIFF
--- a/forc-test/src/lib.rs
+++ b/forc-test/src/lib.rs
@@ -211,7 +211,10 @@ impl<'a> PackageTests {
                     .find_map(|receipt| match receipt {
                         tx::Receipt::ScriptResult { gas_used, .. } => Some(gas_used),
                         _ => None,
-                    }).ok_or_else(|| anyhow::anyhow!("missing used gas information from test execution"))?;
+                    })
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("missing used gas information from test execution")
+                    })?;
 
                 // Only retain `Log` and `LogData` receipts.
                 let logs = receipts

--- a/forc-test/src/lib.rs
+++ b/forc-test/src/lib.rs
@@ -47,7 +47,7 @@ pub struct TestResult {
     pub name: String,
     /// The time taken for the test to execute.
     pub duration: std::time::Duration,
-    /// The span for the function declaring this tests.
+    /// The span for the function declaring this test.
     pub span: Span,
     /// The resulting state after executing the test function.
     pub state: vm::state::ProgramState,
@@ -55,6 +55,8 @@ pub struct TestResult {
     pub condition: pkg::TestPassCondition,
     /// Emitted `Recipt`s during the execution of the test.
     pub logs: Vec<fuel_tx::Receipt>,
+    /// Gas used while executing this test.
+    pub gas_used: u64,
 }
 
 const TEST_METADATA_SEED: u64 = 0x7E57u64;
@@ -204,6 +206,13 @@ impl<'a> PackageTests {
                 let (state, duration, receipts) =
                     exec_test(&pkg_with_tests.bytecode, offset, test_setup);
 
+                let gas_used = *receipts
+                    .iter()
+                    .find_map(|receipt| match receipt {
+                        tx::Receipt::ScriptResult { gas_used, .. } => Some(gas_used),
+                        _ => None,
+                    }).ok_or_else(|| anyhow::anyhow!("missing used gas information from test execution"))?;
+
                 // Only retain `Log` and `LogData` receipts.
                 let logs = receipts
                     .into_iter()
@@ -222,6 +231,7 @@ impl<'a> PackageTests {
                     state,
                     condition,
                     logs,
+                    gas_used,
                 })
             })
             .collect::<anyhow::Result<_>>()?;

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -85,7 +85,7 @@ fn print_tested_pkg(pkg: &TestedPackage, test_print_opts: &TestPrintOpts) -> Res
             false => ("FAILED", Colour::Red),
         };
         info!(
-            "      test {} ... {} ({:?}) - (gas used: {})",
+            "      test {} ... {} ({:?}, {} gas)",
             test.name,
             color.paint(state),
             test.duration,

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -85,10 +85,11 @@ fn print_tested_pkg(pkg: &TestedPackage, test_print_opts: &TestPrintOpts) -> Res
             false => ("FAILED", Colour::Red),
         };
         info!(
-            "      test {} ... {} ({:?})",
+            "      test {} ... {} ({:?}) - (gas used: {})",
             test.name,
             color.paint(state),
-            test.duration
+            test.duration,
+            test.gas_used
         );
 
         // If logs are enabled, print them.


### PR DESCRIPTION
## Description
closes #2411.

This PR adds used gas information to the output of `forc test`. An example run can be seen below:

<img width="534" alt="Screen Shot 2023-02-24 at 4 47 29 PM" src="https://user-images.githubusercontent.com/20915464/221198624-a3bdb264-2182-4b9d-9497-7d8cfe84132b.png">

This is done automatically without any flags. I felt like this should be the default way but open to suggestions if you feel like it should be behind a flag like `--gas-usage`.

Also by accessing `TestResult` struct's new "used gas" field, we can add this information into vscode plugin just like #513. We do not have a line by line gas cost information just yet but we could show the whole test's used gas info next to the run button or something in vscode. Thoughts @JoshuaBatty @sdankel 

Please let me know if anyone has any requests around the flag and the way we are printing the used gas. Maybe @nfurfaro could have some ideas as the prime user of `forc-test` 😄 
## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
