### PR TITLE
feat(forc-pkg): Print *before* compiling each package. Only print after on warnings/error.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,6 +1702,7 @@ dependencies = [
 name = "forc-pkg"
 version = "0.35.3"
 dependencies = [
+ "ansi_term",
  "anyhow",
  "fd-lock",
  "forc-tracing",

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/FuelLabs/sway"
 description = "Building, locking, fetching and updating Sway projects as Forc packages."
 
 [dependencies]
+ansi_term = "0.12"
 anyhow = "1"
 fd-lock = "3.0"
 forc-tracing = { version = "0.35.3", path = "../forc-tracing" }

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2077,12 +2077,10 @@ pub fn build(
         let mut source_map = SourceMap::new();
         let pkg = &plan.graph()[node];
         let manifest = &plan.manifest_map()[&pkg.id()];
-        let program_ty = manifest
-            .program_type()
-            .map_err(|e| anyhow!("Failed to compile {}: {e}", pkg.name))?;
+        let program_ty = manifest.program_type().ok();
 
         print_compiling(
-            &program_ty,
+            program_ty.as_ref(),
             &pkg.name,
             &pkg.source.display_compiling(manifest.dir()),
         );

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Context, Error, Result};
 use forc_util::{
-    default_output_directory, find_file_name, kebab_to_snake_case, print_on_failure,
-    print_on_success, user_forc_directory,
+    default_output_directory, find_file_name, kebab_to_snake_case, print_compiling,
+    print_on_failure, print_warnings, user_forc_directory,
 };
 use fuel_abi_types::program_abi;
 use petgraph::{
@@ -1751,7 +1751,7 @@ pub fn compile(
         }) if bc_res.errors.is_empty()
             && (bc_res.warnings.is_empty() || !build_profile.error_on_warnings) =>
         {
-            print_on_success(terse_mode, &pkg.name, &bc_res.warnings, &tree_type);
+            print_warnings(terse_mode, &pkg.name, &bc_res.warnings, &tree_type);
 
             if let ProgramABI::Fuel(ref mut json_abi_program) = json_abi_program {
                 if let Some(ref mut configurables) = json_abi_program.configurables {
@@ -2077,6 +2077,16 @@ pub fn build(
         let mut source_map = SourceMap::new();
         let pkg = &plan.graph()[node];
         let manifest = &plan.manifest_map()[&pkg.id()];
+        let program_ty = manifest
+            .program_type()
+            .map_err(|e| anyhow!("Failed to compile {}: {e}", pkg.name))?;
+
+        print_compiling(
+            &program_ty,
+            &pkg.name,
+            &pkg.source.display_compiling(manifest.dir()),
+        );
+
         let constants = if let Some(injected_ctc) = const_inject_map.get(pkg) {
             let mut constants = manifest.config_time_constants();
             constants.extend(

--- a/forc-pkg/src/source/git.rs
+++ b/forc-pkg/src/source/git.rs
@@ -190,7 +190,12 @@ impl source::Fetch for Pinned {
         {
             let _guard = lock.write()?;
             if !repo_path.exists() {
-                info!("  Fetching {}", self);
+                info!(
+                    "  {} {} {}",
+                    ansi_term::Color::Green.bold().paint("Fetching"),
+                    ansi_term::Style::new().bold().paint(ctx.name),
+                    self
+                );
                 fetch(ctx.fetch_id(), ctx.name(), self)?;
             }
         }

--- a/forc-tracing/src/lib.rs
+++ b/forc-tracing/src/lib.rs
@@ -25,10 +25,6 @@ pub fn println_red_err(txt: &str) {
     println_std_err(txt, Colour::Red);
 }
 
-pub fn println_green_err(txt: &str) {
-    println_std_err(txt, Colour::Green);
-}
-
 fn println_std_out(txt: &str, color: Colour) {
     tracing::info!("{}", color.paint(txt));
 }

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -185,8 +185,13 @@ pub fn program_type_str(ty: &TreeType) -> &'static str {
     }
 }
 
-pub fn print_compiling(ty: &TreeType, name: &str, src: &dyn std::fmt::Display) {
-    let ty = program_type_str(ty);
+pub fn print_compiling(ty: Option<&TreeType>, name: &str, src: &dyn std::fmt::Display) {
+    // NOTE: We can only print the program type if we can parse the program, so
+    // program type must be optional.
+    let ty = match ty {
+        Some(ty) => format!("{} ", program_type_str(ty)),
+        None => "".to_string(),
+    };
     tracing::error!(
         " {} {ty} {} ({src})",
         Colour::Green.bold().paint("Compiling"),

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -193,7 +193,7 @@ pub fn print_compiling(ty: Option<&TreeType>, name: &str, src: &dyn std::fmt::Di
         None => "".to_string(),
     };
     tracing::error!(
-        " {} {ty} {} ({src})",
+        " {} {ty}{} ({src})",
         Colour::Green.bold().paint("Compiling"),
         ansi_term::Style::new().bold().paint(name)
     );

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -4,6 +4,7 @@ use annotate_snippets::{
     display_list::{DisplayList, FormatOptions},
     snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
 };
+use ansi_term::Colour;
 use anyhow::{bail, Result};
 use forc_tracing::{println_red_err, println_yellow_err};
 use std::ffi::OsStr;
@@ -186,8 +187,11 @@ pub fn program_type_str(ty: &TreeType) -> &'static str {
 
 pub fn print_compiling(ty: &TreeType, name: &str, src: &dyn std::fmt::Display) {
     let ty = program_type_str(ty);
-    let string = format!(" Compiling {ty} {name} ({src})");
-    forc_tracing::println_green(&string)
+    tracing::error!(
+        " {} {ty} {} ({src})",
+        Colour::Green.bold().paint("Compiling"),
+        ansi_term::Style::new().bold().paint(name)
+    );
 }
 
 pub fn print_warnings(


### PR DESCRIPTION
## Description

We now print with the following format *prior* to compiling a package:

```
Compiling <ty> <name> (<src>)
```

Rather than only printing `Compiled` after compilation is complete.

Closes #3780.

This also aims to improve the formatting of the output a little by using ansi_term styling to distinguish between action, program kind, package name and source more clearly.

The fetching, adding and removing actions have had their formatting updated to match. E.g.

![Screenshot from 2023-02-26 20-14-25](https://user-images.githubusercontent.com/4587373/221402630-28b65eb3-ddfb-491f-81a6-4aead5538a28.png)

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
