### PR TITLE
Clear memory from type and decl engines

### DIFF
--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -75,10 +75,6 @@ impl Session {
     }
 
     pub fn init(&self, uri: &Url) -> Result<ProjectDirectory, LanguageServerError> {
-        *self.type_engine.write() = <_>::default();
-
-        *self.decl_engine.write() = <_>::default();
-
         let manifest_dir = PathBuf::from(uri.path());
         // Create a new temp dir that clones the current workspace
         // and store manifest and temp paths
@@ -146,6 +142,9 @@ impl Session {
             warnings: vec![],
             errors: vec![],
         };
+
+        *self.type_engine.write() = <_>::default();
+        *self.decl_engine.write() = <_>::default();
         let type_engine = &*self.type_engine.read();
         let decl_engine = &*self.decl_engine.read();
         let engines = Engines::new(type_engine, decl_engine);


### PR DESCRIPTION
## Description
The memory footprint was growing on each keystroke in the language server. This reinitializes the engines before each subsequent compilation in order to clear existing memory. 

closes #4144

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
