### PR TITLE
Add `std` docs to the sway book

### DIFF
--- a/docs/book/src/introduction/standard_library.md
+++ b/docs/book/src/introduction/standard_library.md
@@ -4,7 +4,7 @@ Similar to Rust, Sway comes with its own standard library.
 
 The Sway Standard Library is the foundation of portable Sway software, a set of minimal shared abstractions for the broader Sway ecosystem. It offers core types, like `Result<T, E>` and `Option<T>`, library-defined operations on language primitives, native asset management, blockchain contextual operations, access control, storage management, and support for types from other VMs, among many other things.
 
-The entire Sway standard library is a Forc project called `std`, and is available directly here: <https://github.com/FuelLabs/sway/tree/master/sway-lib-std> (navigate to the appropriate tagged release if the latest `master` is not compatible).
+The entire Sway standard library is a Forc project called `std`, and is available directly here: <https://github.com/FuelLabs/sway/tree/master/sway-lib-std> (navigate to the appropriate tagged release if the latest `master` is not compatible). For the latest `std` documentation see: <https://fuellabs.github.io/sway/master/std/>.
 
 ## Using the Standard Library
 

--- a/sway-lib-std/src/lib.sw
+++ b/sway-lib-std/src/lib.sw
@@ -1,4 +1,6 @@
 //! The official standard library for the Sway smart contract language.
+//!
+//! Source: https://github.com/FuelLabs/sway/tree/master/sway-lib-std
 library std;
 
 dep error_signals;

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -498,7 +498,7 @@ async fn go_to_definition_for_paths() {
         req_uri: &uri,
         req_line: 10,
         req_char: 13,
-        def_line: 1,
+        def_line: 3,
         def_start_char: 8,
         def_end_char: 11,
         def_path: "sway-lib-std/src/lib.sw",


### PR DESCRIPTION
## Description
Adds a link to the `std` docs in the standard library section of the sway book & links the source code in the root docstring of the `std` library itself.

![Screenshot from 2023-02-28 10-44-52](https://user-images.githubusercontent.com/57543709/221920234-b08548e9-70fc-45f6-a02b-5620a4e64913.png)


## Checklist

- [x] I have linked to any relevant issues. #4200 
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
