### PR TITLE
refactor(forc-pkg): Attempt to simplify build/compile fns by introducing dedicated types

### DIFF
--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -62,7 +62,7 @@ pub(crate) fn exec(cmd: Command) -> Result<()> {
     match tested {
         forc_test::Tested::Workspace(pkgs) => {
             for pkg in pkgs {
-                let built = &pkg.built.pkg_name;
+                let built = &pkg.built.descriptor.name;
                 info!("\n   tested -- {built}\n");
                 print_tested_pkg(&pkg, &test_print_opts)?;
             }

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -135,7 +135,7 @@ pub(crate) fn runs_in_vm(
     script: BuiltPackage,
     script_data: Option<Vec<u8>>,
 ) -> Result<VMExecutionResult> {
-    match script.build_target {
+    match script.descriptor.target {
         BuildTarget::Fuel => {
             let storage = MemoryStorage::default();
 
@@ -307,7 +307,7 @@ pub(crate) fn test_json_abi(file_name: &str, built_package: &BuiltPackage) -> Re
 
 fn emit_json_abi(file_name: &str, built_package: &BuiltPackage) -> Result<()> {
     tracing::info!("ABI gen {} ...", file_name.bold());
-    let json_abi = match &built_package.json_abi_program {
+    let json_abi = match &built_package.program_abi {
         ProgramABI::Fuel(abi) => serde_json::json!(abi),
         ProgramABI::Evm(abi) => serde_json::json!(abi),
         ProgramABI::MidenVM(_) => todo!(),

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -324,7 +324,7 @@ impl TestContext {
                             .map(move |test| {
                                 format!(
                                     "{}: Test '{}' failed with state {:?}, expected: {:?}",
-                                    tested_pkg.built.pkg_name,
+                                    tested_pkg.built.descriptor.name,
                                     test.name,
                                     test.state,
                                     test.condition,


### PR DESCRIPTION
## Description

This introduces the `CompiledPackage` and `CompiledContractDependency` types in order to more accurately model the inputs and outputs of the `compile` function.

We also move the `name` and `target` fields from `BuiltPackage` into the `PackageDescriptor`, construct the descriptor earlier in the build process, and use the descriptor to consolidate more of the `compile` function arguments.

I started on refactoring some of the ABI generation related code, but realised that this might involve a more dedicated effort and opened #4208.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
