### PR TITLE
Use `DeclRef` for struct and enum TypeInfo

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1738,6 +1738,7 @@ pub fn compile(
                         json_abi_with_callpaths: profile.json_abi_with_callpaths,
                     },
                     engines.te(),
+                    engines.de(),
                     &mut types
                 )
             ))
@@ -1755,7 +1756,7 @@ pub fn compile(
 
             let abi = time_expr!(
                 "generate JSON ABI program",
-                evm_json_abi::generate_json_abi_program(typed_program, engines.te())
+                evm_json_abi::generate_json_abi_program(typed_program, &engines)
             );
 
             ops.extend(abi.into_iter());

--- a/forc-plugins/forc-doc/src/descriptor.rs
+++ b/forc-plugins/forc-doc/src/descriptor.rs
@@ -39,8 +39,8 @@ impl Descriptor {
         use swayfmt::parse;
         use TyDeclaration::*;
         match ty_decl {
-            StructDeclaration { decl_id, .. } => {
-                let struct_decl = decl_engine.get_struct(decl_id);
+            StructDeclaration(decl_ref) => {
+                let struct_decl = decl_engine.get_struct(decl_ref);
                 if !document_private_items && struct_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
                 } else {
@@ -71,8 +71,8 @@ impl Descriptor {
                     }))
                 }
             }
-            EnumDeclaration { decl_id, .. } => {
-                let enum_decl = decl_engine.get_enum(decl_id);
+            EnumDeclaration(decl_ref) => {
+                let enum_decl = decl_engine.get_enum(decl_ref);
                 if !document_private_items && enum_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
                 } else {

--- a/sway-core/src/abi_generation/fuel_json_abi.rs
+++ b/sway-core/src/abi_generation/fuel_json_abi.rs
@@ -2,6 +2,7 @@ use fuel_abi_types::program_abi;
 use sway_types::integer_bits::IntegerBits;
 
 use crate::{
+    decl_engine::DeclEngine,
     language::{
         ty::{TyConstantDeclaration, TyFunctionDeclaration, TyProgram, TyProgramKind},
         CallPath,
@@ -18,17 +19,18 @@ pub struct JsonAbiContext<'a> {
 pub fn generate_json_abi_program(
     ctx: &mut JsonAbiContext,
     type_engine: &TypeEngine,
+    decl_engine: &DeclEngine,
     types: &mut Vec<program_abi::TypeDeclaration>,
 ) -> program_abi::ProgramABI {
     match &ctx.program.kind {
         TyProgramKind::Contract { abi_entries, .. } => {
             let functions = abi_entries
                 .iter()
-                .map(|x| x.generate_json_abi_function(ctx, type_engine, types))
+                .map(|x| x.generate_json_abi_function(ctx, type_engine, decl_engine, types))
                 .collect();
-            let logged_types = generate_json_logged_types(ctx, type_engine, types);
-            let messages_types = generate_json_messages_types(ctx, type_engine, types);
-            let configurables = generate_json_configurables(ctx, type_engine, types);
+            let logged_types = generate_json_logged_types(ctx, type_engine, decl_engine, types);
+            let messages_types = generate_json_messages_types(ctx, type_engine, decl_engine, types);
+            let configurables = generate_json_configurables(ctx, type_engine, decl_engine, types);
             program_abi::ProgramABI {
                 types: types.to_vec(),
                 functions,
@@ -39,10 +41,15 @@ pub fn generate_json_abi_program(
         }
         TyProgramKind::Script { main_function, .. }
         | TyProgramKind::Predicate { main_function, .. } => {
-            let functions = vec![main_function.generate_json_abi_function(ctx, type_engine, types)];
-            let logged_types = generate_json_logged_types(ctx, type_engine, types);
-            let messages_types = generate_json_messages_types(ctx, type_engine, types);
-            let configurables = generate_json_configurables(ctx, type_engine, types);
+            let functions = vec![main_function.generate_json_abi_function(
+                ctx,
+                type_engine,
+                decl_engine,
+                types,
+            )];
+            let logged_types = generate_json_logged_types(ctx, type_engine, decl_engine, types);
+            let messages_types = generate_json_messages_types(ctx, type_engine, decl_engine, types);
+            let configurables = generate_json_configurables(ctx, type_engine, decl_engine, types);
             program_abi::ProgramABI {
                 types: types.to_vec(),
                 functions,
@@ -64,6 +71,7 @@ pub fn generate_json_abi_program(
 fn generate_json_logged_types(
     ctx: &mut JsonAbiContext,
     type_engine: &TypeEngine,
+    decl_engine: &DeclEngine,
     types: &mut Vec<program_abi::TypeDeclaration>,
 ) -> Vec<program_abi::LoggedType> {
     // A list of all `program_abi::TypeDeclaration`s needed for the logged types
@@ -73,9 +81,21 @@ fn generate_json_logged_types(
         .iter()
         .map(|(_, type_id)| program_abi::TypeDeclaration {
             type_id: type_id.index(),
-            type_field: type_id.get_json_type_str(ctx, type_engine, *type_id),
-            components: type_id.get_json_type_components(ctx, type_engine, types, *type_id),
-            type_parameters: type_id.get_json_type_parameters(ctx, type_engine, types, *type_id),
+            type_field: type_id.get_json_type_str(ctx, type_engine, decl_engine, *type_id),
+            components: type_id.get_json_type_components(
+                ctx,
+                type_engine,
+                decl_engine,
+                types,
+                *type_id,
+            ),
+            type_parameters: type_id.get_json_type_parameters(
+                ctx,
+                type_engine,
+                decl_engine,
+                types,
+                *type_id,
+            ),
         })
         .collect::<Vec<_>>();
 
@@ -91,7 +111,13 @@ fn generate_json_logged_types(
             application: program_abi::TypeApplication {
                 name: "".to_string(),
                 type_id: type_id.index(),
-                type_arguments: type_id.get_json_type_arguments(ctx, type_engine, types, *type_id),
+                type_arguments: type_id.get_json_type_arguments(
+                    ctx,
+                    type_engine,
+                    decl_engine,
+                    types,
+                    *type_id,
+                ),
             },
         })
         .collect()
@@ -100,6 +126,7 @@ fn generate_json_logged_types(
 fn generate_json_messages_types(
     ctx: &mut JsonAbiContext,
     type_engine: &TypeEngine,
+    decl_engine: &DeclEngine,
     types: &mut Vec<program_abi::TypeDeclaration>,
 ) -> Vec<program_abi::MessageType> {
     // A list of all `program_abi::TypeDeclaration`s needed for the messages types
@@ -109,9 +136,21 @@ fn generate_json_messages_types(
         .iter()
         .map(|(_, type_id)| program_abi::TypeDeclaration {
             type_id: type_id.index(),
-            type_field: type_id.get_json_type_str(ctx, type_engine, *type_id),
-            components: type_id.get_json_type_components(ctx, type_engine, types, *type_id),
-            type_parameters: type_id.get_json_type_parameters(ctx, type_engine, types, *type_id),
+            type_field: type_id.get_json_type_str(ctx, type_engine, decl_engine, *type_id),
+            components: type_id.get_json_type_components(
+                ctx,
+                type_engine,
+                decl_engine,
+                types,
+                *type_id,
+            ),
+            type_parameters: type_id.get_json_type_parameters(
+                ctx,
+                type_engine,
+                decl_engine,
+                types,
+                *type_id,
+            ),
         })
         .collect::<Vec<_>>();
 
@@ -127,7 +166,13 @@ fn generate_json_messages_types(
             application: program_abi::TypeApplication {
                 name: "".to_string(),
                 type_id: type_id.index(),
-                type_arguments: type_id.get_json_type_arguments(ctx, type_engine, types, *type_id),
+                type_arguments: type_id.get_json_type_arguments(
+                    ctx,
+                    type_engine,
+                    decl_engine,
+                    types,
+                    *type_id,
+                ),
             },
         })
         .collect()
@@ -136,6 +181,7 @@ fn generate_json_messages_types(
 fn generate_json_configurables(
     ctx: &mut JsonAbiContext,
     type_engine: &TypeEngine,
+    decl_engine: &DeclEngine,
     types: &mut Vec<program_abi::TypeDeclaration>,
 ) -> Vec<program_abi::Configurable> {
     // A list of all `program_abi::TypeDeclaration`s needed for the configurables types
@@ -151,17 +197,20 @@ fn generate_json_configurables(
                 type_field: type_ascription.type_id.get_json_type_str(
                     ctx,
                     type_engine,
+                    decl_engine,
                     type_ascription.type_id,
                 ),
                 components: type_ascription.type_id.get_json_type_components(
                     ctx,
                     type_engine,
+                    decl_engine,
                     types,
                     type_ascription.type_id,
                 ),
                 type_parameters: type_ascription.type_id.get_json_type_parameters(
                     ctx,
                     type_engine,
+                    decl_engine,
                     types,
                     type_ascription.type_id,
                 ),
@@ -189,6 +238,7 @@ fn generate_json_configurables(
                     type_arguments: type_ascription.type_id.get_json_type_arguments(
                         ctx,
                         type_engine,
+                        decl_engine,
                         types,
                         type_ascription.type_id,
                     ),
@@ -205,21 +255,24 @@ impl TypeId {
         &self,
         ctx: &mut JsonAbiContext,
         type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
         resolved_type_id: TypeId,
     ) -> String {
-        if self.is_generic_parameter(type_engine, resolved_type_id) {
+        if self.is_generic_parameter(type_engine, decl_engine, resolved_type_id) {
             format!(
                 "generic {}",
-                type_engine.get(*self).json_abi_str(ctx, type_engine)
+                type_engine
+                    .get(*self)
+                    .json_abi_str(ctx, type_engine, decl_engine)
             )
         } else {
             match (type_engine.get(*self), type_engine.get(resolved_type_id)) {
                 (TypeInfo::Custom { .. }, TypeInfo::Struct { .. }) => type_engine
                     .get(resolved_type_id)
-                    .json_abi_str(ctx, type_engine),
+                    .json_abi_str(ctx, type_engine, decl_engine),
                 (TypeInfo::Custom { .. }, TypeInfo::Enum { .. }) => type_engine
                     .get(resolved_type_id)
-                    .json_abi_str(ctx, type_engine),
+                    .json_abi_str(ctx, type_engine, decl_engine),
                 (TypeInfo::Tuple(fields), TypeInfo::Tuple(resolved_fields)) => {
                     assert_eq!(fields.len(), resolved_fields.len());
                     let field_strs = fields
@@ -235,10 +288,14 @@ impl TypeId {
                 (TypeInfo::Custom { .. }, _) => {
                     format!(
                         "generic {}",
-                        type_engine.get(*self).json_abi_str(ctx, type_engine)
+                        type_engine
+                            .get(*self)
+                            .json_abi_str(ctx, type_engine, decl_engine)
                     )
                 }
-                _ => type_engine.get(*self).json_abi_str(ctx, type_engine),
+                _ => type_engine
+                    .get(*self)
+                    .json_abi_str(ctx, type_engine, decl_engine),
             }
         }
     }
@@ -252,16 +309,19 @@ impl TypeId {
         &self,
         ctx: &mut JsonAbiContext,
         type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
         types: &mut Vec<program_abi::TypeDeclaration>,
         resolved_type_id: TypeId,
     ) -> Option<Vec<usize>> {
-        match self.is_generic_parameter(type_engine, resolved_type_id) {
+        match self.is_generic_parameter(type_engine, decl_engine, resolved_type_id) {
             true => None,
-            false => resolved_type_id.get_type_parameters(type_engine).map(|v| {
-                v.iter()
-                    .map(|v| v.get_json_type_parameter(ctx, type_engine, types))
-                    .collect::<Vec<_>>()
-            }),
+            false => resolved_type_id
+                .get_type_parameters(type_engine, decl_engine)
+                .map(|v| {
+                    v.iter()
+                        .map(|v| v.get_json_type_parameter(ctx, type_engine, decl_engine, types))
+                        .collect::<Vec<_>>()
+                }),
         }
     }
     /// Return the components of a given (potentially generic) type while considering what it
@@ -272,30 +332,36 @@ impl TypeId {
         &self,
         ctx: &mut JsonAbiContext,
         type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
         types: &mut Vec<program_abi::TypeDeclaration>,
         resolved_type_id: TypeId,
     ) -> Option<Vec<program_abi::TypeApplication>> {
         match type_engine.get(*self) {
-            TypeInfo::Enum { variant_types, .. } => {
+            TypeInfo::Enum(decl_ref) => {
+                let decl = decl_engine.get_enum(&decl_ref);
                 // A list of all `program_abi::TypeDeclaration`s needed for the enum variants
-                let variants = variant_types
+                let variants = decl
+                    .variants
                     .iter()
                     .map(|x| program_abi::TypeDeclaration {
                         type_id: x.type_argument.initial_type_id.index(),
                         type_field: x.type_argument.initial_type_id.get_json_type_str(
                             ctx,
                             type_engine,
+                            decl_engine,
                             x.type_argument.type_id,
                         ),
                         components: x.type_argument.initial_type_id.get_json_type_components(
                             ctx,
                             type_engine,
+                            decl_engine,
                             types,
                             x.type_argument.type_id,
                         ),
                         type_parameters: x.type_argument.initial_type_id.get_json_type_parameters(
                             ctx,
                             type_engine,
+                            decl_engine,
                             types,
                             x.type_argument.type_id,
                         ),
@@ -306,7 +372,7 @@ impl TypeId {
                 // Generate the JSON data for the enum. This is basically a list of
                 // `program_abi::TypeApplication`s
                 Some(
-                    variant_types
+                    decl.variants
                         .iter()
                         .map(|x| program_abi::TypeApplication {
                             name: x.name.to_string(),
@@ -317,6 +383,7 @@ impl TypeId {
                                 .get_json_type_arguments(
                                     ctx,
                                     type_engine,
+                                    decl_engine,
                                     types,
                                     x.type_argument.type_id,
                                 ),
@@ -324,26 +391,32 @@ impl TypeId {
                         .collect(),
                 )
             }
-            TypeInfo::Struct { fields, .. } => {
+            TypeInfo::Struct(decl_ref) => {
+                let decl = decl_engine.get_struct(&decl_ref);
+
                 // A list of all `program_abi::TypeDeclaration`s needed for the struct fields
-                let field_types = fields
+                let field_types = decl
+                    .fields
                     .iter()
                     .map(|x| program_abi::TypeDeclaration {
                         type_id: x.type_argument.initial_type_id.index(),
                         type_field: x.type_argument.initial_type_id.get_json_type_str(
                             ctx,
                             type_engine,
+                            decl_engine,
                             x.type_argument.type_id,
                         ),
                         components: x.type_argument.initial_type_id.get_json_type_components(
                             ctx,
                             type_engine,
+                            decl_engine,
                             types,
                             x.type_argument.type_id,
                         ),
                         type_parameters: x.type_argument.initial_type_id.get_json_type_parameters(
                             ctx,
                             type_engine,
+                            decl_engine,
                             types,
                             x.type_argument.type_id,
                         ),
@@ -354,7 +427,7 @@ impl TypeId {
                 // Generate the JSON data for the struct. This is basically a list of
                 // `program_abi::TypeApplication`s
                 Some(
-                    fields
+                    decl.fields
                         .iter()
                         .map(|x| program_abi::TypeApplication {
                             name: x.name.to_string(),
@@ -365,6 +438,7 @@ impl TypeId {
                                 .get_json_type_arguments(
                                     ctx,
                                     type_engine,
+                                    decl_engine,
                                     types,
                                     x.type_argument.type_id,
                                 ),
@@ -380,17 +454,20 @@ impl TypeId {
                         type_field: elem_ty.initial_type_id.get_json_type_str(
                             ctx,
                             type_engine,
+                            decl_engine,
                             elem_ty.type_id,
                         ),
                         components: elem_ty.initial_type_id.get_json_type_components(
                             ctx,
                             type_engine,
+                            decl_engine,
                             types,
                             elem_ty.type_id,
                         ),
                         type_parameters: elem_ty.initial_type_id.get_json_type_parameters(
                             ctx,
                             type_engine,
+                            decl_engine,
                             types,
                             elem_ty.type_id,
                         ),
@@ -405,6 +482,7 @@ impl TypeId {
                         type_arguments: elem_ty.initial_type_id.get_json_type_arguments(
                             ctx,
                             type_engine,
+                            decl_engine,
                             types,
                             elem_ty.type_id,
                         ),
@@ -423,17 +501,20 @@ impl TypeId {
                             type_field: x.initial_type_id.get_json_type_str(
                                 ctx,
                                 type_engine,
+                                decl_engine,
                                 x.type_id,
                             ),
                             components: x.initial_type_id.get_json_type_components(
                                 ctx,
                                 type_engine,
+                                decl_engine,
                                 types,
                                 x.type_id,
                             ),
                             type_parameters: x.initial_type_id.get_json_type_parameters(
                                 ctx,
                                 type_engine,
+                                decl_engine,
                                 types,
                                 x.type_id,
                             ),
@@ -452,6 +533,7 @@ impl TypeId {
                                 type_arguments: x.initial_type_id.get_json_type_arguments(
                                     ctx,
                                     type_engine,
+                                    decl_engine,
                                     types,
                                     x.type_id,
                                 ),
@@ -463,14 +545,14 @@ impl TypeId {
                 }
             }
             TypeInfo::Custom { type_arguments, .. } => {
-                if !self.is_generic_parameter(type_engine, resolved_type_id) {
+                if !self.is_generic_parameter(type_engine, decl_engine, resolved_type_id) {
                     // A list of all `program_abi::TypeDeclaration`s needed for the type arguments
                     let type_args = type_arguments
                         .unwrap_or_default()
                         .iter()
                         .zip(
                             resolved_type_id
-                                .get_type_parameters(type_engine)
+                                .get_type_parameters(type_engine, decl_engine)
                                 .unwrap_or_default()
                                 .iter(),
                         )
@@ -479,17 +561,20 @@ impl TypeId {
                             type_field: v.initial_type_id.get_json_type_str(
                                 ctx,
                                 type_engine,
+                                decl_engine,
                                 p.type_id,
                             ),
                             components: v.initial_type_id.get_json_type_components(
                                 ctx,
                                 type_engine,
+                                decl_engine,
                                 types,
                                 p.type_id,
                             ),
                             type_parameters: v.initial_type_id.get_json_type_parameters(
                                 ctx,
                                 type_engine,
+                                decl_engine,
                                 types,
                                 p.type_id,
                             ),
@@ -500,6 +585,7 @@ impl TypeId {
                     resolved_type_id.get_json_type_components(
                         ctx,
                         type_engine,
+                        decl_engine,
                         types,
                         resolved_type_id,
                     )
@@ -519,10 +605,11 @@ impl TypeId {
         &self,
         ctx: &mut JsonAbiContext,
         type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
         types: &mut Vec<program_abi::TypeDeclaration>,
         resolved_type_id: TypeId,
     ) -> Option<Vec<program_abi::TypeApplication>> {
-        let resolved_params = resolved_type_id.get_type_parameters(type_engine);
+        let resolved_params = resolved_type_id.get_type_parameters(type_engine, decl_engine);
         match type_engine.get(*self) {
             TypeInfo::Custom {
                 type_arguments: Some(type_arguments),
@@ -537,17 +624,20 @@ impl TypeId {
                         type_field: v.initial_type_id.get_json_type_str(
                             ctx,
                             type_engine,
+                            decl_engine,
                             p.type_id,
                         ),
                         components: v.initial_type_id.get_json_type_components(
                             ctx,
                             type_engine,
+                            decl_engine,
                             types,
                             p.type_id,
                         ),
                         type_parameters: v.initial_type_id.get_json_type_parameters(
                             ctx,
                             type_engine,
+                            decl_engine,
                             types,
                             p.type_id,
                         ),
@@ -563,33 +653,38 @@ impl TypeId {
                         type_arguments: arg.initial_type_id.get_json_type_arguments(
                             ctx,
                             type_engine,
+                            decl_engine,
                             types,
                             arg.type_id,
                         ),
                     })
                     .collect::<Vec<_>>()
             }),
-            TypeInfo::Enum {
-                type_parameters, ..
-            }
-            | TypeInfo::Struct {
-                type_parameters, ..
-            } => {
+            TypeInfo::Enum(decl_ref) => {
+                let decl = decl_engine.get_enum(&decl_ref);
                 // Here, type_id for each type parameter should contain resolved types
-                let json_type_arguments = type_parameters
+                let json_type_arguments = decl
+                    .type_parameters
                     .iter()
                     .map(|v| program_abi::TypeDeclaration {
                         type_id: v.type_id.index(),
-                        type_field: v.type_id.get_json_type_str(ctx, type_engine, v.type_id),
+                        type_field: v.type_id.get_json_type_str(
+                            ctx,
+                            type_engine,
+                            decl_engine,
+                            v.type_id,
+                        ),
                         components: v.type_id.get_json_type_components(
                             ctx,
                             type_engine,
+                            decl_engine,
                             types,
                             v.type_id,
                         ),
                         type_parameters: v.type_id.get_json_type_parameters(
                             ctx,
                             type_engine,
+                            decl_engine,
                             types,
                             v.type_id,
                         ),
@@ -598,7 +693,7 @@ impl TypeId {
                 types.extend(json_type_arguments);
 
                 Some(
-                    type_parameters
+                    decl.type_parameters
                         .iter()
                         .map(|arg| program_abi::TypeApplication {
                             name: "".to_string(),
@@ -606,6 +701,57 @@ impl TypeId {
                             type_arguments: arg.type_id.get_json_type_arguments(
                                 ctx,
                                 type_engine,
+                                decl_engine,
+                                types,
+                                arg.type_id,
+                            ),
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            }
+
+            TypeInfo::Struct(decl_ref) => {
+                let decl = decl_engine.get_struct(&decl_ref);
+                // Here, type_id for each type parameter should contain resolved types
+                let json_type_arguments = decl
+                    .type_parameters
+                    .iter()
+                    .map(|v| program_abi::TypeDeclaration {
+                        type_id: v.type_id.index(),
+                        type_field: v.type_id.get_json_type_str(
+                            ctx,
+                            type_engine,
+                            decl_engine,
+                            v.type_id,
+                        ),
+                        components: v.type_id.get_json_type_components(
+                            ctx,
+                            type_engine,
+                            decl_engine,
+                            types,
+                            v.type_id,
+                        ),
+                        type_parameters: v.type_id.get_json_type_parameters(
+                            ctx,
+                            type_engine,
+                            decl_engine,
+                            types,
+                            v.type_id,
+                        ),
+                    })
+                    .collect::<Vec<_>>();
+                types.extend(json_type_arguments);
+
+                Some(
+                    decl.type_parameters
+                        .iter()
+                        .map(|arg| program_abi::TypeApplication {
+                            name: "".to_string(),
+                            type_id: arg.type_id.index(),
+                            type_arguments: arg.type_id.get_json_type_arguments(
+                                ctx,
+                                type_engine,
+                                decl_engine,
                                 types,
                                 arg.type_id,
                             ),
@@ -619,7 +765,12 @@ impl TypeId {
 }
 
 impl TypeInfo {
-    pub fn json_abi_str(&self, ctx: &mut JsonAbiContext, type_engine: &TypeEngine) -> String {
+    pub fn json_abi_str(
+        &self,
+        ctx: &mut JsonAbiContext,
+        type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
+    ) -> String {
         use TypeInfo::*;
         match self {
             Unknown => "unknown".into(),
@@ -638,7 +789,7 @@ impl TypeInfo {
             Tuple(fields) => {
                 let field_strs = fields
                     .iter()
-                    .map(|field| field.json_abi_str(ctx, type_engine))
+                    .map(|field| field.json_abi_str(ctx, type_engine, decl_engine))
                     .collect::<Vec<String>>();
                 format!("({})", field_strs.join(", "))
             }
@@ -647,11 +798,13 @@ impl TypeInfo {
             Numeric => "u64".into(), // u64 is the default
             Contract => "contract".into(),
             ErrorRecovery => "unknown due to error".into(),
-            Enum { call_path, .. } => {
-                format!("enum {}", call_path_display(ctx, call_path))
+            Enum(decl_ref) => {
+                let decl = decl_engine.get_enum(decl_ref);
+                format!("enum {}", call_path_display(ctx, &decl.call_path))
             }
-            Struct { call_path, .. } => {
-                format!("struct {}", call_path_display(ctx, call_path))
+            Struct(decl_ref) => {
+                let decl = decl_engine.get_struct(decl_ref);
+                format!("struct {}", call_path_display(ctx, &decl.call_path))
             }
             ContractCaller { abi_name, .. } => {
                 format!("contract caller {abi_name}")
@@ -659,7 +812,7 @@ impl TypeInfo {
             Array(elem_ty, length) => {
                 format!(
                     "[{}; {}]",
-                    elem_ty.json_abi_str(ctx, type_engine),
+                    elem_ty.json_abi_str(ctx, type_engine, decl_engine),
                     length.val()
                 )
             }
@@ -701,6 +854,7 @@ impl TyFunctionDeclaration {
         &self,
         ctx: &mut JsonAbiContext,
         type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
         types: &mut Vec<program_abi::TypeDeclaration>,
     ) -> program_abi::ABIFunction {
         // A list of all `program_abi::TypeDeclaration`s needed for inputs
@@ -712,17 +866,20 @@ impl TyFunctionDeclaration {
                 type_field: x.type_argument.initial_type_id.get_json_type_str(
                     ctx,
                     type_engine,
+                    decl_engine,
                     x.type_argument.type_id,
                 ),
                 components: x.type_argument.initial_type_id.get_json_type_components(
                     ctx,
                     type_engine,
+                    decl_engine,
                     types,
                     x.type_argument.type_id,
                 ),
                 type_parameters: x.type_argument.type_id.get_json_type_parameters(
                     ctx,
                     type_engine,
+                    decl_engine,
                     types,
                     x.type_argument.type_id,
                 ),
@@ -735,17 +892,20 @@ impl TyFunctionDeclaration {
             type_field: self.return_type.initial_type_id.get_json_type_str(
                 ctx,
                 type_engine,
+                decl_engine,
                 self.return_type.type_id,
             ),
             components: self.return_type.type_id.get_json_type_components(
                 ctx,
                 type_engine,
+                decl_engine,
                 types,
                 self.return_type.type_id,
             ),
             type_parameters: self.return_type.type_id.get_json_type_parameters(
                 ctx,
                 type_engine,
+                decl_engine,
                 types,
                 self.return_type.type_id,
             ),
@@ -767,6 +927,7 @@ impl TyFunctionDeclaration {
                     type_arguments: x.type_argument.initial_type_id.get_json_type_arguments(
                         ctx,
                         type_engine,
+                        decl_engine,
                         types,
                         x.type_argument.type_id,
                     ),
@@ -778,6 +939,7 @@ impl TyFunctionDeclaration {
                 type_arguments: self.return_type.initial_type_id.get_json_type_arguments(
                     ctx,
                     type_engine,
+                    decl_engine,
                     types,
                     self.return_type.type_id,
                 ),
@@ -814,16 +976,21 @@ impl TypeParameter {
         &self,
         ctx: &mut JsonAbiContext,
         type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
         types: &mut Vec<program_abi::TypeDeclaration>,
     ) -> usize {
         let type_parameter = program_abi::TypeDeclaration {
             type_id: self.initial_type_id.index(),
-            type_field: self
-                .initial_type_id
-                .get_json_type_str(ctx, type_engine, self.type_id),
+            type_field: self.initial_type_id.get_json_type_str(
+                ctx,
+                type_engine,
+                decl_engine,
+                self.type_id,
+            ),
             components: self.initial_type_id.get_json_type_components(
                 ctx,
                 type_engine,
+                decl_engine,
                 types,
                 self.type_id,
             ),
@@ -835,7 +1002,14 @@ impl TypeParameter {
 }
 
 impl TypeArgument {
-    pub(self) fn json_abi_str(&self, ctx: &mut JsonAbiContext, type_engine: &TypeEngine) -> String {
-        type_engine.get(self.type_id).json_abi_str(ctx, type_engine)
+    pub(self) fn json_abi_str(
+        &self,
+        ctx: &mut JsonAbiContext,
+        type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
+    ) -> String {
+        type_engine
+            .get(self.type_id)
+            .json_abi_str(ctx, type_engine, decl_engine)
     }
 }

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -383,14 +383,14 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             connect_abi_declaration(engines, &abi_decl, graph, entry_node)?;
             Ok(leaves.to_vec())
         }
-        StructDeclaration { decl_id, .. } => {
-            let struct_decl = decl_engine.get_struct(decl_id);
-            connect_struct_declaration(&struct_decl, *decl_id, graph, entry_node, tree_type);
+        StructDeclaration(decl_ref) => {
+            let struct_decl = decl_engine.get_struct(decl_ref);
+            connect_struct_declaration(&struct_decl, decl_ref.id, graph, entry_node, tree_type);
             Ok(leaves.to_vec())
         }
-        EnumDeclaration { decl_id, .. } => {
-            let enum_decl = decl_engine.get_enum(decl_id);
-            connect_enum_declaration(&enum_decl, *decl_id, graph, entry_node);
+        EnumDeclaration(decl_ref) => {
+            let enum_decl = decl_engine.get_enum(decl_ref);
+            connect_enum_declaration(&enum_decl, decl_ref.id, graph, entry_node);
             Ok(leaves.to_vec())
         }
         ImplTrait { decl_id, .. } => {
@@ -590,10 +590,13 @@ fn connect_abi_declaration(
         match item {
             ty::TyTraitInterfaceItem::TraitFn(fn_decl_ref) => {
                 let fn_decl = decl_engine.get_trait_fn(fn_decl_ref);
-                if let Some(TypeInfo::Struct { call_path, .. }) =
-                    get_struct_type_info_from_type_id(type_engine, fn_decl.return_type)?
-                {
-                    if let Some(ns) = graph.namespace.get_struct(&call_path.suffix).cloned() {
+                if let Some(TypeInfo::Struct(decl_ref)) = get_struct_type_info_from_type_id(
+                    type_engine,
+                    decl_engine,
+                    fn_decl.return_type,
+                )? {
+                    let decl = decl_engine.get_struct(&decl_ref);
+                    if let Some(ns) = graph.namespace.get_struct(&decl.call_path.suffix).cloned() {
                         for (_, field_ix) in ns.fields.iter() {
                             graph.add_edge(ns.struct_decl_ix, *field_ix, "".into());
                         }
@@ -608,26 +611,26 @@ fn connect_abi_declaration(
 
 fn get_struct_type_info_from_type_id(
     type_engine: &TypeEngine,
+    decl_engine: &DeclEngine,
     type_id: TypeId,
 ) -> Result<Option<TypeInfo>, TypeError> {
     let type_info = type_engine.to_typeinfo(type_id, &Span::dummy())?;
     match type_info {
-        TypeInfo::Enum {
-            type_parameters,
-            variant_types,
-            ..
-        } => {
-            for param in type_parameters.iter() {
+        TypeInfo::Enum(decl_ref) => {
+            let decl = decl_engine.get_enum(&decl_ref);
+            for param in decl.type_parameters.iter() {
                 if let Ok(Some(type_info)) =
-                    get_struct_type_info_from_type_id(type_engine, param.type_id)
+                    get_struct_type_info_from_type_id(type_engine, decl_engine, param.type_id)
                 {
                     return Ok(Some(type_info));
                 }
             }
-            for var in variant_types.iter() {
-                if let Ok(Some(type_info)) =
-                    get_struct_type_info_from_type_id(type_engine, var.type_argument.type_id)
-                {
+            for var in decl.variants.iter() {
+                if let Ok(Some(type_info)) = get_struct_type_info_from_type_id(
+                    type_engine,
+                    decl_engine,
+                    var.type_argument.type_id,
+                ) {
                     return Ok(Some(type_info));
                 }
             }
@@ -636,7 +639,7 @@ fn get_struct_type_info_from_type_id(
         TypeInfo::Tuple(type_args) => {
             for arg in type_args.iter() {
                 if let Ok(Some(type_info)) =
-                    get_struct_type_info_from_type_id(type_engine, arg.type_id)
+                    get_struct_type_info_from_type_id(type_engine, decl_engine, arg.type_id)
                 {
                     return Ok(Some(type_info));
                 }
@@ -647,7 +650,7 @@ fn get_struct_type_info_from_type_id(
             if let Some(type_arguments) = type_arguments {
                 for arg in type_arguments.iter() {
                     if let Ok(Some(type_info)) =
-                        get_struct_type_info_from_type_id(type_engine, arg.type_id)
+                        get_struct_type_info_from_type_id(type_engine, decl_engine, arg.type_id)
                     {
                         return Ok(Some(type_info));
                     }
@@ -657,7 +660,7 @@ fn get_struct_type_info_from_type_id(
         }
         TypeInfo::Struct { .. } => Ok(Some(type_info)),
         TypeInfo::Array(type_arg, _) => {
-            get_struct_type_info_from_type_id(type_engine, type_arg.type_id)
+            get_struct_type_info_from_type_id(type_engine, decl_engine, type_arg.type_id)
         }
         _ => Ok(None),
     }
@@ -758,19 +761,26 @@ fn connect_fn_params_struct_enums<'eng: 'cfg, 'cfg>(
         let ty = type_engine
             .to_typeinfo(fn_param.type_argument.type_id, &fn_param.type_argument.span)?;
         match ty {
-            TypeInfo::Enum { call_path, .. } => {
-                let ty_index = match graph.namespace.find_enum(&call_path.suffix) {
+            TypeInfo::Enum(decl_ref) => {
+                let decl = engines.de().get_enum(&decl_ref);
+                let ty_index = match graph.namespace.find_enum(&decl.call_path.suffix) {
                     Some(ix) => *ix,
-                    None => graph
-                        .add_node(format!("External enum  {}", call_path.suffix.as_str()).into()),
+                    None => graph.add_node(
+                        format!("External enum  {}", decl.call_path.suffix.as_str()).into(),
+                    ),
                 };
                 graph.add_edge(fn_decl_entry_node, ty_index, "".into());
             }
-            TypeInfo::Struct { call_path, .. } => {
-                let ty_index = match graph.namespace.find_struct_decl(call_path.suffix.as_str()) {
+            TypeInfo::Struct(decl_ref) => {
+                let decl = engines.de().get_struct(&decl_ref);
+                let ty_index = match graph
+                    .namespace
+                    .find_struct_decl(decl.call_path.suffix.as_str())
+                {
                     Some(ix) => *ix,
-                    None => graph
-                        .add_node(format!("External struct  {}", call_path.suffix.as_str()).into()),
+                    None => graph.add_node(
+                        format!("External struct  {}", decl.call_path.suffix.as_str()).into(),
+                    ),
                 };
                 graph.add_edge(fn_decl_entry_node, ty_index, "".into());
             }
@@ -816,8 +826,8 @@ fn get_trait_fn_node_index<'a>(
                     .namespace
                     .find_trait_method(&trait_decl.name.into(), &fn_decl.name))
             }
-            ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
-                let struct_decl = decl_engine.get_struct(&decl_id);
+            ty::TyDeclaration::StructDeclaration(decl_ref) => {
+                let struct_decl = decl_engine.get_struct(&decl_ref);
                 Ok(graph
                     .namespace
                     .find_trait_method(&struct_decl.call_path.suffix.into(), &fn_decl.name))
@@ -1189,7 +1199,7 @@ fn connect_expression<'eng: 'cfg, 'cfg>(
 
             assert!(matches!(resolved_type_of_parent, TypeInfo::Struct { .. }));
             let resolved_type_of_parent = match resolved_type_of_parent {
-                TypeInfo::Struct { call_path, .. } => call_path,
+                TypeInfo::Struct(decl_ref) => decl_engine.get_struct(&decl_ref).call_path,
                 _ => panic!("Called subfield on a non-struct"),
             };
             let field_name = &field_to_access.name;
@@ -1665,18 +1675,17 @@ fn construct_dead_code_warning_from_node(
         },
         ty::TyAstNode {
             content:
-                ty::TyAstNodeContent::Declaration(ty::TyDeclaration::StructDeclaration { name, .. }),
+                ty::TyAstNodeContent::Declaration(ty::TyDeclaration::StructDeclaration(decl_ref)),
             ..
         } => CompileWarning {
-            span: name.span(),
+            span: decl_ref.name.span(),
             warning_content: Warning::DeadStructDeclaration,
         },
         ty::TyAstNode {
-            content:
-                ty::TyAstNodeContent::Declaration(ty::TyDeclaration::EnumDeclaration { name, .. }),
+            content: ty::TyAstNodeContent::Declaration(ty::TyDeclaration::EnumDeclaration(decl_ref)),
             ..
         } => CompileWarning {
-            span: name.span(),
+            span: decl_ref.name.span(),
             warning_content: Warning::DeadEnumDeclaration,
         },
         ty::TyAstNode {
@@ -1813,11 +1822,11 @@ fn allow_dead_code_ast_node(decl_engine: &DeclEngine, node: &ty::TyAstNode) -> b
             ty::TyDeclaration::TraitDeclaration { decl_id, .. } => {
                 allow_dead_code(decl_engine.get_trait(decl_id).attributes)
             }
-            ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
-                allow_dead_code(decl_engine.get_struct(decl_id).attributes)
+            ty::TyDeclaration::StructDeclaration(decl_ref) => {
+                allow_dead_code(decl_engine.get_struct(decl_ref).attributes)
             }
-            ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
-                allow_dead_code(decl_engine.get_enum(decl_id).attributes)
+            ty::TyDeclaration::EnumDeclaration(decl_ref) => {
+                allow_dead_code(decl_engine.get_enum(decl_ref).attributes)
             }
             ty::TyDeclaration::ImplTrait { .. } => false,
             ty::TyDeclaration::AbiDeclaration { .. } => false,

--- a/sway-core/src/engine_threading.rs
+++ b/sway-core/src/engine_threading.rs
@@ -92,7 +92,7 @@ where
     T: PartialEqWithEngines,
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.thing.cmp(&other.thing, self.engines.te()))
+        Some(self.thing.cmp(&other.thing, &self.engines))
     }
 }
 
@@ -101,7 +101,7 @@ where
     T: EqWithEngines,
 {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.thing.cmp(&other.thing, self.engines.te())
+        self.thing.cmp(&other.thing, &self.engines)
     }
 }
 
@@ -159,7 +159,7 @@ pub trait PartialEqWithEngines {
 }
 
 pub trait OrdWithEngines {
-    fn cmp(&self, other: &Self, type_engine: &TypeEngine) -> Ordering;
+    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering;
 }
 
 impl<T: EqWithEngines + ?Sized> EqWithEngines for &T {}
@@ -169,15 +169,15 @@ impl<T: PartialEqWithEngines + ?Sized> PartialEqWithEngines for &T {
     }
 }
 impl<T: OrdWithEngines + ?Sized> OrdWithEngines for &T {
-    fn cmp(&self, other: &Self, type_engine: &TypeEngine) -> Ordering {
-        (*self).cmp(*other, type_engine)
+    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
+        (*self).cmp(*other, engines)
     }
 }
 
 impl<T: OrdWithEngines> OrdWithEngines for Option<T> {
-    fn cmp(&self, other: &Self, type_engine: &TypeEngine) -> Ordering {
+    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
         match (self, other) {
-            (Some(x), Some(y)) => x.cmp(y, type_engine),
+            (Some(x), Some(y)) => x.cmp(y, engines),
             (Some(_), None) => Ordering::Less,
             (None, Some(_)) => Ordering::Greater,
             (None, None) => Ordering::Equal,
@@ -203,10 +203,10 @@ impl<T: PartialEqWithEngines> PartialEqWithEngines for [T] {
     }
 }
 impl<T: OrdWithEngines> OrdWithEngines for [T] {
-    fn cmp(&self, other: &Self, type_engine: &TypeEngine) -> Ordering {
+    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
         self.iter()
             .zip(other.iter())
-            .map(|(x, y)| x.cmp(y, type_engine))
+            .map(|(x, y)| x.cmp(y, engines))
             .find(|o| o.is_ne())
             .unwrap_or_else(|| self.len().cmp(&other.len()))
     }

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -1,5 +1,5 @@
 use crate::{
-    decl_engine::DeclRefFunction,
+    decl_engine::{DeclEngine, DeclRefFunction},
     language::{ty, Visibility},
     metadata::MetadataManager,
     semantic_analysis::namespace,
@@ -304,6 +304,7 @@ pub(super) fn compile_function(
     test_decl_ref: Option<DeclRefFunction>,
 ) -> Result<Option<Function>, CompileError> {
     let type_engine = engines.te();
+    let decl_engine = engines.de();
     // Currently monomorphization of generics is inlined into main() and the functions with generic
     // args are still present in the AST declarations, but they can be ignored.
     if !ast_fn_decl.type_parameters.is_empty() {
@@ -312,7 +313,7 @@ pub(super) fn compile_function(
         let args = ast_fn_decl
             .parameters
             .iter()
-            .map(|param| convert_fn_param(type_engine, context, param))
+            .map(|param| convert_fn_param(type_engine, decl_engine, context, param))
             .collect::<Result<Vec<(String, Type, bool, Span)>, CompileError>>()?;
 
         compile_fn_with_args(
@@ -386,11 +387,13 @@ pub(super) fn compile_tests(
 
 fn convert_fn_param(
     type_engine: &TypeEngine,
+    decl_engine: &DeclEngine,
     context: &mut Context,
     param: &ty::TyFunctionParameter,
 ) -> Result<(String, Type, bool, Span), CompileError> {
     convert_resolved_typeid(
         type_engine,
+        decl_engine,
         context,
         &param.type_argument.type_id,
         &param.type_argument.span,
@@ -417,6 +420,7 @@ fn compile_fn_with_args(
     test_decl_ref: Option<DeclRefFunction>,
 ) -> Result<Function, CompileError> {
     let type_engine = engines.te();
+    let decl_engine = engines.de();
 
     let inline_opt = ast_fn_decl.inline();
     let ty::TyFunctionDeclaration {
@@ -436,6 +440,7 @@ fn compile_fn_with_args(
 
     let ret_type = convert_resolved_typeid(
         type_engine,
+        decl_engine,
         context,
         &return_type.type_id,
         &return_type.span,
@@ -566,9 +571,10 @@ fn compile_abi_method(
     engines: Engines<'_>,
 ) -> Result<Function, CompileError> {
     let type_engine = engines.te();
+    let decl_engine = engines.de();
 
     // Use the error from .to_fn_selector_value() if possible, else make an CompileError::Internal.
-    let get_selector_result = ast_fn_decl.to_fn_selector_value(type_engine);
+    let get_selector_result = ast_fn_decl.to_fn_selector_value(type_engine, decl_engine);
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
     let selector = match get_selector_result.ok(&mut warnings, &mut errors) {
@@ -597,6 +603,7 @@ fn compile_abi_method(
         .map(|param| {
             convert_resolved_typeid(
                 type_engine,
+                decl_engine,
                 context,
                 &param.type_argument.type_id,
                 &param.type_argument.span,

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -162,9 +162,15 @@ impl<'eng> FnCompiler<'eng> {
                         span: ast_node.span.clone(),
                     })
                 }
-                ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
-                    let ted = self.decl_engine.get_enum(decl_id);
-                    create_enum_aggregate(self.type_engine, context, &ted.variants).map(|_| ())?;
+                ty::TyDeclaration::EnumDeclaration(decl_ref) => {
+                    let ted = self.decl_engine.get_enum(decl_ref);
+                    create_enum_aggregate(
+                        self.type_engine,
+                        self.decl_engine,
+                        context,
+                        &ted.variants,
+                    )
+                    .map(|_| ())?;
                     Ok(None)
                 }
                 ty::TyDeclaration::ImplTrait { .. } => {
@@ -485,6 +491,7 @@ impl<'eng> FnCompiler<'eng> {
                 // Compile the expression in case of side-effects but ignore its value.
                 let ir_type = convert_resolved_typeid(
                     self.type_engine,
+                    self.decl_engine,
                     context,
                     &exp.return_type,
                     &exp.span,
@@ -498,8 +505,13 @@ impl<'eng> FnCompiler<'eng> {
             }
             Intrinsic::SizeOfType => {
                 let targ = type_arguments[0].clone();
-                let ir_type =
-                    convert_resolved_typeid(self.type_engine, context, &targ.type_id, &targ.span)?;
+                let ir_type = convert_resolved_typeid(
+                    self.type_engine,
+                    self.decl_engine,
+                    context,
+                    &targ.type_id,
+                    &targ.span,
+                )?;
                 Ok(Constant::get_uint(
                     context,
                     64,
@@ -559,6 +571,7 @@ impl<'eng> FnCompiler<'eng> {
                 let target_type = &type_arguments[0];
                 let target_ir_type = convert_resolved_typeid(
                     self.type_engine,
+                    self.decl_engine,
                     context,
                     &target_type.type_id,
                     &target_type.span,
@@ -752,8 +765,13 @@ impl<'eng> FnCompiler<'eng> {
                 };
 
                 let len = type_arguments[0].clone();
-                let ir_type =
-                    convert_resolved_typeid(self.type_engine, context, &len.type_id, &len.span)?;
+                let ir_type = convert_resolved_typeid(
+                    self.type_engine,
+                    self.decl_engine,
+                    context,
+                    &len.type_id,
+                    &len.span,
+                )?;
                 let len_value =
                     Constant::get_uint(context, 64, ir_type_size_in_bytes(context, &ir_type));
 
@@ -1207,7 +1225,12 @@ impl<'eng> FnCompiler<'eng> {
                 .add_metadatum(context, span_md_idx),
         };
 
-        let return_type = convert_resolved_typeid_no_span(self.type_engine, context, &return_type)?;
+        let return_type = convert_resolved_typeid_no_span(
+            self.type_engine,
+            self.decl_engine,
+            context,
+            &return_type,
+        )?;
 
         // Insert the contract_call instruction
         Ok(self
@@ -1394,8 +1417,13 @@ impl<'eng> FnCompiler<'eng> {
             )
             .add_metadatum(context, cond_span_md_idx);
 
-        let return_type = convert_resolved_typeid_no_span(self.type_engine, context, &return_type)
-            .unwrap_or_else(|_| Type::get_unit(context));
+        let return_type = convert_resolved_typeid_no_span(
+            self.type_engine,
+            self.decl_engine,
+            context,
+            &return_type,
+        )
+        .unwrap_or_else(|_| Type::get_unit(context));
         let merge_block = self.function.create_block(context, None);
         // Add a single argument to merge_block that merges true_value and false_value.
         // Rely on the type of the ast node when creating that argument
@@ -1425,6 +1453,7 @@ impl<'eng> FnCompiler<'eng> {
         // retrieve the aggregate info for the enum
         let enum_aggregate = match convert_resolved_typeid(
             self.type_engine,
+            self.decl_engine,
             context,
             &exp.return_type,
             &exp.span,
@@ -1456,6 +1485,7 @@ impl<'eng> FnCompiler<'eng> {
         let tag_span_md_idx = md_mgr.span_to_md(context, &exp.span);
         let enum_aggregate = match convert_resolved_typeid(
             self.type_engine,
+            self.decl_engine,
             context,
             &exp.return_type,
             &exp.span,
@@ -1654,8 +1684,13 @@ impl<'eng> FnCompiler<'eng> {
         }
 
         // Grab these before we move body into compilation.
-        let return_type =
-            convert_resolved_typeid(self.type_engine, context, &body.return_type, &body.span)?;
+        let return_type = convert_resolved_typeid(
+            self.type_engine,
+            self.decl_engine,
+            context,
+            &body.return_type,
+            &body.span,
+        )?;
 
         // We must compile the RHS before checking for shadowing, as it will still be in the
         // previous scope.
@@ -1718,6 +1753,7 @@ impl<'eng> FnCompiler<'eng> {
             let local_name = self.lexical_map.insert(name.as_str().to_owned());
             let return_type = convert_resolved_typeid(
                 self.type_engine,
+                self.decl_engine,
                 context,
                 &value.return_type,
                 &value.span,
@@ -1849,6 +1885,7 @@ impl<'eng> FnCompiler<'eng> {
             // field type for the current iteration.
             let field_idcs = get_indices_for_struct_access(
                 self.type_engine,
+                self.decl_engine,
                 ast_reassignment.lhs_type,
                 &ast_reassignment.lhs_indices,
             )?;
@@ -1896,6 +1933,7 @@ impl<'eng> FnCompiler<'eng> {
         // Get the type of the access which can be a subfield
         let access_type = convert_resolved_typeid_no_span(
             self.type_engine,
+            self.decl_engine,
             context,
             &fields.last().expect("guaranteed by grammar").type_id,
         )?;
@@ -1903,7 +1941,12 @@ impl<'eng> FnCompiler<'eng> {
         // Get the list of indices used to access the storage field. This will be empty
         // if the storage field type is not a struct.
         let base_type = fields[0].type_id;
-        let field_idcs = get_indices_for_struct_access(self.type_engine, base_type, &fields[1..])?;
+        let field_idcs = get_indices_for_struct_access(
+            self.type_engine,
+            self.decl_engine,
+            base_type,
+            &fields[1..],
+        )?;
 
         // Do the actual work. This is a recursive function because we want to drill down
         // to store each primitive type in the storage field in its own storage slot.
@@ -1932,7 +1975,12 @@ impl<'eng> FnCompiler<'eng> {
             // we'll just use Unit.
             Type::get_unit(context)
         } else {
-            convert_resolved_typeid_no_span(self.type_engine, context, &contents[0].return_type)?
+            convert_resolved_typeid_no_span(
+                self.type_engine,
+                self.decl_engine,
+                context,
+                &contents[0].return_type,
+            )?
         };
         let aggregate = Type::new_array(context, elem_type, contents.len() as u64);
 
@@ -2075,7 +2123,8 @@ impl<'eng> FnCompiler<'eng> {
         }
 
         // Start with a temporary empty struct and then fill in the values.
-        let aggregate = get_aggregate_for_types(self.type_engine, context, &field_types)?;
+        let aggregate =
+            get_aggregate_for_types(self.type_engine, self.decl_engine, context, &field_types)?;
         let temp_name = self.lexical_map.insert_anon();
         let struct_var = self
             .function
@@ -2142,6 +2191,7 @@ impl<'eng> FnCompiler<'eng> {
         };
         let field_idx = match get_struct_name_field_index_and_type(
             self.type_engine,
+            self.decl_engine,
             struct_type_id,
             field_kind,
         ) {
@@ -2183,7 +2233,12 @@ impl<'eng> FnCompiler<'eng> {
         // we could potentially use the wrong aggregate with the same name, different module...
         // dunno.
         let span_md_idx = md_mgr.span_to_md(context, &enum_decl.span);
-        let aggregate = create_enum_aggregate(self.type_engine, context, &enum_decl.variants)?;
+        let aggregate = create_enum_aggregate(
+            self.type_engine,
+            self.decl_engine,
+            context,
+            &enum_decl.variants,
+        )?;
         let tag_value =
             Constant::get_uint(context, 64, tag as u64).add_metadatum(context, span_md_idx);
 
@@ -2242,6 +2297,7 @@ impl<'eng> FnCompiler<'eng> {
             for field_expr in fields {
                 let init_type = convert_resolved_typeid_no_span(
                     self.type_engine,
+                    self.decl_engine,
                     context,
                     &field_expr.return_type,
                 )?;
@@ -2289,7 +2345,13 @@ impl<'eng> FnCompiler<'eng> {
         span: Span,
     ) -> Result<Value, CompileError> {
         let tuple_value = self.compile_expression(context, md_mgr, tuple)?;
-        let ty = convert_resolved_typeid(self.type_engine, context, &tuple_type, &span)?;
+        let ty = convert_resolved_typeid(
+            self.type_engine,
+            self.decl_engine,
+            context,
+            &tuple_type,
+            &span,
+        )?;
         if ty.is_struct(context) {
             let span_md_idx = md_mgr.span_to_md(context, &span);
             Ok(self
@@ -2316,6 +2378,7 @@ impl<'eng> FnCompiler<'eng> {
         // Get the type of the access which can be a subfield
         let access_type = convert_resolved_typeid_no_span(
             self.type_engine,
+            self.decl_engine,
             context,
             &fields.last().expect("guaranteed by grammar").type_id,
         )?;
@@ -2324,7 +2387,12 @@ impl<'eng> FnCompiler<'eng> {
         // if the storage field type is not a struct.
         // FIXME: shouldn't have to extract the first field like this.
         let base_type = fields[0].type_id;
-        let field_idcs = get_indices_for_struct_access(self.type_engine, base_type, &fields[1..])?;
+        let field_idcs = get_indices_for_struct_access(
+            self.type_engine,
+            self.decl_engine,
+            base_type,
+            &fields[1..],
+        )?;
 
         // Do the actual work. This is a recursive function because we want to drill down
         // to load each primitive type in the storage field in its own storage slot.
@@ -2380,7 +2448,12 @@ impl<'eng> FnCompiler<'eng> {
         let returns = returns
             .as_ref()
             .map(|(_, asm_reg_span)| Ident::new(asm_reg_span.clone()));
-        let return_type = convert_resolved_typeid_no_span(self.type_engine, context, &return_type)?;
+        let return_type = convert_resolved_typeid_no_span(
+            self.type_engine,
+            self.decl_engine,
+            context,
+            &return_type,
+        )?;
         Ok(self
             .current_block
             .ins(context)

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -252,14 +252,10 @@ impl TyAstNode {
                 } => Ok(decl_engine.get_trait(decl_id).visibility.is_public()),
                 TyAstNode {
                     content:
-                        TyAstNodeContent::Declaration(TyDeclaration::StructDeclaration {
-                            decl_id,
-                            decl_span: _,
-                            ..
-                        }),
+                        TyAstNodeContent::Declaration(TyDeclaration::StructDeclaration(decl_ref)),
                     ..
                 } => {
-                    let struct_decl = decl_engine.get_struct(decl_id);
+                    let struct_decl = decl_engine.get_struct(decl_ref);
                     Ok(struct_decl.visibility == Visibility::Public)
                 }
                 TyAstNode {

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -32,16 +32,8 @@ pub enum TyDeclaration {
         decl_id: DeclId<TyTraitDeclaration>,
         decl_span: Span,
     },
-    StructDeclaration {
-        name: Ident,
-        decl_id: DeclId<TyStructDeclaration>,
-        decl_span: Span,
-    },
-    EnumDeclaration {
-        name: Ident,
-        decl_id: DeclId<TyEnumDeclaration>,
-        decl_span: Span,
-    },
+    StructDeclaration(DeclRefStruct),
+    EnumDeclaration(DeclRefEnum),
     ImplTrait {
         name: Ident,
         decl_id: DeclId<TyImplTrait>,
@@ -110,33 +102,10 @@ impl PartialEqWithEngines for TyDeclaration {
                     ..
                 },
             ) => ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
-
-            (
-                Self::StructDeclaration {
-                    name: ln,
-                    decl_id: lid,
-                    ..
-                },
-                Self::StructDeclaration {
-                    name: rn,
-                    decl_id: rid,
-                    ..
-                },
-            ) => ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
-
-            (
-                Self::EnumDeclaration {
-                    name: ln,
-                    decl_id: lid,
-                    ..
-                },
-                Self::EnumDeclaration {
-                    name: rn,
-                    decl_id: rid,
-                    ..
-                },
-            ) => ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
-
+            (Self::StructDeclaration(lref), Self::StructDeclaration(rref)) => {
+                lref.eq(rref, engines)
+            }
+            (Self::EnumDeclaration(lref), Self::EnumDeclaration(rref)) => lref.eq(rref, engines),
             (
                 Self::ImplTrait {
                     name: ln,
@@ -201,11 +170,11 @@ impl HashWithEngines for TyDeclaration {
             TraitDeclaration { decl_id, .. } => {
                 decl_engine.get(*decl_id).hash(state, engines);
             }
-            StructDeclaration { decl_id, .. } => {
-                decl_engine.get(*decl_id).hash(state, engines);
+            StructDeclaration(decl_ref) => {
+                decl_engine.get_struct(decl_ref).hash(state, engines);
             }
-            EnumDeclaration { decl_id, .. } => {
-                decl_engine.get(*decl_id).hash(state, engines);
+            EnumDeclaration(decl_ref) => {
+                decl_engine.get_enum(decl_ref).hash(state, engines);
             }
             ImplTrait { decl_id, .. } => {
                 decl_engine.get(*decl_id).hash(state, engines);
@@ -236,12 +205,8 @@ impl SubstTypes for TyDeclaration {
             TraitDeclaration {
                 ref mut decl_id, ..
             } => decl_id.subst(type_mapping, engines),
-            StructDeclaration {
-                ref mut decl_id, ..
-            } => decl_id.subst(type_mapping, engines),
-            EnumDeclaration {
-                ref mut decl_id, ..
-            } => decl_id.subst(type_mapping, engines),
+            StructDeclaration(ref mut decl_ref) => decl_ref.subst(type_mapping, engines),
+            EnumDeclaration(ref mut decl_ref) => decl_ref.subst(type_mapping, engines),
             ImplTrait {
                 ref mut decl_id, ..
             } => decl_id.subst(type_mapping, engines),
@@ -266,12 +231,8 @@ impl ReplaceSelfType for TyDeclaration {
             TraitDeclaration {
                 ref mut decl_id, ..
             } => decl_id.replace_self_type(engines, self_type),
-            StructDeclaration {
-                ref mut decl_id, ..
-            } => decl_id.replace_self_type(engines, self_type),
-            EnumDeclaration {
-                ref mut decl_id, ..
-            } => decl_id.replace_self_type(engines, self_type),
+            StructDeclaration(ref mut decl_ref) => decl_ref.replace_self_type(engines, self_type),
+            EnumDeclaration(ref mut decl_ref) => decl_ref.replace_self_type(engines, self_type),
             ImplTrait {
                 ref mut decl_id, ..
             } => decl_id.replace_self_type(engines, self_type),
@@ -311,12 +272,12 @@ impl Spanned for TyDeclaration {
             VariableDeclaration(decl) => decl.name.span(),
             FunctionDeclaration { decl_span, .. }
             | TraitDeclaration { decl_span, .. }
-            | StructDeclaration { decl_span, .. }
-            | EnumDeclaration { decl_span, .. }
             | ImplTrait { decl_span, .. }
             | ConstantDeclaration { decl_span, .. }
             | StorageDeclaration { decl_span, .. }
             | AbiDeclaration { decl_span, .. } => decl_span.clone(),
+            StructDeclaration(decl_ref) => decl_ref.span(),
+            EnumDeclaration(decl_ref) => decl_ref.span(),
             GenericTypeForFunctionScope { name, .. } => name.span(),
             ErrorRecovery(span) => span.clone(),
         }
@@ -357,9 +318,9 @@ impl DisplayWithEngines for TyDeclaration {
                     builder
                 }
                 TyDeclaration::FunctionDeclaration { name, .. }
-                | TyDeclaration::TraitDeclaration { name, .. }
-                | TyDeclaration::StructDeclaration { name, .. }
-                | TyDeclaration::EnumDeclaration { name, .. } => name.as_str().into(),
+                | TyDeclaration::TraitDeclaration { name, .. } => name.as_str().into(),
+                TyDeclaration::StructDeclaration(decl_ref) => decl_ref.name.as_str().into(),
+                TyDeclaration::EnumDeclaration(decl_ref) => decl_ref.name.as_str().into(),
                 _ => String::new(),
             }
         )
@@ -437,12 +398,12 @@ impl GetDeclIdent for TyDeclaration {
             TyDeclaration::VariableDeclaration(decl) => Some(decl.name.clone()),
             TyDeclaration::FunctionDeclaration { name, .. }
             | TyDeclaration::TraitDeclaration { name, .. }
-            | TyDeclaration::StructDeclaration { name, .. }
-            | TyDeclaration::EnumDeclaration { name, .. }
             | TyDeclaration::ConstantDeclaration { name, .. }
             | TyDeclaration::ImplTrait { name, .. }
             | TyDeclaration::AbiDeclaration { name, .. }
             | TyDeclaration::GenericTypeForFunctionScope { name, .. } => Some(name.clone()),
+            TyDeclaration::StructDeclaration(decl_ref) => Some(decl_ref.name.clone()),
+            TyDeclaration::EnumDeclaration(decl_ref) => Some(decl_ref.name.clone()),
             TyDeclaration::ErrorRecovery(_) => None,
             TyDeclaration::StorageDeclaration { .. } => None,
         }
@@ -453,11 +414,9 @@ impl TyDeclaration {
     /// Retrieves the declaration as an enum declaration.
     ///
     /// Returns an error if `self` is not a [TyEnumDeclaration].
-    pub(crate) fn expect_enum(&self, decl_engine: &DeclEngine) -> CompileResult<TyEnumDeclaration> {
+    pub(crate) fn expect_enum(&self) -> CompileResult<DeclRefEnum> {
         match self {
-            TyDeclaration::EnumDeclaration { decl_id, .. } => {
-                ok(decl_engine.get_enum(decl_id), vec![], vec![])
-            }
+            TyDeclaration::EnumDeclaration(decl_ref) => ok(decl_ref.clone(), vec![], vec![]),
             TyDeclaration::ErrorRecovery(_) => err(vec![], vec![]),
             decl => err(
                 vec![],
@@ -472,17 +431,11 @@ impl TyDeclaration {
     /// Retrieves the declaration as a struct declaration.
     ///
     /// Returns an error if `self` is not a [TyStructDeclaration].
-    pub(crate) fn expect_struct(
-        &self,
-        decl_engine: &DeclEngine,
-    ) -> CompileResult<TyStructDeclaration> {
+    pub(crate) fn expect_struct(&self) -> CompileResult<DeclRefStruct> {
         let warnings = vec![];
         let mut errors = vec![];
         match self {
-            TyDeclaration::StructDeclaration { decl_id, .. } => {
-                let decl = decl_engine.get_struct(decl_id);
-                ok(decl, warnings, errors)
-            }
+            TyDeclaration::StructDeclaration(decl_ref) => ok(decl_ref.clone(), warnings, errors),
             TyDeclaration::ErrorRecovery(_) => err(vec![], vec![]),
             decl => {
                 errors.push(CompileError::DeclIsNotAStruct {
@@ -650,13 +603,11 @@ impl TyDeclaration {
                 let decl = decl_engine.get_function(decl_id);
                 decl.return_type.type_id
             }
-            TyDeclaration::StructDeclaration { decl_id, .. } => {
-                let decl = decl_engine.get_struct(decl_id);
-                decl.create_type_id(engines)
+            TyDeclaration::StructDeclaration(decl_ref) => {
+                type_engine.insert(decl_engine, TypeInfo::Struct(decl_ref.clone()))
             }
-            TyDeclaration::EnumDeclaration { decl_id, .. } => {
-                let decl = decl_engine.get_enum(decl_id);
-                decl.create_type_id(engines)
+            TyDeclaration::EnumDeclaration(decl_ref) => {
+                type_engine.insert(decl_engine, TypeInfo::Enum(decl_ref.clone()))
             }
             TyDeclaration::StorageDeclaration { decl_id, .. } => {
                 let storage_decl = decl_engine.get_storage(decl_id);
@@ -691,12 +642,12 @@ impl TyDeclaration {
                 let TyConstantDeclaration { visibility, .. } = decl_engine.get_constant(decl_id);
                 visibility
             }
-            StructDeclaration { decl_id, .. } => {
-                let TyStructDeclaration { visibility, .. } = decl_engine.get_struct(decl_id);
+            StructDeclaration(decl_ref) => {
+                let TyStructDeclaration { visibility, .. } = decl_engine.get_struct(decl_ref);
                 visibility
             }
-            EnumDeclaration { decl_id, .. } => {
-                let TyEnumDeclaration { visibility, .. } = decl_engine.get_enum(decl_id);
+            EnumDeclaration(decl_ref) => {
+                let TyEnumDeclaration { visibility, .. } = decl_engine.get_enum(decl_ref);
                 visibility
             }
             FunctionDeclaration { decl_id, .. } => {

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -81,21 +81,6 @@ impl ReplaceSelfType for TyEnumDeclaration {
     }
 }
 
-impl CreateTypeId for TyEnumDeclaration {
-    fn create_type_id(&self, engines: Engines<'_>) -> TypeId {
-        let type_engine = engines.te();
-        let decl_engine = engines.de();
-        type_engine.insert(
-            decl_engine,
-            TypeInfo::Enum {
-                call_path: self.call_path.clone(),
-                variant_types: self.variants.clone(),
-                type_parameters: self.type_parameters.clone(),
-            },
-        )
-    }
-}
-
 impl Spanned for TyEnumDeclaration {
     fn span(&self) -> Span {
         self.span.clone()
@@ -164,7 +149,7 @@ impl PartialEqWithEngines for TyEnumVariant {
 }
 
 impl OrdWithEngines for TyEnumVariant {
-    fn cmp(&self, other: &Self, type_engine: &TypeEngine) -> Ordering {
+    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
         let TyEnumVariant {
             name: ln,
             type_argument: lta,
@@ -184,7 +169,7 @@ impl OrdWithEngines for TyEnumVariant {
             attributes: _,
         } = other;
         ln.cmp(rn)
-            .then_with(|| lta.cmp(rta, type_engine))
+            .then_with(|| lta.cmp(rta, engines))
             .then_with(|| lt.cmp(rt))
     }
 }

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -259,12 +259,13 @@ impl TyFunctionDeclaration {
     pub fn to_fn_selector_value_untruncated(
         &self,
         type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
     ) -> CompileResult<Vec<u8>> {
         let mut errors = vec![];
         let mut warnings = vec![];
         let mut hasher = Sha256::new();
         let data = check!(
-            self.to_selector_name(type_engine),
+            self.to_selector_name(type_engine, decl_engine),
             return err(warnings, errors),
             warnings,
             errors
@@ -277,11 +278,15 @@ impl TyFunctionDeclaration {
     /// Converts a [TyFunctionDeclaration] into a value that is to be used in contract function
     /// selectors.
     /// Hashes the name and parameters using SHA256, and then truncates to four bytes.
-    pub fn to_fn_selector_value(&self, type_engine: &TypeEngine) -> CompileResult<[u8; 4]> {
+    pub fn to_fn_selector_value(
+        &self,
+        type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
+    ) -> CompileResult<[u8; 4]> {
         let mut errors = vec![];
         let mut warnings = vec![];
         let hash = check!(
-            self.to_fn_selector_value_untruncated(type_engine),
+            self.to_fn_selector_value_untruncated(type_engine, decl_engine),
             return err(warnings, errors),
             warnings,
             errors
@@ -292,7 +297,11 @@ impl TyFunctionDeclaration {
         ok(buf, warnings, errors)
     }
 
-    pub fn to_selector_name(&self, type_engine: &TypeEngine) -> CompileResult<String> {
+    pub fn to_selector_name(
+        &self,
+        type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
+    ) -> CompileResult<String> {
         let mut errors = vec![];
         let mut warnings = vec![];
         let named_params = self
@@ -302,7 +311,7 @@ impl TyFunctionDeclaration {
                 type_engine
                     .to_typeinfo(type_argument.type_id, &type_argument.span)
                     .expect("unreachable I think?")
-                    .to_selector_name(type_engine, &type_argument.span)
+                    .to_selector_name(type_engine, decl_engine, &type_argument.span)
             })
             .filter_map(|name| name.ok(&mut warnings, &mut errors))
             .collect::<Vec<String>>();

--- a/sway-core/src/language/ty/declaration/storage.rs
+++ b/sway-core/src/language/ty/declaration/storage.rs
@@ -3,7 +3,10 @@ use std::hash::{Hash, Hasher};
 use sway_error::error::CompileError;
 use sway_types::{state::StateIndex, Ident, Named, Span, Spanned};
 
-use crate::{engine_threading::*, error::*, language::ty::*, transform, type_system::*};
+use crate::{
+    decl_engine::DeclEngine, engine_threading::*, error::*, language::ty::*, transform,
+    type_system::*,
+};
 
 #[derive(Clone, Debug)]
 pub struct TyStorageDeclaration {
@@ -65,6 +68,7 @@ impl TyStorageDeclaration {
     pub fn apply_storage_load(
         &self,
         type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
         fields: Vec<Ident>,
         storage_fields: &[TyStorageField],
     ) -> CompileResult<(TyStorageAccess, TypeId)> {
@@ -99,7 +103,7 @@ impl TyStorageDeclaration {
         });
 
         let update_available_struct_fields = |id: TypeId| match type_engine.get(id) {
-            TypeInfo::Struct { fields, .. } => fields,
+            TypeInfo::Struct(decl_ref) => decl_engine.get_struct(&decl_ref).fields,
             _ => vec![],
         };
 

--- a/sway-core/src/language/ty/declaration/struct.rs
+++ b/sway-core/src/language/ty/declaration/struct.rs
@@ -81,21 +81,6 @@ impl ReplaceSelfType for TyStructDeclaration {
     }
 }
 
-impl CreateTypeId for TyStructDeclaration {
-    fn create_type_id(&self, engines: Engines<'_>) -> TypeId {
-        let type_engine = engines.te();
-        let decl_engine = engines.de();
-        type_engine.insert(
-            decl_engine,
-            TypeInfo::Struct {
-                call_path: self.call_path.clone(),
-                fields: self.fields.clone(),
-                type_parameters: self.type_parameters.clone(),
-            },
-        )
-    }
-}
-
 impl Spanned for TyStructDeclaration {
     fn span(&self) -> Span {
         self.span.clone()
@@ -171,7 +156,7 @@ impl PartialEqWithEngines for TyStructField {
 }
 
 impl OrdWithEngines for TyStructField {
-    fn cmp(&self, other: &Self, type_engine: &TypeEngine) -> Ordering {
+    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
         let TyStructField {
             name: ln,
             type_argument: lta,
@@ -188,7 +173,7 @@ impl OrdWithEngines for TyStructField {
             span: _,
             attributes: _,
         } = other;
-        ln.cmp(rn).then_with(|| lta.cmp(rta, type_engine))
+        ln.cmp(rn).then_with(|| lta.cmp(rta, engines))
     }
 }
 

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -145,11 +145,9 @@ impl CollectTypesMetadata for TyExpression {
                 }
             }
             StructExpression { fields, span, .. } => {
-                if let TypeInfo::Struct {
-                    type_parameters, ..
-                } = ctx.type_engine.get(self.return_type)
-                {
-                    for type_parameter in type_parameters {
+                if let TypeInfo::Struct(decl_ref) = ctx.type_engine.get(self.return_type) {
+                    let decl = decl_engine.get_struct(&decl_ref);
+                    for type_parameter in decl.type_parameters {
                         ctx.call_site_insert(type_parameter.type_id, span.clone());
                     }
                 }

--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -185,7 +185,7 @@ impl TyProgram {
                             let type_info = ty_engine.get(field.type_argument.type_id);
                             let type_info_str = engines.help_out(&type_info).to_string();
                             let raw_ptr_type = type_info
-                                .extract_nested_types(ty_engine, &field.span)
+                                .extract_nested_types(engines, &field.span)
                                 .value
                                 .and_then(|value| {
                                     value
@@ -255,7 +255,7 @@ impl TyProgram {
                 let nested_types = check!(
                     main_return_type_info
                         .clone()
-                        .extract_nested_types(ty_engine, &main_func.return_type.span),
+                        .extract_nested_types(engines, &main_func.return_type.span),
                     vec![],
                     warnings,
                     errors

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -68,13 +68,12 @@ impl ty::TyCodeBlock {
                         .resolve_symbol(&never_mod_path, &never_ident)
                         .value;
 
-                    if let Some(ty::TyDeclaration::EnumDeclaration {
-                        decl_id: never_decl_id,
-                        ..
-                    }) = never_decl_opt
+                    if let Some(ty::TyDeclaration::EnumDeclaration(never_decl_ref)) = never_decl_opt
                     {
-                        let never_decl = decl_engine.get_enum(never_decl_id);
-                        return never_decl.create_type_id(ctx.engines());
+                        return ctx
+                            .engines()
+                            .te()
+                            .insert(decl_engine, TypeInfo::Enum(never_decl_ref.clone()));
                     }
 
                     ctx.type_engine.insert(decl_engine, TypeInfo::Unknown)

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -176,12 +176,7 @@ impl ty::TyDeclaration {
                     errors
                 );
                 let call_path = enum_decl.call_path.clone();
-                let decl_ref = decl_engine.insert(enum_decl);
-                let decl = ty::TyDeclaration::EnumDeclaration {
-                    name: decl_ref.name,
-                    decl_id: decl_ref.id,
-                    decl_span: decl_ref.decl_span,
-                };
+                let decl = ty::TyDeclaration::EnumDeclaration(decl_engine.insert(enum_decl));
                 check!(
                     ctx.namespace.insert_symbol(call_path.suffix, decl.clone()),
                     return err(warnings, errors),
@@ -339,12 +334,7 @@ impl ty::TyDeclaration {
                     errors
                 );
                 let call_path = decl.call_path.clone();
-                let decl_ref = decl_engine.insert(decl);
-                let decl = ty::TyDeclaration::StructDeclaration {
-                    name: decl_ref.name,
-                    decl_id: decl_ref.id,
-                    decl_span: decl_ref.decl_span,
-                };
+                let decl = ty::TyDeclaration::StructDeclaration(decl_engine.insert(decl));
                 // insert the struct decl into namespace
                 check!(
                     ctx.namespace.insert_symbol(call_path.suffix, decl.clone()),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -225,7 +225,7 @@ fn test_function_selector_behavior() {
         where_clause: vec![],
     };
 
-    let selector_text = match decl.to_selector_name(&type_engine).value {
+    let selector_text = match decl.to_selector_name(&type_engine, &decl_engine).value {
         Some(value) => value,
         _ => panic!("test failure"),
     };
@@ -273,7 +273,7 @@ fn test_function_selector_behavior() {
         where_clause: vec![],
     };
 
-    let selector_text = match decl.to_selector_name(&type_engine).value {
+    let selector_text = match decl.to_selector_name(&type_engine, &decl_engine).value {
         Some(value) => value,
         _ => panic!("test failure"),
     };

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/constructor_factory.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/constructor_factory.rs
@@ -3,7 +3,9 @@ use std::collections::HashSet;
 use sway_error::error::CompileError;
 use sway_types::{Ident, Span};
 
-use crate::{error::*, language::ty, type_system::TypeId, Engines, TypeEngine, TypeInfo};
+use crate::{
+    decl_engine::DeclEngine, error::*, language::ty, type_system::TypeId, Engines, TypeInfo,
+};
 
 use super::{
     patstack::PatStack,
@@ -16,17 +18,14 @@ pub(crate) struct ConstructorFactory {
 }
 
 impl ConstructorFactory {
-    pub(crate) fn new(
-        type_engine: &TypeEngine,
-        type_id: TypeId,
-        span: &Span,
-    ) -> CompileResult<Self> {
+    pub(crate) fn new(engines: Engines<'_>, type_id: TypeId, span: &Span) -> CompileResult<Self> {
         let mut warnings = vec![];
         let mut errors = vec![];
         let possible_types = check!(
-            type_engine
+            engines
+                .te()
                 .get(type_id)
-                .extract_nested_types(type_engine, span),
+                .extract_nested_types(engines, span),
             return err(warnings, errors),
             warnings,
             errors
@@ -285,21 +284,23 @@ impl ConstructorFactory {
             }
             ref pat @ Pattern::Enum(ref enum_pattern) => {
                 let type_info = check!(
-                    self.resolve_possible_types(pat, span),
+                    self.resolve_possible_types(pat, span, engines.de()),
                     return err(warnings, errors),
                     warnings,
                     errors
                 );
-                let (enum_name, enum_variants) = check!(
+                let enum_decl = engines.de().get_enum(&check!(
                     type_info.expect_enum(engines, "", span),
                     return err(warnings, errors),
                     warnings,
                     errors
-                );
+                ));
+                let enum_name = enum_decl.call_path.suffix;
+                let enum_variants = enum_decl.variants;
                 let (all_variants, variant_tracker) = check!(
                     ConstructorFactory::resolve_enum(
-                        enum_name,
-                        enum_variants,
+                        &enum_name,
+                        &enum_variants,
                         enum_pattern,
                         rest,
                         span
@@ -525,21 +526,23 @@ impl ConstructorFactory {
             }
             ref pat @ Pattern::Enum(ref enum_pattern) => {
                 let type_info = check!(
-                    self.resolve_possible_types(pat, span),
+                    self.resolve_possible_types(pat, span, engines.de()),
                     return err(warnings, errors),
                     warnings,
                     errors
                 );
-                let (enum_name, enum_variants) = check!(
+                let enum_decl = engines.de().get_enum(&check!(
                     type_info.expect_enum(engines, "", span),
                     return err(warnings, errors),
                     warnings,
                     errors
-                );
+                ));
+                let enum_name = enum_decl.call_path.suffix;
+                let enum_variants = enum_decl.variants;
                 let (all_variants, variant_tracker) = check!(
                     ConstructorFactory::resolve_enum(
-                        enum_name,
-                        enum_variants,
+                        &enum_name,
+                        &enum_variants,
                         enum_pattern,
                         rest,
                         span
@@ -587,12 +590,17 @@ impl ConstructorFactory {
         }
     }
 
-    fn resolve_possible_types(&self, pattern: &Pattern, span: &Span) -> CompileResult<&TypeInfo> {
+    fn resolve_possible_types(
+        &self,
+        pattern: &Pattern,
+        span: &Span,
+        decl_engine: &DeclEngine,
+    ) -> CompileResult<&TypeInfo> {
         let warnings = vec![];
         let mut errors = vec![];
         let mut type_info = None;
         for possible_type in self.possible_types.iter() {
-            let matches = pattern.matches_type_info(possible_type);
+            let matches = pattern.matches_type_info(possible_type, decl_engine);
             if matches {
                 type_info = Some(possible_type);
                 break;

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/usefulness.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/usefulness.rs
@@ -212,14 +212,19 @@ pub(crate) fn check_match_expression_usefulness(
     // branches in the match expression (i.e. no scrutinees to check), then
     // every scrutinee (i.e. 0 scrutinees) are useful! We return early in this
     // case.
-    if !engines.te().get(type_id).has_valid_constructor() && scrutinees.is_empty() {
+    if !engines
+        .te()
+        .get(type_id)
+        .has_valid_constructor(engines.de())
+        && scrutinees.is_empty()
+    {
         let witness_report = WitnessReport::NoWitnesses;
         let arms_reachability = vec![];
         return ok((witness_report, arms_reachability), warnings, errors);
     }
 
     let factory = check!(
-        ConstructorFactory::new(engines.te(), type_id, &span),
+        ConstructorFactory::new(engines, type_id, &span),
         return err(warnings, errors),
         warnings,
         errors

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_expression.rs
@@ -170,7 +170,10 @@ impl ty::TyMatchExpression {
                 // NOTE: This manual construction of the expression can (and
                 // most likely will) lead to an otherwise improperly typed
                 // expression, in most cases.
-                if !type_engine.get(self.value_type_id).has_valid_constructor() {
+                if !type_engine
+                    .get(self.value_type_id)
+                    .has_valid_constructor(decl_engine)
+                {
                     let condition = ty::TyExpression {
                         expression: ty::TyExpressionVariant::Literal(Literal::Boolean(true)),
                         return_type: type_engine.insert(decl_engine, TypeInfo::Boolean),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -998,7 +998,8 @@ impl ty::TyExpression {
             };
             ctx.namespace
                 .resolve_call_path(&probe_call_path)
-                .flat_map(|decl| decl.expect_enum(decl_engine))
+                .flat_map(|decl| decl.expect_enum())
+                .map(|decl_ref| decl_engine.get_enum(&decl_ref))
                 .flat_map(|decl| decl.expect_variant_from_name(&suffix).map(drop))
                 .value
                 .is_none()
@@ -1119,9 +1120,9 @@ impl ty::TyExpression {
                 span: call_path_binding.span,
             };
             TypeBinding::type_check_with_ident(&mut call_path_binding, ctx.by_ref())
-                .flat_map(|unknown_decl| unknown_decl.expect_enum(decl_engine))
+                .flat_map(|unknown_decl| unknown_decl.expect_enum())
                 .ok(&mut enum_probe_warnings, &mut enum_probe_errors)
-                .map(|enum_decl| (enum_decl, variant_name, call_path_binding))
+                .map(|enum_decl_ref| (enum_decl_ref, variant_name, call_path_binding))
         };
 
         // Check if this could be a constant
@@ -1138,11 +1139,18 @@ impl ty::TyExpression {
 
         // compare the results of the checks
         let exp = match (is_module, maybe_function, maybe_enum, maybe_const) {
-            (false, None, Some((enum_decl, variant_name, call_path_binding)), None) => {
+            (false, None, Some((enum_decl_ref, variant_name, call_path_binding)), None) => {
                 warnings.append(&mut enum_probe_warnings);
                 errors.append(&mut enum_probe_errors);
                 check!(
-                    instantiate_enum(ctx, enum_decl, variant_name, args, call_path_binding, &span),
+                    instantiate_enum(
+                        ctx,
+                        &enum_decl_ref,
+                        variant_name,
+                        args,
+                        call_path_binding,
+                        &span
+                    ),
                     return err(warnings, errors),
                     warnings,
                     errors

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -1,4 +1,5 @@
 use crate::{
+    decl_engine::DeclRefEnum,
     error::*,
     language::{parsed::*, ty, CallPath},
     semantic_analysis::*,
@@ -13,7 +14,7 @@ use sway_types::{Ident, Span, Spanned};
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn instantiate_enum(
     ctx: TypeCheckContext,
-    enum_decl: ty::TyEnumDeclaration,
+    enum_decl_ref: &DeclRefEnum,
     enum_variant_name: Ident,
     args_opt: Option<Vec<Expression>>,
     call_path_binding: TypeBinding<CallPath>,
@@ -26,6 +27,7 @@ pub(crate) fn instantiate_enum(
     let decl_engine = ctx.decl_engine;
     let engines = ctx.engines();
 
+    let enum_decl = decl_engine.get_enum(enum_decl_ref);
     let enum_variant = check!(
         enum_decl
             .expect_variant_from_name(&enum_variant_name)
@@ -59,7 +61,7 @@ pub(crate) fn instantiate_enum(
     ) {
         ([], ty) if ty.is_unit() => ok(
             ty::TyExpression {
-                return_type: enum_decl.create_type_id(engines),
+                return_type: type_engine.insert(decl_engine, TypeInfo::Enum(enum_decl_ref.clone())),
                 expression: ty::TyExpressionVariant::EnumInstantiation {
                     tag: enum_variant.tag,
                     contents: None,
@@ -104,7 +106,8 @@ pub(crate) fn instantiate_enum(
 
             ok(
                 ty::TyExpression {
-                    return_type: enum_decl.create_type_id(engines),
+                    return_type: type_engine
+                        .insert(decl_engine, TypeInfo::Enum(enum_decl_ref.clone())),
                     expression: ty::TyExpressionVariant::EnumInstantiation {
                         tag: enum_variant.tag,
                         contents: Some(Box::new(typed_expr)),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -302,7 +302,7 @@ pub(crate) fn type_check_method_application(
             return err(warnings, errors);
         };
         let func_selector = check!(
-            method.to_fn_selector_value(type_engine),
+            method.to_fn_selector_value(type_engine, decl_engine),
             [0; 4],
             warnings,
             errors

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -86,19 +86,21 @@ pub(crate) fn struct_instantiation(
 
     // extract the struct name and fields from the type info
     let type_info = type_engine.get(type_id);
-    let (struct_name, struct_fields) = check!(
+    let struct_decl = decl_engine.get_struct(&check!(
         type_info.expect_struct(engines, &span),
         return err(warnings, errors),
         warnings,
         errors
-    );
-    let mut struct_fields = struct_fields.clone();
+    ));
+    let struct_name = struct_decl.call_path.suffix;
+    let struct_fields = struct_decl.fields;
+    let mut struct_fields = struct_fields;
 
     let typed_fields = check!(
         type_check_field_arguments(
             ctx.by_ref(),
             &fields,
-            struct_name,
+            &struct_name,
             &mut struct_fields,
             &span
         ),
@@ -127,7 +129,7 @@ pub(crate) fn struct_instantiation(
 
     let exp = ty::TyExpression {
         expression: ty::TyExpressionVariant::StructExpression {
-            struct_name: struct_name.clone(),
+            struct_name,
             fields: typed_fields,
             span: inner_span,
             call_path_binding,

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -103,7 +103,8 @@ impl ty::TyAstNode {
                 r#type: engines.help_out(node.type_info(type_engine)).to_string(),
             };
             assert_or_warn!(
-                node.type_info(type_engine).can_safely_ignore(type_engine),
+                node.type_info(type_engine)
+                    .can_safely_ignore(type_engine, decl_engine),
                 warnings,
                 node.span.clone(),
                 warning
@@ -167,7 +168,7 @@ pub(crate) fn reassign_storage_subfield(
     });
 
     let update_available_struct_fields = |id: TypeId| match type_engine.get(id) {
-        TypeInfo::Struct { fields, .. } => fields,
+        TypeInfo::Struct(decl_ref) => decl_engine.get_struct(&decl_ref).fields,
         _ => vec![],
     };
     let mut curr_type = initial_field_type;

--- a/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
+++ b/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
@@ -514,10 +514,16 @@ fn effects_of_expression(engines: Engines<'_>, expr: &ty::TyExpression) -> HashS
             // accessing a storage map's method (or a storage vector's method),
             // which is represented using a struct with empty fields
             // does not result in a storage read
-            crate::TypeInfo::Struct { fields, .. } if fields.is_empty() => HashSet::new(),
+            crate::TypeInfo::Struct(decl_ref)
+                if decl_engine.get_struct(&decl_ref).fields.is_empty() =>
+            {
+                HashSet::new()
+            }
             // if it's an empty enum then it cannot be constructed and hence cannot be read
             // adding this check here just to be on the safe side
-            crate::TypeInfo::Enum { variant_types, .. } if variant_types.is_empty() => {
+            crate::TypeInfo::Enum(decl_ref)
+                if decl_engine.get_enum(&decl_ref).variants.is_empty() =>
+            {
                 HashSet::new()
             }
             _ => HashSet::from([Effect::StorageRead]),

--- a/sway-core/src/semantic_analysis/module.rs
+++ b/sway-core/src/semantic_analysis/module.rs
@@ -30,6 +30,7 @@ impl ty::TyModule {
         // TODO: Ordering should be solved across all modules prior to the beginning of type-check.
         let ordered_nodes_res = node_dependencies::order_ast_nodes_by_dependency(
             ctx.type_engine,
+            ctx.decl_engine,
             tree.root_nodes.clone(),
         );
 

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -59,7 +59,7 @@ impl Items {
         match self.declared_storage {
             Some(ref decl_ref) => {
                 let storage = decl_engine.get_storage(&decl_ref.id);
-                storage.apply_storage_load(type_engine, fields, storage_fields)
+                storage.apply_storage_load(type_engine, decl_engine, fields, storage_fields)
             }
             None => {
                 errors.push(CompileError::NoDeclaredStorage {
@@ -201,6 +201,7 @@ impl Items {
         let mut errors = vec![];
 
         let type_engine = engines.te();
+        let decl_engine = engines.de();
 
         let symbol = match self.symbols.get(base_name).cloned() {
             Some(s) => s,
@@ -232,15 +233,12 @@ impl Items {
             };
             match (resolved_type, projection) {
                 (
-                    TypeInfo::Struct {
-                        call_path: struct_name,
-                        fields,
-                        ..
-                    },
+                    TypeInfo::Struct(decl_ref),
                     ty::ProjectionKind::StructField { name: field_name },
                 ) => {
+                    let struct_decl = decl_engine.get_struct(&decl_ref);
                     let field_type_opt = {
-                        fields.iter().find_map(
+                        struct_decl.fields.iter().find_map(
                             |ty::TyStructField {
                                  type_argument,
                                  name,
@@ -258,14 +256,15 @@ impl Items {
                         Some(field_type) => field_type,
                         None => {
                             // gather available fields for the error message
-                            let available_fields = fields
+                            let available_fields = struct_decl
+                                .fields
                                 .iter()
                                 .map(|field| field.name.as_str())
                                 .collect::<Vec<_>>();
 
                             errors.push(CompileError::FieldNotFound {
                                 field_name: field_name.clone(),
-                                struct_name: struct_name.suffix,
+                                struct_name: struct_decl.call_path.suffix,
                                 available_fields: available_fields.join(", "),
                                 span: field_name.span(),
                             });

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -15,7 +15,7 @@ use crate::{
         CallPath,
     },
     type_system::{SubstTypes, TypeId},
-    ReplaceSelfType, TraitConstraint, TypeArgument, TypeEngine, TypeInfo, TypeSubstMap,
+    ReplaceSelfType, TraitConstraint, TypeArgument, TypeInfo, TypeSubstMap,
 };
 
 #[derive(Clone, Debug)]
@@ -29,10 +29,10 @@ impl PartialEqWithEngines for TraitSuffix {
     }
 }
 impl OrdWithEngines for TraitSuffix {
-    fn cmp(&self, other: &Self, type_engine: &TypeEngine) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> std::cmp::Ordering {
         self.name
             .cmp(&other.name)
-            .then_with(|| self.args.cmp(&other.args, type_engine))
+            .then_with(|| self.args.cmp(&other.args, engines))
     }
 }
 
@@ -44,10 +44,10 @@ impl<T: PartialEqWithEngines> PartialEqWithEngines for CallPath<T> {
     }
 }
 impl<T: OrdWithEngines> OrdWithEngines for CallPath<T> {
-    fn cmp(&self, other: &Self, type_engine: &TypeEngine) -> Ordering {
+    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
         self.prefixes
             .cmp(&other.prefixes)
-            .then_with(|| self.suffix.cmp(&other.suffix, type_engine))
+            .then_with(|| self.suffix.cmp(&other.suffix, engines))
             .then_with(|| self.is_absolute.cmp(&other.is_absolute))
     }
 }
@@ -61,9 +61,9 @@ struct TraitKey {
 }
 
 impl OrdWithEngines for TraitKey {
-    fn cmp(&self, other: &Self, type_engine: &TypeEngine) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> std::cmp::Ordering {
         self.name
-            .cmp(&other.name, type_engine)
+            .cmp(&other.name, engines)
             .then_with(|| self.type_id.cmp(&other.type_id))
     }
 }
@@ -346,7 +346,7 @@ impl TraitMap {
         for oe in other.trait_impls.into_iter() {
             let pos = self
                 .trait_impls
-                .binary_search_by(|se| se.key.cmp(&oe.key, engines.te()));
+                .binary_search_by(|se| se.key.cmp(&oe.key, &engines));
 
             match pos {
                 Ok(pos) => self.trait_impls[pos].value.extend(oe.value.into_iter()),
@@ -464,11 +464,14 @@ impl TraitMap {
     /// with those entries for `Data<T, T>`.
     pub(crate) fn filter_by_type(&self, type_id: TypeId, engines: Engines<'_>) -> TraitMap {
         let type_engine = engines.te();
+        let decl_engine = engines.de();
         // a curried version of the decider protocol to use in the helper functions
         let decider = |type_info: &TypeInfo, map_type_info: &TypeInfo| {
             type_info.is_subset_of(map_type_info, engines)
         };
-        let mut all_types = type_engine.get(type_id).extract_inner_types(type_engine);
+        let mut all_types = type_engine
+            .get(type_id)
+            .extract_inner_types(type_engine, decl_engine);
         all_types.insert(type_id);
         let all_types = all_types.into_iter().collect::<Vec<_>>();
         self.filter_by_type_inner(engines, all_types, decider)
@@ -538,6 +541,7 @@ impl TraitMap {
         engines: Engines<'_>,
     ) -> TraitMap {
         let type_engine = engines.te();
+        let decl_engine = engines.de();
         // a curried version of the decider protocol to use in the helper functions
         let decider = |type_info: &TypeInfo, map_type_info: &TypeInfo| {
             type_info.is_subset_of(map_type_info, engines)
@@ -546,7 +550,7 @@ impl TraitMap {
         let mut trait_map = self.filter_by_type_inner(engines, vec![type_id], decider);
         let all_types = type_engine
             .get(type_id)
-            .extract_inner_types(type_engine)
+            .extract_inner_types(type_engine, decl_engine)
             .into_iter()
             .collect::<Vec<_>>();
         // a curried version of the decider protocol to use in the helper functions
@@ -580,7 +584,7 @@ impl TraitMap {
         {
             for type_id in all_types.iter_mut() {
                 let type_info = type_engine.get(*type_id);
-                if !type_info.can_change() && *type_id == *map_type_id {
+                if !type_info.can_change(decl_engine) && *type_id == *map_type_id {
                     trait_map.insert_inner(
                         map_trait_name.clone(),
                         *type_id,
@@ -588,8 +592,12 @@ impl TraitMap {
                         engines,
                     );
                 } else if decider(&type_info, &type_engine.get(*map_type_id)) {
-                    let type_mapping =
-                        TypeSubstMap::from_superset_and_subset(type_engine, *map_type_id, *type_id);
+                    let type_mapping = TypeSubstMap::from_superset_and_subset(
+                        type_engine,
+                        decl_engine,
+                        *map_type_id,
+                        *type_id,
+                    );
                     let new_self_type = type_engine.insert(decl_engine, TypeInfo::SelfType);
                     type_id.replace_self_type(engines, new_self_type);
                     let trait_items: TraitItems = map_trait_items
@@ -806,6 +814,7 @@ pub(crate) fn are_equal_minus_dynamic_types(
     }
 
     let type_engine = engines.te();
+    let decl_engine = engines.de();
 
     match (type_engine.get(left), type_engine.get(right)) {
         // these cases are false because, unless left and right have the same
@@ -857,20 +866,12 @@ pub(crate) fn are_equal_minus_dynamic_types(
                         acc && are_equal_minus_dynamic_types(engines, left.type_id, right.type_id)
                     })
         }
-        (
-            TypeInfo::Enum {
-                call_path: l_name,
-                variant_types: l_variant_types,
-                type_parameters: l_type_parameters,
-            },
-            TypeInfo::Enum {
-                call_path: r_name,
-                variant_types: r_variant_types,
-                type_parameters: r_type_parameters,
-            },
-        ) => {
-            l_name.suffix == r_name.suffix
-                && l_variant_types.iter().zip(r_variant_types.iter()).fold(
+        (TypeInfo::Enum(l_decl_ref), TypeInfo::Enum(r_decl_ref)) => {
+            let l_decl = decl_engine.get_enum(&l_decl_ref);
+            let r_decl = decl_engine.get_enum(&r_decl_ref);
+            l_decl.call_path.suffix == r_decl.call_path.suffix
+                && l_decl.call_path.suffix.span() == r_decl.call_path.suffix.span()
+                && l_decl.variants.iter().zip(r_decl.variants.iter()).fold(
                     true,
                     |acc, (left, right)| {
                         acc && left.name == right.name
@@ -881,45 +882,39 @@ pub(crate) fn are_equal_minus_dynamic_types(
                             )
                     },
                 )
-                && l_type_parameters.iter().zip(r_type_parameters.iter()).fold(
-                    true,
-                    |acc, (left, right)| {
-                        acc && left.name_ident == right.name_ident
-                            && are_equal_minus_dynamic_types(engines, left.type_id, right.type_id)
-                    },
-                )
-        }
-        (
-            TypeInfo::Struct {
-                call_path: l_name,
-                fields: l_fields,
-                type_parameters: l_type_parameters,
-            },
-            TypeInfo::Struct {
-                call_path: r_name,
-                fields: r_fields,
-                type_parameters: r_type_parameters,
-            },
-        ) => {
-            l_name.suffix == r_name.suffix
-                && l_fields
+                && l_decl
+                    .type_parameters
                     .iter()
-                    .zip(r_fields.iter())
+                    .zip(r_decl.type_parameters.iter())
                     .fold(true, |acc, (left, right)| {
+                        acc && left.name_ident == right.name_ident
+                            && are_equal_minus_dynamic_types(engines, left.type_id, right.type_id)
+                    })
+        }
+        (TypeInfo::Struct(l_decl_ref), TypeInfo::Struct(r_decl_ref)) => {
+            let l_decl = decl_engine.get_struct(&l_decl_ref);
+            let r_decl = decl_engine.get_struct(&r_decl_ref);
+            l_decl.call_path.suffix == r_decl.call_path.suffix
+                && l_decl.call_path.suffix.span() == r_decl.call_path.suffix.span()
+                && l_decl.fields.iter().zip(r_decl.fields.iter()).fold(
+                    true,
+                    |acc, (left, right)| {
                         acc && left.name == right.name
                             && are_equal_minus_dynamic_types(
                                 engines,
                                 left.type_argument.type_id,
                                 right.type_argument.type_id,
                             )
-                    })
-                && l_type_parameters.iter().zip(r_type_parameters.iter()).fold(
-                    true,
-                    |acc, (left, right)| {
-                        acc && left.name_ident == right.name_ident
-                            && are_equal_minus_dynamic_types(engines, left.type_id, right.type_id)
                     },
                 )
+                && l_decl
+                    .type_parameters
+                    .iter()
+                    .zip(r_decl.type_parameters.iter())
+                    .fold(true, |acc, (left, right)| {
+                        acc && left.name_ident == right.name_ident
+                            && are_equal_minus_dynamic_types(engines, left.type_id, right.type_id)
+                    })
         }
         (TypeInfo::Tuple(l), TypeInfo::Tuple(r)) => {
             if l.len() != r.len() {

--- a/sway-core/src/semantic_analysis/storage_only_types.rs
+++ b/sway-core/src/semantic_analysis/storage_only_types.rs
@@ -157,7 +157,7 @@ fn check_type(
         errors
     );
     let nested_types = check!(
-        type_info.clone().extract_nested_types(ty_engine, &span),
+        type_info.clone().extract_nested_types(engines, &span),
         vec![],
         warnings,
         errors
@@ -224,8 +224,8 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
                 }
             }
         }
-        ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
-            let ty::TyStructDeclaration { fields, .. } = decl_engine.get_struct(decl_id);
+        ty::TyDeclaration::StructDeclaration(decl_ref) => {
+            let ty::TyStructDeclaration { fields, .. } = decl_engine.get_struct(decl_ref);
             for field in fields {
                 check!(
                     check_type(
@@ -240,8 +240,8 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
                 );
             }
         }
-        ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
-            let ty::TyEnumDeclaration { variants, .. } = decl_engine.get_enum(decl_id);
+        ty::TyDeclaration::EnumDeclaration(decl_ref) => {
+            let ty::TyEnumDeclaration { variants, .. } = decl_engine.get_enum(decl_ref);
             for variant in variants {
                 check!(
                     check_type(

--- a/sway-core/src/type_system/binding.rs
+++ b/sway-core/src/type_system/binding.rs
@@ -7,7 +7,7 @@ use crate::{
     language::{ty, CallPath},
     semantic_analysis::TypeCheckContext,
     type_system::*,
-    CreateTypeId, Ident,
+    Ident,
 };
 
 /// A `TypeBinding` is the result of using turbofish to bind types to
@@ -285,13 +285,9 @@ impl TypeBinding<CallPath> {
                     decl_span,
                 }
             }
-            ty::TyDeclaration::EnumDeclaration {
-                decl_id: original_id,
-                name,
-                decl_span,
-            } => {
+            ty::TyDeclaration::EnumDeclaration(original_decl_ref) => {
                 // get the copy from the declaration engine
-                let mut new_copy = decl_engine.get_enum(&original_id);
+                let mut new_copy = decl_engine.get_enum(&original_decl_ref);
 
                 // monomorphize the copy, in place
                 check!(
@@ -306,30 +302,20 @@ impl TypeBinding<CallPath> {
                     errors
                 );
 
+                // insert the new copy into the declaration engine
+                let new_decl_ref = ctx.decl_engine.insert(new_copy);
+
                 // take any trait methods that apply to this type and copy them to the new type
                 ctx.namespace.insert_trait_implementation_for_type(
                     engines,
-                    new_copy.create_type_id(engines),
+                    type_engine.insert(decl_engine, TypeInfo::Enum(new_decl_ref.clone())),
                 );
 
-                // insert the new copy into the declaration engine
-                let DeclRef {
-                    id: new_decl_id, ..
-                } = ctx.decl_engine.insert(new_copy);
-
-                ty::TyDeclaration::EnumDeclaration {
-                    name,
-                    decl_id: new_decl_id,
-                    decl_span,
-                }
+                ty::TyDeclaration::EnumDeclaration(new_decl_ref)
             }
-            ty::TyDeclaration::StructDeclaration {
-                decl_id: original_id,
-                name,
-                decl_span,
-            } => {
+            ty::TyDeclaration::StructDeclaration(original_decl_ref) => {
                 // get the copy from the declaration engine
-                let mut new_copy = decl_engine.get_struct(&original_id);
+                let mut new_copy = decl_engine.get_struct(&original_decl_ref);
 
                 // monomorphize the copy, in place
                 check!(
@@ -344,22 +330,16 @@ impl TypeBinding<CallPath> {
                     errors
                 );
 
+                // insert the new copy into the declaration engine
+                let new_decl_ref = ctx.decl_engine.insert(new_copy);
+
                 // take any trait methods that apply to this type and copy them to the new type
                 ctx.namespace.insert_trait_implementation_for_type(
                     engines,
-                    new_copy.create_type_id(engines),
+                    type_engine.insert(decl_engine, TypeInfo::Struct(new_decl_ref.clone())),
                 );
 
-                // insert the new copy into the declaration engine
-                let DeclRef {
-                    id: new_decl_id, ..
-                } = ctx.decl_engine.insert(new_copy);
-
-                ty::TyDeclaration::StructDeclaration {
-                    name,
-                    decl_id: new_decl_id,
-                    decl_span,
-                }
+                ty::TyDeclaration::StructDeclaration(new_decl_ref)
             }
             _ => unknown_decl,
         };

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -53,7 +53,9 @@ impl TypeEngine {
             .from_hash(ty_hash, |x| x.eq(&ty, engines));
         match raw_entry {
             RawEntryMut::Occupied(o) => return *o.get(),
-            RawEntryMut::Vacant(_) if ty.can_change() => TypeId::new(self.slab.insert(ty)),
+            RawEntryMut::Vacant(_) if ty.can_change(decl_engine) => {
+                TypeId::new(self.slab.insert(ty))
+            }
             RawEntryMut::Vacant(v) => {
                 let type_id = TypeId::new(self.slab.insert(ty.clone()));
                 v.insert_with_hasher(ty_hash, ty, type_id, make_hasher(&hash_builder, engines));
@@ -411,12 +413,9 @@ impl TypeEngine {
                     .ok(&mut warnings, &mut errors)
                     .cloned()
                 {
-                    Some(ty::TyDeclaration::StructDeclaration {
-                        decl_id: original_id,
-                        ..
-                    }) => {
+                    Some(ty::TyDeclaration::StructDeclaration(original_decl_ref)) => {
                         // get the copy from the declaration engine
-                        let mut new_copy = decl_engine.get_struct(&original_id);
+                        let mut new_copy = decl_engine.get_struct(&original_decl_ref);
 
                         // monomorphize the copy, in place
                         check!(
@@ -434,8 +433,13 @@ impl TypeEngine {
                             errors,
                         );
 
+                        // insert the new copy in the decl engine
+                        let new_decl_ref = decl_engine.insert(new_copy);
+
                         // create the type id from the copy
-                        let type_id = new_copy.create_type_id(engines);
+                        let type_id = engines
+                            .te()
+                            .insert(decl_engine, TypeInfo::Struct(new_decl_ref));
 
                         // take any trait methods that apply to this type and copy them to the new type
                         namespace.insert_trait_implementation_for_type(engines, type_id);
@@ -443,12 +447,9 @@ impl TypeEngine {
                         // return the id
                         type_id
                     }
-                    Some(ty::TyDeclaration::EnumDeclaration {
-                        decl_id: original_id,
-                        ..
-                    }) => {
+                    Some(ty::TyDeclaration::EnumDeclaration(original_decl_ref)) => {
                         // get the copy from the declaration engine
-                        let mut new_copy = decl_engine.get_enum(&original_id);
+                        let mut new_copy = decl_engine.get_enum(&original_decl_ref);
 
                         // monomorphize the copy, in place
                         check!(
@@ -466,8 +467,13 @@ impl TypeEngine {
                             errors
                         );
 
+                        // insert the new copy in the decl engine
+                        let new_decl_ref = decl_engine.insert(new_copy);
+
                         // create the type id from the copy
-                        let type_id = new_copy.create_type_id(engines);
+                        let type_id = engines
+                            .te()
+                            .insert(decl_engine, TypeInfo::Enum(new_decl_ref));
 
                         // take any trait methods that apply to this type and copy them to the new type
                         namespace.insert_trait_implementation_for_type(engines, type_id);

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{
+    decl_engine::{DeclEngine, DeclRefEnum, DeclRefStruct},
     engine_threading::*,
     language::{ty, CallPath},
     Ident,
@@ -92,16 +93,8 @@ pub enum TypeInfo {
     Placeholder(TypeParameter),
     Str(Length),
     UnsignedInteger(IntegerBits),
-    Enum {
-        call_path: CallPath,
-        type_parameters: Vec<TypeParameter>,
-        variant_types: Vec<ty::TyEnumVariant>,
-    },
-    Struct {
-        call_path: CallPath,
-        type_parameters: Vec<TypeParameter>,
-        fields: Vec<ty::TyStructField>,
-    },
+    Enum(DeclRefEnum),
+    Struct(DeclRefStruct),
     Boolean,
     Tuple(Vec<TypeArgument>),
     /// Represents a type which contains methods to issue a contract call.
@@ -158,23 +151,11 @@ impl HashWithEngines for TypeInfo {
             TypeInfo::Tuple(fields) => {
                 fields.hash(state, engines);
             }
-            TypeInfo::Enum {
-                call_path,
-                variant_types,
-                type_parameters,
-            } => {
-                call_path.hash(state);
-                variant_types.hash(state, engines);
-                type_parameters.hash(state, engines);
+            TypeInfo::Enum(decl_ref) => {
+                decl_ref.hash(state, engines);
             }
-            TypeInfo::Struct {
-                call_path,
-                fields,
-                type_parameters,
-            } => {
-                call_path.hash(state);
-                fields.hash(state, engines);
-                type_parameters.hash(state, engines);
+            TypeInfo::Struct(decl_ref) => {
+                decl_ref.hash(state, engines);
             }
             TypeInfo::ContractCaller { abi_name, address } => {
                 abi_name.hash(state);
@@ -252,37 +233,21 @@ impl PartialEqWithEngines for TypeInfo {
             }
             (Self::Str(l), Self::Str(r)) => l.val() == r.val(),
             (Self::UnsignedInteger(l), Self::UnsignedInteger(r)) => l == r,
-            (
-                Self::Enum {
-                    call_path: l_name,
-                    variant_types: l_variant_types,
-                    type_parameters: l_type_parameters,
-                },
-                Self::Enum {
-                    call_path: r_name,
-                    variant_types: r_variant_types,
-                    type_parameters: r_type_parameters,
-                },
-            ) => {
-                l_name.suffix == r_name.suffix
-                    && l_variant_types.eq(r_variant_types, engines)
-                    && l_type_parameters.eq(r_type_parameters, engines)
+            (Self::Enum(l_decl_ref), Self::Enum(r_decl_ref)) => {
+                let l_decl = engines.de().get_enum(l_decl_ref);
+                let r_decl = engines.de().get_enum(r_decl_ref);
+                l_decl.call_path.suffix == r_decl.call_path.suffix
+                    && l_decl.call_path.suffix.span() == r_decl.call_path.suffix.span()
+                    && l_decl.variants.eq(&r_decl.variants, engines)
+                    && l_decl.type_parameters.eq(&r_decl.type_parameters, engines)
             }
-            (
-                Self::Struct {
-                    call_path: l_name,
-                    fields: l_fields,
-                    type_parameters: l_type_parameters,
-                },
-                Self::Struct {
-                    call_path: r_name,
-                    fields: r_fields,
-                    type_parameters: r_type_parameters,
-                },
-            ) => {
-                l_name.suffix == r_name.suffix
-                    && l_fields.eq(r_fields, engines)
-                    && l_type_parameters.eq(r_type_parameters, engines)
+            (Self::Struct(l_decl_ref), Self::Struct(r_decl_ref)) => {
+                let l_decl = engines.de().get_struct(l_decl_ref);
+                let r_decl = engines.de().get_struct(r_decl_ref);
+                l_decl.call_path.suffix == r_decl.call_path.suffix
+                    && l_decl.call_path.suffix.span() == r_decl.call_path.suffix.span()
+                    && l_decl.fields.eq(&r_decl.fields, engines)
+                    && l_decl.type_parameters.eq(&r_decl.type_parameters, engines)
             }
             (Self::Tuple(l), Self::Tuple(r)) => l
                 .iter()
@@ -320,7 +285,9 @@ impl PartialEqWithEngines for TypeInfo {
 }
 
 impl OrdWithEngines for TypeInfo {
-    fn cmp(&self, other: &Self, type_engine: &TypeEngine) -> Ordering {
+    fn cmp(&self, other: &Self, engines: &Engines) -> Ordering {
+        let type_engine = engines.te();
+        let decl_engine = engines.de();
         match (self, other) {
             (
                 Self::UnknownGeneric {
@@ -331,8 +298,8 @@ impl OrdWithEngines for TypeInfo {
                     name: r,
                     trait_constraints: rtc,
                 },
-            ) => l.cmp(r).then_with(|| ltc.cmp(rtc, type_engine)),
-            (Self::Placeholder(l), Self::Placeholder(r)) => l.cmp(r, type_engine),
+            ) => l.cmp(r).then_with(|| ltc.cmp(rtc, engines)),
+            (Self::Placeholder(l), Self::Placeholder(r)) => l.cmp(r, engines),
             (
                 Self::Custom {
                     call_path: l_call_path,
@@ -342,46 +309,33 @@ impl OrdWithEngines for TypeInfo {
                     call_path: r_call_path,
                     type_arguments: r_type_args,
                 },
-            ) => l_call_path.suffix.cmp(&r_call_path.suffix).then_with(|| {
-                l_type_args
-                    .as_deref()
-                    .cmp(&r_type_args.as_deref(), type_engine)
-            }),
+            ) => l_call_path
+                .suffix
+                .cmp(&r_call_path.suffix)
+                .then_with(|| l_type_args.as_deref().cmp(&r_type_args.as_deref(), engines)),
             (Self::Str(l), Self::Str(r)) => l.val().cmp(&r.val()),
             (Self::UnsignedInteger(l), Self::UnsignedInteger(r)) => l.cmp(r),
-            (
-                Self::Enum {
-                    call_path: l_call_path,
-                    type_parameters: ltp,
-                    variant_types: lvt,
-                },
-                Self::Enum {
-                    call_path: r_call_path,
-                    type_parameters: rtp,
-                    variant_types: rvt,
-                },
-            ) => l_call_path
-                .suffix
-                .cmp(&r_call_path.suffix)
-                .then_with(|| ltp.cmp(rtp, type_engine))
-                .then_with(|| lvt.cmp(rvt, type_engine)),
-            (
-                Self::Struct {
-                    call_path: l_call_path,
-                    type_parameters: ltp,
-                    fields: lf,
-                },
-                Self::Struct {
-                    call_path: r_call_path,
-                    type_parameters: rtp,
-                    fields: rf,
-                },
-            ) => l_call_path
-                .suffix
-                .cmp(&r_call_path.suffix)
-                .then_with(|| ltp.cmp(rtp, type_engine))
-                .then_with(|| lf.cmp(rf, type_engine)),
-            (Self::Tuple(l), Self::Tuple(r)) => l.cmp(r, type_engine),
+            (Self::Enum(l_decl_ref), Self::Enum(r_decl_ref)) => {
+                let l_decl = decl_engine.get_enum(l_decl_ref);
+                let r_decl = decl_engine.get_enum(r_decl_ref);
+                l_decl
+                    .call_path
+                    .suffix
+                    .cmp(&r_decl.call_path.suffix)
+                    .then_with(|| l_decl.type_parameters.cmp(&r_decl.type_parameters, engines))
+                    .then_with(|| l_decl.variants.cmp(&r_decl.variants, engines))
+            }
+            (Self::Struct(l_decl_ref), Self::Struct(r_decl_ref)) => {
+                let l_decl = decl_engine.get_struct(l_decl_ref);
+                let r_decl = decl_engine.get_struct(r_decl_ref);
+                l_decl
+                    .call_path
+                    .suffix
+                    .cmp(&r_decl.call_path.suffix)
+                    .then_with(|| l_decl.type_parameters.cmp(&r_decl.type_parameters, engines))
+                    .then_with(|| l_decl.fields.cmp(&r_decl.fields, engines))
+            }
+            (Self::Tuple(l), Self::Tuple(r)) => l.cmp(r, engines),
             (
                 Self::ContractCaller {
                     abi_name: l_abi_name,
@@ -397,10 +351,10 @@ impl OrdWithEngines for TypeInfo {
             }
             (Self::Array(l0, l1), Self::Array(r0, r1)) => type_engine
                 .get(l0.type_id)
-                .cmp(&type_engine.get(r0.type_id), type_engine)
+                .cmp(&type_engine.get(r0.type_id), engines)
                 .then_with(|| l1.val().cmp(&r1.val())),
             (TypeInfo::Storage { fields: l_fields }, TypeInfo::Storage { fields: r_fields }) => {
-                l_fields.cmp(r_fields, type_engine)
+                l_fields.cmp(r_fields, engines)
             }
             (l, r) => l.discriminant_value().cmp(&r.discriminant_value()),
         }
@@ -444,24 +398,22 @@ impl DisplayWithEngines for TypeInfo {
             Numeric => "numeric".into(),
             Contract => "contract".into(),
             ErrorRecovery => "unknown due to error".into(),
-            Enum {
-                call_path,
-                type_parameters,
-                ..
-            } => print_inner_types(
-                engines,
-                call_path.suffix.as_str().to_string(),
-                type_parameters.iter().map(|x| x.type_id),
-            ),
-            Struct {
-                call_path,
-                type_parameters,
-                ..
-            } => print_inner_types(
-                engines,
-                call_path.suffix.as_str().to_string(),
-                type_parameters.iter().map(|x| x.type_id),
-            ),
+            Enum(decl_ref) => {
+                let decl = engines.de().get_enum(decl_ref);
+                print_inner_types(
+                    engines,
+                    decl.call_path.suffix.as_str().to_string(),
+                    decl.type_parameters.iter().map(|x| x.type_id),
+                )
+            }
+            Struct(decl_ref) => {
+                let decl = engines.de().get_struct(decl_ref);
+                print_inner_types(
+                    engines,
+                    decl.call_path.suffix.as_str().to_string(),
+                    decl.type_parameters.iter().map(|x| x.type_id),
+                )
+            }
             ContractCaller { abi_name, address } => {
                 format!(
                     "contract caller {} ( {} )",
@@ -507,12 +459,10 @@ impl UnconstrainedTypeParameters for TypeInfo {
                         })
                         .any(|x| x)
             }
-            TypeInfo::Enum {
-                type_parameters,
-                variant_types,
-                ..
-            } => {
-                let unconstrained_in_type_parameters = type_parameters
+            TypeInfo::Enum(decl_ref) => {
+                let decl = engines.de().get_enum(decl_ref);
+                let unconstrained_in_type_parameters = decl
+                    .type_parameters
                     .iter()
                     .map(|type_param| {
                         type_param
@@ -520,7 +470,8 @@ impl UnconstrainedTypeParameters for TypeInfo {
                             .type_parameter_is_unconstrained(engines, type_parameter)
                     })
                     .any(|x| x);
-                let unconstrained_in_variants = variant_types
+                let unconstrained_in_variants = decl
+                    .variants
                     .iter()
                     .map(|variant| {
                         variant
@@ -531,12 +482,10 @@ impl UnconstrainedTypeParameters for TypeInfo {
                     .any(|x| x);
                 unconstrained_in_type_parameters || unconstrained_in_variants
             }
-            TypeInfo::Struct {
-                type_parameters,
-                fields,
-                ..
-            } => {
-                let unconstrained_in_type_parameters = type_parameters
+            TypeInfo::Struct(decl_ref) => {
+                let decl = engines.de().get_struct(decl_ref);
+                let unconstrained_in_type_parameters = decl
+                    .type_parameters
                     .iter()
                     .map(|type_param| {
                         type_param
@@ -544,7 +493,8 @@ impl UnconstrainedTypeParameters for TypeInfo {
                             .type_parameter_is_unconstrained(engines, type_parameter)
                     })
                     .any(|x| x);
-                let unconstrained_in_fields = fields
+                let unconstrained_in_fields = decl
+                    .fields
                     .iter()
                     .map(|field| {
                         field
@@ -627,6 +577,7 @@ impl TypeInfo {
     pub(crate) fn to_selector_name(
         &self,
         type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
         error_msg_span: &Span,
     ) -> CompileResult<String> {
         use TypeInfo::*;
@@ -652,7 +603,7 @@ impl TypeInfo {
                             type_engine
                                 .to_typeinfo(field_type.type_id, error_msg_span)
                                 .expect("unreachable?")
-                                .to_selector_name(type_engine, error_msg_span)
+                                .to_selector_name(type_engine, decl_engine, error_msg_span)
                         })
                         .collect::<Vec<CompileResult<String>>>();
                     let mut buf = vec![];
@@ -668,13 +619,11 @@ impl TypeInfo {
                 format!("({})", field_names.join(","))
             }
             B256 => "b256".into(),
-            Struct {
-                fields,
-                type_parameters,
-                ..
-            } => {
+            Struct(decl_ref) => {
+                let decl = decl_engine.get_struct(decl_ref);
                 let field_names = {
-                    let names = fields
+                    let names = decl
+                        .fields
                         .iter()
                         .map(|ty| {
                             let ty = match type_engine
@@ -683,7 +632,7 @@ impl TypeInfo {
                                 Err(e) => return err(vec![], vec![e.into()]),
                                 Ok(ty) => ty,
                             };
-                            ty.to_selector_name(type_engine, error_msg_span)
+                            ty.to_selector_name(type_engine, decl_engine, error_msg_span)
                         })
                         .collect::<Vec<CompileResult<String>>>();
                     let mut buf = vec![];
@@ -697,14 +646,15 @@ impl TypeInfo {
                 };
 
                 let type_arguments = {
-                    let type_arguments = type_parameters
+                    let type_arguments = decl
+                        .type_parameters
                         .iter()
                         .map(|ty| {
                             let ty = match type_engine.to_typeinfo(ty.type_id, error_msg_span) {
                                 Err(e) => return err(vec![], vec![e.into()]),
                                 Ok(ty) => ty,
                             };
-                            ty.to_selector_name(type_engine, error_msg_span)
+                            ty.to_selector_name(type_engine, decl_engine, error_msg_span)
                         })
                         .collect::<Vec<CompileResult<String>>>();
                     let mut buf = vec![];
@@ -723,13 +673,11 @@ impl TypeInfo {
                     format!("s<{}>({})", type_arguments.join(","), field_names.join(","))
                 }
             }
-            Enum {
-                variant_types,
-                type_parameters,
-                ..
-            } => {
+            Enum(decl_ref) => {
+                let decl = decl_engine.get_enum(decl_ref);
                 let variant_names = {
-                    let names = variant_types
+                    let names = decl
+                        .variants
                         .iter()
                         .map(|ty| {
                             let ty = match type_engine
@@ -738,7 +686,7 @@ impl TypeInfo {
                                 Err(e) => return err(vec![], vec![e.into()]),
                                 Ok(ty) => ty,
                             };
-                            ty.to_selector_name(type_engine, error_msg_span)
+                            ty.to_selector_name(type_engine, decl_engine, error_msg_span)
                         })
                         .collect::<Vec<CompileResult<String>>>();
                     let mut buf = vec![];
@@ -752,14 +700,15 @@ impl TypeInfo {
                 };
 
                 let type_arguments = {
-                    let type_arguments = type_parameters
+                    let type_arguments = decl
+                        .type_parameters
                         .iter()
                         .map(|ty| {
                             let ty = match type_engine.to_typeinfo(ty.type_id, error_msg_span) {
                                 Err(e) => return err(vec![], vec![e.into()]),
                                 Ok(ty) => ty,
                             };
-                            ty.to_selector_name(type_engine, error_msg_span)
+                            ty.to_selector_name(type_engine, decl_engine, error_msg_span)
                         })
                         .collect::<Vec<CompileResult<String>>>();
                     let mut buf = vec![];
@@ -782,9 +731,11 @@ impl TypeInfo {
                 }
             }
             Array(elem_ty, length) => {
-                let name = type_engine
-                    .get(elem_ty.type_id)
-                    .to_selector_name(type_engine, error_msg_span);
+                let name = type_engine.get(elem_ty.type_id).to_selector_name(
+                    type_engine,
+                    decl_engine,
+                    error_msg_span,
+                );
                 let name = match name.value {
                     Some(name) => name,
                     None => return name,
@@ -805,14 +756,18 @@ impl TypeInfo {
         ok(name, vec![], vec![])
     }
 
-    pub fn is_uninhabited(&self, type_engine: &TypeEngine) -> bool {
-        let id_uninhabited = |id| type_engine.get(id).is_uninhabited(type_engine);
+    pub fn is_uninhabited(&self, type_engine: &TypeEngine, decl_engine: &DeclEngine) -> bool {
+        let id_uninhabited = |id| type_engine.get(id).is_uninhabited(type_engine, decl_engine);
 
         match self {
-            TypeInfo::Enum { variant_types, .. } => variant_types
+            TypeInfo::Enum(decl_ref) => decl_engine
+                .get_enum(decl_ref)
+                .variants
                 .iter()
                 .all(|variant_type| id_uninhabited(variant_type.type_argument.type_id)),
-            TypeInfo::Struct { fields, .. } => fields
+            TypeInfo::Struct(decl_ref) => decl_engine
+                .get_struct(decl_ref)
+                .fields
                 .iter()
                 .any(|field| id_uninhabited(field.type_argument.type_id)),
             TypeInfo::Tuple(fields) => fields
@@ -823,16 +778,17 @@ impl TypeInfo {
         }
     }
 
-    pub fn is_zero_sized(&self, type_engine: &TypeEngine) -> bool {
+    pub fn is_zero_sized(&self, type_engine: &TypeEngine, decl_engine: &DeclEngine) -> bool {
         match self {
-            TypeInfo::Enum { variant_types, .. } => {
+            TypeInfo::Enum(decl_ref) => {
+                let decl = decl_engine.get_enum(decl_ref);
                 let mut found_unit_variant = false;
-                for variant_type in variant_types {
+                for variant_type in decl.variants {
                     let type_info = type_engine.get(variant_type.type_argument.type_id);
-                    if type_info.is_uninhabited(type_engine) {
+                    if type_info.is_uninhabited(type_engine, decl_engine) {
                         continue;
                     }
-                    if type_info.is_zero_sized(type_engine) && !found_unit_variant {
+                    if type_info.is_zero_sized(type_engine, decl_engine) && !found_unit_variant {
                         found_unit_variant = true;
                         continue;
                     }
@@ -840,14 +796,15 @@ impl TypeInfo {
                 }
                 true
             }
-            TypeInfo::Struct { fields, .. } => {
+            TypeInfo::Struct(decl_ref) => {
+                let decl = decl_engine.get_struct(decl_ref);
                 let mut all_zero_sized = true;
-                for field in fields {
+                for field in decl.fields {
                     let type_info = type_engine.get(field.type_argument.type_id);
-                    if type_info.is_uninhabited(type_engine) {
+                    if type_info.is_uninhabited(type_engine, decl_engine) {
                         return true;
                     }
-                    if !type_info.is_zero_sized(type_engine) {
+                    if !type_info.is_zero_sized(type_engine, decl_engine) {
                         all_zero_sized = false;
                     }
                 }
@@ -857,37 +814,40 @@ impl TypeInfo {
                 let mut all_zero_sized = true;
                 for field in fields {
                     let field_type = type_engine.get(field.type_id);
-                    if field_type.is_uninhabited(type_engine) {
+                    if field_type.is_uninhabited(type_engine, decl_engine) {
                         return true;
                     }
-                    if !field_type.is_zero_sized(type_engine) {
+                    if !field_type.is_zero_sized(type_engine, decl_engine) {
                         all_zero_sized = false;
                     }
                 }
                 all_zero_sized
             }
             TypeInfo::Array(elem_ty, length) => {
-                length.val() == 0 || type_engine.get(elem_ty.type_id).is_zero_sized(type_engine)
+                length.val() == 0
+                    || type_engine
+                        .get(elem_ty.type_id)
+                        .is_zero_sized(type_engine, decl_engine)
             }
             _ => false,
         }
     }
 
-    pub fn can_safely_ignore(&self, type_engine: &TypeEngine) -> bool {
-        if self.is_zero_sized(type_engine) {
+    pub fn can_safely_ignore(&self, type_engine: &TypeEngine, decl_engine: &DeclEngine) -> bool {
+        if self.is_zero_sized(type_engine, decl_engine) {
             return true;
         }
         match self {
             TypeInfo::Tuple(fields) => fields.iter().all(|type_argument| {
                 type_engine
                     .get(type_argument.type_id)
-                    .can_safely_ignore(type_engine)
+                    .can_safely_ignore(type_engine, decl_engine)
             }),
             TypeInfo::Array(elem_ty, length) => {
                 length.val() == 0
                     || type_engine
                         .get(elem_ty.type_id)
-                        .can_safely_ignore(type_engine)
+                        .can_safely_ignore(type_engine, decl_engine)
             }
             TypeInfo::ErrorRecovery => true,
             TypeInfo::Unknown => true,
@@ -967,49 +927,47 @@ impl TypeInfo {
 
     /// Given a `TypeInfo` `self`, analyze `self` and return all inner
     /// `TypeId`'s of `self`, not including `self`.
-    pub(crate) fn extract_inner_types(&self, type_engine: &TypeEngine) -> HashSet<TypeId> {
+    pub(crate) fn extract_inner_types(
+        &self,
+        type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
+    ) -> HashSet<TypeId> {
         let helper = |type_id: TypeId| {
             let mut inner_types = HashSet::new();
             match type_engine.get(type_id) {
-                TypeInfo::Enum {
-                    type_parameters,
-                    variant_types,
-                    ..
-                } => {
+                TypeInfo::Enum(decl_ref) => {
+                    let decl = decl_engine.get_enum(&decl_ref);
                     inner_types.insert(type_id);
-                    for type_param in type_parameters.iter() {
+                    for type_param in decl.type_parameters.iter() {
                         inner_types.extend(
                             type_engine
                                 .get(type_param.type_id)
-                                .extract_inner_types(type_engine),
+                                .extract_inner_types(type_engine, decl_engine),
                         );
                     }
-                    for variant in variant_types.iter() {
+                    for variant in decl.variants.iter() {
                         inner_types.extend(
                             type_engine
                                 .get(variant.type_argument.type_id)
-                                .extract_inner_types(type_engine),
+                                .extract_inner_types(type_engine, decl_engine),
                         );
                     }
                 }
-                TypeInfo::Struct {
-                    type_parameters,
-                    fields,
-                    ..
-                } => {
+                TypeInfo::Struct(decl_ref) => {
+                    let decl = decl_engine.get_struct(&decl_ref);
                     inner_types.insert(type_id);
-                    for type_param in type_parameters.iter() {
+                    for type_param in decl.type_parameters.iter() {
                         inner_types.extend(
                             type_engine
                                 .get(type_param.type_id)
-                                .extract_inner_types(type_engine),
+                                .extract_inner_types(type_engine, decl_engine),
                         );
                     }
-                    for field in fields.iter() {
+                    for field in decl.fields.iter() {
                         inner_types.extend(
                             type_engine
                                 .get(field.type_argument.type_id)
-                                .extract_inner_types(type_engine),
+                                .extract_inner_types(type_engine, decl_engine),
                         );
                     }
                 }
@@ -1020,14 +978,18 @@ impl TypeInfo {
                             inner_types.extend(
                                 type_engine
                                     .get(type_arg.type_id)
-                                    .extract_inner_types(type_engine),
+                                    .extract_inner_types(type_engine, decl_engine),
                             );
                         }
                     }
                 }
                 TypeInfo::Array(elem_ty, _) => {
                     inner_types.insert(elem_ty.type_id);
-                    inner_types.extend(type_engine.get(type_id).extract_inner_types(type_engine));
+                    inner_types.extend(
+                        type_engine
+                            .get(type_id)
+                            .extract_inner_types(type_engine, decl_engine),
+                    );
                 }
                 TypeInfo::Tuple(elems) => {
                     inner_types.insert(type_id);
@@ -1035,7 +997,7 @@ impl TypeInfo {
                         inner_types.extend(
                             type_engine
                                 .get(elem.type_id)
-                                .extract_inner_types(type_engine),
+                                .extract_inner_types(type_engine, decl_engine),
                         );
                     }
                 }
@@ -1045,7 +1007,7 @@ impl TypeInfo {
                         inner_types.extend(
                             type_engine
                                 .get(field.type_argument.type_id)
-                                .extract_inner_types(type_engine),
+                                .extract_inner_types(type_engine, decl_engine),
                         );
                     }
                 }
@@ -1071,27 +1033,21 @@ impl TypeInfo {
 
         let mut inner_types = HashSet::new();
         match self {
-            TypeInfo::Enum {
-                type_parameters,
-                variant_types,
-                ..
-            } => {
-                for type_param in type_parameters.iter() {
+            TypeInfo::Enum(decl_ref) => {
+                let decl = decl_engine.get_enum(decl_ref);
+                for type_param in decl.type_parameters.iter() {
                     inner_types.extend(helper(type_param.type_id));
                 }
-                for variant in variant_types.iter() {
+                for variant in decl.variants.iter() {
                     inner_types.extend(helper(variant.type_argument.type_id));
                 }
             }
-            TypeInfo::Struct {
-                type_parameters,
-                fields,
-                ..
-            } => {
-                for type_param in type_parameters.iter() {
+            TypeInfo::Struct(decl_ref) => {
+                let decl = decl_engine.get_struct(decl_ref);
+                for type_param in decl.type_parameters.iter() {
                     inner_types.extend(helper(type_param.type_id));
                 }
-                for field in fields.iter() {
+                for field in decl.fields.iter() {
                     inner_types.extend(helper(field.type_argument.type_id));
                 }
             }
@@ -1216,34 +1172,34 @@ impl TypeInfo {
     /// `TypeInfo`'s found in `self`, including `self`.
     pub(crate) fn extract_nested_types(
         self,
-        type_engine: &TypeEngine,
+        engines: Engines<'_>,
         span: &Span,
     ) -> CompileResult<Vec<TypeInfo>> {
+        let type_engine = engines.te();
+        let decl_engine = engines.de();
+
         let mut warnings = vec![];
         let mut errors = vec![];
         let mut all_nested_types = vec![self.clone()];
         match self {
-            TypeInfo::Enum {
-                variant_types,
-                type_parameters,
-                ..
-            } => {
-                for type_parameter in type_parameters.iter() {
+            TypeInfo::Enum(decl_ref) => {
+                let decl = decl_engine.get_enum(&decl_ref);
+                for type_parameter in decl.type_parameters.iter() {
                     let mut nested_types = check!(
                         type_engine
                             .get(type_parameter.type_id)
-                            .extract_nested_types(type_engine, span),
+                            .extract_nested_types(engines, span),
                         return err(warnings, errors),
                         warnings,
                         errors
                     );
                     all_nested_types.append(&mut nested_types);
                 }
-                for variant_type in variant_types.iter() {
+                for variant_type in decl.variants.iter() {
                     let mut nested_types = check!(
                         type_engine
                             .get(variant_type.type_argument.type_id)
-                            .extract_nested_types(type_engine, span),
+                            .extract_nested_types(engines, span),
                         return err(warnings, errors),
                         warnings,
                         errors
@@ -1251,27 +1207,24 @@ impl TypeInfo {
                     all_nested_types.append(&mut nested_types);
                 }
             }
-            TypeInfo::Struct {
-                fields,
-                type_parameters,
-                ..
-            } => {
-                for type_parameter in type_parameters.iter() {
+            TypeInfo::Struct(decl_ref) => {
+                let decl = decl_engine.get_struct(&decl_ref);
+                for type_parameter in decl.type_parameters.iter() {
                     let mut nested_types = check!(
                         type_engine
                             .get(type_parameter.type_id)
-                            .extract_nested_types(type_engine, span),
+                            .extract_nested_types(engines, span),
                         return err(warnings, errors),
                         warnings,
                         errors
                     );
                     all_nested_types.append(&mut nested_types);
                 }
-                for field in fields.iter() {
+                for field in decl.fields.iter() {
                     let mut nested_types = check!(
                         type_engine
                             .get(field.type_argument.type_id)
-                            .extract_nested_types(type_engine, span),
+                            .extract_nested_types(engines, span),
                         return err(warnings, errors),
                         warnings,
                         errors
@@ -1284,7 +1237,7 @@ impl TypeInfo {
                     let mut nested_types = check!(
                         type_engine
                             .get(type_argument.type_id)
-                            .extract_nested_types(type_engine, span),
+                            .extract_nested_types(engines, span),
                         return err(warnings, errors),
                         warnings,
                         errors
@@ -1296,7 +1249,7 @@ impl TypeInfo {
                 let mut nested_types = check!(
                     type_engine
                         .get(elem_ty.type_id)
-                        .extract_nested_types(type_engine, span),
+                        .extract_nested_types(engines, span),
                     return err(warnings, errors),
                     warnings,
                     errors
@@ -1308,7 +1261,7 @@ impl TypeInfo {
                     let mut nested_types = check!(
                         type_engine
                             .get(field.type_argument.type_id)
-                            .extract_nested_types(type_engine, span),
+                            .extract_nested_types(engines, span),
                         return err(warnings, errors),
                         warnings,
                         errors
@@ -1324,7 +1277,7 @@ impl TypeInfo {
                         let mut nested_types = check!(
                             type_engine
                                 .get(type_arg.type_id)
-                                .extract_nested_types(type_engine, span),
+                                .extract_nested_types(engines, span),
                             return err(warnings, errors),
                             warnings,
                             errors
@@ -1367,7 +1320,7 @@ impl TypeInfo {
         let mut warnings = vec![];
         let mut errors = vec![];
         let nested_types = check!(
-            self.clone().extract_nested_types(engines.te(), span),
+            self.clone().extract_nested_types(engines, span),
             return err(warnings, errors),
             warnings,
             errors
@@ -1494,6 +1447,7 @@ impl TypeInfo {
 
     fn is_subset_inner(&self, other: &TypeInfo, engines: Engines<'_>) -> bool {
         let type_engine = engines.te();
+        let decl_engine = engines.de();
         match (self, other) {
             (Self::Array(l0, l1), Self::Array(r0, r1)) => {
                 type_engine
@@ -1525,61 +1479,57 @@ impl TypeInfo {
                     .collect::<Vec<_>>();
                 l_name.suffix == r_name.suffix && types_are_subset_of(engines, &l_types, &r_types)
             }
-            (
-                Self::Enum {
-                    call_path: l_name,
-                    variant_types: l_variant_types,
-                    type_parameters: l_type_parameters,
-                },
-                Self::Enum {
-                    call_path: r_name,
-                    variant_types: r_variant_types,
-                    type_parameters: r_type_parameters,
-                },
-            ) => {
-                let l_names = l_variant_types
+            (Self::Enum(l_decl_ref), Self::Enum(r_decl_ref)) => {
+                let l_decl = decl_engine.get_enum(l_decl_ref);
+                let r_decl = decl_engine.get_enum(r_decl_ref);
+                let l_names = l_decl
+                    .variants
                     .iter()
                     .map(|x| x.name.clone())
                     .collect::<Vec<_>>();
-                let r_names = r_variant_types
+                let r_names = r_decl
+                    .variants
                     .iter()
                     .map(|x| x.name.clone())
                     .collect::<Vec<_>>();
-                let l_types = l_type_parameters
+                let l_types = l_decl
+                    .type_parameters
                     .iter()
                     .map(|x| type_engine.get(x.type_id))
                     .collect::<Vec<_>>();
-                let r_types = r_type_parameters
+                let r_types = r_decl
+                    .type_parameters
                     .iter()
                     .map(|x| type_engine.get(x.type_id))
                     .collect::<Vec<_>>();
-                l_name == r_name
+                l_decl_ref.name == r_decl_ref.name
                     && l_names == r_names
                     && types_are_subset_of(engines, &l_types, &r_types)
             }
-            (
-                Self::Struct {
-                    call_path: l_name,
-                    fields: l_fields,
-                    type_parameters: l_type_parameters,
-                },
-                Self::Struct {
-                    call_path: r_name,
-                    fields: r_fields,
-                    type_parameters: r_type_parameters,
-                },
-            ) => {
-                let l_names = l_fields.iter().map(|x| x.name.clone()).collect::<Vec<_>>();
-                let r_names = r_fields.iter().map(|x| x.name.clone()).collect::<Vec<_>>();
-                let l_types = l_type_parameters
+            (Self::Struct(l_decl_ref), Self::Struct(r_decl_ref)) => {
+                let l_decl = decl_engine.get_struct(l_decl_ref);
+                let r_decl = decl_engine.get_struct(r_decl_ref);
+                let l_names = l_decl
+                    .fields
+                    .iter()
+                    .map(|x| x.name.clone())
+                    .collect::<Vec<_>>();
+                let r_names = r_decl
+                    .fields
+                    .iter()
+                    .map(|x| x.name.clone())
+                    .collect::<Vec<_>>();
+                let l_types = l_decl
+                    .type_parameters
                     .iter()
                     .map(|x| type_engine.get(x.type_id))
                     .collect::<Vec<_>>();
-                let r_types = r_type_parameters
+                let r_types = r_decl
+                    .type_parameters
                     .iter()
                     .map(|x| type_engine.get(x.type_id))
                     .collect::<Vec<_>>();
-                l_name == r_name
+                l_decl_ref.name == r_decl_ref.name
                     && l_names == r_names
                     && types_are_subset_of(engines, &l_types, &r_types)
             }
@@ -1618,26 +1568,27 @@ impl TypeInfo {
         let mut warnings = vec![];
         let mut errors = vec![];
         let type_engine = engines.te();
+        let decl_engine = engines.de();
         match (self, subfields.split_first()) {
             (TypeInfo::Struct { .. }, None) => err(warnings, errors),
-            (
-                TypeInfo::Struct {
-                    call_path, fields, ..
-                },
-                Some((first, rest)),
-            ) => {
-                let field = match fields
+            (TypeInfo::Struct(decl_ref), Some((first, rest))) => {
+                let decl = decl_engine.get_struct(decl_ref);
+                let field = match decl
+                    .fields
                     .iter()
                     .find(|field| field.name.as_str() == first.as_str())
                 {
                     Some(field) => field.clone(),
                     None => {
                         // gather available fields for the error message
-                        let available_fields =
-                            fields.iter().map(|x| x.name.as_str()).collect::<Vec<_>>();
+                        let available_fields = decl
+                            .fields
+                            .iter()
+                            .map(|x| x.name.as_str())
+                            .collect::<Vec<_>>();
                         errors.push(CompileError::FieldNotFound {
                             field_name: first.clone(),
-                            struct_name: call_path.suffix.clone(),
+                            struct_name: decl.call_path.suffix.clone(),
                             available_fields: available_fields.join(", "),
                             span: first.span(),
                         });
@@ -1672,16 +1623,18 @@ impl TypeInfo {
         }
     }
 
-    pub(crate) fn can_change(&self) -> bool {
+    pub(crate) fn can_change(&self, decl_engine: &DeclEngine) -> bool {
         // TODO: there might be an optimization here that if the type params hold
         // only non-dynamic types, then it doesn't matter that there are type params
         match self {
-            TypeInfo::Enum {
-                type_parameters, ..
-            } => !type_parameters.is_empty(),
-            TypeInfo::Struct {
-                type_parameters, ..
-            } => !type_parameters.is_empty(),
+            TypeInfo::Enum(decl_ref) => {
+                let decl = decl_engine.get_enum(decl_ref);
+                !decl.type_parameters.is_empty()
+            }
+            TypeInfo::Struct(decl_ref) => {
+                let decl = decl_engine.get_struct(decl_ref);
+                !decl.type_parameters.is_empty()
+            }
             TypeInfo::Str(_)
             | TypeInfo::UnsignedInteger(_)
             | TypeInfo::Boolean
@@ -1704,10 +1657,13 @@ impl TypeInfo {
     }
 
     /// Checks if a given [TypeInfo] has a valid constructor.
-    pub(crate) fn has_valid_constructor(&self) -> bool {
+    pub(crate) fn has_valid_constructor(&self, decl_engine: &DeclEngine) -> bool {
         match self {
             TypeInfo::Unknown => false,
-            TypeInfo::Enum { variant_types, .. } => !variant_types.is_empty(),
+            TypeInfo::Enum(decl_ref) => {
+                let decl = decl_engine.get_enum(decl_ref);
+                !decl.variants.is_empty()
+            }
             _ => true,
         }
     }
@@ -1747,15 +1703,11 @@ impl TypeInfo {
         engines: Engines<'_>,
         debug_string: impl Into<String>,
         debug_span: &Span,
-    ) -> CompileResult<(&Ident, &Vec<ty::TyEnumVariant>)> {
+    ) -> CompileResult<DeclRefEnum> {
         let warnings = vec![];
         let errors = vec![];
         match self {
-            TypeInfo::Enum {
-                call_path,
-                variant_types,
-                ..
-            } => ok((&call_path.suffix, variant_types), warnings, errors),
+            TypeInfo::Enum(decl_ref) => ok(decl_ref.clone(), warnings, errors),
             TypeInfo::ErrorRecovery => err(warnings, errors),
             a => err(
                 vec![],
@@ -1777,13 +1729,11 @@ impl TypeInfo {
         &self,
         engines: Engines<'_>,
         debug_span: &Span,
-    ) -> CompileResult<(&Ident, &Vec<ty::TyStructField>)> {
+    ) -> CompileResult<DeclRefStruct> {
         let warnings = vec![];
         let errors = vec![];
         match self {
-            TypeInfo::Struct {
-                call_path, fields, ..
-            } => ok((&call_path.suffix, fields), warnings, errors),
+            TypeInfo::Struct(decl_ref) => ok(decl_ref.clone(), warnings, errors),
             TypeInfo::ErrorRecovery => err(warnings, errors),
             a => err(
                 vec![],

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -31,6 +31,10 @@ pub use type_parameter::*;
 pub(crate) use unconstrained_type_parameters::*;
 
 use crate::error::*;
+#[cfg(test)]
+use crate::{
+    decl_engine::DeclEngineIndex, language::ty::TyEnumDeclaration, transform::AttributesMap,
+};
 use std::fmt::Debug;
 
 #[cfg(test)]
@@ -88,14 +92,16 @@ fn generic_enum_resolution() {
         span: sp.clone(),
         attributes: transform::AttributesMap::default(),
     }];
-    let ty_1 = type_engine.insert(
-        &decl_engine,
-        TypeInfo::Enum {
-            call_path: result_name.clone().into(),
-            variant_types,
-            type_parameters: vec![placeholder_type_param],
-        },
-    );
+
+    let decl_ref_1 = decl_engine.insert(TyEnumDeclaration {
+        call_path: result_name.clone().into(),
+        type_parameters: vec![placeholder_type_param],
+        variants: variant_types,
+        span: sp.clone(),
+        visibility: crate::language::Visibility::Public,
+        attributes: AttributesMap::default(),
+    });
+    let ty_1 = type_engine.insert(&decl_engine, TypeInfo::Enum(decl_ref_1));
 
     /*
     Result<bool> {
@@ -122,26 +128,23 @@ fn generic_enum_resolution() {
         trait_constraints: vec![],
         trait_constraints_span: sp.clone(),
     };
-    let ty_2 = type_engine.insert(
-        &decl_engine,
-        TypeInfo::Enum {
-            call_path: result_name.into(),
-            variant_types,
-            type_parameters: vec![type_param],
-        },
-    );
+    let decl_ref_2 = decl_engine.insert(TyEnumDeclaration {
+        call_path: result_name.into(),
+        type_parameters: vec![type_param],
+        variants: variant_types.clone(),
+        span: sp.clone(),
+        visibility: crate::language::Visibility::Public,
+        attributes: AttributesMap::default(),
+    });
+    let ty_2 = type_engine.insert(&decl_engine, TypeInfo::Enum(decl_ref_2));
 
     // Unify them together...
     let (_, errors) = type_engine.unify(&decl_engine, ty_1, ty_2, &sp, "", None);
     assert!(errors.is_empty());
 
-    if let TypeInfo::Enum {
-        call_path: name,
-        variant_types,
-        ..
-    } = type_engine.get(ty_1)
-    {
-        assert_eq!(name.suffix.as_str(), "Result");
+    if let TypeInfo::Enum(decl_ref_1) = type_engine.get(ty_1) {
+        let decl = decl_engine.get_enum(&decl_ref_1);
+        assert_eq!(decl.call_path.suffix.as_str(), "Result");
         assert!(matches!(
             type_engine.get(variant_types[0].type_argument.type_id),
             TypeInfo::Boolean

--- a/sway-core/src/type_system/substitute.rs
+++ b/sway-core/src/type_system/substitute.rs
@@ -1,7 +1,10 @@
 use std::{collections::BTreeMap, fmt};
 
 use super::*;
-use crate::engine_threading::*;
+use crate::{
+    decl_engine::{DeclEngine, DeclEngineIndex},
+    engine_threading::*,
+};
 
 pub trait SubstTypes {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>);
@@ -133,6 +136,7 @@ impl TypeSubstMap {
     /// they can be used for `subset`.
     pub(crate) fn from_superset_and_subset(
         type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
         superset: TypeId,
         subset: TypeId,
     ) -> TypeSubstMap {
@@ -159,46 +163,48 @@ impl TypeSubstMap {
                     .collect::<Vec<_>>();
                 TypeSubstMap::from_superset_and_subset_helper(
                     type_engine,
+                    decl_engine,
                     type_parameters,
                     type_arguments,
                 )
             }
-            (
-                TypeInfo::Enum {
-                    type_parameters, ..
-                },
-                TypeInfo::Enum {
-                    type_parameters: type_arguments,
-                    ..
-                },
-            ) => {
-                let type_parameters = type_parameters
+            (TypeInfo::Enum(decl_ref_params), TypeInfo::Enum(decl_ref_args)) => {
+                let decl_params = decl_engine.get_enum(&decl_ref_params);
+                let decl_args = decl_engine.get_enum(&decl_ref_args);
+                let type_parameters = decl_params
+                    .type_parameters
                     .iter()
                     .map(|x| x.type_id)
                     .collect::<Vec<_>>();
-                let type_arguments = type_arguments.iter().map(|x| x.type_id).collect::<Vec<_>>();
+                let type_arguments = decl_args
+                    .type_parameters
+                    .iter()
+                    .map(|x| x.type_id)
+                    .collect::<Vec<_>>();
                 TypeSubstMap::from_superset_and_subset_helper(
                     type_engine,
+                    decl_engine,
                     type_parameters,
                     type_arguments,
                 )
             }
-            (
-                TypeInfo::Struct {
-                    type_parameters, ..
-                },
-                TypeInfo::Struct {
-                    type_parameters: type_arguments,
-                    ..
-                },
-            ) => {
-                let type_parameters = type_parameters
+            (TypeInfo::Struct(decl_ref_params), TypeInfo::Struct(decl_ref_args)) => {
+                let decl_params = decl_engine.get_struct(&decl_ref_params);
+                let decl_args = decl_engine.get_struct(&decl_ref_args);
+
+                let type_parameters = decl_params
+                    .type_parameters
                     .iter()
                     .map(|x| x.type_id)
                     .collect::<Vec<_>>();
-                let type_arguments = type_arguments.iter().map(|x| x.type_id).collect::<Vec<_>>();
+                let type_arguments = decl_args
+                    .type_parameters
+                    .iter()
+                    .map(|x| x.type_id)
+                    .collect::<Vec<_>>();
                 TypeSubstMap::from_superset_and_subset_helper(
                     type_engine,
+                    decl_engine,
                     type_parameters,
                     type_arguments,
                 )
@@ -206,6 +212,7 @@ impl TypeSubstMap {
             (TypeInfo::Tuple(type_parameters), TypeInfo::Tuple(type_arguments)) => {
                 TypeSubstMap::from_superset_and_subset_helper(
                     type_engine,
+                    decl_engine,
                     type_parameters
                         .iter()
                         .map(|x| x.type_id)
@@ -216,6 +223,7 @@ impl TypeSubstMap {
             (TypeInfo::Array(type_parameter, _), TypeInfo::Array(type_argument, _)) => {
                 TypeSubstMap::from_superset_and_subset_helper(
                     type_engine,
+                    decl_engine,
                     vec![type_parameter.type_id],
                     vec![type_argument.type_id],
                 )
@@ -238,6 +246,7 @@ impl TypeSubstMap {
                     .collect::<Vec<_>>();
                 TypeSubstMap::from_superset_and_subset_helper(
                     type_engine,
+                    decl_engine,
                     type_parameters,
                     type_arguments,
                 )
@@ -266,6 +275,7 @@ impl TypeSubstMap {
     /// with each [SourceType]s and [DestinationType]s in the original [TypeSubstMap].
     fn from_superset_and_subset_helper(
         type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
         type_parameters: Vec<SourceType>,
         type_arguments: Vec<DestinationType>,
     ) -> TypeSubstMap {
@@ -274,7 +284,7 @@ impl TypeSubstMap {
 
         for (s, d) in type_mapping.mapping.clone().iter() {
             type_mapping.mapping.extend(
-                TypeSubstMap::from_superset_and_subset(type_engine, *s, *d)
+                TypeSubstMap::from_superset_and_subset(type_engine, decl_engine, *s, *d)
                     .mapping
                     .iter(),
             );
@@ -322,83 +332,48 @@ impl TypeSubstMap {
             TypeInfo::Custom { .. } => iter_for_match(engines, self, &type_info),
             TypeInfo::UnknownGeneric { .. } => iter_for_match(engines, self, &type_info),
             TypeInfo::Placeholder(_) => iter_for_match(engines, self, &type_info),
-            TypeInfo::Struct {
-                fields,
-                call_path,
-                type_parameters,
-            } => {
+            TypeInfo::Struct(decl_ref) => {
+                let mut decl = decl_engine.get_struct(&decl_ref);
                 let mut need_to_create_new = false;
-                let fields = fields
-                    .into_iter()
-                    .map(|mut field| {
-                        if let Some(type_id) = self.find_match(field.type_argument.type_id, engines)
-                        {
-                            need_to_create_new = true;
-                            field.type_argument.type_id = type_id;
-                        }
-                        field
-                    })
-                    .collect::<Vec<_>>();
-                let type_parameters = type_parameters
-                    .into_iter()
-                    .map(|mut type_param| {
-                        if let Some(type_id) = self.find_match(type_param.type_id, engines) {
-                            need_to_create_new = true;
-                            type_param.type_id = type_id;
-                        }
-                        type_param
-                    })
-                    .collect::<Vec<_>>();
+                for field in decl.fields.iter_mut() {
+                    if let Some(type_id) = self.find_match(field.type_argument.type_id, engines) {
+                        need_to_create_new = true;
+                        field.type_argument.type_id = type_id;
+                    }
+                }
+                for type_param in decl.type_parameters.iter_mut() {
+                    if let Some(type_id) = self.find_match(type_param.type_id, engines) {
+                        need_to_create_new = true;
+                        type_param.type_id = type_id;
+                    }
+                }
                 if need_to_create_new {
-                    Some(type_engine.insert(
-                        decl_engine,
-                        TypeInfo::Struct {
-                            fields,
-                            call_path,
-                            type_parameters,
-                        },
-                    ))
+                    let new_decl_ref = decl_engine.insert(decl);
+                    Some(type_engine.insert(decl_engine, TypeInfo::Struct(new_decl_ref)))
                 } else {
                     None
                 }
             }
-            TypeInfo::Enum {
-                variant_types,
-                call_path,
-                type_parameters,
-            } => {
+            TypeInfo::Enum(decl_ref) => {
+                let mut decl = decl_engine.get_enum(&decl_ref);
                 let mut need_to_create_new = false;
-                let variant_types = variant_types
-                    .into_iter()
-                    .map(|mut variant| {
-                        if let Some(type_id) =
-                            self.find_match(variant.type_argument.type_id, engines)
-                        {
-                            need_to_create_new = true;
-                            variant.type_argument.type_id = type_id;
-                        }
-                        variant
-                    })
-                    .collect::<Vec<_>>();
-                let type_parameters = type_parameters
-                    .into_iter()
-                    .map(|mut type_param| {
-                        if let Some(type_id) = self.find_match(type_param.type_id, engines) {
-                            need_to_create_new = true;
-                            type_param.type_id = type_id;
-                        }
-                        type_param
-                    })
-                    .collect::<Vec<_>>();
+
+                for variant in decl.variants.iter_mut() {
+                    if let Some(type_id) = self.find_match(variant.type_argument.type_id, engines) {
+                        need_to_create_new = true;
+                        variant.type_argument.type_id = type_id;
+                    }
+                }
+
+                for type_param in decl.type_parameters.iter_mut() {
+                    if let Some(type_id) = self.find_match(type_param.type_id, engines) {
+                        need_to_create_new = true;
+                        type_param.type_id = type_id;
+                    }
+                }
                 if need_to_create_new {
-                    Some(type_engine.insert(
-                        decl_engine,
-                        TypeInfo::Enum {
-                            variant_types,
-                            type_parameters,
-                            call_path,
-                        },
-                    ))
+                    let new_decl_ref = decl_engine.insert(decl);
+                    Some(type_engine.insert(decl_engine, TypeInfo::Enum(new_decl_ref)))
                 } else {
                     None
                 }

--- a/sway-core/src/type_system/trait_constraint.rs
+++ b/sway-core/src/type_system/trait_constraint.rs
@@ -37,7 +37,7 @@ impl PartialEqWithEngines for TraitConstraint {
 }
 
 impl OrdWithEngines for TraitConstraint {
-    fn cmp(&self, other: &Self, type_engine: &TypeEngine) -> Ordering {
+    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
         let TraitConstraint {
             trait_name: ltn,
             type_arguments: lta,
@@ -46,7 +46,7 @@ impl OrdWithEngines for TraitConstraint {
             trait_name: rtn,
             type_arguments: rta,
         } = other;
-        ltn.cmp(rtn).then_with(|| lta.cmp(rta, type_engine))
+        ltn.cmp(rtn).then_with(|| lta.cmp(rta, engines))
     }
 }
 

--- a/sway-core/src/type_system/type_argument.rs
+++ b/sway-core/src/type_system/type_argument.rs
@@ -53,7 +53,7 @@ impl PartialEqWithEngines for TypeArgument {
 }
 
 impl OrdWithEngines for TypeArgument {
-    fn cmp(&self, other: &Self, type_engine: &TypeEngine) -> Ordering {
+    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
         let TypeArgument {
             type_id: lti,
             // these fields are not compared because they aren't relevant/a
@@ -70,9 +70,7 @@ impl OrdWithEngines for TypeArgument {
             span: _,
             call_path_tree: _,
         } = other;
-        type_engine
-            .get(*lti)
-            .cmp(&type_engine.get(*rti), type_engine)
+        engines.te().get(*lti).cmp(&engines.te().get(*rti), engines)
     }
 }
 

--- a/sway-core/src/type_system/type_parameter.rs
+++ b/sway-core/src/type_system/type_parameter.rs
@@ -57,7 +57,7 @@ impl PartialEqWithEngines for TypeParameter {
 }
 
 impl OrdWithEngines for TypeParameter {
-    fn cmp(&self, other: &Self, type_engine: &TypeEngine) -> Ordering {
+    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
         let TypeParameter {
             type_id: lti,
             name_ident: ln,
@@ -77,12 +77,8 @@ impl OrdWithEngines for TypeParameter {
             initial_type_id: _,
         } = other;
         ln.cmp(rn)
-            .then_with(|| {
-                type_engine
-                    .get(*lti)
-                    .cmp(&type_engine.get(*rti), type_engine)
-            })
-            .then_with(|| ltc.cmp(rtc, type_engine))
+            .then_with(|| engines.te().get(*lti).cmp(&engines.te().get(*rti), engines))
+            .then_with(|| ltc.cmp(rtc, engines))
     }
 }
 

--- a/sway-core/src/type_system/unify_check.rs
+++ b/sway-core/src/type_system/unify_check.rs
@@ -1,4 +1,5 @@
 use crate::{engine_threading::*, type_system::*};
+use sway_types::Spanned;
 
 /// Helper struct to aid in type coercion.
 pub(super) struct UnifyCheck<'a> {
@@ -170,67 +171,64 @@ impl<'a> UnifyCheck<'a> {
                 l_name.suffix == r_name.suffix && self.check_multiple(&l_types, &r_types)
             }
             // Let empty enums to coerce to any other type. This is useful for Never enum.
-            (
-                Enum {
-                    variant_types: rvs, ..
-                },
-                _,
-            ) if rvs.is_empty() => true,
-            (
-                Enum {
-                    call_path: l_name,
-                    variant_types: l_variant_types,
-                    type_parameters: l_type_parameters,
-                },
-                Enum {
-                    call_path: r_name,
-                    variant_types: r_variant_types,
-                    type_parameters: r_type_parameters,
-                },
-            ) => {
-                let l_names = l_variant_types
+            (Enum(r_decl_ref), _)
+                if self.engines.de().get_enum(&r_decl_ref).variants.is_empty() =>
+            {
+                true
+            }
+            (Enum(l_decl_ref), Enum(r_decl_ref)) => {
+                let l_decl = self.engines.de().get_enum(&l_decl_ref);
+                let r_decl = self.engines.de().get_enum(&r_decl_ref);
+                let l_names = l_decl
+                    .variants
                     .iter()
                     .map(|x| x.name.clone())
                     .collect::<Vec<_>>();
-                let r_names = r_variant_types
+                let r_names = r_decl
+                    .variants
                     .iter()
                     .map(|x| x.name.clone())
                     .collect::<Vec<_>>();
-                let l_types = l_type_parameters
+                let l_types = l_decl
+                    .type_parameters
                     .iter()
                     .map(|x| x.type_id)
                     .collect::<Vec<_>>();
-                let r_types = r_type_parameters
+                let r_types = r_decl
+                    .type_parameters
                     .iter()
                     .map(|x| x.type_id)
                     .collect::<Vec<_>>();
-                l_name.suffix == r_name.suffix
+                l_decl.call_path.suffix == r_decl.call_path.suffix
+                    && l_decl.call_path.suffix.span() == r_decl.call_path.suffix.span()
                     && l_names == r_names
                     && self.check_multiple(&l_types, &r_types)
             }
-            (
-                Struct {
-                    call_path: l_name,
-                    fields: l_fields,
-                    type_parameters: l_type_parameters,
-                },
-                Struct {
-                    call_path: r_name,
-                    fields: r_fields,
-                    type_parameters: r_type_parameters,
-                },
-            ) => {
-                let l_names = l_fields.iter().map(|x| x.name.clone()).collect::<Vec<_>>();
-                let r_names = r_fields.iter().map(|x| x.name.clone()).collect::<Vec<_>>();
-                let l_types = l_type_parameters
+            (Struct(l_decl_ref), Struct(r_decl_ref)) => {
+                let l_decl = self.engines.de().get_struct(&l_decl_ref);
+                let r_decl = self.engines.de().get_struct(&r_decl_ref);
+                let l_names = l_decl
+                    .fields
+                    .iter()
+                    .map(|x| x.name.clone())
+                    .collect::<Vec<_>>();
+                let r_names = r_decl
+                    .fields
+                    .iter()
+                    .map(|x| x.name.clone())
+                    .collect::<Vec<_>>();
+                let l_types = l_decl
+                    .type_parameters
                     .iter()
                     .map(|x| x.type_id)
                     .collect::<Vec<_>>();
-                let r_types = r_type_parameters
+                let r_types = r_decl
+                    .type_parameters
                     .iter()
                     .map(|x| x.type_id)
                     .collect::<Vec<_>>();
-                l_name.suffix == r_name.suffix
+                l_decl.call_path.suffix == r_decl.call_path.suffix
+                    && l_decl.call_path.suffix.span() == r_decl.call_path.suffix.span()
                     && l_names == r_names
                     && self.check_multiple(&l_types, &r_types)
             }

--- a/sway-lsp/src/capabilities/code_actions/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/mod.rs
@@ -53,9 +53,7 @@ pub(crate) fn code_actions(
     token.typed.and_then(|typed_token| match typed_token {
         TypedAstToken::TypedDeclaration(decl) => match decl {
             TyDeclaration::AbiDeclaration { decl_id, .. } => abi_decl::code_actions(&decl_id, ctx),
-            TyDeclaration::StructDeclaration { decl_id, .. } => {
-                struct_decl::code_actions(&decl_id, ctx)
-            }
+            TyDeclaration::StructDeclaration(decl_ref) => struct_decl::code_actions(&decl_ref, ctx),
             _ => None,
         },
         _ => None,

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/mod.rs
@@ -3,14 +3,14 @@ pub(crate) mod struct_new;
 
 use self::{struct_impl::StructImplCodeAction, struct_new::StructNewCodeAction};
 use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
-use sway_core::{decl_engine::id::DeclId, language::ty::TyStructDeclaration};
+use sway_core::decl_engine::DeclRefStruct;
 use tower_lsp::lsp_types::CodeActionOrCommand;
 
 pub(crate) fn code_actions(
-    decl_id: &DeclId<TyStructDeclaration>,
+    decl_ref: &DeclRefStruct,
     ctx: CodeActionContext,
 ) -> Option<Vec<CodeActionOrCommand>> {
-    let decl = ctx.engines.de().get_struct(decl_id);
+    let decl = ctx.engines.de().get_struct(decl_ref);
     Some(vec![
         StructImplCodeAction::new(ctx.clone(), &decl).code_action(),
         StructNewCodeAction::new(ctx, &decl).code_action(),

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
@@ -20,7 +20,7 @@ impl<'a> CodeAction<'a, TyStructDeclaration> for StructNewCodeAction<'a> {
         // First, find the first impl block for this struct if it exists.
         let existing_impl_decl = ctx
             .tokens
-            .all_references_of_token(ctx.token, ctx.engines.te())
+            .all_references_of_token(ctx.token, ctx.engines.te(), ctx.engines.de())
             .find_map(|(_, token)| {
                 if let Some(TypedAstToken::TypedDeclaration(TyDeclaration::ImplTrait {
                     decl_id,

--- a/sway-lsp/src/capabilities/hover.rs
+++ b/sway-lsp/src/capabilities/hover.rs
@@ -39,7 +39,9 @@ pub fn hover_data(
         });
     }
 
-    let (decl_ident, decl_token) = match token.declared_token_ident(&session.type_engine.read()) {
+    let (decl_ident, decl_token) = match token
+        .declared_token_ident(&session.type_engine.read(), &session.decl_engine.read())
+    {
         Some(decl_ident) => {
             let decl_token = session
                 .token_map()
@@ -139,8 +141,8 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
                         &token_name,
                     ))
                 }
-                ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
-                    let struct_decl = decl_engine.get_struct(decl_id);
+                ty::TyDeclaration::StructDeclaration(decl_ref) => {
+                    let struct_decl = decl_engine.get_struct(decl_ref);
                     Some(format_visibility_hover(
                         struct_decl.visibility,
                         decl.friendly_type_name(),
@@ -155,8 +157,8 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
                         &token_name,
                     ))
                 }
-                ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
-                    let enum_decl = decl_engine.get_enum(decl_id);
+                ty::TyDeclaration::EnumDeclaration(decl_ref) => {
+                    let enum_decl = decl_engine.get_enum(decl_ref);
                     Some(format_visibility_hover(
                         enum_decl.visibility,
                         decl.friendly_type_name(),

--- a/sway-lsp/src/capabilities/rename.rs
+++ b/sway-lsp/src/capabilities/rename.rs
@@ -14,10 +14,11 @@ pub fn rename(
     let mut edits = Vec::new();
 
     // todo: currently only supports single file rename
-    for (ident, _) in session
-        .token_map()
-        .all_references_of_token(&token, &session.type_engine.read())
-    {
+    for (ident, _) in session.token_map().all_references_of_token(
+        &token,
+        &session.type_engine.read(),
+        &session.decl_engine.read(),
+    ) {
         let range = get_range_from_span(&ident.span());
         edits.push(TextEdit::new(range, new_name.clone()));
     }

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -215,7 +215,7 @@ impl Session {
         let (_, token) = self.token_map.token_at_position(url, position)?;
         let token_ranges = self
             .token_map
-            .all_references_of_token(&token, &self.type_engine.read())
+            .all_references_of_token(&token, &self.type_engine.read(), &self.decl_engine.read())
             .map(|(ident, _)| get_range_from_span(&ident.span()))
             .collect();
 
@@ -229,7 +229,9 @@ impl Session {
     ) -> Option<GotoDefinitionResponse> {
         self.token_map
             .token_at_position(&uri, position)
-            .and_then(|(_, token)| token.declared_token_ident(&self.type_engine.read()))
+            .and_then(|(_, token)| {
+                token.declared_token_ident(&self.type_engine.read(), &self.decl_engine.read())
+            })
             .and_then(|decl_ident| {
                 let range = get_range_from_span(&decl_ident.span());
                 decl_ident.span().path().and_then(|path| {

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -1,5 +1,6 @@
 use sway_ast::Intrinsic;
 use sway_core::{
+    decl_engine::DeclEngine,
     language::{
         parsed::{
             ConstantDeclaration, Declaration, EnumVariant, Expression, FunctionDeclaration,
@@ -129,9 +130,13 @@ impl Token {
     }
 
     /// Return the [Ident] of the declaration of the provided token.
-    pub fn declared_token_ident(&self, type_engine: &TypeEngine) -> Option<Ident> {
+    pub fn declared_token_ident(
+        &self,
+        type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
+    ) -> Option<Ident> {
         self.type_def.as_ref().and_then(|type_def| match type_def {
-            TypeDefinition::TypeId(type_id) => ident_of_type_id(type_engine, type_id),
+            TypeDefinition::TypeId(type_id) => ident_of_type_id(type_engine, decl_engine, type_id),
             TypeDefinition::Ident(ident) => Some(ident.clone()),
         })
     }
@@ -139,9 +144,15 @@ impl Token {
     /// Return the [Span] of the declaration of the provided token. This is useful for
     /// performaing == comparisons on spans. We need to do this instead of comparing
     /// the [Ident] because the [PartialEq] implementation is only comparing the name.
-    pub fn declared_token_span(&self, type_engine: &TypeEngine) -> Option<Span> {
+    pub fn declared_token_span(
+        &self,
+        type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
+    ) -> Option<Span> {
         self.type_def.as_ref().and_then(|type_def| match type_def {
-            TypeDefinition::TypeId(type_id) => Some(ident_of_type_id(type_engine, type_id)?.span()),
+            TypeDefinition::TypeId(type_id) => {
+                Some(ident_of_type_id(type_engine, decl_engine, type_id)?.span())
+            }
             TypeDefinition::Ident(ident) => Some(ident.span()),
         })
     }
@@ -164,12 +175,16 @@ pub fn to_ident_key(ident: &Ident) -> (Ident, Span) {
 }
 
 /// Use the [TypeId] to look up the associated [TypeInfo] and return the [Ident] if one is found.
-pub fn ident_of_type_id(type_engine: &TypeEngine, type_id: &TypeId) -> Option<Ident> {
+pub fn ident_of_type_id(
+    type_engine: &TypeEngine,
+    decl_engine: &DeclEngine,
+    type_id: &TypeId,
+) -> Option<Ident> {
     match type_engine.get(*type_id) {
         TypeInfo::UnknownGeneric { name, .. } => Some(name),
-        TypeInfo::Enum { call_path, .. }
-        | TypeInfo::Struct { call_path, .. }
-        | TypeInfo::Custom { call_path, .. } => Some(call_path.suffix),
+        TypeInfo::Enum(decl_ref) => Some(decl_engine.get_enum(&decl_ref).call_path.suffix),
+        TypeInfo::Struct(decl_ref) => Some(decl_engine.get_struct(&decl_ref).call_path.suffix),
+        TypeInfo::Custom { call_path, .. } => Some(call_path.suffix),
         _ => None,
     }
 }

--- a/sway-lsp/src/core/token_map.rs
+++ b/sway-lsp/src/core/token_map.rs
@@ -1,6 +1,6 @@
 use crate::core::token::{self, Token, TypedAstToken};
 use dashmap::DashMap;
-use sway_core::{language::ty, type_system::TypeId, Engines, TypeEngine};
+use sway_core::{decl_engine::DeclEngine, language::ty, type_system::TypeId, Engines, TypeEngine};
 use sway_types::{Ident, Span, Spanned};
 use tower_lsp::lsp_types::{Position, Url};
 
@@ -41,13 +41,14 @@ impl TokenMap {
         &'s self,
         token: &Token,
         type_engine: &'s TypeEngine,
+        decl_engine: &'s DeclEngine,
     ) -> impl 's + Iterator<Item = (Ident, Token)> {
-        let current_type_id = token.declared_token_span(type_engine);
+        let current_type_id = token.declared_token_span(type_engine, decl_engine);
 
         self.iter()
             .filter(move |item| {
                 let ((_, _), token) = item.pair();
-                current_type_id == token.declared_token_span(type_engine)
+                current_type_id == token.declared_token_span(type_engine, decl_engine)
             })
             .map(|item| {
                 let ((ident, _), token) = item.pair();
@@ -90,9 +91,10 @@ impl TokenMap {
     pub fn declaration_of_type_id(
         &self,
         type_engine: &TypeEngine,
+        decl_engine: &DeclEngine,
         type_id: &TypeId,
     ) -> Option<ty::TyDeclaration> {
-        token::ident_of_type_id(type_engine, type_id)
+        token::ident_of_type_id(type_engine, decl_engine, type_id)
             .and_then(|decl_ident| self.try_get(&token::to_ident_key(&decl_ident)).try_unwrap())
             .map(|item| item.value().clone())
             .and_then(|token| token.typed)
@@ -111,10 +113,10 @@ impl TokenMap {
     ) -> Option<ty::TyStructDeclaration> {
         let type_engine = engines.te();
         let decl_engine = engines.de();
-        self.declaration_of_type_id(type_engine, type_id)
+        self.declaration_of_type_id(type_engine, decl_engine, type_id)
             .and_then(|decl| match decl {
-                ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
-                    Some(decl_engine.get_struct(&decl_id))
+                ty::TyDeclaration::StructDeclaration(decl_ref) => {
+                    Some(decl_engine.get_struct(&decl_ref))
                 }
                 _ => None,
             })

--- a/sway-lsp/src/traverse/dependency.rs
+++ b/sway-lsp/src/traverse/dependency.rs
@@ -46,11 +46,11 @@ impl<'a> Dependency<'a> {
 
             let ident = match declaration {
                 ty::TyDeclaration::VariableDeclaration(variable) => variable.name.clone(),
-                ty::TyDeclaration::StructDeclaration { name, .. }
-                | ty::TyDeclaration::TraitDeclaration { name, .. }
+                ty::TyDeclaration::StructDeclaration(decl_ref) => decl_ref.name.clone(),
+                ty::TyDeclaration::EnumDeclaration(decl_ref) => decl_ref.name.clone(),
+                ty::TyDeclaration::TraitDeclaration { name, .. }
                 | ty::TyDeclaration::FunctionDeclaration { name, .. }
-                | ty::TyDeclaration::ConstantDeclaration { name, .. }
-                | ty::TyDeclaration::EnumDeclaration { name, .. } => name.clone(),
+                | ty::TyDeclaration::ConstantDeclaration { name, .. } => name.clone(),
                 _ => return,
             };
             let ident = token::to_ident_key(&ident);

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -138,8 +138,8 @@ impl<'a> TypedTree<'a> {
                     self.collect_supertrait(&supertrait);
                 }
             }
-            ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
-                let struct_decl = decl_engine.get_struct(decl_id);
+            ty::TyDeclaration::StructDeclaration(decl_ref) => {
+                let struct_decl = decl_engine.get_struct(decl_ref);
                 if let Some(mut token) = self
                     .tokens
                     .try_get_mut(&to_ident_key(&struct_decl.call_path.suffix))
@@ -164,8 +164,8 @@ impl<'a> TypedTree<'a> {
                     }
                 }
             }
-            ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
-                let enum_decl = decl_engine.get_enum(decl_id);
+            ty::TyDeclaration::EnumDeclaration(decl_ref) => {
+                let enum_decl = decl_engine.get_enum(decl_ref);
                 if let Some(mut token) = self
                     .tokens
                     .try_get_mut(&to_ident_key(&enum_decl.call_path.suffix))
@@ -1024,6 +1024,7 @@ impl<'a> TypedTree<'a> {
 
     fn collect_call_path_tree(&self, tree: &CallPathTree, type_arg: &TypeArgument) {
         let type_engine = self.engines.te();
+        let decl_engine = self.engines.de();
         let type_info = type_engine.get(type_arg.type_id);
 
         self.collect_call_path_prefixes(&tree.call_path.prefixes);
@@ -1034,13 +1035,16 @@ impl<'a> TypedTree<'a> {
         );
 
         match &type_info {
-            TypeInfo::Enum {
-                type_parameters, ..
+            TypeInfo::Enum(decl_ref) => {
+                let decl = decl_engine.get_enum(decl_ref);
+                let child_type_args = decl.type_parameters.iter().map(TypeArgument::from);
+                for (child_tree, type_arg) in tree.children.iter().zip(child_type_args) {
+                    self.collect_call_path_tree(child_tree, &type_arg);
+                }
             }
-            | TypeInfo::Struct {
-                type_parameters, ..
-            } => {
-                let child_type_args = type_parameters.iter().map(TypeArgument::from);
+            TypeInfo::Struct(decl_ref) => {
+                let decl = decl_engine.get_struct(decl_ref);
+                let child_type_args = decl.type_parameters.iter().map(TypeArgument::from);
                 for (child_tree, type_arg) in tree.children.iter().zip(child_type_args) {
                     self.collect_call_path_tree(child_tree, &type_arg);
                 }
@@ -1083,6 +1087,7 @@ impl<'a> TypedTree<'a> {
 
     fn collect_type_id(&self, type_id: TypeId, typed_token: &TypedAstToken, type_span: Span) {
         let type_engine = self.engines.te();
+        let decl_engine = self.engines.de();
         let type_info = type_engine.get(type_id);
         let symbol_kind = type_info_to_symbol_kind(type_engine, &type_info);
         match &type_info {
@@ -1094,11 +1099,8 @@ impl<'a> TypedTree<'a> {
                     self.collect_type_argument(type_arg);
                 }
             }
-            TypeInfo::Enum {
-                type_parameters,
-                variant_types,
-                ..
-            } => {
+            TypeInfo::Enum(decl_ref) => {
+                let decl = decl_engine.get_enum(decl_ref);
                 if let Some(token) = self
                     .tokens
                     .try_get_mut(&to_ident_key(&Ident::new(type_span)))
@@ -1107,7 +1109,7 @@ impl<'a> TypedTree<'a> {
                     assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
                 }
 
-                for param in type_parameters {
+                for param in decl.type_parameters {
                     self.collect_type_id(
                         param.type_id,
                         &TypedAstToken::TypedParameter(param.clone()),
@@ -1115,15 +1117,12 @@ impl<'a> TypedTree<'a> {
                     );
                 }
 
-                for variant in variant_types {
+                for variant in &decl.variants {
                     self.collect_ty_enum_variant(variant);
                 }
             }
-            TypeInfo::Struct {
-                type_parameters,
-                fields,
-                ..
-            } => {
+            TypeInfo::Struct(decl_ref) => {
+                let decl = decl_engine.get_struct(decl_ref);
                 if let Some(token) = self
                     .tokens
                     .try_get_mut(&to_ident_key(&Ident::new(type_span)))
@@ -1132,7 +1131,7 @@ impl<'a> TypedTree<'a> {
                     assign_type_to_token(token, symbol_kind, typed_token.clone(), type_id);
                 }
 
-                for param in type_parameters {
+                for param in decl.type_parameters {
                     self.collect_type_id(
                         param.type_id,
                         &TypedAstToken::TypedParameter(param.clone()),
@@ -1140,8 +1139,8 @@ impl<'a> TypedTree<'a> {
                     );
                 }
 
-                for field in fields {
-                    self.collect_ty_struct_field(field);
+                for field in decl.fields {
+                    self.collect_ty_struct_field(&field);
                 }
             }
             TypeInfo::Custom {

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -81,12 +81,12 @@ pub(crate) fn print_decl_engine_types(
                     let trait_decl = decl_engine.get_trait(decl_id);
                     format!("{trait_decl:#?}")
                 }
-                ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
-                    let struct_decl = decl_engine.get_struct(decl_id);
+                ty::TyDeclaration::StructDeclaration(decl_ref) => {
+                    let struct_decl = decl_engine.get_struct(decl_ref);
                     format!("{struct_decl:#?}")
                 }
-                ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
-                    let enum_decl = decl_engine.get_enum(decl_id);
+                ty::TyDeclaration::EnumDeclaration(decl_ref) => {
+                    let enum_decl = decl_engine.get_enum(decl_ref);
                     format!("{enum_decl:#?}")
                 }
                 ty::TyDeclaration::AbiDeclaration { decl_id, .. } => {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/return_struct/json_abi_oracle.json
@@ -61,7 +61,7 @@
     },
     {
       "components": [],
-      "type": "struct data_structures::MyStruct",
+      "type": "struct interface::data_structures::MyStruct",
       "typeId": 3,
       "typeParameters": null
     }


### PR DESCRIPTION
## Description

Use references and the decl engine to resolve information about structs and enums instead of copying around declaration data.

This should facilitate #3744

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
