### PR TITLE
Implement usize type, using u32 for miden

### DIFF
--- a/sway-ast/src/literal.rs
+++ b/sway-ast/src/literal.rs
@@ -29,6 +29,7 @@ pub enum LitIntType {
     I16,
     I32,
     I64,
+    Usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]

--- a/sway-core/src/abi_generation/evm_json_abi.rs
+++ b/sway-core/src/abi_generation/evm_json_abi.rs
@@ -80,6 +80,7 @@ pub fn json_abi_str(type_info: &TypeInfo, type_engine: &TypeEngine) -> String {
             IntegerBits::Sixteen => "uint16",
             IntegerBits::ThirtyTwo => "uint32",
             IntegerBits::SixtyFour => "uint64",
+            IntegerBits::Usize => todo!(),
         }
         .into(),
         Boolean => "bool".into(),
@@ -127,6 +128,7 @@ pub fn json_abi_param_type(type_info: &TypeInfo, type_engine: &TypeEngine) -> et
             IntegerBits::Sixteen => ethabi::ParamType::Uint(16),
             IntegerBits::ThirtyTwo => ethabi::ParamType::Uint(32),
             IntegerBits::SixtyFour => ethabi::ParamType::Uint(64),
+            IntegerBits::Usize => ethabi::ParamType::Uint(256),
         },
         Boolean => ethabi::ParamType::Bool,
         B256 => ethabi::ParamType::Uint(256),

--- a/sway-core/src/abi_generation/fuel_json_abi.rs
+++ b/sway-core/src/abi_generation/fuel_json_abi.rs
@@ -631,6 +631,8 @@ impl TypeInfo {
                 IntegerBits::Sixteen => "u16",
                 IntegerBits::ThirtyTwo => "u32",
                 IntegerBits::SixtyFour => "u64",
+                // Usize is u64 for fuel
+                IntegerBits::Usize => "u64",
             }
             .into(),
             Boolean => "bool".into(),

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -299,7 +299,12 @@ pub fn parsed_to_ast(
         value: typed_program_opt,
         mut warnings,
         mut errors,
-    } = ty::TyProgram::type_check(engines, parse_program, initial_namespace);
+    } = ty::TyProgram::type_check(
+        engines,
+        parse_program,
+        initial_namespace,
+        build_config.map(|x| x.build_target).unwrap_or_default(),
+    );
     let mut typed_program = match typed_program_opt {
         Some(typed_program) => typed_program,
         None => return err(warnings, errors),

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -838,6 +838,7 @@ fn type_info_name(type_info: &TypeInfo) -> String {
             IntegerBits::Sixteen => "uint16",
             IntegerBits::ThirtyTwo => "uint32",
             IntegerBits::SixtyFour => "uint64",
+            IntegerBits::Usize => "usize",
         },
         TypeInfo::Boolean => "bool",
         TypeInfo::Custom {

--- a/sway-core/src/semantic_analysis/program.rs
+++ b/sway-core/src/semantic_analysis/program.rs
@@ -6,7 +6,7 @@ use crate::{
         namespace::{self, Namespace},
         TypeCheckContext,
     },
-    Engines,
+    BuildTarget, Engines,
 };
 use sway_ir::{Context, Module};
 
@@ -19,10 +19,11 @@ impl ty::TyProgram {
         engines: Engines<'_>,
         parsed: &ParseProgram,
         initial_namespace: namespace::Module,
+        build_target: BuildTarget,
     ) -> CompileResult<Self> {
         let mut namespace = Namespace::init_root(initial_namespace);
-        let ctx =
-            TypeCheckContext::from_root(&mut namespace, engines).with_kind(parsed.kind.clone());
+        let ctx = TypeCheckContext::from_root(&mut namespace, engines, build_target)
+            .with_kind(parsed.kind.clone());
         let ParseProgram { root, kind } = parsed;
         let mod_span = root.tree.span.clone();
         let mod_res = ty::TyModule::type_check(ctx, root);

--- a/sway-core/src/transform/to_parsed_lang/context.rs
+++ b/sway-core/src/transform/to_parsed_lang/context.rs
@@ -1,3 +1,5 @@
+use crate::BuildTarget;
+
 #[derive(Default)]
 pub struct Context {
     /// Indicates whether the module being parsed has a `configurable` block
@@ -11,6 +13,9 @@ pub struct Context {
 
     /// Unique suffix used to generate unique names for vars returned from `match` expressions
     match_expression_return_var_unique_suffix: usize,
+
+    /// The build target for this compilation.
+    target: BuildTarget,
 }
 
 impl Context {
@@ -41,5 +46,9 @@ impl Context {
     pub fn next_match_expression_return_var_unique_suffix(&mut self) -> usize {
         self.match_expression_return_var_unique_suffix += 1;
         self.match_expression_return_var_unique_suffix
+    }
+
+    pub fn target(&self) -> BuildTarget {
+        self.target
     }
 }

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -426,6 +426,7 @@ impl DisplayWithEngines for TypeInfo {
                 IntegerBits::Sixteen => "u16",
                 IntegerBits::ThirtyTwo => "u32",
                 IntegerBits::SixtyFour => "u64",
+                IntegerBits::Usize => "usize",
             }
             .into(),
             Boolean => "bool".into(),
@@ -639,6 +640,7 @@ impl TypeInfo {
                     Sixteen => "u16",
                     ThirtyTwo => "u32",
                     SixtyFour => "u64",
+                    Usize => "usize",
                 }
                 .into()
             }

--- a/sway-lib-core/src/ops.sw
+++ b/sway-lib-core/src/ops.sw
@@ -6,6 +6,12 @@ pub trait Add {
     fn add(self, other: Self) -> Self;
 }
 
+impl Add for usize {
+    fn add(self, other: Self) -> Self {
+        __add(self, other)
+    }
+}
+
 impl Add for u64 {
     fn add(self, other: Self) -> Self {
         __add(self, other)
@@ -32,6 +38,12 @@ impl Add for u8 {
 
 pub trait Subtract {
     fn subtract(self, other: Self) -> Self;
+}
+
+impl Subtract for usize {
+    fn subtract(self, other: Self) -> Self {
+        __sub(self, other)
+    }
 }
 
 impl Subtract for u64 {
@@ -62,6 +74,12 @@ pub trait Multiply {
     fn multiply(self, other: Self) -> Self;
 }
 
+impl Multiply for usize {
+    fn multiply(self, other: Self) -> Self {
+        __mul(self, other)
+    }
+}
+
 impl Multiply for u64 {
     fn multiply(self, other: Self) -> Self {
         __mul(self, other)
@@ -90,6 +108,12 @@ pub trait Divide {
     fn divide(self, other: Self) -> Self;
 }
 
+impl Divide for usize {
+    fn divide(self, other: Self) -> Self {
+        __div(self, other)
+    }
+}
+
 impl Divide for u64 {
     fn divide(self, other: Self) -> Self {
         __div(self, other)
@@ -116,6 +140,15 @@ impl Divide for u8 {
 
 pub trait Mod {
     fn modulo(self, other: Self) -> Self;
+}
+
+impl Mod for usize {
+    fn modulo(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            mod r3 r1 r2;
+            r3: u64
+        }
+    }
 }
 
 impl Mod for u64 {
@@ -178,6 +211,12 @@ impl Eq for bool {
     }
 }
 
+impl Eq for usize {
+    fn eq(self, other: Self) -> bool {
+        __eq(self, other)
+    }
+}
+
 impl Eq for u64 {
     fn eq(self, other: Self) -> bool {
         __eq(self, other)
@@ -222,6 +261,21 @@ impl Eq for raw_ptr {
 pub trait Ord {
     fn gt(self, other: Self) -> bool;
     fn lt(self, other: Self) -> bool;
+}
+
+impl Ord for usize {
+    fn gt(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3) {
+            gt r3 r1 r2;
+            r3: bool
+        }
+    }
+    fn lt(self, other: Self) -> bool {
+        asm(r1: self, r2: other, r3) {
+            lt r3 r1 r2;
+            r3: bool
+        }
+    }
 }
 
 impl Ord for u64 {
@@ -324,6 +378,15 @@ pub trait BitwiseAnd {
     fn binary_and(self, other: Self) -> Self;
 }
 
+impl BitwiseAnd for usize {
+    fn binary_and(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            and r3 r1 r2;
+            r3: u64
+        }
+    }
+}
+
 impl BitwiseAnd for u64 {
     fn binary_and(self, other: Self) -> Self {
         asm(r1: self, r2: other, r3) {
@@ -362,6 +425,15 @@ impl BitwiseAnd for u8 {
 
 pub trait BitwiseOr {
     fn binary_or(self, other: Self) -> Self;
+}
+
+impl BitwiseOr for usize {
+    fn binary_or(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            or r3 r1 r2;
+            r3: u64
+        }
+    }
 }
 
 impl BitwiseOr for u64 {
@@ -404,6 +476,15 @@ pub trait BitwiseXor {
     fn binary_xor(self, other: Self) -> Self;
 }
 
+impl BitwiseXor for usize {
+    fn binary_xor(self, other: Self) -> Self {
+        asm(r1: self, r2: other, r3) {
+            xor r3 r1 r2;
+            r3: u64
+        }
+    }
+}
+
 impl BitwiseXor for u64 {
     fn binary_xor(self, other: Self) -> Self {
         asm(r1: self, r2: other, r3) {
@@ -436,6 +517,15 @@ impl BitwiseXor for u8 {
         asm(r1: self, r2: other, r3) {
             xor r3 r1 r2;
             r3: u8
+        }
+    }
+}
+
+impl Not for usize {
+    fn not(self) -> Self {
+        asm(r1: self, r2) {
+            not r2 r1;
+            r2: u64
         }
     }
 }
@@ -527,6 +617,8 @@ trait OrdEq: Ord + Eq {
     }
 }
 
+impl OrdEq for usize {
+}
 impl OrdEq for u64 {
 }
 impl OrdEq for u32 {
@@ -541,6 +633,21 @@ impl OrdEq for b256 {
 pub trait Shift {
     fn lsh(self, other: u64) -> Self;
     fn rsh(self, other: u64) -> Self;
+}
+
+impl Shift for usize {
+    fn lsh(self, other: u64) -> Self {
+        asm(r1: self, r2: other, r3) {
+            sll r3 r1 r2;
+            r3: u64
+        }
+    }
+    fn rsh(self, other: u64) -> Self {
+        asm(r1: self, r2: other, r3) {
+            srl r3 r1 r2;
+            r3: u64
+        }
+    }
 }
 
 impl Shift for u64 {

--- a/sway-parse/src/token.rs
+++ b/sway-parse/src/token.rs
@@ -724,6 +724,7 @@ fn parse_int_suffix(suffix: &str) -> Option<LitIntType> {
         "u16" => LitIntType::U16,
         "u32" => LitIntType::U32,
         "u64" => LitIntType::U64,
+        "usize" => LitIntType::Usize,
         "i8" => LitIntType::I8,
         "i16" => LitIntType::I16,
         "i32" => LitIntType::I32,

--- a/sway-types/src/integer_bits.rs
+++ b/sway-types/src/integer_bits.rs
@@ -6,6 +6,7 @@ pub enum IntegerBits {
     Sixteen,
     ThirtyTwo,
     SixtyFour,
+    Usize,
 }
 
 impl fmt::Display for IntegerBits {
@@ -16,6 +17,7 @@ impl fmt::Display for IntegerBits {
             Sixteen => "sixteen",
             ThirtyTwo => "thirty two",
             SixtyFour => "sixty four",
+            Usize => "usize",
         };
         write!(f, "{s}")
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/usize_type/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/usize_type/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-79182115A7B30E62'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-79182115A7B30E62'
+dependencies = ['core']
+
+[[package]]
+name = 'usize_type'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/usize_type/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/usize_type/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "usize_type"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/usize_type/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/usize_type/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/usize_type/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/usize_type/src/main.sw
@@ -1,0 +1,8 @@
+script;
+
+fn main() -> usize {
+    let x: usize = 5;
+    let y = 6usize;
+    let z = x + y;
+    z
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/usize_type/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/usize_type/test.toml
@@ -1,0 +1,4 @@
+category = "run"
+expected_result = { action = "return", value = 11 }
+validate_abi = true
+expected_warnings = 0


### PR DESCRIPTION
## Description

This PR adds a `usize` type that is a `u64` for the Fuel VM, a `u32` for the Miden VM, and panics for the EVM (😄 -- sorry. Not sure if I can just make it 256 bits without rewiring some other parts of the compiler to use a bigint, and I felt that was out of the scope of what I was doing).

I don't see an issue for a `usize` type but it was mentioned to me as needing to be done. 

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
