### PR TITLE
Update the invalid link to Developer Quickstart Guide in the Sway Docs.

### DIFF
--- a/docs/book/src/introduction/sway_quickstart.md
+++ b/docs/book/src/introduction/sway_quickstart.md
@@ -2,7 +2,7 @@
 
 Follow this guide to write and deploy a simple smart contract in Sway.
 
-Check out the [Developer Quickstart Guide](https://fuellabs.github.io/fuel-docs/master/developer-quickstart.html) for a step-by-step guide on building a fullstack dapp on Fuel. The guide will walk you through writing a smart contract, setting up a wallet, and building a frontend to interact with your contract.
+Check out the [Developer Quickstart Guide](https://fuelbook.fuel.network/master/quickstart/developer-quickstart.html) for a step-by-step guide on building a fullstack dapp on Fuel. The guide will walk you through writing a smart contract, setting up a wallet, and building a frontend to interact with your contract.
 
 ## Glossary
 


### PR DESCRIPTION
## Description
Remove the invalid link to Developer Quickstart Guide in the official Sway docs and replace it with the valid one.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
