### PR TITLE
ci: check for `fuels` deps in `forc-pkg`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,8 +314,8 @@ jobs:
           deps=$(cargo deps --manifest-path forc-pkg/Cargo.toml)
 
           case "$deps" in
-            *fuel*)
-              echo "\nFound dependency on a 'fuels' crate.
+            *fuels*)
+              echo -e "\nFound dependency on a 'fuels' crate.
           To avoid cyclic dependencies between 'fuels' and 'forc-pkg',
           we want to avoid using 'fuels' crates in 'forc-pkg' since 'fuels-rs' depends on 'forc-pkg' for its integration tests.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,42 @@ jobs:
       - name: Run Unit Tests
         run: forc build --path sway-lib-core && forc test --path sway-lib-core && forc build --path sway-lib-std && forc test --path sway-lib-std
 
+  forc-pkg-fuels-deps-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-deps
+        run: cargo install cargo-deps
+
+      # We require this check to avoid cyclic dependencies between 'fuels' and 'forc-pkg'.
+      # Detailed explanation is found in the echo below.
+      - name: Check 'forc-pkg' dependencies for 'fuels' crates
+        run: |
+          deps=$(cargo deps --manifest-path forc-pkg/Cargo.toml)
+
+          case "$deps" in
+            *fuel*)
+              echo "\nFound dependency on a 'fuels' crate.
+          To avoid cyclic dependencies between 'fuels' and 'forc-pkg',
+          we want to avoid using 'fuels' crates in 'forc-pkg' since 'fuels-rs' depends on 'forc-pkg' for its integration tests.
+
+          To fix this, please remove any 'fuels' dependency from forc-pkg/Cargo.toml.
+
+          Detailed explanation here: https://github.com/FuelLabs/fuels-rs/issues/752#issuecomment-1386242106"
+              exit 1
+              ;;
+            *)
+              exit 0
+              ;;
+          esac
+
+ 
   cargo-test-workspace:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

closes #3447

Failed the first commit deliberately just to [demonstrate the failure case](https://github.com/FuelLabs/sway/actions/runs/4341593516/jobs/7581384965) (there's a mistyped newline in that job, fixed in the following commit), added a little message just to explain why we may not want `fuels` deps in `forc-pkg` - let me know if it is adequately explained!

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
