### PR TITLE
fix(forc-fmt): propagate error on failure

### DIFF
--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -67,6 +67,7 @@ fn run() -> Result<()> {
 
         if is_sway_file(file_path) {
             format_file(&app, file_path.to_path_buf(), manifest_file, &mut formatter)?;
+
             return Ok(());
         }
 
@@ -205,9 +206,7 @@ fn format_workspace_at_dir(app: &App, workspace: &WorkspaceManifestFile, dir: &P
     let manifest_file = dir.join(constants::MANIFEST_FILE_NAME);
 
     // Finally, format the root manifest using taplo formatter
-    if let Ok(edited) = format_manifest(app, manifest_file) {
-        contains_edits |= edited;
-    }
+    contains_edits |= format_manifest(app, manifest_file)?;
 
     if app.check && contains_edits {
         // One or more files are not formatted, exit with error
@@ -262,14 +261,11 @@ fn format_pkg_at_dir(app: &App, dir: &Path, formatter: &mut Formatter) -> Result
             let mut contains_edits = false;
 
             for file in files {
-                if let Ok(edited) = format_file(app, file, Some(manifest_file.clone()), formatter) {
-                    contains_edits |= edited;
-                };
+                let fmted = format_file(app, file, Some(manifest_file.clone()), formatter)?;
+                contains_edits |= fmted;
             }
             // format manifest using taplo formatter
-            if let Ok(edited) = format_manifest(app, manifest_file) {
-                contains_edits |= edited;
-            }
+            contains_edits |= format_manifest(app, manifest_file)?;
 
             if app.check && contains_edits {
                 // One or more files are not formatted, exit with error

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -67,7 +67,6 @@ fn run() -> Result<()> {
 
         if is_sway_file(file_path) {
             format_file(&app, file_path.to_path_buf(), manifest_file, &mut formatter)?;
-
             return Ok(());
         }
 
@@ -261,8 +260,7 @@ fn format_pkg_at_dir(app: &App, dir: &Path, formatter: &mut Formatter) -> Result
             let mut contains_edits = false;
 
             for file in files {
-                let fmted = format_file(app, file, Some(manifest_file.clone()), formatter)?;
-                contains_edits |= fmted;
+                contains_edits |= format_file(app, file, Some(manifest_file.clone()), formatter)?;
             }
             // format manifest using taplo formatter
             contains_edits |= format_manifest(app, manifest_file)?;


### PR DESCRIPTION
## Description

closes #4163

In a previous refactor PR that I submitted the error propagation was accidentally suppressed, causing the formatter to not exit with 1 on error.


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
