### PR TITLE
Remove re-borrow of `Engines`, which is a `Copy` type.

### DIFF
--- a/sway-core/src/engine_threading.rs
+++ b/sway-core/src/engine_threading.rs
@@ -92,7 +92,7 @@ where
     T: PartialEqWithEngines,
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.thing.cmp(&other.thing, &self.engines))
+        Some(self.thing.cmp(&other.thing, self.engines))
     }
 }
 
@@ -101,7 +101,7 @@ where
     T: EqWithEngines,
 {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.thing.cmp(&other.thing, &self.engines)
+        self.thing.cmp(&other.thing, self.engines)
     }
 }
 
@@ -159,7 +159,7 @@ pub trait PartialEqWithEngines {
 }
 
 pub trait OrdWithEngines {
-    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering;
+    fn cmp(&self, other: &Self, engines: Engines<'_>) -> Ordering;
 }
 
 impl<T: EqWithEngines + ?Sized> EqWithEngines for &T {}
@@ -169,13 +169,13 @@ impl<T: PartialEqWithEngines + ?Sized> PartialEqWithEngines for &T {
     }
 }
 impl<T: OrdWithEngines + ?Sized> OrdWithEngines for &T {
-    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
+    fn cmp(&self, other: &Self, engines: Engines<'_>) -> Ordering {
         (*self).cmp(*other, engines)
     }
 }
 
 impl<T: OrdWithEngines> OrdWithEngines for Option<T> {
-    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
+    fn cmp(&self, other: &Self, engines: Engines<'_>) -> Ordering {
         match (self, other) {
             (Some(x), Some(y)) => x.cmp(y, engines),
             (Some(_), None) => Ordering::Less,
@@ -203,7 +203,7 @@ impl<T: PartialEqWithEngines> PartialEqWithEngines for [T] {
     }
 }
 impl<T: OrdWithEngines> OrdWithEngines for [T] {
-    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
+    fn cmp(&self, other: &Self, engines: Engines<'_>) -> Ordering {
         self.iter()
             .zip(other.iter())
             .map(|(x, y)| x.cmp(y, engines))

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -149,7 +149,7 @@ impl PartialEqWithEngines for TyEnumVariant {
 }
 
 impl OrdWithEngines for TyEnumVariant {
-    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
+    fn cmp(&self, other: &Self, engines: Engines<'_>) -> Ordering {
         let TyEnumVariant {
             name: ln,
             type_argument: lta,

--- a/sway-core/src/language/ty/declaration/struct.rs
+++ b/sway-core/src/language/ty/declaration/struct.rs
@@ -156,7 +156,7 @@ impl PartialEqWithEngines for TyStructField {
 }
 
 impl OrdWithEngines for TyStructField {
-    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
+    fn cmp(&self, other: &Self, engines: Engines<'_>) -> Ordering {
         let TyStructField {
             name: ln,
             type_argument: lta,

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -29,7 +29,7 @@ impl PartialEqWithEngines for TraitSuffix {
     }
 }
 impl OrdWithEngines for TraitSuffix {
-    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self, engines: Engines<'_>) -> std::cmp::Ordering {
         self.name
             .cmp(&other.name)
             .then_with(|| self.args.cmp(&other.args, engines))
@@ -44,7 +44,7 @@ impl<T: PartialEqWithEngines> PartialEqWithEngines for CallPath<T> {
     }
 }
 impl<T: OrdWithEngines> OrdWithEngines for CallPath<T> {
-    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
+    fn cmp(&self, other: &Self, engines: Engines<'_>) -> Ordering {
         self.prefixes
             .cmp(&other.prefixes)
             .then_with(|| self.suffix.cmp(&other.suffix, engines))
@@ -61,7 +61,7 @@ struct TraitKey {
 }
 
 impl OrdWithEngines for TraitKey {
-    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self, engines: Engines<'_>) -> std::cmp::Ordering {
         self.name
             .cmp(&other.name, engines)
             .then_with(|| self.type_id.cmp(&other.type_id))
@@ -346,7 +346,7 @@ impl TraitMap {
         for oe in other.trait_impls.into_iter() {
             let pos = self
                 .trait_impls
-                .binary_search_by(|se| se.key.cmp(&oe.key, &engines));
+                .binary_search_by(|se| se.key.cmp(&oe.key, engines));
 
             match pos {
                 Ok(pos) => self.trait_impls[pos].value.extend(oe.value.into_iter()),

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -285,7 +285,7 @@ impl PartialEqWithEngines for TypeInfo {
 }
 
 impl OrdWithEngines for TypeInfo {
-    fn cmp(&self, other: &Self, engines: &Engines) -> Ordering {
+    fn cmp(&self, other: &Self, engines: Engines<'_>) -> Ordering {
         let type_engine = engines.te();
         let decl_engine = engines.de();
         match (self, other) {

--- a/sway-core/src/type_system/trait_constraint.rs
+++ b/sway-core/src/type_system/trait_constraint.rs
@@ -37,7 +37,7 @@ impl PartialEqWithEngines for TraitConstraint {
 }
 
 impl OrdWithEngines for TraitConstraint {
-    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
+    fn cmp(&self, other: &Self, engines: Engines<'_>) -> Ordering {
         let TraitConstraint {
             trait_name: ltn,
             type_arguments: lta,

--- a/sway-core/src/type_system/type_argument.rs
+++ b/sway-core/src/type_system/type_argument.rs
@@ -53,7 +53,7 @@ impl PartialEqWithEngines for TypeArgument {
 }
 
 impl OrdWithEngines for TypeArgument {
-    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
+    fn cmp(&self, other: &Self, engines: Engines<'_>) -> Ordering {
         let TypeArgument {
             type_id: lti,
             // these fields are not compared because they aren't relevant/a

--- a/sway-core/src/type_system/type_parameter.rs
+++ b/sway-core/src/type_system/type_parameter.rs
@@ -57,7 +57,7 @@ impl PartialEqWithEngines for TypeParameter {
 }
 
 impl OrdWithEngines for TypeParameter {
-    fn cmp(&self, other: &Self, engines: &Engines<'_>) -> Ordering {
+    fn cmp(&self, other: &Self, engines: Engines<'_>) -> Ordering {
         let TypeParameter {
             type_id: lti,
             name_ident: ln,


### PR DESCRIPTION
## Description

Simple refactor to remove re-borrows of `Engines`, which is a `Copy` type.

## Checklist

~~- [ ] I have linked to any relevant issues.~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas.~~
~~- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
