### PR TITLE
Improves `forc build --dca-graph`.

### DIFF
--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -604,7 +604,7 @@ fn perform_control_flow_analysis(
     };
     if let Some(graph) = dca_res.clone().value {
         if print_graph {
-            graph.visualize();
+            graph.visualize(engines);
         }
     }
     dca_res.flat_map(|_| rpa_res)


### PR DESCRIPTION
## Description

This commit changes graph.visualize to print nodes using DisplayWithEngines.

Before the changes using `forc build --dca-graph` in a simple example gives:
```
digraph {
    0 [ label = "Program exit" ]
    1 [ label = "TyAstNode { content: Declaration(StructDeclaration(DeclRef { name: BaseIdent { name_override_opt: None, span: Span { src (ptr): 0x562355d3d3d0, path: Some(\"/home/marcos/Documents/dev/sway/test/src/e2e_vm_tests/test_programs/should_pass/dca/unused_struct/src/main.sw\"), start: 16, end: 17, as_str(): \"S\" }, is_raw_ident: false }, id: DeclId(0, PhantomData<sway_core::language::ty::declaration::struct::TyStructDeclaration>), decl_span: Span { src (ptr): 0x562355d3d3d0, path: Some(\"/home/marcos/Documents/dev/sway/test/src/e2e_vm_tests/test_programs/should_pass/dca/unused_struct/src/main.sw\"), start: 9, end: 20, as_str(): \"struct S {}\" } })), span: Span { src (ptr): 0x562355d3d3d0, path: Some(\"/home/marcos/Documents/dev/sway/test/src/e2e_vm_tests/test_programs/should_pass/dca/unused_struct/src/main.sw\"), start: 9, end: 20, as_str(): \"struct S {}\" } }" ]
    2 [ label = "TyAstNode { content: Declaration(FunctionDeclaration { name: BaseIdent { name_override_opt: None, span: Span { src (ptr): 0x562355d3d3d0, path: Some(\"/home/marcos/Documents/dev/sway/test/src/e2e_vm_tests/test_programs/should_pass/dca/unused_struct/src/main.sw\"), start: 25, end: 29, as_str(): \"main\" }, is_raw_ident: false }, decl_id: DeclId(0, PhantomData<sway_core::language::ty::declaration::function::TyFunctionDeclaration>), decl_span: Span { src (ptr): 0x562355d3d3d0, path: Some(\"/home/marcos/Documents/dev/sway/test/src/e2e_vm_tests/test_programs/should_pass/dca/unused_struct/src/main.sw\"), start: 22, end: 34, as_str(): \"fn main() {}\" } }), span: Span { src (ptr): 0x562355d3d3d0, path: Some(\"/home/marcos/Documents/dev/sway/test/src/e2e_vm_tests/test_programs/should_pass/dca/unused_struct/src/main.sw\"), start: 22, end: 34, as_str(): \"fn main() {}\" } }" ]
    3 [ label = "\"main\" fn exit" ]
    3 -> 0 [ ]
}
```

After the changes we get:
```
digraph {
    0 [ label = "\"Program exit\"" ]
    1 [ label = "\"struct declaration (S)\"" ]
    2 [ label = "\"function declaration (main)\"" ]
    3 [ label = "\"\\\"main\\\" fn exit\"" ]
    3 -> 0 [ ]
}
```




## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
