### PR TITLE
Use `DeclId` directly for `TyDeclaration::StructDeclaration` and `TyDeclaration::EnumDeclaration`.

### DIFF
--- a/forc-plugins/forc-doc/src/descriptor.rs
+++ b/forc-plugins/forc-doc/src/descriptor.rs
@@ -39,8 +39,8 @@ impl Descriptor {
         use swayfmt::parse;
         use TyDeclaration::*;
         match ty_decl {
-            StructDeclaration(decl_ref) => {
-                let struct_decl = decl_engine.get_struct(decl_ref);
+            StructDeclaration { decl_id, .. } => {
+                let struct_decl = decl_engine.get_struct(decl_id);
                 if !document_private_items && struct_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
                 } else {
@@ -75,8 +75,8 @@ impl Descriptor {
                     }))
                 }
             }
-            EnumDeclaration(decl_ref) => {
-                let enum_decl = decl_engine.get_enum(decl_ref);
+            EnumDeclaration { decl_id, .. } => {
+                let enum_decl = decl_engine.get_enum(decl_id);
                 if !document_private_items && enum_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
                 } else {

--- a/forc-plugins/forc-doc/src/render.rs
+++ b/forc-plugins/forc-doc/src/render.rs
@@ -1158,8 +1158,8 @@ impl BlockTitle {
 impl DocBlockTitle for TyDeclaration {
     fn as_block_title(&self) -> BlockTitle {
         match self {
-            TyDeclaration::StructDeclaration(_) => BlockTitle::Structs,
-            TyDeclaration::EnumDeclaration(_) => BlockTitle::Enums,
+            TyDeclaration::StructDeclaration { .. } => BlockTitle::Structs,
+            TyDeclaration::EnumDeclaration { .. } => BlockTitle::Enums,
             TyDeclaration::TraitDeclaration { .. } => BlockTitle::Traits,
             TyDeclaration::AbiDeclaration { .. } => BlockTitle::Abi,
             TyDeclaration::StorageDeclaration { .. } => BlockTitle::ContractStorage,

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -387,14 +387,14 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             connect_abi_declaration(engines, &abi_decl, graph, entry_node)?;
             Ok(leaves.to_vec())
         }
-        StructDeclaration(decl_ref) => {
-            let struct_decl = decl_engine.get_struct(decl_ref);
-            connect_struct_declaration(&struct_decl, decl_ref.id, graph, entry_node, tree_type);
+        StructDeclaration { decl_id, .. } => {
+            let struct_decl = decl_engine.get_struct(decl_id);
+            connect_struct_declaration(&struct_decl, *decl_id, graph, entry_node, tree_type);
             Ok(leaves.to_vec())
         }
-        EnumDeclaration(decl_ref) => {
-            let enum_decl = decl_engine.get_enum(decl_ref);
-            connect_enum_declaration(&enum_decl, decl_ref.id, graph, entry_node);
+        EnumDeclaration { decl_id, .. } => {
+            let enum_decl = decl_engine.get_enum(decl_id);
+            connect_enum_declaration(&enum_decl, *decl_id, graph, entry_node);
             Ok(leaves.to_vec())
         }
         ImplTrait { decl_id, .. } => {
@@ -830,8 +830,8 @@ fn get_trait_fn_node_index<'a>(
                     .namespace
                     .find_trait_method(&trait_decl.name.into(), &fn_decl.name))
             }
-            ty::TyDeclaration::StructDeclaration(decl_ref) => {
-                let struct_decl = decl_engine.get_struct(&decl_ref);
+            ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
+                let struct_decl = decl_engine.get_struct(&decl_id);
                 Ok(graph
                     .namespace
                     .find_trait_method(&struct_decl.call_path.suffix.into(), &fn_decl.name))
@@ -1687,17 +1687,18 @@ fn construct_dead_code_warning_from_node(
         },
         ty::TyAstNode {
             content:
-                ty::TyAstNodeContent::Declaration(ty::TyDeclaration::StructDeclaration(decl_ref)),
+                ty::TyAstNodeContent::Declaration(ty::TyDeclaration::StructDeclaration { name, .. }),
             ..
         } => CompileWarning {
-            span: decl_ref.name.span(),
+            span: name.span(),
             warning_content: Warning::DeadStructDeclaration,
         },
         ty::TyAstNode {
-            content: ty::TyAstNodeContent::Declaration(ty::TyDeclaration::EnumDeclaration(decl_ref)),
+            content:
+                ty::TyAstNodeContent::Declaration(ty::TyDeclaration::EnumDeclaration { name, .. }),
             ..
         } => CompileWarning {
-            span: decl_ref.name.span(),
+            span: name.span(),
             warning_content: Warning::DeadEnumDeclaration,
         },
         ty::TyAstNode {
@@ -1834,11 +1835,11 @@ fn allow_dead_code_ast_node(decl_engine: &DeclEngine, node: &ty::TyAstNode) -> b
             ty::TyDeclaration::TraitDeclaration { decl_id, .. } => {
                 allow_dead_code(decl_engine.get_trait(decl_id).attributes)
             }
-            ty::TyDeclaration::StructDeclaration(decl_ref) => {
-                allow_dead_code(decl_engine.get_struct(decl_ref).attributes)
+            ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
+                allow_dead_code(decl_engine.get_struct(decl_id).attributes)
             }
-            ty::TyDeclaration::EnumDeclaration(decl_ref) => {
-                allow_dead_code(decl_engine.get_enum(decl_ref).attributes)
+            ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
+                allow_dead_code(decl_engine.get_enum(decl_id).attributes)
             }
             ty::TyDeclaration::ImplTrait { .. } => false,
             ty::TyDeclaration::AbiDeclaration { .. } => false,

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -162,8 +162,8 @@ impl<'eng> FnCompiler<'eng> {
                         span: ast_node.span.clone(),
                     })
                 }
-                ty::TyDeclaration::EnumDeclaration(decl_ref) => {
-                    let ted = self.decl_engine.get_enum(decl_ref);
+                ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
+                    let ted = self.decl_engine.get_enum(decl_id);
                     create_enum_aggregate(
                         self.type_engine,
                         self.decl_engine,

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -236,10 +236,12 @@ impl TyAstNode {
                 } => decl_engine.get_trait(decl_id).visibility.is_public(),
                 TyAstNode {
                     content:
-                        TyAstNodeContent::Declaration(TyDeclaration::StructDeclaration(decl_ref)),
+                        TyAstNodeContent::Declaration(TyDeclaration::StructDeclaration {
+                            decl_id, ..
+                        }),
                     ..
                 } => {
-                    let struct_decl = decl_engine.get_struct(decl_ref);
+                    let struct_decl = decl_engine.get_struct(decl_id);
                     struct_decl.visibility == Visibility::Public
                 }
                 TyAstNode {

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -457,7 +457,7 @@ impl TyDeclaration {
                 decl_id,
                 decl_span,
             } => ok(
-                DeclRef::new(name.clone(), decl_id.clone(), decl_span.clone()),
+                DeclRef::new(name.clone(), *decl_id, decl_span.clone()),
                 vec![],
                 vec![],
             ),
@@ -484,7 +484,7 @@ impl TyDeclaration {
                 decl_id,
                 decl_span,
             } => ok(
-                DeclRef::new(name.clone(), decl_id.clone(), decl_span.clone()),
+                DeclRef::new(name.clone(), *decl_id, decl_span.clone()),
                 vec![],
                 vec![],
             ),
@@ -661,11 +661,7 @@ impl TyDeclaration {
                 decl_span,
             } => type_engine.insert(
                 decl_engine,
-                TypeInfo::Struct(DeclRef::new(
-                    name.clone(),
-                    decl_id.clone(),
-                    decl_span.clone(),
-                )),
+                TypeInfo::Struct(DeclRef::new(name.clone(), *decl_id, decl_span.clone())),
             ),
             TyDeclaration::EnumDeclaration {
                 name,
@@ -673,11 +669,7 @@ impl TyDeclaration {
                 decl_span,
             } => type_engine.insert(
                 decl_engine,
-                TypeInfo::Enum(DeclRef::new(
-                    name.clone(),
-                    decl_id.clone(),
-                    decl_span.clone(),
-                )),
+                TypeInfo::Enum(DeclRef::new(name.clone(), *decl_id, decl_span.clone())),
             ),
             TyDeclaration::StorageDeclaration { decl_id, .. } => {
                 let storage_decl = decl_engine.get_storage(decl_id);

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -32,8 +32,16 @@ pub enum TyDeclaration {
         decl_id: DeclId<TyTraitDeclaration>,
         decl_span: Span,
     },
-    StructDeclaration(DeclRefStruct),
-    EnumDeclaration(DeclRefEnum),
+    StructDeclaration {
+        name: Ident,
+        decl_id: DeclId<TyStructDeclaration>,
+        decl_span: Span,
+    },
+    EnumDeclaration {
+        name: Ident,
+        decl_id: DeclId<TyEnumDeclaration>,
+        decl_span: Span,
+    },
     ImplTrait {
         name: Ident,
         decl_id: DeclId<TyImplTrait>,
@@ -102,10 +110,30 @@ impl PartialEqWithEngines for TyDeclaration {
                     ..
                 },
             ) => ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
-            (Self::StructDeclaration(lref), Self::StructDeclaration(rref)) => {
-                lref.eq(rref, engines)
-            }
-            (Self::EnumDeclaration(lref), Self::EnumDeclaration(rref)) => lref.eq(rref, engines),
+            (
+                Self::StructDeclaration {
+                    name: ln,
+                    decl_id: lid,
+                    ..
+                },
+                Self::StructDeclaration {
+                    name: rn,
+                    decl_id: rid,
+                    ..
+                },
+            ) => ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
+            (
+                Self::EnumDeclaration {
+                    name: ln,
+                    decl_id: lid,
+                    ..
+                },
+                Self::EnumDeclaration {
+                    name: rn,
+                    decl_id: rid,
+                    ..
+                },
+            ) => ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
             (
                 Self::ImplTrait {
                     name: ln,
@@ -170,11 +198,11 @@ impl HashWithEngines for TyDeclaration {
             TraitDeclaration { decl_id, .. } => {
                 decl_engine.get(*decl_id).hash(state, engines);
             }
-            StructDeclaration(decl_ref) => {
-                decl_engine.get_struct(decl_ref).hash(state, engines);
+            StructDeclaration { decl_id, .. } => {
+                decl_engine.get(*decl_id).hash(state, engines);
             }
-            EnumDeclaration(decl_ref) => {
-                decl_engine.get_enum(decl_ref).hash(state, engines);
+            EnumDeclaration { decl_id, .. } => {
+                decl_engine.get(*decl_id).hash(state, engines);
             }
             ImplTrait { decl_id, .. } => {
                 decl_engine.get(*decl_id).hash(state, engines);
@@ -205,8 +233,12 @@ impl SubstTypes for TyDeclaration {
             TraitDeclaration {
                 ref mut decl_id, ..
             } => decl_id.subst(type_mapping, engines),
-            StructDeclaration(ref mut decl_ref) => decl_ref.subst(type_mapping, engines),
-            EnumDeclaration(ref mut decl_ref) => decl_ref.subst(type_mapping, engines),
+            StructDeclaration {
+                ref mut decl_id, ..
+            } => decl_id.subst(type_mapping, engines),
+            EnumDeclaration {
+                ref mut decl_id, ..
+            } => decl_id.subst(type_mapping, engines),
             ImplTrait {
                 ref mut decl_id, ..
             } => decl_id.subst(type_mapping, engines),
@@ -231,8 +263,12 @@ impl ReplaceSelfType for TyDeclaration {
             TraitDeclaration {
                 ref mut decl_id, ..
             } => decl_id.replace_self_type(engines, self_type),
-            StructDeclaration(ref mut decl_ref) => decl_ref.replace_self_type(engines, self_type),
-            EnumDeclaration(ref mut decl_ref) => decl_ref.replace_self_type(engines, self_type),
+            StructDeclaration {
+                ref mut decl_id, ..
+            } => decl_id.replace_self_type(engines, self_type),
+            EnumDeclaration {
+                ref mut decl_id, ..
+            } => decl_id.replace_self_type(engines, self_type),
             ImplTrait {
                 ref mut decl_id, ..
             } => decl_id.replace_self_type(engines, self_type),
@@ -275,9 +311,9 @@ impl Spanned for TyDeclaration {
             | ImplTrait { decl_span, .. }
             | ConstantDeclaration { decl_span, .. }
             | StorageDeclaration { decl_span, .. }
-            | AbiDeclaration { decl_span, .. } => decl_span.clone(),
-            StructDeclaration(decl_ref) => decl_ref.span(),
-            EnumDeclaration(decl_ref) => decl_ref.span(),
+            | AbiDeclaration { decl_span, .. }
+            | StructDeclaration { decl_span, .. }
+            | EnumDeclaration { decl_span, .. } => decl_span.clone(),
             GenericTypeForFunctionScope { name, .. } => name.span(),
             ErrorRecovery(span) => span.clone(),
         }
@@ -318,9 +354,9 @@ impl DisplayWithEngines for TyDeclaration {
                     builder
                 }
                 TyDeclaration::FunctionDeclaration { name, .. }
-                | TyDeclaration::TraitDeclaration { name, .. } => name.as_str().into(),
-                TyDeclaration::StructDeclaration(decl_ref) => decl_ref.name.as_str().into(),
-                TyDeclaration::EnumDeclaration(decl_ref) => decl_ref.name.as_str().into(),
+                | TyDeclaration::TraitDeclaration { name, .. }
+                | TyDeclaration::StructDeclaration { name, .. }
+                | TyDeclaration::EnumDeclaration { name, .. } => name.as_str().into(),
                 _ => String::new(),
             }
         )
@@ -401,9 +437,9 @@ impl GetDeclIdent for TyDeclaration {
             | TyDeclaration::ConstantDeclaration { name, .. }
             | TyDeclaration::ImplTrait { name, .. }
             | TyDeclaration::AbiDeclaration { name, .. }
-            | TyDeclaration::GenericTypeForFunctionScope { name, .. } => Some(name.clone()),
-            TyDeclaration::StructDeclaration(decl_ref) => Some(decl_ref.name.clone()),
-            TyDeclaration::EnumDeclaration(decl_ref) => Some(decl_ref.name.clone()),
+            | TyDeclaration::GenericTypeForFunctionScope { name, .. }
+            | TyDeclaration::StructDeclaration { name, .. }
+            | TyDeclaration::EnumDeclaration { name, .. } => Some(name.clone()),
             TyDeclaration::ErrorRecovery(_) => None,
             TyDeclaration::StorageDeclaration { .. } => None,
         }
@@ -416,7 +452,15 @@ impl TyDeclaration {
     /// Returns an error if `self` is not a [TyEnumDeclaration].
     pub(crate) fn expect_enum(&self) -> CompileResult<DeclRefEnum> {
         match self {
-            TyDeclaration::EnumDeclaration(decl_ref) => ok(decl_ref.clone(), vec![], vec![]),
+            TyDeclaration::EnumDeclaration {
+                name,
+                decl_id,
+                decl_span,
+            } => ok(
+                DeclRef::new(name.clone(), decl_id.clone(), decl_span.clone()),
+                vec![],
+                vec![],
+            ),
             TyDeclaration::ErrorRecovery(_) => err(vec![], vec![]),
             decl => err(
                 vec![],
@@ -435,7 +479,15 @@ impl TyDeclaration {
         let warnings = vec![];
         let mut errors = vec![];
         match self {
-            TyDeclaration::StructDeclaration(decl_ref) => ok(decl_ref.clone(), warnings, errors),
+            TyDeclaration::StructDeclaration {
+                name,
+                decl_id,
+                decl_span,
+            } => ok(
+                DeclRef::new(name.clone(), decl_id.clone(), decl_span.clone()),
+                vec![],
+                vec![],
+            ),
             TyDeclaration::ErrorRecovery(_) => err(vec![], vec![]),
             decl => {
                 errors.push(CompileError::DeclIsNotAStruct {
@@ -603,12 +655,30 @@ impl TyDeclaration {
                 let decl = decl_engine.get_function(decl_id);
                 decl.return_type.type_id
             }
-            TyDeclaration::StructDeclaration(decl_ref) => {
-                type_engine.insert(decl_engine, TypeInfo::Struct(decl_ref.clone()))
-            }
-            TyDeclaration::EnumDeclaration(decl_ref) => {
-                type_engine.insert(decl_engine, TypeInfo::Enum(decl_ref.clone()))
-            }
+            TyDeclaration::StructDeclaration {
+                name,
+                decl_id,
+                decl_span,
+            } => type_engine.insert(
+                decl_engine,
+                TypeInfo::Struct(DeclRef::new(
+                    name.clone(),
+                    decl_id.clone(),
+                    decl_span.clone(),
+                )),
+            ),
+            TyDeclaration::EnumDeclaration {
+                name,
+                decl_id,
+                decl_span,
+            } => type_engine.insert(
+                decl_engine,
+                TypeInfo::Enum(DeclRef::new(
+                    name.clone(),
+                    decl_id.clone(),
+                    decl_span.clone(),
+                )),
+            ),
             TyDeclaration::StorageDeclaration { decl_id, .. } => {
                 let storage_decl = decl_engine.get_storage(decl_id);
                 type_engine.insert(
@@ -642,12 +712,12 @@ impl TyDeclaration {
                 let TyConstantDeclaration { visibility, .. } = decl_engine.get_constant(decl_id);
                 visibility
             }
-            StructDeclaration(decl_ref) => {
-                let TyStructDeclaration { visibility, .. } = decl_engine.get_struct(decl_ref);
+            StructDeclaration { decl_id, .. } => {
+                let TyStructDeclaration { visibility, .. } = decl_engine.get_struct(decl_id);
                 visibility
             }
-            EnumDeclaration(decl_ref) => {
-                let TyEnumDeclaration { visibility, .. } = decl_engine.get_enum(decl_ref);
+            EnumDeclaration { decl_id, .. } => {
+                let TyEnumDeclaration { visibility, .. } = decl_engine.get_enum(decl_id);
                 visibility
             }
             FunctionDeclaration { decl_id, .. } => {

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -79,11 +79,7 @@ impl ty::TyCodeBlock {
                     {
                         return ctx.engines().te().insert(
                             decl_engine,
-                            TypeInfo::Enum(DeclRef::new(
-                                name.clone(),
-                                decl_id.clone(),
-                                decl_span.clone(),
-                            )),
+                            TypeInfo::Enum(DeclRef::new(name.clone(), *decl_id, decl_span.clone())),
                         );
                     }
 

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::language::{parsed::CodeBlock, ty};
+use crate::{
+    decl_engine::DeclRef,
+    language::{parsed::CodeBlock, ty},
+};
 
 impl ty::TyCodeBlock {
     pub(crate) fn type_check(
@@ -68,12 +71,20 @@ impl ty::TyCodeBlock {
                         .resolve_symbol(&never_mod_path, &never_ident)
                         .value;
 
-                    if let Some(ty::TyDeclaration::EnumDeclaration(never_decl_ref)) = never_decl_opt
+                    if let Some(ty::TyDeclaration::EnumDeclaration {
+                        name,
+                        decl_id,
+                        decl_span,
+                    }) = never_decl_opt
                     {
-                        return ctx
-                            .engines()
-                            .te()
-                            .insert(decl_engine, TypeInfo::Enum(never_decl_ref.clone()));
+                        return ctx.engines().te().insert(
+                            decl_engine,
+                            TypeInfo::Enum(DeclRef::new(
+                                name.clone(),
+                                decl_id.clone(),
+                                decl_span.clone(),
+                            )),
+                        );
                     }
 
                     ctx.type_engine.insert(decl_engine, TypeInfo::Unknown)

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -180,7 +180,12 @@ impl ty::TyDeclaration {
                     errors
                 );
                 let call_path = enum_decl.call_path.clone();
-                let decl = ty::TyDeclaration::EnumDeclaration(decl_engine.insert(enum_decl));
+                let decl_ref = decl_engine.insert(enum_decl);
+                let decl = ty::TyDeclaration::EnumDeclaration {
+                    name: decl_ref.name,
+                    decl_id: decl_ref.id,
+                    decl_span: decl_ref.decl_span,
+                };
                 check!(
                     ctx.namespace.insert_symbol(call_path.suffix, decl.clone()),
                     return err(warnings, errors),
@@ -338,7 +343,12 @@ impl ty::TyDeclaration {
                     errors
                 );
                 let call_path = decl.call_path.clone();
-                let decl = ty::TyDeclaration::StructDeclaration(decl_engine.insert(decl));
+                let decl_ref = decl_engine.insert(decl);
+                let decl = ty::TyDeclaration::StructDeclaration {
+                    name: decl_ref.name,
+                    decl_id: decl_ref.id,
+                    decl_span: decl_ref.decl_span,
+                };
                 // insert the struct decl into namespace
                 check!(
                     ctx.namespace.insert_symbol(call_path.suffix, decl.clone()),

--- a/sway-core/src/semantic_analysis/storage_only_types.rs
+++ b/sway-core/src/semantic_analysis/storage_only_types.rs
@@ -224,8 +224,8 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
                 }
             }
         }
-        ty::TyDeclaration::StructDeclaration(decl_ref) => {
-            let ty::TyStructDeclaration { fields, .. } = decl_engine.get_struct(decl_ref);
+        ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
+            let ty::TyStructDeclaration { fields, .. } = decl_engine.get_struct(decl_id);
             for field in fields {
                 check!(
                     check_type(
@@ -240,8 +240,8 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
                 );
             }
         }
-        ty::TyDeclaration::EnumDeclaration(decl_ref) => {
-            let ty::TyEnumDeclaration { variants, .. } = decl_engine.get_enum(decl_ref);
+        ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
+            let ty::TyEnumDeclaration { variants, .. } = decl_engine.get_enum(decl_id);
             for variant in variants {
                 check!(
                     check_type(

--- a/sway-core/src/type_system/binding.rs
+++ b/sway-core/src/type_system/binding.rs
@@ -287,9 +287,13 @@ impl TypeBinding<CallPath> {
                     decl_span,
                 }
             }
-            ty::TyDeclaration::EnumDeclaration(original_decl_ref) => {
+            ty::TyDeclaration::EnumDeclaration {
+                decl_id: original_id,
+                name,
+                decl_span,
+            } => {
                 // get the copy from the declaration engine
-                let mut new_copy = decl_engine.get_enum(&original_decl_ref);
+                let mut new_copy = decl_engine.get_enum(&original_id);
 
                 // monomorphize the copy, in place
                 check!(
@@ -313,11 +317,19 @@ impl TypeBinding<CallPath> {
                     type_engine.insert(decl_engine, TypeInfo::Enum(new_decl_ref.clone())),
                 );
 
-                ty::TyDeclaration::EnumDeclaration(new_decl_ref)
+                ty::TyDeclaration::EnumDeclaration {
+                    name,
+                    decl_id: new_decl_ref.id,
+                    decl_span,
+                }
             }
-            ty::TyDeclaration::StructDeclaration(original_decl_ref) => {
+            ty::TyDeclaration::StructDeclaration {
+                decl_id: original_id,
+                name,
+                decl_span,
+            } => {
                 // get the copy from the declaration engine
-                let mut new_copy = decl_engine.get_struct(&original_decl_ref);
+                let mut new_copy = decl_engine.get_struct(&original_id);
 
                 // monomorphize the copy, in place
                 check!(
@@ -341,7 +353,11 @@ impl TypeBinding<CallPath> {
                     type_engine.insert(decl_engine, TypeInfo::Struct(new_decl_ref.clone())),
                 );
 
-                ty::TyDeclaration::StructDeclaration(new_decl_ref)
+                ty::TyDeclaration::StructDeclaration {
+                    name,
+                    decl_id: new_decl_ref.id,
+                    decl_span,
+                }
             }
             _ => unknown_decl,
         };

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -413,9 +413,12 @@ impl TypeEngine {
                     .ok(&mut warnings, &mut errors)
                     .cloned()
                 {
-                    Some(ty::TyDeclaration::StructDeclaration(original_decl_ref)) => {
+                    Some(ty::TyDeclaration::StructDeclaration {
+                        decl_id: original_id,
+                        ..
+                    }) => {
                         // get the copy from the declaration engine
-                        let mut new_copy = decl_engine.get_struct(&original_decl_ref);
+                        let mut new_copy = decl_engine.get_struct(&original_id);
 
                         // monomorphize the copy, in place
                         check!(
@@ -447,9 +450,12 @@ impl TypeEngine {
                         // return the id
                         type_id
                     }
-                    Some(ty::TyDeclaration::EnumDeclaration(original_decl_ref)) => {
+                    Some(ty::TyDeclaration::EnumDeclaration {
+                        decl_id: original_id,
+                        ..
+                    }) => {
                         // get the copy from the declaration engine
-                        let mut new_copy = decl_engine.get_enum(&original_decl_ref);
+                        let mut new_copy = decl_engine.get_enum(&original_id);
 
                         // monomorphize the copy, in place
                         check!(

--- a/sway-lsp/src/capabilities/code_actions/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/mod.rs
@@ -53,7 +53,9 @@ pub(crate) fn code_actions(
     token.typed.and_then(|typed_token| match typed_token {
         TypedAstToken::TypedDeclaration(decl) => match decl {
             TyDeclaration::AbiDeclaration { decl_id, .. } => abi_decl::code_actions(&decl_id, ctx),
-            TyDeclaration::StructDeclaration(decl_ref) => struct_decl::code_actions(&decl_ref, ctx),
+            TyDeclaration::StructDeclaration { decl_id, .. } => {
+                struct_decl::code_actions(&decl_id, ctx)
+            }
             _ => None,
         },
         _ => None,

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/mod.rs
@@ -3,14 +3,14 @@ pub(crate) mod struct_new;
 
 use self::{struct_impl::StructImplCodeAction, struct_new::StructNewCodeAction};
 use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
-use sway_core::decl_engine::DeclRefStruct;
+use sway_core::{decl_engine::id::DeclId, language::ty};
 use tower_lsp::lsp_types::CodeActionOrCommand;
 
 pub(crate) fn code_actions(
-    decl_ref: &DeclRefStruct,
+    decl_id: &DeclId<ty::TyStructDeclaration>,
     ctx: CodeActionContext,
 ) -> Option<Vec<CodeActionOrCommand>> {
-    let decl = ctx.engines.de().get_struct(decl_ref);
+    let decl = ctx.engines.de().get_struct(decl_id);
     Some(vec![
         StructImplCodeAction::new(ctx.clone(), &decl).code_action(),
         StructNewCodeAction::new(ctx, &decl).code_action(),

--- a/sway-lsp/src/capabilities/hover.rs
+++ b/sway-lsp/src/capabilities/hover.rs
@@ -141,8 +141,8 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
                         &token_name,
                     ))
                 }
-                ty::TyDeclaration::StructDeclaration(decl_ref) => {
-                    let struct_decl = decl_engine.get_struct(decl_ref);
+                ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
+                    let struct_decl = decl_engine.get_struct(decl_id);
                     Some(format_visibility_hover(
                         struct_decl.visibility,
                         decl.friendly_type_name(),
@@ -157,8 +157,8 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
                         &token_name,
                     ))
                 }
-                ty::TyDeclaration::EnumDeclaration(decl_ref) => {
-                    let enum_decl = decl_engine.get_enum(decl_ref);
+                ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
+                    let enum_decl = decl_engine.get_enum(decl_id);
                     Some(format_visibility_hover(
                         enum_decl.visibility,
                         decl.friendly_type_name(),

--- a/sway-lsp/src/core/token_map.rs
+++ b/sway-lsp/src/core/token_map.rs
@@ -163,8 +163,8 @@ impl TokenMap {
         let decl_engine = engines.de();
         self.declaration_of_type_id(type_engine, decl_engine, type_id)
             .and_then(|decl| match decl {
-                ty::TyDeclaration::StructDeclaration(decl_ref) => {
-                    Some(decl_engine.get_struct(&decl_ref))
+                ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
+                    Some(decl_engine.get_struct(&decl_id))
                 }
                 _ => None,
             })

--- a/sway-lsp/src/traverse/dependency.rs
+++ b/sway-lsp/src/traverse/dependency.rs
@@ -37,9 +37,9 @@ pub fn collect_typed_declaration(node: &ty::TyAstNode, ctx: &ParseContext) {
 
         let ident = match declaration {
             ty::TyDeclaration::VariableDeclaration(variable) => variable.name.clone(),
-            ty::TyDeclaration::StructDeclaration(decl_ref) => decl_ref.name.clone(),
-            ty::TyDeclaration::EnumDeclaration(decl_ref) => decl_ref.name.clone(),
-            ty::TyDeclaration::TraitDeclaration { name, .. }
+            ty::TyDeclaration::StructDeclaration { name, .. }
+            | ty::TyDeclaration::EnumDeclaration { name, .. }
+            | ty::TyDeclaration::TraitDeclaration { name, .. }
             | ty::TyDeclaration::FunctionDeclaration { name, .. }
             | ty::TyDeclaration::ConstantDeclaration { name, .. } => name.clone(),
             _ => return,

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -117,8 +117,8 @@ impl<'a> TypedTree<'a> {
                     self.collect_supertrait(&supertrait);
                 }
             }
-            ty::TyDeclaration::StructDeclaration(decl_ref) => {
-                let struct_decl = decl_engine.get_struct(decl_ref);
+            ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
+                let struct_decl = decl_engine.get_struct(decl_id);
                 if let Some(mut token) = self
                     .ctx
                     .tokens
@@ -145,8 +145,8 @@ impl<'a> TypedTree<'a> {
                     }
                 }
             }
-            ty::TyDeclaration::EnumDeclaration(decl_ref) => {
-                let enum_decl = decl_engine.get_enum(decl_ref);
+            ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
+                let enum_decl = decl_engine.get_enum(decl_id);
                 if let Some(mut token) = self
                     .ctx
                     .tokens

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -81,12 +81,12 @@ pub(crate) fn print_decl_engine_types(
                     let trait_decl = decl_engine.get_trait(decl_id);
                     format!("{trait_decl:#?}")
                 }
-                ty::TyDeclaration::StructDeclaration(decl_ref) => {
-                    let struct_decl = decl_engine.get_struct(decl_ref);
+                ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
+                    let struct_decl = decl_engine.get_struct(decl_id);
                     format!("{struct_decl:#?}")
                 }
-                ty::TyDeclaration::EnumDeclaration(decl_ref) => {
-                    let enum_decl = decl_engine.get_enum(decl_ref);
+                ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
+                    let enum_decl = decl_engine.get_enum(decl_id);
                     format!("{enum_decl:#?}")
                 }
                 ty::TyDeclaration::AbiDeclaration { decl_id, .. } => {


### PR DESCRIPTION
## Description

This PR fixes a regression to `TyDeclaration::StructDeclaration` and `TyDeclaration::EnumDeclaration` and removes the `DeclRef`s that they were holding.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
