### PR TITLE
Add the `TypeInfo::TypeParam` variant but don't use it yet.

### DIFF
--- a/sway-core/src/abi_generation/evm_json_abi.rs
+++ b/sway-core/src/abi_generation/evm_json_abi.rs
@@ -85,7 +85,8 @@ pub fn json_abi_str(
     match type_info {
         Unknown => "unknown".into(),
         UnknownGeneric { name, .. } => name.to_string(),
-        TypeInfo::Placeholder(_) => "_".to_string(),
+        Placeholder(_) => "_".to_string(),
+        TypeParam(n) => format!("typeparam({n})"),
         Str(x) => format!("str[{}]", x.val()),
         UnsignedInteger(x) => match x {
             IntegerBits::Eight => "uint8",

--- a/sway-core/src/abi_generation/fuel_json_abi.rs
+++ b/sway-core/src/abi_generation/fuel_json_abi.rs
@@ -775,7 +775,8 @@ impl TypeInfo {
         match self {
             Unknown => "unknown".into(),
             UnknownGeneric { name, .. } => name.to_string(),
-            TypeInfo::Placeholder(_) => "_".to_string(),
+            Placeholder(_) => "_".to_string(),
+            TypeParam(n) => format!("typeparam({n})"),
             Str(x) => format!("str[{}]", x.val()),
             UnsignedInteger(x) => match x {
                 IntegerBits::Eight => "u8",

--- a/sway-core/src/ir_generation/convert.rs
+++ b/sway-core/src/ir_generation/convert.rs
@@ -153,6 +153,7 @@ fn convert_resolved_type(
         TypeInfo::Unknown => reject_type!("Unknown"),
         TypeInfo::UnknownGeneric { .. } => reject_type!("Generic"),
         TypeInfo::Placeholder(_) => reject_type!("Placeholder"),
+        TypeInfo::TypeParam(_) => reject_type!("TypeParam"),
         TypeInfo::ErrorRecovery => reject_type!("Error recovery"),
         TypeInfo::Storage { .. } => reject_type!("Storage"),
     })

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -831,6 +831,7 @@ fn type_info_name(type_info: &TypeInfo) -> String {
         TypeInfo::ErrorRecovery => "err_recov",
         TypeInfo::Unknown => "unknown",
         TypeInfo::UnknownGeneric { name, .. } => return format!("generic {name}"),
+        TypeInfo::TypeParam(_) => "type param",
         TypeInfo::Placeholder(_) => "_",
         TypeInfo::ContractCaller { abi_name, .. } => {
             return format!("contract caller {abi_name}");

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -82,6 +82,7 @@ impl ReplaceSelfType for TypeId {
             let type_engine = engines.te();
             let decl_engine = engines.de();
             match type_engine.get(type_id) {
+                TypeInfo::TypeParam(_) => None,
                 TypeInfo::SelfType => Some(self_type),
                 TypeInfo::Enum(decl_ref) => {
                     let mut decl = decl_engine.get_enum(&decl_ref);

--- a/sway-core/src/type_system/substitute.rs
+++ b/sway-core/src/type_system/substitute.rs
@@ -332,6 +332,7 @@ impl TypeSubstMap {
             TypeInfo::Custom { .. } => iter_for_match(engines, self, &type_info),
             TypeInfo::UnknownGeneric { .. } => iter_for_match(engines, self, &type_info),
             TypeInfo::Placeholder(_) => iter_for_match(engines, self, &type_info),
+            TypeInfo::TypeParam(_) => None,
             TypeInfo::Struct(decl_ref) => {
                 let mut decl = decl_engine.get_struct(&decl_ref);
                 let mut need_to_create_new = false;


### PR DESCRIPTION
## Description

This PR adds the `TypeInfo::TypeParam` variant as part of #3744, but there are no instances of `TypeInfo::TypeParam` created. To be clear, it's not my preference to add a variant without additional code to test it, but if the compiler detects this variant it will reject the code during IR generation.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
