### PR TITLE
Remove a couple unneeded uses of `CompileResult`.

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -169,7 +169,7 @@ impl<'cfg> ControlFlowGraph<'cfg> {
         let mut entry_points = vec![];
         let mut non_entry_points = vec![];
         for ast_entrypoint in module_nodes {
-            if ast_entrypoint.is_entry_point(decl_engine, tree_type)? {
+            if ast_entrypoint.is_entry_point(decl_engine, tree_type) {
                 entry_points.push(ast_entrypoint);
             } else {
                 non_entry_points.push(ast_entrypoint);
@@ -203,7 +203,7 @@ fn collect_entry_points(
     for i in graph.node_indices() {
         let is_entry = match &graph[i] {
             ControlFlowGraphNode::ProgramNode { node, .. } => {
-                node.is_entry_point(decl_engine, tree_type)?
+                node.is_entry_point(decl_engine, tree_type)
             }
             _ => false,
         };

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -631,9 +631,9 @@ impl TyDeclaration {
         ok(type_id, warnings, errors)
     }
 
-    pub(crate) fn visibility(&self, decl_engine: &DeclEngine) -> CompileResult<Visibility> {
+    pub(crate) fn visibility(&self, decl_engine: &DeclEngine) -> Visibility {
         use TyDeclaration::*;
-        let visibility = match self {
+        match self {
             TraitDeclaration { decl_id, .. } => {
                 let TyTraitDeclaration { visibility, .. } = decl_engine.get_trait(decl_id);
                 visibility
@@ -660,7 +660,6 @@ impl TyDeclaration {
             | AbiDeclaration { .. }
             | ErrorRecovery(_) => Visibility::Public,
             VariableDeclaration(decl) => decl.mutability.visibility(),
-        };
-        ok(visibility, vec![], vec![])
+        }
     }
 }

--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -363,14 +363,8 @@ impl CollectTypesMetadata for TyProgram {
                         .map(|(_, submod)| &submod.module),
                 ) {
                     for node in module.all_nodes.iter() {
-                        let is_public = check!(
-                            node.is_public(decl_engine),
-                            return err(warnings, errors),
-                            warnings,
-                            errors
-                        );
                         let is_generic_function = node.is_generic_function(decl_engine);
-                        if is_public {
+                        if node.is_public(decl_engine) {
                             let node_metadata = check!(
                                 node.collect_types_metadata(ctx),
                                 return err(warnings, errors),

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -1,7 +1,7 @@
 use crate::{
     engine_threading::Engines,
     error::*,
-    language::{parsed::*, ty, Visibility},
+    language::{parsed::*, ty},
     semantic_analysis::*,
     transform::to_parsed_lang,
     Ident, Namespace,
@@ -225,13 +225,7 @@ impl Module {
         let implemented_traits = src_ns.implemented_traits.clone();
         let mut symbols_and_decls = vec![];
         for (symbol, decl) in src_ns.symbols.iter() {
-            let visibility = check!(
-                decl.visibility(decl_engine),
-                return err(warnings, errors),
-                warnings,
-                errors
-            );
-            if visibility == Visibility::Public {
+            if decl.visibility(decl_engine).is_public() {
                 symbols_and_decls.push((symbol.clone(), decl.clone()));
             }
         }
@@ -282,13 +276,7 @@ impl Module {
             .map(|(symbol, (_, _, decl))| (symbol.clone(), decl.clone()))
             .collect::<Vec<_>>();
         for (symbol, decl) in src_ns.symbols.iter() {
-            let visibility = check!(
-                decl.visibility(decl_engine),
-                return err(warnings, errors),
-                warnings,
-                errors
-            );
-            if visibility == Visibility::Public {
+            if decl.visibility(decl_engine).is_public() {
                 symbols_and_decls.push((symbol.clone(), decl.clone()));
             }
         }
@@ -362,13 +350,7 @@ impl Module {
         let mut impls_to_insert = TraitMap::default();
         match src_ns.symbols.get(item).cloned() {
             Some(decl) => {
-                let visibility = check!(
-                    decl.visibility(decl_engine),
-                    return err(warnings, errors),
-                    warnings,
-                    errors
-                );
-                if visibility != Visibility::Public {
+                if !decl.visibility(decl_engine).is_public() {
                     errors.push(CompileError::ImportPrivateSymbol {
                         name: item.clone(),
                         span: item.span(),

--- a/sway-core/src/semantic_analysis/namespace/root.rs
+++ b/sway-core/src/semantic_analysis/namespace/root.rs
@@ -3,7 +3,7 @@ use sway_types::Spanned;
 
 use crate::{
     error::*,
-    language::{ty, CallPath, Visibility},
+    language::{ty, CallPath},
     CompileResult, Engines, Ident,
 };
 
@@ -53,7 +53,7 @@ impl Root {
         mod_path: &Path,
         call_path: &CallPath,
     ) -> CompileResult<&ty::TyDeclaration> {
-        let mut warnings = vec![];
+        let warnings = vec![];
         let mut errors = vec![];
 
         let result = self.resolve_call_path(mod_path, call_path);
@@ -67,13 +67,7 @@ impl Root {
             value: Some(decl), ..
         } = result
         {
-            let visibility = check!(
-                decl.visibility(engines.de()),
-                return err(warnings, errors),
-                warnings,
-                errors
-            );
-            if visibility != Visibility::Public {
+            if !decl.visibility(engines.de()).is_public() {
                 errors.push(CompileError::ImportPrivateSymbol {
                     name: call_path.suffix.clone(),
                     span: call_path.suffix.span(),


### PR DESCRIPTION
## Description

Small PR to remove a couple unneeded uses of `CompileResult`.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
