### PR TITLE
Bump to fuels `v0.37` and add a test and docs for `configurable` blocks

### DIFF
--- a/docs/book/src/basics/variables.md
+++ b/docs/book/src/basics/variables.md
@@ -46,22 +46,18 @@ If the value declared cannot be assigned to the declared type, there will be an 
 
 ## Configuration-time Constants
 
-It is possible to define and initialize constant variables in the manifest file `Forc.toml` of a Sway project. These constants then become visible and usable in the corresponding Sway program. Such variables are called configuration-time constants and have to be defined in their own section called `[constants]` in the manifest file. The syntax for declaring such constants is as follows:
+Configuration-time constants (or configurable constants) are special constants that behave like regular constants in the sense that they cannot change during program execution, but they can be configured _after_ the Sway program has been built. The Rust and TS SDKs allow updating the values of these constants by injecting new values for them directly in the bytecode without having to build the program again. These are useful for contract factories and behave somewhat similarly to `immutable` variables from languages like Solidity.
+
+Configuration-time constants are declared inside a `configurable` block and require a type ascription and an initializer as follows:
 
 ```sway
-{{#include ../../../../examples/config_time_constants/Forc.toml:constants}}
+{{#include ../../../../examples/config_time_constants/src/main.sw:configurable_block}}
 ```
 
-Notice that each constant requires two fields: a `type` and a `value`.
+At most one `configurable` block is allowed in a Sway project. Moreover, `configurable` blocks are not allowed in libraries.
 
-> **Note**
-> Because configuration-time constants are _constants_, they are immutable and cannot be made otherwise.
-
-The constants defined above can now be used in a Sway program that uses the manifest file as follows:
+Configurable constants can be read directly just like regular constants:
 
 ```sway
-{{#include ../../../../examples/config_time_constants/src/main.sw}}
+{{#include ../../../../examples/config_time_constants/src/main.sw:using_configurables}}
 ```
-
-> **Note**
-> Currently, it is only possible to define configuration-time constants that have [primitive types](built_in_types.md#primitive-types) and that are initialized using literals. This will change in the future.

--- a/templates/sway-test-rs/template/Cargo.toml
+++ b/templates/sway-test-rs/template/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["{{authors}}"]
 license = "Apache-2.0"
 
 [dev-dependencies]
-fuels = { version = "0.35", features = ["fuel-core-lib"] }
+fuels = { version = "0.37", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/test/src/sdk-harness/Cargo.lock
+++ b/test/src/sdk-harness/Cargo.lock
@@ -1459,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "fuels"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb5af8cab660ba02d2e61bc16812fdd6e93f64a5c023d510d7fb615e400704c"
+checksum = "ec9f85950c301889c074c3882ccb49fca1900f0d54a434fede12ea55d4583e12"
 dependencies = [
  "fuel-core",
  "fuel-core-client",
@@ -1476,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78cd0139231c728374e54cce8c2277ae1afddcee666547ce30c8a8d7f7b1f06"
+checksum = "7cfe362e48283fcb080c9f435fc1ac18aad34c3c3c91779cc99415862573faed"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -1493,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37aa5dbcf0b1e08818ff8d9caac82e8da8e81748a83860e58979b46aa77b5d28"
+checksum = "d846794076498a56c4fdf64e62852a2e183f4a50a70492a329f54fce3830e95c"
 dependencies = [
  "fuel-tx",
  "fuel-types",
@@ -1508,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-macros"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04fcfb17385f702c9aa7958e57630c3fbdf0d86e34093ced9cc3a606c192962"
+checksum = "ddb21e9d6e680e910e07aaa0b5570e54b93416d68d84dcf01c4df245168bef23"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -1527,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-programs"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bacdabf09515dc95f3251d80ade1a876da951d988d48866c80940d594280a796"
+checksum = "6e736f3c2186876f4f7741f9c390b32d22c9819196470ec875fca6c1cacd74e0"
 dependencies = [
  "bytes",
  "fuel-abi-types",
@@ -1556,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-signers"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee5a705cfb87a8fa51e28478597db38109701be82238534a4a18f34bc8e3d39"
+checksum = "51eff88f45d0b813a9f44200d7bb14678a04c04e4d42f8cdd7e7b4e130ae4664"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1584,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "944433f739289f94e5a415684251211cfdb511849b58e2350c524a9b0d60f1c5"
+checksum = "9b022b5daebc2c9e07bf35e6c7d71bc377859225c985fa900cca406b22a594eb"
 dependencies = [
  "fuel-core",
  "fuel-core-chain-config",
@@ -1613,13 +1613,14 @@ dependencies = [
 
 [[package]]
 name = "fuels-types"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c90a74c9ef4703d87e0085240fb1ef53cf0266174482ba137e00dafd6515e4"
+checksum = "5b3328fa28eac1bd6925a50a9d925a448141d48a1c3cac812defbcee159087f4"
 dependencies = [
  "bech32 0.9.1",
  "chrono",
  "fuel-abi-types",
+ "fuel-asm",
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-tx",
@@ -1635,7 +1636,6 @@ dependencies = [
  "strum 0.21.0",
  "strum_macros 0.21.1",
  "thiserror",
- "tokio",
 ]
 
 [[package]]

--- a/test/src/sdk-harness/Cargo.toml
+++ b/test/src/sdk-harness/Cargo.toml
@@ -12,7 +12,7 @@ fuel-core = { version = "0.17", default-features = false }
 fuel-core-client = { version = "0.17", default-features = false }
 fuel-types = "0.26"
 fuel-vm = "0.26"
-fuels = { version = "0.36", features = ["fuel-core-lib"] }
+fuels = { version = "0.37", features = ["fuel-core-lib"] }
 hex = "0.4.3"
 rand = "0.8"
 sha2 = "0.10"

--- a/test/src/sdk-harness/test_projects/configurables_in_contract/.gitignore
+++ b/test/src/sdk-harness/test_projects/configurables_in_contract/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/sdk-harness/test_projects/configurables_in_contract/Forc.lock
+++ b/test/src/sdk-harness/test_projects/configurables_in_contract/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'configurables_in_contract'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+source = 'path+from-root-3A783B9109EEADE0'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-3A783B9109EEADE0'
+dependencies = ['core']

--- a/test/src/sdk-harness/test_projects/configurables_in_contract/Forc.toml
+++ b/test/src/sdk-harness/test_projects/configurables_in_contract/Forc.toml
@@ -1,8 +1,8 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
-implicit-std = false
 license = "Apache-2.0"
-name = "config_time_constants"
+name = "configurables_in_contract"
 
 [dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/test/src/sdk-harness/test_projects/configurables_in_contract/mod.rs
+++ b/test/src/sdk-harness/test_projects/configurables_in_contract/mod.rs
@@ -1,0 +1,98 @@
+use fuels::{prelude::*, types::SizedAsciiString};
+
+#[tokio::test]
+async fn contract_uses_default_configurables() -> Result<()> {
+    abigen!(Contract(
+        name = "MyContract",
+        abi =
+            "test_projects/configurables_in_contract/out/debug/configurables_in_contract-abi.json"
+    ));
+
+    let wallet = launch_provider_and_get_wallet().await;
+
+    let contract_id = Contract::deploy(
+        "test_projects/configurables_in_contract/out/debug/configurables_in_contract.bin",
+        &wallet,
+        TxParameters::default(),
+        StorageConfiguration::default(),
+    )
+    .await?;
+
+    let contract_instance = MyContract::new(contract_id, wallet.clone());
+
+    let response = contract_instance
+        .methods()
+        .return_configurables()
+        .call()
+        .await?;
+
+    let expected_value = (
+        8u8,
+        true,
+        [253u32, 254u32, 255u32],
+        "fuel".try_into()?,
+        StructWithGeneric {
+            field_1: 8u8,
+            field_2: 16,
+        },
+        EnumWithGeneric::VariantOne(true),
+    );
+
+    assert_eq!(response.value, expected_value);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn contract_configurables() -> Result<()> {
+    abigen!(Contract(
+        name = "MyContract",
+        abi =
+            "test_projects/configurables_in_contract/out/debug/configurables_in_contract-abi.json"
+    ));
+
+    let wallet = launch_provider_and_get_wallet().await;
+
+    let new_str: SizedAsciiString<4> = "FUEL".try_into()?;
+    let new_struct = StructWithGeneric {
+        field_1: 16u8,
+        field_2: 32,
+    };
+    let new_enum = EnumWithGeneric::VariantTwo;
+
+    let configurables = MyContractConfigurables::new()
+        .set_STR_4(new_str.clone())
+        .set_STRUCT(new_struct.clone())
+        .set_ENUM(new_enum.clone());
+
+    let contract_id = Contract::deploy_with_parameters(
+        "test_projects/configurables_in_contract/out/debug/configurables_in_contract.bin",
+        &wallet,
+        TxParameters::default(),
+        StorageConfiguration::default(),
+        configurables.into(),
+        Salt::default(),
+    )
+    .await?;
+
+    let contract_instance = MyContract::new(contract_id, wallet.clone());
+
+    let response = contract_instance
+        .methods()
+        .return_configurables()
+        .call()
+        .await?;
+
+    let expected_value = (
+        8u8,
+        true,
+        [253u32, 254u32, 255u32],
+        new_str,
+        new_struct,
+        new_enum,
+    );
+
+    assert_eq!(response.value, expected_value);
+
+    Ok(())
+}

--- a/test/src/sdk-harness/test_projects/configurables_in_contract/src/main.sw
+++ b/test/src/sdk-harness/test_projects/configurables_in_contract/src/main.sw
@@ -10,7 +10,6 @@ struct StructWithGeneric<D> {
     field_2: u64,
 }
 
-// ANCHOR: configurable_block
 configurable {
     U8: u8 = 8u8,
     BOOL: bool = true,
@@ -22,16 +21,13 @@ configurable {
     },
     ENUM: EnumWithGeneric<bool> = EnumWithGeneric::VariantOne(true),
 }
-// ANCHOR_END: configurable_block 
 
 abi TestContract {
-    fn return_configurables() -> (u8, bool, [u32; 3], str[4], StructWithGeneric<u8>);
+    fn return_configurables() -> (u8, bool, [u32; 3], str[4], StructWithGeneric<u8>, EnumWithGeneric<bool>);
 }
 
 impl TestContract for Contract {
-// ANCHOR: using_configurables
-    fn return_configurables() -> (u8, bool, [u32; 3], str[4], StructWithGeneric<u8>) {
-        (U8, BOOL, ARRAY, STR_4, STRUCT)
+    fn return_configurables(    ) -> (u8, bool, [u32; 3], str[4], StructWithGeneric<u8>, EnumWithGeneric<bool>) {
+        (U8, BOOL, ARRAY, STR_4, STRUCT, ENUM)
     }
-// ANCHOR_END: using_configurables
 }

--- a/test/src/sdk-harness/test_projects/configurables_in_script/.gitignore
+++ b/test/src/sdk-harness/test_projects/configurables_in_script/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/sdk-harness/test_projects/configurables_in_script/Forc.lock
+++ b/test/src/sdk-harness/test_projects/configurables_in_script/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'configurables_in_script'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+source = 'path+from-root-6F15923604F9775D'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-6F15923604F9775D'
+dependencies = ['core']

--- a/test/src/sdk-harness/test_projects/configurables_in_script/Forc.toml
+++ b/test/src/sdk-harness/test_projects/configurables_in_script/Forc.toml
@@ -1,8 +1,8 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
-implicit-std = false
 license = "Apache-2.0"
-name = "config_time_constants"
+name = "configurables_in_script"
 
 [dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/test/src/sdk-harness/test_projects/configurables_in_script/mod.rs
+++ b/test/src/sdk-harness/test_projects/configurables_in_script/mod.rs
@@ -1,0 +1,74 @@
+use fuels::{prelude::*, types::SizedAsciiString};
+
+#[tokio::test]
+async fn script_uses_default_configurables() -> Result<()> {
+    abigen!(Script(
+        name = "MyScript",
+        abi = "test_projects/configurables_in_script/out/debug/configurables_in_script-abi.json"
+    ));
+
+    let wallet = launch_provider_and_get_wallet().await;
+    let bin_path = "test_projects/configurables_in_script/out/debug/configurables_in_script.bin";
+    let instance = MyScript::new(wallet, bin_path);
+
+    let response = instance.main().call().await?;
+
+    let expected_value = (
+        8u8,
+        true,
+        [253u32, 254u32, 255u32],
+        "fuel".try_into()?,
+        StructWithGeneric {
+            field_1: 8u8,
+            field_2: 16,
+        },
+        EnumWithGeneric::VariantOne(true),
+    );
+
+    assert_eq!(response.value, expected_value);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn script_configurables() -> Result<()> {
+    abigen!(Script(
+        name = "MyScript",
+        abi = "test_projects/configurables_in_script/out/debug/configurables_in_script-abi.json"
+    ));
+
+    let wallet = launch_provider_and_get_wallet().await;
+    let bin_path = "test_projects/configurables_in_script/out/debug/configurables_in_script.bin";
+    let instance = MyScript::new(wallet, bin_path);
+
+    let new_str: SizedAsciiString<4> = "FUEL".try_into()?;
+    let new_struct = StructWithGeneric {
+        field_1: 16u8,
+        field_2: 32,
+    };
+    let new_enum = EnumWithGeneric::VariantTwo;
+
+    let configurables = MyScriptConfigurables::new()
+        .set_STR_4(new_str.clone())
+        .set_STRUCT(new_struct.clone())
+        .set_ENUM(new_enum.clone());
+
+    let response = instance
+        .with_configurables(configurables.into())
+        .main()
+        .call()
+        .await?;
+
+    let expected_value = (
+        8u8,
+        true,
+        [253u32, 254u32, 255u32],
+        new_str,
+        new_struct,
+        new_enum,
+    );
+
+    assert_eq!(response.value, expected_value);
+
+    Ok(())
+}

--- a/test/src/sdk-harness/test_projects/configurables_in_script/src/main.sw
+++ b/test/src/sdk-harness/test_projects/configurables_in_script/src/main.sw
@@ -1,4 +1,4 @@
-contract;
+script;
 
 enum EnumWithGeneric<D> {
     VariantOne: D,
@@ -10,7 +10,6 @@ struct StructWithGeneric<D> {
     field_2: u64,
 }
 
-// ANCHOR: configurable_block
 configurable {
     U8: u8 = 8u8,
     BOOL: bool = true,
@@ -22,16 +21,7 @@ configurable {
     },
     ENUM: EnumWithGeneric<bool> = EnumWithGeneric::VariantOne(true),
 }
-// ANCHOR_END: configurable_block 
 
-abi TestContract {
-    fn return_configurables() -> (u8, bool, [u32; 3], str[4], StructWithGeneric<u8>);
-}
-
-impl TestContract for Contract {
-// ANCHOR: using_configurables
-    fn return_configurables() -> (u8, bool, [u32; 3], str[4], StructWithGeneric<u8>) {
-        (U8, BOOL, ARRAY, STR_4, STRUCT)
-    }
-// ANCHOR_END: using_configurables
+fn main() -> (u8, bool, [u32; 3], str[4], StructWithGeneric<u8>, EnumWithGeneric<bool>) {
+    (U8, BOOL, ARRAY, STR_4, STRUCT, ENUM)
 }

--- a/test/src/sdk-harness/test_projects/harness.rs
+++ b/test/src/sdk-harness/test_projects/harness.rs
@@ -3,6 +3,8 @@
 mod auth;
 mod block;
 mod call_frames;
+mod configurables_in_contract;
+mod configurables_in_script;
 mod context;
 mod contract_bytecode;
 mod ec_recover;

--- a/test/src/sdk-harness/test_projects/logging/mod.rs
+++ b/test/src/sdk-harness/test_projects/logging/mod.rs
@@ -1,37 +1,31 @@
-use fuels::{
-    prelude::*,
-    programs::execution_script::ExecutableFuelCall,
-    tx::{ConsensusParameters, Transaction},
-};
+use fuels::{prelude::*, tx::ConsensusParameters};
 use hex;
 
 #[tokio::test]
-async fn run_valid() {
-    let bin = std::fs::read("test_projects/logging/out/debug/logging.bin");
-
+async fn run_valid() -> Result<()> {
     let wallet = launch_provider_and_get_wallet().await;
 
-    let mut tx = Transaction::script(
-        0,
-        ConsensusParameters::DEFAULT.max_gas_per_tx,
-        0,
-        bin.unwrap(),
+    let mut tx = ScriptTransaction::new(
         vec![],
         vec![],
-        vec![],
-        vec![],
-    );
+        TxParameters::new(
+            None,
+            Some(ConsensusParameters::DEFAULT.max_gas_per_tx),
+            None,
+        ),
+    )
+    .with_script(std::fs::read(
+        "test_projects/logging/out/debug/logging.bin",
+    )?);
 
-    wallet.sign_transaction(&mut tx).await.unwrap();
+    wallet.sign_transaction(&mut tx).await?;
 
-    let script = ExecutableFuelCall::new(tx);
-    let receipts = script
-        .execute(&wallet.get_provider().unwrap())
-        .await
-        .unwrap();
+    let receipts = wallet.get_provider()?.send_transaction(&tx).await?;
 
     let correct_hex =
         hex::decode("ef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a");
 
     assert_eq!(correct_hex.unwrap(), receipts[0].data().unwrap());
+
+    Ok(())
 }

--- a/test/src/sdk-harness/test_projects/predicate_data_struct/mod.rs
+++ b/test/src/sdk-harness/test_projects/predicate_data_struct/mod.rs
@@ -2,10 +2,9 @@ use fuel_vm::fuel_asm::{op, RegId};
 use fuels::{
     core::abi_encoder::ABIEncoder,
     prelude::*,
-    programs::execution_script::ExecutableFuelCall,
     signers::wallet::Wallet,
     test_helpers::Config,
-    tx::{Address, AssetId, Contract, Input, Output, Transaction, TxPointer, UtxoId},
+    tx::{Address, AssetId, Contract, Input, Output, TxPointer, UtxoId},
     types::{resource::Resource, Token},
 };
 use rand::{
@@ -56,16 +55,13 @@ async fn create_predicate(
 
     let output_coin = Output::coin(predicate_address, amount_to_predicate, asset_id);
     let output_change = Output::change(wallet.address().into(), 0, asset_id);
-    let mut tx = Transaction::script(
-        1,
-        1000000,
-        0,
-        op::ret(RegId::ONE).to_bytes().to_vec(),
-        vec![],
+    let mut tx = ScriptTransaction::new(
         wallet_coins,
         vec![output_coin, output_change],
-        vec![],
-    );
+        TxParameters::new(Some(1), Some(1_000_000), None),
+    )
+    .with_script(op::ret(RegId::ONE).to_bytes().to_vec());
+
     wallet.sign_transaction(&mut tx).await.unwrap();
     wallet
         .get_provider()
@@ -121,19 +117,17 @@ async fn submit_to_predicate(
 
     let output_coin = Output::coin(receiver_address, total_amount_in_predicate, asset_id);
     let output_change = Output::change(predicate_address, 0, asset_id);
-    let new_tx = Transaction::script(
-        0,
-        1000000,
-        0,
-        vec![],
-        vec![],
+    let new_tx = ScriptTransaction::new(
         inputs,
         vec![output_coin, output_change],
-        vec![],
+        TxParameters::new(None, Some(1_000_000), None),
     );
 
-    let script = ExecutableFuelCall::new(new_tx);
-    let _call_result = script.execute(&wallet.get_provider().unwrap()).await;
+    let _call_result = wallet
+        .get_provider()
+        .unwrap()
+        .send_transaction(&new_tx)
+        .await;
 }
 
 async fn get_balance(wallet: &Wallet, address: Address, asset_id: AssetId) -> u64 {

--- a/test/src/sdk-harness/test_projects/storage_vec/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec/mod.rs
@@ -8,7 +8,7 @@ mod svec_enum;
 mod svec_str;
 mod svec_struct;
 mod svec_tuple;
-mod svec_u8;
 mod svec_u16;
 mod svec_u32;
 mod svec_u64;
+mod svec_u8;


### PR DESCRIPTION
## Description
Closes #4206 

Three main changes: 
* Add new configuration-time constants tests to `sdk-harness`. This is important to make sure there are no regression in the backend.
* Add a new example for `configurable`
* Document `configurable`
* Had to bump to `fuels 0.37` to be able to update `configurable` variables from the SDK.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
