### PR TITLE
Share utils between sway-parse unit tests

### DIFF
--- a/sway-parse/src/attribute.rs
+++ b/sway-parse/src/attribute.rs
@@ -115,24 +115,13 @@ impl ParseToEnd for Attribute {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::parse;
     use insta::*;
-    use std::sync::Arc;
     use sway_ast::ItemFn;
-
-    fn parse_annotated<T>(input: &str) -> Annotated<T>
-    where
-        T: Parse,
-    {
-        let handler = <_>::default();
-        let ts = crate::token::lex(&handler, &Arc::from(input), 0, input.len(), None).unwrap();
-        Parser::new(&handler, &ts)
-            .parse()
-            .unwrap_or_else(|_| panic!("Parse error: {:?}", handler.consume().0))
-    }
 
     #[test]
     fn parse_annotated_fn() {
-        assert_ron_snapshot!(parse_annotated::<ItemFn>(r#"
+        assert_ron_snapshot!(parse::<Annotated<ItemFn>>(r#"
             // I will be ignored.
             //! I will be ignored.
             /// This is a doc comment.

--- a/sway-parse/src/item/mod.rs
+++ b/sway-parse/src/item/mod.rs
@@ -167,16 +167,8 @@ impl Parse for FnSignature {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use crate::test_utils::parse;
     use sway_ast::{AttributeDecl, Item, ItemTraitItem};
-
-    fn parse_item(input: &str) -> Item {
-        let handler = <_>::default();
-        let ts = crate::token::lex(&handler, &Arc::from(input), 0, input.len(), None).unwrap();
-        Parser::new(&handler, &ts)
-            .parse()
-            .unwrap_or_else(|_| panic!("Parse error: {:?}", handler.consume().0))
-    }
 
     // Attribute name and its list of parameters
     type ParameterizedAttr<'a> = (&'a str, Option<Vec<&'a str>>);
@@ -204,7 +196,7 @@ mod tests {
 
     #[test]
     fn parse_doc_comment() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             // I will be ignored.
             //! I will be ignored.
@@ -225,7 +217,7 @@ mod tests {
 
     #[test]
     fn parse_doc_comment_struct() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             // I will be ignored.
             //! I will be ignored. 
@@ -264,7 +256,7 @@ mod tests {
 
     #[test]
     fn parse_attributes_none() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             fn f() -> bool {
                 false
@@ -278,7 +270,7 @@ mod tests {
 
     #[test]
     fn parse_attributes_fn_basic() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             #[foo]
             fn f() -> bool {
@@ -293,7 +285,7 @@ mod tests {
 
     #[test]
     fn parse_attributes_fn_two_basic() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             #[foo]
             #[bar]
@@ -313,7 +305,7 @@ mod tests {
 
     #[test]
     fn parse_attributes_fn_one_arg() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             #[foo(one)]
             fn f() -> bool {
@@ -331,7 +323,7 @@ mod tests {
 
     #[test]
     fn parse_attributes_fn_empty_parens() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             #[foo()]
             fn f() -> bool {
@@ -349,7 +341,7 @@ mod tests {
 
     #[test]
     fn parse_attributes_fn_zero_and_one_arg() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             #[bar]
             #[foo(one)]
@@ -368,7 +360,7 @@ mod tests {
 
     #[test]
     fn parse_attributes_fn_one_and_zero_arg() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             #[foo(one)]
             #[bar]
@@ -387,7 +379,7 @@ mod tests {
 
     #[test]
     fn parse_attributes_fn_two_args() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             #[foo(one, two)]
             fn f() -> bool {
@@ -405,7 +397,7 @@ mod tests {
 
     #[test]
     fn parse_attributes_fn_zero_one_and_three_args() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             #[bar]
             #[foo(one)]
@@ -429,7 +421,7 @@ mod tests {
 
     #[test]
     fn parse_attributes_fn_zero_one_and_three_args_in_one_attribute_decl() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             #[bar, foo(one), baz(two,three,four)]
             fn f() -> bool {
@@ -451,7 +443,7 @@ mod tests {
 
     #[test]
     fn parse_attributes_trait() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             trait T {
                 #[foo(one)]
@@ -505,7 +497,7 @@ mod tests {
 
     #[test]
     fn parse_attributes_abi() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             abi A {
                 #[bar(one, two, three)]
@@ -564,7 +556,7 @@ mod tests {
 
     #[test]
     fn parse_attributes_doc_comment() {
-        let item = parse_item(
+        let item = parse::<Item>(
             r#"
             /// This is a doc comment.
             /// This is another doc comment.

--- a/sway-parse/src/lib.rs
+++ b/sway-parse/src/lib.rs
@@ -59,3 +59,32 @@ pub fn parse_module_kind(
     }
     parser.parse()
 }
+
+#[cfg(test)]
+mod test_utils {
+    use crate::{priv_prelude::ParseToEnd, Parse, Parser};
+    use std::sync::Arc;
+
+    pub fn parse<T>(input: &str) -> T
+    where
+        T: Parse,
+    {
+        let handler = <_>::default();
+        let ts = crate::token::lex(&handler, &Arc::from(input), 0, input.len(), None).unwrap();
+        Parser::new(&handler, &ts)
+            .parse()
+            .unwrap_or_else(|_| panic!("Parse error: {:?}", handler.consume().0))
+    }
+
+    pub fn parse_to_end<T>(input: &str) -> T
+    where
+        T: ParseToEnd,
+    {
+        let handler = <_>::default();
+        let ts = crate::token::lex(&handler, &Arc::from(input), 0, input.len(), None).unwrap();
+        Parser::new(&handler, &ts)
+            .parse_to_end()
+            .map(|(m, _)| m)
+            .unwrap_or_else(|_| panic!("Parse error: {:?}", handler.consume().0))
+    }
+}

--- a/sway-parse/src/lib.rs
+++ b/sway-parse/src/lib.rs
@@ -13,6 +13,8 @@ mod pattern;
 mod priv_prelude;
 mod punctuated;
 mod submodule;
+#[cfg(test)]
+mod test_utils;
 mod token;
 mod ty;
 mod where_clause;
@@ -58,33 +60,4 @@ pub fn parse_module_kind(
         parser.parse::<DocComment>()?;
     }
     parser.parse()
-}
-
-#[cfg(test)]
-mod test_utils {
-    use crate::{priv_prelude::ParseToEnd, Parse, Parser};
-    use std::sync::Arc;
-
-    pub fn parse<T>(input: &str) -> T
-    where
-        T: Parse,
-    {
-        let handler = <_>::default();
-        let ts = crate::token::lex(&handler, &Arc::from(input), 0, input.len(), None).unwrap();
-        Parser::new(&handler, &ts)
-            .parse()
-            .unwrap_or_else(|_| panic!("Parse error: {:?}", handler.consume().0))
-    }
-
-    pub fn parse_to_end<T>(input: &str) -> T
-    where
-        T: ParseToEnd,
-    {
-        let handler = <_>::default();
-        let ts = crate::token::lex(&handler, &Arc::from(input), 0, input.len(), None).unwrap();
-        Parser::new(&handler, &ts)
-            .parse_to_end()
-            .map(|(m, _)| m)
-            .unwrap_or_else(|_| panic!("Parse error: {:?}", handler.consume().0))
-    }
 }

--- a/sway-parse/src/module.rs
+++ b/sway-parse/src/module.rs
@@ -78,21 +78,12 @@ impl ParseToEnd for Annotated<Module> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::parse_to_end;
     use insta::*;
-    use std::sync::Arc;
-
-    fn parse_annotated_module(input: &str) -> Annotated<Module> {
-        let handler = <_>::default();
-        let ts = crate::token::lex(&handler, &Arc::from(input), 0, input.len(), None).unwrap();
-        Parser::new(&handler, &ts)
-            .parse_to_end()
-            .map(|(m, _)| m)
-            .unwrap_or_else(|_| panic!("Parse error: {:?}", handler.consume().0))
-    }
 
     #[test]
     fn parse_noop_script_module() {
-        assert_ron_snapshot!(parse_annotated_module(r#"
+        assert_ron_snapshot!(parse_to_end::<Annotated<Module>>(r#"
             script;
         
             fn main() {

--- a/sway-parse/src/path.rs
+++ b/sway-parse/src/path.rs
@@ -132,20 +132,12 @@ impl Parse for QualifiedPathRoot {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::parse;
     use insta::*;
-    use std::sync::Arc;
-
-    fn parse_path_expr(input: &str) -> PathExpr {
-        let handler = <_>::default();
-        let ts = crate::token::lex(&handler, &Arc::from(input), 0, input.len(), None).unwrap();
-        Parser::new(&handler, &ts)
-            .parse()
-            .unwrap_or_else(|_| panic!("Parse error: {:?}", handler.consume().0))
-    }
 
     #[test]
     fn parse_nested_path() {
-        assert_ron_snapshot!(parse_path_expr(r#"
+        assert_ron_snapshot!(parse::<PathExpr>(r#"
             std::vec::Vec
         "#,), @r###"
         PathExpr(

--- a/sway-parse/src/test_utils.rs
+++ b/sway-parse/src/test_utils.rs
@@ -1,0 +1,25 @@
+use crate::{priv_prelude::ParseToEnd, Parse, Parser};
+use std::sync::Arc;
+
+pub fn parse<T>(input: &str) -> T
+where
+    T: Parse,
+{
+    let handler = <_>::default();
+    let ts = crate::token::lex(&handler, &Arc::from(input), 0, input.len(), None).unwrap();
+    Parser::new(&handler, &ts)
+        .parse()
+        .unwrap_or_else(|_| panic!("Parse error: {:?}", handler.consume().0))
+}
+
+pub fn parse_to_end<T>(input: &str) -> T
+where
+    T: ParseToEnd,
+{
+    let handler = <_>::default();
+    let ts = crate::token::lex(&handler, &Arc::from(input), 0, input.len(), None).unwrap();
+    Parser::new(&handler, &ts)
+        .parse_to_end()
+        .map(|(m, _)| m)
+        .unwrap_or_else(|_| panic!("Parse error: {:?}", handler.consume().0))
+}


### PR DESCRIPTION
This PR adds `mod sway_parse::test_utils` containing two utils, `fn parse<T>` and `fn parse_to_end<T>`, to replace non-generic utils like `fn parse_item`  or `fn parse_path_expr`.