### PR TITLE
fix: extra spaces in empty fn args

### DIFF
--- a/swayfmt/src/items/item_fn/mod.rs
+++ b/swayfmt/src/items/item_fn/mod.rs
@@ -170,12 +170,32 @@ fn format_fn_sig(
     if let Some(generics) = &fn_sig.generics {
         generics.format(formatted_code, formatter)?;
     }
+
+    let fn_args = fn_sig.arguments.get();
+
+    if let FnArgs::Static(args) = fn_args {
+        if args.value_separator_pairs.is_empty() && args.final_value_opt.is_none() {
+            formatter
+                .shape
+                .code_line
+                .update_line_style(LineStyle::Inline);
+        }
+    };
     // `(`
     FnSignature::open_parenthesis(formatted_code, formatter)?;
     // FnArgs
     format_fn_args(fn_sig.arguments.get(), formatted_code, formatter)?;
     // `)`
     FnSignature::close_parenthesis(formatted_code, formatter)?;
+
+    if let FnArgs::Static(args) = fn_args {
+        if args.value_separator_pairs.is_empty() && args.final_value_opt.is_none() {
+            formatter
+                .shape
+                .code_line
+                .update_line_style(LineStyle::Multiline);
+        }
+    };
     // `return_type_opt`
     if let Some((right_arrow, ty)) = &fn_sig.return_type_opt {
         write!(

--- a/swayfmt/src/items/item_fn/mod.rs
+++ b/swayfmt/src/items/item_fn/mod.rs
@@ -184,7 +184,7 @@ fn format_fn_sig(
     // `(`
     FnSignature::open_parenthesis(formatted_code, formatter)?;
     // FnArgs
-    format_fn_args(fn_sig.arguments.get(), formatted_code, formatter)?;
+    format_fn_args(fn_args, formatted_code, formatter)?;
     // `)`
     FnSignature::close_parenthesis(formatted_code, formatter)?;
 

--- a/swayfmt/src/items/item_impl/tests.rs
+++ b/swayfmt/src/items/item_impl/tests.rs
@@ -74,3 +74,17 @@ fmt_test_item!(  normal_with_generics
                 }
             }"
 );
+
+fmt_test_item!(  empty_fn_args
+"impl TestContract for Contract {
+    fn return_configurables() -> (u8, bool, [u32; 3], str[4], StructWithGeneric<u8>, EnumWithGeneric<bool>) {
+        (U8, BOOL, ARRAY, STR_4, STRUCT, ENUM)
+    }
+}",
+intermediate_whitespace
+"impl TestContract for Contract {
+    fn return_configurables(  ) -> ( u8, bool, [u32; 3], str[4], StructWithGeneric<u8>, EnumWithGeneric<bool>  )  {
+        ( U8,   BOOL, ARRAY, STR_4, STRUCT, ENUM )
+     }
+}"
+);


### PR DESCRIPTION
## Description

Closes #4250

The reason for the extra whitespaces is that even when the fn args are empty the linestyle was still being treated as multiline. A simple fix is to switch it to inline if there are no args, then switch it back after formatting.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
