### PR TITLE
Improve debug printing for `DeclId`.

### DIFF
--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -1,5 +1,5 @@
-use std::hash::Hash;
 use std::marker::PhantomData;
+use std::{fmt, hash::Hash};
 
 use crate::{
     decl_engine::*,
@@ -12,8 +12,14 @@ use crate::{
 };
 
 /// An ID used to refer to an item in the [DeclEngine](super::decl_engine::DeclEngine)
-#[derive(Debug, Ord, PartialOrd)]
+#[derive(Ord, PartialOrd)]
 pub struct DeclId<T>(usize, PhantomData<T>);
+
+impl<T> fmt::Debug for DeclId<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("DeclId").field(&self.0).finish()
+    }
+}
 
 impl<T> DeclId<T> {
     pub(crate) fn inner(&self) -> usize {


### PR DESCRIPTION
## Description

This basically gets rid of `PhantomData` noise in the default debug print.

Before:
`Constant(DeclRef { name: ID, id: DeclId(0, PhantomData<sway_core::language::ty::declaration::constant::TyConstantDeclaration>), decl_span: Span { as_str(): "ID" } })`

After:
`Constant(DeclRef { name: ID, id: DeclId(0), decl_span: Span { as_str(): "ID" } })`

