### PR TITLE
Make string representations of build targets consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ checksum = "af523c38969b431b33b06a82756659c9a07ea9aa185cb8a770c15fd5c95a0da6"
 dependencies = [
  "proc-macro2",
  "serde",
- "strum_macros",
+ "strum_macros 0.21.1",
 ]
 
 [[package]]
@@ -2229,8 +2229,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.21.0",
+ "strum_macros 0.21.1",
  "thiserror",
  "tokio",
 ]
@@ -4967,6 +4967,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
 
 [[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros 0.24.3",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4975,6 +4984,19 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn",
 ]
 
@@ -5036,6 +5058,7 @@ dependencies = [
  "serde_json",
  "sha2 0.9.9",
  "smallvec",
+ "strum 0.24.1",
  "sway-ast",
  "sway-error",
  "sway-ir",

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.91"
 sha2 = "0.9"
 smallvec = "1.7"
+strum = { version = "0.24.1", features = ["derive"] }
 sway-ast = { version = "0.35.5", path = "../sway-ast" }
 sway-error = { version = "0.35.5", path = "../sway-error" }
 sway-ir = { version = "0.35.5", path = "../sway-ir" }

--- a/sway-core/src/build_config.rs
+++ b/sway-core/src/build_config.rs
@@ -1,14 +1,34 @@
 use std::{path::PathBuf, sync::Arc};
 
 use serde::{Deserialize, Serialize};
+use strum::EnumString;
 
 #[derive(
-    Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize, clap::ValueEnum,
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    Hash,
+    Serialize,
+    Deserialize,
+    clap::ValueEnum,
+    EnumString,
 )]
 pub enum BuildTarget {
     #[default]
+    #[serde(rename = "fuel")]
+    #[clap(name = "fuel")]
+    #[strum(serialize = "fuel")]
     Fuel,
+    #[serde(rename = "evm")]
+    #[clap(name = "evm")]
+    #[strum(serialize = "evm")]
     EVM,
+    #[serde(rename = "midenvm")]
+    #[clap(name = "midenvm")]
+    #[strum(serialize = "midenvm")]
     MidenVM,
 }
 

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -16,6 +16,7 @@ use regex::Regex;
 use std::collections::HashSet;
 use std::io::stdout;
 use std::io::Write;
+use std::str::FromStr;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -707,10 +708,8 @@ fn parse_test_toml(path: &Path) -> Result<TestDescription> {
 
 fn get_test_abi_from_value(value: &toml::Value) -> Result<BuildTarget> {
     match value.as_str() {
-        Some(target) => match target {
-            "fuel" => Ok(BuildTarget::Fuel),
-            "evm" => Ok(BuildTarget::EVM),
-            "miden-vm" | "midenvm" => Ok(BuildTarget::MidenVM),
+        Some(target) => match BuildTarget::from_str(target) {
+            Ok(target) => Ok(target),
             _ => Err(anyhow!(format!("Unknown build target: {target}"))),
         },
         None => Err(anyhow!("Invalid TOML value")),

--- a/test/src/e2e_vm_tests/test_programs/should_pass/midenvm/midenvm_trivial/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/midenvm/midenvm_trivial/Forc.toml
@@ -4,5 +4,5 @@ license = "Apache-2.0"
 name = "midenvm-trivial"
 entry = "main.sw"
 implicit-std = false
-target = "miden-vm"
+target = "midenvm"
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/midenvm/midenvm_trivial/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/midenvm/midenvm_trivial/test.toml
@@ -1,3 +1,3 @@
 category = "run"
 expected_result = { action = "return", value = 42 }
-supported_targets = ["miden-vm"]
+supported_targets = ["midenvm"]

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -4,6 +4,7 @@ mod ir_generation;
 use anyhow::Result;
 use clap::Parser;
 use forc_tracing::init_tracing_subscriber;
+use std::str::FromStr;
 use sway_core::BuildTarget;
 use tracing::Instrument;
 
@@ -78,10 +79,8 @@ async fn main() -> Result<()> {
         first_only: cli.first_only,
     };
     let build_target = match cli.build_target {
-        Some(target) => match target.to_lowercase().as_str() {
-            "fuel" => BuildTarget::Fuel,
-            "evm" => BuildTarget::EVM,
-            "miden" | "midenvm" => BuildTarget::MidenVM,
+        Some(target) => match BuildTarget::from_str(target.as_str()) {
+            Ok(target) => target,
             _ => panic!("unexpected build target"),
         },
         None => BuildTarget::default(),


### PR DESCRIPTION
We had two implementations for converting a string to a `BuildTarget` and they didn't match. (One accepted "miden-vm" or "midenvm" and the other "miden" or "midenvm".) Now only "midenvm" is accepted and we use the same codepath everywhere.