### PR TITLE
Update `DeclEngine` API to use more abstract methods.

### DIFF
--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -72,34 +72,10 @@ impl<T> Into<usize> for DeclId<T> {
     }
 }
 
-impl<T> From<&DeclId<T>> for DeclId<T> {
-    fn from(value: &DeclId<T>) -> Self {
-        DeclId::new(value.0)
-    }
-}
-
-impl<T> From<&mut DeclId<T>> for DeclId<T> {
-    fn from(value: &mut DeclId<T>) -> Self {
-        DeclId::new(value.0)
-    }
-}
-
-impl<T> From<&DeclRef<DeclId<T>>> for DeclId<T> {
-    fn from(value: &DeclRef<DeclId<T>>) -> Self {
-        *value.id()
-    }
-}
-
-impl<T> From<&mut DeclRef<DeclId<T>>> for DeclId<T> {
-    fn from(value: &mut DeclRef<DeclId<T>>) -> Self {
-        *value.id()
-    }
-}
-
 impl SubstTypes for DeclId<TyFunctionDeclaration> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -107,7 +83,7 @@ impl SubstTypes for DeclId<TyFunctionDeclaration> {
 impl SubstTypes for DeclId<TyTraitDeclaration> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -115,7 +91,7 @@ impl SubstTypes for DeclId<TyTraitDeclaration> {
 impl SubstTypes for DeclId<TyTraitFn> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -123,7 +99,7 @@ impl SubstTypes for DeclId<TyTraitFn> {
 impl SubstTypes for DeclId<TyImplTrait> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -131,7 +107,7 @@ impl SubstTypes for DeclId<TyImplTrait> {
 impl SubstTypes for DeclId<TyStructDeclaration> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -139,7 +115,7 @@ impl SubstTypes for DeclId<TyStructDeclaration> {
 impl SubstTypes for DeclId<TyEnumDeclaration> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -147,7 +123,7 @@ impl SubstTypes for DeclId<TyEnumDeclaration> {
 impl SubstTypes for DeclId<TyTypeAliasDeclaration> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -156,7 +132,7 @@ impl SubstTypes for DeclId<TyTypeAliasDeclaration> {
 impl ReplaceSelfType for DeclId<TyFunctionDeclaration> {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.replace_self_type(engines, self_type);
         decl_engine.replace(*self, decl);
     }
@@ -164,7 +140,7 @@ impl ReplaceSelfType for DeclId<TyFunctionDeclaration> {
 impl ReplaceSelfType for DeclId<TyTraitDeclaration> {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.replace_self_type(engines, self_type);
         decl_engine.replace(*self, decl);
     }
@@ -172,7 +148,7 @@ impl ReplaceSelfType for DeclId<TyTraitDeclaration> {
 impl ReplaceSelfType for DeclId<TyTraitFn> {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.replace_self_type(engines, self_type);
         decl_engine.replace(*self, decl);
     }
@@ -180,7 +156,7 @@ impl ReplaceSelfType for DeclId<TyTraitFn> {
 impl ReplaceSelfType for DeclId<TyImplTrait> {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.replace_self_type(engines, self_type);
         decl_engine.replace(*self, decl);
     }
@@ -188,7 +164,7 @@ impl ReplaceSelfType for DeclId<TyImplTrait> {
 impl ReplaceSelfType for DeclId<TyStructDeclaration> {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.replace_self_type(engines, self_type);
         decl_engine.replace(*self, decl);
     }
@@ -196,7 +172,7 @@ impl ReplaceSelfType for DeclId<TyStructDeclaration> {
 impl ReplaceSelfType for DeclId<TyEnumDeclaration> {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.replace_self_type(engines, self_type);
         decl_engine.replace(*self, decl);
     }
@@ -204,7 +180,7 @@ impl ReplaceSelfType for DeclId<TyEnumDeclaration> {
 impl ReplaceSelfType for DeclId<TyTypeAliasDeclaration> {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(*self);
+        let mut decl = decl_engine.get(self);
         decl.replace_self_type(engines, self_type);
         decl_engine.replace(*self, decl);
     }

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -111,7 +111,7 @@ where
         engines: Engines<'_>,
     ) -> Self {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self.id);
+        let mut decl = decl_engine.get(&self.id);
         decl.subst(type_mapping, engines);
         decl_engine.insert(decl)
     }
@@ -127,7 +127,7 @@ where
         self_type: TypeId,
     ) -> Self {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self.id);
+        let mut decl = decl_engine.get(&self.id);
         decl.replace_self_type(engines, self_type);
         decl_engine.insert(decl)
     }
@@ -156,7 +156,7 @@ where
         engines: Engines<'_>,
     ) -> Self {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self.id);
+        let mut decl = decl_engine.get(&self.id);
         decl.subst(type_mapping, engines);
         decl_engine
             .insert(decl)
@@ -175,7 +175,7 @@ where
         self_type: TypeId,
     ) -> Self {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self.id);
+        let mut decl = decl_engine.get(&self.id);
         decl.replace_self_type(engines, self_type);
         decl_engine
             .insert(decl)
@@ -194,7 +194,7 @@ where
         engines: Engines<'_>,
     ) -> Self {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self.id);
+        let mut decl = decl_engine.get(&self.id);
         decl.replace_decls(decl_mapping, engines);
         decl_engine
             .insert(decl)
@@ -233,7 +233,7 @@ where
             // temporarily omitted
             subst_list: _,
         } = other;
-        ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines)
+        ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines)
     }
 }
 
@@ -254,7 +254,7 @@ where
             subst_list: _,
         } = self;
         name.hash(state);
-        decl_engine.get(*id).hash(state, engines);
+        decl_engine.get(id).hash(state, engines);
     }
 }
 
@@ -264,13 +264,13 @@ impl PartialEqWithEngines for DeclRefMixedInterface {
         let decl_engine = engines.de();
         match (&self.id, &other.id) {
             (InterfaceDeclId::Abi(self_id), InterfaceDeclId::Abi(other_id)) => {
-                let left = decl_engine.get(*self_id);
-                let right = decl_engine.get(*other_id);
+                let left = decl_engine.get(self_id);
+                let right = decl_engine.get(other_id);
                 self.name == other.name && left.eq(&right, engines)
             }
             (InterfaceDeclId::Trait(self_id), InterfaceDeclId::Trait(other_id)) => {
-                let left = decl_engine.get(*self_id);
-                let right = decl_engine.get(*other_id);
+                let left = decl_engine.get(self_id);
+                let right = decl_engine.get(other_id);
                 self.name == other.name && left.eq(&right, engines)
             }
             _ => false,
@@ -284,13 +284,13 @@ impl HashWithEngines for DeclRefMixedInterface {
             InterfaceDeclId::Abi(id) => {
                 state.write_u8(0);
                 let decl_engine = engines.de();
-                let decl = decl_engine.get(id);
+                let decl = decl_engine.get(&id);
                 decl.hash(state, engines);
             }
             InterfaceDeclId::Trait(id) => {
                 state.write_u8(1);
                 let decl_engine = engines.de();
-                let decl = decl_engine.get(id);
+                let decl = decl_engine.get(&id);
                 decl.hash(state, engines);
             }
         }
@@ -310,7 +310,7 @@ where
 {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self.id);
+        let mut decl = decl_engine.get(&self.id);
         decl.subst(type_mapping, engines);
         decl_engine.replace(self.id, decl);
     }
@@ -323,7 +323,7 @@ where
 {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self.id);
+        let mut decl = decl_engine.get(&self.id);
         decl.replace_self_type(engines, self_type);
         decl_engine.replace(self.id, decl);
     }
@@ -357,7 +357,7 @@ impl ReplaceFunctionImplementingType for DeclRefFunction {
         implementing_type: ty::TyDeclaration,
     ) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self.id);
+        let mut decl = decl_engine.get(&self.id);
         decl.set_implementing_type(implementing_type);
         decl_engine.replace(self.id, decl);
     }

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -93,7 +93,7 @@ impl PartialEqWithEngines for TyDeclaration {
                     decl_id: rid,
                     ..
                 },
-            ) => ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
 
             (
                 Self::FunctionDeclaration {
@@ -106,7 +106,7 @@ impl PartialEqWithEngines for TyDeclaration {
                     decl_id: rid,
                     ..
                 },
-            ) => ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
 
             (
                 Self::TraitDeclaration {
@@ -119,7 +119,7 @@ impl PartialEqWithEngines for TyDeclaration {
                     decl_id: rid,
                     ..
                 },
-            ) => ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
             (
                 Self::StructDeclaration {
                     name: ln,
@@ -131,7 +131,7 @@ impl PartialEqWithEngines for TyDeclaration {
                     decl_id: rid,
                     ..
                 },
-            ) => ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
             (
                 Self::EnumDeclaration {
                     name: ln,
@@ -143,7 +143,7 @@ impl PartialEqWithEngines for TyDeclaration {
                     decl_id: rid,
                     ..
                 },
-            ) => ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
             (
                 Self::ImplTrait {
                     name: ln,
@@ -155,7 +155,7 @@ impl PartialEqWithEngines for TyDeclaration {
                     decl_id: rid,
                     ..
                 },
-            ) => ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
 
             (
                 Self::AbiDeclaration {
@@ -168,15 +168,15 @@ impl PartialEqWithEngines for TyDeclaration {
                     decl_id: rid,
                     ..
                 },
-            ) => ln == rn && decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
             (
                 Self::StorageDeclaration { decl_id: lid, .. },
                 Self::StorageDeclaration { decl_id: rid, .. },
-            ) => decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
+            ) => decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
             (
                 Self::TypeAliasDeclaration { decl_id: lid, .. },
                 Self::TypeAliasDeclaration { decl_id: rid, .. },
-            ) => decl_engine.get(*lid).eq(&decl_engine.get(*rid), engines),
+            ) => decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
             (
                 Self::GenericTypeForFunctionScope {
                     name: xn,
@@ -204,31 +204,31 @@ impl HashWithEngines for TyDeclaration {
                 decl.hash(state, engines);
             }
             ConstantDeclaration { decl_id, .. } => {
-                decl_engine.get(*decl_id).hash(state, engines);
+                decl_engine.get(decl_id).hash(state, engines);
             }
             FunctionDeclaration { decl_id, .. } => {
-                decl_engine.get(*decl_id).hash(state, engines);
+                decl_engine.get(decl_id).hash(state, engines);
             }
             TraitDeclaration { decl_id, .. } => {
-                decl_engine.get(*decl_id).hash(state, engines);
+                decl_engine.get(decl_id).hash(state, engines);
             }
             StructDeclaration { decl_id, .. } => {
-                decl_engine.get(*decl_id).hash(state, engines);
+                decl_engine.get(decl_id).hash(state, engines);
             }
             EnumDeclaration { decl_id, .. } => {
-                decl_engine.get(*decl_id).hash(state, engines);
+                decl_engine.get(decl_id).hash(state, engines);
             }
             ImplTrait { decl_id, .. } => {
-                decl_engine.get(*decl_id).hash(state, engines);
+                decl_engine.get(decl_id).hash(state, engines);
             }
             AbiDeclaration { decl_id, .. } => {
-                decl_engine.get(*decl_id).hash(state, engines);
+                decl_engine.get(decl_id).hash(state, engines);
             }
             TypeAliasDeclaration { decl_id, .. } => {
-                decl_engine.get(*decl_id).hash(state, engines);
+                decl_engine.get(decl_id).hash(state, engines);
             }
             StorageDeclaration { decl_id, .. } => {
-                decl_engine.get(*decl_id).hash(state, engines);
+                decl_engine.get(decl_id).hash(state, engines);
             }
             GenericTypeForFunctionScope { name, type_id } => {
                 name.hash(state);

--- a/sway-core/src/language/ty/declaration/trait.rs
+++ b/sway-core/src/language/ty/declaration/trait.rs
@@ -143,13 +143,13 @@ impl SubstTypes for TyTraitDeclaration {
                     let new_item_ref = item_ref
                         .clone()
                         .subst_types_and_insert_new_with_parent(type_mapping, engines);
-                    item_ref.replace_id((&new_item_ref).into());
+                    item_ref.replace_id(*new_item_ref.id());
                 }
                 TyTraitInterfaceItem::Constant(decl_ref) => {
                     let new_decl_ref = decl_ref
                         .clone()
                         .subst_types_and_insert_new(type_mapping, engines);
-                    decl_ref.replace_id((&new_decl_ref).into());
+                    decl_ref.replace_id(*new_decl_ref.id());
                 }
             });
         self.items.iter_mut().for_each(|item| match item {
@@ -157,13 +157,13 @@ impl SubstTypes for TyTraitDeclaration {
                 let new_item_ref = item_ref
                     .clone()
                     .subst_types_and_insert_new_with_parent(type_mapping, engines);
-                item_ref.replace_id((&new_item_ref).into());
+                item_ref.replace_id(*new_item_ref.id());
             }
             TyTraitItem::Constant(item_ref) => {
-                let new_item_ref = item_ref
+                let new_decl_ref = item_ref
                     .clone()
                     .subst_types_and_insert_new_with_parent(type_mapping, engines);
-                item_ref.replace_id((&new_item_ref).into());
+                item_ref.replace_id(*new_decl_ref.id());
             }
         });
     }
@@ -190,13 +190,13 @@ impl ReplaceSelfType for TyTraitDeclaration {
                     let new_item_ref = item_ref
                         .clone()
                         .replace_self_type_and_insert_new_with_parent(engines, self_type);
-                    item_ref.replace_id((&new_item_ref).into());
+                    item_ref.replace_id(*new_item_ref.id());
                 }
                 TyTraitInterfaceItem::Constant(decl_ref) => {
-                    let new_decl_id = decl_ref
+                    let new_decl_ref = decl_ref
                         .clone()
                         .replace_self_type_and_insert_new(engines, self_type);
-                    decl_ref.replace_id((&new_decl_id).into());
+                    decl_ref.replace_id(*new_decl_ref.id());
                 }
             });
         self.items.iter_mut().for_each(|item| match item {
@@ -204,13 +204,13 @@ impl ReplaceSelfType for TyTraitDeclaration {
                 let new_item_ref = item_ref
                     .clone()
                     .replace_self_type_and_insert_new_with_parent(engines, self_type);
-                item_ref.replace_id((&new_item_ref).into());
+                item_ref.replace_id(*new_item_ref.id());
             }
             TyTraitItem::Constant(item_ref) => {
-                let new_item_ref = item_ref
+                let new_decl_ref = item_ref
                     .clone()
                     .replace_self_type_and_insert_new(engines, self_type);
-                item_ref.replace_id((&new_item_ref).into());
+                item_ref.replace_id(*new_decl_ref.id());
             }
         });
     }

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -577,7 +577,7 @@ impl SubstTypes for TyExpressionVariant {
                 let new_decl_ref = fn_ref
                     .clone()
                     .subst_types_and_insert_new_with_parent(type_mapping, engines);
-                fn_ref.replace_id((&new_decl_ref).into());
+                fn_ref.replace_id(*new_decl_ref.id());
             }
             LazyOperator { lhs, rhs, .. } => {
                 (*lhs).subst(type_mapping, engines);
@@ -603,7 +603,7 @@ impl SubstTypes for TyExpressionVariant {
                 let new_struct_ref = struct_ref
                     .clone()
                     .subst_types_and_insert_new(type_mapping, engines);
-                struct_ref.replace_id((&new_struct_ref).into());
+                struct_ref.replace_id(*new_struct_ref.id());
                 fields
                     .iter_mut()
                     .for_each(|x| x.subst(type_mapping, engines));
@@ -658,7 +658,7 @@ impl SubstTypes for TyExpressionVariant {
                 let new_enum_ref = enum_ref
                     .clone()
                     .subst_types_and_insert_new(type_mapping, engines);
-                enum_ref.replace_id((&new_enum_ref).into());
+                enum_ref.replace_id(*new_enum_ref.id());
                 if let Some(ref mut contents) = contents {
                     contents.subst(type_mapping, engines)
                 };
@@ -709,7 +709,7 @@ impl ReplaceSelfType for TyExpressionVariant {
                 let new_decl_ref = fn_ref
                     .clone()
                     .replace_self_type_and_insert_new_with_parent(engines, self_type);
-                fn_ref.replace_id((&new_decl_ref).into());
+                fn_ref.replace_id(*new_decl_ref.id());
             }
             LazyOperator { lhs, rhs, .. } => {
                 (*lhs).replace_self_type(engines, self_type);
@@ -735,7 +735,7 @@ impl ReplaceSelfType for TyExpressionVariant {
                 let new_struct_ref = struct_ref
                     .clone()
                     .replace_self_type_and_insert_new(engines, self_type);
-                struct_ref.replace_id((&new_struct_ref).into());
+                struct_ref.replace_id(*new_struct_ref.id());
                 fields
                     .iter_mut()
                     .for_each(|x| x.replace_self_type(engines, self_type));
@@ -785,7 +785,7 @@ impl ReplaceSelfType for TyExpressionVariant {
                 let new_enum_ref = enum_ref
                     .clone()
                     .replace_self_type_and_insert_new(engines, self_type);
-                enum_ref.replace_id((&new_enum_ref).into());
+                enum_ref.replace_id(*new_enum_ref.id());
                 if let Some(ref mut contents) = contents {
                     contents.replace_self_type(engines, self_type)
                 };
@@ -833,7 +833,7 @@ impl ReplaceDecls for TyExpressionVariant {
                 let new_decl_ref = fn_ref
                     .clone()
                     .replace_decls_and_insert_new_with_parent(decl_mapping, engines);
-                fn_ref.replace_id((&new_decl_ref).into());
+                fn_ref.replace_id(*new_decl_ref.id());
                 for (_, arg) in arguments.iter_mut() {
                     arg.replace_decls(decl_mapping, engines);
                 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -2,7 +2,7 @@ use sway_error::error::CompileError;
 use sway_types::Spanned;
 
 use crate::{
-    decl_engine::DeclEngineIndex,
+    decl_engine::DeclEngineInsert,
     error::*,
     language::{
         parsed::*,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -1,7 +1,7 @@
 use sway_types::{Named, Spanned};
 
 use crate::{
-    decl_engine::{DeclEngineIndex, DeclRef, ReplaceFunctionImplementingType},
+    decl_engine::{DeclEngineInsert, DeclRef, ReplaceFunctionImplementingType},
     error::*,
     language::{parsed, ty},
     semantic_analysis::TypeCheckContext,

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -2,7 +2,7 @@ use sway_error::error::CompileError;
 use sway_types::{BaseIdent, Ident, Span, Spanned};
 
 use crate::{
-    decl_engine::DeclEngineIndex,
+    decl_engine::DeclEngineInsert,
     error::*,
     language::{parsed::*, ty, CallPath},
     semantic_analysis::TypeCheckContext,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -1,5 +1,5 @@
 use crate::{
-    decl_engine::{DeclEngineIndex, DeclRefFunction, ReplaceDecls},
+    decl_engine::{DeclEngineInsert, DeclRefFunction, ReplaceDecls},
     error::*,
     language::{ty, *},
     semantic_analysis::{ast_node::*, TypeCheckContext},

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -1,5 +1,5 @@
 use crate::{
-    decl_engine::{DeclEngineIndex, DeclRefFunction},
+    decl_engine::{DeclEngineInsert, DeclRefFunction},
     error::*,
     language::{parsed::*, ty, *},
     semantic_analysis::*,

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -7,7 +7,7 @@ use sway_error::error::CompileError;
 use sway_types::{Ident, Span, Spanned};
 
 use crate::{
-    decl_engine::DeclEngineIndex,
+    decl_engine::{DeclEngineGet, DeclEngineInsert},
     engine_threading::*,
     error::*,
     language::{
@@ -614,7 +614,7 @@ impl TraitMap {
                         .into_iter()
                         .map(|(name, item)| match &item {
                             ty::TyTraitItem::Fn(decl_ref) => {
-                                let mut decl = decl_engine.get(*decl_ref.id());
+                                let mut decl = decl_engine.get(decl_ref.id());
                                 decl.subst(&type_mapping, engines);
                                 decl.replace_self_type(engines, new_self_type);
                                 let new_ref = decl_engine
@@ -623,7 +623,7 @@ impl TraitMap {
                                 (name, TyImplItem::Fn(new_ref))
                             }
                             ty::TyTraitItem::Constant(decl_ref) => {
-                                let mut decl = decl_engine.get(*decl_ref.id());
+                                let mut decl = decl_engine.get(decl_ref.id());
                                 decl.subst(&type_mapping, engines);
                                 decl.replace_self_type(engines, new_self_type);
                                 let new_ref = decl_engine.insert(decl);

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    decl_engine::{DeclEngine, DeclEngineIndex},
+    decl_engine::{DeclEngine, DeclEngineInsert},
     engine_threading::*,
 };
 

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -33,7 +33,7 @@ pub(crate) use unconstrained_type_parameters::*;
 use crate::error::*;
 #[cfg(test)]
 use crate::{
-    decl_engine::DeclEngineIndex, language::ty::TyEnumDeclaration, transform::AttributesMap,
+    decl_engine::DeclEngineInsert, language::ty::TyEnumDeclaration, transform::AttributesMap,
 };
 use std::fmt::Debug;
 

--- a/sway-core/src/type_system/substitute.rs
+++ b/sway-core/src/type_system/substitute.rs
@@ -8,7 +8,7 @@ use std::{
 
 use super::*;
 use crate::{
-    decl_engine::{DeclEngine, DeclEngineIndex},
+    decl_engine::{DeclEngine, DeclEngineInsert},
     engine_threading::*,
 };
 


### PR DESCRIPTION
## Description

This PR updates the `DeclEngine` API to use more abstract implementations of `get`, `insert`, and `replace`. The goal of this PR is to move the `get` method into a separate trait so that there can be individual implementations for `DeclId` and `DeclRef`. In this PR there is no need to introduce different behavior between the two implementations, but there will be in the future.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
