### PR TITLE
Rename `Declaration` to `Decl` in a number of places.

### DIFF
--- a/forc-plugins/forc-doc/src/descriptor.rs
+++ b/forc-plugins/forc-doc/src/descriptor.rs
@@ -6,7 +6,7 @@ use crate::{
 use anyhow::Result;
 use sway_core::{
     decl_engine::*,
-    language::ty::{TyDeclaration, TyTraitFn, TyTraitInterfaceItem},
+    language::ty::{TyDecl, TyTraitFn, TyTraitInterfaceItem},
 };
 
 trait RequiredMethods {
@@ -30,16 +30,16 @@ impl Descriptor {
     /// Decides whether a [TyDeclaration] is [Descriptor::Documentable].
     pub(crate) fn from_typed_decl(
         decl_engine: &DeclEngine,
-        ty_decl: &TyDeclaration,
+        ty_decl: &TyDecl,
         module_info: ModuleInfo,
         document_private_items: bool,
     ) -> Result<Self> {
         const CONTRACT_STORAGE: &str = "Contract Storage";
 
         use swayfmt::parse;
-        use TyDeclaration::*;
+        use TyDecl::*;
         match ty_decl {
-            StructDeclaration { decl_id, .. } => {
+            StructDecl { decl_id, .. } => {
                 let struct_decl = decl_engine.get_struct(decl_id);
                 if !document_private_items && struct_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
@@ -75,7 +75,7 @@ impl Descriptor {
                     }))
                 }
             }
-            EnumDeclaration { decl_id, .. } => {
+            EnumDecl { decl_id, .. } => {
                 let enum_decl = decl_engine.get_enum(decl_id);
                 if !document_private_items && enum_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
@@ -111,7 +111,7 @@ impl Descriptor {
                     }))
                 }
             }
-            TraitDeclaration { decl_id, .. } => {
+            TraitDecl { decl_id, .. } => {
                 let trait_decl = decl_engine.get_trait(decl_id);
                 if !document_private_items && trait_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
@@ -158,7 +158,7 @@ impl Descriptor {
                     }))
                 }
             }
-            AbiDeclaration { decl_id, .. } => {
+            AbiDecl { decl_id, .. } => {
                 let abi_decl = decl_engine.get_abi(decl_id);
                 let item_name = abi_decl.name;
                 let attrs_opt =
@@ -198,7 +198,7 @@ impl Descriptor {
                     raw_attributes: attrs_opt,
                 }))
             }
-            StorageDeclaration { decl_id, .. } => {
+            StorageDecl { decl_id, .. } => {
                 let storage_decl = decl_engine.get_storage(decl_id);
                 let item_name = sway_types::BaseIdent::new_no_trim(
                     sway_types::span::Span::from_string(CONTRACT_STORAGE.to_string()),
@@ -260,7 +260,7 @@ impl Descriptor {
             //         raw_attributes: None,
             //     }))
             // }
-            FunctionDeclaration { decl_id, .. } => {
+            FunctionDecl { decl_id, .. } => {
                 let fn_decl = decl_engine.get_function(decl_id);
                 if !document_private_items && fn_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
@@ -290,7 +290,7 @@ impl Descriptor {
                     }))
                 }
             }
-            ConstantDeclaration { decl_id, .. } => {
+            ConstantDecl { decl_id, .. } => {
                 let const_decl = decl_engine.get_constant(decl_id);
                 if !document_private_items && const_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)

--- a/forc-plugins/forc-doc/src/descriptor.rs
+++ b/forc-plugins/forc-doc/src/descriptor.rs
@@ -27,7 +27,7 @@ pub(crate) enum Descriptor {
 }
 
 impl Descriptor {
-    /// Decides whether a [TyDeclaration] is [Descriptor::Documentable].
+    /// Decides whether a [TyDecl] is [Descriptor::Documentable].
     pub(crate) fn from_typed_decl(
         decl_engine: &DeclEngine,
         ty_decl: &TyDecl,

--- a/forc-plugins/forc-doc/src/doc.rs
+++ b/forc-plugins/forc-doc/src/doc.rs
@@ -30,9 +30,9 @@ pub(crate) struct Document {
 impl Document {
     /// Creates an HTML file name from the [Document].
     pub(crate) fn html_filename(&self) -> String {
-        use sway_core::language::ty::TyDeclaration::StorageDeclaration;
+        use sway_core::language::ty::TyDecl::StorageDecl;
         let name = match &self.item_body.ty_decl {
-            StorageDeclaration { .. } => None,
+            StorageDecl { .. } => None,
             _ => Some(self.item_header.item_name.as_str()),
         };
 

--- a/forc-plugins/forc-doc/src/render.rs
+++ b/forc-plugins/forc-doc/src/render.rs
@@ -8,7 +8,7 @@ use horrorshow::{box_html, helper::doctype, html, prelude::*, Raw};
 use std::{collections::BTreeMap, fmt::Write, path::PathBuf};
 use sway_core::{
     language::ty::{
-        TyDeclaration::{self, *},
+        TyDecl::{self, *},
         TyEnumVariant, TyProgramKind, TyStorageField, TyStructField, TyTraitFn,
     },
     transform::{AttributeKind, AttributesMap},
@@ -68,31 +68,31 @@ impl RenderedDocumentation {
             match module_map.get_mut(&location) {
                 Some(doc_links) => {
                     match doc.item_body.ty_decl {
-                        StructDeclaration { .. } => match doc_links.get_mut(&BlockTitle::Structs) {
+                        StructDecl { .. } => match doc_links.get_mut(&BlockTitle::Structs) {
                             Some(links) => links.push(doc.link()),
                             None => {
                                 doc_links.insert(BlockTitle::Structs, vec![doc.link()]);
                             }
                         },
-                        EnumDeclaration { .. } => match doc_links.get_mut(&BlockTitle::Enums) {
+                        EnumDecl { .. } => match doc_links.get_mut(&BlockTitle::Enums) {
                             Some(links) => links.push(doc.link()),
                             None => {
                                 doc_links.insert(BlockTitle::Enums, vec![doc.link()]);
                             }
                         },
-                        TraitDeclaration { .. } => match doc_links.get_mut(&BlockTitle::Traits) {
+                        TraitDecl { .. } => match doc_links.get_mut(&BlockTitle::Traits) {
                             Some(links) => links.push(doc.link()),
                             None => {
                                 doc_links.insert(BlockTitle::Traits, vec![doc.link()]);
                             }
                         },
-                        AbiDeclaration { .. } => match doc_links.get_mut(&BlockTitle::Abi) {
+                        AbiDecl { .. } => match doc_links.get_mut(&BlockTitle::Abi) {
                             Some(links) => links.push(doc.link()),
                             None => {
                                 doc_links.insert(BlockTitle::Abi, vec![doc.link()]);
                             }
                         },
-                        StorageDeclaration { .. } => {
+                        StorageDecl { .. } => {
                             match doc_links.get_mut(&BlockTitle::ContractStorage) {
                                 Some(links) => links.push(doc.link()),
                                 None => {
@@ -100,47 +100,43 @@ impl RenderedDocumentation {
                                 }
                             }
                         }
-                        FunctionDeclaration { .. } => {
-                            match doc_links.get_mut(&BlockTitle::Functions) {
-                                Some(links) => links.push(doc.link()),
-                                None => {
-                                    doc_links.insert(BlockTitle::Functions, vec![doc.link()]);
-                                }
+                        FunctionDecl { .. } => match doc_links.get_mut(&BlockTitle::Functions) {
+                            Some(links) => links.push(doc.link()),
+                            None => {
+                                doc_links.insert(BlockTitle::Functions, vec![doc.link()]);
                             }
-                        }
-                        ConstantDeclaration { .. } => {
-                            match doc_links.get_mut(&BlockTitle::Constants) {
-                                Some(links) => links.push(doc.link()),
-                                None => {
-                                    doc_links.insert(BlockTitle::Constants, vec![doc.link()]);
-                                }
+                        },
+                        ConstantDecl { .. } => match doc_links.get_mut(&BlockTitle::Constants) {
+                            Some(links) => links.push(doc.link()),
+                            None => {
+                                doc_links.insert(BlockTitle::Constants, vec![doc.link()]);
                             }
-                        }
+                        },
                         _ => {} // TODO: ImplTraitDeclaration
                     }
                 }
                 None => {
                     let mut doc_links: BTreeMap<BlockTitle, Vec<DocLink>> = BTreeMap::new();
                     match doc.item_body.ty_decl {
-                        StructDeclaration { .. } => {
+                        StructDecl { .. } => {
                             doc_links.insert(BlockTitle::Structs, vec![doc.link()]);
                         }
-                        EnumDeclaration { .. } => {
+                        EnumDecl { .. } => {
                             doc_links.insert(BlockTitle::Enums, vec![doc.link()]);
                         }
-                        TraitDeclaration { .. } => {
+                        TraitDecl { .. } => {
                             doc_links.insert(BlockTitle::Traits, vec![doc.link()]);
                         }
-                        AbiDeclaration { .. } => {
+                        AbiDecl { .. } => {
                             doc_links.insert(BlockTitle::Abi, vec![doc.link()]);
                         }
-                        StorageDeclaration { .. } => {
+                        StorageDecl { .. } => {
                             doc_links.insert(BlockTitle::ContractStorage, vec![doc.link()]);
                         }
-                        FunctionDeclaration { .. } => {
+                        FunctionDecl { .. } => {
                             doc_links.insert(BlockTitle::Functions, vec![doc.link()]);
                         }
-                        ConstantDeclaration { .. } => {
+                        ConstantDecl { .. } => {
                             doc_links.insert(BlockTitle::Constants, vec![doc.link()]);
                         }
                         _ => {} // TODO: ImplTraitDeclaration
@@ -187,60 +183,54 @@ impl RenderedDocumentation {
             }
             // Above we check for the module a link belongs to, here we want _all_ links so the check is much more shallow.
             match doc.item_body.ty_decl {
-                StructDeclaration { .. } => match all_docs.links.get_mut(&BlockTitle::Structs) {
+                StructDecl { .. } => match all_docs.links.get_mut(&BlockTitle::Structs) {
                     Some(links) => links.push(doc.link()),
                     None => {
                         all_docs.links.insert(BlockTitle::Structs, vec![doc.link()]);
                     }
                 },
-                EnumDeclaration { .. } => match all_docs.links.get_mut(&BlockTitle::Enums) {
+                EnumDecl { .. } => match all_docs.links.get_mut(&BlockTitle::Enums) {
                     Some(links) => links.push(doc.link()),
                     None => {
                         all_docs.links.insert(BlockTitle::Enums, vec![doc.link()]);
                     }
                 },
-                TraitDeclaration { .. } => match all_docs.links.get_mut(&BlockTitle::Traits) {
+                TraitDecl { .. } => match all_docs.links.get_mut(&BlockTitle::Traits) {
                     Some(links) => links.push(doc.link()),
                     None => {
                         all_docs.links.insert(BlockTitle::Traits, vec![doc.link()]);
                     }
                 },
-                AbiDeclaration { .. } => match all_docs.links.get_mut(&BlockTitle::Abi) {
+                AbiDecl { .. } => match all_docs.links.get_mut(&BlockTitle::Abi) {
                     Some(links) => links.push(doc.link()),
                     None => {
                         all_docs.links.insert(BlockTitle::Abi, vec![doc.link()]);
                     }
                 },
-                StorageDeclaration { .. } => {
-                    match all_docs.links.get_mut(&BlockTitle::ContractStorage) {
-                        Some(links) => links.push(doc.link()),
-                        None => {
-                            all_docs
-                                .links
-                                .insert(BlockTitle::ContractStorage, vec![doc.link()]);
-                        }
+                StorageDecl { .. } => match all_docs.links.get_mut(&BlockTitle::ContractStorage) {
+                    Some(links) => links.push(doc.link()),
+                    None => {
+                        all_docs
+                            .links
+                            .insert(BlockTitle::ContractStorage, vec![doc.link()]);
                     }
-                }
-                FunctionDeclaration { .. } => {
-                    match all_docs.links.get_mut(&BlockTitle::Functions) {
-                        Some(links) => links.push(doc.link()),
-                        None => {
-                            all_docs
-                                .links
-                                .insert(BlockTitle::Functions, vec![doc.link()]);
-                        }
+                },
+                FunctionDecl { .. } => match all_docs.links.get_mut(&BlockTitle::Functions) {
+                    Some(links) => links.push(doc.link()),
+                    None => {
+                        all_docs
+                            .links
+                            .insert(BlockTitle::Functions, vec![doc.link()]);
                     }
-                }
-                ConstantDeclaration { .. } => {
-                    match all_docs.links.get_mut(&BlockTitle::Constants) {
-                        Some(links) => links.push(doc.link()),
-                        None => {
-                            all_docs
-                                .links
-                                .insert(BlockTitle::Constants, vec![doc.link()]);
-                        }
+                },
+                ConstantDecl { .. } => match all_docs.links.get_mut(&BlockTitle::Constants) {
+                    Some(links) => links.push(doc.link()),
+                    None => {
+                        all_docs
+                            .links
+                            .insert(BlockTitle::Constants, vec![doc.link()]);
                     }
-                }
+                },
                 _ => {} // TODO: ImplTraitDeclaration
             }
         }
@@ -380,7 +370,7 @@ impl Renderable for ItemHeader {
 #[derive(Clone)]
 pub(crate) struct ItemBody {
     pub(crate) module_info: ModuleInfo,
-    pub(crate) ty_decl: TyDeclaration,
+    pub(crate) ty_decl: TyDecl,
     /// The item name varies depending on type.
     /// We store it during info gathering to avoid
     /// multiple match statements.
@@ -1155,16 +1145,16 @@ impl BlockTitle {
     }
 }
 
-impl DocBlockTitle for TyDeclaration {
+impl DocBlockTitle for TyDecl {
     fn as_block_title(&self) -> BlockTitle {
         match self {
-            TyDeclaration::StructDeclaration { .. } => BlockTitle::Structs,
-            TyDeclaration::EnumDeclaration { .. } => BlockTitle::Enums,
-            TyDeclaration::TraitDeclaration { .. } => BlockTitle::Traits,
-            TyDeclaration::AbiDeclaration { .. } => BlockTitle::Abi,
-            TyDeclaration::StorageDeclaration { .. } => BlockTitle::ContractStorage,
-            TyDeclaration::ConstantDeclaration { .. } => BlockTitle::Constants,
-            TyDeclaration::FunctionDeclaration { .. } => BlockTitle::Functions,
+            TyDecl::StructDecl { .. } => BlockTitle::Structs,
+            TyDecl::EnumDecl { .. } => BlockTitle::Enums,
+            TyDecl::TraitDecl { .. } => BlockTitle::Traits,
+            TyDecl::AbiDecl { .. } => BlockTitle::Abi,
+            TyDecl::StorageDecl { .. } => BlockTitle::ContractStorage,
+            TyDecl::ConstantDecl { .. } => BlockTitle::Constants,
+            TyDecl::FunctionDecl { .. } => BlockTitle::Functions,
             _ => {
                 unreachable!("All other TyDecls are non-documentable and will never be matched on")
             }

--- a/sway-core/src/abi_generation/evm_json_abi.rs
+++ b/sway-core/src/abi_generation/evm_json_abi.rs
@@ -3,7 +3,7 @@ use sway_types::integer_bits::IntegerBits;
 use crate::{
     asm_generation::EvmAbiResult,
     decl_engine::DeclEngine,
-    language::ty::{TyFunctionDeclaration, TyProgram, TyProgramKind},
+    language::ty::{TyFunctionDecl, TyProgram, TyProgramKind},
     Engines, TypeArgument, TypeEngine, TypeId, TypeInfo,
 };
 
@@ -183,7 +183,7 @@ pub fn json_abi_param_type(
 }
 
 pub(self) fn generate_json_abi_function(
-    fn_decl: &TyFunctionDeclaration,
+    fn_decl: &TyFunctionDecl,
     type_engine: &TypeEngine,
     decl_engine: &DeclEngine,
 ) -> ethabi::operation::Operation {

--- a/sway-core/src/abi_generation/fuel_json_abi.rs
+++ b/sway-core/src/abi_generation/fuel_json_abi.rs
@@ -4,7 +4,7 @@ use sway_types::integer_bits::IntegerBits;
 use crate::{
     decl_engine::DeclEngine,
     language::{
-        ty::{TyConstantDeclaration, TyFunctionDeclaration, TyProgram, TyProgramKind},
+        ty::{TyConstantDecl, TyFunctionDecl, TyProgram, TyProgramKind},
         CallPath,
     },
     transform::AttributesMap,
@@ -190,7 +190,7 @@ fn generate_json_configurables(
         .configurables
         .iter()
         .map(
-            |TyConstantDeclaration {
+            |TyConstantDecl {
                  type_ascription, ..
              }| program_abi::TypeDeclaration {
                 type_id: type_ascription.type_id.index(),
@@ -226,7 +226,7 @@ fn generate_json_configurables(
         .configurables
         .iter()
         .map(
-            |TyConstantDeclaration {
+            |TyConstantDecl {
                  call_path,
                  type_ascription,
                  ..
@@ -868,7 +868,7 @@ fn call_path_display(ctx: &mut JsonAbiContext, call_path: &CallPath) -> String {
     buf
 }
 
-impl TyFunctionDeclaration {
+impl TyFunctionDecl {
     pub(self) fn generate_json_abi_function(
         &self,
         ctx: &mut JsonAbiContext,

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -175,28 +175,28 @@ fn connect_node<'eng: 'cfg, 'cfg>(
 fn connect_declaration<'eng: 'cfg, 'cfg>(
     engines: Engines<'eng>,
     node: &ty::TyAstNode,
-    decl: &ty::TyDeclaration,
+    decl: &ty::TyDecl,
     graph: &mut ControlFlowGraph<'cfg>,
     leaves: &[NodeIndex],
 ) -> Result<Vec<NodeIndex>, CompileError> {
-    use ty::TyDeclaration::*;
+    use ty::TyDecl::*;
     let decl_engine = engines.de();
     match decl {
-        TraitDeclaration { .. }
-        | AbiDeclaration { .. }
-        | StructDeclaration { .. }
-        | EnumDeclaration { .. }
-        | StorageDeclaration { .. }
-        | TypeAliasDeclaration { .. }
+        TraitDecl { .. }
+        | AbiDecl { .. }
+        | StructDecl { .. }
+        | EnumDecl { .. }
+        | StorageDecl { .. }
+        | TypeAliasDecl { .. }
         | GenericTypeForFunctionScope { .. } => Ok(leaves.to_vec()),
-        VariableDeclaration(_) | ConstantDeclaration { .. } => {
+        VariableDecl(_) | ConstantDecl { .. } => {
             let entry_node = graph.add_node(ControlFlowGraphNode::from_node(node));
             for leaf in leaves {
                 graph.add_edge(*leaf, entry_node, "".into());
             }
             Ok(vec![entry_node])
         }
-        FunctionDeclaration { decl_id, .. } => {
+        FunctionDecl { decl_id, .. } => {
             let fn_decl = decl_engine.get_function(decl_id);
             let entry_node = graph.add_node(ControlFlowGraphNode::from_node(node));
             for leaf in leaves {
@@ -277,7 +277,7 @@ fn connect_impl_trait<'eng: 'cfg, 'cfg>(
 /// When something eventually calls it, it gets connected to the declaration.
 fn connect_typed_fn_decl<'eng: 'cfg, 'cfg>(
     engines: Engines<'eng>,
-    fn_decl: &ty::TyFunctionDeclaration,
+    fn_decl: &ty::TyFunctionDecl,
     graph: &mut ControlFlowGraph<'cfg>,
     entry_node: NodeIndex,
 ) -> Result<(), CompileError> {

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -44,10 +44,7 @@ impl<'cfg> ControlFlowGraph<'cfg> {
             if let ControlFlowGraphNode::ProgramNode {
                 node:
                     ty::TyAstNode {
-                        content:
-                            ty::TyAstNodeContent::Declaration(ty::TyDeclaration::VariableDeclaration {
-                                ..
-                            }),
+                        content: ty::TyAstNodeContent::Declaration(ty::TyDecl::VariableDecl { .. }),
                         ..
                     },
                 ..
@@ -67,10 +64,7 @@ impl<'cfg> ControlFlowGraph<'cfg> {
             if let ControlFlowGraphNode::ProgramNode {
                 node:
                     ty::TyAstNode {
-                        content:
-                            ty::TyAstNodeContent::Declaration(ty::TyDeclaration::VariableDeclaration {
-                                ..
-                            }),
+                        content: ty::TyAstNodeContent::Declaration(ty::TyDecl::VariableDecl { .. }),
                         ..
                     },
                 ..
@@ -107,9 +101,7 @@ impl<'cfg> ControlFlowGraph<'cfg> {
                         ty::TyAstNode {
                             span: function_span,
                             content:
-                                ty::TyAstNodeContent::Declaration(
-                                    ty::TyDeclaration::FunctionDeclaration { .. },
-                                ),
+                                ty::TyAstNodeContent::Declaration(ty::TyDecl::FunctionDecl { .. }),
                         },
                     ..
                 } = &self.graph[*x]
@@ -383,7 +375,7 @@ fn connect_node<'eng: 'cfg, 'cfg>(
 #[allow(clippy::too_many_arguments)]
 fn connect_declaration<'eng: 'cfg, 'cfg>(
     engines: Engines<'eng>,
-    decl: &ty::TyDeclaration,
+    decl: &ty::TyDecl,
     graph: &mut ControlFlowGraph<'cfg>,
     entry_node: NodeIndex,
     span: Span,
@@ -392,11 +384,11 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
     leaves: &[NodeIndex],
     options: NodeConnectionOptions,
 ) -> Result<Vec<NodeIndex>, CompileError> {
-    use ty::TyDeclaration::*;
+    use ty::TyDecl::*;
     let decl_engine = engines.de();
     match decl {
-        VariableDeclaration(var_decl) => {
-            let ty::TyVariableDeclaration { body, name, .. } = &**var_decl;
+        VariableDecl(var_decl) => {
+            let ty::TyVariableDecl { body, name, .. } = &**var_decl;
             let result = connect_expression(
                 engines,
                 &body.expression,
@@ -421,8 +413,8 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             );
             result
         }
-        ConstantDeclaration { decl_id, .. } => {
-            let ty::TyConstantDeclaration {
+        ConstantDecl { decl_id, .. } => {
+            let ty::TyConstantDecl {
                 call_path, value, ..
             } = decl_engine.get_constant(decl_id);
             graph
@@ -444,29 +436,29 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
                 Ok(leaves.to_vec())
             }
         }
-        FunctionDeclaration { decl_id, .. } => {
+        FunctionDecl { decl_id, .. } => {
             let fn_decl = decl_engine.get_function(decl_id);
             connect_typed_fn_decl(
                 engines, &fn_decl, graph, entry_node, span, exit_node, tree_type, options,
             )?;
             Ok(leaves.to_vec())
         }
-        TraitDeclaration { decl_id, .. } => {
+        TraitDecl { decl_id, .. } => {
             let trait_decl = decl_engine.get_trait(decl_id);
             connect_trait_declaration(&trait_decl, graph, entry_node, tree_type);
             Ok(leaves.to_vec())
         }
-        AbiDeclaration { decl_id, .. } => {
+        AbiDecl { decl_id, .. } => {
             let abi_decl = decl_engine.get_abi(decl_id);
             connect_abi_declaration(engines, &abi_decl, graph, entry_node, tree_type)?;
             Ok(leaves.to_vec())
         }
-        StructDeclaration { decl_id, .. } => {
+        StructDecl { decl_id, .. } => {
             let struct_decl = decl_engine.get_struct(decl_id);
             connect_struct_declaration(&struct_decl, *decl_id, graph, entry_node, tree_type);
             Ok(leaves.to_vec())
         }
-        EnumDeclaration { decl_id, .. } => {
+        EnumDecl { decl_id, .. } => {
             let enum_decl = decl_engine.get_enum(decl_id);
             connect_enum_declaration(&enum_decl, *decl_id, graph, entry_node);
             Ok(leaves.to_vec())
@@ -491,12 +483,12 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             )?;
             Ok(leaves.to_vec())
         }
-        StorageDeclaration { decl_id, .. } => {
+        StorageDecl { decl_id, .. } => {
             let storage = decl_engine.get_storage(decl_id);
             connect_storage_declaration(&storage, graph, entry_node, tree_type);
             Ok(leaves.to_vec())
         }
-        TypeAliasDeclaration { .. } => {
+        TypeAliasDecl { .. } => {
             // TODO - handle type aliases properly. For now, always skip DCA for them.
             Ok(leaves.to_vec())
         }
@@ -507,13 +499,13 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
 /// Connect each individual struct field, and when that field is accessed in a subfield expression,
 /// connect that field.
 fn connect_struct_declaration<'eng: 'cfg, 'cfg>(
-    struct_decl: &ty::TyStructDeclaration,
-    struct_decl_id: DeclId<ty::TyStructDeclaration>,
+    struct_decl: &ty::TyStructDecl,
+    struct_decl_id: DeclId<ty::TyStructDecl>,
     graph: &mut ControlFlowGraph<'cfg>,
     entry_node: NodeIndex,
     tree_type: &TreeType,
 ) {
-    let ty::TyStructDeclaration {
+    let ty::TyStructDecl {
         call_path,
         fields,
         visibility,
@@ -669,7 +661,7 @@ fn connect_impl_trait<'eng: 'cfg, 'cfg>(
 /// The trait node itself has already been added (as `entry_node`), so we just need to insert that
 /// node index into the namespace for the trait.
 fn connect_trait_declaration(
-    decl: &ty::TyTraitDeclaration,
+    decl: &ty::TyTraitDecl,
     graph: &mut ControlFlowGraph,
     entry_node: NodeIndex,
     tree_type: &TreeType,
@@ -690,7 +682,7 @@ fn connect_trait_declaration(
 /// See [connect_trait_declaration] for implementation details.
 fn connect_abi_declaration(
     engines: Engines<'_>,
-    decl: &ty::TyAbiDeclaration,
+    decl: &ty::TyAbiDecl,
     graph: &mut ControlFlowGraph,
     entry_node: NodeIndex,
     tree_type: &TreeType,
@@ -798,8 +790,8 @@ fn get_struct_type_info_from_type_id(
 /// variant. When a variant is constructed, we can point an edge at that variant. This way,
 /// we can see clearly, and thusly warn, when individual variants are not ever constructed.
 fn connect_enum_declaration<'eng: 'cfg, 'cfg>(
-    enum_decl: &ty::TyEnumDeclaration,
-    enum_decl_id: DeclId<ty::TyEnumDeclaration>,
+    enum_decl: &ty::TyEnumDecl,
+    enum_decl_id: DeclId<ty::TyEnumDecl>,
     graph: &mut ControlFlowGraph<'cfg>,
     entry_node: NodeIndex,
 ) {
@@ -830,7 +822,7 @@ fn connect_enum_declaration<'eng: 'cfg, 'cfg>(
 #[allow(clippy::too_many_arguments)]
 fn connect_typed_fn_decl<'eng: 'cfg, 'cfg>(
     engines: Engines<'eng>,
-    fn_decl: &ty::TyFunctionDeclaration,
+    fn_decl: &ty::TyFunctionDecl,
     graph: &mut ControlFlowGraph<'cfg>,
     entry_node: NodeIndex,
     span: Span,
@@ -880,7 +872,7 @@ fn connect_typed_fn_decl<'eng: 'cfg, 'cfg>(
 // making sure they are considered used by the DCA pass.
 fn connect_fn_params_struct_enums<'eng: 'cfg, 'cfg>(
     engines: Engines<'eng>,
-    fn_decl: &ty::TyFunctionDeclaration,
+    fn_decl: &ty::TyFunctionDecl,
     graph: &mut ControlFlowGraph<'cfg>,
     fn_decl_entry_node: NodeIndex,
 ) -> Result<(), CompileError> {
@@ -950,25 +942,25 @@ fn get_trait_fn_node_index<'a>(
     let fn_decl = decl_engine.get_function(&function_decl_ref);
     if let Some(implementing_type) = fn_decl.implementing_type {
         match implementing_type {
-            ty::TyDeclaration::TraitDeclaration { decl_id, .. } => {
+            ty::TyDecl::TraitDecl { decl_id, .. } => {
                 let trait_decl = decl_engine.get_trait(&decl_id);
                 Ok(graph
                     .namespace
                     .find_trait_method(&trait_decl.name.into(), &fn_decl.name))
             }
-            ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
+            ty::TyDecl::StructDecl { decl_id, .. } => {
                 let struct_decl = decl_engine.get_struct(&decl_id);
                 Ok(graph
                     .namespace
                     .find_trait_method(&struct_decl.call_path.suffix.into(), &fn_decl.name))
             }
-            ty::TyDeclaration::ImplTrait { decl_id, .. } => {
+            ty::TyDecl::ImplTrait { decl_id, .. } => {
                 let impl_trait = decl_engine.get_impl_trait(&decl_id);
                 Ok(graph
                     .namespace
                     .find_trait_method(&impl_trait.trait_name, &fn_decl.name))
             }
-            ty::TyDeclaration::AbiDeclaration { decl_id, .. } => {
+            ty::TyDecl::AbiDecl { decl_id, .. } => {
                 let abi_decl = decl_engine.get_abi(&decl_id);
                 Ok(graph
                     .namespace
@@ -1769,7 +1761,7 @@ fn connect_code_block<'eng: 'cfg, 'cfg>(
 #[allow(clippy::too_many_arguments)]
 fn connect_enum_instantiation<'eng: 'cfg, 'cfg>(
     engines: Engines<'eng>,
-    enum_decl: &ty::TyEnumDeclaration,
+    enum_decl: &ty::TyEnumDecl,
     contents: &Option<Box<ty::TyExpression>>,
     variant_name: &Ident,
     graph: &mut ControlFlowGraph<'cfg>,
@@ -1840,51 +1832,42 @@ fn construct_dead_code_warning_from_node(
         // if this is a function, struct, or trait declaration that is never called, then it is dead
         // code.
         ty::TyAstNode {
-            content:
-                ty::TyAstNodeContent::Declaration(ty::TyDeclaration::FunctionDeclaration {
-                    name, ..
-                }),
+            content: ty::TyAstNodeContent::Declaration(ty::TyDecl::FunctionDecl { name, .. }),
             ..
         } => CompileWarning {
             span: name.span(),
             warning_content: Warning::DeadFunctionDeclaration,
         },
         ty::TyAstNode {
-            content:
-                ty::TyAstNodeContent::Declaration(ty::TyDeclaration::StructDeclaration { name, .. }),
+            content: ty::TyAstNodeContent::Declaration(ty::TyDecl::StructDecl { name, .. }),
             ..
         } => CompileWarning {
             span: name.span(),
             warning_content: Warning::DeadStructDeclaration,
         },
         ty::TyAstNode {
-            content:
-                ty::TyAstNodeContent::Declaration(ty::TyDeclaration::EnumDeclaration { name, .. }),
+            content: ty::TyAstNodeContent::Declaration(ty::TyDecl::EnumDecl { name, .. }),
             ..
         } => CompileWarning {
             span: name.span(),
             warning_content: Warning::DeadEnumDeclaration,
         },
         ty::TyAstNode {
-            content:
-                ty::TyAstNodeContent::Declaration(ty::TyDeclaration::TraitDeclaration { name, .. }),
+            content: ty::TyAstNodeContent::Declaration(ty::TyDecl::TraitDecl { name, .. }),
             ..
         } => CompileWarning {
             span: name.span(),
             warning_content: Warning::DeadTrait,
         },
         ty::TyAstNode {
-            content:
-                ty::TyAstNodeContent::Declaration(ty::TyDeclaration::ConstantDeclaration {
-                    name, ..
-                }),
+            content: ty::TyAstNodeContent::Declaration(ty::TyDecl::ConstantDecl { name, .. }),
             ..
         } => CompileWarning {
             span: name.span(),
             warning_content: Warning::DeadDeclaration,
         },
         ty::TyAstNode {
-            content: ty::TyAstNodeContent::Declaration(ty::TyDeclaration::VariableDeclaration(decl)),
+            content: ty::TyAstNodeContent::Declaration(ty::TyDecl::VariableDecl(decl)),
             span,
         } => {
             if decl.name.as_str().starts_with('_') {
@@ -1906,7 +1889,7 @@ fn construct_dead_code_warning_from_node(
             }
         }
         ty::TyAstNode {
-            content: ty::TyAstNodeContent::Declaration(ty::TyDeclaration::ImplTrait { decl_id, .. }),
+            content: ty::TyAstNodeContent::Declaration(ty::TyDecl::ImplTrait { decl_id, .. }),
             span,
         } => {
             let ty::TyImplTrait { items: methods, .. } = decl_engine.get_impl_trait(decl_id);
@@ -1920,18 +1903,18 @@ fn construct_dead_code_warning_from_node(
             }
         }
         ty::TyAstNode {
-            content: ty::TyAstNodeContent::Declaration(ty::TyDeclaration::AbiDeclaration { .. }),
+            content: ty::TyAstNodeContent::Declaration(ty::TyDecl::AbiDecl { .. }),
             ..
         } => return None,
         // We handle storage fields individually. There is no need to emit any warnings for the
         // storage declaration itself.
         ty::TyAstNode {
-            content: ty::TyAstNodeContent::Declaration(ty::TyDeclaration::StorageDeclaration { .. }),
+            content: ty::TyAstNodeContent::Declaration(ty::TyDecl::StorageDecl { .. }),
             ..
         } => return None,
         // If there is already an error for the declaration, we don't need to emit a dead code warning.
         ty::TyAstNode {
-            content: ty::TyAstNodeContent::Declaration(ty::TyDeclaration::ErrorRecovery(..)),
+            content: ty::TyAstNodeContent::Declaration(ty::TyDecl::ErrorRecovery(..)),
             ..
         } => return None,
         ty::TyAstNode {
@@ -1956,12 +1939,12 @@ fn construct_dead_code_warning_from_node(
 }
 
 fn connect_storage_declaration<'eng: 'cfg, 'cfg>(
-    decl: &ty::TyStorageDeclaration,
+    decl: &ty::TyStorageDecl,
     graph: &mut ControlFlowGraph<'cfg>,
     _entry_node: NodeIndex,
     _tree_type: &TreeType,
 ) {
-    let ty::TyStorageDeclaration { fields, .. } = decl;
+    let ty::TyStorageDecl { fields, .. } = decl;
     let field_nodes = fields
         .iter()
         .map(|field| (field.clone(), graph.add_node(field.into())))
@@ -1993,31 +1976,31 @@ fn allow_dead_code(attributes: AttributesMap) -> bool {
 fn allow_dead_code_ast_node(decl_engine: &DeclEngine, node: &ty::TyAstNode) -> bool {
     match &node.content {
         ty::TyAstNodeContent::Declaration(decl) => match &decl {
-            ty::TyDeclaration::VariableDeclaration(_) => false,
-            ty::TyDeclaration::ConstantDeclaration { decl_id, .. } => {
+            ty::TyDecl::VariableDecl(_) => false,
+            ty::TyDecl::ConstantDecl { decl_id, .. } => {
                 allow_dead_code(decl_engine.get_constant(decl_id).attributes)
             }
-            ty::TyDeclaration::FunctionDeclaration { decl_id, .. } => {
+            ty::TyDecl::FunctionDecl { decl_id, .. } => {
                 allow_dead_code(decl_engine.get_function(decl_id).attributes)
             }
-            ty::TyDeclaration::TraitDeclaration { decl_id, .. } => {
+            ty::TyDecl::TraitDecl { decl_id, .. } => {
                 allow_dead_code(decl_engine.get_trait(decl_id).attributes)
             }
-            ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
+            ty::TyDecl::StructDecl { decl_id, .. } => {
                 allow_dead_code(decl_engine.get_struct(decl_id).attributes)
             }
-            ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
+            ty::TyDecl::EnumDecl { decl_id, .. } => {
                 allow_dead_code(decl_engine.get_enum(decl_id).attributes)
             }
-            ty::TyDeclaration::TypeAliasDeclaration { .. } => {
+            ty::TyDecl::TypeAliasDecl { .. } => {
                 // TODO - handle type aliases properly. For now, always skip DCA for them.
                 true
             }
-            ty::TyDeclaration::ImplTrait { .. } => false,
-            ty::TyDeclaration::AbiDeclaration { .. } => false,
-            ty::TyDeclaration::GenericTypeForFunctionScope { .. } => false,
-            ty::TyDeclaration::ErrorRecovery(_) => false,
-            ty::TyDeclaration::StorageDeclaration { .. } => false,
+            ty::TyDecl::ImplTrait { .. } => false,
+            ty::TyDecl::AbiDecl { .. } => false,
+            ty::TyDecl::GenericTypeForFunctionScope { .. } => false,
+            ty::TyDecl::ErrorRecovery(_) => false,
+            ty::TyDecl::StorageDecl { .. } => false,
         },
         ty::TyAstNodeContent::Expression(_) => false,
         ty::TyAstNodeContent::ImplicitReturnExpression(_) => false,

--- a/sway-core/src/control_flow_analysis/flow_graph/mod.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/mod.rs
@@ -62,7 +62,7 @@ pub enum ControlFlowGraphNode<'cfg> {
         parent_node: Option<NodeIndex>,
     },
     EnumVariant {
-        enum_decl_id: DeclId<ty::TyEnumDeclaration>,
+        enum_decl_id: DeclId<ty::TyEnumDecl>,
         variant_name: Ident,
         is_public: bool,
     },
@@ -73,7 +73,7 @@ pub enum ControlFlowGraphNode<'cfg> {
         engines: Engines<'cfg>,
     },
     StructField {
-        struct_decl_id: DeclId<ty::TyStructDeclaration>,
+        struct_decl_id: DeclId<ty::TyStructDecl>,
         struct_field_name: Ident,
         attributes: transform::AttributesMap,
         span: Span,
@@ -214,7 +214,7 @@ impl<'cfg> ControlFlowGraph<'cfg> {
 
 impl<'cfg> ControlFlowGraphNode<'cfg> {
     pub(crate) fn from_enum_variant(
-        enum_decl_id: DeclId<ty::TyEnumDeclaration>,
+        enum_decl_id: DeclId<ty::TyEnumDecl>,
         other_name: BaseIdent,
         is_public: bool,
     ) -> ControlFlowGraphNode<'cfg> {

--- a/sway-core/src/control_flow_analysis/flow_graph/namespace.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/namespace.rs
@@ -2,7 +2,7 @@ use super::{EntryPoint, ExitPoint};
 use crate::{
     language::{
         parsed::TreeType,
-        ty::{self, TyFunctionDeclaration, TyFunctionSig},
+        ty::{self, TyFunctionDecl, TyFunctionSig},
         CallPath,
     },
     type_system::TypeInfo,
@@ -66,17 +66,14 @@ pub struct ControlFlowCodeBlock {
 }
 
 impl ControlFlowNamespace {
-    pub(crate) fn get_function(
-        &self,
-        fn_decl: &TyFunctionDeclaration,
-    ) -> Option<&FunctionNamespaceEntry> {
+    pub(crate) fn get_function(&self, fn_decl: &TyFunctionDecl) -> Option<&FunctionNamespaceEntry> {
         let ident: IdentUnique = fn_decl.name.clone().into();
         self.function_namespace
             .get(&(ident, TyFunctionSig::from_fn_decl(fn_decl)))
     }
     pub(crate) fn insert_function(
         &mut self,
-        fn_decl: &ty::TyFunctionDeclaration,
+        fn_decl: &ty::TyFunctionDecl,
         entry: FunctionNamespaceEntry,
     ) {
         let ident = &fn_decl.name;

--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -10,25 +10,24 @@ use crate::{
     decl_engine::*,
     engine_threading::*,
     language::ty::{
-        self, TyAbiDeclaration, TyConstantDeclaration, TyEnumDeclaration, TyFunctionDeclaration,
-        TyImplTrait, TyStorageDeclaration, TyStructDeclaration, TyTraitDeclaration, TyTraitFn,
-        TyTypeAliasDeclaration,
+        self, TyAbiDecl, TyConstantDecl, TyEnumDecl, TyFunctionDecl, TyImplTrait, TyStorageDecl,
+        TyStructDecl, TyTraitDecl, TyTraitFn, TyTypeAliasDecl,
     },
 };
 
 /// Used inside of type inference to store declarations.
 #[derive(Debug, Default)]
 pub struct DeclEngine {
-    function_slab: ConcurrentSlab<TyFunctionDeclaration>,
-    trait_slab: ConcurrentSlab<TyTraitDeclaration>,
+    function_slab: ConcurrentSlab<TyFunctionDecl>,
+    trait_slab: ConcurrentSlab<TyTraitDecl>,
     trait_fn_slab: ConcurrentSlab<TyTraitFn>,
     impl_trait_slab: ConcurrentSlab<TyImplTrait>,
-    struct_slab: ConcurrentSlab<TyStructDeclaration>,
-    storage_slab: ConcurrentSlab<TyStorageDeclaration>,
-    abi_slab: ConcurrentSlab<TyAbiDeclaration>,
-    constant_slab: ConcurrentSlab<TyConstantDeclaration>,
-    enum_slab: ConcurrentSlab<TyEnumDeclaration>,
-    type_alias_slab: ConcurrentSlab<TyTypeAliasDeclaration>,
+    struct_slab: ConcurrentSlab<TyStructDecl>,
+    storage_slab: ConcurrentSlab<TyStorageDecl>,
+    abi_slab: ConcurrentSlab<TyAbiDecl>,
+    constant_slab: ConcurrentSlab<TyConstantDecl>,
+    enum_slab: ConcurrentSlab<TyEnumDecl>,
+    type_alias_slab: ConcurrentSlab<TyTypeAliasDecl>,
 
     parents: RwLock<HashMap<FunctionalDeclId, Vec<FunctionalDeclId>>>,
 }
@@ -70,16 +69,16 @@ macro_rules! decl_engine_get {
         }
     };
 }
-decl_engine_get!(function_slab, ty::TyFunctionDeclaration);
-decl_engine_get!(trait_slab, ty::TyTraitDeclaration);
+decl_engine_get!(function_slab, ty::TyFunctionDecl);
+decl_engine_get!(trait_slab, ty::TyTraitDecl);
 decl_engine_get!(trait_fn_slab, ty::TyTraitFn);
 decl_engine_get!(impl_trait_slab, ty::TyImplTrait);
-decl_engine_get!(struct_slab, ty::TyStructDeclaration);
-decl_engine_get!(storage_slab, ty::TyStorageDeclaration);
-decl_engine_get!(abi_slab, ty::TyAbiDeclaration);
-decl_engine_get!(constant_slab, ty::TyConstantDeclaration);
-decl_engine_get!(enum_slab, ty::TyEnumDeclaration);
-decl_engine_get!(type_alias_slab, ty::TyTypeAliasDeclaration);
+decl_engine_get!(struct_slab, ty::TyStructDecl);
+decl_engine_get!(storage_slab, ty::TyStorageDecl);
+decl_engine_get!(abi_slab, ty::TyAbiDecl);
+decl_engine_get!(constant_slab, ty::TyConstantDecl);
+decl_engine_get!(enum_slab, ty::TyEnumDecl);
+decl_engine_get!(type_alias_slab, ty::TyTypeAliasDecl);
 
 macro_rules! decl_engine_insert {
     ($slab:ident, $decl:ty) => {
@@ -95,16 +94,16 @@ macro_rules! decl_engine_insert {
         }
     };
 }
-decl_engine_insert!(function_slab, ty::TyFunctionDeclaration);
-decl_engine_insert!(trait_slab, ty::TyTraitDeclaration);
+decl_engine_insert!(function_slab, ty::TyFunctionDecl);
+decl_engine_insert!(trait_slab, ty::TyTraitDecl);
 decl_engine_insert!(trait_fn_slab, ty::TyTraitFn);
 decl_engine_insert!(impl_trait_slab, ty::TyImplTrait);
-decl_engine_insert!(struct_slab, ty::TyStructDeclaration);
-decl_engine_insert!(storage_slab, ty::TyStorageDeclaration);
-decl_engine_insert!(abi_slab, ty::TyAbiDeclaration);
-decl_engine_insert!(constant_slab, ty::TyConstantDeclaration);
-decl_engine_insert!(enum_slab, ty::TyEnumDeclaration);
-decl_engine_insert!(type_alias_slab, ty::TyTypeAliasDeclaration);
+decl_engine_insert!(struct_slab, ty::TyStructDecl);
+decl_engine_insert!(storage_slab, ty::TyStorageDecl);
+decl_engine_insert!(abi_slab, ty::TyAbiDecl);
+decl_engine_insert!(constant_slab, ty::TyConstantDecl);
+decl_engine_insert!(enum_slab, ty::TyEnumDecl);
+decl_engine_insert!(type_alias_slab, ty::TyTypeAliasDecl);
 
 macro_rules! decl_engine_replace {
     ($slab:ident, $decl:ty) => {
@@ -115,32 +114,32 @@ macro_rules! decl_engine_replace {
         }
     };
 }
-decl_engine_replace!(function_slab, ty::TyFunctionDeclaration);
-decl_engine_replace!(trait_slab, ty::TyTraitDeclaration);
+decl_engine_replace!(function_slab, ty::TyFunctionDecl);
+decl_engine_replace!(trait_slab, ty::TyTraitDecl);
 decl_engine_replace!(trait_fn_slab, ty::TyTraitFn);
 decl_engine_replace!(impl_trait_slab, ty::TyImplTrait);
-decl_engine_replace!(struct_slab, ty::TyStructDeclaration);
-decl_engine_replace!(storage_slab, ty::TyStorageDeclaration);
-decl_engine_replace!(abi_slab, ty::TyAbiDeclaration);
-decl_engine_replace!(constant_slab, ty::TyConstantDeclaration);
-decl_engine_replace!(enum_slab, ty::TyEnumDeclaration);
-decl_engine_replace!(type_alias_slab, ty::TyTypeAliasDeclaration);
+decl_engine_replace!(struct_slab, ty::TyStructDecl);
+decl_engine_replace!(storage_slab, ty::TyStorageDecl);
+decl_engine_replace!(abi_slab, ty::TyAbiDecl);
+decl_engine_replace!(constant_slab, ty::TyConstantDecl);
+decl_engine_replace!(enum_slab, ty::TyEnumDecl);
+decl_engine_replace!(type_alias_slab, ty::TyTypeAliasDecl);
 
 macro_rules! decl_engine_index {
     ($slab:ident, $decl:ty) => {
         impl DeclEngineIndex<$decl> for DeclEngine {}
     };
 }
-decl_engine_index!(function_slab, ty::TyFunctionDeclaration);
-decl_engine_index!(trait_slab, ty::TyTraitDeclaration);
+decl_engine_index!(function_slab, ty::TyFunctionDecl);
+decl_engine_index!(trait_slab, ty::TyTraitDecl);
 decl_engine_index!(trait_fn_slab, ty::TyTraitFn);
 decl_engine_index!(impl_trait_slab, ty::TyImplTrait);
-decl_engine_index!(struct_slab, ty::TyStructDeclaration);
-decl_engine_index!(storage_slab, ty::TyStorageDeclaration);
-decl_engine_index!(abi_slab, ty::TyAbiDeclaration);
-decl_engine_index!(constant_slab, ty::TyConstantDeclaration);
-decl_engine_index!(enum_slab, ty::TyEnumDeclaration);
-decl_engine_index!(type_alias_slab, ty::TyTypeAliasDeclaration);
+decl_engine_index!(struct_slab, ty::TyStructDecl);
+decl_engine_index!(storage_slab, ty::TyStorageDecl);
+decl_engine_index!(abi_slab, ty::TyAbiDecl);
+decl_engine_index!(constant_slab, ty::TyConstantDecl);
+decl_engine_index!(enum_slab, ty::TyEnumDecl);
+decl_engine_index!(type_alias_slab, ty::TyTypeAliasDecl);
 
 impl DeclEngine {
     /// Given a [DeclRef] `index`, finds all the parents of `index` and all the
@@ -205,9 +204,9 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_function<I>(&self, index: &I) -> ty::TyFunctionDeclaration
+    pub fn get_function<I>(&self, index: &I) -> ty::TyFunctionDecl
     where
-        DeclEngine: DeclEngineGet<I, ty::TyFunctionDeclaration>,
+        DeclEngine: DeclEngineGet<I, ty::TyFunctionDecl>,
     {
         self.get(index)
     }
@@ -217,9 +216,9 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_trait<I>(&self, index: &I) -> ty::TyTraitDeclaration
+    pub fn get_trait<I>(&self, index: &I) -> ty::TyTraitDecl
     where
-        DeclEngine: DeclEngineGet<I, ty::TyTraitDeclaration>,
+        DeclEngine: DeclEngineGet<I, ty::TyTraitDecl>,
     {
         self.get(index)
     }
@@ -253,9 +252,9 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_struct<I>(&self, index: &I) -> ty::TyStructDeclaration
+    pub fn get_struct<I>(&self, index: &I) -> ty::TyStructDecl
     where
-        DeclEngine: DeclEngineGet<I, ty::TyStructDeclaration>,
+        DeclEngine: DeclEngineGet<I, ty::TyStructDecl>,
     {
         self.get(index)
     }
@@ -265,9 +264,9 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_storage<I>(&self, index: &I) -> ty::TyStorageDeclaration
+    pub fn get_storage<I>(&self, index: &I) -> ty::TyStorageDecl
     where
-        DeclEngine: DeclEngineGet<I, ty::TyStorageDeclaration>,
+        DeclEngine: DeclEngineGet<I, ty::TyStorageDecl>,
     {
         self.get(index)
     }
@@ -277,9 +276,9 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_abi<I>(&self, index: &I) -> ty::TyAbiDeclaration
+    pub fn get_abi<I>(&self, index: &I) -> ty::TyAbiDecl
     where
-        DeclEngine: DeclEngineGet<I, ty::TyAbiDeclaration>,
+        DeclEngine: DeclEngineGet<I, ty::TyAbiDecl>,
     {
         self.get(index)
     }
@@ -289,9 +288,9 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_constant<I>(&self, index: &I) -> ty::TyConstantDeclaration
+    pub fn get_constant<I>(&self, index: &I) -> ty::TyConstantDecl
     where
-        DeclEngine: DeclEngineGet<I, ty::TyConstantDeclaration>,
+        DeclEngine: DeclEngineGet<I, ty::TyConstantDecl>,
     {
         self.get(index)
     }
@@ -301,9 +300,9 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_enum<I>(&self, index: &I) -> ty::TyEnumDeclaration
+    pub fn get_enum<I>(&self, index: &I) -> ty::TyEnumDecl
     where
-        DeclEngine: DeclEngineGet<I, ty::TyEnumDeclaration>,
+        DeclEngine: DeclEngineGet<I, ty::TyEnumDecl>,
     {
         self.get(index)
     }
@@ -313,9 +312,9 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_type_alias<I>(&self, index: &I) -> ty::TyTypeAliasDeclaration
+    pub fn get_type_alias<I>(&self, index: &I) -> ty::TyTypeAliasDecl
     where
-        DeclEngine: DeclEngineGet<I, ty::TyTypeAliasDeclaration>,
+        DeclEngine: DeclEngineGet<I, ty::TyTypeAliasDecl>,
     {
         self.get(index)
     }

--- a/sway-core/src/decl_engine/functional_decl_id.rs
+++ b/sway-core/src/decl_engine/functional_decl_id.rs
@@ -3,28 +3,28 @@ use sway_types::Span;
 
 use crate::{
     decl_engine::*,
-    language::ty::{self, TyFunctionDeclaration},
+    language::ty::{self, TyFunctionDecl},
 };
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum FunctionalDeclId {
     TraitFn(DeclId<ty::TyTraitFn>),
-    Function(DeclId<ty::TyFunctionDeclaration>),
-    Constant(DeclId<ty::TyConstantDeclaration>),
+    Function(DeclId<ty::TyFunctionDecl>),
+    Constant(DeclId<ty::TyConstantDecl>),
 }
 
-impl From<DeclId<ty::TyFunctionDeclaration>> for FunctionalDeclId {
-    fn from(val: DeclId<ty::TyFunctionDeclaration>) -> Self {
+impl From<DeclId<ty::TyFunctionDecl>> for FunctionalDeclId {
+    fn from(val: DeclId<ty::TyFunctionDecl>) -> Self {
         Self::Function(val)
     }
 }
-impl From<&DeclId<ty::TyFunctionDeclaration>> for FunctionalDeclId {
-    fn from(val: &DeclId<ty::TyFunctionDeclaration>) -> Self {
+impl From<&DeclId<ty::TyFunctionDecl>> for FunctionalDeclId {
+    fn from(val: &DeclId<ty::TyFunctionDecl>) -> Self {
         Self::Function(*val)
     }
 }
-impl From<&mut DeclId<ty::TyFunctionDeclaration>> for FunctionalDeclId {
-    fn from(val: &mut DeclId<ty::TyFunctionDeclaration>) -> Self {
+impl From<&mut DeclId<ty::TyFunctionDecl>> for FunctionalDeclId {
+    fn from(val: &mut DeclId<ty::TyFunctionDecl>) -> Self {
         Self::Function(*val)
     }
 }
@@ -45,18 +45,18 @@ impl From<&mut DeclId<ty::TyTraitFn>> for FunctionalDeclId {
     }
 }
 
-impl From<DeclId<ty::TyConstantDeclaration>> for FunctionalDeclId {
-    fn from(val: DeclId<ty::TyConstantDeclaration>) -> Self {
+impl From<DeclId<ty::TyConstantDecl>> for FunctionalDeclId {
+    fn from(val: DeclId<ty::TyConstantDecl>) -> Self {
         Self::Constant(val)
     }
 }
-impl From<&DeclId<ty::TyConstantDeclaration>> for FunctionalDeclId {
-    fn from(val: &DeclId<ty::TyConstantDeclaration>) -> Self {
+impl From<&DeclId<ty::TyConstantDecl>> for FunctionalDeclId {
+    fn from(val: &DeclId<ty::TyConstantDecl>) -> Self {
         Self::Constant(*val)
     }
 }
-impl From<&mut DeclId<ty::TyConstantDeclaration>> for FunctionalDeclId {
-    fn from(val: &mut DeclId<ty::TyConstantDeclaration>) -> Self {
+impl From<&mut DeclId<ty::TyConstantDecl>> for FunctionalDeclId {
+    fn from(val: &mut DeclId<ty::TyConstantDecl>) -> Self {
         Self::Constant(*val)
     }
 }
@@ -104,7 +104,7 @@ impl TryFrom<&DeclRefMixedFunctional> for DeclRefFunction {
     }
 }
 
-impl TryFrom<FunctionalDeclId> for DeclId<TyFunctionDeclaration> {
+impl TryFrom<FunctionalDeclId> for DeclId<TyFunctionDecl> {
     type Error = CompileError;
     fn try_from(value: FunctionalDeclId) -> Result<Self, Self::Error> {
         match value {
@@ -120,7 +120,7 @@ impl TryFrom<FunctionalDeclId> for DeclId<TyFunctionDeclaration> {
         }
     }
 }
-impl TryFrom<&FunctionalDeclId> for DeclId<TyFunctionDeclaration> {
+impl TryFrom<&FunctionalDeclId> for DeclId<TyFunctionDecl> {
     type Error = CompileError;
     fn try_from(value: &FunctionalDeclId) -> Result<Self, Self::Error> {
         value.clone().try_into()

--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -5,8 +5,8 @@ use crate::{
     decl_engine::*,
     engine_threading::*,
     language::ty::{
-        TyEnumDeclaration, TyFunctionDeclaration, TyImplTrait, TyStructDeclaration,
-        TyTraitDeclaration, TyTraitFn, TyTypeAliasDeclaration,
+        TyEnumDecl, TyFunctionDecl, TyImplTrait, TyStructDecl, TyTraitDecl, TyTraitFn,
+        TyTypeAliasDecl,
     },
     type_system::*,
 };
@@ -72,7 +72,7 @@ impl<T> Into<usize> for DeclId<T> {
     }
 }
 
-impl SubstTypes for DeclId<TyFunctionDeclaration> {
+impl SubstTypes for DeclId<TyFunctionDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         let decl_engine = engines.de();
         let mut decl = decl_engine.get(self);
@@ -80,7 +80,7 @@ impl SubstTypes for DeclId<TyFunctionDeclaration> {
         decl_engine.replace(*self, decl);
     }
 }
-impl SubstTypes for DeclId<TyTraitDeclaration> {
+impl SubstTypes for DeclId<TyTraitDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         let decl_engine = engines.de();
         let mut decl = decl_engine.get(self);
@@ -104,7 +104,7 @@ impl SubstTypes for DeclId<TyImplTrait> {
         decl_engine.replace(*self, decl);
     }
 }
-impl SubstTypes for DeclId<TyStructDeclaration> {
+impl SubstTypes for DeclId<TyStructDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         let decl_engine = engines.de();
         let mut decl = decl_engine.get(self);
@@ -112,7 +112,7 @@ impl SubstTypes for DeclId<TyStructDeclaration> {
         decl_engine.replace(*self, decl);
     }
 }
-impl SubstTypes for DeclId<TyEnumDeclaration> {
+impl SubstTypes for DeclId<TyEnumDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         let decl_engine = engines.de();
         let mut decl = decl_engine.get(self);
@@ -120,7 +120,7 @@ impl SubstTypes for DeclId<TyEnumDeclaration> {
         decl_engine.replace(*self, decl);
     }
 }
-impl SubstTypes for DeclId<TyTypeAliasDeclaration> {
+impl SubstTypes for DeclId<TyTypeAliasDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         let decl_engine = engines.de();
         let mut decl = decl_engine.get(self);
@@ -129,7 +129,7 @@ impl SubstTypes for DeclId<TyTypeAliasDeclaration> {
     }
 }
 
-impl ReplaceSelfType for DeclId<TyFunctionDeclaration> {
+impl ReplaceSelfType for DeclId<TyFunctionDecl> {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         let decl_engine = engines.de();
         let mut decl = decl_engine.get(self);
@@ -137,7 +137,7 @@ impl ReplaceSelfType for DeclId<TyFunctionDeclaration> {
         decl_engine.replace(*self, decl);
     }
 }
-impl ReplaceSelfType for DeclId<TyTraitDeclaration> {
+impl ReplaceSelfType for DeclId<TyTraitDecl> {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         let decl_engine = engines.de();
         let mut decl = decl_engine.get(self);
@@ -161,7 +161,7 @@ impl ReplaceSelfType for DeclId<TyImplTrait> {
         decl_engine.replace(*self, decl);
     }
 }
-impl ReplaceSelfType for DeclId<TyStructDeclaration> {
+impl ReplaceSelfType for DeclId<TyStructDecl> {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         let decl_engine = engines.de();
         let mut decl = decl_engine.get(self);
@@ -169,7 +169,7 @@ impl ReplaceSelfType for DeclId<TyStructDeclaration> {
         decl_engine.replace(*self, decl);
     }
 }
-impl ReplaceSelfType for DeclId<TyEnumDeclaration> {
+impl ReplaceSelfType for DeclId<TyEnumDecl> {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         let decl_engine = engines.de();
         let mut decl = decl_engine.get(self);
@@ -177,7 +177,7 @@ impl ReplaceSelfType for DeclId<TyEnumDeclaration> {
         decl_engine.replace(*self, decl);
     }
 }
-impl ReplaceSelfType for DeclId<TyTypeAliasDeclaration> {
+impl ReplaceSelfType for DeclId<TyTypeAliasDecl> {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         let decl_engine = engines.de();
         let mut decl = decl_engine.get(self);

--- a/sway-core/src/decl_engine/interface_decl_id.rs
+++ b/sway-core/src/decl_engine/interface_decl_id.rs
@@ -2,18 +2,18 @@ use crate::{decl_engine::*, language::ty};
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum InterfaceDeclId {
-    Abi(DeclId<ty::TyAbiDeclaration>),
-    Trait(DeclId<ty::TyTraitDeclaration>),
+    Abi(DeclId<ty::TyAbiDecl>),
+    Trait(DeclId<ty::TyTraitDecl>),
 }
 
-impl From<DeclId<ty::TyAbiDeclaration>> for InterfaceDeclId {
-    fn from(id: DeclId<ty::TyAbiDeclaration>) -> Self {
+impl From<DeclId<ty::TyAbiDecl>> for InterfaceDeclId {
+    fn from(id: DeclId<ty::TyAbiDecl>) -> Self {
         Self::Abi(id)
     }
 }
 
-impl From<DeclId<ty::TyTraitDeclaration>> for InterfaceDeclId {
-    fn from(id: DeclId<ty::TyTraitDeclaration>) -> Self {
+impl From<DeclId<ty::TyTraitDecl>> for InterfaceDeclId {
+    fn from(id: DeclId<ty::TyTraitDecl>) -> Self {
         Self::Trait(id)
     }
 }

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -28,21 +28,21 @@ use crate::{
     decl_engine::*,
     engine_threading::*,
     language::ty::{
-        self, TyAbiDeclaration, TyConstantDeclaration, TyEnumDeclaration, TyFunctionDeclaration,
-        TyImplTrait, TyStorageDeclaration, TyStructDeclaration, TyTraitDeclaration, TyTraitFn,
+        self, TyAbiDecl, TyConstantDecl, TyEnumDecl, TyFunctionDecl, TyImplTrait, TyStorageDecl,
+        TyStructDecl, TyTraitDecl, TyTraitFn,
     },
     type_system::*,
 };
 
-pub type DeclRefFunction = DeclRef<DeclId<TyFunctionDeclaration>>;
-pub type DeclRefTrait = DeclRef<DeclId<TyTraitDeclaration>>;
+pub type DeclRefFunction = DeclRef<DeclId<TyFunctionDecl>>;
+pub type DeclRefTrait = DeclRef<DeclId<TyTraitDecl>>;
 pub type DeclRefTraitFn = DeclRef<DeclId<TyTraitFn>>;
 pub type DeclRefImplTrait = DeclRef<DeclId<TyImplTrait>>;
-pub type DeclRefStruct = DeclRef<DeclId<TyStructDeclaration>>;
-pub type DeclRefStorage = DeclRef<DeclId<TyStorageDeclaration>>;
-pub type DeclRefAbi = DeclRef<DeclId<TyAbiDeclaration>>;
-pub type DeclRefConstant = DeclRef<DeclId<TyConstantDeclaration>>;
-pub type DeclRefEnum = DeclRef<DeclId<TyEnumDeclaration>>;
+pub type DeclRefStruct = DeclRef<DeclId<TyStructDecl>>;
+pub type DeclRefStorage = DeclRef<DeclId<TyStorageDecl>>;
+pub type DeclRefAbi = DeclRef<DeclId<TyAbiDecl>>;
+pub type DeclRefConstant = DeclRef<DeclId<TyConstantDecl>>;
+pub type DeclRefEnum = DeclRef<DeclId<TyEnumDecl>>;
 
 pub type DeclRefMixedFunctional = DeclRef<FunctionalDeclId>;
 pub type DeclRefMixedInterface = DeclRef<InterfaceDeclId>;
@@ -351,11 +351,7 @@ impl ReplaceDecls for DeclRefFunction {
 }
 
 impl ReplaceFunctionImplementingType for DeclRefFunction {
-    fn replace_implementing_type(
-        &mut self,
-        engines: Engines<'_>,
-        implementing_type: ty::TyDeclaration,
-    ) {
+    fn replace_implementing_type(&mut self, engines: Engines<'_>, implementing_type: ty::TyDecl) {
         let decl_engine = engines.de();
         let mut decl = decl_engine.get(&self.id);
         decl.set_implementing_type(implementing_type);

--- a/sway-core/src/decl_engine/replace_decls.rs
+++ b/sway-core/src/decl_engine/replace_decls.rs
@@ -13,9 +13,5 @@ pub trait ReplaceDecls {
 }
 
 pub(crate) trait ReplaceFunctionImplementingType {
-    fn replace_implementing_type(
-        &mut self,
-        engines: Engines<'_>,
-        implementing_type: ty::TyDeclaration,
-    );
+    fn replace_implementing_type(&mut self, engines: Engines<'_>, implementing_type: ty::TyDecl);
 }

--- a/sway-core/src/decl_engine/template.rs
+++ b/sway-core/src/decl_engine/template.rs
@@ -1,12 +1,12 @@
 /// An object that is a template for copies from the template.
 ///
 /// This is predominantly used with [SubstList](crate::type_system::SubstList)
-/// and [TyDeclaration](crate::language::ty::TyDeclaration). The various
-/// variants of [TyDeclaration](crate::language::ty::TyDeclaration) contain
-/// fields `subst_list: Template<SubstList>`. This type indicates that the
+/// and [TyDecl](crate::language::ty::TyDecl). The various variants of
+/// [TyDecl](crate::language::ty::TyDecl) contain fields
+/// `subst_list: Template<SubstList>`. This type indicates that the
 /// [SubstList](crate::type_system::SubstList) contained in this field is simply
 /// a template for usages of the declaration declared in that particular
-/// [TyDeclaration](crate::language::ty::TyDeclaration) node.
+/// [TyDecl](crate::language::ty::TyDecl) node.
 #[derive(Clone, Debug)]
 pub struct Template<T>(T)
 where

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -24,12 +24,12 @@ use std::collections::HashMap;
 pub(super) fn compile_script(
     engines: Engines<'_>,
     context: &mut Context,
-    main_function: &ty::TyFunctionDeclaration,
+    main_function: &ty::TyFunctionDecl,
     namespace: &namespace::Module,
-    declarations: &[ty::TyDeclaration],
+    declarations: &[ty::TyDecl],
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
-    test_fns: &[(ty::TyFunctionDeclaration, DeclRefFunction)],
+    test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
 ) -> Result<Module, CompileError> {
     let module = Module::new(context, Kind::Script);
     let mut md_mgr = MetadataManager::default();
@@ -70,12 +70,12 @@ pub(super) fn compile_script(
 pub(super) fn compile_predicate(
     engines: Engines<'_>,
     context: &mut Context,
-    main_function: &ty::TyFunctionDeclaration,
+    main_function: &ty::TyFunctionDecl,
     namespace: &namespace::Module,
-    declarations: &[ty::TyDeclaration],
+    declarations: &[ty::TyDecl],
     logged_types: &HashMap<TypeId, LogId>,
     messages_types: &HashMap<TypeId, MessageId>,
-    test_fns: &[(ty::TyFunctionDeclaration, DeclRefFunction)],
+    test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
 ) -> Result<Module, CompileError> {
     let module = Module::new(context, Kind::Predicate);
     let mut md_mgr = MetadataManager::default();
@@ -115,12 +115,12 @@ pub(super) fn compile_predicate(
 #[allow(clippy::too_many_arguments)]
 pub(super) fn compile_contract(
     context: &mut Context,
-    abi_entries: &[ty::TyFunctionDeclaration],
+    abi_entries: &[ty::TyFunctionDecl],
     namespace: &namespace::Module,
-    declarations: &[ty::TyDeclaration],
+    declarations: &[ty::TyDecl],
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
-    test_fns: &[(ty::TyFunctionDeclaration, DeclRefFunction)],
+    test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
     engines: Engines<'_>,
 ) -> Result<Module, CompileError> {
     let module = Module::new(context, Kind::Contract);
@@ -163,10 +163,10 @@ pub(super) fn compile_library(
     engines: Engines<'_>,
     context: &mut Context,
     namespace: &namespace::Module,
-    declarations: &[ty::TyDeclaration],
+    declarations: &[ty::TyDecl],
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
-    test_fns: &[(ty::TyFunctionDeclaration, DeclRefFunction)],
+    test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
 ) -> Result<Module, CompileError> {
     let module = Module::new(context, Kind::Library);
     let mut md_mgr = MetadataManager::default();
@@ -202,10 +202,8 @@ pub(crate) fn compile_constants(
 ) -> Result<(), CompileError> {
     let (type_engine, decl_engine) = engines.unwrap();
     for decl_name in module_ns.get_all_declared_symbols() {
-        if let Some(ty::TyDeclaration::ConstantDeclaration { decl_id, .. }) =
-            module_ns.symbols.get(decl_name)
-        {
-            let ty::TyConstantDeclaration { call_path, .. } = engines.de().get_constant(decl_id);
+        if let Some(ty::TyDecl::ConstantDecl { decl_id, .. }) = module_ns.symbols.get(decl_name) {
+            let ty::TyConstantDecl { call_path, .. } = engines.de().get_constant(decl_id);
             compile_const_decl(
                 &mut LookupEnv {
                     type_engine,
@@ -244,12 +242,12 @@ fn compile_declarations(
     md_mgr: &mut MetadataManager,
     module: Module,
     namespace: &namespace::Module,
-    declarations: &[ty::TyDeclaration],
+    declarations: &[ty::TyDecl],
 ) -> Result<(), CompileError> {
     let (type_engine, decl_engine) = engines.unwrap();
     for declaration in declarations {
         match declaration {
-            ty::TyDeclaration::ConstantDeclaration { decl_id, .. } => {
+            ty::TyDecl::ConstantDecl { decl_id, .. } => {
                 let decl = decl_engine.get_constant(decl_id);
                 compile_const_decl(
                     &mut LookupEnv {
@@ -266,14 +264,14 @@ fn compile_declarations(
                 )?;
             }
 
-            ty::TyDeclaration::FunctionDeclaration { .. } => {
+            ty::TyDecl::FunctionDecl { .. } => {
                 // We no longer compile functions other than `main()` until we can improve the name
                 // resolution.  Currently there isn't enough information in the AST to fully
                 // distinguish similarly named functions and especially trait methods.
                 //
                 //compile_function(context, module, decl).map(|_| ())?
             }
-            ty::TyDeclaration::ImplTrait { .. } => {
+            ty::TyDecl::ImplTrait { .. } => {
                 // And for the same reason we don't need to compile impls at all.
                 //
                 // compile_impl(
@@ -284,15 +282,15 @@ fn compile_declarations(
                 //)?,
             }
 
-            ty::TyDeclaration::StructDeclaration { .. }
-            | ty::TyDeclaration::EnumDeclaration { .. }
-            | ty::TyDeclaration::TraitDeclaration { .. }
-            | ty::TyDeclaration::VariableDeclaration(_)
-            | ty::TyDeclaration::AbiDeclaration { .. }
-            | ty::TyDeclaration::GenericTypeForFunctionScope { .. }
-            | ty::TyDeclaration::StorageDeclaration { .. }
-            | ty::TyDeclaration::TypeAliasDeclaration { .. }
-            | ty::TyDeclaration::ErrorRecovery(_) => (),
+            ty::TyDecl::StructDecl { .. }
+            | ty::TyDecl::EnumDecl { .. }
+            | ty::TyDecl::TraitDecl { .. }
+            | ty::TyDecl::VariableDecl(_)
+            | ty::TyDecl::AbiDecl { .. }
+            | ty::TyDecl::GenericTypeForFunctionScope { .. }
+            | ty::TyDecl::StorageDecl { .. }
+            | ty::TyDecl::TypeAliasDecl { .. }
+            | ty::TyDecl::ErrorRecovery(_) => (),
         }
     }
     Ok(())
@@ -304,7 +302,7 @@ pub(super) fn compile_function(
     context: &mut Context,
     md_mgr: &mut MetadataManager,
     module: Module,
-    ast_fn_decl: &ty::TyFunctionDeclaration,
+    ast_fn_decl: &ty::TyFunctionDecl,
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
     is_entry: bool,
@@ -346,7 +344,7 @@ pub(super) fn compile_entry_function(
     context: &mut Context,
     md_mgr: &mut MetadataManager,
     module: Module,
-    ast_fn_decl: &ty::TyFunctionDeclaration,
+    ast_fn_decl: &ty::TyFunctionDecl,
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
     test_decl_ref: Option<DeclRefFunction>,
@@ -373,7 +371,7 @@ pub(super) fn compile_tests(
     module: Module,
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
-    test_fns: &[(ty::TyFunctionDeclaration, DeclRefFunction)],
+    test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
 ) -> Result<Vec<Function>, CompileError> {
     test_fns
         .iter()
@@ -418,7 +416,7 @@ fn compile_fn_with_args(
     context: &mut Context,
     md_mgr: &mut MetadataManager,
     module: Module,
-    ast_fn_decl: &ty::TyFunctionDeclaration,
+    ast_fn_decl: &ty::TyFunctionDecl,
     is_entry: bool,
     args: Vec<(String, Type, bool, Span)>,
     selector: Option<[u8; 4]>,
@@ -430,7 +428,7 @@ fn compile_fn_with_args(
     let decl_engine = engines.de();
 
     let inline_opt = ast_fn_decl.inline();
-    let ty::TyFunctionDeclaration {
+    let ty::TyFunctionDecl {
         name,
         body,
         return_type,
@@ -572,7 +570,7 @@ fn compile_abi_method(
     context: &mut Context,
     md_mgr: &mut MetadataManager,
     module: Module,
-    ast_fn_decl: &ty::TyFunctionDeclaration,
+    ast_fn_decl: &ty::TyFunctionDecl,
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
     engines: Engines<'_>,

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -105,8 +105,8 @@ pub(crate) fn compile_const_decl(
             // See if we it's a global const and whether we can compile it *now*.
             let decl = module_ns.check_symbol(&call_path.suffix)?;
             let decl_name_value = match decl {
-                ty::TyDeclaration::ConstantDeclaration { decl_id, .. } => {
-                    let ty::TyConstantDeclaration {
+                ty::TyDecl::ConstantDecl { decl_id, .. } => {
+                    let ty::TyConstantDecl {
                         call_path,
                         value,
                         is_configurable,

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -135,33 +135,27 @@ impl<'eng> FnCompiler<'eng> {
         let span_md_idx = md_mgr.span_to_md(context, &ast_node.span);
         match &ast_node.content {
             ty::TyAstNodeContent::Declaration(td) => match td {
-                ty::TyDeclaration::VariableDeclaration(tvd) => {
+                ty::TyDecl::VariableDecl(tvd) => {
                     self.compile_var_decl(context, md_mgr, tvd, span_md_idx)
                 }
-                ty::TyDeclaration::ConstantDeclaration { decl_id, .. } => {
+                ty::TyDecl::ConstantDecl { decl_id, .. } => {
                     let tcd = self.decl_engine.get_constant(decl_id);
                     self.compile_const_decl(context, md_mgr, tcd, span_md_idx)?;
                     Ok(None)
                 }
-                ty::TyDeclaration::FunctionDeclaration { .. } => {
-                    Err(CompileError::UnexpectedDeclaration {
-                        decl_type: "function",
-                        span: ast_node.span.clone(),
-                    })
-                }
-                ty::TyDeclaration::TraitDeclaration { .. } => {
-                    Err(CompileError::UnexpectedDeclaration {
-                        decl_type: "trait",
-                        span: ast_node.span.clone(),
-                    })
-                }
-                ty::TyDeclaration::StructDeclaration { .. } => {
-                    Err(CompileError::UnexpectedDeclaration {
-                        decl_type: "struct",
-                        span: ast_node.span.clone(),
-                    })
-                }
-                ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
+                ty::TyDecl::FunctionDecl { .. } => Err(CompileError::UnexpectedDeclaration {
+                    decl_type: "function",
+                    span: ast_node.span.clone(),
+                }),
+                ty::TyDecl::TraitDecl { .. } => Err(CompileError::UnexpectedDeclaration {
+                    decl_type: "trait",
+                    span: ast_node.span.clone(),
+                }),
+                ty::TyDecl::StructDecl { .. } => Err(CompileError::UnexpectedDeclaration {
+                    decl_type: "struct",
+                    span: ast_node.span.clone(),
+                }),
+                ty::TyDecl::EnumDecl { decl_id, .. } => {
                     let ted = self.decl_engine.get_enum(decl_id);
                     create_enum_aggregate(
                         self.type_engine,
@@ -172,7 +166,7 @@ impl<'eng> FnCompiler<'eng> {
                     .map(|_| ())?;
                     Ok(None)
                 }
-                ty::TyDeclaration::ImplTrait { .. } => {
+                ty::TyDecl::ImplTrait { .. } => {
                     // XXX What if we ignore the trait implementation???  Potentially since
                     // we currently inline everything and below we 'recreate' the functions
                     // lazily as they are called, nothing needs to be done here.  BUT!
@@ -180,36 +174,28 @@ impl<'eng> FnCompiler<'eng> {
                     // compile and then call these properly.
                     Ok(None)
                 }
-                ty::TyDeclaration::AbiDeclaration { .. } => {
+                ty::TyDecl::AbiDecl { .. } => Err(CompileError::UnexpectedDeclaration {
+                    decl_type: "abi",
+                    span: ast_node.span.clone(),
+                }),
+                ty::TyDecl::GenericTypeForFunctionScope { .. } => {
                     Err(CompileError::UnexpectedDeclaration {
                         decl_type: "abi",
                         span: ast_node.span.clone(),
                     })
                 }
-                ty::TyDeclaration::GenericTypeForFunctionScope { .. } => {
-                    Err(CompileError::UnexpectedDeclaration {
-                        decl_type: "abi",
-                        span: ast_node.span.clone(),
-                    })
-                }
-                ty::TyDeclaration::ErrorRecovery { .. } => {
-                    Err(CompileError::UnexpectedDeclaration {
-                        decl_type: "error recovery",
-                        span: ast_node.span.clone(),
-                    })
-                }
-                ty::TyDeclaration::StorageDeclaration { .. } => {
-                    Err(CompileError::UnexpectedDeclaration {
-                        decl_type: "storage",
-                        span: ast_node.span.clone(),
-                    })
-                }
-                ty::TyDeclaration::TypeAliasDeclaration { .. } => {
-                    Err(CompileError::UnexpectedDeclaration {
-                        decl_type: "type alias",
-                        span: ast_node.span.clone(),
-                    })
-                }
+                ty::TyDecl::ErrorRecovery { .. } => Err(CompileError::UnexpectedDeclaration {
+                    decl_type: "error recovery",
+                    span: ast_node.span.clone(),
+                }),
+                ty::TyDecl::StorageDecl { .. } => Err(CompileError::UnexpectedDeclaration {
+                    decl_type: "storage",
+                    span: ast_node.span.clone(),
+                }),
+                ty::TyDecl::TypeAliasDecl { .. } => Err(CompileError::UnexpectedDeclaration {
+                    decl_type: "type alias",
+                    span: ast_node.span.clone(),
+                }),
             },
             ty::TyAstNodeContent::Expression(te) => {
                 // An expression with an ignored return value... I assume.
@@ -1276,7 +1262,7 @@ impl<'eng> FnCompiler<'eng> {
         context: &mut Context,
         md_mgr: &mut MetadataManager,
         ast_args: &[(Ident, ty::TyExpression)],
-        callee: &ty::TyFunctionDeclaration,
+        callee: &ty::TyFunctionDecl,
         self_state_idx: Option<StateIndex>,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Value, CompileError> {
@@ -1309,7 +1295,7 @@ impl<'eng> FnCompiler<'eng> {
         let new_callee = match self.recreated_fns.get(&fn_key).copied() {
             Some(func) => func,
             None => {
-                let callee_fn_decl = ty::TyFunctionDeclaration {
+                let callee_fn_decl = ty::TyFunctionDecl {
                     type_parameters: Vec::new(),
                     name: Ident::new(Span::from_string(format!(
                         "{}_{}",
@@ -1700,10 +1686,10 @@ impl<'eng> FnCompiler<'eng> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_var_decl: &ty::TyVariableDeclaration,
+        ast_var_decl: &ty::TyVariableDecl,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<Option<Value>, CompileError> {
-        let ty::TyVariableDeclaration { name, body, .. } = ast_var_decl;
+        let ty::TyVariableDecl { name, body, .. } = ast_var_decl;
         // Nothing to do for an abi cast declarations. The address specified in them is already
         // provided in each contract call node in the AST.
         if matches!(
@@ -1761,13 +1747,13 @@ impl<'eng> FnCompiler<'eng> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        ast_const_decl: ty::TyConstantDeclaration,
+        ast_const_decl: ty::TyConstantDecl,
         span_md_idx: Option<MetadataIndex>,
     ) -> Result<(), CompileError> {
         // This is local to the function, so we add it to the locals, rather than the module
         // globals like other const decls.
         // `is_configurable` should be `false` here.
-        let ty::TyConstantDeclaration {
+        let ty::TyConstantDecl {
             call_path,
             value,
             is_configurable,
@@ -2259,7 +2245,7 @@ impl<'eng> FnCompiler<'eng> {
         &mut self,
         context: &mut Context,
         md_mgr: &mut MetadataManager,
-        enum_decl: &ty::TyEnumDeclaration,
+        enum_decl: &ty::TyEnumDecl,
         tag: usize,
         contents: Option<&ty::TyExpression>,
     ) -> Result<Value, CompileError> {

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -136,7 +136,7 @@ impl TyAstNode {
         match &self.content {
             TyAstNodeContent::ImplicitReturnExpression(ref exp) => exp.gather_return_statements(),
             // assignments and  reassignments can happen during control flow and can abort
-            TyAstNodeContent::Declaration(TyDeclaration::VariableDeclaration(decl)) => {
+            TyAstNodeContent::Declaration(TyDecl::VariableDecl(decl)) => {
                 decl.body.gather_return_statements()
             }
             TyAstNodeContent::Expression(exp) => exp.gather_return_statements(),
@@ -159,13 +159,10 @@ impl TyAstNode {
         match &self {
             TyAstNode {
                 span: _,
-                content:
-                    TyAstNodeContent::Declaration(TyDeclaration::FunctionDeclaration {
-                        decl_id, ..
-                    }),
+                content: TyAstNodeContent::Declaration(TyDecl::FunctionDecl { decl_id, .. }),
                 ..
             } => {
-                let TyFunctionDeclaration {
+                let TyFunctionDecl {
                     type_parameters, ..
                 } = decl_engine.get_function(decl_id);
                 !type_parameters.is_empty()
@@ -179,13 +176,10 @@ impl TyAstNode {
         match &self {
             TyAstNode {
                 span: _,
-                content:
-                    TyAstNodeContent::Declaration(TyDeclaration::FunctionDeclaration {
-                        decl_id, ..
-                    }),
+                content: TyAstNodeContent::Declaration(TyDecl::FunctionDecl { decl_id, .. }),
                 ..
             } => {
-                let TyFunctionDeclaration { attributes, .. } = decl_engine.get_function(decl_id);
+                let TyFunctionDecl { attributes, .. } = decl_engine.get_function(decl_id);
                 attributes.contains_key(&AttributeKind::Test)
             }
             _ => false,
@@ -199,11 +193,7 @@ impl TyAstNode {
                 match self {
                     TyAstNode {
                         span: _,
-                        content:
-                            TyAstNodeContent::Declaration(TyDeclaration::FunctionDeclaration {
-                                decl_id,
-                                ..
-                            }),
+                        content: TyAstNodeContent::Declaration(TyDecl::FunctionDecl { decl_id, .. }),
                         ..
                     } => {
                         let decl = decl_engine.get_function(decl_id);
@@ -215,7 +205,7 @@ impl TyAstNode {
             TreeType::Contract | TreeType::Library { .. } => match self {
                 TyAstNode {
                     content:
-                        TyAstNodeContent::Declaration(TyDeclaration::FunctionDeclaration {
+                        TyAstNodeContent::Declaration(TyDecl::FunctionDecl {
                             decl_id,
                             decl_span: _,
                             ..
@@ -227,7 +217,7 @@ impl TyAstNode {
                 }
                 TyAstNode {
                     content:
-                        TyAstNodeContent::Declaration(TyDeclaration::TraitDeclaration {
+                        TyAstNodeContent::Declaration(TyDecl::TraitDecl {
                             decl_id,
                             decl_span: _,
                             ..
@@ -235,22 +225,19 @@ impl TyAstNode {
                     ..
                 } => decl_engine.get_trait(decl_id).visibility.is_public(),
                 TyAstNode {
-                    content:
-                        TyAstNodeContent::Declaration(TyDeclaration::StructDeclaration {
-                            decl_id, ..
-                        }),
+                    content: TyAstNodeContent::Declaration(TyDecl::StructDecl { decl_id, .. }),
                     ..
                 } => {
                     let struct_decl = decl_engine.get_struct(decl_id);
                     struct_decl.visibility == Visibility::Public
                 }
                 TyAstNode {
-                    content: TyAstNodeContent::Declaration(TyDeclaration::ImplTrait { .. }),
+                    content: TyAstNodeContent::Declaration(TyDecl::ImplTrait { .. }),
                     ..
                 } => true,
                 TyAstNode {
                     content:
-                        TyAstNodeContent::Declaration(TyDeclaration::ConstantDeclaration {
+                        TyAstNodeContent::Declaration(TyDecl::ConstantDecl {
                             decl_id,
                             decl_span: _,
                             ..
@@ -282,7 +269,7 @@ impl TyAstNode {
 
 #[derive(Clone, Debug)]
 pub enum TyAstNodeContent {
-    Declaration(TyDeclaration),
+    Declaration(TyDecl),
     Expression(TyExpression),
     ImplicitReturnExpression(TyExpression),
     // a no-op node used for something that just issues a side effect, like an import statement.

--- a/sway-core/src/language/ty/declaration/abi.rs
+++ b/sway-core/src/language/ty/declaration/abi.rs
@@ -7,7 +7,7 @@ use super::{TyTraitInterfaceItem, TyTraitItem};
 
 /// A [TyAbiDeclaration] contains the type-checked version of the parse tree's `AbiDeclaration`.
 #[derive(Clone, Debug)]
-pub struct TyAbiDeclaration {
+pub struct TyAbiDecl {
     /// The name of the abi trait (also known as a "contract trait")
     pub name: Ident,
     /// The methods a contract is required to implement in order opt in to this interface
@@ -18,10 +18,10 @@ pub struct TyAbiDeclaration {
     pub attributes: transform::AttributesMap,
 }
 
-impl EqWithEngines for TyAbiDeclaration {}
-impl PartialEqWithEngines for TyAbiDeclaration {
+impl EqWithEngines for TyAbiDecl {}
+impl PartialEqWithEngines for TyAbiDecl {
     fn eq(&self, other: &Self, engines: Engines<'_>) -> bool {
-        let TyAbiDeclaration {
+        let TyAbiDecl {
             name: ln,
             interface_surface: lis,
             supertraits: ls,
@@ -31,7 +31,7 @@ impl PartialEqWithEngines for TyAbiDeclaration {
             attributes: _,
             span: _,
         } = self;
-        let TyAbiDeclaration {
+        let TyAbiDecl {
             name: rn,
             interface_surface: ris,
             supertraits: rs,
@@ -45,9 +45,9 @@ impl PartialEqWithEngines for TyAbiDeclaration {
     }
 }
 
-impl HashWithEngines for TyAbiDeclaration {
+impl HashWithEngines for TyAbiDecl {
     fn hash<H: Hasher>(&self, state: &mut H, engines: Engines<'_>) {
-        let TyAbiDeclaration {
+        let TyAbiDecl {
             name,
             interface_surface,
             items,
@@ -64,7 +64,7 @@ impl HashWithEngines for TyAbiDeclaration {
     }
 }
 
-impl CreateTypeId for TyAbiDeclaration {
+impl CreateTypeId for TyAbiDecl {
     fn create_type_id(&self, engines: Engines<'_>) -> TypeId {
         let type_engine = engines.te();
         let decl_engine = engines.de();
@@ -76,13 +76,13 @@ impl CreateTypeId for TyAbiDeclaration {
     }
 }
 
-impl Spanned for TyAbiDeclaration {
+impl Spanned for TyAbiDecl {
     fn span(&self) -> Span {
         self.span.clone()
     }
 }
 
-impl Named for TyAbiDeclaration {
+impl Named for TyAbiDecl {
     fn name(&self) -> &Ident {
         &self.name
     }

--- a/sway-core/src/language/ty/declaration/abi.rs
+++ b/sway-core/src/language/ty/declaration/abi.rs
@@ -5,7 +5,8 @@ use sway_types::{Ident, Named, Span, Spanned};
 
 use super::{TyTraitInterfaceItem, TyTraitItem};
 
-/// A [TyAbiDeclaration] contains the type-checked version of the parse tree's `AbiDeclaration`.
+/// A [TyAbiDecl] contains the type-checked version of the parse tree's
+/// `AbiDeclaration`.
 #[derive(Clone, Debug)]
 pub struct TyAbiDecl {
     /// The name of the abi trait (also known as a "contract trait")

--- a/sway-core/src/language/ty/declaration/constant.rs
+++ b/sway-core/src/language/ty/declaration/constant.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct TyConstantDeclaration {
+pub struct TyConstantDecl {
     pub call_path: CallPath,
     pub value: Option<TyExpression>,
     pub visibility: Visibility,
@@ -20,11 +20,11 @@ pub struct TyConstantDeclaration {
     pub return_type: TypeId,
     pub type_ascription: TypeArgument,
     pub span: Span,
-    pub implementing_type: Option<TyDeclaration>,
+    pub implementing_type: Option<TyDecl>,
 }
 
-impl EqWithEngines for TyConstantDeclaration {}
-impl PartialEqWithEngines for TyConstantDeclaration {
+impl EqWithEngines for TyConstantDecl {}
+impl PartialEqWithEngines for TyConstantDecl {
     fn eq(&self, other: &Self, engines: Engines<'_>) -> bool {
         let type_engine = engines.te();
         self.call_path == other.call_path
@@ -42,10 +42,10 @@ impl PartialEqWithEngines for TyConstantDeclaration {
     }
 }
 
-impl HashWithEngines for TyConstantDeclaration {
+impl HashWithEngines for TyConstantDecl {
     fn hash<H: Hasher>(&self, state: &mut H, engines: Engines<'_>) {
         let type_engine = engines.te();
-        let TyConstantDeclaration {
+        let TyConstantDecl {
             call_path,
             value,
             visibility,
@@ -70,19 +70,19 @@ impl HashWithEngines for TyConstantDeclaration {
     }
 }
 
-impl Named for TyConstantDeclaration {
+impl Named for TyConstantDecl {
     fn name(&self) -> &Ident {
         &self.call_path.suffix
     }
 }
 
-impl Spanned for TyConstantDeclaration {
+impl Spanned for TyConstantDecl {
     fn span(&self) -> Span {
         self.span.clone()
     }
 }
 
-impl SubstTypes for TyConstantDeclaration {
+impl SubstTypes for TyConstantDecl {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         self.return_type.subst(type_mapping, engines);
         self.type_ascription.subst(type_mapping, engines);
@@ -92,7 +92,7 @@ impl SubstTypes for TyConstantDeclaration {
     }
 }
 
-impl ReplaceSelfType for TyConstantDeclaration {
+impl ReplaceSelfType for TyConstantDecl {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         self.return_type.replace_self_type(engines, self_type);
         self.type_ascription.replace_self_type(engines, self_type);
@@ -102,7 +102,7 @@ impl ReplaceSelfType for TyConstantDeclaration {
     }
 }
 
-impl ReplaceDecls for TyConstantDeclaration {
+impl ReplaceDecls for TyConstantDecl {
     fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, engines: Engines<'_>) {
         if let Some(expr) = &mut self.value {
             expr.replace_decls(decl_mapping, engines);

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -470,9 +470,9 @@ impl GetDeclIdent for TyDecl {
 }
 
 impl TyDecl {
-    /// Retrieves the declaration as a `DeclRef<DeclId<TyEnumDeclaration>>`.
+    /// Retrieves the declaration as a `DeclRef<DeclId<TyEnumDecl>>`.
     ///
-    /// Returns an error if `self` is not the [TyDeclaration][EnumDeclaration] variant.
+    /// Returns an error if `self` is not the [TyDecl][EnumDecl] variant.
     pub(crate) fn to_enum_ref(&self, engines: Engines) -> CompileResult<DeclRefEnum> {
         match self {
             TyDecl::EnumDecl {
@@ -500,9 +500,9 @@ impl TyDecl {
         }
     }
 
-    /// Retrieves the declaration as a `DeclRef<DeclId<TyStructDeclaration>>`.
+    /// Retrieves the declaration as a `DeclRef<DeclId<TyStructDecl>>`.
     ///
-    /// Returns an error if `self` is not the [TyDeclaration][StructDeclaration] variant.
+    /// Returns an error if `self` is not the [TyDecl][StructDecl] variant.
     pub(crate) fn to_struct_ref(&self, engines: Engines) -> CompileResult<DeclRefStruct> {
         match self {
             TyDecl::StructDecl {
@@ -530,10 +530,9 @@ impl TyDecl {
         }
     }
 
-    /// Retrieves the declaration as a `DeclRef<DeclId<TyFunctionDeclaration>>`.
+    /// Retrieves the declaration as a `DeclRef<DeclId<TyFunctionDecl>>`.
     ///
-    /// Returns an error if `self` is not the
-    /// [TyDeclaration][FunctionDeclaration] variant.
+    /// Returns an error if `self` is not the [TyDecl][FunctionDecl] variant.
     pub(crate) fn to_fn_ref(&self) -> CompileResult<DeclRef<DeclId<TyFunctionDecl>>> {
         match self {
             TyDecl::FunctionDecl {
@@ -559,7 +558,7 @@ impl TyDecl {
 
     /// Retrieves the declaration as a variable declaration.
     ///
-    /// Returns an error if `self` is not a [TyVariableDeclaration].
+    /// Returns an error if `self` is not a [TyVariableDecl].
     pub(crate) fn expect_variable(&self) -> CompileResult<&TyVariableDecl> {
         let warnings = vec![];
         let mut errors = vec![];
@@ -576,10 +575,9 @@ impl TyDecl {
         }
     }
 
-    /// Retrieves the declaration as a `DeclRef<DeclId<TyAbiDeclaration>>`.
+    /// Retrieves the declaration as a `DeclRef<DeclId<TyAbiDecl>>`.
     ///
-    /// Returns an error if `self` is not the
-    /// [TyDeclaration][AbiDeclaration] variant.
+    /// Returns an error if `self` is not the [TyDecl][AbiDecl] variant.
     pub(crate) fn to_abi_ref(&self) -> CompileResult<DeclRef<DeclId<TyAbiDecl>>> {
         match self {
             TyDecl::AbiDecl {
@@ -602,10 +600,9 @@ impl TyDecl {
         }
     }
 
-    /// Retrieves the declaration as a `DeclRef<DeclId<TyConstantDeclaration>>`.
+    /// Retrieves the declaration as a `DeclRef<DeclId<TyConstantDecl>>`.
     ///
-    /// Returns an error if `self` is not the
-    /// [TyDeclaration][ConstantDeclaration] variant.
+    /// Returns an error if `self` is not the [TyDecl][ConstantDecl] variant.
     pub(crate) fn to_const_ref(&self) -> CompileResult<DeclRef<DeclId<TyConstantDecl>>> {
         match self {
             TyDecl::ConstantDecl {

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -16,34 +16,34 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub enum TyDeclaration {
-    VariableDeclaration(Box<TyVariableDeclaration>),
-    ConstantDeclaration {
+pub enum TyDecl {
+    VariableDecl(Box<TyVariableDecl>),
+    ConstantDecl {
         name: Ident,
-        decl_id: DeclId<TyConstantDeclaration>,
+        decl_id: DeclId<TyConstantDecl>,
         decl_span: Span,
     },
-    FunctionDeclaration {
+    FunctionDecl {
         name: Ident,
-        decl_id: DeclId<TyFunctionDeclaration>,
+        decl_id: DeclId<TyFunctionDecl>,
         subst_list: Template<SubstList>,
         decl_span: Span,
     },
-    TraitDeclaration {
+    TraitDecl {
         name: Ident,
-        decl_id: DeclId<TyTraitDeclaration>,
+        decl_id: DeclId<TyTraitDecl>,
         subst_list: Template<SubstList>,
         decl_span: Span,
     },
-    StructDeclaration {
+    StructDecl {
         name: Ident,
-        decl_id: DeclId<TyStructDeclaration>,
+        decl_id: DeclId<TyStructDecl>,
         subst_list: Template<SubstList>,
         decl_span: Span,
     },
-    EnumDeclaration {
+    EnumDecl {
         name: Ident,
-        decl_id: DeclId<TyEnumDeclaration>,
+        decl_id: DeclId<TyEnumDecl>,
         subst_list: Template<SubstList>,
         decl_span: Span,
     },
@@ -53,9 +53,9 @@ pub enum TyDeclaration {
         subst_list: Template<SubstList>,
         decl_span: Span,
     },
-    AbiDeclaration {
+    AbiDecl {
         name: Ident,
-        decl_id: DeclId<TyAbiDeclaration>,
+        decl_id: DeclId<TyAbiDecl>,
         decl_span: Span,
     },
     // If type parameters are defined for a function, they are put in the namespace just for
@@ -65,31 +65,31 @@ pub enum TyDeclaration {
         type_id: TypeId,
     },
     ErrorRecovery(Span),
-    StorageDeclaration {
-        decl_id: DeclId<TyStorageDeclaration>,
+    StorageDecl {
+        decl_id: DeclId<TyStorageDecl>,
         decl_span: Span,
     },
-    TypeAliasDeclaration {
+    TypeAliasDecl {
         name: Ident,
-        decl_id: DeclId<TyTypeAliasDeclaration>,
+        decl_id: DeclId<TyTypeAliasDecl>,
         decl_span: Span,
     },
 }
 
-impl EqWithEngines for TyDeclaration {}
-impl PartialEqWithEngines for TyDeclaration {
+impl EqWithEngines for TyDecl {}
+impl PartialEqWithEngines for TyDecl {
     fn eq(&self, other: &Self, engines: Engines<'_>) -> bool {
         let decl_engine = engines.de();
         let type_engine = engines.te();
         match (self, other) {
-            (Self::VariableDeclaration(x), Self::VariableDeclaration(y)) => x.eq(y, engines),
+            (Self::VariableDecl(x), Self::VariableDecl(y)) => x.eq(y, engines),
             (
-                Self::ConstantDeclaration {
+                Self::ConstantDecl {
                     name: ln,
                     decl_id: lid,
                     ..
                 },
-                Self::ConstantDeclaration {
+                Self::ConstantDecl {
                     name: rn,
                     decl_id: rid,
                     ..
@@ -97,12 +97,12 @@ impl PartialEqWithEngines for TyDeclaration {
             ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
 
             (
-                Self::FunctionDeclaration {
+                Self::FunctionDecl {
                     name: ln,
                     decl_id: lid,
                     ..
                 },
-                Self::FunctionDeclaration {
+                Self::FunctionDecl {
                     name: rn,
                     decl_id: rid,
                     ..
@@ -110,36 +110,36 @@ impl PartialEqWithEngines for TyDeclaration {
             ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
 
             (
-                Self::TraitDeclaration {
+                Self::TraitDecl {
                     name: ln,
                     decl_id: lid,
                     ..
                 },
-                Self::TraitDeclaration {
+                Self::TraitDecl {
                     name: rn,
                     decl_id: rid,
                     ..
                 },
             ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
             (
-                Self::StructDeclaration {
+                Self::StructDecl {
                     name: ln,
                     decl_id: lid,
                     ..
                 },
-                Self::StructDeclaration {
+                Self::StructDecl {
                     name: rn,
                     decl_id: rid,
                     ..
                 },
             ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
             (
-                Self::EnumDeclaration {
+                Self::EnumDecl {
                     name: ln,
                     decl_id: lid,
                     ..
                 },
-                Self::EnumDeclaration {
+                Self::EnumDecl {
                     name: rn,
                     decl_id: rid,
                     ..
@@ -159,24 +159,23 @@ impl PartialEqWithEngines for TyDeclaration {
             ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
 
             (
-                Self::AbiDeclaration {
+                Self::AbiDecl {
                     name: ln,
                     decl_id: lid,
                     ..
                 },
-                Self::AbiDeclaration {
+                Self::AbiDecl {
                     name: rn,
                     decl_id: rid,
                     ..
                 },
             ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
+            (Self::StorageDecl { decl_id: lid, .. }, Self::StorageDecl { decl_id: rid, .. }) => {
+                decl_engine.get(lid).eq(&decl_engine.get(rid), engines)
+            }
             (
-                Self::StorageDeclaration { decl_id: lid, .. },
-                Self::StorageDeclaration { decl_id: rid, .. },
-            ) => decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
-            (
-                Self::TypeAliasDeclaration { decl_id: lid, .. },
-                Self::TypeAliasDeclaration { decl_id: rid, .. },
+                Self::TypeAliasDecl { decl_id: lid, .. },
+                Self::TypeAliasDecl { decl_id: rid, .. },
             ) => decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
             (
                 Self::GenericTypeForFunctionScope {
@@ -194,41 +193,41 @@ impl PartialEqWithEngines for TyDeclaration {
     }
 }
 
-impl HashWithEngines for TyDeclaration {
+impl HashWithEngines for TyDecl {
     fn hash<H: Hasher>(&self, state: &mut H, engines: Engines<'_>) {
-        use TyDeclaration::*;
+        use TyDecl::*;
         let decl_engine = engines.de();
         let type_engine = engines.te();
         std::mem::discriminant(self).hash(state);
         match self {
-            VariableDeclaration(decl) => {
+            VariableDecl(decl) => {
                 decl.hash(state, engines);
             }
-            ConstantDeclaration { decl_id, .. } => {
+            ConstantDecl { decl_id, .. } => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            FunctionDeclaration { decl_id, .. } => {
+            FunctionDecl { decl_id, .. } => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            TraitDeclaration { decl_id, .. } => {
+            TraitDecl { decl_id, .. } => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            StructDeclaration { decl_id, .. } => {
+            StructDecl { decl_id, .. } => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            EnumDeclaration { decl_id, .. } => {
+            EnumDecl { decl_id, .. } => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
             ImplTrait { decl_id, .. } => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            AbiDeclaration { decl_id, .. } => {
+            AbiDecl { decl_id, .. } => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            TypeAliasDeclaration { decl_id, .. } => {
+            TypeAliasDecl { decl_id, .. } => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            StorageDeclaration { decl_id, .. } => {
+            StorageDecl { decl_id, .. } => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
             GenericTypeForFunctionScope { name, type_id } => {
@@ -240,75 +239,75 @@ impl HashWithEngines for TyDeclaration {
     }
 }
 
-impl SubstTypes for TyDeclaration {
+impl SubstTypes for TyDecl {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
-        use TyDeclaration::*;
+        use TyDecl::*;
         match self {
-            VariableDeclaration(ref mut var_decl) => var_decl.subst(type_mapping, engines),
-            FunctionDeclaration {
+            VariableDecl(ref mut var_decl) => var_decl.subst(type_mapping, engines),
+            FunctionDecl {
                 ref mut decl_id, ..
             } => decl_id.subst(type_mapping, engines),
-            TraitDeclaration {
+            TraitDecl {
                 ref mut decl_id, ..
             } => decl_id.subst(type_mapping, engines),
-            StructDeclaration {
+            StructDecl {
                 ref mut decl_id, ..
             } => decl_id.subst(type_mapping, engines),
-            EnumDeclaration {
+            EnumDecl {
                 ref mut decl_id, ..
             } => decl_id.subst(type_mapping, engines),
             ImplTrait {
                 ref mut decl_id, ..
             } => decl_id.subst(type_mapping, engines),
-            TypeAliasDeclaration {
+            TypeAliasDecl {
                 ref mut decl_id, ..
             } => decl_id.subst(type_mapping, engines),
             // generics in an ABI is unsupported by design
-            AbiDeclaration { .. }
-            | ConstantDeclaration { .. }
-            | StorageDeclaration { .. }
+            AbiDecl { .. }
+            | ConstantDecl { .. }
+            | StorageDecl { .. }
             | GenericTypeForFunctionScope { .. }
             | ErrorRecovery(_) => (),
         }
     }
 }
 
-impl ReplaceSelfType for TyDeclaration {
+impl ReplaceSelfType for TyDecl {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
-        use TyDeclaration::*;
+        use TyDecl::*;
         match self {
-            VariableDeclaration(ref mut var_decl) => var_decl.replace_self_type(engines, self_type),
-            FunctionDeclaration {
+            VariableDecl(ref mut var_decl) => var_decl.replace_self_type(engines, self_type),
+            FunctionDecl {
                 ref mut decl_id, ..
             } => decl_id.replace_self_type(engines, self_type),
-            TraitDeclaration {
+            TraitDecl {
                 ref mut decl_id, ..
             } => decl_id.replace_self_type(engines, self_type),
-            StructDeclaration {
+            StructDecl {
                 ref mut decl_id, ..
             } => decl_id.replace_self_type(engines, self_type),
-            EnumDeclaration {
+            EnumDecl {
                 ref mut decl_id, ..
             } => decl_id.replace_self_type(engines, self_type),
             ImplTrait {
                 ref mut decl_id, ..
             } => decl_id.replace_self_type(engines, self_type),
-            TypeAliasDeclaration {
+            TypeAliasDecl {
                 ref mut decl_id, ..
             } => decl_id.replace_self_type(engines, self_type),
             // generics in an ABI is unsupported by design
-            AbiDeclaration { .. }
-            | ConstantDeclaration { .. }
-            | StorageDeclaration { .. }
+            AbiDecl { .. }
+            | ConstantDecl { .. }
+            | StorageDecl { .. }
             | GenericTypeForFunctionScope { .. }
             | ErrorRecovery(_) => (),
         }
     }
 }
 
-impl TyDeclaration {
+impl TyDecl {
     pub fn get_fun_decl_ref(&self) -> Option<DeclRefFunction> {
-        if let TyDeclaration::FunctionDeclaration {
+        if let TyDecl::FunctionDecl {
             name,
             decl_id,
             subst_list: _,
@@ -322,27 +321,27 @@ impl TyDeclaration {
     }
 }
 
-impl Spanned for TyDeclaration {
+impl Spanned for TyDecl {
     fn span(&self) -> Span {
-        use TyDeclaration::*;
+        use TyDecl::*;
         match self {
-            VariableDeclaration(decl) => decl.name.span(),
-            FunctionDeclaration { decl_span, .. }
-            | TraitDeclaration { decl_span, .. }
+            VariableDecl(decl) => decl.name.span(),
+            FunctionDecl { decl_span, .. }
+            | TraitDecl { decl_span, .. }
             | ImplTrait { decl_span, .. }
-            | ConstantDeclaration { decl_span, .. }
-            | StorageDeclaration { decl_span, .. }
-            | TypeAliasDeclaration { decl_span, .. }
-            | AbiDeclaration { decl_span, .. }
-            | StructDeclaration { decl_span, .. }
-            | EnumDeclaration { decl_span, .. } => decl_span.clone(),
+            | ConstantDecl { decl_span, .. }
+            | StorageDecl { decl_span, .. }
+            | TypeAliasDecl { decl_span, .. }
+            | AbiDecl { decl_span, .. }
+            | StructDecl { decl_span, .. }
+            | EnumDecl { decl_span, .. } => decl_span.clone(),
             GenericTypeForFunctionScope { name, .. } => name.span(),
             ErrorRecovery(span) => span.clone(),
         }
     }
 }
 
-impl DisplayWithEngines for TyDeclaration {
+impl DisplayWithEngines for TyDecl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, engines: Engines<'_>) -> std::fmt::Result {
         let type_engine = engines.te();
         write!(
@@ -350,8 +349,8 @@ impl DisplayWithEngines for TyDeclaration {
             "{} declaration ({})",
             self.friendly_type_name(),
             match self {
-                TyDeclaration::VariableDeclaration(decl) => {
-                    let TyVariableDeclaration {
+                TyDecl::VariableDecl(decl) => {
+                    let TyVariableDecl {
                         mutability,
                         name,
                         type_ascription,
@@ -375,28 +374,28 @@ impl DisplayWithEngines for TyDeclaration {
                     builder.push_str(&engines.help_out(body).to_string());
                     builder
                 }
-                TyDeclaration::FunctionDeclaration { name, .. }
-                | TyDeclaration::TraitDeclaration { name, .. }
-                | TyDeclaration::StructDeclaration { name, .. }
-                | TyDeclaration::EnumDeclaration { name, .. } => name.as_str().into(),
+                TyDecl::FunctionDecl { name, .. }
+                | TyDecl::TraitDecl { name, .. }
+                | TyDecl::StructDecl { name, .. }
+                | TyDecl::EnumDecl { name, .. } => name.as_str().into(),
                 _ => String::new(),
             }
         )
     }
 }
 
-impl CollectTypesMetadata for TyDeclaration {
+impl CollectTypesMetadata for TyDecl {
     // this is only run on entry nodes, which must have all well-formed types
     fn collect_types_metadata(
         &self,
         ctx: &mut CollectTypesMetadataContext,
     ) -> CompileResult<Vec<TypeMetadata>> {
-        use TyDeclaration::*;
+        use TyDecl::*;
         let mut warnings = vec![];
         let mut errors = vec![];
         let decl_engine = ctx.decl_engine;
         let metadata = match self {
-            VariableDeclaration(decl) => {
+            VariableDecl(decl) => {
                 let mut body = check!(
                     decl.body.collect_types_metadata(ctx),
                     return err(warnings, errors),
@@ -411,7 +410,7 @@ impl CollectTypesMetadata for TyDeclaration {
                 ));
                 body
             }
-            FunctionDeclaration { decl_id, .. } => {
+            FunctionDecl { decl_id, .. } => {
                 let decl = decl_engine.get_function(decl_id);
                 check!(
                     decl.collect_types_metadata(ctx),
@@ -420,8 +419,8 @@ impl CollectTypesMetadata for TyDeclaration {
                     errors
                 )
             }
-            ConstantDeclaration { decl_id, .. } => {
-                let TyConstantDeclaration { value, .. } = decl_engine.get_constant(decl_id);
+            ConstantDecl { decl_id, .. } => {
+                let TyConstantDecl { value, .. } = decl_engine.get_constant(decl_id);
                 if let Some(value) = value {
                     check!(
                         value.collect_types_metadata(ctx),
@@ -434,13 +433,13 @@ impl CollectTypesMetadata for TyDeclaration {
                 }
             }
             ErrorRecovery(_)
-            | StorageDeclaration { .. }
-            | TraitDeclaration { .. }
-            | StructDeclaration { .. }
-            | EnumDeclaration { .. }
+            | StorageDecl { .. }
+            | TraitDecl { .. }
+            | StructDecl { .. }
+            | EnumDecl { .. }
             | ImplTrait { .. }
-            | AbiDeclaration { .. }
-            | TypeAliasDeclaration { .. }
+            | AbiDecl { .. }
+            | TypeAliasDecl { .. }
             | GenericTypeForFunctionScope { .. } => vec![],
         };
         if errors.is_empty() {
@@ -451,32 +450,32 @@ impl CollectTypesMetadata for TyDeclaration {
     }
 }
 
-impl GetDeclIdent for TyDeclaration {
+impl GetDeclIdent for TyDecl {
     fn get_decl_ident(&self) -> Option<Ident> {
         match self {
-            TyDeclaration::VariableDeclaration(decl) => Some(decl.name.clone()),
-            TyDeclaration::FunctionDeclaration { name, .. }
-            | TyDeclaration::TraitDeclaration { name, .. }
-            | TyDeclaration::ConstantDeclaration { name, .. }
-            | TyDeclaration::ImplTrait { name, .. }
-            | TyDeclaration::AbiDeclaration { name, .. }
-            | TyDeclaration::TypeAliasDeclaration { name, .. }
-            | TyDeclaration::GenericTypeForFunctionScope { name, .. }
-            | TyDeclaration::StructDeclaration { name, .. }
-            | TyDeclaration::EnumDeclaration { name, .. } => Some(name.clone()),
-            TyDeclaration::ErrorRecovery(_) => None,
-            TyDeclaration::StorageDeclaration { .. } => None,
+            TyDecl::VariableDecl(decl) => Some(decl.name.clone()),
+            TyDecl::FunctionDecl { name, .. }
+            | TyDecl::TraitDecl { name, .. }
+            | TyDecl::ConstantDecl { name, .. }
+            | TyDecl::ImplTrait { name, .. }
+            | TyDecl::AbiDecl { name, .. }
+            | TyDecl::TypeAliasDecl { name, .. }
+            | TyDecl::GenericTypeForFunctionScope { name, .. }
+            | TyDecl::StructDecl { name, .. }
+            | TyDecl::EnumDecl { name, .. } => Some(name.clone()),
+            TyDecl::ErrorRecovery(_) => None,
+            TyDecl::StorageDecl { .. } => None,
         }
     }
 }
 
-impl TyDeclaration {
+impl TyDecl {
     /// Retrieves the declaration as a `DeclRef<DeclId<TyEnumDeclaration>>`.
     ///
     /// Returns an error if `self` is not the [TyDeclaration][EnumDeclaration] variant.
     pub(crate) fn to_enum_ref(&self, engines: Engines) -> CompileResult<DeclRefEnum> {
         match self {
-            TyDeclaration::EnumDeclaration {
+            TyDecl::EnumDecl {
                 name,
                 decl_id,
                 subst_list: _,
@@ -486,11 +485,11 @@ impl TyDeclaration {
                 vec![],
                 vec![],
             ),
-            TyDeclaration::TypeAliasDeclaration { decl_id, .. } => {
-                let TyTypeAliasDeclaration { ty, span, .. } = engines.de().get_type_alias(decl_id);
+            TyDecl::TypeAliasDecl { decl_id, .. } => {
+                let TyTypeAliasDecl { ty, span, .. } = engines.de().get_type_alias(decl_id);
                 engines.te().get(ty.type_id).expect_enum(engines, "", &span)
             }
-            TyDeclaration::ErrorRecovery(_) => err(vec![], vec![]),
+            TyDecl::ErrorRecovery(_) => err(vec![], vec![]),
             decl => err(
                 vec![],
                 vec![CompileError::DeclIsNotAnEnum {
@@ -506,7 +505,7 @@ impl TyDeclaration {
     /// Returns an error if `self` is not the [TyDeclaration][StructDeclaration] variant.
     pub(crate) fn to_struct_ref(&self, engines: Engines) -> CompileResult<DeclRefStruct> {
         match self {
-            TyDeclaration::StructDeclaration {
+            TyDecl::StructDecl {
                 name,
                 decl_id,
                 subst_list: _,
@@ -516,11 +515,11 @@ impl TyDeclaration {
                 vec![],
                 vec![],
             ),
-            TyDeclaration::TypeAliasDeclaration { decl_id, .. } => {
-                let TyTypeAliasDeclaration { ty, span, .. } = engines.de().get_type_alias(decl_id);
+            TyDecl::TypeAliasDecl { decl_id, .. } => {
+                let TyTypeAliasDecl { ty, span, .. } = engines.de().get_type_alias(decl_id);
                 engines.te().get(ty.type_id).expect_struct(engines, &span)
             }
-            TyDeclaration::ErrorRecovery(_) => err(vec![], vec![]),
+            TyDecl::ErrorRecovery(_) => err(vec![], vec![]),
             decl => err(
                 vec![],
                 vec![CompileError::DeclIsNotAStruct {
@@ -535,9 +534,9 @@ impl TyDeclaration {
     ///
     /// Returns an error if `self` is not the
     /// [TyDeclaration][FunctionDeclaration] variant.
-    pub(crate) fn to_fn_ref(&self) -> CompileResult<DeclRef<DeclId<TyFunctionDeclaration>>> {
+    pub(crate) fn to_fn_ref(&self) -> CompileResult<DeclRef<DeclId<TyFunctionDecl>>> {
         match self {
-            TyDeclaration::FunctionDeclaration {
+            TyDecl::FunctionDecl {
                 name,
                 decl_id,
                 subst_list: _,
@@ -547,7 +546,7 @@ impl TyDeclaration {
                 vec![],
                 vec![],
             ),
-            TyDeclaration::ErrorRecovery(_) => err(vec![], vec![]),
+            TyDecl::ErrorRecovery(_) => err(vec![], vec![]),
             decl => err(
                 vec![],
                 vec![CompileError::DeclIsNotAFunction {
@@ -561,12 +560,12 @@ impl TyDeclaration {
     /// Retrieves the declaration as a variable declaration.
     ///
     /// Returns an error if `self` is not a [TyVariableDeclaration].
-    pub(crate) fn expect_variable(&self) -> CompileResult<&TyVariableDeclaration> {
+    pub(crate) fn expect_variable(&self) -> CompileResult<&TyVariableDecl> {
         let warnings = vec![];
         let mut errors = vec![];
         match self {
-            TyDeclaration::VariableDeclaration(decl) => ok(decl, warnings, errors),
-            TyDeclaration::ErrorRecovery(_) => err(vec![], vec![]),
+            TyDecl::VariableDecl(decl) => ok(decl, warnings, errors),
+            TyDecl::ErrorRecovery(_) => err(vec![], vec![]),
             decl => {
                 errors.push(CompileError::DeclIsNotAVariable {
                     actually: decl.friendly_type_name().to_string(),
@@ -581,9 +580,9 @@ impl TyDeclaration {
     ///
     /// Returns an error if `self` is not the
     /// [TyDeclaration][AbiDeclaration] variant.
-    pub(crate) fn to_abi_ref(&self) -> CompileResult<DeclRef<DeclId<TyAbiDeclaration>>> {
+    pub(crate) fn to_abi_ref(&self) -> CompileResult<DeclRef<DeclId<TyAbiDecl>>> {
         match self {
-            TyDeclaration::AbiDeclaration {
+            TyDecl::AbiDecl {
                 name,
                 decl_id,
                 decl_span,
@@ -592,7 +591,7 @@ impl TyDeclaration {
                 vec![],
                 vec![],
             ),
-            TyDeclaration::ErrorRecovery(_) => err(vec![], vec![]),
+            TyDecl::ErrorRecovery(_) => err(vec![], vec![]),
             decl => err(
                 vec![],
                 vec![CompileError::DeclIsNotAnAbi {
@@ -607,9 +606,9 @@ impl TyDeclaration {
     ///
     /// Returns an error if `self` is not the
     /// [TyDeclaration][ConstantDeclaration] variant.
-    pub(crate) fn to_const_ref(&self) -> CompileResult<DeclRef<DeclId<TyConstantDeclaration>>> {
+    pub(crate) fn to_const_ref(&self) -> CompileResult<DeclRef<DeclId<TyConstantDecl>>> {
         match self {
-            TyDeclaration::ConstantDeclaration {
+            TyDecl::ConstantDecl {
                 name,
                 decl_id,
                 decl_span,
@@ -618,7 +617,7 @@ impl TyDeclaration {
                 vec![],
                 vec![],
             ),
-            TyDeclaration::ErrorRecovery(_) => err(vec![], vec![]),
+            TyDecl::ErrorRecovery(_) => err(vec![], vec![]),
             decl => err(
                 vec![],
                 vec![CompileError::DeclIsNotAConstant {
@@ -632,7 +631,7 @@ impl TyDeclaration {
     /// friendly name string used for error reporting,
     /// which consists of the the identifier for the declaration.
     pub fn friendly_name(&self, engines: &Engines) -> String {
-        use TyDeclaration::*;
+        use TyDecl::*;
         let decl_engine = engines.de();
         let type_engine = engines.te();
         match self {
@@ -655,36 +654,36 @@ impl TyDeclaration {
     /// friendly type name string used for error reporting,
     /// which consists of the type name of the declaration AST node.
     pub fn friendly_type_name(&self) -> &'static str {
-        use TyDeclaration::*;
+        use TyDecl::*;
         match self {
-            VariableDeclaration(_) => "variable",
-            ConstantDeclaration { .. } => "constant",
-            FunctionDeclaration { .. } => "function",
-            TraitDeclaration { .. } => "trait",
-            StructDeclaration { .. } => "struct",
-            EnumDeclaration { .. } => "enum",
+            VariableDecl(_) => "variable",
+            ConstantDecl { .. } => "constant",
+            FunctionDecl { .. } => "function",
+            TraitDecl { .. } => "trait",
+            StructDecl { .. } => "struct",
+            EnumDecl { .. } => "enum",
             ImplTrait { .. } => "impl trait",
-            AbiDeclaration { .. } => "abi",
+            AbiDecl { .. } => "abi",
             GenericTypeForFunctionScope { .. } => "generic type parameter",
             ErrorRecovery(_) => "error",
-            StorageDeclaration { .. } => "contract storage declaration",
-            TypeAliasDeclaration { .. } => "type alias declaration",
+            StorageDecl { .. } => "contract storage declaration",
+            TypeAliasDecl { .. } => "type alias declaration",
         }
     }
 
     /// name string used in `forc doc` file path generation that mirrors `cargo doc`.
     pub fn doc_name(&self) -> &'static str {
-        use TyDeclaration::*;
+        use TyDecl::*;
         match self {
-            StructDeclaration { .. } => "struct",
-            EnumDeclaration { .. } => "enum",
-            TraitDeclaration { .. } => "trait",
-            AbiDeclaration { .. } => "abi",
-            StorageDeclaration { .. } => "contract_storage",
+            StructDecl { .. } => "struct",
+            EnumDecl { .. } => "enum",
+            TraitDecl { .. } => "trait",
+            AbiDecl { .. } => "abi",
+            StorageDecl { .. } => "contract_storage",
             ImplTrait { .. } => "impl_trait",
-            FunctionDeclaration { .. } => "fn",
-            ConstantDeclaration { .. } => "constant",
-            TypeAliasDeclaration { .. } => "type alias",
+            FunctionDecl { .. } => "fn",
+            ConstantDecl { .. } => "constant",
+            TypeAliasDecl { .. } => "type alias",
             _ => unreachable!("these items are non-documentable"),
         }
     }
@@ -695,12 +694,12 @@ impl TyDeclaration {
         let type_engine = engines.te();
         let decl_engine = engines.de();
         let type_id = match self {
-            TyDeclaration::VariableDeclaration(decl) => decl.body.return_type,
-            TyDeclaration::FunctionDeclaration { decl_id, .. } => {
+            TyDecl::VariableDecl(decl) => decl.body.return_type,
+            TyDecl::FunctionDecl { decl_id, .. } => {
                 let decl = decl_engine.get_function(decl_id);
                 decl.return_type.type_id
             }
-            TyDeclaration::StructDeclaration {
+            TyDecl::StructDecl {
                 name,
                 decl_id,
                 subst_list: _,
@@ -709,7 +708,7 @@ impl TyDeclaration {
                 decl_engine,
                 TypeInfo::Struct(DeclRef::new(name.clone(), *decl_id, decl_span.clone())),
             ),
-            TyDeclaration::EnumDeclaration {
+            TyDecl::EnumDecl {
                 name,
                 decl_id,
                 subst_list: _,
@@ -718,7 +717,7 @@ impl TyDeclaration {
                 decl_engine,
                 TypeInfo::Enum(DeclRef::new(name.clone(), *decl_id, decl_span.clone())),
             ),
-            TyDeclaration::StorageDeclaration { decl_id, .. } => {
+            TyDecl::StorageDecl { decl_id, .. } => {
                 let storage_decl = decl_engine.get_storage(decl_id);
                 type_engine.insert(
                     decl_engine,
@@ -727,11 +726,11 @@ impl TyDeclaration {
                     },
                 )
             }
-            TyDeclaration::TypeAliasDeclaration { decl_id, .. } => {
+            TyDecl::TypeAliasDecl { decl_id, .. } => {
                 let decl = decl_engine.get_type_alias(decl_id);
                 decl.create_type_id(engines)
             }
-            TyDeclaration::GenericTypeForFunctionScope { type_id, .. } => *type_id,
+            TyDecl::GenericTypeForFunctionScope { type_id, .. } => *type_id,
             decl => {
                 errors.push(CompileError::NotAType {
                     span: decl.span(),
@@ -745,45 +744,45 @@ impl TyDeclaration {
     }
 
     pub(crate) fn visibility(&self, decl_engine: &DeclEngine) -> Visibility {
-        use TyDeclaration::*;
+        use TyDecl::*;
         match self {
-            TraitDeclaration { decl_id, .. } => {
-                let TyTraitDeclaration { visibility, .. } = decl_engine.get_trait(decl_id);
+            TraitDecl { decl_id, .. } => {
+                let TyTraitDecl { visibility, .. } = decl_engine.get_trait(decl_id);
                 visibility
             }
-            ConstantDeclaration { decl_id, .. } => {
-                let TyConstantDeclaration { visibility, .. } = decl_engine.get_constant(decl_id);
+            ConstantDecl { decl_id, .. } => {
+                let TyConstantDecl { visibility, .. } = decl_engine.get_constant(decl_id);
                 visibility
             }
-            StructDeclaration { decl_id, .. } => {
-                let TyStructDeclaration { visibility, .. } = decl_engine.get_struct(decl_id);
+            StructDecl { decl_id, .. } => {
+                let TyStructDecl { visibility, .. } = decl_engine.get_struct(decl_id);
                 visibility
             }
-            EnumDeclaration { decl_id, .. } => {
-                let TyEnumDeclaration { visibility, .. } = decl_engine.get_enum(decl_id);
+            EnumDecl { decl_id, .. } => {
+                let TyEnumDecl { visibility, .. } = decl_engine.get_enum(decl_id);
                 visibility
             }
-            FunctionDeclaration { decl_id, .. } => {
-                let TyFunctionDeclaration { visibility, .. } = decl_engine.get_function(decl_id);
+            FunctionDecl { decl_id, .. } => {
+                let TyFunctionDecl { visibility, .. } = decl_engine.get_function(decl_id);
                 visibility
             }
-            TypeAliasDeclaration { decl_id, .. } => {
-                let TyTypeAliasDeclaration { visibility, .. } = decl_engine.get_type_alias(decl_id);
+            TypeAliasDecl { decl_id, .. } => {
+                let TyTypeAliasDecl { visibility, .. } = decl_engine.get_type_alias(decl_id);
                 visibility
             }
             GenericTypeForFunctionScope { .. }
             | ImplTrait { .. }
-            | StorageDeclaration { .. }
-            | AbiDeclaration { .. }
+            | StorageDecl { .. }
+            | AbiDecl { .. }
             | ErrorRecovery(_) => Visibility::Public,
-            VariableDeclaration(decl) => decl.mutability.visibility(),
+            VariableDecl(decl) => decl.mutability.visibility(),
         }
     }
 }
 
-impl From<DeclRef<DeclId<TyConstantDeclaration>>> for TyDeclaration {
-    fn from(decl_ref: DeclRef<DeclId<TyConstantDeclaration>>) -> Self {
-        TyDeclaration::ConstantDeclaration {
+impl From<DeclRef<DeclId<TyConstantDecl>>> for TyDecl {
+    fn from(decl_ref: DeclRef<DeclId<TyConstantDecl>>) -> Self {
+        TyDecl::ConstantDecl {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             decl_span: decl_ref.decl_span().clone(),
@@ -791,20 +790,9 @@ impl From<DeclRef<DeclId<TyConstantDeclaration>>> for TyDeclaration {
     }
 }
 
-impl From<DeclRef<DeclId<TyEnumDeclaration>>> for TyDeclaration {
-    fn from(decl_ref: DeclRef<DeclId<TyEnumDeclaration>>) -> Self {
-        TyDeclaration::EnumDeclaration {
-            name: decl_ref.name().clone(),
-            decl_id: *decl_ref.id(),
-            subst_list: Template::new(decl_ref.subst_list().clone()),
-            decl_span: decl_ref.decl_span().clone(),
-        }
-    }
-}
-
-impl From<DeclRef<DeclId<TyFunctionDeclaration>>> for TyDeclaration {
-    fn from(decl_ref: DeclRef<DeclId<TyFunctionDeclaration>>) -> Self {
-        TyDeclaration::FunctionDeclaration {
+impl From<DeclRef<DeclId<TyEnumDecl>>> for TyDecl {
+    fn from(decl_ref: DeclRef<DeclId<TyEnumDecl>>) -> Self {
+        TyDecl::EnumDecl {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             subst_list: Template::new(decl_ref.subst_list().clone()),
@@ -813,9 +801,9 @@ impl From<DeclRef<DeclId<TyFunctionDeclaration>>> for TyDeclaration {
     }
 }
 
-impl From<DeclRef<DeclId<TyTraitDeclaration>>> for TyDeclaration {
-    fn from(decl_ref: DeclRef<DeclId<TyTraitDeclaration>>) -> Self {
-        TyDeclaration::TraitDeclaration {
+impl From<DeclRef<DeclId<TyFunctionDecl>>> for TyDecl {
+    fn from(decl_ref: DeclRef<DeclId<TyFunctionDecl>>) -> Self {
+        TyDecl::FunctionDecl {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             subst_list: Template::new(decl_ref.subst_list().clone()),
@@ -824,9 +812,20 @@ impl From<DeclRef<DeclId<TyTraitDeclaration>>> for TyDeclaration {
     }
 }
 
-impl From<DeclRef<DeclId<TyImplTrait>>> for TyDeclaration {
+impl From<DeclRef<DeclId<TyTraitDecl>>> for TyDecl {
+    fn from(decl_ref: DeclRef<DeclId<TyTraitDecl>>) -> Self {
+        TyDecl::TraitDecl {
+            name: decl_ref.name().clone(),
+            decl_id: *decl_ref.id(),
+            subst_list: Template::new(decl_ref.subst_list().clone()),
+            decl_span: decl_ref.decl_span().clone(),
+        }
+    }
+}
+
+impl From<DeclRef<DeclId<TyImplTrait>>> for TyDecl {
     fn from(decl_ref: DeclRef<DeclId<TyImplTrait>>) -> Self {
-        TyDeclaration::ImplTrait {
+        TyDecl::ImplTrait {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             subst_list: Template::new(decl_ref.subst_list().clone()),
@@ -835,9 +834,9 @@ impl From<DeclRef<DeclId<TyImplTrait>>> for TyDeclaration {
     }
 }
 
-impl From<DeclRef<DeclId<TyStructDeclaration>>> for TyDeclaration {
-    fn from(decl_ref: DeclRef<DeclId<TyStructDeclaration>>) -> Self {
-        TyDeclaration::StructDeclaration {
+impl From<DeclRef<DeclId<TyStructDecl>>> for TyDecl {
+    fn from(decl_ref: DeclRef<DeclId<TyStructDecl>>) -> Self {
+        TyDecl::StructDecl {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             subst_list: Template::new(decl_ref.subst_list().clone()),
@@ -846,9 +845,9 @@ impl From<DeclRef<DeclId<TyStructDeclaration>>> for TyDeclaration {
     }
 }
 
-impl From<DeclRef<DeclId<TyAbiDeclaration>>> for TyDeclaration {
-    fn from(decl_ref: DeclRef<DeclId<TyAbiDeclaration>>) -> Self {
-        TyDeclaration::AbiDeclaration {
+impl From<DeclRef<DeclId<TyAbiDecl>>> for TyDecl {
+    fn from(decl_ref: DeclRef<DeclId<TyAbiDecl>>) -> Self {
+        TyDecl::AbiDecl {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             decl_span: decl_ref.decl_span().clone(),
@@ -856,17 +855,17 @@ impl From<DeclRef<DeclId<TyAbiDeclaration>>> for TyDeclaration {
     }
 }
 
-impl From<DeclRef<DeclId<TyStorageDeclaration>>> for TyDeclaration {
-    fn from(decl_ref: DeclRef<DeclId<TyStorageDeclaration>>) -> Self {
-        TyDeclaration::StorageDeclaration {
+impl From<DeclRef<DeclId<TyStorageDecl>>> for TyDecl {
+    fn from(decl_ref: DeclRef<DeclId<TyStorageDecl>>) -> Self {
+        TyDecl::StorageDecl {
             decl_id: *decl_ref.id(),
             decl_span: decl_ref.decl_span().clone(),
         }
     }
 }
-impl From<DeclRef<DeclId<TyTypeAliasDeclaration>>> for TyDeclaration {
-    fn from(decl_ref: DeclRef<DeclId<TyTypeAliasDeclaration>>) -> Self {
-        TyDeclaration::TypeAliasDeclaration {
+impl From<DeclRef<DeclId<TyTypeAliasDecl>>> for TyDecl {
+    fn from(decl_ref: DeclRef<DeclId<TyTypeAliasDecl>>) -> Self {
+        TyDecl::TypeAliasDecl {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             decl_span: decl_ref.decl_span().clone(),

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct TyEnumDeclaration {
+pub struct TyEnumDecl {
     pub call_path: CallPath,
     pub type_parameters: Vec<TypeParameter>,
     pub attributes: transform::AttributesMap,
@@ -24,14 +24,14 @@ pub struct TyEnumDeclaration {
     pub visibility: Visibility,
 }
 
-impl Named for TyEnumDeclaration {
+impl Named for TyEnumDecl {
     fn name(&self) -> &Ident {
         &self.call_path.suffix
     }
 }
 
-impl EqWithEngines for TyEnumDeclaration {}
-impl PartialEqWithEngines for TyEnumDeclaration {
+impl EqWithEngines for TyEnumDecl {}
+impl PartialEqWithEngines for TyEnumDecl {
     fn eq(&self, other: &Self, engines: Engines<'_>) -> bool {
         self.call_path.suffix == other.call_path.suffix
             && self.type_parameters.eq(&other.type_parameters, engines)
@@ -40,9 +40,9 @@ impl PartialEqWithEngines for TyEnumDeclaration {
     }
 }
 
-impl HashWithEngines for TyEnumDeclaration {
+impl HashWithEngines for TyEnumDecl {
     fn hash<H: Hasher>(&self, state: &mut H, engines: Engines<'_>) {
-        let TyEnumDeclaration {
+        let TyEnumDecl {
             call_path,
             type_parameters,
             variants,
@@ -59,7 +59,7 @@ impl HashWithEngines for TyEnumDeclaration {
     }
 }
 
-impl SubstTypes for TyEnumDeclaration {
+impl SubstTypes for TyEnumDecl {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         self.variants
             .iter_mut()
@@ -70,7 +70,7 @@ impl SubstTypes for TyEnumDeclaration {
     }
 }
 
-impl ReplaceSelfType for TyEnumDeclaration {
+impl ReplaceSelfType for TyEnumDecl {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         self.variants
             .iter_mut()
@@ -81,13 +81,13 @@ impl ReplaceSelfType for TyEnumDeclaration {
     }
 }
 
-impl Spanned for TyEnumDeclaration {
+impl Spanned for TyEnumDecl {
     fn span(&self) -> Span {
         self.span.clone()
     }
 }
 
-impl MonomorphizeHelper for TyEnumDeclaration {
+impl MonomorphizeHelper for TyEnumDecl {
     fn type_parameters(&self) -> &[TypeParameter] {
         &self.type_parameters
     }
@@ -97,7 +97,7 @@ impl MonomorphizeHelper for TyEnumDeclaration {
     }
 }
 
-impl TyEnumDeclaration {
+impl TyEnumDecl {
     pub(crate) fn expect_variant_from_name(
         &self,
         variant_name: &Ident,

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -21,11 +21,11 @@ use sway_types::{
 };
 
 #[derive(Clone, Debug)]
-pub struct TyFunctionDeclaration {
+pub struct TyFunctionDecl {
     pub name: Ident,
     pub body: TyCodeBlock,
     pub parameters: Vec<TyFunctionParameter>,
-    pub implementing_type: Option<TyDeclaration>,
+    pub implementing_type: Option<TyDecl>,
     pub span: Span,
     pub attributes: transform::AttributesMap,
     pub type_parameters: Vec<TypeParameter>,
@@ -37,14 +37,14 @@ pub struct TyFunctionDeclaration {
     pub where_clause: Vec<(Ident, Vec<TraitConstraint>)>,
 }
 
-impl Named for TyFunctionDeclaration {
+impl Named for TyFunctionDecl {
     fn name(&self) -> &Ident {
         &self.name
     }
 }
 
-impl EqWithEngines for TyFunctionDeclaration {}
-impl PartialEqWithEngines for TyFunctionDeclaration {
+impl EqWithEngines for TyFunctionDecl {}
+impl PartialEqWithEngines for TyFunctionDecl {
     fn eq(&self, other: &Self, engines: Engines<'_>) -> bool {
         self.name == other.name
             && self.body.eq(&other.body, engines)
@@ -57,9 +57,9 @@ impl PartialEqWithEngines for TyFunctionDeclaration {
     }
 }
 
-impl HashWithEngines for TyFunctionDeclaration {
+impl HashWithEngines for TyFunctionDecl {
     fn hash<H: Hasher>(&self, state: &mut H, engines: Engines<'_>) {
-        let TyFunctionDeclaration {
+        let TyFunctionDecl {
             name,
             body,
             parameters,
@@ -86,7 +86,7 @@ impl HashWithEngines for TyFunctionDeclaration {
     }
 }
 
-impl SubstTypes for TyFunctionDeclaration {
+impl SubstTypes for TyFunctionDecl {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         self.type_parameters
             .iter_mut()
@@ -99,7 +99,7 @@ impl SubstTypes for TyFunctionDeclaration {
     }
 }
 
-impl ReplaceSelfType for TyFunctionDeclaration {
+impl ReplaceSelfType for TyFunctionDecl {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         self.type_parameters
             .iter_mut()
@@ -112,19 +112,19 @@ impl ReplaceSelfType for TyFunctionDeclaration {
     }
 }
 
-impl ReplaceDecls for TyFunctionDeclaration {
+impl ReplaceDecls for TyFunctionDecl {
     fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, engines: Engines<'_>) {
         self.body.replace_decls(decl_mapping, engines);
     }
 }
 
-impl Spanned for TyFunctionDeclaration {
+impl Spanned for TyFunctionDecl {
     fn span(&self) -> Span {
         self.span.clone()
     }
 }
 
-impl MonomorphizeHelper for TyFunctionDeclaration {
+impl MonomorphizeHelper for TyFunctionDecl {
     fn type_parameters(&self) -> &[TypeParameter] {
         &self.type_parameters
     }
@@ -134,7 +134,7 @@ impl MonomorphizeHelper for TyFunctionDeclaration {
     }
 }
 
-impl UnconstrainedTypeParameters for TyFunctionDeclaration {
+impl UnconstrainedTypeParameters for TyFunctionDecl {
     fn type_parameter_is_unconstrained(
         &self,
         engines: Engines<'_>,
@@ -166,7 +166,7 @@ impl UnconstrainedTypeParameters for TyFunctionDeclaration {
     }
 }
 
-impl CollectTypesMetadata for TyFunctionDeclaration {
+impl CollectTypesMetadata for TyFunctionDecl {
     fn collect_types_metadata(
         &self,
         ctx: &mut CollectTypesMetadataContext,
@@ -208,14 +208,14 @@ impl CollectTypesMetadata for TyFunctionDeclaration {
     }
 }
 
-impl TyFunctionDeclaration {
-    pub(crate) fn set_implementing_type(&mut self, decl: TyDeclaration) {
+impl TyFunctionDecl {
+    pub(crate) fn set_implementing_type(&mut self, decl: TyDecl) {
         self.implementing_type = Some(decl);
     }
 
     /// Used to create a stubbed out function when the function fails to
     /// compile, preventing cascading namespace errors.
-    pub(crate) fn error(decl: parsed::FunctionDeclaration) -> TyFunctionDeclaration {
+    pub(crate) fn error(decl: parsed::FunctionDeclaration) -> TyFunctionDecl {
         let parsed::FunctionDeclaration {
             name,
             return_type,
@@ -225,7 +225,7 @@ impl TyFunctionDeclaration {
             where_clause,
             ..
         } = decl;
-        TyFunctionDeclaration {
+        TyFunctionDecl {
             purity,
             name,
             body: TyCodeBlock {
@@ -423,7 +423,7 @@ pub struct TyFunctionSig {
 }
 
 impl TyFunctionSig {
-    pub fn from_fn_decl(fn_decl: &TyFunctionDeclaration) -> Self {
+    pub fn from_fn_decl(fn_decl: &TyFunctionDecl) -> Self {
         Self {
             return_type: fn_decl.return_type.type_id,
             parameters: fn_decl

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -276,7 +276,7 @@ impl TyFunctionDecl {
         ok(hash.to_vec(), warnings, errors)
     }
 
-    /// Converts a [TyFunctionDeclaration] into a value that is to be used in contract function
+    /// Converts a [TyFunctionDecl] into a value that is to be used in contract function
     /// selectors.
     /// Hashes the name and parameters using SHA256, and then truncates to four bytes.
     pub fn to_fn_selector_value(

--- a/sway-core/src/language/ty/declaration/storage.rs
+++ b/sway-core/src/language/ty/declaration/storage.rs
@@ -9,29 +9,29 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct TyStorageDeclaration {
+pub struct TyStorageDecl {
     pub fields: Vec<TyStorageField>,
     pub span: Span,
     pub attributes: transform::AttributesMap,
     pub storage_keyword: Ident,
 }
 
-impl Named for TyStorageDeclaration {
+impl Named for TyStorageDecl {
     fn name(&self) -> &Ident {
         &self.storage_keyword
     }
 }
 
-impl EqWithEngines for TyStorageDeclaration {}
-impl PartialEqWithEngines for TyStorageDeclaration {
+impl EqWithEngines for TyStorageDecl {}
+impl PartialEqWithEngines for TyStorageDecl {
     fn eq(&self, other: &Self, engines: Engines<'_>) -> bool {
         self.fields.eq(&other.fields, engines) && self.attributes == other.attributes
     }
 }
 
-impl HashWithEngines for TyStorageDeclaration {
+impl HashWithEngines for TyStorageDecl {
     fn hash<H: Hasher>(&self, state: &mut H, engines: Engines<'_>) {
-        let TyStorageDeclaration {
+        let TyStorageDecl {
             fields,
             // these fields are not hashed because they aren't relevant/a
             // reliable source of obj v. obj distinction
@@ -43,13 +43,13 @@ impl HashWithEngines for TyStorageDeclaration {
     }
 }
 
-impl Spanned for TyStorageDeclaration {
+impl Spanned for TyStorageDecl {
     fn span(&self) -> Span {
         self.span.clone()
     }
 }
 
-impl TyStorageDeclaration {
+impl TyStorageDecl {
     /// Given a field, find its type information in the declaration and return it. If the field has not
     /// been declared as a part of storage, return an error.
     pub fn apply_storage_load(

--- a/sway-core/src/language/ty/declaration/struct.rs
+++ b/sway-core/src/language/ty/declaration/struct.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct TyStructDeclaration {
+pub struct TyStructDecl {
     pub call_path: CallPath,
     pub fields: Vec<TyStructField>,
     pub type_parameters: Vec<TypeParameter>,
@@ -24,14 +24,14 @@ pub struct TyStructDeclaration {
     pub attributes: transform::AttributesMap,
 }
 
-impl Named for TyStructDeclaration {
+impl Named for TyStructDecl {
     fn name(&self) -> &Ident {
         &self.call_path.suffix
     }
 }
 
-impl EqWithEngines for TyStructDeclaration {}
-impl PartialEqWithEngines for TyStructDeclaration {
+impl EqWithEngines for TyStructDecl {}
+impl PartialEqWithEngines for TyStructDecl {
     fn eq(&self, other: &Self, engines: Engines<'_>) -> bool {
         self.call_path.suffix == other.call_path.suffix
             && self.fields.eq(&other.fields, engines)
@@ -40,9 +40,9 @@ impl PartialEqWithEngines for TyStructDeclaration {
     }
 }
 
-impl HashWithEngines for TyStructDeclaration {
+impl HashWithEngines for TyStructDecl {
     fn hash<H: Hasher>(&self, state: &mut H, engines: Engines<'_>) {
-        let TyStructDeclaration {
+        let TyStructDecl {
             call_path,
             fields,
             type_parameters,
@@ -59,7 +59,7 @@ impl HashWithEngines for TyStructDeclaration {
     }
 }
 
-impl SubstTypes for TyStructDeclaration {
+impl SubstTypes for TyStructDecl {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         self.fields
             .iter_mut()
@@ -70,7 +70,7 @@ impl SubstTypes for TyStructDeclaration {
     }
 }
 
-impl ReplaceSelfType for TyStructDeclaration {
+impl ReplaceSelfType for TyStructDecl {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         self.fields
             .iter_mut()
@@ -81,13 +81,13 @@ impl ReplaceSelfType for TyStructDeclaration {
     }
 }
 
-impl Spanned for TyStructDeclaration {
+impl Spanned for TyStructDecl {
     fn span(&self) -> Span {
         self.span.clone()
     }
 }
 
-impl MonomorphizeHelper for TyStructDeclaration {
+impl MonomorphizeHelper for TyStructDecl {
     fn type_parameters(&self) -> &[TypeParameter] {
         &self.type_parameters
     }
@@ -97,7 +97,7 @@ impl MonomorphizeHelper for TyStructDeclaration {
     }
 }
 
-impl TyStructDeclaration {
+impl TyStructDecl {
     pub(crate) fn expect_field(&self, field_to_access: &Ident) -> CompileResult<&TyStructField> {
         let warnings = vec![];
         let mut errors = vec![];

--- a/sway-core/src/language/ty/declaration/trait.rs
+++ b/sway-core/src/language/ty/declaration/trait.rs
@@ -12,10 +12,10 @@ use crate::{
     type_system::*,
 };
 
-use super::TyDeclaration;
+use super::TyDecl;
 
 #[derive(Clone, Debug)]
-pub struct TyTraitDeclaration {
+pub struct TyTraitDecl {
     pub name: Ident,
     pub type_parameters: Vec<TypeParameter>,
     pub interface_surface: Vec<TyTraitInterfaceItem>,
@@ -38,20 +38,20 @@ pub enum TyTraitItem {
     Constant(DeclRefConstant),
 }
 
-impl Named for TyTraitDeclaration {
+impl Named for TyTraitDecl {
     fn name(&self) -> &Ident {
         &self.name
     }
 }
 
-impl Spanned for TyTraitDeclaration {
+impl Spanned for TyTraitDecl {
     fn span(&self) -> Span {
         self.span.clone()
     }
 }
 
-impl EqWithEngines for TyTraitDeclaration {}
-impl PartialEqWithEngines for TyTraitDeclaration {
+impl EqWithEngines for TyTraitDecl {}
+impl PartialEqWithEngines for TyTraitDecl {
     fn eq(&self, other: &Self, engines: Engines<'_>) -> bool {
         self.name == other.name
             && self.type_parameters.eq(&other.type_parameters, engines)
@@ -62,9 +62,9 @@ impl PartialEqWithEngines for TyTraitDeclaration {
     }
 }
 
-impl HashWithEngines for TyTraitDeclaration {
+impl HashWithEngines for TyTraitDecl {
     fn hash<H: Hasher>(&self, state: &mut H, engines: Engines<'_>) {
-        let TyTraitDeclaration {
+        let TyTraitDecl {
             name,
             type_parameters,
             interface_surface,
@@ -131,7 +131,7 @@ impl HashWithEngines for TyTraitItem {
     }
 }
 
-impl SubstTypes for TyTraitDeclaration {
+impl SubstTypes for TyTraitDecl {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         self.type_parameters
             .iter_mut()
@@ -178,7 +178,7 @@ impl SubstTypes for TyTraitItem {
     }
 }
 
-impl ReplaceSelfType for TyTraitDeclaration {
+impl ReplaceSelfType for TyTraitDecl {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         self.type_parameters
             .iter_mut()
@@ -237,11 +237,7 @@ impl ReplaceSelfType for TyTraitItem {
 }
 
 impl ReplaceFunctionImplementingType for TyTraitItem {
-    fn replace_implementing_type(
-        &mut self,
-        engines: Engines<'_>,
-        implementing_type: TyDeclaration,
-    ) {
+    fn replace_implementing_type(&mut self, engines: Engines<'_>, implementing_type: TyDecl) {
         match self {
             TyTraitItem::Fn(decl_ref) => {
                 decl_ref.replace_implementing_type(engines, implementing_type)
@@ -253,7 +249,7 @@ impl ReplaceFunctionImplementingType for TyTraitItem {
     }
 }
 
-impl MonomorphizeHelper for TyTraitDeclaration {
+impl MonomorphizeHelper for TyTraitDecl {
     fn name(&self) -> &Ident {
         &self.name
     }

--- a/sway-core/src/language/ty/declaration/type_alias.rs
+++ b/sway-core/src/language/ty/declaration/type_alias.rs
@@ -5,7 +5,7 @@ use sway_types::{Ident, Named, Span, Spanned};
 use crate::{engine_threading::*, language::Visibility, transform, type_system::*};
 
 #[derive(Clone, Debug)]
-pub struct TyTypeAliasDeclaration {
+pub struct TyTypeAliasDecl {
     pub name: Ident,
     pub attributes: transform::AttributesMap,
     pub ty: TypeArgument,
@@ -13,14 +13,14 @@ pub struct TyTypeAliasDeclaration {
     pub span: Span,
 }
 
-impl Named for TyTypeAliasDeclaration {
+impl Named for TyTypeAliasDecl {
     fn name(&self) -> &Ident {
         &self.name
     }
 }
 
-impl EqWithEngines for TyTypeAliasDeclaration {}
-impl PartialEqWithEngines for TyTypeAliasDeclaration {
+impl EqWithEngines for TyTypeAliasDecl {}
+impl PartialEqWithEngines for TyTypeAliasDecl {
     fn eq(&self, other: &Self, engines: Engines<'_>) -> bool {
         self.name == other.name
             && self.ty.eq(&other.ty, engines)
@@ -28,9 +28,9 @@ impl PartialEqWithEngines for TyTypeAliasDeclaration {
     }
 }
 
-impl HashWithEngines for TyTypeAliasDeclaration {
+impl HashWithEngines for TyTypeAliasDecl {
     fn hash<H: Hasher>(&self, state: &mut H, engines: Engines<'_>) {
-        let TyTypeAliasDeclaration {
+        let TyTypeAliasDecl {
             name,
             ty,
             visibility,
@@ -45,19 +45,19 @@ impl HashWithEngines for TyTypeAliasDeclaration {
     }
 }
 
-impl SubstTypes for TyTypeAliasDeclaration {
+impl SubstTypes for TyTypeAliasDecl {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         self.ty.subst(type_mapping, engines);
     }
 }
 
-impl ReplaceSelfType for TyTypeAliasDeclaration {
+impl ReplaceSelfType for TyTypeAliasDecl {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         self.ty.replace_self_type(engines, self_type);
     }
 }
 
-impl CreateTypeId for TyTypeAliasDeclaration {
+impl CreateTypeId for TyTypeAliasDecl {
     fn create_type_id(&self, engines: Engines<'_>) -> TypeId {
         let type_engine = engines.te();
         let decl_engine = engines.de();
@@ -71,7 +71,7 @@ impl CreateTypeId for TyTypeAliasDeclaration {
     }
 }
 
-impl Spanned for TyTypeAliasDeclaration {
+impl Spanned for TyTypeAliasDecl {
     fn span(&self) -> Span {
         self.span.clone()
     }

--- a/sway-core/src/language/ty/declaration/variable.rs
+++ b/sway-core/src/language/ty/declaration/variable.rs
@@ -5,7 +5,7 @@ use sway_types::Ident;
 use crate::{engine_threading::*, language::ty::*, type_system::*};
 
 #[derive(Clone, Debug)]
-pub struct TyVariableDeclaration {
+pub struct TyVariableDecl {
     pub name: Ident,
     pub body: TyExpression,
     pub mutability: VariableMutability,
@@ -13,8 +13,8 @@ pub struct TyVariableDeclaration {
     pub type_ascription: TypeArgument,
 }
 
-impl EqWithEngines for TyVariableDeclaration {}
-impl PartialEqWithEngines for TyVariableDeclaration {
+impl EqWithEngines for TyVariableDecl {}
+impl PartialEqWithEngines for TyVariableDecl {
     fn eq(&self, other: &Self, engines: Engines<'_>) -> bool {
         let type_engine = engines.te();
         self.name == other.name
@@ -27,9 +27,9 @@ impl PartialEqWithEngines for TyVariableDeclaration {
     }
 }
 
-impl HashWithEngines for TyVariableDeclaration {
+impl HashWithEngines for TyVariableDecl {
     fn hash<H: Hasher>(&self, state: &mut H, engines: Engines<'_>) {
-        let TyVariableDeclaration {
+        let TyVariableDecl {
             name,
             body,
             mutability,
@@ -45,7 +45,7 @@ impl HashWithEngines for TyVariableDeclaration {
     }
 }
 
-impl SubstTypes for TyVariableDeclaration {
+impl SubstTypes for TyVariableDecl {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
         self.return_type.subst(type_mapping, engines);
         self.type_ascription.subst(type_mapping, engines);
@@ -53,7 +53,7 @@ impl SubstTypes for TyVariableDeclaration {
     }
 }
 
-impl ReplaceSelfType for TyVariableDeclaration {
+impl ReplaceSelfType for TyVariableDecl {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
         self.return_type.replace_self_type(engines, self_type);
         self.type_ascription.replace_self_type(engines, self_type);

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -50,7 +50,7 @@ pub enum TyExpressionVariant {
         index: Box<TyExpression>,
     },
     StructExpression {
-        struct_ref: DeclRef<DeclId<TyStructDeclaration>>,
+        struct_ref: DeclRef<DeclId<TyStructDecl>>,
         fields: Vec<TyStructExpressionField>,
         instantiation_span: Span,
         call_path_binding: TypeBinding<CallPath>,
@@ -88,7 +88,7 @@ pub enum TyExpressionVariant {
         elem_to_access_span: Span,
     },
     EnumInstantiation {
-        enum_ref: DeclRef<DeclId<TyEnumDeclaration>>,
+        enum_ref: DeclRef<DeclId<TyEnumDecl>>,
         /// for printing
         variant_name: Ident,
         tag: usize,

--- a/sway-core/src/language/ty/expression/scrutinee.rs
+++ b/sway-core/src/language/ty/expression/scrutinee.rs
@@ -18,7 +18,7 @@ pub enum TyScrutineeVariant {
     CatchAll,
     Literal(Literal),
     Variable(Ident),
-    Constant(Ident, Literal, TyConstantDeclaration),
+    Constant(Ident, Literal, TyConstantDecl),
     StructScrutinee {
         struct_ref: DeclRefStruct,
         fields: Vec<TyStructScrutineeField>,

--- a/sway-core/src/language/ty/module.rs
+++ b/sway-core/src/language/ty/module.rs
@@ -47,9 +47,9 @@ impl TyModule {
     pub fn test_fns<'a: 'b, 'b>(
         &'b self,
         decl_engine: &'a DeclEngine,
-    ) -> impl '_ + Iterator<Item = (TyFunctionDeclaration, DeclRefFunction)> {
+    ) -> impl '_ + Iterator<Item = (TyFunctionDecl, DeclRefFunction)> {
         self.all_nodes.iter().filter_map(|node| {
-            if let TyAstNodeContent::Declaration(TyDeclaration::FunctionDeclaration {
+            if let TyAstNodeContent::Declaration(TyDecl::FunctionDecl {
                 decl_id,
                 subst_list: _,
                 name,

--- a/sway-core/src/metadata.rs
+++ b/sway-core/src/metadata.rs
@@ -1,6 +1,6 @@
 use crate::{
     decl_engine::DeclId,
-    language::{ty::TyFunctionDeclaration, Inline, Purity},
+    language::{ty::TyFunctionDecl, Inline, Purity},
 };
 
 use sway_ir::{Context, MetadataIndex, Metadatum, Value};
@@ -23,7 +23,7 @@ pub(crate) struct MetadataManager {
     md_storage_op_cache: HashMap<MetadataIndex, StorageOperation>,
     md_storage_key_cache: HashMap<MetadataIndex, u64>,
     md_inline_cache: HashMap<MetadataIndex, Inline>,
-    md_test_decl_index_cache: HashMap<MetadataIndex, DeclId<TyFunctionDeclaration>>,
+    md_test_decl_index_cache: HashMap<MetadataIndex, DeclId<TyFunctionDecl>>,
     md_config_const_name_cache: HashMap<MetadataIndex, Rc<str>>,
 
     span_md_cache: HashMap<Span, MetadataIndex>,
@@ -31,7 +31,7 @@ pub(crate) struct MetadataManager {
     storage_op_md_cache: HashMap<Purity, MetadataIndex>,
     storage_key_md_cache: HashMap<u64, MetadataIndex>,
     inline_md_cache: HashMap<Inline, MetadataIndex>,
-    test_decl_index_md_cache: HashMap<DeclId<TyFunctionDeclaration>, MetadataIndex>,
+    test_decl_index_md_cache: HashMap<DeclId<TyFunctionDecl>, MetadataIndex>,
     config_const_name_md_cache: HashMap<Rc<str>, MetadataIndex>,
 }
 
@@ -72,7 +72,7 @@ impl MetadataManager {
         &mut self,
         context: &Context,
         md_idx: Option<MetadataIndex>,
-    ) -> Option<DeclId<TyFunctionDeclaration>> {
+    ) -> Option<DeclId<TyFunctionDecl>> {
         Self::for_each_md_idx(context, md_idx, |md_idx| {
             self.md_test_decl_index_cache
                 .get(&md_idx)
@@ -263,7 +263,7 @@ impl MetadataManager {
     pub(crate) fn test_decl_index_to_md(
         &mut self,
         context: &mut Context,
-        decl_index: DeclId<TyFunctionDeclaration>,
+        decl_index: DeclId<TyFunctionDecl>,
     ) -> Option<MetadataIndex> {
         self.test_decl_index_md_cache
             .get(&decl_index)

--- a/sway-core/src/monomorphize/constraint.rs
+++ b/sway-core/src/monomorphize/constraint.rs
@@ -19,7 +19,7 @@ pub(crate) enum Constraint {
     /// Function call.
     FnCall {
         call_path: CallPath,
-        decl_id: DeclId<ty::TyFunctionDeclaration>,
+        decl_id: DeclId<ty::TyFunctionDecl>,
         subst_list: SubstList,
         arguments: Vec<TypeId>,
     },

--- a/sway-core/src/monomorphize/gather/declaration.rs
+++ b/sway-core/src/monomorphize/gather/declaration.rs
@@ -5,29 +5,29 @@ use crate::{decl_engine::DeclId, language::ty, monomorphize::priv_prelude::*, Su
 pub(crate) fn gather_from_decl(
     ctx: GatherContext,
     handler: &Handler,
-    decl: &ty::TyDeclaration,
+    decl: &ty::TyDecl,
 ) -> Result<(), ErrorEmitted> {
     match decl {
-        ty::TyDeclaration::VariableDeclaration(decl) => {
+        ty::TyDecl::VariableDecl(decl) => {
             gather_from_exp(ctx, handler, &decl.body)?;
         }
-        ty::TyDeclaration::ConstantDeclaration { .. } => todo!(),
-        ty::TyDeclaration::FunctionDeclaration {
+        ty::TyDecl::ConstantDecl { .. } => todo!(),
+        ty::TyDecl::FunctionDecl {
             decl_id,
             subst_list,
             ..
         } => {
             gather_from_fn_decl(ctx, handler, decl_id, subst_list.inner())?;
         }
-        ty::TyDeclaration::TraitDeclaration { .. } => todo!(),
-        ty::TyDeclaration::StructDeclaration { .. } => todo!(),
-        ty::TyDeclaration::EnumDeclaration { .. } => todo!(),
-        ty::TyDeclaration::ImplTrait { .. } => todo!(),
-        ty::TyDeclaration::AbiDeclaration { .. } => todo!(),
-        ty::TyDeclaration::GenericTypeForFunctionScope { .. } => todo!(),
-        ty::TyDeclaration::StorageDeclaration { .. } => todo!(),
-        ty::TyDeclaration::ErrorRecovery(_) => {}
-        ty::TyDeclaration::TypeAliasDeclaration { .. } => todo!(),
+        ty::TyDecl::TraitDecl { .. } => todo!(),
+        ty::TyDecl::StructDecl { .. } => todo!(),
+        ty::TyDecl::EnumDecl { .. } => todo!(),
+        ty::TyDecl::ImplTrait { .. } => todo!(),
+        ty::TyDecl::AbiDecl { .. } => todo!(),
+        ty::TyDecl::GenericTypeForFunctionScope { .. } => todo!(),
+        ty::TyDecl::StorageDecl { .. } => todo!(),
+        ty::TyDecl::ErrorRecovery(_) => {}
+        ty::TyDecl::TypeAliasDecl { .. } => todo!(),
     }
 
     Ok(())
@@ -36,7 +36,7 @@ pub(crate) fn gather_from_decl(
 fn gather_from_fn_decl(
     mut ctx: GatherContext,
     handler: &Handler,
-    decl_id: &DeclId<ty::TyFunctionDeclaration>,
+    decl_id: &DeclId<ty::TyFunctionDecl>,
     subst_list: &SubstList,
 ) -> Result<(), ErrorEmitted> {
     let decl = ctx.decl_engine.get_function(decl_id);
@@ -45,7 +45,7 @@ fn gather_from_fn_decl(
         unimplemented!("{}", decl.name);
     }
 
-    let ty::TyFunctionDeclaration {
+    let ty::TyFunctionDecl {
         body,
         parameters,
         return_type,

--- a/sway-core/src/monomorphize/instruct/context.rs
+++ b/sway-core/src/monomorphize/instruct/context.rs
@@ -58,11 +58,11 @@ impl<'a> InstructContext<'a> {
     }
 }
 
-type FnMap = HashMap<DeclId<ty::TyFunctionDeclaration>, Vec<Instruction>>;
-type TraitMap = HashMap<DeclId<ty::TyTraitDeclaration>, Vec<Instruction>>;
+type FnMap = HashMap<DeclId<ty::TyFunctionDecl>, Vec<Instruction>>;
+type TraitMap = HashMap<DeclId<ty::TyTraitDecl>, Vec<Instruction>>;
 type ImplTraitMap = HashMap<DeclId<ty::TyImplTrait>, Vec<Instruction>>;
-type StructMap = HashMap<DeclId<ty::TyStructDeclaration>, Vec<Instruction>>;
-type EnumMap = HashMap<DeclId<ty::TyEnumDeclaration>, Vec<Instruction>>;
+type StructMap = HashMap<DeclId<ty::TyStructDecl>, Vec<Instruction>>;
+type EnumMap = HashMap<DeclId<ty::TyEnumDecl>, Vec<Instruction>>;
 
 pub(crate) struct InstructionItems {
     /// A map of [TyFunctionDeclaration](ty::TyFunctionDeclaration) [DeclId]s to

--- a/sway-core/src/monomorphize/instruct/context.rs
+++ b/sway-core/src/monomorphize/instruct/context.rs
@@ -65,23 +65,20 @@ type StructMap = HashMap<DeclId<ty::TyStructDecl>, Vec<Instruction>>;
 type EnumMap = HashMap<DeclId<ty::TyEnumDecl>, Vec<Instruction>>;
 
 pub(crate) struct InstructionItems {
-    /// A map of [TyFunctionDeclaration](ty::TyFunctionDeclaration) [DeclId]s to
-    /// be monomorphized.
+    /// A map of [TyFunctionDecl](ty::TyFunctionDecl) [DeclId]s to be
+    /// monomorphized.
     fn_map: FnMap,
 
-    /// A map of [TyTraitDeclaration](ty::TyTraitDeclaration) [DeclId]s to be
-    /// monomorphized.
+    /// A map of [TyTraitDecl](ty::TyTraitDecl) [DeclId]s to be monomorphized.
     trait_map: TraitMap,
 
     /// A map of [TyImplTrait](ty::TyImplTrait) [DeclId]s to be monomorphized.
     impl_trait_map: ImplTraitMap,
 
-    /// A map of [TyStructDeclaration](ty::TyStructDeclaration) [DeclId]s to be
-    /// monomorphized.
+    /// A map of [TyStructDecl](ty::TyStructDecl) [DeclId]s to be monomorphized.
     struct_map: StructMap,
 
-    /// A map of [TyEnumDeclaration](ty::TyEnumDeclaration) [DeclId]s to be
-    /// monomorphized.
+    /// A map of [TyEnumDecl](ty::TyEnumDecl) [DeclId]s to be monomorphized.
     enum_map: EnumMap,
 
     /// The list of instructions not included in any of the previous fields.

--- a/sway-core/src/monomorphize/instruct/declaration.rs
+++ b/sway-core/src/monomorphize/instruct/declaration.rs
@@ -5,29 +5,29 @@ use crate::{decl_engine::DeclId, language::ty, monomorphize::priv_prelude::*, Su
 pub(crate) fn instruct_decl(
     ctx: InstructContext,
     handler: &Handler,
-    decl: &ty::TyDeclaration,
+    decl: &ty::TyDecl,
 ) -> Result<(), ErrorEmitted> {
     match decl {
-        ty::TyDeclaration::VariableDeclaration(decl) => {
+        ty::TyDecl::VariableDecl(decl) => {
             instruct_exp(ctx, handler, &decl.body)?;
         }
-        ty::TyDeclaration::ConstantDeclaration { .. } => todo!(),
-        ty::TyDeclaration::FunctionDeclaration {
+        ty::TyDecl::ConstantDecl { .. } => todo!(),
+        ty::TyDecl::FunctionDecl {
             decl_id,
             subst_list,
             ..
         } => {
             instruct_fn_decl(ctx, handler, decl_id, subst_list.inner())?;
         }
-        ty::TyDeclaration::TraitDeclaration { .. } => todo!(),
-        ty::TyDeclaration::StructDeclaration { .. } => todo!(),
-        ty::TyDeclaration::EnumDeclaration { .. } => todo!(),
-        ty::TyDeclaration::ImplTrait { .. } => todo!(),
-        ty::TyDeclaration::AbiDeclaration { .. } => todo!(),
-        ty::TyDeclaration::GenericTypeForFunctionScope { .. } => todo!(),
-        ty::TyDeclaration::StorageDeclaration { .. } => todo!(),
-        ty::TyDeclaration::ErrorRecovery(_) => {}
-        ty::TyDeclaration::TypeAliasDeclaration { .. } => todo!(),
+        ty::TyDecl::TraitDecl { .. } => todo!(),
+        ty::TyDecl::StructDecl { .. } => todo!(),
+        ty::TyDecl::EnumDecl { .. } => todo!(),
+        ty::TyDecl::ImplTrait { .. } => todo!(),
+        ty::TyDecl::AbiDecl { .. } => todo!(),
+        ty::TyDecl::GenericTypeForFunctionScope { .. } => todo!(),
+        ty::TyDecl::StorageDecl { .. } => todo!(),
+        ty::TyDecl::ErrorRecovery(_) => {}
+        ty::TyDecl::TypeAliasDecl { .. } => todo!(),
     }
 
     Ok(())
@@ -36,7 +36,7 @@ pub(crate) fn instruct_decl(
 fn instruct_fn_decl(
     mut ctx: InstructContext,
     handler: &Handler,
-    decl_id: &DeclId<ty::TyFunctionDeclaration>,
+    decl_id: &DeclId<ty::TyFunctionDecl>,
     subst_list: &SubstList,
 ) -> Result<(), ErrorEmitted> {
     let decl = ctx.decl_engine.get_function(decl_id);
@@ -45,7 +45,7 @@ fn instruct_fn_decl(
         unimplemented!("{}", decl.name);
     }
 
-    let ty::TyFunctionDeclaration { body, .. } = decl;
+    let ty::TyFunctionDecl { body, .. } = decl;
 
     // NOTE: todo here
     instruct_code_block(ctx.by_ref(), handler, &body)?;

--- a/sway-core/src/monomorphize/instructions.rs
+++ b/sway-core/src/monomorphize/instructions.rs
@@ -5,11 +5,11 @@ use crate::{decl_engine::DeclId, engine_threading::*, language::ty, type_system:
 #[derive(Debug)]
 pub(crate) enum Instruction {
     Type(TypeId, SubstList),
-    FnDecl(DeclId<ty::TyFunctionDeclaration>, SubstList),
-    TraitDecl(DeclId<ty::TyTraitDeclaration>, SubstList),
+    FnDecl(DeclId<ty::TyFunctionDecl>, SubstList),
+    TraitDecl(DeclId<ty::TyTraitDecl>, SubstList),
     ImplTrait(DeclId<ty::TyImplTrait>, SubstList),
-    StructDecl(DeclId<ty::TyStructDeclaration>, SubstList),
-    EnumDecl(DeclId<ty::TyEnumDeclaration>, SubstList),
+    StructDecl(DeclId<ty::TyStructDecl>, SubstList),
+    EnumDecl(DeclId<ty::TyEnumDecl>, SubstList),
 }
 
 impl Instruction {

--- a/sway-core/src/monomorphize/solve/solver.rs
+++ b/sway-core/src/monomorphize/solve/solver.rs
@@ -159,7 +159,7 @@ impl<'a> Solver<'a> {
     fn helper_fn_call(
         &self,
         _handler: &Handler,
-        decl_id: DeclId<ty::TyFunctionDeclaration>,
+        decl_id: DeclId<ty::TyFunctionDecl>,
         subst_list: SubstList,
         _arguments: Vec<TypeId>,
     ) -> Result<InstructionResult, ErrorEmitted> {

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -71,7 +71,7 @@ impl ty::TyCodeBlock {
                         .resolve_symbol(&never_mod_path, &never_ident)
                         .value;
 
-                    if let Some(ty::TyDeclaration::EnumDeclaration {
+                    if let Some(ty::TyDecl::EnumDecl {
                         name,
                         decl_id,
                         subst_list: _,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -12,7 +12,7 @@ use crate::{
     CompileResult,
 };
 
-impl ty::TyAbiDeclaration {
+impl ty::TyAbiDecl {
     pub(crate) fn type_check(
         ctx: TypeCheckContext,
         abi_decl: AbiDeclaration,
@@ -84,8 +84,8 @@ impl ty::TyAbiDeclaration {
         let mut new_items = vec![];
         for method in methods.into_iter() {
             let method = check!(
-                ty::TyFunctionDeclaration::type_check(ctx.by_ref(), method.clone(), true, false),
-                ty::TyFunctionDeclaration::error(method.clone()),
+                ty::TyFunctionDecl::type_check(ctx.by_ref(), method.clone(), true, false),
+                ty::TyFunctionDecl::error(method.clone()),
                 warnings,
                 errors
             );
@@ -103,7 +103,7 @@ impl ty::TyAbiDeclaration {
         // Compared to regular traits, we do not insert recursively methods of ABI supertraits
         // into the interface surface, we do not want supertrait methods to be available to
         // the ABI user, only the contract methods can use supertrait methods
-        let abi_decl = ty::TyAbiDeclaration {
+        let abi_decl = ty::TyAbiDecl {
             interface_surface: new_interface_surface,
             supertraits,
             items: new_items,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
@@ -5,14 +5,14 @@ use crate::{
     error::*,
     language::{
         parsed::{self, *},
-        ty::{self, TyConstantDeclaration},
+        ty::{self, TyConstantDecl},
         CallPath,
     },
     semantic_analysis::*,
     EnforceTypeArguments, Engines, TypeInfo,
 };
 
-impl ty::TyConstantDeclaration {
+impl ty::TyConstantDecl {
     pub fn type_check(mut ctx: TypeCheckContext, decl: ConstantDeclaration) -> CompileResult<Self> {
         let mut errors = vec![];
         let mut warnings = vec![];
@@ -89,7 +89,7 @@ impl ty::TyConstantDeclaration {
         call_path = call_path.to_fullpath(ctx.namespace);
 
         // create the const decl
-        let decl = ty::TyConstantDeclaration {
+        let decl = ty::TyConstantDecl {
             call_path,
             attributes,
             is_configurable,
@@ -105,10 +105,7 @@ impl ty::TyConstantDeclaration {
 
     /// Used to create a stubbed out constant when the constant fails to
     /// compile, preventing cascading namespace errors.
-    pub(crate) fn error(
-        engines: Engines<'_>,
-        decl: parsed::ConstantDeclaration,
-    ) -> TyConstantDeclaration {
+    pub(crate) fn error(engines: Engines<'_>, decl: parsed::ConstantDeclaration) -> TyConstantDecl {
         let type_engine = engines.te();
         let decl_engine = engines.de();
         let parsed::ConstantDeclaration {
@@ -119,7 +116,7 @@ impl ty::TyConstantDeclaration {
             ..
         } = decl;
         let call_path: CallPath = name.into();
-        TyConstantDeclaration {
+        TyConstantDecl {
             call_path,
             span,
             attributes: Default::default(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -9,11 +9,11 @@ use crate::{
     CompileResult,
 };
 
-impl ty::TyDeclaration {
+impl ty::TyDecl {
     pub(crate) fn type_check(
         mut ctx: TypeCheckContext,
         decl: parsed::Declaration,
-    ) -> CompileResult<ty::TyDeclaration> {
+    ) -> CompileResult<ty::TyDecl> {
         let mut warnings = vec![];
         let mut errors = vec![];
 
@@ -61,14 +61,13 @@ impl ty::TyDeclaration {
                     TypeInfo::UnsignedInteger(_) => type_ascription.type_id,
                     _ => body.return_type,
                 };
-                let typed_var_decl =
-                    ty::TyDeclaration::VariableDeclaration(Box::new(ty::TyVariableDeclaration {
-                        name: name.clone(),
-                        body,
-                        mutability: ty::VariableMutability::new_from_ref_mut(false, is_mutable),
-                        return_type,
-                        type_ascription,
-                    }));
+                let typed_var_decl = ty::TyDecl::VariableDecl(Box::new(ty::TyVariableDecl {
+                    name: name.clone(),
+                    body,
+                    mutability: ty::VariableMutability::new_from_ref_mut(false, is_mutable),
+                    return_type,
+                    type_ascription,
+                }));
                 check!(
                     ctx.namespace.insert_symbol(name, typed_var_decl.clone()),
                     return err(warnings, errors),
@@ -80,13 +79,12 @@ impl ty::TyDeclaration {
             parsed::Declaration::ConstantDeclaration(decl) => {
                 let span = decl.span.clone();
                 let const_decl = check!(
-                    ty::TyConstantDeclaration::type_check(ctx.by_ref(), decl),
-                    return ok(ty::TyDeclaration::ErrorRecovery(span), warnings, errors),
+                    ty::TyConstantDecl::type_check(ctx.by_ref(), decl),
+                    return ok(ty::TyDecl::ErrorRecovery(span), warnings, errors),
                     warnings,
                     errors
                 );
-                let typed_const_decl: ty::TyDeclaration =
-                    decl_engine.insert(const_decl.clone()).into();
+                let typed_const_decl: ty::TyDecl = decl_engine.insert(const_decl.clone()).into();
                 check!(
                     ctx.namespace
                         .insert_symbol(const_decl.name().clone(), typed_const_decl.clone()),
@@ -99,13 +97,13 @@ impl ty::TyDeclaration {
             parsed::Declaration::EnumDeclaration(decl) => {
                 let span = decl.span.clone();
                 let enum_decl = check!(
-                    ty::TyEnumDeclaration::type_check(ctx.by_ref(), decl),
-                    return ok(ty::TyDeclaration::ErrorRecovery(span), warnings, errors),
+                    ty::TyEnumDecl::type_check(ctx.by_ref(), decl),
+                    return ok(ty::TyDecl::ErrorRecovery(span), warnings, errors),
                     warnings,
                     errors
                 );
                 let call_path = enum_decl.call_path.clone();
-                let decl: ty::TyDeclaration = decl_engine.insert(enum_decl).into();
+                let decl: ty::TyDecl = decl_engine.insert(enum_decl).into();
                 check!(
                     ctx.namespace.insert_symbol(call_path.suffix, decl.clone()),
                     return err(warnings, errors),
@@ -119,21 +117,21 @@ impl ty::TyDeclaration {
                 let mut ctx =
                     ctx.with_type_annotation(type_engine.insert(decl_engine, TypeInfo::Unknown));
                 let fn_decl = check!(
-                    ty::TyFunctionDeclaration::type_check(ctx.by_ref(), fn_decl, false, false),
-                    return ok(ty::TyDeclaration::ErrorRecovery(span), warnings, errors),
+                    ty::TyFunctionDecl::type_check(ctx.by_ref(), fn_decl, false, false),
+                    return ok(ty::TyDecl::ErrorRecovery(span), warnings, errors),
                     warnings,
                     errors
                 );
                 let name = fn_decl.name.clone();
-                let decl: ty::TyDeclaration = decl_engine.insert(fn_decl).into();
+                let decl: ty::TyDecl = decl_engine.insert(fn_decl).into();
                 ctx.namespace.insert_symbol(name, decl.clone());
                 decl
             }
             parsed::Declaration::TraitDeclaration(trait_decl) => {
                 let span = trait_decl.span.clone();
                 let mut trait_decl = check!(
-                    ty::TyTraitDeclaration::type_check(ctx.by_ref(), trait_decl),
-                    return ok(ty::TyDeclaration::ErrorRecovery(span), warnings, errors),
+                    ty::TyTraitDecl::type_check(ctx.by_ref(), trait_decl),
+                    return ok(ty::TyDecl::ErrorRecovery(span), warnings, errors),
                     warnings,
                     errors
                 );
@@ -145,7 +143,7 @@ impl ty::TyDeclaration {
                         .resolve_call_path(&supertrait.name)
                         .cloned()
                         .map(|supertrait_decl| {
-                            if let ty::TyDeclaration::TraitDeclaration {
+                            if let ty::TyDecl::TraitDecl {
                                 name: supertrait_name,
                                 decl_id: supertrait_decl_id,
                                 subst_list: _,
@@ -161,7 +159,7 @@ impl ty::TyDeclaration {
                         });
                 }
 
-                let decl: ty::TyDeclaration = decl_engine.insert(trait_decl.clone()).into();
+                let decl: ty::TyDecl = decl_engine.insert(trait_decl.clone()).into();
 
                 trait_decl
                     .items
@@ -179,7 +177,7 @@ impl ty::TyDeclaration {
                 let span = impl_trait.block_span.clone();
                 let mut impl_trait = check!(
                     ty::TyImplTrait::type_check_impl_trait(ctx.by_ref(), impl_trait),
-                    return ok(ty::TyDeclaration::ErrorRecovery(span), warnings, errors),
+                    return ok(ty::TyDecl::ErrorRecovery(span), warnings, errors),
                     warnings,
                     errors
                 );
@@ -197,8 +195,7 @@ impl ty::TyDeclaration {
                     warnings,
                     errors
                 );
-                let impl_trait_decl: ty::TyDeclaration =
-                    decl_engine.insert(impl_trait.clone()).into();
+                let impl_trait_decl: ty::TyDecl = decl_engine.insert(impl_trait.clone()).into();
                 impl_trait.items.iter_mut().for_each(|item| {
                     item.replace_implementing_type(engines, impl_trait_decl.clone());
                 });
@@ -208,7 +205,7 @@ impl ty::TyDeclaration {
                 let span = impl_self.block_span.clone();
                 let mut impl_trait = check!(
                     ty::TyImplTrait::type_check_impl_self(ctx.by_ref(), impl_self),
-                    return ok(ty::TyDeclaration::ErrorRecovery(span), warnings, errors),
+                    return ok(ty::TyDecl::ErrorRecovery(span), warnings, errors),
                     warnings,
                     errors
                 );
@@ -226,8 +223,7 @@ impl ty::TyDeclaration {
                     warnings,
                     errors
                 );
-                let impl_trait_decl: ty::TyDeclaration =
-                    decl_engine.insert(impl_trait.clone()).into();
+                let impl_trait_decl: ty::TyDecl = decl_engine.insert(impl_trait.clone()).into();
                 impl_trait.items.iter_mut().for_each(|item| {
                     item.replace_implementing_type(engines, impl_trait_decl.clone())
                 });
@@ -236,13 +232,13 @@ impl ty::TyDeclaration {
             parsed::Declaration::StructDeclaration(decl) => {
                 let span = decl.span.clone();
                 let decl = check!(
-                    ty::TyStructDeclaration::type_check(ctx.by_ref(), decl),
-                    return ok(ty::TyDeclaration::ErrorRecovery(span), warnings, errors),
+                    ty::TyStructDecl::type_check(ctx.by_ref(), decl),
+                    return ok(ty::TyDecl::ErrorRecovery(span), warnings, errors),
                     warnings,
                     errors
                 );
                 let call_path = decl.call_path.clone();
-                let decl: ty::TyDeclaration = decl_engine.insert(decl).into();
+                let decl: ty::TyDecl = decl_engine.insert(decl).into();
                 // insert the struct decl into namespace
                 check!(
                     ctx.namespace.insert_symbol(call_path.suffix, decl.clone()),
@@ -255,8 +251,8 @@ impl ty::TyDeclaration {
             parsed::Declaration::AbiDeclaration(abi_decl) => {
                 let span = abi_decl.span.clone();
                 let mut abi_decl = check!(
-                    ty::TyAbiDeclaration::type_check(ctx.by_ref(), abi_decl),
-                    return ok(ty::TyDeclaration::ErrorRecovery(span), warnings, errors),
+                    ty::TyAbiDecl::type_check(ctx.by_ref(), abi_decl),
+                    return ok(ty::TyDecl::ErrorRecovery(span), warnings, errors),
                     warnings,
                     errors
                 );
@@ -268,7 +264,7 @@ impl ty::TyDeclaration {
                         .resolve_call_path(&supertrait.name)
                         .cloned()
                         .map(|supertrait_decl| {
-                            if let ty::TyDeclaration::TraitDeclaration {
+                            if let ty::TyDecl::TraitDecl {
                                 name: supertrait_name,
                                 decl_id: supertrait_decl_id,
                                 subst_list: _,
@@ -284,7 +280,7 @@ impl ty::TyDeclaration {
                         });
                 }
 
-                let decl: ty::TyDeclaration = decl_engine.insert(abi_decl.clone()).into();
+                let decl: ty::TyDecl = decl_engine.insert(abi_decl.clone()).into();
                 abi_decl
                     .items
                     .iter_mut()
@@ -336,7 +332,7 @@ impl ty::TyDeclaration {
                         attributes,
                     });
                 }
-                let decl = ty::TyStorageDeclaration {
+                let decl = ty::TyStorageDecl {
                     fields: fields_buf,
                     span,
                     attributes,
@@ -369,7 +365,7 @@ impl ty::TyDeclaration {
                 );
 
                 // create the type alias decl using the resolved type above
-                let decl = ty::TyTypeAliasDeclaration {
+                let decl = ty::TyTypeAliasDecl {
                     name: name.clone(),
                     attributes: decl.attributes,
                     ty: TypeArgument {
@@ -382,7 +378,7 @@ impl ty::TyDeclaration {
                     span,
                 };
 
-                let decl: ty::TyDeclaration = decl_engine.insert(decl).into();
+                let decl: ty::TyDecl = decl_engine.insert(decl).into();
 
                 // insert the type alias name and decl into namespace
                 check!(

--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -5,7 +5,7 @@ use crate::{
     type_system::*,
 };
 
-impl ty::TyEnumDeclaration {
+impl ty::TyEnumDecl {
     pub fn type_check(ctx: TypeCheckContext, decl: EnumDeclaration) -> CompileResult<Self> {
         let mut errors = vec![];
         let mut warnings = vec![];
@@ -48,7 +48,7 @@ impl ty::TyEnumDeclaration {
         call_path = call_path.to_fullpath(ctx.namespace);
 
         // create the enum decl
-        let decl = ty::TyEnumDeclaration {
+        let decl = ty::TyEnumDecl {
             call_path,
             type_parameters: new_type_parameters,
             variants: variants_buf,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use sway_types::{style::is_snake_case, Spanned};
 
-impl ty::TyFunctionDeclaration {
+impl ty::TyFunctionDecl {
     pub fn type_check(
         mut ctx: TypeCheckContext,
         fn_decl: FunctionDeclaration,
@@ -146,7 +146,7 @@ impl ty::TyFunctionDeclaration {
             (visibility, ctx.mode() == Mode::ImplAbiFn)
         };
 
-        let function_decl = ty::TyFunctionDeclaration {
+        let function_decl = ty::TyFunctionDecl {
             name,
             body,
             parameters: new_parameters,
@@ -210,7 +210,7 @@ fn test_function_selector_behavior() {
     let type_engine = TypeEngine::default();
     let decl_engine = DeclEngine::default();
 
-    let decl = ty::TyFunctionDeclaration {
+    let decl = ty::TyFunctionDecl {
         purity: Default::default(),
         name: Ident::new_no_span("foo".into()),
         implementing_type: None,
@@ -232,7 +232,7 @@ fn test_function_selector_behavior() {
 
     assert_eq!(selector_text, "foo()".to_string());
 
-    let decl = ty::TyFunctionDeclaration {
+    let decl = ty::TyFunctionDecl {
         purity: Default::default(),
         name: Ident::new_with_override("bar".into(), Span::dummy()),
         implementing_type: None,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
@@ -110,7 +110,7 @@ impl ty::TyFunctionParameter {
 fn insert_into_namespace(ctx: TypeCheckContext, typed_parameter: &ty::TyFunctionParameter) {
     ctx.namespace.insert_symbol(
         typed_parameter.name.clone(),
-        ty::TyDeclaration::VariableDeclaration(Box::new(ty::TyVariableDeclaration {
+        ty::TyDecl::VariableDecl(Box::new(ty::TyVariableDecl {
             name: typed_parameter.name.clone(),
             body: ty::TyExpression {
                 expression: ty::TyExpressionVariant::FunctionParameter,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -105,7 +105,7 @@ impl ty::TyImplTrait {
             .ok(&mut warnings, &mut errors)
             .cloned()
         {
-            Some(ty::TyDeclaration::TraitDeclaration { decl_id, .. }) => {
+            Some(ty::TyDecl::TraitDecl { decl_id, .. }) => {
                 let mut trait_decl = decl_engine.get_trait(&decl_id);
 
                 // monomorphize the trait declaration
@@ -153,7 +153,7 @@ impl ty::TyImplTrait {
                     implementing_for,
                 }
             }
-            Some(ty::TyDeclaration::AbiDeclaration { decl_id, .. }) => {
+            Some(ty::TyDecl::AbiDecl { decl_id, .. }) => {
                 // if you are comparing this with the `impl_trait` branch above, note that
                 // there are no type arguments here because we don't support generic types
                 // in contract ABIs yet (or ever?) due to the complexity of communicating
@@ -351,16 +351,15 @@ impl ty::TyImplTrait {
 
         fn decl_contains_get_storage_index(
             decl_engine: &DeclEngine,
-            decl: &ty::TyDeclaration,
+            decl: &ty::TyDecl,
             access_span: &Span,
         ) -> Result<bool, CompileError> {
             match decl {
-                ty::TyDeclaration::VariableDeclaration(decl) => {
+                ty::TyDecl::VariableDecl(decl) => {
                     expr_contains_get_storage_index(decl_engine, &decl.body, access_span)
                 }
-                ty::TyDeclaration::ConstantDeclaration { decl_id, .. } => {
-                    let ty::TyConstantDeclaration { value: expr, .. } =
-                        decl_engine.get_constant(decl_id);
+                ty::TyDecl::ConstantDecl { decl_id, .. } => {
+                    let ty::TyConstantDecl { value: expr, .. } = decl_engine.get_constant(decl_id);
                     match expr {
                         Some(expr) => {
                             expr_contains_get_storage_index(decl_engine, &expr, access_span)
@@ -370,16 +369,16 @@ impl ty::TyImplTrait {
                 }
                 // We're already inside a type's impl. So we can't have these
                 // nested functions etc. We just ignore them.
-                ty::TyDeclaration::FunctionDeclaration { .. }
-                | ty::TyDeclaration::TraitDeclaration { .. }
-                | ty::TyDeclaration::StructDeclaration { .. }
-                | ty::TyDeclaration::EnumDeclaration { .. }
-                | ty::TyDeclaration::ImplTrait { .. }
-                | ty::TyDeclaration::AbiDeclaration { .. }
-                | ty::TyDeclaration::GenericTypeForFunctionScope { .. }
-                | ty::TyDeclaration::ErrorRecovery(_)
-                | ty::TyDeclaration::TypeAliasDeclaration { .. }
-                | ty::TyDeclaration::StorageDeclaration { .. } => Ok(false),
+                ty::TyDecl::FunctionDecl { .. }
+                | ty::TyDecl::TraitDecl { .. }
+                | ty::TyDecl::StructDecl { .. }
+                | ty::TyDecl::EnumDecl { .. }
+                | ty::TyDecl::ImplTrait { .. }
+                | ty::TyDecl::AbiDecl { .. }
+                | ty::TyDecl::GenericTypeForFunctionScope { .. }
+                | ty::TyDecl::ErrorRecovery(_)
+                | ty::TyDecl::TypeAliasDecl { .. }
+                | ty::TyDecl::StorageDecl { .. } => Ok(false),
             }
         }
 
@@ -513,7 +512,7 @@ impl ty::TyImplTrait {
             match item {
                 ImplItem::Fn(fn_decl) => {
                     let fn_decl = check!(
-                        ty::TyFunctionDeclaration::type_check(ctx.by_ref(), fn_decl, true, true),
+                        ty::TyFunctionDecl::type_check(ctx.by_ref(), fn_decl, true, true),
                         continue,
                         warnings,
                         errors
@@ -522,7 +521,7 @@ impl ty::TyImplTrait {
                 }
                 ImplItem::Constant(const_decl) => {
                     let const_decl = check!(
-                        ty::TyConstantDeclaration::type_check(ctx.by_ref(), const_decl),
+                        ty::TyConstantDecl::type_check(ctx.by_ref(), const_decl),
                         continue,
                         warnings,
                         errors
@@ -533,7 +532,7 @@ impl ty::TyImplTrait {
                     check!(
                         ctx.namespace.insert_symbol(
                             decl_ref.name().clone(),
-                            ty::TyDeclaration::ConstantDeclaration {
+                            ty::TyDecl::ConstantDecl {
                                 name: decl_ref.name().clone(),
                                 decl_id: *decl_ref.id(),
                                 decl_span: decl_ref.span().clone()
@@ -621,7 +620,7 @@ fn type_check_trait_implementation(
 
     // This map keeps track of the remaining constants in the interface surface
     // that still need to be implemented for the trait to be fully implemented.
-    let mut constant_checklist: BTreeMap<Ident, ty::TyConstantDeclaration> = BTreeMap::new();
+    let mut constant_checklist: BTreeMap<Ident, ty::TyConstantDecl> = BTreeMap::new();
 
     // This map keeps track of the interface declaration id's of the trait
     // definition.
@@ -698,7 +697,7 @@ fn type_check_trait_implementation(
                         &impld_item_refs,
                         &method_checklist
                     ),
-                    ty::TyFunctionDeclaration::error(impl_method.clone()),
+                    ty::TyFunctionDecl::error(impl_method.clone()),
                     warnings,
                     errors
                 );
@@ -721,7 +720,7 @@ fn type_check_trait_implementation(
                         &impld_item_refs,
                         &constant_checklist
                     ),
-                    ty::TyConstantDeclaration::error(ctx.engines(), const_decl.clone()),
+                    ty::TyConstantDecl::error(ctx.engines(), const_decl.clone()),
                     warnings,
                     errors
                 );
@@ -823,7 +822,7 @@ fn type_check_impl_method(
     is_contract: bool,
     impld_item_refs: &ItemMap,
     method_checklist: &BTreeMap<Ident, ty::TyTraitFn>,
-) -> CompileResult<ty::TyFunctionDeclaration> {
+) -> CompileResult<ty::TyFunctionDecl> {
     let mut warnings = vec![];
     let mut errors = vec![];
 
@@ -847,7 +846,7 @@ fn type_check_impl_method(
 
     // type check the function declaration
     let mut impl_method = check!(
-        ty::TyFunctionDeclaration::type_check(ctx.by_ref(), impl_method.clone(), true, false),
+        ty::TyFunctionDecl::type_check(ctx.by_ref(), impl_method.clone(), true, false),
         return err(warnings, errors),
         warnings,
         errors
@@ -1065,8 +1064,8 @@ fn type_check_const_decl(
     trait_name: &CallPath,
     is_contract: bool,
     impld_constant_ids: &ItemMap,
-    constant_checklist: &BTreeMap<Ident, ty::TyConstantDeclaration>,
-) -> CompileResult<ty::TyConstantDeclaration> {
+    constant_checklist: &BTreeMap<Ident, ty::TyConstantDecl>,
+) -> CompileResult<ty::TyConstantDecl> {
     let mut warnings = vec![];
     let mut errors = vec![];
 
@@ -1090,7 +1089,7 @@ fn type_check_const_decl(
 
     // type check the constant declaration
     let const_decl = check!(
-        ty::TyConstantDeclaration::type_check(ctx.by_ref(), const_decl.clone()),
+        ty::TyConstantDecl::type_check(ctx.by_ref(), const_decl.clone()),
         return err(warnings, errors),
         warnings,
         errors
@@ -1269,7 +1268,7 @@ fn handle_supertraits(
             .ok(&mut warnings, &mut errors)
             .cloned()
         {
-            Some(ty::TyDeclaration::TraitDeclaration { decl_id, .. }) => {
+            Some(ty::TyDecl::TraitDecl { decl_id, .. }) => {
                 let trait_decl = decl_engine.get_trait(&decl_id);
 
                 // Right now we don't parse type arguments for supertraits, so
@@ -1304,11 +1303,9 @@ fn handle_supertraits(
                 interface_surface_item_ids.extend(next_interface_supertrait_decl_refs);
                 impld_item_refs.extend(next_these_supertrait_decl_refs);
             }
-            Some(ty::TyDeclaration::AbiDeclaration { .. }) => {
-                errors.push(CompileError::AbiAsSupertrait {
-                    span: supertrait.name.span().clone(),
-                })
-            }
+            Some(ty::TyDecl::AbiDecl { .. }) => errors.push(CompileError::AbiAsSupertrait {
+                span: supertrait.name.span().clone(),
+            }),
             _ => errors.push(CompileError::TraitNotFound {
                 name: supertrait.name.to_string(),
                 span: supertrait.name.span(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
@@ -12,7 +12,7 @@ use sway_error::error::CompileError;
 use sway_ir::{Context, Module};
 use sway_types::state::StateIndex;
 
-impl ty::TyStorageDeclaration {
+impl ty::TyStorageDecl {
     pub(crate) fn get_initialized_storage_slots(
         &self,
         engines: Engines<'_>,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
@@ -5,7 +5,7 @@ use crate::{
     type_system::*,
 };
 
-impl ty::TyStructDeclaration {
+impl ty::TyStructDecl {
     pub(crate) fn type_check(
         ctx: TypeCheckContext,
         decl: StructDeclaration,
@@ -51,7 +51,7 @@ impl ty::TyStructDeclaration {
         path = path.to_fullpath(ctx.namespace);
 
         // create the struct decl
-        let decl = ty::TyStructDeclaration {
+        let decl = ty::TyStructDecl {
             call_path: path,
             type_parameters: new_type_parameters,
             fields: new_fields,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
@@ -39,7 +39,7 @@ pub(crate) fn insert_supertraits_into_namespace(
             .ok(&mut warnings, &mut errors)
             .cloned()
         {
-            Some(ty::TyDeclaration::TraitDeclaration { decl_id, .. }) => {
+            Some(ty::TyDecl::TraitDecl { decl_id, .. }) => {
                 let mut trait_decl = decl_engine.get_trait(&decl_id);
 
                 // Right now we don't parse type arguments for supertraits, so
@@ -90,11 +90,9 @@ pub(crate) fn insert_supertraits_into_namespace(
                     errors
                 );
             }
-            Some(ty::TyDeclaration::AbiDeclaration { .. }) => {
-                errors.push(CompileError::AbiAsSupertrait {
-                    span: supertrait.name.span().clone(),
-                })
-            }
+            Some(ty::TyDecl::AbiDecl { .. }) => errors.push(CompileError::AbiAsSupertrait {
+                span: supertrait.name.span().clone(),
+            }),
             _ => errors.push(CompileError::TraitNotFound {
                 name: supertrait.name.to_string(),
                 span: supertrait.name.span(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -18,7 +18,7 @@ use crate::{
     type_system::*,
 };
 
-impl ty::TyTraitDeclaration {
+impl ty::TyTraitDecl {
     pub(crate) fn type_check(
         ctx: TypeCheckContext,
         trait_decl: TraitDeclaration,
@@ -97,7 +97,7 @@ impl ty::TyTraitDeclaration {
                 }
                 TraitItem::Constant(const_decl) => {
                     let const_decl = check!(
-                        ty::TyConstantDeclaration::type_check(ctx.by_ref(), const_decl.clone(),),
+                        ty::TyConstantDecl::type_check(ctx.by_ref(), const_decl.clone(),),
                         return err(warnings, errors),
                         warnings,
                         errors
@@ -110,7 +110,7 @@ impl ty::TyTraitDeclaration {
                     check!(
                         ctx.namespace.insert_symbol(
                             const_name.clone(),
-                            ty::TyDeclaration::ConstantDeclaration {
+                            ty::TyDecl::ConstantDecl {
                                 name: const_name.clone(),
                                 decl_id: *decl_ref.id(),
                                 decl_span: const_decl.span.clone()
@@ -158,15 +158,15 @@ impl ty::TyTraitDeclaration {
         let mut new_items = vec![];
         for method in methods.into_iter() {
             let method = check!(
-                ty::TyFunctionDeclaration::type_check(ctx.by_ref(), method.clone(), true, false),
-                ty::TyFunctionDeclaration::error(method),
+                ty::TyFunctionDecl::type_check(ctx.by_ref(), method.clone(), true, false),
+                ty::TyFunctionDecl::error(method),
                 warnings,
                 errors
             );
             new_items.push(ty::TyTraitItem::Fn(decl_engine.insert(method)));
         }
 
-        let typed_trait_decl = ty::TyTraitDeclaration {
+        let typed_trait_decl = ty::TyTraitDecl {
             name,
             type_parameters: new_type_parameters,
             interface_surface: new_interface_surface,
@@ -189,7 +189,7 @@ impl ty::TyTraitDeclaration {
         let mut interface_surface_item_refs: InterfaceItemMap = BTreeMap::new();
         let mut impld_item_refs: ItemMap = BTreeMap::new();
 
-        let ty::TyTraitDeclaration {
+        let ty::TyTraitDecl {
             interface_surface, ..
         } = self;
 
@@ -239,7 +239,7 @@ impl ty::TyTraitDeclaration {
         let mut item_refs: ItemMap = BTreeMap::new();
         let mut impld_item_refs: ItemMap = BTreeMap::new();
 
-        let ty::TyTraitDeclaration {
+        let ty::TyTraitDecl {
             interface_surface,
             items,
             type_parameters,
@@ -326,7 +326,7 @@ impl ty::TyTraitDeclaration {
         let decl_engine = ctx.decl_engine;
         let engines = ctx.engines();
 
-        let ty::TyTraitDeclaration {
+        let ty::TyTraitDecl {
             interface_surface,
             items,
             type_parameters,
@@ -366,7 +366,7 @@ impl ty::TyTraitDeclaration {
                     let const_name = const_decl.call_path.suffix.clone();
                     ctx.namespace.insert_symbol(
                         const_name.clone(),
-                        ty::TyDeclaration::ConstantDeclaration {
+                        ty::TyDecl::ConstantDecl {
                             name: const_name,
                             decl_id: *decl_ref.id(),
                             decl_span: const_decl.span.clone(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
@@ -72,8 +72,8 @@ impl ty::TyTraitFn {
     /// This function is used in trait declarations to insert "placeholder"
     /// functions in the methods. This allows the methods to use functions
     /// declared in the interface surface.
-    pub(crate) fn to_dummy_func(&self, mode: Mode) -> ty::TyFunctionDeclaration {
-        ty::TyFunctionDeclaration {
+    pub(crate) fn to_dummy_func(&self, mode: Mode) -> ty::TyFunctionDecl {
+        ty::TyFunctionDecl {
             purity: self.purity,
             name: self.name.clone(),
             body: ty::TyCodeBlock { contents: vec![] },

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
@@ -55,14 +55,13 @@ impl ty::TyMatchBranch {
             let type_ascription = right_decl.return_type.into();
             let return_type = right_decl.return_type;
             let span = left_decl.span().clone();
-            let var_decl =
-                ty::TyDeclaration::VariableDeclaration(Box::new(ty::TyVariableDeclaration {
-                    name: left_decl.clone(),
-                    body: right_decl,
-                    mutability: ty::VariableMutability::Immutable,
-                    return_type,
-                    type_ascription,
-                }));
+            let var_decl = ty::TyDecl::VariableDecl(Box::new(ty::TyVariableDecl {
+                name: left_decl.clone(),
+                body: right_decl,
+                mutability: ty::VariableMutability::Immutable,
+                return_type,
+                type_ascription,
+            }));
             ctx.namespace.insert_symbol(left_decl, var_decl.clone());
             code_block_contents.push(ty::TyAstNode {
                 content: ty::TyAstNodeContent::Declaration(var_decl),

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -71,7 +71,7 @@ fn type_check_variable(
 
     let typed_scrutinee = match ctx.namespace.resolve_symbol(&name).value {
         // If this variable is a constant, then we turn it into a [TyScrutinee::Constant](ty::TyScrutinee::Constant).
-        Some(ty::TyDeclaration::ConstantDeclaration { decl_id, .. }) => {
+        Some(ty::TyDecl::ConstantDecl { decl_id, .. }) => {
             let constant_decl = decl_engine.get_constant(decl_id);
             let value = match constant_decl.value {
                 Some(ref value) => value,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -388,8 +388,8 @@ impl ty::TyExpression {
         let engines = ctx.engines();
 
         let exp = match ctx.namespace.resolve_symbol(&name).value {
-            Some(ty::TyDeclaration::VariableDeclaration(decl)) => {
-                let ty::TyVariableDeclaration {
+            Some(ty::TyDecl::VariableDecl(decl)) => {
+                let ty::TyVariableDecl {
                     name: decl_name,
                     mutability,
                     return_type,
@@ -408,8 +408,8 @@ impl ty::TyExpression {
                     span,
                 }
             }
-            Some(ty::TyDeclaration::ConstantDeclaration { decl_id, .. }) => {
-                let ty::TyConstantDeclaration {
+            Some(ty::TyDecl::ConstantDecl { decl_id, .. }) => {
+                let ty::TyConstantDecl {
                     call_path: decl_name,
                     return_type,
                     ..
@@ -427,7 +427,7 @@ impl ty::TyExpression {
                     span,
                 }
             }
-            Some(ty::TyDeclaration::AbiDeclaration { decl_id, .. }) => {
+            Some(ty::TyDecl::AbiDecl { decl_id, .. }) => {
                 let decl = decl_engine.get_abi(decl_id);
                 ty::TyExpression {
                     return_type: decl.create_type_id(engines),
@@ -1294,13 +1294,13 @@ impl ty::TyExpression {
             errors
         );
         let abi_ref = match abi {
-            ty::TyDeclaration::AbiDeclaration {
+            ty::TyDecl::AbiDecl {
                 name,
                 decl_id,
                 decl_span,
             } => DeclRef::new(name, decl_id, decl_span),
-            ty::TyDeclaration::VariableDeclaration(ref decl) => {
-                let ty::TyVariableDeclaration { body: expr, .. } = &**decl;
+            ty::TyDecl::VariableDecl(ref decl) => {
+                let ty::TyVariableDecl { body: expr, .. } = &**decl;
                 let ret_ty = type_engine.get(expr.return_type);
                 let abi_name = match ret_ty {
                     TypeInfo::ContractCaller { abi_name, .. } => abi_name,
@@ -1355,7 +1355,7 @@ impl ty::TyExpression {
                 return err(warnings, errors);
             }
         };
-        let ty::TyAbiDeclaration {
+        let ty::TyAbiDecl {
             interface_surface,
             items,
             span,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -197,7 +197,7 @@ fn unify_arguments_and_parameters(
 
 pub(crate) fn check_function_arguments_arity(
     arguments_len: usize,
-    function_decl: &ty::TyFunctionDeclaration,
+    function_decl: &ty::TyFunctionDecl,
     call_path: &CallPath,
     is_method_call_syntax_used: bool,
 ) -> CompileResult<()> {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -231,7 +231,7 @@ pub(crate) fn type_check_method_application(
             );
 
             let is_decl_mutable = match unknown_decl {
-                ty::TyDeclaration::ConstantDeclaration { .. } => false,
+                ty::TyDecl::ConstantDecl { .. } => false,
                 _ => {
                     let variable_decl = check!(
                         unknown_decl.expect_variable().cloned(),

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -62,7 +62,7 @@ impl ty::TyAstNode {
                     })
                 }
                 AstNodeContent::Declaration(decl) => ty::TyAstNodeContent::Declaration(check!(
-                    ty::TyDeclaration::type_check(ctx, decl),
+                    ty::TyDecl::type_check(ctx, decl),
                     return err(warnings, errors),
                     warnings,
                     errors

--- a/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
+++ b/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
@@ -11,7 +11,7 @@
 use crate::{
     decl_engine::*,
     language::{
-        ty::{self, TyFunctionDeclaration, TyImplTrait},
+        ty::{self, TyFunctionDecl, TyImplTrait},
         AsmOp,
     },
     Engines,
@@ -93,15 +93,15 @@ fn analyze_contract(engines: Engines<'_>, ast_nodes: &[ty::TyAstNode]) -> Vec<Co
 fn contract_entry_points(
     decl_engine: &DeclEngine,
     ast_nodes: &[ty::TyAstNode],
-) -> Vec<ty::TyFunctionDeclaration> {
+) -> Vec<ty::TyFunctionDecl> {
     use crate::ty::TyAstNodeContent::Declaration;
     ast_nodes
         .iter()
         .flat_map(|ast_node| match &ast_node.content {
-            Declaration(ty::TyDeclaration::FunctionDeclaration { decl_id, .. }) => {
+            Declaration(ty::TyDecl::FunctionDecl { decl_id, .. }) => {
                 decl_id_to_fn_decls(decl_engine, decl_id)
             }
-            Declaration(ty::TyDeclaration::ImplTrait { decl_id, .. }) => {
+            Declaration(ty::TyDecl::ImplTrait { decl_id, .. }) => {
                 impl_trait_methods(decl_engine, decl_id)
             }
             _ => vec![],
@@ -111,15 +111,15 @@ fn contract_entry_points(
 
 fn decl_id_to_fn_decls(
     decl_engine: &DeclEngine,
-    decl_id: &DeclId<TyFunctionDeclaration>,
-) -> Vec<TyFunctionDeclaration> {
+    decl_id: &DeclId<TyFunctionDecl>,
+) -> Vec<TyFunctionDecl> {
     vec![decl_engine.get_function(decl_id)]
 }
 
 fn impl_trait_methods(
     decl_engine: &DeclEngine,
     impl_trait_decl_id: &DeclId<TyImplTrait>,
-) -> Vec<ty::TyFunctionDeclaration> {
+) -> Vec<ty::TyFunctionDecl> {
     let impl_trait = decl_engine.get_impl_trait(impl_trait_decl_id);
     impl_trait
         .items
@@ -187,16 +187,14 @@ fn analyze_code_block_entry(
 
 fn analyze_codeblock_decl(
     engines: Engines<'_>,
-    decl: &ty::TyDeclaration,
+    decl: &ty::TyDecl,
     block_name: &Ident,
     warnings: &mut Vec<CompileWarning>,
 ) -> HashSet<Effect> {
     // Declarations (except variable declarations) are not allowed in a codeblock
-    use crate::ty::TyDeclaration::*;
+    use crate::ty::TyDecl::*;
     match decl {
-        VariableDeclaration(var_decl) => {
-            analyze_expression(engines, &var_decl.body, block_name, warnings)
-        }
+        VariableDecl(var_decl) => analyze_expression(engines, &var_decl.body, block_name, warnings),
         _ => HashSet::new(),
     }
 }
@@ -489,10 +487,10 @@ fn effects_of_codeblock_entry(engines: Engines<'_>, ast_node: &ty::TyAstNode) ->
     }
 }
 
-fn effects_of_codeblock_decl(engines: Engines<'_>, decl: &ty::TyDeclaration) -> HashSet<Effect> {
-    use crate::ty::TyDeclaration::*;
+fn effects_of_codeblock_decl(engines: Engines<'_>, decl: &ty::TyDecl) -> HashSet<Effect> {
+    use crate::ty::TyDecl::*;
     match decl {
-        VariableDeclaration(var_decl) => effects_of_expression(engines, &var_decl.body),
+        VariableDecl(var_decl) => effects_of_expression(engines, &var_decl.body),
         // Declarations (except variable declarations) are not allowed in the body of a function
         _ => HashSet::new(),
     }

--- a/sway-core/src/semantic_analysis/coins_analysis.rs
+++ b/sway-core/src/semantic_analysis/coins_analysis.rs
@@ -18,10 +18,10 @@ pub fn possibly_nonzero_u64_expression(
             match namespace.resolve_symbol(name).value {
                 Some(ty_decl) => {
                     match ty_decl {
-                        ty::TyDeclaration::VariableDeclaration(var_decl) => {
+                        ty::TyDecl::VariableDecl(var_decl) => {
                             possibly_nonzero_u64_expression(namespace, decl_engine, &var_decl.body)
                         }
-                        ty::TyDeclaration::ConstantDeclaration { decl_id, .. } => {
+                        ty::TyDecl::ConstantDecl { decl_id, .. } => {
                             let const_decl = decl_engine.get_constant(decl_id);
                             match const_decl.value {
                                 Some(value) => {

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -2,7 +2,7 @@ use crate::{
     decl_engine::*,
     engine_threading::Engines,
     error::*,
-    language::ty::{self, TyStorageDeclaration},
+    language::ty::{self, TyStorageDecl},
     namespace::*,
     type_system::*,
 };
@@ -21,8 +21,8 @@ pub(crate) enum GlobImport {
     No,
 }
 
-pub(super) type SymbolMap = im::OrdMap<Ident, ty::TyDeclaration>;
-pub(super) type UseSynonyms = im::HashMap<Ident, (Vec<Ident>, GlobImport, ty::TyDeclaration)>;
+pub(super) type SymbolMap = im::OrdMap<Ident, ty::TyDecl>;
+pub(super) type UseSynonyms = im::HashMap<Ident, (Vec<Ident>, GlobImport, ty::TyDecl)>;
 pub(super) type UseAliases = im::HashMap<String, Ident>;
 
 /// The set of items that exist within some lexical scope via declaration or importing.
@@ -92,39 +92,35 @@ impl Items {
         self.symbols().keys()
     }
 
-    pub(crate) fn insert_symbol(
-        &mut self,
-        name: Ident,
-        item: ty::TyDeclaration,
-    ) -> CompileResult<()> {
+    pub(crate) fn insert_symbol(&mut self, name: Ident, item: ty::TyDecl) -> CompileResult<()> {
         let mut errors = vec![];
 
         let append_shadowing_error =
-            |decl: &ty::TyDeclaration, item: &ty::TyDeclaration, errors: &mut Vec<CompileError>| {
-                use ty::TyDeclaration::*;
+            |decl: &ty::TyDecl, item: &ty::TyDecl, errors: &mut Vec<CompileError>| {
+                use ty::TyDecl::*;
                 match (decl, &item) {
                 // variable shadowing a constant
                 // constant shadowing a constant
                 (
-                    ConstantDeclaration { .. },
-                    VariableDeclaration { .. } | ConstantDeclaration { .. },
+                    ConstantDecl { .. },
+                    VariableDecl { .. } | ConstantDecl { .. },
                 )
                 // constant shadowing a variable
-                | (VariableDeclaration { .. }, ConstantDeclaration { .. })
+                | (VariableDecl { .. }, ConstantDecl { .. })
                 // type or type alias shadowing another type or type alias
                 // trait/abi shadowing another trait/abi
                 // type or type alias shadowing a trait/abi, or vice versa
                 | (
-                    StructDeclaration { .. }
-                    | EnumDeclaration { .. }
-                    | TypeAliasDeclaration { .. }
-                    | TraitDeclaration { .. }
-                    | AbiDeclaration { .. },
-                    StructDeclaration { .. }
-                    | EnumDeclaration { .. }
-                    | TypeAliasDeclaration { .. }
-                    | TraitDeclaration { .. }
-                    | AbiDeclaration { .. },
+                    StructDecl { .. }
+                    | EnumDecl { .. }
+                    | TypeAliasDecl { .. }
+                    | TraitDecl { .. }
+                    | AbiDecl { .. },
+                    StructDecl { .. }
+                    | EnumDecl { .. }
+                    | TypeAliasDecl { .. }
+                    | TraitDecl { .. }
+                    | AbiDecl { .. },
                 ) => errors.push(CompileError::NameDefinedMultipleTimes { name: name.to_string(), span: name.span() }),
                 // Generic parameter shadowing another generic parameter
                 (GenericTypeForFunctionScope { .. }, GenericTypeForFunctionScope { .. }) => {
@@ -146,7 +142,7 @@ impl Items {
         ok((), vec![], errors)
     }
 
-    pub(crate) fn check_symbol(&self, name: &Ident) -> Result<&ty::TyDeclaration, CompileError> {
+    pub(crate) fn check_symbol(&self, name: &Ident) -> Result<&ty::TyDecl, CompileError> {
         self.symbols
             .get(name)
             .ok_or_else(|| CompileError::SymbolNotFound {
@@ -189,7 +185,7 @@ impl Items {
         self.declared_storage.is_some()
     }
 
-    pub fn get_declared_storage(&self, decl_engine: &DeclEngine) -> Option<TyStorageDeclaration> {
+    pub fn get_declared_storage(&self, decl_engine: &DeclEngine) -> Option<TyStorageDecl> {
         self.declared_storage
             .as_ref()
             .map(|decl_ref| decl_engine.get_storage(decl_ref))

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -285,7 +285,7 @@ impl Module {
             .implemented_traits
             .extend(implemented_traits, engines);
 
-        let mut try_add = |symbol, path, decl: ty::TyDeclaration| {
+        let mut try_add = |symbol, path, decl: ty::TyDecl| {
             dst_ns
                 .use_synonyms
                 .insert(symbol, (path, GlobImport::Yes, decl));

--- a/sway-core/src/semantic_analysis/namespace/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace/namespace.rs
@@ -93,15 +93,12 @@ impl Namespace {
     }
 
     /// Short-hand for calling [Root::resolve_symbol] on `root` with the `mod_path`.
-    pub(crate) fn resolve_symbol(&self, symbol: &Ident) -> CompileResult<&ty::TyDeclaration> {
+    pub(crate) fn resolve_symbol(&self, symbol: &Ident) -> CompileResult<&ty::TyDecl> {
         self.root.resolve_symbol(&self.mod_path, symbol)
     }
 
     /// Short-hand for calling [Root::resolve_call_path] on `root` with the `mod_path`.
-    pub(crate) fn resolve_call_path(
-        &self,
-        call_path: &CallPath,
-    ) -> CompileResult<&ty::TyDeclaration> {
+    pub(crate) fn resolve_call_path(&self, call_path: &CallPath) -> CompileResult<&ty::TyDecl> {
         self.root.resolve_call_path(&self.mod_path, call_path)
     }
 
@@ -110,7 +107,7 @@ impl Namespace {
         &self,
         engines: Engines<'_>,
         call_path: &CallPath,
-    ) -> CompileResult<&ty::TyDeclaration> {
+    ) -> CompileResult<&ty::TyDecl> {
         self.root
             .resolve_call_path_with_visibility_check(engines, &self.mod_path, call_path)
     }

--- a/sway-core/src/semantic_analysis/namespace/root.rs
+++ b/sway-core/src/semantic_analysis/namespace/root.rs
@@ -73,7 +73,7 @@ impl Root {
                     span: call_path.suffix.span(),
                 });
                 // Returns ok with error, this allows functions which call this to
-                // also access the returned TyDeclaration and throw more suitable errors.
+                // also access the returned TyDecl and throw more suitable errors.
                 return ok(decl, warnings, errors);
             }
         }

--- a/sway-core/src/semantic_analysis/namespace/root.rs
+++ b/sway-core/src/semantic_analysis/namespace/root.rs
@@ -31,7 +31,7 @@ impl Root {
         &self,
         mod_path: &Path,
         call_path: &CallPath,
-    ) -> CompileResult<&ty::TyDeclaration> {
+    ) -> CompileResult<&ty::TyDecl> {
         let symbol_path: Vec<_> = mod_path
             .iter()
             .chain(&call_path.prefixes)
@@ -52,7 +52,7 @@ impl Root {
         engines: Engines<'_>,
         mod_path: &Path,
         call_path: &CallPath,
-    ) -> CompileResult<&ty::TyDeclaration> {
+    ) -> CompileResult<&ty::TyDecl> {
         let warnings = vec![];
         let mut errors = vec![];
 
@@ -90,7 +90,7 @@ impl Root {
         &self,
         mod_path: &Path,
         symbol: &Ident,
-    ) -> CompileResult<&ty::TyDeclaration> {
+    ) -> CompileResult<&ty::TyDecl> {
         self.check_submodule(mod_path).flat_map(|module| {
             let true_symbol = self[mod_path]
                 .use_aliases

--- a/sway-core/src/semantic_analysis/program.rs
+++ b/sway-core/src/semantic_analysis/program.rs
@@ -55,11 +55,11 @@ impl ty::TyProgram {
                 let storage_decl = self
                     .declarations
                     .iter()
-                    .find(|decl| matches!(decl, ty::TyDeclaration::StorageDeclaration { .. }));
+                    .find(|decl| matches!(decl, ty::TyDecl::StorageDecl { .. }));
 
                 // Expecting at most a single storage declaration
                 match storage_decl {
-                    Some(ty::TyDeclaration::StorageDeclaration {
+                    Some(ty::TyDecl::StorageDecl {
                         decl_id,
                         decl_span: _,
                         ..

--- a/sway-core/src/semantic_analysis/storage_only_types.rs
+++ b/sway-core/src/semantic_analysis/storage_only_types.rs
@@ -6,7 +6,7 @@ use crate::{
     decl_engine::DeclId,
     engine_threading::*,
     error::*,
-    language::ty::{self, TyConstantDeclaration, TyFunctionDeclaration},
+    language::ty::{self, TyConstantDecl, TyFunctionDecl},
     type_system::*,
 };
 
@@ -171,12 +171,12 @@ fn check_type(
     ok((), warnings, errors)
 }
 
-fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResult<()> {
+fn decl_validate(engines: Engines<'_>, decl: &ty::TyDecl) -> CompileResult<()> {
     let mut warnings: Vec<CompileWarning> = vec![];
     let mut errors: Vec<CompileError> = vec![];
     let decl_engine = engines.de();
     match decl {
-        ty::TyDeclaration::VariableDeclaration(decl) => {
+        ty::TyDecl::VariableDecl(decl) => {
             check!(
                 check_type(engines, decl.body.return_type, decl.name.span(), false),
                 (),
@@ -185,7 +185,7 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
             );
             check!(expr_validate(engines, &decl.body), (), warnings, errors)
         }
-        ty::TyDeclaration::ConstantDeclaration { decl_id, .. } => {
+        ty::TyDecl::ConstantDecl { decl_id, .. } => {
             check!(
                 validate_const_decl(engines, decl_id),
                 return err(warnings, errors),
@@ -193,7 +193,7 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
                 errors
             );
         }
-        ty::TyDeclaration::FunctionDeclaration { decl_id, .. } => {
+        ty::TyDecl::FunctionDecl { decl_id, .. } => {
             check!(
                 validate_fn_decl(engines, decl_id),
                 return err(warnings, errors),
@@ -201,10 +201,10 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
                 errors
             );
         }
-        ty::TyDeclaration::AbiDeclaration { .. } | ty::TyDeclaration::TraitDeclaration { .. } => {
+        ty::TyDecl::AbiDecl { .. } | ty::TyDecl::TraitDecl { .. } => {
             // These methods are not typed. They are however handled from ImplTrait.
         }
-        ty::TyDeclaration::ImplTrait { decl_id, .. } => {
+        ty::TyDecl::ImplTrait { decl_id, .. } => {
             let ty::TyImplTrait { items, .. } = decl_engine.get_impl_trait(decl_id);
             for item in items {
                 match item {
@@ -227,8 +227,8 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
                 }
             }
         }
-        ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
-            let ty::TyStructDeclaration { fields, .. } = decl_engine.get_struct(decl_id);
+        ty::TyDecl::StructDecl { decl_id, .. } => {
+            let ty::TyStructDecl { fields, .. } = decl_engine.get_struct(decl_id);
             for field in fields {
                 check!(
                     check_type(
@@ -243,8 +243,8 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
                 );
             }
         }
-        ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
-            let ty::TyEnumDeclaration { variants, .. } = decl_engine.get_enum(decl_id);
+        ty::TyDecl::EnumDecl { decl_id, .. } => {
+            let ty::TyEnumDecl { variants, .. } = decl_engine.get_enum(decl_id);
             for variant in variants {
                 check!(
                     check_type(
@@ -259,11 +259,11 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
                 );
             }
         }
-        ty::TyDeclaration::StorageDeclaration {
+        ty::TyDecl::StorageDecl {
             decl_id,
             decl_span: _,
         } => {
-            let ty::TyStorageDeclaration { fields, .. } = decl_engine.get_storage(decl_id);
+            let ty::TyStorageDecl { fields, .. } = decl_engine.get_storage(decl_id);
             for field in fields {
                 check!(
                     check_type(
@@ -278,8 +278,8 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
                 );
             }
         }
-        ty::TyDeclaration::TypeAliasDeclaration { decl_id, .. } => {
-            let ty::TyTypeAliasDeclaration { ty, span, .. } = decl_engine.get_type_alias(decl_id);
+        ty::TyDecl::TypeAliasDecl { decl_id, .. } => {
+            let ty::TyTypeAliasDecl { ty, span, .. } = decl_engine.get_type_alias(decl_id);
             check!(
                 check_type(engines, ty.type_id, span, false),
                 (),
@@ -287,8 +287,7 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
                 errors
             );
         }
-        ty::TyDeclaration::GenericTypeForFunctionScope { .. }
-        | ty::TyDeclaration::ErrorRecovery(_) => {}
+        ty::TyDecl::GenericTypeForFunctionScope { .. } | ty::TyDecl::ErrorRecovery(_) => {}
     }
     if errors.is_empty() {
         ok((), warnings, errors)
@@ -299,12 +298,12 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDeclaration) -> CompileResul
 
 pub fn validate_const_decl(
     engines: Engines<'_>,
-    decl_id: &DeclId<TyConstantDeclaration>,
+    decl_id: &DeclId<TyConstantDecl>,
 ) -> CompileResult<()> {
     let mut warnings: Vec<CompileWarning> = vec![];
     let mut errors: Vec<CompileError> = vec![];
     let decl_engine = engines.de();
-    let ty::TyConstantDeclaration {
+    let ty::TyConstantDecl {
         value: expr,
         call_path,
         ..
@@ -327,12 +326,12 @@ pub fn validate_const_decl(
 
 pub fn validate_fn_decl(
     engines: Engines<'_>,
-    decl_id: &DeclId<TyFunctionDeclaration>,
+    decl_id: &DeclId<TyFunctionDecl>,
 ) -> CompileResult<()> {
     let mut warnings: Vec<CompileWarning> = vec![];
     let mut errors: Vec<CompileError> = vec![];
     let decl_engine = engines.de();
-    let ty::TyFunctionDeclaration {
+    let ty::TyFunctionDecl {
         body,
         parameters,
         return_type,

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -220,11 +220,11 @@ pub(crate) trait TypeCheckTypeBinding<T> {
     ) -> CompileResult<(DeclRef<DeclId<T>>, Option<TypeId>)>;
 }
 
-impl TypeCheckTypeBinding<ty::TyFunctionDeclaration> for TypeBinding<CallPath> {
+impl TypeCheckTypeBinding<ty::TyFunctionDecl> for TypeBinding<CallPath> {
     fn type_check(
         &mut self,
         mut ctx: TypeCheckContext,
-    ) -> CompileResult<(DeclRef<DeclId<ty::TyFunctionDeclaration>>, Option<TypeId>)> {
+    ) -> CompileResult<(DeclRef<DeclId<ty::TyFunctionDecl>>, Option<TypeId>)> {
         let mut warnings = vec![];
         let mut errors = vec![];
         let type_engine = ctx.type_engine;
@@ -289,11 +289,11 @@ impl TypeCheckTypeBinding<ty::TyFunctionDeclaration> for TypeBinding<CallPath> {
     }
 }
 
-impl TypeCheckTypeBinding<ty::TyStructDeclaration> for TypeBinding<CallPath> {
+impl TypeCheckTypeBinding<ty::TyStructDecl> for TypeBinding<CallPath> {
     fn type_check(
         &mut self,
         mut ctx: TypeCheckContext,
-    ) -> CompileResult<(DeclRef<DeclId<ty::TyStructDeclaration>>, Option<TypeId>)> {
+    ) -> CompileResult<(DeclRef<DeclId<ty::TyStructDecl>>, Option<TypeId>)> {
         let mut warnings = vec![];
         let mut errors = vec![];
         let type_engine = ctx.type_engine;
@@ -339,11 +339,11 @@ impl TypeCheckTypeBinding<ty::TyStructDeclaration> for TypeBinding<CallPath> {
     }
 }
 
-impl TypeCheckTypeBinding<ty::TyEnumDeclaration> for TypeBinding<CallPath> {
+impl TypeCheckTypeBinding<ty::TyEnumDecl> for TypeBinding<CallPath> {
     fn type_check(
         &mut self,
         mut ctx: TypeCheckContext,
-    ) -> CompileResult<(DeclRef<DeclId<ty::TyEnumDeclaration>>, Option<TypeId>)> {
+    ) -> CompileResult<(DeclRef<DeclId<ty::TyEnumDecl>>, Option<TypeId>)> {
         let mut warnings = vec![];
         let mut errors = vec![];
         let type_engine = ctx.type_engine;
@@ -389,11 +389,11 @@ impl TypeCheckTypeBinding<ty::TyEnumDeclaration> for TypeBinding<CallPath> {
     }
 }
 
-impl TypeCheckTypeBinding<ty::TyConstantDeclaration> for TypeBinding<CallPath> {
+impl TypeCheckTypeBinding<ty::TyConstantDecl> for TypeBinding<CallPath> {
     fn type_check(
         &mut self,
         ctx: TypeCheckContext,
-    ) -> CompileResult<(DeclRef<DeclId<ty::TyConstantDeclaration>>, Option<TypeId>)> {
+    ) -> CompileResult<(DeclRef<DeclId<ty::TyConstantDecl>>, Option<TypeId>)> {
         let mut warnings = vec![];
         let mut errors = vec![];
 

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -189,7 +189,7 @@ impl TraitConstraint {
             .ok(&mut warnings, &mut errors)
             .cloned()
         {
-            Some(ty::TyDeclaration::TraitDeclaration { decl_id, .. }) => {
+            Some(ty::TyDecl::TraitDecl { decl_id, .. }) => {
                 let mut trait_decl = decl_engine.get_trait(&decl_id);
 
                 // Monomorphize the trait declaration.
@@ -227,11 +227,9 @@ impl TraitConstraint {
                     errors
                 );
             }
-            Some(ty::TyDeclaration::AbiDeclaration { .. }) => {
-                errors.push(CompileError::AbiAsSupertrait {
-                    span: trait_name.span(),
-                })
-            }
+            Some(ty::TyDecl::AbiDecl { .. }) => errors.push(CompileError::AbiAsSupertrait {
+                span: trait_name.span(),
+            }),
             _ => errors.push(CompileError::TraitNotFound {
                 name: trait_name.to_string(),
                 span: trait_name.span(),

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -203,7 +203,7 @@ impl TypeParameter {
 
         // Insert the type parameter into the namespace as a dummy type
         // declaration.
-        let type_parameter_decl = ty::TyDeclaration::GenericTypeForFunctionScope {
+        let type_parameter_decl = ty::TyDecl::GenericTypeForFunctionScope {
             name: name_ident.clone(),
             type_id,
         };
@@ -308,7 +308,7 @@ fn handle_trait(
         .ok(&mut warnings, &mut errors)
         .cloned()
     {
-        Some(ty::TyDeclaration::TraitDeclaration { decl_id, .. }) => {
+        Some(ty::TyDecl::TraitDecl { decl_id, .. }) => {
             let trait_decl = decl_engine.get_trait(&decl_id);
 
             let (trait_interface_item_refs, trait_item_refs, trait_impld_item_refs) = trait_decl

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -303,7 +303,7 @@ impl TypeEngine {
                     .ok(&mut warnings, &mut errors)
                     .cloned()
                 {
-                    Some(ty::TyDeclaration::StructDeclaration {
+                    Some(ty::TyDecl::StructDecl {
                         decl_id: original_id,
                         ..
                     }) => {
@@ -340,7 +340,7 @@ impl TypeEngine {
                         // return the id
                         type_id
                     }
-                    Some(ty::TyDeclaration::EnumDeclaration {
+                    Some(ty::TyDecl::EnumDecl {
                         decl_id: original_id,
                         ..
                     }) => {
@@ -377,7 +377,7 @@ impl TypeEngine {
                         // return the id
                         type_id
                     }
-                    Some(ty::TyDeclaration::TypeAliasDeclaration {
+                    Some(ty::TyDecl::TypeAliasDecl {
                         decl_id: original_id,
                         ..
                     }) => {
@@ -391,7 +391,7 @@ impl TypeEngine {
 
                         type_id
                     }
-                    Some(ty::TyDeclaration::GenericTypeForFunctionScope { type_id, .. }) => type_id,
+                    Some(ty::TyDecl::GenericTypeForFunctionScope { type_id, .. }) => type_id,
                     _ => {
                         errors.push(CompileError::UnknownTypeName {
                             name: call_path.to_string(),

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -9,9 +9,7 @@ mod unify;
 pub use priv_prelude::*;
 
 #[cfg(test)]
-use crate::{
-    decl_engine::DeclEngineInsert, language::ty::TyEnumDeclaration, transform::AttributesMap,
-};
+use crate::{decl_engine::DeclEngineInsert, language::ty::TyEnumDecl, transform::AttributesMap};
 
 #[cfg(test)]
 use sway_types::{integer_bits::IntegerBits, Span};
@@ -69,7 +67,7 @@ fn generic_enum_resolution() {
         attributes: transform::AttributesMap::default(),
     }];
 
-    let decl_ref_1 = decl_engine.insert(TyEnumDeclaration {
+    let decl_ref_1 = decl_engine.insert(TyEnumDecl {
         call_path: result_name.clone().into(),
         type_parameters: vec![placeholder_type_param],
         variants: variant_types,
@@ -104,7 +102,7 @@ fn generic_enum_resolution() {
         trait_constraints: vec![],
         trait_constraints_span: sp.clone(),
     };
-    let decl_ref_2 = decl_engine.insert(TyEnumDeclaration {
+    let decl_ref_2 = decl_engine.insert(TyEnumDecl {
         call_path: result_name.into(),
         type_parameters: vec![type_param],
         variants: variant_types.clone(),

--- a/sway-lsp/src/capabilities/code_actions/abi_decl/abi_impl.rs
+++ b/sway-lsp/src/capabilities/code_actions/abi_decl/abi_impl.rs
@@ -1,5 +1,5 @@
 use sway_core::{
-    language::ty::{self, TyAbiDeclaration, TyFunctionParameter, TyTraitFn},
+    language::ty::{self, TyAbiDecl, TyFunctionParameter, TyTraitFn},
     Engines,
 };
 use tower_lsp::lsp_types::Url;
@@ -10,12 +10,12 @@ use crate::capabilities::code_actions::{
 
 pub(crate) struct AbiImplCodeAction<'a> {
     engines: Engines<'a>,
-    decl: &'a TyAbiDeclaration,
+    decl: &'a TyAbiDecl,
     uri: &'a Url,
 }
 
-impl<'a> CodeAction<'a, TyAbiDeclaration> for AbiImplCodeAction<'a> {
-    fn new(ctx: CodeActionContext<'a>, decl: &'a TyAbiDeclaration) -> Self {
+impl<'a> CodeAction<'a, TyAbiDecl> for AbiImplCodeAction<'a> {
+    fn new(ctx: CodeActionContext<'a>, decl: &'a TyAbiDecl) -> Self {
         Self {
             engines: ctx.engines,
             decl,
@@ -39,7 +39,7 @@ impl<'a> CodeAction<'a, TyAbiDeclaration> for AbiImplCodeAction<'a> {
         self.decl.name.to_string()
     }
 
-    fn decl(&self) -> &TyAbiDeclaration {
+    fn decl(&self) -> &TyAbiDecl {
         self.decl
     }
 

--- a/sway-lsp/src/capabilities/code_actions/abi_decl/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/abi_decl/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod abi_impl;
 
-use sway_core::{decl_engine::id::DeclId, language::ty::TyAbiDeclaration};
+use sway_core::{decl_engine::id::DeclId, language::ty::TyAbiDecl};
 use tower_lsp::lsp_types::CodeActionOrCommand;
 
 use self::abi_impl::AbiImplCodeAction;
@@ -8,7 +8,7 @@ use self::abi_impl::AbiImplCodeAction;
 use super::{CodeAction, CodeActionContext};
 
 pub(crate) fn code_actions(
-    decl_id: &DeclId<TyAbiDeclaration>,
+    decl_id: &DeclId<TyAbiDecl>,
     ctx: CodeActionContext,
 ) -> Option<Vec<CodeActionOrCommand>> {
     let decl = ctx.engines.de().get_abi(decl_id);

--- a/sway-lsp/src/capabilities/code_actions/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/mod.rs
@@ -10,7 +10,7 @@ pub use crate::error::DocumentError;
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
 use sway_core::{
-    language::ty::TyDeclaration,
+    language::ty::TyDecl,
     transform::{AttributeKind, AttributesMap},
     Engines, TypeParameter,
 };
@@ -52,10 +52,8 @@ pub(crate) fn code_actions(
     };
     token.typed.and_then(|typed_token| match typed_token {
         TypedAstToken::TypedDeclaration(decl) => match decl {
-            TyDeclaration::AbiDeclaration { decl_id, .. } => abi_decl::code_actions(&decl_id, ctx),
-            TyDeclaration::StructDeclaration { decl_id, .. } => {
-                struct_decl::code_actions(&decl_id, ctx)
-            }
+            TyDecl::AbiDecl { decl_id, .. } => abi_decl::code_actions(&decl_id, ctx),
+            TyDecl::StructDecl { decl_id, .. } => struct_decl::code_actions(&decl_id, ctx),
             _ => None,
         },
         _ => None,

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/mod.rs
@@ -7,7 +7,7 @@ use sway_core::{decl_engine::id::DeclId, language::ty};
 use tower_lsp::lsp_types::CodeActionOrCommand;
 
 pub(crate) fn code_actions(
-    decl_id: &DeclId<ty::TyStructDeclaration>,
+    decl_id: &DeclId<ty::TyStructDecl>,
     ctx: CodeActionContext,
 ) -> Option<Vec<CodeActionOrCommand>> {
     let decl = ctx.engines.de().get_struct(decl_id);

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/struct_impl.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/struct_impl.rs
@@ -1,4 +1,4 @@
-use sway_core::language::ty::TyStructDeclaration;
+use sway_core::language::ty::TyStructDecl;
 use tower_lsp::lsp_types::Url;
 
 use crate::capabilities::code_actions::{
@@ -6,12 +6,12 @@ use crate::capabilities::code_actions::{
 };
 
 pub(crate) struct StructImplCodeAction<'a> {
-    decl: &'a TyStructDeclaration,
+    decl: &'a TyStructDecl,
     uri: &'a Url,
 }
 
-impl<'a> CodeAction<'a, TyStructDeclaration> for StructImplCodeAction<'a> {
-    fn new(ctx: CodeActionContext<'a>, decl: &'a TyStructDeclaration) -> Self {
+impl<'a> CodeAction<'a, TyStructDecl> for StructImplCodeAction<'a> {
+    fn new(ctx: CodeActionContext<'a>, decl: &'a TyStructDecl) -> Self {
         Self { decl, uri: ctx.uri }
     }
 
@@ -31,7 +31,7 @@ impl<'a> CodeAction<'a, TyStructDeclaration> for StructImplCodeAction<'a> {
         self.decl.call_path.suffix.to_string()
     }
 
-    fn decl(&self) -> &TyStructDeclaration {
+    fn decl(&self) -> &TyStructDecl {
         self.decl
     }
 

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
@@ -1,4 +1,4 @@
-use sway_core::language::ty::{TyDeclaration, TyImplTrait, TyStructDeclaration, TyStructField};
+use sway_core::language::ty::{TyDecl, TyImplTrait, TyStructDecl, TyStructField};
 use sway_types::Spanned;
 use tower_lsp::lsp_types::{CodeActionDisabled, Position, Range, Url};
 
@@ -8,13 +8,13 @@ use crate::{
 };
 
 pub(crate) struct StructNewCodeAction<'a> {
-    decl: &'a TyStructDeclaration,
+    decl: &'a TyStructDecl,
     uri: &'a Url,
     existing_impl_decl: Option<TyImplTrait>,
 }
 
-impl<'a> CodeAction<'a, TyStructDeclaration> for StructNewCodeAction<'a> {
-    fn new(ctx: CodeActionContext<'a>, decl: &'a TyStructDeclaration) -> Self {
+impl<'a> CodeAction<'a, TyStructDecl> for StructNewCodeAction<'a> {
+    fn new(ctx: CodeActionContext<'a>, decl: &'a TyStructDecl) -> Self {
         // Before the other functions are called, we need to determine if the new function
         // should be generated in a new impl block, an existing impl block, or not at all.
         // First, find the first impl block for this struct if it exists.
@@ -22,9 +22,8 @@ impl<'a> CodeAction<'a, TyStructDeclaration> for StructNewCodeAction<'a> {
             .tokens
             .all_references_of_token(ctx.token, ctx.engines.te(), ctx.engines.de())
             .find_map(|(_, token)| {
-                if let Some(TypedAstToken::TypedDeclaration(TyDeclaration::ImplTrait {
-                    decl_id,
-                    ..
+                if let Some(TypedAstToken::TypedDeclaration(TyDecl::ImplTrait {
+                    decl_id, ..
                 })) = token.typed
                 {
                     Some(ctx.engines.de().get_impl_trait(&decl_id))
@@ -96,7 +95,7 @@ impl<'a> CodeAction<'a, TyStructDeclaration> for StructNewCodeAction<'a> {
         self.decl.call_path.suffix.to_string()
     }
 
-    fn decl(&self) -> &TyStructDeclaration {
+    fn decl(&self) -> &TyStructDecl {
         self.decl
     }
 

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -115,7 +115,7 @@ fn replace_self_with_type_str(type_str: String, parent_type_info: &TypeInfo) -> 
 
 /// Returns the [TypeId] of an ident that may include field accesses and may be incomplete.
 /// For the first part of the ident, it looks for instantiation in the scope of the given
-/// [TyFunctionDeclaration]. For example, given `a.b.c`, it will return the type ID of `c`
+/// [TyFunctionDecl]. For example, given `a.b.c`, it will return the type ID of `c`
 /// if it can resolve `a` in the given function.
 fn type_id_of_raw_ident(
     engines: Engines,
@@ -167,7 +167,7 @@ fn type_id_of_raw_ident(
 }
 
 /// Returns the [TypeId] of an ident by looking for its instantiation within the scope of the
-/// given [TyFunctionDeclaration].
+/// given [TyFunctionDecl].
 fn type_id_of_local_ident(ident_name: &str, fn_decl: &TyFunctionDecl) -> Option<TypeId> {
     fn_decl
         .parameters

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -1,5 +1,5 @@
 use sway_core::{
-    language::ty::{TyAstNodeContent, TyDeclaration, TyFunctionDeclaration},
+    language::ty::{TyAstNodeContent, TyDecl, TyFunctionDecl},
     namespace::Items,
     Engines, TypeId, TypeInfo,
 };
@@ -13,7 +13,7 @@ pub(crate) fn to_completion_items(
     namespace: &Items,
     engines: Engines<'_>,
     ident_to_complete: &Ident,
-    fn_decl: &TyFunctionDeclaration,
+    fn_decl: &TyFunctionDecl,
     position: Position,
 ) -> Vec<CompletionItem> {
     type_id_of_raw_ident(engines, namespace, ident_to_complete, fn_decl)
@@ -91,7 +91,7 @@ fn completion_items_for_type_id(
 }
 
 /// Returns the [String] of the shortened function signature to display in the completion item's label details.
-fn fn_signature_string(fn_decl: &TyFunctionDeclaration, parent_type_info: &TypeInfo) -> String {
+fn fn_signature_string(fn_decl: &TyFunctionDecl, parent_type_info: &TypeInfo) -> String {
     let params_str = fn_decl
         .parameters
         .iter()
@@ -121,7 +121,7 @@ fn type_id_of_raw_ident(
     engines: Engines,
     namespace: &Items,
     ident: &Ident,
-    fn_decl: &TyFunctionDeclaration,
+    fn_decl: &TyFunctionDecl,
 ) -> Option<TypeId> {
     let full_ident = ident.as_str();
 
@@ -168,7 +168,7 @@ fn type_id_of_raw_ident(
 
 /// Returns the [TypeId] of an ident by looking for its instantiation within the scope of the
 /// given [TyFunctionDeclaration].
-fn type_id_of_local_ident(ident_name: &str, fn_decl: &TyFunctionDeclaration) -> Option<TypeId> {
+fn type_id_of_local_ident(ident_name: &str, fn_decl: &TyFunctionDecl) -> Option<TypeId> {
     fn_decl
         .parameters
         .iter()
@@ -182,9 +182,8 @@ fn type_id_of_local_ident(ident_name: &str, fn_decl: &TyFunctionDeclaration) -> 
         .or_else(|| {
             // Check if there is a variable declaration for this ident
             fn_decl.body.contents.iter().find_map(|node| {
-                if let TyAstNodeContent::Declaration(TyDeclaration::VariableDeclaration(
-                    variable_decl,
-                )) = node.content.clone()
+                if let TyAstNodeContent::Declaration(TyDecl::VariableDecl(variable_decl)) =
+                    node.content.clone()
                 {
                     if variable_decl.name.as_str() == ident_name {
                         return Some(variable_decl.return_type);

--- a/sway-lsp/src/capabilities/hover.rs
+++ b/sway-lsp/src/capabilities/hover.rs
@@ -132,7 +132,7 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
         .as_ref()
         .and_then(|typed_token| match typed_token {
             TypedAstToken::TypedDeclaration(decl) => match decl {
-                ty::TyDeclaration::VariableDeclaration(var_decl) => {
+                ty::TyDecl::VariableDecl(var_decl) => {
                     let type_name =
                         format!("{}", engines.help_out(var_decl.type_ascription.type_id));
                     Some(format_variable_hover(
@@ -141,7 +141,7 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
                         &token_name,
                     ))
                 }
-                ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
+                ty::TyDecl::StructDecl { decl_id, .. } => {
                     let struct_decl = decl_engine.get_struct(decl_id);
                     Some(format_visibility_hover(
                         struct_decl.visibility,
@@ -149,7 +149,7 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
                         &token_name,
                     ))
                 }
-                ty::TyDeclaration::TraitDeclaration { decl_id, .. } => {
+                ty::TyDecl::TraitDecl { decl_id, .. } => {
                     let trait_decl = decl_engine.get_trait(decl_id);
                     Some(format_visibility_hover(
                         trait_decl.visibility,
@@ -157,7 +157,7 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
                         &token_name,
                     ))
                 }
-                ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
+                ty::TyDecl::EnumDecl { decl_id, .. } => {
                     let enum_decl = decl_engine.get_enum(decl_id);
                     Some(format_visibility_hover(
                         enum_decl.visibility,
@@ -165,7 +165,7 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
                         &token_name,
                     ))
                 }
-                ty::TyDeclaration::AbiDeclaration { .. } => {
+                ty::TyDecl::AbiDecl { .. } => {
                     Some(format!("{} {}", decl.friendly_type_name(), &token_name))
                 }
                 _ => None,

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -6,7 +6,7 @@ use crate::{
     },
 };
 use std::sync::Arc;
-use sway_core::{language::ty::TyDeclaration, type_system::TypeInfo, Engines};
+use sway_core::{language::ty::TyDecl, type_system::TypeInfo, Engines};
 use sway_types::Spanned;
 use tower_lsp::lsp_types::{self, Range, Url};
 
@@ -47,7 +47,7 @@ pub(crate) fn inlay_hints(
         .tokens_for_file(uri)
         .filter_map(|(_, token)| {
             token.typed.as_ref().and_then(|t| match t {
-                TypedAstToken::TypedDeclaration(TyDeclaration::VariableDeclaration(var_decl)) => {
+                TypedAstToken::TypedDeclaration(TyDecl::VariableDecl(var_decl)) => {
                     match var_decl.type_ascription.call_path_tree {
                         Some(_) => None,
                         None => {

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -57,12 +57,12 @@ pub enum AstToken {
 /// The `TypedAstToken` holds the types produced by the [sway_core::language::ty::TyProgram].
 #[derive(Debug, Clone)]
 pub enum TypedAstToken {
-    TypedTypeAliasDeclaration(ty::TyTypeAliasDeclaration),
-    TypedDeclaration(ty::TyDeclaration),
+    TypedTypeAliasDeclaration(ty::TyTypeAliasDecl),
+    TypedDeclaration(ty::TyDecl),
     TypedExpression(ty::TyExpression),
     TypedScrutinee(ty::TyScrutinee),
-    TypedConstantDeclaration(ty::TyConstantDeclaration),
-    TypedFunctionDeclaration(ty::TyFunctionDeclaration),
+    TypedConstantDeclaration(ty::TyConstantDecl),
+    TypedFunctionDeclaration(ty::TyFunctionDecl),
     TypedFunctionParameter(ty::TyFunctionParameter),
     TypedStructField(ty::TyStructField),
     TypedEnumVariant(ty::TyEnumVariant),

--- a/sway-lsp/src/core/token_map.rs
+++ b/sway-lsp/src/core/token_map.rs
@@ -132,7 +132,7 @@ impl TokenMap {
             .collect()
     }
 
-    /// Uses the [TypeId] to find the associated [ty::TyDeclaration] in the TokenMap.
+    /// Uses the [TypeId] to find the associated [ty::TyDecl] in the TokenMap.
     ///
     /// This is useful when dealing with tokens that are of the [sway_core::language::ty::TyExpression] type in the AST.
     /// For example, we can then use the `return_type` field which is a [TypeId] to retrieve the declaration Token.
@@ -152,8 +152,8 @@ impl TokenMap {
             })
     }
 
-    /// Returns the [ty::TyStructDeclaration] associated with the TypeId if it
-    /// exists within the TokenMap.
+    /// Returns the [ty::TyStructDecl] associated with the TypeId if it exists
+    /// within the TokenMap.
     pub fn struct_declaration_of_type_id(
         &self,
         engines: Engines<'_>,

--- a/sway-lsp/src/core/token_map.rs
+++ b/sway-lsp/src/core/token_map.rs
@@ -141,7 +141,7 @@ impl TokenMap {
         type_engine: &TypeEngine,
         decl_engine: &DeclEngine,
         type_id: &TypeId,
-    ) -> Option<ty::TyDeclaration> {
+    ) -> Option<ty::TyDecl> {
         token::ident_of_type_id(type_engine, decl_engine, type_id)
             .and_then(|decl_ident| self.try_get(&token::to_ident_key(&decl_ident)).try_unwrap())
             .map(|item| item.value().clone())
@@ -158,14 +158,12 @@ impl TokenMap {
         &self,
         engines: Engines<'_>,
         type_id: &TypeId,
-    ) -> Option<ty::TyStructDeclaration> {
+    ) -> Option<ty::TyStructDecl> {
         let type_engine = engines.te();
         let decl_engine = engines.de();
         self.declaration_of_type_id(type_engine, decl_engine, type_id)
             .and_then(|decl| match decl {
-                ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
-                    Some(decl_engine.get_struct(&decl_id))
-                }
+                ty::TyDecl::StructDecl { decl_id, .. } => Some(decl_engine.get_struct(&decl_id)),
                 _ => None,
             })
     }

--- a/sway-lsp/src/traverse/dependency.rs
+++ b/sway-lsp/src/traverse/dependency.rs
@@ -36,12 +36,12 @@ pub fn collect_typed_declaration(node: &ty::TyAstNode, ctx: &ParseContext) {
         let typed_token = TypedAstToken::TypedDeclaration(declaration.clone());
 
         let ident = match declaration {
-            ty::TyDeclaration::VariableDeclaration(variable) => variable.name.clone(),
-            ty::TyDeclaration::StructDeclaration { name, .. }
-            | ty::TyDeclaration::EnumDeclaration { name, .. }
-            | ty::TyDeclaration::TraitDeclaration { name, .. }
-            | ty::TyDeclaration::FunctionDeclaration { name, .. }
-            | ty::TyDeclaration::ConstantDeclaration { name, .. } => name.clone(),
+            ty::TyDecl::VariableDecl(variable) => variable.name.clone(),
+            ty::TyDecl::StructDecl { name, .. }
+            | ty::TyDecl::EnumDecl { name, .. }
+            | ty::TyDecl::TraitDecl { name, .. }
+            | ty::TyDecl::FunctionDecl { name, .. }
+            | ty::TyDecl::ConstantDecl { name, .. } => name.clone(),
             _ => return,
         };
         let ident = token::to_ident_key(&ident);

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -67,10 +67,10 @@ impl<'a> TypedTree<'a> {
         }
     }
 
-    fn handle_declaration(&self, declaration: &ty::TyDeclaration) {
+    fn handle_declaration(&self, declaration: &ty::TyDecl) {
         let decl_engine = self.ctx.engines.de();
         match declaration {
-            ty::TyDeclaration::VariableDeclaration(variable) => {
+            ty::TyDecl::VariableDecl(variable) => {
                 if let Some(mut token) = self
                     .ctx
                     .tokens
@@ -85,15 +85,15 @@ impl<'a> TypedTree<'a> {
                 }
                 self.handle_expression(&variable.body);
             }
-            ty::TyDeclaration::ConstantDeclaration { decl_id, .. } => {
+            ty::TyDecl::ConstantDecl { decl_id, .. } => {
                 let const_decl = decl_engine.get_constant(decl_id);
                 self.collect_const_decl(&const_decl);
             }
-            ty::TyDeclaration::FunctionDeclaration { decl_id, .. } => {
+            ty::TyDecl::FunctionDecl { decl_id, .. } => {
                 let func_decl = decl_engine.get_function(decl_id);
                 self.collect_typed_fn_decl(&func_decl);
             }
-            ty::TyDeclaration::TraitDeclaration { decl_id, .. } => {
+            ty::TyDecl::TraitDecl { decl_id, .. } => {
                 let trait_decl = decl_engine.get_trait(decl_id);
                 if let Some(mut token) = self
                     .ctx
@@ -121,7 +121,7 @@ impl<'a> TypedTree<'a> {
                     self.collect_supertrait(&supertrait);
                 }
             }
-            ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
+            ty::TyDecl::StructDecl { decl_id, .. } => {
                 let struct_decl = decl_engine.get_struct(decl_id);
                 if let Some(mut token) = self
                     .ctx
@@ -149,7 +149,7 @@ impl<'a> TypedTree<'a> {
                     }
                 }
             }
-            ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
+            ty::TyDecl::EnumDecl { decl_id, .. } => {
                 let enum_decl = decl_engine.get_enum(decl_id);
                 if let Some(mut token) = self
                     .ctx
@@ -178,7 +178,7 @@ impl<'a> TypedTree<'a> {
                     self.collect_ty_enum_variant(variant);
                 }
             }
-            ty::TyDeclaration::ImplTrait { decl_id, .. } => {
+            ty::TyDecl::ImplTrait { decl_id, .. } => {
                 let ty::TyImplTrait {
                     impl_type_parameters,
                     trait_name,
@@ -262,7 +262,7 @@ impl<'a> TypedTree<'a> {
                         .unwrap_or(implementing_for.span()),
                 );
             }
-            ty::TyDeclaration::AbiDeclaration { decl_id, .. } => {
+            ty::TyDecl::AbiDecl { decl_id, .. } => {
                 let abi_decl = decl_engine.get_abi(decl_id);
                 if let Some(mut token) = self
                     .ctx
@@ -291,7 +291,7 @@ impl<'a> TypedTree<'a> {
                     self.collect_supertrait(&supertrait);
                 }
             }
-            ty::TyDeclaration::GenericTypeForFunctionScope { name, type_id } => {
+            ty::TyDecl::GenericTypeForFunctionScope { name, type_id } => {
                 if let Some(mut token) = self
                     .ctx
                     .tokens
@@ -302,8 +302,8 @@ impl<'a> TypedTree<'a> {
                     token.type_def = Some(TypeDefinition::TypeId(*type_id));
                 }
             }
-            ty::TyDeclaration::ErrorRecovery(_) => {}
-            ty::TyDeclaration::StorageDeclaration { decl_id, .. } => {
+            ty::TyDecl::ErrorRecovery(_) => {}
+            ty::TyDecl::StorageDecl { decl_id, .. } => {
                 let storage_decl = decl_engine.get_storage(decl_id);
                 for field in &storage_decl.fields {
                     if let Some(mut token) = self
@@ -321,7 +321,7 @@ impl<'a> TypedTree<'a> {
                     self.handle_expression(&field.initializer);
                 }
             }
-            ty::TyDeclaration::TypeAliasDeclaration { decl_id, .. } => {
+            ty::TyDecl::TypeAliasDecl { decl_id, .. } => {
                 let type_alias_decl = decl_engine.get_type_alias(decl_id);
                 self.collect_type_alias_decl(&type_alias_decl);
             }
@@ -1325,7 +1325,7 @@ impl<'a> TypedTree<'a> {
         }
     }
 
-    fn collect_const_decl(&self, const_decl: &ty::TyConstantDeclaration) {
+    fn collect_const_decl(&self, const_decl: &ty::TyConstantDecl) {
         if let Some(mut token) = self
             .ctx
             .tokens
@@ -1345,7 +1345,7 @@ impl<'a> TypedTree<'a> {
         }
     }
 
-    fn collect_typed_fn_decl(&self, func_decl: &ty::TyFunctionDeclaration) {
+    fn collect_typed_fn_decl(&self, func_decl: &ty::TyFunctionDecl) {
         let typed_token = TypedAstToken::TypedFunctionDeclaration(func_decl.clone());
         if let Some(mut token) = self
             .ctx
@@ -1427,7 +1427,7 @@ impl<'a> TypedTree<'a> {
         self.collect_type_argument(&field.type_argument);
     }
 
-    fn collect_type_alias_decl(&self, type_alias_decl: &ty::TyTypeAliasDeclaration) {
+    fn collect_type_alias_decl(&self, type_alias_decl: &ty::TyTypeAliasDecl) {
         if let Some(mut token) = self
             .ctx
             .tokens

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -69,31 +69,31 @@ pub(crate) fn print_decl_engine_types(
         .iter()
         .map(|n| match &n.content {
             ty::TyAstNodeContent::Declaration(declaration) => match declaration {
-                ty::TyDeclaration::ConstantDeclaration { decl_id, .. } => {
+                ty::TyDecl::ConstantDecl { decl_id, .. } => {
                     let const_decl = decl_engine.get_constant(decl_id);
                     format!("{const_decl:#?}")
                 }
-                ty::TyDeclaration::FunctionDeclaration { decl_id, .. } => {
+                ty::TyDecl::FunctionDecl { decl_id, .. } => {
                     let func_decl = decl_engine.get_function(decl_id);
                     format!("{func_decl:#?}")
                 }
-                ty::TyDeclaration::TraitDeclaration { decl_id, .. } => {
+                ty::TyDecl::TraitDecl { decl_id, .. } => {
                     let trait_decl = decl_engine.get_trait(decl_id);
                     format!("{trait_decl:#?}")
                 }
-                ty::TyDeclaration::StructDeclaration { decl_id, .. } => {
+                ty::TyDecl::StructDecl { decl_id, .. } => {
                     let struct_decl = decl_engine.get_struct(decl_id);
                     format!("{struct_decl:#?}")
                 }
-                ty::TyDeclaration::EnumDeclaration { decl_id, .. } => {
+                ty::TyDecl::EnumDecl { decl_id, .. } => {
                     let enum_decl = decl_engine.get_enum(decl_id);
                     format!("{enum_decl:#?}")
                 }
-                ty::TyDeclaration::AbiDeclaration { decl_id, .. } => {
+                ty::TyDecl::AbiDecl { decl_id, .. } => {
                     let abi_decl = decl_engine.get_abi(decl_id);
                     format!("{abi_decl:#?}")
                 }
-                ty::TyDeclaration::StorageDeclaration { decl_id, .. } => {
+                ty::TyDecl::StorageDecl { decl_id, .. } => {
                     let storage_decl = decl_engine.get_storage(decl_id);
                     format!("{storage_decl:#?}")
                 }


### PR DESCRIPTION
## Description

Some function signatures are beginning to get rather unwieldy with the introduction of new traits, impl blocks for types with nested type arguments, etc.

This change canonicalizes the name "declaration" to "decl". "decl" was already being used in the `DeclEngine`, and now "decl" is used elsewhere as well. This change will allow for more simple formatting from `cargo fmt` and function signatures that are easier to read.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
