### PR TITLE
Fix semantic definitions for `Self` and `self` tokens

### DIFF
--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -35,8 +35,10 @@ pub(crate) fn symbol_kind(symbol_kind: &SymbolKind) -> lsp_types::SymbolKind {
         SymbolKind::ValueParam
         | SymbolKind::ByteLiteral
         | SymbolKind::Variable
-        | SymbolKind::Type
+        | SymbolKind::TypeAlias
         | SymbolKind::Keyword
+        | SymbolKind::SelfKeyword
+        | SymbolKind::SelfTypeKeyword
         | SymbolKind::Unknown => lsp_types::SymbolKind::VARIABLE,
     }
 }

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -112,7 +112,6 @@ pub(crate) const SUPPORTED_TYPES: &[SemanticTokenType] = &[
     SemanticTokenType::STRING,
     SemanticTokenType::NUMBER,
     SemanticTokenType::NAMESPACE,
-    SemanticTokenType::TYPE,
     SemanticTokenType::STRUCT,
     SemanticTokenType::CLASS,
     SemanticTokenType::INTERFACE,
@@ -129,6 +128,9 @@ pub(crate) const SUPPORTED_TYPES: &[SemanticTokenType] = &[
     SemanticTokenType::new("keyword"),
     SemanticTokenType::new("builtinType"),
     SemanticTokenType::new("deriveHelper"),
+    SemanticTokenType::new("selfKeyword"),
+    SemanticTokenType::new("selfTypeKeyword"),
+    SemanticTokenType::new("typeAlias"),
 ];
 
 pub(crate) const SUPPORTED_MODIFIERS: &[SemanticTokenModifier] = &[
@@ -162,11 +164,13 @@ fn semantic_token_type(kind: &SymbolKind) -> SemanticTokenType {
         SymbolKind::StringLiteral => SemanticTokenType::STRING,
         SymbolKind::ByteLiteral | SymbolKind::NumericLiteral => SemanticTokenType::NUMBER,
         SymbolKind::BoolLiteral => SemanticTokenType::new("boolean"),
-        SymbolKind::Type => SemanticTokenType::TYPE,
+        SymbolKind::TypeAlias => SemanticTokenType::new("typeAlias"),
         SymbolKind::Keyword => SemanticTokenType::new("keyword"),
         SymbolKind::Unknown => SemanticTokenType::new("generic"),
         SymbolKind::BuiltinType => SemanticTokenType::new("builtinType"),
         SymbolKind::DeriveHelper => SemanticTokenType::new("deriveHelper"),
+        SymbolKind::SelfKeyword => SemanticTokenType::new("selfKeyword"),
+        SymbolKind::SelfTypeKeyword => SemanticTokenType::new("selfTypeKeyword"),
     }
 }
 

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -118,7 +118,7 @@ pub enum SymbolKind {
     Struct,
     /// Emitted for traits.
     Trait,
-    /// Emitted for type aliases and `Self` in `impl`s.
+    /// Emitted for type aliases.
     TypeAlias,
     /// Emitted for type parameters.
     TypeParameter,
@@ -239,6 +239,7 @@ pub fn type_info_to_symbol_kind(type_engine: &TypeEngine, type_info: &TypeInfo) 
             let type_info = type_engine.get(elem_ty.type_id);
             type_info_to_symbol_kind(type_engine, &type_info)
         }
+        TypeInfo::SelfType => SymbolKind::SelfTypeKeyword,
         _ => SymbolKind::Unknown,
     }
 }

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -84,27 +84,52 @@ pub enum TypedAstToken {
 /// These variants are used to represent the semantic type of the [Token].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SymbolKind {
-    Field,
-    ValueParam,
-    Function,
-    Const,
-    Struct,
-    Trait,
-    Storage,
-    Enum,
-    Variant,
+    /// Emitted for the boolean literals `true` and `false`.
     BoolLiteral,
-    ByteLiteral,
-    StringLiteral,
-    NumericLiteral,
-    Variable,
+    /// Emitted for builtin types like `u32`, and `str`.
     BuiltinType,
+    /// Emitted for byte literals.
+    ByteLiteral,
+    /// Emitted for constants.
+    Const,
+    /// Emitted for derive helper attributes.
     DeriveHelper,
-    Module,
-    TypeParameter,
+    /// Emitted for enums.
+    Enum,
+    /// Emitted for struct fields.
+    Field,
+    /// Emitted for free-standing & associated functions.
+    Function,
+    /// Emitted for keywords.
     Keyword,
-    Type,
+    /// Emitted for modules.
+    Module,
+    /// Emitted for numeric literals.
+    NumericLiteral,
+    /// Emitted for the self function parameter and self path-specifier.
+    SelfKeyword,
+    /// Emitted for the Self type parameter.
+    SelfTypeKeyword,
+    /// Emitted for storage.
+    Storage,
+    /// Emitted for string literals.
+    StringLiteral,
+    /// Emitted for structs.
+    Struct,
+    /// Emitted for traits.
+    Trait,
+    /// Emitted for type aliases and `Self` in `impl`s.
+    TypeAlias,
+    /// Emitted for type parameters.
+    TypeParameter,
+    /// Emitted for generic tokens that have no mapping.
     Unknown,
+    /// Emitted for non-self function parameters.
+    ValueParam,
+    /// Emitted for enum variants.
+    Variant,
+    /// Emitted for locals.
+    Variable,
 }
 
 #[derive(Debug, Clone)]

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -234,12 +234,12 @@ pub fn type_info_to_symbol_kind(
     // We want to keep the semantics of these keywords.
     if let Some(type_span) = type_span {
         if type_span.as_str() == "Self" {
-            return SymbolKind::SelfTypeKeyword
+            return SymbolKind::SelfTypeKeyword;
         } else if type_span.as_str() == "self" {
-            return SymbolKind::SelfKeyword
+            return SymbolKind::SelfKeyword;
         }
     }
-    
+
     match type_info {
         TypeInfo::UnsignedInteger(..) | TypeInfo::Boolean | TypeInfo::B256 => {
             SymbolKind::BuiltinType

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -197,6 +197,8 @@ impl Parse for Expression {
                 {
                     let symbol_kind = if name.as_str().contains(DESTRUCTURE_PREFIX) {
                         SymbolKind::Struct
+                    } else if name.as_str() == "self" {
+                        SymbolKind::SelfKeyword
                     } else {
                         SymbolKind::Variable
                     };

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -992,7 +992,7 @@ impl Parse for TypeAliasDeclaration {
             to_ident_key(&self.name),
             Token::from_parsed(
                 AstToken::Declaration(Declaration::TypeAliasDeclaration(self.clone())),
-                SymbolKind::Type,
+                SymbolKind::TypeAlias,
             ),
         );
         self.ty.parse(ctx);

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -458,7 +458,7 @@ impl Parse for MethodApplicationExpression {
         } = &self.method_name_binding.inner
         {
             let (type_info, ident) = &call_path_binding.inner.suffix;
-            collect_type_info_token(ctx, type_info, Some(ident.span()));
+            collect_type_info_token(ctx, type_info, Some(&ident.span()));
         }
         self.method_name_binding
             .type_arguments
@@ -886,7 +886,7 @@ impl Parse for TraitFn {
         self.parameters.iter().for_each(|param| {
             param.parse(ctx);
         });
-        collect_type_info_token(ctx, &self.return_type, Some(self.return_type_span.clone()));
+        collect_type_info_token(ctx, &self.return_type, Some(&self.return_type_span));
         self.attributes.parse(ctx);
     }
 }
@@ -977,7 +977,7 @@ impl Parse for TypeArgument {
                 }
             }
             _ => {
-                let symbol_kind = type_info_to_symbol_kind(ctx.engines.te(), &type_info);
+                let symbol_kind = type_info_to_symbol_kind(ctx.engines.te(), &type_info, None);
                 if let Some(tree) = &self.call_path_tree {
                     let token =
                         Token::from_parsed(AstToken::TypeArgument(self.clone()), symbol_kind);
@@ -1002,8 +1002,8 @@ impl Parse for TypeAliasDeclaration {
     }
 }
 
-fn collect_type_info_token(ctx: &ParseContext, type_info: &TypeInfo, type_span: Option<Span>) {
-    let symbol_kind = type_info_to_symbol_kind(ctx.engines.te(), type_info);
+fn collect_type_info_token(ctx: &ParseContext, type_info: &TypeInfo, type_span: Option<&Span>) {
+    let symbol_kind = type_info_to_symbol_kind(ctx.engines.te(), type_info, type_span);
     match type_info {
         TypeInfo::Str(length) => {
             let ident = Ident::new(length.span());
@@ -1041,7 +1041,7 @@ fn collect_type_info_token(ctx: &ParseContext, type_info: &TypeInfo, type_span: 
         }
         _ => {
             if let Some(type_span) = type_span {
-                let ident = Ident::new(type_span);
+                let ident = Ident::new(type_span.clone());
                 ctx.tokens.insert(
                     to_ident_key(&ident),
                     Token::from_parsed(AstToken::Ident(ident.clone()), symbol_kind),

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -1231,8 +1231,7 @@ impl<'a> TypedTree<'a> {
         let type_engine = self.ctx.engines.te();
         let decl_engine = self.ctx.engines.de();
         let type_info = type_engine.get(type_id);
-        let symbol_kind = 
-            type_info_to_symbol_kind(type_engine, &type_info, Some(&type_span));
+        let symbol_kind = type_info_to_symbol_kind(type_engine, &type_info, Some(&type_span));
         match &type_info {
             TypeInfo::Array(type_arg, ..) => {
                 self.collect_type_argument(type_arg);

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -1231,15 +1231,8 @@ impl<'a> TypedTree<'a> {
         let type_engine = self.ctx.engines.te();
         let decl_engine = self.ctx.engines.de();
         let type_info = type_engine.get(type_id);
-        // This is necessary because the type engine resolves `Self` & `self` to the type it refers to.
-        // We want to keep the semantics of these keywords.
-        let symbol_kind = if type_span.as_str() == "Self" {
-            SymbolKind::SelfTypeKeyword
-        } else if type_span.as_str() == "self" {
-            SymbolKind::SelfKeyword
-        } else {
-            type_info_to_symbol_kind(type_engine, &type_info)
-        };
+        let symbol_kind = 
+            type_info_to_symbol_kind(type_engine, &type_info, Some(&type_span));
         match &type_info {
             TypeInfo::Array(type_arg, ..) => {
                 self.collect_type_argument(type_arg);

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -1231,7 +1231,15 @@ impl<'a> TypedTree<'a> {
         let type_engine = self.ctx.engines.te();
         let decl_engine = self.ctx.engines.de();
         let type_info = type_engine.get(type_id);
-        let symbol_kind = type_info_to_symbol_kind(type_engine, &type_info);
+        // This is necessary because the type engine resolves `Self` & `self` to the type it refers to.
+        // We want to keep the semantics of these keywords.
+        let symbol_kind = if type_span.as_str() == "Self" {
+            SymbolKind::SelfTypeKeyword
+        } else if type_span.as_str() == "self" {
+            SymbolKind::SelfKeyword
+        } else {
+            type_info_to_symbol_kind(type_engine, &type_info)
+        };
         match &type_info {
             TypeInfo::Array(type_arg, ..) => {
                 self.collect_type_argument(type_arg);


### PR DESCRIPTION
## Description
Fixes incorrect semantic token definitions for `Self` and `self` tokens so they match how `rust-anaylzer` treats these tokens. Also adds simple docs for the variants in `SymbolKind`. 

closes #4058 
closes #4062

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
