### PR TITLE
Fixes DCA warning in impl block instead of method.

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_alias_shadowing_methods/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_alias_shadowing_methods/test.toml
@@ -1,8 +1,5 @@
 category = "fail"
 
-# Consume `impl Alias2` form an earlier warning
-#check: $() impl Alias2 {
-
 #check: $()impl Alias2 {
 #nextln: $()fn foo() {}
 #nextln: $()Duplicate definitions for the method "foo" for type "type Alias2 = MyStruct1".

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/impl_unused_fn/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/impl_unused_fn/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'impl_unused_fn'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/impl_unused_fn/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/impl_unused_fn/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "impl_unused_fn"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/impl_unused_fn/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/impl_unused_fn/src/main.sw
@@ -1,0 +1,20 @@
+script;
+
+struct Data1 {
+    value: u64
+}
+
+impl Data1 {
+    fn get(self) -> u64 {
+        self.value
+    }
+
+
+    fn get2(self) -> u64 {
+        self.value
+    }
+}
+
+fn main() -> u64 {
+    0
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/impl_unused_fn/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/impl_unused_fn/src/main.sw
@@ -13,8 +13,13 @@ impl Data1 {
     fn get2(self) -> u64 {
         self.value
     }
+
+    fn get3(self) -> u64 {
+        self.value
+    }
 }
 
 fn main() -> u64 {
-    0
+    let d = Data1 { value: 42 };
+    d.get3()
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/impl_unused_fn/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/impl_unused_fn/test.toml
@@ -1,8 +1,5 @@
 category = "compile"
 
-# check: $()struct Data1 {
-# nextln: $()This struct is never used.
-
 # check: $()fn get(self) -> u64 {
 # nextln: $()
 # nextln: $()
@@ -15,4 +12,4 @@ category = "compile"
 # nextln: $()
 # nextln: $()This method is never called.
 
-expected_warnings = 3
+expected_warnings = 2

--- a/test/src/e2e_vm_tests/test_programs/should_pass/dca/impl_unused_fn/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/dca/impl_unused_fn/test.toml
@@ -1,0 +1,18 @@
+category = "compile"
+
+# check: $()struct Data1 {
+# nextln: $()This struct is never used.
+
+# check: $()fn get(self) -> u64 {
+# nextln: $()
+# nextln: $()
+# nextln: $()
+# nextln: $()This method is never called.
+
+# check: $()fn get2(self) -> u64 {
+# nextln: $()
+# nextln: $()
+# nextln: $()
+# nextln: $()This method is never called.
+
+expected_warnings = 3


### PR DESCRIPTION
## Description

When all of the impl methods are unused the whole impl block was marked as unused.

Now the compiler shows a DCA warning for the unused methods instead of a single warning for the impl block.

Closes #4311

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
