### PR TITLE
Refactor `TyScrutinee` to use `DeclRef`.

### DIFF
--- a/sway-core/src/language/ty/expression/scrutinee.rs
+++ b/sway-core/src/language/ty/expression/scrutinee.rs
@@ -22,7 +22,7 @@ pub enum TyScrutineeVariant {
     StructScrutinee {
         struct_ref: DeclRefStruct,
         fields: Vec<TyStructScrutineeField>,
-        instantiation_span: Span,
+        instantiation_call_path: CallPath,
     },
     EnumScrutinee {
         enum_ref: DeclRefEnum,

--- a/sway-core/src/language/ty/expression/scrutinee.rs
+++ b/sway-core/src/language/ty/expression/scrutinee.rs
@@ -1,7 +1,7 @@
 use sway_types::{Ident, Span};
 
 use crate::{
-    decl_engine::DeclRefStruct,
+    decl_engine::{DeclRefEnum, DeclRefStruct},
     language::{ty::*, *},
     type_system::*,
 };
@@ -24,12 +24,11 @@ pub enum TyScrutineeVariant {
         fields: Vec<TyStructScrutineeField>,
         instantiation_span: Span,
     },
-    #[allow(dead_code)]
     EnumScrutinee {
-        call_path: CallPath,
+        enum_ref: DeclRefEnum,
         variant: Box<TyEnumVariant>,
-        decl_name: Ident,
         value: Box<TyScrutinee>,
+        instantiation_call_path: CallPath,
     },
     Tuple(Vec<TyScrutinee>),
 }

--- a/sway-core/src/language/ty/expression/scrutinee.rs
+++ b/sway-core/src/language/ty/expression/scrutinee.rs
@@ -1,6 +1,7 @@
 use sway_types::{Ident, Span};
 
 use crate::{
+    decl_engine::DeclRefStruct,
     language::{ty::*, *},
     type_system::*,
 };
@@ -19,9 +20,9 @@ pub enum TyScrutineeVariant {
     Variable(Ident),
     Constant(Ident, Literal, TyConstantDeclaration),
     StructScrutinee {
-        struct_name: Ident,
-        decl_name: Ident,
+        struct_ref: DeclRefStruct,
         fields: Vec<TyStructScrutineeField>,
+        instantiation_span: Span,
     },
     #[allow(dead_code)]
     EnumScrutinee {

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
@@ -157,23 +157,20 @@ impl Pattern {
                 Pattern::Tuple(new_elems)
             }
             ty::TyScrutineeVariant::EnumScrutinee {
-                call_path,
-                decl_name,
+                enum_ref,
+                variant,
                 value,
                 ..
-            } => {
-                let variant_name = call_path.suffix.to_string();
-                Pattern::Enum(EnumPattern {
-                    enum_name: decl_name.to_string(),
-                    variant_name,
-                    value: Box::new(check!(
-                        Pattern::from_scrutinee(*value),
-                        return err(warnings, errors),
-                        warnings,
-                        errors
-                    )),
-                })
-            }
+            } => Pattern::Enum(EnumPattern {
+                enum_name: enum_ref.name().to_string(),
+                variant_name: variant.name.to_string(),
+                value: Box::new(check!(
+                    Pattern::from_scrutinee(*value),
+                    return err(warnings, errors),
+                    warnings,
+                    errors
+                )),
+            }),
         };
         ok(pat, warnings, errors)
     }

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
@@ -124,7 +124,7 @@ impl Pattern {
             ty::TyScrutineeVariant::StructScrutinee {
                 struct_ref,
                 fields,
-                instantiation_span: _,
+                instantiation_call_path: _,
             } => {
                 let mut new_fields = vec![];
                 for field in fields.into_iter() {

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/pattern.rs
@@ -122,9 +122,9 @@ impl Pattern {
             ty::TyScrutineeVariant::Literal(value) => Pattern::from_literal(value),
             ty::TyScrutineeVariant::Constant(_, value, _) => Pattern::from_literal(value),
             ty::TyScrutineeVariant::StructScrutinee {
-                struct_name,
+                struct_ref,
                 fields,
-                ..
+                instantiation_span: _,
             } => {
                 let mut new_fields = vec![];
                 for field in fields.into_iter() {
@@ -140,7 +140,7 @@ impl Pattern {
                     new_fields.push((field.field.as_str().to_string(), f));
                 }
                 Pattern::Struct(StructPattern {
-                    struct_name: struct_name.to_string(),
+                    struct_name: struct_ref.name().to_string(),
                     fields: new_fields,
                 })
             }

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
@@ -102,7 +102,11 @@ pub(crate) fn matcher(
             vec![],
             vec![],
         ),
-        ty::TyScrutineeVariant::StructScrutinee { fields, .. } => match_struct(ctx, exp, fields),
+        ty::TyScrutineeVariant::StructScrutinee {
+            struct_ref: _,
+            fields,
+            ..
+        } => match_struct(ctx, exp, fields),
         ty::TyScrutineeVariant::EnumScrutinee { value, variant, .. } => {
             match_enum(ctx, exp, *variant, *value, span)
         }

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
@@ -107,9 +107,12 @@ pub(crate) fn matcher(
             fields,
             ..
         } => match_struct(ctx, exp, fields),
-        ty::TyScrutineeVariant::EnumScrutinee { value, variant, .. } => {
-            match_enum(ctx, exp, *variant, *value, span)
-        }
+        ty::TyScrutineeVariant::EnumScrutinee {
+            enum_ref: _,
+            variant,
+            value,
+            ..
+        } => match_enum(ctx, exp, *variant, *value, span),
         ty::TyScrutineeVariant::Tuple(elems) => match_tuple(ctx, exp, elems, span),
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -255,13 +255,13 @@ fn type_check_enum(
         warnings,
         errors
     );
-    let original_decl_ref = check!(
+    let enum_ref = check!(
         unknown_decl.to_enum_ref(ctx.engines()),
         return err(warnings, errors),
         warnings,
         errors
     );
-    let mut enum_decl = decl_engine.get_enum(&original_decl_ref);
+    let mut enum_decl = decl_engine.get_enum(&enum_ref);
 
     // monomorphize the enum definition
     check!(
@@ -284,10 +284,6 @@ fn type_check_enum(
         errors
     );
 
-    let decl_name = enum_decl.call_path.suffix.clone();
-    let new_decl_ref = decl_engine.insert(enum_decl.clone());
-    let enum_type_id = type_engine.insert(decl_engine, TypeInfo::Enum(new_decl_ref));
-
     // type check the nested scrutinee
     let typed_value = check!(
         ty::TyScrutinee::type_check(ctx, value),
@@ -296,14 +292,15 @@ fn type_check_enum(
         errors
     );
 
+    let enum_ref = decl_engine.insert(enum_decl);
     let typed_scrutinee = ty::TyScrutinee {
         variant: ty::TyScrutineeVariant::EnumScrutinee {
-            call_path,
-            decl_name,
+            enum_ref: enum_ref.clone(),
             variant: Box::new(variant),
             value: Box::new(typed_value),
+            instantiation_call_path: call_path,
         },
-        type_id: enum_type_id,
+        type_id: type_engine.insert(decl_engine, TypeInfo::Enum(enum_ref)),
         span,
     };
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -212,7 +212,11 @@ fn type_check_struct(
         variant: ty::TyScrutineeVariant::StructScrutinee {
             struct_ref,
             fields: typed_fields,
-            instantiation_span: struct_name.span(),
+            instantiation_call_path: CallPath {
+                prefixes: vec![],
+                suffix: struct_name,
+                is_absolute: false,
+            },
         },
     };
 

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -941,18 +941,18 @@ impl<'a> TypedTree<'a> {
                 }
             }
             StructScrutinee {
-                struct_name,
-                decl_name,
+                struct_ref,
                 fields,
+                instantiation_span: _,
             } => {
                 if let Some(mut token) = self
                     .ctx
                     .tokens
-                    .try_get_mut(&to_ident_key(struct_name))
+                    .try_get_mut(&to_ident_key(struct_ref.name()))
                     .try_unwrap()
                 {
                     token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));
-                    token.type_def = Some(TypeDefinition::Ident(decl_name.clone()));
+                    token.type_def = Some(TypeDefinition::Ident(struct_ref.name().clone()));
                 }
 
                 for field in fields {

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -943,12 +943,12 @@ impl<'a> TypedTree<'a> {
             StructScrutinee {
                 struct_ref,
                 fields,
-                instantiation_span: _,
+                instantiation_call_path,
             } => {
                 if let Some(mut token) = self
                     .ctx
                     .tokens
-                    .try_get_mut(&to_ident_key(struct_ref.name()))
+                    .try_get_mut(&to_ident_key(&instantiation_call_path.suffix))
                     .try_unwrap()
                 {
                     token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));
@@ -987,7 +987,9 @@ impl<'a> TypedTree<'a> {
                             .try_unwrap()
                         {
                             token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));
-                            token.type_def = Some(TypeDefinition::Ident(enum_ref.name().clone()));
+                            token.type_def = Some(TypeDefinition::Ident(
+                                enum_ref.name().clone(), // prefixes.last().cloned().unwrap_or(enum_ref.name().clone()),
+                            ));
                         }
                         prefixes
                     } else {
@@ -998,7 +1000,7 @@ impl<'a> TypedTree<'a> {
                 if let Some(mut token) = self
                     .ctx
                     .tokens
-                    .try_get_mut(&to_ident_key(enum_ref.name()))
+                    .try_get_mut(&to_ident_key(&instantiation_call_path.suffix))
                     .try_unwrap()
                 {
                     token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -972,32 +972,33 @@ impl<'a> TypedTree<'a> {
                 }
             }
             EnumScrutinee {
-                call_path,
-                decl_name,
+                enum_ref,
                 variant,
                 value,
+                instantiation_call_path,
             } => {
-                let prefixes = if let Some((last, prefixes)) = call_path.prefixes.split_last() {
-                    // the last prefix of the call path is not a module but a type
-                    if let Some(mut token) = self
-                        .ctx
-                        .tokens
-                        .try_get_mut(&to_ident_key(last))
-                        .try_unwrap()
-                    {
-                        token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));
-                        token.type_def = Some(TypeDefinition::Ident(decl_name.clone()));
-                    }
-                    prefixes
-                } else {
-                    &call_path.prefixes
-                };
+                let prefixes =
+                    if let Some((last, prefixes)) = instantiation_call_path.prefixes.split_last() {
+                        // the last prefix of the call path is not a module but a type
+                        if let Some(mut token) = self
+                            .ctx
+                            .tokens
+                            .try_get_mut(&to_ident_key(last))
+                            .try_unwrap()
+                        {
+                            token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));
+                            token.type_def = Some(TypeDefinition::Ident(enum_ref.name().clone()));
+                        }
+                        prefixes
+                    } else {
+                        &instantiation_call_path.prefixes
+                    };
                 self.collect_call_path_prefixes(prefixes);
 
                 if let Some(mut token) = self
                     .ctx
                     .tokens
-                    .try_get_mut(&to_ident_key(&call_path.suffix))
+                    .try_get_mut(&to_ident_key(enum_ref.name()))
                     .try_unwrap()
                 {
                     token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -987,9 +987,7 @@ impl<'a> TypedTree<'a> {
                             .try_unwrap()
                         {
                             token.typed = Some(TypedAstToken::TypedScrutinee(scrutinee.clone()));
-                            token.type_def = Some(TypeDefinition::Ident(
-                                enum_ref.name().clone(), // prefixes.last().cloned().unwrap_or(enum_ref.name().clone()),
-                            ));
+                            token.type_def = Some(TypeDefinition::Ident(enum_ref.name().clone()));
                         }
                         prefixes
                     } else {


### PR DESCRIPTION
## Description

This PR refactors `TyScrutinee` to use `DeclRef`, where needed.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
