### PR TITLE
Double "Number of" removed from `StorageVec` inline documentation

### DIFF
--- a/sway-lib-std/src/storage.sw
+++ b/sway-lib-std/src/storage.sw
@@ -353,7 +353,7 @@ impl<V> StorageVec<V> {
     ///
     /// * `value` - The item being added to the end of the vector.
     ///
-    /// ### Number of Number of Storage Accesses
+    /// ### Number of Storage Accesses
     ///
     /// * Reads: `1`
     /// * Writes: `2`


### PR DESCRIPTION
## Description

Removed "Number of"

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
