### PR TITLE
Remove the obsolete `unify_adt` method.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -88,7 +88,7 @@ pub(crate) fn instantiate_enum(
 
             // unify the value of the argument with the variant
             check!(
-                CompileResult::from(type_engine.unify_adt(
+                CompileResult::from(type_engine.unify(
                     decl_engine,
                     typed_expr.return_type,
                     enum_variant.type_argument.type_id,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -216,7 +216,7 @@ fn unify_field_arguments_and_struct_fields(
     for struct_field in struct_fields.iter() {
         if let Some(typed_field) = typed_fields.iter().find(|x| x.name == struct_field.name) {
             check!(
-                CompileResult::from(type_engine.unify_adt(
+                CompileResult::from(type_engine.unify(
                     decl_engine,
                     typed_field.value.return_type,
                     struct_field.type_argument.type_id,


### PR DESCRIPTION
## Description

This method was obsolete and was adding unnecessary complexity, so this PR removes it 😄 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
