### PR TITLE
fix(fmt): item trait comment/annotation formatting

### DIFF
--- a/swayfmt/src/items/item_trait/mod.rs
+++ b/swayfmt/src/items/item_trait/mod.rs
@@ -11,6 +11,9 @@ use std::fmt::Write;
 use sway_ast::{keywords::Token, token::Delimiter, ItemTrait, ItemTraitItem, Traits};
 use sway_types::Spanned;
 
+#[cfg(test)]
+mod tests;
+
 impl Format for ItemTrait {
     fn format(
         &self,
@@ -67,6 +70,14 @@ impl Format for ItemTrait {
             write_comments(formatted_code, self.trait_items.span().into(), formatter)?;
         } else {
             for (annotated, semicolon_token) in trait_items {
+                for attr in &annotated.attribute_list {
+                    write!(
+                        formatted_code,
+                        "{}",
+                        &formatter.shape.indent.to_string(&formatter.config)?,
+                    )?;
+                    attr.format(formatted_code, formatter)?;
+                }
                 match &annotated.value {
                     sway_ast::ItemTraitItem::Fn(fn_signature) => {
                         // format `Annotated<FnSignature>`

--- a/swayfmt/src/items/item_trait/mod.rs
+++ b/swayfmt/src/items/item_trait/mod.rs
@@ -80,7 +80,6 @@ impl Format for ItemTrait {
                 }
                 match &annotated.value {
                     sway_ast::ItemTraitItem::Fn(fn_signature) => {
-                        // format `Annotated<FnSignature>`
                         write!(
                             formatted_code,
                             "{}",
@@ -90,7 +89,6 @@ impl Format for ItemTrait {
                         writeln!(formatted_code, "{}", semicolon_token.ident().as_str())?;
                     }
                     sway_ast::ItemTraitItem::Const(const_decl) => {
-                        // format `Annotated<ItemConst>`
                         write!(
                             formatted_code,
                             "{}",

--- a/swayfmt/src/items/item_trait/tests.rs
+++ b/swayfmt/src/items/item_trait/tests.rs
@@ -51,3 +51,18 @@ intermediate_whitespace
      fn foo(self);
 }   "
 );
+
+fmt_test_item!(
+trait_commented_fn
+"pub trait MyTrait {
+    /// Comment
+    fn foo(self);
+}",
+
+intermediate_whitespace
+"  pub   trait   MyTrait {
+/// Comment
+      
+     fn foo(self);
+}   "
+);

--- a/swayfmt/src/items/item_trait/tests.rs
+++ b/swayfmt/src/items/item_trait/tests.rs
@@ -1,0 +1,53 @@
+use forc_tracing::{println_green, println_red};
+use paste::paste;
+use prettydiff::{basic::DiffOp, diff_lines};
+use test_macros::fmt_test_item;
+
+fmt_test_item!(
+trait_annotated_fn
+"pub trait MyTrait {
+    #[storage(read, write)]
+    fn foo(self);
+}",
+intermediate_whitespace
+"   pub   trait   MyTrait {
+    #[storage(  read , write) ]
+      
+     fn foo(self);
+}   "
+);
+
+fmt_test_item!(
+trait_vertically_annotated_fn
+"pub trait MyTrait {
+    #[storage(read)]
+    #[storage(write)]
+    fn foo(self);
+}",
+intermediate_whitespace
+"   pub   trait   MyTrait {
+        #[storage(  read  ) ]
+#[  storage(  write)]
+      
+     fn foo(self);
+}   "
+);
+
+fmt_test_item!(
+trait_commented_annotated_fn
+"pub trait MyTrait {
+    /// Doc
+    /// Comment
+    #[storage(read, write)]
+    fn foo(self);
+}",
+
+intermediate_whitespace
+"  pub   trait   MyTrait {
+        /// Doc
+/// Comment
+    #[storage(  read , write) ]
+      
+     fn foo(self);
+}   "
+);


### PR DESCRIPTION
## Description

Closes #4359 
Closes #4360 

Simple fix because we weren't including the attributes into the formatting.


## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
