### PR TITLE
Use a `DeclRef` for the "EnumVariant" variant.

### DIFF
--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -473,9 +473,14 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             connect_struct_declaration(&struct_decl, *decl_id, graph, entry_node, tree_type);
             Ok(leaves.to_vec())
         }
-        EnumDecl { decl_id, .. } | EnumVariantDecl { decl_id, .. } => {
+        EnumDecl { decl_id, .. } => {
             let enum_decl = decl_engine.get_enum(decl_id);
             connect_enum_declaration(&enum_decl, *decl_id, graph, entry_node);
+            Ok(leaves.to_vec())
+        }
+        EnumVariantDecl { enum_ref, .. } => {
+            let enum_decl = decl_engine.get_enum(enum_ref.id());
+            connect_enum_declaration(&enum_decl, *enum_ref.id(), graph, entry_node);
             Ok(leaves.to_vec())
         }
         ImplTrait { decl_id, .. } => {
@@ -2021,11 +2026,11 @@ fn allow_dead_code_ast_node(decl_engine: &DeclEngine, node: &ty::TyAstNode) -> b
                 allow_dead_code(decl_engine.get_enum(decl_id).attributes)
             }
             ty::TyDecl::EnumVariantDecl {
-                decl_id,
+                enum_ref,
                 variant_name,
                 ..
             } => decl_engine
-                .get_enum(decl_id)
+                .get_enum(enum_ref.id())
                 .variants
                 .into_iter()
                 .find(|v| v.name == *variant_name)

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -48,8 +48,7 @@ pub enum TyDecl {
         decl_span: Span,
     },
     EnumVariantDecl {
-        decl_id: DeclId<TyEnumDecl>,
-        subst_list: Template<SubstList>,
+        enum_ref: DeclRefEnum,
         variant_name: Ident,
         variant_decl_span: Span,
     },
@@ -225,11 +224,11 @@ impl HashWithEngines for TyDecl {
                 decl_engine.get(decl_id).hash(state, engines);
             }
             EnumVariantDecl {
-                decl_id,
+                enum_ref,
                 variant_name,
                 ..
             } => {
-                decl_engine.get(decl_id).hash(state, engines);
+                enum_ref.hash(state, engines);
                 variant_name.hash(state);
             }
             ImplTrait { decl_id, .. } => {
@@ -269,10 +268,10 @@ impl SubstTypes for TyDecl {
             } => decl_id.subst(type_mapping, engines),
             EnumDecl {
                 ref mut decl_id, ..
-            }
-            | EnumVariantDecl {
-                ref mut decl_id, ..
             } => decl_id.subst(type_mapping, engines),
+            EnumVariantDecl {
+                ref mut enum_ref, ..
+            } => enum_ref.subst(type_mapping, engines),
             ImplTrait {
                 ref mut decl_id, ..
             } => decl_id.subst(type_mapping, engines),
@@ -305,10 +304,10 @@ impl ReplaceSelfType for TyDecl {
             } => decl_id.replace_self_type(engines, self_type),
             EnumDecl {
                 ref mut decl_id, ..
-            }
-            | EnumVariantDecl {
-                ref mut decl_id, ..
             } => decl_id.replace_self_type(engines, self_type),
+            EnumVariantDecl {
+                ref mut enum_ref, ..
+            } => enum_ref.replace_self_type(engines, self_type),
             ImplTrait {
                 ref mut decl_id, ..
             } => decl_id.replace_self_type(engines, self_type),
@@ -830,8 +829,8 @@ impl TyDecl {
                 let TyEnumDecl { visibility, .. } = decl_engine.get_enum(decl_id);
                 visibility
             }
-            EnumVariantDecl { decl_id, .. } => {
-                let TyEnumDecl { visibility, .. } = decl_engine.get_enum(decl_id);
+            EnumVariantDecl { enum_ref, .. } => {
+                let TyEnumDecl { visibility, .. } = decl_engine.get_enum(enum_ref.id());
                 visibility
             }
             FunctionDecl { decl_id, .. } => {

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -270,8 +270,8 @@ fn type_check_enum(
                 warnings,
                 errors
             );
-            if let TyDecl::EnumVariantDecl { decl_id, .. } = decl {
-                (call_path.suffix.span(), decl_engine.get_enum(&decl_id))
+            if let TyDecl::EnumVariantDecl { enum_ref, .. } = decl {
+                (call_path.suffix.span(), decl_engine.get_enum(enum_ref.id()))
             } else {
                 errors.push(CompileError::EnumNotFound {
                     name: call_path.suffix.clone(),

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -1,4 +1,5 @@
 use crate::{
+    decl_engine::DeclRef,
     engine_threading::Engines,
     error::*,
     language::{
@@ -438,18 +439,23 @@ impl Module {
 
                 if let TyDecl::EnumDecl {
                     decl_id,
-                    subst_list,
+                    subst_list: _,
                     ..
                 } = decl
                 {
                     let enum_decl = decl_engine.get_enum(&decl_id);
+                    let enum_ref = DeclRef::new(
+                        enum_decl.call_path.suffix.clone(),
+                        decl_id,
+                        enum_decl.span(),
+                    );
 
                     if let Some(variant_decl) =
                         enum_decl.variants.iter().find(|v| v.name == *variant_name)
                     {
                         // import it this way.
                         let dst_ns = &mut self[dst];
-                        let add_synonym = |name| {
+                        let mut add_synonym = |name| {
                             if let Some((_, GlobImport::No, _)) = dst_ns.use_synonyms.get(name) {
                                 errors
                                     .push(CompileError::ShadowsOtherSymbol { name: name.clone() });
@@ -460,8 +466,7 @@ impl Module {
                                     src.to_vec(),
                                     GlobImport::No,
                                     TyDecl::EnumVariantDecl {
-                                        decl_id,
-                                        subst_list,
+                                        enum_ref: enum_ref.clone(),
                                         variant_name: variant_name.clone(),
                                         variant_decl_span: variant_decl.span.clone(),
                                     },
@@ -536,11 +541,16 @@ impl Module {
 
                 if let TyDecl::EnumDecl {
                     decl_id,
-                    subst_list,
+                    subst_list: _,
                     ..
                 } = decl
                 {
                     let enum_decl = decl_engine.get_enum(&decl_id);
+                    let enum_ref = DeclRef::new(
+                        enum_decl.call_path.suffix.clone(),
+                        decl_id,
+                        enum_decl.span(),
+                    );
 
                     for variant_decl in enum_decl.variants {
                         let variant_name = variant_decl.name;
@@ -553,8 +563,7 @@ impl Module {
                                 src.to_vec(),
                                 GlobImport::Yes,
                                 TyDecl::EnumVariantDecl {
-                                    decl_id,
-                                    subst_list: subst_list.clone(),
+                                    enum_ref: enum_ref.clone(),
                                     variant_name,
                                     variant_decl_span: variant_decl.span.clone(),
                                 },

--- a/sway-core/src/semantic_analysis/storage_only_types.rs
+++ b/sway-core/src/semantic_analysis/storage_only_types.rs
@@ -264,11 +264,11 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDecl) -> CompileResult<()> {
             }
         }
         ty::TyDecl::EnumVariantDecl {
-            decl_id,
+            enum_ref,
             variant_name,
             ..
         } => {
-            let enum_decl = decl_engine.get_enum(decl_id);
+            let enum_decl = decl_engine.get_enum(enum_ref.id());
             let variant = check!(
                 enum_decl.expect_variant_from_name(variant_name),
                 return err(warnings, errors),

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -360,8 +360,8 @@ impl TypeCheckTypeBinding<ty::TyEnumDecl> for TypeBinding<CallPath> {
         );
 
         // Get a new copy from the declaration engine.
-        let mut new_copy = if let ty::TyDecl::EnumVariantDecl { decl_id, .. } = &unknown_decl {
-            decl_engine.get_enum(decl_id)
+        let mut new_copy = if let ty::TyDecl::EnumVariantDecl { enum_ref, .. } = &unknown_decl {
+            decl_engine.get_enum(enum_ref.id())
         } else {
             // Check to see if this is a enum declaration.
             let enum_ref = check!(


### PR DESCRIPTION
## Description

This PR refactors the "EnumVariant" variant to use a `DeclRef` instead of a separate `DeclId` and `Template<SubstList>`.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
