### PR TITLE
Switch the `cargo-test-lib-std` CI job to use `buildjet-4vcpu-ubuntu-2204` (Speeding up CI ~2X)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
 
   # TODO: Remove this upon merging std tests with the rest of the E2E tests.
   cargo-test-lib-std:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain


### PR DESCRIPTION
`cargo-test-lib-std` is only the job that seems to benefit from the faster runner. This is still quite beneficial though because this job is the bottleneck in our CI. I noticed a reduction from 16min to 8min or so.