### PR TITLE
Add timestamps to LSP logging and filter dep logs

### DIFF
--- a/forc-plugins/forc-client/src/bin/deploy.rs
+++ b/forc-plugins/forc-client/src/bin/deploy.rs
@@ -1,9 +1,12 @@
 use clap::Parser;
-use forc_tracing::init_tracing_subscriber;
+use forc_tracing::{init_tracing_subscriber, TracingSubscriberOptions};
 
 #[tokio::main]
 async fn main() {
-    init_tracing_subscriber(Default::default());
+    init_tracing_subscriber(TracingSubscriberOptions {
+        ansi: Some(true),
+        ..Default::default()
+    });
     let command = forc_client::cmd::Deploy::parse();
     if let Err(err) = forc_client::op::deploy(command).await {
         tracing::error!("Error: {:?}", err);

--- a/forc-plugins/forc-client/src/bin/run.rs
+++ b/forc-plugins/forc-client/src/bin/run.rs
@@ -1,9 +1,12 @@
 use clap::Parser;
-use forc_tracing::init_tracing_subscriber;
+use forc_tracing::{init_tracing_subscriber, TracingSubscriberOptions};
 
 #[tokio::main]
 async fn main() {
-    init_tracing_subscriber(Default::default());
+    init_tracing_subscriber(TracingSubscriberOptions {
+        ansi: Some(true),
+        ..Default::default()
+    });
     let command = forc_client::cmd::Run::parse();
     if let Err(err) = forc_client::op::run(command).await {
         tracing::error!("Error: {:?}", err);

--- a/forc-plugins/forc-client/src/bin/submit.rs
+++ b/forc-plugins/forc-client/src/bin/submit.rs
@@ -1,9 +1,12 @@
 use clap::Parser;
-use forc_tracing::init_tracing_subscriber;
+use forc_tracing::{init_tracing_subscriber, TracingSubscriberOptions};
 
 #[tokio::main]
 async fn main() {
-    init_tracing_subscriber(Default::default());
+    init_tracing_subscriber(TracingSubscriberOptions {
+        ansi: Some(true),
+        ..Default::default()
+    });
     let command = forc_client::cmd::Submit::parse();
     if let Err(err) = forc_client::op::submit(command).await {
         tracing::error!("Error: {:?}", err);

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -13,7 +13,7 @@ use std::{
 use taplo::formatter as taplo_fmt;
 use tracing::{error, info};
 
-use forc_tracing::{init_tracing_subscriber, println_green, println_red};
+use forc_tracing::{init_tracing_subscriber, println_green, println_red, TracingSubscriberOptions};
 use forc_util::{find_manifest_dir, is_sway_file};
 use sway_core::{BuildConfig, BuildTarget};
 use sway_utils::{constants, get_sway_files};
@@ -41,7 +41,10 @@ pub struct App {
 }
 
 fn main() {
-    init_tracing_subscriber(Default::default());
+    init_tracing_subscriber(TracingSubscriberOptions {
+        ansi: Some(true),
+        ..Default::default()
+    });
     if let Err(err) = run() {
         error!("Error: {:?}", err);
         std::process::exit(1);

--- a/forc-tracing/src/lib.rs
+++ b/forc-tracing/src/lib.rs
@@ -110,7 +110,7 @@ pub fn init_tracing_subscriber(options: TracingSubscriberOptions) {
                 return EnvFilter::new(LevelFilter::OFF.to_string());
             }
 
-            // The options level filter only applies to packages prefixed with `forc` and `sway`. This is to filter out
+            // The options level filter only applies to packages prefixed with `forc`, `sway`, or `test`. This is to filter out
             // noisy logs from dependencies. To get all logs, use `RUST_LOG=trace`.
             let env_log_level = env::var("RUST_LOG").unwrap_or(LevelFilter::INFO.to_string());
             EnvFilter::builder().parse_lossy(format!(

--- a/forc-tracing/src/lib.rs
+++ b/forc-tracing/src/lib.rs
@@ -110,12 +110,12 @@ pub fn init_tracing_subscriber(options: TracingSubscriberOptions) {
                 return EnvFilter::new(LevelFilter::OFF.to_string());
             }
 
-            // The options level filter only applies to packages prefixed with `forc`, `sway`, or `test`. This is to filter out
-            // noisy logs from dependencies. To get all logs, use `RUST_LOG=trace`.
+            // The options level filter only applies to packages prefixed with `forc`, `sway`, `test`, or `mdbook-forc-documenter`.
+            // This is to filter out noisy logs from dependencies. To get all logs, use `RUST_LOG=trace`.
             let env_log_level = env::var("RUST_LOG").unwrap_or(LevelFilter::INFO.to_string());
             EnvFilter::builder().parse_lossy(format!(
-                "{},forc={},sway={},test={}",
-                env_log_level, level_filter, level_filter, level_filter
+                "{},forc={},sway={},test={},mdbook-forc-documenter={}",
+                env_log_level, level_filter, level_filter, level_filter, level_filter
             ))
         })
         .unwrap_or_else(|| EnvFilter::builder().from_env_lossy());

--- a/forc-tracing/src/lib.rs
+++ b/forc-tracing/src/lib.rs
@@ -114,8 +114,8 @@ pub fn init_tracing_subscriber(options: TracingSubscriberOptions) {
             // noisy logs from dependencies. To get all logs, use `RUST_LOG=trace`.
             let env_log_level = env::var("RUST_LOG").unwrap_or(LevelFilter::INFO.to_string());
             EnvFilter::builder().parse_lossy(format!(
-                "{},forc={},sway={}",
-                env_log_level, level_filter, level_filter
+                "{},forc={},sway={},test={}",
+                env_log_level, level_filter, level_filter, level_filter
             ))
         })
         .unwrap_or_else(|| EnvFilter::builder().from_env_lossy());

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -84,6 +84,7 @@ pub async fn run_cli() -> Result<()> {
         verbosity: Some(opt.verbose),
         silent: Some(opt.silent),
         log_level: opt.log_level,
+        ansi: Some(true),
         ..Default::default()
     };
 

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -206,6 +206,7 @@ impl LanguageServer for Backend {
             let tracing_options = TracingSubscriberOptions {
                 log_level: Some(config.logging.level),
                 writer_mode: Some(TracingWriterMode::Stderr),
+                display_time: Some(true),
                 ..Default::default()
             };
             init_tracing_subscriber(tracing_options);

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -3,7 +3,7 @@ mod ir_generation;
 
 use anyhow::Result;
 use clap::Parser;
-use forc_tracing::init_tracing_subscriber;
+use forc_tracing::{init_tracing_subscriber, TracingSubscriberOptions};
 use std::str::FromStr;
 use sway_core::BuildTarget;
 use tracing::Instrument;
@@ -66,7 +66,10 @@ pub struct RunConfig {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    init_tracing_subscriber(Default::default());
+    init_tracing_subscriber(TracingSubscriberOptions {
+        ansi: Some(true),
+        ..Default::default()
+    });
 
     // Parse args
     let cli = Cli::parse();


### PR DESCRIPTION
## Description

This PR does a few things to improve logging:
- Provides an option to filter out debug/trace logs from dependencies (any crates not prefixed with `sway`, `forc`, `mdbook-forc-documenter`, or `test`)
- Adds timestamps to LSP logs. This will be useful for tracking down latency between the client and server.
- Adds the option to disable ansi (it does not render well in the VSCode output window, so it's disabled for LSP logs)

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
