### PR TITLE
Fixes unifier generated warning spans.

### DIFF
--- a/sway-core/src/type_system/unify/unifier.rs
+++ b/sway-core/src/type_system/unify/unifier.rs
@@ -4,7 +4,7 @@ use sway_error::{
     type_error::TypeError,
     warning::{CompileWarning, Warning},
 };
-use sway_types::{integer_bits::IntegerBits, Ident, Span, Spanned};
+use sway_types::{integer_bits::IntegerBits, Ident, Span};
 
 use crate::{engine_threading::*, language::ty, type_system::priv_prelude::*};
 
@@ -348,17 +348,13 @@ impl<'a> Unifier<'a> {
         if rn == en && rfs.len() == efs.len() && rtps.len() == etps.len() {
             rfs.iter().zip(efs.iter()).for_each(|(rf, ef)| {
                 append!(
-                    self.unify(rf.type_argument.type_id, ef.type_argument.type_id, &rf.span),
+                    self.unify(rf.type_argument.type_id, ef.type_argument.type_id, span),
                     warnings,
                     errors
                 );
             });
             rtps.iter().zip(etps.iter()).for_each(|(rtp, etp)| {
-                append!(
-                    self.unify(rtp.type_id, etp.type_id, &rtp.name_ident.span()),
-                    warnings,
-                    errors
-                );
+                append!(self.unify(rtp.type_id, etp.type_id, span), warnings, errors);
             });
         } else {
             let (received, expected) = self.assign_args(received, expected);
@@ -387,17 +383,13 @@ impl<'a> Unifier<'a> {
         if rn == en && rvs.len() == evs.len() && rtps.len() == etps.len() {
             rvs.iter().zip(evs.iter()).for_each(|(rv, ev)| {
                 append!(
-                    self.unify(rv.type_argument.type_id, ev.type_argument.type_id, &rv.span),
+                    self.unify(rv.type_argument.type_id, ev.type_argument.type_id, span),
                     warnings,
                     errors
                 );
             });
             rtps.iter().zip(etps.iter()).for_each(|(rtp, etp)| {
-                append!(
-                    self.unify(rtp.type_id, etp.type_id, &rtp.name_ident.span()),
-                    warnings,
-                    errors
-                );
+                append!(self.unify(rtp.type_id, etp.type_id, span), warnings, errors);
             });
         } else {
             let (received, expected) = self.assign_args(received, expected);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_casting/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_casting/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-4FF9192341EE8DE7'
+
+[[package]]
+name = 'implicit_casting'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-4FF9192341EE8DE7'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_casting/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_casting/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+name = "implicit_casting"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_casting/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_casting/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_casting/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_casting/src/main.sw
@@ -1,0 +1,16 @@
+script;
+
+use std::result::*;
+
+struct MyStruct<T> {
+    #[allow(dead_code)]
+    a: T
+}
+
+fn main() -> u64 {
+    let _a: Result<u32, u8> = Result::Ok(5);
+
+    let _b: MyStruct<u32> = MyStruct{ a:5 };
+
+    42
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_casting/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/implicit_casting/test.toml
@@ -1,0 +1,11 @@
+category = "run"
+expected_result = { action = "return", value = 42 }
+validate_abi = true
+
+# check: let _a: Result<u32, u8> = Result::Ok(5);
+# nextln: $()This cast, from integer type of width sixty four to integer type of width thirty two, will lose precision.
+
+# check: let _b: MyStruct<u32> = MyStruct{ a:5 };
+# nextln: $()This cast, from integer type of width sixty four to integer type of width thirty two, will lose precision.
+
+expected_warnings = 2


### PR DESCRIPTION
## Description

Enums and structs unify warning messages were pointing to the declared types.

With these changes the warning messages now point to the place of usage span.

Closes #3584

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
