### PR TITLE
Add the LSP highlighting capability.

### DIFF
--- a/sway-lsp/src/capabilities/code_actions/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/mod.rs
@@ -42,6 +42,7 @@ pub(crate) fn code_actions(
     let (_, token) = session
         .token_map()
         .token_at_position(temp_uri, range.start)?;
+
     let type_engine = session.type_engine.read();
     let decl_engine = session.decl_engine.read();
     let ctx = CodeActionContext {

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
@@ -4,7 +4,7 @@ use tower_lsp::lsp_types::{CodeActionDisabled, Position, Range, Url};
 
 use crate::{
     capabilities::code_actions::{CodeAction, CodeActionContext, CODE_ACTION_NEW_TITLE},
-    core::token::TypedAstToken,
+    core::{token::TypedAstToken, token_map::TokenMapExt},
 };
 
 pub(crate) struct StructNewCodeAction<'a> {
@@ -20,6 +20,7 @@ impl<'a> CodeAction<'a, TyStructDecl> for StructNewCodeAction<'a> {
         // First, find the first impl block for this struct if it exists.
         let existing_impl_decl = ctx
             .tokens
+            .iter()
             .all_references_of_token(ctx.token, ctx.engines)
             .find_map(|(_, token)| {
                 if let Some(TypedAstToken::TypedDeclaration(TyDecl::ImplTrait {

--- a/sway-lsp/src/capabilities/rename.rs
+++ b/sway-lsp/src/capabilities/rename.rs
@@ -2,6 +2,7 @@ use crate::{
     core::{
         session::Session,
         token::{get_range_from_span, SymbolKind, Token, TypedAstToken},
+        token_map::TokenMapExt,
     },
     error::{LanguageServerError, RenameError},
 };
@@ -61,6 +62,7 @@ pub fn rename(
         // otherwise, just find all references of the token in the token map
         session
             .token_map()
+            .iter()
             .all_references_of_token(&token, engines)
             .map(|(ident, _)| ident)
             .collect::<Vec<Ident>>()
@@ -191,6 +193,7 @@ fn find_all_methods_for_decl(
 
     let idents = session
         .token_map()
+        .iter()
         .all_references_of_token(&decl_token, engines)
         .filter_map(|(_, token)| {
             token.typed.as_ref().and_then(|typed| match typed {

--- a/sway-lsp/src/core/mod.rs
+++ b/sway-lsp/src/core/mod.rs
@@ -3,3 +3,4 @@ pub mod session;
 pub(crate) mod sync;
 pub(crate) mod token;
 pub(crate) mod token_map;
+pub(crate) mod token_map_ext;

--- a/sway-lsp/src/core/mod.rs
+++ b/sway-lsp/src/core/mod.rs
@@ -3,4 +3,4 @@ pub mod session;
 pub(crate) mod sync;
 pub(crate) mod token;
 pub(crate) mod token_map;
-pub(crate) mod token_map_ext;
+pub mod token_map_ext;

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -262,7 +262,7 @@ impl Session {
 
         let mut token_ranges: Vec<_> = self
             .token_map
-            .tokens_for_file(&url)
+            .tokens_for_file(url)
             .all_references_of_token(&token, engines)
             .map(|(ident, _)| get_range_from_span(&ident.span()))
             .collect();

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -256,13 +256,23 @@ impl Session {
 
     pub fn token_ranges(&self, url: &Url, position: Position) -> Option<Vec<Range>> {
         let (_, token) = self.token_map.token_at_position(url, position)?;
+        //let tokens = self.token_map.tokens_for_file(url);
+
+
         let te = self.type_engine.read();
         let de = self.decl_engine.read();
         let engines = Engines::new(&te, &de);
+
+        let x = self.token_map.tokens_for_file(&url).iter().self.token_map.all_references_of_token(&token, engines).collect::<Vec<_>>();
+
+
         let mut token_ranges: Vec<_> = self
             .token_map
             .all_references_of_token(&token, engines)
-            .map(|(ident, _)| get_range_from_span(&ident.span()))
+            .map(|(ident, _)| {
+                eprintln!("ident: {:#?}", ident);
+                get_range_from_span(&ident.span())
+            })
             .collect();
         token_ranges.sort_by(|a, b| a.start.line.cmp(&b.start.line));
 

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -9,7 +9,7 @@ use crate::{
         document::TextDocument,
         sync::SyncWorkspace,
         token::{get_range_from_span, TypedAstToken},
-        token_map::TokenMap,
+        token_map::{TokenMap, TokenMapExt},
     },
     error::{DocumentError, LanguageServerError},
     traverse::{
@@ -256,30 +256,18 @@ impl Session {
 
     pub fn token_ranges(&self, url: &Url, position: Position) -> Option<Vec<Range>> {
         let (_, token) = self.token_map.token_at_position(url, position)?;
-        //let tokens = self.token_map.tokens_for_file(url);
-
         let te = self.type_engine.read();
         let de = self.decl_engine.read();
         let engines = Engines::new(&te, &de);
 
-        use crate::core::token_map::TokenMapExt;
-        let x = self
+        let mut token_ranges: Vec<_> = self
             .token_map
             .tokens_for_file(&url)
             .all_references_of_token(&token, engines)
-            .collect::<Vec<_>>();
-
-        let mut token_ranges: Vec<_> = self
-            .token_map
-            .iter()
-            .all_references_of_token(&token, engines)
-            .map(|(ident, _)| {
-                eprintln!("ident: {:#?}", ident);
-                get_range_from_span(&ident.span())
-            })
+            .map(|(ident, _)| get_range_from_span(&ident.span()))
             .collect();
-        token_ranges.sort_by(|a, b| a.start.line.cmp(&b.start.line));
 
+        token_ranges.sort_by(|a, b| a.start.line.cmp(&b.start.line));
         Some(token_ranges)
     }
 

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -258,16 +258,20 @@ impl Session {
         let (_, token) = self.token_map.token_at_position(url, position)?;
         //let tokens = self.token_map.tokens_for_file(url);
 
-
         let te = self.type_engine.read();
         let de = self.decl_engine.read();
         let engines = Engines::new(&te, &de);
 
-        let x = self.token_map.tokens_for_file(&url).iter().self.token_map.all_references_of_token(&token, engines).collect::<Vec<_>>();
-
+        use crate::core::token_map::TokenMapExt;
+        let x = self
+            .token_map
+            .tokens_for_file(&url)
+            .all_references_of_token(&token, engines)
+            .collect::<Vec<_>>();
 
         let mut token_ranges: Vec<_> = self
             .token_map
+            .iter()
             .all_references_of_token(&token, engines)
             .map(|(ident, _)| {
                 eprintln!("ident: {:#?}", ident);

--- a/sway-lsp/src/core/token_map_ext.rs
+++ b/sway-lsp/src/core/token_map_ext.rs
@@ -51,13 +51,13 @@ where
     type Item = (Ident, Token);
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some((ident, token)) = self.iter.next() {
+        for (ident, token) in self.iter.by_ref() {
             let decl_span_to_match = self.token_to_match.declared_token_span(self.engines);
             let is_same_type = decl_span_to_match == token.declared_token_span(self.engines);
             let is_decl_of_token = Some(&ident.span()) == decl_span_to_match.as_ref();
 
             if decl_span_to_match.is_some() && is_same_type || is_decl_of_token {
-                return Some((ident.clone(), token.clone()));
+                return Some((ident, token));
             }
         }
         None

--- a/sway-lsp/src/core/token_map_ext.rs
+++ b/sway-lsp/src/core/token_map_ext.rs
@@ -56,7 +56,7 @@ where
             let is_same_type = decl_span_to_match == token.declared_token_span(self.engines);
             let is_decl_of_token = Some(&ident.span()) == decl_span_to_match.as_ref();
 
-            if is_same_type || is_decl_of_token {
+            if decl_span_to_match.is_some() && is_same_type || is_decl_of_token {
                 return Some((ident.clone(), token.clone()));
             }
         }

--- a/sway-lsp/src/core/token_map_ext.rs
+++ b/sway-lsp/src/core/token_map_ext.rs
@@ -1,0 +1,65 @@
+//! This module provides the `TokenMapExt` trait, which extends iterators over tokens with
+//! additional functionality, such as finding all references of a given token in a TokenMap.
+//!
+//! The `TokenMapExt` trait is implemented for any iterator that yields (Ident, Token) pairs.
+
+use crate::core::token::Token;
+use sway_core::Engines;
+use sway_types::{Ident, Spanned};
+
+/// A trait for extending iterators with the `all_references_of_token` method.
+pub trait TokenMapExt: Sized {
+    /// Find all references in the TokenMap for a given token.
+    ///
+    /// This is useful for the highlighting and renaming LSP capabilities.
+    fn all_references_of_token<'s>(
+        self,
+        token_to_match: &'s Token,
+        engines: Engines<'s>,
+    ) -> AllReferencesOfToken<'s, Self>;
+}
+
+/// Implement `TokenMapExt` for any iterator that yields (Ident, Token) pairs.
+impl<I> TokenMapExt for I
+where
+    I: Iterator<Item = (Ident, Token)>,
+{
+    fn all_references_of_token<'s>(
+        self,
+        token_to_match: &'s Token,
+        engines: Engines<'s>,
+    ) -> AllReferencesOfToken<'s, Self> {
+        AllReferencesOfToken {
+            token_to_match,
+            engines,
+            iter: self,
+        }
+    }
+}
+
+/// A custom iterator that returns all references of a given token.
+pub struct AllReferencesOfToken<'s, I> {
+    token_to_match: &'s Token,
+    engines: Engines<'s>,
+    iter: I,
+}
+
+impl<'s, I> Iterator for AllReferencesOfToken<'s, I>
+where
+    I: Iterator<Item = (Ident, Token)>,
+{
+    type Item = (Ident, Token);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some((ident, token)) = self.iter.next() {
+            let decl_span_to_match = self.token_to_match.declared_token_span(self.engines);
+            let is_same_type = decl_span_to_match == token.declared_token_span(self.engines);
+            let is_decl_of_token = Some(&ident.span()) == decl_span_to_match.as_ref();
+
+            if is_same_type || is_decl_of_token {
+                return Some((ident.clone(), token.clone()));
+            }
+        }
+        None
+    }
+}

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -88,9 +88,30 @@ async fn run_blocking_parse_project(uri: Url, session: Arc<Session>) -> bool {
 /// indicating its support for various language server protocol features.
 pub fn capabilities() -> ServerCapabilities {
     ServerCapabilities {
-        text_document_sync: Some(TextDocumentSyncCapability::Kind(
-            TextDocumentSyncKind::INCREMENTAL,
-        )),
+        code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+        code_lens_provider: Some(CodeLensOptions {
+            resolve_provider: Some(false),
+        }),
+        completion_provider: Some(CompletionOptions {
+            trigger_characters: Some(vec![".".to_string()]),
+            ..Default::default()
+        }),
+        definition_provider: Some(OneOf::Left(true)),
+        document_formatting_provider: Some(OneOf::Left(true)),
+        document_highlight_provider: Some(OneOf::Left(true)),
+        document_symbol_provider: Some(OneOf::Left(true)),
+        execute_command_provider: Some(ExecuteCommandOptions {
+            commands: vec![],
+            ..Default::default()
+        }),
+        hover_provider: Some(HoverProviderCapability::Simple(true)),
+        inlay_hint_provider: Some(OneOf::Left(true)),
+        rename_provider: Some(OneOf::Right(RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: WorkDoneProgressOptions {
+                work_done_progress: Some(true),
+            },
+        })),
         semantic_tokens_provider: Some(
             SemanticTokensOptions {
                 legend: SemanticTokensLegend {
@@ -103,29 +124,9 @@ pub fn capabilities() -> ServerCapabilities {
             }
             .into(),
         ),
-        document_symbol_provider: Some(OneOf::Left(true)),
-        completion_provider: Some(CompletionOptions {
-            trigger_characters: Some(vec![".".to_string()]),
-            ..Default::default()
-        }),
-        document_formatting_provider: Some(OneOf::Left(true)),
-        definition_provider: Some(OneOf::Left(true)),
-        inlay_hint_provider: Some(OneOf::Left(true)),
-        code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
-        code_lens_provider: Some(CodeLensOptions {
-            resolve_provider: Some(false),
-        }),
-        hover_provider: Some(HoverProviderCapability::Simple(true)),
-        rename_provider: Some(OneOf::Right(RenameOptions {
-            prepare_provider: Some(true),
-            work_done_progress_options: WorkDoneProgressOptions {
-                work_done_progress: Some(true),
-            },
-        })),
-        execute_command_provider: Some(ExecuteCommandOptions {
-            commands: vec![],
-            ..Default::default()
-        }),
+        text_document_sync: Some(TextDocumentSyncCapability::Kind(
+            TextDocumentSyncKind::INCREMENTAL,
+        )),
         ..ServerCapabilities::default()
     }
 }

--- a/sway-lsp/tests/fixtures/renaming/src/test_mod.sw
+++ b/sway-lsp/tests/fixtures/renaming/src/test_mod.sw
@@ -19,4 +19,4 @@ pub enum DeepEnum {
     Number: u32,
 }
 
-struct Empty{}
+pub struct Empty{}


### PR DESCRIPTION
## Description
This pull request implements the LSP highlighting capability, which allows for improved code readability. The addition includes:

- Implementing a custom iterator for the `TokenMap`, along with a new associated `TokenMapExt` trait.
- `all_references_of_token` has been implemented as an iterator. This allows us to filter the tokens that are operated on to be only those in the current file. for example.

```rust
self.token_map
    .tokens_for_file(&url)
    .all_references_of_token(&token, engines)
    .map(|(ident, _)| get_range_from_span(&ident.span()))
    .collect();
```

closes #2258

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
