### PR TITLE
U256 c fix

### DIFF
--- a/sway-lib-std/src/u256.sw
+++ b/sway-lib-std/src/u256.sw
@@ -455,10 +455,19 @@ impl core::ops::Multiply for U256 {
                 let result_d_c = self.d.overflowing_mul(other.c);
                 let result_d_d = self.d.overflowing_mul(other.d);
 
+                let (overflow_of_c_to_b_1, mut c) = result_d_d.upper.overflowing_add(result_c_d.lower).into();
+                let (mut overflow_of_c_to_b_2, c) = c.overflowing_add(result_d_c.lower).into();
+
+                let (overflow_of_b_to_a_0, overflow_of_c_to_b_2) = overflow_of_c_to_b_1.overflowing_add(overflow_of_c_to_b_2).into();
+
+                let (overflow_of_b_to_a_1, mut b) = result_b_d.lower.overflowing_add(result_c_d.upper).into();
+                let (overflow_of_b_to_a_2, b) = b.overflowing_add(result_d_c.upper).into();
+                let (overflow_of_b_to_a_3, b) = b.overflowing_add(overflow_of_c_to_b_2).into();
+
                 U256::from((
-                    self.b * other.c + result_b_d.upper,
-                    result_b_d.lower + result_c_d.upper + result_d_c.upper,
-                    result_d_d.upper + result_c_d.lower + result_d_c.lower,
+                    self.b * other.c + result_b_d.upper + overflow_of_b_to_a_3 + overflow_of_b_to_a_2 + overflow_of_b_to_a_1 + overflow_of_b_to_a_0,
+                    b,
+                    c,
                     result_d_d.lower,
                 ))
             } else if other.b != 0 {

--- a/sway-lib-std/src/u256.sw
+++ b/sway-lib-std/src/u256.sw
@@ -4,7 +4,6 @@ use ::assert::assert;
 use ::convert::From;
 use ::result::Result;
 use ::u128::U128;
-use ::logging::log;
 
 /// Left shift a `u64` and preserve the overflow amount if any.
 fn lsh_with_carry(word: u64, shift_amount: u64) -> (u64, u64) {

--- a/sway-lib-std/src/u256.sw
+++ b/sway-lib-std/src/u256.sw
@@ -4,6 +4,7 @@ use ::assert::assert;
 use ::convert::From;
 use ::result::Result;
 use ::u128::U128;
+use ::logging::log;
 
 /// Left shift a `u64` and preserve the overflow amount if any.
 fn lsh_with_carry(word: u64, shift_amount: u64) -> (u64, u64) {
@@ -471,10 +472,19 @@ impl core::ops::Multiply for U256 {
                 let result_d_c = other.d.overflowing_mul(self.c);
                 let result_d_d = other.d.overflowing_mul(self.d);
 
+                let (overflow_of_c_to_b_1, mut c) = result_d_d.upper.overflowing_add(result_c_d.lower).into();
+                let (mut overflow_of_c_to_b_2, c) = c.overflowing_add(result_d_c.lower).into();
+
+                let (overflow_of_b_to_a_0, overflow_of_c_to_b_2) = overflow_of_c_to_b_1.overflowing_add(overflow_of_c_to_b_2).into();
+
+                let (overflow_of_b_to_a_1, mut b) = result_b_d.lower.overflowing_add(result_c_d.upper).into();
+                let (overflow_of_b_to_a_2, b) = b.overflowing_add(result_d_c.upper).into();
+                let (overflow_of_b_to_a_3, b) = b.overflowing_add(overflow_of_c_to_b_2).into();
+
                 U256::from((
-                    other.b * self.c + result_b_d.upper,
-                    result_b_d.lower + result_c_d.upper + result_d_c.upper,
-                    result_d_d.upper + result_c_d.lower + result_d_c.lower,
+                    other.b * self.c + result_b_d.upper + overflow_of_b_to_a_3 + overflow_of_b_to_a_2 + overflow_of_b_to_a_1 + overflow_of_b_to_a_0,
+                    b,
+                    c,
                     result_d_d.lower,
                 ))
             } else {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_mul_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_mul_test/src/main.sw
@@ -39,5 +39,9 @@ fn main() -> bool {
     let expected = U256::from((17, 9666297223066687219, 7425695065611822185, 14699749183737298944));
     assert(product == expected);
 
+    let product_reverse = y * x;
+    let expected_reverse = U256::from((17, 9666297223066687219, 7425695065611822185, 14699749183737298944));
+    assert(product_reverse == expected_reverse);
+
     true
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_mul_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_mul_test/src/main.sw
@@ -35,13 +35,15 @@ fn main() -> bool {
 
     let x = U256::from((0, 0, 0, 11000000000000000000));
     let y = U256::from((0, 29, 7145508105175220139, 13399722918938673152));
-    let product = x * y;
-    let expected = U256::from((17, 9666297223066687219, 7425695065611822185, 14699749183737298944));
-    assert(product == expected);
 
+    let product = x * y;
     let product_reverse = y * x;
-    let expected_reverse = U256::from((17, 9666297223066687219, 7425695065611822185, 14699749183737298944));
-    assert(product_reverse == expected_reverse);
+    
+    let expected = U256::from((17, 9666297223066687219, 7425695065611822185, 14699749183737298944));
+    
+    assert(product == expected);
+    assert(product_reverse == expected);
+    assert(product_reverse == product);
 
     true
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_mul_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u256_mul_test/src/main.sw
@@ -33,5 +33,11 @@ fn main() -> bool {
     let expected = U256::from((0, 43, 480205198502801427, 2874424729911951360));
     assert(sq == expected);
 
+    let x = U256::from((0, 0, 0, 11000000000000000000));
+    let y = U256::from((0, 29, 7145508105175220139, 13399722918938673152));
+    let product = x * y;
+    let expected = U256::from((17, 9666297223066687219, 7425695065611822185, 14699749183737298944));
+    assert(product == expected);
+
     true
 }


### PR DESCRIPTION
## Description

There were issues in `U256` multiplication due to overflowing. Logic is fixed to take this into account

Related issue: https://github.com/FuelLabs/sway/issues/4376

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
