### PR TITLE
chore: deprecate `built_pkgs_with_manifest()`

### DIFF
--- a/forc-plugins/forc-client/src/util/pkg.rs
+++ b/forc-plugins/forc-client/src/util/pkg.rs
@@ -1,59 +1,33 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use forc_pkg::{self as pkg, manifest::ManifestFile, BuildOpts, BuildPlan};
-use pkg::{build_with_options, BuiltPackage, PackageManifestFile};
+use pkg::{build_with_options, BuiltPackage};
 
-#[derive(Clone, Debug)]
-pub struct BuiltPackageWithManifest(Arc<BuiltPackage>, PackageManifestFile);
-
-impl BuiltPackageWithManifest {
-    /// Returns an immutable reference into the Arc<BuiltPackage>.
-    pub fn built_package(&self) -> &Arc<BuiltPackage> {
-        &self.0
-    }
-
-    /// Returns an immutable reference into the PackageManifestFile.
-    pub fn package_manifest_file(&self) -> &PackageManifestFile {
-        &self.1
-    }
-}
-
-pub(crate) fn built_pkgs_with_manifest(
-    path: &Path,
-    build_opts: BuildOpts,
-) -> Result<Vec<BuiltPackageWithManifest>> {
+pub(crate) fn built_pkgs(path: &Path, build_opts: BuildOpts) -> Result<Vec<Arc<BuiltPackage>>> {
     let manifest_file = ManifestFile::from_dir(path)?;
-    let mut member_manifests = manifest_file.member_manifests()?;
     let lock_path = manifest_file.lock_path()?;
     let build_plan = BuildPlan::from_lock_and_manifests(
         &lock_path,
-        &member_manifests,
+        &manifest_file.member_manifests()?,
         build_opts.pkg.locked,
         build_opts.pkg.offline,
     )?;
     let graph = build_plan.graph();
     let built = build_with_options(build_opts)?;
-    let mut built_pkgs: HashMap<&pkg::Pinned, Arc<_>> = built.into_members().collect();
-    let mut pkgs_with_manifest = Vec::new();
+    let mut members: HashMap<&pkg::Pinned, Arc<_>> = built.into_members().collect();
+    let mut built_pkgs = Vec::new();
+
     for member_index in build_plan.member_nodes() {
         let pkg = &graph[member_index];
-        let pkg_name = &pkg.name;
         // Check if the current member is built.
         //
         // For individual members of the workspace, member nodes would be iterating
         // over all the members but only the relevant member would be built.
-        if let Some(built_pkg) = built_pkgs.remove(pkg) {
-            let member_manifest = member_manifests
-                .remove(pkg_name)
-                .expect("Member manifest file is missing");
-            pkgs_with_manifest.push(BuiltPackageWithManifest(built_pkg, member_manifest));
+        if let Some(built_pkg) = members.remove(pkg) {
+            built_pkgs.push(built_pkg);
         }
     }
 
-    if pkgs_with_manifest.is_empty() {
-        bail!("No built packages collected");
-    }
-
-    Ok(pkgs_with_manifest)
+    Ok(built_pkgs)
 }


### PR DESCRIPTION
closes #4374

@kayagokalp rightfully mentioned in the issue that the package descriptor is already contained within the `BuiltPackage` struct, which means we do not need this representation anymore:

> This is a nice abstractions but it made me think a little and I think returning Vec of (PackageManifestFile, Arc<BuiltPackage>) might be unnecessary at the first place from built_pkg_with_manifest function.
> 
> Every built package contains a package descriptor which contains the related package manifest so returning a tuple is kind of a data duplication.

## Description


## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
