### PR TITLE
refactor: Introduce `ForcResult` and `ForcError` to propagate return code with error message 

### DIFF
--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -70,6 +70,19 @@ impl Termination for ForcError {
     }
 }
 
+#[macro_export]
+macro_rules! forc_result_bail {
+    ($msg:literal $(,)?) => {
+        return $crate::ForcResult::Err(anyhow::anyhow!($msg).into())
+    };
+    ($err:expr $(,)?) => {
+        return $crate::ForcResult::Err(anyhow::anyhow!($err).into())
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        return $crate::ForcResult::Err(anyhow::anyhow!($fmt, $($arg)*).into())
+    };
+}
+
 /// Added salt used to derive the contract ID.
 #[derive(Debug, Args, Default, Deserialize, Serialize)]
 pub struct Salt {

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -45,6 +45,15 @@ impl AsRef<anyhow::Error> for ForcError {
     }
 }
 
+impl From<&str> for ForcError {
+    fn from(value: &str) -> Self {
+        Self {
+            error: anyhow::anyhow!("{value}"),
+            exit_code: DEFAULT_ERROR_EXIT_CODE,
+        }
+    }
+}
+
 impl From<anyhow::Error> for ForcError {
     fn from(value: anyhow::Error) -> Self {
         Self {

--- a/forc/src/cli/commands/addr2line.rs
+++ b/forc/src/cli/commands/addr2line.rs
@@ -1,5 +1,6 @@
-use anyhow::{anyhow, Result};
+use anyhow::anyhow;
 use clap::Parser;
+use forc_util::ForcResult;
 use std::collections::VecDeque;
 use std::fs::{self, File};
 use std::io::{self, prelude::*, BufReader};
@@ -30,7 +31,7 @@ pub(crate) struct Command {
     pub opcode_index: usize,
 }
 
-pub(crate) fn exec(command: Command) -> Result<()> {
+pub(crate) fn exec(command: Command) -> ForcResult<()> {
     let contents = fs::read(&command.sourcemap_path)
         .map_err(|err| anyhow!("{:?}: could not read: {:?}", command.sourcemap_path, err))?;
 
@@ -74,7 +75,7 @@ pub(crate) fn exec(command: Command) -> Result<()> {
 
         Ok(())
     } else {
-        Err(anyhow!("Address did not map to any source code location"))
+        Err(anyhow!("Address did not map to any source code location").into())
     }
 }
 

--- a/forc/src/cli/commands/addr2line.rs
+++ b/forc/src/cli/commands/addr2line.rs
@@ -75,7 +75,7 @@ pub(crate) fn exec(command: Command) -> ForcResult<()> {
 
         Ok(())
     } else {
-        Err(anyhow!("Address did not map to any source code location").into())
+        Err("Address did not map to any source code location".into())
     }
 }
 

--- a/forc/src/cli/commands/build.rs
+++ b/forc/src/cli/commands/build.rs
@@ -1,6 +1,6 @@
 use crate::{cli, ops::forc_build};
-use anyhow::Result;
 use clap::Parser;
+use forc_util::ForcResult;
 
 /// Compile the current or target project.
 ///
@@ -25,7 +25,7 @@ pub struct Command {
     pub tests: bool,
 }
 
-pub(crate) fn exec(command: Command) -> Result<()> {
+pub(crate) fn exec(command: Command) -> ForcResult<()> {
     forc_build::build(command)?;
     Ok(())
 }

--- a/forc/src/cli/commands/check.rs
+++ b/forc/src/cli/commands/check.rs
@@ -1,6 +1,6 @@
 use crate::ops::forc_check;
-use anyhow::Result;
 use clap::Parser;
+use forc_util::ForcResult;
 use sway_core::{decl_engine::DeclEngine, BuildTarget, Engines, TypeEngine};
 
 /// Check the current or target project and all of its dependencies for errors.
@@ -31,13 +31,13 @@ pub struct Command {
     pub disable_tests: bool,
 }
 
-pub(crate) fn exec(command: Command) -> Result<()> {
+pub(crate) fn exec(command: Command) -> ForcResult<()> {
     let type_engine = TypeEngine::default();
     let decl_engine = DeclEngine::default();
     let engines = Engines::new(&type_engine, &decl_engine);
     let res = forc_check::check(command, engines)?;
     if !res.is_ok() {
-        anyhow::bail!("unable to type check");
+        return ForcResult::Err(anyhow::anyhow!("unable to type check").into());
     }
     Ok(())
 }

--- a/forc/src/cli/commands/check.rs
+++ b/forc/src/cli/commands/check.rs
@@ -1,6 +1,6 @@
 use crate::ops::forc_check;
 use clap::Parser;
-use forc_util::ForcResult;
+use forc_util::{forc_result_bail, ForcResult};
 use sway_core::{decl_engine::DeclEngine, BuildTarget, Engines, TypeEngine};
 
 /// Check the current or target project and all of its dependencies for errors.
@@ -37,7 +37,7 @@ pub(crate) fn exec(command: Command) -> ForcResult<()> {
     let engines = Engines::new(&type_engine, &decl_engine);
     let res = forc_check::check(command, engines)?;
     if !res.is_ok() {
-        return ForcResult::Err(anyhow::anyhow!("unable to type check").into());
+        forc_result_bail!("unable to type check");
     }
     Ok(())
 }

--- a/forc/src/cli/commands/clean.rs
+++ b/forc/src/cli/commands/clean.rs
@@ -1,6 +1,6 @@
 use crate::ops::forc_clean;
-use anyhow::Result;
 use clap::Parser;
+use forc_util::ForcResult;
 
 /// Removes the default forc compiler output artifact directory, i.e. `<project-name>/out`.
 #[derive(Debug, Parser)]
@@ -10,6 +10,7 @@ pub struct Command {
     pub path: Option<String>,
 }
 
-pub fn exec(command: Command) -> Result<()> {
-    forc_clean::clean(command)
+pub fn exec(command: Command) -> ForcResult<()> {
+    forc_clean::clean(command)?;
+    Ok(())
 }

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
 use clap::Command as ClapCommand;
 use clap::{CommandFactory, Parser};
 use clap_complete::{generate, Generator, Shell};
+use forc_util::ForcResult;
 
 /// Generate tab-completion scripts for your shell
 #[derive(Debug, Parser)]
@@ -15,7 +15,7 @@ pub struct Command {
     shell: Shell,
 }
 
-pub(crate) fn exec(command: Command) -> Result<()> {
+pub(crate) fn exec(command: Command) -> ForcResult<()> {
     let mut cmd = super::super::Opt::command();
     print_completions(command.shell, &mut cmd);
     Ok(())

--- a/forc/src/cli/commands/contract_id.rs
+++ b/forc/src/cli/commands/contract_id.rs
@@ -2,9 +2,8 @@ use crate::{
     cli::shared::{BuildOutput, BuildProfile, Minify, Pkg, Print},
     ops::forc_contract_id,
 };
-use anyhow::Result;
 use clap::Parser;
-use forc_util::Salt;
+use forc_util::{ForcResult, Salt};
 
 /// Determine contract-id for a contract. For workspaces outputs all contract ids in the workspace.
 #[derive(Debug, Parser)]
@@ -23,6 +22,6 @@ pub struct Command {
     pub salt: Salt,
 }
 
-pub(crate) fn exec(cmd: Command) -> Result<()> {
-    forc_contract_id::contract_id(cmd)
+pub(crate) fn exec(cmd: Command) -> ForcResult<()> {
+    forc_contract_id::contract_id(cmd).map_err(|e| e.into())
 }

--- a/forc/src/cli/commands/init.rs
+++ b/forc/src/cli/commands/init.rs
@@ -1,6 +1,6 @@
 use crate::ops::forc_init;
-use anyhow::Result;
 use clap::Parser;
+use forc_util::ForcResult;
 
 /// Create a new Forc project in an existing directory.
 #[derive(Debug, Parser)]
@@ -28,7 +28,7 @@ pub struct Command {
     pub name: Option<String>,
 }
 
-pub(crate) fn exec(command: Command) -> Result<()> {
+pub(crate) fn exec(command: Command) -> ForcResult<()> {
     forc_init::init(command)?;
     Ok(())
 }

--- a/forc/src/cli/commands/new.rs
+++ b/forc/src/cli/commands/new.rs
@@ -1,7 +1,7 @@
 use crate::{cli::init::Command as InitCommand, ops::forc_init::init};
-use anyhow::{anyhow, bail, Result};
+use anyhow::anyhow;
 use clap::Parser;
-use forc_util::validate_name;
+use forc_util::{validate_name, ForcResult};
 use std::path::{Path, PathBuf};
 
 /// Create a new Forc project at `<path>`.
@@ -30,7 +30,7 @@ pub struct Command {
     pub path: String,
 }
 
-pub(crate) fn exec(command: Command) -> Result<()> {
+pub(crate) fn exec(command: Command) -> ForcResult<()> {
     // `forc new` is roughly short-hand for `forc init`, but we create the directory first if it
     // doesn't yet exist. Here we create the directory if it doesn't exist then re-use the existing
     // `forc init` logic.
@@ -60,12 +60,13 @@ pub(crate) fn exec(command: Command) -> Result<()> {
 
     let dir_path = Path::new(&path);
     if dir_path.exists() {
-        bail!(
+        return Err(anyhow::anyhow!(
             "Directory \"{}\" already exists.\nIf you wish to initialise a forc project inside \
             this directory, consider using `forc init --path {}`",
             dir_path.canonicalize()?.display(),
             dir_path.display(),
-        );
+        )
+        .into());
     } else {
         std::fs::create_dir_all(dir_path)?;
     }
@@ -80,5 +81,6 @@ pub(crate) fn exec(command: Command) -> Result<()> {
         name,
     };
 
-    init(init_cmd)
+    init(init_cmd)?;
+    Ok(())
 }

--- a/forc/src/cli/commands/new.rs
+++ b/forc/src/cli/commands/new.rs
@@ -1,7 +1,7 @@
 use crate::{cli::init::Command as InitCommand, ops::forc_init::init};
 use anyhow::anyhow;
 use clap::Parser;
-use forc_util::{validate_name, ForcResult};
+use forc_util::{forc_result_bail, validate_name, ForcResult};
 use std::path::{Path, PathBuf};
 
 /// Create a new Forc project at `<path>`.
@@ -60,13 +60,12 @@ pub(crate) fn exec(command: Command) -> ForcResult<()> {
 
     let dir_path = Path::new(&path);
     if dir_path.exists() {
-        return Err(anyhow::anyhow!(
+        forc_result_bail!(
             "Directory \"{}\" already exists.\nIf you wish to initialise a forc project inside \
             this directory, consider using `forc init --path {}`",
             dir_path.canonicalize()?.display(),
             dir_path.display(),
-        )
-        .into());
+        );
     } else {
         std::fs::create_dir_all(dir_path)?;
     }

--- a/forc/src/cli/commands/parse_bytecode.rs
+++ b/forc/src/cli/commands/parse_bytecode.rs
@@ -1,5 +1,6 @@
-use anyhow::{anyhow, Result};
+use anyhow::anyhow;
 use clap::Parser;
+use forc_util::ForcResult;
 use std::fs::{self, File};
 use std::io::Read;
 use term_table::row::Row;
@@ -12,7 +13,7 @@ pub(crate) struct Command {
     file_path: String,
 }
 
-pub(crate) fn exec(command: Command) -> Result<()> {
+pub(crate) fn exec(command: Command) -> ForcResult<()> {
     let mut f = File::open(&command.file_path)
         .map_err(|_| anyhow!("{}: file not found", command.file_path))?;
     let metadata = fs::metadata(&command.file_path)

--- a/forc/src/cli/commands/plugins.rs
+++ b/forc/src/cli/commands/plugins.rs
@@ -1,6 +1,7 @@
 use crate::cli::PluginsCommand;
-use anyhow::{anyhow, Result};
+use anyhow::anyhow;
 use clap::Parser;
+use forc_util::ForcResult;
 use std::path::{Path, PathBuf};
 use tracing::info;
 
@@ -17,7 +18,7 @@ pub struct Command {
     describe: bool,
 }
 
-pub(crate) fn exec(command: PluginsCommand) -> Result<()> {
+pub(crate) fn exec(command: PluginsCommand) -> ForcResult<()> {
     let PluginsCommand {
         print_full_path,
         describe,
@@ -67,7 +68,7 @@ fn format_print_description(
     path: PathBuf,
     print_full_path: bool,
     describe: bool,
-) -> Result<String> {
+) -> ForcResult<String> {
     let display = if print_full_path {
         path.display().to_string()
     } else {
@@ -93,7 +94,7 @@ fn format_print_description(
 /// paths yielded from plugin::find_all(), as well as that the file names are in valid
 /// unicode format since file names should be prefixed with `forc-`. Should one of these 2
 /// assumptions fail, this function panics.
-fn print_plugin(path: PathBuf, print_full_path: bool, describe: bool) -> Result<String> {
+fn print_plugin(path: PathBuf, print_full_path: bool, describe: bool) -> ForcResult<String> {
     format_print_description(path, print_full_path, describe)
-        .map_err(|e| anyhow!("Could not get plugin info: {}", e))
+        .map_err(|e| anyhow!("Could not get plugin info: {}", e.as_ref()).into())
 }

--- a/forc/src/cli/commands/predicate_root.rs
+++ b/forc/src/cli/commands/predicate_root.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use clap::Parser;
+use forc_util::ForcResult;
 
 pub use crate::cli::shared::{BuildOutput, BuildProfile, Minify, Pkg, Print};
 use crate::ops::forc_predicate_root;
@@ -20,6 +20,6 @@ pub struct Command {
     pub build_profile: BuildProfile,
 }
 
-pub(crate) fn exec(cmd: Command) -> Result<()> {
-    forc_predicate_root::predicate_root(cmd)
+pub(crate) fn exec(cmd: Command) -> ForcResult<()> {
+    forc_predicate_root::predicate_root(cmd).map_err(|e| e.into())
 }

--- a/forc/src/cli/commands/template.rs
+++ b/forc/src/cli/commands/template.rs
@@ -1,6 +1,6 @@
 use crate::ops::forc_template;
-use anyhow::Result;
 use clap::Parser;
+use forc_util::ForcResult;
 
 /// Create a new Forc project from a git template.
 #[derive(Debug, Parser)]
@@ -17,7 +17,7 @@ pub struct Command {
     pub project_name: String,
 }
 
-pub(crate) fn exec(command: Command) -> Result<()> {
+pub(crate) fn exec(command: Command) -> ForcResult<()> {
     forc_template::init(command)?;
     Ok(())
 }

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -3,7 +3,7 @@ use ansi_term::Colour;
 use clap::Parser;
 use forc_pkg as pkg;
 use forc_test::{TestRunnerCount, TestedPackage};
-use forc_util::{format_log_receipts, ForcResult};
+use forc_util::{forc_result_bail, format_log_receipts, ForcResult};
 use tracing::info;
 
 /// Run the Sway unit tests for the current project.
@@ -50,7 +50,7 @@ pub struct TestPrintOpts {
 
 pub(crate) fn exec(cmd: Command) -> ForcResult<()> {
     if let Some(ref _filter) = cmd.filter {
-        return ForcResult::Err(anyhow::anyhow!("unit test filter not yet supported").into());
+        forc_result_bail!("unit test filter not yet supported");
     }
 
     let test_runner_count = match cmd.test_threads {

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -1,10 +1,9 @@
 use crate::cli;
 use ansi_term::Colour;
-use anyhow::{bail, Result};
 use clap::Parser;
 use forc_pkg as pkg;
 use forc_test::{TestRunnerCount, TestedPackage};
-use forc_util::format_log_receipts;
+use forc_util::{format_log_receipts, ForcResult};
 use tracing::info;
 
 /// Run the Sway unit tests for the current project.
@@ -49,9 +48,9 @@ pub struct TestPrintOpts {
     pub print_logs: bool,
 }
 
-pub(crate) fn exec(cmd: Command) -> Result<()> {
+pub(crate) fn exec(cmd: Command) -> ForcResult<()> {
     if let Some(ref _filter) = cmd.filter {
-        bail!("unit test filter not yet supported");
+        return ForcResult::Err(anyhow::anyhow!("unit test filter not yet supported").into());
     }
 
     let test_runner_count = match cmd.test_threads {
@@ -87,11 +86,11 @@ pub(crate) fn exec(cmd: Command) -> Result<()> {
     if all_tests_passed {
         Ok(())
     } else {
-        bail!("Some tests failed")
+        Err(anyhow::anyhow!("Some tests failed.").into())
     }
 }
 
-fn print_tested_pkg(pkg: &TestedPackage, test_print_opts: &TestPrintOpts) -> Result<()> {
+fn print_tested_pkg(pkg: &TestedPackage, test_print_opts: &TestPrintOpts) -> ForcResult<()> {
     let succeeded = pkg.tests.iter().filter(|t| t.passed()).count();
     let failed = pkg.tests.len() - succeeded;
     let mut failed_tests = Vec::new();

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -86,7 +86,7 @@ pub(crate) fn exec(cmd: Command) -> ForcResult<()> {
     if all_tests_passed {
         Ok(())
     } else {
-        Err(anyhow::anyhow!("Some tests failed.").into())
+        Err("Some tests failed.".into())
     }
 }
 

--- a/forc/src/cli/commands/update.rs
+++ b/forc/src/cli/commands/update.rs
@@ -1,6 +1,6 @@
 use crate::ops::forc_update;
-use anyhow::{bail, Result};
 use clap::Parser;
+use forc_util::ForcResult;
 
 /// Update dependencies in the Forc dependencies directory.
 #[derive(Debug, Parser)]
@@ -21,9 +21,9 @@ pub struct Command {
     pub check: bool,
 }
 
-pub(crate) async fn exec(command: Command) -> Result<()> {
+pub(crate) async fn exec(command: Command) -> ForcResult<()> {
     match forc_update::update(command).await {
         Ok(_) => Ok(()),
-        Err(e) => bail!("couldn't update dependencies: {}", e),
+        Err(e) => Err(anyhow::anyhow!("couldn't update dependencies: {}", e).into()),
     }
 }

--- a/forc/src/cli/commands/update.rs
+++ b/forc/src/cli/commands/update.rs
@@ -24,6 +24,8 @@ pub struct Command {
 pub(crate) async fn exec(command: Command) -> ForcResult<()> {
     match forc_update::update(command).await {
         Ok(_) => Ok(()),
-        Err(e) => Err(anyhow::anyhow!("couldn't update dependencies: {}", e).into()),
+        Err(e) => Err(format!("couldn't update dependencies: {}", e)
+            .as_str()
+            .into()),
     }
 }

--- a/forc/src/cli/mod.rs
+++ b/forc/src/cli/mod.rs
@@ -5,7 +5,7 @@ use self::commands::{
     predicate_root, template, test, update,
 };
 use addr2line::Command as Addr2LineCommand;
-use anyhow::{anyhow, Result};
+use anyhow::anyhow;
 pub use build::Command as BuildCommand;
 pub use check::Command as CheckCommand;
 use clap::{Parser, Subcommand};
@@ -13,6 +13,7 @@ pub use clean::Command as CleanCommand;
 pub use completions::Command as CompletionsCommand;
 pub(crate) use contract_id::Command as ContractIdCommand;
 use forc_tracing::{init_tracing_subscriber, TracingSubscriberOptions};
+use forc_util::ForcResult;
 pub use init::Command as InitCommand;
 pub use new::Command as NewCommand;
 use parse_bytecode::Command as ParseBytecodeCommand;
@@ -78,7 +79,7 @@ enum Forc {
     Plugin(Vec<String>),
 }
 
-pub async fn run_cli() -> Result<()> {
+pub async fn run_cli() -> ForcResult<()> {
     let opt = Opt::parse();
     let tracing_options = TracingSubscriberOptions {
         verbosity: Some(opt.verbose),

--- a/forc/src/main.rs
+++ b/forc/src/main.rs
@@ -1,9 +1,6 @@
-use tracing::error;
+use forc_util::ForcResult;
 
 #[tokio::main]
-async fn main() {
-    if let Err(err) = forc::cli::run_cli().await {
-        error!("Error: {:?}", err);
-        std::process::exit(1);
-    }
+async fn main() -> ForcResult<()> {
+    forc::cli::run_cli().await.into()
 }

--- a/forc/src/main.rs
+++ b/forc/src/main.rs
@@ -2,5 +2,5 @@ use forc_util::ForcResult;
 
 #[tokio::main]
 async fn main() -> ForcResult<()> {
-    forc::cli::run_cli().await.into()
+    forc::cli::run_cli().await
 }

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -1,8 +1,8 @@
 use crate::cli::BuildCommand;
-use anyhow::Result;
 use forc_pkg as pkg;
+use forc_util::ForcResult;
 
-pub fn build(cmd: BuildCommand) -> Result<pkg::Built> {
+pub fn build(cmd: BuildCommand) -> ForcResult<pkg::Built> {
     let opts = opts_from_cmd(cmd);
     let built = pkg::build_with_options(opts)?;
     Ok(built)

--- a/forc/src/ops/forc_init.rs
+++ b/forc/src/ops/forc_init.rs
@@ -1,7 +1,7 @@
 use crate::cli::InitCommand;
 use crate::utils::{defaults, program_type::ProgramType};
 use anyhow::Context;
-use forc_util::{validate_name, ForcResult};
+use forc_util::{forc_result_bail, validate_name, ForcResult};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -50,17 +50,17 @@ pub fn init(command: InitCommand) -> ForcResult<()> {
     };
 
     if !project_dir.is_dir() {
-        return Err(
-            anyhow::anyhow!("'{}' is not a valid directory.", project_dir.display()).into(),
-        );
+        forc_result_bail!(format!(
+            "'{}' is not a valid directory.",
+            project_dir.display()
+        ),);
     }
 
     if project_dir.join(constants::MANIFEST_FILE_NAME).exists() {
-        return Err(anyhow::anyhow!(
+        forc_result_bail!(
             "'{}' already includes a Forc.toml file.",
             project_dir.display()
-        )
-        .into());
+        );
     }
 
     debug!(
@@ -92,11 +92,10 @@ pub fn init(command: InitCommand) -> ForcResult<()> {
         (false, false, false, true, false) => InitType::Package(ProgramType::Library),
         (false, false, false, false, true) => InitType::Workspace,
         _ => {
-            return Err(anyhow::anyhow!(
+            forc_result_bail!(
                 "Multiple types detected, please specify only one initialization type: \
         \n Possible Types:\n - contract\n - script\n - predicate\n - library\n - workspace"
             )
-            .into())
         }
     };
 


### PR DESCRIPTION
## Description
closes #4420.

This PR introduces `ForcResult` and `ForcError` which enables us to return with custom exit code via propagating the desired exit code alongside the error message. Using `ForcResult` we can exit with different return code for different cases. Cargo uses similar approach for similar purposes.


## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
