### PR TITLE
Refactor `TyDecl` Enum and Separate Structs for Improved Code Organization

### DIFF
--- a/forc-plugins/forc-doc/src/doc/descriptor.rs
+++ b/forc-plugins/forc-doc/src/doc/descriptor.rs
@@ -9,7 +9,7 @@ use crate::{
 use anyhow::Result;
 use sway_core::{
     decl_engine::*,
-    language::ty::{TyDecl, TyTraitFn, TyTraitInterfaceItem},
+    language::ty::{self, TyTraitFn, TyTraitInterfaceItem},
 };
 
 trait RequiredMethods {
@@ -33,16 +33,14 @@ impl Descriptor {
     /// Decides whether a [TyDecl] is [Descriptor::Documentable].
     pub(crate) fn from_typed_decl(
         decl_engine: &DeclEngine,
-        ty_decl: &TyDecl,
+        ty_decl: &ty::TyDecl,
         module_info: ModuleInfo,
         document_private_items: bool,
     ) -> Result<Self> {
-        const CONTRACT_STORAGE: &str = "Contract Storage";
-
         use swayfmt::parse;
-        use TyDecl::*;
+        const CONTRACT_STORAGE: &str = "Contract Storage";
         match ty_decl {
-            StructDecl { decl_id, .. } => {
+            ty::TyDecl::StructDecl(ty::StructDecl { decl_id, .. }) => {
                 let struct_decl = decl_engine.get_struct(decl_id);
                 if !document_private_items && struct_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
@@ -78,7 +76,7 @@ impl Descriptor {
                     }))
                 }
             }
-            EnumDecl { decl_id, .. } => {
+            ty::TyDecl::EnumDecl(ty::EnumDecl { decl_id, .. }) => {
                 let enum_decl = decl_engine.get_enum(decl_id);
                 if !document_private_items && enum_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
@@ -114,7 +112,7 @@ impl Descriptor {
                     }))
                 }
             }
-            TraitDecl { decl_id, .. } => {
+            ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. }) => {
                 let trait_decl = decl_engine.get_trait(decl_id);
                 if !document_private_items && trait_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
@@ -161,7 +159,7 @@ impl Descriptor {
                     }))
                 }
             }
-            AbiDecl { decl_id, .. } => {
+            ty::TyDecl::AbiDecl(ty::AbiDecl { decl_id, .. }) => {
                 let abi_decl = decl_engine.get_abi(decl_id);
                 let item_name = abi_decl.name;
                 let attrs_opt =
@@ -201,7 +199,7 @@ impl Descriptor {
                     raw_attributes: attrs_opt,
                 }))
             }
-            StorageDecl { decl_id, .. } => {
+            ty::TyDecl::StorageDecl(ty::StorageDecl { decl_id, .. }) => {
                 let storage_decl = decl_engine.get_storage(decl_id);
                 let item_name = sway_types::BaseIdent::new_no_trim(
                     sway_types::span::Span::from_string(CONTRACT_STORAGE.to_string()),
@@ -263,7 +261,7 @@ impl Descriptor {
             //         raw_attributes: None,
             //     }))
             // }
-            FunctionDecl { decl_id, .. } => {
+            ty::TyDecl::FunctionDecl(ty::FunctionDecl { decl_id, .. }) => {
                 let fn_decl = decl_engine.get_function(decl_id);
                 if !document_private_items && fn_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
@@ -293,7 +291,7 @@ impl Descriptor {
                     }))
                 }
             }
-            ConstantDecl { decl_id, .. } => {
+            ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
                 let const_decl = decl_engine.get_constant(decl_id);
                 if !document_private_items && const_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -179,25 +179,24 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
     graph: &mut ControlFlowGraph<'cfg>,
     leaves: &[NodeIndex],
 ) -> Result<Vec<NodeIndex>, CompileError> {
-    use ty::TyDecl::*;
     let decl_engine = engines.de();
     match decl {
-        TraitDecl { .. }
-        | AbiDecl { .. }
-        | StructDecl { .. }
-        | EnumDecl { .. }
-        | EnumVariantDecl { .. }
-        | StorageDecl { .. }
-        | TypeAliasDecl { .. }
-        | GenericTypeForFunctionScope { .. } => Ok(leaves.to_vec()),
-        VariableDecl(_) | ConstantDecl { .. } => {
+        ty::TyDecl::TraitDecl(_)
+        | ty::TyDecl::AbiDecl(_)
+        | ty::TyDecl::StructDecl(_)
+        | ty::TyDecl::EnumDecl(_)
+        | ty::TyDecl::EnumVariantDecl(_)
+        | ty::TyDecl::StorageDecl(_)
+        | ty::TyDecl::TypeAliasDecl(_)
+        | ty::TyDecl::GenericTypeForFunctionScope(_) => Ok(leaves.to_vec()),
+        ty::TyDecl::VariableDecl(_) | ty::TyDecl::ConstantDecl(_) => {
             let entry_node = graph.add_node(ControlFlowGraphNode::from_node(node));
             for leaf in leaves {
                 graph.add_edge(*leaf, entry_node, "".into());
             }
             Ok(vec![entry_node])
         }
-        FunctionDecl { decl_id, .. } => {
+        ty::TyDecl::FunctionDecl(ty::FunctionDecl { decl_id, .. }) => {
             let fn_decl = decl_engine.get_function(decl_id);
             let entry_node = graph.add_node(ControlFlowGraphNode::from_node(node));
             for leaf in leaves {
@@ -206,7 +205,7 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             connect_typed_fn_decl(engines, &fn_decl, graph, entry_node)?;
             Ok(leaves.to_vec())
         }
-        ImplTrait { decl_id, .. } => {
+        ty::TyDecl::ImplTrait(ty::ImplTrait { decl_id, .. }) => {
             let ty::TyImplTrait {
                 trait_name, items, ..
             } = decl_engine.get_impl_trait(decl_id);
@@ -218,7 +217,7 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             connect_impl_trait(engines, &trait_name, graph, &items, entry_node)?;
             Ok(leaves.to_vec())
         }
-        ErrorRecovery(_) => Ok(leaves.to_vec()),
+        ty::TyDecl::ErrorRecovery(_) => Ok(leaves.to_vec()),
     }
 }
 

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -214,7 +214,9 @@ pub(crate) fn compile_constants(
 ) -> Result<(), CompileError> {
     let (type_engine, decl_engine) = engines.unwrap();
     for decl_name in module_ns.get_all_declared_symbols() {
-        if let Some(ty::TyDecl::ConstantDecl { decl_id, .. }) = module_ns.symbols.get(decl_name) {
+        if let Some(ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. })) =
+            module_ns.symbols.get(decl_name)
+        {
             let ty::TyConstantDecl { call_path, .. } = engines.de().get_constant(decl_id);
             compile_const_decl(
                 &mut LookupEnv {
@@ -259,7 +261,7 @@ fn compile_declarations(
     let (type_engine, decl_engine) = engines.unwrap();
     for declaration in declarations {
         match declaration {
-            ty::TyDecl::ConstantDecl { decl_id, .. } => {
+            ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
                 let decl = decl_engine.get_constant(decl_id);
                 compile_const_decl(
                     &mut LookupEnv {

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -105,7 +105,7 @@ pub(crate) fn compile_const_decl(
             // See if we it's a global const and whether we can compile it *now*.
             let decl = module_ns.check_symbol(&call_path.suffix)?;
             let decl_name_value = match decl {
-                ty::TyDecl::ConstantDecl { decl_id, .. } => {
+                ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
                     let ty::TyConstantDecl {
                         call_path,
                         value,

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -160,12 +160,12 @@ impl<'eng> FnCompiler<'eng> {
                 ty::TyDecl::VariableDecl(tvd) => {
                     self.compile_var_decl(context, md_mgr, tvd, span_md_idx)
                 }
-                ty::TyDecl::ConstantDecl { decl_id, .. } => {
+                ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
                     let tcd = self.decl_engine.get_constant(decl_id);
                     self.compile_const_decl(context, md_mgr, &tcd, span_md_idx, false)?;
                     Ok(None)
                 }
-                ty::TyDecl::EnumDecl { decl_id, .. } => {
+                ty::TyDecl::EnumDecl(ty::EnumDecl { decl_id, .. }) => {
                     let ted = self.decl_engine.get_enum(decl_id);
                     create_tagged_union_type(
                         self.type_engine,

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -174,7 +174,10 @@ impl TyAstNode {
         match &self {
             TyAstNode {
                 span: _,
-                content: TyAstNodeContent::Declaration(TyDecl::FunctionDecl { decl_id, .. }),
+                content:
+                    TyAstNodeContent::Declaration(TyDecl::FunctionDecl(FunctionDecl {
+                        decl_id, ..
+                    })),
                 ..
             } => {
                 let TyFunctionDecl {
@@ -191,7 +194,10 @@ impl TyAstNode {
         match &self {
             TyAstNode {
                 span: _,
-                content: TyAstNodeContent::Declaration(TyDecl::FunctionDecl { decl_id, .. }),
+                content:
+                    TyAstNodeContent::Declaration(TyDecl::FunctionDecl(FunctionDecl {
+                        decl_id, ..
+                    })),
                 ..
             } => {
                 let TyFunctionDecl { attributes, .. } = decl_engine.get_function(decl_id);
@@ -208,7 +214,11 @@ impl TyAstNode {
                 match self {
                     TyAstNode {
                         span: _,
-                        content: TyAstNodeContent::Declaration(TyDecl::FunctionDecl { decl_id, .. }),
+                        content:
+                            TyAstNodeContent::Declaration(TyDecl::FunctionDecl(FunctionDecl {
+                                decl_id,
+                                ..
+                            })),
                         ..
                     } => {
                         let decl = decl_engine.get_function(decl_id);
@@ -220,11 +230,11 @@ impl TyAstNode {
             TreeType::Contract | TreeType::Library { .. } => match self {
                 TyAstNode {
                     content:
-                        TyAstNodeContent::Declaration(TyDecl::FunctionDecl {
+                        TyAstNodeContent::Declaration(TyDecl::FunctionDecl(FunctionDecl {
                             decl_id,
                             decl_span: _,
                             ..
-                        }),
+                        })),
                     ..
                 } => {
                     let decl = decl_engine.get_function(decl_id);
@@ -232,15 +242,18 @@ impl TyAstNode {
                 }
                 TyAstNode {
                     content:
-                        TyAstNodeContent::Declaration(TyDecl::TraitDecl {
+                        TyAstNodeContent::Declaration(TyDecl::TraitDecl(TraitDecl {
                             decl_id,
                             decl_span: _,
                             ..
-                        }),
+                        })),
                     ..
                 } => decl_engine.get_trait(decl_id).visibility.is_public(),
                 TyAstNode {
-                    content: TyAstNodeContent::Declaration(TyDecl::StructDecl { decl_id, .. }),
+                    content:
+                        TyAstNodeContent::Declaration(TyDecl::StructDecl(StructDecl {
+                            decl_id, ..
+                        })),
                     ..
                 } => {
                     let struct_decl = decl_engine.get_struct(decl_id);
@@ -252,11 +265,11 @@ impl TyAstNode {
                 } => true,
                 TyAstNode {
                     content:
-                        TyAstNodeContent::Declaration(TyDecl::ConstantDecl {
+                        TyAstNodeContent::Declaration(TyDecl::ConstantDecl(ConstantDecl {
                             decl_id,
                             decl_span: _,
                             ..
-                        }),
+                        })),
                     ..
                 } => {
                     let decl = decl_engine.get_constant(decl_id);

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -18,67 +18,100 @@ use crate::{
 #[derive(Clone, Debug)]
 pub enum TyDecl {
     VariableDecl(Box<TyVariableDecl>),
-    ConstantDecl {
-        name: Ident,
-        decl_id: DeclId<TyConstantDecl>,
-        decl_span: Span,
-    },
-    FunctionDecl {
-        name: Ident,
-        decl_id: DeclId<TyFunctionDecl>,
-        subst_list: Template<SubstList>,
-        decl_span: Span,
-    },
-    TraitDecl {
-        name: Ident,
-        decl_id: DeclId<TyTraitDecl>,
-        subst_list: Template<SubstList>,
-        decl_span: Span,
-    },
-    StructDecl {
-        name: Ident,
-        decl_id: DeclId<TyStructDecl>,
-        subst_list: Template<SubstList>,
-        decl_span: Span,
-    },
-    EnumDecl {
-        name: Ident,
-        decl_id: DeclId<TyEnumDecl>,
-        subst_list: Template<SubstList>,
-        decl_span: Span,
-    },
-    EnumVariantDecl {
-        enum_ref: DeclRefEnum,
-        variant_name: Ident,
-        variant_decl_span: Span,
-    },
-    ImplTrait {
-        name: Ident,
-        decl_id: DeclId<TyImplTrait>,
-        subst_list: Template<SubstList>,
-        decl_span: Span,
-    },
-    AbiDecl {
-        name: Ident,
-        decl_id: DeclId<TyAbiDecl>,
-        decl_span: Span,
-    },
+    ConstantDecl(ConstantDecl),
+    FunctionDecl(FunctionDecl),
+    TraitDecl(TraitDecl),
+    StructDecl(StructDecl),
+    EnumDecl(EnumDecl),
+    EnumVariantDecl(EnumVariantDecl),
+    ImplTrait(ImplTrait),
+    AbiDecl(AbiDecl),
     // If type parameters are defined for a function, they are put in the namespace just for
     // the body of that function.
-    GenericTypeForFunctionScope {
-        name: Ident,
-        type_id: TypeId,
-    },
+    GenericTypeForFunctionScope(GenericTypeForFunctionScope),
     ErrorRecovery(Span),
-    StorageDecl {
-        decl_id: DeclId<TyStorageDecl>,
-        decl_span: Span,
-    },
-    TypeAliasDecl {
-        name: Ident,
-        decl_id: DeclId<TyTypeAliasDecl>,
-        decl_span: Span,
-    },
+    StorageDecl(StorageDecl),
+    TypeAliasDecl(TypeAliasDecl),
+}
+
+#[derive(Clone, Debug)]
+pub struct ConstantDecl {
+    pub name: Ident,
+    pub decl_id: DeclId<TyConstantDecl>,
+    pub decl_span: Span,
+}
+
+#[derive(Clone, Debug)]
+pub struct FunctionDecl {
+    pub name: Ident,
+    pub decl_id: DeclId<TyFunctionDecl>,
+    pub subst_list: Template<SubstList>,
+    pub decl_span: Span,
+}
+
+#[derive(Clone, Debug)]
+pub struct TraitDecl {
+    pub name: Ident,
+    pub decl_id: DeclId<TyTraitDecl>,
+    pub subst_list: Template<SubstList>,
+    pub decl_span: Span,
+}
+
+#[derive(Clone, Debug)]
+pub struct StructDecl {
+    pub name: Ident,
+    pub decl_id: DeclId<TyStructDecl>,
+    pub subst_list: Template<SubstList>,
+    pub decl_span: Span,
+}
+
+#[derive(Clone, Debug)]
+pub struct EnumDecl {
+    pub name: Ident,
+    pub decl_id: DeclId<TyEnumDecl>,
+    pub subst_list: Template<SubstList>,
+    pub decl_span: Span,
+}
+
+#[derive(Clone, Debug)]
+pub struct EnumVariantDecl {
+    pub enum_ref: DeclRefEnum,
+    pub variant_name: Ident,
+    pub variant_decl_span: Span,
+}
+
+#[derive(Clone, Debug)]
+pub struct ImplTrait {
+    pub name: Ident,
+    pub decl_id: DeclId<TyImplTrait>,
+    pub subst_list: Template<SubstList>,
+    pub decl_span: Span,
+}
+
+#[derive(Clone, Debug)]
+pub struct AbiDecl {
+    pub name: Ident,
+    pub decl_id: DeclId<TyAbiDecl>,
+    pub decl_span: Span,
+}
+
+#[derive(Clone, Debug)]
+pub struct GenericTypeForFunctionScope {
+    pub name: Ident,
+    pub type_id: TypeId,
+}
+
+#[derive(Clone, Debug)]
+pub struct StorageDecl {
+    pub decl_id: DeclId<TyStorageDecl>,
+    pub decl_span: Span,
+}
+
+#[derive(Clone, Debug)]
+pub struct TypeAliasDecl {
+    pub name: Ident,
+    pub decl_id: DeclId<TyTypeAliasDecl>,
+    pub decl_span: Span,
 }
 
 impl EqWithEngines for TyDecl {}

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -120,112 +120,110 @@ impl PartialEqWithEngines for TyDecl {
         let decl_engine = engines.de();
         let type_engine = engines.te();
         match (self, other) {
-            (Self::VariableDecl(x), Self::VariableDecl(y)) => x.eq(y, engines),
+            (TyDecl::VariableDecl(x), TyDecl::VariableDecl(y)) => x.eq(y, engines),
             (
-                Self::ConstantDecl {
+                TyDecl::ConstantDecl(ConstantDecl {
                     name: ln,
                     decl_id: lid,
                     ..
-                },
-                Self::ConstantDecl {
+                }),
+                TyDecl::ConstantDecl(ConstantDecl {
                     name: rn,
                     decl_id: rid,
                     ..
-                },
+                }),
             ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
-
             (
-                Self::FunctionDecl {
+                TyDecl::FunctionDecl(FunctionDecl {
                     name: ln,
                     decl_id: lid,
                     ..
-                },
-                Self::FunctionDecl {
+                }),
+                TyDecl::FunctionDecl(FunctionDecl {
                     name: rn,
                     decl_id: rid,
                     ..
-                },
+                }),
             ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
-
             (
-                Self::TraitDecl {
+                TyDecl::TraitDecl(TraitDecl {
                     name: ln,
                     decl_id: lid,
                     ..
-                },
-                Self::TraitDecl {
+                }),
+                TyDecl::TraitDecl(TraitDecl {
                     name: rn,
                     decl_id: rid,
                     ..
-                },
+                }),
             ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
             (
-                Self::StructDecl {
+                TyDecl::StructDecl(StructDecl {
                     name: ln,
                     decl_id: lid,
                     ..
-                },
-                Self::StructDecl {
+                }),
+                TyDecl::StructDecl(StructDecl {
                     name: rn,
                     decl_id: rid,
                     ..
-                },
+                }),
             ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
             (
-                Self::EnumDecl {
+                TyDecl::EnumDecl(EnumDecl {
                     name: ln,
                     decl_id: lid,
                     ..
-                },
-                Self::EnumDecl {
+                }),
+                TyDecl::EnumDecl(EnumDecl {
                     name: rn,
                     decl_id: rid,
                     ..
-                },
+                }),
             ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
             (
-                Self::ImplTrait {
+                TyDecl::ImplTrait(ImplTrait {
                     name: ln,
                     decl_id: lid,
                     ..
-                },
-                Self::ImplTrait {
+                }),
+                TyDecl::ImplTrait(ImplTrait {
                     name: rn,
                     decl_id: rid,
                     ..
-                },
+                }),
             ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
-
             (
-                Self::AbiDecl {
+                TyDecl::AbiDecl(AbiDecl {
                     name: ln,
                     decl_id: lid,
                     ..
-                },
-                Self::AbiDecl {
+                }),
+                TyDecl::AbiDecl(AbiDecl {
                     name: rn,
                     decl_id: rid,
                     ..
-                },
+                }),
             ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
-            (Self::StorageDecl { decl_id: lid, .. }, Self::StorageDecl { decl_id: rid, .. }) => {
-                decl_engine.get(lid).eq(&decl_engine.get(rid), engines)
-            }
             (
-                Self::TypeAliasDecl { decl_id: lid, .. },
-                Self::TypeAliasDecl { decl_id: rid, .. },
+                TyDecl::StorageDecl(StorageDecl { decl_id: lid, .. }),
+                TyDecl::StorageDecl(StorageDecl { decl_id: rid, .. }),
             ) => decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
             (
-                Self::GenericTypeForFunctionScope {
+                TyDecl::TypeAliasDecl(TypeAliasDecl { decl_id: lid, .. }),
+                TyDecl::TypeAliasDecl(TypeAliasDecl { decl_id: rid, .. }),
+            ) => decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
+            (
+                TyDecl::GenericTypeForFunctionScope(GenericTypeForFunctionScope {
                     name: xn,
                     type_id: xti,
-                },
-                Self::GenericTypeForFunctionScope {
+                }),
+                TyDecl::GenericTypeForFunctionScope(GenericTypeForFunctionScope {
                     name: yn,
                     type_id: yti,
-                },
+                }),
             ) => xn == yn && type_engine.get(*xti).eq(&type_engine.get(*yti), engines),
-            (Self::ErrorRecovery(x), Self::ErrorRecovery(y)) => x == y,
+            (TyDecl::ErrorRecovery(x), TyDecl::ErrorRecovery(y)) => x == y,
             _ => false,
         }
     }
@@ -233,138 +231,151 @@ impl PartialEqWithEngines for TyDecl {
 
 impl HashWithEngines for TyDecl {
     fn hash<H: Hasher>(&self, state: &mut H, engines: Engines<'_>) {
-        use TyDecl::*;
         let decl_engine = engines.de();
         let type_engine = engines.te();
         std::mem::discriminant(self).hash(state);
         match self {
-            VariableDecl(decl) => {
+            TyDecl::VariableDecl(decl) => {
                 decl.hash(state, engines);
             }
-            ConstantDecl { decl_id, .. } => {
+            TyDecl::ConstantDecl(ConstantDecl { decl_id, .. }) => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            FunctionDecl { decl_id, .. } => {
+            TyDecl::FunctionDecl(FunctionDecl { decl_id, .. }) => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            TraitDecl { decl_id, .. } => {
+            TyDecl::TraitDecl(TraitDecl { decl_id, .. }) => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            StructDecl { decl_id, .. } => {
+            TyDecl::StructDecl(StructDecl { decl_id, .. }) => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            EnumDecl { decl_id, .. } => {
+            TyDecl::EnumDecl(EnumDecl { decl_id, .. }) => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            EnumVariantDecl {
+            TyDecl::EnumVariantDecl(EnumVariantDecl {
                 enum_ref,
                 variant_name,
                 ..
-            } => {
+            }) => {
                 enum_ref.hash(state, engines);
                 variant_name.hash(state);
             }
-            ImplTrait { decl_id, .. } => {
+            TyDecl::ImplTrait(ImplTrait { decl_id, .. }) => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            AbiDecl { decl_id, .. } => {
+            TyDecl::AbiDecl(AbiDecl { decl_id, .. }) => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            TypeAliasDecl { decl_id, .. } => {
+            TyDecl::TypeAliasDecl(TypeAliasDecl { decl_id, .. }) => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            StorageDecl { decl_id, .. } => {
+            TyDecl::StorageDecl(StorageDecl { decl_id, .. }) => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
-            GenericTypeForFunctionScope { name, type_id } => {
+            TyDecl::GenericTypeForFunctionScope(GenericTypeForFunctionScope { name, type_id }) => {
                 name.hash(state);
                 type_engine.get(*type_id).hash(state, engines);
             }
-            ErrorRecovery(_) => {}
+            TyDecl::ErrorRecovery(_) => {}
         }
     }
 }
 
 impl SubstTypes for TyDecl {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: Engines<'_>) {
-        use TyDecl::*;
         match self {
-            VariableDecl(ref mut var_decl) => var_decl.subst(type_mapping, engines),
-            FunctionDecl {
+            TyDecl::VariableDecl(ref mut var_decl) => var_decl.subst(type_mapping, engines),
+            TyDecl::FunctionDecl(FunctionDecl {
                 ref mut decl_id, ..
-            } => decl_id.subst(type_mapping, engines),
-            TraitDecl {
+            }) => {
+                decl_id.subst(type_mapping, engines);
+            }
+            TyDecl::TraitDecl(TraitDecl {
                 ref mut decl_id, ..
-            } => decl_id.subst(type_mapping, engines),
-            StructDecl {
+            }) => {
+                decl_id.subst(type_mapping, engines);
+            }
+            TyDecl::StructDecl(StructDecl {
                 ref mut decl_id, ..
-            } => decl_id.subst(type_mapping, engines),
-            EnumDecl {
+            }) => {
+                decl_id.subst(type_mapping, engines);
+            }
+            TyDecl::EnumDecl(EnumDecl {
                 ref mut decl_id, ..
-            } => decl_id.subst(type_mapping, engines),
-            EnumVariantDecl {
+            }) => {
+                decl_id.subst(type_mapping, engines);
+            }
+            TyDecl::EnumVariantDecl(EnumVariantDecl {
                 ref mut enum_ref, ..
-            } => enum_ref.subst(type_mapping, engines),
-            ImplTrait {
+            }) => {
+                enum_ref.subst(type_mapping, engines);
+            }
+            TyDecl::ImplTrait(ImplTrait {
                 ref mut decl_id, ..
-            } => decl_id.subst(type_mapping, engines),
-            TypeAliasDecl {
+            }) => {
+                decl_id.subst(type_mapping, engines);
+            }
+            TyDecl::TypeAliasDecl(TypeAliasDecl {
                 ref mut decl_id, ..
-            } => decl_id.subst(type_mapping, engines),
+            }) => {
+                decl_id.subst(type_mapping, engines);
+            }
             // generics in an ABI is unsupported by design
-            AbiDecl { .. }
-            | ConstantDecl { .. }
-            | StorageDecl { .. }
-            | GenericTypeForFunctionScope { .. }
-            | ErrorRecovery(_) => (),
+            TyDecl::AbiDecl(_)
+            | TyDecl::ConstantDecl(_)
+            | TyDecl::StorageDecl(_)
+            | TyDecl::GenericTypeForFunctionScope(_)
+            | TyDecl::ErrorRecovery(_) => (),
         }
     }
 }
 
 impl ReplaceSelfType for TyDecl {
     fn replace_self_type(&mut self, engines: Engines<'_>, self_type: TypeId) {
-        use TyDecl::*;
         match self {
-            VariableDecl(ref mut var_decl) => var_decl.replace_self_type(engines, self_type),
-            FunctionDecl {
+            TyDecl::VariableDecl(ref mut var_decl) => {
+                var_decl.replace_self_type(engines, self_type)
+            }
+            TyDecl::FunctionDecl(FunctionDecl {
                 ref mut decl_id, ..
-            } => decl_id.replace_self_type(engines, self_type),
-            TraitDecl {
+            }) => decl_id.replace_self_type(engines, self_type),
+            TyDecl::TraitDecl(TraitDecl {
                 ref mut decl_id, ..
-            } => decl_id.replace_self_type(engines, self_type),
-            StructDecl {
+            }) => decl_id.replace_self_type(engines, self_type),
+            TyDecl::StructDecl(StructDecl {
                 ref mut decl_id, ..
-            } => decl_id.replace_self_type(engines, self_type),
-            EnumDecl {
+            }) => decl_id.replace_self_type(engines, self_type),
+            TyDecl::EnumDecl(EnumDecl {
                 ref mut decl_id, ..
-            } => decl_id.replace_self_type(engines, self_type),
-            EnumVariantDecl {
+            }) => decl_id.replace_self_type(engines, self_type),
+            TyDecl::EnumVariantDecl(EnumVariantDecl {
                 ref mut enum_ref, ..
-            } => enum_ref.replace_self_type(engines, self_type),
-            ImplTrait {
+            }) => enum_ref.replace_self_type(engines, self_type),
+            TyDecl::ImplTrait(ImplTrait {
                 ref mut decl_id, ..
-            } => decl_id.replace_self_type(engines, self_type),
-            TypeAliasDecl {
+            }) => decl_id.replace_self_type(engines, self_type),
+            TyDecl::TypeAliasDecl(TypeAliasDecl {
                 ref mut decl_id, ..
-            } => decl_id.replace_self_type(engines, self_type),
+            }) => decl_id.replace_self_type(engines, self_type),
             // generics in an ABI is unsupported by design
-            AbiDecl { .. }
-            | ConstantDecl { .. }
-            | StorageDecl { .. }
-            | GenericTypeForFunctionScope { .. }
-            | ErrorRecovery(_) => (),
+            TyDecl::AbiDecl(_)
+            | TyDecl::ConstantDecl(_)
+            | TyDecl::StorageDecl(_)
+            | TyDecl::GenericTypeForFunctionScope(_)
+            | TyDecl::ErrorRecovery(_) => (),
         }
     }
 }
 
 impl TyDecl {
     pub fn get_fun_decl_ref(&self) -> Option<DeclRefFunction> {
-        if let TyDecl::FunctionDecl {
+        if let TyDecl::FunctionDecl(FunctionDecl {
             name,
             decl_id,
             subst_list: _,
             decl_span,
-        } = self
+        }) = self
         {
             Some(DeclRef::new(name.clone(), *decl_id, decl_span.clone()))
         } else {
@@ -375,23 +386,24 @@ impl TyDecl {
 
 impl Spanned for TyDecl {
     fn span(&self) -> Span {
-        use TyDecl::*;
         match self {
-            VariableDecl(decl) => decl.name.span(),
-            FunctionDecl { decl_span, .. }
-            | TraitDecl { decl_span, .. }
-            | ImplTrait { decl_span, .. }
-            | ConstantDecl { decl_span, .. }
-            | StorageDecl { decl_span, .. }
-            | TypeAliasDecl { decl_span, .. }
-            | AbiDecl { decl_span, .. }
-            | StructDecl { decl_span, .. }
-            | EnumDecl { decl_span, .. } => decl_span.clone(),
-            EnumVariantDecl {
+            TyDecl::VariableDecl(decl) => decl.name.span(),
+            TyDecl::FunctionDecl(FunctionDecl { decl_span, .. })
+            | TyDecl::TraitDecl(TraitDecl { decl_span, .. })
+            | TyDecl::ImplTrait(ImplTrait { decl_span, .. })
+            | TyDecl::ConstantDecl(ConstantDecl { decl_span, .. })
+            | TyDecl::StorageDecl(StorageDecl { decl_span, .. })
+            | TyDecl::TypeAliasDecl(TypeAliasDecl { decl_span, .. })
+            | TyDecl::AbiDecl(AbiDecl { decl_span, .. })
+            | TyDecl::StructDecl(StructDecl { decl_span, .. })
+            | TyDecl::EnumDecl(EnumDecl { decl_span, .. }) => decl_span.clone(),
+            TyDecl::EnumVariantDecl(EnumVariantDecl {
                 variant_decl_span, ..
-            } => variant_decl_span.clone(),
-            GenericTypeForFunctionScope { name, .. } => name.span(),
-            ErrorRecovery(span) => span.clone(),
+            }) => variant_decl_span.clone(),
+            TyDecl::GenericTypeForFunctionScope(GenericTypeForFunctionScope { name, .. }) => {
+                name.span()
+            }
+            TyDecl::ErrorRecovery(span) => span.clone(),
         }
     }
 }
@@ -429,10 +441,10 @@ impl DisplayWithEngines for TyDecl {
                     builder.push_str(&engines.help_out(body).to_string());
                     builder
                 }
-                TyDecl::FunctionDecl { name, .. }
-                | TyDecl::TraitDecl { name, .. }
-                | TyDecl::StructDecl { name, .. }
-                | TyDecl::EnumDecl { name, .. } => name.as_str().into(),
+                TyDecl::FunctionDecl(FunctionDecl { name, .. })
+                | TyDecl::TraitDecl(TraitDecl { name, .. })
+                | TyDecl::StructDecl(StructDecl { name, .. })
+                | TyDecl::EnumDecl(EnumDecl { name, .. }) => name.as_str().into(),
                 _ => String::new(),
             }
         )
@@ -474,10 +486,10 @@ impl DebugWithEngines for TyDecl {
                     builder.push_str(format!("{:?}", engines.help_out(body)).as_str());
                     builder
                 }
-                TyDecl::FunctionDecl { name, .. }
-                | TyDecl::TraitDecl { name, .. }
-                | TyDecl::StructDecl { name, .. }
-                | TyDecl::EnumDecl { name, .. } => name.as_str().into(),
+                TyDecl::FunctionDecl(FunctionDecl { name, .. })
+                | TyDecl::TraitDecl(TraitDecl { name, .. })
+                | TyDecl::StructDecl(StructDecl { name, .. })
+                | TyDecl::EnumDecl(EnumDecl { name, .. }) => name.as_str().into(),
                 _ => String::new(),
             }
         )
@@ -490,12 +502,11 @@ impl CollectTypesMetadata for TyDecl {
         &self,
         ctx: &mut CollectTypesMetadataContext,
     ) -> CompileResult<Vec<TypeMetadata>> {
-        use TyDecl::*;
         let mut warnings = vec![];
         let mut errors = vec![];
         let decl_engine = ctx.decl_engine;
         let metadata = match self {
-            VariableDecl(decl) => {
+            TyDecl::VariableDecl(decl) => {
                 let mut body = check!(
                     decl.body.collect_types_metadata(ctx),
                     return err(warnings, errors),
@@ -510,7 +521,7 @@ impl CollectTypesMetadata for TyDecl {
                 ));
                 body
             }
-            FunctionDecl { decl_id, .. } => {
+            TyDecl::FunctionDecl(FunctionDecl { decl_id, .. }) => {
                 let decl = decl_engine.get_function(decl_id);
                 check!(
                     decl.collect_types_metadata(ctx),
@@ -519,7 +530,7 @@ impl CollectTypesMetadata for TyDecl {
                     errors
                 )
             }
-            ConstantDecl { decl_id, .. } => {
+            TyDecl::ConstantDecl(ConstantDecl { decl_id, .. }) => {
                 let TyConstantDecl { value, .. } = decl_engine.get_constant(decl_id);
                 if let Some(value) = value {
                     check!(
@@ -532,16 +543,16 @@ impl CollectTypesMetadata for TyDecl {
                     return ok(vec![], warnings, errors);
                 }
             }
-            ErrorRecovery(_)
-            | StorageDecl { .. }
-            | TraitDecl { .. }
-            | StructDecl { .. }
-            | EnumDecl { .. }
-            | EnumVariantDecl { .. }
-            | ImplTrait { .. }
-            | AbiDecl { .. }
-            | TypeAliasDecl { .. }
-            | GenericTypeForFunctionScope { .. } => vec![],
+            TyDecl::ErrorRecovery(_)
+            | TyDecl::StorageDecl(_)
+            | TyDecl::TraitDecl(_)
+            | TyDecl::StructDecl(_)
+            | TyDecl::EnumDecl(_)
+            | TyDecl::EnumVariantDecl(_)
+            | TyDecl::ImplTrait(_)
+            | TyDecl::AbiDecl(_)
+            | TyDecl::TypeAliasDecl(_)
+            | TyDecl::GenericTypeForFunctionScope(_) => vec![],
         };
         if errors.is_empty() {
             ok(metadata, warnings, errors)
@@ -555,18 +566,20 @@ impl GetDeclIdent for TyDecl {
     fn get_decl_ident(&self) -> Option<Ident> {
         match self {
             TyDecl::VariableDecl(decl) => Some(decl.name.clone()),
-            TyDecl::FunctionDecl { name, .. }
-            | TyDecl::TraitDecl { name, .. }
-            | TyDecl::ConstantDecl { name, .. }
-            | TyDecl::ImplTrait { name, .. }
-            | TyDecl::AbiDecl { name, .. }
-            | TyDecl::TypeAliasDecl { name, .. }
-            | TyDecl::GenericTypeForFunctionScope { name, .. }
-            | TyDecl::StructDecl { name, .. }
-            | TyDecl::EnumDecl { name, .. } => Some(name.clone()),
-            TyDecl::EnumVariantDecl { variant_name, .. } => Some(variant_name.clone()),
+            TyDecl::FunctionDecl(FunctionDecl { name, .. })
+            | TyDecl::TraitDecl(TraitDecl { name, .. })
+            | TyDecl::ConstantDecl(ConstantDecl { name, .. })
+            | TyDecl::ImplTrait(ImplTrait { name, .. })
+            | TyDecl::AbiDecl(AbiDecl { name, .. })
+            | TyDecl::TypeAliasDecl(TypeAliasDecl { name, .. })
+            | TyDecl::GenericTypeForFunctionScope(GenericTypeForFunctionScope { name, .. })
+            | TyDecl::StructDecl(StructDecl { name, .. })
+            | TyDecl::EnumDecl(EnumDecl { name, .. }) => Some(name.clone()),
+            TyDecl::EnumVariantDecl(EnumVariantDecl { variant_name, .. }) => {
+                Some(variant_name.clone())
+            }
             TyDecl::ErrorRecovery(_) => None,
-            TyDecl::StorageDecl { .. } => None,
+            TyDecl::StorageDecl(_) => None,
         }
     }
 }
@@ -577,17 +590,17 @@ impl TyDecl {
     /// Returns an error if `self` is not the [TyDecl][EnumDecl] variant.
     pub(crate) fn to_enum_ref(&self, engines: Engines) -> CompileResult<DeclRefEnum> {
         match self {
-            TyDecl::EnumDecl {
+            TyDecl::EnumDecl(EnumDecl {
                 name,
                 decl_id,
                 subst_list: _,
                 decl_span,
-            } => ok(
+            }) => ok(
                 DeclRef::new(name.clone(), *decl_id, decl_span.clone()),
                 vec![],
                 vec![],
             ),
-            TyDecl::TypeAliasDecl { decl_id, .. } => {
+            TyDecl::TypeAliasDecl(TypeAliasDecl { decl_id, .. }) => {
                 let TyTypeAliasDecl { ty, span, .. } = engines.de().get_type_alias(decl_id);
                 engines.te().get(ty.type_id).expect_enum(engines, "", &span)
             }
@@ -607,17 +620,17 @@ impl TyDecl {
     /// Returns an error if `self` is not the [TyDecl][StructDecl] variant.
     pub(crate) fn to_struct_ref(&self, engines: Engines) -> CompileResult<DeclRefStruct> {
         match self {
-            TyDecl::StructDecl {
+            TyDecl::StructDecl(StructDecl {
                 name,
                 decl_id,
                 subst_list: _,
                 decl_span,
-            } => ok(
+            }) => ok(
                 DeclRef::new(name.clone(), *decl_id, decl_span.clone()),
                 vec![],
                 vec![],
             ),
-            TyDecl::TypeAliasDecl { decl_id, .. } => {
+            TyDecl::TypeAliasDecl(TypeAliasDecl { decl_id, .. }) => {
                 let TyTypeAliasDecl { ty, span, .. } = engines.de().get_type_alias(decl_id);
                 engines.te().get(ty.type_id).expect_struct(engines, &span)
             }
@@ -637,12 +650,12 @@ impl TyDecl {
     /// Returns an error if `self` is not the [TyDecl][FunctionDecl] variant.
     pub(crate) fn to_fn_ref(&self) -> CompileResult<DeclRef<DeclId<TyFunctionDecl>>> {
         match self {
-            TyDecl::FunctionDecl {
+            TyDecl::FunctionDecl(FunctionDecl {
                 name,
                 decl_id,
                 subst_list: _,
                 decl_span,
-            } => ok(
+            }) => ok(
                 DeclRef::new(name.clone(), *decl_id, decl_span.clone()),
                 vec![],
                 vec![],
@@ -682,11 +695,11 @@ impl TyDecl {
     /// Returns an error if `self` is not the [TyDecl][AbiDecl] variant.
     pub(crate) fn to_abi_ref(&self) -> CompileResult<DeclRef<DeclId<TyAbiDecl>>> {
         match self {
-            TyDecl::AbiDecl {
+            TyDecl::AbiDecl(AbiDecl {
                 name,
                 decl_id,
                 decl_span,
-            } => ok(
+            }) => ok(
                 DeclRef::new(name.clone(), *decl_id, decl_span.clone()),
                 vec![],
                 vec![],
@@ -707,11 +720,11 @@ impl TyDecl {
     /// Returns an error if `self` is not the [TyDecl][ConstantDecl] variant.
     pub(crate) fn to_const_ref(&self) -> CompileResult<DeclRef<DeclId<TyConstantDecl>>> {
         match self {
-            TyDecl::ConstantDecl {
+            TyDecl::ConstantDecl(ConstantDecl {
                 name,
                 decl_id,
                 decl_span,
-            } => ok(
+            }) => ok(
                 DeclRef::new(name.clone(), *decl_id, decl_span.clone()),
                 vec![],
                 vec![],
@@ -730,11 +743,10 @@ impl TyDecl {
     /// friendly name string used for error reporting,
     /// which consists of the the identifier for the declaration.
     pub fn friendly_name(&self, engines: &Engines) -> String {
-        use TyDecl::*;
         let decl_engine = engines.de();
         let type_engine = engines.te();
         match self {
-            ImplTrait { decl_id, .. } => {
+            TyDecl::ImplTrait(ImplTrait { decl_id, .. }) => {
                 let decl = decl_engine.get_impl_trait(decl_id);
                 let implementing_for_type_id = type_engine.get(decl.implementing_for.type_id);
                 format!(
@@ -756,18 +768,18 @@ impl TyDecl {
         use TyDecl::*;
         match self {
             VariableDecl(_) => "variable",
-            ConstantDecl { .. } => "constant",
-            FunctionDecl { .. } => "function",
-            TraitDecl { .. } => "trait",
-            StructDecl { .. } => "struct",
-            EnumDecl { .. } => "enum",
-            EnumVariantDecl { .. } => "enum variant",
-            ImplTrait { .. } => "impl trait",
-            AbiDecl { .. } => "abi",
-            GenericTypeForFunctionScope { .. } => "generic type parameter",
+            ConstantDecl(_) => "constant",
+            FunctionDecl(_) => "function",
+            TraitDecl(_) => "trait",
+            StructDecl(_) => "struct",
+            EnumDecl(_) => "enum",
+            EnumVariantDecl(_) => "enum variant",
+            ImplTrait(_) => "impl trait",
+            AbiDecl(_) => "abi",
+            GenericTypeForFunctionScope(_) => "generic type parameter",
             ErrorRecovery(_) => "error",
-            StorageDecl { .. } => "contract storage declaration",
-            TypeAliasDecl { .. } => "type alias declaration",
+            StorageDecl(_) => "contract storage declaration",
+            TypeAliasDecl(_) => "type alias declaration",
         }
     }
 
@@ -775,15 +787,15 @@ impl TyDecl {
     pub fn doc_name(&self) -> &'static str {
         use TyDecl::*;
         match self {
-            StructDecl { .. } => "struct",
-            EnumDecl { .. } => "enum",
-            TraitDecl { .. } => "trait",
-            AbiDecl { .. } => "abi",
-            StorageDecl { .. } => "contract_storage",
-            ImplTrait { .. } => "impl_trait",
-            FunctionDecl { .. } => "fn",
-            ConstantDecl { .. } => "constant",
-            TypeAliasDecl { .. } => "type alias",
+            StructDecl(_) => "struct",
+            EnumDecl(_) => "enum",
+            TraitDecl(_) => "trait",
+            AbiDecl(_) => "abi",
+            StorageDecl(_) => "contract_storage",
+            ImplTrait(_) => "impl_trait",
+            FunctionDecl(_) => "fn",
+            ConstantDecl(_) => "constant",
+            TypeAliasDecl(_) => "type alias",
             _ => unreachable!("these items are non-documentable"),
         }
     }
@@ -795,29 +807,29 @@ impl TyDecl {
         let decl_engine = engines.de();
         let type_id = match self {
             TyDecl::VariableDecl(decl) => decl.body.return_type,
-            TyDecl::FunctionDecl { decl_id, .. } => {
+            TyDecl::FunctionDecl(FunctionDecl { decl_id, .. }) => {
                 let decl = decl_engine.get_function(decl_id);
                 decl.return_type.type_id
             }
-            TyDecl::StructDecl {
+            TyDecl::StructDecl(StructDecl {
                 name,
                 decl_id,
                 subst_list: _,
                 decl_span,
-            } => type_engine.insert(
+            }) => type_engine.insert(
                 decl_engine,
                 TypeInfo::Struct(DeclRef::new(name.clone(), *decl_id, decl_span.clone())),
             ),
-            TyDecl::EnumDecl {
+            TyDecl::EnumDecl(EnumDecl {
                 name,
                 decl_id,
                 subst_list: _,
                 decl_span,
-            } => type_engine.insert(
+            }) => type_engine.insert(
                 decl_engine,
                 TypeInfo::Enum(DeclRef::new(name.clone(), *decl_id, decl_span.clone())),
             ),
-            TyDecl::StorageDecl { decl_id, .. } => {
+            TyDecl::StorageDecl(StorageDecl { decl_id, .. }) => {
                 let storage_decl = decl_engine.get_storage(decl_id);
                 type_engine.insert(
                     decl_engine,
@@ -826,11 +838,13 @@ impl TyDecl {
                     },
                 )
             }
-            TyDecl::TypeAliasDecl { decl_id, .. } => {
+            TyDecl::TypeAliasDecl(TypeAliasDecl { decl_id, .. }) => {
                 let decl = decl_engine.get_type_alias(decl_id);
                 decl.create_type_id(engines)
             }
-            TyDecl::GenericTypeForFunctionScope { type_id, .. } => *type_id,
+            TyDecl::GenericTypeForFunctionScope(GenericTypeForFunctionScope {
+                type_id, ..
+            }) => *type_id,
             decl => {
                 errors.push(CompileError::NotAType {
                     span: decl.span(),
@@ -844,135 +858,134 @@ impl TyDecl {
     }
 
     pub(crate) fn visibility(&self, decl_engine: &DeclEngine) -> Visibility {
-        use TyDecl::*;
         match self {
-            TraitDecl { decl_id, .. } => {
+            TyDecl::TraitDecl(TraitDecl { decl_id, .. }) => {
                 let TyTraitDecl { visibility, .. } = decl_engine.get_trait(decl_id);
                 visibility
             }
-            ConstantDecl { decl_id, .. } => {
+            TyDecl::ConstantDecl(ConstantDecl { decl_id, .. }) => {
                 let TyConstantDecl { visibility, .. } = decl_engine.get_constant(decl_id);
                 visibility
             }
-            StructDecl { decl_id, .. } => {
+            TyDecl::StructDecl(StructDecl { decl_id, .. }) => {
                 let TyStructDecl { visibility, .. } = decl_engine.get_struct(decl_id);
                 visibility
             }
-            EnumDecl { decl_id, .. } => {
+            TyDecl::EnumDecl(EnumDecl { decl_id, .. }) => {
                 let TyEnumDecl { visibility, .. } = decl_engine.get_enum(decl_id);
                 visibility
             }
-            EnumVariantDecl { enum_ref, .. } => {
+            TyDecl::EnumVariantDecl(EnumVariantDecl { enum_ref, .. }) => {
                 let TyEnumDecl { visibility, .. } = decl_engine.get_enum(enum_ref.id());
                 visibility
             }
-            FunctionDecl { decl_id, .. } => {
+            TyDecl::FunctionDecl(FunctionDecl { decl_id, .. }) => {
                 let TyFunctionDecl { visibility, .. } = decl_engine.get_function(decl_id);
                 visibility
             }
-            TypeAliasDecl { decl_id, .. } => {
+            TyDecl::TypeAliasDecl(TypeAliasDecl { decl_id, .. }) => {
                 let TyTypeAliasDecl { visibility, .. } = decl_engine.get_type_alias(decl_id);
                 visibility
             }
-            GenericTypeForFunctionScope { .. }
-            | ImplTrait { .. }
-            | StorageDecl { .. }
-            | AbiDecl { .. }
-            | ErrorRecovery(_) => Visibility::Public,
-            VariableDecl(decl) => decl.mutability.visibility(),
+            TyDecl::GenericTypeForFunctionScope(_)
+            | TyDecl::ImplTrait(_)
+            | TyDecl::StorageDecl(_)
+            | TyDecl::AbiDecl(_)
+            | TyDecl::ErrorRecovery(_) => Visibility::Public,
+            TyDecl::VariableDecl(decl) => decl.mutability.visibility(),
         }
     }
 }
 
 impl From<DeclRef<DeclId<TyConstantDecl>>> for TyDecl {
     fn from(decl_ref: DeclRef<DeclId<TyConstantDecl>>) -> Self {
-        TyDecl::ConstantDecl {
+        TyDecl::ConstantDecl(ConstantDecl {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             decl_span: decl_ref.decl_span().clone(),
-        }
+        })
     }
 }
 
 impl From<DeclRef<DeclId<TyEnumDecl>>> for TyDecl {
     fn from(decl_ref: DeclRef<DeclId<TyEnumDecl>>) -> Self {
-        TyDecl::EnumDecl {
+        TyDecl::EnumDecl(EnumDecl {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             subst_list: Template::new(decl_ref.subst_list().clone()),
             decl_span: decl_ref.decl_span().clone(),
-        }
+        })
     }
 }
 
 impl From<DeclRef<DeclId<TyFunctionDecl>>> for TyDecl {
     fn from(decl_ref: DeclRef<DeclId<TyFunctionDecl>>) -> Self {
-        TyDecl::FunctionDecl {
+        TyDecl::FunctionDecl(FunctionDecl {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             subst_list: Template::new(decl_ref.subst_list().clone()),
             decl_span: decl_ref.decl_span().clone(),
-        }
+        })
     }
 }
 
 impl From<DeclRef<DeclId<TyTraitDecl>>> for TyDecl {
     fn from(decl_ref: DeclRef<DeclId<TyTraitDecl>>) -> Self {
-        TyDecl::TraitDecl {
+        TyDecl::TraitDecl(TraitDecl {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             subst_list: Template::new(decl_ref.subst_list().clone()),
             decl_span: decl_ref.decl_span().clone(),
-        }
+        })
     }
 }
 
 impl From<DeclRef<DeclId<TyImplTrait>>> for TyDecl {
     fn from(decl_ref: DeclRef<DeclId<TyImplTrait>>) -> Self {
-        TyDecl::ImplTrait {
+        TyDecl::ImplTrait(ImplTrait {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             subst_list: Template::new(decl_ref.subst_list().clone()),
             decl_span: decl_ref.decl_span().clone(),
-        }
+        })
     }
 }
 
 impl From<DeclRef<DeclId<TyStructDecl>>> for TyDecl {
     fn from(decl_ref: DeclRef<DeclId<TyStructDecl>>) -> Self {
-        TyDecl::StructDecl {
+        TyDecl::StructDecl(StructDecl {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             subst_list: Template::new(decl_ref.subst_list().clone()),
             decl_span: decl_ref.decl_span().clone(),
-        }
+        })
     }
 }
 
 impl From<DeclRef<DeclId<TyAbiDecl>>> for TyDecl {
     fn from(decl_ref: DeclRef<DeclId<TyAbiDecl>>) -> Self {
-        TyDecl::AbiDecl {
+        TyDecl::AbiDecl(AbiDecl {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             decl_span: decl_ref.decl_span().clone(),
-        }
+        })
     }
 }
 
 impl From<DeclRef<DeclId<TyStorageDecl>>> for TyDecl {
     fn from(decl_ref: DeclRef<DeclId<TyStorageDecl>>) -> Self {
-        TyDecl::StorageDecl {
+        TyDecl::StorageDecl(StorageDecl {
             decl_id: *decl_ref.id(),
             decl_span: decl_ref.decl_span().clone(),
-        }
+        })
     }
 }
 impl From<DeclRef<DeclId<TyTypeAliasDecl>>> for TyDecl {
     fn from(decl_ref: DeclRef<DeclId<TyTypeAliasDecl>>) -> Self {
-        TyDecl::TypeAliasDecl {
+        TyDecl::TypeAliasDecl(TypeAliasDecl {
             name: decl_ref.name().clone(),
             decl_id: *decl_ref.id(),
             decl_span: decl_ref.decl_span().clone(),
-        }
+        })
     }
 }

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -1082,7 +1082,7 @@ fn find_const_decl_from_impl(
     const_decl: &mut Box<TyConstantDecl>,
 ) -> Option<TyConstantDecl> {
     match implementing_type {
-        TyDecl::ImplTrait { decl_id, .. } => {
+        TyDecl::ImplTrait(ImplTrait { decl_id, .. }) => {
             let impl_trait = decl_engine.get_impl_trait(&decl_id.clone());
             impl_trait
                 .items
@@ -1099,9 +1099,9 @@ fn find_const_decl_from_impl(
                     _ => unreachable!(),
                 })
         }
-        TyDecl::AbiDecl {
+        TyDecl::AbiDecl(AbiDecl {
             decl_id: _decl_id, ..
-        } => todo!(),
+        }) => todo!(),
         _ => unreachable!(),
     }
 }

--- a/sway-core/src/language/ty/module.rs
+++ b/sway-core/src/language/ty/module.rs
@@ -49,12 +49,12 @@ impl TyModule {
         decl_engine: &'a DeclEngine,
     ) -> impl '_ + Iterator<Item = (TyFunctionDecl, DeclRefFunction)> {
         self.all_nodes.iter().filter_map(|node| {
-            if let TyAstNodeContent::Declaration(TyDecl::FunctionDecl {
+            if let TyAstNodeContent::Declaration(TyDecl::FunctionDecl(FunctionDecl {
                 decl_id,
                 subst_list: _,
                 name,
                 decl_span,
-            }) = &node.content
+            })) = &node.content
             {
                 let fn_decl = decl_engine.get_function(decl_id);
                 if fn_decl.is_test() {

--- a/sway-core/src/monomorphize/gather/declaration.rs
+++ b/sway-core/src/monomorphize/gather/declaration.rs
@@ -11,24 +11,24 @@ pub(crate) fn gather_from_decl(
         ty::TyDecl::VariableDecl(decl) => {
             gather_from_exp(ctx, handler, &decl.body)?;
         }
-        ty::TyDecl::ConstantDecl { .. } => todo!(),
-        ty::TyDecl::FunctionDecl {
+        ty::TyDecl::ConstantDecl(_) => todo!(),
+        ty::TyDecl::FunctionDecl(ty::FunctionDecl {
             decl_id,
             subst_list,
             ..
-        } => {
+        }) => {
             gather_from_fn_decl(ctx, handler, decl_id, subst_list.inner())?;
         }
-        ty::TyDecl::TraitDecl { .. } => todo!(),
-        ty::TyDecl::StructDecl { .. } => todo!(),
-        ty::TyDecl::EnumDecl { .. } => todo!(),
-        ty::TyDecl::EnumVariantDecl { .. } => todo!(),
-        ty::TyDecl::ImplTrait { .. } => todo!(),
-        ty::TyDecl::AbiDecl { .. } => todo!(),
-        ty::TyDecl::GenericTypeForFunctionScope { .. } => todo!(),
-        ty::TyDecl::StorageDecl { .. } => todo!(),
+        ty::TyDecl::TraitDecl(_) => todo!(),
+        ty::TyDecl::StructDecl(_) => todo!(),
+        ty::TyDecl::EnumDecl(_) => todo!(),
+        ty::TyDecl::EnumVariantDecl(_) => todo!(),
+        ty::TyDecl::ImplTrait(_) => todo!(),
+        ty::TyDecl::AbiDecl(_) => todo!(),
+        ty::TyDecl::GenericTypeForFunctionScope(_) => todo!(),
+        ty::TyDecl::StorageDecl(_) => todo!(),
         ty::TyDecl::ErrorRecovery(_) => {}
-        ty::TyDecl::TypeAliasDecl { .. } => todo!(),
+        ty::TyDecl::TypeAliasDecl(_) => todo!(),
     }
 
     Ok(())

--- a/sway-core/src/monomorphize/instruct/declaration.rs
+++ b/sway-core/src/monomorphize/instruct/declaration.rs
@@ -11,26 +11,25 @@ pub(crate) fn instruct_decl(
         ty::TyDecl::VariableDecl(decl) => {
             instruct_exp(ctx, handler, &decl.body)?;
         }
-        ty::TyDecl::ConstantDecl { .. } => todo!(),
-        ty::TyDecl::FunctionDecl {
+        ty::TyDecl::ConstantDecl(_) => todo!(),
+        ty::TyDecl::FunctionDecl(ty::FunctionDecl {
             decl_id,
             subst_list,
             ..
-        } => {
+        }) => {
             instruct_fn_decl(ctx, handler, decl_id, subst_list.inner())?;
         }
-        ty::TyDecl::TraitDecl { .. } => todo!(),
-        ty::TyDecl::StructDecl { .. } => todo!(),
-        ty::TyDecl::EnumDecl { .. } => todo!(),
-        ty::TyDecl::EnumVariantDecl { .. } => todo!(),
-        ty::TyDecl::ImplTrait { .. } => todo!(),
-        ty::TyDecl::AbiDecl { .. } => todo!(),
-        ty::TyDecl::GenericTypeForFunctionScope { .. } => todo!(),
-        ty::TyDecl::StorageDecl { .. } => todo!(),
+        ty::TyDecl::TraitDecl(_) => todo!(),
+        ty::TyDecl::StructDecl(_) => todo!(),
+        ty::TyDecl::EnumDecl(_) => todo!(),
+        ty::TyDecl::EnumVariantDecl(_) => todo!(),
+        ty::TyDecl::ImplTrait(_) => todo!(),
+        ty::TyDecl::AbiDecl(_) => todo!(),
+        ty::TyDecl::GenericTypeForFunctionScope(_) => todo!(),
+        ty::TyDecl::StorageDecl(_) => todo!(),
         ty::TyDecl::ErrorRecovery(_) => {}
-        ty::TyDecl::TypeAliasDecl { .. } => todo!(),
+        ty::TyDecl::TypeAliasDecl(_) => todo!(),
     }
-
     Ok(())
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -71,12 +71,12 @@ impl ty::TyCodeBlock {
                         .resolve_symbol(&never_mod_path, &never_ident)
                         .value;
 
-                    if let Some(ty::TyDecl::EnumDecl {
+                    if let Some(ty::TyDecl::EnumDecl(ty::EnumDecl {
                         name,
                         decl_id,
                         subst_list: _,
                         decl_span,
-                    }) = never_decl_opt
+                    })) = never_decl_opt
                     {
                         return ctx.engines().te().insert(
                             decl_engine,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -143,12 +143,12 @@ impl ty::TyDecl {
                         .resolve_call_path(&supertrait.name)
                         .cloned()
                         .map(|supertrait_decl| {
-                            if let ty::TyDecl::TraitDecl {
+                            if let ty::TyDecl::TraitDecl(ty::TraitDecl {
                                 name: supertrait_name,
                                 decl_id: supertrait_decl_id,
                                 subst_list: _,
                                 decl_span: supertrait_decl_span,
-                            } = supertrait_decl
+                            }) = supertrait_decl
                             {
                                 supertrait.decl_ref = Some(DeclRef::new(
                                     supertrait_name,
@@ -264,12 +264,12 @@ impl ty::TyDecl {
                         .resolve_call_path(&supertrait.name)
                         .cloned()
                         .map(|supertrait_decl| {
-                            if let ty::TyDecl::TraitDecl {
+                            if let ty::TyDecl::TraitDecl(ty::TraitDecl {
                                 name: supertrait_name,
                                 decl_id: supertrait_decl_id,
                                 subst_list: _,
                                 decl_span: supertrait_decl_span,
-                            } = supertrait_decl
+                            }) = supertrait_decl
                             {
                                 supertrait.decl_ref = Some(DeclRef::new(
                                     supertrait_name,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -105,7 +105,7 @@ impl ty::TyImplTrait {
             .ok(&mut warnings, &mut errors)
             .cloned()
         {
-            Some(ty::TyDecl::TraitDecl { decl_id, .. }) => {
+            Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
                 let mut trait_decl = decl_engine.get_trait(&decl_id);
 
                 // monomorphize the trait declaration
@@ -153,7 +153,7 @@ impl ty::TyImplTrait {
                     implementing_for,
                 }
             }
-            Some(ty::TyDecl::AbiDecl { decl_id, .. }) => {
+            Some(ty::TyDecl::AbiDecl(ty::AbiDecl { decl_id, .. })) => {
                 // if you are comparing this with the `impl_trait` branch above, note that
                 // there are no type arguments here because we don't support generic types
                 // in contract ABIs yet (or ever?) due to the complexity of communicating
@@ -362,7 +362,7 @@ impl ty::TyImplTrait {
                 ty::TyDecl::VariableDecl(decl) => {
                     expr_contains_get_storage_index(decl_engine, &decl.body, access_span)
                 }
-                ty::TyDecl::ConstantDecl { decl_id, .. } => {
+                ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
                     let ty::TyConstantDecl { value: expr, .. } = decl_engine.get_constant(decl_id);
                     match expr {
                         Some(expr) => {
@@ -537,11 +537,11 @@ impl ty::TyImplTrait {
                     check!(
                         ctx.namespace.insert_symbol(
                             decl_ref.name().clone(),
-                            ty::TyDecl::ConstantDecl {
+                            ty::TyDecl::ConstantDecl(ty::ConstantDecl {
                                 name: decl_ref.name().clone(),
                                 decl_id: *decl_ref.id(),
                                 decl_span: decl_ref.span().clone()
-                            }
+                            })
                         ),
                         return err(warnings, errors),
                         warnings,
@@ -1273,7 +1273,7 @@ fn handle_supertraits(
             .ok(&mut warnings, &mut errors)
             .cloned()
         {
-            Some(ty::TyDecl::TraitDecl { decl_id, .. }) => {
+            Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
                 let trait_decl = decl_engine.get_trait(&decl_id);
 
                 // Right now we don't parse type arguments for supertraits, so

--- a/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
@@ -39,7 +39,7 @@ pub(crate) fn insert_supertraits_into_namespace(
             .ok(&mut warnings, &mut errors)
             .cloned()
         {
-            Some(ty::TyDecl::TraitDecl { decl_id, .. }) => {
+            Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
                 let mut trait_decl = decl_engine.get_trait(&decl_id);
 
                 // Right now we don't parse type arguments for supertraits, so

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -110,11 +110,11 @@ impl ty::TyTraitDecl {
                     check!(
                         ctx.namespace.insert_symbol(
                             const_name.clone(),
-                            ty::TyDecl::ConstantDecl {
+                            ty::TyDecl::ConstantDecl(ty::ConstantDecl {
                                 name: const_name.clone(),
                                 decl_id: *decl_ref.id(),
                                 decl_span: const_decl.span.clone()
-                            }
+                            })
                         ),
                         return err(warnings, errors),
                         warnings,
@@ -366,11 +366,11 @@ impl ty::TyTraitDecl {
                     let const_name = const_decl.call_path.suffix.clone();
                     ctx.namespace.insert_symbol(
                         const_name.clone(),
-                        ty::TyDecl::ConstantDecl {
+                        ty::TyDecl::ConstantDecl(ty::ConstantDecl {
                             name: const_name,
                             decl_id: *decl_ref.id(),
                             decl_span: const_decl.span.clone(),
-                        },
+                        }),
                     );
                 }
             }

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -75,7 +75,7 @@ fn type_check_variable(
 
     let typed_scrutinee = match ctx.namespace.resolve_symbol(&name).value {
         // If this variable is a constant, then we turn it into a [TyScrutinee::Constant](ty::TyScrutinee::Constant).
-        Some(ty::TyDecl::ConstantDecl { decl_id, .. }) => {
+        Some(ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. })) => {
             let constant_decl = decl_engine.get_constant(decl_id);
             let value = match constant_decl.value {
                 Some(ref value) => value,
@@ -270,7 +270,7 @@ fn type_check_enum(
                 warnings,
                 errors
             );
-            if let TyDecl::EnumVariantDecl { enum_ref, .. } = decl {
+            if let TyDecl::EnumVariantDecl(ty::EnumVariantDecl { enum_ref, .. }) = decl {
                 (call_path.suffix.span(), decl_engine.get_enum(enum_ref.id()))
             } else {
                 errors.push(CompileError::EnumNotFound {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -408,7 +408,7 @@ impl ty::TyExpression {
                     span,
                 }
             }
-            Some(ty::TyDecl::ConstantDecl { decl_id, .. }) => {
+            Some(ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. })) => {
                 let const_decl = decl_engine.get_constant(decl_id);
                 let decl_name = const_decl.name().clone();
                 ty::TyExpression {
@@ -421,7 +421,7 @@ impl ty::TyExpression {
                     span,
                 }
             }
-            Some(ty::TyDecl::AbiDecl { decl_id, .. }) => {
+            Some(ty::TyDecl::AbiDecl(ty::AbiDecl { decl_id, .. })) => {
                 let decl = decl_engine.get_abi(decl_id);
                 ty::TyExpression {
                     return_type: decl.create_type_id(engines),
@@ -1382,11 +1382,11 @@ impl ty::TyExpression {
             errors
         );
         let abi_ref = match abi {
-            ty::TyDecl::AbiDecl {
+            ty::TyDecl::AbiDecl(ty::AbiDecl {
                 name,
                 decl_id,
                 decl_span,
-            } => DeclRef::new(name, decl_id, decl_span),
+            }) => DeclRef::new(name, decl_id, decl_span),
             ty::TyDecl::VariableDecl(ref decl) => {
                 let ty::TyVariableDecl { body: expr, .. } = &**decl;
                 let ret_ty = type_engine.get(expr.return_type);

--- a/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
+++ b/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
@@ -98,10 +98,10 @@ fn contract_entry_points(
     ast_nodes
         .iter()
         .flat_map(|ast_node| match &ast_node.content {
-            Declaration(ty::TyDecl::FunctionDecl { decl_id, .. }) => {
+            Declaration(ty::TyDecl::FunctionDecl(ty::FunctionDecl { decl_id, .. })) => {
                 decl_id_to_fn_decls(decl_engine, decl_id)
             }
-            Declaration(ty::TyDecl::ImplTrait { decl_id, .. }) => {
+            Declaration(ty::TyDecl::ImplTrait(ty::ImplTrait { decl_id, .. })) => {
                 impl_trait_methods(decl_engine, decl_id)
             }
             _ => vec![],

--- a/sway-core/src/semantic_analysis/coins_analysis.rs
+++ b/sway-core/src/semantic_analysis/coins_analysis.rs
@@ -25,7 +25,7 @@ pub fn possibly_nonzero_u64_expression(
                         ty::TyDecl::VariableDecl(var_decl) => {
                             possibly_nonzero_u64_expression(namespace, decl_engine, &var_decl.body)
                         }
-                        ty::TyDecl::ConstantDecl { decl_id, .. } => {
+                        ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
                             let const_decl = decl_engine.get_constant(decl_id);
                             match const_decl.value {
                                 Some(value) => {

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -437,11 +437,11 @@ impl Module {
                     });
                 }
 
-                if let TyDecl::EnumDecl {
+                if let TyDecl::EnumDecl(ty::EnumDecl {
                     decl_id,
                     subst_list: _,
                     ..
-                } = decl
+                }) = decl
                 {
                     let enum_decl = decl_engine.get_enum(&decl_id);
                     let enum_ref = DeclRef::new(
@@ -465,11 +465,11 @@ impl Module {
                                 (
                                     src.to_vec(),
                                     GlobImport::No,
-                                    TyDecl::EnumVariantDecl {
+                                    TyDecl::EnumVariantDecl(ty::EnumVariantDecl {
                                         enum_ref: enum_ref.clone(),
                                         variant_name: variant_name.clone(),
                                         variant_decl_span: variant_decl.span.clone(),
-                                    },
+                                    }),
                                 ),
                             );
                         };
@@ -539,11 +539,11 @@ impl Module {
                     });
                 }
 
-                if let TyDecl::EnumDecl {
+                if let TyDecl::EnumDecl(ty::EnumDecl {
                     decl_id,
                     subst_list: _,
                     ..
-                } = decl
+                }) = decl
                 {
                     let enum_decl = decl_engine.get_enum(&decl_id);
                     let enum_ref = DeclRef::new(
@@ -562,11 +562,11 @@ impl Module {
                             (
                                 src.to_vec(),
                                 GlobImport::Yes,
-                                TyDecl::EnumVariantDecl {
+                                TyDecl::EnumVariantDecl(ty::EnumVariantDecl {
                                     enum_ref: enum_ref.clone(),
                                     variant_name,
                                     variant_decl_span: variant_decl.span.clone(),
-                                },
+                                }),
                             ),
                         );
                     }

--- a/sway-core/src/semantic_analysis/program.rs
+++ b/sway-core/src/semantic_analysis/program.rs
@@ -68,11 +68,11 @@ impl ty::TyProgram {
 
                 // Expecting at most a single storage declaration
                 match storage_decl {
-                    Some(ty::TyDecl::StorageDecl {
+                    Some(ty::TyDecl::StorageDecl(ty::StorageDecl {
                         decl_id,
                         decl_span: _,
                         ..
-                    }) => {
+                    })) => {
                         let decl = decl_engine.get_storage(decl_id);
                         let mut storage_slots = check!(
                             decl.get_initialized_storage_slots(

--- a/sway-core/src/semantic_analysis/storage_only_types.rs
+++ b/sway-core/src/semantic_analysis/storage_only_types.rs
@@ -189,7 +189,7 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDecl) -> CompileResult<()> {
             );
             check!(expr_validate(engines, &decl.body), (), warnings, errors)
         }
-        ty::TyDecl::ConstantDecl { decl_id, .. } => {
+        ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
             check!(
                 validate_const_decl(engines, decl_id),
                 return err(warnings, errors),
@@ -197,7 +197,7 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDecl) -> CompileResult<()> {
                 errors
             );
         }
-        ty::TyDecl::FunctionDecl { decl_id, .. } => {
+        ty::TyDecl::FunctionDecl(ty::FunctionDecl { decl_id, .. }) => {
             check!(
                 validate_fn_decl(engines, decl_id),
                 return err(warnings, errors),
@@ -205,10 +205,10 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDecl) -> CompileResult<()> {
                 errors
             );
         }
-        ty::TyDecl::AbiDecl { .. } | ty::TyDecl::TraitDecl { .. } => {
+        ty::TyDecl::AbiDecl(_) | ty::TyDecl::TraitDecl(_) => {
             // These methods are not typed. They are however handled from ImplTrait.
         }
-        ty::TyDecl::ImplTrait { decl_id, .. } => {
+        ty::TyDecl::ImplTrait(ty::ImplTrait { decl_id, .. }) => {
             let ty::TyImplTrait { items, .. } = decl_engine.get_impl_trait(decl_id);
             for item in items {
                 match item {
@@ -231,7 +231,7 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDecl) -> CompileResult<()> {
                 }
             }
         }
-        ty::TyDecl::StructDecl { decl_id, .. } => {
+        ty::TyDecl::StructDecl(ty::StructDecl { decl_id, .. }) => {
             let ty::TyStructDecl { fields, .. } = decl_engine.get_struct(decl_id);
             for field in fields {
                 check!(
@@ -247,7 +247,7 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDecl) -> CompileResult<()> {
                 );
             }
         }
-        ty::TyDecl::EnumDecl { decl_id, .. } => {
+        ty::TyDecl::EnumDecl(ty::EnumDecl { decl_id, .. }) => {
             let ty::TyEnumDecl { variants, .. } = decl_engine.get_enum(decl_id);
             for variant in variants {
                 check!(
@@ -263,11 +263,11 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDecl) -> CompileResult<()> {
                 );
             }
         }
-        ty::TyDecl::EnumVariantDecl {
+        ty::TyDecl::EnumVariantDecl(ty::EnumVariantDecl {
             enum_ref,
             variant_name,
             ..
-        } => {
+        }) => {
             let enum_decl = decl_engine.get_enum(enum_ref.id());
             let variant = check!(
                 enum_decl.expect_variant_from_name(variant_name),
@@ -287,10 +287,10 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDecl) -> CompileResult<()> {
                 errors
             );
         }
-        ty::TyDecl::StorageDecl {
+        ty::TyDecl::StorageDecl(ty::StorageDecl {
             decl_id,
             decl_span: _,
-        } => {
+        }) => {
             let ty::TyStorageDecl { fields, .. } = decl_engine.get_storage(decl_id);
             for field in fields {
                 check!(
@@ -306,7 +306,7 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDecl) -> CompileResult<()> {
                 );
             }
         }
-        ty::TyDecl::TypeAliasDecl { decl_id, .. } => {
+        ty::TyDecl::TypeAliasDecl(ty::TypeAliasDecl { decl_id, .. }) => {
             let ty::TyTypeAliasDecl { ty, span, .. } = decl_engine.get_type_alias(decl_id);
             check!(
                 check_type(engines, ty.type_id, span, false),
@@ -315,7 +315,7 @@ fn decl_validate(engines: Engines<'_>, decl: &ty::TyDecl) -> CompileResult<()> {
                 errors
             );
         }
-        ty::TyDecl::GenericTypeForFunctionScope { .. } | ty::TyDecl::ErrorRecovery(_) => {}
+        ty::TyDecl::GenericTypeForFunctionScope(_) | ty::TyDecl::ErrorRecovery(_) => {}
     }
     if errors.is_empty() {
         ok((), warnings, errors)

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -360,7 +360,11 @@ impl TypeCheckTypeBinding<ty::TyEnumDecl> for TypeBinding<CallPath> {
         );
 
         // Get a new copy from the declaration engine.
-        let mut new_copy = if let ty::TyDecl::EnumVariantDecl { enum_ref, .. } = &unknown_decl {
+        let mut new_copy = if let ty::TyDecl::EnumVariantDecl(ty::EnumVariantDecl {
+            enum_ref,
+            ..
+        }) = &unknown_decl
+        {
             decl_engine.get_enum(enum_ref.id())
         } else {
             // Check to see if this is a enum declaration.

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -189,7 +189,7 @@ impl TraitConstraint {
             .ok(&mut warnings, &mut errors)
             .cloned()
         {
-            Some(ty::TyDecl::TraitDecl { decl_id, .. }) => {
+            Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
                 let mut trait_decl = decl_engine.get_trait(&decl_id);
 
                 // Monomorphize the trait declaration.

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -208,10 +208,11 @@ impl TypeParameter {
 
         // Insert the type parameter into the namespace as a dummy type
         // declaration.
-        let type_parameter_decl = ty::TyDecl::GenericTypeForFunctionScope {
-            name: name_ident.clone(),
-            type_id,
-        };
+        let type_parameter_decl =
+            ty::TyDecl::GenericTypeForFunctionScope(ty::GenericTypeForFunctionScope {
+                name: name_ident.clone(),
+                type_id,
+            });
         ctx.namespace
             .insert_symbol(name_ident.clone(), type_parameter_decl)
             .ok(&mut warnings, &mut errors);
@@ -313,7 +314,7 @@ fn handle_trait(
         .ok(&mut warnings, &mut errors)
         .cloned()
     {
-        Some(ty::TyDecl::TraitDecl { decl_id, .. }) => {
+        Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
             let trait_decl = decl_engine.get_trait(&decl_id);
 
             let (trait_interface_item_refs, trait_item_refs, trait_impld_item_refs) = trait_decl

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -314,10 +314,10 @@ impl TypeEngine {
                     .ok(&mut warnings, &mut errors)
                     .cloned()
                 {
-                    Some(ty::TyDecl::StructDecl {
+                    Some(ty::TyDecl::StructDecl(ty::StructDecl {
                         decl_id: original_id,
                         ..
-                    }) => {
+                    })) => {
                         // get the copy from the declaration engine
                         let mut new_copy = decl_engine.get_struct(&original_id);
 
@@ -351,10 +351,10 @@ impl TypeEngine {
                         // return the id
                         type_id
                     }
-                    Some(ty::TyDecl::EnumDecl {
+                    Some(ty::TyDecl::EnumDecl(ty::EnumDecl {
                         decl_id: original_id,
                         ..
-                    }) => {
+                    })) => {
                         // get the copy from the declaration engine
                         let mut new_copy = decl_engine.get_enum(&original_id);
 
@@ -388,10 +388,10 @@ impl TypeEngine {
                         // return the id
                         type_id
                     }
-                    Some(ty::TyDecl::TypeAliasDecl {
+                    Some(ty::TyDecl::TypeAliasDecl(ty::TypeAliasDecl {
                         decl_id: original_id,
                         ..
-                    }) => {
+                    })) => {
                         let new_copy = decl_engine.get_type_alias(&original_id);
 
                         // TODO: monomorphize the copy, in place, when generic type aliases are
@@ -402,7 +402,9 @@ impl TypeEngine {
 
                         type_id
                     }
-                    Some(ty::TyDecl::GenericTypeForFunctionScope { type_id, .. }) => type_id,
+                    Some(ty::TyDecl::GenericTypeForFunctionScope(
+                        ty::GenericTypeForFunctionScope { type_id, .. },
+                    )) => type_id,
                     _ => {
                         errors.push(CompileError::UnknownTypeName {
                             name: call_path.to_string(),

--- a/sway-lsp/src/capabilities/code_actions/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/mod.rs
@@ -10,7 +10,7 @@ pub use crate::error::DocumentError;
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
 use sway_core::{
-    language::ty::TyDecl,
+    language::ty,
     transform::{AttributeKind, AttributesMap},
     Engines, TypeParameter,
 };
@@ -53,8 +53,12 @@ pub(crate) fn code_actions(
     };
     token.typed.and_then(|typed_token| match typed_token {
         TypedAstToken::TypedDeclaration(decl) => match decl {
-            TyDecl::AbiDecl { decl_id, .. } => abi_decl::code_actions(&decl_id, ctx),
-            TyDecl::StructDecl { decl_id, .. } => struct_decl::code_actions(&decl_id, ctx),
+            ty::TyDecl::AbiDecl(ty::AbiDecl { decl_id, .. }) => {
+                abi_decl::code_actions(&decl_id, ctx)
+            }
+            ty::TyDecl::StructDecl(ty::StructDecl { decl_id, .. }) => {
+                struct_decl::code_actions(&decl_id, ctx)
+            }
             _ => None,
         },
         _ => None,

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
@@ -1,4 +1,4 @@
-use sway_core::language::ty::{TyDecl, TyImplTrait, TyStructDecl, TyStructField};
+use sway_core::language::ty::{self, TyImplTrait, TyStructDecl, TyStructField};
 use sway_types::Spanned;
 use tower_lsp::lsp_types::{CodeActionDisabled, Position, Range, Url};
 
@@ -23,9 +23,9 @@ impl<'a> CodeAction<'a, TyStructDecl> for StructNewCodeAction<'a> {
             .iter()
             .all_references_of_token(ctx.token, ctx.engines)
             .find_map(|(_, token)| {
-                if let Some(TypedAstToken::TypedDeclaration(TyDecl::ImplTrait {
-                    decl_id, ..
-                })) = token.typed
+                if let Some(TypedAstToken::TypedDeclaration(ty::TyDecl::ImplTrait(
+                    ty::ImplTrait { decl_id, .. },
+                ))) = token.typed
                 {
                     Some(ctx.engines.de().get_impl_trait(&decl_id))
                 } else {

--- a/sway-lsp/src/capabilities/hover.rs
+++ b/sway-lsp/src/capabilities/hover.rs
@@ -138,7 +138,7 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
                         &token_name,
                     ))
                 }
-                ty::TyDecl::StructDecl { decl_id, .. } => {
+                ty::TyDecl::StructDecl(ty::StructDecl { decl_id, .. }) => {
                     let struct_decl = decl_engine.get_struct(decl_id);
                     Some(format_visibility_hover(
                         struct_decl.visibility,
@@ -146,7 +146,7 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
                         &token_name,
                     ))
                 }
-                ty::TyDecl::TraitDecl { decl_id, .. } => {
+                ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. }) => {
                     let trait_decl = decl_engine.get_trait(decl_id);
                     Some(format_visibility_hover(
                         trait_decl.visibility,
@@ -154,7 +154,7 @@ fn hover_format(engines: Engines<'_>, token: &Token, ident: &Ident) -> lsp_types
                         &token_name,
                     ))
                 }
-                ty::TyDecl::EnumDecl { decl_id, .. } => {
+                ty::TyDecl::EnumDecl(ty::EnumDecl { decl_id, .. }) => {
                     let enum_decl = decl_engine.get_enum(decl_id);
                     Some(format_visibility_hover(
                         enum_decl.visibility,

--- a/sway-lsp/src/core/token_map.rs
+++ b/sway-lsp/src/core/token_map.rs
@@ -168,7 +168,9 @@ impl TokenMap {
     ) -> Option<ty::TyStructDecl> {
         self.declaration_of_type_id(engines, type_id)
             .and_then(|decl| match decl {
-                ty::TyDecl::StructDecl { decl_id, .. } => Some(engines.de().get_struct(&decl_id)),
+                ty::TyDecl::StructDecl(ty::StructDecl { decl_id, .. }) => {
+                    Some(engines.de().get_struct(&decl_id))
+                }
                 _ => None,
             })
     }

--- a/sway-lsp/src/traverse/dependency.rs
+++ b/sway-lsp/src/traverse/dependency.rs
@@ -37,11 +37,11 @@ pub fn collect_typed_declaration(node: &ty::TyAstNode, ctx: &ParseContext) {
 
         let ident = match declaration {
             ty::TyDecl::VariableDecl(variable) => variable.name.clone(),
-            ty::TyDecl::StructDecl { name, .. }
-            | ty::TyDecl::EnumDecl { name, .. }
-            | ty::TyDecl::TraitDecl { name, .. }
-            | ty::TyDecl::FunctionDecl { name, .. }
-            | ty::TyDecl::ConstantDecl { name, .. } => name.clone(),
+            ty::TyDecl::StructDecl(ty::StructDecl { name, .. })
+            | ty::TyDecl::EnumDecl(ty::EnumDecl { name, .. })
+            | ty::TyDecl::TraitDecl(ty::TraitDecl { name, .. })
+            | ty::TyDecl::FunctionDecl(ty::FunctionDecl { name, .. })
+            | ty::TyDecl::ConstantDecl(ty::ConstantDecl { name, .. }) => name.clone(),
             _ => return,
         };
         let ident = token::to_ident_key(&ident);

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -85,17 +85,17 @@ impl<'a> TypedTree<'a> {
                 }
                 self.handle_expression(&variable.body);
             }
-            ty::TyDecl::ConstantDecl {
+            ty::TyDecl::ConstantDecl(ty::ConstantDecl {
                 decl_id, decl_span, ..
-            } => {
+            }) => {
                 let const_decl = decl_engine.get_constant(decl_id);
                 self.collect_const_decl(&const_decl, decl_span);
             }
-            ty::TyDecl::FunctionDecl { decl_id, .. } => {
+            ty::TyDecl::FunctionDecl(ty::FunctionDecl { decl_id, .. }) => {
                 let func_decl = decl_engine.get_function(decl_id);
                 self.collect_typed_fn_decl(&func_decl);
             }
-            ty::TyDecl::TraitDecl { decl_id, .. } => {
+            ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. }) => {
                 let trait_decl = decl_engine.get_trait(decl_id);
                 if let Some(mut token) = self
                     .ctx
@@ -123,7 +123,7 @@ impl<'a> TypedTree<'a> {
                     self.collect_supertrait(&supertrait);
                 }
             }
-            ty::TyDecl::StructDecl { decl_id, .. } => {
+            ty::TyDecl::StructDecl(ty::StructDecl { decl_id, .. }) => {
                 let struct_decl = decl_engine.get_struct(decl_id);
                 if let Some(mut token) = self
                     .ctx
@@ -151,13 +151,13 @@ impl<'a> TypedTree<'a> {
                     }
                 }
             }
-            ty::TyDecl::EnumDecl { decl_id, .. } => {
+            ty::TyDecl::EnumDecl(ty::EnumDecl { decl_id, .. }) => {
                 self.handle_enum(decl_id, declaration);
             }
-            ty::TyDecl::EnumVariantDecl { enum_ref, .. } => {
+            ty::TyDecl::EnumVariantDecl(ty::EnumVariantDecl { enum_ref, .. }) => {
                 self.handle_enum(enum_ref.id(), declaration);
             }
-            ty::TyDecl::ImplTrait { decl_id, .. } => {
+            ty::TyDecl::ImplTrait(ty::ImplTrait { decl_id, .. }) => {
                 let ty::TyImplTrait {
                     impl_type_parameters,
                     trait_name,
@@ -251,7 +251,7 @@ impl<'a> TypedTree<'a> {
                     );
                 }
             }
-            ty::TyDecl::AbiDecl { decl_id, .. } => {
+            ty::TyDecl::AbiDecl(ty::AbiDecl { decl_id, .. }) => {
                 let abi_decl = decl_engine.get_abi(decl_id);
                 if let Some(mut token) = self
                     .ctx
@@ -280,7 +280,10 @@ impl<'a> TypedTree<'a> {
                     self.collect_supertrait(&supertrait);
                 }
             }
-            ty::TyDecl::GenericTypeForFunctionScope { name, type_id } => {
+            ty::TyDecl::GenericTypeForFunctionScope(ty::GenericTypeForFunctionScope {
+                name,
+                type_id,
+            }) => {
                 if let Some(mut token) = self
                     .ctx
                     .tokens
@@ -292,7 +295,7 @@ impl<'a> TypedTree<'a> {
                 }
             }
             ty::TyDecl::ErrorRecovery(_) => {}
-            ty::TyDecl::StorageDecl { decl_id, .. } => {
+            ty::TyDecl::StorageDecl(ty::StorageDecl { decl_id, .. }) => {
                 let storage_decl = decl_engine.get_storage(decl_id);
                 for field in &storage_decl.fields {
                     if let Some(mut token) = self
@@ -310,7 +313,7 @@ impl<'a> TypedTree<'a> {
                     self.handle_expression(&field.initializer);
                 }
             }
-            ty::TyDecl::TypeAliasDecl { decl_id, .. } => {
+            ty::TyDecl::TypeAliasDecl(ty::TypeAliasDecl { decl_id, .. }) => {
                 let type_alias_decl = decl_engine.get_type_alias(decl_id);
                 self.collect_type_alias_decl(&type_alias_decl);
             }

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -69,31 +69,31 @@ pub(crate) fn print_decl_engine_types(
         .iter()
         .map(|n| match &n.content {
             ty::TyAstNodeContent::Declaration(declaration) => match declaration {
-                ty::TyDecl::ConstantDecl { decl_id, .. } => {
+                ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
                     let const_decl = decl_engine.get_constant(decl_id);
                     format!("{const_decl:#?}")
                 }
-                ty::TyDecl::FunctionDecl { decl_id, .. } => {
+                ty::TyDecl::FunctionDecl(ty::FunctionDecl { decl_id, .. }) => {
                     let func_decl = decl_engine.get_function(decl_id);
                     format!("{func_decl:#?}")
                 }
-                ty::TyDecl::TraitDecl { decl_id, .. } => {
+                ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. }) => {
                     let trait_decl = decl_engine.get_trait(decl_id);
                     format!("{trait_decl:#?}")
                 }
-                ty::TyDecl::StructDecl { decl_id, .. } => {
+                ty::TyDecl::StructDecl(ty::StructDecl { decl_id, .. }) => {
                     let struct_decl = decl_engine.get_struct(decl_id);
                     format!("{struct_decl:#?}")
                 }
-                ty::TyDecl::EnumDecl { decl_id, .. } => {
+                ty::TyDecl::EnumDecl(ty::EnumDecl { decl_id, .. }) => {
                     let enum_decl = decl_engine.get_enum(decl_id);
                     format!("{enum_decl:#?}")
                 }
-                ty::TyDecl::AbiDecl { decl_id, .. } => {
+                ty::TyDecl::AbiDecl(ty::AbiDecl { decl_id, .. }) => {
                     let abi_decl = decl_engine.get_abi(decl_id);
                     format!("{abi_decl:#?}")
                 }
-                ty::TyDecl::StorageDecl { decl_id, .. } => {
+                ty::TyDecl::StorageDecl(ty::StorageDecl { decl_id, .. }) => {
                     let storage_decl = decl_engine.get_storage(decl_id);
                     format!("{storage_decl:#?}")
                 }


### PR DESCRIPTION
## Description
This PR refactors the `TyDecl` enum by separating its variants into individual structs and simplifying the enum itself, leading to better code organization and maintainability.

This refactoring enhances modularity making it easier to implement a Parse trait on these types in the language server when matching on the variants during AST traversal, which is required to unblock #3799. I had attempted to do this in #4247 but it was reverted by @emilyaherbert. Hopefully, this new approach is acceptable.

The main change is

```rust
#[derive(Clone, Debug)]
pub enum TyDecl {
    ConstantDecl {
        name: Ident,
        decl_id: DeclId<TyConstantDecl>,
        decl_span: Span,
    },
    FunctionDecl {
        name: Ident,
        decl_id: DeclId<TyFunctionDecl>,
        subst_list: Template<SubstList>,
        decl_span: Span,
    },
    ....
}
```

Has been changed to 

```rust
#[derive(Clone, Debug)]
pub enum TyDecl {
    ConstantDecl(ConstantDecl),
    FunctionDecl(FunctionDecl),
    ....
}

#[derive(Clone, Debug)]
pub struct ConstantDecl {
    pub name: Ident,
    pub decl_id: DeclId<TyConstantDecl>,
    pub decl_span: Span,
}

#[derive(Clone, Debug)]
pub struct FunctionDecl {
    pub name: Ident,
    pub decl_id: DeclId<TyFunctionDecl>,
    pub subst_list: Template<SubstList>,
    pub decl_span: Span,
}
```

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
