### PR TITLE
refactor: better error formatting for `ForcResult`

### DIFF
--- a/forc/src/main.rs
+++ b/forc/src/main.rs
@@ -1,6 +1,6 @@
-use forc_util::ForcResult;
+use forc_util::ForcCliResult;
 
 #[tokio::main]
-async fn main() -> ForcResult<()> {
-    forc::cli::run_cli().await
+async fn main() -> ForcCliResult<()> {
+    forc::cli::run_cli().await.into()
 }


### PR DESCRIPTION
## Description
closes #4461.

We introduced `ForcResult` in #4455. While implementing it I took a look at the cargo's design and saw that they also have `CargoCliResult` which did not make a lot of sense then but it looks like without that piece we cannot format the error nicely because of rust's orphan rule. This PR introduces `ForcCliResult` which enables us to return nice and clean errors.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
