### PR TITLE
LSP: Rewrite `TyProgram` traversal to use the `Parse` trait.

### DIFF
--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -60,6 +60,7 @@ pub enum TypedAstToken {
     TypedDeclaration(ty::TyDecl),
     TypedExpression(ty::TyExpression),
     TypedScrutinee(ty::TyScrutinee),
+    TyStructScrutineeField(ty::TyStructScrutineeField),
     TypedConstantDeclaration(ty::TyConstantDecl),
     TypedFunctionDeclaration(ty::TyFunctionDecl),
     TypedFunctionParameter(ty::TyFunctionParameter),

--- a/sway-lsp/src/traverse/mod.rs
+++ b/sway-lsp/src/traverse/mod.rs
@@ -1,5 +1,5 @@
 use crate::core::token_map::TokenMap;
-use sway_core::Engines;
+use sway_core::{namespace, Engines};
 
 pub(crate) mod dependency;
 pub(crate) mod lexed_tree;
@@ -9,11 +9,20 @@ pub(crate) mod typed_tree;
 pub struct ParseContext<'a> {
     tokens: &'a TokenMap,
     engines: Engines<'a>,
+    namespace: &'a namespace::Module,
 }
 
 impl<'a> ParseContext<'a> {
-    pub fn new(tokens: &'a TokenMap, engines: Engines<'a>) -> Self {
-        Self { tokens, engines }
+    pub fn new(
+        tokens: &'a TokenMap,
+        engines: Engines<'a>,
+        namespace: &'a namespace::Module,
+    ) -> Self {
+        Self {
+            tokens,
+            engines,
+            namespace,
+        }
     }
 }
 

--- a/sway-lsp/src/traverse/mod.rs
+++ b/sway-lsp/src/traverse/mod.rs
@@ -1,5 +1,5 @@
 use crate::core::token_map::TokenMap;
-use sway_core::{namespace, Engines};
+use sway_core::{namespace::Module, Engines};
 
 pub(crate) mod dependency;
 pub(crate) mod lexed_tree;
@@ -9,15 +9,11 @@ pub(crate) mod typed_tree;
 pub struct ParseContext<'a> {
     tokens: &'a TokenMap,
     engines: Engines<'a>,
-    namespace: &'a namespace::Module,
+    namespace: &'a Module,
 }
 
 impl<'a> ParseContext<'a> {
-    pub fn new(
-        tokens: &'a TokenMap,
-        engines: Engines<'a>,
-        namespace: &'a namespace::Module,
-    ) -> Self {
+    pub fn new(tokens: &'a TokenMap, engines: Engines<'a>, namespace: &'a Module) -> Self {
         Self {
             tokens,
             engines,

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -7,13 +7,12 @@ use crate::{
 };
 use dashmap::mapref::one::RefMut;
 use sway_core::{
-    decl_engine::{id::DeclId, DeclRefConstant, InterfaceDeclId},
+    decl_engine::{id::DeclId, InterfaceDeclId},
     language::{
         parsed::{ImportType, Supertrait},
-        ty::{self, GetDeclIdent, TyEnumVariant, TyModule, TyProgram, TySubmodule},
+        ty::{self, GetDeclIdent, TyModule, TyProgram, TySubmodule},
         CallPathTree,
     },
-    namespace,
     type_system::TypeArgument,
     TraitConstraint, TypeId, TypeInfo,
 };
@@ -21,12 +20,11 @@ use sway_types::{Ident, Span, Spanned};
 
 pub struct TypedTree<'a> {
     ctx: &'a ParseContext<'a>,
-    namespace: &'a namespace::Module,
 }
 
 impl<'a> TypedTree<'a> {
-    pub fn new(ctx: &'a ParseContext<'a>, namespace: &'a namespace::Module) -> Self {
-        Self { ctx, namespace }
+    pub fn new(ctx: &'a ParseContext<'a>) -> Self {
+        Self { ctx }
     }
 
     pub fn traverse_node(&self, node: &ty::TyAstNode) {
@@ -185,7 +183,7 @@ impl Parse for ty::TySideEffect {
 
 impl Parse for ty::TyExpression {
     fn parse(&self, ctx: &ParseContext) {
-        match self.expression {
+        match &self.expression {
             ty::TyExpressionVariant::Literal { .. } => {
                 if let Some(mut token) = ctx
                     .tokens
@@ -215,7 +213,7 @@ impl Parse for ty::TyExpression {
                 let implementing_type_name = ctx
                     .engines
                     .de()
-                    .get_function(&fn_ref)
+                    .get_function(fn_ref)
                     .implementing_type
                     .and_then(|impl_type| impl_type.get_decl_ident());
                 let prefixes = if let Some(impl_type_name) = implementing_type_name {
@@ -241,7 +239,7 @@ impl Parse for ty::TyExpression {
                     .try_unwrap()
                 {
                     token.typed = Some(TypedAstToken::TypedExpression(self.clone()));
-                    let function_decl = ctx.engines.de().get_function(&fn_ref);
+                    let function_decl = ctx.engines.de().get_function(fn_ref);
                     token.type_def = Some(TypeDefinition::Ident(function_decl.name));
                 }
                 contract_call_params.values().for_each(|exp| exp.parse(ctx));
@@ -253,7 +251,7 @@ impl Parse for ty::TyExpression {
                     }
                     exp.parse(ctx);
                 }
-                let function_decl = ctx.engines.de().get_function(&fn_ref);
+                let function_decl = ctx.engines.de().get_function(fn_ref);
                 function_decl
                     .body
                     .contents

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -79,7 +79,7 @@ impl Parse for ty::TyDecl {
             ty::TyDecl::TraitDecl(decl) => decl.parse(ctx),
             ty::TyDecl::StructDecl(decl) => decl.parse(ctx),
             ty::TyDecl::EnumDecl(decl) => collect_enum(ctx, &decl.decl_id, self),
-            ty::TyDecl::EnumVariantDecl(decl) => collect_enum(ctx, &decl.enum_ref.id(), self),
+            ty::TyDecl::EnumVariantDecl(decl) => collect_enum(ctx, decl.enum_ref.id(), self),
             ty::TyDecl::ImplTrait(decl) => decl.parse(ctx),
             ty::TyDecl::AbiDecl(decl) => decl.parse(ctx),
             ty::TyDecl::GenericTypeForFunctionScope(decl) => decl.parse(ctx),
@@ -245,7 +245,7 @@ impl Parse for ty::TyExpression {
                 contract_call_params.values().for_each(|exp| exp.parse(ctx));
                 for (ident, exp) in arguments {
                     if let Some(mut token) =
-                        ctx.tokens.try_get_mut(&to_ident_key(&ident)).try_unwrap()
+                        ctx.tokens.try_get_mut(&to_ident_key(ident)).try_unwrap()
                     {
                         token.typed = Some(TypedAstToken::Ident(ident.clone()));
                     }
@@ -267,7 +267,7 @@ impl Parse for ty::TyExpression {
                 span,
                 call_path,
             } => {
-                collect_const_decl(ctx, const_decl, &span);
+                collect_const_decl(ctx, const_decl, span);
                 if let Some(call_path) = call_path {
                     collect_call_path_prefixes(ctx, &call_path.prefixes);
                 }
@@ -567,7 +567,7 @@ impl Parse for ty::FunctionDecl {
                 ctx,
                 type_param.type_id,
                 &typed_token,
-                type_param.name_ident.span().clone(),
+                type_param.name_ident.span(),
             );
         });
         collect_type_argument(ctx, &func_decl.return_type);
@@ -667,7 +667,7 @@ impl Parse for ty::ImplTrait {
                 ctx,
                 param.type_id,
                 &TypedAstToken::TypedParameter(param.clone()),
-                param.name_ident.span().clone(),
+                param.name_ident.span(),
             );
         });
         trait_name.prefixes.iter().for_each(|ident| {
@@ -896,13 +896,13 @@ impl Parse for ty::TyFunctionDecl {
                 ctx,
                 type_param.type_id,
                 &typed_token,
-                type_param.name_ident.span().clone(),
+                type_param.name_ident.span(),
             );
         });
         collect_type_argument(ctx, &self.return_type);
         for (ident, trait_constraints) in &self.where_clause {
             trait_constraints.iter().for_each(|constraint| {
-                collect_trait_constraint(ctx, &constraint);
+                collect_trait_constraint(ctx, constraint);
             });
             if let Some(mut token) = ctx.tokens.try_get_mut(&to_ident_key(ident)).try_unwrap() {
                 token.typed = Some(typed_token.clone());
@@ -1285,7 +1285,7 @@ fn collect_type_id(
                     ctx,
                     param.type_id,
                     &TypedAstToken::TypedParameter(param.clone()),
-                    param.name_ident.span().clone(),
+                    param.name_ident.span(),
                 );
             });
             decl.variants.iter().for_each(|variant| {
@@ -1306,7 +1306,7 @@ fn collect_type_id(
                     ctx,
                     param.type_id,
                     &TypedAstToken::TypedParameter(param.clone()),
-                    param.name_ident.span().clone(),
+                    param.name_ident.span(),
                 );
             });
             decl.fields.iter().for_each(|field| {


### PR DESCRIPTION
## Description
This PR finishes off migrating to use the `Parse` trait during AST traversal that was started in #4220. Once again, the diff is quite big but it's just essentially moving the logic that was there into the trait impl's.

closes #3799

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
