### PR TITLE
Improves error message when log is used in predicate.

### DIFF
--- a/sway-core/src/ir_generation.rs
+++ b/sway-core/src/ir_generation.rs
@@ -8,7 +8,7 @@ pub mod storage;
 mod types;
 
 use sway_error::error::CompileError;
-use sway_ir::Context;
+use sway_ir::{Context, Kind};
 use sway_types::span::Span;
 
 pub(crate) use purity::{check_function_purity, PurityEnv};
@@ -48,6 +48,13 @@ pub fn compile_program(
         .collect();
 
     let mut ctx = Context::default();
+    ctx.program_kind = match kind {
+        ty::TyProgramKind::Script { .. } => Kind::Script,
+        ty::TyProgramKind::Predicate { .. } => Kind::Predicate,
+        ty::TyProgramKind::Contract { .. } => Kind::Contract,
+        ty::TyProgramKind::Library { .. } => Kind::Library,
+    };
+
     match kind {
         // predicates and scripts have the same codegen, their only difference is static
         // type-check time checks.

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -746,6 +746,13 @@ impl<'eng> FnCompiler<'eng> {
                 }
             }
             Intrinsic::Log => {
+                if context.program_kind == Kind::Predicate {
+                    return Err(CompileError::DisallowedIntrinsicInPredicate {
+                        intrinsic: kind.to_string(),
+                        span: span.clone(),
+                    });
+                }
+
                 // The log value and the log ID are just Value.
                 let log_val = self.compile_expression_to_value(context, md_mgr, &arguments[0])?;
                 let log_id = match self.logged_types_map.get(&arguments[0].return_type) {

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -612,6 +612,8 @@ pub enum CompileError {
     CallingPrivateLibraryMethod { name: String, span: Span },
     #[error("Using \"while\" in a predicate is not allowed.")]
     DisallowedWhileInPredicate { span: Span },
+    #[error("Using intrinsic \"{intrinsic}\" in a predicate is not allowed.")]
+    DisallowedIntrinsicInPredicate { intrinsic: String, span: Span },
     #[error("Possibly non-zero amount of coins transferred to non-payable contract method \"{fn_name}\".")]
     CoinsPassedToNonPayableMethod { fn_name: Ident, span: Span },
     #[error(
@@ -799,6 +801,7 @@ impl Spanned for CompileError {
             DisallowedControlFlowInstruction { span, .. } => span.clone(),
             CallingPrivateLibraryMethod { span, .. } => span.clone(),
             DisallowedWhileInPredicate { span } => span.clone(),
+            DisallowedIntrinsicInPredicate { span, .. } => span.clone(),
             CoinsPassedToNonPayableMethod { span, .. } => span.clone(),
             TraitImplPayabilityMismatch { span, .. } => span.clone(),
             ConfigurableInLibrary { span } => span.clone(),

--- a/sway-ir/src/context.rs
+++ b/sway-ir/src/context.rs
@@ -11,8 +11,8 @@ use rustc_hash::FxHashMap;
 
 use crate::{
     asm::AsmBlockContent, block::BlockContent, function::FunctionContent,
-    local_var::LocalVarContent, metadata::Metadatum, module::ModuleContent, module::ModuleIterator,
-    value::ValueContent, Type, TypeContent,
+    local_var::LocalVarContent, metadata::Metadatum, module::Kind, module::ModuleContent,
+    module::ModuleIterator, value::ValueContent, Type, TypeContent,
 };
 
 /// The main IR context handle.
@@ -30,6 +30,8 @@ pub struct Context {
     pub(crate) asm_blocks: Arena<AsmBlockContent>,
     pub(crate) metadata: Arena<Metadatum>,
 
+    pub program_kind: Kind,
+
     next_unique_sym_tag: u64,
 }
 
@@ -46,6 +48,7 @@ impl Default for Context {
             asm_blocks: Default::default(),
             metadata: Default::default(),
             next_unique_sym_tag: Default::default(),
+            program_kind: Kind::Contract,
         };
         Type::create_basic_types(&mut def);
         def

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_log/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_log/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-58F9DCE1E1853B21'
+
+[[package]]
+name = 'predicate_log'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-58F9DCE1E1853B21'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_log/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_log/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "predicate_log"
+entry = "main.sw"
+implicit-std = false
+
+[dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_log/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_log/src/main.sw
@@ -1,0 +1,12 @@
+predicate;
+
+use std::{
+    inputs::input_owner,
+    logging::log,
+};
+
+fn main() -> bool {
+    log::<Address>(input_owner(0).unwrap());
+        
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_log/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_log/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: __log::<T>(value);
+# nextln: $()Using intrinsic "log" in a predicate is not allowed.


### PR DESCRIPTION
## Description

Previously when log was used in predicate the error message would be: `Internal compiler error: Unable to determine ID for log instance.`

Now the error message is:
`Using intrinsic "log" in a predicate is not allowed.`

Closes #4415

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
