### PR TITLE
ci: bump ci to use rust 1.69.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.68.2
+  RUST_VERSION: 1.69.0
   NIGHTLY_RUST_VERSION: nightly-2023-02-08
 
 jobs:

--- a/sway-ast/src/brackets.rs
+++ b/sway-ast/src/brackets.rs
@@ -9,7 +9,7 @@ macro_rules! define_brackets (
         }
 
         impl<T> $ty_name<T> {
-            pub fn new<'a>(inner: T, span: Span) -> $ty_name<T> {
+            pub fn new(inner: T, span: Span) -> $ty_name<T> {
                 $ty_name {
                     inner,
                     span,


### PR DESCRIPTION
## Description
rust 1.69 is [released](https://blog.rust-lang.org/2023/04/20/Rust-1.69.0.html), this PR configures our CI to use 1.69 and fixes new lints raised by clippy v1.69.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
