### PR TITLE
Re-publish 0.37.2 as 0.38.0 due to breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "once_cell",
  "version_check",
 ]
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -115,42 +115,51 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.2.6"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+checksum = "6342bd4f5a1205d7f41e94a41a901f5647c938cdfa96036338e8533c9d6c2450"
 dependencies = [
  "anstyle",
  "anstyle-parse",
+ "anstyle-query",
  "anstyle-wincon",
- "concolor-override",
- "concolor-query",
+ "colorchoice",
  "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
-name = "anstyle-wincon"
-version = "0.2.0"
+name = "anstyle-query"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -207,7 +216,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -515,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "byte-slice-cast"
@@ -625,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.1"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
 dependencies = [
  "clap_builder",
  "clap_derive 4.2.0",
@@ -636,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.1"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
 dependencies = [
  "anstream",
  "anstyle",
@@ -660,11 +669,11 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c22dcfb410883764b29953103d9ef7bb8fe21b3fa1158bc99986c2067294bd"
+checksum = "1a19591b2ab0e3c04b588a0e04ddde7b9eaa423646d1b4a8092879216bf47473"
 dependencies = [
- "clap 4.2.1",
+ "clap 4.2.4",
 ]
 
 [[package]]
@@ -689,7 +698,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -733,7 +742,7 @@ dependencies = [
  "bs58",
  "coins-core",
  "digest 0.10.6",
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "hmac 0.12.1",
  "k256",
  "lazy_static",
@@ -750,7 +759,7 @@ checksum = "2a11892bcac83b4c6e95ab84b5b06c76d9d70ad73548dd07418269c5c7977171"
 dependencies = [
  "bitvec 0.17.4",
  "coins-bip32",
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "hex",
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
@@ -776,9 +785,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3 0.10.7",
  "thiserror",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -810,7 +825,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784836d0812dade01579cc0cc9b1684847044e716fd7aa6bffbc172e42199500"
 dependencies = [
- "clap 4.2.1",
+ "clap 4.2.4",
  "entities",
  "memchr",
  "once_cell",
@@ -823,21 +838,6 @@ dependencies = [
  "typed-arena",
  "unicode_categories",
  "xdg",
-]
-
-[[package]]
-name = "concolor-override"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
-
-[[package]]
-name = "concolor-query"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
-dependencies = [
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -942,9 +942,9 @@ checksum = "328b822bdcba4d4e402be8d9adb6eebf269f969f8eadef977a553ff3c4fbcb58"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -966,9 +966,9 @@ checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -1120,7 +1120,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1137,7 +1137,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1404,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "educe"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0188e3c3ba8df5753894d54461f0e39bc91741dc5b22e1c46999ec2c71f4e4"
+checksum = "4af7804abe0786a9b69375115821fedc9995f21ab63ae285184b96b01ec50b1a"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2",
@@ -1511,13 +1511,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1602,7 +1602,7 @@ checksum = "dd65f1b59dd22d680c7a626cc4a000c1e03d241c51c3e034d2bc9f1e90734f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1632,13 +1632,13 @@ dependencies = [
 
 [[package]]
 name = "fd-lock"
-version = "3.0.11"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9799aefb4a2e4a01cc47610b1dd47c18ab13d991f27bbcaed9296f5a53d5cbad"
+checksum = "39ae6b3d9530211fb3b12a95374b8b0823be812f53d09e18c5675c0146b09642"
 dependencies = [
  "cfg-if 1.0.0",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1788,7 +1788,7 @@ name = "forc-doc"
 version = "0.38.0"
 dependencies = [
  "anyhow",
- "clap 4.2.1",
+ "clap 4.2.4",
  "comrak",
  "forc-pkg",
  "forc-util",
@@ -1969,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2848e936ce953d9571771279b270ee6f098c04ad5cbb7227bf5dc04abfc57b59"
+checksum = "0030cc1247de0507e547d8ea33484b82420fe61221b94b985d193ec7f63587ae"
 dependencies = [
  "fuel-types",
  "serde",
@@ -1979,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.17.8"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d2a0e5a8b376d21d034bddeebf80bd1bb932f095533b3f4de4cec8f861f65"
+checksum = "50ad76abdb1ea002d186b3acd6e539292ba4dbb5252c732dba0a13b717363a9f"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.17.8"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6913aaa745e3447adcfd7985c2ad335f92bab8d1d03354b0128b4df15bd9b3"
+checksum = "eb79711c8da796bcc007e612a5182c7a10657d079870f9f4176e7878cf259b04"
 dependencies = [
  "anyhow",
  "cynic",
@@ -2022,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.17.8"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c656357943728a0b9b1c2dcdd2ea0b17f1ade335592b1186be20e52b4cdac46"
+checksum = "e4c610880a9dac06c5ee416a8675ea706300f2257732043abd918c259b7581ef"
 dependencies = [
  "anyhow",
  "fuel-core-types",
@@ -2034,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.17.8"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a81cfe60a469b55604d648d3eb500b664322e72620ea8325084f06fe0fe6af2"
+checksum = "0e7605cdf54d2cf583e5b87e85e17b9d466c81ea704d80ed18ea8692e97339c1"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2050,15 +2050,15 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efba8a3c2c91bdec93b5328b31f71167a42c23555a8885cb7d55ab66632d8fa1"
+checksum = "9e7356deff8ce5a9b6bc8d9e7cacc6c1d1f7abf5cdd4d729869afb401befa495"
 dependencies = [
  "borrown",
  "coins-bip32",
  "coins-bip39",
  "fuel-types",
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "lazy_static",
  "rand",
  "secp256k1",
@@ -2079,7 +2079,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha3 0.10.6",
+ "sha3 0.10.7",
  "thiserror",
  "uint",
 ]
@@ -2108,7 +2108,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "rand",
- "sha3 0.10.6",
+ "sha3 0.10.7",
  "snafu",
 ]
 
@@ -2140,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9d6caf8ad593cd8665e431aec18c1b4550db2e0f52d958547fca81c2c07077"
+checksum = "b13103bf12f62930dd26f75f90d6a95d952fdcd677a356f57d8ef8df7ae02b84"
 dependencies = [
  "digest 0.10.6",
  "fuel-storage",
@@ -2154,15 +2154,15 @@ dependencies = [
 
 [[package]]
 name = "fuel-storage"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7969a1fab462d0ed9aadb9df98ff40c92b9d5b7e029de6e48d40a068e49e05"
+checksum = "998d49926c8ae3e545e348075075c2fe85caae4474e01d2da65a9a8edc3277e9"
 
 [[package]]
 name = "fuel-tx"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0bbf8d062f8a41395184b7d60c1bb674254545dd64a0026beda65005de8bc7"
+checksum = "e09bb28731979db1f5192c04f2a330a15b8c2f5ef2b47836b3282c7fd9d7703c"
 dependencies = [
  "derivative",
  "fuel-asm",
@@ -2178,21 +2178,23 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b8c43ba619e6259a74c9368109006937dfd62cc0b875c2ae13ae6ffa52264f2"
+checksum = "89fc99a9878b98135c4b05c71fe63b82f4cb3a00abac278935f8be7282f8e468"
 dependencies = [
+ "hex",
  "rand",
  "serde",
 ]
 
 [[package]]
 name = "fuel-vm"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dbbf70e3be9243d5cb237e6e3ad2ef18fcad8c725f6c50e2451546e3f61636"
+checksum = "b36aac727729b94c620265da76112e1d36a1af0c067745491c376f084f5b7b38"
 dependencies = [
  "bitflags",
+ "derivative",
  "fuel-asm",
  "fuel-crypto",
  "fuel-merkle",
@@ -2202,10 +2204,9 @@ dependencies = [
  "itertools",
  "rand",
  "serde",
- "sha3 0.10.6",
+ "sha3 0.10.7",
  "tai64",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -2376,7 +2377,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2460,9 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2504,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0c5a9f4d621d4f4ea046bb331df5c746ca735b8cae5b234cc2be70ee4dbef0"
+checksum = "2a258595457bc192d1f1c59d0d168a1e34e2be9b97a614e14995416185de41a7"
 dependencies = [
  "hex",
  "thiserror",
@@ -2566,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",
@@ -2768,9 +2769,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3029,14 +3030,14 @@ checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3124,9 +3125,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libgit2-sys"
@@ -3194,9 +3195,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
 
 [[package]]
 name = "lock_api"
@@ -3236,7 +3237,7 @@ dependencies = [
  "fnv",
  "proc-macro2",
  "quote",
- "regex-syntax",
+ "regex-syntax 0.6.29",
  "syn 1.0.109",
 ]
 
@@ -3276,8 +3277,8 @@ checksum = "764dcbfc2e5f868bc1b566eb179dff1a06458fd0cff846aae2579392dd3f01a0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.2.1",
- "clap_complete 4.2.0",
+ "clap 4.2.4",
+ "clap_complete 4.2.1",
  "env_logger",
  "handlebars",
  "log",
@@ -3665,18 +3666,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.25.2+1.1.1t"
+version = "111.25.3+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320708a054ad9b3bf314688b5db87cf4d6683d64cfc835e2337924ae62bf4431"
+checksum = "924757a6a226bf60da5f7dd0311a34d2b52283dd82ddeb103208ddc66362f80c"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.84"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
  "cc",
  "libc",
@@ -3902,7 +3903,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -4064,9 +4065,9 @@ dependencies = [
 
 [[package]]
 name = "prettydiff"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68de4fde4bfc3cea8d816d3b941fc7917e6a68e8b966eb94b7e47277421b2f75"
+checksum = "8ff1fec61082821f8236cf6c0c14e8172b62ce8a72a0eedc30d3b247bb68dc11"
 dependencies = [
  "ansi_term",
  "pad",
@@ -4193,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c1a97b1bc42b1d550bfb48d4262153fe400a12bab1511821736f7eac76d7e2"
+checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
 dependencies = [
  "memchr",
 ]
@@ -4248,7 +4249,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
 ]
 
 [[package]]
@@ -4323,20 +4324,20 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "redox_syscall 0.2.16",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -4345,7 +4346,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -4353,6 +4354,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "reqwest"
@@ -4409,7 +4416,7 @@ dependencies = [
  "primitive-types",
  "revm_precompiles",
  "rlp",
- "sha3 0.10.6",
+ "sha3 0.10.7",
 ]
 
 [[package]]
@@ -4426,7 +4433,7 @@ dependencies = [
  "ripemd",
  "secp256k1",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3 0.10.7",
  "substrate-bn",
 ]
 
@@ -4523,9 +4530,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -4550,16 +4557,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.7"
+version = "0.37.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4775,22 +4782,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -4804,9 +4811,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -4821,7 +4828,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -4908,9 +4915,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
 dependencies = [
  "digest 0.10.6",
  "keccak",
@@ -5358,7 +5365,7 @@ dependencies = [
  "forc-tracing",
  "forc-util",
  "paste",
- "prettydiff 0.6.3",
+ "prettydiff 0.6.4",
  "ropey",
  "serde",
  "serde_ignored",
@@ -5385,9 +5392,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.13"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5409,7 +5416,7 @@ dependencies = [
  "once_cell",
  "onig",
  "plist",
- "regex-syntax",
+ "regex-syntax 0.6.29",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5522,7 +5529,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "bytes",
- "clap 4.2.1",
+ "clap 4.2.4",
  "colored",
  "filecheck",
  "forc",
@@ -5535,7 +5542,7 @@ dependencies = [
  "gag",
  "hex",
  "miden",
- "prettydiff 0.6.3",
+ "prettydiff 0.6.4",
  "rand",
  "regex",
  "revm",
@@ -5553,7 +5560,7 @@ name = "test-macros"
 version = "0.0.0"
 dependencies = [
  "paste",
- "prettydiff 0.6.3",
+ "prettydiff 0.6.4",
 ]
 
 [[package]]
@@ -5599,7 +5606,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -5711,7 +5718,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -5856,13 +5863,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -5898,9 +5905,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -6056,7 +6063,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "serde",
 ]
 
@@ -6496,7 +6503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bd17ea728ff42185c54dfbabaafd0b442207df6b2cc60f74c607d8c01e9c4db"
 dependencies = [
  "blake3",
- "sha3 0.10.6",
+ "sha3 0.10.7",
  "winter-math",
  "winter-utils",
 ]
@@ -6607,5 +6614,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.13",
+ "syn 2.0.15",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,7 +1720,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "annotate-snippets",
  "ansi_term",
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "forc-client"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "forc-doc"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 4.2.1",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "forc-fmt"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "forc-lsp"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "forc-pkg"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "forc-test"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "forc-pkg",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "forc-tracing"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "ansi_term",
  "tracing",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "forc-tx"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 3.2.23",
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "forc-util"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "annotate-snippets",
  "ansi_term",
@@ -5181,7 +5181,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "sway-ast"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "extension-trait",
  "num-bigint",
@@ -5192,7 +5192,7 @@ dependencies = [
 
 [[package]]
 name = "sway-core"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "clap 3.2.23",
  "derivative",
@@ -5233,7 +5233,7 @@ dependencies = [
 
 [[package]]
 name = "sway-error"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "extension-trait",
  "num-bigint",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "downcast-rs",
@@ -5260,7 +5260,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir-macros"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -5270,7 +5270,7 @@ dependencies = [
 
 [[package]]
 name = "sway-lsp"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "sway-parse"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "assert_matches",
  "extension-trait",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "sway-types"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "fuel-asm",
  "fuel-crypto",
@@ -5348,11 +5348,11 @@ dependencies = [
 
 [[package]]
 name = "sway-utils"
-version = "0.37.2"
+version = "0.38.0"
 
 [[package]]
 name = "swayfmt"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "forc-tracing",

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-pkg"
-version = "0.37.2"
+version = "0.38.0"
 description = "Building, locking, fetching and updating Sway projects as Forc packages."
 authors.workspace = true
 edition.workspace = true
@@ -12,8 +12,8 @@ repository.workspace = true
 ansi_term = "0.12"
 anyhow = "1"
 fd-lock = "3.0"
-forc-tracing = { version = "0.37.2", path = "../forc-tracing" }
-forc-util = { version = "0.37.2", path = "../forc-util" }
+forc-tracing = { version = "0.38.0", path = "../forc-tracing" }
+forc-util = { version = "0.38.0", path = "../forc-util" }
 fuel-abi-types = "0.1"
 git2 = { version = "0.16.1", features = ["vendored-libgit2", "vendored-openssl"] }
 gix-url = { version = "0.16.0", features = ["serde1"] }
@@ -23,10 +23,10 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
 serde_json = "1.0"
-sway-core = { version = "0.37.2", path = "../sway-core" }
-sway-error = { version = "0.37.2", path = "../sway-error" }
-sway-types = { version = "0.37.2", path = "../sway-types" }
-sway-utils = { version = "0.37.2", path = "../sway-utils" }
+sway-core = { version = "0.38.0", path = "../sway-core" }
+sway-error = { version = "0.38.0", path = "../sway-error" }
+sway-types = { version = "0.38.0", path = "../sway-types" }
+sway-utils = { version = "0.38.0", path = "../sway-utils" }
 toml = "0.5"
 tracing = "0.1"
 url = { version = "2.2", features = ["serde"] }

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-client"
-version = "0.37.2"
+version = "0.38.0"
 description = "A `forc` plugin for interacting with a Fuel node."
 authors.workspace = true
 edition.workspace = true
@@ -14,11 +14,11 @@ async-trait = "0.1.58"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = { version = "3", features = ["derive", "env"] }
 devault = "0.1"
-forc = { version = "0.37.2", path = "../../forc" }
-forc-pkg = { version = "0.37.2", path = "../../forc-pkg" }
-forc-tracing = { version = "0.37.2", path = "../../forc-tracing" }
-forc-tx = { version = "0.37.2", path = "../forc-tx" }
-forc-util = { version = "0.37.2", path = "../../forc-util" }
+forc = { version = "0.38.0", path = "../../forc" }
+forc-pkg = { version = "0.38.0", path = "../../forc-pkg" }
+forc-tracing = { version = "0.38.0", path = "../../forc-tracing" }
+forc-tx = { version = "0.38.0", path = "../forc-tx" }
+forc-util = { version = "0.38.0", path = "../../forc-util" }
 fuel-core-client = { workspace = true, default-features = false }
 fuel-crypto = { workspace = true }
 fuel-tx = { workspace = true, features = ["builder"] }
@@ -31,9 +31,9 @@ hex = "0.4.3"
 rand = "0.8"
 serde = "1.0"
 serde_json = "1"
-sway-core = { version = "0.37.2", path = "../../sway-core" }
-sway-types = { version = "0.37.2", path = "../../sway-types" }
-sway-utils = { version = "0.37.2", path = "../../sway-utils" }
+sway-core = { version = "0.38.0", path = "../../sway-core" }
+sway-types = { version = "0.38.0", path = "../../sway-types" }
+sway-utils = { version = "0.38.0", path = "../../sway-utils" }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "process"] }
 tracing = "0.1"
 

--- a/forc-plugins/forc-doc/Cargo.toml
+++ b/forc-plugins/forc-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-doc"
-version = "0.37.2"
+version = "0.38.0"
 description = "Build the documentation for the local package and all dependencies. The output is placed in `out/doc` in the same format as the project."
 authors.workspace = true
 edition.workspace = true
@@ -12,13 +12,13 @@ repository.workspace = true
 anyhow = "1.0.65"
 clap = { version = "4.0.18", features = ["derive"] }
 comrak = "0.16"
-forc-pkg = { version = "0.37.2", path = "../../forc-pkg" }
-forc-util = { version = "0.37.2", path = "../../forc-util" }
+forc-pkg = { version = "0.38.0", path = "../../forc-pkg" }
+forc-util = { version = "0.38.0", path = "../../forc-util" }
 horrorshow = "0.8.4"
 include_dir = "0.7.3"
 opener = "0.5.0"
-sway-ast = { version = "0.37.2", path = "../../sway-ast" }
-sway-core = { version = "0.37.2", path = "../../sway-core" }
-sway-lsp = { version = "0.37.2", path = "../../sway-lsp" }
-sway-types = { version = "0.37.2", path = "../../sway-types" }
-swayfmt = { version = "0.37.2", path = "../../swayfmt" }
+sway-ast = { version = "0.38.0", path = "../../sway-ast" }
+sway-core = { version = "0.38.0", path = "../../sway-core" }
+sway-lsp = { version = "0.38.0", path = "../../sway-lsp" }
+sway-types = { version = "0.38.0", path = "../../sway-types" }
+swayfmt = { version = "0.38.0", path = "../../swayfmt" }

--- a/forc-plugins/forc-fmt/Cargo.toml
+++ b/forc-plugins/forc-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-fmt"
-version = "0.37.2"
+version = "0.38.0"
 description = "A `forc` plugin for running the Sway code formatter."
 authors.workspace = true
 edition.workspace = true
@@ -11,12 +11,12 @@ repository.workspace = true
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-forc-pkg = { version = "0.37.2", path = "../../forc-pkg" }
-forc-tracing = { version = "0.37.2", path = "../../forc-tracing" }
-forc-util = { version = "0.37.2", path = "../../forc-util" }
+forc-pkg = { version = "0.38.0", path = "../../forc-pkg" }
+forc-tracing = { version = "0.38.0", path = "../../forc-tracing" }
+forc-util = { version = "0.38.0", path = "../../forc-util" }
 prettydiff = "0.5"
-sway-core = { version = "0.37.2", path = "../../sway-core" }
-sway-utils = { version = "0.37.2", path = "../../sway-utils" }
-swayfmt = { version = "0.37.2", path = "../../swayfmt" }
+sway-core = { version = "0.38.0", path = "../../sway-core" }
+sway-utils = { version = "0.38.0", path = "../../sway-utils" }
+swayfmt = { version = "0.38.0", path = "../../swayfmt" }
 taplo = "0.7"
 tracing = "0.1"

--- a/forc-plugins/forc-lsp/Cargo.toml
+++ b/forc-plugins/forc-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-lsp"
-version = "0.37.2"
+version = "0.38.0"
 description = "A simple `forc` plugin for starting the sway language server."
 authors.workspace = true
 edition.workspace = true
@@ -11,5 +11,5 @@ repository.workspace = true
 [dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
-sway-lsp = { version = "0.37.2", path = "../../sway-lsp" }
+sway-lsp = { version = "0.38.0", path = "../../sway-lsp" }
 tokio = { version = "1.8" }

--- a/forc-plugins/forc-tx/Cargo.toml
+++ b/forc-plugins/forc-tx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-tx"
-version = "0.37.2"
+version = "0.38.0"
 description = "A `forc` plugin for constructing transactions."
 authors.workspace = true
 edition.workspace = true
@@ -19,7 +19,7 @@ path = "src/main.rs"
 anyhow = "1"
 clap = { version = "3", features = ["derive", "env"] }
 devault = "0.1"
-forc-util = { version = "0.37.2", path = "../../forc-util" }
+forc-util = { version = "0.38.0", path = "../../forc-util" }
 fuel-tx = { workspace = true, features = ["serde"] }
 serde = "1.0"
 serde_json = { version = "1" }

--- a/forc-test/Cargo.toml
+++ b/forc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-test"
-version = "0.37.2"
+version = "0.38.0"
 description = "A library for building and running Sway unit tests within Forc packages."
 authors.workspace = true
 edition.workspace = true
@@ -10,11 +10,11 @@ repository.workspace = true
 
 [dependencies]
 anyhow = "1"
-forc-pkg = { version = "0.37.2", path = "../forc-pkg" }
+forc-pkg = { version = "0.38.0", path = "../forc-pkg" }
 fuel-abi-types = "0.2"
 fuel-tx = { workspace = true, features = ["builder"] }
 fuel-vm = { workspace = true, features = ["random"] }
 rand = "0.8"
 rayon = "1.7.0"
-sway-core = { version = "0.37.2", path = "../sway-core" }
-sway-types = { version = "0.37.2", path = "../sway-types" }
+sway-core = { version = "0.38.0", path = "../sway-core" }
+sway-types = { version = "0.38.0", path = "../sway-types" }

--- a/forc-tracing/Cargo.toml
+++ b/forc-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-tracing"
-version = "0.37.2"
+version = "0.38.0"
 description = "Tracing utility shared between forc crates."
 authors.workspace = true
 edition.workspace = true

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-util"
-version = "0.37.2"
+version = "0.38.0"
 description = "Utility items shared between forc crates."
 authors.workspace = true
 edition.workspace = true
@@ -14,15 +14,15 @@ ansi_term = "0.12"
 anyhow = "1"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 dirs = "3.0.2"
-forc-tracing = { version = "0.37.2", path = "../forc-tracing" }
+forc-tracing = { version = "0.38.0", path = "../forc-tracing" }
 fuel-tx = { workspace = true, features = ["serde"] }
 hex = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.73"
-sway-core = { version = "0.37.2", path = "../sway-core" }
-sway-error = { version = "0.37.2", path = "../sway-error" }
-sway-types = { version = "0.37.2", path = "../sway-types" }
-sway-utils = { version = "0.37.2", path = "../sway-utils" }
+sway-core = { version = "0.38.0", path = "../sway-core" }
+sway-error = { version = "0.38.0", path = "../sway-error" }
+sway-types = { version = "0.38.0", path = "../sway-types" }
+sway-utils = { version = "0.38.0", path = "../sway-utils" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }
 unicode-xid = "0.2.2"

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc"
-version = "0.37.2"
+version = "0.38.0"
 description = "Fuel Orchestrator."
 authors.workspace = true
 edition.workspace = true
@@ -22,18 +22,18 @@ ansi_term = "0.12"
 anyhow = "1.0.41"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 clap_complete = "3.1"
-forc-pkg = { version = "0.37.2", path = "../forc-pkg" }
-forc-test = { version = "0.37.2", path = "../forc-test" }
-forc-tracing = { version = "0.37.2", path = "../forc-tracing" }
-forc-util = { version = "0.37.2", path = "../forc-util" }
+forc-pkg = { version = "0.38.0", path = "../forc-pkg" }
+forc-test = { version = "0.38.0", path = "../forc-test" }
+forc-tracing = { version = "0.38.0", path = "../forc-tracing" }
+forc-util = { version = "0.38.0", path = "../forc-util" }
 fs_extra = "1.2"
 fuel-asm = { workspace = true }
 hex = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.73"
-sway-core = { version = "0.37.2", path = "../sway-core" }
-sway-types = { version = "0.37.2", path = "../sway-types" }
-sway-utils = { version = "0.37.2", path = "../sway-utils" }
+sway-core = { version = "0.38.0", path = "../sway-core" }
+sway-types = { version = "0.38.0", path = "../sway-types" }
+sway-utils = { version = "0.38.0", path = "../sway-utils" }
 term-table = "1.3"
 tokio = { version = "1.8.0", features = ["macros", "rt-multi-thread"] }
 toml = "0.5"

--- a/sway-ast/Cargo.toml
+++ b/sway-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ast"
-version = "0.37.2"
+version = "0.38.0"
 description = "Sway's AST"
 authors.workspace = true
 edition.workspace = true
@@ -13,4 +13,4 @@ extension-trait = "1.0.1"
 num-bigint = { version = "0.4.3", features = ["serde"] }
 num-traits = "0.2.14"
 serde = { version = "1.0", features = ["derive"] }
-sway-types = { version = "0.37.2", path = "../sway-types" }
+sway-types = { version = "0.38.0", path = "../sway-types" }

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-core"
-version = "0.37.2"
+version = "0.38.0"
 description = "Sway core language."
 authors.workspace = true
 edition.workspace = true
@@ -34,12 +34,12 @@ serde_json = "1.0.91"
 sha2 = "0.9"
 smallvec = "1.7"
 strum = { version = "0.24.1", features = ["derive"] }
-sway-ast = { version = "0.37.2", path = "../sway-ast" }
-sway-error = { version = "0.37.2", path = "../sway-error" }
-sway-ir = { version = "0.37.2", path = "../sway-ir" }
-sway-parse = { version = "0.37.2", path = "../sway-parse" }
-sway-types = { version = "0.37.2", path = "../sway-types" }
-sway-utils = { version = "0.37.2", path = "../sway-utils" }
+sway-ast = { version = "0.38.0", path = "../sway-ast" }
+sway-error = { version = "0.38.0", path = "../sway-error" }
+sway-ir = { version = "0.38.0", path = "../sway-ir" }
+sway-parse = { version = "0.38.0", path = "../sway-parse" }
+sway-types = { version = "0.38.0", path = "../sway-types" }
+sway-utils = { version = "0.38.0", path = "../sway-utils" }
 thiserror = "1.0"
 tracing = "0.1"
 uint = "0.9"

--- a/sway-error/Cargo.toml
+++ b/sway-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-error"
-version = "0.37.2"
+version = "0.38.0"
 description = "Sway's error handling"
 authors.workspace = true
 edition.workspace = true
@@ -12,6 +12,6 @@ repository.workspace = true
 extension-trait = "1.0.1"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
-sway-ast = { version = "0.37.2", path = "../sway-ast" }
-sway-types = { version = "0.37.2", path = "../sway-types" }
+sway-ast = { version = "0.38.0", path = "../sway-ast" }
+sway-types = { version = "0.38.0", path = "../sway-types" }
 thiserror = "1.0"

--- a/sway-ir/Cargo.toml
+++ b/sway-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ir"
-version = "0.37.2"
+version = "0.38.0"
 description = "Sway intermediate representation."
 authors.workspace = true
 edition.workspace = true
@@ -15,6 +15,6 @@ filecheck = "0.5"
 generational-arena = "0.2"
 peg = "0.7"
 rustc-hash = "1.1.0"
-sway-ir-macros = { version = "0.37.2", path = "sway-ir-macros" }
-sway-types = { version = "0.37.2", path = "../sway-types" }
-sway-utils = { version = "0.37.2", path = "../sway-utils" }
+sway-ir-macros = { version = "0.38.0", path = "sway-ir-macros" }
+sway-types = { version = "0.38.0", path = "../sway-types" }
+sway-utils = { version = "0.38.0", path = "../sway-utils" }

--- a/sway-ir/sway-ir-macros/Cargo.toml
+++ b/sway-ir/sway-ir-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ir-macros"
-version = "0.37.2"
+version = "0.38.0"
 description = "Macros for sway's intermediate representation."
 authors.workspace = true
 edition.workspace = true

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-lsp"
-version = "0.37.2"
+version = "0.38.0"
 description = "LSP server for Sway."
 authors.workspace = true
 edition.workspace = true
@@ -11,8 +11,8 @@ repository.workspace = true
 [dependencies]
 anyhow = "1.0.41"
 dashmap = "5.4"
-forc-pkg = { version = "0.37.2", path = "../forc-pkg" }
-forc-tracing = { version = "0.37.2", path = "../forc-tracing" }
+forc-pkg = { version = "0.38.0", path = "../forc-pkg" }
+forc-tracing = { version = "0.38.0", path = "../forc-tracing" }
 notify = "5.0.0"
 notify-debouncer-mini = { version = "0.2.0" }
 parking_lot = "0.12.1"
@@ -21,13 +21,13 @@ quote = "1.0.9"
 ropey = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.60"
-sway-ast = { version = "0.37.2", path = "../sway-ast" }
-sway-core = { version = "0.37.2", path = "../sway-core" }
-sway-error = { version = "0.37.2", path = "../sway-error" }
-sway-parse = { version = "0.37.2", path = "../sway-parse" }
-sway-types = { version = "0.37.2", path = "../sway-types" }
-sway-utils = { version = "0.37.2", path = "../sway-utils" }
-swayfmt = { version = "0.37.2", path = "../swayfmt" }
+sway-ast = { version = "0.38.0", path = "../sway-ast" }
+sway-core = { version = "0.38.0", path = "../sway-core" }
+sway-error = { version = "0.38.0", path = "../sway-error" }
+sway-parse = { version = "0.38.0", path = "../sway-parse" }
+sway-types = { version = "0.38.0", path = "../sway-types" }
+sway-utils = { version = "0.38.0", path = "../sway-utils" }
+swayfmt = { version = "0.38.0", path = "../swayfmt" }
 syn = { version = "1.0.73", features = ["full"] }
 tempfile = "3"
 thiserror = "1.0.30"

--- a/sway-parse/Cargo.toml
+++ b/sway-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-parse"
-version = "0.37.2"
+version = "0.38.0"
 description = "Sway's parser"
 authors.workspace = true
 edition.workspace = true
@@ -13,9 +13,9 @@ extension-trait = "1.0.1"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 phf = { version = "0.10.1", features = ["macros"] }
-sway-ast = { version = "0.37.2", path = "../sway-ast" }
-sway-error = { version = "0.37.2", path = "../sway-error" }
-sway-types = { version = "0.37.2", path = "../sway-types" }
+sway-ast = { version = "0.38.0", path = "../sway-ast" }
+sway-error = { version = "0.38.0", path = "../sway-error" }
+sway-types = { version = "0.38.0", path = "../sway-types" }
 thiserror = "1.0"
 unicode-xid = "0.2.2"
 

--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-types"
-version = "0.37.2"
+version = "0.38.0"
 description = "Sway core types."
 authors.workspace = true
 edition.workspace = true

--- a/sway-utils/Cargo.toml
+++ b/sway-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-utils"
-version = "0.37.2"
+version = "0.38.0"
 description = "Sway common utils."
 authors.workspace = true
 edition.workspace = true

--- a/swayfmt/Cargo.toml
+++ b/swayfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swayfmt"
-version = "0.37.2"
+version = "0.38.0"
 description = "Sway language formatter."
 authors.workspace = true
 edition.workspace = true
@@ -10,16 +10,16 @@ repository.workspace = true
 
 [dependencies]
 anyhow = "1"
-forc-tracing = { version = "0.37.2", path = "../forc-tracing" }
-forc-util = { version = "0.37.2", path = "../forc-util" }
+forc-tracing = { version = "0.38.0", path = "../forc-tracing" }
+forc-util = { version = "0.38.0", path = "../forc-util" }
 ropey = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1"
-sway-ast = { version = "0.37.2", path = "../sway-ast" }
-sway-core = { version = "0.37.2", path = "../sway-core" }
-sway-error = { version = "0.37.2", path = "../sway-error" }
-sway-parse = { version = "0.37.2", path = "../sway-parse" }
-sway-types = { version = "0.37.2", path = "../sway-types" }
+sway-ast = { version = "0.38.0", path = "../sway-ast" }
+sway-core = { version = "0.38.0", path = "../sway-core" }
+sway-error = { version = "0.38.0", path = "../sway-error" }
+sway-parse = { version = "0.38.0", path = "../sway-parse" }
+sway-types = { version = "0.38.0", path = "../sway-types" }
 thiserror = "1.0.30"
 toml = "0.5"
 


### PR DESCRIPTION
See here for context: https://github.com/FuelLabs/sway/pull/4492#issuecomment-1520949069

This follows a re-release of 0.37.1 as 0.37.3: https://github.com/FuelLabs/sway/releases/tag/v0.37.3

The outcome of all this is that ideally, users previously on 0.37.1 will now pull 0.37.3 next time they run `cargo update` and will not encounter any breakage. Those ready to update can point to 0.38.0 after this is published.

Also runs `cargo update` in order to update deps to their latest patch release.