### PR TITLE
Typed Pointers

### DIFF
--- a/sway-ast/src/intrinsics.rs
+++ b/sway-ast/src/intrinsics.rs
@@ -31,6 +31,8 @@ pub enum Intrinsic {
     Revert,
     PtrAdd,
     PtrSub,
+    SlicePtr,
+    SliceLen,
     Smo,
 }
 
@@ -66,6 +68,8 @@ impl fmt::Display for Intrinsic {
             Intrinsic::Revert => "revert",
             Intrinsic::PtrAdd => "ptr_add",
             Intrinsic::PtrSub => "ptr_sub",
+            Intrinsic::SlicePtr => "slice_ptr",
+            Intrinsic::SliceLen => "slice_len",
             Intrinsic::Smo => "smo",
         };
         write!(f, "{s}")
@@ -105,6 +109,8 @@ impl Intrinsic {
             "__revert" => Revert,
             "__ptr_add" => PtrAdd,
             "__ptr_sub" => PtrSub,
+            "__slice_ptr" => SlicePtr,
+            "__slice_len" => SliceLen,
             "__smo" => Smo,
             _ => return None,
         })

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -732,6 +732,8 @@ fn const_eval_intrinsic(
         sway_ast::Intrinsic::AddrOf => Ok(None),
         sway_ast::Intrinsic::PtrAdd => Ok(None),
         sway_ast::Intrinsic::PtrSub => Ok(None),
+        sway_ast::Intrinsic::SlicePtr => Ok(None),
+        sway_ast::Intrinsic::SliceLen => Ok(None),
         sway_ast::Intrinsic::IsReferenceType
         | sway_ast::Intrinsic::IsStrType
         | sway_ast::Intrinsic::Gtf

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -846,6 +846,12 @@ impl<'eng> FnCompiler<'eng> {
                     .ins(context)
                     .binary_op(op, lhs_value, rhs_value))
             }
+            Intrinsic::SlicePtr => {
+                unimplemented!("__slice_ptr intrinsic not yet implemented.")
+            }
+            Intrinsic::SliceLen => {
+                unimplemented!("__slice_len intrinsic not yet implemented.")
+            }
             Intrinsic::Smo => {
                 let span_md_idx = md_mgr.span_to_md(context, &span);
 

--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -178,7 +178,12 @@ impl TyProgram {
                                 .type_id
                                 .extract_any_including_self(
                                     engines,
-                                    &|type_info| matches!(type_info, TypeInfo::RawUntypedPtr),
+                                    &|type_info| {
+                                        matches!(
+                                            type_info,
+                                            TypeInfo::RawUntypedPtr | TypeInfo::Ptr(..)
+                                        )
+                                    },
                                     vec![],
                                 )
                                 .is_empty()

--- a/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
+++ b/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
@@ -605,7 +605,7 @@ fn effects_of_intrinsic(intr: &sway_ast::Intrinsic) -> HashSet<Effect> {
         Smo => HashSet::from([Effect::OutputMessage]),
         Revert | IsReferenceType | IsStrType | SizeOfType | SizeOfVal | SizeOfStr | Eq | Gt
         | Lt | Gtf | AddrOf | Log | Add | Sub | Mul | Div | And | Or | Xor | Mod | Rsh | Lsh
-        | PtrAdd | PtrSub => HashSet::new(),
+        | PtrAdd | PtrSub | SlicePtr | SliceLen => HashSet::new(),
     }
 }
 

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -715,6 +715,8 @@ impl Dependencies {
                 |deps, variant| deps.gather_from_type_argument(engines, &variant.type_argument),
             ),
             TypeInfo::Alias { ty, .. } => self.gather_from_type_argument(engines, ty),
+            TypeInfo::Ptr(ty) => self.gather_from_type_argument(engines, ty),
+            TypeInfo::Slice(ty) => self.gather_from_type_argument(engines, ty),
             _ => self,
         }
     }

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -420,6 +420,40 @@ impl TypeEngine {
                 }
                 self.insert(engines, TypeInfo::Tuple(type_arguments))
             }
+            TypeInfo::Ptr(mut ty) => {
+                ty.type_id = check!(
+                    self.resolve(
+                        engines,
+                        ty.type_id,
+                        span,
+                        enforce_type_arguments,
+                        None,
+                        namespace,
+                        mod_path,
+                    ),
+                    self.insert(engines, TypeInfo::ErrorRecovery),
+                    warnings,
+                    errors
+                );
+                self.insert(engines, TypeInfo::Ptr(ty))
+            }
+            TypeInfo::Slice(mut ty) => {
+                ty.type_id = check!(
+                    self.resolve(
+                        engines,
+                        ty.type_id,
+                        span,
+                        enforce_type_arguments,
+                        None,
+                        namespace,
+                        mod_path,
+                    ),
+                    self.insert(engines, TypeInfo::ErrorRecovery),
+                    warnings,
+                    errors
+                );
+                self.insert(engines, TypeInfo::Slice(ty))
+            }
             _ => type_id,
         };
         ok(type_id, warnings, errors)

--- a/sway-core/src/type_system/substitute/subst_map.rs
+++ b/sway-core/src/type_system/substitute/subst_map.rs
@@ -240,6 +240,22 @@ impl TypeSubstMap {
                     type_arguments,
                 )
             }
+            (TypeInfo::Ptr(type_parameter), TypeInfo::Ptr(type_argument)) => {
+                TypeSubstMap::from_superset_and_subset_helper(
+                    type_engine,
+                    decl_engine,
+                    vec![type_parameter.type_id],
+                    vec![type_argument.type_id],
+                )
+            }
+            (TypeInfo::Slice(type_parameter), TypeInfo::Slice(type_argument)) => {
+                TypeSubstMap::from_superset_and_subset_helper(
+                    type_engine,
+                    decl_engine,
+                    vec![type_parameter.type_id],
+                    vec![type_argument.type_id],
+                )
+            }
             (TypeInfo::Unknown, TypeInfo::Unknown)
             | (TypeInfo::Boolean, TypeInfo::Boolean)
             | (TypeInfo::SelfType, TypeInfo::SelfType)

--- a/sway-core/src/type_system/unify/unifier.rs
+++ b/sway-core/src/type_system/unify/unifier.rs
@@ -91,6 +91,10 @@ impl<'a> Unifier<'a> {
             (Contract, Contract) => (vec![], vec![]),
             (RawUntypedPtr, RawUntypedPtr) => (vec![], vec![]),
             (RawUntypedSlice, RawUntypedSlice) => (vec![], vec![]),
+            (Ptr(r), Ptr(e)) => self.unify_arrays(received, expected, span, r.type_id, e.type_id),
+            (Slice(r), Slice(e)) => {
+                self.unify_arrays(received, expected, span, r.type_id, e.type_id)
+            }
             (Str(l), Str(r)) => self.unify_strs(received, expected, span, l.val(), r.val()),
             (Tuple(rfs), Tuple(efs)) if rfs.len() == efs.len() => self.unify_tuples(rfs, efs),
             (Array(re, rc), Array(ee, ec)) if rc.val() == ec.val() => {

--- a/sway-core/src/type_system/unify/unify_check.rs
+++ b/sway-core/src/type_system/unify/unify_check.rs
@@ -238,6 +238,13 @@ impl<'a> UnifyCheck<'a> {
                 return self.check_multiple(&l_types, &r_types);
             }
 
+            (TypeInfo::Ptr(l0), TypeInfo::Ptr(r0)) => {
+                return self.check_inner(l0.type_id, r0.type_id);
+            }
+            (TypeInfo::Slice(l0), TypeInfo::Slice(r0)) => {
+                return self.check_inner(l0.type_id, r0.type_id);
+            }
+
             (Struct(l_decl_ref), Struct(r_decl_ref)) => {
                 let l_decl = self.engines.de().get_struct(l_decl_ref);
                 let r_decl = self.engines.de().get_struct(r_decl_ref);

--- a/sway-lib-core/src/lib.sw
+++ b/sway-lib-core/src/lib.sw
@@ -3,6 +3,8 @@ library;
 pub mod primitives;
 pub mod raw_ptr;
 pub mod raw_slice;
+pub mod ptr;
+pub mod slice;
 pub mod ops;
 pub mod primitive_conversions;
 pub mod never;

--- a/sway-lib-core/src/ops.sw
+++ b/sway-lib-core/src/ops.sw
@@ -253,6 +253,12 @@ impl Eq for raw_ptr {
     }
 }
 
+impl<T> Eq for __ptr[T] {
+    fn eq(self, other: Self) -> bool {
+        __eq(self, other)
+    }
+}
+
 pub trait Ord {
     fn gt(self, other: Self) -> bool;
     fn lt(self, other: Self) -> bool;

--- a/sway-lib-core/src/prelude.sw
+++ b/sway-lib-core/src/prelude.sw
@@ -6,6 +6,8 @@ library;
 use ::primitives::*;
 use ::raw_ptr::*;
 use ::raw_slice::*;
+use ::ptr::*;
+use ::slice::*;
 use ::never::*;
 use ::ops::*;
 use ::storage::*;

--- a/sway-lib-core/src/ptr.sw
+++ b/sway-lib-core/src/ptr.sw
@@ -1,0 +1,46 @@
+library;
+
+impl<T> __ptr[T] {
+    /// Calculates the offset from the pointer.
+    pub fn add(self, count: u64) -> __ptr[T] {
+        __ptr_add::<T>(self, count)
+    }
+
+    /// Calculates the offset from the pointer.
+    pub fn sub(self, count: u64) -> __ptr[T] {
+        __ptr_sub::<T>(self, count)
+    }
+
+    /// Reads the given type of value from the address.
+    pub fn read<U>(self) -> U {
+        if __is_reference_type::<U>() {
+            asm(ptr: self) { ptr: U }
+        } else {
+            asm(ptr: self, val) {
+                lw val ptr i0;
+                val: U
+            }
+        }
+    }
+
+    /// Copies `count * size_of<T>` bytes from `self` to `dst`.
+    pub fn copy_to(self, dst: __ptr[T], count: u64) {
+        let len = __mul(count, __size_of::<T>());
+        asm(dst: dst, src: self, len: len) {
+            mcp dst src len;
+        };
+    }
+
+    /// Writes the given value to the address.
+    pub fn write<U>(self, val: U) {
+        if __is_reference_type::<U>() {
+            asm(dst: self, src: val, count: __size_of_val(val)) {
+                mcp dst src count;
+            };
+        } else {
+            asm(ptr: self, val: val) {
+                sw ptr val i0;
+            };
+        }
+    }
+}

--- a/sway-lib-core/src/slice.sw
+++ b/sway-lib-core/src/slice.sw
@@ -1,0 +1,19 @@
+library;
+
+use ::ptr::*;
+
+pub trait AsSlice<T> {
+    fn as_slice(self) -> __slice[T];
+}
+
+impl<T> __slice[T] {
+    // /// Returns the pointer to the slice.
+    // pub fn ptr(self) -> __ptr[T] {
+    //     __slice_ptr::<T>(self)
+    // }
+
+    /// Returns the number of elements in the slice.
+    pub fn len(self) -> u64 {
+        __slice_len::<T>(self)
+    }
+}

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -237,6 +237,14 @@ pub fn type_info_to_symbol_kind(
             let type_info = type_engine.get(elem_ty.type_id);
             type_info_to_symbol_kind(type_engine, &type_info, Some(&elem_ty.span()))
         }
+        TypeInfo::Ptr(ty) => {
+            let type_info = type_engine.get(ty.type_id);
+            type_info_to_symbol_kind(type_engine, &type_info, Some(&ty.span()))
+        }
+        TypeInfo::Slice(ty) => {
+            let type_info = type_engine.get(ty.type_id);
+            type_info_to_symbol_kind(type_engine, &type_info, Some(&ty.span()))
+        }
         TypeInfo::SelfType => SymbolKind::SelfTypeKeyword,
         _ => SymbolKind::Unknown,
     }

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -987,6 +987,12 @@ impl Parse for TypeArgument {
                     type_arg.parse(ctx);
                 }
             }
+            TypeInfo::Ptr(type_arg) => {
+                type_arg.parse(ctx);
+            }
+            TypeInfo::Slice(type_arg) => {
+                type_arg.parse(ctx);
+            }
             _ => {
                 let symbol_kind = type_info_to_symbol_kind(ctx.engines.te(), &type_info, None);
                 if let Some(tree) = &self.call_path_tree {
@@ -1035,6 +1041,12 @@ fn collect_type_info_token(ctx: &ParseContext, type_info: &TypeInfo, type_span: 
             type_arguments.iter().for_each(|type_arg| {
                 type_arg.parse(ctx);
             });
+        }
+        TypeInfo::Ptr(type_arg) => {
+            type_arg.parse(ctx);
+        }
+        TypeInfo::Slice(type_arg) => {
+            type_arg.parse(ctx);
         }
         TypeInfo::Custom {
             call_path,

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -1256,6 +1256,12 @@ fn collect_type_id(
                 field.parse(ctx);
             });
         }
+        TypeInfo::Ptr(type_arg) => {
+            collect_type_argument(ctx, type_arg);
+        }
+        TypeInfo::Slice(type_arg) => {
+            collect_type_argument(ctx, type_arg);
+        }
         _ => {
             if let Some(token) = ctx
                 .tokens

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ptr/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ptr/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-D1B3D64D60AA755E'
+
+[[package]]
+name = 'ptr'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-D1B3D64D60AA755E'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ptr/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ptr/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "ptr"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ptr/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ptr/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "bool",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ptr/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ptr/src/main.sw
@@ -1,0 +1,85 @@
+script;
+
+use std::{intrinsics::{size_of, size_of_val}};
+
+fn addr_of<T>(val: T) -> __ptr[u64] {
+    asm(r1: val) { r1: __ptr[u64] }
+}
+fn alloc<T>(count: u64) -> __ptr[u64] {
+    asm(size: (size_of::<T>() * count) + 1, ptr) {
+        aloc size;
+        addi ptr hp i1;
+        ptr: __ptr[u64]
+    }
+}
+
+struct TestStruct {
+    boo: bool,
+    uwu: u64,
+}
+
+struct ExtendedTestStruct {
+    boo: bool,
+    uwu: u64,
+    kek: bool,
+    bur: u64,
+}
+
+fn main() -> bool {
+    // Create a struct
+    let foo = TestStruct {
+        boo: true,
+        uwu: 42,
+    };
+    let foo_len = size_of_val(foo);
+    assert(foo_len == 16);
+
+    // Get a pointer to it
+    let foo_ptr = addr_of(foo);
+    assert(foo_ptr == asm(r1: foo) { r1: __ptr[u64] });
+
+    // Get another pointer to it and compare
+    let foo_ptr_2 = addr_of(foo);
+    assert(foo_ptr_2 == foo_ptr);
+
+    // Copy the struct into a buffer
+    let buf_ptr = alloc::<u64>(2);
+    foo_ptr.copy_to(buf_ptr, 2);
+    assert(asm(r1: buf_ptr, r2: foo_ptr, r3: foo_len, res) {
+        meq res r1 r2 r3;
+        res: bool
+    });
+
+    // Read the pointer as a TestStruct
+    let foo: TestStruct = buf_ptr.read();
+    assert(foo.boo == true);
+    assert(foo.uwu == 42);
+
+    // Read fields of the struct
+    let uwu_ptr = buf_ptr.add(1);
+    let uwu: u64 = uwu_ptr.read();
+    assert(uwu == 42);
+    let boo_ptr = uwu_ptr.sub(1);
+    let boo: bool = boo_ptr.read();
+    assert(boo == true);
+
+    // Write values into a buffer
+    let buf_ptr = alloc::<u64>(2);
+    // buf_ptr.write(true);
+    // buf_ptr.add(1).write(42);
+    let foo: TestStruct = buf_ptr.read();
+    assert(foo.boo == true);
+    assert(foo.uwu == 42);
+
+    // Write structs into a buffer
+    let buf_ptr = alloc::<u64>(4);
+    buf_ptr.write(foo);
+    buf_ptr.add(2).write(foo);
+    let bar: ExtendedTestStruct = buf_ptr.read();
+    assert(bar.boo == true);
+    assert(bar.uwu == 42);
+    assert(bar.kek == true);
+    assert(bar.bur == 42);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ptr/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ptr/test.toml
@@ -1,0 +1,4 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+validate_abi = true
+expected_warnings = 1

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/slice/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/slice/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-8175BA0DBE650EFE'
+
+[[package]]
+name = 'slice'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-8175BA0DBE650EFE'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/slice/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/slice/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "slice"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/slice/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/slice/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "raw untyped slice",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/slice/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/slice/src/main.sw
@@ -1,0 +1,36 @@
+script;
+
+use std::{intrinsics::{size_of, size_of_val}};
+
+fn addr_of<T>(val: T) -> __ptr[u64] {
+    asm(r1: val) { r1: __ptr[u64] }
+}
+
+struct TestStruct {
+    boo: bool,
+    uwu: u64,
+}
+
+fn main() -> __slice[T] {
+    // Create a struct
+    let foo = TestStruct {
+        boo: true,
+        uwu: 42,
+    };
+    let foo_len = size_of_val(foo);
+    assert(foo_len == 16);
+
+    // Get a slice to it
+    let foo_ptr = addr_of(foo);
+    let buf_len = foo_len / size_of::<u64>();
+    let foo_buf = __slice[T]::from_parts(foo_ptr, buf_len);
+    assert(foo_buf.ptr() == foo_ptr);
+    assert(foo_buf.len() == 2);
+
+    // Convert to a vector
+    let foo_vec: Vec<u64> = Vec::<u64>::from(foo_buf);
+    assert(foo_vec.len() == 2);
+
+    // Return it
+    foo_vec.as_slice()
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/slice/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/slice/test.toml
@@ -1,0 +1,4 @@
+category = "run"
+expected_result = { action = "return_data", value = "0000000000000001000000000000002a" }
+validate_abi = true
+expected_warnings = 2


### PR DESCRIPTION
- [ ] Tests are failing. Fix parsing of `__ptr[T]` and `__slice[T]`.
- [ ] Replicate `raw_ptr` and `raw_slice` tests for the typed variants.
- [ ] Contact the SDK team and make sure this actually opens up the way for returning `Vec<T>`s from scripts. (Even though we need to convert them into a slice first.)