### PR TITLE
Fix `--finalized-asm` output and docs

### DIFF
--- a/docs/book/src/forc/manifest_reference.md
+++ b/docs/book/src/forc/manifest_reference.md
@@ -16,7 +16,7 @@ The `Forc.toml` (the _manifest_ file) is a compulsory file for each package and 
 * `[network]` — Defines a network for forc to interact with.
   * `url` — URL of the network.
 
-* [`[build-profiles]`](#the-build-profiles--section) - Defines the build profiles.
+* [`[build-profile]`](#the-build-profile-section) - Defines the build profiles.
 
 * [`[patch]`](#the-patch-section) - Defines the patches.
 
@@ -62,18 +62,23 @@ For the following fields, a default value is provided so omitting them is allowe
 
 * `URL` - (default: _<http://127.0.0.1:4000>_)
 
-## The `[build-profiles-*]` section
+## The `[build-profile.*]` section
 
-The `[build-profiles]` tables provide a way to customize compiler settings such as debug options.
+The `[build-profile]` tables provide a way to customize compiler settings such as debug options.
 
-The following fields needs to be provided for a build-profile:
+The following fields can be provided for a build-profile:
 
-* `print-ast` - Whether to print out the generated AST (true) or not (false).
-* `print-dca-graph` - Whether to print out the computed DCA graph (in GraphViz DOT format).
-* `print-finalized-asm` - Whether to compile to bytecode (false) or to print out the generated ASM (true).
-* `print-intermediate-asm` - Whether to compile to bytecode (false) or to print out the generated ASM (true).
-* `print-ir` - Whether to compile to bytecode (false) or to print out the generated IR (true).
-* `terse-mode` - Terse mode. Limited warning and error output.
+* `print-ast` - Whether to print out the generated AST or not, defaults to false.
+* `print-dca-graph` - Whether to print out the computed DCA graph (in GraphViz DOT format), defaults to false.
+* `print-dca-graph-url-format` - The URL format to be used in the generated DOT file, an example for vscode would be: "vscode://file/{path}:{line}:{col}"
+* `print-ir` - Whether to compile to bytecode (false) or to print out the generated IR (true), defaults to false.
+* `print-finalized-asm` - Whether to compile to bytecode (false) or to print out the generated ASM (true), defaults to false.
+* `print-intermediate-asm` - Whether to compile to bytecode (false) or to print out the generated ASM (true), defaults to false.
+* `terse` - Terse mode. Limited warning and error output, defaults to false.
+* `time_phases` - Whether to output the time elapsed over each part of the compilation process, defaults to false.
+* `include_tests` -  Whether or not to include test functions in parsing, type-checking and codegen, this is set to true by invocations like `forc test`, defaults to false.
+* `json_abi_with_callpaths` - Whether to json abi with callpaths instead of names for struct and enums, defaults to false.
+* `error_on_warnings` - Whether to treat errors as warnings, defaults to false.
 
 There are two default `[build-profile]` available with every manifest file. These are `debug` and `release` profiles. If you want to override these profiles, you can provide them explicitly in the manifest file like the following example:
 
@@ -85,13 +90,13 @@ organization = "Fuel_Labs"
 license = "Apache-2.0"
 name = "wallet_contract"
 
-[build-profiles.debug]
+[build-profile.debug]
 print-finalized-asm = false
 print-intermediate-asm = false
 print-ir = false
 terse = false
 
-[build-profiles.release]
+[build-profile.release]
 print-finalized-asm = false 
 print-intermediate-asm = false
 print-ir = false
@@ -100,12 +105,20 @@ terse = true
 
 Since `release` and `debug` implicitly included in every manifest file, you can use them by just passing `--release` or by not passing anything (debug is default). For using a user defined build profile there is `--build-profile <profile name>` option available to the relevant commands. (For an example see [forc-build](../forc/commands/forc_build.md))
 
-Note that providing the corresponding cli options (like `--print-finalized-asm`) will override the selected build profile. For example if you pass both `--release` and `--print-finalized-asm`, release build profile is omitted and resulting build profile would have a structure like the following:
+Note that providing the corresponding cli options (like `--finalized-asm`) will override the selected build profile. For example if you pass both `--release` and `--finalized-asm`, release build profile is omitted and resulting build profile would have a structure like the following:
 
-* print-finalized-asm - true
-* print-intermediate-asm - false
-* print-ir - false
-* terse - false
+```toml
+print-ast = false
+print-ir = false
+print-finalized-asm = false
+print-intermediate-asm = false
+terse = false
+time-phases = false
+include-tests = false
+json-abi-with-callpaths = false
+error-on-warnings = false
+experimental-private-modules = false
+```
 
 ## The `[patch]` section
 

--- a/docs/book/src/introduction/forc_project.md
+++ b/docs/book/src/introduction/forc_project.md
@@ -48,10 +48,10 @@ impl MyContract for Contract {
 
 The project is a _contract_, one of four different project types. For additional information on different project types, see [here](../sway-program-types/index.md).
 
-We now compile our project with `forc build`, passing the flag `--print-finalized-asm` to view the generated assembly:
+We now compile our project with `forc build`, passing the flag `--finalized-asm` to view the generated assembly:
 
 ```console
-$ forc build --print-finalized-asm
+$ forc build --finalized-asm
 ...
 .program:
 ji   i4

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -203,17 +203,27 @@ pub struct DependencyDetails {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct BuildProfile {
+    #[serde(default)]
     pub print_ast: bool,
     pub print_dca_graph: Option<String>,
     pub print_dca_graph_url_format: Option<String>,
+    #[serde(default)]
     pub print_ir: bool,
+    #[serde(default)]
     pub print_finalized_asm: bool,
+    #[serde(default)]
     pub print_intermediate_asm: bool,
+    #[serde(default)]
     pub terse: bool,
+    #[serde(default)]
     pub time_phases: bool,
+    #[serde(default)]
     pub include_tests: bool,
+    #[serde(default)]
     pub json_abi_with_callpaths: bool,
+    #[serde(default)]
     pub error_on_warnings: bool,
+    #[serde(default)]
     pub experimental_private_modules: bool,
 }
 

--- a/sway-core/src/asm_generation/programs/final.rs
+++ b/sway-core/src/asm_generation/programs/final.rs
@@ -58,7 +58,15 @@ impl std::fmt::Display for FinalProgram {
         match self {
             FinalProgram::Fuel {
                 data_section, ops, ..
-            } => write!(f, "{ops:?}\n{data_section}"),
+            } => write!(
+                f,
+                ".program:\n{}\n{}",
+                ops.iter()
+                    .map(|x| format!("{x}"))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+                data_section,
+            ),
             FinalProgram::Evm { ops, .. } => {
                 let mut separator = etk_dasm::blocks::basic::Separator::new();
 


### PR DESCRIPTION


## Description

This change does three things.

First it repairs the output of the `--finalize-asm` build option so it actually outputs readable asm.

Second it updates the documentation on build profiles and in all occurences of `--print-finalize-asm` to use the new flag, use the correct names of build profile options and adds documentation for the new flags. Fixes #4481

Third, it lets the deserialization of the flags to use default values when the flags for a certain build profile are not all defined, so users can define a new build profile to tweak a small number of options and get the least surprising behavior.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
