### PR TITLE
const-demotion locals must be loaded in same basic block as its use.

### DIFF
--- a/sway-ir/src/block.rs
+++ b/sway-ir/src/block.rs
@@ -368,6 +368,13 @@ impl Block {
         ins.retain(|value| !pred(*value));
     }
 
+    /// Insert instruction(s) at the beginning of the block.
+    pub fn prepend_instructions(&self, context: &mut Context, mut insts: Vec<Value>) {
+        let block_ins = &mut context.blocks[self.0].instructions;
+        insts.append(block_ins);
+        context.blocks[self.0].instructions = insts;
+    }
+
     /// Replace an instruction in this block with another.  Will return a ValueNotFound on error.
     /// Any use of the old instruction value will also be replaced by the new value throughout the
     /// owning function.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle.json
@@ -7,7 +7,7 @@
         "typeArguments": null
       },
       "name": "C0",
-      "offset": 3764
+      "offset": 3740
     },
     {
       "configurableType": {
@@ -16,7 +16,7 @@
         "typeArguments": null
       },
       "name": "C1",
-      "offset": 3772
+      "offset": 3748
     },
     {
       "configurableType": {
@@ -25,7 +25,7 @@
         "typeArguments": null
       },
       "name": "C2",
-      "offset": 3788
+      "offset": 3764
     },
     {
       "configurableType": {
@@ -34,7 +34,7 @@
         "typeArguments": []
       },
       "name": "C3",
-      "offset": 3820
+      "offset": 3796
     },
     {
       "configurableType": {
@@ -43,7 +43,7 @@
         "typeArguments": []
       },
       "name": "C4",
-      "offset": 3836
+      "offset": 3812
     },
     {
       "configurableType": {
@@ -52,7 +52,7 @@
         "typeArguments": []
       },
       "name": "C5",
-      "offset": 3852
+      "offset": 3828
     },
     {
       "configurableType": {
@@ -61,7 +61,7 @@
         "typeArguments": null
       },
       "name": "C6",
-      "offset": 3868
+      "offset": 3844
     },
     {
       "configurableType": {
@@ -70,7 +70,7 @@
         "typeArguments": null
       },
       "name": "C7",
-      "offset": 3884
+      "offset": 3860
     }
   ],
   "functions": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -2,7 +2,7 @@ script;
 use basic_storage_abi::{BasicStorage, Quad};
 
 fn main() -> u64 {
-    let addr = abi(BasicStorage, 0x47ddf698943d2327a24e9ef44c8d21f752d5d9eedd8d5f29c1835c3ba0092f28);
+    let addr = abi(BasicStorage, 0xb58bd85320e71f5d4f079ee969c7eeda8bf6284d0604b8ff70806355ab90aef4);
     let key = 0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
@@ -3,7 +3,7 @@ script;
 use increment_abi::Incrementor;
 
 fn main() -> bool {
-    let the_abi = abi(Incrementor, 0xa99b5dd42245f9d214f8066a2bb92439cc3e2282625d1980b50552b2f64de2b1);
+    let the_abi = abi(Incrementor, 0xabc8916cc1d37a762308deab3fc46e2fbe2ce3b9c918002c28368e0e026aa418);
     the_abi.increment(5);
     the_abi.increment(5);
     let result = the_abi.get();


### PR DESCRIPTION
## Description

Previously, const-demotion would load all demoted consts from a new block at entry. The problem with this is that optimizing sequences of load+store (memcpy) via copy-propagation would then require a function wide data-flow analysis. In the same block, it's easier to do, and we already have the optimization.

Related to #4345 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
