### PR TITLE
Fixes method application self mutability check.

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_fail/method_requires_mut_var/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/method_requires_mut_var/src/main.sw
@@ -4,9 +4,31 @@ struct A {
     a: u64,
 }
 
+struct B {
+    a: A,
+}
+
+struct C {
+    b: B,
+}
+
 impl A {
     fn f(ref mut self) {
         self.a = 42;
+    }
+}
+
+impl B {
+    fn f(self) {
+        // Expecting error: Cannot call method "f" on variable "self" because "self" is not declared as mutable.
+        self.a.f();
+    }
+}
+
+impl C {
+    fn f(self) {
+        // Expecting error: Cannot call method "f" on variable "self" because "self" is not declared as mutable.
+        self.b.a.f();
     }
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_fail/method_requires_mut_var/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/method_requires_mut_var/test.toml
@@ -1,3 +1,10 @@
 category = "fail"
 
-# check: $()Cannot call method "f" on variable "a" because "a" is not declared as mutable.
+# check: $()self.a.f();
+# nextln: $()Cannot call method "f" on variable "self" because "self" is not declared as mutable.
+
+# check: $()self.b.a.f();
+# nextln: $()Cannot call method "f" on variable "self" because "self" is not declared as mutable.
+
+# check: $()a.f();
+# nextln: $()Cannot call method "f" on variable "a" because "a" is not declared as mutable.


### PR DESCRIPTION
## Description
We now check method application self parameters mutability when the used arguments is a `StructFieldAccess`. When a `StructFieldAccess` is used to call a method application with a mutable self we now make sure that the `StructFieldAccess` prefix variable is also mutable.

Closes #4408

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
