### PR TITLE
Fix `StorageVec` bugs with use of `field_id`

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/empty_fields_in_storage_struct/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/empty_fields_in_storage_struct/Forc.toml
@@ -1,8 +1,8 @@
 [project]
 authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
 license = "Apache-2.0"
 name = "empty_fields_in_storage_struct"
-entry = "main.sw"
 
 [dependencies]
 std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/empty_fields_in_storage_struct/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/empty_fields_in_storage_struct/src/main.sw
@@ -54,6 +54,16 @@ impl ReproAttempt for Contract {
     fn bar_get(key: u64) -> Option<u64> {
         storage.struct_of_maps.bar.get(key).try_read()
     }
+
+    #[storage(read)]    
+    fn foo_len() -> u64 {
+        storage.struct_of_maps.foo.len().try_read()
+    }
+
+    #[storage(read)]
+    fn bar_len() -> u64 {
+        storage.struct_of_maps.bar.len().try_read()
+    }
 }
 
 #[test()]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/empty_fields_in_storage_struct/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/empty_fields_in_storage_struct/src/main.sw
@@ -1,25 +1,38 @@
 contract;
 
 use std::storage::storage_map::*;
+use std::storage::storage_vec::*;
 
 abi ReproAttempt {
     #[storage(read, write)]
-    fn foo_insert(key: u64, value: u64);
+    fn map_foo_insert(key: u64, value: u64);
 
     #[storage(read)]
-    fn foo_get(key: u64) -> Option<u64>;
-
-    #[storage(read)]
-    fn foo_len() -> u64;
+    fn map_foo_get(key: u64) -> Option<u64>;
 
     #[storage(read, write)]
-    fn bar_insert(key: u64, value: u64);
+    fn map_bar_insert(key: u64, value: u64);
 
     #[storage(read)]
-    fn bar_get(key: u64) -> Option<u64>;
+    fn map_bar_get(key: u64) -> Option<u64>;
+
+    #[storage(read, write)]
+    fn vec_foo_push(value: u64);
 
     #[storage(read)]
-    fn bar_len() -> u64;
+    fn vec_foo_get(index: u64) -> Option<u64>;
+
+    #[storage(read, write)]
+    fn vec_bar_push(value: u64);
+
+    #[storage(read)]
+    fn vec_bar_get(index: u64) -> Option<u64>;
+
+    #[storage(read)]
+    fn vec_foo_len() -> u64;
+
+    #[storage(read)]
+    fn vec_bar_len() -> u64;
 }
 
 struct StructOfStorageMaps {
@@ -27,59 +40,111 @@ struct StructOfStorageMaps {
     bar: StorageMap<u64, u64>,
 }
 
+struct StructOfStorageVecs {
+    foo: StorageVec<u64>,
+    bar: StorageVec<u64>,
+}
+
 storage {
     struct_of_maps: StructOfStorageMaps = StructOfStorageMaps {
         foo: StorageMap {},
         bar: StorageMap {},
     },
+    struct_of_vecs: StructOfStorageVecs = StructOfStorageVecs {
+        foo: StorageVec {},
+        bar: StorageVec {},
+    },
 }
 
 impl ReproAttempt for Contract {
     #[storage(read, write)]
-    fn foo_insert(key: u64, value: u64) {
+    fn map_foo_insert(key: u64, value: u64) {
         storage.struct_of_maps.foo.insert(key, value);
     }
 
     #[storage(read)]
-    fn foo_get(key: u64) -> Option<u64> {
+    fn map_foo_get(key: u64) -> Option<u64> {
         storage.struct_of_maps.foo.get(key).try_read()
     }
 
     #[storage(read, write)]
-    fn bar_insert(key: u64, value: u64) {
+    fn map_bar_insert(key: u64, value: u64) {
         storage.struct_of_maps.bar.insert(key, value);
     }
 
     #[storage(read)]
-    fn bar_get(key: u64) -> Option<u64> {
+    fn map_bar_get(key: u64) -> Option<u64> {
         storage.struct_of_maps.bar.get(key).try_read()
     }
 
-    #[storage(read)]    
-    fn foo_len() -> u64 {
-        storage.struct_of_maps.foo.len().try_read()
+    #[storage(read, write)]
+    fn vec_foo_push(value: u64) {
+        storage.struct_of_vecs.foo.push(value)
     }
 
     #[storage(read)]
-    fn bar_len() -> u64 {
-        storage.struct_of_maps.bar.len().try_read()
+    fn vec_foo_get(index: u64) -> Option<u64> {
+        match storage.struct_of_vecs.foo.get(index) {
+            Option::Some(key) => {
+                key.try_read()
+            },
+            Option::None => Option::None,
+        }
+    }
+
+    #[storage(read, write)]
+    fn vec_bar_push(value: u64) {
+        storage.struct_of_vecs.bar.push(value)
+    }
+
+    #[storage(read)]
+    fn vec_bar_get(index: u64) -> Option<u64> {
+        match storage.struct_of_vecs.bar.get(index) {
+            Option::Some(key) => {
+                key.try_read()
+            },
+            Option::None => Option::None,
+        }
+    }
+
+    #[storage(read)]
+    fn vec_foo_len() -> u64 {
+        storage.struct_of_vecs.foo.len()
+    }
+
+    #[storage(read)]
+    fn vec_bar_len() -> u64 {
+        storage.struct_of_vecs.bar.len()
     }
 }
 
 #[test()]
-fn test_read_write() {
+fn test_read_write_map() {
     let repro = abi(ReproAttempt, CONTRACT_ID);
 
-    assert(repro.foo_get(1).is_none());
-    assert(repro.foo_len() == 0);
-    assert(repro.bar_get(1).is_none());
-    assert(repro.bar_len() == 0);
+    assert(repro.map_foo_get(1).is_none());
+    assert(repro.map_bar_get(1).is_none());
 
-    repro.foo_insert(1, 2);
+    repro.map_foo_insert(1, 2);
 
-    assert(repro.foo_get(1).unwrap() == 2);
-    assert(repro.foo_len() == 1);
+    assert(repro.map_foo_get(1).unwrap() == 2);
+    assert(repro.map_bar_get(1).is_none());
+}
 
-    assert(repro.bar_get(1).is_none());
-    assert(repro.bar_len() == 0);
+#[test()]
+fn test_read_write_vec() {
+    let repro = abi(ReproAttempt, CONTRACT_ID);
+
+    assert(repro.vec_foo_get(0).is_none());
+    assert(repro.vec_foo_len() == 0);
+    assert(repro.vec_bar_get(0).is_none());
+    assert(repro.vec_bar_len() == 0);
+
+    repro.vec_foo_push(1);
+
+    assert(repro.vec_foo_get(0).unwrap() == 1);
+    assert(repro.vec_foo_len() == 1);
+
+    assert(repro.vec_bar_get(0).is_none());
+    assert(repro.vec_bar_len() == 0);
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/empty_fields_in_storage_struct/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/empty_fields_in_storage_struct/src/main.sw
@@ -9,11 +9,17 @@ abi ReproAttempt {
     #[storage(read)]
     fn foo_get(key: u64) -> Option<u64>;
 
+    #[storage(read)]
+    fn foo_len() -> u64;
+
     #[storage(read, write)]
     fn bar_insert(key: u64, value: u64);
 
     #[storage(read)]
     fn bar_get(key: u64) -> Option<u64>;
+
+    #[storage(read)]
+    fn bar_len() -> u64;
 }
 
 struct StructOfStorageMaps {
@@ -55,8 +61,15 @@ fn test_read_write() {
     let repro = abi(ReproAttempt, CONTRACT_ID);
 
     assert(repro.foo_get(1).is_none());
+    assert(repro.foo_len() == 0);
+    assert(repro.bar_get(1).is_none());
+    assert(repro.bar_len() == 0);
+
     repro.foo_insert(1, 2);
+
     assert(repro.foo_get(1).unwrap() == 2);
+    assert(repro.foo_len() == 1);
 
     assert(repro.bar_get(1).is_none());
+    assert(repro.bar_len() == 0);
 }


### PR DESCRIPTION
## Description

Only some of the read/writes in `StorageVec` were updated to use `field_id` in https://github.com/FuelLabs/sway/pull/4537. For example, there are two writes when inserting, the length and value itself. Only the value was updated meaning the lengths would still be overwriting one another.
 
Tests to ensure both values and lengths are updated separately have been added.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
