### PR TITLE
Update `StorableSlice` function naming to match storage API

### DIFF
--- a/sway-lib-std/src/storage/storable_slice.sw
+++ b/sway-lib-std/src/storage/storable_slice.sw
@@ -15,16 +15,16 @@ use ::storage::storage_api::*;
 /// ### Examples
 ///
 /// ```sway
-/// use std::{alloc::alloc_bytes, storage::{store_slice, get_slice}, constants::ZERO_B256};
+/// use std::{alloc::alloc_bytes, storage::{write_slice, read_slice}, constants::ZERO_B256};
 ///
 /// let slice = asm(ptr: (alloc_bytes(1), 1)) { ptr: raw_slice };
-/// assert(get_slice(ZERO_B256).is_none());
-/// store_slice(ZERO_B256, slice);
-/// let stored_slice = get_slice(ZERO_B256).unwrap();
+/// assert(read_slice(ZERO_B256).is_none());
+/// write_slice(ZERO_B256, slice);
+/// let stored_slice = read_slice(ZERO_B256).unwrap();
 /// assert(slice == stored_slice);
 /// ```
 #[storage(read, write)]
-pub fn store_slice(key: b256, slice: raw_slice) {
+pub fn write_slice(key: b256, slice: raw_slice) {
     // Get the number of storage slots needed based on the size of bytes.
     let number_of_bytes = slice.number_of_bytes();
     let number_of_slots = (number_of_bytes + 31) >> 5;
@@ -53,16 +53,16 @@ pub fn store_slice(key: b256, slice: raw_slice) {
 /// ### Examples
 ///
 /// ```sway
-/// use std::{alloc::alloc_bytes, storage::{store_slice, get_slice}, constants::ZERO_B256};
+/// use std::{alloc::alloc_bytes, storage::{write_slice, read_slice}, constants::ZERO_B256};
 ///
 /// let slice = asm(ptr: (alloc_bytes(1), 1)) { ptr: raw_slice };
-/// assert(get_slice(ZERO_B256).is_none());
-/// store_slice(ZERO_B256, slice);
-/// let stored_slice = get_slice(ZERO_B256).unwrap();
+/// assert(read_slice(ZERO_B256).is_none());
+/// write_slice(ZERO_B256, slice);
+/// let stored_slice = read_slice(ZERO_B256).unwrap();
 /// assert(slice == stored_slice);
 /// ```
 #[storage(read)]
-pub fn get_slice(key: b256) -> Option<raw_slice> {
+pub fn read_slice(key: b256) -> Option<raw_slice> {
     // Get the length of the slice that is stored.
     match read::<u64>(key, 0).unwrap_or(0) {
         0 => None,
@@ -87,14 +87,14 @@ pub fn get_slice(key: b256) -> Option<raw_slice> {
 /// ### Examples
 ///
 /// ```sway
-/// use std::{alloc::alloc_bytes, storage::{clear_slice, store_slice, get_slice}, constants::ZERO_B256};
+/// use std::{alloc::alloc_bytes, storage::{clear_slice, write_slice, read_slice}, constants::ZERO_B256};
 ///
 /// let slice = asm(ptr: (alloc_bytes(1), 1)) { ptr: raw_slice };
-/// store_slice(ZERO_B256, slice);
-/// assert(get_slice(ZERO_B256).is_some());
+/// write_slice(ZERO_B256, slice);
+/// assert(read_slice(ZERO_B256).is_some());
 /// let cleared = clear_slice(ZERO_B256);
 /// assert(cleared);
-/// assert(get_slice(ZERO_B256).is_none());
+/// assert(read_slice(ZERO_B256).is_none());
 /// ```
 #[storage(read, write)]
 pub fn clear_slice(key: b256) -> bool {
@@ -110,9 +110,9 @@ pub fn clear_slice(key: b256) -> bool {
 /// A general way to persistently store heap types.
 pub trait StorableSlice<T> {
     #[storage(read, write)]
-    fn store(self, argument: T);
+    fn write(self, argument: T);
     #[storage(read)]
-    fn load(self) -> Option<T>;
+    fn read(self) -> Option<T>;
     #[storage(read, write)]
     fn clear(self) -> bool;
     #[storage(read)]

--- a/sway-lib-std/src/storage/storage_bytes.sw
+++ b/sway-lib-std/src/storage/storage_bytes.sw
@@ -32,12 +32,12 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
     ///     bytes.push(7_u8);
     ///     bytes.push(9_u8);
     ///
-    ///     storage.stored_bytes.store(bytes);
+    ///     storage.stored_bytes.write(bytes);
     /// }
     /// ```
     #[storage(read, write)]
-    fn store(self, bytes: Bytes) {
-        store_slice(self.field_id, bytes.as_raw_slice());
+    fn write(self, bytes: Bytes) {
+        write_slice(self.field_id, bytes.as_raw_slice());
     }
 
     /// Constructs a `Bytes` type from a collection of tightly packed bytes in storage.
@@ -59,14 +59,14 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
     ///     bytes.push(7_u8);
     ///     bytes.push(9_u8);
     ///
-    ///     assert(storage.stored_bytes.load(key).is_none());
-    ///     storage.stored_bytes.store(bytes);
-    ///     let retrieved_bytes = storage.stored_bytes.load(key).unwrap();
+    ///     assert(storage.stored_bytes.read(key).is_none());
+    ///     storage.stored_bytes.write(bytes);
+    ///     let retrieved_bytes = storage.stored_bytes.read(key).unwrap();
     ///     assert(bytes == retrieved_bytes);
     /// }
     /// ```
     #[storage(read)]
-    fn load(self) -> Option<Bytes> {
+    fn read(self) -> Option<Bytes> {
         match get_slice(self.field_id) {
             Some(slice) => {
                 Some(Bytes::from_raw_slice(slice))
@@ -94,12 +94,12 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
     ///     bytes.push(5_u8);
     ///     bytes.push(7_u8);
     ///     bytes.push(9_u8);
-    ///     storage.stored_bytes.store(bytes);
+    ///     storage.stored_bytes.write(bytes);
     ///
-    ///     assert(storage.stored_bytes.load(key).is_some());
+    ///     assert(storage.stored_bytes.read(key).is_some());
     ///     let cleared = storage.stored_bytes.clear();
     ///     assert(cleared);
-    ///     let retrieved_bytes = storage.stored_bytes.load(key);
+    ///     let retrieved_bytes = storage.stored_bytes.read(key);
     ///     assert(retrieved_bytes.is_none());
     /// }
     /// ```
@@ -128,7 +128,7 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
     ///     bytes.push(9_u8);
     ///
     ///     assert(storage.stored_bytes.len() == 0)
-    ///     storage.stored_bytes.store(bytes);
+    ///     storage.stored_bytes.write(bytes);
     ///     assert(storage.stored_bytes.len() == 3);
     /// }
     /// ```

--- a/test/src/e2e_vm_tests/test_programs/should_pass/empty_fields_in_storage_struct/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/empty_fields_in_storage_struct/src/main.sw
@@ -88,12 +88,12 @@ storage {
 impl ReproAttempt for Contract {
     #[storage(read, write)]
     fn bytes_foo_store(bytes: Bytes) {
-        storage.struct_of_bytes.foo.store(bytes);
+        storage.struct_of_bytes.foo.write(bytes);
     }
 
     #[storage(read)]
     fn bytes_foo_get() -> Option<Bytes> {
-        storage.struct_of_bytes.foo.load()
+        storage.struct_of_bytes.foo.read()
     }
 
     #[storage(read)]
@@ -103,12 +103,12 @@ impl ReproAttempt for Contract {
 
     #[storage(read, write)]
     fn bytes_bar_store(bytes: Bytes) {
-        storage.struct_of_bytes.bar.store(bytes);
+        storage.struct_of_bytes.bar.write(bytes);
     }
 
     #[storage(read)]
     fn bytes_bar_get() -> Option<Bytes> {
-        storage.struct_of_bytes.bar.load()
+        storage.struct_of_bytes.bar.read()
     }
 
     #[storage(read)]

--- a/test/src/sdk-harness/test_projects/storage_bytes/src/main.sw
+++ b/test/src/sdk-harness/test_projects/storage_bytes/src/main.sw
@@ -24,14 +24,14 @@ impl StorageBytesTest for Contract {
         let mut vec = vec;
         let bytes = Bytes::from_vec_u8(vec);
 
-        storage.bytes.store(bytes);
+        storage.bytes.write(bytes);
     }
 
     #[storage(read)]
     fn assert_stored_bytes(vec: Vec<u8>) {
         let mut vec = vec;
         let bytes = Bytes::from_vec_u8(vec);
-        let stored_bytes = storage.bytes.load().unwrap();
+        let stored_bytes = storage.bytes.read().unwrap();
 
         assert(bytes.len() == stored_bytes.len());
         assert(bytes == stored_bytes);
@@ -42,7 +42,7 @@ impl StorageBytesTest for Contract {
         let cleared = storage.bytes.clear();
 
         assert(storage.bytes.len() == 0);
-        assert(storage.bytes.load().is_none());
+        assert(storage.bytes.read().is_none());
 
         cleared
     }


### PR DESCRIPTION
## Description

The storage API in the standard library uses read/write naming convention. Only storage slices uses store/load. This has been updated to homogenize naming between all storage access in the standard library. 

This is a breaking change as the function definitions in the storage slice and storage bytes files have changed.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
