### PR TITLE
Add intrinsics tests

### DIFF
--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -661,7 +661,8 @@ fn instruction_to_doc<'a>(
                 } => maybe_constant_to_doc(context, md_namer, namer, number_of_slots).append(
                     Doc::line(
                         Doc::text(format!(
-                            "state_load_quad_word {}, key {}, {}",
+                            "{} = state_load_quad_word {}, key {}, {}",
+                            namer.name(context, ins_value),
                             namer.name(context, load_val),
                             namer.name(context, key),
                             namer.name(context, number_of_slots),
@@ -684,7 +685,8 @@ fn instruction_to_doc<'a>(
                 } => maybe_constant_to_doc(context, md_namer, namer, number_of_slots).append(
                     Doc::line(
                         Doc::text(format!(
-                            "state_store_quad_word {}, key {}, {}",
+                            "{} = state_store_quad_word {}, key {}, {}",
+                            namer.name(context, ins_value),
                             namer.name(context, stored_val),
                             namer.name(context, key),
                             namer.name(context, number_of_slots),
@@ -695,7 +697,8 @@ fn instruction_to_doc<'a>(
                 FuelVmInstruction::StateStoreWord { stored_val, key } => {
                     maybe_constant_to_doc(context, md_namer, namer, stored_val).append(Doc::line(
                         Doc::text(format!(
-                            "state_store_word {}, key {}",
+                            "{} = state_store_word {}, key {}",
+                            namer.name(context, ins_value),
                             namer.name(context, stored_val),
                             namer.name(context, key),
                         ))

--- a/test/src/ir_generation/tests/addr_of.sw
+++ b/test/src/ir_generation/tests/addr_of.sw
@@ -1,0 +1,15 @@
+
+script;
+
+fn main() {
+    let a: b256 =  0x0000000000000000000000000000000000000000000000000000000000000001;
+    let _ = __addr_of(a);
+}
+
+// check: v0 = get_local ptr b256, a, !2
+// check: v1 = const b256 0x0000000000000000000000000000000000000000000000000000000000000001, !3
+// check: store v1 to v0, !2
+// check: v2 = get_local ptr b256, a, !4
+// check: v3 = ptr_to_int v2 to u64, !5
+// check: v4 = get_local ptr u64, _, !6
+// check: store v3 to v4, !6

--- a/test/src/ir_generation/tests/eq.sw
+++ b/test/src/ir_generation/tests/eq.sw
@@ -1,0 +1,9 @@
+script;
+
+fn main() {
+   let _ = __eq(1, 2);
+}
+
+// check: $(l=$VAL) = const u64 1, $MD
+// check: $(r=$VAL) = const u64 2, $MD
+// check: $VAL = cmp eq $l $r

--- a/test/src/ir_generation/tests/gt.sw
+++ b/test/src/ir_generation/tests/gt.sw
@@ -1,0 +1,9 @@
+script;
+
+fn main() {
+    let _ = __gt(1, 2);
+}
+
+// check: $(l=$VAL) = const u64 1, $MD
+// check: $(r=$VAL) = const u64 2, $MD
+// check: cmp gt $l $r

--- a/test/src/ir_generation/tests/is_reference_type.sw
+++ b/test/src/ir_generation/tests/is_reference_type.sw
@@ -1,0 +1,9 @@
+script;
+
+fn main() {
+    let _ = __is_reference_type::<u64>();
+    let _ = __is_reference_type::<b256>();
+}
+
+// check: $VAL = const bool false
+// check: $VAL = const bool true

--- a/test/src/ir_generation/tests/lt.sw
+++ b/test/src/ir_generation/tests/lt.sw
@@ -1,0 +1,9 @@
+script;
+
+fn main() {
+    let _ = __lt(1, 2);
+}
+
+// check: $(l=$VAL) = const u64 1, $MD
+// check: $(r=$VAL) = const u64 2, $MD
+// check: cmp lt $l $r

--- a/test/src/ir_generation/tests/ptr_add.sw
+++ b/test/src/ir_generation/tests/ptr_add.sw
@@ -1,0 +1,15 @@
+script;
+
+fn main() {
+    let null = asm(output) { zero: raw_ptr };
+    let _ = __ptr_add::<u64>(null, 1);
+}
+// check: $VAL = get_local ptr u64, null, $MD
+// check: $(ptr=$VAL) = get_local ptr u64, null, $MD
+// check: $(ptr_op=$VAL) = load $ptr
+// check: $(size=$VAL) = const u64 8
+// check: $(count=$VAL) = const u64 1, $MD
+// check: $(mul_res=$VAL) = mul $size, $count
+// check: $(add_res=$VAL) = add $ptr_op, $mul_res
+// check: $(dst_ptr=$VAL) = get_local ptr u64, _, $(dst_md=$MD)
+// check: store $add_res to $dst_ptr, $dst_md

--- a/test/src/ir_generation/tests/ptr_sub.sw
+++ b/test/src/ir_generation/tests/ptr_sub.sw
@@ -1,0 +1,15 @@
+script;
+
+fn main() {
+    let null = asm(output) { zero: raw_ptr };
+    let _ = __ptr_sub::<u64>(null, 1);
+}
+// check: $VAL = get_local ptr u64, null, $MD
+// check: $(ptr=$VAL) = get_local ptr u64, null, $MD
+// check: $(ptr_op=$VAL) = load $ptr
+// check: $(size=$VAL) = const u64 8
+// check: $(count=$VAL) = const u64 1, $MD
+// check: $(mul_res=$VAL) = mul $size, $count
+// check: $(add_res=$VAL) = sub $ptr_op, $mul_res
+// check: $(dst_ptr=$VAL) = get_local ptr u64, _, $(dst_md=$MD)
+// check: store $add_res to $dst_ptr, $dst_md

--- a/test/src/ir_generation/tests/size_of.sw
+++ b/test/src/ir_generation/tests/size_of.sw
@@ -1,0 +1,8 @@
+script;
+
+fn main() {
+    let _ = __size_of::<b256>();
+}
+
+// check: $VAL = const u64 32
+

--- a/test/src/ir_generation/tests/size_of_val.sw
+++ b/test/src/ir_generation/tests/size_of_val.sw
@@ -1,0 +1,9 @@
+script;
+
+fn main() {
+    let _ = __size_of_val(1);
+}
+
+// check: v0 = get_local ptr u64, _, !2
+// check: v1 = const u64 8
+// check: store v1 to v0, !2

--- a/test/src/ir_generation/tests/state_load_quad.sw
+++ b/test/src/ir_generation/tests/state_load_quad.sw
@@ -1,0 +1,13 @@
+script;
+fn main() {
+    let null = asm(output) { zero: raw_ptr };
+    let res = __state_load_quad(
+      0x0000000000000000000000000000000000000000000000000000000000000001,
+      null,
+      1,
+    );
+}
+// check: $(key=$VAL) = get_local ptr b256, key_for_storage, $(meta=$MD)
+// check: $(ptr=$VAL) = int_to_ptr $VAL to ptr b256, $meta
+// check: $(count=$VAL) = const u64 1, $MD
+// check: $VAL = state_load_quad_word $ptr, key $key, $count, $meta

--- a/test/src/ir_generation/tests/state_load_word.sw
+++ b/test/src/ir_generation/tests/state_load_word.sw
@@ -1,0 +1,14 @@
+script;
+
+fn main() {
+    let _ = __state_load_word(
+      0x0000000000000000000000000000000000000000000000000000000000000001,
+    );
+}
+
+// check: v0 = get_local ptr b256, key_for_storage, !2
+// check: v1 = const b256 0x0000000000000000000000000000000000000000000000000000000000000001, !3
+// check: store v1 to v0, !2
+// check: v2 = state_load_word key v0, !2
+// check: v3 = get_local ptr u64, _, !4
+// check: store v2 to v3, !4

--- a/test/src/ir_generation/tests/state_store_quad.sw
+++ b/test/src/ir_generation/tests/state_store_quad.sw
@@ -1,0 +1,14 @@
+script;
+
+fn main() {
+    let null = asm(output) { zero: raw_ptr };
+    let _ = __state_store_quad(
+      0x0000000000000000000000000000000000000000000000000000000000000001,
+      null,
+      1,
+    );
+}
+// check: $(key=$VAL) = get_local ptr b256, key_for_storage, $(meta=$MD)
+// check: $(ptr=$VAL) = int_to_ptr $VAL to ptr b256, $meta
+// check: $(count=$VAL) = const u64 1, $MD
+// check: $VAL = state_store_quad_word $ptr, key $key, $count, $meta

--- a/test/src/ir_generation/tests/state_store_word.sw
+++ b/test/src/ir_generation/tests/state_store_word.sw
@@ -1,0 +1,11 @@
+script;
+
+fn main() {
+    let _ = __state_store_word(
+      0x0000000000000000000000000000000000000000000000000000000000000001,
+      1,
+    );
+}
+// check: $(key=$VAL) = get_local ptr b256, key_for_storage, $(meta=$MD)
+// check: $(count=$VAL) = const u64 1, $MD
+// check: $VAL = state_store_word $count, key $key, $meta


### PR DESCRIPTION
## Description

Add missing tests for the ir generation of all intrinsics and fix a bug in the ir printer that elided the output value for `state_store_word`, `state_store_quad` and `state_load_quad`.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
