### PR TITLE
Remove aggressive predicate inlining

### DIFF
--- a/sway-core/src/asm_generation/fuel/checks.rs
+++ b/sway-core/src/asm_generation/fuel/checks.rs
@@ -103,8 +103,6 @@ pub(crate) fn check_predicate_opcodes(ops: &[AllocatedOp]) -> CompileResult<()> 
                     span: get_op_span(op),
                 });
             }
-            JMP(..) => invalid_opcode("JMP", &mut errors),
-            JNE(..) => invalid_opcode("JNE", &mut errors),
             LDC(..) => invalid_opcode("LDC", &mut errors),
             LOG(..) => invalid_opcode("LOG", &mut errors),
             LOGD(..) => invalid_opcode("LOGD", &mut errors),

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -21,7 +21,6 @@ pub mod transform;
 pub mod type_system;
 
 use crate::ir_generation::check_function_purity;
-use crate::language::parsed::TreeType;
 use crate::{error::*, source_map::SourceMap};
 pub use asm_generation::from_ir::compile_ir_to_asm;
 use asm_generation::FinalizedAsm;
@@ -569,7 +568,6 @@ pub(crate) fn compile_ast_to_ir_to_asm(
     // errors and then hold as a runtime invariant that none of the types will be unresolved in the
     // IR phase.
 
-    let tree_type = program.kind.tree_type();
     let mut ir = match ir_generation::compile_program(program, build_config.include_tests, engines)
     {
         Ok(ir) => ir,
@@ -599,7 +597,7 @@ pub(crate) fn compile_ast_to_ir_to_asm(
     // Initialize the pass manager and register known passes.
     let mut pass_mgr = PassManager::default();
     register_known_passes(&mut pass_mgr);
-    let mut pass_group = create_o1_pass_group(matches!(tree_type, TreeType::Predicate));
+    let mut pass_group = create_o1_pass_group();
 
     // Target specific transforms should be moved into something more configured.
     if build_config.build_target == BuildTarget::Fuel {

--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -32,25 +32,14 @@ pub fn create_inline_in_main_pass() -> Pass {
     }
 }
 
-pub const INLINE_PREDICATE_NAME: &str = "inline_predicate_module";
+pub const INLINE_MODULE_NAME: &str = "inline_module";
 
-pub fn create_inline_in_predicate_pass() -> Pass {
+pub fn create_inline_in_module_pass() -> Pass {
     Pass {
-        name: INLINE_PREDICATE_NAME,
-        descr: "inline function calls in a predicate module.",
+        name: INLINE_MODULE_NAME,
+        descr: "inline function calls in a module.",
         deps: vec![],
-        runner: ScopedPass::ModulePass(PassMutability::Transform(inline_in_predicate_module)),
-    }
-}
-
-pub const INLINE_NONPREDICATE_NAME: &str = "inline_non_predicate_module";
-
-pub fn create_inline_in_non_predicate_pass() -> Pass {
-    Pass {
-        name: INLINE_NONPREDICATE_NAME,
-        descr: "inline function calls in a non-predicate module.",
-        deps: vec![],
-        runner: ScopedPass::ModulePass(PassMutability::Transform(inline_in_non_predicate_module)),
+        runner: ScopedPass::ModulePass(PassMutability::Transform(inline_in_module)),
     }
 }
 
@@ -99,31 +88,7 @@ fn metadata_to_inline(context: &Context, md_idx: Option<MetadataIndex>) -> Optio
     })
 }
 
-/// Inline function calls based on two conditions:
-/// 1. The program we're compiling is a "predicate". Predicates cannot jump backwards which means
-///    that supporting function calls (i.e. without inlining) is not possible. This is a protocol
-///    restriction and not a heuristic.
-/// 2. If the program is not a "predicate" then, we rely on some heuristic which is described below
-///    in the `inline_heuristc` closure in `inline_in_non_predicate_module`.
-pub fn inline_in_predicate_module(
-    context: &mut Context,
-    _: &AnalysisResults,
-    module: Module,
-) -> Result<bool, IrError> {
-    let cg =
-        call_graph::build_call_graph(context, &module.function_iter(context).collect::<Vec<_>>());
-
-    let functions = call_graph::callee_first_order(&cg);
-
-    let mut modified = false;
-
-    for function in functions {
-        modified |= inline_all_function_calls(context, &function)?;
-    }
-    Ok(modified)
-}
-
-pub fn inline_in_non_predicate_module(
+pub fn inline_in_module(
     context: &mut Context,
     _: &AnalysisResults,
     module: Module,

--- a/sway-ir/src/pass_manager.rs
+++ b/sway-ir/src/pass_manager.rs
@@ -1,12 +1,11 @@
 use crate::{
     create_arg_demotion_pass, create_const_combine_pass, create_const_demotion_pass,
     create_dce_pass, create_dom_fronts_pass, create_dominators_pass, create_func_dce_pass,
-    create_inline_in_main_pass, create_inline_in_non_predicate_pass,
-    create_inline_in_predicate_pass, create_mem2reg_pass, create_memcpyopt_pass,
-    create_misc_demotion_pass, create_module_printer_pass, create_module_verifier_pass,
-    create_postorder_pass, create_ret_demotion_pass, create_simplify_cfg_pass, Context, Function,
-    IrError, Module, CONSTCOMBINE_NAME, DCE_NAME, FUNC_DCE_NAME, INLINE_NONPREDICATE_NAME,
-    INLINE_PREDICATE_NAME, MEM2REG_NAME, SIMPLIFYCFG_NAME,
+    create_inline_in_main_pass, create_inline_in_module_pass, create_mem2reg_pass,
+    create_memcpyopt_pass, create_misc_demotion_pass, create_module_printer_pass,
+    create_module_verifier_pass, create_postorder_pass, create_ret_demotion_pass,
+    create_simplify_cfg_pass, Context, Function, IrError, Module, CONSTCOMBINE_NAME, DCE_NAME,
+    FUNC_DCE_NAME, INLINE_MODULE_NAME, MEM2REG_NAME, SIMPLIFYCFG_NAME,
 };
 use downcast_rs::{impl_downcast, Downcast};
 use rustc_hash::FxHashMap;
@@ -306,8 +305,7 @@ pub fn register_known_passes(pm: &mut PassManager) {
     pm.register(create_module_verifier_pass());
     // Optimization passes.
     pm.register(create_mem2reg_pass());
-    pm.register(create_inline_in_predicate_pass());
-    pm.register(create_inline_in_non_predicate_pass());
+    pm.register(create_inline_in_module_pass());
     pm.register(create_inline_in_main_pass());
     pm.register(create_const_combine_pass());
     pm.register(create_simplify_cfg_pass());
@@ -320,16 +318,12 @@ pub fn register_known_passes(pm: &mut PassManager) {
     pm.register(create_memcpyopt_pass());
 }
 
-pub fn create_o1_pass_group(is_predicate: bool) -> PassGroup {
+pub fn create_o1_pass_group() -> PassGroup {
     // Create a configuration to specify which passes we want to run now.
     let mut o1 = PassGroup::default();
     // Configure to run our passes.
     o1.append_pass(MEM2REG_NAME);
-    if is_predicate {
-        o1.append_pass(INLINE_PREDICATE_NAME);
-    } else {
-        o1.append_pass(INLINE_NONPREDICATE_NAME);
-    }
+    o1.append_pass(INLINE_MODULE_NAME);
     o1.append_pass(CONSTCOMBINE_NAME);
     o1.append_pass(SIMPLIFYCFG_NAME);
     o1.append_pass(CONSTCOMBINE_NAME);


### PR DESCRIPTION
## Description
Now that jumps are allowed in predicates, this change uses the regular inlining pass and its heuristics instead of just inlining everything, which slowed down compilation significantly.


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
