### PR TITLE
Stabilize module privacy

### DIFF
--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -223,8 +223,6 @@ pub struct BuildProfile {
     pub json_abi_with_callpaths: bool,
     #[serde(default)]
     pub error_on_warnings: bool,
-    #[serde(default)]
-    pub experimental_private_modules: bool,
 }
 
 impl Dependency {
@@ -668,7 +666,6 @@ impl BuildProfile {
             include_tests: false,
             json_abi_with_callpaths: false,
             error_on_warnings: false,
-            experimental_private_modules: false,
         }
     }
 
@@ -685,7 +682,6 @@ impl BuildProfile {
             include_tests: false,
             json_abi_with_callpaths: false,
             error_on_warnings: false,
-            experimental_private_modules: false,
         }
     }
 }

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -303,8 +303,6 @@ pub struct BuildOpts {
     pub tests: bool,
     /// The set of options to filter by member project kind.
     pub member_filter: MemberFilter,
-    /// Enable the experimental module privacy enforcement.
-    pub experimental_private_modules: bool,
 }
 
 /// The set of options to filter type of projects to build in a workspace.
@@ -1547,8 +1545,7 @@ pub fn sway_build_config(
     .print_finalized_asm(build_profile.print_finalized_asm)
     .print_intermediate_asm(build_profile.print_intermediate_asm)
     .print_ir(build_profile.print_ir)
-    .include_tests(build_profile.include_tests)
-    .experimental_private_modules(build_profile.experimental_private_modules);
+    .include_tests(build_profile.include_tests);
     Ok(build_config)
 }
 
@@ -1574,7 +1571,6 @@ pub fn dependency_namespace(
     node: NodeIx,
     engines: Engines<'_>,
     contract_id_value: Option<ContractIdConst>,
-    experimental_private_modules: bool,
 ) -> Result<namespace::Module, vec1::Vec1<CompileError>> {
     // TODO: Clean this up when config-time constants v1 are removed.
     let node_idx = &graph[node];
@@ -1640,7 +1636,6 @@ pub fn dependency_namespace(
         &[CORE, PRELUDE].map(|s| Ident::new_no_span(s.into())),
         &[],
         engines,
-        experimental_private_modules,
     );
 
     if has_std_dep(graph, node) {
@@ -1648,7 +1643,6 @@ pub fn dependency_namespace(
             &[STD, PRELUDE].map(|s| Ident::new_no_span(s.into())),
             &[],
             engines,
-            experimental_private_modules,
         );
     }
 
@@ -2012,7 +2006,6 @@ fn build_profile_from_opts(
         time_phases,
         tests,
         error_on_warnings,
-        experimental_private_modules,
         ..
     } = build_options;
     let mut selected_build_profile = BuildProfile::DEBUG;
@@ -2063,7 +2056,6 @@ fn build_profile_from_opts(
     profile.include_tests |= tests;
     profile.json_abi_with_callpaths |= pkg.json_abi_with_callpaths;
     profile.error_on_warnings |= error_on_warnings;
-    profile.experimental_private_modules |= experimental_private_modules;
 
     Ok((selected_build_profile.to_string(), profile))
 }
@@ -2297,7 +2289,6 @@ pub fn build(
                 node,
                 engines,
                 None,
-                profile.experimental_private_modules,
             ) {
                 Ok(o) => o,
                 Err(errs) => return fail(&[], &errs),
@@ -2353,7 +2344,6 @@ pub fn build(
             node,
             engines,
             contract_id_value.clone(),
-            profile.experimental_private_modules,
         ) {
             Ok(o) => o,
             Err(errs) => return fail(&[], &errs),
@@ -2537,7 +2527,6 @@ pub fn check(
     terse_mode: bool,
     include_tests: bool,
     engines: Engines<'_>,
-    experimental_private_modules: bool,
 ) -> anyhow::Result<Vec<CompileResult<Programs>>> {
     let mut lib_namespace_map = Default::default();
     let mut source_map = SourceMap::new();
@@ -2555,7 +2544,6 @@ pub fn check(
             node,
             engines,
             None,
-            experimental_private_modules,
         )
         .expect("failed to create dependency namespace");
 

--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -255,7 +255,6 @@ fn build_opts_from_cmd(cmd: &cmd::Deploy) -> pkg::BuildOpts {
         build_target: BuildTarget::default(),
         tests: false,
         member_filter: pkg::MemberFilter::only_contracts(),
-        experimental_private_modules: cmd.build_profile.experimental_private_modules,
     }
 }
 

--- a/forc-plugins/forc-client/src/op/run.rs
+++ b/forc-plugins/forc-client/src/op/run.rs
@@ -176,6 +176,5 @@ fn build_opts_from_cmd(cmd: &cmd::Run) -> pkg::BuildOpts {
         debug_outfile: cmd.build_output.debug_file.clone(),
         tests: false,
         member_filter: pkg::MemberFilter::only_scripts(),
-        experimental_private_modules: cmd.build_profile.experimental_private_modules,
     }
 }

--- a/forc-plugins/forc-doc/src/main.rs
+++ b/forc-plugins/forc-doc/src/main.rs
@@ -161,7 +161,6 @@ fn build_docs(
         silent,
         tests_enabled,
         engines,
-        true,
     )?
     .pop()
     .and_then(|compilation| compilation.value)

--- a/forc-test/src/lib.rs
+++ b/forc-test/src/lib.rs
@@ -160,8 +160,6 @@ pub struct Opts {
     pub error_on_warnings: bool,
     /// Output the time elapsed over each part of the compilation process.
     pub time_phases: bool,
-    /// Enable the experimental module privacy enforcement.
-    pub experimental_private_modules: bool,
 }
 
 /// The set of options provided for controlling logs printed for each test.
@@ -500,7 +498,6 @@ impl Opts {
             time_phases: self.time_phases,
             tests: true,
             member_filter: Default::default(),
-            experimental_private_modules: self.experimental_private_modules,
         }
     }
 }

--- a/forc/src/cli/commands/check.rs
+++ b/forc/src/cli/commands/check.rs
@@ -31,9 +31,6 @@ pub struct Command {
     /// Disable checking unit tests.
     #[clap(long = "disable-tests")]
     pub disable_tests: bool,
-    /// Enable the experimental module privacy enforcement.
-    #[clap(long)]
-    pub experimental_private_modules: bool,
 }
 
 pub(crate) fn exec(command: Command) -> ForcResult<()> {

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -212,7 +212,6 @@ fn opts_from_cmd(cmd: Command) -> forc_test::Opts {
         binary_outfile: cmd.build.output.bin_file,
         debug_outfile: cmd.build.output.debug_file,
         build_target: cmd.build.build_target,
-        experimental_private_modules: cmd.build.profile.experimental_private_modules,
     }
 }
 

--- a/forc/src/cli/shared.rs
+++ b/forc/src/cli/shared.rs
@@ -49,8 +49,6 @@ pub struct BuildProfile {
     /// Treat warnings as errors.
     #[clap(long)]
     pub error_on_warnings: bool,
-    #[clap(long)]
-    pub experimental_private_modules: bool,
 }
 
 /// Options related to printing stages of compiler output.

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -39,6 +39,5 @@ fn opts_from_cmd(cmd: BuildCommand) -> pkg::BuildOpts {
         build_target: cmd.build.build_target,
         tests: cmd.tests,
         member_filter: Default::default(),
-        experimental_private_modules: cmd.build.profile.experimental_private_modules,
     }
 }

--- a/forc/src/ops/forc_check.rs
+++ b/forc/src/ops/forc_check.rs
@@ -13,7 +13,6 @@ pub fn check(command: CheckCommand, engines: Engines<'_>) -> Result<CompileResul
         terse_mode,
         locked,
         disable_tests,
-        experimental_private_modules,
     } = command;
 
     let this_dir = if let Some(ref path) = path {
@@ -28,14 +27,7 @@ pub fn check(command: CheckCommand, engines: Engines<'_>) -> Result<CompileResul
         pkg::BuildPlan::from_lock_and_manifests(&lock_path, &member_manifests, locked, offline)?;
     let tests_enabled = !disable_tests;
 
-    let mut v = pkg::check(
-        &plan,
-        build_target,
-        terse_mode,
-        tests_enabled,
-        engines,
-        experimental_private_modules,
-    )?;
+    let mut v = pkg::check(&plan, build_target, terse_mode, tests_enabled, engines)?;
     let res = v
         .pop()
         .expect("there is guaranteed to be at least one elem in the vector")

--- a/forc/src/ops/forc_contract_id.rs
+++ b/forc/src/ops/forc_contract_id.rs
@@ -75,6 +75,5 @@ fn build_opts_from_cmd(cmd: &ContractIdCommand) -> pkg::BuildOpts {
         build_target: BuildTarget::default(),
         tests: false,
         member_filter: pkg::MemberFilter::only_contracts(),
-        experimental_private_modules: cmd.build_profile.experimental_private_modules,
     }
 }

--- a/forc/src/ops/forc_predicate_root.rs
+++ b/forc/src/ops/forc_predicate_root.rs
@@ -43,6 +43,5 @@ fn build_opts_from_cmd(cmd: PredicateRootCommand) -> pkg::BuildOpts {
         build_target: BuildTarget::default(),
         tests: false,
         member_filter: pkg::MemberFilter::only_predicates(),
-        experimental_private_modules: cmd.build_profile.experimental_private_modules,
     }
 }

--- a/sway-core/src/build_config.rs
+++ b/sway-core/src/build_config.rs
@@ -46,7 +46,6 @@ pub struct BuildConfig {
     pub(crate) print_finalized_asm: bool,
     pub(crate) print_ir: bool,
     pub(crate) include_tests: bool,
-    pub(crate) experimental_private_modules: bool,
 }
 
 impl BuildConfig {
@@ -89,7 +88,6 @@ impl BuildConfig {
             print_finalized_asm: false,
             print_ir: false,
             include_tests: false,
-            experimental_private_modules: false,
         }
     }
 
@@ -124,13 +122,6 @@ impl BuildConfig {
     pub fn print_ir(self, a: bool) -> Self {
         Self {
             print_ir: a,
-            ..self
-        }
-    }
-
-    pub fn experimental_private_modules(self, a: bool) -> Self {
-        Self {
-            experimental_private_modules: a,
             ..self
         }
     }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -48,7 +48,7 @@ pub mod types;
 
 pub use error::CompileResult;
 use sway_error::error::CompileError;
-use sway_error::warning::{CompileWarning, Warning};
+use sway_error::warning::CompileWarning;
 use sway_types::{ident::Ident, span, Spanned};
 pub use type_system::*;
 
@@ -338,27 +338,12 @@ pub fn parsed_to_ast(
     build_config: Option<&BuildConfig>,
     package_name: &str,
 ) -> CompileResult<ty::TyProgram> {
-    let experimental_private_modules =
-        build_config.map_or(true, |b| b.experimental_private_modules);
     // Type check the program.
     let CompileResult {
         value: typed_program_opt,
         mut warnings,
         mut errors,
-    } = ty::TyProgram::type_check(
-        engines,
-        parse_program,
-        initial_namespace,
-        package_name,
-        experimental_private_modules,
-    );
-
-    if !experimental_private_modules {
-        warnings.push(CompileWarning {
-            span: parse_program.root.span.clone(),
-            warning_content: Warning::ModulePrivacyDisabled,
-        })
-    }
+    } = ty::TyProgram::type_check(engines, parse_program, initial_namespace, package_name);
 
     let mut typed_program = match typed_program_opt {
         Some(typed_program) => typed_program,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1369,7 +1369,6 @@ impl ty::TyExpression {
                 &suffix,
                 ctx.self_type(),
                 ctx.engines(),
-                ctx.experimental_private_modules_enabled()
             ),
             return None,
             const_probe_warnings,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -465,7 +465,6 @@ pub(crate) fn resolve_method_name(
                     ctx.self_type(),
                     &arguments,
                     engines,
-                    ctx.experimental_private_modules_enabled()
                 ),
                 return err(warnings, errors),
                 warnings,
@@ -493,7 +492,6 @@ pub(crate) fn resolve_method_name(
                     ctx.self_type(),
                     &arguments,
                     engines,
-                    ctx.experimental_private_modules_enabled(),
                 ),
                 return err(warnings, errors),
                 warnings,
@@ -521,7 +519,6 @@ pub(crate) fn resolve_method_name(
                     ctx.self_type(),
                     &arguments,
                     engines,
-                    ctx.experimental_private_modules_enabled(),
                 ),
                 return err(warnings, errors),
                 warnings,

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -38,22 +38,14 @@ impl ty::TyAstNode {
                     let mut res = match a.import_type {
                         ImportType::Star => {
                             // try a standard starimport first
-                            let import = ctx.namespace.star_import(
-                                &path,
-                                engines,
-                                ctx.experimental_private_modules_enabled(),
-                            );
+                            let import = ctx.namespace.star_import(&path, engines);
                             if import.is_ok() {
                                 import
                             } else {
                                 // if it doesn't work it could be an enum star import
                                 if let Some((enum_name, path)) = path.split_last() {
-                                    let variant_import = ctx.namespace.variant_star_import(
-                                        path,
-                                        engines,
-                                        enum_name,
-                                        ctx.experimental_private_modules_enabled(),
-                                    );
+                                    let variant_import =
+                                        ctx.namespace.variant_star_import(path, engines, enum_name);
                                     if variant_import.is_ok() {
                                         variant_import
                                     } else {
@@ -64,21 +56,14 @@ impl ty::TyAstNode {
                                 }
                             }
                         }
-                        ImportType::SelfImport(_) => ctx.namespace.self_import(
-                            engines,
-                            &path,
-                            a.alias.clone(),
-                            ctx.experimental_private_modules_enabled(),
-                        ),
+                        ImportType::SelfImport(_) => {
+                            ctx.namespace.self_import(engines, &path, a.alias.clone())
+                        }
                         ImportType::Item(ref s) => {
                             // try a standard item import first
-                            let import = ctx.namespace.item_import(
-                                engines,
-                                &path,
-                                s,
-                                a.alias.clone(),
-                                ctx.experimental_private_modules_enabled(),
-                            );
+                            let import =
+                                ctx.namespace
+                                    .item_import(engines, &path, s, a.alias.clone());
 
                             if import.is_ok() {
                                 import
@@ -91,7 +76,6 @@ impl ty::TyAstNode {
                                         enum_name,
                                         s,
                                         a.alias.clone(),
-                                        ctx.experimental_private_modules_enabled(),
                                     );
                                     if variant_import.is_ok() {
                                         variant_import

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -236,13 +236,12 @@ impl Module {
         src: &Path,
         dst: &Path,
         engines: Engines<'_>,
-        experimental_private_modules: bool,
     ) -> CompileResult<()> {
         let mut warnings = vec![];
         let mut errors = vec![];
 
         check!(
-            self.check_module_privacy(src, dst, experimental_private_modules),
+            self.check_module_privacy(src, dst),
             return err(warnings, errors),
             warnings,
             errors
@@ -260,9 +259,7 @@ impl Module {
         let implemented_traits = src_ns.implemented_traits.clone();
         let mut symbols_and_decls = vec![];
         for (symbol, decl) in src_ns.symbols.iter() {
-            if is_ancestor(src, dst, experimental_private_modules)
-                || decl.visibility(decl_engine).is_public()
-            {
+            if is_ancestor(src, dst) || decl.visibility(decl_engine).is_public() {
                 symbols_and_decls.push((symbol.clone(), decl.clone()));
             }
         }
@@ -292,13 +289,12 @@ impl Module {
         src: &Path,
         dst: &Path,
         engines: Engines<'_>,
-        experimental_private_modules: bool,
     ) -> CompileResult<()> {
         let mut warnings = vec![];
         let mut errors = vec![];
 
         check!(
-            self.check_module_privacy(src, dst, experimental_private_modules),
+            self.check_module_privacy(src, dst),
             return err(warnings, errors),
             warnings,
             errors
@@ -321,9 +317,7 @@ impl Module {
             .map(|(symbol, (_, _, decl))| (symbol.clone(), decl.clone()))
             .collect::<Vec<_>>();
         for (symbol, decl) in src_ns.symbols.iter() {
-            if is_ancestor(src, dst, experimental_private_modules)
-                || decl.visibility(decl_engine).is_public()
-            {
+            if is_ancestor(src, dst) || decl.visibility(decl_engine).is_public() {
                 symbols_and_decls.push((symbol.clone(), decl.clone()));
             }
         }
@@ -378,17 +372,9 @@ impl Module {
         src: &Path,
         dst: &Path,
         alias: Option<Ident>,
-        experimental_private_modules: bool,
     ) -> CompileResult<()> {
         let (last_item, src) = src.split_last().expect("guaranteed by grammar");
-        self.item_import(
-            engines,
-            src,
-            last_item,
-            dst,
-            alias,
-            experimental_private_modules,
-        )
+        self.item_import(engines, src, last_item, dst, alias)
     }
 
     /// Pull a single `item` from the given `src` module and import it into the `dst` module.
@@ -401,13 +387,12 @@ impl Module {
         item: &Ident,
         dst: &Path,
         alias: Option<Ident>,
-        experimental_private_modules: bool,
     ) -> CompileResult<()> {
         let mut warnings = vec![];
         let mut errors = vec![];
 
         check!(
-            self.check_module_privacy(src, dst, experimental_private_modules),
+            self.check_module_privacy(src, dst),
             return err(warnings, errors),
             warnings,
             errors
@@ -424,9 +409,7 @@ impl Module {
         let mut impls_to_insert = TraitMap::default();
         match src_ns.symbols.get(item).cloned() {
             Some(decl) => {
-                if !decl.visibility(decl_engine).is_public()
-                    && !is_ancestor(src, dst, experimental_private_modules)
-                {
+                if !decl.visibility(decl_engine).is_public() && !is_ancestor(src, dst) {
                     errors.push(CompileError::ImportPrivateSymbol {
                         name: item.clone(),
                         span: item.span(),
@@ -490,13 +473,12 @@ impl Module {
         variant_name: &Ident,
         dst: &Path,
         alias: Option<Ident>,
-        experimental_private_modules: bool,
     ) -> CompileResult<()> {
         let mut warnings = vec![];
         let mut errors = vec![];
 
         check!(
-            self.check_module_privacy(src, dst, experimental_private_modules),
+            self.check_module_privacy(src, dst),
             return err(warnings, errors),
             warnings,
             errors
@@ -512,9 +494,7 @@ impl Module {
         );
         match src_ns.symbols.get(enum_name).cloned() {
             Some(decl) => {
-                if !decl.visibility(decl_engine).is_public()
-                    && !is_ancestor(src, dst, experimental_private_modules)
-                {
+                if !decl.visibility(decl_engine).is_public() && !is_ancestor(src, dst) {
                     errors.push(CompileError::ImportPrivateSymbol {
                         name: enum_name.clone(),
                         span: enum_name.span(),
@@ -602,13 +582,12 @@ impl Module {
         dst: &Path,
         engines: Engines<'_>,
         enum_name: &Ident,
-        experimental_private_modules: bool,
     ) -> CompileResult<()> {
         let mut warnings = vec![];
         let mut errors = vec![];
 
         check!(
-            self.check_module_privacy(src, dst, experimental_private_modules),
+            self.check_module_privacy(src, dst),
             return err(warnings, errors),
             warnings,
             errors
@@ -624,9 +603,7 @@ impl Module {
         );
         match src_ns.symbols.get(enum_name).cloned() {
             Some(decl) => {
-                if !decl.visibility(decl_engine).is_public()
-                    && !is_ancestor(src, dst, experimental_private_modules)
-                {
+                if !decl.visibility(decl_engine).is_public() && !is_ancestor(src, dst) {
                     errors.push(CompileError::ImportPrivateSymbol {
                         name: enum_name.clone(),
                         span: enum_name.span(),
@@ -684,33 +661,26 @@ impl Module {
         ok((), warnings, errors)
     }
 
-    fn check_module_privacy(
-        &self,
-        src: &Path,
-        dst: &Path,
-        experimental_private_modules: bool,
-    ) -> CompileResult<()> {
+    fn check_module_privacy(&self, src: &Path, dst: &Path) -> CompileResult<()> {
         let mut warnings = vec![];
         let mut errors = vec![];
 
-        if experimental_private_modules {
-            // you are always allowed to access your ancestor's symbols
-            if !is_ancestor(src, dst, experimental_private_modules) {
-                // we don't check the first prefix because direct children are always accessible
-                for prefix in iter_prefixes(src).skip(1) {
-                    let module = check!(
-                        self.check_submodule(prefix),
-                        return err(warnings, errors),
-                        warnings,
-                        errors
-                    );
-                    if module.visibility.is_private() {
-                        let prefix_last = prefix[prefix.len() - 1].clone();
-                        errors.push(CompileError::ImportPrivateModule {
-                            span: prefix_last.span(),
-                            name: prefix_last,
-                        });
-                    }
+        // you are always allowed to access your ancestor's symbols
+        if !is_ancestor(src, dst) {
+            // we don't check the first prefix because direct children are always accessible
+            for prefix in iter_prefixes(src).skip(1) {
+                let module = check!(
+                    self.check_submodule(prefix),
+                    return err(warnings, errors),
+                    warnings,
+                    errors
+                );
+                if module.visibility.is_private() {
+                    let prefix_last = prefix[prefix.len() - 1].clone();
+                    errors.push(CompileError::ImportPrivateModule {
+                        span: prefix_last.span(),
+                        name: prefix_last,
+                    });
                 }
             }
         }
@@ -769,8 +739,6 @@ fn module_not_found(path: &[Ident]) -> CompileError {
     }
 }
 
-fn is_ancestor(src: &Path, dst: &Path, experimental_private_modules: bool) -> bool {
-    experimental_private_modules
-        && dst.len() >= src.len()
-        && src.iter().zip(dst).all(|(src, dst)| src == dst)
+fn is_ancestor(src: &Path, dst: &Path) -> bool {
+    dst.len() >= src.len() && src.iter().zip(dst).all(|(src, dst)| src == dst)
 }

--- a/sway-core/src/semantic_analysis/namespace/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace/namespace.rs
@@ -107,14 +107,9 @@ impl Namespace {
         &self,
         engines: Engines<'_>,
         call_path: &CallPath,
-        experimental_private_modules: bool,
     ) -> CompileResult<&ty::TyDecl> {
-        self.root.resolve_call_path_with_visibility_check(
-            engines,
-            &self.mod_path,
-            call_path,
-            experimental_private_modules,
-        )
+        self.root
+            .resolve_call_path_with_visibility_check(engines, &self.mod_path, call_path)
     }
 
     /// Short-hand for calling [Root::resolve_type_with_self] on `root` with the `mod_path`.
@@ -127,7 +122,6 @@ impl Namespace {
         span: &Span,
         enforce_type_arguments: EnforceTypeArguments,
         type_info_prefix: Option<&Path>,
-        experimental_private_modules: bool,
     ) -> CompileResult<TypeId> {
         let mod_path = self.mod_path.clone();
         engines.te().resolve_with_self(
@@ -139,7 +133,6 @@ impl Namespace {
             type_info_prefix,
             self,
             &mod_path,
-            experimental_private_modules,
         )
     }
 
@@ -150,7 +143,6 @@ impl Namespace {
         type_id: TypeId,
         span: &Span,
         type_info_prefix: Option<&Path>,
-        experimental_private_modules: bool,
     ) -> CompileResult<TypeId> {
         let mod_path = self.mod_path.clone();
         engines.te().resolve(
@@ -161,7 +153,6 @@ impl Namespace {
             type_info_prefix,
             self,
             &mod_path,
-            experimental_private_modules,
         )
     }
 
@@ -174,7 +165,6 @@ impl Namespace {
         item_name: &Ident,
         self_type: TypeId,
         engines: Engines<'_>,
-        experimental_private_modules: bool,
     ) -> CompileResult<Vec<ty::TyTraitItem>> {
         let mut warnings = vec![];
         let mut errors = vec![];
@@ -212,7 +202,6 @@ impl Namespace {
                 None,
                 self,
                 item_prefix,
-                experimental_private_modules,
             ),
             type_engine.insert(engines, TypeInfo::ErrorRecovery),
             warnings,
@@ -269,7 +258,6 @@ impl Namespace {
         self_type: TypeId,
         args_buf: &VecDeque<ty::TyExpression>,
         engines: Engines<'_>,
-        experimental_private_modules: bool,
     ) -> CompileResult<DeclRefFunction> {
         let mut warnings = vec![];
         let mut errors = vec![];
@@ -278,14 +266,7 @@ impl Namespace {
         let type_engine = engines.te();
 
         let matching_item_decl_refs = check!(
-            self.find_items_for_type(
-                type_id,
-                method_prefix,
-                method_name,
-                self_type,
-                engines,
-                experimental_private_modules
-            ),
+            self.find_items_for_type(type_id, method_prefix, method_name, self_type, engines,),
             return err(warnings, errors),
             warnings,
             errors
@@ -364,20 +345,12 @@ impl Namespace {
         item_name: &Ident,
         self_type: TypeId,
         engines: Engines<'_>,
-        experimental_private_modules: bool,
     ) -> CompileResult<DeclRefConstant> {
         let mut warnings = vec![];
         let mut errors = vec![];
 
         let matching_item_decl_refs = check!(
-            self.find_items_for_type(
-                type_id,
-                &Vec::<Ident>::new(),
-                item_name,
-                self_type,
-                engines,
-                experimental_private_modules
-            ),
+            self.find_items_for_type(type_id, &Vec::<Ident>::new(), item_name, self_type, engines,),
             return err(warnings, errors),
             warnings,
             errors
@@ -399,14 +372,8 @@ impl Namespace {
     }
 
     /// Short-hand for performing a [Module::star_import] with `mod_path` as the destination.
-    pub(crate) fn star_import(
-        &mut self,
-        src: &Path,
-        engines: Engines<'_>,
-        experimental_private_modules: bool,
-    ) -> CompileResult<()> {
-        self.root
-            .star_import(src, &self.mod_path, engines, experimental_private_modules)
+    pub(crate) fn star_import(&mut self, src: &Path, engines: Engines<'_>) -> CompileResult<()> {
+        self.root.star_import(src, &self.mod_path, engines)
     }
 
     /// Short-hand for performing a [Module::variant_star_import] with `mod_path` as the destination.
@@ -415,15 +382,9 @@ impl Namespace {
         src: &Path,
         engines: Engines<'_>,
         enum_name: &Ident,
-        experimental_private_modules: bool,
     ) -> CompileResult<()> {
-        self.root.variant_star_import(
-            src,
-            &self.mod_path,
-            engines,
-            enum_name,
-            experimental_private_modules,
-        )
+        self.root
+            .variant_star_import(src, &self.mod_path, engines, enum_name)
     }
 
     /// Short-hand for performing a [Module::self_import] with `mod_path` as the destination.
@@ -432,15 +393,8 @@ impl Namespace {
         engines: Engines<'_>,
         src: &Path,
         alias: Option<Ident>,
-        experimental_private_modules: bool,
     ) -> CompileResult<()> {
-        self.root.self_import(
-            engines,
-            src,
-            &self.mod_path,
-            alias,
-            experimental_private_modules,
-        )
+        self.root.self_import(engines, src, &self.mod_path, alias)
     }
 
     /// Short-hand for performing a [Module::item_import] with `mod_path` as the destination.
@@ -450,16 +404,9 @@ impl Namespace {
         src: &Path,
         item: &Ident,
         alias: Option<Ident>,
-        experimental_private_modules: bool,
     ) -> CompileResult<()> {
-        self.root.item_import(
-            engines,
-            src,
-            item,
-            &self.mod_path,
-            alias,
-            experimental_private_modules,
-        )
+        self.root
+            .item_import(engines, src, item, &self.mod_path, alias)
     }
 
     /// Short-hand for performing a [Module::variant_import] with `mod_path` as the destination.
@@ -470,17 +417,9 @@ impl Namespace {
         enum_name: &Ident,
         variant_name: &Ident,
         alias: Option<Ident>,
-        experimental_private_modules: bool,
     ) -> CompileResult<()> {
-        self.root.variant_import(
-            engines,
-            src,
-            enum_name,
-            variant_name,
-            &self.mod_path,
-            alias,
-            experimental_private_modules,
-        )
+        self.root
+            .variant_import(engines, src, enum_name, variant_name, &self.mod_path, alias)
     }
 
     /// "Enter" the submodule at the given path by returning a new [SubmoduleNamespace].

--- a/sway-core/src/semantic_analysis/program.rs
+++ b/sway-core/src/semantic_analysis/program.rs
@@ -20,12 +20,10 @@ impl ty::TyProgram {
         parsed: &ParseProgram,
         initial_namespace: namespace::Module,
         package_name: &str,
-        experimental_private_modules: bool,
     ) -> CompileResult<Self> {
         let mut namespace = Namespace::init_root(initial_namespace);
-        let ctx = TypeCheckContext::from_root(&mut namespace, engines)
-            .with_kind(parsed.kind.clone())
-            .with_experimental_private_modules(experimental_private_modules);
+        let ctx =
+            TypeCheckContext::from_root(&mut namespace, engines).with_kind(parsed.kind.clone());
         let ParseProgram { root, kind } = parsed;
         let mod_res = ty::TyModule::type_check(ctx, root);
         mod_res.flat_map(|root| {

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -66,9 +66,6 @@ pub struct TypeCheckContext<'a> {
     /// disallowing functions from being defined inside of another function
     /// body).
     disallow_functions: bool,
-
-    /// Enable experimental module privacy rules
-    experimental_private_modules: bool,
 }
 
 impl<'a> TypeCheckContext<'a> {
@@ -99,7 +96,6 @@ impl<'a> TypeCheckContext<'a> {
             purity: Purity::default(),
             kind: TreeType::Contract,
             disallow_functions: false,
-            experimental_private_modules: false,
         }
     }
 
@@ -124,7 +120,6 @@ impl<'a> TypeCheckContext<'a> {
             decl_engine: self.decl_engine,
             query_engine: self.query_engine,
             disallow_functions: self.disallow_functions,
-            experimental_private_modules: self.experimental_private_modules,
         }
     }
 
@@ -142,7 +137,6 @@ impl<'a> TypeCheckContext<'a> {
             decl_engine: self.decl_engine,
             query_engine: self.query_engine,
             disallow_functions: self.disallow_functions,
-            experimental_private_modules: self.experimental_private_modules,
         }
     }
 
@@ -195,17 +189,6 @@ impl<'a> TypeCheckContext<'a> {
     /// Map this `TypeCheckContext` instance to a new one with the given module kind.
     pub(crate) fn with_kind(self, kind: TreeType) -> Self {
         Self { kind, ..self }
-    }
-
-    /// Map this `TypeCheckContext` instance to a new one with the given module kind.
-    pub(crate) fn with_experimental_private_modules(
-        self,
-        experimental_private_modules: bool,
-    ) -> Self {
-        Self {
-            experimental_private_modules,
-            ..self
-        }
     }
 
     /// Map this `TypeCheckContext` instance to a new one with the given purity.
@@ -263,10 +246,6 @@ impl<'a> TypeCheckContext<'a> {
         self.disallow_functions
     }
 
-    pub(crate) fn experimental_private_modules_enabled(&self) -> bool {
-        self.experimental_private_modules
-    }
-
     // Provide some convenience functions around the inner context.
 
     /// Short-hand for calling the `monomorphize` function in the type engine
@@ -289,7 +268,6 @@ impl<'a> TypeCheckContext<'a> {
             call_site_span,
             self.namespace,
             &mod_path,
-            self.experimental_private_modules,
         )
     }
 
@@ -309,7 +287,6 @@ impl<'a> TypeCheckContext<'a> {
             span,
             enforce_type_args,
             type_info_prefix,
-            self.experimental_private_modules,
         )
     }
 
@@ -320,13 +297,8 @@ impl<'a> TypeCheckContext<'a> {
         span: &Span,
         type_info_prefix: Option<&Path>,
     ) -> CompileResult<TypeId> {
-        self.namespace.resolve_type_without_self(
-            self.engines(),
-            type_id,
-            span,
-            type_info_prefix,
-            self.experimental_private_modules,
-        )
+        self.namespace
+            .resolve_type_without_self(self.engines(), type_id, span, type_info_prefix)
     }
 
     /// Short-hand around `type_system::unify_with_self`, where the `TypeCheckContext` provides the

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -238,11 +238,7 @@ impl TypeCheckTypeBinding<ty::TyFunctionDecl> for TypeBinding<CallPath> {
         // Grab the declaration.
         let unknown_decl = check!(
             ctx.namespace
-                .resolve_call_path_with_visibility_check(
-                    engines,
-                    &self.inner,
-                    ctx.experimental_private_modules_enabled()
-                )
+                .resolve_call_path_with_visibility_check(engines, &self.inner)
                 .cloned(),
             return err(warnings, errors),
             warnings,
@@ -315,11 +311,7 @@ impl TypeCheckTypeBinding<ty::TyStructDecl> for TypeBinding<CallPath> {
         // Grab the declaration.
         let unknown_decl = check!(
             ctx.namespace
-                .resolve_call_path_with_visibility_check(
-                    engines,
-                    &self.inner,
-                    ctx.experimental_private_modules_enabled()
-                )
+                .resolve_call_path_with_visibility_check(engines, &self.inner,)
                 .cloned(),
             return err(warnings, errors),
             warnings,
@@ -373,11 +365,7 @@ impl TypeCheckTypeBinding<ty::TyEnumDecl> for TypeBinding<CallPath> {
         // Grab the declaration.
         let unknown_decl = check!(
             ctx.namespace
-                .resolve_call_path_with_visibility_check(
-                    engines,
-                    &self.inner,
-                    ctx.experimental_private_modules_enabled()
-                )
+                .resolve_call_path_with_visibility_check(engines, &self.inner,)
                 .cloned(),
             return err(warnings, errors),
             warnings,
@@ -445,11 +433,7 @@ impl TypeCheckTypeBinding<ty::TyConstantDecl> for TypeBinding<CallPath> {
         // Grab the declaration.
         let unknown_decl = check!(
             ctx.namespace
-                .resolve_call_path_with_visibility_check(
-                    engines,
-                    &self.inner,
-                    ctx.experimental_private_modules_enabled()
-                )
+                .resolve_call_path_with_visibility_check(engines, &self.inner,)
                 .cloned(),
             return err(warnings, errors),
             warnings,

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -100,7 +100,6 @@ impl TypeEngine {
         call_site_span: &Span,
         namespace: &mut Namespace,
         mod_path: &Path,
-        experimental_private_modules: bool,
     ) -> CompileResult<()>
     where
         T: MonomorphizeHelper + SubstTypes,
@@ -161,7 +160,6 @@ impl TypeEngine {
                             None,
                             namespace,
                             mod_path,
-                            experimental_private_modules,
                         ),
                         self.insert(engines, TypeInfo::ErrorRecovery),
                         warnings,
@@ -274,7 +272,6 @@ impl TypeEngine {
         type_info_prefix: Option<&Path>,
         namespace: &mut Namespace,
         mod_path: &Path,
-        experimental_private_modules: bool,
     ) -> CompileResult<TypeId> {
         let mut warnings = vec![];
         let mut errors = vec![];
@@ -287,12 +284,7 @@ impl TypeEngine {
             } => {
                 match namespace
                     .root()
-                    .resolve_call_path_with_visibility_check(
-                        engines,
-                        module_path,
-                        &call_path,
-                        experimental_private_modules,
-                    )
+                    .resolve_call_path_with_visibility_check(engines, module_path, &call_path)
                     .ok(&mut warnings, &mut errors)
                     .cloned()
                 {
@@ -313,7 +305,6 @@ impl TypeEngine {
                                 span,
                                 namespace,
                                 mod_path,
-                                experimental_private_modules,
                             ),
                             return err(warnings, errors),
                             warnings,
@@ -349,7 +340,6 @@ impl TypeEngine {
                                 span,
                                 namespace,
                                 mod_path,
-                                experimental_private_modules,
                             ),
                             return err(warnings, errors),
                             warnings,
@@ -404,7 +394,6 @@ impl TypeEngine {
                         None,
                         namespace,
                         mod_path,
-                        experimental_private_modules
                     ),
                     self.insert(engines, TypeInfo::ErrorRecovery),
                     warnings,
@@ -423,7 +412,6 @@ impl TypeEngine {
                             None,
                             namespace,
                             mod_path,
-                            experimental_private_modules
                         ),
                         self.insert(engines, TypeInfo::ErrorRecovery),
                         warnings,
@@ -450,7 +438,6 @@ impl TypeEngine {
         type_info_prefix: Option<&Path>,
         namespace: &mut Namespace,
         mod_path: &Path,
-        experimental_private_modules: bool,
     ) -> CompileResult<TypeId> {
         type_id.replace_self_type(engines, self_type);
         self.resolve(
@@ -461,7 +448,6 @@ impl TypeEngine {
             type_info_prefix,
             namespace,
             mod_path,
-            experimental_private_modules,
         )
     }
 

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -175,7 +175,6 @@ impl Session {
             true,
             tests_enabled,
             Engines::new(&new_type_engine, &new_decl_engine, &new_query_engine),
-            true,
         )
         .map_err(LanguageServerError::FailedToCompile)?;
 

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -218,7 +218,6 @@ pub(crate) async fn compile_to_bytes(file_name: &str, run_config: &RunConfig) ->
     println!("Compiling {} ...", file_name.bold());
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let build_opts = forc_pkg::BuildOpts {
-        experimental_private_modules: true,
         build_target: run_config.build_target,
         pkg: forc_pkg::PkgOpts {
             path: Some(format!(

--- a/test/src/ir_generation/mod.rs
+++ b/test/src/ir_generation/mod.rs
@@ -341,7 +341,6 @@ fn compile_core(build_target: BuildTarget, engines: Engines<'_>) -> namespace::M
         terse_mode: true,
         disable_tests: false,
         locked: false,
-        experimental_private_modules: true,
     };
 
     let res = forc::test::forc_check::check(check_cmd, engines)


### PR DESCRIPTION
## Description

Set experimental module privacy rules as the default and remove the experimental flag.
Closes #4506 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
