### PR TITLE
ci: use `--locked` while installing `cargo-generate`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       # - name: Run test project's test suite
       #   run: (cd test-proj && forc test)
       - name: Install cargo-generate
-        run: cargo install cargo-generate
+        run: cargo install --locked cargo-generate
       - name: Generate Rust Integration Tests
         run: (cd test-proj && cargo generate --init --path ../templates/sway-test-rs --name test-proj)
       - name: Update project cargo manifest with workspace


### PR DESCRIPTION
## Description
closes #4577.

Because of an upstream issue in `cargo-generate`, which can be seen from https://github.com/cargo-generate/cargo-generate/issues/942, our CI is blocked. Until the fix lands we need the `--locked` flag added to install step.