### PR TITLE
Enables where clauses for traits.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -27,7 +27,7 @@ impl ty::TyEnumDecl {
         // Type check the type parameters. This will also insert them into the
         // current namespace.
         let new_type_parameters = check!(
-            TypeParameter::type_check_type_params(ctx.by_ref(), type_parameters, false),
+            TypeParameter::type_check_type_params(ctx.by_ref(), type_parameters),
             return err(warnings, errors),
             warnings,
             errors

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -68,7 +68,7 @@ impl ty::TyFunctionDecl {
         // Type check the type parameters. This will also insert them into the
         // current namespace.
         let new_type_parameters = check!(
-            TypeParameter::type_check_type_params(ctx.by_ref(), type_parameters, false),
+            TypeParameter::type_check_type_params(ctx.by_ref(), type_parameters),
             return err(warnings, errors),
             warnings,
             errors
@@ -149,7 +149,7 @@ impl ty::TyFunctionDecl {
         check!(
             return_type
                 .type_id
-                .check_type_parameter_bounds(&ctx, &return_type.span),
+                .check_type_parameter_bounds(&ctx, &return_type.span, vec![]),
             return err(warnings, errors),
             warnings,
             errors

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
@@ -43,7 +43,7 @@ impl ty::TyFunctionParameter {
         check!(
             type_argument
                 .type_id
-                .check_type_parameter_bounds(&ctx, &type_argument.span),
+                .check_type_parameter_bounds(&ctx, &type_argument.span, vec![]),
             return err(warnings, errors),
             warnings,
             errors

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -44,7 +44,7 @@ impl ty::TyImplTrait {
         // Type check the type parameters. This will also insert them into the
         // current namespace.
         let new_impl_type_parameters = check!(
-            TypeParameter::type_check_type_params(ctx.by_ref(), impl_type_parameters, false),
+            TypeParameter::type_check_type_params(ctx.by_ref(), impl_type_parameters),
             return err(warnings, errors),
             warnings,
             errors
@@ -262,7 +262,7 @@ impl ty::TyImplTrait {
         // Type check the type parameters. This will also insert them into the
         // current namespace.
         let new_impl_type_parameters = check!(
-            TypeParameter::type_check_type_params(ctx.by_ref(), impl_type_parameters, false),
+            TypeParameter::type_check_type_params(ctx.by_ref(), impl_type_parameters),
             return err(warnings, errors),
             warnings,
             errors
@@ -300,9 +300,11 @@ impl ty::TyImplTrait {
         );
 
         check!(
-            implementing_for
-                .type_id
-                .check_type_parameter_bounds(&ctx, &implementing_for.span),
+            implementing_for.type_id.check_type_parameter_bounds(
+                &ctx,
+                &implementing_for.span,
+                vec![]
+            ),
             return err(warnings, errors),
             warnings,
             errors
@@ -420,6 +422,19 @@ fn type_check_trait_implementation(
         warnings,
         errors
     );
+
+    for (type_arg, type_param) in trait_type_arguments.iter().zip(trait_type_parameters) {
+        check!(
+            type_arg.type_id.check_type_parameter_bounds(
+                &ctx,
+                &type_arg.span(),
+                type_param.trait_constraints.clone()
+            ),
+            return err(warnings, errors),
+            warnings,
+            errors
+        );
+    }
 
     // This map keeps track of the remaining functions in the interface surface
     // that still need to be implemented for the trait to be fully implemented.

--- a/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
@@ -30,7 +30,7 @@ impl ty::TyStructDecl {
         // Type check the type parameters. This will also insert them into the
         // current namespace.
         let new_type_parameters = check!(
-            TypeParameter::type_check_type_params(ctx.by_ref(), type_parameters, false),
+            TypeParameter::type_check_type_params(ctx.by_ref(), type_parameters),
             return err(warnings, errors),
             warnings,
             errors

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -56,7 +56,7 @@ impl ty::TyTraitDecl {
         // Type check the type parameters. This will also insert them into the
         // current namespace.
         let new_type_parameters = check!(
-            TypeParameter::type_check_type_params(ctx.by_ref(), type_parameters, true),
+            TypeParameter::type_check_type_params(ctx.by_ref(), type_parameters),
             return err(warnings, errors),
             warnings,
             errors

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -110,7 +110,7 @@ pub(crate) fn instantiate_enum(
             let type_id = type_engine.insert(decl_engine, TypeInfo::Enum(enum_ref.clone()));
 
             check!(
-                type_id.check_type_parameter_bounds(&ctx, &enum_variant_name.span()),
+                type_id.check_type_parameter_bounds(&ctx, &enum_variant_name.span(), vec![]),
                 return err(warnings, errors),
                 warnings,
                 errors

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -131,7 +131,7 @@ pub(crate) fn struct_instantiation(
     }
 
     check!(
-        type_id.check_type_parameter_bounds(&ctx, &span),
+        type_id.check_type_parameter_bounds(&ctx, &span, vec![]),
         return err(warnings, errors),
         warnings,
         errors

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -134,7 +134,6 @@ impl TypeParameter {
     pub(crate) fn type_check_type_params(
         mut ctx: TypeCheckContext,
         type_params: Vec<TypeParameter>,
-        disallow_trait_constraints: bool,
     ) -> CompileResult<Vec<TypeParameter>> {
         let mut warnings = vec![];
         let mut errors = vec![];
@@ -142,12 +141,6 @@ impl TypeParameter {
         let mut new_type_params: Vec<TypeParameter> = vec![];
 
         for type_param in type_params.into_iter() {
-            if disallow_trait_constraints && !type_param.trait_constraints.is_empty() {
-                let errors = vec![CompileError::WhereClauseNotYetSupported {
-                    span: type_param.trait_constraints_span,
-                }];
-                return err(vec![], errors);
-            }
             new_type_params.push(check!(
                 TypeParameter::type_check(ctx.by_ref(), type_param),
                 continue,

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -363,15 +363,20 @@ impl TypeId {
         &self,
         ctx: &TypeCheckContext,
         span: &Span,
+        trait_constraints: Vec<TraitConstraint>,
     ) -> CompileResult<()> {
         let warnings = vec![];
         let mut errors = vec![];
         let engines = ctx.engines();
 
-        let structure_generics = engines
+        let mut structure_generics = engines
             .te()
             .get(*self)
             .extract_inner_types_with_trait_constraints(engines);
+
+        if !trait_constraints.is_empty() {
+            structure_generics.insert(*self, trait_constraints);
+        }
 
         for (structure_type_id, structure_trait_constraints) in &structure_generics {
             if structure_trait_constraints.is_empty() {

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -564,8 +564,6 @@ pub enum CompileError {
     Lex { error: LexError },
     #[error("{}", error)]
     Parse { error: ParseError },
-    #[error("\"where\" clauses are not yet supported")]
-    WhereClauseNotYetSupported { span: Span },
     #[error("Could not evaluate initializer to a const declaration.")]
     NonConstantDeclValue { span: Span },
     #[error("Declaring storage in a {program_kind} is not allowed.")]
@@ -787,7 +785,6 @@ impl Spanned for CompileError {
             UnexpectedDeclaration { span, .. } => span.clone(),
             ContractAddressMustBeKnown { span, .. } => span.clone(),
             ConvertParseTree { error } => error.span(),
-            WhereClauseNotYetSupported { span, .. } => span.clone(),
             Lex { error } => error.span(),
             Parse { error } => error.span.clone(),
             EnumNotFound { span, .. } => span.clone(),

--- a/test/src/e2e_vm_tests/test_programs/should_fail/where_clause_traits/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/where_clause_traits/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-8E4C78460FB62C32'
+
+[[package]]
+name = 'where_clause_traits'
+source = 'member'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/where_clause_traits/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/where_clause_traits/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+name = "where_clause_traits"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/where_clause_traits/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/where_clause_traits/src/main.sw
@@ -1,0 +1,26 @@
+script;
+
+trait MyTrait {
+    fn method(self);
+}
+
+trait MyTraitGeneric<T> where T : MyTrait {
+    fn method(self);
+}
+
+struct S1 {
+    s1: u64
+}
+
+impl MyTraitGeneric<S1> for u64 {
+    fn method(self){
+    }
+}
+
+impl<T> MyTraitGeneric<T> for u32 {
+    fn method(self){
+    }
+}
+
+fn main() {
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/where_clause_traits/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/where_clause_traits/test.toml
@@ -1,0 +1,8 @@
+category = "fail"
+
+# check: $()impl MyTraitGeneric<S1> for u64 {
+# nextln:$()Trait "MyTrait" is not implemented for type "S1".
+
+# check: $()impl<T> MyTraitGeneric<T> for u32 {
+# nextln: $()Expects trait constraint "T: MyTrait" which is missing from type parameter "T".
+

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_traits/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_traits/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-8E4C78460FB62C32'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-8E4C78460FB62C32'
+dependencies = ['core']
+
+[[package]]
+name = 'where_clause_traits'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_traits/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_traits/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+name = "where_clause_traits"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_traits/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_traits/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "u8",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_traits/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_traits/src/main.sw
@@ -1,0 +1,31 @@
+script;
+
+trait MyTrait {
+    fn new() -> Self;
+}
+
+trait MyTraitGeneric<T> where T : MyTrait {
+    fn get_value(self) -> T;
+}
+
+struct S1 {
+    s1: u64
+}
+
+impl MyTrait for S1 {
+    fn new() -> Self {
+        S1 {s1: 0}
+    }
+}
+
+impl MyTraitGeneric<S1> for u64 {
+    fn get_value(self) -> S1 {
+        S1::new()
+    }
+}
+
+fn main() -> u8 {
+    let _s0: S1 = 42u64.get_value();
+
+    0u8
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_traits/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_traits/test.toml
@@ -1,0 +1,5 @@
+category = "run"
+expected_result = { action = "return", value = 0 }
+validate_abi = true
+
+expected_warnings = 1


### PR DESCRIPTION
## Description

With these changes where clauses are enabled for traits. This commit also adds error handling when an `impl` is created for a generic trait with where clause.

Generic traits are not supported yet on super traits or where clauses, when the support is added we should also perform the bounds check there.

Fixes #4560
Fixes #970

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
