### PR TITLE
Fix forc-run-benchmarks checkout steps for non-PR CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,13 @@ jobs:
       - name: Run benchmarks
         run: ./benchmark.sh
       - name: Checkout benchmark data
+        if: github.event_name != 'push'
+        uses: actions/checkout@v3
+        with:
+          repository: FuelLabs/sway-performance-data
+          path: performance-data
+      - name: Checkout benchmark data
+        if: github.event_name == 'push'
         uses: actions/checkout@v3
         with:
           repository: FuelLabs/sway-performance-data


### PR DESCRIPTION
## Description

The checkout step was failing on a PR running from my fork because the PAT token is not setup in that case. This fixes that issue.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
