### PR TITLE
ci-fix: use latest (sourced via path) version of std while testing sway reference examples

### DIFF
--- a/ci_checks.sh
+++ b/ci_checks.sh
@@ -36,6 +36,7 @@ forc build --path sway-lib-std &&
 forc test --path sway-lib-std &&
 cargo run --locked -p forc -- build --locked --path ./examples/Forc.toml &&
 cargo run --locked -p forc-fmt -- --check --path ./examples/Forc.toml &&
+cargo run --locked -p forc -- build --path ./docs/reference/src/code/Forc.toml &&
 rm -Rf test-proj &&
 forc new test-proj &&
 echo "std = { path = \"../sway-lib-std/\" }" >> test-proj/Forc.toml &&

--- a/docs/reference/src/code/Forc.lock
+++ b/docs/reference/src/code/Forc.lock
@@ -71,7 +71,7 @@ dependencies = ['std']
 
 [[package]]
 name = 'core'
-source = 'path+from-root-B313E39BF6A5D375'
+source = 'path+from-root-0F28276288D2432C'
 
 [[package]]
 name = 'counter'
@@ -162,21 +162,8 @@ source = 'member'
 dependencies = ['std']
 
 [[package]]
-name = 're_entrency'
-source = 'member'
-dependencies = [
-    'reentrancy',
-    'std',
-]
-
-[[package]]
 name = 'reading_writing_to_storage'
 source = 'member'
-dependencies = ['std']
-
-[[package]]
-name = 'reentrancy'
-source = 'git+https://github.com/FuelLabs/sway-libs?tag=v0.10.0#0444499cf24b383eda96ad24c93e3b8bc31ab1b9'
 dependencies = ['std']
 
 [[package]]
@@ -191,7 +178,7 @@ dependencies = ['std']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.39.1#e3065657c907225a8fdfe2d2210a7a3bd2b55c73'
+source = 'path+from-root-0F28276288D2432C'
 dependencies = ['core']
 
 [[package]]

--- a/docs/reference/src/code/Forc.toml
+++ b/docs/reference/src/code/Forc.toml
@@ -40,7 +40,7 @@ members = [
   "operations/hashing",
   "operations/logging",
   "operations/namespace",
-  "operations/re_entrency",
+# "operations/re_entrency", # Re-enable this once https://github.com/FuelLabs/sway/issues/4596 is fixed
   "operations/storage/empty_storage_init",
   "operations/storage/reading_writing_to_storage",
   "operations/storage/storage_init",

--- a/docs/reference/src/code/examples/access-control/ownership/Forc.toml
+++ b/docs/reference/src/code/examples/access-control/ownership/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "ownership"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/examples/counter/Forc.toml
+++ b/docs/reference/src/code/examples/counter/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "counter"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/examples/fizzbuzz/Forc.toml
+++ b/docs/reference/src/code/examples/fizzbuzz/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "fizzbuzz"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/examples/wallet_example/Forc.toml
+++ b/docs/reference/src/code/examples/wallet_example/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "wallet_example"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/annotations/Forc.toml
+++ b/docs/reference/src/code/language/annotations/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "annotations"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/built-ins/arrays/Forc.toml
+++ b/docs/reference/src/code/language/built-ins/arrays/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "arrays"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/built-ins/booleans/Forc.toml
+++ b/docs/reference/src/code/language/built-ins/booleans/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "booleans"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/built-ins/bytes/Forc.toml
+++ b/docs/reference/src/code/language/built-ins/bytes/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "bytes"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/built-ins/enums/Forc.toml
+++ b/docs/reference/src/code/language/built-ins/enums/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "enums"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/built-ins/numerics/Forc.toml
+++ b/docs/reference/src/code/language/built-ins/numerics/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "numerics"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/built-ins/strings/Forc.toml
+++ b/docs/reference/src/code/language/built-ins/strings/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "strings"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/built-ins/structs/Forc.toml
+++ b/docs/reference/src/code/language/built-ins/structs/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "structs"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/built-ins/tuples/Forc.toml
+++ b/docs/reference/src/code/language/built-ins/tuples/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "tuples"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/comments/Forc.toml
+++ b/docs/reference/src/code/language/comments/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "comments"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/control_flow/Forc.toml
+++ b/docs/reference/src/code/language/control_flow/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "control_flow"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/functions/Forc.toml
+++ b/docs/reference/src/code/language/functions/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "functions"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/program-types/contracts/interface/Forc.toml
+++ b/docs/reference/src/code/language/program-types/contracts/interface/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "interface"
 
 [dependencies]
+std = { path = "../../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/program-types/contracts/wallet/Forc.toml
+++ b/docs/reference/src/code/language/program-types/contracts/wallet/Forc.toml
@@ -9,3 +9,4 @@ OWNER_ADDRESS = { type = "b256", value = "0x8900c5bec4ca97d4febf9ceb4754a60d782a
 
 [dependencies]
 interface = { path = "../interface" }
+std = { path = "../../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/program-types/libraries/external/my_library/Forc.toml
+++ b/docs/reference/src/code/language/program-types/libraries/external/my_library/Forc.toml
@@ -6,3 +6,4 @@ name = "my_library"
 
 [dependencies]
 my_other_library = { path = "../my_other_library" }
+std = { path = "../../../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/program-types/libraries/external/my_other_library/Forc.toml
+++ b/docs/reference/src/code/language/program-types/libraries/external/my_other_library/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "my_other_library"
 
 [dependencies]
+std = { path = "../../../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/program-types/libraries/internal/my_lib/Forc.toml
+++ b/docs/reference/src/code/language/program-types/libraries/internal/my_lib/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "my_lib"
 
 [dependencies]
+std = { path = "../../../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/program-types/predicates/simple_predicate/Forc.toml
+++ b/docs/reference/src/code/language/program-types/predicates/simple_predicate/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "simple_predicate"
 
 [dependencies]
+std = { path = "../../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/program-types/scripts/simple_script/Forc.toml
+++ b/docs/reference/src/code/language/program-types/scripts/simple_script/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "simple_script"
 
 [dependencies]
+std = { path = "../../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/style-guide/annotation_style/Forc.toml
+++ b/docs/reference/src/code/language/style-guide/annotation_style/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "annotation_style"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/style-guide/enum_style/Forc.toml
+++ b/docs/reference/src/code/language/style-guide/enum_style/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "enum_style"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/style-guide/getters/Forc.toml
+++ b/docs/reference/src/code/language/style-guide/getters/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "getters"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/style-guide/letter_casing/Forc.toml
+++ b/docs/reference/src/code/language/style-guide/letter_casing/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "letter_casing"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/style-guide/struct_shorthand/Forc.toml
+++ b/docs/reference/src/code/language/style-guide/struct_shorthand/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "struct_shorthand"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/language/variables/Forc.toml
+++ b/docs/reference/src/code/language/variables/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "variables"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/misc/advanced-concepts/enum_advanced/Forc.toml
+++ b/docs/reference/src/code/misc/advanced-concepts/enum_advanced/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "enum-advanced"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/misc/known-issues/string_issue/Forc.toml
+++ b/docs/reference/src/code/misc/known-issues/string_issue/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "string_issue"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/assertions/Forc.toml
+++ b/docs/reference/src/code/operations/assertions/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "assertions"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/asset_operations/Forc.toml
+++ b/docs/reference/src/code/operations/asset_operations/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "asset_operations"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/call_data/Forc.toml
+++ b/docs/reference/src/code/operations/call_data/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "call_data"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/contract_calling/call/Forc.toml
+++ b/docs/reference/src/code/operations/contract_calling/call/Forc.toml
@@ -6,3 +6,4 @@ name = "call"
 
 [dependencies]
 contract_interface = { path = "../contract_interface" }
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/contract_calling/contract_interface/Forc.toml
+++ b/docs/reference/src/code/operations/contract_calling/contract_interface/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "contract_interface"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/hashing/Forc.toml
+++ b/docs/reference/src/code/operations/hashing/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "hashing"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/logging/Forc.toml
+++ b/docs/reference/src/code/operations/logging/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "logging"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/namespace/Forc.toml
+++ b/docs/reference/src/code/operations/namespace/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "namespace"
 
 [dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/storage/empty_storage_init/Forc.toml
+++ b/docs/reference/src/code/operations/storage/empty_storage_init/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "empty_storage_init"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/storage/reading_writing_to_storage/Forc.toml
+++ b/docs/reference/src/code/operations/storage/reading_writing_to_storage/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "reading_writing_to_storage"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/storage/storage_init/Forc.toml
+++ b/docs/reference/src/code/operations/storage/storage_init/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "storage_init"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/storage/storage_map/Forc.toml
+++ b/docs/reference/src/code/operations/storage/storage_map/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "storage_map"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/storage/storage_vec/Forc.toml
+++ b/docs/reference/src/code/operations/storage/storage_vec/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "storage_vec"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/docs/reference/src/code/operations/storage/store_get/Forc.toml
+++ b/docs/reference/src/code/operations/storage/store_get/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "store_get"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }


### PR DESCRIPTION
## Description

closes #4595.
unblocks #4525.

Once #4596 is fixed we can remove std declarations in each manifest file with a single patch statement in the workspace level manifest file. That will also open the way to re-enable the disabled member (reentrancy) as the example depends on sway-lib and sway-lib depends on latest released std. So without the patch table it is not useable.

follow-up: #4596.