### PR TITLE
Fix `pub` token being removed by swayfmt

### DIFF
--- a/swayfmt/src/module/submodule.rs
+++ b/swayfmt/src/module/submodule.rs
@@ -12,6 +12,9 @@ impl Format for Submodule {
         formatted_code: &mut FormattedCode,
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
+        if let Some(pub_token) = &self.visibility {
+            write!(formatted_code, "{} ", pub_token.span().as_str())?;
+        }
         write!(formatted_code, "{} ", self.mod_token.span().as_str())?;
         self.name.format(formatted_code, formatter)?;
         writeln!(formatted_code, "{}", self.semicolon_token.span().as_str())?;
@@ -21,10 +24,15 @@ impl Format for Submodule {
 
 impl LeafSpans for Submodule {
     fn leaf_spans(&self) -> Vec<ByteSpan> {
-        vec![
+        let mut spans = Vec::with_capacity(4);
+        if let Some(visibility) = &self.visibility {
+            spans.push(ByteSpan::from(visibility.span()));
+        }
+        spans.extend_from_slice(&[
             ByteSpan::from(self.mod_token.span()),
             ByteSpan::from(self.name.span()),
             ByteSpan::from(self.semicolon_token.span()),
-        ]
+        ]);
+        spans
     }
 }

--- a/swayfmt/tests/mod.rs
+++ b/swayfmt/tests/mod.rs
@@ -21,6 +21,18 @@ fn check(unformatted: &str, expected: &str) {
 }
 
 #[test]
+fn conserve_pub_mod() {
+    check(
+        r#"contract;
+pub mod foo;
+"#,
+        r#"contract;
+pub mod foo;
+"#,
+    )
+}
+
+#[test]
 fn const_spacing() {
     check(
         r#"contract;


### PR DESCRIPTION

## Description
Fix a bug where the `pub` token in any `pub mod` expression would get elided by swayfmt.


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
