### PR TITLE
Fixes module path issue in core.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -482,7 +482,20 @@ pub(crate) fn resolve_method_name(
         }
         MethodName::FromTrait { call_path } => {
             // find the module that the symbol is in
-            let module_path = ctx.namespace.find_module_path(&call_path.prefixes);
+            let module_path = if !call_path.is_absolute {
+                ctx.namespace.find_module_path(&call_path.prefixes)
+            } else {
+                let mut module_path = call_path.prefixes.clone();
+                if let (Some(root_mod), Some(root_name)) = (
+                    module_path.get(0).cloned(),
+                    ctx.namespace.root().name.clone(),
+                ) {
+                    if root_mod.as_str() == root_name.as_str() {
+                        module_path.remove(0);
+                    }
+                }
+                module_path
+            };
 
             // find the type of the first argument
             let type_id = arguments


### PR DESCRIPTION
## Description

Fixes issue where the compiler would try to use module path `primitive_conversions::core::ops`. With this fix the module path will be `ops`.
We also ignore `core` because it is in the name of the root module.

The test case is `core` specific and should be added to the repo once #4630 is merged.

Fixes issue found in #4630

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
