### PR TITLE
Test dot method calls disambiguation with `self`

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_method_qualified/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_method_qualified/src/main.sw
@@ -12,7 +12,7 @@ trait MySuperTrait {
     fn method() -> u64;
 }
 
-trait MyTrait : MySuperTrait {
+trait MyTrait: MySuperTrait {
     fn method() -> u64;
 }
 
@@ -28,10 +28,45 @@ impl MyTrait for S {
     }
 }
 
+// same test case but the methods take `self` as a parameter
+struct T {}
+
+impl T {
+    fn method_self(self) -> u64 {
+        1
+    }
+}
+
+trait MySuperTraitSelf {
+    fn method_self(self) -> u64;
+}
+
+trait MyTraitSelf: MySuperTraitSelf {
+    fn method_self(self) -> u64;
+}
+
+impl MySuperTraitSelf for T {
+    fn method_self(self) -> u64 {
+        2
+    }
+}
+
+impl MyTraitSelf for T {
+    fn method_self(self) -> u64 {
+        3
+    }
+}
+
 fn main() -> bool {
     assert(S::method() == 1);
     assert(<S as MySuperTrait>::method() == 2);
     assert(<S as MyTrait>::method() == 3);
 
-    true   
+    let t = T {};
+    // t.method_self() disambiguates to T::method_self
+    assert(t.method_self() == T::method_self(t));
+    assert(<T as MySuperTraitSelf>::method_self(t) == 2);
+    assert(<T as MyTraitSelf>::method_self(t) == 3);
+
+    true
 }


### PR DESCRIPTION
related to issues #4383 and #4563

## Description


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
