### PR TITLE
Bump tower-lsp and use the lsp_types crate directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3047,9 +3047,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.93.2"
+version = "0.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be6e9c7e2d18f651974370d7aff703f9513e0df6e464fd795660edc77e6ca51"
+checksum = "0b63735a13a1f9cd4f4835223d828ed9c2e35c8c5e61837774399f558b6a1237"
 dependencies = [
  "bitflags",
  "serde",
@@ -5076,6 +5076,7 @@ dependencies = [
  "forc-pkg",
  "forc-tracing",
  "futures",
+ "lsp-types",
  "notify",
  "notify-debouncer-mini",
  "parking_lot 0.12.1",
@@ -5620,9 +5621,9 @@ checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-lsp"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0ad391e4e58fccec398abd3da22d5e59fbcbae8d036df0d00dfd9703c7ee96"
+checksum = "9b38fb0e6ce037835174256518aace3ca621c4f96383c56bb846cfc11b341910"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -5643,9 +5644,9 @@ dependencies = [
 
 [[package]]
 name = "tower-lsp-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74697a0324a76eedfc784ffef1cc4de2300af19720de3c3fd99cd7ec484479da"
+checksum = "34723c06344244474fdde365b76aebef8050bf6be61a935b91ee9ff7c4e91157"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.41"
 dashmap = "5.4"
 forc-pkg = { version = "0.40.1", path = "../forc-pkg" }
 forc-tracing = { version = "0.40.1", path = "../forc-tracing" }
+lsp-types = { version = "0.94", features = ["proposed"] }
 notify = "5.0.0"
 notify-debouncer-mini = { version = "0.2.0" }
 parking_lot = "0.12.1"
@@ -33,7 +34,7 @@ tempfile = "3"
 thiserror = "1.0.30"
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 toml_edit = "0.19"
-tower-lsp = { version = "0.18", features = ["proposed"] }
+tower-lsp = { version = "0.19", features = ["proposed"] }
 tracing = "0.1"
 urlencoding = "2.1.2"
 

--- a/sway-lsp/src/capabilities/code_actions/abi_decl/abi_impl.rs
+++ b/sway-lsp/src/capabilities/code_actions/abi_decl/abi_impl.rs
@@ -1,8 +1,8 @@
+use lsp_types::{Range, Url};
 use sway_core::{
     language::ty::{self, TyAbiDecl, TyFunctionParameter, TyTraitFn},
     Engines,
 };
-use tower_lsp::lsp_types::{Range, Url};
 
 use crate::capabilities::code_actions::{
     common::generate_impl::{GenerateImplCodeAction, CONTRACT},

--- a/sway-lsp/src/capabilities/code_actions/abi_decl/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/abi_decl/mod.rs
@@ -1,11 +1,9 @@
 pub(crate) mod abi_impl;
 
-use sway_core::{decl_engine::id::DeclId, language::ty::TyAbiDecl};
-use tower_lsp::lsp_types::CodeActionOrCommand;
-
 use self::abi_impl::AbiImplCodeAction;
-
 use super::{CodeAction, CodeActionContext};
+use lsp_types::CodeActionOrCommand;
+use sway_core::{decl_engine::id::DeclId, language::ty::TyAbiDecl};
 
 pub(crate) fn code_actions(
     decl_id: &DeclId<TyAbiDecl>,

--- a/sway-lsp/src/capabilities/code_actions/common/generate_doc.rs
+++ b/sway-lsp/src/capabilities/code_actions/common/generate_doc.rs
@@ -1,8 +1,7 @@
+use crate::capabilities::code_actions::{CodeAction, CodeActionContext, CODE_ACTION_DOC_TITLE};
+use lsp_types::{Range, Url};
 use sway_core::{Engines, TypeId};
 use sway_types::Spanned;
-use tower_lsp::lsp_types::{Range, Url};
-
-use crate::capabilities::code_actions::{CodeAction, CodeActionContext, CODE_ACTION_DOC_TITLE};
 
 pub(crate) trait GenerateDocCodeAction<'a, T: Spanned>: CodeAction<'a, T> {
     /// Returns a placeholder description as a vector of strings.

--- a/sway-lsp/src/capabilities/code_actions/constant_decl/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/constant_decl/mod.rs
@@ -1,8 +1,7 @@
-use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
-use sway_core::language::ty;
-use tower_lsp::lsp_types::CodeActionOrCommand;
-
 use super::common::generate_doc::BasicDocCommentCodeAction;
+use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
+use lsp_types::CodeActionOrCommand;
+use sway_core::language::ty;
 
 pub(crate) fn code_actions(
     decl: &ty::TyConstantDecl,

--- a/sway-lsp/src/capabilities/code_actions/enum_decl/doc_comment.rs
+++ b/sway-lsp/src/capabilities/code_actions/enum_decl/doc_comment.rs
@@ -2,8 +2,8 @@ use crate::capabilities::code_actions::{
     common::generate_doc::GenerateDocCodeAction, CodeAction, CodeActionContext,
     CODE_ACTION_DOC_TITLE,
 };
+use lsp_types::{Range, Url};
 use sway_core::language::ty::TyEnumDecl;
-use tower_lsp::lsp_types::{Range, Url};
 
 pub(crate) struct DocCommentCodeAction<'a> {
     decl: &'a TyEnumDecl,

--- a/sway-lsp/src/capabilities/code_actions/enum_decl/enum_impl.rs
+++ b/sway-lsp/src/capabilities/code_actions/enum_decl/enum_impl.rs
@@ -2,8 +2,8 @@ use crate::capabilities::code_actions::{
     common::generate_impl::{GenerateImplCodeAction, TAB},
     CodeAction, CodeActionContext, CODE_ACTION_IMPL_TITLE,
 };
+use lsp_types::{Range, Url};
 use sway_core::language::ty::TyEnumDecl;
-use tower_lsp::lsp_types::{Range, Url};
 
 pub(crate) struct EnumImplCodeAction<'a> {
     decl: &'a TyEnumDecl,

--- a/sway-lsp/src/capabilities/code_actions/enum_decl/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/enum_decl/mod.rs
@@ -3,8 +3,8 @@ pub(crate) mod enum_impl;
 
 use self::enum_impl::EnumImplCodeAction;
 use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
+use lsp_types::CodeActionOrCommand;
 use sway_core::{decl_engine::id::DeclId, language::ty};
-use tower_lsp::lsp_types::CodeActionOrCommand;
 
 use super::common::generate_doc::BasicDocCommentCodeAction;
 

--- a/sway-lsp/src/capabilities/code_actions/enum_variant/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/enum_variant/mod.rs
@@ -1,6 +1,6 @@
 use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
+use lsp_types::CodeActionOrCommand;
 use sway_core::language::ty;
-use tower_lsp::lsp_types::CodeActionOrCommand;
 
 use super::common::generate_doc::BasicDocCommentCodeAction;
 

--- a/sway-lsp/src/capabilities/code_actions/function_decl/doc_comment.rs
+++ b/sway-lsp/src/capabilities/code_actions/function_decl/doc_comment.rs
@@ -2,8 +2,8 @@ use crate::capabilities::code_actions::{
     common::generate_doc::GenerateDocCodeAction, CodeAction, CodeActionContext,
     CODE_ACTION_DOC_TITLE,
 };
+use lsp_types::{Range, Url};
 use sway_core::{language::ty::TyFunctionDecl, Engines};
-use tower_lsp::lsp_types::{Range, Url};
 
 pub(crate) struct DocCommentCodeAction<'a> {
     engines: &'a Engines,

--- a/sway-lsp/src/capabilities/code_actions/function_decl/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/function_decl/mod.rs
@@ -2,8 +2,8 @@ pub(crate) mod doc_comment;
 
 use self::doc_comment::DocCommentCodeAction;
 use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
+use lsp_types::CodeActionOrCommand;
 use sway_core::language::ty;
-use tower_lsp::lsp_types::CodeActionOrCommand;
 
 pub(crate) fn code_actions(
     decl: &ty::TyFunctionDecl,

--- a/sway-lsp/src/capabilities/code_actions/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/mod.rs
@@ -14,14 +14,14 @@ use crate::core::{
     token_map::TokenMap,
 };
 pub use crate::error::DocumentError;
+use lsp_types::{
+    CodeAction as LspCodeAction, CodeActionDisabled, CodeActionKind, CodeActionOrCommand,
+    CodeActionResponse, Position, Range, TextDocumentIdentifier, TextEdit, Url, WorkspaceEdit,
+};
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
 use sway_core::{language::ty, Engines};
 use sway_types::Spanned;
-use tower_lsp::lsp_types::{
-    CodeAction as LspCodeAction, CodeActionDisabled, CodeActionKind, CodeActionOrCommand,
-    CodeActionResponse, Position, Range, TextDocumentIdentifier, TextEdit, Url, WorkspaceEdit,
-};
 
 pub(crate) const CODE_ACTION_IMPL_TITLE: &str = "Generate impl for";
 pub(crate) const CODE_ACTION_NEW_TITLE: &str = "Generate `new`";

--- a/sway-lsp/src/capabilities/code_actions/storage_field/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/storage_field/mod.rs
@@ -1,6 +1,6 @@
 use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
+use lsp_types::CodeActionOrCommand;
 use sway_core::language::ty;
-use tower_lsp::lsp_types::CodeActionOrCommand;
 
 use super::common::generate_doc::BasicDocCommentCodeAction;
 

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/mod.rs
@@ -3,8 +3,8 @@ pub(crate) mod struct_new;
 
 use self::{struct_impl::StructImplCodeAction, struct_new::StructNewCodeAction};
 use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
+use lsp_types::CodeActionOrCommand;
 use sway_core::{decl_engine::id::DeclId, language::ty};
-use tower_lsp::lsp_types::CodeActionOrCommand;
 
 use super::common::generate_doc::BasicDocCommentCodeAction;
 

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/struct_impl.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/struct_impl.rs
@@ -2,8 +2,8 @@ use crate::capabilities::code_actions::{
     common::generate_impl::{GenerateImplCodeAction, TAB},
     CodeAction, CodeActionContext, CODE_ACTION_IMPL_TITLE,
 };
+use lsp_types::{Range, Url};
 use sway_core::language::ty::TyStructDecl;
-use tower_lsp::lsp_types::{Range, Url};
 
 pub(crate) struct StructImplCodeAction<'a> {
     decl: &'a TyStructDecl,

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
@@ -5,9 +5,9 @@ use crate::{
     },
     core::{token::TypedAstToken, token_map::TokenMapExt},
 };
+use lsp_types::{CodeActionDisabled, Position, Range, Url};
 use sway_core::language::ty::{self, TyImplTrait, TyStructDecl, TyStructField};
 use sway_types::Spanned;
-use tower_lsp::lsp_types::{CodeActionDisabled, Position, Range, Url};
 
 pub(crate) struct StructNewCodeAction<'a> {
     decl: &'a TyStructDecl,

--- a/sway-lsp/src/capabilities/code_actions/struct_field/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_field/mod.rs
@@ -1,6 +1,6 @@
 use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
+use lsp_types::CodeActionOrCommand;
 use sway_core::language::ty;
-use tower_lsp::lsp_types::CodeActionOrCommand;
 
 use super::common::generate_doc::BasicDocCommentCodeAction;
 

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -1,13 +1,13 @@
+use lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionTextEdit, Position,
+    Range, TextEdit,
+};
 use sway_core::{
     language::ty::{TyAstNodeContent, TyDecl, TyFunctionDecl},
     namespace::Items,
     Engines, TypeId, TypeInfo,
 };
 use sway_types::Ident;
-use tower_lsp::lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionTextEdit, Position,
-    Range, TextEdit,
-};
 
 pub(crate) fn to_completion_items(
     namespace: &Items,

--- a/sway-lsp/src/capabilities/diagnostic.rs
+++ b/sway-lsp/src/capabilities/diagnostic.rs
@@ -1,5 +1,4 @@
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, DiagnosticTag, Position, Range};
-
+use lsp_types::{Diagnostic, DiagnosticSeverity, DiagnosticTag, Position, Range};
 use sway_error::warning::CompileWarning;
 use sway_error::{error::CompileError, warning::Warning};
 use sway_types::{LineCol, Spanned};

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -1,6 +1,6 @@
 use crate::core::token::{get_range_from_span, SymbolKind, Token};
+use lsp_types::{self, Location, SymbolInformation, Url};
 use sway_types::{Ident, Spanned};
-use tower_lsp::lsp_types::{self, Location, SymbolInformation, Url};
 
 pub fn to_symbol_information<I>(tokens: I, url: Url) -> Vec<SymbolInformation>
 where

--- a/sway-lsp/src/capabilities/formatting.rs
+++ b/sway-lsp/src/capabilities/formatting.rs
@@ -1,7 +1,7 @@
 use crate::error::LanguageServerError;
+use lsp_types::{Position, Range, TextEdit};
 use std::sync::Arc;
 use swayfmt::Formatter;
-use tower_lsp::lsp_types::{Position, Range, TextEdit};
 
 pub fn get_page_text_edit(
     text: Arc<str>,

--- a/sway-lsp/src/capabilities/highlight.rs
+++ b/sway-lsp/src/capabilities/highlight.rs
@@ -1,6 +1,6 @@
 use crate::core::session::Session;
+use lsp_types::{DocumentHighlight, Position, Url};
 use std::sync::Arc;
-use tower_lsp::lsp_types::{DocumentHighlight, Position, Url};
 
 pub fn get_highlights(
     session: Arc<Session>,

--- a/sway-lsp/src/capabilities/hover/hover_link_contents.rs
+++ b/sway-lsp/src/capabilities/hover/hover_link_contents.rs
@@ -11,8 +11,8 @@ use sway_core::{
     Engines, TypeId, TypeInfo,
 };
 
+use lsp_types::{Range, Url};
 use sway_types::{Span, Spanned};
-use tower_lsp::lsp_types::{Range, Url};
 
 #[derive(Debug, Clone)]
 pub struct RelatedType {

--- a/sway-lsp/src/capabilities/hover/mod.rs
+++ b/sway-lsp/src/capabilities/hover/mod.rs
@@ -15,8 +15,8 @@ use sway_core::{
     Engines, TypeId,
 };
 
+use lsp_types::{self, Position, Url};
 use sway_types::{Ident, Span, Spanned};
-use tower_lsp::lsp_types::{self, Position, Url};
 
 use self::hover_link_contents::HoverLinkContents;
 

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -5,10 +5,10 @@ use crate::{
         token::{get_range_from_span, TypedAstToken},
     },
 };
+use lsp_types::{self, Range, Url};
 use std::sync::Arc;
 use sway_core::{language::ty::TyDecl, type_system::TypeInfo};
 use sway_types::Spanned;
-use tower_lsp::lsp_types::{self, Range, Url};
 
 // Future PR's will add more kinds
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/sway-lsp/src/capabilities/on_enter.rs
+++ b/sway-lsp/src/capabilities/on_enter.rs
@@ -99,10 +99,10 @@ fn get_comment_workspace_edit(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sway_lsp_test_utils::get_absolute_path;
-    use tower_lsp::lsp_types::{
+    use lsp_types::{
         AnnotatedTextEdit, TextDocumentContentChangeEvent, VersionedTextDocumentIdentifier,
     };
+    use sway_lsp_test_utils::get_absolute_path;
 
     fn assert_text_edit(
         actual: &OneOf<TextEdit, AnnotatedTextEdit>,

--- a/sway-lsp/src/capabilities/rename.rs
+++ b/sway-lsp/src/capabilities/rename.rs
@@ -7,10 +7,10 @@ use crate::{
     error::{LanguageServerError, RenameError},
     utils::document::get_url_from_path,
 };
+use lsp_types::{Position, PrepareRenameResponse, TextEdit, Url, WorkspaceEdit};
 use std::{collections::HashMap, sync::Arc};
 use sway_core::{language::ty, Engines};
 use sway_types::{Ident, Spanned};
-use tower_lsp::lsp_types::{Position, PrepareRenameResponse, TextEdit, Url, WorkspaceEdit};
 
 const RAW_IDENTIFIER: &str = "r#";
 

--- a/sway-lsp/src/capabilities/runnable.rs
+++ b/sway-lsp/src/capabilities/runnable.rs
@@ -1,9 +1,8 @@
+use crate::core::token::get_range_from_span;
+use lsp_types::{Command, Range};
 use serde_json::{json, Value};
 use sway_core::language::parsed::TreeType;
 use sway_types::Span;
-use tower_lsp::lsp_types::{Command, Range};
-
-use crate::core::token::get_range_from_span;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct RunnableMainFn {

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -2,15 +2,15 @@ use crate::core::{
     session::Session,
     token::{get_range_from_span, SymbolKind, Token},
 };
+use lsp_types::{
+    Range, SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
+    SemanticTokensResult, Url,
+};
 use std::sync::{
     atomic::{AtomicU32, Ordering},
     Arc,
 };
 use sway_types::{Span, Spanned};
-use tower_lsp::lsp_types::{
-    Range, SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
-    SemanticTokensResult, Url,
-};
 
 // https://github.com/microsoft/vscode-extension-samples/blob/5ae1f7787122812dcc84e37427ca90af5ee09f14/semantic-tokens-sample/vscode.proposed.d.ts#L71
 pub fn semantic_tokens_full(session: Arc<Session>, url: &Url) -> Option<SemanticTokensResult> {

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
+use lsp_types::{Position, Range, TextDocumentContentChangeEvent};
 use ropey::Rope;
-use tower_lsp::lsp_types::{Position, Range, TextDocumentContentChangeEvent};
 
 use crate::error::DocumentError;
 

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -18,6 +18,10 @@ use crate::{
 };
 use dashmap::DashMap;
 use forc_pkg as pkg;
+use lsp_types::{
+    CompletionItem, GotoDefinitionResponse, Location, Position, Range, SymbolInformation,
+    TextDocumentContentChangeEvent, TextEdit, Url,
+};
 use parking_lot::RwLock;
 use pkg::{manifest::ManifestFile, Programs};
 use std::{fs::File, io::Write, path::PathBuf, sync::Arc, vec};
@@ -33,10 +37,6 @@ use sway_core::{
 use sway_types::{Span, Spanned};
 use sway_utils::helpers::get_sway_files;
 use tokio::sync::Semaphore;
-use tower_lsp::lsp_types::{
-    CompletionItem, GotoDefinitionResponse, Location, Position, Range, SymbolInformation,
-    TextDocumentContentChangeEvent, TextEdit, Url,
-};
 
 pub type Documents = DashMap<String, TextDocument>;
 pub type ProjectDirectory = PathBuf;

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use dashmap::DashMap;
 use forc_pkg::{manifest::Dependency, PackageManifestFile};
+use lsp_types::Url;
 use notify::RecursiveMode;
 use notify_debouncer_mini::new_debouncer;
 use parking_lot::RwLock;
@@ -16,7 +17,6 @@ use std::{
 };
 use sway_types::{SourceEngine, Span};
 use tempfile::Builder;
-use tower_lsp::lsp_types::Url;
 
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub enum Directory {

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -1,3 +1,4 @@
+use lsp_types::{Position, Range};
 use sway_ast::Intrinsic;
 use sway_core::{
     language::{
@@ -15,7 +16,6 @@ use sway_core::{
     Engines, TraitConstraint, TypeArgument, TypeEngine,
 };
 use sway_types::{Ident, Span, Spanned};
-use tower_lsp::lsp_types::{Position, Range};
 
 /// The `AstToken` holds the types produced by the [sway_core::language::parsed::ParseProgram].
 /// These tokens have not been type-checked.

--- a/sway-lsp/src/core/token_map.rs
+++ b/sway-lsp/src/core/token_map.rs
@@ -1,8 +1,8 @@
 use crate::core::token::{self, Token, TypedAstToken};
 use dashmap::DashMap;
+use lsp_types::{Position, Url};
 use sway_core::{language::ty, type_system::TypeId, Engines};
 use sway_types::{Ident, SourceEngine, Span, Spanned};
-use tower_lsp::lsp_types::{Position, Url};
 
 // Re-export the TokenMapExt trait.
 pub use crate::core::token_map_ext::TokenMapExt;

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -9,6 +9,7 @@ use crate::{
 use dashmap::DashMap;
 use forc_pkg::manifest::PackageManifestFile;
 use forc_tracing::{init_tracing_subscriber, TracingSubscriberOptions, TracingWriterMode};
+use lsp_types::*;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -19,7 +20,6 @@ use std::{
 };
 use sway_types::{Ident, Spanned};
 use tokio::task;
-use tower_lsp::lsp_types::*;
 use tower_lsp::{jsonrpc, Client, LanguageServer};
 use tracing::metadata::LevelFilter;
 

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code)]
 use crate::core::token::{get_range_from_span, Token};
+use lsp_types::{Diagnostic, DiagnosticSeverity};
 use sway_core::{
     decl_engine::DeclEngine,
     language::{ty, Literal},
 };
 use sway_types::{Ident, Spanned};
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
 pub(crate) fn generate_warnings_non_typed_tokens<I>(tokens: I) -> Vec<Diagnostic>
 where

--- a/sway-lsp/src/utils/document.rs
+++ b/sway-lsp/src/utils/document.rs
@@ -1,7 +1,7 @@
 use crate::error::DirectoryError;
+use lsp_types::Url;
 use std::path::PathBuf;
 use sway_types::{SourceEngine, Span};
-use tower_lsp::lsp_types::Url;
 
 /// Create a [Url] from a [PathBuf].
 pub fn get_url_from_path(path: &PathBuf) -> Result<Url, DirectoryError> {

--- a/sway-lsp/tests/utils/Cargo.toml
+++ b/sway-lsp/tests/utils/Cargo.toml
@@ -16,4 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.60"
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tower = { version = "0.4.12", default-features = false, features = ["util"] }
-tower-lsp = { version = "0.18", features = ["proposed"] }
+tower-lsp = { version = "0.19", features = ["proposed"] }


### PR DESCRIPTION
## Description
Currently we have been using lsp_types through tower-lsp. 

We are going to be deprecating using tower-lsp soon and will instead need to use the lsp_types crate directly. This PR removes importing lsp_types through tower-lsp to achieve this. 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
