### PR TITLE
make dir watcher use std::thread instead of async

### DIFF
--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -20,7 +20,13 @@ use dashmap::DashMap;
 use forc_pkg as pkg;
 use parking_lot::RwLock;
 use pkg::{manifest::ManifestFile, Programs};
-use std::{fs::File, io::Write, path::PathBuf, sync::Arc, vec};
+use std::{
+    fs::File,
+    io::Write,
+    path::PathBuf,
+    sync::{atomic::Ordering, Arc},
+    vec,
+};
 use sway_core::{
     decl_engine::DeclEngine,
     language::{
@@ -99,10 +105,13 @@ impl Session {
     }
 
     pub fn shutdown(&self) {
-        // shutdown the thread watching the manifest file
-        let handle = self.sync.notify_join_handle.read();
-        if let Some(join_handle) = &*handle {
-            join_handle.abort();
+        // Set the should_end flag to true
+        self.sync.should_end.store(true, Ordering::Relaxed);
+
+        // Wait for the thread to finish
+        let mut join_handle_option = self.sync.notify_join_handle.write();
+        if let Some(join_handle) = std::mem::take(&mut *join_handle_option) {
+            let _ = join_handle.join();
         }
 
         // Delete the temporary directory.

--- a/sway-lsp/src/utils/keyword_docs.rs
+++ b/sway-lsp/src/utils/keyword_docs.rs
@@ -837,8 +837,8 @@ fn extract_lit(tokens: TokenStream) -> String {
     res
 }
 
-#[tokio::test]
-async fn keywords_in_sync() {
+#[test]
+fn keywords_in_sync() {
     let keyword_docs = KeywordDocs::new();
     let lsp_keywords: Vec<_> = keyword_docs.keys().collect();
     let compiler_keywords: Vec<_> = sway_parse::RESERVED_KEYWORDS


### PR DESCRIPTION
## Description
This PR changes how we are watching for directory changes in the language server. Previously we were using tokio, this has now been changed to use a regular thread and `std::mpsc::channel`. We are about to move away from an `async` framework in the language server so this is a small effort towards removing reliance on tokio.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
