### PR TITLE
chore: fix default-feature warning for forc-client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ fuel-asm = "0.31.1"
 fuel-crypto = "0.31.1"
 fuel-types = "0.31.1"
 fuel-tx = "0.31.1"
-fuel-core-client = "0.18.2"
+fuel-core-client = { version = "0.18.2", default-features = false }
 fuel-vm = "0.31.2"
 fuels-core = "0.43"
 fuels-accounts = "0.43"

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -19,7 +19,7 @@ forc-pkg = { version = "0.40.1", path = "../../forc-pkg" }
 forc-tracing = { version = "0.40.1", path = "../../forc-tracing" }
 forc-tx = { version = "0.40.1", path = "../forc-tx" }
 forc-util = { version = "0.40.1", path = "../../forc-util" }
-fuel-core-client = { workspace = true, default-features = false }
+fuel-core-client = { workspace = true }
 fuel-crypto = { workspace = true }
 fuel-tx = { workspace = true, features = ["builder"] }
 fuel-vm = { workspace = true }


### PR DESCRIPTION
## Description

Fixes the following warning by moving `default-features = false` to workspace level:

```
warning: /Users/kayagokalp/fuel/dev/sway/forc-plugins/forc-client/Cargo.toml: `default-features` is ignored for fuel-core-client, since `default-features` was not specified for `workspace.dependencies.fuel-core-client`, this could become a hard error in the future
```

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
