### PR TITLE
chore: make `clippy` warnings errors in `ci_checks` script

### DIFF
--- a/ci_checks.sh
+++ b/ci_checks.sh
@@ -16,7 +16,7 @@
 # `cargo install cargo-generate`
 # `cargo install cargo-udeps`
 
-cargo clippy --all-features --all-targets &&
+cargo clippy --all-features --all-targets -- -D warnings &&
 cargo sort -w --check &&
 cargo sort -w --check templates/sway-test-rs/template &&
 cargo fmt --all -- --check &&


### PR DESCRIPTION
## Description
closes #4678.

This PR updates `ci_checks.sh` so that `clippy` warnings are treated as errors, just like the CI. This improves the correspondence between ci and the `ci_checks.sh` script.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
