### PR TITLE
Wrong example in documentation fixed

### DIFF
--- a/sway-lib-std/src/token.sw
+++ b/sway-lib-std/src/token.sw
@@ -198,7 +198,7 @@ pub fn transfer(amount: u64, asset_id: AssetId, to: Identity) {
 /// use std::{constants::{BASE_ASSET_ID, ZERO_B256}, token::force_transfer_to_contract};
 ///
 /// // replace the zero ContractId with your desired ContractId
-/// let to_contract_id = Identity::ContractId(ContractId::from(ZERO_B256));
+/// let to_contract_id = ContractId::from(ZERO_B256);
 /// force_transfer_to_contract(500, BASE_ASSET_ID, to_contract_id);
 /// ```
 pub fn force_transfer_to_contract(amount: u64, asset_id: AssetId, to: ContractId) {
@@ -228,7 +228,7 @@ pub fn force_transfer_to_contract(amount: u64, asset_id: AssetId, to: ContractId
 /// use std::{constants::{BASE_ASSET_ID, ZERO_B256}, token::transfer_to_address};
 ///
 /// // replace the zero Address with your desired Address
-/// let to_address = Identity::Address(Address::from(ZERO_B256));
+/// let to_address = Address::from(ZERO_B256);
 /// transfer_to_address(500, BASE_ASSET_ID, to_address);
 /// ```
 pub fn transfer_to_address(amount: u64, asset_id: AssetId, to: Address) {


### PR DESCRIPTION
## Description
The parameters to those functions take ContractId and Address respectively. Not Identity

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
