### PR TITLE
Add `GTF_OUTPUT_COIN_ASSET_ID` and `GTF_OUTPUT_COIN_TO` opcode getters

### DIFF
--- a/sway-lib-std/src/outputs.sw
+++ b/sway-lib-std/src/outputs.sw
@@ -99,7 +99,7 @@ pub fn output_asset_id(index: u64) -> Option<ContractId> {
     }
 }
 
-/// If the output's type is `Output::Coin` return the to b256 as an `Some(to)`.
+/// If the output's type is `Output::Coin` return the b256 as `Some(to)`.
 /// Otherwise, returns `None`.
 /// TODO: Update to `Identity` when https://github.com/FuelLabs/sway/issues/4569 is resolved
 pub fn output_asset_to(index: u64) -> Option<b256> {

--- a/sway-lib-std/src/outputs.sw
+++ b/sway-lib-std/src/outputs.sw
@@ -12,13 +12,14 @@ use ::tx::{
     Transaction,
     tx_type,
 };
+use ::option::*;
 
 // GTF Opcode const selectors
 //
 pub const GTF_OUTPUT_TYPE = 0x201;
-// pub const GTF_OUTPUT_COIN_TO = 0x202;
+pub const GTF_OUTPUT_COIN_TO = 0x202;
 pub const GTF_OUTPUT_COIN_AMOUNT = 0x203;
-// pub const GTF_OUTPUT_COIN_ASSET_ID = 0x204;
+pub const GTF_OUTPUT_COIN_ASSET_ID = 0x204;
 // pub const GTF_OUTPUT_CONTRACT_INPUT_INDEX = 0x205;
 // pub const GTF_OUTPUT_CONTRACT_BALANCE_ROOT = 0x206;
 // pub const GTF_OUTPUT_CONTRACT_STATE_ROOT = 0x207;
@@ -86,5 +87,24 @@ pub fn output_amount(index: u64) -> u64 {
                 r1: u64
             }
         },
+    }
+}
+
+/// If the output's type is `Output::Coin` return the asset ID as an `Some(id)`.
+/// Otherwise, returns `None`.
+pub fn output_asset_id(index: u64) -> Option<ContractId> {
+    match output_type(index) {
+        Output::Coin => Option::Some(ContractId::from(__gtf::<b256>(index, GTF_OUTPUT_COIN_ASSET_ID))),
+        _ => Option::None,
+    }
+}
+
+/// If the output's type is `Output::Coin` return the to b256 as an `Some(to)`.
+/// Otherwise, returns `None`.
+/// TODO: Update to `Identity` when https://github.com/FuelLabs/sway/issues/4569 is resolved
+pub fn output_asset_to(index: u64) -> Option<b256> {
+    match output_type(index) {
+        Output::Coin => Option::Some(__gtf::<b256>(index, GTF_OUTPUT_COIN_TO)),
+        _ => Option::None,
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -2,7 +2,7 @@ script;
 use basic_storage_abi::{BasicStorage, Quad};
 
 fn main() -> u64 {
-    let addr = abi(BasicStorage, 0xe685bfdc8217d28b5710a8e441cf151e3eed6749923aae8b747a7f1f51e7469a);
+    let addr = abi(BasicStorage, 0x03ce81c0cfbe6287ecff739afeb92cdce9c6d0d3bcb066648b2239f502b86144);
     let key = 0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
@@ -7,7 +7,7 @@ fn main() -> bool {
     let zero = b256::min();
     let gas: u64 = u64::max();
     let amount: u64 = 11;
-    let other_contract_id = ContractId::from(0x338000acdb5764cdaaf90a70b2fa73c68fed43ce2b7bdb329d361cb6b5393a43);
+    let other_contract_id = ContractId::from(0xbc40f25981f0778159e3dea633562c4b633ec2a37de91ca0f43005908d6df935);
     let base_asset_id = BASE_ASSET_ID;
 
     let test_contract = abi(ContextTesting, other_contract_id.into());

--- a/test/src/sdk-harness/Forc.lock
+++ b/test/src/sdk-harness/Forc.lock
@@ -332,6 +332,11 @@ source = 'member'
 dependencies = ['std']
 
 [[package]]
+name = 'tx_output_predicate'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
 name = 'tx_predicate'
 source = 'member'
 dependencies = ['std']

--- a/test/src/sdk-harness/Forc.toml
+++ b/test/src/sdk-harness/Forc.toml
@@ -62,4 +62,5 @@ members = [
   "test_artifacts/storage_vec/svec_u16",
   "test_artifacts/storage_vec/svec_u64",
   "test_artifacts/tx_contract",
+  "test_artifacts/tx_output_predicate",
 ]

--- a/test/src/sdk-harness/test_artifacts/tx_output_predicate/Forc.lock
+++ b/test/src/sdk-harness/test_artifacts/tx_output_predicate/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-3E8AFAF9D04B1844'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-3E8AFAF9D04B1844'
+dependencies = ['core']
+
+[[package]]
+name = 'tx_output_predicate'
+source = 'member'
+dependencies = ['std']

--- a/test/src/sdk-harness/test_artifacts/tx_output_predicate/Forc.toml
+++ b/test/src/sdk-harness/test_artifacts/tx_output_predicate/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "tx_output_predicate"
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/test/src/sdk-harness/test_artifacts/tx_output_predicate/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/tx_output_predicate/src/main.sw
@@ -1,0 +1,14 @@
+predicate;
+
+use std::outputs::{output_asset_id, output_asset_to};
+
+fn main(index: u64, asset_id: ContractId, to: b256) -> bool {
+
+    let tx_asset_id = output_asset_id(index);
+    let tx_to = output_asset_to(index);
+
+    assert(tx_asset_id.is_some() && tx_asset_id.unwrap() == asset_id);
+    assert(tx_to.is_some() && tx_to.unwrap() == to);
+
+    true
+}

--- a/test/src/sdk-harness/test_projects/tx_fields/mod.rs
+++ b/test/src/sdk-harness/test_projects/tx_fields/mod.rs
@@ -826,14 +826,14 @@ mod outputs {
         #[tokio::test]
         #[should_panic]
         async fn fails_output_predicate_when_incorrect_asset() {
-            let (wallet1, _, predicate, _, asset_id) = setup_output_predicate().await;
+            let (wallet1, _, predicate, _, asset_id2) = setup_output_predicate().await;
 
             let transfer_amount = 10;
             predicate
                 .transfer(
                     wallet1.address(),
                     transfer_amount,
-                    asset_id,
+                    asset_id2,
                     TxParameters::default(),
                 )
                 .await


### PR DESCRIPTION
## Description

Added getters for the `GTF_OUTPUT_COIN_ASSET_ID` and `GTF_OUTPUT_COIN_TO` opcodes. These have been highly requested by external teams for use in predicates.

Note: The `output_asset_to()` getter currently returns a `b256` rather than an `Identity`. This should be updated when https://github.com/FuelLabs/sway/issues/4569 is resolved.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
