### PR TITLE
Fixes trait map issue on the use of absolute path

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -1681,6 +1681,7 @@ pub fn dependency_namespace(
         &[CORE, PRELUDE].map(|s| Ident::new_no_span(s.into())),
         &[],
         engines,
+        true,
     );
 
     if has_std_dep(graph, node) {
@@ -1688,6 +1689,7 @@ pub fn dependency_namespace(
             &[STD, PRELUDE].map(|s| Ident::new_no_span(s.into())),
             &[],
             engines,
+            true,
         );
     }
 

--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -111,9 +111,11 @@ impl CallPath {
             // current submodule.
             let mut synonym_prefixes = vec![];
             let mut is_external = false;
+            let mut is_absolute = false;
 
             if let Some(use_synonym) = namespace.use_synonyms.get(&self.suffix) {
                 synonym_prefixes = use_synonym.0.clone();
+                is_absolute = use_synonym.3;
                 let submodule = namespace.submodule(&[use_synonym.0[0].clone()]);
                 if let Some(submodule) = submodule {
                     is_external = submodule.is_external;
@@ -127,8 +129,10 @@ impl CallPath {
                     prefixes.push(pkg_name.clone());
                 }
 
-                for mod_path in namespace.mod_path() {
-                    prefixes.push(mod_path.clone());
+                if !is_absolute {
+                    for mod_path in namespace.mod_path() {
+                        prefixes.push(mod_path.clone());
+                    }
                 }
             }
 

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -38,14 +38,18 @@ impl ty::TyAstNode {
                     let mut res = match a.import_type {
                         ImportType::Star => {
                             // try a standard starimport first
-                            let import = ctx.namespace.star_import(&path, engines);
+                            let import = ctx.namespace.star_import(&path, engines, a.is_absolute);
                             if import.is_ok() {
                                 import
                             } else {
                                 // if it doesn't work it could be an enum star import
                                 if let Some((enum_name, path)) = path.split_last() {
-                                    let variant_import =
-                                        ctx.namespace.variant_star_import(path, engines, enum_name);
+                                    let variant_import = ctx.namespace.variant_star_import(
+                                        path,
+                                        engines,
+                                        enum_name,
+                                        a.is_absolute,
+                                    );
                                     if variant_import.is_ok() {
                                         variant_import
                                     } else {
@@ -56,14 +60,21 @@ impl ty::TyAstNode {
                                 }
                             }
                         }
-                        ImportType::SelfImport(_) => {
-                            ctx.namespace.self_import(engines, &path, a.alias.clone())
-                        }
+                        ImportType::SelfImport(_) => ctx.namespace.self_import(
+                            engines,
+                            &path,
+                            a.alias.clone(),
+                            a.is_absolute,
+                        ),
                         ImportType::Item(ref s) => {
                             // try a standard item import first
-                            let import =
-                                ctx.namespace
-                                    .item_import(engines, &path, s, a.alias.clone());
+                            let import = ctx.namespace.item_import(
+                                engines,
+                                &path,
+                                s,
+                                a.alias.clone(),
+                                a.is_absolute,
+                            );
 
                             if import.is_ok() {
                                 import
@@ -76,6 +87,7 @@ impl ty::TyAstNode {
                                         enum_name,
                                         s,
                                         a.alias.clone(),
+                                        a.is_absolute,
                                     );
                                     if variant_import.is_ok() {
                                         variant_import

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -25,7 +25,7 @@ pub(crate) enum GlobImport {
 }
 
 pub(super) type SymbolMap = im::OrdMap<Ident, ty::TyDecl>;
-pub(super) type UseSynonyms = im::HashMap<Ident, (Vec<Ident>, GlobImport, ty::TyDecl)>;
+pub(super) type UseSynonyms = im::HashMap<Ident, (Vec<Ident>, GlobImport, ty::TyDecl, bool)>;
 pub(super) type UseAliases = im::HashMap<String, Ident>;
 
 /// The set of items that exist within some lexical scope via declaration or importing.
@@ -137,7 +137,7 @@ impl Items {
             append_shadowing_error(decl, &item, &mut errors);
         }
 
-        if let Some((_, GlobImport::No, decl)) = self.use_synonyms.get(&name) {
+        if let Some((_, GlobImport::No, decl, _)) = self.use_synonyms.get(&name) {
             append_shadowing_error(decl, &item, &mut errors);
         }
 

--- a/sway-core/src/semantic_analysis/namespace/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace/namespace.rs
@@ -509,8 +509,14 @@ impl Namespace {
     }
 
     /// Short-hand for performing a [Module::star_import] with `mod_path` as the destination.
-    pub(crate) fn star_import(&mut self, src: &Path, engines: &Engines) -> CompileResult<()> {
-        self.root.star_import(src, &self.mod_path, engines)
+    pub(crate) fn star_import(
+        &mut self,
+        src: &Path,
+        engines: &Engines,
+        is_absolute: bool,
+    ) -> CompileResult<()> {
+        self.root
+            .star_import(src, &self.mod_path, engines, is_absolute)
     }
 
     /// Short-hand for performing a [Module::variant_star_import] with `mod_path` as the destination.
@@ -519,9 +525,10 @@ impl Namespace {
         src: &Path,
         engines: &Engines,
         enum_name: &Ident,
+        is_absolute: bool,
     ) -> CompileResult<()> {
         self.root
-            .variant_star_import(src, &self.mod_path, engines, enum_name)
+            .variant_star_import(src, &self.mod_path, engines, enum_name, is_absolute)
     }
 
     /// Short-hand for performing a [Module::self_import] with `mod_path` as the destination.
@@ -530,8 +537,10 @@ impl Namespace {
         engines: &Engines,
         src: &Path,
         alias: Option<Ident>,
+        is_absolute: bool,
     ) -> CompileResult<()> {
-        self.root.self_import(engines, src, &self.mod_path, alias)
+        self.root
+            .self_import(engines, src, &self.mod_path, alias, is_absolute)
     }
 
     /// Short-hand for performing a [Module::item_import] with `mod_path` as the destination.
@@ -541,9 +550,10 @@ impl Namespace {
         src: &Path,
         item: &Ident,
         alias: Option<Ident>,
+        is_absolute: bool,
     ) -> CompileResult<()> {
         self.root
-            .item_import(engines, src, item, &self.mod_path, alias)
+            .item_import(engines, src, item, &self.mod_path, alias, is_absolute)
     }
 
     /// Short-hand for performing a [Module::variant_import] with `mod_path` as the destination.
@@ -554,9 +564,17 @@ impl Namespace {
         enum_name: &Ident,
         variant_name: &Ident,
         alias: Option<Ident>,
+        is_absolute: bool,
     ) -> CompileResult<()> {
-        self.root
-            .variant_import(engines, src, enum_name, variant_name, &self.mod_path, alias)
+        self.root.variant_import(
+            engines,
+            src,
+            enum_name,
+            variant_name,
+            &self.mod_path,
+            alias,
+            is_absolute,
+        )
     }
 
     /// "Enter" the submodule at the given path by returning a new [SubmoduleNamespace].

--- a/sway-core/src/semantic_analysis/namespace/root.rs
+++ b/sway-core/src/semantic_analysis/namespace/root.rs
@@ -115,8 +115,10 @@ impl Root {
                 .get(symbol.as_str())
                 .unwrap_or(symbol);
             match module.use_synonyms.get(symbol) {
-                Some((_, _, decl @ ty::TyDecl::EnumVariantDecl { .. })) => ok(decl, vec![], vec![]),
-                Some((src_path, _, _)) if mod_path != src_path => {
+                Some((_, _, decl @ ty::TyDecl::EnumVariantDecl { .. }, _)) => {
+                    ok(decl, vec![], vec![])
+                }
+                Some((src_path, _, _, _)) if mod_path != src_path => {
                     // TODO: check that the symbol import is public?
                     self.resolve_symbol(src_path, true_symbol)
                 }


### PR DESCRIPTION
## Description

The test case use_absolute_path included in this PR was generating an error due to the `CallPath` `to_fullpath` generating `use_absolute_path::foo::trait::Trait` instead of `use_absolute_path::trait::Trait`.

The issue was fixed by including a boolean in `namespace.use_synonyms` that indicates when the path is absolute. With that information `to_fullpath` can behave accordingly.

Fixes #4696

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
