### PR TITLE
Handle integer overflow/underflow for non-64-bit integers

### DIFF
--- a/docs/book/src/basics/built_in_types.md
+++ b/docs/book/src/basics/built_in_types.md
@@ -42,6 +42,13 @@ Numbers can be declared with binary syntax, hexadecimal syntax, base-10 syntax, 
 <!-- This section should explain the default numeric type in Sway -->
 <!-- default_num:example:start -->
 The default numeric type is `u64`. The FuelVM's word size is 64 bits, and the cases where using a smaller numeric type saves space are minimal.
+
+If a 64-bit arithmetic operation produces an overflow or an underflow,
+computation gets reverted automatically by FuelVM.
+
+8/16/32-bit arithmetic operations are emulated using their 64-bit analogues with
+additional overflow/underflow checks inserted, which generally results in
+somewhat higher gas consumption.
 <!-- default_num:example:end -->
 
 ## Boolean Type

--- a/docs/book/src/basics/constants.md
+++ b/docs/book/src/basics/constants.md
@@ -13,6 +13,27 @@ Constants are similar to variables; however, there are a few differences:
 const ID: u32 = 0;
 ```
 
+Constant initializer expressions can be quite complex, but they cannot use, for
+instance, assembly instructions, storage access, mutable variables, loops and
+`return` statements. Although, function calls, primitive types and compound data
+structures are perfectly fine to use:
+
+```sway
+fn bool_to_num(b: bool) -> u64 {
+    if b {
+        1
+    } else {
+        0
+    }
+}
+
+fn arr_wrapper(a: u64, b: u64, c: u64) -> [u64; 3] {
+    [a, b, c]
+}
+
+const ARR2 = arr_wrapper(bool_to_num(1) + 42, 2, 3);
+```
+
 ## Associated Constants
 
 <!-- This section should explain what associated constants are -->

--- a/sway-lib-core/src/ops.sw
+++ b/sway-lib-core/src/ops.sw
@@ -528,7 +528,9 @@ impl Shift for u64 {
 
 impl Shift for u32 {
     fn lsh(self, other: u64) -> Self {
-        __lsh(self, other)
+        // any non-64-bit value is compiled to a u64 value under-the-hood
+        // so we need to clear upper bits here
+        __and(__lsh(self, other), Self::max())
     }
     fn rsh(self, other: u64) -> Self {
         __rsh(self, other)
@@ -537,7 +539,7 @@ impl Shift for u32 {
 
 impl Shift for u16 {
     fn lsh(self, other: u64) -> Self {
-        __lsh(self, other)
+        __and(__lsh(self, other), Self::max())
     }
     fn rsh(self, other: u64) -> Self {
         __rsh(self, other)
@@ -546,7 +548,7 @@ impl Shift for u16 {
 
 impl Shift for u8 {
     fn lsh(self, other: u64) -> Self {
-        __lsh(self, other)
+        __and(__lsh(self, other), Self::max())
     }
     fn rsh(self, other: u64) -> Self {
         __rsh(self, other)

--- a/sway-lib-core/src/ops.sw
+++ b/sway-lib-core/src/ops.sw
@@ -12,21 +12,41 @@ impl Add for u64 {
     }
 }
 
+// Emulate overflowing arithmetic for non-64-bit integer types
 impl Add for u32 {
     fn add(self, other: Self) -> Self {
-        __add(self, other)
+        // any non-64-bit value is compiled to a u64 value under-the-hood
+        // constants (like Self::max() below) are also automatically promoted to u64
+        let res = __add(self, other);
+        if __gt(res, Self::max()) {
+            // integer overflow
+            __revert(0)
+        } else {
+            // no overflow
+            res
+        }
     }
 }
 
 impl Add for u16 {
     fn add(self, other: Self) -> Self {
-        __add(self, other)
+        let res = __add(self, other);
+        if __gt(res, Self::max()) {
+            __revert(0)
+        } else {
+            res
+        }
     }
 }
 
 impl Add for u8 {
     fn add(self, other: Self) -> Self {
-        __add(self, other)
+        let res = __add(self, other);
+        if __gt(res, Self::max()) {
+            __revert(0)
+        } else {
+            res
+        }
     }
 }
 
@@ -40,6 +60,8 @@ impl Subtract for u64 {
     }
 }
 
+// unlike addition, underflowing subtraction does not need special treatment
+// because VM handles underflow
 impl Subtract for u32 {
     fn subtract(self, other: Self) -> Self {
         __sub(self, other)
@@ -68,21 +90,41 @@ impl Multiply for u64 {
     }
 }
 
+// Emulate overflowing arithmetic for non-64-bit integer types
 impl Multiply for u32 {
     fn multiply(self, other: Self) -> Self {
-        __mul(self, other)
+        // any non-64-bit value is compiled to a u64 value under-the-hood
+        // constants (like Self::max() below) are also automatically promoted to u64
+        let res = __mul(self, other);
+        if __gt(res, Self::max()) {
+            // integer overflow
+            __revert(0)
+        } else {
+            // no overflow
+            res
+        }
     }
 }
 
 impl Multiply for u16 {
     fn multiply(self, other: Self) -> Self {
-        __mul(self, other)
+        let res = __mul(self, other);
+        if __gt(res, Self::max()) {
+            __revert(0)
+        } else {
+            res
+        }
     }
 }
 
 impl Multiply for u8 {
     fn multiply(self, other: Self) -> Self {
-        __mul(self, other)
+        let res = __mul(self, other);
+        if __gt(res, Self::max()) {
+            __revert(0)
+        } else {
+            res
+        }
     }
 }
 
@@ -96,6 +138,10 @@ impl Divide for u64 {
     }
 }
 
+// division for unsigned integers cannot overflow,
+// but if signed integers are ever introduced,
+// overflow needs to be handled, since
+// Self::max() / -1 overflows
 impl Divide for u32 {
     fn divide(self, other: Self) -> Self {
         __div(self, other)

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_const_eval_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_const_eval_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-0EAD15BE42537FD3'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-0EAD15BE42537FD3'
+dependencies = ['core']
+
+[[package]]
+name = 'u16_add_const_eval_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_const_eval_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_const_eval_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u16_add_const_eval_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_const_eval_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_const_eval_overflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+const RESULT: u16 = u16::max() + 1;
+
+fn main() -> bool {
+    log(RESULT);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_const_eval_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_const_eval_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Could not evaluate initializer to a const declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-DD034BDFC1AFC889'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-DD034BDFC1AFC889'
+dependencies = ['core']
+
+[[package]]
+name = 'u16_add_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u16_add_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_overflow/src/main.sw
@@ -1,0 +1,11 @@
+script;
+
+fn main() -> bool {
+    let a: u16 = u16::max();
+    let b: u16 = 1;
+
+    let result: u16 = a + b;
+    log(result);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_add_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "revert", value = 0 }
+validate_abi = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_const_eval_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_const_eval_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-035E1AC835A9A958'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-035E1AC835A9A958'
+dependencies = ['core']
+
+[[package]]
+name = 'u16_mul_const_eval_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_const_eval_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_const_eval_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u16_mul_const_eval_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_const_eval_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_const_eval_overflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+const RESULT: u16 = u16::max() * 2;
+
+fn main() -> bool {
+    log(RESULT);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_const_eval_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_const_eval_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Could not evaluate initializer to a const declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-EFC151B1487B0E88'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-EFC151B1487B0E88'
+dependencies = ['core']
+
+[[package]]
+name = 'u16_mul_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u16_mul_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_overflow/src/main.sw
@@ -1,0 +1,11 @@
+script;
+
+fn main() -> bool {
+    let a: u16 = u16::max();
+    let b: u16 = 2;
+
+    let result: u16 = a * b;
+    log(result);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_mul_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "revert", value = 0 }
+validate_abi = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_const_eval_underflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_const_eval_underflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-FF708CA3420F9A17'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-FF708CA3420F9A17'
+dependencies = ['core']
+
+[[package]]
+name = 'u16_sub_const_eval_underflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_const_eval_underflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_const_eval_underflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u16_sub_const_eval_underflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_const_eval_underflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_const_eval_underflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+const RESULT: u16 = u16::min() - 1;
+
+fn main() -> bool {
+    log(RESULT);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_const_eval_underflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_const_eval_underflow/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Could not evaluate initializer to a const declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_underflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_underflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-DDD16884D4F7CFAB'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-DDD16884D4F7CFAB'
+dependencies = ['core']
+
+[[package]]
+name = 'u16_sub_underflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_underflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_underflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u16_sub_underflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_underflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_underflow/src/main.sw
@@ -1,0 +1,11 @@
+script;
+
+fn main() -> bool {
+    let a: u16 = u16::min();
+    let b: u16 = 1;
+
+    let result: u16 = a - b;
+    log(result);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_underflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u16_sub_underflow/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "revert", value = 0 }
+validate_abi = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_const_eval_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_const_eval_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-A1E0DED8BFC6F271'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-A1E0DED8BFC6F271'
+dependencies = ['core']
+
+[[package]]
+name = 'u32_add_const_eval_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_const_eval_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_const_eval_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u32_add_const_eval_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_const_eval_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_const_eval_overflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+const RESULT: u32 = u32::max() + 1;
+
+fn main() -> bool {
+    log(RESULT);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_const_eval_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_const_eval_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Could not evaluate initializer to a const declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-17020687432C56B1'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-17020687432C56B1'
+dependencies = ['core']
+
+[[package]]
+name = 'u32_add_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u32_add_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_overflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+fn main() -> u32 {
+    let a: u32 = u32::max();
+    let b: u32 = 1u32;
+
+    let result: u32 = a + b;
+    result
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_add_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "revert", value = 0 }
+validate_abi = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_const_eval_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_const_eval_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-6BD6A91180934A67'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-6BD6A91180934A67'
+dependencies = ['core']
+
+[[package]]
+name = 'u32_mul_const_eval_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_const_eval_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_const_eval_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u32_mul_const_eval_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_const_eval_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_const_eval_overflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+const RESULT: u32 = u32::max() * 2;
+
+fn main() -> bool {
+    log(RESULT);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_const_eval_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_const_eval_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Could not evaluate initializer to a const declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-AB517F9AE0FD4751'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-AB517F9AE0FD4751'
+dependencies = ['core']
+
+[[package]]
+name = 'u32_mul_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u32_mul_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_overflow/src/main.sw
@@ -1,0 +1,11 @@
+script;
+
+fn main() -> bool {
+    let a: u32 = u32::max();
+    let b: u32 = 2;
+
+    let result: u32 = a * b;
+    log(result);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_mul_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "revert", value = 0 }
+validate_abi = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_const_eval_underflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_const_eval_underflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-16573F11625D3117'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-16573F11625D3117'
+dependencies = ['core']
+
+[[package]]
+name = 'u32_sub_const_eval_underflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_const_eval_underflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_const_eval_underflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u32_sub_const_eval_underflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_const_eval_underflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_const_eval_underflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+const RESULT: u32 = u32::min() - 1;
+
+fn main() -> bool {
+    log(RESULT);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_const_eval_underflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_const_eval_underflow/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Could not evaluate initializer to a const declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_underflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_underflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-5A0E88DB9F5ED146'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-5A0E88DB9F5ED146'
+dependencies = ['core']
+
+[[package]]
+name = 'u32_sub_underflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_underflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_underflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u32_sub_underflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_underflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_underflow/src/main.sw
@@ -1,0 +1,11 @@
+script;
+
+fn main() -> bool {
+    let a: u32 = u32::min();
+    let b: u32 = 1;
+
+    let result: u32 = a - b;
+    log(result);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_underflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u32_sub_underflow/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "revert", value = 0 }
+validate_abi = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_const_eval_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_const_eval_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-0E1504C05220483B'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-0E1504C05220483B'
+dependencies = ['core']
+
+[[package]]
+name = 'u64_add_const_eval_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_const_eval_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_const_eval_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u64_add_const_eval_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_const_eval_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_const_eval_overflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+const RESULT: u64 = u64::max() + 1;
+
+fn main() -> bool {
+    log(RESULT);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_const_eval_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_const_eval_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Could not evaluate initializer to a const declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-E7EF2FDC0B057C10'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-E7EF2FDC0B057C10'
+dependencies = ['core']
+
+[[package]]
+name = 'u64_add_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u64_add_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_overflow/src/main.sw
@@ -1,0 +1,11 @@
+script;
+
+fn main() -> bool {
+    let a: u64 = u64::max();
+    let b: u64 = 1;
+
+    let result: u64 = a + b;
+    log(result);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_add_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "revert", value = 0 }
+validate_abi = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_const_eval_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_const_eval_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-DE1E6791086C4731'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-DE1E6791086C4731'
+dependencies = ['core']
+
+[[package]]
+name = 'u64_mul_const_eval_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_const_eval_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_const_eval_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u64_mul_const_eval_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_const_eval_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_const_eval_overflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+const RESULT: u64 = u64::max() * 2;
+
+fn main() -> bool {
+    log(RESULT);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_const_eval_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_const_eval_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Could not evaluate initializer to a const declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-B55D1092CCC6CF95'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-B55D1092CCC6CF95'
+dependencies = ['core']
+
+[[package]]
+name = 'u64_mul_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u64_mul_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_overflow/src/main.sw
@@ -1,0 +1,11 @@
+script;
+
+fn main() -> bool {
+    let a: u64 = u64::max();
+    let b: u64 = 2;
+
+    let result: u64 = a * b;
+    log(result);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_mul_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "revert", value = 0 }
+validate_abi = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_const_eval_underflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_const_eval_underflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-4DC90293EA7B6056'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-4DC90293EA7B6056'
+dependencies = ['core']
+
+[[package]]
+name = 'u64_sub_const_eval_underflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_const_eval_underflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_const_eval_underflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u64_sub_const_eval_underflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_const_eval_underflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_const_eval_underflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+const RESULT: u64 = u64::min() - 1;
+
+fn main() -> bool {
+    log(RESULT);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_const_eval_underflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_const_eval_underflow/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Could not evaluate initializer to a const declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_underflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_underflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-D434508E66F5B3EA'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-D434508E66F5B3EA'
+dependencies = ['core']
+
+[[package]]
+name = 'u64_sub_underflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_underflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_underflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u64_sub_underflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_underflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_underflow/src/main.sw
@@ -1,0 +1,11 @@
+script;
+
+fn main() -> bool {
+    let a: u64 = u64::min();
+    let b: u64 = 1;
+
+    let result: u64 = a - b;
+    log(result);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_underflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u64_sub_underflow/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "revert", value = 0 }
+validate_abi = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_const_eval_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_const_eval_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-AE9ADFE237B0A38F'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-AE9ADFE237B0A38F'
+dependencies = ['core']
+
+[[package]]
+name = 'u8_add_const_eval_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_const_eval_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_const_eval_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u8_add_const_eval_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_const_eval_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_const_eval_overflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+const RESULT: u8 = u8::max() + 1;
+
+fn main() -> bool {
+    log(RESULT);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_const_eval_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_const_eval_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Could not evaluate initializer to a const declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-6A0B0BB6D9599A3B'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-6A0B0BB6D9599A3B'
+dependencies = ['core']
+
+[[package]]
+name = 'u8_add_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u8_add_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_overflow/src/main.sw
@@ -1,0 +1,11 @@
+script;
+
+fn main() -> bool {
+    let a: u8 = u8::max();
+    let b: u8 = 1;
+
+    let result: u8 = a + b;
+    log(result);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_add_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "revert", value = 0 }
+validate_abi = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_const_eval_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_const_eval_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-A18BA26192A1D371'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-A18BA26192A1D371'
+dependencies = ['core']
+
+[[package]]
+name = 'u8_mul_const_eval_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_const_eval_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_const_eval_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u8_mul_const_eval_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_const_eval_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_const_eval_overflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+const RESULT: u8 = u8::max() * 2;
+
+fn main() -> bool {
+    log(RESULT);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_const_eval_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_const_eval_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Could not evaluate initializer to a const declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_overflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-266A49018292505D'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-266A49018292505D'
+dependencies = ['core']
+
+[[package]]
+name = 'u8_mul_overflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u8_mul_overflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_overflow/src/main.sw
@@ -1,0 +1,11 @@
+script;
+
+fn main() -> bool {
+    let a: u8 = u8::max();
+    let b: u8 = 2;
+
+    let result: u8 = a * b;
+    log(result);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_mul_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "revert", value = 0 }
+validate_abi = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_const_eval_underflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_const_eval_underflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-F069F51B6DE417DE'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-F069F51B6DE417DE'
+dependencies = ['core']
+
+[[package]]
+name = 'u8_sub_const_eval_underflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_const_eval_underflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_const_eval_underflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u8_sub_const_eval_underflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_const_eval_underflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_const_eval_underflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+const RESULT: u8 = u8::min() - 1;
+
+fn main() -> bool {
+    log(RESULT);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_const_eval_underflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_const_eval_underflow/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Could not evaluate initializer to a const declaration.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_underflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_underflow/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-7FEE5C5203242351'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-7FEE5C5203242351'
+dependencies = ['core']
+
+[[package]]
+name = 'u8_sub_underflow'
+source = 'member'
+dependencies = ['std']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_underflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_underflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "u8_sub_underflow"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_underflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_underflow/src/main.sw
@@ -1,0 +1,11 @@
+script;
+
+fn main() -> bool {
+    let a: u8 = u8::min();
+    let b: u8 = 1;
+
+    let result: u8 = a - b;
+    log(result);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_underflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/arith_overflow/u8_sub_underflow/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "revert", value = 0 }
+validate_abi = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_inits/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_inits/src/main.sw
@@ -6,6 +6,34 @@ fn contract_id_wrapper(b: b256) -> ContractId {
 }
 const ETH_ID1 = contract_id_wrapper(0x0000000000000000000000000000000000000000000000000000000000000001);
 
+// test if-expressions
+fn bool_to_num(b: bool) -> u64 {
+    if b {
+        1
+    } else {
+        0
+    }
+}
+
+// test variable shadowing and local const
+fn const_42(x: u64) -> u64 {
+    const forty_two = 42;
+    let x: u64 = forty_two;
+    x
+}
+
+// test variable scopes and local const
+fn id(x: u64) -> u64 {
+    const forty_two = 42;
+    {
+        let x: u64 = forty_two;
+    };
+    x
+}
+
+const QUUX: u64 = id(0);
+const BAZ: u64 = const_42(123456);
+
 const TUP1 = (2, 1, 21);
 const ARR1 = [1, 2, 3];
 
@@ -15,8 +43,9 @@ fn tup_wrapper(a: u64, b: u64, c: u64) -> (u64, u64, u64) {
 const TUP2 = tup_wrapper(2, 1, 21);
 
 fn arr_wrapper(a: u64, b: u64, c: u64) -> [u64; 3] {
-    return [a, b, c];
+    [a, b, c]
 }
+
 const ARR2 = arr_wrapper(1, 2, 3);
 
 enum En1 {
@@ -50,12 +79,12 @@ const ZERO_B256 = 0x000000000000000000000000000000000000000000000000000000000000
 const KEY = ZERO_B256;
 
 const BAR: u32 = 6;
-const FOO: u32 = 5;
+const FOO: u32 = ((u32::min() + 1) * 12 / 2 - 1) % 6;
 const MASK: u32 = 11;
 const MASK2: u32 = 8;
 const MASK3: u32 = 15;
 const FOO_MIDDLE: u32 = ((FOO & MASK) | MASK2) ^ MASK3;
-const OPS: u64 = 10 + 9 - 8 * 7 / 6 << 5 >> 4 ^ 3 | 2 & 1;
+const OPS: u64 = 10 + 9 - 8 * 7 / 6 << 5 >> 4 ^ 3 | 2 & bool_to_num(true);
 
 const CARR1 = [X_SIZE - Y_SIZE + 1; 4];
 // This doesn't work because const-eval happens after type-checking,
@@ -70,6 +99,8 @@ fn main() -> u64 {
     const eth_id0 = ContractId::from(0x0000000000000000000000000000000000000000000000000000000000000000);
     const eth_id1 = ContractId::from(0x0000000000000000000000000000000000000000000000000000000000000001);
     assert(eth_id0 == ETH_ID0 && eth_id1 == ETH_ID1);
+    assert(BAZ == 42);
+    assert(QUUX == 0);
 
     // tuples and arrays.
     const t1 = (2, 1, 21);
@@ -117,6 +148,7 @@ fn main() -> u64 {
     assert(SOV == __size_of_val("hello"));
     assert(TRUEB != FALSEB);
     assert(TRUEB1 != FALSEB1);
+    assert(FOO == 5);
     assert(FOO_MIDDLE == BAR);
     assert(OPS == 23);
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_inits/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_inits/test.toml
@@ -1,4 +1,4 @@
 category = "run"
 expected_result = { action = "return", value = 1 }
 validate_abi = true
-expected_warnings = 9
+expected_warnings = 19

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/ops/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/ops/src/main.sw
@@ -134,11 +134,11 @@ fn u32_ops() -> bool {
     assert(1_u32 << 1 == 2_u32);
     assert(2_u32 << 1 == 4_u32);
     assert(255_u32 << 21 == 534773760_u32);
-    assert(max << 1 & max == 4294967294_u32);
-    assert(max << 2 & max == 4294967292_u32);
-    assert(A << 1 & max == C);
-    assert(max << 31 & max == E);
-    assert(max << 32 & max == 0_u32);
+    assert(max << 1 == 4294967294_u32);
+    assert(max << 2 == 4294967292_u32);
+    assert(A << 1 == C);
+    assert(max << 31 == E);
+    assert(max << 32 == 0_u32);
 
     assert(0_u32 >> 0 == 0_u32);
     assert(0_u32 >> 1 == 0_u32);
@@ -152,8 +152,8 @@ fn u32_ops() -> bool {
     assert(A >> 1 == D);
     assert(A >> 21 == 1036_u32);
     assert(max >> 1 == 2147483647_u32);
-    assert(max >> 31 & max == 1_u32);
-    assert(max >> 32 & max == 0_u32);
+    assert(max >> 31 == 1_u32);
+    assert(max >> 32 == 0_u32);
 
     true
 }
@@ -209,11 +209,11 @@ fn u16_ops() -> bool {
     assert(1_u16 << 1 == 2_u16);
     assert(2_u16 << 1 == 4_u16);
     assert(255_u16 << 4 == 4080_u16);
-    assert(max << 1 & max == 65534_u16);
-    assert(max << 2 & max == 65532_u16);
-    assert(A << 1 & max == C);
-    assert(max << 15 & max == E);
-    assert(max << 16 & max == 0_u16);
+    assert(max << 1 == 65534_u16);
+    assert(max << 2 == 65532_u16);
+    assert(A << 1 == C);
+    assert(max << 15 == E);
+    assert(max << 16 == 0_u16);
 
     assert(0_u16 >> 0 == 0_u16);
     assert(0_u16 >> 1 == 0_u16);
@@ -227,8 +227,8 @@ fn u16_ops() -> bool {
     assert(A >> 1 == D);
     assert(A >> 4 == 2072_u16);
     assert(max >> 1 == 32767_u16);
-    assert(max >> 15 & max == 1_u16);
-    assert(max >> 16 & max == 0_u16);
+    assert(max >> 15 == 1_u16);
+    assert(max >> 16 == 0_u16);
 
     true
 }
@@ -284,11 +284,11 @@ fn u8_ops() -> bool {
     assert(1_u8 << 1 == 2_u8);
     assert(2_u8 << 1 == 4_u8);
     assert(31_u8 << 2 == 124_u8);
-    assert(max << 1 & max == 254_u8);
-    assert(max << 2 & max == 252_u8);
-    assert(A << 1 & max == C);
-    assert(max << 7 & max == E);
-    assert(max << 8 & max == 0_u8);
+    assert(max << 1 == 254_u8);
+    assert(max << 2 == 252_u8);
+    assert(A << 1 == C);
+    assert(max << 7 == E);
+    assert(max << 8 == 0_u8);
 
     assert(0_u8 >> 0 == 0_u8);
     assert(0_u8 >> 1 == 0_u8);
@@ -302,8 +302,8 @@ fn u8_ops() -> bool {
     assert(A >> 1 == D);
     assert(A >> 4 == 8_u8);
     assert(max >> 1 == 127_u8);
-    assert(max >> 7 & max == 1_u8);
-    assert(max >> 8 & max == 0_u8);
+    assert(max >> 7 == 1_u8);
+    assert(max >> 8 == 0_u8);
 
     true
 }


### PR DESCRIPTION
fixes #4646

## Description

This PR fixes the linked issue by introducing overflow/underflow checks in the `Add`, `Mul`, `Sub` stdlib traits implementations for the `u8`, `u16` and `u32` types.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
