### PR TITLE
chore: bump git2-rs version to 0.17.2 and required libgit2 to v1.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,9 +2406,9 @@ checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "git2"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
+checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
 dependencies = [
  "bitflags",
  "libc",
@@ -3138,9 +3138,9 @@ checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
+version = "0.15.2+1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
 dependencies = [
  "cc",
  "libc",
@@ -3152,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.23"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
 dependencies = [
  "cc",
  "libc",

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -17,7 +17,7 @@ forc-tracing = { version = "0.40.1", path = "../forc-tracing" }
 forc-util = { version = "0.40.1", path = "../forc-util" }
 fuel-abi-types = "0.1"
 futures = "0.3"
-git2 = { version = "0.16.1", features = ["vendored-libgit2", "vendored-openssl"] }
+git2 = { version = "0.17.2", features = ["vendored-libgit2", "vendored-openssl"] }
 gix-url = { version = "0.16.0", features = ["serde1"] }
 hex = "0.4.3"
 ipfs-api-backend-hyper = { version = "0.6", features = ["with-builder"] }


### PR DESCRIPTION
## Description

Bumps git2-rs to 0.17.2, so that forc requires libgit2 v1.6.4 to compile. This is needed as fuel.nix flake is in a deadlock; sysinfo dependency introduced in #4564 requires us to bump macos sdk versions while libgit2 v0.1.5.1 fails to compile with the bumped SDK version.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
