### PR TITLE
Fix style guide example not using local std

### DIFF
--- a/docs/reference/src/code/Forc.lock
+++ b/docs/reference/src/code/Forc.lock
@@ -1,27 +1,27 @@
 [[package]]
 name = 'annotation_style'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'annotations'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'arrays'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'assertions'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'asset_operations'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'associated-consts'
@@ -30,30 +30,30 @@ source = 'member'
 [[package]]
 name = 'booleans'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'bytes'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'call'
 source = 'member'
 dependencies = [
     'contract_interface',
-    'std path+from-root-0F28276288D2432C',
+    'std',
 ]
 
 [[package]]
 name = 'call_data'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'comments'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'constants'
@@ -62,198 +62,189 @@ source = 'member'
 [[package]]
 name = 'contract_interface'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'control_flow'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'core'
 source = 'path+from-root-0F28276288D2432C'
 
 [[package]]
-name = 'core'
-source = 'path+from-root-D62A8C57DD8D2801'
-
-[[package]]
 name = 'counter'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'empty_storage_init'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'enum-advanced'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'enum_style'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'enums'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'fizzbuzz'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'functions'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'hashing'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'interface'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'letter_casing'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'logging'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'my_lib'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'my_library'
 source = 'member'
 dependencies = [
     'my_other_library',
-    'std path+from-root-0F28276288D2432C',
+    'std',
 ]
 
 [[package]]
 name = 'my_other_library'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'namespace'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'numerics'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'ownership'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'pattern_matching'
 source = 'member'
-dependencies = ['std git+https://github.com/fuellabs/sway?tag=v0.40.1#48104d0bde0d343154a5bc39a310092532883235']
+dependencies = ['std']
 
 [[package]]
 name = 'reading_writing_to_storage'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'simple_predicate'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'simple_script'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
-
-[[package]]
-name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.40.1#48104d0bde0d343154a5bc39a310092532883235'
-dependencies = ['core path+from-root-D62A8C57DD8D2801']
+dependencies = ['std']
 
 [[package]]
 name = 'std'
 source = 'path+from-root-0F28276288D2432C'
-dependencies = ['core path+from-root-0F28276288D2432C']
+dependencies = ['core']
 
 [[package]]
 name = 'storage_init'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'storage_map'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'storage_vec'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'store_get'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'string_issue'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'strings'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'struct_shorthand'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'structs'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'tuples'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'variables'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']
 
 [[package]]
 name = 'wallet'
 source = 'member'
 dependencies = [
     'interface',
-    'std path+from-root-0F28276288D2432C',
+    'std',
 ]
 
 [[package]]
 name = 'wallet_example'
 source = 'member'
-dependencies = ['std path+from-root-0F28276288D2432C']
+dependencies = ['std']

--- a/docs/reference/src/code/language/style-guide/pattern_matching/Forc.toml
+++ b/docs/reference/src/code/language/style-guide/pattern_matching/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "pattern_matching"
 
 [dependencies]
+std = { path = "../../../../../../../sway-lib-std" }


### PR DESCRIPTION
## Description

Style guide example is blocking new releases because it tries to use an unpublished version of std

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
