### PR TITLE
remove unused debug flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,6 @@ exclude = [
     "forc-test/test_data"
 ]
 
-[profile.dev.package.sway-lsp]
-debug = 2
-
 [workspace.dependencies]
 fuel-asm = "0.31.1"
 fuel-crypto = "0.31.1"


### PR DESCRIPTION
## Description
I noticed the following warning was printing to the console when building `forc`

```
warning: profile package spec `sway-lsp` in profile `dev` did not match any packages
```

This flag isn't being used as we are using tracing now in the language server to set debug levels so we can safely remove this from the workspace `Cargo.toml`.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
