### PR TITLE
Fixes invalid IR, on impl self with where clause.

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-AA4B286930BA1707'
+
+[[package]]
+name = 'generic_where_in_impl_self'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-AA4B286930BA1707'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "generic_where_in_impl_self"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "bool",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self/src/main.sw
@@ -1,0 +1,35 @@
+script;
+
+use std::assert::*;
+
+trait Trait {
+    #[inline(never)]
+    fn method(self) -> u64;
+}
+
+impl Trait for u64 {
+    #[inline(never)]
+    fn method(self) -> u64{
+        42
+    }
+}
+
+struct CallTrait<V> {}
+
+#[inline(never)]
+fn call_trait<T>(t: T) -> u64 where T: Trait {
+    t.method()
+}
+
+impl<K> CallTrait<K> where K: Trait {
+    pub fn call_trait(self, key: K) -> u64 {
+        call_trait(key)
+    }
+}
+
+fn main() -> bool {
+    let _  = call_trait(1);
+    let ct = CallTrait::<u64> {};
+    assert(ct.call_trait(1) == 42);
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+validate_abi = true


### PR DESCRIPTION
## Description
Methods were missing type_parameters from impl self where clauses.

This caused the trait methods not to be replaced with a valid implementation.

Fixes #4719

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
