### PR TITLE
Fix inlay hints

### DIFF
--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -26,7 +26,6 @@ use tower_lsp::{LspService, Server};
 pub async fn start() {
     let (service, socket) = LspService::build(ServerState::new)
         .custom_method("sway/show_ast", ServerState::show_ast)
-        .custom_method("textDocument/inlayHint", ServerState::inlay_hints)
         .finish();
     Server::new(tokio::io::stdin(), tokio::io::stdout(), socket)
         .serve(service)

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -106,14 +106,14 @@ impl LanguageServer for ServerState {
     ) -> Result<Option<PrepareRenameResponse>> {
         request::handle_prepare_rename(self, params)
     }
+
+    async fn inlay_hint(&self, params: InlayHintParams) -> Result<Option<Vec<InlayHint>>> {
+        request::handle_inlay_hints(self, params)
+    }
 }
 
 // Custom LSP-Server Methods
 impl ServerState {
-    pub async fn inlay_hints(&self, params: InlayHintParams) -> Result<Option<Vec<InlayHint>>> {
-        request::handle_inlay_hints(self, params)
-    }
-
     pub async fn show_ast(&self, params: ShowAstParams) -> Result<Option<TextDocumentIdentifier>> {
         request::handle_show_ast(self, params)
     }


### PR DESCRIPTION
## Description

Inlay hints haven't been working for me, and I see this error in the LSP server logs:

```
Got a textDocument/inlayHint request, but it is not implemented
[Trace - 10:53:49 AM] Received response 'textDocument/inlayHint - (11)' in 1ms. Request failed: Method not found (-32601).
[Error - 10:53:49 AM] Request textDocument/inlayHint failed.
```

This change fixes it for me locally.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
