### PR TITLE
Doc storage read unwrap_or clarification.

### DIFF
--- a/examples/storage_variables/src/main.sw
+++ b/examples/storage_variables/src/main.sw
@@ -42,10 +42,10 @@ impl StorageExample for Contract {
     #[storage(read)]
     fn get_something() -> (u64, u64, b256, bool) {
         (
-            storage.var1.x.read(),
-            storage.var1.y.read(),
-            storage.var2.w.read(),
-            storage.var2.z.read(),
+            storage.var1.x.read().unwrap_or(0),
+            storage.var1.y.read().unwrap_or(0),
+            storage.var2.w.read().unwrap_or(0),
+            storage.var2.z.read().unwrap_or(0),
         )
     }
     // ANCHOR_END: storage_read

--- a/examples/storage_variables/src/main.sw
+++ b/examples/storage_variables/src/main.sw
@@ -42,10 +42,10 @@ impl StorageExample for Contract {
     #[storage(read)]
     fn get_something() -> (u64, u64, b256, bool) {
         (
-            storage.var1.x.read().unwrap_or(0),
-            storage.var1.y.read().unwrap_or(0),
-            storage.var2.w.read().unwrap_or(0x0000000000000000000000000000000000000000000000000000000000000000),
-            storage.var2.z.read().unwrap_or(false),
+            storage.var1.x.try_read().unwrap_or(0),
+            storage.var1.y.try_read().unwrap_or(0),
+            storage.var2.w.try_read().unwrap_or(0x0000000000000000000000000000000000000000000000000000000000000000),
+            storage.var2.z.try_read().unwrap_or(false),
         )
     }
     // ANCHOR_END: storage_read

--- a/examples/storage_variables/src/main.sw
+++ b/examples/storage_variables/src/main.sw
@@ -44,8 +44,8 @@ impl StorageExample for Contract {
         (
             storage.var1.x.read().unwrap_or(0),
             storage.var1.y.read().unwrap_or(0),
-            storage.var2.w.read().unwrap_or(0),
-            storage.var2.z.read().unwrap_or(0),
+            storage.var2.w.read().unwrap_or(0x0000000000000000000000000000000000000000000000000000000000000000),
+            storage.var2.z.read().unwrap_or(false),
         )
     }
     // ANCHOR_END: storage_read


### PR DESCRIPTION
## Description
Document clarification around ensuring .unwrap_or(0) is used for storage read examples.
