### PR TITLE
Fix: resolve to constant when compiling expressions to ir

### DIFF
--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -258,6 +258,19 @@ impl<'eng> FnCompiler<'eng> {
         md_mgr: &mut MetadataManager,
         ast_expr: &ty::TyExpression,
     ) -> Result<Value, CompileError> {
+        // resolve expression to a constant, if possible
+        if let Ok(constant) = compile_constant_expression_to_constant(
+            self.engines,
+            context,
+            md_mgr,
+            self.module,
+            None,
+            Some(self),
+            ast_expr,
+        ) {
+            return Ok(Value::new_constant(context, constant));
+        }
+
         let span_md_idx = md_mgr.span_to_md(context, &ast_expr.span);
         match &ast_expr.expression {
             ty::TyExpressionVariant::Literal(l) => {

--- a/test/src/ir_generation/tests/local_const_init.sw
+++ b/test/src/ir_generation/tests/local_const_init.sw
@@ -8,12 +8,43 @@ fn s(x : u64) -> S {
   S { s: x }
 }
 
+fn return_49() -> u64 { 7 * 7 }
+fn return_times_8(v: u64) -> u64 { v * 8 }
+fn max(l: u64, r: u64) -> u64 {
+  if l > r { l } else { r }
+}
+
 fn main() -> u64 {
+  let A: u64 = 0 + 1 + 2 + 3 + 4 + 5;
+  let B = return_49();
+  let C = return_times_8(8);
+  let D = max(23, 45);
+  
   const X = s(1);
   X.s
 }
 
+// check:        local u64 A
+// check:        local u64 B
+// check:        local u64 C
+// check:        local u64 D
 // check:        local { u64 } X
+
+// not: call
+// check: $(A_var=$VAL) = get_local ptr u64, A
+// check: const u64 15
+
+// not: call
+// check: $(B_var=$VAL) = get_local ptr u64, B
+// check: const u64 49
+
+// not: call
+// check: $(C_var=$VAL) = get_local ptr u64, C
+// check: const u64 64
+
+// not: call
+// check: $(D_var=$VAL) = get_local ptr u64, D
+// check: const u64 45
 
 // check: $(x_var=$VAL) = get_local ptr { u64 }, X
 // check: $(one=$VAL) = const { u64 } { u64 1 }


### PR DESCRIPTION
## Description

Closes https://github.com/FuelLabs/sway/issues/4708.

This PR checks if an expression resolves to constant and, thus, avoids generating any IR.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
