### PR TITLE
ci: bump rust version to 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.69.0
+  RUST_VERSION: 1.70.0
   NIGHTLY_RUST_VERSION: nightly-2023-02-08
 
 jobs:


### PR DESCRIPTION
## Description
rust v1.70 is [released](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html) and probably most of us are using that version. This PR bumps CI to that version.