### PR TITLE
Fix block height type to conform to spec

### DIFF
--- a/sway-lib-std/src/block.sw
+++ b/sway-lib-std/src/block.sw
@@ -11,10 +11,10 @@ enum BlockHashError {
 }
 
 /// Get the current block height.
-pub fn height() -> u64 {
+pub fn height() -> u32 {
     asm(height) {
         bhei height;
-        height: u64
+        height: u32
     }
 }
 
@@ -24,7 +24,7 @@ pub fn timestamp() -> u64 {
 }
 
 /// Get the TAI64 timestamp of a block at a given `block_height`.
-pub fn timestamp_of_block(block_height: u64) -> u64 {
+pub fn timestamp_of_block(block_height: u32) -> u64 {
     asm(timestamp, height: block_height) {
         time timestamp height;
         timestamp: u64
@@ -32,7 +32,7 @@ pub fn timestamp_of_block(block_height: u64) -> u64 {
 }
 
 /// Get the header hash of the block at height `block_height`
-pub fn block_header_hash(block_height: u64) -> Result<b256, BlockHashError> {
+pub fn block_header_hash(block_height: u32) -> Result<b256, BlockHashError> {
 
     let mut header_hash = ZERO_B256;
 
@@ -69,7 +69,7 @@ fn test_block_header_hash_err_future_height() {
 
     // Try to get header hash of a block in the future
     // The function should return a BlockHashError
-    let hash = block_header_hash(height() + 1);
+    let hash = block_header_hash(height() + 1u32);
     let correct_error = match hash {
         Ok(_) => false,
         Err(BlockHashError::BlockHeightTooHigh) => true,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/block_height/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/block_height/src/main.sw
@@ -4,6 +4,6 @@ use std::block::height;
 
 fn main() -> bool {
     let h = height();
-    assert(h >= 1);
+    assert(h >= 1u32);
     true
 }

--- a/test/src/sdk-harness/test_artifacts/block_test_abi/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/block_test_abi/src/main.sw
@@ -1,13 +1,13 @@
 library;
 
 abi BlockTest {
-    fn get_block_height() -> u64;
+    fn get_block_height() -> u32;
 
     fn get_timestamp() -> u64;
 
-    fn get_timestamp_of_block(block_height: u64) -> u64;
+    fn get_timestamp_of_block(block_height: u32) -> u64;
 
-    fn get_block_and_timestamp() -> (u64, u64);
+    fn get_block_and_timestamp() -> (u32, u64);
 
-    fn get_block_header_hash(h: u64) -> b256;
+    fn get_block_header_hash(h: u32) -> b256;
 }

--- a/test/src/sdk-harness/test_projects/block/src/main.sw
+++ b/test/src/sdk-harness/test_projects/block/src/main.sw
@@ -4,7 +4,7 @@ use std::block::{block_header_hash, height, timestamp, timestamp_of_block};
 use block_test_abi::BlockTest;
 
 impl BlockTest for Contract {
-    fn get_block_height() -> u64 {
+    fn get_block_height() -> u32 {
         height()
     }
 
@@ -12,15 +12,15 @@ impl BlockTest for Contract {
         timestamp()
     }
 
-    fn get_timestamp_of_block(block_height: u64) -> u64 {
+    fn get_timestamp_of_block(block_height: u32) -> u64 {
         timestamp_of_block(block_height)
     }
 
-    fn get_block_and_timestamp() -> (u64, u64) {
+    fn get_block_and_timestamp() -> (u32, u64) {
         (height(), timestamp())
     }
 
-    fn get_block_header_hash(h: u64) -> b256 {
+    fn get_block_header_hash(h: u32) -> b256 {
         let res = block_header_hash(h);
         match res {
             Ok(h) => h,


### PR DESCRIPTION
## Description
The fuel specification consistently refers to the block height as an unsigned 32 bit integer, which is also what the SDK uses, this change brings the Sway standard library in line with the spec.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
