### PR TITLE
feat: make `--random-salt` default to forc-deploy and remove it as a flag

### DIFF
--- a/forc-plugins/forc-client/src/cmd/deploy.rs
+++ b/forc-plugins/forc-client/src/cmd/deploy.rs
@@ -29,10 +29,10 @@ pub struct Command {
     /// --salt contract_b:0x0000000000000000000000000000000000000000000000000000000000000002
     #[clap(long)]
     pub salt: Option<Vec<String>>,
-    /// Generate a random salt for the contract.
-    /// Useful for testing or deploying examples to a shared network.
+    /// Generate a defualt salt (0x0000000000000000000000000000000000000000000000000000000000000000) for the contract.
+    /// Useful for CI, to create reproducable deployments.
     #[clap(long)]
-    pub random_salt: bool,
+    pub default_salt: bool,
     #[clap(flatten)]
     pub build_output: BuildOutput,
     #[clap(flatten)]

--- a/forc-plugins/forc-client/src/cmd/deploy.rs
+++ b/forc-plugins/forc-client/src/cmd/deploy.rs
@@ -29,7 +29,7 @@ pub struct Command {
     /// --salt contract_b:0x0000000000000000000000000000000000000000000000000000000000000002
     #[clap(long)]
     pub salt: Option<Vec<String>>,
-    /// Generate a defualt salt (0x0000000000000000000000000000000000000000000000000000000000000000) for the contract.
+    /// Generate a default salt (0x0000000000000000000000000000000000000000000000000000000000000000) for the contract.
     /// Useful for CI, to create reproducable deployments.
     #[clap(long)]
     pub default_salt: bool,

--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -131,7 +131,7 @@ pub async fn deploy(command: cmd::Deploy) -> Result<Vec<DeployedContract>> {
             .check_program_type(vec![TreeType::Contract])
             .is_ok()
         {
-            let salt = match (&contract_salt_map, command.random_salt) {
+            let salt = match (&contract_salt_map, command.default_salt) {
                 (Some(map), false) => {
                     if let Some(salt) = map.get(pkg.descriptor.manifest_file.project_name()) {
                         *salt
@@ -139,10 +139,10 @@ pub async fn deploy(command: cmd::Deploy) -> Result<Vec<DeployedContract>> {
                         Default::default()
                     }
                 }
-                (None, true) => rand::random(),
-                (None, false) => Default::default(),
+                (None, true) => Default::default(),
+                (None, false) => rand::random(),
                 (Some(_), true) => {
-                    bail!("Both `--salt` and `--random-salt` were specified: must choose one")
+                    bail!("Both `--salt` and `--default-salt` were specified: must choose one")
                 }
             };
             let contract_id =

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -72,6 +72,7 @@ pub(crate) async fn deploy_contract(file_name: &str, run_config: &RunConfig) -> 
             ..Default::default()
         },
         signing_key: Some(SecretKey::from_str(SECRET_KEY).unwrap()),
+        default_salt: true,
         ..Default::default()
     })
     .await


### PR DESCRIPTION
## Description
closes #4758.

This PR makes --random-salt the default behaviour of forc-deploy, if salt information is passed, the passed salt would be used but otherwise, random-salt would be implied by default. Also adds --default-salt for CI so that in CI we can always create the same contract id if we want to. Useful for reproducible deployments.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
