### PR TITLE
feat: improve error message in case of insufficient funds

### DIFF
--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -198,6 +198,7 @@ pub async fn deploy_pkg(
         .await?;
 
     let tx = Transaction::from(tx);
+    println!("here");
 
     let deployment_request = client.submit_and_await_commit(&tx).map(|res| match res {
         Ok(logs) => match logs {
@@ -216,12 +217,7 @@ pub async fn deploy_pkg(
                 )
             }
         },
-        Err(e) => { 
-            if e.to_string().contains("not enough coins to fit the target") {
-                bail!("Deployment failed due to insufficient funds. Please be sure to have enough coins to pay for deployment transaction.")
-            }
-            bail!("{e}") 
-        },
+        Err(e) => bail!("{e}"),
     });
 
     // submit contract deployment with a timeout

--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -198,7 +198,6 @@ pub async fn deploy_pkg(
         .await?;
 
     let tx = Transaction::from(tx);
-    println!("here");
 
     let deployment_request = client.submit_and_await_commit(&tx).map(|res| match res {
         Ok(logs) => match logs {

--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -216,7 +216,12 @@ pub async fn deploy_pkg(
                 )
             }
         },
-        Err(e) => bail!("{e}"),
+        Err(e) => { 
+            if e.to_string().contains("not enough coins to fit the target") {
+                bail!("Deployment failed due to insufficent funds. Please be sure to have enough coins to pay for deployment transaction.")
+            }
+            bail!("{e}") 
+        },
     });
 
     // submit contract deployment with a timeout

--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -218,7 +218,7 @@ pub async fn deploy_pkg(
         },
         Err(e) => { 
             if e.to_string().contains("not enough coins to fit the target") {
-                bail!("Deployment failed due to insufficent funds. Please be sure to have enough coins to pay for deployment transaction.")
+                bail!("Deployment failed due to insufficient funds. Please be sure to have enough coins to pay for deployment transaction.")
             }
             bail!("{e}") 
         },

--- a/forc-plugins/forc-client/src/util/tx.rs
+++ b/forc-plugins/forc-client/src/util/tx.rs
@@ -207,7 +207,6 @@ impl<Tx: Buildable + SerializableVec + field::Witnesses + Send> TransactionBuild
             } else {
                 e
             })?;
-            println!("here");
             key
         } else {
             None
@@ -231,9 +230,7 @@ impl<Tx: Buildable + SerializableVec + field::Witnesses + Send> TransactionBuild
             let witness = Witness::from(signature.as_ref());
             tx.replace_witness(signature_witness_index, witness);
         }
-        println!("here");
         tx.precompute(&params);
-        println!("here");
 
         Ok(tx)
     }

--- a/forc-plugins/forc-client/src/util/tx.rs
+++ b/forc-plugins/forc-client/src/util/tx.rs
@@ -202,7 +202,12 @@ impl<Tx: Buildable + SerializableVec + field::Witnesses + Send> TransactionBuild
                 Provider::new(client, params),
                 signature_witness_index,
             )
-            .await?;
+            .await.map_err(|e| if e.to_string().contains("not enough coins to fit the target") {
+                anyhow::anyhow!("Deployment failed due to insufficient funds. Please be sure to have enough coins to pay for deployment transaction.")
+            } else {
+                e
+            })?;
+            println!("here");
             key
         } else {
             None
@@ -226,7 +231,9 @@ impl<Tx: Buildable + SerializableVec + field::Witnesses + Send> TransactionBuild
             let witness = Witness::from(signature.as_ref());
             tx.replace_witness(signature_witness_index, witness);
         }
+        println!("here");
         tx.precompute(&params);
+        println!("here");
 
         Ok(tx)
     }


### PR DESCRIPTION
## Description
closes #4043.

Improves error message by stating the failure reason clearly if the reason is insufficient funds. If the transaction is failing due to insufficient funds we are outputing:

```console
Contract id: 0xa8f18533afc18453323bdf17c83750c556916ab183daacf46d7a8d3c633a40ee

Please provide the password of your encrypted wallet vault at "/Users/kayagokalp/.fuel/wallets/.wallet":
Do you accept to sign this transaction with fuel1egx2nvm4395gukm8uyh4zzxdlx3hht9ulu6n67nhwq57zs74camskx7klp [y/N]:y
Error: Deployment failed due to insufficient funds. Please be sure to have enough coins to pay for deployment transaction.
```

We will have a balance checking mechanism before signing the transaction for test-net which would make this error only visible to manual signers and people that are working against a local node.
## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
