### PR TITLE
 feat: add `--target` and `--testnet` parameters to `forc-deploy`

### DIFF
--- a/forc-plugins/forc-client/src/cmd/deploy.rs
+++ b/forc-plugins/forc-client/src/cmd/deploy.rs
@@ -56,4 +56,7 @@ pub struct Command {
     /// Possible values are: [beta-1, beta-2, beta-3, latest]
     #[clap(long)]
     pub target: Option<Target>,
+    /// Use preset configuration for the latest testnet.
+    #[clap(long)]
+    pub testnet: bool,
 }

--- a/forc-plugins/forc-client/src/cmd/deploy.rs
+++ b/forc-plugins/forc-client/src/cmd/deploy.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use fuel_crypto::SecretKey;
 
+pub use crate::util::Target;
 pub use forc::cli::shared::{BuildOutput, BuildProfile, Minify, Pkg, Print};
 pub use forc_tx::{Gas, Maturity};
 pub use forc_util::tx_utils::Salt;
@@ -50,4 +51,9 @@ pub struct Command {
     /// Sign the deployment transaction manually.
     #[clap(long)]
     pub manual_signing: bool,
+    /// Use preset configurations for deploying to a specific target.
+    ///
+    /// Possible values are: [beta-1, beta-2, beta-3, latest]
+    #[clap(long)]
+    pub target: Option<Target>,
 }

--- a/forc-plugins/forc-client/src/lib.rs
+++ b/forc-plugins/forc-client/src/lib.rs
@@ -5,4 +5,6 @@ mod util;
 pub mod default {
     /// Default to localhost to favour the common case of testing.
     pub const NODE_URL: &str = sway_utils::constants::DEFAULT_NODE_URL;
+    pub const BETA_2_ENDPOINT_URL: &str = "node-beta-2.fuel.network/graphql";
+    pub const BETA_3_ENDPOINT_URL: &str = "beta-3.fuel.network/graphql";
 }

--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -155,7 +155,7 @@ pub async fn deploy(command: cmd::Deploy) -> Result<Vec<DeployedContract>> {
     Ok(contract_ids)
 }
 
-/// Applies specified target information to the provided arguments. 
+/// Applies specified target information to the provided arguments.
 ///
 /// Basically provides preset configurations for known test-nets.
 fn apply_target(command: cmd::Deploy) -> Result<cmd::Deploy> {

--- a/forc-plugins/forc-client/src/util/mod.rs
+++ b/forc-plugins/forc-client/src/util/mod.rs
@@ -1,3 +1,49 @@
+use std::str::FromStr;
+
 pub(crate) mod encode;
 pub(crate) mod pkg;
 pub(crate) mod tx;
+
+use crate::default::{BETA_2_ENDPOINT_URL, BETA_3_ENDPOINT_URL, NODE_URL};
+
+#[derive(Debug, Clone)]
+/// Possible target values that forc-client can interact with.
+pub enum Target {
+    Beta2,
+    Beta3,
+    LATEST,
+}
+
+impl Default for Target {
+    fn default() -> Self {
+        Self::LATEST
+    }
+}
+
+impl Target {
+    pub fn target_url(&self) -> &str {
+        match self {
+            Target::Beta2 => BETA_2_ENDPOINT_URL,
+            Target::Beta3 => BETA_3_ENDPOINT_URL,
+            Target::LATEST => NODE_URL,
+        }
+    }
+}
+
+impl FromStr for Target {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "latest" {
+            Ok(Target::LATEST)
+        } else if s == "beta-2" {
+            Ok(Target::Beta2)
+        } else if s == "beta-3" {
+            Ok(Target::Beta3)
+        } else {
+            anyhow::bail!(
+                "invalid testnet name provided. Possible values are 'beta-2', 'beta-3', 'latest'."
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Description
closes #4759.

Adds --target parameter to forc-deploy which can take `beta-2`, `beta-3` or `latest`. If nothing is specified it defaults to `latest`. If `beta-2` or `beta-3` is specified, preset values are used for node-url and gas price so that users can deploy with a single parameter. So `forc deploy --target beta-3` would work but since forc-deploy is not compatible with beta-3 that feature will fail until we have a beta-4 released.

Also adds `--testnet` flag which is translated into a `--target beta-3`. So once a beta network release is done with this additions, users will be able to simply use

```console
forc deploy --testnet
```
to deploy to the latest test-net supported by that forc-deploy version
## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
