### PR TITLE
fix: remove dependency on std for `regalloc_spill` unit test

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/regalloc_spill/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/regalloc_spill/Forc.lock
@@ -1,13 +1,3 @@
 [[package]]
-name = 'core'
-source = 'path+from-root-CA82D6910AC0C4B8'
-
-[[package]]
 name = 'regalloc_spill'
 source = 'member'
-dependencies = ['std']
-
-[[package]]
-name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.42.0#c4e4ef7e4ae52a21ae1aa709d1f43ac680987bd1'
-dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/regalloc_spill/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/regalloc_spill/Forc.toml
@@ -3,5 +3,6 @@ authors = ["fuel"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "regalloc_spill"
+implicit-std = false
 
 [dependencies]


### PR DESCRIPTION
## Description
closes #4774.

This PR removes std library dependency for regalloc unit test so that we can publish a new version without blocking our CI. In general we should either not depend on std or we should only depend it by explicitly depending on it by path. Otherwise we cannot bump version in our repo.

unblocks: #4767 
## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
