### PR TITLE
Fixes missing replace_decl for variable declarations.

### DIFF
--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -92,6 +92,9 @@ impl ReplaceDecls for TyAstNode {
             TyAstNodeContent::ImplicitReturnExpression(ref mut exp) => {
                 exp.replace_decls(decl_mapping, engines)
             }
+            TyAstNodeContent::Declaration(TyDecl::VariableDecl(ref mut decl)) => {
+                decl.body.replace_decls(decl_mapping, engines);
+            }
             TyAstNodeContent::Declaration(_) => {}
             TyAstNodeContent::Expression(ref mut expr) => expr.replace_decls(decl_mapping, engines),
             TyAstNodeContent::SideEffect(_) => (),

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self2/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self2/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'core'
+source = 'path+from-root-B5A424CFF35B4F1C'
+
+[[package]]
+name = 'generic_where_in_impl_self2'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-B5A424CFF35B4F1C'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self2/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self2/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "generic_where_in_impl_self2"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self2/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self2/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "bool",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self2/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self2/src/main.sw
@@ -1,0 +1,36 @@
+script;
+
+use std::assert::*;
+
+trait Trait {
+    #[inline(never)]
+    fn method(self) -> u64;
+}
+
+impl Trait for u64 {
+    #[inline(never)]
+    fn method(self) -> u64{
+        42
+    }
+}
+
+struct CallTrait<V> {}
+
+#[inline(never)]
+fn call_trait<T>(t: T) -> u64 where T: Trait {
+    t.method()
+}
+
+impl<K> CallTrait<K> where K: Trait {
+    pub fn call_trait(self, key: K) -> u64 {
+        let v = call_trait(key);
+        v
+    }
+}
+
+fn main() -> bool {
+    let _  = call_trait(1);
+    let ct = CallTrait::<u64> {};
+    assert(ct.call_trait(1) == 42);
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self2/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_where_in_impl_self2/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+validate_abi = true


### PR DESCRIPTION
## Description

We were not calling replace_decl for variable declarations.
This was making some trait method calls to not be replaced.

Unblocks #4701
Fixes #4773

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
