### PR TITLE
Improve error message when contract calls its own method

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -9,6 +9,7 @@ use crate::{
     language::{
         parsed::*,
         ty::{self, TyImplItem, TyTraitItem},
+        CallPath,
     },
     semantic_analysis::{declaration::insert_supertraits_into_namespace, Mode, TypeCheckContext},
     CompileResult, ReplaceSelfType, TypeId, TypeInfo,
@@ -215,5 +216,21 @@ impl ty::TyAbiDecl {
                 }
             }
         }
+        // Insert the methods of the ABI into the namespace.
+        // Specifically do not check for conflicting definitions because
+        // this is just a temporary namespace for type checking and
+        // these are not actual impl blocks.
+        // We check that a contract method cannot call a contract method
+        // from the same ABI later, during method application typechecking.
+        ctx.namespace.insert_trait_implementation(
+            CallPath::from(self.name.clone()),
+            vec![],
+            type_id,
+            &all_items,
+            &self.span,
+            Some(self.span()),
+            false,
+            ctx.engines,
+        );
     }
 }

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -652,6 +652,8 @@ pub enum CompileError {
         method_name: String,
         as_traits: Vec<String>,
     },
+    #[error("A contract method cannot call methods belonging to the same ABI")]
+    ContractCallsItsOwnMethod { span: Span },
 }
 
 impl std::convert::From<TypeError> for CompileError {
@@ -824,6 +826,7 @@ impl Spanned for CompileError {
             NameDefinedMultipleTimes { span, .. } => span.clone(),
             MultipleApplicableItemsInScope { span, .. } => span.clone(),
             CannotBeEvaluatedToConst { span } => span.clone(),
+            ContractCallsItsOwnMethod { span } => span.clone(),
         }
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/contract_calls_its_method/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/contract_calls_its_method/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'contract_calls_its_method'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_fail/contract_calls_its_method/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/contract_calls_its_method/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "contract_calls_its_method"
+entry = "main.sw"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/contract_calls_its_method/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/contract_calls_its_method/src/main.sw
@@ -1,0 +1,14 @@
+contract;
+
+abi ContractCallsItsOwnMethod {
+    fn method1();
+    fn method2();
+}
+
+impl ContractCallsItsOwnMethod for Contract {
+    fn method1() {
+    }
+    fn method2() {
+        Self::method1()
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/contract_calls_its_method/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/contract_calls_its_method/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()A contract method cannot call methods belonging to the same ABI


### PR DESCRIPTION
close #1491

We add ABI methods to the namespace (this is going to be useful for the super-ABI feature) and filter out same contract method calls during method application typechecking, instead of not adding ABI methods to the namespace and providing a bit confusing error message like `No method named "method1" found for type "contract".`

## Description


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
