### PR TITLE
Improve flag library functionality

### DIFF
--- a/sway-lib-core/src/ops.sw
+++ b/sway-lib-core/src/ops.sw
@@ -484,21 +484,17 @@ trait OrdEq: Ord + Eq {
 } {
     fn ge(self, other: Self) -> bool {
         self.gt(other) || self.eq(other)
-    }    fn le(self, other: Self) -> bool {
+    }
+    fn le(self, other: Self) -> bool {
         self.lt(other) || self.eq(other)
     }
 }
 
-impl OrdEq for u64 {
-}
-impl OrdEq for u32 {
-}
-impl OrdEq for u16 {
-}
-impl OrdEq for u8 {
-}
-impl OrdEq for b256 {
-}
+impl OrdEq for u64 {}
+impl OrdEq for u32 {}
+impl OrdEq for u16 {}
+impl OrdEq for u8 {}
+impl OrdEq for b256 {}
 
 pub trait Shift {
     fn lsh(self, other: u64) -> Self;

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -264,6 +264,7 @@ fn test_disable_panic_on_unsafe_math_preserving() {
 
     let prior_flags = disable_panic_on_unsafe_math_preserving();
     let _bar = 1 / 0;
+    ::logging::log(error());
     assert(error() == 1);
     set_flags(prior_flags);
 

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -267,7 +267,7 @@ fn test_disable_panic_on_unsafe_math() {
 #[test]
 fn test_disable_panic_on_unsafe_math_preserving() {
     disable_panic_on_unsafe_math();
-    log(error())
+    log(error());
 
     let prior_flags = disable_panic_on_unsafe_math_preserving();
     let _bar = 1 / 0;

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -274,6 +274,7 @@ fn test_disable_panic_on_unsafe_math_preserving() {
         r1: u64
     };
     log(error());
+    log(error());
     assert(error() == 1);
     set_flags(prior_flags);
 

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -138,7 +138,7 @@ fn test_disable_panic_on_overflow_preserving() {
     disable_panic_on_overflow();
 
     let prior_flags = disable_panic_on_overflow_preserving();
-    let _bar = u64::max() + 1;
+    let mut _bar = u64::max() + 1;
     set_flags(prior_flags);
 
     _bar = u64::max() + 1;

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -267,10 +267,11 @@ fn test_disable_panic_on_unsafe_math() {
 #[test]
 fn test_disable_panic_on_unsafe_math_preserving() {
     disable_panic_on_unsafe_math();
-    log(error());
 
     let prior_flags = disable_panic_on_unsafe_math_preserving();
-    let _bar = 1 / 0;
+    let _bar = asm(r2: 1, r3: 0, r1) {
+        div r1 r2 r3
+    };
     log(error());
     assert(error() == 1);
     set_flags(prior_flags);

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -252,12 +252,10 @@ fn test_disable_panic_on_overflow_preserving() {
 fn test_disable_panic_on_unsafe_math() {
     disable_panic_on_unsafe_math();
 
-    let _bar = 1 / 0;
-    
-    let log_var = asm(t_val: true) {
-        t_val: u64
+    let _bar = asm(r2: 1, r3: 0, r1) {
+        div r1 r2 r3;
+        r1: u64
     };
-    log(log_var);
     
     assert(error() == 1);
 
@@ -273,12 +271,13 @@ fn test_disable_panic_on_unsafe_math_preserving() {
         div r1 r2 r3;
         r1: u64
     };
-    log(error());
-    log(error());
     assert(error() == 1);
     set_flags(prior_flags);
 
-    let _bar = 1 / 0;
+    let _bar = asm(r2: 1, r3: 0, r1) {
+        div r1 r2 r3;
+        r1: u64
+    };
     assert(error() == 1);
 
     enable_panic_on_unsafe_math();

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -129,7 +129,7 @@ pub fn set_flags(new_flags: u64) {
 #[test]
 fn test_disable_panic_on_overflow() {
     disable_panic_on_overflow();
-    let bar = u64::max() + 1;
+    let _bar = u64::max() + 1;
     enable_panic_on_overflow();
 }
 
@@ -138,10 +138,10 @@ fn test_disable_panic_on_overflow_preserving() {
     disable_panic_on_overflow();
 
     let prior_flags = disable_panic_on_overflow_preserving();
-    let bar = u64::max() + 1;
+    let _bar = u64::max() + 1;
     set_flags(prior_flags);
 
-    let bar = u64::max() + 1;
+    _bar = u64::max() + 1;
 
     enable_panic_on_overflow();
 }

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -142,7 +142,7 @@ pub fn disable_panic_on_overflow_preserving() -> u64 {
 ///     disable_panic_on_unsafe_math();
 ///      
 ///     let bar = 1 / 0; // Division by zero is considered unsafe math.
-///     assert(error() == true); // Error flag is set to true whenever unsafe math occurs.
+///     assert(error() == 1); // Error flag is set to true whenever unsafe math occurs.
 ///
 ///     enable_panic_on_unsafe_math();
 /// }
@@ -174,7 +174,7 @@ pub fn disable_panic_on_unsafe_math() {
 ///     disable_panic_on_unsafe_math();
 ///      
 ///     let bar = 1 / 0; // Division by zero is considered unsafe math.
-///     assert(error() == true); // Error flag is set to true whenever unsafe math occurs.
+///     assert(error() == 1); // Error flag is set to true whenever unsafe math occurs.
 ///
 ///     enable_panic_on_unsafe_math();
 /// }
@@ -207,7 +207,7 @@ pub fn enable_panic_on_unsafe_math() {
 ///     let prior_flags = disable_panic_on_unsafe_math_preserving();
 ///      
 ///     let bar = 1 / 0; // Division by zero is considered unsafe math.
-///     assert(error() == true); // Error flag is set to true whenever unsafe math occurs.
+///     assert(error() == 1); // Error flag is set to true whenever unsafe math occurs.
 ///
 ///     set_flags(prior_flags);
 /// }
@@ -253,7 +253,7 @@ fn test_disable_panic_on_unsafe_math() {
     disable_panic_on_unsafe_math();
 
     let _bar = 1 / 0;
-    assert(error() == true);
+    assert(error() == 1);
 
     enable_panic_on_unsafe_math();
 }
@@ -264,11 +264,11 @@ fn test_disable_panic_on_unsafe_math_preserving() {
 
     let prior_flags = disable_panic_on_unsafe_math_preserving();
     let _bar = 1 / 0;
-    assert(error() == true);
+    assert(error() == 1);
     set_flags(prior_flags);
 
     let _bar = 1 / 0;
-    assert(error() == true);
+    assert(error() == 1);
 
     enable_panic_on_unsafe_math();
 }

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -3,8 +3,25 @@ library;
 
 use ::registers::flags;
 
-/// Call this function to allow overflowing operations to occur without a FuelVM panic.
-/// > **_IMPORTANT:_** Don't forget to call `enable_panic_on_overflow` after performing the operations for which you disabled the default `panic-on-overflow` behavior in the first place!
+/// Allows overflowing operations to occur without a FuelVM panic.
+///
+/// > **_WARNING:_**
+/// >
+/// > Don't forget to call `enable_panic_on_overflow` after performing the operations for which you disabled the default `panic-on-overflow` behavior in the first place!
+///
+/// ### Examples
+///
+/// ```sway
+/// use std::flags::{disable_panic_on_overflow, enable_panic_on_overflow};
+///
+/// fn main() {
+///     disable_panic_on_overflow();
+///      
+///     let bar = u64::max() + 1;
+///
+///     enable_panic_on_overflow();
+/// }
+/// ```
 pub fn disable_panic_on_overflow() {
     // Mask second bit, which is `F_WRAPPING`.
     let mask = 0b00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000010;
@@ -17,8 +34,25 @@ pub fn disable_panic_on_overflow() {
     }
 }
 
-/// Call this function to re-enable the `panic-on-overflow` behavior in the FuelVM.
-/// > **_Note:_** `panic-on-overflow` is the default, so there is no need to use this function unless you have previously called `disable_panic_on_overflow`.
+/// Enables the default `panic-on-overflow` behavior in the FuelVM.
+///
+/// > **_Note:_**
+/// >
+/// > `panic-on-overflow` is the default, so there is no need to use this function unless you have previously called `disable_panic_on_overflow`.
+///
+/// ### Examples
+///
+/// ```sway
+/// use std::flags::{disable_panic_on_overflow, enable_panic_on_overflow};
+///
+/// fn main() {
+///     disable_panic_on_overflow();
+///      
+///     let bar = u64::max() + 1;
+///
+///     enable_panic_on_overflow();
+/// }
+/// ```
 pub fn enable_panic_on_overflow() {
     // Mask second bit, which is `F_WRAPPING`.
     let mask = 0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111101;
@@ -29,4 +63,85 @@ pub fn enable_panic_on_overflow() {
     asm(flag_val: flag_val) {
         flag flag_val;
     }
+}
+
+/// Allows overflowing operations to occur without a FuelVM panic.
+/// More suitable than `disable_panic_on_overflow` for use in functions that are not the entry point of a program.
+///
+/// > **_WARNING:_**
+/// >
+/// > Don't forget to call `set_flags` after performing the operations for which you disabled the default `panic-on-overflow` behavior in the first place!
+///
+/// ### Examples
+///
+/// ```sway
+/// use std::flags::{disable_panic_on_overflow_preserving, set_flags};
+///
+/// fn foo() {
+///     let prior_flags = disable_panic_on_overflow_preserving();
+///      
+///     let bar = u64::max() + 1;
+///
+///     set_flags(prior_flags);
+/// }
+/// ```
+pub fn disable_panic_on_overflow_preserving() -> u64 {
+    let prior_flags = flags();
+
+    // Mask second bit, which is `F_WRAPPING`.
+    let mask = 0b00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000010;
+
+    // Get the current value of the flags register and mask it, setting the
+    // masked bit. Flags are inverted, so set = off.
+    let flag_val = prior_flags | mask;
+    asm(flag_val: flag_val) {
+        flag flag_val;
+    }
+
+    prior_flags
+}
+
+/// Sets the flag register to the given value.
+///
+/// ### Arguments
+///
+/// * `flags` - Binary encoded 64 bit value representing the flags to set.
+///
+/// ### Examples
+///
+/// ```sway
+/// use std::flags::{disable_panic_on_overflow_preserving, set_flags};
+///
+/// fn foo() {
+///     let prior_flags = disable_panic_on_overflow_preserving();
+///      
+///     let bar = u64::max() + 1;
+///
+///     set_flags(prior_flags);
+/// }
+/// ```
+pub fn set_flags(flags: u64) {
+    asm(flags: flags) {
+        flag flags;
+    }
+}
+
+#[test]
+fn test_disable_panic_on_overflow() {
+    disable_panic_on_overflow();
+    let bar = u64::max() + 1;
+    enable_panic_on_overflow();
+}
+
+#[test]
+fn test_disable_panic_on_overflow_preserving() {
+    disable_panic_on_overflow();
+
+    let prior_flags = disable_panic_on_overflow_preserving();
+    let bar = u64::max() + 1;
+    set_flags(prior_flags);
+    
+    let bar = u64::max() + 1;
+
+    enable_panic_on_overflow();
 }

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -159,7 +159,7 @@ pub fn enable_panic_on_overflow() {
 ///     set_flags(prior_flags);
 /// }
 /// ```
-pub fn disable_panic_on_unsafe_math() {
+pub fn disable_panic_on_unsafe_math() -> u64 {
     let prior_flags = flags();
 
     // Get the current value of the flags register and mask it, setting the
@@ -205,14 +205,14 @@ pub fn enable_panic_on_unsafe_math() {
 
 #[test]
 fn test_disable_panic_on_overflow() {
-    disable_panic_on_overflow();
+    let _ = disable_panic_on_overflow();
     let _bar = u64::max() + 1;
     enable_panic_on_overflow();
 }
 
 #[test]
 fn test_disable_panic_on_overflow_preserving() {
-    disable_panic_on_overflow();
+    let _ = disable_panic_on_overflow();
 
     let prior_flags = disable_panic_on_overflow();
     let _bar = u64::max() + 1;
@@ -225,7 +225,7 @@ fn test_disable_panic_on_overflow_preserving() {
 
 #[test]
 fn test_disable_panic_on_unsafe_math() {
-    disable_panic_on_unsafe_math();
+    let _ = disable_panic_on_unsafe_math();
 
     let _bar = asm(r2: 1, r3: 0, r1) {
         div r1 r2 r3;
@@ -239,7 +239,7 @@ fn test_disable_panic_on_unsafe_math() {
 
 #[test]
 fn test_disable_panic_on_unsafe_math_preserving() {
-    disable_panic_on_unsafe_math();
+    let _ = disable_panic_on_unsafe_math();
 
     let prior_flags = disable_panic_on_unsafe_math();
     let _bar = asm(r2: 1, r3: 0, r1) {

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -1,7 +1,7 @@
 //! Functionality for setting and unsetting FuelVM flags to modify behavior related to the `$err` and `$of` registers.
 library;
 
-use ::{assert::assert, registers::{flags, error}};
+use ::{assert::assert, logging::log, registers::{flags, error}};
 
 /// Sets the flag register to the given value.
 ///
@@ -253,6 +253,12 @@ fn test_disable_panic_on_unsafe_math() {
     disable_panic_on_unsafe_math();
 
     let _bar = 1 / 0;
+    
+    let log_var = asm(t_val: true) {
+        t_val: u64;
+    }
+    log(log_var);
+    
     assert(error() == 1);
 
     enable_panic_on_unsafe_math();
@@ -264,7 +270,7 @@ fn test_disable_panic_on_unsafe_math_preserving() {
 
     let prior_flags = disable_panic_on_unsafe_math_preserving();
     let _bar = 1 / 0;
-    ::logging::log(error());
+    log(error());
     assert(error() == 1);
     set_flags(prior_flags);
 

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -1,7 +1,32 @@
 //! Functionality for setting and unsetting FuelVM flags to modify behavior related to the `$err` and `$of` registers.
 library;
 
-use ::registers::flags;
+use ::{assert::assert, registers::{flags, error}};
+
+/// Sets the flag register to the given value.
+///
+/// ### Arguments
+///
+/// * `flags` - Binary encoded 64 bit value representing the flags to set.
+///
+/// ### Examples
+///
+/// ```sway
+/// use std::flags::{disable_panic_on_overflow_preserving, set_flags};
+///
+/// fn foo() {
+///     let prior_flags = disable_panic_on_overflow_preserving();
+///      
+///     let bar = u64::max() + 1;
+///
+///     set_flags(prior_flags);
+/// }
+/// ```
+pub fn set_flags(new_flags: u64) {
+    asm(new_flags: new_flags) {
+        flag new_flags;
+    }
+}
 
 /// Allows overflowing operations to occur without a FuelVM panic.
 ///
@@ -101,29 +126,106 @@ pub fn disable_panic_on_overflow_preserving() -> u64 {
     prior_flags
 }
 
-/// Sets the flag register to the given value.
+/// Allows unsafe math operations to occur without a FuelVM panic.
+/// Sets the `$err` register to `true` whenever unsafe math occurs.
 ///
-/// ### Arguments
-///
-/// * `flags` - Binary encoded 64 bit value representing the flags to set.
+/// > **_WARNING:_**
+/// >
+/// > Don't forget to call `enable_panic_on_unsafe_math` after performing the operations for which you disabled the default `panic-on-unsafe-math` behavior in the first place!
 ///
 /// ### Examples
 ///
 /// ```sway
-/// use std::flags::{disable_panic_on_overflow_preserving, set_flags};
+/// use std::{assert::assert, flags::{disable_panic_on_unsafe_math, enable_panic_on_unsafe_math}, registers::error};
+///
+/// fn main() {
+///     disable_panic_on_unsafe_math();
+///      
+///     let bar = 1 / 0; // Division by zero is considered unsafe math.
+///     assert(error() == true); // Error flag is set to true whenever unsafe math occurs.
+///
+///     enable_panic_on_unsafe_math();
+/// }
+/// ```
+pub fn disable_panic_on_unsafe_math() {
+    // Mask first bit, which is `F_UNSAFEMATH`.
+    let mask = 0b00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000001;
+
+    // Get the current value of the flags register and mask it, setting the
+    // masked bit. Flags are inverted, so set = off.
+    let flag_val = flags() | mask;
+    asm(flag_val: flag_val) {
+        flag flag_val;
+    }
+}
+
+/// Enables the default `panic-on-unsafe-math` behavior in the FuelVM.
+///
+/// > **_Note:_**
+/// >
+/// > `panic-on-unsafe-math` is the default, so there is no need to use this function unless you have previously called `disable_panic_on_unsafe_math`.
+///
+/// ### Examples
+///
+/// ```sway
+/// use std::{assert::assert, flags::{disable_panic_on_unsafe_math, enable_panic_on_unsafe_math}, registers::error};
+///
+/// fn main() {
+///     disable_panic_on_unsafe_math();
+///      
+///     let bar = 1 / 0; // Division by zero is considered unsafe math.
+///     assert(error() == true); // Error flag is set to true whenever unsafe math occurs.
+///
+///     enable_panic_on_unsafe_math();
+/// }
+/// ```
+pub fn enable_panic_on_unsafe_math() {
+    // Mask first bit, which is `F_UNSAFEMATH`.
+    let mask = 0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111110;
+
+    // Get the current value of the flags register and mask it, unsetting the
+    // masked bit. Flags are inverted, so unset = on.
+    let flag_val = flags() & mask;
+    asm(flag_val: flag_val) {
+        flag flag_val;
+    }
+}
+
+/// Allows unsafe math operations to occur without a FuelVM panic.
+/// More suitable than `disable_panic_on_unsafe_math` for use in functions that are not the entry point of a program.
+///
+/// > **_WARNING:_**
+/// >
+/// > Don't forget to call `set_flags` after performing the operations for which you disabled the default `panic-on-unsafe-math` behavior in the first place!
+///
+/// ### Examples
+///
+/// ```sway
+/// use std::{assert::assert, flags::{disable_panic_on_unsafe_math_preserving, set_flags}, registers::error};
 ///
 /// fn foo() {
-///     let prior_flags = disable_panic_on_overflow_preserving();
+///     let prior_flags = disable_panic_on_unsafe_math_preserving();
 ///      
-///     let bar = u64::max() + 1;
+///     let bar = 1 / 0; // Division by zero is considered unsafe math.
+///     assert(error() == true); // Error flag is set to true whenever unsafe math occurs.
 ///
 ///     set_flags(prior_flags);
 /// }
 /// ```
-pub fn set_flags(new_flags: u64) {
-    asm(new_flags: new_flags) {
-        flag new_flags;
+pub fn disable_panic_on_unsafe_math_preserving() -> u64 {
+    let prior_flags = flags();
+
+    // Mask first bit, which is `F_UNSAFEMATH`.
+    let mask = 0b00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000001;
+
+    // Get the current value of the flags register and mask it, setting the
+    // masked bit. Flags are inverted, so set = off.
+    let flag_val = prior_flags | mask;
+    asm(flag_val: flag_val) {
+        flag flag_val;
     }
+
+    prior_flags
 }
 
 #[test]
@@ -138,10 +240,35 @@ fn test_disable_panic_on_overflow_preserving() {
     disable_panic_on_overflow();
 
     let prior_flags = disable_panic_on_overflow_preserving();
-    let mut _bar = u64::max() + 1;
+    let _bar = u64::max() + 1;
     set_flags(prior_flags);
 
-    _bar = u64::max() + 1;
+    let _bar = u64::max() + 1;
 
     enable_panic_on_overflow();
+}
+
+#[test]
+fn test_disable_panic_on_unsafe_math() {
+    disable_panic_on_unsafe_math();
+
+    let _bar = 1 / 0;
+    assert(error() == true);
+
+    enable_panic_on_unsafe_math();
+}
+
+#[test]
+fn test_disable_panic_on_unsafe_math_preserving() {
+    disable_panic_on_unsafe_math();
+
+    let prior_flags = disable_panic_on_unsafe_math_preserving();
+    let _bar = 1 / 0;
+    assert(error() == true);
+    set_flags(prior_flags);
+
+    let _bar = 1 / 0;
+    assert(error() == true);
+
+    enable_panic_on_unsafe_math();
 }

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -270,7 +270,8 @@ fn test_disable_panic_on_unsafe_math_preserving() {
 
     let prior_flags = disable_panic_on_unsafe_math_preserving();
     let _bar = asm(r2: 1, r3: 0, r1) {
-        div r1 r2 r3
+        div r1 r2 r3;
+        r1: u64
     };
     log(error());
     assert(error() == 1);

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -255,8 +255,8 @@ fn test_disable_panic_on_unsafe_math() {
     let _bar = 1 / 0;
     
     let log_var = asm(t_val: true) {
-        t_val: u64;
-    }
+        t_val: u64
+    };
     log(log_var);
     
     assert(error() == 1);

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -267,6 +267,7 @@ fn test_disable_panic_on_unsafe_math() {
 #[test]
 fn test_disable_panic_on_unsafe_math_preserving() {
     disable_panic_on_unsafe_math();
+    log(error())
 
     let prior_flags = disable_panic_on_unsafe_math_preserving();
     let _bar = 1 / 0;

--- a/sway-lib-std/src/flags.sw
+++ b/sway-lib-std/src/flags.sw
@@ -120,9 +120,9 @@ pub fn disable_panic_on_overflow_preserving() -> u64 {
 ///     set_flags(prior_flags);
 /// }
 /// ```
-pub fn set_flags(flags: u64) {
-    asm(flags: flags) {
-        flag flags;
+pub fn set_flags(new_flags: u64) {
+    asm(new_flags: new_flags) {
+        flag new_flags;
     }
 }
 
@@ -140,7 +140,7 @@ fn test_disable_panic_on_overflow_preserving() {
     let prior_flags = disable_panic_on_overflow_preserving();
     let bar = u64::max() + 1;
     set_flags(prior_flags);
-    
+
     let bar = u64::max() + 1;
 
     enable_panic_on_overflow();

--- a/sway-lib-std/src/u128.sw
+++ b/sway-lib-std/src/u128.sw
@@ -3,7 +3,7 @@ library;
 
 use ::assert::assert;
 use ::convert::From;
-use ::flags::{disable_panic_on_overflow, enable_panic_on_overflow};
+use ::flags::{disable_panic_on_overflow_preserving, set_flags};
 use ::math::*;
 use ::result::Result::{self, *};
 
@@ -53,11 +53,13 @@ impl core::ops::Ord for U128 {
 // }
 impl u64 {
     pub fn overflowing_add(self, right: Self) -> U128 {
-        disable_panic_on_overflow();
+        let prior_flags = disable_panic_on_overflow_preserving();
+
         let mut result = U128 {
             upper: 0,
             lower: 0,
         };
+
         asm(sum, overflow, left: self, right: right, result_ptr: result) {
             // Add left and right.
             add sum left right;
@@ -69,16 +71,20 @@ impl u64 {
             // Store the sum into the second word of result.
             sw result_ptr sum i1;
         };
-        enable_panic_on_overflow();
+        
+        set_flags(prior_flags);
+
         result
     }
 
     pub fn overflowing_mul(self, right: Self) -> U128 {
-        disable_panic_on_overflow();
+        let prior_flags = disable_panic_on_overflow_preserving();
+
         let mut result = U128 {
             upper: 0,
             lower: 0,
         };
+        
         asm(product, overflow, left: self, right: right, result_ptr: result) {
             // Multiply left and right.
             mul product left right;
@@ -90,7 +96,9 @@ impl u64 {
             // Store the product into the second word of result.
             sw result_ptr product i1;
         };
-        enable_panic_on_overflow();
+        
+        set_flags(prior_flags);
+
         result
     }
 }

--- a/sway-lib-std/src/u128.sw
+++ b/sway-lib-std/src/u128.sw
@@ -3,7 +3,7 @@ library;
 
 use ::assert::assert;
 use ::convert::From;
-use ::flags::{disable_panic_on_overflow_preserving, set_flags};
+use ::flags::{disable_panic_on_overflow, set_flags};
 use ::math::*;
 use ::result::Result::{self, *};
 
@@ -53,7 +53,7 @@ impl core::ops::Ord for U128 {
 // }
 impl u64 {
     pub fn overflowing_add(self, right: Self) -> U128 {
-        let prior_flags = disable_panic_on_overflow_preserving();
+        let prior_flags = disable_panic_on_overflow();
 
         let mut result = U128 {
             upper: 0,
@@ -78,7 +78,7 @@ impl u64 {
     }
 
     pub fn overflowing_mul(self, right: Self) -> U128 {
-        let prior_flags = disable_panic_on_overflow_preserving();
+        let prior_flags = disable_panic_on_overflow();
 
         let mut result = U128 {
             upper: 0,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -2,7 +2,7 @@ script;
 use basic_storage_abi::{BasicStorage, Quad};
 
 fn main() -> u64 {
-    let addr = abi(BasicStorage, 0x114a1d41516bbdd263bded801621ada8c825f34e86ad75bfde29bd1172e52bb4);
+    let addr = abi(BasicStorage, 0xb6d07fb970699bc520a53e0534c3d3bdfadfa67e171d2e830d36f65cea014350);
     let key = 0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -2,7 +2,7 @@ script;
 use basic_storage_abi::{BasicStorage, Quad};
 
 fn main() -> u64 {
-    let addr = abi(BasicStorage, 0x5fb94a3be74746afab028d56f22d5b6057e49629182312ca26e5de23798c6b7f);
+    let addr = abi(BasicStorage, 0x114a1d41516bbdd263bded801621ada8c825f34e86ad75bfde29bd1172e52bb4);
     let key = 0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -2,7 +2,7 @@ script;
 use basic_storage_abi::{BasicStorage, Quad};
 
 fn main() -> u64 {
-    let addr = abi(BasicStorage, 0x6a550eadf838642881db8c66f40c1fc8442ee625212f3f2943850b2c12d12275);
+    let addr = abi(BasicStorage, 0x5fb94a3be74746afab028d56f22d5b6057e49629182312ca26e5de23798c6b7f);
     let key = 0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -2,7 +2,7 @@ script;
 use basic_storage_abi::{BasicStorage, Quad};
 
 fn main() -> u64 {
-    let addr = abi(BasicStorage, 0xb6d07fb970699bc520a53e0534c3d3bdfadfa67e171d2e830d36f65cea014350);
+    let addr = abi(BasicStorage, 0x114a1d41516bbdd263bded801621ada8c825f34e86ad75bfde29bd1172e52bb4);
     let key = 0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
@@ -3,7 +3,7 @@ script;
 use increment_abi::Incrementor;
 
 fn main() -> bool {
-    let the_abi = abi(Incrementor, 0xe1439dbffde3e8680420e453ce7f8e74c390708c367dbd702c7e5b50a303fa0f);
+    let the_abi = abi(Incrementor, 0xb6d07fb970699bc520a53e0534c3d3bdfadfa67e171d2e830d36f65cea014350);
     the_abi.increment(5);
     the_abi.increment(5);
     let result = the_abi.get();


### PR DESCRIPTION
## Description
- Changes `disable_panic_on_overflow()` function to return the flags set prior to calling the function
- Adds a `set_flags` function that simply sets the given value to the flag register
- Changed u64 `overflowing_add` and `overflowing_mul` to use the new functions
- Adds equivalent functions for unsafe-math flag aswell
- Additional documentation for all functions in the library

closes #4355 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
