### PR TITLE
Give more helpful error when shadowing constants

### DIFF
--- a/docs/book/src/basics/constants.md
+++ b/docs/book/src/basics/constants.md
@@ -4,7 +4,7 @@
 <!-- constants:example:start -->
 Constants are similar to variables; however, there are a few differences:
 
-- Constants are always evaluated at compile-time
+- Constants are always evaluated at compile-time.
 - Constants can be declared both inside of a [function](../index.md) and at global / `impl` scope.
 - The `mut` keyword cannot be used with constants.
 <!-- constants:example:end -->
@@ -77,7 +77,7 @@ fn main() -> u32 {
 }
 ```
 
-### `impl self` consts
+### `impl self` Constants
 
 Constants can also be declared inside non-trait `impl` blocks.
 

--- a/docs/reference/src/documentation/language/variables/const.md
+++ b/docs/reference/src/documentation/language/variables/const.md
@@ -2,7 +2,7 @@
 
 Constants are similar to [immutable let](./let.md#immutable) variables; however, there are a few differences:
 
-- Constants are always evaluated at compile-time
+- Constants are always evaluated at compile-time.
 - Constants can be declared both inside of a [function](../functions/index.md) and at global/`impl` scope.
 - The `mut` keyword cannot be used with constants.
 
@@ -16,9 +16,9 @@ To define a constant the `const` keyword is used followed by a name and an assig
 
 The example above hardcodes the value of `5` however function calls may also be used alongside [built-in types](../built-ins/index.md).
 
-## `impl` consts
+## `impl self` Constants
 
-Constants can also be declared inside `impl` blocks. In this case, the constant is referred to as an associated const.
+Constants can also be declared inside `impl` blocks. In this case, the constant is referred to as an associated constant.
 
 ```sway
 struct Point {

--- a/docs/reference/src/documentation/language/variables/variable-shadowing.md
+++ b/docs/reference/src/documentation/language/variables/variable-shadowing.md
@@ -1,6 +1,6 @@
 # Shadowing
 
-When looking at the [let](let.md) variable we've seen that the value can be changed through the use of the `mut` keyword. We can take this a couple steps further through [reassignment](#reassignment) and [variable shadowing](#variable-shadowing).
+When looking at the [let](let.md) variable we've seen that the value can be changed through the use of the `mut` keyword. We can take this a couple steps further through [reassignment](#reassignment) and [variable shadowing](#variable-shadowing). Note that shadowing applies only to variables. [Constants](const.md) cannot be shadowed.
 
 ## Reassignment
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -94,7 +94,7 @@ impl ty::TyAbiDecl {
 
                     let const_name = const_decl.call_path.suffix.clone();
                     check!(
-                        ctx.namespace.insert_symbol(
+                        ctx.insert_symbol(
                             const_name.clone(),
                             ty::TyDecl::ConstantDecl(ty::ConstantDecl {
                                 name: const_name.clone(),
@@ -185,13 +185,14 @@ impl ty::TyAbiDecl {
                     let const_decl = decl_engine.get_constant(decl_ref);
                     let const_name = const_decl.call_path.suffix.clone();
                     all_items.push(TyImplItem::Constant(decl_ref.clone()));
+                    let const_shadowing_mode = ctx.const_shadowing_mode();
                     ctx.namespace.insert_symbol(
                         const_name.clone(),
                         ty::TyDecl::ConstantDecl(ty::ConstantDecl {
                             name: const_name,
                             decl_id: *decl_ref.id(),
                             decl_span: const_decl.span.clone(),
-                        }),
+                        }), const_shadowing_mode
                     );
                 }
             }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -10,7 +10,7 @@ use crate::{
         parsed::*,
         ty::{self, TyImplItem, TyTraitItem},
     },
-    semantic_analysis::{declaration::insert_supertraits_into_namespace, Mode, TypeCheckContext},
+    semantic_analysis::{declaration::insert_supertraits_into_namespace, AbiMode, TypeCheckContext},
     CompileResult, ReplaceSelfType, TypeId, TypeInfo,
 };
 
@@ -42,7 +42,7 @@ impl ty::TyAbiDecl {
         let self_type = type_engine.insert(ctx.engines(), TypeInfo::SelfType);
         let mut ctx = ctx
             .scoped(&mut abi_namespace)
-            .with_mode(Mode::ImplAbiFn)
+            .with_abi_mode(AbiMode::ImplAbiFn)
             .with_self_type(self_type);
 
         // Recursively make the interface surfaces and methods of the
@@ -177,7 +177,7 @@ impl ty::TyAbiDecl {
                     all_items.push(TyImplItem::Fn(
                         ctx.engines
                             .de()
-                            .insert(method.to_dummy_func(Mode::ImplAbiFn))
+                            .insert(method.to_dummy_func(AbiMode::ImplAbiFn))
                             .with_parent(ctx.engines.de(), (*decl_ref.id()).into()),
                     ));
                 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -69,7 +69,7 @@ impl ty::TyDecl {
                     type_ascription,
                 }));
                 check!(
-                    ctx.namespace.insert_symbol(name, typed_var_decl.clone()),
+                    ctx.insert_symbol(name, typed_var_decl.clone()),
                     return err(warnings, errors),
                     warnings,
                     errors
@@ -86,8 +86,7 @@ impl ty::TyDecl {
                 );
                 let typed_const_decl: ty::TyDecl = decl_engine.insert(const_decl.clone()).into();
                 check!(
-                    ctx.namespace
-                        .insert_symbol(const_decl.name().clone(), typed_const_decl.clone()),
+                    ctx.insert_symbol(const_decl.name().clone(), typed_const_decl.clone()),
                     return err(warnings, errors),
                     warnings,
                     errors
@@ -105,7 +104,7 @@ impl ty::TyDecl {
                 let call_path = enum_decl.call_path.clone();
                 let decl: ty::TyDecl = decl_engine.insert(enum_decl).into();
                 check!(
-                    ctx.namespace.insert_symbol(call_path.suffix, decl.clone()),
+                    ctx.insert_symbol(call_path.suffix, decl.clone()),
                     return err(warnings, errors),
                     warnings,
                     errors
@@ -124,7 +123,7 @@ impl ty::TyDecl {
                 );
                 let name = fn_decl.name.clone();
                 let decl: ty::TyDecl = decl_engine.insert(fn_decl).into();
-                ctx.namespace.insert_symbol(name, decl.clone());
+                ctx.insert_symbol(name, decl.clone());
                 decl
             }
             parsed::Declaration::TraitDeclaration(trait_decl) => {
@@ -166,7 +165,7 @@ impl ty::TyDecl {
                     .iter_mut()
                     .for_each(|item| item.replace_implementing_type(engines, decl.clone()));
                 check!(
-                    ctx.namespace.insert_symbol(name, decl.clone()),
+                    ctx.insert_symbol(name, decl.clone()),
                     return err(warnings, errors),
                     warnings,
                     errors
@@ -249,7 +248,7 @@ impl ty::TyDecl {
                 let decl: ty::TyDecl = decl_engine.insert(decl).into();
                 // insert the struct decl into namespace
                 check!(
-                    ctx.namespace.insert_symbol(call_path.suffix, decl.clone()),
+                    ctx.insert_symbol(call_path.suffix, decl.clone()),
                     return err(warnings, errors),
                     warnings,
                     errors
@@ -294,7 +293,7 @@ impl ty::TyDecl {
                     .iter_mut()
                     .for_each(|item| item.replace_implementing_type(engines, decl.clone()));
                 check!(
-                    ctx.namespace.insert_symbol(name, decl.clone()),
+                    ctx.insert_symbol(name, decl.clone()),
                     return err(warnings, errors),
                     warnings,
                     errors
@@ -390,7 +389,7 @@ impl ty::TyDecl {
 
                 // insert the type alias name and decl into namespace
                 check!(
-                    ctx.namespace.insert_symbol(name, decl.clone()),
+                    ctx.insert_symbol(name, decl.clone()),
                     return err(warnings, errors),
                     warnings,
                     errors

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -63,6 +63,7 @@ impl ty::TyFunctionDecl {
             .by_ref()
             .scoped(&mut fn_namespace)
             .with_purity(purity)
+            .with_const_shadowing_mode(ConstShadowingMode::Sequential)
             .disallow_functions();
 
         // Type check the type parameters. This will also insert them into the

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -144,7 +144,7 @@ impl ty::TyFunctionDecl {
                 (Visibility::Public, false)
             }
         } else {
-            (visibility, ctx.mode() == Mode::ImplAbiFn)
+            (visibility, ctx.abi_mode() == AbiMode::ImplAbiFn)
         };
 
         check!(

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
@@ -114,6 +114,7 @@ impl ty::TyFunctionParameter {
 }
 
 fn insert_into_namespace(ctx: TypeCheckContext, typed_parameter: &ty::TyFunctionParameter) {
+    let const_shadowing_mode = ctx.const_shadowing_mode();
     ctx.namespace.insert_symbol(
         typed_parameter.name.clone(),
         ty::TyDecl::VariableDecl(Box::new(ty::TyVariableDecl {
@@ -129,6 +130,6 @@ fn insert_into_namespace(ctx: TypeCheckContext, typed_parameter: &ty::TyFunction
             ),
             return_type: typed_parameter.type_argument.type_id,
             type_ascription: typed_parameter.type_argument.clone(),
-        })),
+        })), const_shadowing_mode
     );
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -12,7 +12,7 @@ use crate::{
         ty::{self, TyImplItem, TyTraitInterfaceItem, TyTraitItem},
         *,
     },
-    semantic_analysis::{Mode, TypeCheckContext},
+    semantic_analysis::{Mode, ConstShadowingMode, TypeCheckContext},
     type_system::*,
 };
 
@@ -39,7 +39,7 @@ impl ty::TyImplTrait {
 
         // create a namespace for the impl
         let mut impl_namespace = ctx.namespace.clone();
-        let mut ctx = ctx.by_ref().scoped(&mut impl_namespace).allow_functions();
+        let mut ctx = ctx.by_ref().scoped(&mut impl_namespace).with_const_shadowing_mode(ConstShadowingMode::ItemStyle).allow_functions();
 
         // Type check the type parameters. This will also insert them into the
         // current namespace.
@@ -249,7 +249,7 @@ impl ty::TyImplTrait {
 
         // create the namespace for the impl
         let mut impl_namespace = ctx.namespace.clone();
-        let mut ctx = ctx.scoped(&mut impl_namespace).allow_functions();
+        let mut ctx = ctx.scoped(&mut impl_namespace).with_const_shadowing_mode(ConstShadowingMode::ItemStyle).allow_functions();
 
         // create the trait name
         let trait_name = CallPath {
@@ -324,8 +324,7 @@ impl ty::TyImplTrait {
             _ => None,
         };
         if let Some(self_decl) = self_decl {
-            ctx.namespace
-                .insert_symbol(Ident::new_no_span("Self".to_string()), self_decl);
+            ctx.insert_symbol(Ident::new_no_span("Self".to_string()), self_decl);
         }
 
         // type check the items inside of the impl block
@@ -353,7 +352,7 @@ impl ty::TyImplTrait {
                     new_items.push(TyImplItem::Constant(decl_ref.clone()));
 
                     check!(
-                        ctx.namespace.insert_symbol(
+                        ctx.insert_symbol(
                             decl_ref.name().clone(),
                             ty::TyDecl::ConstantDecl(ty::ConstantDecl {
                                 name: decl_ref.name().clone(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -12,7 +12,7 @@ use crate::{
         ty::{self, TyImplItem, TyTraitInterfaceItem, TyTraitItem},
         *,
     },
-    semantic_analysis::{Mode, ConstShadowingMode, TypeCheckContext},
+    semantic_analysis::{AbiMode, ConstShadowingMode, TypeCheckContext},
     type_system::*,
 };
 
@@ -180,7 +180,7 @@ impl ty::TyImplTrait {
                     });
                 }
 
-                let mut ctx = ctx.with_mode(Mode::ImplAbiFn);
+                let mut ctx = ctx.with_abi_mode(AbiMode::ImplAbiFn);
 
                 // Insert the interface surface and methods from this trait into
                 // the namespace.

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -108,7 +108,7 @@ impl ty::TyTraitDecl {
 
                     let const_name = const_decl.call_path.suffix.clone();
                     check!(
-                        ctx.namespace.insert_symbol(
+                        ctx.insert_symbol(
                             const_name.clone(),
                             ty::TyDecl::ConstantDecl(ty::ConstantDecl {
                                 name: const_name.clone(),
@@ -367,13 +367,14 @@ impl ty::TyTraitDecl {
                     let const_decl = decl_engine.get_constant(decl_ref);
                     let const_name = const_decl.call_path.suffix.clone();
                     all_items.push(TyImplItem::Constant(decl_ref.clone()));
+                    let const_shadowing_mode = ctx.const_shadowing_mode();
                     ctx.namespace.insert_symbol(
                         const_name.clone(),
                         ty::TyDecl::ConstantDecl(ty::ConstantDecl {
                             name: const_name,
                             decl_id: *decl_ref.id(),
                             decl_span: const_decl.span.clone(),
-                        }),
+                        }), const_shadowing_mode
                     );
                 }
             }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -14,7 +14,7 @@ use crate::{
         ty::{self, TyImplItem, TyTraitItem},
         CallPath,
     },
-    semantic_analysis::{declaration::insert_supertraits_into_namespace, Mode, TypeCheckContext},
+    semantic_analysis::{declaration::insert_supertraits_into_namespace, AbiMode, TypeCheckContext},
     type_system::*,
 };
 
@@ -89,7 +89,7 @@ impl ty::TyTraitDecl {
                     let decl_ref = decl_engine.insert(method.clone());
                     dummy_interface_surface.push(ty::TyImplItem::Fn(
                         decl_engine
-                            .insert(method.to_dummy_func(Mode::NonAbi))
+                            .insert(method.to_dummy_func(AbiMode::NonAbi))
                             .with_parent(decl_engine, (*decl_ref.id()).into()),
                     ));
                     new_interface_surface.push(ty::TyTraitInterfaceItem::TraitFn(decl_ref));
@@ -359,7 +359,7 @@ impl ty::TyTraitDecl {
                     all_items.push(TyImplItem::Fn(
                         ctx.engines
                             .de()
-                            .insert(method.to_dummy_func(Mode::NonAbi))
+                            .insert(method.to_dummy_func(AbiMode::NonAbi))
                             .with_parent(ctx.engines.de(), (*decl_ref.id()).into()),
                     ));
                 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
@@ -3,7 +3,7 @@ use sway_types::Spanned;
 use crate::{
     error::*,
     language::{parsed, ty, Visibility},
-    semantic_analysis::{Mode, TypeCheckContext},
+    semantic_analysis::{AbiMode, TypeCheckContext},
     type_system::*,
 };
 
@@ -72,7 +72,7 @@ impl ty::TyTraitFn {
     /// This function is used in trait declarations to insert "placeholder"
     /// functions in the methods. This allows the methods to use functions
     /// declared in the interface surface.
-    pub(crate) fn to_dummy_func(&self, mode: Mode) -> ty::TyFunctionDecl {
+    pub(crate) fn to_dummy_func(&self, abi_mode: AbiMode) -> ty::TyFunctionDecl {
         ty::TyFunctionDecl {
             purity: self.purity,
             name: self.name.clone(),
@@ -84,7 +84,7 @@ impl ty::TyTraitFn {
             return_type: self.return_type.clone(),
             visibility: Visibility::Public,
             type_parameters: vec![],
-            is_contract_call: mode == Mode::ImplAbiFn,
+            is_contract_call: abi_mode == AbiMode::ImplAbiFn,
             where_clause: vec![],
         }
     }

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
@@ -63,7 +63,7 @@ impl ty::TyMatchBranch {
                 return_type,
                 type_ascription,
             }));
-            ctx.namespace.insert_symbol(left_decl, var_decl.clone());
+            ctx.insert_symbol(left_decl, var_decl.clone());
             code_block_contents.push(ty::TyAstNode {
                 content: ty::TyAstNodeContent::Declaration(var_decl),
                 span,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1538,7 +1538,7 @@ impl ty::TyExpression {
                     let method = decl_engine.get_trait_fn(&decl_ref);
                     abi_items.push(TyImplItem::Fn(
                         decl_engine
-                            .insert(method.to_dummy_func(Mode::ImplAbiFn))
+                            .insert(method.to_dummy_func(AbiMode::ImplAbiFn))
                             .with_parent(decl_engine, (*decl_ref.id()).into()),
                     ));
                 }

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -1,10 +1,10 @@
 pub mod code_block;
 pub mod declaration;
 pub mod expression;
-pub mod mode;
+pub mod modes;
 
 pub(crate) use expression::*;
-pub(crate) use mode::*;
+pub(crate) use modes::*;
 
 use crate::{
     error::*,

--- a/sway-core/src/semantic_analysis/ast_node/mode.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mode.rs
@@ -4,3 +4,10 @@ pub enum Mode {
     #[default]
     NonAbi,
 }
+
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub enum ConstShadowingMode {
+    Sequential,
+    #[default]
+    ItemStyle,
+}

--- a/sway-core/src/semantic_analysis/ast_node/modes.rs
+++ b/sway-core/src/semantic_analysis/ast_node/modes.rs
@@ -1,5 +1,5 @@
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
-pub enum Mode {
+pub enum AbiMode {
     ImplAbiFn,
     #[default]
     NonAbi,

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -108,7 +108,7 @@ impl Items {
                 // constant shadowing a variable
                 (VariableDecl { .. }, ConstantDecl {..}, _) => errors.push(CompileError::ConstantShadowsVariable { name: name.clone() }),
                 // constant shadowing a constant outside function body
-                (ConstantDecl { .. }, ConstantDecl { .. }, ConstShadowingMode::ItemStyle) => errors.push(CompileError::NameDefinedMultipleTimes { name: name.to_string(), span: name.span() }),
+                (ConstantDecl { .. }, ConstantDecl { .. }, ConstShadowingMode::ItemStyle) => errors.push(CompileError::MultipleDefinitionsOfName { name: name.clone(), span: name.span() }),
                 // constant shadowing a constant within function body
                 (ConstantDecl { .. }, ConstantDecl { .. }, ConstShadowingMode::Sequential) => errors.push(CompileError::ConstantShadowsConstant { name: name.clone() }),
                 // type or type alias shadowing another type or type alias
@@ -126,7 +126,7 @@ impl Items {
                     | TraitDecl { .. }
                     | AbiDecl { .. },
                     _
-                ) => errors.push(CompileError::NameDefinedMultipleTimes { name: name.to_string(), span: name.span() }),
+                ) => errors.push(CompileError::MultipleDefinitionsOfName { name: name.clone(), span: name.span() }),
                 // Generic parameter shadowing another generic parameter
                 (GenericTypeForFunctionScope { .. }, GenericTypeForFunctionScope { .. }, _) => {
                     errors.push(CompileError::GenericShadowsGeneric { name: name.clone() });

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -108,7 +108,7 @@ impl Items {
                 // constant shadowing a variable
                 (VariableDecl { .. }, ConstantDecl {..}, _) => errors.push(CompileError::ConstantShadowsVariable { name: name.clone() }),
                 // constant shadowing a constant outside function body
-                (ConstantDecl { .. }, ConstantDecl { .. }, ConstShadowingMode::ItemStyle) => errors.push(CompileError::MultipleDefinitionsOfName { name: name.clone(), span: name.span() }),
+                (ConstantDecl { .. }, ConstantDecl { .. }, ConstShadowingMode::ItemStyle) => errors.push(CompileError::MultipleDefinitionsOfConstant { name: name.clone(), span: name.span() }),
                 // constant shadowing a constant within function body
                 (ConstantDecl { .. }, ConstantDecl { .. }, ConstShadowingMode::Sequential) => errors.push(CompileError::ConstantShadowsConstant { name: name.clone() }),
                 // type or type alias shadowing another type or type alias

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -103,13 +103,11 @@ impl Items {
                 use ty::TyDecl::*;
                 match (decl, &item) {
                 // variable shadowing a constant
-                // constant shadowing a constant
-                (
-                    ConstantDecl { .. },
-                    VariableDecl { .. } | ConstantDecl { .. },
-                )
+                (ConstantDecl {..}, VariableDecl { .. }) => errors.push(CompileError::VariableShadowsConstant { name: name.clone() }),
                 // constant shadowing a variable
-                | (VariableDecl { .. }, ConstantDecl { .. })
+                (VariableDecl { .. }, ConstantDecl {..}) => errors.push(CompileError::ConstantShadowsVariable { name: name.clone() }),
+                // constant shadowing a constant
+                (ConstantDecl { .. }, ConstantDecl { .. })
                 // type or type alias shadowing another type or type alias
                 // trait/abi shadowing another trait/abi
                 // type or type alias shadowing a trait/abi, or vice versa

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -1,8 +1,8 @@
 use crate::{
     engine_threading::*,
-    language::{parsed::TreeType, Purity, Visibility},
+    language::{parsed::TreeType, ty::TyDecl, Purity, Visibility},
     namespace::Path,
-    semantic_analysis::{ast_node::Mode, Namespace},
+    semantic_analysis::{ast_node::{Mode, ConstShadowingMode}, Namespace},
     type_system::{
         EnforceTypeArguments, MonomorphizeHelper, SubstTypes, TypeArgument, TypeId, TypeInfo,
     },
@@ -42,6 +42,10 @@ pub struct TypeCheckContext<'a> {
     /// This is `ImplAbiFn` while checking `abi` implementations whether at their original impl
     /// declaration or within an abi cast expression.
     mode: Mode,
+    /// Whether or not a const declaration shadows previous const declarations sequentially.
+    ///
+    /// This is `Sequential` while checking const declarations in functions, otherwise `ItemStyle`.
+    const_shadowing_mode: ConstShadowingMode,
     /// Provides "help text" to `TypeError`s during unification.
     // TODO: We probably shouldn't carry this through the `Context`, but instead pass it directly
     // to `unify` as necessary?
@@ -81,6 +85,7 @@ impl<'a> TypeCheckContext<'a> {
             // TODO: Contract? Should this be passed in based on program kind (aka TreeType)?
             self_type: engines.te().insert(engines, TypeInfo::Contract),
             mode: Mode::NonAbi,
+            const_shadowing_mode: ConstShadowingMode::ItemStyle,
             purity: Purity::default(),
             kind: TreeType::Contract,
             disallow_functions: false,
@@ -101,6 +106,7 @@ impl<'a> TypeCheckContext<'a> {
             type_annotation: self.type_annotation,
             self_type: self.self_type,
             mode: self.mode,
+            const_shadowing_mode: self.const_shadowing_mode,
             help_text: self.help_text,
             purity: self.purity,
             kind: self.kind.clone(),
@@ -116,6 +122,7 @@ impl<'a> TypeCheckContext<'a> {
             type_annotation: self.type_annotation,
             self_type: self.self_type,
             mode: self.mode,
+            const_shadowing_mode: self.const_shadowing_mode,
             help_text: self.help_text,
             purity: self.purity,
             kind: self.kind,
@@ -160,6 +167,11 @@ impl<'a> TypeCheckContext<'a> {
     /// Map this `TypeCheckContext` instance to a new one with the given ABI `mode`.
     pub(crate) fn with_mode(self, mode: Mode) -> Self {
         Self { mode, ..self }
+    }
+
+    /// Map this `TypeCheckContext` instance to a new one with the given const shadowing `mode`.
+    pub(crate) fn with_const_shadowing_mode(self, const_shadowing_mode: ConstShadowingMode) -> Self {
+        Self { const_shadowing_mode, ..self }
     }
 
     /// Map this `TypeCheckContext` instance to a new one with the given purity.
@@ -208,6 +220,10 @@ impl<'a> TypeCheckContext<'a> {
 
     pub(crate) fn mode(&self) -> Mode {
         self.mode
+    }
+
+    pub(crate) fn const_shadowing_mode(&self) -> ConstShadowingMode {
+        self.const_shadowing_mode
     }
 
     pub(crate) fn purity(&self) -> Purity {
@@ -298,6 +314,12 @@ impl<'a> TypeCheckContext<'a> {
             self.help_text(),
             None,
         )
+    }
+
+    /// Short-hand for calling [Namespace::insert_symbol] with the `const_shadowing_mode` provided by
+    /// the `TypeCheckContext`.
+    pub(crate) fn insert_symbol(&mut self, name: Ident, item: TyDecl) -> CompileResult<()> {
+        self.namespace.insert_symbol(name, item, self.const_shadowing_mode)
     }
 
     /// Get the engines needed for engine threading.

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -2,7 +2,7 @@ use crate::{
     engine_threading::*,
     language::{parsed::TreeType, ty::TyDecl, Purity, Visibility},
     namespace::Path,
-    semantic_analysis::{ast_node::{Mode, ConstShadowingMode}, Namespace},
+    semantic_analysis::{ast_node::{AbiMode, ConstShadowingMode}, Namespace},
     type_system::{
         EnforceTypeArguments, MonomorphizeHelper, SubstTypes, TypeArgument, TypeId, TypeInfo,
     },
@@ -41,7 +41,7 @@ pub struct TypeCheckContext<'a> {
     ///
     /// This is `ImplAbiFn` while checking `abi` implementations whether at their original impl
     /// declaration or within an abi cast expression.
-    mode: Mode,
+    abi_mode: AbiMode,
     /// Whether or not a const declaration shadows previous const declarations sequentially.
     ///
     /// This is `Sequential` while checking const declarations in functions, otherwise `ItemStyle`.
@@ -84,7 +84,7 @@ impl<'a> TypeCheckContext<'a> {
             help_text: "",
             // TODO: Contract? Should this be passed in based on program kind (aka TreeType)?
             self_type: engines.te().insert(engines, TypeInfo::Contract),
-            mode: Mode::NonAbi,
+            abi_mode: AbiMode::NonAbi,
             const_shadowing_mode: ConstShadowingMode::ItemStyle,
             purity: Purity::default(),
             kind: TreeType::Contract,
@@ -105,7 +105,7 @@ impl<'a> TypeCheckContext<'a> {
             namespace: self.namespace,
             type_annotation: self.type_annotation,
             self_type: self.self_type,
-            mode: self.mode,
+            abi_mode: self.abi_mode,
             const_shadowing_mode: self.const_shadowing_mode,
             help_text: self.help_text,
             purity: self.purity,
@@ -121,7 +121,7 @@ impl<'a> TypeCheckContext<'a> {
             namespace,
             type_annotation: self.type_annotation,
             self_type: self.self_type,
-            mode: self.mode,
+            abi_mode: self.abi_mode,
             const_shadowing_mode: self.const_shadowing_mode,
             help_text: self.help_text,
             purity: self.purity,
@@ -165,8 +165,8 @@ impl<'a> TypeCheckContext<'a> {
     }
 
     /// Map this `TypeCheckContext` instance to a new one with the given ABI `mode`.
-    pub(crate) fn with_mode(self, mode: Mode) -> Self {
-        Self { mode, ..self }
+    pub(crate) fn with_abi_mode(self, abi_mode: AbiMode) -> Self {
+        Self { abi_mode, ..self }
     }
 
     /// Map this `TypeCheckContext` instance to a new one with the given const shadowing `mode`.
@@ -218,8 +218,8 @@ impl<'a> TypeCheckContext<'a> {
         self.type_annotation
     }
 
-    pub(crate) fn mode(&self) -> Mode {
-        self.mode
+    pub(crate) fn abi_mode(&self) -> AbiMode {
+        self.abi_mode
     }
 
     pub(crate) fn const_shadowing_mode(&self) -> ConstShadowingMode {

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -240,8 +240,7 @@ impl TypeParameter {
                     name: name_ident.clone(),
                     type_id,
                 });
-            ctx.namespace
-                .insert_symbol(name_ident.clone(), type_parameter_decl)
+            ctx.insert_symbol(name_ident.clone(), type_parameter_decl)
                 .ok(&mut warnings, &mut errors);
         }
 

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -457,6 +457,8 @@ pub enum CompileError {
     VariableShadowsConstant { name: Ident },
     #[error("Constants cannot shadow variables. The constant \"{name}\" shadows variable with the same name.")]
     ConstantShadowsVariable { name: Ident },
+    #[error("Constants cannot shadow constants. The constant \"{name}\" shadows constant with the same name.")]
+    ConstantShadowsConstant { name: Ident },
     #[error("The name \"{name}\" shadows another symbol with the same name.")]
     ShadowsOtherSymbol { name: Ident },
     #[error("The name \"{name}\" is already used for a generic parameter in this scope.")]
@@ -766,6 +768,7 @@ impl Spanned for CompileError {
             ArrayOutOfBounds { span, .. } => span.clone(),
             VariableShadowsConstant { name } => name.span(),
             ConstantShadowsVariable { name } => name.span(),
+            ConstantShadowsConstant { name } => name.span(),
             ShadowsOtherSymbol { name } => name.span(),
             GenericShadowsGeneric { name } => name.span(),
             MatchExpressionNonExhaustive { span, .. } => span.clone(),

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -643,8 +643,6 @@ pub enum CompileError {
     },
     #[error("Configurable constants are not allowed in libraries.")]
     ConfigurableInLibrary { span: Span },
-    #[error("The name `{name}` is defined multiple times")]
-    NameDefinedMultipleTimes { name: String, span: Span },
     #[error("Multiple applicable items in scope. {}", {
         let mut candidates = "".to_string();
         for (index, as_trait) in as_traits.iter().enumerate() {
@@ -830,7 +828,6 @@ impl Spanned for CompileError {
             CoinsPassedToNonPayableMethod { span, .. } => span.clone(),
             TraitImplPayabilityMismatch { span, .. } => span.clone(),
             ConfigurableInLibrary { span } => span.clone(),
-            NameDefinedMultipleTimes { span, .. } => span.clone(),
             MultipleApplicableItemsInScope { span, .. } => span.clone(),
             CannotBeEvaluatedToConst { span } => span.clone(),
         }

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -459,7 +459,7 @@ pub enum CompileError {
     ConstantShadowsVariable { name: Ident },
     #[error("Constants cannot shadow constants. The constant \"{name}\" shadows constant with the same name.")]
     ConstantShadowsConstant { name: Ident },
-    #[error("The name \"{name}\" shadows another symbol with the same name.")]
+    #[error("The imported symbol \"{name}\" shadows another symbol with the same name.")]
     ShadowsOtherSymbol { name: Ident },
     #[error("The name \"{name}\" is already used for a generic parameter in this scope.")]
     GenericShadowsGeneric { name: Ident },

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -453,6 +453,10 @@ pub enum CompileError {
         count: usize,
         span: Span,
     },
+    #[error("Variables cannot shadow constants. The variable \"{name}\" shadows constant with the same name.")]
+    VariableShadowsConstant { name: Ident },
+    #[error("Constants cannot shadow variables. The constant \"{name}\" shadows variable with the same name.")]
+    ConstantShadowsVariable { name: Ident },
     #[error("The name \"{name}\" shadows another symbol with the same name.")]
     ShadowsOtherSymbol { name: Ident },
     #[error("The name \"{name}\" is already used for a generic parameter in this scope.")]
@@ -760,6 +764,8 @@ impl Spanned for CompileError {
             ContractStorageFromExternalContext { span, .. } => span.clone(),
             InvalidOpcodeFromPredicate { span, .. } => span.clone(),
             ArrayOutOfBounds { span, .. } => span.clone(),
+            VariableShadowsConstant { name } => name.span(),
+            ConstantShadowsVariable { name } => name.span(),
             ShadowsOtherSymbol { name } => name.span(),
             GenericShadowsGeneric { name } => name.span(),
             MatchExpressionNonExhaustive { span, .. } => span.clone(),

--- a/test/src/e2e_vm_tests/test_programs/README.md
+++ b/test/src/e2e_vm_tests/test_programs/README.md
@@ -74,7 +74,7 @@ with an escape sequence and can cause the check to fail.
 To avoid this problem one may either not use the first word in the error message, or use the 'empty
 string' pattern `$()` to direct the matcher as to where the pattern starts.
 
-E.g, `# check: $()The name "S" shadows another symbol with the same name.`
+E.g, `# check: $()The imported symbol "S" shadows another symbol with the same name.`
 
 ## Examples
 

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadow_import/test.toml
@@ -1,4 +1,4 @@
 category = "fail"
 
-# check: $()The name "Foo" shadows another symbol with the same name.
-# check: $()The name "Bar2" shadows another symbol with the same name.
+# check: $()The imported symbol "Foo" shadows another symbol with the same name.
+# check: $()The imported symbol "Bar2" shadows another symbol with the same name.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/src/lib.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/src/lib.sw
@@ -1,3 +1,9 @@
 library;
 
 pub const X = 5;
+
+pub const L = 5;
+
+pub const P = 5;
+
+pub const R = 5;

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/src/lib.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/src/lib.sw
@@ -1,9 +1,15 @@
 library;
 
-pub const X = 5;
+pub const L_A = 5;
 
-pub const L = 5;
+pub const L_X = 5;
 
-pub const P = 5;
+pub const L_Y = 5;
 
-pub const R = 5;
+pub const L_Z = 5;
+
+pub const L_K = 5;
+
+pub const L_M = 5;
+
+pub const L_N = 5;

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/src/main.sw
@@ -9,9 +9,17 @@ const X = 6;
 // const shadowing a local const
 const Y = 7;
 const Y = 8;
+
+const C = 1;
+
+use lib::L;
+
 fn main() {
     // variable shadowing an imported const
     let X = 9;
+    {
+        let X = 3; // no error message here
+    }
 
     // variable shadowing a const
     const Z = 3;
@@ -21,7 +29,35 @@ fn main() {
     let W = 2;
     const W = 1;
 
-    // Variable shadowing a variable - this is okay!
+    // variable shadowing a variable - this is okay!
     let P = 7;
     let P = 8;
+
+    // variable shadowing a global const
+    let Y = 10;
+
+    {
+        // scoped variable shadowing a global const
+        let C = 2;
+    }
+
+    let A = 1;
+    {
+        // scoped const shadowing a variable
+        const A = 2;
+    }
+
+    const B = 1;
+    {
+        // scoped variable shadowing a const
+        let B = 2;
+    }
+
+    {
+        // scoped variable shadowing imported const
+        let L = 1;
+    }
+
+    use lib::R;
+    let R = 1;
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/src/main.sw
@@ -2,62 +2,136 @@ script;
 
 mod lib;
 
-// const shadowing an imported const
-use lib::X;
-const X = 6; 
+// module const imported more then once
+use lib::L_A;
+use lib::L_A;
 
-// const shadowing a local const
-const Y = 7;
-const Y = 8;
+// module const shadowing an imported const
+use lib::L_X;
+const L_X = 1; 
 
-const C = 1;
+// module const shadowing a module const
+const M_X = 2;
+const M_X = 3;
 
-use lib::L;
+const M_Y = 4;
+
+const M_Z = 41;
+
+use lib::L_Y;
+use lib::L_Z;
 
 fn main() {
-    // variable shadowing an imported const
-    let X = 9;
+    // local const shadowing a module const
+    const M_Y = 5;
     {
-        let X = 3; // no error message here
+        const M_Y = 55; // no error message here
     }
 
-    // variable shadowing a const
-    const Z = 3;
-    let Z = 4;
+    // local const shadowing a const imported in module
+    const L_Y = 6;
 
-    // const shadowing a variable
-    let W = 2;
-    const W = 1;
+    // local const shadowing a local const
+    const F_X = 7;
+    const F_X = 8;
+    {
+        const F_X = 81; // no error message here
+    }
+
+    {
+        // scoped local const shadowing a scoped local const
+        const F_Y = 9;
+        {
+            const F_Y = 10;
+        }
+    }
+
+    // variable shadowing an imported const
+    let L_X = 100;
+    {
+        let L_X = 101; // no error message here
+    }
+
+    // variable shadowing a local const
+    const F_Z = 11;
+    let F_Z = 102;
+
+    // local const shadowing a variable
+    let F_A = 103;
+    const F_A = 12;
 
     // variable shadowing a variable - this is okay!
-    let P = 7;
-    let P = 8;
+    let A = 104;
+    let A = 105;
 
-    // variable shadowing a global const
-    let Y = 10;
+    // variable shadowing a module const
+    let M_Y = 106;
 
     {
-        // scoped variable shadowing a global const
-        let C = 2;
+        // scoped variable shadowing a module const
+        let M_Z = 107;
     }
 
-    let A = 1;
+    let B = 108;
     {
         // scoped const shadowing a variable
-        const A = 2;
+        const B = 13;
     }
 
-    const B = 1;
+    const F_K = 14;
     {
-        // scoped variable shadowing a const
-        let B = 2;
+        // scoped variable shadowing a local const
+        let F_K = 109;
     }
 
     {
         // scoped variable shadowing imported const
-        let L = 1;
+        let L_Z = 110;
     }
 
-    use lib::R;
-    let R = 1;
+    // variable shadowing a locally imported const
+    use lib::L_K;
+    let L_K = 111;
+
+    // const shadowing a locally imported const
+    use lib::L_M;
+    const L_M = 15;
+}
+
+use lib::L_N;
+
+const M_M = 16;
+
+struct S { }
+
+impl S {
+    const S_X = 200;
+    const S_X = 201;
+
+    const L_N = 202;
+
+    const M_M = 203;
+
+    const S_Y = 204;
+
+    fn f() {
+        const S_Y = 205;
+    }
+}
+
+enum E { }
+
+impl E {
+    const E_X = 300;
+    const E_X = 301;
+
+    const L_N = 302;
+
+    const M_M = 303;
+
+    const E_Y = 304;
+
+    fn f() {
+        const E_Y = 305;
+    }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/test.toml
@@ -10,12 +10,30 @@ category = "fail"
 #nextln: $()The name `Y` is defined multiple times
 
 #check: $()let X = 9;
-#nextln: $()The name `X` is defined multiple times
+#nextln: $()Variables cannot shadow constants. The variable "X" shadows constant with the same name.
 
 #check: $()const Z = 3;
 #nextln: $()let Z = 4;
-#nextln: $()The name `Z` is defined multiple times
+#nextln: $()Variables cannot shadow constants. The variable "Z" shadows constant with the same name.
 
 #check: $()let W = 2;
-#check: $()const W = 1;
-#check: $()The name `W` is defined multiple times
+#nextln: $()const W = 1;
+#nextln: $()Constants cannot shadow variables. The constant "W" shadows variable with the same name.
+
+#check: $()let Y = 10;
+#nextln: $()Variables cannot shadow constants. The variable "Y" shadows constant with the same name.
+
+#check: $()let C = 2;
+#nextln: $()Variables cannot shadow constants. The variable "C" shadows constant with the same name.
+
+#check: $()const A = 2;
+#nextln: $()Constants cannot shadow variables. The constant "A" shadows variable with the same name.
+
+#check: $()let B = 2;
+#nextln: $()Variables cannot shadow constants. The variable "B" shadows constant with the same name.
+
+#check: $()let L = 1;
+#nextln: $()Variables cannot shadow constants. The variable "L" shadows constant with the same name.
+
+#check: $()let R = 1;
+#nextln: $()Variables cannot shadow constants. The variable "R" shadows constant with the same name.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/test.toml
@@ -7,11 +7,11 @@ category = "fail"
 #nextln: $()The name "L_A" shadows another symbol with the same name.
 
 #check: $()const L_X = 1;
-#nextln: $()Name "L_X" is defined multiple times.
+#nextln: $()Constant "L_X" was already defined in scope.
 
 #check: $()const M_X = 2;
 #nextln: $()const M_X = 3;
-#nextln: $()Name "M_X" is defined multiple times.
+#nextln: $()Constant "M_X" was already defined in scope.
 
 #check: $()const M_Y = 5;
 #nextln: $()Constants cannot shadow constants. The constant "M_Y" shadows constant with the same name.
@@ -59,25 +59,25 @@ category = "fail"
 #nextln: $()Constants cannot shadow constants. The constant "L_M" shadows constant with the same name.
 
 #check: $()const S_X = 201;
-#nextln: $()Name "S_X" is defined multiple times.
+#nextln: $()Constant "S_X" was already defined in scope.
 
 #check: $()const L_N = 202;
-#check: $()Name "L_N" is defined multiple times.
+#check: $()Constant "L_N" was already defined in scope.
 
 #check: $()const M_M = 203;
-#check: $()Name "M_M" is defined multiple times.
+#check: $()Constant "M_M" was already defined in scope.
 
 #check: $()const S_Y = 205;
 #nextln: $()Constants cannot shadow constants. The constant "S_Y" shadows constant with the same name.
 
 #check: $()const E_X = 301;
-#nextln: $()Name "E_X" is defined multiple times.
+#nextln: $()Constant "E_X" was already defined in scope.
 
 #check: $()const L_N = 302;
-#check: $()Name "L_N" is defined multiple times.
+#check: $()Constant "L_N" was already defined in scope.
 
 #check: $()const M_M = 303;
-#check: $()Name "M_M" is defined multiple times.
+#check: $()Constant "M_M" was already defined in scope.
 
 #check: $()const E_Y = 305;
 #nextln: $()Constants cannot shadow constants. The constant "E_Y" shadows constant with the same name.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/test.toml
@@ -7,11 +7,11 @@ category = "fail"
 #nextln: $()The name "L_A" shadows another symbol with the same name.
 
 #check: $()const L_X = 1;
-#nextln: $()The name `L_X` is defined multiple times
+#nextln: $()Name "L_X" is defined multiple times.
 
 #check: $()const M_X = 2;
 #nextln: $()const M_X = 3;
-#nextln: $()The name `M_X` is defined multiple times
+#nextln: $()Name "M_X" is defined multiple times.
 
 #check: $()const M_Y = 5;
 #nextln: $()Constants cannot shadow constants. The constant "M_Y" shadows constant with the same name.
@@ -59,25 +59,25 @@ category = "fail"
 #nextln: $()Constants cannot shadow constants. The constant "L_M" shadows constant with the same name.
 
 #check: $()const S_X = 201;
-#nextln: $()The name `S_X` is defined multiple times
+#nextln: $()Name "S_X" is defined multiple times.
 
 #check: $()const L_N = 202;
-#check: $()The name `L_N` is defined multiple times
+#check: $()Name "L_N" is defined multiple times.
 
 #check: $()const M_M = 203;
-#check: $()The name `M_M` is defined multiple times
+#check: $()Name "M_M" is defined multiple times.
 
 #check: $()const S_Y = 205;
 #nextln: $()Constants cannot shadow constants. The constant "S_Y" shadows constant with the same name.
 
 #check: $()const E_X = 301;
-#nextln: $()The name `E_X` is defined multiple times
+#nextln: $()Name "E_X" is defined multiple times.
 
 #check: $()const L_N = 302;
-#check: $()The name `L_N` is defined multiple times
+#check: $()Name "L_N" is defined multiple times.
 
 #check: $()const M_M = 303;
-#check: $()The name `M_M` is defined multiple times
+#check: $()Name "M_M" is defined multiple times.
 
 #check: $()const E_Y = 305;
 #nextln: $()Constants cannot shadow constants. The constant "E_Y" shadows constant with the same name.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/test.toml
@@ -4,7 +4,7 @@ category = "fail"
 
 #check: $()use lib::L_A;
 #nextln: $()use lib::L_A;
-#nextln: $()The name "L_A" shadows another symbol with the same name.
+#nextln: $()The imported symbol "L_A" shadows another symbol with the same name.
 
 #check: $()const L_X = 1;
 #nextln: $()Constant "L_X" was already defined in scope.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars/test.toml
@@ -2,38 +2,82 @@ category = "fail"
 
 #check: $()error
 
-#check: $()const X = 6;
-#nextln: $()The name `X` is defined multiple times
+#check: $()use lib::L_A;
+#nextln: $()use lib::L_A;
+#nextln: $()The name "L_A" shadows another symbol with the same name.
 
-#check: $()const Y = 7;
-#nextln: $()const Y = 8;
-#nextln: $()The name `Y` is defined multiple times
+#check: $()const L_X = 1;
+#nextln: $()The name `L_X` is defined multiple times
 
-#check: $()let X = 9;
-#nextln: $()Variables cannot shadow constants. The variable "X" shadows constant with the same name.
+#check: $()const M_X = 2;
+#nextln: $()const M_X = 3;
+#nextln: $()The name `M_X` is defined multiple times
 
-#check: $()const Z = 3;
-#nextln: $()let Z = 4;
-#nextln: $()Variables cannot shadow constants. The variable "Z" shadows constant with the same name.
+#check: $()const M_Y = 5;
+#nextln: $()Constants cannot shadow constants. The constant "M_Y" shadows constant with the same name.
 
-#check: $()let W = 2;
-#nextln: $()const W = 1;
-#nextln: $()Constants cannot shadow variables. The constant "W" shadows variable with the same name.
+#check: $()const L_Y = 6;
+#nextln: $()Constants cannot shadow constants. The constant "L_Y" shadows constant with the same name.
 
-#check: $()let Y = 10;
-#nextln: $()Variables cannot shadow constants. The variable "Y" shadows constant with the same name.
+#check: $()const F_X = 7;
+#nextln: $()const F_X = 8;
+#nextln: $()Constants cannot shadow constants. The constant "F_X" shadows constant with the same name.
 
-#check: $()let C = 2;
-#nextln: $()Variables cannot shadow constants. The variable "C" shadows constant with the same name.
+#check: $()const F_Y = 10;
+#nextln: $()Constants cannot shadow constants. The constant "F_Y" shadows constant with the same name.
 
-#check: $()const A = 2;
-#nextln: $()Constants cannot shadow variables. The constant "A" shadows variable with the same name.
+#check: $()let L_X = 100;
+#nextln: $()Variables cannot shadow constants. The variable "L_X" shadows constant with the same name.
 
-#check: $()let B = 2;
-#nextln: $()Variables cannot shadow constants. The variable "B" shadows constant with the same name.
+#check: $()const F_Z = 11;
+#nextln: $()let F_Z = 102;
+#nextln: $()Variables cannot shadow constants. The variable "F_Z" shadows constant with the same name.
 
-#check: $()let L = 1;
-#nextln: $()Variables cannot shadow constants. The variable "L" shadows constant with the same name.
+#check: $()let F_A = 103;
+#nextln: $()const F_A = 12;
+#nextln: $()Constants cannot shadow variables. The constant "F_A" shadows variable with the same name.
 
-#check: $()let R = 1;
-#nextln: $()Variables cannot shadow constants. The variable "R" shadows constant with the same name.
+#check: $()let M_Y = 106;
+#nextln: $()Variables cannot shadow constants. The variable "M_Y" shadows constant with the same name.
+
+#check: $()let M_Z = 107;
+#nextln: $()Variables cannot shadow constants. The variable "M_Z" shadows constant with the same name.
+
+#check: $()const B = 13;
+#nextln: $()Constants cannot shadow variables. The constant "B" shadows variable with the same name.
+
+#check: $()let F_K = 109;
+#nextln: $()Variables cannot shadow constants. The variable "F_K" shadows constant with the same name.
+
+#check: $()let L_Z = 110;
+#nextln: $()Variables cannot shadow constants. The variable "L_Z" shadows constant with the same name.
+
+#check: $()let L_K = 111;
+#nextln: $()Variables cannot shadow constants. The variable "L_K" shadows constant with the same name.
+
+#check: $()const L_M = 15;
+#nextln: $()Constants cannot shadow constants. The constant "L_M" shadows constant with the same name.
+
+#check: $()const S_X = 201;
+#nextln: $()The name `S_X` is defined multiple times
+
+#check: $()const L_N = 202;
+#check: $()The name `L_N` is defined multiple times
+
+#check: $()const M_M = 203;
+#check: $()The name `M_M` is defined multiple times
+
+#check: $()const S_Y = 205;
+#nextln: $()Constants cannot shadow constants. The constant "S_Y" shadows constant with the same name.
+
+#check: $()const E_X = 301;
+#nextln: $()The name `E_X` is defined multiple times
+
+#check: $()const L_N = 302;
+#check: $()The name `L_N` is defined multiple times
+
+#check: $()const M_M = 303;
+#check: $()The name `M_M` is defined multiple times
+
+#check: $()const E_Y = 305;
+#nextln: $()Constants cannot shadow constants. The constant "E_Y" shadows constant with the same name.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars_alias/src/lib.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars_alias/src/lib.sw
@@ -1,3 +1,7 @@
 library;
 
 pub const X = 5;
+
+pub const L = 5;
+
+pub const P = 5;

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars_alias/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars_alias/src/main.sw
@@ -6,7 +6,14 @@ mod lib;
 use lib::X as Y;
 const Y = 7;
 
+use lib::L as M;
+
 fn main() {
     // var shadowing an imported const with alias
     let Y = 4;
+
+    let M = 4;
+
+    use lib::P as R;
+    let R = 5;
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars_alias/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars_alias/test.toml
@@ -6,4 +6,10 @@ category = "fail"
 #nextln: $()The name `Y` is defined multiple times
 
 #check: $()let Y = 4;
-#nextln: $()The name `Y` is defined multiple times
+#nextln: $()Variables cannot shadow constants. The variable "Y" shadows constant with the same name.
+
+#check: $()let M = 4;
+#check: $()Variables cannot shadow constants. The variable "M" shadows constant with the same name.
+
+#check: $()let R = 5;
+#check: $()Variables cannot shadow constants. The variable "R" shadows constant with the same name.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars_alias/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars_alias/test.toml
@@ -3,7 +3,7 @@ category = "fail"
 #check: $()error
 
 #check: $()const Y = 7;
-#nextln: $()Name "Y" is defined multiple times.
+#nextln: $()Constant "Y" was already defined in scope.
 
 #check: $()let Y = 4;
 #nextln: $()Variables cannot shadow constants. The variable "Y" shadows constant with the same name.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars_alias/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_consts_and_vars_alias/test.toml
@@ -3,7 +3,7 @@ category = "fail"
 #check: $()error
 
 #check: $()const Y = 7;
-#nextln: $()The name `Y` is defined multiple times
+#nextln: $()Name "Y" is defined multiple times.
 
 #check: $()let Y = 4;
 #nextln: $()Variables cannot shadow constants. The variable "Y" shadows constant with the same name.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_types_and_traits/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_types_and_traits/test.toml
@@ -3,122 +3,122 @@ category = "fail"
 #check: $()error
 
 #check: $()struct MyStruct1
-#nextln: $()The name `MyStruct1` is defined multiple times
+#nextln: $()Name "MyStruct1" is defined multiple times.
 #nextln: $()enum MyStruct1
 
 #check: $()enum MyStruct1
-#nextln: $()The name `MyStruct1` is defined multiple times
+#nextln: $()Name "MyStruct1" is defined multiple times.
 #nextln: $()trait MyStruct1
 
 #check: $()trait MyStruct1
-#nextln: $()The name `MyStruct1` is defined multiple times
+#nextln: $()Name "MyStruct1" is defined multiple times.
 #check: $()abi MyStruct1
 
 #check: $()abi MyStruct1
-#nextln: $()The name `MyStruct1` is defined multiple times
+#nextln: $()Name "MyStruct1" is defined multiple times.
 
 #check: $()struct MyEnum1
-#nextln: $()The name `MyEnum1` is defined multiple times
+#nextln: $()Name "MyEnum1" is defined multiple times.
 #nextln: $()enum MyEnum1
 
 #check: $()enum MyEnum1
-#nextln: $()The name `MyEnum1` is defined multiple times
+#nextln: $()Name "MyEnum1" is defined multiple times.
 #nextln: $()trait MyEnum1
 
 #check: $()trait MyEnum1
-#nextln: $()The name `MyEnum1` is defined multiple times
+#nextln: $()Name "MyEnum1" is defined multiple times.
 #check: $()abi MyEnum1
 
 #check: $()abi MyEnum1
-#nextln: $()The name `MyEnum1` is defined multiple times
+#nextln: $()Name "MyEnum1" is defined multiple times.
 
 #check: $()struct MyTrait1
-#nextln: $()The name `MyTrait1` is defined multiple times
+#nextln: $()Name "MyTrait1" is defined multiple times.
 #nextln: $()enum MyTrait1
 
 #check: $()enum MyTrait1
-#nextln: $()The name `MyTrait1` is defined multiple times
+#nextln: $()Name "MyTrait1" is defined multiple times.
 #nextln: $()trait MyTrait1
 
 #check: $()trait MyTrait1
-#nextln: $()The name `MyTrait1` is defined multiple times
+#nextln: $()Name "MyTrait1" is defined multiple times.
 #check: $()abi MyTrait1
 
 #check: $()abi MyTrait1
-#nextln: $()The name `MyTrait1` is defined multiple times
+#nextln: $()Name "MyTrait1" is defined multiple times.
 
 #check: $()struct MyAbi1
-#nextln: $()The name `MyAbi1` is defined multiple times
+#nextln: $()Name "MyAbi1" is defined multiple times.
 #nextln: $()enum MyAbi1
 
 #check: $()enum MyAbi1
-#nextln: $()The name `MyAbi1` is defined multiple times
+#nextln: $()Name "MyAbi1" is defined multiple times.
 #nextln: $()trait MyAbi1
 
 #check: $()trait MyAbi1
-#nextln: $()The name `MyAbi1` is defined multiple times
+#nextln: $()Name "MyAbi1" is defined multiple times.
 #check: $()abi MyAbi1
 
 #check: $()abi MyAbi1
-#nextln: $()The name `MyAbi1` is defined multiple times
+#nextln: $()Name "MyAbi1" is defined multiple times.
 
 #check: $()struct MyStruct2
-#nextln: $()The name `MyStruct2` is defined multiple times
+#nextln: $()Name "MyStruct2" is defined multiple times.
 #nextln: $()enum MyStruct2
 
 #check: $()enum MyStruct2
-#nextln: $()The name `MyStruct2` is defined multiple times
+#nextln: $()Name "MyStruct2" is defined multiple times.
 #nextln: $()trait MyStruct2
 
 #check: $()trait MyStruct2
-#nextln: $()The name `MyStruct2` is defined multiple times
+#nextln: $()Name "MyStruct2" is defined multiple times.
 #check: $()abi MyStruct2
 
 #check: $()abi MyStruct2
-#nextln: $()The name `MyStruct2` is defined multiple times
+#nextln: $()Name "MyStruct2" is defined multiple times.
 
 #check: $()struct MyEnum2
-#nextln: $()The name `MyEnum2` is defined multiple times
+#nextln: $()Name "MyEnum2" is defined multiple times.
 #nextln: $()enum MyEnum2
 
 #check: $()enum MyEnum2
-#nextln: $()The name `MyEnum2` is defined multiple times
+#nextln: $()Name "MyEnum2" is defined multiple times.
 #nextln: $()trait MyEnum2
 
 #check: $()trait MyEnum2
-#nextln: $()The name `MyEnum2` is defined multiple times
+#nextln: $()Name "MyEnum2" is defined multiple times.
 #check: $()abi MyEnum2
 
 #check: $()abi MyEnum2
-#nextln: $()The name `MyEnum2` is defined multiple times
+#nextln: $()Name "MyEnum2" is defined multiple times.
 
 #check: $()struct MyTrait2
-#nextln: $()The name `MyTrait2` is defined multiple times
+#nextln: $()Name "MyTrait2" is defined multiple times.
 #nextln: $()enum MyTrait2
 
 #check: $()enum MyTrait2
-#nextln: $()The name `MyTrait2` is defined multiple times
+#nextln: $()Name "MyTrait2" is defined multiple times.
 #nextln: $()trait MyTrait2
 
 #check: $()trait MyTrait2
-#nextln: $()The name `MyTrait2` is defined multiple times
+#nextln: $()Name "MyTrait2" is defined multiple times.
 #check: $()abi MyTrait2
 
 #check: $()abi MyTrait2
-#nextln: $()The name `MyTrait2` is defined multiple times
+#nextln: $()Name "MyTrait2" is defined multiple times.
 
 #check: $()struct MyAbi2
-#nextln: $()The name `MyAbi2` is defined multiple times
+#nextln: $()Name "MyAbi2" is defined multiple times.
 #nextln: $()enum MyAbi2
 
 #check: $()enum MyAbi2
-#nextln: $()The name `MyAbi2` is defined multiple times
+#nextln: $()Name "MyAbi2" is defined multiple times.
 #nextln: $()trait MyAbi2
 
 #check: $()trait MyAbi2
-#nextln: $()The name `MyAbi2` is defined multiple times
+#nextln: $()Name "MyAbi2" is defined multiple times.
 #check: $()abi MyAbi2
 
 #check: $()abi MyAbi2
-#nextln: $()The name `MyAbi2` is defined multiple times
+#nextln: $()Name "MyAbi2" is defined multiple times.
 

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_types_and_traits_alias/src/lib.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_types_and_traits_alias/src/lib.sw
@@ -2,7 +2,5 @@ library;
 
 pub struct MyStruct0 {}
 pub enum MyEnum0 {}
-pub trait MyTrait0 {
-}
-abi MyAbi0 {
-}
+pub trait MyTrait0 {}
+abi MyAbi0 {}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_types_and_traits_alias/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/shadowing/shadowed_types_and_traits_alias/test.toml
@@ -3,61 +3,61 @@ category = "fail"
 #check: $()error
 
 #check: $()struct MyStruct1
-#nextln: $()The name `MyStruct1` is defined multiple times
+#nextln: $()Name "MyStruct1" is defined multiple times.
 #nextln: $()enum MyStruct1
 
 #check: $()enum MyStruct1
-#nextln: $()The name `MyStruct1` is defined multiple times
+#nextln: $()Name "MyStruct1" is defined multiple times.
 #nextln: $()trait MyStruct1
 
 #check: $()trait MyStruct1
-#nextln: $()The name `MyStruct1` is defined multiple times
+#nextln: $()Name "MyStruct1" is defined multiple times.
 #check: $()abi MyStruct1
 
 #check: $()abi MyStruct1
-#nextln: $()The name `MyStruct1` is defined multiple times
+#nextln: $()Name "MyStruct1" is defined multiple times.
 
 #check: $()struct MyEnum1
-#nextln: $()The name `MyEnum1` is defined multiple times
+#nextln: $()Name "MyEnum1" is defined multiple times.
 #nextln: $()enum MyEnum1
 
 #check: $()enum MyEnum1
-#nextln: $()The name `MyEnum1` is defined multiple times
+#nextln: $()Name "MyEnum1" is defined multiple times.
 #nextln: $()trait MyEnum1
 
 #check: $()trait MyEnum1
-#nextln: $()The name `MyEnum1` is defined multiple times
+#nextln: $()Name "MyEnum1" is defined multiple times.
 #check: $()abi MyEnum1
 
 #check: $()abi MyEnum1
-#nextln: $()The name `MyEnum1` is defined multiple times
+#nextln: $()Name "MyEnum1" is defined multiple times.
 
 #check: $()struct MyTrait1
-#nextln: $()The name `MyTrait1` is defined multiple times
+#nextln: $()Name "MyTrait1" is defined multiple times.
 #nextln: $()enum MyTrait1
 
 #check: $()enum MyTrait1
-#nextln: $()The name `MyTrait1` is defined multiple times
+#nextln: $()Name "MyTrait1" is defined multiple times.
 #nextln: $()trait MyTrait1
 
 #check: $()trait MyTrait1
-#nextln: $()The name `MyTrait1` is defined multiple times
+#nextln: $()Name "MyTrait1" is defined multiple times.
 #check: $()abi MyTrait1
 
 #check: $()abi MyTrait1
-#nextln: $()The name `MyTrait1` is defined multiple times
+#nextln: $()Name "MyTrait1" is defined multiple times.
 
 #check: $()struct MyAbi1
-#nextln: $()The name `MyAbi1` is defined multiple times
+#nextln: $()Name "MyAbi1" is defined multiple times.
 #nextln: $()enum MyAbi1
 
 #check: $()enum MyAbi1
-#nextln: $()The name `MyAbi1` is defined multiple times
+#nextln: $()Name "MyAbi1" is defined multiple times.
 #nextln: $()trait MyAbi1
 
 #check: $()trait MyAbi1
-#nextln: $()The name `MyAbi1` is defined multiple times
+#nextln: $()Name "MyAbi1" is defined multiple times.
 #check: $()abi MyAbi1
 
 #check: $()abi MyAbi1
-#nextln: $()The name `MyAbi1` is defined multiple times
+#nextln: $()Name "MyAbi1" is defined multiple times.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_alias_lib_shadowing/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_alias_lib_shadowing/test.toml
@@ -1,4 +1,4 @@
 category = "fail"
 
 # check: $()type MyType = MyStruct;
-# nextln: $()The name `MyType` is defined multiple times
+# nextln: $()Name "MyType" is defined multiple times.


### PR DESCRIPTION
## Description

- Introduce three distinguished new error messages on const shadowing as defined in #4587:
  - Variables shadowing constants.
  - Constants shadowing variables.
  - Constants shadowing constants, _item-style_ and _sequentially_.
- _Item-style_ and _sequential shadowing_ are added as an explicit concept to the `TypeCheckContext`. This follows the same pattern that we have in passing _ABI mode_ and _disallow functions_ contextual information. Basically, the parts of the semantic analysis lower in the chain need contextual information available and deducible in the upper parts of the chain. In this case, the deduction is simple - as soon as we are within a function body, we apply _sequential shadowing_. (Note that this simple approach will not work if we ever introduce types local to functions. But this is not an issues. In that case we will need to redefine the const shadowing within functions in general, and also by that time I assume we will have the graph collections which will allow us different approach :-)
- Clean up of redundant error messages as defined in  #4799.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
