### PR TITLE
Collect module kind span for ParseModule

### DIFF
--- a/sway-core/src/language/parsed/module.rs
+++ b/sway-core/src/language/parsed/module.rs
@@ -14,6 +14,8 @@ pub struct ParseModule {
     /// Submodules introduced within this module using the `dep` syntax in order of declaration.
     pub submodules: Vec<(ModName, ParseSubmodule)>,
     pub attributes: transform::AttributesMap,
+    /// The span of the module kind.
+    pub module_kind_span: Span,
     /// an empty span at the beginning of the file containing the module
     pub span: Span,
 }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -178,10 +178,12 @@ fn parse_in_memory(
         engines,
         module.value.clone(),
     )?;
+    let module_kind_span = module.value.kind.span().clone();
     let submodules = Default::default();
     let attributes = module_attrs_to_map(handler, &module.attribute_list)?;
     let root = parsed::ParseModule {
         span: span::Span::dummy(),
+        module_kind_span,
         tree,
         submodules,
         attributes,
@@ -301,6 +303,7 @@ fn parse_module_tree(
         engines,
         module.value.clone(),
     )?;
+    let module_kind_span = module.value.kind.span().clone();
     let attributes = module_attrs_to_map(handler, &module.attribute_list)?;
 
     let lexed = lexed::LexedModule {
@@ -310,6 +313,7 @@ fn parse_module_tree(
     let source_id = engines.se().get_source_id(&path.clone());
     let parsed = parsed::ParseModule {
         span: span::Span::new(src, 0, 0, Some(source_id)).unwrap(),
+        module_kind_span,
         tree,
         submodules: submodules.parsed,
         attributes,

--- a/sway-core/src/semantic_analysis/module.rs
+++ b/sway-core/src/semantic_analysis/module.rs
@@ -14,6 +14,7 @@ impl ty::TyModule {
             tree,
             attributes,
             span,
+            ..
         } = parsed;
 
         // Type-check submodules first in order of declaration.

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -56,19 +56,21 @@ impl ServerState {
                 // take over the normal error and warning display behavior
                 // and instead show the either the parsed or typed tokens as warnings.
                 // This is useful for debugging the lsp parser.
-                Warnings::Parsed => diagnostics_to_publish
-                    .extend(debug::generate_warnings_for_parsed_tokens(tokens)),
-                Warnings::Typed => {
-                    diagnostics_to_publish.extend(debug::generate_warnings_for_typed_tokens(tokens))
+                Warnings::Parsed => {
+                    diagnostics_to_publish = debug::generate_warnings_for_parsed_tokens(tokens)
                 }
-                Warnings::Default => {}
-            }
-            let diagnostics = session.wait_for_parsing();
-            if config.diagnostic.show_warnings {
-                diagnostics_to_publish.extend(diagnostics.warnings);
-            }
-            if config.diagnostic.show_errors {
-                diagnostics_to_publish.extend(diagnostics.errors);
+                Warnings::Typed => {
+                    diagnostics_to_publish = debug::generate_warnings_for_typed_tokens(tokens)
+                }
+                Warnings::Default => {
+                    let diagnostics = session.wait_for_parsing();
+                    if config.diagnostic.show_warnings {
+                        diagnostics_to_publish.extend(diagnostics.warnings);
+                    }
+                    if config.diagnostic.show_errors {
+                        diagnostics_to_publish.extend(diagnostics.errors);
+                    }
+                }
             }
             diagnostics_to_publish
         };

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -56,10 +56,10 @@ impl<'a> ParsedTree<'a> {
 
     fn collect_parse_module(&self, parse_module: &ParseModule) {
         self.ctx.tokens.insert(
-            to_ident_key(&Ident::new(parse_module.span.clone())),
+            to_ident_key(&Ident::new(parse_module.module_kind_span.clone())),
             Token::from_parsed(
-                AstToken::LibrarySpan(parse_module.span.clone()),
-                SymbolKind::Module,
+                AstToken::LibrarySpan(parse_module.module_kind_span.clone()),
+                SymbolKind::Keyword,
             ),
         );
         for (


### PR DESCRIPTION
## Description
This PR replaces collecting the dummy spans for the module kind token with the span of the module kind. 

These were introduced in #4232. This was causing an issue in the language server where we were unable to debug parsed tokens as warnings if the span was all 0's. 

closes #4809 

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
