### PR TITLE
ci: bump nightly rust version to 2023-04-01

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.71.0
-  NIGHTLY_RUST_VERSION: nightly-2023-02-08
+  NIGHTLY_RUST_VERSION: nightly-2023-07-19
 
 jobs:
   build-sway-lib-core:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.71.0
-  NIGHTLY_RUST_VERSION: nightly-2023-07-19
+  NIGHTLY_RUST_VERSION: nightly-2023-04-01
 
 jobs:
   build-sway-lib-core:


### PR DESCRIPTION
## Description
Unused dependency check is failing as nightly version that we use for that step is too old for fuels-program v0.44 dependency which is being added in a separate PR. (failing PR: #4771)