### PR TITLE
Numeric type inference

### DIFF
--- a/sway-core/src/asm_generation/from_ir.rs
+++ b/sway-core/src/asm_generation/from_ir.rs
@@ -200,28 +200,7 @@ pub enum StateAccessType {
 }
 
 pub(crate) fn ir_type_size_in_bytes(context: &Context, ty: &Type) -> u64 {
-    match ty.get_content(context) {
-        TypeContent::Unit | TypeContent::Bool | TypeContent::Uint(_) | TypeContent::Pointer(_) => 8,
-        TypeContent::Slice => 16,
-        TypeContent::B256 => 32,
-        TypeContent::String(n) => size_bytes_round_up_to_word_alignment!(*n),
-        TypeContent::Array(el_ty, cnt) => cnt * ir_type_size_in_bytes(context, el_ty),
-        TypeContent::Struct(field_tys) => {
-            // Sum up all the field sizes.
-            field_tys
-                .iter()
-                .map(|field_ty| ir_type_size_in_bytes(context, field_ty))
-                .sum()
-        }
-        TypeContent::Union(field_tys) => {
-            // Find the max size for field sizes.
-            field_tys
-                .iter()
-                .map(|field_ty| ir_type_size_in_bytes(context, field_ty))
-                .max()
-                .unwrap_or(0)
-        }
-    }
+    ty.size_in_bytes(context)
 }
 
 pub(crate) fn ir_type_str_size_in_bytes(context: &Context, ty: &Type) -> u64 {

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     metadata::MetadataManager,
     semantic_analysis::*,
+    UnifyCheck,
 };
 
 use super::{
@@ -424,14 +425,10 @@ fn const_eval_typed_expr(
             let te = lookup.engines.te();
 
             assert!({
-                let elem_type_info = te.get(*elem_type);
-                element_typs.iter().all(|tid| {
-                    lookup
-                        .engines
-                        .te()
-                        .get(*tid)
-                        .eq(&elem_type_info, lookup.engines)
-                })
+                let unify_check = UnifyCheck::coercion(lookup.engines);
+                element_typs
+                    .iter()
+                    .all(|tid| unify_check.check(*tid, *elem_type))
             });
 
             create_array_aggregate(

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -2016,15 +2016,10 @@ impl ty::TyExpression {
                     ),
                 },
                 TypeInfo::Numeric => (
-                    num.to_string().parse().map(Literal::U64).map_err(|e| {
-                        Literal::handle_parse_int_error(
-                            engines,
-                            e,
-                            TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-                            span.clone(),
-                        )
+                    num.to_string().parse().map(Literal::Numeric).map_err(|e| {
+                        Literal::handle_parse_int_error(engines, e, TypeInfo::Numeric, span.clone())
                     }),
-                    type_engine.insert(engines, TypeInfo::UnsignedInteger(IntegerBits::SixtyFour)),
+                    type_engine.insert(engines, TypeInfo::Numeric),
                 ),
                 _ => unreachable!("Unexpected type for integer literals"),
             },

--- a/sway-core/src/semantic_analysis/coins_analysis.rs
+++ b/sway-core/src/semantic_analysis/coins_analysis.rs
@@ -12,6 +12,7 @@ pub fn possibly_nonzero_u64_expression(
     use ty::TyExpressionVariant::*;
     match &expr.expression {
         Literal(crate::language::Literal::U64(value)) => *value != 0,
+        Literal(crate::language::Literal::Numeric(value)) => *value != 0,
         // not a u64 literal, hence we return true to be on the safe side
         Literal(_) => true,
         ConstantExpression { const_decl, .. } => match &const_decl.value {

--- a/sway-core/src/semantic_analysis/namespace/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace/namespace.rs
@@ -264,7 +264,18 @@ impl Namespace {
         let decl_engine = engines.de();
         let type_engine = engines.te();
 
-        let unify_check = UnifyCheck::non_dynamic_equality(engines);
+        let eq_check = UnifyCheck::non_dynamic_equality(engines);
+        let coercion_check = UnifyCheck::coercion(engines);
+
+        // default numeric types to u64
+        if type_engine.contains_numeric(decl_engine, type_id) {
+            check!(
+                type_engine.decay_numeric(engines, type_id, &method_name.span()),
+                return err(warnings, errors),
+                warnings,
+                errors
+            );
+        }
 
         let matching_item_decl_refs = check!(
             self.find_items_for_type(type_id, method_prefix, method_name, self_type, engines,),
@@ -294,9 +305,9 @@ impl Namespace {
                         .parameters
                         .iter()
                         .zip(args_buf.iter())
-                        .all(|(p, a)| unify_check.check(p.type_argument.type_id, a.return_type))
+                        .all(|(p, a)| coercion_check.check(p.type_argument.type_id, a.return_type))
                     && (matches!(type_engine.get(annotation_type), TypeInfo::Unknown)
-                        || unify_check.check(annotation_type, method.return_type.type_id))
+                        || coercion_check.check(annotation_type, method.return_type.type_id))
                 {
                     maybe_method_decl_refs.push(decl_ref);
                 }
@@ -346,7 +357,7 @@ impl Namespace {
                                                 warnings,
                                                 errors
                                             );
-                                            if !unify_check.check(p1_type_id, p2_type_id) {
+                                            if !eq_check.check(p1_type_id, p2_type_id) {
                                                 params_equal = false;
                                                 break;
                                             }

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -860,12 +860,20 @@ impl TraitMap {
         access_span: &Span,
         engines: &Engines,
     ) -> CompileResult<()> {
-        let warnings = vec![];
+        let mut warnings = vec![];
         let mut errors = vec![];
 
         let type_engine = engines.te();
         let _decl_engine = engines.de();
         let unify_check = UnifyCheck::non_dynamic_equality(engines);
+
+        // resolving trait constraits require a concrete type, we need to default numeric to u64
+        check!(
+            type_engine.decay_numeric(engines, type_id, access_span),
+            return err(warnings, errors),
+            warnings,
+            errors
+        );
 
         let all_impld_traits: BTreeMap<Ident, TypeId> = self
             .trait_impls

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -2809,7 +2809,7 @@ fn literal_to_literal(
                     if let Some(hex_digits) = orig_str.strip_prefix("0x") {
                         let num_digits = hex_digits.chars().filter(|c| *c != '_').count();
                         match num_digits {
-                            1..=16 => Literal::U64(u64::try_from(parsed).unwrap()),
+                            1..=16 => Literal::Numeric(u64::try_from(parsed).unwrap()),
                             64 => {
                                 let bytes = parsed.to_bytes_be();
                                 let mut full_bytes = [0u8; 32];
@@ -2824,7 +2824,7 @@ fn literal_to_literal(
                     } else if let Some(bin_digits) = orig_str.strip_prefix("0b") {
                         let num_digits = bin_digits.chars().filter(|c| *c != '_').count();
                         match num_digits {
-                            1..=64 => Literal::U64(u64::try_from(parsed).unwrap()),
+                            1..=64 => Literal::Numeric(u64::try_from(parsed).unwrap()),
                             256 => {
                                 let bytes = parsed.to_bytes_be();
                                 let mut full_bytes = [0u8; 32];

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -2,6 +2,7 @@ use core::fmt::Write;
 use hashbrown::hash_map::RawEntryMut;
 use hashbrown::HashMap;
 use std::sync::RwLock;
+use sway_types::integer_bits::IntegerBits;
 
 use crate::concurrent_slab::ListDisplay;
 use crate::error::{err, ok};
@@ -257,6 +258,150 @@ impl TypeEngine {
             }),
             ty => Ok(ty),
         }
+    }
+
+    /// Return whether a given type still contains undecayed references to [TypeInfo::Numeric]
+    pub(crate) fn contains_numeric(&self, decl_engine: &DeclEngine, type_id: TypeId) -> bool {
+        match &self.get(type_id) {
+            TypeInfo::Enum(decl_ref) => {
+                decl_engine
+                    .get_enum(decl_ref)
+                    .variants
+                    .iter()
+                    .all(|variant_type| {
+                        self.contains_numeric(decl_engine, variant_type.type_argument.type_id)
+                    })
+            }
+            TypeInfo::Struct(decl_ref) => decl_engine
+                .get_struct(decl_ref)
+                .fields
+                .iter()
+                .any(|field| self.contains_numeric(decl_engine, field.type_argument.type_id)),
+            TypeInfo::Tuple(fields) => fields
+                .iter()
+                .any(|field_type| self.contains_numeric(decl_engine, field_type.type_id)),
+            TypeInfo::Array(elem_ty, _length) => {
+                self.contains_numeric(decl_engine, elem_ty.type_id)
+            }
+            TypeInfo::Ptr(targ) => self.contains_numeric(decl_engine, targ.type_id),
+            TypeInfo::Slice(targ) => self.contains_numeric(decl_engine, targ.type_id),
+            TypeInfo::Unknown
+            | TypeInfo::UnknownGeneric { .. }
+            | TypeInfo::Placeholder(..)
+            | TypeInfo::TypeParam(..)
+            | TypeInfo::Str(..)
+            | TypeInfo::UnsignedInteger(..)
+            | TypeInfo::Boolean
+            | TypeInfo::ContractCaller { .. }
+            | TypeInfo::Custom { .. }
+            | TypeInfo::SelfType
+            | TypeInfo::B256
+            | TypeInfo::Contract
+            | TypeInfo::ErrorRecovery
+            | TypeInfo::Storage { .. }
+            | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
+            | TypeInfo::Alias { .. } => false,
+            TypeInfo::Numeric => true,
+        }
+    }
+
+    /// Resolve all inner types that still are a [TypeInfo::Numeric] to a concrete `u64`
+    pub(crate) fn decay_numeric(
+        &self,
+        engines: &Engines,
+        type_id: TypeId,
+        span: &Span,
+    ) -> CompileResult<()> {
+        let mut warnings = vec![];
+        let mut errors = vec![];
+
+        let decl_engine = engines.de();
+
+        match &self.get(type_id) {
+            TypeInfo::Enum(decl_ref) => {
+                for variant_type in decl_engine.get_enum(decl_ref).variants.iter() {
+                    check!(
+                        self.decay_numeric(engines, variant_type.type_argument.type_id, span),
+                        return err(warnings, errors),
+                        warnings,
+                        errors
+                    )
+                }
+            }
+            TypeInfo::Struct(decl_ref) => {
+                for field in decl_engine.get_struct(decl_ref).fields.iter() {
+                    check!(
+                        self.decay_numeric(engines, field.type_argument.type_id, span),
+                        return err(warnings, errors),
+                        warnings,
+                        errors
+                    )
+                }
+            }
+            TypeInfo::Tuple(fields) => {
+                for field_type in fields {
+                    check!(
+                        self.decay_numeric(engines, field_type.type_id, span),
+                        return err(warnings, errors),
+                        warnings,
+                        errors
+                    )
+                }
+            }
+            TypeInfo::Array(elem_ty, _length) => check!(
+                self.decay_numeric(engines, elem_ty.type_id, span),
+                return err(warnings, errors),
+                warnings,
+                errors
+            ),
+            TypeInfo::Ptr(targ) => check!(
+                self.decay_numeric(engines, targ.type_id, span),
+                return err(warnings, errors),
+                warnings,
+                errors
+            ),
+            TypeInfo::Slice(targ) => check!(
+                self.decay_numeric(engines, targ.type_id, span),
+                return err(warnings, errors),
+                warnings,
+                errors
+            ),
+
+            TypeInfo::Unknown
+            | TypeInfo::UnknownGeneric { .. }
+            | TypeInfo::Placeholder(..)
+            | TypeInfo::TypeParam(..)
+            | TypeInfo::Str(..)
+            | TypeInfo::UnsignedInteger(..)
+            | TypeInfo::Boolean
+            | TypeInfo::ContractCaller { .. }
+            | TypeInfo::Custom { .. }
+            | TypeInfo::SelfType
+            | TypeInfo::B256
+            | TypeInfo::Contract
+            | TypeInfo::ErrorRecovery
+            | TypeInfo::Storage { .. }
+            | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
+            | TypeInfo::Alias { .. } => {}
+            TypeInfo::Numeric => {
+                check!(
+                    CompileResult::from(self.unify(
+                        engines,
+                        type_id,
+                        self.insert(engines, TypeInfo::UnsignedInteger(IntegerBits::SixtyFour)),
+                        span,
+                        "",
+                        None,
+                    )),
+                    (),
+                    warnings,
+                    errors,
+                );
+            }
+        }
+        ok((), warnings, errors)
     }
 
     /// Resolve the type of the given [TypeId], replacing any instances of

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -365,7 +365,7 @@ impl TypeId {
         span: &Span,
         trait_constraints: Vec<TraitConstraint>,
     ) -> CompileResult<()> {
-        let warnings = vec![];
+        let mut warnings = vec![];
         let mut errors = vec![];
         let engines = ctx.engines();
 
@@ -382,6 +382,16 @@ impl TypeId {
             if structure_trait_constraints.is_empty() {
                 continue;
             }
+
+            // resolving trait constraits require a concrete type, we need to default numeric to u64
+            check!(
+                engines
+                    .te()
+                    .decay_numeric(engines, *structure_type_id, span),
+                return err(warnings, errors),
+                warnings,
+                errors
+            );
 
             let structure_type_info = engines.te().get(*structure_type_id);
             let structure_type_info_with_engines = engines.help_out(structure_type_info.clone());

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -898,7 +898,10 @@ impl TypeInfo {
         // whether they're actually asking 'is_aggregate()` or something else.
         matches!(
             self,
-            TypeInfo::Boolean | TypeInfo::UnsignedInteger(_) | TypeInfo::RawUntypedPtr
+            TypeInfo::Boolean
+                | TypeInfo::UnsignedInteger(_)
+                | TypeInfo::RawUntypedPtr
+                | TypeInfo::Numeric
         ) || self.is_unit()
     }
 

--- a/sway-core/src/type_system/unify/unify_check.rs
+++ b/sway-core/src/type_system/unify/unify_check.rs
@@ -627,7 +627,13 @@ impl<'a> UnifyCheck<'a> {
                         let a = right_types.get(i).unwrap();
                         let b = right_types.get(j).unwrap();
                         if matches!(&self.mode, Coercion)
-                            && (matches!(a, Placeholder(_)) || matches!(b, Placeholder(_)))
+                            && (matches!(
+                                (a, b),
+                                (_, Placeholder(_))
+                                    | (Placeholder(_), _)
+                                    | (UnsignedInteger(_), Numeric)
+                                    | (Numeric, UnsignedInteger(_))
+                            ))
                         {
                             continue;
                         }
@@ -641,7 +647,13 @@ impl<'a> UnifyCheck<'a> {
                     let a = left_types.get(i).unwrap();
                     let b = left_types.get(j).unwrap();
                     if matches!(&self.mode, Coercion)
-                        && (matches!(a, Placeholder(_)) || matches!(b, Placeholder(_)))
+                        && (matches!(
+                            (a, b),
+                            (_, Placeholder(_))
+                                | (Placeholder(_), _)
+                                | (UnsignedInteger(_), Numeric)
+                                | (Numeric, UnsignedInteger(_))
+                        ))
                     {
                         continue;
                     }

--- a/sway-error/src/warning.rs
+++ b/sway-error/src/warning.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use sway_types::{integer_bits::IntegerBits, Ident, SourceId, Span, Spanned};
+use sway_types::{Ident, SourceId, Span, Spanned};
 
 // TODO: since moving to using Idents instead of strings,
 // the warning_content will usually contain a duplicate of the span.
@@ -51,10 +51,6 @@ pub enum Warning {
     },
     NonScreamingSnakeCaseConstName {
         name: Ident,
-    },
-    LossOfPrecision {
-        initial_type: IntegerBits,
-        cast_to: IntegerBits,
     },
     UnusedReturnValue {
         r#type: String,
@@ -177,12 +173,6 @@ impl fmt::Display for Warning {
                     to_screaming_snake_case(name.as_str()),
                 )
             },
-            LossOfPrecision {
-                initial_type,
-                cast_to,
-            } => write!(f,
-                "This cast, from integer type of width {initial_type} to integer type of width {cast_to}, will lose precision."
-            ),
             UnusedReturnValue { r#type } => write!(
                 f,
                 "This returns a value of type {type}, which is not assigned to anything and is \

--- a/sway-ir/src/error.rs
+++ b/sway-ir/src/error.rs
@@ -23,7 +23,7 @@ pub enum IrError {
     VerifyBlockArgMalformed,
     VerifyBranchParamsMismatch,
     VerifyBranchToMissingBlock(String),
-    VerifyCallArgTypeMismatch(String),
+    VerifyCallArgTypeMismatch(String, String, String),
     VerifyCallToMissingFunction(String),
     VerifyCmpBadTypes(String, String),
     VerifyCmpTypeMismatch(String, String),
@@ -136,10 +136,10 @@ impl fmt::Display for IrError {
                     Branch to block '{label}' is not a block in the current function."
                 )
             }
-            IrError::VerifyCallArgTypeMismatch(callee) => {
+            IrError::VerifyCallArgTypeMismatch(callee, caller_ty, callee_ty) => {
                 write!(
                     f,
-                    "Verification failed: Type mismatch found for call to '{callee}'."
+                    "Verification failed: Type mismatch found for call to '{callee}': {caller_ty} is not a {callee_ty}."
                 )
             }
             IrError::VerifyCallToMissingFunction(callee) => {

--- a/sway-ir/src/irtype.rs
+++ b/sway-ir/src/irtype.rs
@@ -50,7 +50,6 @@ impl Type {
         Self::get_or_create_unique_type(context, TypeContent::Unit);
         Self::get_or_create_unique_type(context, TypeContent::Bool);
         Self::get_or_create_unique_type(context, TypeContent::Uint(8));
-        Self::get_or_create_unique_type(context, TypeContent::Uint(32));
         Self::get_or_create_unique_type(context, TypeContent::Uint(64));
         Self::get_or_create_unique_type(context, TypeContent::B256);
         Self::get_or_create_unique_type(context, TypeContent::Slice);
@@ -79,11 +78,6 @@ impl Type {
     /// New u8 type
     pub fn get_uint8(context: &Context) -> Type {
         Self::get_type(context, &TypeContent::Uint(8)).expect("create_basic_types not called")
-    }
-
-    /// New u32 type
-    pub fn get_uint32(context: &Context) -> Type {
-        Self::get_type(context, &TypeContent::Uint(32)).expect("create_basic_types not called")
     }
 
     /// New u64 type

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -372,6 +372,8 @@ impl<'a, 'eng> InstructionVerifier<'a, 'eng> {
             if !caller_arg_type.eq(self.context, callee_arg_type) {
                 return Err(IrError::VerifyCallArgTypeMismatch(
                     callee_content.name.clone(),
+                    caller_arg_type.as_string(self.context),
+                    callee_arg_type.as_string(self.context),
                 ));
             }
         }

--- a/sway-lib-core/src/primitive_conversions.sw
+++ b/sway-lib-core/src/primitive_conversions.sw
@@ -141,6 +141,12 @@ impl u64 {
 }
 
 impl u32 {
+    pub fn as_u64(self) -> u64 {
+        asm(input: self) {
+            input: u64
+        }
+    }
+
     pub fn to_le_bytes(self) -> [u8; 4] {
         let output = [0_u8, 0_u8, 0_u8, 0_u8];
 
@@ -213,6 +219,18 @@ impl u32 {
 }
 
 impl u16 {
+    pub fn as_u32(self) -> u32 {
+        asm(input: self) {
+            input: u32
+        }
+    }
+
+    pub fn as_u64(self) -> u64 {
+        asm(input: self) {
+            input: u64
+        }
+    }
+
     pub fn to_le_bytes(self) -> [u8; 2] {
         let output = [0_u8, 0_u8];
 
@@ -255,6 +273,26 @@ impl u16 {
             sll  r1 a i;
             or   r1 r1 b;
             r1: u16
+        }
+    }
+}
+
+impl u8 {
+    pub fn as_u16(self) -> u16 {
+        asm(input: self) {
+            input: u16
+        }
+    }
+
+    pub fn as_u32(self) -> u32 {
+        asm(input: self) {
+            input: u32
+        }
+    }
+
+    pub fn as_u64(self) -> u64 {
+        asm(input: self) {
+            input: u64
         }
     }
 }
@@ -463,7 +501,7 @@ fn test_b256_to_le_bytes() {
 
     let mut i: u8 = 0;
     while i < 32_u8 {
-        assert(bytes[i] == 32_u8 - i);
+        assert(bytes[i.as_u64()] == 32_u8 - i);
         i += 1_u8;
     }
 
@@ -489,7 +527,7 @@ fn test_b256_to_be_bytes() {
 
     let mut i: u8 = 0;
     while i < 32_u8 {
-        assert(bytes[i] == i + 1_u8);
+        assert(bytes[i.as_u64()] == i + 1_u8);
         i += 1_u8;
     }
 }

--- a/sway-lib-core/src/primitives.sw
+++ b/sway-lib-core/src/primitives.sw
@@ -13,7 +13,7 @@ impl u64 {
     }
 
     /// The size of this integer type in bits.
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         64
     }
 }
@@ -31,7 +31,7 @@ impl u32 {
     }
 
     /// The size of this integer type in bits.
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         32
     }
 }
@@ -49,7 +49,7 @@ impl u16 {
     }
 
     /// The size of this integer type in bits.
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         16
     }
 }
@@ -67,7 +67,7 @@ impl u8 {
     }
 
     /// The size of this integer type in bits.
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         8
     }
 }

--- a/sway-lib-std/src/auth.sw
+++ b/sway-lib-std/src/auth.sw
@@ -52,7 +52,7 @@ fn inputs_owner() -> Result<Identity, AuthError> {
 
     // Note: `inputs_count` is guaranteed to be at least 1 for any valid tx.
     while i < inputs {
-        let type_of_input = input_type(i);
+        let type_of_input = input_type(i.as_u64());
         match type_of_input {
             Input::Coin => (),
             Input::Message => (),
@@ -64,7 +64,7 @@ fn inputs_owner() -> Result<Identity, AuthError> {
         }
 
         // type == InputCoin or InputMessage.
-        let owner_of_input = input_owner(i);
+        let owner_of_input = input_owner(i.as_u64());
         if candidate.is_none() {
             // This is the first input seen of the correct type.
             candidate = owner_of_input;

--- a/sway-lib-std/src/inputs.sw
+++ b/sway-lib-std/src/inputs.sw
@@ -18,6 +18,7 @@ use ::tx::{
     tx_type,
 };
 use core::ops::Eq;
+use core::primitive_conversions::*;
 
 const GTF_INPUT_TYPE = 0x101;
 
@@ -203,7 +204,7 @@ pub fn input_predicate(index: u64) -> Bytes {
     if wrapped.is_none() {
         revert(0);
     };
-    let length = wrapped.unwrap();
+    let length = wrapped.unwrap().as_u64();
     let mut data_bytes = Bytes::with_capacity(length);
     match input_predicate_pointer(index) {
         Some(d) => {
@@ -265,7 +266,7 @@ pub fn input_message_data(index: u64, offset: u64) -> Bytes {
     assert(valid_input_type(index, Input::Message));
     let data = __gtf::<raw_ptr>(index, GTF_INPUT_MESSAGE_DATA);
     let data_with_offset = data.add_uint_offset(offset);
-    let length = input_message_data_length(index);
+    let length = input_message_data_length(index).as_u64();
     let mut data_bytes = Bytes::with_capacity(length);
     data_bytes.len = length;
     data_with_offset.copy_bytes_to(data_bytes.buf.ptr, length);

--- a/sway-lib-std/src/lib.sw
+++ b/sway-lib-std/src/lib.sw
@@ -5,6 +5,7 @@ pub mod logging;
 pub mod revert;
 pub mod result;
 pub mod option;
+pub mod primitive_conversions;
 pub mod convert;
 pub mod intrinsics;
 pub mod assert;

--- a/sway-lib-std/src/prelude.sw
+++ b/sway-lib-std/src/prelude.sw
@@ -24,6 +24,9 @@ use ::revert::{require, revert};
 // Convert
 use ::convert::From;
 
+// Primitive conversions
+use ::primitive_conversions::*;
+
 // Logging
 use ::logging::log;
 

--- a/sway-lib-std/src/primitive_conversions.sw
+++ b/sway-lib-std/src/primitive_conversions.sw
@@ -1,0 +1,70 @@
+library;
+
+use ::option::Option::{self, *};
+use core::primitive_conversions::*;
+
+impl u16 {
+    pub fn try_as_u8(self) -> Option<u8> {
+        if self <= u8::max().as_u16() {
+            Some(asm(input: self) {
+                input: u8
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl u32 {
+    pub fn try_as_u8(self) -> Option<u8> {
+        if self <= u8::max().as_u32() {
+            Some(asm(input: self) {
+                input: u8
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn try_as_u16(self) -> Option<u16> {
+        if self <= u16::max().as_u32() {
+            Some(asm(input: self) {
+                input: u16
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl u64 {
+    pub fn try_as_u8(self) -> Option<u8> {
+        if self <= u8::max().as_u64() {
+            Some(asm(input: self) {
+                input: u8
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn try_as_u16(self) -> Option<u16> {
+        if self <= u16::max().as_u64() {
+            Some(asm(input: self) {
+                input: u16
+            })
+        } else {
+            None
+        }
+    }
+    
+    pub fn try_as_u32(self) -> Option<u32> {
+        if self <= u32::max().as_u64() {
+            Some(asm(input: self) {
+                input: u32
+            })
+        } else {
+            None
+        }
+    }
+}

--- a/sway-lsp/tests/fixtures/tokens/consts/src/more_consts.sw
+++ b/sway-lsp/tests/fixtures/tokens/consts/src/more_consts.sw
@@ -9,6 +9,6 @@ enum Data {
     B: Value,
 }
 
-pub const CONSTANT_3: u32 = 300;
+pub const CONSTANT_3: u64 = 300;
 pub const CONSTANT_4: u32 = 400;
 pub const MY_DATA1: Data = Data::A(true);

--- a/test/src/e2e_vm_tests/test_programs/should_fail/abort_control_flow_bad/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abort_control_flow_bad/test.toml
@@ -3,7 +3,7 @@ category = "fail"
 # check: return 42;
 # nextln: $()Mismatched types.
 # nextln: $()expected: ()
-# nextln: $()found:    u64.
+# nextln: $()found:    numeric.
 # nextln: $()help: Return statement must return the declared function return type.
 
 # This 'return true' line appears in both error messages..

--- a/test/src/e2e_vm_tests/test_programs/should_fail/binop_intrinsics/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/binop_intrinsics/src/main.sw
@@ -9,5 +9,9 @@ fn main() {
    let _ = __add("Hello", 22);
    let _ = __add("Hello", "Hello");
    let _ = __add(false, true);
+   let _ = __add(1u32, 1u64);
    let _ = __add::<u32>(0, 1);
+
+   let _ = __rsh("Hello", 1);
+   let _ = __rsh(1, "Hello");
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/binop_intrinsics/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/binop_intrinsics/test.toml
@@ -2,20 +2,67 @@ category = "fail"
 
 # check: $()error
 # check: $()__add(A { a: 32 }, 32);
-# nextln: $()Unsupported argument type to intrinsic "add"
+# nextln: $()Mismatched types
+# nextln: $()expected: numeric
+# nextln: $()found:    A.
+# nextln: $()help: Incorrect argument type
 
 # check: $()error
 # check: $()__add("Hello", 22);
-# nextln: $()Unsupported argument type to intrinsic "add"
+# nextln: $()Mismatched types
+# nextln: $()expected: numeric
+# nextln: $()found:    str[5].
+# nextln: $()help: Incorrect argument type
 
 # check: $()error
 # check: $()__add("Hello", "Hello")
-# nextln: $()Unsupported argument type to intrinsic "add"
+# nextln: $()Mismatched types
+# nextln: $()expected: numeric
+# nextln: $()found:    str[5].
+# nextln: $()help: Incorrect argument type
+
+# check: $()error
+# check: $()__add("Hello", "Hello")
+# nextln: $()Mismatched types
+# nextln: $()expected: numeric
+# nextln: $()found:    str[5].
+# nextln: $()help: Incorrect argument type
 
 # check: $()error
 # check: $()__add(false, true)
-# nextln: $()Unsupported argument type to intrinsic "add"
+# nextln: $()Mismatched types
+# nextln: $()expected: numeric
+# nextln: $()found:    bool.
+# nextln: $()help: Incorrect argument type
+
+# check: $()error
+# check: $()__add(false, true)
+# nextln: $()Mismatched types
+# nextln: $()expected: numeric
+# nextln: $()found:    bool.
+# nextln: $()help: Incorrect argument type
+
+# check: $()error
+# check: $()__add(1u32, 1u64)
+# nextln: $()Mismatched types
+# nextln: $()expected: u32
+# nextln: $()found:    u64.
+# nextln: $()help: Incorrect argument type
 
 # check: $()error
 # check: $()__add::<u32>(0, 1)
 # nextln: $()Call to "add" expects 0 type arguments
+
+# check: $()error
+# check: $()__rsh("Hello", 1)
+# nextln: $()Mismatched types
+# nextln: $()expected: numeric
+# nextln: $()found:    str[5].
+# nextln: $()help: Incorrect argument type
+
+# check: $()error
+# check: $()__rsh(1, "Hello")
+# nextln: $()Mismatched types
+# nextln: $()expected: numeric
+# nextln: $()found:    str[5].
+# nextln: $()help: Incorrect argument type

--- a/test/src/e2e_vm_tests/test_programs/should_fail/eq_intrinsic/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/eq_intrinsic/src/main.sw
@@ -13,6 +13,7 @@ fn main() {
     let _ = __eq("hi", "ho");
     let _ = __eq(false, 11);
     let _ = __eq(A { a: 1 }, B { a: 1 });
+    let _ = __eq(A { a: 1 }, A { a: 1 });
     let _ = __eq((1, 2), (1, 2));
     let _ = __eq([1, 2], [1, 2]);
     let _ = __eq(B::First, B::First);

--- a/test/src/e2e_vm_tests/test_programs/should_fail/eq_intrinsic/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/eq_intrinsic/test.toml
@@ -1,12 +1,20 @@
 category = "fail"
 
 # check: $()__eq("hi", "ho");
-# nextln: $()Unsupported argument type to intrinsic "eq".
+# check: $()Unsupported argument type to intrinsic "eq".
+
+# check: $()__eq(false, 11);
 
 # check: $()__eq(false, 11);
 # check: $()Mismatched types.
+# check: $()expected: bool
+# check: $()found:    numeric.
+# check: $()help: Variable declaration's type annotation does not match up with the assigned expression's type.
 
 # check: $()__eq(A { a: 1 }, B { a: 1 });
+# check: $()This is a B, not a struct.
+
+# check: $()__eq(A { a: 1 }, A { a: 1 });
 # check: $()Unsupported argument type to intrinsic "eq".
 
 # check: $()__eq((1, 2), (1, 2));

--- a/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_wrong_struct/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/match_expressions_wrong_struct/test.toml
@@ -2,14 +2,14 @@ category = "fail"
 
 # check: Point { x: 3, y } => { y },
 # nextln: $()Mismatched types.
-# nextln: $()expected: u64
+# nextln: $()expected: numeric
 # nextln: $()found:    Point.
 
 # check: Point { x: 3, y: 4 } => { 24 },
 
 # check: Point { x: 3, y: 4 } => { 24 },
 # nextln: $()Mismatched types.
-# nextln: $()expected: u64
+# nextln: $()expected: numeric
 # nextln: $()found:    Point.
 
 # check: Data { value: 1u64 } => { false },

--- a/test/src/e2e_vm_tests/test_programs/should_fail/where_clause_impls/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/where_clause_impls/src/main.sw
@@ -46,11 +46,11 @@ impl<T> MyAdd for MyPoint<T> {
 fn main() -> u8 {
     let foo = MyPoint {
         x: 1u32,
-        y: 2u64,
+        y: 2u32,
     };
     let bar = MyPoint {
         x: 3u32,
-        y: 4u64,
+        y: 4u32,
     };
     let baz = foo.my_add(bar);
     baz.y

--- a/test/src/e2e_vm_tests/test_programs/should_fail/wrongly_sized_tuple_destructuring/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/wrongly_sized_tuple_destructuring/test.toml
@@ -3,5 +3,5 @@ category = "fail"
 # check: let (_b, _c) = a;
 # nextln: $()Mismatched types.
 # nextln: $()expected: (_, _)
-# nextln: $()found:    (bool, u64, u64).
+# nextln: $()found:    (bool, numeric, numeric).
 # nextln: $()help: Variable declaration's type annotation does not match up with the assigned expression's type.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_const_impl_local_same_name/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_const_impl_local_same_name/src/main.sw
@@ -6,7 +6,7 @@ impl Struct {
     const ID: u32 = 1;
 }
 
-fn main() -> u64 {
+fn main() -> u32 {
   const ID: u32 = 1;
   Struct::ID
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_const_impl_multiple/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_const_impl_multiple/src/main.sw
@@ -10,6 +10,6 @@ impl Struct {
     const ID2: u32 = 2;
 }
 
-fn main() -> u64 {
+fn main() -> u32 {
   Struct::ID
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/binop_intrinsics/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/binop_intrinsics/src/main.sw
@@ -56,6 +56,7 @@ fn main() -> u64 {
   assert(__lsh(2, 3) == 16);
   assert(__rsh(16, 3) == 2);
   assert(__rsh(1, 1) == 0);
+  assert(__rsh(1u8, 1u64) == 0);
 
   2
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/json_abi_oracle.json
@@ -17,7 +17,7 @@
   "types": [
     {
       "components": null,
-      "type": "u32",
+      "type": "u64",
       "typeId": 0,
       "typeParameters": null
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/fix_opcode_bug/src/main.sw
@@ -120,7 +120,7 @@ fn where_x() -> u64 {
     return 1;
 }
 
-fn main() -> u32 {
+fn main() -> u64 {
     let where_y = abi_x()
         + enum_x()
         + fn_x()

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_functions/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_functions/src/main.sw
@@ -15,7 +15,7 @@ fn three_generics<A, B, C>(a: A, b: B, _c: C) -> B {
 
 fn main() -> bool {
   let a: bool   = identity(true);
-  let _b: u32    = identity(10);
+  let _b: u32    = identity(10u32);
   let _c: u64    = identity(42);
   let _e: str[3] = identity("foo");
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_impl_self/src/main.sw
@@ -166,7 +166,7 @@ fn generic_impl_self_test() {
     assert(f.first && f.second);
 
     let g: DoubleIdentity<u32, u64> = double_identity(10u32, 43u64);
-    assert((g.first + 33u32) == g.second);
+    assert((g.first + 33u32).as_u64() == g.second);
 
     let h = DoubleIdentity::<u64, bool>::new(3u64, false);
     assert(!h.second);
@@ -182,10 +182,10 @@ fn generic_impl_self_test() {
 
     let m: DoubleIdentity<Data<u8>, Data<u64>> = DoubleIdentity {
         first: Data { value: 1u8 },
-        second: Data { value: 2u8 },
+        second: Data { value: 2u64 },
         third: 1u64,
     };
-    assert(m.second.value == (m.first.value + m.third));
+    assert(m.second.value == (m.first.value.as_u64() + m.third));
 
     let n = DoubleIdentity::<Data<u8>, Data<u8>>::new(Data::<u8>::new(3u8), Data::<u8>::new(4u8));
     assert(n.third == 10u64);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_traits/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_traits/src/main.sw
@@ -41,34 +41,24 @@ trait MyAdd<T> {
     fn my_add(self, a: T, b: T) -> T;
 }
 
-// impl<T> MyAdd<u8> for FooBarData<T> {
-//     fn my_add(self, a: u8, b: u8) -> u8 {
-//         a + b
-//     }
-// }
-
-impl<T> MyAdd<u64> for FooBarData<T> {
-    fn my_add(self, a: u64, b: u64) -> u64 {
+impl<T> MyAdd<u8> for FooBarData<T> {
+    fn my_add(self, a: u8, b: u8) -> u8 {
         a + b
     }
 }
+
+// impl<T> MyAdd<u64> for FooBarData<T> {
+//     fn my_add(self, a: u64, b: u64) -> u64 {
+//         a + b
+//     }
+// }
 
 trait MySub<T> {
     fn my_sub(a: T, b: T) -> T;
 }
 
-// impl<T> MySub<u8> for FooBarData<T> {
-//     fn my_sub(a: u8, b: u8) -> u8 {
-//         if a >= b {
-//             a - b
-//         } else {
-//             b - a
-//         }
-//     }
-// }
-
-impl<T> MySub<u64> for FooBarData<T> {
-    fn my_sub(a: u64, b: u64) -> u64 {
+impl<T> MySub<u8> for FooBarData<T> {
+    fn my_sub(a: u8, b: u8) -> u8 {
         if a >= b {
             a - b
         } else {
@@ -76,36 +66,36 @@ impl<T> MySub<u64> for FooBarData<T> {
         }
     }
 }
+
+// impl<T> MySub<u64> for FooBarData<T> {
+//     fn my_sub(a: u64, b: u64) -> u64 {
+//         if a >= b {
+//             a - b
+//         } else {
+//             b - a
+//         }
+//     }
+// }
 
 struct OtherData<T> {
     a: T,
     b: T,
 }
 
-// impl<T> MyAdd<u8> for OtherData<T> {
-//     fn my_add(self, a: u8, b: u8) -> u8 {
-//         a + b
-//     }
-// }
-
-impl<T> MyAdd<u64> for OtherData<T> {
-    fn my_add(self, a: u64, b: u64) -> u64 {
+impl<T> MyAdd<u8> for OtherData<T> {
+    fn my_add(self, a: u8, b: u8) -> u8 {
         a + b
     }
 }
 
-// impl<T> MySub<u8> for OtherData<T> {
-//     fn my_sub(a: u8, b: u8) -> u8 {
-//         if a >= b {
-//             a - b
-//         } else {
-//             b - a
-//         }
+// impl<T> MyAdd<u64> for OtherData<T> {
+//     fn my_add(self, a: u64, b: u64) -> u64 {
+//         a + b
 //     }
 // }
 
-impl<T> MySub<u64> for OtherData<T> {
-    fn my_sub(a: u64, b: u64) -> u64 {
+impl<T> MySub<u8> for OtherData<T> {
+    fn my_sub(a: u8, b: u8) -> u8 {
         if a >= b {
             a - b
         } else {
@@ -113,6 +103,16 @@ impl<T> MySub<u64> for OtherData<T> {
         }
     }
 }
+
+// impl<T> MySub<u64> for OtherData<T> {
+//     fn my_sub(a: u64, b: u64) -> u64 {
+//         if a >= b {
+//             a - b
+//         } else {
+//             b - a
+//         }
+//     }
+// }
 
 impl MyTriple<u64> for MyPoint<u64> {
     fn my_triple(self, value: u64) -> u64 {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/integer_type_inference/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/integer_type_inference/Forc.lock
@@ -1,3 +1,13 @@
 [[package]]
+name = 'core'
+source = 'path+from-root-5D74C309D88B9A80'
+
+[[package]]
 name = 'integer_type_inference'
 source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'std'
+source = 'path+from-root-5D74C309D88B9A80'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/integer_type_inference/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/integer_type_inference/Forc.toml
@@ -4,3 +4,6 @@ entry = "main.sw"
 implicit-std = false
 license = "Apache-2.0"
 name = "integer_type_inference"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/integer_type_inference/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/integer_type_inference/src/main.sw
@@ -2,28 +2,16 @@ script;
 
 /* Test Constants */
 const X1: u8 = 4u8;
-const X2: u8 = 4u16;
-const X3: u8 = 4u32;
-const X4: u8 = 4u64;
-const X5: u8 = 4;
+const X2: u8 = 4;
 
-const Y1: u16 = 4u8;
-const Y2: u16 = 4u16;
-const Y3: u16 = 4u32;
-const Y4: u16 = 4u64;
-const Y5: u16 = 4;
+const Y1: u16 = 4u16;
+const Y2: u16 = 4;
 
-const Z1: u32 = 4u8;
-const Z2: u32 = 4u16;
-const Z3: u32 = 4u32;
-const Z4: u32 = 4u64;
-const Z5: u32 = 4;
+const Z1: u32 = 4u32;
+const Z2: u32 = 4;
 
-const W1: u64 = 4u8;
-const W2: u64 = 4u16;
-const W3: u64 = 4u32;
-const W4: u64 = 4u64;
-const W5: u64 = 4;
+const W1: u64 = 4u64;
+const W2: u64 = 4;
 
 const V1 = 4u8;
 const V2 = 4u16;
@@ -69,27 +57,15 @@ fn main() {
     /* Make sure that the resulting types of constants are correct */
     X1.foo_u8();
     X2.foo_u8();
-    X3.foo_u8();
-    X4.foo_u8();
-    X5.foo_u8();
 
     Y1.foo_u16();
     Y2.foo_u16();
-    Y3.foo_u16();
-    Y4.foo_u16();
-    Y5.foo_u16();
 
     Z1.foo_u32();
     Z2.foo_u32();
-    Z3.foo_u32();
-    Z4.foo_u32();
-    Z5.foo_u32();
 
     W1.foo_u64();
     W2.foo_u64();
-    W3.foo_u64();
-    W4.foo_u64();
-    W5.foo_u64();
 
     V1.foo_u8();
     V2.foo_u16();
@@ -99,26 +75,26 @@ fn main() {
 
     /* Make sure that the resulting types of variables are correct */
     let x1: u8 = 4u8;
-    let x2: u8 = 4u16;
-    let x3: u8 = 4u32;
-    let x4: u8 = 4u64;
+    let x2: u8 = 4u16.try_as_u8().unwrap();
+    let x3: u8 = 4u32.try_as_u8().unwrap();
+    let x4: u8 = 4u64.try_as_u8().unwrap();
     let x5: u8 = 4;
 
-    let y1: u16 = 4u8;
+    let y1: u16 = 4u8.as_u16();
     let y2: u16 = 4u16;
-    let y3: u16 = 4u32;
-    let y4: u16 = 4u64;
+    let y3: u16 = 4u32.try_as_u16().unwrap();
+    let y4: u16 = 4u64.try_as_u16().unwrap();
     let y5: u16 = 4;
 
-    let z1: u32 = 4u8;
-    let z2: u32 = 4u16;
+    let z1: u32 = 4u8.as_u32();
+    let z2: u32 = 4u16.as_u32();
     let z3: u32 = 4u32;
-    let z4: u32 = 4u64;
+    let z4: u32 = 4u64.try_as_u32().unwrap();
     let z5: u32 = 4;
 
-    let w1: u64 = 4u8;
-    let w2: u64 = 4u16;
-    let w3: u64 = 4u32;
+    let w1: u64 = 4u8.as_u64();
+    let w2: u64 = 4u16.as_u64();
+    let w3: u64 = 4u32.as_u64();
     let w4: u64 = 4u64;
     let w5: u64 = 4;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/src/main.sw
@@ -1,18 +1,19 @@
 script;
 
 fn main() -> bool {
-    assert(u64::max() == 18446744073709551615);
+    assert(u64::max() == 18446744073709551615u64);
     assert(u64::min() == 0u64);
-    assert(u64::bits() == 64u32);
     assert(u32::max() == 4294967295u32);
     assert(u32::min() == 0u32);
-    assert(u32::bits() == 32u16);
     assert(u16::max() == 65535u16);
     assert(u16::min() == 0u16);
-    assert(u16::bits() == 16u8);
     assert(u8::max() == 255u8);
     assert(u8::min() == 0u8);
-    assert(u8::bits() == 8u32);
+
+    assert(u64::bits() == 64u64);
+    assert(u32::bits() == 32u64);
+    assert(u16::bits() == 16u64);
+    assert(u8::bits() == 8u64);
 
     true
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_access/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_access/json_abi_oracle.json
@@ -17,7 +17,7 @@
   "types": [
     {
       "components": null,
-      "type": "u32",
+      "type": "u64",
       "typeId": 0,
       "typeParameters": null
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_access/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/tuple_access/src/main.sw
@@ -8,7 +8,7 @@ fn test<T, E>(a: T, b: E) {
     let (_x, _y): (T, E) = (a, b);
 } 
 
-fn main() -> u32 {
+fn main() -> u64 {
     let (_foo, _bar) = gimme_a_pair();
     let (_x, _y): (u32, bool) = (10, true);
     //let (x, y): (u32, _) = (42, true); // this generates a parsing error

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/use_full_path_names/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/use_full_path_names/json_abi_oracle.json
@@ -17,7 +17,7 @@
   "types": [
     {
       "components": null,
-      "type": "u64",
+      "type": "u32",
       "typeId": 0,
       "typeParameters": null
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/use_full_path_names/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/use_full_path_names/src/main.sw
@@ -4,7 +4,7 @@ mod foo;
 mod bar;
 mod baz;
 
-fn main() -> u64 {
+fn main() -> u32 {
     let _x = foo::Foo {
         foo: 1u32,
     };

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/vec/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/vec/src/main.sw
@@ -67,7 +67,7 @@ fn test_vector_new_u8() {
         Some(val) => assert(val == number4), None => revert(0),
     }
 
-    match vector.get(number6) {
+    match vector.get(number6.as_u64()) {
         Some(val) => assert(val == number6), None => revert(0),
     }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/issue_1512_repro/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/issue_1512_repro/Forc.lock
@@ -5,4 +5,12 @@ source = 'path+from-root-C086F5BB5B0BA300'
 [[package]]
 name = 'issue_1512_repro'
 source = 'member'
+dependencies = [
+    'core',
+    'std',
+]
+
+[[package]]
+name = 'std'
+source = 'path+from-root-C086F5BB5B0BA300'
 dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/issue_1512_repro/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/issue_1512_repro/Forc.toml
@@ -7,3 +7,4 @@ name = "issue_1512_repro"
 
 [dependencies]
 core = { path = "../../../../../../../sway-lib-core" }
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/issue_1512_repro/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/issue_1512_repro/src/main.sw
@@ -17,7 +17,7 @@ pub struct U128 {
     lower: u64,
 }
 
-pub trait From {
+pub trait AltFrom {
     fn from(h: u64, l: u64) -> Self;
 } {
 }
@@ -29,7 +29,7 @@ impl core::ops::Eq for U128 {
 }
 
 /// Function for creating U128 from its u64 components
-impl From for U128 {
+impl AltFrom for U128 {
     fn from(h: u64, l: u64) -> U128 {
         U128 {
             upper: h,
@@ -91,28 +91,28 @@ impl U128 {
     // TO DO : mul, div, inequalities, etc.
 }
 
-// Downcast from u64 to u32, losing precision
-fn u64_to_u32(a: u64) -> u32 {
-    let result: u32 = a;
-    result
-}
-
 // Multiply two u64 values, producing a U128
 pub fn mul64(a: u64, b: u64) -> U128 {
     // Split a and b into 32-bit lo and hi components
-    let a_lo = u64_to_u32(a);
-    let a_hi = u64_to_u32(a >> 32);
-    let b_lo = u64_to_u32(b);
-    let b_hi = u64_to_u32(b >> 32);
+    let a_lo = (a & 0x00000000ffffffff).try_as_u32().unwrap();
+    let a_hi = (a >> 32).try_as_u32().unwrap();
+    let b_lo = (b & 0x00000000ffffffff).try_as_u32().unwrap();
+    let b_hi = (b >> 32).try_as_u32().unwrap();
 
     // Calculate low, high, and mid multiplications
-    let ab_hi: u64 = a_hi * b_hi;
-    let ab_mid: u64 = a_hi * b_lo;
-    let ba_mid: u64 = b_hi * a_lo;
-    let ab_lo: u64 = a_lo * b_lo;
+    let ab_hi = (a_hi * b_hi).as_u64();
+    let ab_mid = (a_hi * b_lo).as_u64();
+    let ba_mid = (b_hi * a_lo).as_u64();
+    let ab_lo = (a_lo * b_lo).as_u64();
 
     // Calculate the carry bit
-    let carry_bit: u64 = (u64_to_u32(ab_mid) + u64_to_u32(ba_mid) + (ab_lo >> 32)) >> 32;
+    let carry_bit = (
+        (
+            ab_mid.try_as_u32().unwrap() +
+            ba_mid.try_as_u32().unwrap() +
+            (ab_lo >> 32).try_as_u32().unwrap()
+        ) >> 32
+    ).as_u64();
 
     // low result is what's left after the (overflowing) multiplication of a and b
     let result_lo: u64 = a * b;

--- a/test/src/sdk-harness/test_artifacts/tx_contract/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/tx_contract/src/main.sw
@@ -73,7 +73,7 @@ impl TxContractTest for Contract {
         tx_script_data_length()
     }
     fn get_tx_inputs_count() -> u64 {
-        input_count()
+        input_count().as_u64()
     }
     fn get_tx_outputs_count() -> u64 {
         output_count()
@@ -154,7 +154,7 @@ impl TxContractTest for Contract {
 
     fn get_input_predicate(index: u64, bytecode: Vec<u8>) -> bool {
         let code = input_predicate(index);
-        assert(input_predicate_length(index).unwrap() == bytecode.len());
+        assert(input_predicate_length(index).unwrap().as_u64() == bytecode.len());
         let mut i = 0;
         while i < bytecode.len() {
             assert(bytecode.get(i).unwrap() == code.get(i).unwrap());

--- a/test/src/sdk-harness/test_projects/generics_in_abi/src/main.sw
+++ b/test/src/sdk-harness/test_projects/generics_in_abi/src/main.sw
@@ -79,7 +79,7 @@ impl MyContract for Contract {
     }
 
     fn struct_w_generic_in_tuple(arg1: StructWTupleGeneric<u32>) -> StructWTupleGeneric<u32> {
-        let expected = StructWTupleGeneric { a: (1, 2) };
+        let expected = StructWTupleGeneric { a: (1u32, 2u32) };
         assert(expected.a.0 == arg1.a.0);
         assert(expected.a.1 == arg1.a.1);
 
@@ -89,7 +89,7 @@ impl MyContract for Contract {
     fn struct_w_diff_generic_in_tuple(
         arg1: StructWDiffTupleGeneric<u32, bool>,
     ) -> StructWDiffTupleGeneric<u32, bool> {
-        let expected = StructWDiffTupleGeneric { a: (1, false) };
+        let expected = StructWDiffTupleGeneric { a: (1u32, false) };
         assert(expected.a.0 == arg1.a.0);
         assert(expected.a.1 == arg1.a.1);
 

--- a/test/src/sdk-harness/test_projects/token_ops/src/main.sw
+++ b/test/src/sdk-harness/test_projects/token_ops/src/main.sw
@@ -62,9 +62,9 @@ impl TestFuelCoin for Contract {
     fn send_message(recipient: b256, msg_data: Vec<u64>, coins: u64) {
         let mut data = Bytes::new();
         if msg_data.len() > 0 {
-            data.push(msg_data.get(0).unwrap());
-            data.push(msg_data.get(1).unwrap());
-            data.push(msg_data.get(2).unwrap());
+            data.push(msg_data.get(0).unwrap().try_as_u8().unwrap());
+            data.push(msg_data.get(1).unwrap().try_as_u8().unwrap());
+            data.push(msg_data.get(2).unwrap().try_as_u8().unwrap());
         }
 
         send_message(recipient, data, coins);


### PR DESCRIPTION
## Description

This does two things.

1. Integer types no longer automatically cast to each other. Methods such as `as_u64` and `try_as_u8` have been introduced to require the user to explicit the cast.
Warnings about casts losing precision have been removed as they are no longer possible.

2. Numeric literals (such as `32` without further qualifications) no longer immediately decay to a `u64` and we instead attempt to type them as `TypeInfo::Numeric` as far as possible to allow their usage with any integer type.
Numeric intrinsics unify arguments with the numeric type to enforce their constraints.
Numeric values are forced to decay to `u64` when resolving methods or traits.

This change is a prerequisite to move our representation of sub-byte-sized values to a different memory representation, as numeric types need to be distinct if we are ever to treat them differently.

Fixes #3470

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
