### PR TITLE
Remove dependency on external library for Ownership example

### DIFF
--- a/examples/Forc.lock
+++ b/examples/Forc.lock
@@ -5,22 +5,22 @@ source = 'member'
 [[package]]
 name = 'array'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'asm_return_tuple_pointer'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'break_and_continue'
 source = 'member'
-dependencies = ['core path+from-root-087D5D776F294F03']
+dependencies = ['core']
 
 [[package]]
 name = 'cei_analysis'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'configurable_constants'
@@ -31,13 +31,9 @@ name = 'core'
 source = 'path+from-root-087D5D776F294F03'
 
 [[package]]
-name = 'core'
-source = 'path+from-root-9BFE6D5D0CBDF740'
-
-[[package]]
 name = 'counter'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'enums'
@@ -46,105 +42,92 @@ source = 'member'
 [[package]]
 name = 'fizzbuzz'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'hashing'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'identity'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'liquidity_pool'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'match_statements'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'methods_and_associated_functions'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'msg_sender'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'mut_ref_params'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'native_token'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'option'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
-
-[[package]]
-name = 'ownership'
-source = 'git+https://github.com/FuelLabs/sway-libs?tag=v0.12.0#063f118a3104adb6a04207ca877993b5ad03a492'
-dependencies = ['std git+https://github.com/fuellabs/sway?tag=v0.42.1#3b66f8e424bd21e3ba467783b10b36e808cfa6ee']
+dependencies = ['std']
 
 [[package]]
 name = 'ownership'
 source = 'member'
-dependencies = [
-    'ownership git+https://github.com/FuelLabs/sway-libs?tag=v0.12.0#063f118a3104adb6a04207ca877993b5ad03a492',
-    'std path+from-root-087D5D776F294F03',
-]
+dependencies = ['std']
 
 [[package]]
 name = 'result'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'signatures'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
-
-[[package]]
-name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.42.1#3b66f8e424bd21e3ba467783b10b36e808cfa6ee'
-dependencies = ['core path+from-root-9BFE6D5D0CBDF740']
+dependencies = ['std']
 
 [[package]]
 name = 'std'
 source = 'path+from-root-087D5D776F294F03'
-dependencies = ['core path+from-root-087D5D776F294F03']
+dependencies = ['core']
 
 [[package]]
 name = 'storage_example'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'storage_map'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'storage_variables'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'storage_vec'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'structs'
@@ -153,7 +136,7 @@ source = 'member'
 [[package]]
 name = 'subcurrency'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'tuples'
@@ -162,23 +145,23 @@ source = 'member'
 [[package]]
 name = 'type_aliases'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'vec'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'wallet_abi'
 source = 'member'
-dependencies = ['std path+from-root-087D5D776F294F03']
+dependencies = ['std']
 
 [[package]]
 name = 'wallet_contract_caller_script'
 source = 'member'
 dependencies = [
-    'std path+from-root-087D5D776F294F03',
+    'std',
     'wallet_abi',
 ]
 
@@ -186,6 +169,6 @@ dependencies = [
 name = 'wallet_smart_contract'
 source = 'member'
 dependencies = [
-    'std path+from-root-087D5D776F294F03',
+    'std',
     'wallet_abi',
 ]

--- a/examples/ownership/Forc.toml
+++ b/examples/ownership/Forc.toml
@@ -5,5 +5,4 @@ license = "Apache-2.0"
 name = "ownership"
 
 [dependencies]
-ownership = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.12.0" }
 std = { path = "../../sway-lib-std" }

--- a/examples/ownership/src/main.sw
+++ b/examples/ownership/src/main.sw
@@ -1,7 +1,37 @@
 contract;
 
 use std::constants::ZERO_B256;
-use ownership::{*, data_structures::State};
+
+// SRC-5 Ownership Standard `State` enum
+pub enum State {
+    Uninitialized: (),
+    Initialized: Identity,
+    Revoked: (),
+}
+
+// SRC-5 Ownership Standard `Ownership` struct
+pub struct Ownership {
+    state: State,
+}
+
+// Skeleton implementation of the Ownership Library.
+// The library can be found here https://github.com/FuelLabs/sway-libs/tree/master/libs/ownership
+impl StorageKey<Ownership> {
+    fn renounce_ownership(self) {}
+    fn set_ownership(self, identity: Identity) {}
+    fn owner(self) -> State {
+        State::Uninitialized
+    }
+    fn only_owner(self) {}
+}
+
+impl Ownership {
+    fn initialized(identity: Identity) -> Self {
+        Self {
+            state: State::Initialized(identity),
+        }
+    }
+}
 
 abi OwnershipExample {
     #[storage(write)]


### PR DESCRIPTION
## Description

It was noted that in the case of a breaking change to the std-lib, the external Ownership library would need to be updated, which depended on the std-lib creating a circular dependency.

The external library has been removed from the example and a skeleton of its implementation has been added with a link to the actual implementation.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
