### PR TITLE
Update all storage inline docs to follow SRC-2 standard

### DIFF
--- a/sway-lib-std/src/storage/storable_slice.sw
+++ b/sway-lib-std/src/storage/storable_slice.sw
@@ -7,21 +7,27 @@ use ::storage::storage_api::*;
 
 /// Store a raw_slice from the heap into storage.
 ///
-/// ### Arguments
+/// # Arguments
 ///
-/// * `key` - The storage slot at which the variable will be stored.
-/// * `slice` - The raw_slice to be stored.
+/// * `key`: [b256] - The storage slot at which the variable will be stored.
+/// * `slice`: [raw_slice] - The raw_slice to be stored.
+/// 
+/// # Number of Storage Accesses
 ///
-/// ### Examples
+/// * Writes: `2`
+///
+/// # Examples
 ///
 /// ```sway
 /// use std::{alloc::alloc_bytes, storage::{write_slice, read_slice}, constants::ZERO_B256};
 ///
-/// let slice = asm(ptr: (alloc_bytes(1), 1)) { ptr: raw_slice };
-/// assert(read_slice(ZERO_B256).is_none());
-/// write_slice(ZERO_B256, slice);
-/// let stored_slice = read_slice(ZERO_B256).unwrap();
-/// assert(slice == stored_slice);
+/// fn foo() {
+///     let slice = asm(ptr: (alloc_bytes(1), 1)) { ptr: raw_slice };
+///     assert(read_slice(ZERO_B256).is_none());
+///     write_slice(ZERO_B256, slice);
+///     let stored_slice = read_slice(ZERO_B256).unwrap();
+///     assert(slice == stored_slice);
+/// }
 /// ```
 #[storage(read, write)]
 pub fn write_slice(key: b256, slice: raw_slice) {
@@ -43,23 +49,31 @@ pub fn write_slice(key: b256, slice: raw_slice) {
 
 /// Load a raw_slice from storage.
 ///
-/// If no value was previously stored at `key`, `None` is returned. Otherwise,
+/// # Arguments
+///
+/// * `key`: [b256] - The storage slot to load the value from.
+/// 
+/// # Returns
+///
+/// - [Option<raw_slice>] - If no value was previously stored at `key`, `None` is returned. Otherwise,
 /// `Some(value)` is returned, where `value` is the value stored at `key`.
 ///
-/// ### Arguments
+/// # Number of Storage Accesses
 ///
-/// * `key` - The storage slot to load the value from.
-///
-/// ### Examples
+/// * Reads: `2`
+/// 
+/// # Examples
 ///
 /// ```sway
 /// use std::{alloc::alloc_bytes, storage::{write_slice, read_slice}, constants::ZERO_B256};
 ///
-/// let slice = asm(ptr: (alloc_bytes(1), 1)) { ptr: raw_slice };
-/// assert(read_slice(ZERO_B256).is_none());
-/// write_slice(ZERO_B256, slice);
-/// let stored_slice = read_slice(ZERO_B256).unwrap();
-/// assert(slice == stored_slice);
+/// fn foo {
+///     let slice = asm(ptr: (alloc_bytes(1), 1)) { ptr: raw_slice };
+///     assert(read_slice(ZERO_B256).is_none());
+///     write_slice(ZERO_B256, slice);
+///     let stored_slice = read_slice(ZERO_B256).unwrap();
+///     assert(slice == stored_slice);
+/// }
 /// ```
 #[storage(read)]
 pub fn read_slice(key: b256) -> Option<raw_slice> {
@@ -77,24 +91,34 @@ pub fn read_slice(key: b256) -> Option<raw_slice> {
     }
 }
 
-/// Clear a sequence of storage slots starting at a some key. Returns a Boolean
-/// indicating whether all of the storage slots cleared were previously set.
+/// Clear a sequence of storage slots starting at a some key. 
 ///
-/// ### Arguments
+/// # Arguments
 ///
-/// * `key` - The key of the first storage slot that will be cleared
+/// * `key`: [b256] - The key of the first storage slot that will be cleared
 ///
-/// ### Examples
+/// # Returns
+///
+/// * [bool] - Indicates whether all of the storage slots cleared were previously set.
+/// 
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
+/// * Clears: `2`
+///
+/// # Examples
 ///
 /// ```sway
 /// use std::{alloc::alloc_bytes, storage::{clear_slice, write_slice, read_slice}, constants::ZERO_B256};
 ///
-/// let slice = asm(ptr: (alloc_bytes(1), 1)) { ptr: raw_slice };
-/// write_slice(ZERO_B256, slice);
-/// assert(read_slice(ZERO_B256).is_some());
-/// let cleared = clear_slice(ZERO_B256);
-/// assert(cleared);
-/// assert(read_slice(ZERO_B256).is_none());
+/// fn foo() {
+///     let slice = asm(ptr: (alloc_bytes(1), 1)) { ptr: raw_slice };
+///     write_slice(ZERO_B256, slice);
+///     assert(read_slice(ZERO_B256).is_some());
+///     let cleared = clear_slice(ZERO_B256);
+///     assert(cleared);
+///     assert(read_slice(ZERO_B256).is_none());
+/// }
 /// ```
 #[storage(read, write)]
 pub fn clear_slice(key: b256) -> bool {

--- a/sway-lib-std/src/storage/storage_api.sw
+++ b/sway-lib-std/src/storage/storage_api.sw
@@ -5,20 +5,27 @@ use ::option::Option::{self, *};
 
 /// Store a stack value in storage. Will not work for heap values.
 ///
-/// ### Arguments
+/// # Arguments
 ///
-/// * `slot` - The storage slot at which the variable will be stored.
-/// * `value` - The value to be stored.
-/// * `offset` - An offset, in words, from the beginning of `slot`, at which `value` should be
+/// * `slot`: [b256] - The storage slot at which the variable will be stored.
+/// * `offset`: [u64] - An offset, in words, from the beginning of `slot`, at which `value` should be
 ///              stored.
+/// * `value`: [T] - The value to be stored.
 ///
-/// ### Examples
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
+/// * Writes: `1`
+///  
+/// # Examples
 ///
 /// ```sway
-/// let five = 5_u64;
-/// write(ZERO_B256, 2, five);
-/// let stored_five = read::<u64>(ZERO_B256, 2).unwrap();
-/// assert(five == stored_five);
+/// fn foo() {
+///     let five = 5_u64;
+///     write(ZERO_B256, 2, five);
+///     let stored_five = read::<u64>(ZERO_B256, 2).unwrap();
+///     assert(five == stored_five);
+/// }
 /// ```
 #[storage(read, write)]
 pub fn write<T>(slot: b256, offset: u64, value: T) {
@@ -51,21 +58,29 @@ pub fn write<T>(slot: b256, offset: u64, value: T) {
 /// Reads a value of type `T` starting at the location specified by `slot` and `offset`. If the
 /// value crosses the boundary of a storage slot, reading continues at the following slot.
 ///
-/// Returns `Option(value)` if the storage slots read were valid and contain `value`. Otherwise,
-/// return `None`.
+/// # Arguments
 ///
-/// ### Arguments
+/// * `slot`: [b256] - The storage slot to load the value from.
+/// * `offset`: [u64] - An offset, in words, from the start of `slot`, from which the value should be read.
 ///
-/// * `slot` - The storage slot to load the value from.
-/// * `offset` - An offset, in words, from the start of `slot`, from which the value should be read.
+/// # Returns
 ///
-/// ### Examples
+/// * [Option<T>] - `Option(value)` if the storage slots read were valid and contain `value`. Otherwise,
+/// returns `None`.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
+/// 
+/// # Examples
 ///
 /// ```sway
-/// let five = 5_u64;
-/// write(ZERO_B256, 2, five);
-/// let stored_five = read::<u64>(ZERO_B256, 2);
-/// assert(five == stored_five);
+/// fn foo() {
+///     let five = 5_u64;
+///     write(ZERO_B256, 2, five);
+///     let stored_five = read::<u64>(ZERO_B256, 2);
+///     assert(five == stored_five.unwrap());
+/// }
 /// ```
 #[storage(read)]
 pub fn read<T>(slot: b256, offset: u64) -> Option<T> {
@@ -91,21 +106,30 @@ pub fn read<T>(slot: b256, offset: u64) -> Option<T> {
     }
 }
 
-/// Clear a sequence of consecutive storage slots starting at a some slot. Returns a Boolean
-/// indicating whether all of the storage slots cleared were previously set.
+/// Clear a sequence of consecutive storage slots starting at a some slot. 
 ///
-/// ### Arguments
+/// # Arguments
 ///
-/// * `slot` - The key of the first storage slot that will be cleared
+/// * `slot`: [b256] - The key of the first storage slot that will be cleared
 ///
-/// ### Examples
+/// # Returns
+///
+/// * [bool] - Indicates whether all of the storage slots cleared were previously set.
+/// 
+/// # Number of Storage Accesses
+///
+/// * Clears: `1`
+///
+/// # Examples
 ///
 /// ```sway
-/// let five = 5_u64;
-/// write(ZERO_B256, 0, five);
-/// let cleared = clear::<u64>(ZERO_B256);
-/// assert(cleared);
-/// assert(read::<u64>(ZERO_B256, 0).is_none());
+/// fn foo() {
+///      let five = 5_u64;
+///     write(ZERO_B256, 0, five);
+///     let cleared = clear::<u64>(ZERO_B256);
+///     assert(cleared);
+///     assert(read::<u64>(ZERO_B256, 0).is_none());
+/// }
 /// ```
 #[storage(write)]
 pub fn clear<T>(slot: b256) -> bool {

--- a/sway-lib-std/src/storage/storage_bytes.sw
+++ b/sway-lib-std/src/storage/storage_bytes.sw
@@ -11,15 +11,15 @@ pub struct StorageBytes {}
 impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
     /// Takes a `Bytes` type and stores the underlying collection of tightly packed bytes.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * `bytes` - The bytes which will be stored.
+    /// * `bytes`: [Bytes] - The bytes which will be stored.
     ///
-    /// ### Number of Storage Accesses
+    /// # Number of Storage Accesses
     ///
     /// * Writes: `2`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// storage {
@@ -42,11 +42,15 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
 
     /// Constructs a `Bytes` type from a collection of tightly packed bytes in storage.
     ///
-    /// ### Number of Storage Accesses
+    /// # Returns
+    ///
+    /// * [Option<Bytes>] - The valid `Bytes` stored, otherwise `None`.
+    ///
+    /// # Number of Storage Accesses
     ///
     /// * Reads: `2`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// storage {
@@ -77,12 +81,16 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
 
     /// Clears a collection of tightly packed bytes in storage.
     ///
-    /// ### Number of Storage Accesses
+    /// # Returns
+    ///
+    /// * [bool] - Indicates whether all of the storage slots cleared were previously set.
+    ///
+    /// # Number of Storage Accesses
     ///
     /// * Reads: `1`
     /// * Clears: `2`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// storage {
@@ -110,11 +118,15 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
 
     /// Returns the length of tightly packed bytes in storage.
     ///
-    /// ### Number of Storage Accesses
+    /// # Returns
+    ///
+    /// * [u64] - The length of the bytes in storage.
+    ///
+    /// # Number of Storage Accesses
     ///
     /// * Reads: `1`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// storage {

--- a/sway-lib-std/src/storage/storage_key.sw
+++ b/sway-lib-std/src/storage/storage_key.sw
@@ -7,14 +7,16 @@ impl<T> StorageKey<T> {
     /// Reads a value of type `T` starting at the location specified by `self`. If the value
     /// crosses the boundary of a storage slot, reading continues at the following slot.
     ///
-    /// Returns the value previously stored if a the storage slots read were
+    /// # Returns
+    ///
+    /// * [T] - Returns the value previously stored if a the storage slots read were
     /// valid and contain `value`. Panics otherwise.
     ///
-    /// ### Arguments
+    /// # Number of Storage Accesses
     ///
-    /// None
+    /// * Reads: `1`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// fn foo() {
@@ -36,14 +38,16 @@ impl<T> StorageKey<T> {
     /// Reads a value of type `T` starting at the location specified by `self`. If the value
     /// crosses the boundary of a storage slot, reading continues at the following slot.
     ///
-    /// Returns `Some(value)` if a the storage slots read were valid and contain `value`.
+    /// # Returns
+    ///
+    /// * [Option<T>] - Returns `Some(value)` if a the storage slots read were valid and contain `value`.
     /// Otherwise, return `None`.
     ///
-    /// ### Arguments
+    /// # Number of Storage Accesses
     ///
-    /// None
+    /// * Reads: `1`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// fn foo() {
@@ -65,11 +69,17 @@ impl<T> StorageKey<T> {
     /// Writes a value of type `T` starting at the location specified by `self`. If the value
     /// crosses the boundary of a storage slot, writing continues at the following slot.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * value: the value of type `T` to write
+    /// * `value`: [T] - The value of type `T` to write.
     ///
-    /// ### Examples
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    /// * Writes: `1`
+    ///
+    /// # Examples
     ///
     /// ```sway
     /// fn foo() {
@@ -78,7 +88,9 @@ impl<T> StorageKey<T> {
     ///         offset: 2,
     ///         field_id: 0x0000000000000000000000000000000000000000000000000000000000000000,
     ///     };
-    ///     let x = r.write(42); // Writes 42 at the third word of storage slot with key 0x000...0
+    ///
+    ///     // Writes 42 at the third word of storage slot with key 0x000...0
+    ///     let x = r.write(42); 
     /// }
     /// ```
     #[storage(read, write)]

--- a/sway-lib-std/src/storage/storage_map.sw
+++ b/sway-lib-std/src/storage/storage_map.sw
@@ -10,12 +10,17 @@ pub struct StorageMap<K, V> {}
 impl<K, V> StorageKey<StorageMap<K, V>> {
     /// Inserts a key-value pair into the map.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * `key` - The key to which the value is paired.
-    /// * `value` - The value to be stored.
+    /// * `key`: [K] - The key to which the value is paired.
+    /// * `value`: [V] - The value to be stored.
     ///
-    /// ### Examples
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    /// * Writes: `1`
+    ///
+    /// # Examples
     ///
     /// ```sway
     /// storage {
@@ -39,11 +44,15 @@ impl<K, V> StorageKey<StorageMap<K, V>> {
     /// Retrieves the `StorageKey` that describes the raw location in storage of the value
     /// stored at `key`, regardless of whether a value is actually stored at that location or not.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * `key` - The key to which the value is paired.
+    /// * `key`: [K] - The key to which the value is paired.
     ///
-    /// ### Examples
+    /// # Returns
+    ///
+    /// * [StorageKey<V>] - Describes the raw location in storage of the value stored at `key`.
+    ///
+    /// # Examples
     ///
     /// ```sway
     /// storage {
@@ -68,13 +77,19 @@ impl<K, V> StorageKey<StorageMap<K, V>> {
 
     /// Clears a value previously stored using a key
     ///
-    /// Return a Boolean indicating whether there was a value previously stored at `key`.
+    /// # Arguments
     ///
-    /// ### Arguments
+    /// * `key`: [K] - The key to which the value is paired.
     ///
-    /// * `key` - The key to which the value is paired
+    /// # Returns
     ///
-    /// ### Examples
+    /// * [bool] - Indicates whether there was a value previously stored at `key`.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Clears: `1`
+    ///
+    /// # Examples
     ///
     /// ```sway
     /// storage {

--- a/sway-lib-std/src/storage/storage_string.sw
+++ b/sway-lib-std/src/storage/storage_string.sw
@@ -11,15 +11,15 @@ pub struct StorageString {}
 impl StorableSlice<String> for StorageKey<StorageString> {
     /// Takes a `String` type and saves the underlying data in storage.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * `string` - The string which will be stored.
+    /// * `string`: [String] - The string which will be stored.
     ///
-    /// ### Number of Storage Accesses
+    /// # Number of Storage Accesses
     ///
     /// * Writes: `2`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// storage {
@@ -43,11 +43,15 @@ impl StorableSlice<String> for StorageKey<StorageString> {
 
     /// Constructs a `String` type from storage.
     ///
-    /// ### Number of Storage Accesses
+    /// # Returns
+    /// 
+    /// * [Option<String>] - The valid `String` stored, otherwise `None`.
+    ///
+    /// # Number of Storage Accesses
     ///
     /// * Reads: `2`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// storage {
@@ -79,12 +83,16 @@ impl StorableSlice<String> for StorageKey<StorageString> {
 
     /// Clears a stored `String` in storage.
     ///
-    /// ### Number of Storage Accesses
+    /// # Returns
+    ///
+    /// * [bool] - Indicates whether all of the storage slots cleared were previously set.
+    ///
+    /// # Number of Storage Accesses
     ///
     /// * Reads: `1`
     /// * Clears: `2`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// storage {
@@ -114,11 +122,15 @@ impl StorableSlice<String> for StorageKey<StorageString> {
 
     /// Returns the length of `String` in storage.
     ///
-    /// ### Number of Storage Accesses
+    /// # Returns
+    ///
+    /// * [u64] - The length of the bytes in storage.
+    ///
+    /// # Number of Storage Accesses
     ///
     /// * Reads: `1`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// storage {

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -13,16 +13,16 @@ pub struct StorageVec<V> {}
 impl<V> StorageKey<StorageVec<V>> {
     /// Appends the value to the end of the vector.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * `value` - The item being added to the end of the vector.
+    /// * `value`: [V] - The item being added to the end of the vector.
     ///
-    /// ### Number of Storage Accesses
+    /// # Number of Storage Accesses
     ///
-    /// * Reads: `1`
+    /// * Reads: `3`
     /// * Writes: `2`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// use std::storage::storage_vec::*;
@@ -51,12 +51,16 @@ impl<V> StorageKey<StorageVec<V>> {
 
     /// Removes the last element of the vector and returns it, `None` if empty.
     ///
-    /// ### Number of Storage Accesses
+    /// # Returns
     ///
-    /// * Reads: `2`
+    /// * [Option<V>] - The last element `V` or `None`.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `3`
     /// * Writes: `1`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// use std::storage::storage_vec::*;
@@ -92,15 +96,20 @@ impl<V> StorageKey<StorageVec<V>> {
 
     /// Gets the value in the given index, `None` if index is out of bounds.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * `index` - The index of the vec to retrieve the item from.
+    /// * `index`: [u64] - The index of the vec to retrieve the item from.
     ///
-    /// ### Number of Storage Accesses
+    /// # Returns
     ///
-    /// * Reads: `2`
+    /// * [Option<StorageKey<V>>] - Describes the raw location in storage of the value stored at
+    /// `key` or `None` if out of bounds.
     ///
-    /// ### Examples
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
     ///
     /// ```sway
     /// use std::storage::storage_vec::*;
@@ -135,22 +144,28 @@ impl<V> StorageKey<StorageVec<V>> {
     /// Removes the element in the given index and moves all the elements in the following indexes
     /// down one index. Also returns the element.
     ///
-    /// > **_WARNING:_** Expensive for larger vecs.
+    /// # Additional Information
     ///
-    /// ### Arguments
+    ///  **_WARNING:_** Expensive for larger vecs.
     ///
-    /// * `index` - The index of the vec to remove the item from.
+    /// # Arguments
     ///
-    /// ### Reverts
+    /// * `index`: [u64] - The index of the vec to remove the item from.
+    /// 
+    /// # Returns
     ///
-    /// Reverts if index is larger or equal to length of the vec.
+    /// * [V] - The element that has been removed at the index.
     ///
-    /// ### Number of Storage Accesses
+    /// # Panics
     ///
-    /// * Reads: `2 + self.len() - index`
+    /// * Panics if index is larger or equal to length of the vec.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `3 + (2 * (self.len() - index))`
     /// * Writes: `self.len() - index`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// use std::storage::storage_vec::*;
@@ -199,20 +214,24 @@ impl<V> StorageKey<StorageVec<V>> {
     /// Removes the element at the specified index and fills it with the last element.
     /// This does not preserve ordering and returns the element.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * `index` - The index of the vec to remove the item from.
+    /// * `index`: [u64] - The index of the vec to remove the item from.
     ///
-    /// ### Reverts
+    /// # Returns
     ///
-    /// Reverts if index is larger or equal to length of the vec.
+    /// * [V] - The element that has been removed at the index.
     ///
-    /// ### Number of Storage Accesses
+    /// # Panics
     ///
-    /// * Reads: `3`
+    /// * Panics if index is larger or equal to length of the vec.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `5`
     /// * Writes: `2`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// use std::storage::storage_vec::*;
@@ -253,21 +272,21 @@ impl<V> StorageKey<StorageVec<V>> {
 
     /// Sets or mutates the value at the given index.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * `index` - The index of the vec to set the value at
-    /// * `value` - The value to be set
+    /// * `index`: [u64] - The index of the vec to set the value at
+    /// * `value`: [V] - The value to be set
     ///
-    /// ### Reverts
+    /// # Panics
     ///
-    /// Reverts if index is larger than or equal to the length of the vec.
+    /// * Panics if index is larger than or equal to the length of the vec.
     ///
-    /// ### Number of Storage Accesses
+    /// # Number of Storage Accesses
     ///
-    /// * Reads: `1`
+    /// * Reads: `2`
     /// * Writes: `1`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// use std::storage::storage_vec::*;
@@ -300,23 +319,25 @@ impl<V> StorageKey<StorageVec<V>> {
     /// Inserts the value at the given index, moving the current index's value
     /// as well as the following index's value up by one index.
     ///
+    /// # Additional Information
+    ///
     /// > **_WARNING:_** Expensive for larger vecs.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * `index` - The index of the vec to insert the item into.
-    /// * `value` - The value to insert into the vec.
+    /// * `index`: [u64] - The index of the vec to insert the item into.
+    /// * `value`: [V] - The value to insert into the vec.
     ///
-    /// ### Reverts
+    /// # Panics
     ///
-    /// Reverts if index is larger than the length of the vec.
+    /// * Panics if index is larger than the length of the vec.
     ///
-    /// ### Number of Storage Accesses
+    /// # Number of Storage Accesses
     ///
-    /// * Reads: `if self.len() == index { 1 } else { 1 + self.len() - index }`
+    /// * Reads: `if self.len() == index { 3 } else { 5 + (2 * (self.len() - index)) }`
     /// * Writes: `if self.len() == index { 2 } else { 2 + self.len() - index }`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// use std::storage::storage_vec::*;
@@ -377,11 +398,15 @@ impl<V> StorageKey<StorageVec<V>> {
 
     /// Returns the length of the vector.
     ///
-    /// ### Number of Storage Accesses
+    /// # Returns
+    ///
+    /// * [u64] - The stored length of the vector.
+    ///
+    /// # Number of Storage Accesses
     ///
     /// * Reads: `1`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// use std::storage::storage_vec::*;
@@ -405,11 +430,15 @@ impl<V> StorageKey<StorageVec<V>> {
 
     /// Checks whether the len is zero or not.
     ///
-    /// ### Number of Storage Accesses
+    /// # Returns
+    ///
+    /// * [bool] - Indicates whether the vector is or is not empty.
+    ///
+    /// # Number of Storage Accesses
     ///
     /// * Reads: `1`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// use std::storage::storage_vec::*;
@@ -437,11 +466,11 @@ impl<V> StorageKey<StorageVec<V>> {
 
     /// Sets the len to zero.
     ///
-    /// ### Number of Storage Accesses
+    /// # Number of Storage Accesses
     ///
     /// * Clears: `1`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// use std::storage::storage_vec::*;
@@ -465,21 +494,21 @@ impl<V> StorageKey<StorageVec<V>> {
 
     /// Swaps two elements.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * element1_index - The index of the first element.
-    /// * element2_index - The index of the second element.
+    /// * `element1_index`: [u64] - The index of the first element.
+    /// * `element2_index`: [u64] - The index of the second element.
     ///
-    /// ### Reverts
+    /// # Panics
     ///
     /// * If `element1_index` or `element2_index` is greater than the length of the vector.
     ///
-    /// ### Number of Storage Accesses
+    /// # Number of Storage Accesses
     ///
-    /// * Reads: `3`
+    /// * Reads: `5`
     /// * Writes: `2`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// use std::storage::storage_vec::*;
@@ -518,11 +547,16 @@ impl<V> StorageKey<StorageVec<V>> {
 
     /// Returns the first element of the vector, or `None` if it is empty.
     ///
-    /// ### Number of Storage Accesses
+    /// # Returns
     ///
-    /// * Reads: `2`
+    /// * [Option<StorageKey<V>>] - Describes the raw location in storage of the value stored at
+    /// the start of the vector or zero if the vector is empty.
     ///
-    /// ### Examples
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
     ///
     /// ```sway
     /// storage {
@@ -551,11 +585,16 @@ impl<V> StorageKey<StorageVec<V>> {
 
     /// Returns the last element of the vector, or `None` if it is empty.
     ///
-    /// ### Number of Storage Accesses
+    /// # Returns
     ///
-    /// * Reads: `2`
+    /// * [Option<StorageKey<V>>] - Describes the raw location in storage of the value stored at
+    /// the end of the vector or zero if the vector is empty.
     ///
-    /// ### Examples
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
     ///
     /// ```sway
     /// storage {
@@ -585,12 +624,12 @@ impl<V> StorageKey<StorageVec<V>> {
 
     /// Reverses the order of elements in the vector, in place.
     ///
-    /// ### Number of Storage Accesses
+    /// # Number of Storage Accesses
     ///
-    /// * Reads: `1 + (2 * (self.len() / 2))`
+    /// * Reads: `1 + (3 * (self.len() / 2))`
     /// * Writes: `2 * (self.len() / 2)`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// storage {
@@ -632,16 +671,16 @@ impl<V> StorageKey<StorageVec<V>> {
 
     /// Fills `self` with elements by cloning `value`.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * value - Value to copy to each element of the vector.
+    /// * `value`: [V] - Value to copy to each element of the vector.
     ///
-    /// ### Number of Storage Accesses
+    /// # Number of Storage Accesses
     ///
-    /// * Reads: `1`
+    /// * Reads: `1 + self.len()`
     /// * Writes: `self.len()`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// storage {
@@ -672,21 +711,23 @@ impl<V> StorageKey<StorageVec<V>> {
 
     /// Resizes `self` in place so that `len` is equal to `new_len`.
     ///
+    /// # Additional Information
+    ///
     /// If `new_len` is greater than `len`, `self` is extended by the difference, with each
     /// additional slot being filled with `value`. If the `new_len` is less than `len`, `self` is
     /// simply truncated.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * new_len - The new length to expand or truncate to
-    /// * value - The value to fill into new slots if the `new_len` is greater than the current length
+    /// * `new_len`: [u64] - The new length to expand or truncate to
+    /// * `value`: [V] - The value to fill into new slots if the `new_len` is greater than the current length
     ///
-    /// ### Number of Storage Accesses
+    /// # Number of Storage Accesses
     ///
-    /// * Reads - `1`
+    /// * Reads - `if new_len > self.len() { new_len - len + 2 } else { 2 }`
     /// * Writes - `if new_len > self.len() { new_len - len + 1 } else { 1 }`
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// storage {


### PR DESCRIPTION
## Description

Updating the storage inline docs to follow the new SRC-2 inline docs standard. Note that this is being merged into the staging branch

 Closes the following tasks of https://github.com/FuelLabs/sway/issues/4812 
storage/storable_slice.sw
 storage/storage_api.sw
 storage/storage_bytes.sw
 storage/storage_key.sw
 storage/storage_map.sw
 storage/storage_string.sw
 storage/storage_vec.sw

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
