### PR TITLE
Update inline docs of address, contract id, and identity to meet SRC-2 standards

### DIFF
--- a/sway-lib-std/src/address.sw
+++ b/sway-lib-std/src/address.sw
@@ -41,8 +41,8 @@ impl From<b256> for Address {
     ///    let address = Address::from(ZERO_B256);
     /// }
     /// ```
-    fn from(bits: b256) -> Self {
-        Self { value: bits }
+    fn from(bits: b256) -> Address {
+        Address { value: bits }
     }
 
     /// Casts an `Address` to raw `b256` data.

--- a/sway-lib-std/src/address.sw
+++ b/sway-lib-std/src/address.sw
@@ -10,6 +10,7 @@ use ::outputs::{Output, output_amount, output_count, output_type};
 
 /// The `Address` type, a struct wrapper around the inner `b256` value.
 pub struct Address {
+    /// The underlying raw `b256` data of the address.
     value: b256,
 }
 
@@ -21,10 +22,46 @@ impl core::ops::Eq for Address {
 
 /// Functions for casting between the `b256` and `Address` types.
 impl From<b256> for Address {
-    fn from(bits: b256) -> Address {
-        Address { value: bits }
+    /// Casts raw `b256` data to an `Address`.
+    /// 
+    /// # Arguments
+    ///
+    /// * `bits`: [b256] - The raw `b256` data to be casted.
+    /// 
+    /// # Returns
+    ///
+    /// * [Address] - The newly created `Address` from the raw `b256`.
+    ///
+    /// # Examples
+    /// 
+    /// ```sway
+    /// use std::constants::ZERO_B256;
+    ///
+    /// fn foo() {
+    ///    let address = Address::from(ZERO_B256);
+    /// }
+    /// ```
+    fn from(bits: b256) -> Self {
+        Self { value: bits }
     }
 
+    /// Casts an `Address` to raw `b256` data.
+    /// 
+    /// # Returns
+    ///
+    /// * [b256] - The underlying raw `b256` data of the `Address`.
+    ///
+    /// # Examples
+    /// 
+    /// ```sway
+    /// use std::constants::ZERO_B256;
+    ///
+    /// fn foo() {
+    ///     let address = Address::from(ZERO_B256);
+    ///     let b256_data = address.into();
+    ///     assert(b256_data == ZERO_B256);
+    /// }
+    /// ```
     fn into(self) -> b256 {
         self.value
     }
@@ -34,25 +71,27 @@ impl Address {
     /// Transfer `amount` coins of type `asset_id` and send them to
     /// the Address.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * `amount` - The amount of tokens to transfer.
-    /// * `asset_id` - The `AssetId` of the token to transfer.
+    /// * `amount`: [u64] - The amount of tokens to transfer.
+    /// * `asset_id`: [AssetId] - The `AssetId` of the token to transfer.
     ///
-    /// ### Reverts
+    /// # Panics
     ///
-    /// * If `amount` is greater than the contract balance for `asset_id`.
-    /// * If `amount` is equal to zero.
-    /// * If there are no free variable outputs.
+    /// * When `amount` is greater than the contract balance for `asset_id`.
+    /// * When `amount` is equal to zero.
+    /// * When there are no free variable outputs.
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// use std::constants::{BASE_ASSET_ID, ZERO_B256};
     ///
-    /// // replace the zero Address with your desired Address
-    /// let address = Address::from(ZERO_B256);
-    /// address.transfer(500, BASE_ASSET_ID)
+    /// fn foo() {
+    ///     // replace the zero Address with your desired Address
+    ///     let address = Address::from(ZERO_B256);
+    ///     address.transfer(500, BASE_ASSET_ID)
+    /// }
     /// ```
     pub fn transfer(self, amount: u64, asset_id: AssetId) {
         // maintain a manual index as we only have `while` loops in sway atm:
@@ -82,18 +121,20 @@ impl Address {
     /// Mint `amount` coins of the current contract's `asset_id` and send them to
     /// the Address.
     ///
-    /// ### Arguments
+    /// # Arguments
     ///
-    /// * `amount` - The amount of tokens to mint.
+    /// * `amount`: [u64] - The amount of tokens to mint.
     ///
-    /// ### Examples
+    /// # Examples
     ///
     /// ```sway
     /// use std::constants::ZERO_B256;
     ///
-    /// // replace the zero Address with your desired Address
-    /// let address = Address::from(ZERO_B256);
-    /// address.mint_to(500);
+    /// fn foo() {
+    ///     // replace the zero Address with your desired Address
+    ///     let address = Address::from(ZERO_B256);
+    ///     address.mint_to(500);
+    /// }
     /// ```
     pub fn mint_to(self, amount: u64) {
         asm(r1: amount) {

--- a/sway-lib-std/src/contract_id.sw
+++ b/sway-lib-std/src/contract_id.sw
@@ -36,8 +36,8 @@ impl From<b256> for ContractId {
     ///    let contract_id = ContractId::from(ZERO_B256);
     /// }
     /// ```
-    fn from(bits: b256) -> Self {
-        Self { value: bits }
+    fn from(bits: b256) -> ContractId {
+        ContractId { value: bits }
     }
 
 

--- a/sway-lib-std/src/contract_id.sw
+++ b/sway-lib-std/src/contract_id.sw
@@ -132,8 +132,7 @@ impl ContractId {
         asm(r1: amount) {
             mint r1;
         };
-        // Transfer the self contract token
-        self.transfer(amount, ContractId::from(asm() { fp: b256 }));
+        self.transfer(amount, ContractId::from(asm() { fp: b256 })); // Transfer the self contract token
     }
 }
 

--- a/sway-lib-std/src/contract_id.sw
+++ b/sway-lib-std/src/contract_id.sw
@@ -5,6 +5,7 @@ use ::convert::From;
 
 /// The `ContractId` type, a struct wrapper around the inner `b256` value.
 pub struct ContractId {
+    /// The underlying raw `b256` data of the contract id.
     value: b256,
 }
 
@@ -16,10 +17,47 @@ impl core::ops::Eq for ContractId {
 
 /// Functions for casting between the `b256` and `ContractId` types.
 impl From<b256> for ContractId {
-    fn from(bits: b256) -> ContractId {
-        ContractId { value: bits }
+    /// Casts raw `b256` data to a `ContractId`.
+    /// 
+    /// # Arguments
+    ///
+    /// * `bits`: [b256] - The raw `b256` data to be casted.
+    /// 
+    /// # Returns
+    ///
+    /// * [ContractId] - The newly created `ContractId` from the raw `b256`.
+    ///
+    /// # Examples
+    /// 
+    /// ```sway
+    /// use std::constants::ZERO_B256;
+    ///
+    /// fn foo() {
+    ///    let contract_id = ContractId::from(ZERO_B256);
+    /// }
+    /// ```
+    fn from(bits: b256) -> Self {
+        Self { value: bits }
     }
 
+
+    /// Casts a `ContractId` to raw `b256` data.
+    /// 
+    /// # Returns
+    ///
+    /// * [b256] - The underlying raw `b256` data of the `ContractId`.
+    ///
+    /// # Examples
+    /// 
+    /// ```sway
+    /// use std::constants::ZERO_B256;
+    ///
+    /// fn foo() {
+    ///     let contract_id = ContractId::from(ZERO_B256);
+    ///     let b256_data = contract_id.into();
+    ///     assert(b256_data == ZERO_B256);
+    /// }
+    /// ```
     fn into(self) -> b256 {
         self.value
     }
@@ -29,30 +67,33 @@ impl ContractId {
     /// UNCONDITIONAL transfer of `amount` coins of type `asset_id` to
     /// the ContractId.
     ///
-    /// > **_WARNING:_**
-    /// >
-    /// > This will transfer coins to a contract even with no way to retrieve them
-    /// > (i.e. no withdrawal functionality on receiving contract), possibly leading
-    /// > to the **_PERMANENT LOSS OF COINS_** if not used with care.
+    /// # Additional Informations
     ///
-    /// ### Arguments
+    /// **_WARNING:_**
+    /// This will transfer coins to a contract even with no way to retrieve them
+    /// (i.e. no withdrawal functionality on receiving contract), possibly leading
+    /// to the **_PERMANENT LOSS OF COINS_** if not used with care.
     ///
-    /// * `amount` - The amount of tokens to transfer.
-    /// * `asset_id` - The `AssetId` of the token to transfer.
+    /// # Arguments
     ///
-    /// ### Reverts
+    /// * `amount`: [u64] - The amount of tokens to transfer.
+    /// * `asset_id`: [AssetId] - The `AssetId` of the token to transfer.
     ///
-    /// * If `amount` is greater than the contract balance for `asset_id`.
-    /// * If `amount` is equal to zero.
+    /// # Panics
     ///
-    /// ### Examples
+    /// * When `amount` is greater than the contract balance for `asset_id`.
+    /// * When `amount` is equal to zero.
+    ///
+    /// # Examples
     ///
     /// ```sway
     /// use std::constants::{BASE_ASSET_ID, ZERO_B256};
     ///
-    /// // replace the zero ContractId with your desired ContractId
-    /// let contract_id = ContractId::from(ZERO_B256);
-    /// contract_id.transfer(500, BASE_ASSET_ID);
+    /// fn foo() {
+    ///     // replace the zero ContractId with your desired ContractId
+    ///     let contract_id = ContractId::from(ZERO_B256);
+    ///     contract_id.transfer(500, BASE_ASSET_ID);
+    /// }
     /// ```
     pub fn transfer(self, amount: u64, asset_id: AssetId) {
         asm(r1: amount, r2: asset_id.value, r3: self.value) {
@@ -65,31 +106,34 @@ impl ContractId {
     /// Mint `amount` coins of the current contract's `asset_id` and send them
     /// UNCONDITIONALLY to the contract at `to`.
     ///
-    /// > **_WARNING:_**
-    /// >
-    /// > This will transfer coins to a contract even with no way to retrieve them
-    /// > (i.e: no withdrawal functionality on the receiving contract), possibly leading to
-    /// > the **_PERMANENT LOSS OF COINS_** if not used with care.
+    /// # Additional Information
     ///
-    /// ### Arguments
+    /// **_WARNING:_**
+    /// This will transfer coins to a contract even with no way to retrieve them
+    /// (i.e: no withdrawal functionality on the receiving contract), possibly leading to
+    /// the **_PERMANENT LOSS OF COINS_** if not used with care.
     ///
-    /// * `amount` - The amount of tokens to mint.
-    /// * `to` - The `ContractId` to which to send the tokens.
+    /// # Arguments
     ///
-    /// ### Examples
+    /// * `amount`: [u64] - The amount of tokens to mint.
+    ///
+    /// # Examples
     ///
     /// ```sway
     /// use std::constants::ZERO_B256;
     ///
-    /// // replace the zero ContractId with your desired ContractId
-    /// let contract_id = ContractId::from(ZERO_B256);
-    /// contract_id.mint_to(500);
+    /// fn foo() {
+    ///     // replace the zero ContractId with your desired ContractId
+    ///     let contract_id = ContractId::from(ZERO_B256);
+    ///     contract_id.mint_to(500);
+    /// }
     /// ```
     pub fn mint_to(self, amount: u64) {
         asm(r1: amount) {
             mint r1;
         };
-        self.transfer(amount, ContractId::from(asm() { fp: b256 })); // Transfer the self contract token
+        // Transfer the self contract token
+        self.transfer(amount, ContractId::from(asm() { fp: b256 }));
     }
 }
 

--- a/sway-lib-std/src/identity.sw
+++ b/sway-lib-std/src/identity.sw
@@ -27,6 +27,23 @@ impl core::ops::Eq for Identity {
 }
 
 impl Identity {
+    /// Returns the `Address` of the `Identity`.
+    ///
+    /// # Returns
+    /// 
+    /// * [Option<Address>] - `Some(Address)` if the underlying type is an `Address`, otherwise `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::constants::ZERO_B256;
+    ///
+    /// fn foo() {
+    ///     let identity = Identity::Address(Address::from(ZERO_B256));
+    ///     let address = identity.as_address();
+    ///     assert(address == Address::from(ZERO_B256));
+    /// }
+    /// ```
     pub fn as_address(self) -> Option<Address> {
         match self {
             Identity::Address(addr) => Option::Some(addr),
@@ -34,6 +51,23 @@ impl Identity {
         }
     }
 
+    /// Returns the `ContractId` of the `Identity`.
+    ///
+    /// # Returns
+    /// 
+    /// * [Option<ContractId>] - `Some(Contract)` if the underlying type is an `ContractId`, otherwise `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::constants::ZERO_B256;
+    ///
+    /// fn foo() {
+    ///     let identity = Identity::ContractId(ContractId::from(ZERO_B256));
+    ///     let contract_id = identity.as_contract_id();
+    ///     assert(contract_id == ContractId::from(ZERO_B256));
+    /// }
+    /// ```
     pub fn as_contract_id(self) -> Option<ContractId> {
         match self {
             Identity::Address(_) => Option::None,
@@ -41,6 +75,22 @@ impl Identity {
         }
     }
 
+    /// Returns whether the `Identity` represents an `Address`.
+    ///
+    /// # Returns
+    /// 
+    /// * [bool] - Indicates whether the `Identity` holds an `Address`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::constants::ZERO_B256;
+    ///
+    /// fn foo() {
+    ///     let identity = Identity::Address(Address::from(ZERO_B256));
+    ///     assert(identity.is_address() == true);
+    /// }
+    /// ```
     pub fn is_address(self) -> bool {
         match self {
             Identity::Address(_) => true,
@@ -48,6 +98,22 @@ impl Identity {
         }
     }
 
+    /// Returns whether the `Identity` represents a `ContractId`.
+    ///
+    /// # Returns
+    /// 
+    /// * [bool] - Indicates whether the `Identity` holds a `ContractId`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::constants::ZERO_B256;
+    ///
+    /// fn foo() {
+    ///     let identity = Identity::ContractId(ContractId::from(ZERO_B256));
+    ///     assert(identity.is_contract_id() == true);
+    /// }
+    /// ```
     pub fn is_contract_id(self) -> bool {
         match self {
             Identity::Address(_) => false,
@@ -58,33 +124,36 @@ impl Identity {
     /// Transfer `amount` coins of the type `asset_id` and send them
     /// to the Identity.
     ///
-    /// > **_WARNING:_**
-    /// >
-    /// > If the Identity is a contract this may transfer coins to the contract even with no way to retrieve them
-    /// > (i.e. no withdrawal functionality on receiving contract), possibly leading
-    /// > to the **_PERMANENT LOSS OF COINS_** if not used with care.
+    /// # Additional Information
     ///
-    /// ### Arguments
+    /// **_WARNING:_**
+    /// If the Identity is a contract this may transfer coins to the contract even with no way to retrieve them
+    /// (i.e. no withdrawal functionality on receiving contract), possibly leading
+    /// to the **_PERMANENT LOSS OF COINS_** if not used with care.
     ///
-    /// * `amount` - The amount of tokens to transfer.
-    /// * `asset_id` - The `AssetId` of the token to transfer.
+    /// # Arguments
     ///
-    /// ### Reverts
+    /// * `amount`: [u64] - The amount of tokens to transfer.
+    /// * `asset_id`: [AssetId] - The `AssetId` of the token to transfer.
     ///
-    /// * If `amount` is greater than the contract balance for `asset_id`.
-    /// * If `amount` is equal to zero.
-    /// * If there are no free variable outputs when transferring to an `Address`.
+    /// # Panics
     ///
-    /// ### Examples
+    /// * When `amount` is greater than the contract balance for `asset_id`.
+    /// * When `amount` is equal to zero.
+    /// * When there are no free variable outputs when transferring to an `Address`.
+    ///
+    /// # Examples
     ///
     /// ```sway
     /// use std::constants::{BASE_ASSET_ID, ZERO_B256};
     ///
-    /// // replace the zero Address/ContractId with your desired Address/ContractId
-    /// let to_address = Identity::Address(Address::from(ZERO_B256));
-    /// let to_contract_id = Identity::ContractId(ContractId::from(ZERO_B256));
-    /// to_address.transfer(500, BASE_ASSET_ID);
-    /// to_contract_id.transfer(500, BASE_ASSET_ID);
+    /// fn foo() {
+    ///     // replace the zero Address/ContractId with your desired Address/ContractId
+    ///     let to_address = Identity::Address(Address::from(ZERO_B256));
+    ///     let to_contract_id = Identity::ContractId(ContractId::from(ZERO_B256));
+    ///     to_address.transfer(500, BASE_ASSET_ID);
+    ///     to_contract_id.transfer(500, BASE_ASSET_ID);
+    /// }
     /// ```
     pub fn transfer(self, amount: u64, asset_id: AssetId) {
         match self {
@@ -98,26 +167,29 @@ impl Identity {
     /// Mint `amount` coins of the current contract's `asset_id` and transfer them
     /// to the Identity.
     ///
-    /// > **_WARNING:_**
-    /// >
-    /// > If the Identity is a contract, this will transfer coins to the contract even with no way to retrieve them
-    /// > (i.e: no withdrawal functionality on the receiving contract), possibly leading to
-    /// > the **_PERMANENT LOSS OF COINS_** if not used with care.
+    /// # Additional Information
     ///
-    /// ### Arguments
+    /// **_WARNING:_**
+    /// If the Identity is a contract, this will transfer coins to the contract even with no way to retrieve them
+    /// (i.e: no withdrawal functionality on the receiving contract), possibly leading to
+    /// the **_PERMANENT LOSS OF COINS_** if not used with care.
     ///
-    /// * `amount` - The amount of tokens to mint.
+    /// # Arguments
     ///
-    /// ### Examples
+    /// * `amount`: [u64] - The amount of tokens to mint.
+    ///
+    /// # Examples
     ///
     /// ```sway
     /// use std::constants::ZERO_B256;
     ///
-    /// // replace the zero Address/ContractId with your desired Address/ContractId
-    /// let address_identity = Identity::Address(Address::from(ZERO_B256));
-    /// let contract_identity = Identity::ContractId(ContractId::from(ZERO_B256));
-    /// address_identity.mint_to(500);
-    /// contract_identity.mint_to(500);
+    /// fn foo() {
+    ///     // replace the zero Address/ContractId with your desired Address/ContractId
+    ///     let address_identity = Identity::Address(Address::from(ZERO_B256));
+    ///     let contract_identity = Identity::ContractId(ContractId::from(ZERO_B256));
+    ///     address_identity.mint_to(500);
+    ///     contract_identity.mint_to(500);
+    /// }
     /// ```
     pub fn mint_to(self, amount: u64) {
         asm(r1: amount) {

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -1020,7 +1020,7 @@ async fn go_to_definition_for_consts() {
         req_uri: &uri,
         req_line: 9,
         req_char: 24,
-        def_line: 17,
+        def_line: 18,
         def_start_char: 5,
         def_end_char: 9,
         def_path: "sway-lib-std/src/contract_id.sw",
@@ -1028,7 +1028,7 @@ async fn go_to_definition_for_consts() {
     let _ = lsp::definition_check(&mut service, &contract_go_to, &mut i).await;
 
     contract_go_to.req_char = 34;
-    contract_go_to.def_line = 18;
+    contract_go_to.def_line = 38;
     contract_go_to.def_start_char = 7;
     contract_go_to.def_end_char = 11;
     let _ = lsp::definition_check(&mut service, &contract_go_to, &mut i).await;


### PR DESCRIPTION
## Description

Updated the `contract_id.sw`, `address.sw`, and `identity.sw` files to meet the SRC-2 inline documentation standard.

This PR completes the following tasks of https://github.com/FuelLabs/sway/issues/4812 
 - address.sw
 - contract_id.sw
 - identity.sw
 
## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
