### PR TITLE
Chore: Remove unused dependencies from new projects created by `forc init`

### DIFF
--- a/docs/reference/src/code/language/program-types/contracts/wallet/Forc.toml
+++ b/docs/reference/src/code/language/program-types/contracts/wallet/Forc.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "wallet"
 
 [constants]
-OWNER_ADDRESS = { type = "b256", value = "0x8900c5bec4ca97d4febf9ceb4754a60d782abbf3cd815836c1872116f203f861" }
+# OWNER_ADDRESS = { type = "b256", value = "0x8900c5bec4ca97d4febf9ceb4754a60d782abbf3cd815836c1872116f203f861" }
 
 [dependencies]
 interface = { path = "../interface" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/conditional_compilation/bad_target/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/conditional_compilation/bad_target/Forc.toml
@@ -4,4 +4,4 @@ entry = "main.sw"
 implicit-std = false
 license = "Apache-2.0"
 name = "conditional_compilation_bad_target"
-target = "evm"
+# target = "evm"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/conditional_compilation/no_target/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/conditional_compilation/no_target/Forc.toml
@@ -4,4 +4,4 @@ entry = "main.sw"
 implicit-std = false
 license = "Apache-2.0"
 name = "conditional_compilation_no_target"
-target = "fuel"
+# target = "fuel"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/conditional_compilation/compile/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/conditional_compilation/compile/Forc.toml
@@ -4,4 +4,4 @@ entry = "main.sw"
 implicit-std = false
 license = "Apache-2.0"
 name = "conditional_compilation_compile"
-target = "evm"
+# target = "evm"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/conditional_compilation/run/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/conditional_compilation/run/Forc.toml
@@ -4,4 +4,4 @@ entry = "main.sw"
 implicit-std = false
 license = "Apache-2.0"
 name = "conditional_compilation_run"
-target = "fuel"
+# target = "fuel"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/evm/evm_basic/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/evm/evm_basic/Forc.toml
@@ -4,4 +4,4 @@ entry = "main.sw"
 implicit-std = false
 license = "Apache-2.0"
 name = "evm_basic"
-target = "evm"
+# target = "evm"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/midenvm/midenvm_trivial/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/midenvm/midenvm_trivial/Forc.toml
@@ -4,5 +4,5 @@ license = "Apache-2.0"
 name = "midenvm-trivial"
 entry = "main.sw"
 implicit-std = false
-target = "midenvm"
+# target = "midenvm"
 


### PR DESCRIPTION
## Description
Remove unused dependencies from new projects created by `forc init` causing warnings to appear.


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
