### PR TITLE
Fix flaky lsp test: publish_diagnostics_dead_code_warning

### DIFF
--- a/sway-lsp/tests/utils/src/lib.rs
+++ b/sway-lsp/tests/utils/src/lib.rs
@@ -103,11 +103,7 @@ pub async fn assert_server_requests(
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         let request_stream = socket.take(expected_requests.len()).collect::<Vec<_>>();
-        let requests =
-            tokio::time::timeout(timeout.unwrap_or(Duration::from_secs(10)), request_stream)
-                .await
-                .expect("Timed out waiting for requests from server");
-
+        let requests = request_stream.await;
         assert_eq!(requests.len(), expected_requests.len());
         for (actual, expected) in requests.iter().zip(expected_requests.iter()) {
             assert_eq!(expected["method"], actual.method());


### PR DESCRIPTION
## Description

~~Temporarily removing the `publish_diagnostics_dead_code_warning` test so it unblocks our CI until I can work out how to fix it.~~

Managed to fix the test while this was open. We now no longer timeout waiting for the requests and instead await until they are ready. 

Closes #4855

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
