### PR TITLE
Updates to storage docs to meet SRC-2 inline docs standard

### DIFF
--- a/sway-lib-core/src/storage.sw
+++ b/sway-lib-core/src/storage.sw
@@ -1,13 +1,20 @@
 library;
 
-/// Describes a location in storage specified by the `b256` key of a particular storage slot and an
+/// Describes a location in storage.
+///
+/// # Additional Information
+/// 
+/// The location in storage is specified by the `b256` key of a particular storage slot and an
 /// offset, in words, from the start of the storage slot at `key`. The parameter `T` is the type of 
 /// the data to be read from or written to at `offset`.
 /// `field_id` is a unique identifier for the storage field being referred to, it is different even
 /// for multiple zero sized fields that might live at the same location but
 /// represent different storage constructs.
 pub struct StorageKey<T> {
+    /// The assigned location in storage.
     slot: b256,
+    /// The assigned offset based on the data structure `T`.
     offset: u64,
+    /// A unqiue identifier.
     field_id: b256,
 }

--- a/sway-lib-std/src/storage/storage_api.sw
+++ b/sway-lib-std/src/storage/storage_api.sw
@@ -20,6 +20,8 @@ use ::option::Option::{self, *};
 /// # Examples
 ///
 /// ```sway
+/// use std::{storage::storage_api::{read, write}, constants::ZERO_B256};
+///
 /// fn foo() {
 ///     let five = 5_u64;
 ///     write(ZERO_B256, 2, five);
@@ -75,6 +77,8 @@ pub fn write<T>(slot: b256, offset: u64, value: T) {
 /// # Examples
 ///
 /// ```sway
+/// use std::{storage::storage_api::{read, write}, constants::ZERO_B256};
+///
 /// fn foo() {
 ///     let five = 5_u64;
 ///     write(ZERO_B256, 2, five);
@@ -123,6 +127,8 @@ pub fn read<T>(slot: b256, offset: u64) -> Option<T> {
 /// # Examples
 ///
 /// ```sway
+/// use std::{storage::storage_api::{read, write, clear}, constants::ZERO_B256};
+///
 /// fn foo() {
 ///      let five = 5_u64;
 ///     write(ZERO_B256, 0, five);

--- a/sway-lib-std/src/storage/storage_bytes.sw
+++ b/sway-lib-std/src/storage/storage_bytes.sw
@@ -22,6 +22,8 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
     /// # Examples
     ///
     /// ```sway
+    /// use std::{storage::storage_bytes::StorageBytes, bytes::Bytes};
+    ///
     /// storage {
     ///     stored_bytes: StorageBytes = StorageBytes {}
     /// }
@@ -53,6 +55,8 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
     /// # Examples
     ///
     /// ```sway
+    /// use std::{storage::storage_bytes::StorageBytes, bytes::Bytes};
+    ///
     /// storage {
     ///     stored_bytes: StorageBytes = StorageBytes {}
     /// }
@@ -93,6 +97,8 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
     /// # Examples
     ///
     /// ```sway
+    /// use std::{storage::storage_bytes::StorageBytes, bytes::Bytes};
+    ///
     /// storage {
     ///     stored_bytes: StorageBytes = StorageBytes {}
     /// }
@@ -129,6 +135,8 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
     /// # Examples
     ///
     /// ```sway
+    /// use std::{storage::storage_bytes::StorageBytes, bytes::Bytes};
+    ///
     /// storage {
     ///     stored_bytes: StorageBytes = StorageBytes {}
     /// }

--- a/sway-lib-std/src/storage/storage_string.sw
+++ b/sway-lib-std/src/storage/storage_string.sw
@@ -22,6 +22,8 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     /// # Examples
     ///
     /// ```sway
+    /// use std::{storage::storage_string::StorageString, bytes::Bytes, string::String};
+    ///
     /// storage {
     ///     stored_string: StorageString = StorageString {}
     /// }
@@ -54,6 +56,8 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     /// # Examples
     ///
     /// ```sway
+    /// use std::{storage::storage_string::StorageString, bytes::Bytes, string::String};
+    ///
     /// storage {
     ///     stored_string: StorageString = StorageString {}
     /// }
@@ -95,6 +99,8 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     /// # Examples
     ///
     /// ```sway
+    /// use std::{storage::storage_string::StorageString, bytes::Bytes, string::String};
+    ///
     /// storage {
     ///     stored_string: StorageString = StorageString {}
     /// }
@@ -133,6 +139,8 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     /// # Examples
     ///
     /// ```sway
+    /// use std::{storage::storage_string::StorageString, bytes::Bytes, string::String};
+    ///
     /// storage {
     ///     stored_string: StorageString = StorageString {}
     /// }


### PR DESCRIPTION
## Description

It was noted that the most recent updates to the storage docs did not include imports for examples. This has been added.

Documentation of the `StorageKey` type has also been included, completing the storage.sw task of https://github.com/FuelLabs/sway/issues/4812

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
