### PR TITLE
Use the `Self` annotation in implementation blocks

### DIFF
--- a/sway-lib-core/src/primitive_conversions.sw
+++ b/sway-lib-core/src/primitive_conversions.sw
@@ -40,7 +40,7 @@ impl u64 {
         }
     }
 
-    pub fn from_le_bytes(bytes: [u8; 8]) -> u64 {
+    pub fn from_le_bytes(bytes: [u8; 8]) -> Self {
         let a = bytes[0];
         let b = bytes[1];
         let c = bytes[2];
@@ -109,7 +109,7 @@ impl u64 {
         }
     }
 
-    pub fn from_be_bytes(bytes: [u8; 8]) -> u64 {
+    pub fn from_be_bytes(bytes: [u8; 8]) -> Self {
         let a = bytes[0];
         let b = bytes[1];
         let c = bytes[2];
@@ -170,7 +170,7 @@ impl u32 {
         }
     }
 
-    pub fn from_le_bytes(bytes: [u8; 4]) -> u32 {
+    pub fn from_le_bytes(bytes: [u8; 4]) -> Self {
         asm(a: bytes[0], b: bytes[1], c: bytes[2], d: bytes[3], i: 0x8, j: 0x10, k: 0x18, r1, r2, r3) {
             sll  r1 c j;
             sll  r2 d k;
@@ -205,7 +205,7 @@ impl u32 {
         }
     }
 
-    pub fn from_be_bytes(bytes: [u8; 4]) -> u32 {
+    pub fn from_be_bytes(bytes: [u8; 4]) -> Self {
         asm(a: bytes[0], b: bytes[1], c: bytes[2], d: bytes[3], i: 0x8, j: 0x10, k: 0x18, r1, r2, r3) {
             sll  r1 a k;
             sll  r2 b j;
@@ -246,7 +246,7 @@ impl u16 {
         }
     }
 
-    pub fn from_le_bytes(bytes: [u8; 2]) -> u16 {
+    pub fn from_le_bytes(bytes: [u8; 2]) -> Self {
         asm(a: bytes[0], b: bytes[1], i: 0x8, r1) {
             sll  r1 b i;
             or   r1 a r1;
@@ -268,7 +268,7 @@ impl u16 {
         }
     }
 
-    pub fn from_be_bytes(bytes: [u8; 2]) -> u16 {
+    pub fn from_be_bytes(bytes: [u8; 2]) -> Self {
         asm(a: bytes[0], b: bytes[1], i: 0x8, r1) {
             sll  r1 a i;
             or   r1 r1 b;
@@ -315,7 +315,7 @@ impl b256 {
         output
     }
 
-    pub fn from_le_bytes(bytes: [u8; 32]) -> b256 {
+    pub fn from_le_bytes(bytes: [u8; 32]) -> Self {
         let a = u64::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]]);
         let b = u64::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]]);
         let c = u64::from_le_bytes([bytes[16], bytes[17], bytes[18], bytes[19], bytes[20], bytes[21], bytes[22], bytes[23]]);
@@ -343,7 +343,7 @@ impl b256 {
         output
     }
 
-    pub fn from_be_bytes(bytes: [u8; 32]) -> b256 {
+    pub fn from_be_bytes(bytes: [u8; 32]) -> Self {
         let a = u64::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]]);
         let b = u64::from_be_bytes([bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]]);
         let c = u64::from_be_bytes([bytes[16], bytes[17], bytes[18], bytes[19], bytes[20], bytes[21], bytes[22], bytes[23]]);

--- a/sway-lib-core/src/primitives.sw
+++ b/sway-lib-core/src/primitives.sw
@@ -2,13 +2,13 @@ library;
 
 impl u64 {
     /// The smallest value that can be represented by this integer type.
-    pub fn min() -> u64 {
+    pub fn min() -> Self {
         0
     }
 
     /// The largest value that can be represented by this integer type,
     /// 2<sup>64</sup> - 1.
-    pub fn max() -> u64 {
+    pub fn max() -> Self {
         18446744073709551615
     }
 
@@ -20,13 +20,13 @@ impl u64 {
 
 impl u32 {
     /// The smallest value that can be represented by this integer type.
-    pub fn min() -> u32 {
+    pub fn min() -> Self {
         0
     }
 
     /// The largest value that can be represented by this integer type,
     /// 2<sup>32</sup> - 1.
-    pub fn max() -> u32 {
+    pub fn max() -> Self {
         4294967295
     }
 
@@ -38,13 +38,13 @@ impl u32 {
 
 impl u16 {
     /// The smallest value that can be represented by this integer type.
-    pub fn min() -> u16 {
+    pub fn min() -> Self {
         0
     }
 
     /// The largest value that can be represented by this integer type,
     /// 2<sup>16</sup> - 1.
-    pub fn max() -> u16 {
+    pub fn max() -> Self {
         65535
     }
 
@@ -56,13 +56,13 @@ impl u16 {
 
 impl u8 {
     /// The smallest value that can be represented by this integer type.
-    pub fn min() -> u8 {
+    pub fn min() -> Self {
         0
     }
 
     /// The largest value that can be represented by this integer type,
     /// 2<sup>8</sup> - 1.
-    pub fn max() -> u8 {
+    pub fn max() -> Self {
         255
     }
 
@@ -74,13 +74,13 @@ impl u8 {
 
 impl b256 {
     /// The smallest value that can be represented by this type.
-    pub fn min() -> b256 {
+    pub fn min() -> Self {
         0x0000000000000000000000000000000000000000000000000000000000000000
     }
 
     /// The largest value that can be represented by this type,
     /// 2<sup>256</sup> - 1.
-    pub fn max() -> b256 {
+    pub fn max() -> Self {
         0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
     }
 

--- a/sway-lib-core/src/raw_ptr.sw
+++ b/sway-lib-core/src/raw_ptr.sw
@@ -8,12 +8,12 @@ impl raw_ptr {
     }
 
     /// Calculates the offset from the pointer.
-    pub fn add<T>(self, count: u64) -> raw_ptr {
+    pub fn add<T>(self, count: u64) -> Self {
         __ptr_add::<T>(self, count)
     }
 
     /// Calculates the offset from the pointer.
-    pub fn sub<T>(self, count: u64) -> raw_ptr {
+    pub fn sub<T>(self, count: u64) -> Self {
         __ptr_sub::<T>(self, count)
     }
 
@@ -30,7 +30,7 @@ impl raw_ptr {
     }
 
     /// Copies `count * size_of<T>` bytes from `self` to `dst`.
-    pub fn copy_to<T>(self, dst: raw_ptr, count: u64) {
+    pub fn copy_to<T>(self, dst: Self, count: u64) {
         let len = __mul(count, __size_of::<T>());
         asm(dst: dst, src: self, len: len) {
             mcp dst src len;
@@ -67,14 +67,14 @@ impl raw_ptr {
     }
 
     /// Copies `count` bytes from `self` to `dst`
-    pub fn copy_bytes_to(self, dst: raw_ptr, count: u64) {
+    pub fn copy_bytes_to(self, dst: Self, count: u64) {
         asm(dst: dst, src: self, len: count) {
             mcp dst src len;
         };
     }
 
     /// Add a u64 offset to a raw_ptr
-    pub fn add_uint_offset(self, offset: u64) -> raw_ptr {
+    pub fn add_uint_offset(self, offset: u64) -> Self {
         asm(ptr: self, offset: offset, new) {
             add new ptr offset;
             new: raw_ptr
@@ -82,7 +82,7 @@ impl raw_ptr {
     }
 
     /// Subtract a u64 offset from a raw_ptr
-    pub fn sub_uint_offset(self, offset: u64) -> raw_ptr {
+    pub fn sub_uint_offset(self, offset: u64) -> Self {
         asm(ptr: self, offset: offset, new) {
             sub new ptr offset;
             new: raw_ptr

--- a/sway-lib-std/src/address.sw
+++ b/sway-lib-std/src/address.sw
@@ -21,8 +21,8 @@ impl core::ops::Eq for Address {
 
 /// Functions for casting between the `b256` and `Address` types.
 impl From<b256> for Address {
-    fn from(bits: b256) -> Address {
-        Address { value: bits }
+    fn from(bits: b256) -> Self {
+        Self { value: bits }
     }
 
     fn into(self) -> b256 {

--- a/sway-lib-std/src/b512.sw
+++ b/sway-lib-std/src/b512.sw
@@ -19,8 +19,8 @@ impl core::ops::Eq for B512 {
 
 /// Functions for casting between `B512` and an array of two `b256`s.
 impl From<(b256, b256)> for B512 {
-    fn from(components: (b256, b256)) -> B512 {
-        B512 {
+    fn from(components: (b256, b256)) -> Self {
+        Self {
             bytes: [components.0, components.1],
         }
     }
@@ -33,8 +33,8 @@ impl From<(b256, b256)> for B512 {
 /// Methods on the `B512` type.
 impl B512 {
     /// Initializes a new, zeroed `B512`.
-    pub fn new() -> B512 {
-        B512 {
+    pub fn new() -> Self {
+        Self {
             bytes: [ZERO_B256, ZERO_B256],
         }
     }

--- a/sway-lib-std/src/bytes.sw
+++ b/sway-lib-std/src/bytes.sw
@@ -72,7 +72,7 @@ impl Bytes {
     /// assert(bytes.capacity() == 0);
     /// ```
     pub fn new() -> Self {
-        Bytes {
+        Self {
             buf: RawBytes::new(),
             len: 0,
         }
@@ -98,7 +98,7 @@ impl Bytes {
     /// bytes.push(10);
     /// ```
     pub fn with_capacity(capacity: u64) -> Self {
-        Bytes {
+        Self {
             buf: RawBytes::with_capacity(capacity),
             len: 0,
         }
@@ -513,7 +513,7 @@ impl Bytes {
     /// assert(left.len() == 1);
     /// assert(right.len() == 2);
     /// ```
-    pub fn split_at(self, mid: u64) -> (Bytes, Bytes) {
+    pub fn split_at(self, mid: u64) -> (Self, Self) {
         assert(self.len >= mid);
 
         let left_len = mid;
@@ -624,9 +624,9 @@ impl AsRawSlice for Bytes {
 
 /// Methods for converting between the `Bytes` and the `b256` types.
 impl From<b256> for Bytes {
-    fn from(b: b256) -> Bytes {
+    fn from(b: b256) -> Self {
         // Artificially create bytes with capacity and len
-        let mut bytes = Bytes::with_capacity(32);
+        let mut bytes = Self::with_capacity(32);
         bytes.len = 32;
         // Copy bytes from contract_id into the buffer of the target bytes
         __addr_of(b).copy_bytes_to(bytes.buf.ptr, 32);
@@ -734,7 +734,7 @@ impl From<Vec<u8>> for Bytes {
     /// assert(bytes.get(2).unwrap() == c);
     /// ```
     fn from(vec: Vec<u8>) -> Self {
-        let mut bytes = Bytes::with_capacity(vec.len());
+        let mut bytes = Self::with_capacity(vec.len());
         let mut i = 0;
         while i < vec.len() {
             bytes.push(vec.get(i).unwrap());

--- a/sway-lib-std/src/contract_id.sw
+++ b/sway-lib-std/src/contract_id.sw
@@ -16,8 +16,8 @@ impl core::ops::Eq for ContractId {
 
 /// Functions for casting between the `b256` and `ContractId` types.
 impl From<b256> for ContractId {
-    fn from(bits: b256) -> ContractId {
-        ContractId { value: bits }
+    fn from(bits: b256) -> Self {
+        Self { value: bits }
     }
 
     fn into(self) -> b256 {
@@ -89,7 +89,7 @@ impl ContractId {
         asm(r1: amount) {
             mint r1;
         };
-        self.transfer(amount, ContractId::from(asm() { fp: b256 })); // Transfer the self contract token
+        self.transfer(amount, Self::from(asm() { fp: b256 })); // Transfer the self contract token
     }
 }
 

--- a/sway-lib-std/src/identity.sw
+++ b/sway-lib-std/src/identity.sw
@@ -29,29 +29,29 @@ impl core::ops::Eq for Identity {
 impl Identity {
     pub fn as_address(self) -> Option<Address> {
         match self {
-            Identity::Address(addr) => Option::Some(addr),
-            Identity::ContractId(_) => Option::None,
+            Self::Address(addr) => Option::Some(addr),
+            Self::ContractId(_) => Option::None,
         }
     }
 
     pub fn as_contract_id(self) -> Option<ContractId> {
         match self {
-            Identity::Address(_) => Option::None,
-            Identity::ContractId(id) => Option::Some(id),
+            Self::Address(_) => Option::None,
+            Self::ContractId(id) => Option::Some(id),
         }
     }
 
     pub fn is_address(self) -> bool {
         match self {
-            Identity::Address(_) => true,
-            Identity::ContractId(_) => false,
+            Self::Address(_) => true,
+            Self::ContractId(_) => false,
         }
     }
 
     pub fn is_contract_id(self) -> bool {
         match self {
-            Identity::Address(_) => false,
-            Identity::ContractId(_) => true,
+            Self::Address(_) => false,
+            Self::ContractId(_) => true,
         }
     }
   
@@ -88,8 +88,8 @@ impl Identity {
     /// ```
     pub fn transfer(self, amount: u64, asset_id: AssetId) {
         match self {
-            Identity::Address(addr) => addr.transfer(amount, asset_id),
-            Identity::ContractId(id) => id.transfer(amount, asset_id),
+            Self::Address(addr) => addr.transfer(amount, asset_id),
+            Self::ContractId(id) => id.transfer(amount, asset_id),
         };
     }
 }

--- a/sway-lib-std/src/option.sw
+++ b/sway-lib-std/src/option.sw
@@ -105,7 +105,7 @@ impl<T> Option<T> {
     /// ```
     pub fn is_some(self) -> bool {
         match self {
-            Option::Some(_) => true,
+            Self::Some(_) => true,
             _ => false,
         }
     }
@@ -123,7 +123,7 @@ impl<T> Option<T> {
     /// ```
     pub fn is_none(self) -> bool {
         match self {
-            Option::Some(_) => false,
+            Self::Some(_) => false,
             _ => true,
         }
     }
@@ -155,7 +155,7 @@ impl<T> Option<T> {
     /// ```
     pub fn unwrap(self) -> T {
         match self {
-            Option::Some(inner_value) => inner_value,
+            Self::Some(inner_value) => inner_value,
             _ => revert(0),
         }
     }
@@ -172,8 +172,8 @@ impl<T> Option<T> {
     /// ```
     pub fn unwrap_or(self, default: T) -> T {
         match self {
-            Option::Some(x) => x,
-            Option::None => default,
+            Self::Some(x) => x,
+            Self::None => default,
         }
     }
 
@@ -204,8 +204,8 @@ impl<T> Option<T> {
     /// ```
     pub fn ok_or<E>(self, err: E) -> Result<T, E> {
         match self {
-            Option::Some(v) => Result::Ok(v),
-            Option::None => Result::Err(err),
+            Self::Some(v) => Result::Ok(v),
+            Self::None => Result::Err(err),
         }
     }
 }

--- a/sway-lib-std/src/result.sw
+++ b/sway-lib-std/src/result.sw
@@ -91,7 +91,7 @@ impl<T, E> Result<T, E> {
     /// ```
     pub fn is_ok(self) -> bool {
         match self {
-            Result::Ok(_) => true,
+            Self::Ok(_) => true,
             _ => false,
         }
     }
@@ -114,7 +114,7 @@ impl<T, E> Result<T, E> {
     /// ```
     pub fn is_err(self) -> bool {
         match self {
-            Result::Ok(_) => false,
+            Self::Ok(_) => false,
             _ => true,
         }
     }
@@ -145,7 +145,7 @@ impl<T, E> Result<T, E> {
     /// ```
     pub fn unwrap(self) -> T {
         match self {
-            Result::Ok(inner_value) => inner_value,
+            Self::Ok(inner_value) => inner_value,
             _ => revert(0),
         }
     }
@@ -168,8 +168,8 @@ impl<T, E> Result<T, E> {
     /// ```
     pub fn unwrap_or(self, default: T) -> T {
         match self {
-            Result::Ok(inner_value) => inner_value,
-            Result::Err(_) => default,
+            Self::Ok(inner_value) => inner_value,
+            Self::Err(_) => default,
         }
     }
 

--- a/sway-lib-std/src/string.sw
+++ b/sway-lib-std/src/string.sw
@@ -102,7 +102,7 @@ impl AsRawSlice for String {
 }
 
 impl From<raw_slice> for String {
-    fn from(slice: raw_slice) -> String {
+    fn from(slice: raw_slice) -> Self {
         Self {
             bytes: Bytes::from(slice),
         }

--- a/sway-lib-std/src/u128.sw
+++ b/sway-lib-std/src/u128.sw
@@ -20,8 +20,8 @@ pub enum U128Error {
 }
 
 impl From<(u64, u64)> for U128 {
-    fn from(components: (u64, u64)) -> U128 {
-        U128 {
+    fn from(components: (u64, u64)) -> Self {
+        Self {
             upper: components.0,
             lower: components.1,
         }
@@ -116,8 +116,8 @@ impl U128 {
     ///
     /// assert(new_u128 == zero_u128);
     /// ```
-    pub fn new() -> U128 {
-        U128 {
+    pub fn new() -> Self {
+        Self {
             upper: 0,
             lower: 0,
         }
@@ -161,8 +161,8 @@ impl U128 {
     ///
     /// assert(min_u128 == zero_u128);
     /// ```
-    pub fn min() -> U128 {
-        U128 {
+    pub fn min() -> Self {
+        Self {
             upper: 0,
             lower: 0,
         }
@@ -181,8 +181,8 @@ impl U128 {
     ///
     /// assert(max_u128 == maxed_u128);
     /// ```
-    pub fn max() -> U128 {
-        U128 {
+    pub fn max() -> Self {
+        Self {
             upper: u64::max(),
             lower: u64::max(),
         }
@@ -206,13 +206,13 @@ impl U128 {
 
 impl core::ops::BitwiseAnd for U128 {
     fn binary_and(self, other: Self) -> Self {
-        U128::from((self.upper & other.upper, self.lower & other.lower))
+        Self::from((self.upper & other.upper, self.lower & other.lower))
     }
 }
 
 impl core::ops::BitwiseOr for U128 {
     fn binary_or(self, other: Self) -> Self {
-        U128::from((self.upper | other.upper, self.lower | other.lower))
+        Self::from((self.upper | other.upper, self.lower | other.lower))
     }
 }
 
@@ -293,7 +293,7 @@ impl core::ops::Add for U128 {
         // If overflow has occurred in the upper component addition, panic.
         assert(upper_128.upper == 0);
 
-        U128 {
+        Self {
             upper: upper_128.lower,
             lower: lower_128.lower,
         }
@@ -317,7 +317,7 @@ impl core::ops::Subtract for U128 {
             lower = self.lower - other.lower;
         }
 
-        U128 { upper, lower }
+        Self { upper, lower }
     }
 }
 impl core::ops::Multiply for U128 {
@@ -344,16 +344,16 @@ impl core::ops::Multiply for U128 {
 impl core::ops::Divide for U128 {
     /// Divide a `U128` by a `U128`. Panics if divisor is zero.
     fn divide(self, divisor: Self) -> Self {
-        let zero = U128::from((0, 0));
+        let zero = Self::from((0, 0));
 
         assert(divisor != zero);
 
         if self.upper == 0 && divisor.upper == 0 {
-            return U128::from((0, self.lower / divisor.lower));
+            return Self::from((0, self.lower / divisor.lower));
         }
 
-        let mut quotient = U128::new();
-        let mut remainder = U128::new();
+        let mut quotient = Self::new();
+        let mut remainder = Self::new();
         let mut i = 128 - 1;
         while true {
             quotient <<= 1;
@@ -380,8 +380,8 @@ impl Power for U128 {
     fn pow(self, exponent: Self) -> Self {
         let mut value = self;
         let mut exp = exponent;
-        let one = U128::from((0, 1));
-        let zero = U128::from((0, 0));
+        let one = Self::from((0, 1));
+        let zero = Self::from((0, 0));
 
         if exp == zero {
             return one;
@@ -390,7 +390,7 @@ impl Power for U128 {
         if exp == one {
             // Manually clone `self`. Otherwise, we may have a `MemoryOverflow`
             // issue with code that looks like: `x = x.pow(other)`
-            return U128::from((self.upper, self.lower));
+            return Self::from((self.upper, self.lower));
         }
 
         while exp & one == zero {
@@ -417,7 +417,7 @@ impl Power for U128 {
 impl Root for U128 {
     /// Integer square root using [Newton's Method](https://en.wikipedia.org/wiki/Integer_square_root#Algorithm_using_Newton's_method).
     fn sqrt(self) -> Self {
-        let zero = U128::from((0, 0));
+        let zero = Self::from((0, 0));
         let mut x0 = self >> 1;
         let mut s = self;
 
@@ -444,14 +444,14 @@ impl BinaryLogarithm for U128 {
     /// * Otherwise, we can find the highest non-zero bit by taking the regular log of the upper
     /// part of the `U128`, and then add 64.
     fn log2(self) -> Self {
-        let zero = U128::from((0, 0));
+        let zero = Self::from((0, 0));
         let mut res = zero;
         // If trying to get a log2(0), panic, as infinity is not a number.
         assert(self != zero);
         if self.upper != 0 {
-            res = U128::from((0, self.upper.log(2) + 64));
+            res = Self::from((0, self.upper.log(2) + 64));
         } else if self.lower != 0 {
-            res = U128::from((0, self.lower.log(2)));
+            res = Self::from((0, self.lower.log(2)));
         }
         res
     }

--- a/sway-lib-std/src/u256.sw
+++ b/sway-lib-std/src/u256.sw
@@ -37,8 +37,8 @@ pub enum U256Error {
 }
 
 impl From<(u64, u64, u64, u64)> for U256 {
-    fn from(components: (u64, u64, u64, u64)) -> U256 {
-        U256 {
+    fn from(components: (u64, u64, u64, u64)) -> Self {
+        Self {
             a: components.0,
             b: components.1,
             c: components.2,
@@ -72,8 +72,8 @@ impl U256 {
     ///
     /// assert(new_u256 == zero_u256);
     /// ```
-    pub fn new() -> U256 {
-        U256 {
+    pub fn new() -> Self {
+        Self {
             a: 0,
             b: 0,
             c: 0,
@@ -145,8 +145,8 @@ impl U256 {
     ///
     /// assert(min_u256 == zero_u256);
     /// ```
-    pub fn min() -> U256 {
-        U256 {
+    pub fn min() -> Self {
+        Self {
             a: 0,
             b: 0,
             c: 0,
@@ -167,8 +167,8 @@ impl U256 {
     ///
     /// assert(max_u256 == maxed_u256);
     /// ```
-    pub fn max() -> U256 {
-        U256 {
+    pub fn max() -> Self {
+        Self {
             a: u64::max(),
             b: u64::max(),
             c: u64::max(),
@@ -230,7 +230,7 @@ impl core::ops::BitwiseAnd for U256 {
         let word_2 = value_word_2 & other_word_2;
         let word_3 = value_word_3 & other_word_3;
         let word_4 = value_word_4 & other_word_4;
-        U256::from((word_1, word_2, word_3, word_4))
+        Self::from((word_1, word_2, word_3, word_4))
     }
 }
 
@@ -242,7 +242,7 @@ impl core::ops::BitwiseOr for U256 {
         let word_2 = value_word_2 | other_word_2;
         let word_3 = value_word_3 | other_word_3;
         let word_4 = value_word_4 | other_word_4;
-        U256::from((word_1, word_2, word_3, word_4))
+        Self::from((word_1, word_2, word_3, word_4))
     }
 }
 
@@ -254,7 +254,7 @@ impl core::ops::BitwiseXor for U256 {
         let word_2 = value_word_2 ^ other_word_2;
         let word_3 = value_word_3 ^ other_word_3;
         let word_4 = value_word_4 ^ other_word_4;
-        U256::from((word_1, word_2, word_3, word_4))
+        Self::from((word_1, word_2, word_3, word_4))
     }
 }
 
@@ -290,7 +290,7 @@ impl core::ops::Shift for U256 {
             w1 = word_4 << b;
         }
 
-        U256::from((w1, w2, w3, w4))
+        Self::from((w1, w2, w3, w4))
     }
 
     fn rsh(self, shift_amount: u64) -> Self {
@@ -324,7 +324,7 @@ impl core::ops::Shift for U256 {
             w4 = word_1 >> b;
         };
 
-        U256::from((w1, w2, w3, w4))
+        Self::from((w1, w2, w3, w4))
     }
 }
 
@@ -362,7 +362,7 @@ impl core::ops::Add for U256 {
         let result_a = local_res.lower;
         // panic on overflow
         assert(local_res.upper == 0);
-        U256::from((result_a, result_b, result_c, result_d))
+        Self::from((result_a, result_b, result_c, result_d))
     }
 }
 
@@ -374,7 +374,7 @@ impl core::ops::Subtract for U256 {
         } else if other == Self::min() {
             // Manually clone `self`. Otherwise, we may have a `MemoryOverflow`
             // issue with code that looks like: `x = x - other`
-            return U256::from((self.a, self.b, self.c, self.d));
+            return Self::from((self.a, self.b, self.c, self.d));
         }
         // If trying to subtract a larger number, panic.
         assert(self > other);
@@ -426,7 +426,7 @@ impl core::ops::Subtract for U256 {
             result_d = word_4 - other_word_4;
         }
 
-        U256::from((result_a, result_b, result_c, result_d))
+        Self::from((result_a, result_b, result_c, result_d))
     }
 }
 
@@ -440,12 +440,12 @@ impl core::ops::Multiply for U256 {
             // If `self.a` is non-zero, all words of `other`, except for `d`, should be zero.
             // Otherwise, overflow is guaranteed.
             assert(other.b == 0 && other.c == 0);
-            U256::from((self.a * other.d, 0, 0, 0))
+            Self::from((self.a * other.d, 0, 0, 0))
         } else if other.a != 0 {
             // If `other.a` is non-zero, all words of `self`, except for `d`, should be zero.
             // Otherwise, overflow is guaranteed.
             assert(self.b == 0 && self.c == 0);
-            U256::from((other.a * self.d, 0, 0, 0))
+            Self::from((other.a * self.d, 0, 0, 0))
         } else {
             if self.b != 0 {
                 // If `self.b` is non-zero, `other.b` has  to be zero. Otherwise, overflow is
@@ -466,7 +466,7 @@ impl core::ops::Multiply for U256 {
                 let (overflow_of_b_to_a_2, b) = b.overflowing_add(result_d_c.upper).into();
                 let (overflow_of_b_to_a_3, b) = b.overflowing_add(overflow_of_c_to_b_2).into();
 
-                U256::from((
+                Self::from((
                     self.b * other.c + result_b_d.upper + overflow_of_b_to_a_3 + overflow_of_b_to_a_2 + overflow_of_b_to_a_1 + overflow_of_b_to_a_0,
                     b,
                     c,
@@ -491,7 +491,7 @@ impl core::ops::Multiply for U256 {
                 let (overflow_of_b_to_a_2, b) = b.overflowing_add(result_d_c.upper).into();
                 let (overflow_of_b_to_a_3, b) = b.overflowing_add(overflow_of_c_to_b_2).into();
 
-                U256::from((
+                Self::from((
                     other.b * self.c + result_b_d.upper + overflow_of_b_to_a_3 + overflow_of_b_to_a_2 + overflow_of_b_to_a_1 + overflow_of_b_to_a_0,
                     b,
                     c,
@@ -514,7 +514,7 @@ impl core::ops::Multiply for U256 {
                 let (overflow_of_b_to_a_2, b) = b.overflowing_add(result_d_c.upper).into();
                 let (overflow_of_b_to_a_3, b) = b.overflowing_add(overflow_of_c_to_b_2).into();
 
-                U256::from((
+                Self::from((
                     // as overflow for a means overflow for the whole number, we are adding as is, not using `overflowing_add`
                     result_c_c.upper + overflow_of_b_to_a_3 + overflow_of_b_to_a_2 + overflow_of_b_to_a_1 + overflow_of_b_to_a_0,
                     b,
@@ -529,8 +529,8 @@ impl core::ops::Multiply for U256 {
 impl core::ops::Divide for U256 {
     /// Divide a `U256` by a `U256`. Panics if divisor is zero.
     fn divide(self, divisor: Self) -> Self {
-        let zero = U256::from((0, 0, 0, 0));
-        let one = U256::from((0, 0, 0, 1));
+        let zero = Self::from((0, 0, 0, 0));
+        let one = Self::from((0, 0, 0, 1));
 
         assert(divisor != zero);
 
@@ -540,11 +540,11 @@ impl core::ops::Divide for U256 {
             && divisor.b == 0
         {
             let res = U128::from((self.c, self.d)) / U128::from((divisor.c, divisor.d));
-            return U256::from((0, 0, res.upper, res.lower));
+            return Self::from((0, 0, res.upper, res.lower));
         }
 
-        let mut quotient = U256::from((0, 0, 0, 0));
-        let mut remainder = U256::from((0, 0, 0, 0));
+        let mut quotient = Self::from((0, 0, 0, 0));
+        let mut remainder = Self::from((0, 0, 0, 0));
 
         let mut i = 256 - 1;
 

--- a/sway-lib-std/src/vec.sw
+++ b/sway-lib-std/src/vec.sw
@@ -435,7 +435,7 @@ impl<T> AsRawSlice for Vec<T> {
 }
 
 impl<T> From<raw_slice> for Vec<T> {
-    fn from(slice: raw_slice) -> Vec<T> {
+    fn from(slice: raw_slice) -> Self {
         let buf = RawVec {
             ptr: slice.ptr(),
             cap: slice.len::<T>(),

--- a/sway-lib-std/src/vm/evm/evm_address.sw
+++ b/sway-lib-std/src/vm/evm/evm_address.sw
@@ -17,7 +17,7 @@ impl core::ops::Eq for EvmAddress {
 
 /// Functions for casting between the `b256` and `EvmAddress` types.
 impl From<b256> for EvmAddress {
-    fn from(bits: b256) -> EvmAddress {
+    fn from(bits: b256) -> Self {
         // An EVM address is only 20 bytes, so the first 12 are set to zero
         // Create a mutable local copy of `bits`
         let mut local_bits = bits;
@@ -25,7 +25,7 @@ impl From<b256> for EvmAddress {
             mcli r1 i12;
         };
 
-        EvmAddress {
+        Self {
             value: local_bits,
         }
     }


### PR DESCRIPTION
## Description

In Rust, when implementing traits the type `Self` is used instead of the concrete type. This provides a more flexible and generic API design and it promotes code reusability and simplifies the creation of fluent interfaces. The same has now been done for Sway.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
