### PR TITLE
Update `CallPath<T>` impl of `Display`

### DIFF
--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -36,13 +36,10 @@ where
     T: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut buf = String::new();
         for prefix in self.prefixes.iter() {
-            buf.push_str(prefix.as_str());
-            buf.push_str("::");
+            write!(f, "{}::", prefix.as_str())?;
         }
-        buf.push_str(&self.suffix.to_string());
-        write!(f, "{buf}")
+        write!(f, "{}", &self.suffix)?;
     }
 }
 

--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -39,7 +39,7 @@ where
         for prefix in self.prefixes.iter() {
             write!(f, "{}::", prefix.as_str())?;
         }
-        write!(f, "{}", &self.suffix)?;
+        write!(f, "{}", &self.suffix)?
     }
 }
 

--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -39,7 +39,7 @@ where
         for prefix in self.prefixes.iter() {
             write!(f, "{}::", prefix.as_str())?;
         }
-        write!(f, "{}", &self.suffix)?
+        write!(f, "{}", &self.suffix)
     }
 }
 


### PR DESCRIPTION
## Description
avoids the extra `String` alloc from `to_string()`.
Closes #2225

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
