### PR TITLE
Fixes replace_decls issue with nested and multiple types.

### DIFF
--- a/sway-core/src/decl_engine/mapping.rs
+++ b/sway-core/src/decl_engine/mapping.rs
@@ -103,7 +103,12 @@ impl DeclMapping {
         None
     }
 
-    pub(crate) fn filter(&self, self_type: TypeId, engines: &Engines) -> DeclMapping {
+    /// This method returns only associated item functions that have as self type the given type.
+    pub(crate) fn filter_functions_by_self_type(
+        &self,
+        self_type: TypeId,
+        engines: &Engines,
+    ) -> DeclMapping {
         let mut mapping: Vec<(SourceDecl, DestinationDecl)> = vec![];
         for (source_decl_ref, dest_decl_ref) in self.mapping.iter().cloned() {
             match dest_decl_ref {

--- a/sway-core/src/decl_engine/mod.rs
+++ b/sway-core/src/decl_engine/mod.rs
@@ -30,7 +30,10 @@ pub(crate) use replace_decls::*;
 use sway_types::Ident;
 pub(crate) use template::*;
 
-use crate::language::ty::{TyTraitInterfaceItem, TyTraitItem};
+use crate::{
+    language::ty::{TyTraitInterfaceItem, TyTraitItem},
+    TypeId,
+};
 
-pub(crate) type InterfaceItemMap = BTreeMap<Ident, TyTraitInterfaceItem>;
-pub(crate) type ItemMap = BTreeMap<Ident, TyTraitItem>;
+pub(crate) type InterfaceItemMap = BTreeMap<(Ident, TypeId), TyTraitInterfaceItem>;
+pub(crate) type ItemMap = BTreeMap<(Ident, TypeId), TyTraitItem>;

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -31,6 +31,7 @@ use crate::{
         self, TyAbiDecl, TyConstantDecl, TyEnumDecl, TyFunctionDecl, TyImplTrait, TyStorageDecl,
         TyStructDecl, TyTraitDecl, TyTraitFn,
     },
+    semantic_analysis::TypeCheckContext,
     type_system::*,
 };
 
@@ -195,11 +196,11 @@ where
     pub(crate) fn replace_decls_and_insert_new_with_parent(
         &self,
         decl_mapping: &DeclMapping,
-        engines: &Engines,
+        ctx: &TypeCheckContext,
     ) -> Self {
-        let decl_engine = engines.de();
+        let decl_engine = ctx.engines().de();
         let mut decl = decl_engine.get(&self.id);
-        decl.replace_decls(decl_mapping, engines);
+        decl.replace_decls(decl_mapping, ctx);
         decl_engine
             .insert(decl)
             .with_parent(decl_engine, self.id.into())
@@ -334,7 +335,8 @@ where
 }
 
 impl ReplaceDecls for DeclRefFunction {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, engines: &Engines) {
+    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
+        let engines = ctx.engines();
         let decl_engine = engines.de();
         if let Some(new_decl_ref) = decl_mapping.find_match(self.id.into()) {
             if let AssociatedItemDeclId::Function(new_decl_ref) = new_decl_ref {

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -22,6 +22,7 @@
 
 use std::hash::{Hash, Hasher};
 
+use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::{Ident, Named, Span, Spanned};
 
 use crate::{
@@ -196,14 +197,15 @@ where
     pub(crate) fn replace_decls_and_insert_new_with_parent(
         &self,
         decl_mapping: &DeclMapping,
+        handler: &Handler,
         ctx: &TypeCheckContext,
-    ) -> Self {
+    ) -> Result<Self, ErrorEmitted> {
         let decl_engine = ctx.engines().de();
         let mut decl = decl_engine.get(&self.id);
-        decl.replace_decls(decl_mapping, ctx);
-        decl_engine
+        decl.replace_decls(decl_mapping, handler, ctx)?;
+        Ok(decl_engine
             .insert(decl)
-            .with_parent(decl_engine, self.id.into())
+            .with_parent(decl_engine, self.id.into()))
     }
 }
 
@@ -335,14 +337,19 @@ where
 }
 
 impl ReplaceDecls for DeclRefFunction {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
+    fn replace_decls_inner(
+        &mut self,
+        decl_mapping: &DeclMapping,
+        _handler: &Handler,
+        ctx: &TypeCheckContext,
+    ) -> Result<(), ErrorEmitted> {
         let engines = ctx.engines();
         let decl_engine = engines.de();
         if let Some(new_decl_ref) = decl_mapping.find_match(self.id.into()) {
             if let AssociatedItemDeclId::Function(new_decl_ref) = new_decl_ref {
                 self.id = new_decl_ref;
             }
-            return;
+            return Ok(());
         }
         let all_parents = decl_engine.find_all_parents(engines, &self.id);
         for parent in all_parents.iter() {
@@ -350,9 +357,10 @@ impl ReplaceDecls for DeclRefFunction {
                 if let AssociatedItemDeclId::Function(new_decl_ref) = new_decl_ref {
                     self.id = new_decl_ref;
                 }
-                return;
+                return Ok(());
             }
         }
+        Ok(())
     }
 }
 

--- a/sway-core/src/decl_engine/replace_decls.rs
+++ b/sway-core/src/decl_engine/replace_decls.rs
@@ -1,16 +1,17 @@
 use crate::{
     engine_threading::Engines,
     language::ty::{self, TyDecl},
+    semantic_analysis::TypeCheckContext,
 };
 
 use super::DeclMapping;
 
 pub trait ReplaceDecls {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, engines: &Engines);
+    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext);
 
-    fn replace_decls(&mut self, decl_mapping: &DeclMapping, engines: &Engines) {
+    fn replace_decls(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
         if !decl_mapping.is_empty() {
-            self.replace_decls_inner(decl_mapping, engines);
+            self.replace_decls_inner(decl_mapping, ctx);
         }
     }
 }

--- a/sway-core/src/decl_engine/replace_decls.rs
+++ b/sway-core/src/decl_engine/replace_decls.rs
@@ -1,3 +1,5 @@
+use sway_error::handler::{ErrorEmitted, Handler};
+
 use crate::{
     engine_threading::Engines,
     language::ty::{self, TyDecl},
@@ -7,12 +9,24 @@ use crate::{
 use super::DeclMapping;
 
 pub trait ReplaceDecls {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext);
+    fn replace_decls_inner(
+        &mut self,
+        decl_mapping: &DeclMapping,
+        handler: &Handler,
+        ctx: &TypeCheckContext,
+    ) -> Result<(), ErrorEmitted>;
 
-    fn replace_decls(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
+    fn replace_decls(
+        &mut self,
+        decl_mapping: &DeclMapping,
+        handler: &Handler,
+        ctx: &TypeCheckContext,
+    ) -> Result<(), ErrorEmitted> {
         if !decl_mapping.is_empty() {
-            self.replace_decls_inner(decl_mapping, ctx);
+            self.replace_decls_inner(decl_mapping, handler, ctx)?;
         }
+
+        Ok(())
     }
 }
 

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -88,17 +88,24 @@ impl ReplaceSelfType for TyAstNode {
 }
 
 impl ReplaceDecls for TyAstNode {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
+    fn replace_decls_inner(
+        &mut self,
+        decl_mapping: &DeclMapping,
+        handler: &Handler,
+        ctx: &TypeCheckContext,
+    ) -> Result<(), ErrorEmitted> {
         match self.content {
             TyAstNodeContent::ImplicitReturnExpression(ref mut exp) => {
-                exp.replace_decls(decl_mapping, ctx)
+                exp.replace_decls(decl_mapping, handler, ctx)
             }
             TyAstNodeContent::Declaration(TyDecl::VariableDecl(ref mut decl)) => {
-                decl.body.replace_decls(decl_mapping, ctx);
+                decl.body.replace_decls(decl_mapping, handler, ctx)
             }
-            TyAstNodeContent::Declaration(_) => {}
-            TyAstNodeContent::Expression(ref mut expr) => expr.replace_decls(decl_mapping, ctx),
-            TyAstNodeContent::SideEffect(_) => (),
+            TyAstNodeContent::Declaration(_) => Ok(()),
+            TyAstNodeContent::Expression(ref mut expr) => {
+                expr.replace_decls(decl_mapping, handler, ctx)
+            }
+            TyAstNodeContent::SideEffect(_) => Ok(()),
         }
     }
 }

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -10,6 +10,7 @@ use crate::{
     decl_engine::*,
     engine_threading::*,
     language::{parsed::TreeType, ty::*, Visibility},
+    semantic_analysis::TypeCheckContext,
     transform::AttributeKind,
     type_system::*,
     types::*,
@@ -87,16 +88,16 @@ impl ReplaceSelfType for TyAstNode {
 }
 
 impl ReplaceDecls for TyAstNode {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, engines: &Engines) {
+    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
         match self.content {
             TyAstNodeContent::ImplicitReturnExpression(ref mut exp) => {
-                exp.replace_decls(decl_mapping, engines)
+                exp.replace_decls(decl_mapping, ctx)
             }
             TyAstNodeContent::Declaration(TyDecl::VariableDecl(ref mut decl)) => {
-                decl.body.replace_decls(decl_mapping, engines);
+                decl.body.replace_decls(decl_mapping, ctx);
             }
             TyAstNodeContent::Declaration(_) => {}
-            TyAstNodeContent::Expression(ref mut expr) => expr.replace_decls(decl_mapping, engines),
+            TyAstNodeContent::Expression(ref mut expr) => expr.replace_decls(decl_mapping, ctx),
             TyAstNodeContent::SideEffect(_) => (),
         }
     }

--- a/sway-core/src/language/ty/code_block.rs
+++ b/sway-core/src/language/ty/code_block.rs
@@ -1,8 +1,8 @@
 use std::hash::Hasher;
 
 use crate::{
-    decl_engine::*, engine_threading::*, language::ty::*, type_system::*,
-    types::DeterministicallyAborts,
+    decl_engine::*, engine_threading::*, language::ty::*, semantic_analysis::TypeCheckContext,
+    type_system::*, types::DeterministicallyAborts,
 };
 
 #[derive(Clone, Debug)]
@@ -41,10 +41,10 @@ impl ReplaceSelfType for TyCodeBlock {
 }
 
 impl ReplaceDecls for TyCodeBlock {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, engines: &Engines) {
+    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
         self.contents
             .iter_mut()
-            .for_each(|x| x.replace_decls(decl_mapping, engines));
+            .for_each(|x| x.replace_decls(decl_mapping, ctx));
     }
 }
 

--- a/sway-core/src/language/ty/code_block.rs
+++ b/sway-core/src/language/ty/code_block.rs
@@ -49,23 +49,18 @@ impl ReplaceDecls for TyCodeBlock {
         handler: &Handler,
         ctx: &TypeCheckContext,
     ) -> Result<(), ErrorEmitted> {
-        let mut error_emitted = None;
+        handler.scope(|handler| {
+            for x in self.contents.iter_mut() {
+                match x.replace_decls(decl_mapping, handler, ctx) {
+                    Ok(res) => res,
+                    Err(_) => {
+                        continue;
+                    }
+                };
+            }
 
-        for x in self.contents.iter_mut() {
-            match x.replace_decls(decl_mapping, handler, ctx) {
-                Ok(res) => res,
-                Err(err) => {
-                    error_emitted = Some(err);
-                    continue;
-                }
-            };
-        }
-
-        if let Some(err) = error_emitted {
-            Err(err)
-        } else {
             Ok(())
-        }
+        })
     }
 }
 

--- a/sway-core/src/language/ty/declaration/constant.rs
+++ b/sway-core/src/language/ty/declaration/constant.rs
@@ -1,5 +1,6 @@
 use std::hash::{Hash, Hasher};
 
+use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::{Ident, Named, Span, Spanned};
 
 use crate::{
@@ -104,9 +105,16 @@ impl ReplaceSelfType for TyConstantDecl {
 }
 
 impl ReplaceDecls for TyConstantDecl {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
+    fn replace_decls_inner(
+        &mut self,
+        decl_mapping: &DeclMapping,
+        handler: &Handler,
+        ctx: &TypeCheckContext,
+    ) -> Result<(), ErrorEmitted> {
         if let Some(expr) = &mut self.value {
-            expr.replace_decls(decl_mapping, ctx);
+            expr.replace_decls(decl_mapping, handler, ctx)
+        } else {
+            Ok(())
         }
     }
 }

--- a/sway-core/src/language/ty/declaration/constant.rs
+++ b/sway-core/src/language/ty/declaration/constant.rs
@@ -6,6 +6,7 @@ use crate::{
     decl_engine::{DeclMapping, ReplaceDecls},
     engine_threading::*,
     language::{ty::*, CallPath, Visibility},
+    semantic_analysis::TypeCheckContext,
     transform,
     type_system::*,
 };
@@ -103,9 +104,9 @@ impl ReplaceSelfType for TyConstantDecl {
 }
 
 impl ReplaceDecls for TyConstantDecl {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, engines: &Engines) {
+    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
         if let Some(expr) = &mut self.value {
-            expr.replace_decls(decl_mapping, engines);
+            expr.replace_decls(decl_mapping, ctx);
         }
     }
 }

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -10,6 +10,7 @@ use crate::{
     decl_engine::*,
     engine_threading::*,
     language::{parsed, ty::*, Inline, Purity, Visibility},
+    semantic_analysis::TypeCheckContext,
     transform,
     type_system::*,
     types::*,
@@ -123,8 +124,8 @@ impl ReplaceSelfType for TyFunctionDecl {
 }
 
 impl ReplaceDecls for TyFunctionDecl {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, engines: &Engines) {
-        self.body.replace_decls(decl_mapping, engines);
+    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
+        self.body.replace_decls(decl_mapping, ctx);
     }
 }
 

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -124,8 +124,13 @@ impl ReplaceSelfType for TyFunctionDecl {
 }
 
 impl ReplaceDecls for TyFunctionDecl {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
-        self.body.replace_decls(decl_mapping, ctx);
+    fn replace_decls_inner(
+        &mut self,
+        decl_mapping: &DeclMapping,
+        handler: &Handler,
+        ctx: &TypeCheckContext,
+    ) -> Result<(), ErrorEmitted> {
+        self.body.replace_decls(decl_mapping, handler, ctx)
     }
 }
 

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -7,6 +7,7 @@ use crate::{
     decl_engine::*,
     engine_threading::*,
     language::{ty::*, Literal},
+    semantic_analysis::TypeCheckContext,
     type_system::*,
     types::*,
 };
@@ -59,8 +60,8 @@ impl ReplaceSelfType for TyExpression {
 }
 
 impl ReplaceDecls for TyExpression {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, engines: &Engines) {
-        self.expression.replace_decls(decl_mapping, engines);
+    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
+        self.expression.replace_decls(decl_mapping, ctx);
     }
 }
 

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -60,8 +60,13 @@ impl ReplaceSelfType for TyExpression {
 }
 
 impl ReplaceDecls for TyExpression {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
-        self.expression.replace_decls(decl_mapping, ctx);
+    fn replace_decls_inner(
+        &mut self,
+        decl_mapping: &DeclMapping,
+        handler: &Handler,
+        ctx: &TypeCheckContext,
+    ) -> Result<(), ErrorEmitted> {
+        self.expression.replace_decls(decl_mapping, handler, ctx)
     }
 }
 

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -911,7 +911,8 @@ impl ReplaceDecls for TyExpressionVariant {
                 }
 
                 if let Some(filter_type) = filter_type_opt {
-                    let filtered_decl_mapping = decl_mapping.filter(filter_type, ctx.engines());
+                    let filtered_decl_mapping =
+                        decl_mapping.filter_functions_by_self_type(filter_type, ctx.engines());
                     fn_ref.replace_decls(&filtered_decl_mapping, handler, ctx)?;
                 } else {
                     fn_ref.replace_decls(decl_mapping, handler, ctx)?;

--- a/sway-core/src/language/ty/expression/reassignment.rs
+++ b/sway-core/src/language/ty/expression/reassignment.rs
@@ -3,6 +3,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
+use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::{Ident, Span, Spanned};
 
 use crate::{
@@ -64,8 +65,13 @@ impl ReplaceSelfType for TyReassignment {
 }
 
 impl ReplaceDecls for TyReassignment {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
-        self.rhs.replace_decls(decl_mapping, ctx);
+    fn replace_decls_inner(
+        &mut self,
+        decl_mapping: &DeclMapping,
+        handler: &Handler,
+        ctx: &TypeCheckContext,
+    ) -> Result<(), ErrorEmitted> {
+        self.rhs.replace_decls(decl_mapping, handler, ctx)
     }
 }
 

--- a/sway-core/src/language/ty/expression/reassignment.rs
+++ b/sway-core/src/language/ty/expression/reassignment.rs
@@ -5,7 +5,10 @@ use std::{
 
 use sway_types::{Ident, Span, Spanned};
 
-use crate::{decl_engine::*, engine_threading::*, language::ty::*, type_system::*};
+use crate::{
+    decl_engine::*, engine_threading::*, language::ty::*, semantic_analysis::TypeCheckContext,
+    type_system::*,
+};
 
 #[derive(Clone, Debug)]
 pub struct TyReassignment {
@@ -61,8 +64,8 @@ impl ReplaceSelfType for TyReassignment {
 }
 
 impl ReplaceDecls for TyReassignment {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, engines: &Engines) {
-        self.rhs.replace_decls(decl_mapping, engines);
+    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
+        self.rhs.replace_decls(decl_mapping, ctx);
     }
 }
 

--- a/sway-core/src/language/ty/expression/struct_exp_field.rs
+++ b/sway-core/src/language/ty/expression/struct_exp_field.rs
@@ -2,7 +2,10 @@ use std::hash::{Hash, Hasher};
 
 use sway_types::Ident;
 
-use crate::{decl_engine::*, engine_threading::*, language::ty::*, type_system::*};
+use crate::{
+    decl_engine::*, engine_threading::*, language::ty::*, semantic_analysis::TypeCheckContext,
+    type_system::*,
+};
 
 #[derive(Clone, Debug)]
 pub struct TyStructExpressionField {
@@ -38,7 +41,7 @@ impl ReplaceSelfType for TyStructExpressionField {
 }
 
 impl ReplaceDecls for TyStructExpressionField {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, engines: &Engines) {
-        self.value.replace_decls(decl_mapping, engines);
+    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
+        self.value.replace_decls(decl_mapping, ctx);
     }
 }

--- a/sway-core/src/language/ty/expression/struct_exp_field.rs
+++ b/sway-core/src/language/ty/expression/struct_exp_field.rs
@@ -1,5 +1,6 @@
 use std::hash::{Hash, Hasher};
 
+use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::Ident;
 
 use crate::{
@@ -41,7 +42,12 @@ impl ReplaceSelfType for TyStructExpressionField {
 }
 
 impl ReplaceDecls for TyStructExpressionField {
-    fn replace_decls_inner(&mut self, decl_mapping: &DeclMapping, ctx: &TypeCheckContext) {
-        self.value.replace_decls(decl_mapping, ctx);
+    fn replace_decls_inner(
+        &mut self,
+        decl_mapping: &DeclMapping,
+        handler: &Handler,
+        ctx: &TypeCheckContext,
+    ) -> Result<(), ErrorEmitted> {
+        self.value.replace_decls(decl_mapping, handler, ctx)
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -533,7 +533,7 @@ fn type_check_trait_implementation(
         match item {
             TyImplItem::Fn(decl_ref) => {
                 let mut method = decl_engine.get_function(decl_ref);
-                method.replace_decls(&decl_mapping, &ctx);
+                method.replace_decls(&decl_mapping, handler, &ctx)?;
                 method.subst(&type_mapping, engines);
                 method.replace_self_type(engines, ctx.self_type());
                 all_items_refs.push(TyImplItem::Fn(
@@ -544,7 +544,7 @@ fn type_check_trait_implementation(
             }
             TyImplItem::Constant(decl_ref) => {
                 let mut const_decl = decl_engine.get_constant(decl_ref);
-                const_decl.replace_decls(&decl_mapping, &ctx);
+                const_decl.replace_decls(&decl_mapping, handler, &ctx)?;
                 const_decl.subst(&type_mapping, engines);
                 const_decl.replace_self_type(engines, ctx.self_type());
                 all_items_refs.push(TyImplItem::Constant(decl_engine.insert(const_decl)));
@@ -613,7 +613,7 @@ fn type_check_impl_method(
         ty::TyFunctionDecl::type_check(handler, ctx.by_ref(), impl_method.clone(), true, false)?;
 
     // Ensure that there aren't multiple definitions of this function impl'd
-    if impld_item_refs.contains_key(&(impl_method.name, self_type)) {
+    if impld_item_refs.contains_key(&(impl_method.name.clone(), self_type)) {
         return Err(
             handler.emit_err(CompileError::MultipleDefinitionsOfFunction {
                 name: impl_method.name.clone(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -447,13 +447,13 @@ fn type_check_trait_implementation(
                 let method = decl_engine.get_trait_fn(decl_ref);
                 let name = method.name.clone();
                 method_checklist.insert(name.clone(), method);
-                interface_item_refs.insert(name, item.clone());
+                interface_item_refs.insert((name, self_type), item.clone());
             }
             TyTraitInterfaceItem::Constant(decl_ref) => {
                 let constant = decl_engine.get_constant(decl_ref);
                 let name = constant.call_path.suffix.clone();
                 constant_checklist.insert(name.clone(), constant);
-                interface_item_refs.insert(name, item.clone());
+                interface_item_refs.insert((name, self_type), item.clone());
             }
         }
     }
@@ -479,7 +479,7 @@ fn type_check_trait_implementation(
 
                 // Add this method to the "impld items".
                 let decl_ref = decl_engine.insert(impl_method);
-                impld_item_refs.insert(name, TyTraitItem::Fn(decl_ref));
+                impld_item_refs.insert((name, self_type), TyTraitItem::Fn(decl_ref));
             }
             ImplItem::Constant(const_decl) => {
                 let const_decl = type_check_const_decl(
@@ -499,7 +499,7 @@ fn type_check_trait_implementation(
 
                 // Add this constant to the "impld decls".
                 let decl_ref = decl_engine.insert(const_decl);
-                impld_item_refs.insert(name, TyTraitItem::Constant(decl_ref));
+                impld_item_refs.insert((name, self_type), TyTraitItem::Constant(decl_ref));
             }
         }
     }
@@ -533,7 +533,7 @@ fn type_check_trait_implementation(
         match item {
             TyImplItem::Fn(decl_ref) => {
                 let mut method = decl_engine.get_function(decl_ref);
-                method.replace_decls(&decl_mapping, engines);
+                method.replace_decls(&decl_mapping, &ctx);
                 method.subst(&type_mapping, engines);
                 method.replace_self_type(engines, ctx.self_type());
                 all_items_refs.push(TyImplItem::Fn(
@@ -544,7 +544,7 @@ fn type_check_trait_implementation(
             }
             TyImplItem::Constant(decl_ref) => {
                 let mut const_decl = decl_engine.get_constant(decl_ref);
-                const_decl.replace_decls(&decl_mapping, engines);
+                const_decl.replace_decls(&decl_mapping, &ctx);
                 const_decl.subst(&type_mapping, engines);
                 const_decl.replace_self_type(engines, ctx.self_type());
                 all_items_refs.push(TyImplItem::Constant(decl_engine.insert(const_decl)));
@@ -613,7 +613,7 @@ fn type_check_impl_method(
         ty::TyFunctionDecl::type_check(handler, ctx.by_ref(), impl_method.clone(), true, false)?;
 
     // Ensure that there aren't multiple definitions of this function impl'd
-    if impld_item_refs.contains_key(&impl_method.name) {
+    if impld_item_refs.contains_key(&(impl_method.name, self_type)) {
         return Err(
             handler.emit_err(CompileError::MultipleDefinitionsOfFunction {
                 name: impl_method.name.clone(),
@@ -825,7 +825,7 @@ fn type_check_const_decl(
     let const_name = const_decl.call_path.suffix.clone();
 
     // Ensure that there aren't multiple definitions of this constant
-    if impld_constant_ids.contains_key(&const_name) {
+    if impld_constant_ids.contains_key(&(const_name.clone(), self_type)) {
         return Err(
             handler.emit_err(CompileError::MultipleDefinitionsOfConstant {
                 name: const_name.clone(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -178,10 +178,12 @@ impl ty::TyTraitDecl {
         for item in interface_surface.iter() {
             match item {
                 ty::TyTraitInterfaceItem::TraitFn(decl_ref) => {
-                    interface_surface_item_refs.insert(decl_ref.name().clone(), item.clone());
+                    interface_surface_item_refs
+                        .insert((decl_ref.name().clone(), type_id), item.clone());
                 }
                 ty::TyTraitInterfaceItem::Constant(decl_ref) => {
-                    interface_surface_item_refs.insert(decl_ref.name().clone(), item.clone());
+                    interface_surface_item_refs
+                        .insert((decl_ref.name().clone(), type_id), item.clone());
                 }
             }
         }
@@ -194,10 +196,10 @@ impl ty::TyTraitDecl {
         {
             match &item {
                 ty::TyTraitItem::Fn(decl_ref) => {
-                    impld_item_refs.insert(decl_ref.name().clone(), item.clone());
+                    impld_item_refs.insert((decl_ref.name().clone(), type_id), item.clone());
                 }
                 ty::TyTraitItem::Constant(decl_ref) => {
-                    impld_item_refs.insert(decl_ref.name().clone(), item.clone());
+                    impld_item_refs.insert((decl_ref.name().clone(), type_id), item.clone());
                 }
             };
         }
@@ -209,7 +211,7 @@ impl ty::TyTraitDecl {
     /// this trait.
     pub(crate) fn retrieve_interface_surface_and_items_and_implemented_items_for_type(
         &self,
-        ctx: TypeCheckContext,
+        ctx: &TypeCheckContext,
         type_id: TypeId,
         call_path: &CallPath,
         type_arguments: &[TypeArgument],
@@ -232,10 +234,12 @@ impl ty::TyTraitDecl {
         for item in interface_surface.iter() {
             match item {
                 ty::TyTraitInterfaceItem::TraitFn(decl_ref) => {
-                    interface_surface_item_refs.insert(decl_ref.name().clone(), item.clone());
+                    interface_surface_item_refs
+                        .insert((decl_ref.name().clone(), type_id), item.clone());
                 }
                 ty::TyTraitInterfaceItem::Constant(decl_ref) => {
-                    interface_surface_item_refs.insert(decl_ref.name().clone(), item.clone());
+                    interface_surface_item_refs
+                        .insert((decl_ref.name().clone(), type_id), item.clone());
                 }
             }
         }
@@ -244,10 +248,10 @@ impl ty::TyTraitDecl {
         for item in items.iter() {
             match item {
                 ty::TyTraitItem::Fn(decl_ref) => {
-                    item_refs.insert(decl_ref.name().clone(), item.clone());
+                    item_refs.insert((decl_ref.name().clone(), type_id), item.clone());
                 }
                 ty::TyTraitItem::Constant(decl_ref) => {
-                    item_refs.insert(decl_ref.name().clone(), item.clone());
+                    item_refs.insert((decl_ref.name().clone(), type_id), item.clone());
                 }
             }
         }
@@ -273,7 +277,7 @@ impl ty::TyTraitDecl {
                     let mut method = decl_engine.get_function(&decl_ref);
                     method.subst(&type_mapping, engines);
                     impld_item_refs.insert(
-                        method.name.clone(),
+                        (method.name.clone(), type_id),
                         TyTraitItem::Fn(
                             decl_engine
                                 .insert(method)
@@ -285,7 +289,7 @@ impl ty::TyTraitDecl {
                     let mut const_decl = decl_engine.get_constant(&decl_ref);
                     const_decl.subst(&type_mapping, engines);
                     impld_item_refs.insert(
-                        const_decl.call_path.suffix.clone(),
+                        (const_decl.call_path.suffix.clone(), type_id),
                         TyTraitItem::Constant(decl_engine.insert(const_decl)),
                     );
                 }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -71,7 +71,7 @@ pub(crate) fn instantiate_function_application(
         &function_decl.type_parameters,
         &call_path_binding.span(),
     )?;
-    function_decl.replace_decls(&decl_mapping, &ctx);
+    function_decl.replace_decls(&decl_mapping, handler, &ctx)?;
     let return_type = function_decl.return_type.clone();
     let new_decl_ref = decl_engine
         .insert(function_decl)

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -67,11 +67,11 @@ pub(crate) fn instantiate_function_application(
     // constraint with new decl ids based on the new type.
     let decl_mapping = TypeParameter::gather_decl_mapping_from_trait_constraints(
         handler,
-        ctx.by_ref(),
+        &ctx,
         &function_decl.type_parameters,
         &call_path_binding.span(),
     )?;
-    function_decl.replace_decls(&decl_mapping, engines);
+    function_decl.replace_decls(&decl_mapping, &ctx);
     let return_type = function_decl.return_type.clone();
     let new_decl_ref = decl_engine
         .insert(function_decl)

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -332,11 +332,11 @@ pub(crate) fn type_check_method_application(
     // constraint with new decl ids based on the new type.
     let decl_mapping = TypeParameter::gather_decl_mapping_from_trait_constraints(
         handler,
-        ctx.by_ref(),
+        &ctx,
         &method.type_parameters,
         &call_path.span(),
     )?;
-    method.replace_decls(&decl_mapping, ctx.engines());
+    method.replace_decls(&decl_mapping, &ctx);
     let return_type = method.return_type.type_id;
     let new_decl_ref = decl_engine
         .insert(method)

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -336,7 +336,7 @@ pub(crate) fn type_check_method_application(
         &method.type_parameters,
         &call_path.span(),
     )?;
-    method.replace_decls(&decl_mapping, &ctx);
+    method.replace_decls(&decl_mapping, handler, &ctx)?;
     let return_type = method.return_type.type_id;
     let new_decl_ref = decl_engine
         .insert(method)

--- a/sway-core/src/semantic_analysis/namespace/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace/namespace.rs
@@ -675,7 +675,7 @@ impl Namespace {
     }
 
     pub(crate) fn get_items_for_type_and_trait_name(
-        &mut self,
+        &self,
         engines: &Engines,
         type_id: TypeId,
         trait_name: &CallPath,

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -251,7 +251,7 @@ impl TypeParameter {
     /// Creates a [DeclMapping] from a list of [TypeParameter]s.
     pub(crate) fn gather_decl_mapping_from_trait_constraints(
         handler: &Handler,
-        mut ctx: TypeCheckContext,
+        ctx: &TypeCheckContext,
         type_parameters: &[TypeParameter],
         access_span: &Span,
     ) -> Result<DeclMapping, ErrorEmitted> {
@@ -289,13 +289,8 @@ impl TypeParameter {
                     } = trait_constraint;
 
                     let (trait_interface_item_refs, trait_item_refs, trait_impld_item_refs) =
-                        match handle_trait(
-                            handler,
-                            ctx.by_ref(),
-                            *type_id,
-                            trait_name,
-                            trait_type_arguments,
-                        ) {
+                        match handle_trait(handler, ctx, *type_id, trait_name, trait_type_arguments)
+                        {
                             Ok(res) => res,
                             Err(_) => continue,
                         };
@@ -317,7 +312,7 @@ impl TypeParameter {
 
 fn handle_trait(
     handler: &Handler,
-    mut ctx: TypeCheckContext,
+    ctx: &TypeCheckContext,
     type_id: TypeId,
     trait_name: &CallPath,
     type_arguments: &[TypeArgument],
@@ -340,7 +335,7 @@ fn handle_trait(
 
                 let (trait_interface_item_refs, trait_item_refs, trait_impld_item_refs) =
                     trait_decl.retrieve_interface_surface_and_items_and_implemented_items_for_type(
-                        ctx.by_ref(),
+                        ctx,
                         type_id,
                         trait_name,
                         type_arguments,
@@ -354,7 +349,7 @@ fn handle_trait(
                         supertrait_interface_item_refs,
                         supertrait_item_refs,
                         supertrait_impld_item_refs,
-                    ) = match handle_trait(handler, ctx.by_ref(), type_id, &supertrait.name, &[]) {
+                    ) = match handle_trait(handler, ctx, type_id, &supertrait.name, &[]) {
                         Ok(res) => res,
                         Err(_) => continue,
                     };

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_tuple_trait/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_tuple_trait/src/main.sw
@@ -22,6 +22,14 @@ impl Trait2 for u64 {
     }
 }
 
+struct S {}
+
+impl Trait2 for S {
+    fn method2(self) -> u64 {
+        2
+    }
+}
+
 impl<A, B> Trait2 for (A, B) where A: Trait2, B: Trait2 {
     fn method2(self) -> u64 {
         self.0.method2() + self.1.method2()
@@ -31,5 +39,9 @@ impl<A, B> Trait2 for (A, B) where A: Trait2, B: Trait2 {
 fn main() -> bool {
     assert((1,2).method() == 42);
     assert((1,2).method2() == 3);
+    assert((1, S{}).method2() == 3);
+    assert(((1,2),(1,2)).method2() == 6);
+    assert(((1, S{}),(1,(1,2))).method2() == 7);
+
     true
 }


### PR DESCRIPTION
## Description

When a single method uses multiple trait implementation errors are thrown by the compiler similar issue occurs when a method requires a trait implementation and then calls another method that requires another implementation of the same trait.

This PR fixes both issues by filtering traits to be replaced by the arguments type used and trait method self type, and by gathering decl mapping of nested methods.

Fixes #4852

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
