### PR TITLE
parser recovery for let statements

### DIFF
--- a/sway-ast/src/statement.rs
+++ b/sway-ast/src/statement.rs
@@ -1,3 +1,5 @@
+use sway_error::handler::ErrorEmitted;
+
 use crate::priv_prelude::*;
 
 #[allow(clippy::large_enum_variant)]
@@ -9,6 +11,8 @@ pub enum Statement {
         expr: Expr,
         semicolon_token_opt: Option<SemicolonToken>,
     },
+    // to handle parser recovery: Error represents an unknown statement
+    Error(Box<[Span]>, #[serde(skip_serializing)] ErrorEmitted),
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -33,6 +37,7 @@ impl Spanned for Statement {
                 None => expr.span(),
                 Some(semicolon_token) => Span::join(expr.span(), semicolon_token.span()),
             },
+            Statement::Error(spans, _) => Span::join_all(spans.iter().cloned()),
         }
     }
 }

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -169,6 +169,10 @@ fn connect_node<'eng: 'cfg, 'cfg>(
         ty::TyAstNodeContent::Declaration(decl) => Ok(NodeConnection::NextStep(
             connect_declaration(engines, node, decl, graph, leaves)?,
         )),
+        ty::TyAstNodeContent::Error(spans, _) => {
+            let span = Span::join_all(spans.iter().cloned());
+            return Err(CompileError::InvalidStatement { span });
+        }
     }
 }
 

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -182,10 +182,7 @@ fn connect_node<'eng: 'cfg, 'cfg>(
         ty::TyAstNodeContent::Declaration(decl) => Ok(NodeConnection::NextStep(
             connect_declaration(engines, node, decl, graph, leaves)?,
         )),
-        ty::TyAstNodeContent::Error(spans, _) => {
-            let span = Span::join_all(spans.iter().cloned());
-            return Err(vec![CompileError::InvalidStatement { span }]);
-        }
+        ty::TyAstNodeContent::Error(_, _) => Ok(NodeConnection::NextStep(vec![])),
     }
 }
 

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -26,11 +26,10 @@ impl<'cfg> ControlFlowGraph<'cfg> {
         let mut leaves = vec![];
         for ast_entrypoint in module_nodes {
             match connect_node(engines, ast_entrypoint, &mut graph, &leaves) {
-                Ok(l_leaves) => {
-                    if let NodeConnection::NextStep(nodes) = l_leaves {
-                        leaves = nodes;
-                    }
+                Ok(NodeConnection::NextStep(nodes)) => {
+                    leaves = nodes;
                 }
+                Ok(_) => {}
                 Err(mut e) => {
                     errors.append(&mut e);
                 }

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -3,7 +3,7 @@ use crate::{
     decl_engine::*,
     language::{
         parsed::TreeType,
-        ty::{self, TyImplItem},
+        ty::{self, TyAstNodeContent, TyImplItem},
         CallPath, Visibility,
     },
     transform::{self, AttributesMap},
@@ -425,6 +425,10 @@ fn connect_node<'eng: 'cfg, 'cfg>(
                 )?,
                 exit_node,
             )
+        }
+        ty::TyAstNodeContent::Error(spans, _) => {
+            let span = Span::join_all(spans.iter().cloned());
+            return Err(CompileError::InvalidStatement { span });
         }
     })
 }
@@ -2099,6 +2103,10 @@ fn construct_dead_code_warning_from_node(
             span: span.clone(),
             warning_content: Warning::UnreachableCode,
         },
+        ty::TyAstNode {
+            content: TyAstNodeContent::Error(_, _),
+            ..
+        } => return None,
     })
 }
 
@@ -2258,6 +2266,7 @@ fn allow_dead_code_ast_node(decl_engine: &DeclEngine, node: &ty::TyAstNode) -> b
         ty::TyAstNodeContent::Expression(_) => false,
         ty::TyAstNodeContent::ImplicitReturnExpression(_) => false,
         ty::TyAstNodeContent::SideEffect(_) => false,
+        ty::TyAstNodeContent::Error(_, _) => false,
     }
 }
 

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -426,10 +426,7 @@ fn connect_node<'eng: 'cfg, 'cfg>(
                 exit_node,
             )
         }
-        ty::TyAstNodeContent::Error(spans, _) => {
-            let span = Span::join_all(spans.iter().cloned());
-            return Err(CompileError::InvalidStatement { span });
-        }
+        ty::TyAstNodeContent::Error(_, _) => (vec![], None),
     })
 }
 

--- a/sway-core/src/ir_generation.rs
+++ b/sway-core/src/ir_generation.rs
@@ -20,7 +20,6 @@ pub fn compile_program<'eng>(
     include_tests: bool,
     engines: &'eng Engines,
 ) -> Result<Context<'eng>, Vec<CompileError>> {
-    dbg!(1);
     let declaration_engine = engines.de();
 
     let test_fns = match include_tests {

--- a/sway-core/src/ir_generation.rs
+++ b/sway-core/src/ir_generation.rs
@@ -19,7 +19,8 @@ pub fn compile_program<'eng>(
     program: &ty::TyProgram,
     include_tests: bool,
     engines: &'eng Engines,
-) -> Result<Context<'eng>, CompileError> {
+) -> Result<Context<'eng>, Vec<CompileError>> {
+    dbg!(1);
     let declaration_engine = engines.de();
 
     let test_fns = match include_tests {
@@ -101,6 +102,9 @@ pub fn compile_program<'eng>(
     //println!("{ctx}");
 
     ctx.verify().map_err(|ir_error: sway_ir::IrError| {
-        CompileError::InternalOwned(ir_error.to_string(), Span::dummy())
+        vec![CompileError::InternalOwned(
+            ir_error.to_string(),
+            Span::dummy(),
+        )]
     })
 }

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -317,7 +317,6 @@ pub(super) fn compile_function(
     is_entry: bool,
     test_decl_ref: Option<DeclRefFunction>,
 ) -> Result<Option<Function>, Vec<CompileError>> {
-    dbg!(1);
     // Currently monomorphization of generics is inlined into main() and the functions with generic
     // args are still present in the AST declarations, but they can be ignored.
     if !ast_fn_decl.type_parameters.is_empty() {
@@ -350,7 +349,6 @@ pub(super) fn compile_entry_function(
     messages_types_map: &HashMap<TypeId, MessageId>,
     test_decl_ref: Option<DeclRefFunction>,
 ) -> Result<Function, Vec<CompileError>> {
-    dbg!(1);
     let is_entry = true;
     compile_function(
         engines,
@@ -406,7 +404,6 @@ fn compile_fn(
     messages_types_map: &HashMap<TypeId, MessageId>,
     test_decl_ref: Option<DeclRefFunction>,
 ) -> Result<Function, Vec<CompileError>> {
-    dbg!(1);
     let type_engine = engines.te();
     let decl_engine = engines.de();
 

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -30,11 +30,12 @@ pub(super) fn compile_script(
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
     test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
-) -> Result<Module, CompileError> {
+) -> Result<Module, Vec<CompileError>> {
+    println!("1");
     let module = Module::new(context, Kind::Script);
     let mut md_mgr = MetadataManager::default();
 
-    compile_constants(engines, context, &mut md_mgr, module, namespace)?;
+    compile_constants(engines, context, &mut md_mgr, module, namespace).map_err(|err| vec![err])?;
     compile_declarations(
         engines,
         context,
@@ -42,7 +43,8 @@ pub(super) fn compile_script(
         module,
         namespace,
         declarations,
-    )?;
+    )
+    .map_err(|err| vec![err])?;
     compile_entry_function(
         engines,
         context,
@@ -76,11 +78,11 @@ pub(super) fn compile_predicate(
     logged_types: &HashMap<TypeId, LogId>,
     messages_types: &HashMap<TypeId, MessageId>,
     test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
-) -> Result<Module, CompileError> {
+) -> Result<Module, Vec<CompileError>> {
     let module = Module::new(context, Kind::Predicate);
     let mut md_mgr = MetadataManager::default();
 
-    compile_constants(engines, context, &mut md_mgr, module, namespace)?;
+    compile_constants(engines, context, &mut md_mgr, module, namespace).map_err(|err| vec![err])?;
     compile_declarations(
         engines,
         context,
@@ -88,7 +90,8 @@ pub(super) fn compile_predicate(
         module,
         namespace,
         declarations,
-    )?;
+    )
+    .map_err(|err| vec![err])?;
     compile_entry_function(
         engines,
         context,
@@ -122,11 +125,11 @@ pub(super) fn compile_contract(
     messages_types_map: &HashMap<TypeId, MessageId>,
     test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
     engines: &Engines,
-) -> Result<Module, CompileError> {
+) -> Result<Module, Vec<CompileError>> {
     let module = Module::new(context, Kind::Contract);
     let mut md_mgr = MetadataManager::default();
 
-    compile_constants(engines, context, &mut md_mgr, module, namespace)?;
+    compile_constants(engines, context, &mut md_mgr, module, namespace).map_err(|err| vec![err])?;
     compile_declarations(
         engines,
         context,
@@ -134,7 +137,8 @@ pub(super) fn compile_contract(
         module,
         namespace,
         declarations,
-    )?;
+    )
+    .map_err(|err| vec![err])?;
     for decl in abi_entries {
         compile_abi_method(
             context,
@@ -168,11 +172,11 @@ pub(super) fn compile_library(
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
     test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
-) -> Result<Module, CompileError> {
+) -> Result<Module, Vec<CompileError>> {
     let module = Module::new(context, Kind::Library);
     let mut md_mgr = MetadataManager::default();
 
-    compile_constants(engines, context, &mut md_mgr, module, namespace)?;
+    compile_constants(engines, context, &mut md_mgr, module, namespace).map_err(|err| vec![err])?;
     compile_declarations(
         engines,
         context,
@@ -180,7 +184,8 @@ pub(super) fn compile_library(
         module,
         namespace,
         declarations,
-    )?;
+    )
+    .map_err(|err| vec![err])?;
     compile_tests(
         engines,
         context,
@@ -311,7 +316,8 @@ pub(super) fn compile_function(
     messages_types_map: &HashMap<TypeId, MessageId>,
     is_entry: bool,
     test_decl_ref: Option<DeclRefFunction>,
-) -> Result<Option<Function>, CompileError> {
+) -> Result<Option<Function>, Vec<CompileError>> {
+    dbg!(1);
     // Currently monomorphization of generics is inlined into main() and the functions with generic
     // args are still present in the AST declarations, but they can be ignored.
     if !ast_fn_decl.type_parameters.is_empty() {
@@ -343,7 +349,8 @@ pub(super) fn compile_entry_function(
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
     test_decl_ref: Option<DeclRefFunction>,
-) -> Result<Function, CompileError> {
+) -> Result<Function, Vec<CompileError>> {
+    dbg!(1);
     let is_entry = true;
     compile_function(
         engines,
@@ -368,7 +375,7 @@ pub(super) fn compile_tests(
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
     test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
-) -> Result<Vec<Function>, CompileError> {
+) -> Result<Vec<Function>, Vec<CompileError>> {
     test_fns
         .iter()
         .map(|(ast_fn_decl, decl_ref)| {
@@ -398,7 +405,8 @@ fn compile_fn(
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
     test_decl_ref: Option<DeclRefFunction>,
-) -> Result<Function, CompileError> {
+) -> Result<Function, Vec<CompileError>> {
+    dbg!(1);
     let type_engine = engines.te();
     let decl_engine = engines.de();
 
@@ -439,7 +447,8 @@ fn compile_fn(
                 )
             })
         })
-        .collect::<Result<Vec<_>, CompileError>>()?;
+        .collect::<Result<Vec<_>, CompileError>>()
+        .map_err(|err| vec![err])?;
 
     let ret_type = convert_resolved_typeid(
         type_engine,
@@ -447,7 +456,8 @@ fn compile_fn(
         context,
         &return_type.type_id,
         &return_type.span,
-    )?;
+    )
+    .map_err(|err| vec![err])?;
 
     let span_md_idx = md_mgr.span_to_md(context, span);
     let storage_md_idx = md_mgr.purity_to_md(context, *purity);
@@ -529,7 +539,7 @@ fn compile_abi_method(
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
     engines: &Engines,
-) -> Result<Function, CompileError> {
+) -> Result<Function, Vec<CompileError>> {
     // Use the error from .to_fn_selector_value() if possible, else make an CompileError::Internal.
     let handler = Handler::default();
     let get_selector_result = ast_fn_decl.to_fn_selector_value(&handler, engines);
@@ -538,15 +548,15 @@ fn compile_abi_method(
         Some(selector) => selector,
         None => {
             return if !errors.is_empty() {
-                Err(errors[0].clone())
+                Err(vec![errors[0].clone()])
             } else {
-                Err(CompileError::InternalOwned(
+                Err(vec![CompileError::InternalOwned(
                     format!(
                         "Cannot generate selector for ABI method: {}",
                         ast_fn_decl.name.as_str()
                     ),
                     ast_fn_decl.name.span(),
-                ))
+                )])
             };
         }
     };

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -693,11 +693,8 @@ fn const_eval_codeblock(
             ty::TyAstNodeContent::SideEffect(_) => Err(ConstEvalError::CannotBeEvaluatedToConst {
                 span: ast_node.span.clone(),
             }),
-            ty::TyAstNodeContent::Error(spans, _) => {
-                let span = Span::join_all(spans.iter().cloned());
-                Err(ConstEvalError::CompileError(
-                    CompileError::InvalidStatement { span },
-                ))
+            ty::TyAstNodeContent::Error(_, _) => {
+                unreachable!("error node found when generating IR");
             }
         };
 

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -693,6 +693,12 @@ fn const_eval_codeblock(
             ty::TyAstNodeContent::SideEffect(_) => Err(ConstEvalError::CannotBeEvaluatedToConst {
                 span: ast_node.span.clone(),
             }),
+            ty::TyAstNodeContent::Error(spans, _) => {
+                let span = Span::join_all(spans.iter().cloned());
+                Err(ConstEvalError::CompileError(
+                    CompileError::InvalidStatement { span },
+                ))
+            }
         };
 
         if result.is_err() {

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -136,7 +136,6 @@ impl<'eng> FnCompiler<'eng> {
                 }
             };
 
-            dbg!(&errors);
             if !errors.is_empty() {
                 Err(errors)
             } else {

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -216,9 +216,8 @@ impl<'eng> FnCompiler<'eng> {
             // a side effect can be () because it just impacts the type system/namespacing.
             // There should be no new IR generated.
             ty::TyAstNodeContent::SideEffect(_) => Ok(None),
-            ty::TyAstNodeContent::Error(spans, _) => {
-                let span = Span::join_all(spans.iter().cloned());
-                Err(CompileError::InvalidStatement { span })
+            ty::TyAstNodeContent::Error(_, _) => {
+                unreachable!("error node found when generating IR");
             }
         }
     }

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -205,6 +205,10 @@ impl<'eng> FnCompiler<'eng> {
             // a side effect can be () because it just impacts the type system/namespacing.
             // There should be no new IR generated.
             ty::TyAstNodeContent::SideEffect(_) => Ok(None),
+            ty::TyAstNodeContent::Error(spans, err) => {
+                let span = Span::join_all(spans.iter().cloned());
+                Err(CompileError::InvalidStatement { span })
+            }
         }
     }
 

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -118,7 +118,6 @@ impl<'eng> FnCompiler<'eng> {
         md_mgr: &mut MetadataManager,
         ast_block: &ty::TyCodeBlock,
     ) -> Result<Value, Vec<CompileError>> {
-        dbg!(1);
         self.compile_with_new_scope(|fn_compiler| {
             let mut errors = vec![];
 

--- a/sway-core/src/language/parsed/mod.rs
+++ b/sway-core/src/language/parsed/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use include_statement::IncludeStatement;
 pub use module::{ParseModule, ParseSubmodule};
 pub use program::{ParseProgram, TreeType};
 pub use return_statement::*;
+use sway_error::handler::ErrorEmitted;
 pub use use_statement::{ImportType, UseStatement};
 
 use sway_types::span::Span;
@@ -59,6 +60,12 @@ pub enum AstNodeContent {
     ImplicitReturnExpression(Expression),
     /// A statement of the form `mod foo::bar;` which imports/includes another source file.
     IncludeStatement(IncludeStatement),
+    /// A malformed statement.
+    ///
+    /// Used for parser recovery when we cannot form a more specific node.
+    /// The list of `Span`s are for consumption by the LSP and are,
+    /// when joined, the same as that stored in `statement.span`.
+    Error(Box<[Span]>, ErrorEmitted),
 }
 
 impl ParseTree {

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -53,7 +53,7 @@ impl DebugWithEngines for TyAstNode {
             Expression(exp) => DebugWithEngines::fmt(exp, f, engines),
             ImplicitReturnExpression(exp) => write!(f, "return {:?}", engines.help_out(exp)),
             SideEffect(_) => f.write_str(""),
-            Error(_, err) => f.write_str("error"),
+            Error(_, _) => f.write_str("error"),
         }
     }
 }

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -53,6 +53,7 @@ impl DebugWithEngines for TyAstNode {
             Expression(exp) => DebugWithEngines::fmt(exp, f, engines),
             ImplicitReturnExpression(exp) => write!(f, "return {:?}", engines.help_out(exp)),
             SideEffect(_) => f.write_str(""),
+            Error(_, err) => f.write_str("error"),
         }
     }
 }
@@ -66,6 +67,7 @@ impl SubstTypes for TyAstNode {
             TyAstNodeContent::Declaration(ref mut decl) => decl.subst(type_mapping, engines),
             TyAstNodeContent::Expression(ref mut expr) => expr.subst(type_mapping, engines),
             TyAstNodeContent::SideEffect(_) => (),
+            TyAstNodeContent::Error(_, _) => (),
         }
     }
 }
@@ -83,6 +85,7 @@ impl ReplaceSelfType for TyAstNode {
                 expr.replace_self_type(engines, self_type)
             }
             TyAstNodeContent::SideEffect(_) => (),
+            TyAstNodeContent::Error(_, _) => (),
         }
     }
 }
@@ -106,6 +109,7 @@ impl ReplaceDecls for TyAstNode {
                 expr.replace_decls(decl_mapping, handler, ctx)
             }
             TyAstNodeContent::SideEffect(_) => Ok(()),
+            TyAstNodeContent::Error(_, _) => Ok(()),
         }
     }
 }
@@ -121,6 +125,7 @@ impl UpdateConstantExpression for TyAstNode {
                 expr.update_constant_expression(engines, implementing_type)
             }
             TyAstNodeContent::SideEffect(_) => (),
+            TyAstNodeContent::Error(_, _) => (),
         }
     }
 }
@@ -144,6 +149,7 @@ impl DeterministicallyAborts for TyAstNode {
                 exp.deterministically_aborts(decl_engine, check_call_body)
             }
             SideEffect(_) => false,
+            Error(_, _) => false,
         }
     }
 }
@@ -167,6 +173,7 @@ impl TyAstNode {
                 decl.body.gather_return_statements()
             }
             TyAstNodeContent::Expression(exp) => exp.gather_return_statements(),
+            TyAstNodeContent::Error(_, _) => vec![],
             TyAstNodeContent::SideEffect(_) | TyAstNodeContent::Declaration(_) => vec![],
         }
     }
@@ -177,6 +184,7 @@ impl TyAstNode {
             TyAstNodeContent::Declaration(decl) => decl.visibility(decl_engine).is_public(),
             TyAstNodeContent::Expression(_)
             | TyAstNodeContent::SideEffect(_)
+            | TyAstNodeContent::Error(_, _)
             | TyAstNodeContent::ImplicitReturnExpression(_) => false,
         }
     }
@@ -314,6 +322,7 @@ impl TyAstNode {
                 type_engine.get(*return_type)
             }
             TyAstNodeContent::SideEffect(_) => TypeInfo::Tuple(Vec::new()),
+            TyAstNodeContent::Error(_, error) => TypeInfo::ErrorRecovery(*error),
         }
     }
 }
@@ -325,6 +334,7 @@ pub enum TyAstNodeContent {
     ImplicitReturnExpression(TyExpression),
     // a no-op node used for something that just issues a side effect, like an import statement.
     SideEffect(TySideEffect),
+    Error(Box<[Span]>, ErrorEmitted),
 }
 
 impl EqWithEngines for TyAstNodeContent {}
@@ -356,6 +366,7 @@ impl HashWithEngines for TyAstNodeContent {
             SideEffect(effect) => {
                 effect.hash(state);
             }
+            Error(_, _) => {}
         }
     }
 }
@@ -372,6 +383,7 @@ impl CollectTypesMetadata for TyAstNodeContent {
             Expression(expr) => expr.collect_types_metadata(handler, ctx),
             ImplicitReturnExpression(expr) => expr.collect_types_metadata(handler, ctx),
             SideEffect(_) => Ok(vec![]),
+            Error(_, _) => Ok(vec![]),
         }
     }
 }
@@ -383,6 +395,7 @@ impl GetDeclIdent for TyAstNodeContent {
             TyAstNodeContent::Expression(_expr) => None, //expr.get_decl_ident(),
             TyAstNodeContent::ImplicitReturnExpression(_expr) => None, //expr.get_decl_ident(),
             TyAstNodeContent::SideEffect(_) => None,
+            TyAstNodeContent::Error(_, _) => None,
         }
     }
 }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -513,9 +513,6 @@ pub fn compile_to_ast(
         metrics
     );
 
-    //  // Fail compilation if we have errors
-    //  handler.ok()?;
-
     handler.dedup();
     Ok(Programs::new(lexed_program, parsed_program, typed_res))
 }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -171,9 +171,7 @@ fn parse_in_memory(
     engines: &Engines,
     src: Arc<str>,
 ) -> Result<(lexed::LexedProgram, parsed::ParseProgram), ErrorEmitted> {
-    dbg!(1);
     let module = sway_parse::parse_file(handler, src, None)?;
-    dbg!(1);
 
     let (kind, tree) = to_parsed_lang::convert_parse_tree(
         &mut to_parsed_lang::Context::default(),
@@ -529,7 +527,6 @@ pub fn compile_to_asm(
     package_name: &str,
     metrics: &mut PerformanceData,
 ) -> Result<CompiledAsm, ErrorEmitted> {
-    dbg!(1);
     let ast_res = compile_to_ast(
         handler,
         engines,
@@ -550,7 +547,6 @@ pub fn ast_to_asm(
     programs: &Programs,
     build_config: &BuildConfig,
 ) -> Result<CompiledAsm, ErrorEmitted> {
-    dbg!(1);
     let typed_program = match &programs.typed {
         Ok(typed_program) => typed_program,
         Err(err) => return Err(*err),
@@ -572,7 +568,6 @@ pub(crate) fn compile_ast_to_ir_to_asm(
     program: &ty::TyProgram,
     build_config: &BuildConfig,
 ) -> Result<FinalizedAsm, ErrorEmitted> {
-    dbg!(1);
     // the IR pipeline relies on type information being fully resolved.
     // If type information is found to still be generic or unresolved inside of
     // IR, this is considered an internal compiler error. To resolve this situation,

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -481,9 +481,6 @@ pub fn compile_to_ast(
         metrics
     );
 
-    // Fail compilation if we have errors
-    handler.ok()?;
-
     let (lexed_program, mut parsed_program) = match parse_program_opt {
         Ok(modules) => modules,
         Err(e) => {
@@ -515,6 +512,9 @@ pub fn compile_to_ast(
         build_config,
         metrics
     );
+
+    //  // Fail compilation if we have errors
+    //  handler.ok()?;
 
     handler.dedup();
     Ok(Programs::new(lexed_program, parsed_program, typed_res))

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -196,6 +196,7 @@ fn parse_in_memory(
             submodules: Default::default(),
         },
     );
+
     Ok((lexed_program, parsed::ParseProgram { kind, root }))
 }
 
@@ -479,6 +480,9 @@ pub fn compile_to_ast(
         build_config,
         metrics
     );
+
+    // Fail compilation if we have errors
+    handler.ok()?;
 
     let (lexed_program, mut parsed_program) = match parse_program_opt {
         Ok(modules) => modules,
@@ -946,7 +950,6 @@ fn test_unary_ordering() {
 
 #[test]
 fn test_parser_recovery() {
-    use crate::language::{self, parsed};
     let handler = Handler::default();
     let engines = Engines::default();
     let prog = parse(
@@ -962,7 +965,7 @@ fn test_parser_recovery() {
         &engines,
         None,
     );
-    let (lexed, parsed) = prog.unwrap();
+    let (_, _) = prog.unwrap();
     assert!(handler.has_errors());
     dbg!(handler);
 }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -171,7 +171,10 @@ fn parse_in_memory(
     engines: &Engines,
     src: Arc<str>,
 ) -> Result<(lexed::LexedProgram, parsed::ParseProgram), ErrorEmitted> {
+    dbg!(1);
     let module = sway_parse::parse_file(handler, src, None)?;
+    dbg!(1);
+
     let (kind, tree) = to_parsed_lang::convert_parse_tree(
         &mut to_parsed_lang::Context::default(),
         handler,
@@ -935,4 +938,27 @@ fn test_unary_ordering() {
     } else {
         panic!("Was not ast node")
     };
+}
+
+#[test]
+fn test_parser_recovery() {
+    use crate::language::{self, parsed};
+    let handler = Handler::default();
+    let engines = Engines::default();
+    let prog = parse(
+        r#"
+    script;
+    fn main() -> bool {
+        let
+        let a = true;
+        true
+    }"#
+        .into(),
+        &handler,
+        &engines,
+        None,
+    );
+    let (lexed, parsed) = prog.unwrap();
+    assert!(handler.has_errors());
+    dbg!(handler);
 }

--- a/sway-core/src/monomorphize/gather/node.rs
+++ b/sway-core/src/monomorphize/gather/node.rs
@@ -12,5 +12,6 @@ pub(crate) fn gather_from_node(
         ty::TyAstNodeContent::Expression(exp) => gather_from_exp(ctx, handler, exp),
         ty::TyAstNodeContent::ImplicitReturnExpression(exp) => gather_from_exp(ctx, handler, exp),
         ty::TyAstNodeContent::SideEffect(_) => Ok(()),
+        ty::TyAstNodeContent::Error(_, _) => Ok(()),
     }
 }

--- a/sway-core/src/monomorphize/instruct/node.rs
+++ b/sway-core/src/monomorphize/instruct/node.rs
@@ -12,5 +12,6 @@ pub(crate) fn instruct_node(
         ty::TyAstNodeContent::Expression(exp) => instruct_exp(ctx, handler, exp),
         ty::TyAstNodeContent::ImplicitReturnExpression(exp) => instruct_exp(ctx, handler, exp),
         ty::TyAstNodeContent::SideEffect(_) => Ok(()),
+        ty::TyAstNodeContent::Error(_, _) => Ok(()),
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -156,6 +156,7 @@ impl ty::TyAstNode {
                         .unwrap_or_else(|err| ty::TyExpression::error(err, expr.span(), engines));
                     ty::TyAstNodeContent::ImplicitReturnExpression(typed_expr)
                 }
+                AstNodeContent::Error(spans, err) => ty::TyAstNodeContent::Error(spans, err),
             },
             span: node.span,
         };

--- a/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
+++ b/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
@@ -181,7 +181,7 @@ fn analyze_code_block_entry(
         | ty::TyAstNodeContent::ImplicitReturnExpression(expr) => {
             analyze_expression(engines, expr, block_name, warnings)
         }
-        ty::TyAstNodeContent::SideEffect(_) => HashSet::new(),
+        ty::TyAstNodeContent::SideEffect(_) | ty::TyAstNodeContent::Error(_, _) => HashSet::new(),
     }
 }
 
@@ -474,7 +474,7 @@ fn effects_of_codeblock_entry(engines: &Engines, ast_node: &ty::TyAstNode) -> Ha
         | ty::TyAstNodeContent::ImplicitReturnExpression(expr) => {
             effects_of_expression(engines, expr)
         }
-        ty::TyAstNodeContent::SideEffect(_) => HashSet::new(),
+        ty::TyAstNodeContent::SideEffect(_) | ty::TyAstNodeContent::Error(_, _) => HashSet::new(),
     }
 }
 

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -633,8 +633,9 @@ impl Dependencies {
             AstNodeContent::Declaration(decl) => self.gather_from_decl(engines, decl),
 
             // No deps from these guys.
-            AstNodeContent::UseStatement(_) => self,
-            AstNodeContent::IncludeStatement(_) => self,
+            AstNodeContent::UseStatement(_)
+            | AstNodeContent::IncludeStatement(_)
+            | AstNodeContent::Error(_, _) => self,
         }
     }
 

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -2375,6 +2375,13 @@ fn statement_to_ast_nodes(
         Statement::Expr { expr, .. } => {
             vec![expr_to_ast_node(context, handler, engines, expr, true)?]
         }
+        Statement::Error(spans, error) => {
+            let span = Span::join_all(spans.iter().cloned());
+            vec![AstNode {
+                content: AstNodeContent::Error(spans, error),
+                span,
+            }]
+        }
     };
     Ok(ast_nodes)
 }

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -287,9 +287,6 @@ pub enum CompileError {
     #[error("This opcode takes an immediate value but none was provided.")]
     MissingImmediate { span: Span },
 
-    #[error("This statement is invalid.")]
-    InvalidStatement { span: Span },
-
     #[error("This immediate value is invalid.")]
     InvalidImmediateValue { span: Span },
     #[error("Variant \"{variant_name}\" does not exist on enum \"{enum_name}\"")]
@@ -855,7 +852,6 @@ impl Spanned for CompileError {
             AbiShadowsSuperAbiMethod { span, .. } => span.clone(),
             ConflictingSuperAbiMethods { span, .. } => span.clone(),
             AbiSupertraitMethodCallAsContractCall { span, .. } => span.clone(),
-            InvalidStatement { span } => span.clone(),
         }
     }
 }

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -286,6 +286,10 @@ pub enum CompileError {
     },
     #[error("This opcode takes an immediate value but none was provided.")]
     MissingImmediate { span: Span },
+
+    #[error("This statement is invalid.")]
+    InvalidStatement { span: Span },
+
     #[error("This immediate value is invalid.")]
     InvalidImmediateValue { span: Span },
     #[error("Variant \"{variant_name}\" does not exist on enum \"{enum_name}\"")]
@@ -851,6 +855,7 @@ impl Spanned for CompileError {
             AbiShadowsSuperAbiMethod { span, .. } => span.clone(),
             ConflictingSuperAbiMethods { span, .. } => span.clone(),
             AbiSupertraitMethodCallAsContractCall { span, .. } => span.clone(),
+            InvalidStatement { span } => span.clone(),
         }
     }
 }

--- a/sway-error/src/handler.rs
+++ b/sway-error/src/handler.rs
@@ -80,10 +80,39 @@ impl Handler {
         }
     }
 
+    pub fn append_ref(&self, other: &Handler) {
+        let other = other.inner.borrow();
+
+        for warn in other.warnings.iter() {
+            self.emit_warn(warn.clone());
+        }
+        for err in other.errors.iter() {
+            self.emit_err(err.clone());
+        }
+    }
+
     pub fn dedup(&self) {
         let mut inner = self.inner.borrow_mut();
         inner.errors = dedup_unsorted(inner.errors.clone());
         inner.warnings = dedup_unsorted(inner.warnings.clone());
+    }
+
+    pub fn ok(&self) -> Result<(), ErrorEmitted> {
+        if !self.has_errors() {
+            Ok(())
+        } else {
+            Err(ErrorEmitted { _priv: () })
+        }
+    }
+
+    pub fn clear_errors(&self) {
+        let mut inner = self.inner.borrow_mut();
+        inner.errors.clear();
+    }
+
+    pub fn clear_warnings(&self) {
+        let mut inner = self.inner.borrow_mut();
+        inner.warnings.clear();
     }
 }
 

--- a/sway-error/src/handler.rs
+++ b/sway-error/src/handler.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use core::cell::RefCell;
 
 /// A handler with which you can emit diagnostics.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct Handler {
     /// The inner handler.
     /// This construction is used to avoid `&mut` all over the compiler.
@@ -13,7 +13,7 @@ pub struct Handler {
 
 /// Contains the actual data for `Handler`.
 /// Modelled this way to afford an API using interior mutability.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 struct HandlerInner {
     /// The sink through which errors will be emitted.
     errors: Vec<CompileError>,
@@ -80,39 +80,10 @@ impl Handler {
         }
     }
 
-    pub fn append_ref(&self, other: &Handler) {
-        let other = other.inner.borrow();
-
-        for warn in other.warnings.iter() {
-            self.emit_warn(warn.clone());
-        }
-        for err in other.errors.iter() {
-            self.emit_err(err.clone());
-        }
-    }
-
     pub fn dedup(&self) {
         let mut inner = self.inner.borrow_mut();
         inner.errors = dedup_unsorted(inner.errors.clone());
         inner.warnings = dedup_unsorted(inner.warnings.clone());
-    }
-
-    pub fn ok(&self) -> Result<(), ErrorEmitted> {
-        if !self.has_errors() {
-            Ok(())
-        } else {
-            Err(ErrorEmitted { _priv: () })
-        }
-    }
-
-    pub fn clear_errors(&self) {
-        let mut inner = self.inner.borrow_mut();
-        inner.errors.clear();
-    }
-
-    pub fn clear_warnings(&self) {
-        let mut inner = self.inner.borrow_mut();
-        inner.warnings.clear();
     }
 }
 

--- a/sway-error/src/parser_error.rs
+++ b/sway-error/src/parser_error.rs
@@ -20,6 +20,8 @@ pub enum ParseErrorKind {
     UnexpectedTokenAfterArrayIndex,
     #[error("Invalid literal to use as a field name.")]
     InvalidLiteralFieldName,
+    #[error("Invalid statement.")]
+    InvalidStatement,
     #[error("Integer field names cannot have type suffixes.")]
     IntFieldWithTypeSuffix,
     #[error("Expected a field name.")]
@@ -38,6 +40,8 @@ pub enum ParseErrorKind {
     MalformedAsmImmediate,
     #[error("Expected an identifier.")]
     ExpectedIdent,
+    #[error("Expected an pattern.")]
+    ExpectedPattern,
     #[error("Unexpected token after str length.")]
     UnexpectedTokenAfterStrLength,
     #[error("Expected a type.")]

--- a/sway-lsp/src/traverse/lexed_tree.rs
+++ b/sway-lsp/src/traverse/lexed_tree.rs
@@ -541,6 +541,7 @@ impl Parse for Statement {
             Statement::Item(item) => {
                 item.value.parse(ctx);
             }
+            Statement::Error(_, _) => {}
         }
     }
 }

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -108,6 +108,7 @@ impl Parse for AstNode {
             AstNodeContent::UseStatement(use_statement) => use_statement.parse(ctx),
             // include statements are handled throught [`collect_module_spans`]
             AstNodeContent::IncludeStatement(_) => {}
+            AstNodeContent::Error(_, _) => {}
         }
     }
 }

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -67,6 +67,7 @@ impl Parse for ty::TyAstNode {
             ty::TyAstNodeContent::Expression(expression)
             | ty::TyAstNodeContent::ImplicitReturnExpression(expression) => expression.parse(ctx),
             ty::TyAstNodeContent::SideEffect(side_effect) => side_effect.parse(ctx),
+            ty::TyAstNodeContent::Error(_, _) => {}
         };
     }
 }

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -105,6 +105,7 @@ pub(crate) fn print_decl_engine_types(
                 format!("{expression:#?}")
             }
             ty::TyAstNodeContent::SideEffect(side_effect) => format!("{side_effect:#?}"),
+            ty::TyAstNodeContent::Error(_, _) => todo!(),
         })
         .map(|s| format!("{s}\n"))
         .collect()

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -105,7 +105,7 @@ pub(crate) fn print_decl_engine_types(
                 format!("{expression:#?}")
             }
             ty::TyAstNodeContent::SideEffect(side_effect) => format!("{side_effect:#?}"),
-            ty::TyAstNodeContent::Error(_, _) => todo!(),
+            ty::TyAstNodeContent::Error(_, _) => format!("error"),
         })
         .map(|s| format!("{s}\n"))
         .collect()

--- a/sway-lsp/src/utils/debug.rs
+++ b/sway-lsp/src/utils/debug.rs
@@ -105,7 +105,7 @@ pub(crate) fn print_decl_engine_types(
                 format!("{expression:#?}")
             }
             ty::TyAstNodeContent::SideEffect(side_effect) => format!("{side_effect:#?}"),
-            ty::TyAstNodeContent::Error(_, _) => format!("error"),
+            ty::TyAstNodeContent::Error(_, _) => "error".to_string(),
         })
         .map(|s| format!("{s}\n"))
         .collect()

--- a/sway-parse/src/expr/mod.rs
+++ b/sway-parse/src/expr/mod.rs
@@ -94,23 +94,24 @@ impl Parse for Expr {
 impl Parse for StatementLet {
     fn parse(parser: &mut Parser) -> ParseResult<Self> {
         let let_token: LetToken = parser.parse()?;
-        let pattern = parser.try_parse().map_err(|err| {
-            parser.emit_error_with_span(
+
+        if parser.peek::<EqToken>().is_some() {
+            return Err(parser.emit_error_with_span(
                 ParseErrorKind::ExpectedPattern,
                 let_token.span().next_char(),
-            );
-            err
-        })?;
+            ));
+        }
+        let pattern = parser.try_parse(true)?;
+
         let ty_opt = match parser.take() {
             Some(colon_token) => Some((colon_token, parser.parse()?)),
             None => None,
         };
-        let eq_token: EqToken = parser.try_parse()?;
-
-        let expr = parser.try_parse()?;
+        let eq_token: EqToken = parser.try_parse(true)?;
+        let expr = parser.try_parse(true)?;
 
         // Recover on missing semicolon.
-        let semicolon_token = parser.try_parse()?;
+        let semicolon_token = parser.try_parse(true)?;
 
         Ok(StatementLet {
             let_token,

--- a/sway-parse/src/expr/mod.rs
+++ b/sway-parse/src/expr/mod.rs
@@ -98,7 +98,10 @@ impl Parse for StatementLet {
         if parser.peek::<EqToken>().is_some() {
             return Err(parser.emit_error_with_span(
                 ParseErrorKind::ExpectedPattern,
-                let_token.span().next_char(),
+                let_token
+                    .span()
+                    .next_char_utf8()
+                    .unwrap_or_else(|| let_token.span()),
             ));
         }
         let pattern = parser.try_parse(true)?;

--- a/sway-parse/src/expr/mod.rs
+++ b/sway-parse/src/expr/mod.rs
@@ -178,29 +178,11 @@ fn parse_stmt<'a>(parser: &mut Parser<'a, '_>) -> ParseResult<StmtOrTail<'a>> {
     }
 
     // Try a `let` statement.
-    // |p| {
-    //     p.peek::<LetToken>().is_some() || p.take::<SemicolonToken>().is_some()
-    // }
-    println!(
-        "{:?}",
-        parser
-            .debug_tokens()
-            .iter()
-            .map(|x| x.span().as_str().to_string())
-            .collect::<Vec<_>>()
-    );
     match parser.guarded_parse_with_recovery::<LetToken, StatementLet>() {
         Ok(None) => {}
         Ok(Some(slet)) => return stmt(Statement::Let(slet)),
         Err(recovery) => {
             let p = recovery.start();
-            println!(
-                "    {:?}",
-                p.debug_tokens()
-                    .iter()
-                    .map(|x| x.span().as_str().to_string())
-                    .collect::<Vec<_>>()
-            );
             let (spans, error) = recovery.finish(p);
             return stmt(Statement::Error(spans, error));
         }

--- a/sway-parse/src/lib.rs
+++ b/sway-parse/src/lib.rs
@@ -43,7 +43,8 @@ pub fn parse_file(
     source_id: Option<SourceId>,
 ) -> Result<Annotated<Module>, ErrorEmitted> {
     let ts = lex(handler, &src, 0, src.len(), source_id)?;
-    Parser::new(handler, &ts).parse_to_end().map(|(m, _)| m)
+    let (m, _) = Parser::new(handler, &ts).parse_to_end()?;
+    Ok(m)
 }
 
 pub fn parse_module_kind(

--- a/sway-parse/src/parse.rs
+++ b/sway-parse/src/parse.rs
@@ -120,7 +120,6 @@ impl Parse for Ident {
                 }
 
                 if !ident.is_raw_ident() && RESERVED_KEYWORDS.contains(ident_str) {
-                    // todo!();
                     return Err(parser.emit_error_with_span(
                         ParseErrorKind::ReservedKeywordIdentifier,
                         ident.span(),

--- a/sway-parse/src/parse.rs
+++ b/sway-parse/src/parse.rs
@@ -120,6 +120,7 @@ impl Parse for Ident {
                 }
 
                 if !ident.is_raw_ident() && RESERVED_KEYWORDS.contains(ident_str) {
+                    // todo!();
                     return Err(parser.emit_error_with_span(
                         ParseErrorKind::ReservedKeywordIdentifier,
                         ident.span(),

--- a/sway-parse/src/parser.rs
+++ b/sway-parse/src/parser.rs
@@ -245,14 +245,6 @@ impl<'a, 'e> Parser<'a, 'e> {
         }
     }
 
-    pub fn clear_errors(&mut self) {
-        self.handler.clear_errors();
-    }
-
-    pub fn clear_warnings(&mut self) {
-        self.handler.clear_errors();
-    }
-
     pub fn has_errors(&self) -> bool {
         self.handler.has_errors()
     }
@@ -482,7 +474,7 @@ impl<'original, 'a, 'e> Recoverer<'original, 'a, 'e> {
             .collect();
 
         original.token_trees = p.token_trees;
-        original.handler.append_ref(&self.handler);
+        original.handler.append(self.handler.clone());
 
         (garbage.into_boxed_slice(), self.error)
     }

--- a/sway-types/src/span.rs
+++ b/sway-types/src/span.rs
@@ -190,13 +190,21 @@ impl Span {
         }
     }
 
-    pub fn next_char(&self) -> Span {
-        Span {
+    /// Creates a new span that points to very next char of the current span.
+    ///
+    /// ```ignore
+    /// let
+    ///    ^ <- span returned
+    /// ^^^  <- original span
+    /// ```
+    pub fn next_char_utf8(&self) -> Option<Span> {
+        let char = self.src[self.end..].chars().next()?;
+        Some(Span {
             src: self.src.clone(),
             source_id: self.source_id,
             start: self.end,
-            end: self.end + 1,
-        }
+            end: self.end + char.len_utf8(),
+        })
     }
 
     /// This panics if the spans are not from the same file. This should

--- a/sway-types/src/span.rs
+++ b/sway-types/src/span.rs
@@ -190,6 +190,15 @@ impl Span {
         }
     }
 
+    pub fn next_char(&self) -> Span {
+        Span {
+            src: self.src.clone(),
+            source_id: self.source_id,
+            start: self.end,
+            end: self.end + 1,
+        }
+    }
+
     /// This panics if the spans are not from the same file. This should
     /// only be used on spans that are actually next to each other.
     pub fn join(s1: Span, s2: Span) -> Span {

--- a/swayfmt/src/utils/language/statement.rs
+++ b/swayfmt/src/utils/language/statement.rs
@@ -43,6 +43,7 @@ fn format_statement(
                 }
             }
         }
+        Statement::Error(_, _) => todo!(),
     }
 
     Ok(())
@@ -94,6 +95,7 @@ impl LeafSpans for Statement {
                 }
                 collected_spans
             }
+            Statement::Error(_, _) => todo!(),
         }
     }
 }

--- a/swayfmt/src/utils/language/statement.rs
+++ b/swayfmt/src/utils/language/statement.rs
@@ -43,7 +43,7 @@ fn format_statement(
                 }
             }
         }
-        Statement::Error(_, _) => todo!(),
+        Statement::Error(_, _) => {}
     }
 
     Ok(())
@@ -95,7 +95,9 @@ impl LeafSpans for Statement {
                 }
                 collected_spans
             }
-            Statement::Error(_, _) => todo!(),
+            Statement::Error(spans, _) => {
+                vec![sway_types::Span::join_all(spans.iter().cloned()).into()]
+            }
         }
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_var/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_var/test.toml
@@ -1,4 +1,6 @@
 category = "fail"
 
 # check: __a
+
+# check: __a
 # nextln: $()Identifiers cannot begin with a double underscore, as that naming convention is reserved for compiler intrinsics.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_var/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_var/test.toml
@@ -1,5 +1,6 @@
 category = "fail"
 
+# this is needed because __a appear in the snippet of a unrelated warning
 # check: __a
 
 # check: __a

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recover_letx_no_expr/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recover_letx_no_expr/src/main.sw
@@ -6,4 +6,6 @@ fn main() {
     let b =
     let c = 1
     let d = 1;
+    let asdoij ojasd 123 apasdok asdpokasd;
+    let e = 1;
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recover_letx_no_expr/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recover_letx_no_expr/src/main.sw
@@ -1,6 +1,7 @@
 script;
 
 fn main() {
+    let
     let y: bool = 0; // recovery witness
     let x =
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recover_letx_no_expr/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recover_letx_no_expr/src/main.sw
@@ -2,6 +2,8 @@ script;
 
 fn main() {
     let
-    let y: bool = 0; // recovery witness
-    let x =
+    let a
+    let b =
+    let c = 1
+    let d = 1;
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recover_letx_no_expr/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recover_letx_no_expr/src/main.sw
@@ -2,6 +2,7 @@ script;
 
 fn main() {
     let
+    let = 1;
     let a
     let b =
     let c = 1

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recover_letx_no_expr/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recover_letx_no_expr/test.toml
@@ -1,16 +1,19 @@
 category = "fail"
 
-# check: $()let a
+# check: $()let = 1;
 # check: $()Identifiers cannot be a reserved keyword.
 
+# check: $()let = 1;
+# check: $()Expected an pattern.
+
 # check: $()let b
-# check: $()Expected
+# check: $()Expected `=`
 
 # check: $()let c = 1
 # check: $()Identifiers cannot be a reserved keyword.
 
 # check: $()let d = 1;
-# check: $()Expected
+# check: $()Expected `;`
 
 # check: $()let asdoij ojasd 123 apasdok asdpokasd;
-# check: $()Expected
+# check: $()Expected `=`

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recover_letx_no_expr/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recover_letx_no_expr/test.toml
@@ -1,5 +1,16 @@
 category = "fail"
 
-# check: $()Expected an expression.
-# check: $()Expected `;`.
-# check: $()Mismatched types.
+# check: $()let a
+# check: $()Identifiers cannot be a reserved keyword.
+
+# check: $()let b
+# check: $()Expected
+
+# check: $()let c = 1
+# check: $()Identifiers cannot be a reserved keyword.
+
+# check: $()let d = 1;
+# check: $()Expected
+
+# check: $()let asdoij ojasd 123 apasdok asdpokasd;
+# check: $()Expected

--- a/test/src/ir_generation/mod.rs
+++ b/test/src/ir_generation/mod.rs
@@ -251,9 +251,9 @@ pub(super) async fn run(filter_regex: Option<&regex::Regex>, verbose: bool) -> R
                 // Compile to IR.
                 let include_tests = true;
                 let mut ir = compile_program(typed_program, include_tests, &engines)
-                    .unwrap_or_else(|mut e| {
+                    .unwrap_or_else(|e| {
                         use sway_types::span::Spanned;
-                        let e = e.pop().unwrap();
+                        let e = e[0].clone();
                         let span = e.span();
                         panic!(
                             "Failed to compile test {}:\nError \"{e}\" at {}:{}\nCode: \"{}\"",

--- a/test/src/ir_generation/mod.rs
+++ b/test/src/ir_generation/mod.rs
@@ -251,8 +251,9 @@ pub(super) async fn run(filter_regex: Option<&regex::Regex>, verbose: bool) -> R
                 // Compile to IR.
                 let include_tests = true;
                 let mut ir = compile_program(typed_program, include_tests, &engines)
-                    .unwrap_or_else(|e| {
+                    .unwrap_or_else(|mut e| {
                         use sway_types::span::Spanned;
+                        let e = e.pop().unwrap();
                         let span = e.span();
                         panic!(
                             "Failed to compile test {}:\nError \"{e}\" at {}:{}\nCode: \"{}\"",


### PR DESCRIPTION
## Description

This PR closes https://github.com/FuelLabs/sway/issues/4911.

It primarily does two things:

1 - Extend a lot of functions that return `CompileError` to return `Vec<CompileError>` allowing multiple errors to return;
2 - Implements the concept of parser recovery.

This happens when using the function `guarded_parse_with_recovery`, exemplified below. When the guard fails, this function return `Ok(None)`; when it succeeds it returns `Ok(item)`. The exciting part is when the parsing fails.

It returns an instance of `Recoverer` which contains a reference to the original parser before any tentative parser was done and the forked as left by the parsing function.

The idea is that it is the caller's responsibility to put the forked parser in a "good position". For that, it offers some helpers function and access to the forked parser.

To avoid boilerplate code one recovery strategy is already implemented `recover_at_next_line_with_fallback_error` which consumes everything at the forked parser's current line and emits an error if none were generated by the tentative parser.

```rust
 match parser.guarded_parse_with_recovery::<LetToken, StatementLet>() {
        Ok(None) => {}
        Ok(Some(item)) => return stmt(Statement::Let(item)),
        Err(r) => {
            let (spans, error) =
                r.recover_at_next_line_with_fallback_error(ParseErrorKind::InvalidStatement);
            return stmt(Statement::Error(spans, error));
        }
    }
```

With this, we have the LSP not "dying" when a strange error happens. The errors themselves are not brilliant, but they will be improved in other PRs.

![image](https://github.com/FuelLabs/sway/assets/83425/234b8b34-d19e-45ec-9fd3-d538ff5c06d2)

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
