### PR TITLE
Fix indentation for closing brace after comment

### DIFF
--- a/swayfmt/src/comments.rs
+++ b/swayfmt/src/comments.rs
@@ -79,7 +79,7 @@ pub fn write_comments(
     range: Range<usize>,
     formatter: &mut Formatter,
 ) -> Result<bool, FormatterError> {
-    {        
+    {
         let mut comments_iter = formatter
             .comments_context
             .map

--- a/swayfmt/src/comments.rs
+++ b/swayfmt/src/comments.rs
@@ -79,7 +79,7 @@ pub fn write_comments(
     range: Range<usize>,
     formatter: &mut Formatter,
 ) -> Result<bool, FormatterError> {
-    {
+    {        
         let mut comments_iter = formatter
             .comments_context
             .map

--- a/swayfmt/src/formatter/mod.rs
+++ b/swayfmt/src/formatter/mod.rs
@@ -47,7 +47,10 @@ impl Formatter {
 
     /// Collect a mapping of Span -> Comment from unformatted input.
     pub fn with_comments_context(&mut self, src: &str) -> &mut Self {
-        let comments_context = CommentsContext::new(CommentMap::from_src(Arc::from(src)).unwrap(), src.to_string());
+        let comments_context = CommentsContext::new(
+            CommentMap::from_src(Arc::from(src)).unwrap(),
+            src.to_string(),
+        );
         self.comments_context = comments_context;
         self
     }

--- a/swayfmt/src/formatter/mod.rs
+++ b/swayfmt/src/formatter/mod.rs
@@ -44,6 +44,14 @@ impl Formatter {
             ..Default::default()
         })
     }
+
+    /// Collect a mapping of Span -> Comment from unformatted input.
+    pub fn with_comments_context(&mut self, src: &str) -> &mut Self {
+        let comments_context = CommentsContext::new(CommentMap::from_src(Arc::from(src)).unwrap(), src.to_string());
+        self.comments_context = comments_context;
+        self
+    }
+
     pub fn format(
         &mut self,
         src: Arc<str>,
@@ -65,9 +73,7 @@ impl Formatter {
         // which will reduce the number of reallocations
         let mut raw_formatted_code = String::with_capacity(src.len());
 
-        // Collect Span -> Comment mapping from unformatted input.
-        self.comments_context =
-            CommentsContext::new(CommentMap::from_src(Arc::from(src))?, src.to_string());
+        self.with_comments_context(src);
 
         let module = parse_file(&self.source_engine, Arc::from(src), path.clone())?.value;
         module.format(&mut raw_formatted_code, self)?;

--- a/swayfmt/src/items/item_fn/mod.rs
+++ b/swayfmt/src/items/item_fn/mod.rs
@@ -53,8 +53,10 @@ impl Format for ItemFn {
                 } else {
                     Self::open_curly_brace(formatted_code, formatter)?;
                     formatter.shape.block_indent(&formatter.config);
-                    write_comments(formatted_code, self.span().into(), formatter)?;
-                    formatter.shape.block_unindent(&formatter.config);
+                    let comments = write_comments(formatted_code, self.span().into(), formatter)?;
+                    if !comments {
+                        formatter.shape.block_unindent(&formatter.config);
+                    }
                     Self::close_curly_brace(formatted_code, formatter)?;
                 }
 

--- a/swayfmt/src/items/item_impl/tests.rs
+++ b/swayfmt/src/items/item_impl/tests.rs
@@ -90,3 +90,17 @@ fmt_test_item!(    impl_empty_fn_args
 }
 "
 );
+
+fmt_test_item!(    impl_empty_fn_comment
+"impl MyAbi for Contract {
+    fn foo() {
+        // ... logic ...
+    }
+}",
+            intermediate_whitespace
+"impl   MyAbi for Contract {
+fn foo(  ) {
+            // ... logic ...
+}
+}"
+);

--- a/swayfmt/src/parse.rs
+++ b/swayfmt/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::{Formatter, error::ParseFileError};
+use crate::{error::ParseFileError, Formatter};
 use std::path::PathBuf;
 use std::sync::Arc;
 use sway_ast::{attribute::Annotated, token::CommentedTokenStream, Module};

--- a/swayfmt/src/parse.rs
+++ b/swayfmt/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::error::ParseFileError;
+use crate::{Formatter, error::ParseFileError};
 use std::path::PathBuf;
 use std::sync::Arc;
 use sway_ast::{attribute::Annotated, token::CommentedTokenStream, Module};
@@ -36,8 +36,12 @@ pub fn parse_format<P: sway_parse::Parse + crate::Format>(input: &str) -> String
     })
     .unwrap();
 
+    // Allow test cases that include comments.
+    let mut formatter = Formatter::default();
+    formatter.with_comments_context(input);
+
     let mut buf = <_>::default();
-    parsed.format(&mut buf, &mut <_>::default()).unwrap();
+    parsed.format(&mut buf, &mut formatter).unwrap();
     buf
 }
 


### PR DESCRIPTION
## Description

Closes https://github.com/FuelLabs/sway/issues/4824

- Added a test. I had to modify the test macro for it to recognize comments in test cases.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
