### PR TITLE
Fix formatting conditionals with comments

### DIFF
--- a/sway-ast/src/expr/mod.rs
+++ b/sway-ast/src/expr/mod.rs
@@ -406,6 +406,13 @@ impl Spanned for MatchBranchKind {
 pub struct CodeBlockContents {
     pub statements: Vec<Statement>,
     pub final_expr_opt: Option<Box<Expr>>,
+    pub span: Span,
+}
+
+impl Spanned for CodeBlockContents {
+    fn span(&self) -> Span {
+        self.span.clone()
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/sway-parse/src/attribute.rs
+++ b/sway-parse/src/attribute.rs
@@ -237,6 +237,7 @@ mod tests {
                   inner: Nil,
                   span: (178, 180),
                 ))),
+                span: (161, 193),
               ),
               span: (160, 194),
             ),

--- a/sway-parse/src/expr/mod.rs
+++ b/sway-parse/src/expr/mod.rs
@@ -139,6 +139,7 @@ impl ParseToEnd for CodeBlockContents {
         let code_block_contents = CodeBlockContents {
             statements,
             final_expr_opt,
+            span: parser.full_span().clone(),
         };
         Ok((code_block_contents, consumed))
     }

--- a/sway-parse/src/module.rs
+++ b/sway-parse/src/module.rs
@@ -132,6 +132,7 @@ mod tests {
                         inner: Nil,
                         span: (70, 72),
                       ))),
+                      span: (53, 85),
                     ),
                     span: (52, 86),
                   ),

--- a/sway-parse/src/parser.rs
+++ b/sway-parse/src/parser.rs
@@ -149,6 +149,10 @@ impl<'a, 'e> Parser<'a, 'e> {
         }
         Ok(())
     }
+
+    pub fn full_span(&self) -> &Span {
+        &self.full_span
+    }
 }
 
 pub struct Peeker<'a> {

--- a/sway-parse/tests/noop_script.rs
+++ b/sway-parse/tests/noop_script.rs
@@ -55,6 +55,7 @@ fn noop_script_file() {
                     inner: Nil,
                     span: (48, 50),
                   ))),
+                  span: (39, 57),
                 ),
                 span: (38, 58),
               ),

--- a/swayfmt/src/items/item_fn/tests.rs
+++ b/swayfmt/src/items/item_fn/tests.rs
@@ -88,3 +88,35 @@ fmt_test_item!(  fn_nested_if_lets
     };
 }"
 );
+
+fmt_test_item!(  fn_conditional_with_comment
+"fn conditional_with_comment() {
+    if true {
+        // comment here
+    }
+}",
+intermediate_whitespace
+"fn conditional_with_comment() {
+    if true {
+        // comment here
+    }
+}"
+);
+
+fmt_test_item!(  fn_conditional_with_comment_and_else
+"fn conditional_with_comment() {
+    if true {
+        // if
+    } else {
+        // else
+    }
+}",
+intermediate_whitespace
+"fn conditional_with_comment() {
+    if true {
+        // if
+    } else {
+        // else
+    }
+}"
+);

--- a/swayfmt/src/utils/language/expr/code_block.rs
+++ b/swayfmt/src/utils/language/expr/code_block.rs
@@ -1,4 +1,5 @@
 use crate::{
+    comments::write_comments,
     config::items::ItemBraceStyle,
     formatter::{shape::LineStyle, *},
     utils::{
@@ -8,7 +9,7 @@ use crate::{
 };
 use std::fmt::Write;
 use sway_ast::CodeBlockContents;
-use sway_types::ast::Delimiter;
+use sway_types::{ast::Delimiter, Spanned};
 
 impl Format for CodeBlockContents {
     fn format(
@@ -51,6 +52,15 @@ impl Format for CodeBlockContents {
                         writeln!(formatted_code)?;
                     }
                 }
+            }
+        } else {
+            let comments: bool = write_comments(
+                formatted_code,
+                self.span().start()..self.span().end(),
+                formatter,
+            )?;
+            if !comments {
+                formatter.shape.block_unindent(&formatter.config);
             }
         }
 

--- a/swayfmt/src/utils/language/expr/conditional.rs
+++ b/swayfmt/src/utils/language/expr/conditional.rs
@@ -142,16 +142,24 @@ fn format_then_block(
     formatted_code: &mut FormattedCode,
     formatter: &mut Formatter,
 ) -> Result<(), FormatterError> {
+    IfExpr::open_curly_brace(formatted_code, formatter)?;
+
     if !if_expr.then_block.get().statements.is_empty()
         || if_expr.then_block.get().final_expr_opt.is_some()
     {
-        IfExpr::open_curly_brace(formatted_code, formatter)?;
         if_expr.then_block.get().format(formatted_code, formatter)?;
-        if if_expr.else_opt.is_none() {
-            IfExpr::close_curly_brace(formatted_code, formatter)?;
-        }
     } else {
-        write!(formatted_code, " {{}}")?;
+        let comments = write_comments(
+            formatted_code,
+            if_expr.then_block.span().start()..if_expr.then_block.span().end(),
+            formatter,
+        )?;
+        if !comments {
+            formatter.shape.block_unindent(&formatter.config);
+        }
+    }
+    if if_expr.else_opt.is_none() {
+        IfExpr::close_curly_brace(formatted_code, formatter)?;
     }
 
     Ok(())

--- a/swayfmt/src/utils/language/literal.rs
+++ b/swayfmt/src/utils/language/literal.rs
@@ -1,15 +1,17 @@
 use crate::{
+    comments::write_comments,
     formatter::*,
     utils::map::byte_span::{ByteSpan, LeafSpans},
 };
 use std::fmt::Write;
 use sway_ast::Literal;
+use sway_types::Spanned;
 
 impl Format for Literal {
     fn format(
         &self,
         formatted_code: &mut FormattedCode,
-        _formatter: &mut Formatter,
+        formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         match self {
             // TODO: do more digging into `Literal` and see if there is more formatting to do.

--- a/swayfmt/src/utils/language/literal.rs
+++ b/swayfmt/src/utils/language/literal.rs
@@ -1,17 +1,15 @@
 use crate::{
-    comments::write_comments,
     formatter::*,
     utils::map::byte_span::{ByteSpan, LeafSpans},
 };
 use std::fmt::Write;
 use sway_ast::Literal;
-use sway_types::Spanned;
 
 impl Format for Literal {
     fn format(
         &self,
         formatted_code: &mut FormattedCode,
-        formatter: &mut Formatter,
+        _formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         match self {
             // TODO: do more digging into `Literal` and see if there is more formatting to do.


### PR DESCRIPTION
## Description

Closes https://github.com/FuelLabs/sway/issues/4935

- In order to write comments for the else block when it only contains a comment, I had to add the span to `CodeBlockContents`

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
