### PR TITLE
Refactor indent utilies for readability

### DIFF
--- a/swayfmt/src/comments.rs
+++ b/swayfmt/src/comments.rs
@@ -104,7 +104,7 @@ pub fn write_comments(
                     write!(
                         formatted_code,
                         "{}{}{}",
-                        formatter.shape.indent.to_string(&formatter.config)?,
+                        formatter.indent_str()?,
                         comment.span().as_str(),
                         newlines
                     )?;

--- a/swayfmt/src/formatter/mod.rs
+++ b/swayfmt/src/formatter/mod.rs
@@ -7,7 +7,7 @@ pub use crate::{
     config::manifest::Config,
     error::{ConfigError, FormatterError},
 };
-use std::{fmt::Write, path::Path, sync::Arc};
+use std::{borrow::Cow, fmt::Write, path::Path, sync::Arc};
 use sway_core::BuildConfig;
 use sway_types::{SourceEngine, Spanned};
 
@@ -43,6 +43,18 @@ impl Formatter {
             config,
             ..Default::default()
         })
+    }
+
+    pub fn indent(&mut self) {
+        self.shape.block_indent(&self.config);
+    }
+
+    pub fn unindent(&mut self) {
+        self.shape.block_unindent(&self.config);
+    }
+
+    pub fn indent_str(&self) -> Result<Cow<'static, str>, FormatterError> {
+        self.shape.indent.to_string(&self.config)
     }
 
     /// Collect a mapping of Span -> Comment from unformatted input.

--- a/swayfmt/src/formatter/shape.rs
+++ b/swayfmt/src/formatter/shape.rs
@@ -351,7 +351,7 @@ mod test {
         formatter.config.whitespace.tab_spaces = 24;
         let max_width = formatter.config.whitespace.max_width;
         formatter.shape.code_line.width = max_width;
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
 
         assert_eq!(max_width, formatter.shape.code_line.width);
         assert_eq!(24, formatter.shape.indent.block_indent);

--- a/swayfmt/src/items/item_abi.rs
+++ b/swayfmt/src/items/item_abi.rs
@@ -35,11 +35,7 @@ impl Format for ItemAbi {
         // abi_items
         for (annotated, semicolon) in abi_items.iter() {
             // add indent + format item
-            write!(
-                formatted_code,
-                "{}",
-                formatter.shape.indent.to_string(&formatter.config)?,
-            )?;
+            write!(formatted_code, "{}", formatter.indent_str()?)?;
             annotated.format(formatted_code, formatter)?;
             writeln!(
                 formatted_code,
@@ -63,11 +59,7 @@ impl Format for ItemAbi {
             Self::open_curly_brace(formatted_code, formatter)?;
             for item in abi_defs.get().iter() {
                 // add indent + format item
-                write!(
-                    formatted_code,
-                    "{}",
-                    formatter.shape.indent.to_string(&formatter.config)?,
-                )?;
+                write!(formatted_code, "{}", formatter.indent_str()?,)?;
                 item.format(formatted_code, formatter)?;
             }
             writeln!(formatted_code)?;
@@ -93,7 +85,7 @@ impl CurlyBrace for ItemAbi {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         let brace_style = formatter.config.items.item_brace_style;
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
         let open_brace = Delimiter::Brace.as_open_char();
         match brace_style {
             ItemBraceStyle::AlwaysNextLine => {
@@ -113,11 +105,11 @@ impl CurlyBrace for ItemAbi {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         // If shape is becoming left-most alligned or - indent just have the defualt shape
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         write!(
             line,
             "{}{}",
-            formatter.shape.indent.to_string(&formatter.config)?,
+            formatter.indent_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 

--- a/swayfmt/src/items/item_configurable/mod.rs
+++ b/swayfmt/src/items/item_configurable/mod.rs
@@ -74,11 +74,7 @@ impl Format for ItemConfigurable {
                         for (field_index, (configurable_field, comma_token)) in
                             value_pairs_iter.clone()
                         {
-                            write!(
-                                formatted_code,
-                                "{}",
-                                &formatter.shape.indent.to_string(&formatter.config)?
-                            )?;
+                            write!(formatted_code, "{}", &formatter.indent_str()?)?;
 
                             // Add name
                             configurable_field.name.format(formatted_code, formatter)?;
@@ -135,7 +131,7 @@ impl CurlyBrace for ItemConfigurable {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         let brace_style = formatter.config.items.item_brace_style;
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
         let open_brace = Delimiter::Brace.as_open_char();
         match brace_style {
             ItemBraceStyle::AlwaysNextLine => {
@@ -156,11 +152,11 @@ impl CurlyBrace for ItemConfigurable {
     ) -> Result<(), FormatterError> {
         // shrink_left would return error if the current indentation level is becoming < 0, in that
         // case we should use the Shape::default() which has 0 indentation level.
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         write!(
             line,
             "{}{}",
-            formatter.shape.indent.to_string(&formatter.config)?,
+            formatter.indent_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 

--- a/swayfmt/src/items/item_enum/mod.rs
+++ b/swayfmt/src/items/item_enum/mod.rs
@@ -77,11 +77,7 @@ impl Format for ItemEnum {
 
                         let value_pairs_iter = value_pairs.iter().enumerate();
                         for (var_index, (type_field, comma_token)) in value_pairs_iter.clone() {
-                            write!(
-                                formatted_code,
-                                "{}",
-                                &formatter.shape.indent.to_string(&formatter.config)?
-                            )?;
+                            write!(formatted_code, "{}", &formatter.indent_str()?)?;
 
                             // Add name
                             type_field.name.format(formatted_code, formatter)?;
@@ -147,14 +143,14 @@ impl CurlyBrace for ItemEnum {
         let open_brace = Delimiter::Brace.as_open_char();
         match brace_style {
             ItemBraceStyle::AlwaysNextLine => {
-                // Add openning brace to the next line.
+                // Add opening brace to the next line.
                 writeln!(line, "\n{open_brace}")?;
-                formatter.shape.block_indent(&formatter.config);
+                formatter.indent();
             }
             _ => {
                 // Add opening brace to the same line
                 write!(line, " {open_brace}")?;
-                formatter.shape.block_indent(&formatter.config);
+                formatter.indent();
             }
         }
 
@@ -165,11 +161,11 @@ impl CurlyBrace for ItemEnum {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         // If shape is becoming left-most aligned or - indent just have the defualt shape
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         write!(
             line,
             "{}{}",
-            formatter.shape.indent.to_string(&formatter.config)?,
+            formatter.indent_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 

--- a/swayfmt/src/items/item_fn/mod.rs
+++ b/swayfmt/src/items/item_fn/mod.rs
@@ -38,7 +38,7 @@ impl Format for ItemFn {
                 let body = self.body.get();
                 if !body.statements.is_empty() || body.final_expr_opt.is_some() {
                     Self::open_curly_brace(formatted_code, formatter)?;
-                    formatter.shape.block_indent(&formatter.config);
+                    formatter.indent();
                     body.format(formatted_code, formatter)?;
 
                     if let Some(final_expr_opt) = body.final_expr_opt.as_ref() {
@@ -52,10 +52,10 @@ impl Format for ItemFn {
                     Self::close_curly_brace(formatted_code, formatter)?;
                 } else {
                     Self::open_curly_brace(formatted_code, formatter)?;
-                    formatter.shape.block_indent(&formatter.config);
+                    formatter.indent();
                     let comments = write_comments(formatted_code, self.span().into(), formatter)?;
                     if !comments {
-                        formatter.shape.block_unindent(&formatter.config);
+                        formatter.unindent();
                     }
                     Self::close_curly_brace(formatted_code, formatter)?;
                 }
@@ -110,11 +110,11 @@ impl CurlyBrace for ItemFn {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         // If shape is becoming left-most alligned or - indent just have the defualt shape
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         write!(
             line,
             "{}{}",
-            formatter.shape.indent.to_string(&formatter.config)?,
+            formatter.indent_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 
@@ -205,14 +205,10 @@ fn format_fn_args(
         FnArgs::Static(args) => match formatter.shape.code_line.line_style {
             LineStyle::Multiline => {
                 if !args.value_separator_pairs.is_empty() || args.final_value_opt.is_some() {
-                    formatter.shape.block_indent(&formatter.config);
+                    formatter.indent();
                     args.format(formatted_code, formatter)?;
-                    formatter.shape.block_unindent(&formatter.config);
-                    write!(
-                        formatted_code,
-                        "{}",
-                        formatter.shape.indent.to_string(&formatter.config)?
-                    )?;
+                    formatter.unindent();
+                    write!(formatted_code, "{}", formatter.indent_str()?)?;
                 }
             }
             _ => args.format(formatted_code, formatter)?,
@@ -225,12 +221,8 @@ fn format_fn_args(
         } => {
             match formatter.shape.code_line.line_style {
                 LineStyle::Multiline => {
-                    formatter.shape.block_indent(&formatter.config);
-                    write!(
-                        formatted_code,
-                        "\n{}",
-                        formatter.shape.indent.to_string(&formatter.config)?
-                    )?;
+                    formatter.indent();
+                    write!(formatted_code, "\n{}", formatter.indent_str()?)?;
                     format_self(self_token, ref_self, mutable_self, formatted_code)?;
                     // `args_opt`
                     if let Some((comma, args)) = args_opt {

--- a/swayfmt/src/items/item_impl/mod.rs
+++ b/swayfmt/src/items/item_impl/mod.rs
@@ -41,11 +41,7 @@ impl Format for ItemImpl {
         Self::open_curly_brace(formatted_code, formatter)?;
         let contents = self.contents.get();
         for item in contents.iter() {
-            write!(
-                formatted_code,
-                "{}",
-                formatter.shape.indent.to_string(&formatter.config)?,
-            )?;
+            write!(formatted_code, "{}", formatter.indent_str()?,)?;
             item.format(formatted_code, formatter)?;
             writeln!(formatted_code)?;
         }
@@ -82,7 +78,7 @@ impl CurlyBrace for ItemImpl {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         let brace_style = formatter.config.items.item_brace_style;
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
         let open_brace = Delimiter::Brace.as_open_char();
         match brace_style {
             ItemBraceStyle::AlwaysNextLine => {
@@ -110,11 +106,11 @@ impl CurlyBrace for ItemImpl {
         line: &mut FormattedCode,
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         write!(
             line,
             "{}{}",
-            formatter.shape.indent.to_string(&formatter.config)?,
+            formatter.indent_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 

--- a/swayfmt/src/items/item_storage/mod.rs
+++ b/swayfmt/src/items/item_storage/mod.rs
@@ -70,11 +70,7 @@ impl Format for ItemStorage {
                         let value_pairs_iter = value_pairs.iter().enumerate();
                         for (field_index, (storage_field, comma_token)) in value_pairs_iter.clone()
                         {
-                            write!(
-                                formatted_code,
-                                "{}",
-                                &formatter.shape.indent.to_string(&formatter.config)?
-                            )?;
+                            write!(formatted_code, "{}", &formatter.indent_str()?)?;
 
                             // Add name
                             storage_field.name.format(formatted_code, formatter)?;
@@ -140,7 +136,7 @@ impl CurlyBrace for ItemStorage {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         let brace_style = formatter.config.items.item_brace_style;
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
         let open_brace = Delimiter::Brace.as_open_char();
         match brace_style {
             ItemBraceStyle::AlwaysNextLine => {
@@ -161,11 +157,11 @@ impl CurlyBrace for ItemStorage {
     ) -> Result<(), FormatterError> {
         // shrink_left would return error if the current indentation level is becoming < 0, in that
         // case we should use the Shape::default() which has 0 indentation level.
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         write!(
             line,
             "{}{}",
-            formatter.shape.indent.to_string(&formatter.config)?,
+            formatter.indent_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 

--- a/swayfmt/src/items/item_struct/mod.rs
+++ b/swayfmt/src/items/item_struct/mod.rs
@@ -79,11 +79,7 @@ impl Format for ItemStruct {
 
                         let value_pairs_iter = value_pairs.iter().enumerate();
                         for (var_index, (type_field, comma_token)) in value_pairs_iter.clone() {
-                            write!(
-                                formatted_code,
-                                "{}",
-                                &formatter.shape.indent.to_string(&formatter.config)?
-                            )?;
+                            write!(formatted_code, "{}", &formatter.indent_str()?)?;
 
                             // Add name
                             type_field.name.format(formatted_code, formatter)?;
@@ -141,7 +137,7 @@ impl CurlyBrace for ItemStruct {
         line: &mut String,
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
         let brace_style = formatter.config.items.item_brace_style;
         match brace_style {
             ItemBraceStyle::AlwaysNextLine => {
@@ -162,11 +158,11 @@ impl CurlyBrace for ItemStruct {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         // If shape is becoming left-most alligned or - indent just have the defualt shape
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         write!(
             line,
             "{}{}",
-            formatter.shape.indent.to_string(&formatter.config)?,
+            formatter.indent_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 

--- a/swayfmt/src/items/item_trait/mod.rs
+++ b/swayfmt/src/items/item_trait/mod.rs
@@ -71,29 +71,17 @@ impl Format for ItemTrait {
         } else {
             for (annotated, semicolon_token) in trait_items {
                 for attr in &annotated.attribute_list {
-                    write!(
-                        formatted_code,
-                        "{}",
-                        &formatter.shape.indent.to_string(&formatter.config)?,
-                    )?;
+                    write!(formatted_code, "{}", &formatter.indent_str()?,)?;
                     attr.format(formatted_code, formatter)?;
                 }
                 match &annotated.value {
                     sway_ast::ItemTraitItem::Fn(fn_signature) => {
-                        write!(
-                            formatted_code,
-                            "{}",
-                            formatter.shape.indent.to_string(&formatter.config)?,
-                        )?;
+                        write!(formatted_code, "{}", formatter.indent_str()?,)?;
                         fn_signature.format(formatted_code, formatter)?;
                         writeln!(formatted_code, "{}", semicolon_token.ident().as_str())?;
                     }
                     sway_ast::ItemTraitItem::Const(const_decl) => {
-                        write!(
-                            formatted_code,
-                            "{}",
-                            formatter.shape.indent.to_string(&formatter.config)?,
-                        )?;
+                        write!(formatted_code, "{}", formatter.indent_str()?,)?;
                         const_decl.format(formatted_code, formatter)?;
                         writeln!(formatted_code, "{}", semicolon_token.ident().as_str())?;
                     }
@@ -106,11 +94,7 @@ impl Format for ItemTrait {
             write!(formatted_code, " ")?;
             Self::open_curly_brace(formatted_code, formatter)?;
             for trait_items in trait_defs.get() {
-                write!(
-                    formatted_code,
-                    "{}",
-                    formatter.shape.indent.to_string(&formatter.config)?
-                )?;
+                write!(formatted_code, "{}", formatter.indent_str()?)?;
                 // format `Annotated<ItemFn>`
                 trait_items.format(formatted_code, formatter)?;
             }
@@ -148,7 +132,7 @@ impl CurlyBrace for ItemTrait {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         let brace_style = formatter.config.items.item_brace_style;
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
         let open_brace = Delimiter::Brace.as_open_char();
         match brace_style {
             ItemBraceStyle::AlwaysNextLine => {
@@ -166,7 +150,7 @@ impl CurlyBrace for ItemTrait {
         line: &mut FormattedCode,
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         write!(line, "\n{}", Delimiter::Brace.as_close_char())?;
         Ok(())
     }

--- a/swayfmt/src/items/item_use/mod.rs
+++ b/swayfmt/src/items/item_use/mod.rs
@@ -92,11 +92,8 @@ impl Format for UseTree {
                     LineStyle::Multiline => writeln!(
                         formatted_code,
                         "{}{}",
-                        formatter.shape.indent.to_string(&formatter.config)?,
-                        ord_vec.join(&format!(
-                            "\n{}",
-                            formatter.shape.indent.to_string(&formatter.config)?
-                        ))
+                        formatter.indent_str()?,
+                        ord_vec.join(&format!("\n{}", formatter.indent_str()?))
                     )?,
                     _ => {
                         let mut import_str = ord_vec.join(" ");
@@ -152,7 +149,7 @@ impl CurlyBrace for UseTree {
     ) -> Result<(), FormatterError> {
         match formatter.shape.code_line.line_style {
             LineStyle::Multiline => {
-                formatter.shape.block_indent(&formatter.config);
+                formatter.indent();
                 writeln!(line, "{}", Delimiter::Brace.as_open_char())?;
             }
             _ => write!(line, "{}", Delimiter::Brace.as_open_char())?,
@@ -166,11 +163,11 @@ impl CurlyBrace for UseTree {
     ) -> Result<(), FormatterError> {
         match formatter.shape.code_line.line_style {
             LineStyle::Multiline => {
-                formatter.shape.block_unindent(&formatter.config);
+                formatter.unindent();
                 write!(
                     line,
                     "{}{}",
-                    formatter.shape.indent.to_string(&formatter.config)?,
+                    formatter.indent_str()?,
                     Delimiter::Brace.as_close_char()
                 )?;
             }

--- a/swayfmt/src/utils/language/attribute.rs
+++ b/swayfmt/src/utils/language/attribute.rs
@@ -23,11 +23,7 @@ impl<T: Format + Spanned> Format for Annotated<T> {
         for attr in &self.attribute_list {
             attr.format(formatted_code, formatter)?;
 
-            write!(
-                formatted_code,
-                "{}",
-                &formatter.shape.indent.to_string(&formatter.config)?,
-            )?;
+            write!(formatted_code, "{}", &formatter.indent_str()?,)?;
         }
         // format `ItemKind`
         self.value.format(formatted_code, formatter)?;

--- a/swayfmt/src/utils/language/expr/asm_block.rs
+++ b/swayfmt/src/utils/language/expr/asm_block.rs
@@ -101,7 +101,7 @@ impl CurlyBrace for AsmBlock {
         line: &mut FormattedCode,
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
         match formatter.shape.code_line.line_style {
             LineStyle::Inline => {
                 write!(line, " {} ", Delimiter::Brace.as_open_char())?;
@@ -116,7 +116,7 @@ impl CurlyBrace for AsmBlock {
         line: &mut FormattedCode,
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         match formatter.shape.code_line.line_style {
             LineStyle::Inline => {
                 write!(line, " {}", Delimiter::Brace.as_close_char())?;
@@ -125,7 +125,7 @@ impl CurlyBrace for AsmBlock {
                 write!(
                     line,
                     "{}{}",
-                    formatter.shape.indent.to_string(&formatter.config)?,
+                    formatter.indent_str()?,
                     Delimiter::Brace.as_close_char()
                 )?;
             }
@@ -174,21 +174,13 @@ impl Format for AsmBlockContents {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         for (instruction, semicolon_token) in self.instructions.iter() {
-            write!(
-                formatted_code,
-                "{}",
-                formatter.shape.indent.to_string(&formatter.config)?
-            )?;
+            write!(formatted_code, "{}", formatter.indent_str()?)?;
             instruction.format(formatted_code, formatter)?;
             writeln!(formatted_code, "{}", semicolon_token.span().as_str())?
         }
         if let Some(final_expr) = &self.final_expr_opt {
             if formatter.shape.code_line.line_style == LineStyle::Multiline {
-                write!(
-                    formatted_code,
-                    "{}",
-                    formatter.shape.indent.to_string(&formatter.config)?
-                )?;
+                write!(formatted_code, "{}", formatter.indent_str()?)?;
                 final_expr.format(formatted_code, formatter)?;
                 writeln!(formatted_code)?;
             } else {

--- a/swayfmt/src/utils/language/expr/code_block.rs
+++ b/swayfmt/src/utils/language/expr/code_block.rs
@@ -31,22 +31,14 @@ impl Format for CodeBlockContents {
                 _ => {
                     writeln!(formatted_code)?;
                     for statement in self.statements.iter() {
-                        write!(
-                            formatted_code,
-                            "{}",
-                            formatter.shape.indent.to_string(&formatter.config)?
-                        )?;
+                        write!(formatted_code, "{}", formatter.indent_str()?)?;
                         statement.format(formatted_code, formatter)?;
                         if !formatted_code.ends_with('\n') {
                             writeln!(formatted_code)?;
                         }
                     }
                     if let Some(final_expr) = &self.final_expr_opt {
-                        write!(
-                            formatted_code,
-                            "{}",
-                            formatter.shape.indent.to_string(&formatter.config)?
-                        )?;
+                        write!(formatted_code, "{}", formatter.indent_str()?)?;
                         final_expr.format(formatted_code, formatter)?;
                         writeln!(formatted_code)?;
                     }
@@ -63,7 +55,7 @@ impl CurlyBrace for CodeBlockContents {
         line: &mut FormattedCode,
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
 
         let brace_style = formatter.config.items.item_brace_style;
         match brace_style {
@@ -84,11 +76,11 @@ impl CurlyBrace for CodeBlockContents {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         // Unindent by one block
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         write!(
             line,
             "{}{}",
-            formatter.shape.indent.to_string(&formatter.config)?,
+            formatter.indent_str()?,
             Delimiter::Brace.as_close_char()
         )?;
         Ok(())

--- a/swayfmt/src/utils/language/expr/collections.rs
+++ b/swayfmt/src/utils/language/expr/collections.rs
@@ -24,11 +24,7 @@ impl Format for ExprTupleDescriptor {
                 tail,
             } => match formatter.shape.code_line.line_style {
                 LineStyle::Multiline => {
-                    write!(
-                        formatted_code,
-                        "{}",
-                        formatter.shape.indent.to_string(&formatter.config)?
-                    )?;
+                    write!(formatted_code, "{}", formatter.indent_str()?)?;
                     head.format(formatted_code, formatter)?;
                     write!(formatted_code, "{}", comma_token.span().as_str())?;
                     tail.format(formatted_code, formatter)?;
@@ -53,7 +49,7 @@ impl Parenthesis for ExprTupleDescriptor {
     ) -> Result<(), FormatterError> {
         match formatter.shape.code_line.line_style {
             LineStyle::Multiline => {
-                formatter.shape.block_indent(&formatter.config);
+                formatter.indent();
                 writeln!(line, "{}", Delimiter::Parenthesis.as_open_char())?;
             }
             _ => write!(line, "{}", Delimiter::Parenthesis.as_open_char())?,
@@ -67,11 +63,11 @@ impl Parenthesis for ExprTupleDescriptor {
     ) -> Result<(), FormatterError> {
         match formatter.shape.code_line.line_style {
             LineStyle::Multiline => {
-                formatter.shape.block_unindent(&formatter.config);
+                formatter.unindent();
                 write!(
                     line,
                     "{}{}",
-                    formatter.shape.indent.to_string(&formatter.config)?,
+                    formatter.indent_str()?,
                     Delimiter::Parenthesis.as_close_char()
                 )?;
             }
@@ -116,7 +112,7 @@ impl SquareBracket for ExprArrayDescriptor {
     ) -> Result<(), FormatterError> {
         match formatter.shape.code_line.line_style {
             LineStyle::Multiline => {
-                formatter.shape.block_indent(&formatter.config);
+                formatter.indent();
                 write!(line, "{}", Delimiter::Bracket.as_open_char())?;
             }
             _ => write!(line, "{}", Delimiter::Bracket.as_open_char())?,
@@ -130,11 +126,11 @@ impl SquareBracket for ExprArrayDescriptor {
     ) -> Result<(), FormatterError> {
         match formatter.shape.code_line.line_style {
             LineStyle::Multiline => {
-                formatter.shape.block_unindent(&formatter.config);
+                formatter.unindent();
                 write!(
                     line,
                     "{}{}",
-                    formatter.shape.indent.to_string(&formatter.config)?,
+                    formatter.indent_str()?,
                     Delimiter::Bracket.as_close_char()
                 )?;
             }

--- a/swayfmt/src/utils/language/expr/conditional.rs
+++ b/swayfmt/src/utils/language/expr/conditional.rs
@@ -127,9 +127,9 @@ fn format_if_condition(
 ) -> Result<(), FormatterError> {
     write!(formatted_code, "{} ", if_expr.if_token.span().as_str())?;
     if formatter.shape.code_line.line_style == LineStyle::Multiline {
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
         if_expr.condition.format(formatted_code, formatter)?;
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
     } else {
         if_expr.condition.format(formatted_code, formatter)?;
     }
@@ -173,11 +173,7 @@ fn format_else_opt(
         )?;
 
         if comments_written {
-            write!(
-                else_if_str,
-                "{}",
-                formatter.shape.indent.to_string(&formatter.config)?,
-            )?;
+            write!(else_if_str, "{}", formatter.indent_str()?,)?;
         } else {
             write!(else_if_str, " ")?;
         }
@@ -211,11 +207,7 @@ impl CurlyBrace for IfExpr {
         match formatter.shape.code_line.line_style {
             LineStyle::Multiline => {
                 formatter.shape.code_line.reset_width();
-                write!(
-                    line,
-                    "\n{}{open_brace}",
-                    formatter.shape.indent.to_string(&formatter.config)?
-                )?;
+                write!(line, "\n{}{open_brace}", formatter.indent_str()?)?;
                 formatter
                     .shape
                     .code_line
@@ -225,7 +217,7 @@ impl CurlyBrace for IfExpr {
                 write!(line, " {open_brace}")?;
             }
         }
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
 
         Ok(())
     }
@@ -233,7 +225,7 @@ impl CurlyBrace for IfExpr {
         line: &mut FormattedCode,
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         match formatter.shape.code_line.line_style {
             LineStyle::Inline => {
                 write!(line, "{}", Delimiter::Brace.as_close_char())?;
@@ -242,7 +234,7 @@ impl CurlyBrace for IfExpr {
                 write!(
                     line,
                     "{}{}",
-                    formatter.shape.indent.to_string(&formatter.config)?,
+                    formatter.indent_str()?,
                     Delimiter::Brace.as_close_char()
                 )?;
             }
@@ -302,7 +294,7 @@ impl CurlyBrace for MatchBranch {
         line: &mut FormattedCode,
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
         writeln!(line, "{}", Delimiter::Brace.as_open_char())?;
 
         Ok(())
@@ -311,11 +303,11 @@ impl CurlyBrace for MatchBranch {
         line: &mut FormattedCode,
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         write!(
             line,
             "{}{}",
-            formatter.shape.indent.to_string(&formatter.config)?,
+            formatter.indent_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 
@@ -340,16 +332,12 @@ impl Format for MatchBranchKind {
                 if block.statements.is_empty() && block.final_expr_opt.is_none() {
                     // even if there is no code block we still want to unindent
                     // before the closing brace
-                    formatter.shape.block_unindent(&formatter.config);
+                    formatter.unindent();
                 } else {
                     block.format(formatted_code, formatter)?;
                     // we handle this here to avoid needless indents
-                    formatter.shape.block_unindent(&formatter.config);
-                    write!(
-                        formatted_code,
-                        "{}",
-                        formatter.shape.indent.to_string(&formatter.config)?
-                    )?;
+                    formatter.unindent();
+                    write!(formatted_code, "{}", formatter.indent_str()?)?;
                 }
                 Self::close_curly_brace(formatted_code, formatter)?;
                 if let Some(comma_token) = comma_token_opt {
@@ -371,7 +359,7 @@ impl CurlyBrace for MatchBranchKind {
         line: &mut FormattedCode,
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
         write!(line, "{}", Delimiter::Brace.as_open_char())?;
         Ok(())
     }

--- a/swayfmt/src/utils/language/expr/mod.rs
+++ b/swayfmt/src/utils/language/expr/mod.rs
@@ -165,11 +165,7 @@ impl Format for Expr {
                     MatchBranch::open_curly_brace(formatted_code, formatter)?;
                     let branches = branches.get();
                     for match_branch in branches.iter() {
-                        write!(
-                            formatted_code,
-                            "{}",
-                            formatter.shape.indent.to_string(&formatter.config)?
-                        )?;
+                        write!(formatted_code, "{}", formatter.indent_str()?)?;
                         match_branch.format(formatted_code, formatter)?;
                         writeln!(formatted_code)?;
                     }
@@ -195,11 +191,7 @@ impl Format for Expr {
                     |formatter| -> Result<(), FormatterError> {
                         // don't indent unless on new line
                         if formatted_code.ends_with('\n') {
-                            write!(
-                                formatted_code,
-                                "{}",
-                                formatter.shape.indent.to_string(&formatter.config)?
-                            )?;
+                            write!(formatted_code, "{}", formatter.indent_str()?)?;
                         }
                         func.format(formatted_code, formatter)?;
                         Self::open_parenthesis(formatted_code, formatter)?;
@@ -392,7 +384,7 @@ impl Format for Expr {
                         write!(
                             formatted_code,
                             "\n{}{} ",
-                            formatter.shape.indent.to_string(&formatter.config)?,
+                            formatter.indent_str()?,
                             ampersand_token.span().as_str()
                         )?;
                     }
@@ -413,7 +405,7 @@ impl Format for Expr {
                         write!(
                             formatted_code,
                             "\n{}{} ",
-                            formatter.shape.indent.to_string(&formatter.config)?,
+                            formatter.indent_str()?,
                             caret_token.span().as_str()
                         )?;
                     }
@@ -434,7 +426,7 @@ impl Format for Expr {
                         write!(
                             formatted_code,
                             "\n{}{} ",
-                            formatter.shape.indent.to_string(&formatter.config)?,
+                            formatter.indent_str()?,
                             pipe_token.span().as_str()
                         )?;
                     }
@@ -513,7 +505,7 @@ impl Format for Expr {
                         write!(
                             formatted_code,
                             "\n{}{} ",
-                            formatter.shape.indent.to_string(&formatter.config)?,
+                            formatter.indent_str()?,
                             double_ampersand_token.span().as_str()
                         )?;
                     }
@@ -538,7 +530,7 @@ impl Format for Expr {
                         write!(
                             formatted_code,
                             "\n{}{} ",
-                            formatter.shape.indent.to_string(&formatter.config)?,
+                            formatter.indent_str()?,
                             double_pipe_token.span().as_str()
                         )?;
                     }
@@ -648,11 +640,7 @@ fn format_method_call(
 ) -> Result<(), FormatterError> {
     // don't indent unless on new line
     if formatted_code.ends_with('\n') {
-        write!(
-            formatted_code,
-            "{}",
-            formatter.shape.indent.to_string(&formatter.config)?
-        )?;
+        write!(formatted_code, "{}", formatter.indent_str()?)?;
     }
     target.format(formatted_code, formatter)?;
     write!(formatted_code, "{}", dot_token.span().as_str())?;

--- a/swayfmt/src/utils/language/expr/struct_field.rs
+++ b/swayfmt/src/utils/language/expr/struct_field.rs
@@ -36,12 +36,12 @@ impl CurlyBrace for ExprStructField {
             ItemBraceStyle::AlwaysNextLine => {
                 // Add openning brace to the next line.
                 write!(line, "\n{}", Delimiter::Brace.as_open_char())?;
-                formatter.shape.block_indent(&formatter.config);
+                formatter.indent();
             }
             _ => {
                 // Add opening brace to the same line
                 write!(line, " {}", Delimiter::Brace.as_open_char())?;
-                formatter.shape.block_indent(&formatter.config);
+                formatter.indent();
             }
         }
 
@@ -53,13 +53,13 @@ impl CurlyBrace for ExprStructField {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         // Unindent by one block
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         match formatter.shape.code_line.line_style {
             LineStyle::Inline => write!(line, "{}", Delimiter::Brace.as_close_char())?,
             _ => write!(
                 line,
                 "{}{}",
-                formatter.shape.indent.to_string(&formatter.config)?,
+                formatter.indent_str()?,
                 Delimiter::Brace.as_close_char()
             )?,
         }

--- a/swayfmt/src/utils/language/pattern.rs
+++ b/swayfmt/src/utils/language/pattern.rs
@@ -159,12 +159,12 @@ impl CurlyBrace for Pattern {
             ItemBraceStyle::AlwaysNextLine => {
                 // Add openning brace to the next line.
                 write!(line, "\n{}", Delimiter::Brace.as_open_char())?;
-                formatter.shape.block_indent(&formatter.config);
+                formatter.indent();
             }
             _ => {
                 // Add opening brace to the same line
                 write!(line, " {}", Delimiter::Brace.as_open_char())?;
-                formatter.shape.block_indent(&formatter.config);
+                formatter.indent();
             }
         }
 
@@ -175,13 +175,13 @@ impl CurlyBrace for Pattern {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         // Unindent by one block
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         match formatter.shape.code_line.line_style {
             LineStyle::Inline => write!(line, "{}", Delimiter::Brace.as_close_char())?,
             _ => write!(
                 line,
                 "{}{}",
-                formatter.shape.indent.to_string(&formatter.config)?,
+                formatter.indent_str()?,
                 Delimiter::Brace.as_close_char()
             )?,
         }

--- a/swayfmt/src/utils/language/punctuated.rs
+++ b/swayfmt/src/utils/language/punctuated.rs
@@ -59,22 +59,14 @@ where
                     }
                     let value_pairs_iter = self.value_separator_pairs.iter();
                     for (type_field, comma_token) in value_pairs_iter.clone() {
-                        write!(
-                            formatted_code,
-                            "{}",
-                            &formatter.shape.indent.to_string(&formatter.config)?
-                        )?;
+                        write!(formatted_code, "{}", &formatter.indent_str()?)?;
                         type_field.format(formatted_code, formatter)?;
 
                         comma_token.format(formatted_code, formatter)?;
                         writeln!(formatted_code)?;
                     }
                     if let Some(final_value) = &self.final_value_opt {
-                        write!(
-                            formatted_code,
-                            "{}",
-                            &formatter.shape.indent.to_string(&formatter.config)?
-                        )?;
+                        write!(formatted_code, "{}", &formatter.indent_str()?)?;
                         final_value.format(formatted_code, formatter)?;
                         writeln!(formatted_code, "{}", PunctKind::Comma.as_char())?;
                     }

--- a/swayfmt/src/utils/language/where_clause.rs
+++ b/swayfmt/src/utils/language/where_clause.rs
@@ -15,10 +15,10 @@ impl Format for WhereClause {
         writeln!(
             formatted_code,
             "{}{}",
-            &formatter.shape.indent.to_string(&formatter.config)?,
+            &formatter.indent_str()?,
             self.where_token.span().as_str(),
         )?;
-        formatter.shape.block_indent(&formatter.config);
+        formatter.indent();
         // We should add a multiline field to `Shape`
         // so we can reduce this code block to:
         //
@@ -38,7 +38,7 @@ impl Format for WhereClause {
             writeln!(formatted_code)?;
         }
         // reset indent
-        formatter.shape.block_unindent(&formatter.config);
+        formatter.unindent();
         Ok(())
     }
 }
@@ -52,9 +52,9 @@ impl Format for WhereBound {
         write!(
             formatted_code,
             "{}{}{} ",
-            &formatter.shape.indent.to_string(&formatter.config)?, // `Indent`
-            self.ty_name.span().as_str(),                          // `Ident`
-            self.colon_token.span().as_str(),                      // `ColonToken`
+            &formatter.indent_str()?,         // `Indent`
+            self.ty_name.span().as_str(),     // `Ident`
+            self.colon_token.span().as_str(), // `ColonToken`
         )?;
         self.bounds.format(formatted_code, formatter)?;
         Ok(())


### PR DESCRIPTION
## Description

Simply adding some utility functions in the formatter to make the code easier to read.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
