### PR TITLE
docs-ci: temporarily disable check-links for exact version usages in docs

### DIFF
--- a/docs/reference/src/documentation/introduction/installation/cargo.md
+++ b/docs/reference/src/documentation/introduction/installation/cargo.md
@@ -1,6 +1,8 @@
 # Cargo
 
+<!-- markdown-link-check-disable -->
 Cargo can be used to install the Sway toolchain with various [`plugins`](https://fuellabs.github.io/sway/v0.43.2/book/forc/plugins/index.html).
+<!-- markdown-link-check-enable -->
 
 ## Dependencies
 

--- a/docs/reference/src/documentation/introduction/installation/index.md
+++ b/docs/reference/src/documentation/introduction/installation/index.md
@@ -18,9 +18,11 @@ The supported operating systems include Linux and macOS; however, Windows is [`u
 
 `Cargo` may be used instead of [`Fuelup`](fuelup.md); however, the user needs to manage the toolchain themselves.
 
+<!-- markdown-link-check-disable -->
 The advantage of using `Cargo` is the installation of [`plugins`](https://fuellabs.github.io/sway/v0.43.2/book/forc/plugins/index.html) that have not been added into [`Fuelup`](fuelup.md).
 
 The disadvantage occurs when [`Fuelup`](fuelup.md) and `Cargo` are used in tandem because the latest [`plugins`](https://fuellabs.github.io/sway/v0.43.2/book/forc/plugins/index.html) may not be recognized.
+<!-- markdown-link-check-enable -->
 
 ## Source
 

--- a/docs/reference/src/documentation/introduction/installation/source.md
+++ b/docs/reference/src/documentation/introduction/installation/source.md
@@ -4,7 +4,9 @@ The `Sway toolchain` can be built directly from the [`Sway repository`](https://
 
 ## Installation & Updating
 
+<!-- markdown-link-check-disable -->
 In the root of the repository `/sway/<here>` build [`forc`](https://fuellabs.github.io/sway/v0.43.2/book/forc/commands/index.html) with the following command:
+<!-- markdown-link-check-enable -->
 
 ```bash
 cargo build

--- a/docs/reference/src/index.md
+++ b/docs/reference/src/index.md
@@ -1,3 +1,5 @@
 # The Sway Reference
 
+<!-- markdown-link-check-disable -->
 This is the technical reference for the Sway programming language. For a prose explanation and introduction to the language, please refer to the [Sway Book](https://fuellabs.github.io/sway/v0.43.2/book/).
+<!-- markdown-link-check-enable -->


### PR DESCRIPTION
## Description
related to #4946.

Directly using `/latest` instead of exact versioning does not work for some reason. To unblock bump PRs (one waiting, #4945) this PR disables link checks at links which uses exact latest versions. We should find a way to point to `latest` without using an exact version.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
