### PR TITLE
better error message for doc comment without an item

### DIFF
--- a/sway-error/src/parser_error.rs
+++ b/sway-error/src/parser_error.rs
@@ -8,6 +8,8 @@ pub enum ParseErrorKind {
     ExpectedImportNameGroupOrGlob,
     #[error("Expected an item.")]
     ExpectedAnItem,
+    #[error("Expected item after doc comment.")]
+    ExpectedAnItemAfterDocComment,
     #[error("Expected a comma or closing parenthesis in function arguments.")]
     ExpectedCommaOrCloseParenInFnArgs,
     #[error("Unrecognized op code.")]

--- a/sway-parse/src/attribute.rs
+++ b/sway-parse/src/attribute.rs
@@ -59,13 +59,18 @@ impl<T: Parse> Parse for Annotated<T> {
             attribute_list.push(attr);
         }
 
-        // Parse the `T` value.
-        let value = parser.parse()?;
+        if let Some(_) = parser.check_empty() {
+            let error = parser.emit_error(ParseErrorKind::ExpectedAnItemAfterDocComment);
+            Err(error)
+        } else {
+            // Parse the `T` value.
+            let value = parser.parse()?;
 
-        Ok(Annotated {
-            attribute_list,
-            value,
-        })
+            Ok(Annotated {
+                attribute_list,
+                value,
+            })
+        }
     }
 }
 

--- a/sway-parse/src/attribute.rs
+++ b/sway-parse/src/attribute.rs
@@ -59,7 +59,7 @@ impl<T: Parse> Parse for Annotated<T> {
             attribute_list.push(attr);
         }
 
-        if let Some(_) = parser.check_empty() {
+        if parser.check_empty().is_some() {
             let error = parser.emit_error(ParseErrorKind::ExpectedAnItemAfterDocComment);
             Err(error)
         } else {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/annotated_missing_item/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/annotated_missing_item/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = 'addrof_intrinsic'
+source = 'member'
+dependencies = ['std']
+
+[[package]]
+name = 'core'
+source = 'path+from-root-B3EAB3022B5FAD04'
+
+[[package]]
+name = 'std'
+source = 'path+from-root-B3EAB3022B5FAD04'
+dependencies = ['core']

--- a/test/src/e2e_vm_tests/test_programs/should_fail/annotated_missing_item/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/annotated_missing_item/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "addrof_intrinsic"
+
+[dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/annotated_missing_item/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/annotated_missing_item/src/main.sw
@@ -1,0 +1,11 @@
+script;
+
+use std::{constants::ZERO_B256, vm::evm::evm_address::EvmAddress};
+
+configurable {
+    /// SIGNER: EvmAddress = EvmAddress {
+    ///    value: ZERO_B256,
+    /// }
+}
+
+fn main() {}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/annotated_missing_item/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/annotated_missing_item/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Expected item after doc comment


### PR DESCRIPTION
## Description

This PR closes https://github.com/FuelLabs/sway/issues/4968. The problem here is that doc comments are special in the sense that they demand an item after. 

I am following the `rustc` error message of my machine, but rust playground message is a little different. Not sure which way we want to go.

https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=34097e067111a355e70767be7965952c


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
