### PR TITLE
feat: forc-client points empty accounts to beta-4 faucet

### DIFF
--- a/forc-plugins/forc-client/src/lib.rs
+++ b/forc-plugins/forc-client/src/lib.rs
@@ -7,4 +7,5 @@ pub mod default {
     pub const NODE_URL: &str = sway_utils::constants::DEFAULT_NODE_URL;
     pub const BETA_2_ENDPOINT_URL: &str = "node-beta-2.fuel.network/graphql";
     pub const BETA_3_ENDPOINT_URL: &str = "beta-3.fuel.network/graphql";
+    pub const BETA_4_FAUCET_URL: &str = "https://faucet-beta-4.fuel.network";
 }

--- a/forc-plugins/forc-client/src/util/tx.rs
+++ b/forc-plugins/forc-client/src/util/tx.rs
@@ -25,6 +25,8 @@ use forc_wallet::{
     utils::default_wallet_path,
 };
 
+use crate::default::BETA_4_FAUCET_URL;
+
 /// The maximum time to wait for a transaction to be included in a block by the node
 pub const TX_SUBMIT_TIMEOUT_MS: u64 = 30_000u64;
 
@@ -203,11 +205,14 @@ impl<Tx: Buildable + SerializableVec + field::Witnesses + Send> TransactionBuild
                     .flat_map(|account| account.values())
                     .sum::<u64>();
                 if total_balance == 0 {
-                    // TODO: Point to latest test-net faucet with account info added to the
-                    // link as a parameter.
-                    anyhow::bail!("Your wallet does not have any funds to pay for the deployment transaction.\
-                                      \nIf you are deploying to a testnet consider using the faucet.\
-                                      \nIf you are deploying to a local node, consider providing a chainConfig which funds your account.")
+                    let first_account = accounts
+                        .get(&0)
+                        .ok_or_else(|| anyhow::anyhow!("No account derived for this wallet"))?;
+                    let faucet_link = format!("{}/?address={first_account}", BETA_4_FAUCET_URL);
+                    anyhow::bail!("Your wallet does not have any funds to pay for the transaction.\
+                                      \n\nIf you are interacting with a testnet consider using the faucet.\
+                                      \n-> beta-4 network faucet: {faucet_link}\
+                                      \nIf you are interacting with a local node, consider providing a chainConfig which funds your account.")
                 }
                 print_account_balances(&accounts, &account_balances);
 

--- a/forc-plugins/forc-client/src/util/tx.rs
+++ b/forc-plugins/forc-client/src/util/tx.rs
@@ -16,7 +16,7 @@ use fuels_core::types::{
 };
 
 use forc_wallet::{
-    account::derive_secret_key,
+    account::{derive_secret_key, new_at_index_cli},
     balance::{
         collect_accounts_with_verification, print_account_balances, AccountBalances,
         AccountVerification, AccountsMap,
@@ -181,7 +181,10 @@ impl<Tx: Buildable + SerializableVec + field::Witnesses + Send> TransactionBuild
                     let accepted = ask_user_yes_no_question(&question)?;
                     if accepted {
                         new_wallet_cli(&wallet_path)?;
-                        println!("Wallet created successfully.")
+                        println!("Wallet created successfully.");
+                        // Derive first account for the fresh wallet we created.
+                        new_at_index_cli(&wallet_path, 0)?;
+                        println!("Account derived successfully.");
                     } else {
                         anyhow::bail!("Refused to create a new wallet. If you don't want to use forc-wallet, you can sign this transaction manually with --manual-signing flag.")
                     }


### PR DESCRIPTION
## Description
closes #4862.

waiting for #4905 to be merged first.

With this PR, we are now pointing empty accounts to beta-4 faucet with their address already inserted so that people can click on it and get funded.

```console
Please provide the password of your encrypted wallet vault at "/Users/kayagokalp/.fuel/wallets/.wallet": 
Error: Your wallet does not have any funds to pay for the transaction.

If you are interacting with a testnet consider using the faucet.
-> beta-4 network faucet: https://faucet-beta-4.fuel.network/?address=fuel1l6su7ldka75ntmz7vx05tfznshxjpa4ftt4p537vl2ck45a5p5tsmwjevm
If you are interacting with a local node, consider providing a chainConfig which funds your account.
```
