### PR TITLE
Removes outdated note in documentation.

### DIFF
--- a/docs/book/src/advanced/generic_types.md
+++ b/docs/book/src/advanced/generic_types.md
@@ -30,8 +30,6 @@ purely shorthand for the sake of ergonomics.
 
 ## Trait Constraints
 
-> **Note** Trait constraints [have not yet been implemented](https://github.com/FuelLabs/sway/issues/970)
-
 Important background to know before diving into trait constraints is that the `where` clause can be used to specify the required traits for the generic argument. So, when writing something like a `HashMap` you may
 want to specify that the generic argument implements a `Hash` trait.
 


### PR DESCRIPTION
## Description

Trait constraints are already implemented so remove outdated note in documentation.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
