### PR TITLE
Add AST module caching support to the LSP.

### DIFF
--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -14,6 +14,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use sway_types::{Ident, Spanned};
+use sway_utils::PerformanceData;
 use tower_lsp::jsonrpc::Result;
 use tracing::metadata::LevelFilter;
 
@@ -430,6 +431,36 @@ pub(crate) fn on_enter(
         Ok((uri, session)) => {
             // handle on_enter capabilities if they are enabled
             Ok(capabilities::on_enter(config, &session, &uri, &params))
+        }
+        Err(err) => {
+            tracing::error!("{}", err.to_string());
+            Ok(None)
+        }
+    }
+}
+
+/// This method is triggered by the test suite to request the latest compilation metrics.
+pub(crate) fn metrics(
+    state: &ServerState,
+    params: lsp_ext::MetricsParams,
+) -> Result<Option<Vec<(String, PerformanceData)>>> {
+    match state
+        .sessions
+        .uri_and_session_from_workspace(&params.text_document.uri)
+    {
+        Ok((_, session)) => {
+            let engines = session.engines.read();
+            let mut metrics = vec![];
+            for kv in session.metrics.iter() {
+                let path = engines
+                    .se()
+                    .get_path(kv.key())
+                    .to_str()
+                    .unwrap_or("")
+                    .to_string();
+                metrics.push((path, kv.value().clone()));
+            }
+            Ok(Some(metrics))
         }
         Err(err) => {
             tracing::error!("{}", err.to_string());

--- a/sway-lsp/src/lib.rs
+++ b/sway-lsp/src/lib.rs
@@ -27,6 +27,7 @@ pub async fn start() {
     let (service, socket) = LspService::build(ServerState::new)
         .custom_method("sway/show_ast", ServerState::show_ast)
         .custom_method("sway/on_enter", ServerState::on_enter)
+        .custom_method("sway/metrics", ServerState::metrics)
         .finish();
     Server::new(tokio::io::stdin(), tokio::io::stdout(), socket)
         .serve(service)

--- a/sway-lsp/src/lsp_ext.rs
+++ b/sway-lsp/src/lsp_ext.rs
@@ -18,3 +18,9 @@ pub struct OnEnterParams {
     /// The actual content changes, including the newline.
     pub content_changes: Vec<TextDocumentContentChangeEvent>,
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricsParams {
+    pub text_document: TextDocumentIdentifier,
+}

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     handlers::{notification, request},
-    lsp_ext::{OnEnterParams, ShowAstParams},
+    lsp_ext::{MetricsParams, OnEnterParams, ShowAstParams},
     server_state::ServerState,
 };
 use lsp_types::{
@@ -16,6 +16,7 @@ use lsp_types::{
     RenameParams, SemanticTokensParams, SemanticTokensResult, TextDocumentIdentifier,
     TextDocumentPositionParams, TextEdit, WorkspaceEdit,
 };
+use sway_utils::PerformanceData;
 use tower_lsp::{jsonrpc::Result, LanguageServer};
 
 #[tower_lsp::async_trait]
@@ -126,5 +127,12 @@ impl ServerState {
 
     pub async fn on_enter(&self, params: OnEnterParams) -> Result<Option<WorkspaceEdit>> {
         request::on_enter(self, params)
+    }
+
+    pub async fn metrics(
+        &self,
+        params: MetricsParams,
+    ) -> Result<Option<Vec<(String, PerformanceData)>>> {
+        request::metrics(self, params)
     }
 }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -176,6 +176,43 @@ async fn did_change() {
 }
 
 #[tokio::test]
+async fn did_cache_test() {
+    let (mut service, _) = LspService::build(ServerState::new)
+        .custom_method("sway/metrics", ServerState::metrics)
+        .finish();
+    let uri = init_and_open(&mut service, doc_comments_dir().join("src/main.sw")).await;
+    let _ = lsp::did_change_request(&mut service, &uri).await;
+    let metrics = lsp::metrics_request(&mut service, &uri).await;
+    assert!(metrics.len() >= 2);
+    println!("metrics req: {:?}", metrics);
+    for (path, metrics) in metrics {
+        if path.contains("sway-lib-core") || path.contains("sway-lib-std") {
+            assert!(metrics.reused_modules >= 1);
+        }
+    }
+    shutdown_and_exit(&mut service).await;
+}
+
+#[tokio::test]
+async fn did_change_stress_test() {
+    let (mut service, _) = LspService::build(ServerState::new)
+        .custom_method("sway/metrics", ServerState::metrics)
+        .finish();
+    let uri = init_and_open(&mut service, doc_comments_dir().join("src/main.sw")).await;
+    let times = 20;
+    for _ in 0..times {
+        let _ = lsp::did_change_request(&mut service, &uri).await;
+        let metrics = lsp::metrics_request(&mut service, &uri).await;
+        for (path, metrics) in metrics {
+            if path.contains("sway-lib-core") || path.contains("sway-lib-std") {
+                assert!(metrics.reused_modules >= 1);
+            }
+        }
+    }
+    shutdown_and_exit(&mut service).await;
+}
+
+#[tokio::test]
 async fn lsp_syncs_with_workspace_edits() {
     let (mut service, _) = LspService::new(ServerState::new);
     let uri = init_and_open(&mut service, doc_comments_dir().join("src/main.sw")).await;


### PR DESCRIPTION
## Description

This adds AST module caching support to the LSP.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
