### PR TITLE
Parallelize traversing AST's in the language server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5903,6 +5903,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "proc-macro2",
  "quote",
+ "rayon",
  "ropey",
  "serde",
  "serde_json",

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -19,6 +19,7 @@ notify-debouncer-mini = { version = "0.2.0" }
 parking_lot = "0.12.1"
 proc-macro2 = "1.0.5"
 quote = "1.0.9"
+rayon = "1.5.0"
 ropey = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.60"

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -542,9 +542,7 @@ fn parse_ast_to_typed_tokens(
         .iter()
         .flat_map(|(_, submodule)| submodule.module.all_nodes.iter());
 
-    root_nodes
-        .chain(sub_nodes)
-        .for_each(|n| f(n, ctx));
+    root_nodes.chain(sub_nodes).for_each(|n| f(n, ctx));
 }
 
 #[cfg(test)]

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -523,7 +523,10 @@ fn parse_ast_to_tokens(
         .iter()
         .flat_map(|(_, submodule)| &submodule.module.tree.root_nodes);
 
-    root_nodes.chain(sub_nodes).par_bridge().for_each(|n| f(n, ctx));
+    root_nodes
+        .chain(sub_nodes)
+        .par_bridge()
+        .for_each(|n| f(n, ctx));
 }
 
 /// Parse the [ty::TyProgram] AST to populate the [TokenMap] with typed AST nodes.
@@ -539,7 +542,10 @@ fn parse_ast_to_typed_tokens(
         .iter()
         .flat_map(|(_, submodule)| submodule.module.all_nodes.iter());
 
-    root_nodes.chain(sub_nodes).par_bridge().for_each(|n| f(n, ctx));
+    root_nodes
+        .chain(sub_nodes)
+        .par_bridge()
+        .for_each(|n| f(n, ctx));
 }
 
 #[cfg(test)]

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -544,7 +544,6 @@ fn parse_ast_to_typed_tokens(
 
     root_nodes
         .chain(sub_nodes)
-        .par_bridge()
         .for_each(|n| f(n, ctx));
 }
 

--- a/sway-lsp/src/core/token_map.rs
+++ b/sway-lsp/src/core/token_map.rs
@@ -17,7 +17,7 @@ pub struct TokenMap(DashMap<TokenIdent, Token>);
 impl TokenMap {
     /// Create a new token map.
     pub fn new() -> TokenMap {
-        TokenMap(DashMap::new())
+        TokenMap(DashMap::with_capacity(2048))
     }
 
     /// Create a custom iterator for the TokenMap.

--- a/sway-lsp/src/traverse/lexed_tree.rs
+++ b/sway-lsp/src/traverse/lexed_tree.rs
@@ -149,7 +149,7 @@ impl Parse for Expr {
             } => {
                 insert_keyword(ctx, match_token.span());
                 value.parse(ctx);
-                branches.get().into_iter().par_bridge().for_each(|branch| {
+                branches.get().iter().par_bridge().for_each(|branch| {
                     branch.pattern.parse(ctx);
                     branch.kind.parse(ctx);
                 });

--- a/sway-lsp/src/traverse/lexed_tree.rs
+++ b/sway-lsp/src/traverse/lexed_tree.rs
@@ -16,7 +16,12 @@ use sway_types::{Ident, Span, Spanned};
 
 pub fn parse(lexed_program: &LexedProgram, ctx: &ParseContext) {
     insert_module_kind(ctx, &lexed_program.root.tree.kind);
-    lexed_program.root.tree.items.par_iter().for_each(|item| item.value.parse(ctx));
+    lexed_program
+        .root
+        .tree
+        .items
+        .par_iter()
+        .for_each(|item| item.value.parse(ctx));
 
     lexed_program
         .root
@@ -24,7 +29,11 @@ pub fn parse(lexed_program: &LexedProgram, ctx: &ParseContext) {
         .par_iter()
         .for_each(|(_, dep)| {
             insert_module_kind(ctx, &dep.module.tree.kind);
-            dep.module.tree.items.par_iter().for_each(|item| item.value.parse(ctx));
+            dep.module
+                .tree
+                .items
+                .par_iter()
+                .for_each(|item| item.value.parse(ctx));
         });
 }
 
@@ -103,7 +112,11 @@ impl Parse for Expr {
                 args.get().address.parse(ctx);
             }
             Expr::Struct { fields, .. } => {
-                fields.get().into_iter().par_bridge().for_each(|field| field.parse(ctx));
+                fields
+                    .get()
+                    .into_iter()
+                    .par_bridge()
+                    .for_each(|field| field.parse(ctx));
             }
             Expr::Tuple(tuple) => {
                 tuple.get().parse(ctx);
@@ -152,7 +165,10 @@ impl Parse for Expr {
             }
             Expr::FuncApp { func, args } => {
                 func.parse(ctx);
-                args.get().into_iter().par_bridge().for_each(|expr| expr.parse(ctx));
+                args.get()
+                    .into_iter()
+                    .par_bridge()
+                    .for_each(|expr| expr.parse(ctx));
             }
             Expr::Index { target, arg } => {
                 target.parse(ctx);
@@ -166,9 +182,16 @@ impl Parse for Expr {
             } => {
                 target.parse(ctx);
                 if let Some(contract_args) = contract_args_opt {
-                    contract_args.get().into_iter().par_bridge().for_each(|expr| expr.parse(ctx));
+                    contract_args
+                        .get()
+                        .into_iter()
+                        .par_bridge()
+                        .for_each(|expr| expr.parse(ctx));
                 }
-                args.get().into_iter().par_bridge().for_each(|expr| expr.parse(ctx));
+                args.get()
+                    .into_iter()
+                    .par_bridge()
+                    .for_each(|expr| expr.parse(ctx));
             }
             Expr::FieldProjection { target, .. } => {
                 target.parse(ctx);
@@ -488,7 +511,10 @@ impl Parse for FnArgs {
     fn parse(&self, ctx: &ParseContext) {
         match self {
             FnArgs::Static(punct) => {
-                punct.into_iter().par_bridge().for_each(|fn_arg| fn_arg.parse(ctx));
+                punct
+                    .into_iter()
+                    .par_bridge()
+                    .for_each(|fn_arg| fn_arg.parse(ctx));
             }
             FnArgs::NonStatic {
                 self_token,
@@ -504,7 +530,10 @@ impl Parse for FnArgs {
                     insert_keyword(ctx, mut_token.span());
                 }
                 if let Some((.., punct)) = args_opt {
-                    punct.into_iter().par_bridge().for_each(|fn_arg| fn_arg.parse(ctx));
+                    punct
+                        .into_iter()
+                        .par_bridge()
+                        .for_each(|fn_arg| fn_arg.parse(ctx));
                 }
             }
         }
@@ -520,7 +549,9 @@ impl Parse for FnArg {
 
 impl Parse for CodeBlockContents {
     fn parse(&self, ctx: &ParseContext) {
-        self.statements.par_iter().for_each(|statement| statement.parse(ctx));
+        self.statements
+            .par_iter()
+            .for_each(|statement| statement.parse(ctx));
         if let Some(expr) = self.final_expr_opt.as_ref() {
             expr.parse(ctx);
         }
@@ -559,7 +590,10 @@ impl Parse for ExprArrayDescriptor {
     fn parse(&self, ctx: &ParseContext) {
         match self {
             ExprArrayDescriptor::Sequence(punct) => {
-                punct.into_iter().par_bridge().for_each(|expr| expr.parse(ctx));
+                punct
+                    .into_iter()
+                    .par_bridge()
+                    .for_each(|expr| expr.parse(ctx));
             }
             ExprArrayDescriptor::Repeat { value, length, .. } => {
                 value.parse(ctx);
@@ -622,10 +656,17 @@ impl Parse for Pattern {
                 }
             }
             Pattern::Constructor { args, .. } | Pattern::Tuple(args) => {
-                args.get().into_iter().par_bridge().for_each(|pattern| pattern.parse(ctx));
+                args.get()
+                    .into_iter()
+                    .par_bridge()
+                    .for_each(|pattern| pattern.parse(ctx));
             }
             Pattern::Struct { fields, .. } => {
-                fields.get().into_iter().par_bridge().for_each(|field| field.parse(ctx));
+                fields
+                    .get()
+                    .into_iter()
+                    .par_bridge()
+                    .for_each(|field| field.parse(ctx));
             }
             _ => {}
         }
@@ -669,7 +710,9 @@ impl Parse for ExprTupleDescriptor {
     fn parse(&self, ctx: &ParseContext) {
         if let ExprTupleDescriptor::Cons { head, tail, .. } = self {
             head.parse(ctx);
-            tail.into_iter().par_bridge().for_each(|expr| expr.parse(ctx));
+            tail.into_iter()
+                .par_bridge()
+                .for_each(|expr| expr.parse(ctx));
         }
     }
 }
@@ -678,7 +721,9 @@ impl Parse for TyTupleDescriptor {
     fn parse(&self, ctx: &ParseContext) {
         if let TyTupleDescriptor::Cons { head, tail, .. } = self {
             head.parse(ctx);
-            tail.into_iter().par_bridge().for_each(|expr| expr.parse(ctx));
+            tail.into_iter()
+                .par_bridge()
+                .for_each(|expr| expr.parse(ctx));
         }
     }
 }

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -230,7 +230,10 @@ impl Parse for Expression {
                 struct_expression.parse(ctx);
             }
             ExpressionKind::CodeBlock(code_block) => {
-                code_block.contents.par_iter().for_each(|node| node.parse(ctx));
+                code_block
+                    .contents
+                    .par_iter()
+                    .for_each(|node| node.parse(ctx));
             }
             ExpressionKind::If(IfExpression {
                 condition,
@@ -846,11 +849,20 @@ impl Parse for AbiDeclaration {
                 SymbolKind::Trait,
             ),
         );
+<<<<<<< HEAD
         self.interface_surface.par_iter().for_each(|item| match item {
             TraitItem::TraitFn(trait_fn) => trait_fn.parse(ctx),
             TraitItem::Constant(const_decl) => const_decl.parse(ctx),
             TraitItem::Error(_, _) => {}
         });
+=======
+        self.interface_surface
+            .par_iter()
+            .for_each(|item| match item {
+                TraitItem::TraitFn(trait_fn) => trait_fn.parse(ctx),
+                TraitItem::Constant(const_decl) => const_decl.parse(ctx),
+            });
+>>>>>>> 6ac65958e (fmt)
         self.supertraits.par_iter().for_each(|supertrait| {
             supertrait.parse(ctx);
         });

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -732,11 +732,13 @@ impl Parse for TraitDeclaration {
                 SymbolKind::Trait,
             ),
         );
-        self.interface_surface.par_iter().for_each(|item| match item {
-            TraitItem::TraitFn(trait_fn) => trait_fn.parse(ctx),
-            TraitItem::Constant(const_decl) => const_decl.parse(ctx),
-            TraitItem::Error(_, _) => {}
-        });
+        self.interface_surface
+            .par_iter()
+            .for_each(|item| match item {
+                TraitItem::TraitFn(trait_fn) => trait_fn.parse(ctx),
+                TraitItem::Constant(const_decl) => const_decl.parse(ctx),
+                TraitItem::Error(_, _) => {}
+            });
         self.methods.par_iter().for_each(|func_dec| {
             func_dec.parse(ctx);
         });
@@ -849,20 +851,13 @@ impl Parse for AbiDeclaration {
                 SymbolKind::Trait,
             ),
         );
-<<<<<<< HEAD
-        self.interface_surface.par_iter().for_each(|item| match item {
-            TraitItem::TraitFn(trait_fn) => trait_fn.parse(ctx),
-            TraitItem::Constant(const_decl) => const_decl.parse(ctx),
-            TraitItem::Error(_, _) => {}
-        });
-=======
         self.interface_surface
             .par_iter()
             .for_each(|item| match item {
                 TraitItem::TraitFn(trait_fn) => trait_fn.parse(ctx),
                 TraitItem::Constant(const_decl) => const_decl.parse(ctx),
+                TraitItem::Error(_, _) => {}
             });
->>>>>>> 6ac65958e (fmt)
         self.supertraits.par_iter().for_each(|supertrait| {
             supertrait.parse(ctx);
         });

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -105,8 +105,7 @@ impl Parse for ty::TySideEffect {
                 },
             ) => {
                 for (mod_path, ident) in iter_prefixes(call_path).zip(call_path) {
-                    if let Some(mut token) =
-                        ctx.tokens.try_get_mut(&ctx.ident(ident)).try_unwrap()
+                    if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(ident)).try_unwrap()
                     {
                         token.typed = Some(TypedAstToken::TypedUseStatement(use_statement.clone()));
 
@@ -246,8 +245,7 @@ impl Parse for ty::TyExpression {
                 }
                 contract_call_params.values().for_each(|exp| exp.parse(ctx));
                 for (ident, exp) in arguments {
-                    if let Some(mut token) =
-                        ctx.tokens.try_get_mut(&ctx.ident(ident)).try_unwrap()
+                    if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(ident)).try_unwrap()
                     {
                         token.typed = Some(TypedAstToken::Ident(ident.clone()));
                     }
@@ -327,10 +325,8 @@ impl Parse for ty::TyExpression {
                     });
                 collect_call_path_prefixes(ctx, &call_path_binding.inner.prefixes);
                 fields.iter().for_each(|field| {
-                    if let Some(mut token) = ctx
-                        .tokens
-                        .try_get_mut(&ctx.ident(&field.name))
-                        .try_unwrap()
+                    if let Some(mut token) =
+                        ctx.tokens.try_get_mut(&ctx.ident(&field.name)).try_unwrap()
                     {
                         token.typed = Some(TypedAstToken::TypedExpression(field.value.clone()));
 
@@ -510,10 +506,8 @@ impl Parse for ty::TyExpression {
                         .iter()
                         .zip(storage_access.fields.iter().map(|f| f.type_id))
                     {
-                        if let Some(mut token) = ctx
-                            .tokens
-                            .try_get_mut(&ctx.ident(&field.name))
-                            .try_unwrap()
+                        if let Some(mut token) =
+                            ctx.tokens.try_get_mut(&ctx.ident(&field.name)).try_unwrap()
                         {
                             token.typed = Some(TypedAstToken::Ident(field.name.clone()));
                             match ctx.engines.te().get(container_type_id) {
@@ -580,11 +574,7 @@ impl Parse for ty::TyExpression {
 
 impl Parse for ty::TyVariableDecl {
     fn parse(&self, ctx: &ParseContext) {
-        if let Some(mut token) = ctx
-            .tokens
-            .try_get_mut(&ctx.ident(&self.name))
-            .try_unwrap()
-        {
+        if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(&self.name)).try_unwrap() {
             token.typed = Some(TypedAstToken::TypedDeclaration(ty::TyDecl::VariableDecl(
                 Box::new(self.clone()),
             )));
@@ -836,11 +826,7 @@ impl Parse for ty::AbiDecl {
 
 impl Parse for ty::GenericTypeForFunctionScope {
     fn parse(&self, ctx: &ParseContext) {
-        if let Some(mut token) = ctx
-            .tokens
-            .try_get_mut(&ctx.ident(&self.name))
-            .try_unwrap()
-        {
+        if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(&self.name)).try_unwrap() {
             token.typed = Some(TypedAstToken::TypedDeclaration(
                 ty::TyDecl::GenericTypeForFunctionScope(self.clone()),
             ));
@@ -853,11 +839,7 @@ impl Parse for ty::StorageDecl {
     fn parse(&self, ctx: &ParseContext) {
         let storage_decl = ctx.engines.de().get_storage(&self.decl_id);
         for field in &storage_decl.fields {
-            if let Some(mut token) = ctx
-                .tokens
-                .try_get_mut(&ctx.ident(&field.name))
-                .try_unwrap()
-            {
+            if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(&field.name)).try_unwrap() {
                 token.typed = Some(TypedAstToken::TypedStorageField(field.clone()));
                 token.type_def = Some(TypeDefinition::Ident(field.name.clone()));
             }
@@ -877,11 +859,7 @@ impl Parse for ty::TypeAliasDecl {
 impl Parse for ty::TyFunctionParameter {
     fn parse(&self, ctx: &ParseContext) {
         let typed_token = TypedAstToken::TypedFunctionParameter(self.clone());
-        if let Some(mut token) = ctx
-            .tokens
-            .try_get_mut(&ctx.ident(&self.name))
-            .try_unwrap()
-        {
+        if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(&self.name)).try_unwrap() {
             token.typed = Some(typed_token);
             token.type_def = Some(TypeDefinition::Ident(self.name.clone()));
         }
@@ -891,11 +869,7 @@ impl Parse for ty::TyFunctionParameter {
 
 impl Parse for ty::TyTraitFn {
     fn parse(&self, ctx: &ParseContext) {
-        if let Some(mut token) = ctx
-            .tokens
-            .try_get_mut(&ctx.ident(&self.name))
-            .try_unwrap()
-        {
+        if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(&self.name)).try_unwrap() {
             token.typed = Some(TypedAstToken::TypedTraitFn(self.clone()));
             token.type_def = Some(TypeDefinition::Ident(self.name.clone()));
         }
@@ -914,11 +888,7 @@ impl Parse for ty::TyTraitFn {
 
 impl Parse for ty::TyStructField {
     fn parse(&self, ctx: &ParseContext) {
-        if let Some(mut token) = ctx
-            .tokens
-            .try_get_mut(&ctx.ident(&self.name))
-            .try_unwrap()
-        {
+        if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(&self.name)).try_unwrap() {
             token.typed = Some(TypedAstToken::TypedStructField(self.clone()));
             token.type_def = Some(TypeDefinition::Ident(self.name.clone()));
         }
@@ -929,11 +899,7 @@ impl Parse for ty::TyStructField {
 impl Parse for ty::TyEnumVariant {
     fn parse(&self, ctx: &ParseContext) {
         let typed_token = TypedAstToken::TypedEnumVariant(self.clone());
-        if let Some(mut token) = ctx
-            .tokens
-            .try_get_mut(&ctx.ident(&self.name))
-            .try_unwrap()
-        {
+        if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(&self.name)).try_unwrap() {
             token.typed = Some(typed_token);
             token.type_def = Some(TypeDefinition::TypeId(self.type_argument.type_id));
         }
@@ -944,11 +910,7 @@ impl Parse for ty::TyEnumVariant {
 impl Parse for ty::TyFunctionDecl {
     fn parse(&self, ctx: &ParseContext) {
         let typed_token = TypedAstToken::TypedFunctionDeclaration(self.clone());
-        if let Some(mut token) = ctx
-            .tokens
-            .try_get_mut(&ctx.ident(&self.name))
-            .try_unwrap()
-        {
+        if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(&self.name)).try_unwrap() {
             token.typed = Some(typed_token.clone());
             token.type_def = Some(TypeDefinition::Ident(self.name.clone()));
         }
@@ -984,11 +946,7 @@ impl Parse for ty::TyFunctionDecl {
 
 impl Parse for ty::TyTypeAliasDecl {
     fn parse(&self, ctx: &ParseContext) {
-        if let Some(mut token) = ctx
-            .tokens
-            .try_get_mut(&ctx.ident(&self.name))
-            .try_unwrap()
-        {
+        if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(&self.name)).try_unwrap() {
             token.typed = Some(TypedAstToken::TypedTypeAliasDeclaration(self.clone()));
             token.type_def = Some(TypeDefinition::Ident(self.name.clone()));
         }
@@ -1059,8 +1017,7 @@ impl Parse for ty::TyScrutinee {
                     instantiation_call_path.prefixes.split_last()
                 {
                     // the last prefix of the call path is not a module but a type
-                    if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(last)).try_unwrap()
-                    {
+                    if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(last)).try_unwrap() {
                         token.typed = Some(TypedAstToken::TypedScrutinee(self.clone()));
                         token.type_def = Some(TypeDefinition::Ident(enum_ref.name().clone()));
                     }
@@ -1088,11 +1045,7 @@ impl Parse for ty::TyScrutinee {
 
 impl Parse for ty::TyStructScrutineeField {
     fn parse(&self, ctx: &ParseContext) {
-        if let Some(mut token) = ctx
-            .tokens
-            .try_get_mut(&ctx.ident(&self.field))
-            .try_unwrap()
-        {
+        if let Some(mut token) = ctx.tokens.try_get_mut(&ctx.ident(&self.field)).try_unwrap() {
             token.typed = Some(TypedAstToken::TyStructScrutineeField(self.clone()));
             token.type_def = Some(TypeDefinition::Ident(self.field_def_name.clone()));
         }


### PR DESCRIPTION
## Description
This PR introduces using rayon's parallel iterators when traversing the lexed and parsed AST's. I initially extended this to also occur on the typed AST but was running into deadlock issues with how DashMap works. 

closes #4959

| Request Type/Method    | Previous  | New      | Improvement % |
|------------------------|-----------|----------|---------------|
| compile_and_traverse   | 2.7732s   | 2.5632s  | 7.57%         |

**edit**

I've split the compilation and traversal stages so they can be benchmarked independently. Here are the actual traversal performance results.

| Request Type/Method    | Previous  | New      | Improvement % |
|------------------------|-----------|----------|---------------|
| traverse   | 422ms   | 211ms  | 50.0%         |

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
