### PR TITLE
Remove extra insert_trait_implementation_for_type

### DIFF
--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -311,10 +311,7 @@ impl TypeCheckTypeBinding<ty::TyStructDecl> for TypeBinding<CallPath> {
         )?;
         // Insert the new copy into the declaration engine.
         let new_struct_ref = ctx.engines.de().insert(new_copy);
-        // Take any trait items that apply to the old type and copy them to the new type.
         let type_id = type_engine.insert(engines, TypeInfo::Struct(new_struct_ref.clone()));
-        ctx.namespace
-            .insert_trait_implementation_for_type(engines, type_id);
         Ok((new_struct_ref, Some(type_id), None))
     }
 }
@@ -364,10 +361,7 @@ impl TypeCheckTypeBinding<ty::TyEnumDecl> for TypeBinding<CallPath> {
         )?;
         // Insert the new copy into the declaration engine.
         let new_enum_ref = ctx.engines.de().insert(new_copy);
-        // Take any trait items that apply to the old type and copy them to the new type.
         let type_id = type_engine.insert(engines, TypeInfo::Enum(new_enum_ref.clone()));
-        ctx.namespace
-            .insert_trait_implementation_for_type(engines, type_id);
         Ok((new_enum_ref, Some(type_id), Some(unknown_decl)))
     }
 }


### PR DESCRIPTION
The type resolution function calls this function at a later stage, hence this one is not needed.

This makes trait map sizes smaller and saves a bunch of type ids.

Partially resolves issue #5002

## Description


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
