### PR TITLE
Update `msg_sender()` to return sender when input type is `Input::Message`

### DIFF
--- a/sway-lib-std/src/auth.sw
+++ b/sway-lib-std/src/auth.sw
@@ -6,7 +6,7 @@ use ::contract_id::ContractId;
 use ::identity::Identity;
 use ::option::Option::{self, *};
 use ::result::Result::{self, *};
-use ::inputs::{Input, input_count, input_owner, input_type};
+use ::inputs::{Input, input_count, input_message_sender, input_owner, input_type};
 
 /// The error type used when an `Identity` cannot be determined.
 pub enum AuthError {
@@ -148,7 +148,11 @@ fn inputs_owner() -> Result<Identity, AuthError> {
         }
 
         // type == InputCoin or InputMessage.
-        let owner_of_input = input_owner(i.as_u64());
+        let owner_of_input = match type_of_input {
+            Input::Coin => input_owner(i.as_u64()),
+            Input::Message => Some(input_message_sender(i.as_u64())),
+            _ => return Err(AuthError::InputsNotAllOwnedBySameAddress),
+        };
         if candidate.is_none() {
             // This is the first input seen of the correct type.
             candidate = owner_of_input;

--- a/test/src/sdk-harness/test_projects/auth/mod.rs
+++ b/test/src/sdk-harness/test_projects/auth/mod.rs
@@ -3,6 +3,8 @@ use fuels::{
     prelude::*,
     types::ContractId,
 };
+use fuel_core_client::client::types::primitives::ChainId;
+use fuel_vm::fuel_tx::{field::*, Input as TxInput};
 
 abigen!(
     Contract(
@@ -54,6 +56,69 @@ async fn msg_sender_from_contract() {
         .unwrap();
 
     assert_eq!(result.value, true);
+}
+
+
+#[tokio::test]
+async fn msg_sender_message() {
+    let (auth_instance, _, _, _, wallet) = get_contracts().await;
+
+    const MESSAGE_DATA: [u8; 3] = [1u8, 2u8, 3u8];
+    let mut wallet = WalletUnlocked::new_random(None);
+    let mut coins = setup_single_asset_coins(wallet.address(), BASE_ASSET_ID, 100, 1000);
+    let messages = setup_single_message(
+        &Bech32Address {
+            hrp: "".to_string(),
+            hash: Default::default(),
+        },
+        wallet.address(),
+        DEFAULT_COIN_AMOUNT,
+        0.into(),
+        MESSAGE_DATA.to_vec(),
+    );
+    let (provider, _address) = setup_test_provider(coins.clone(), vec![messages], None, None).await;
+    wallet.set_provider(provider.clone());
+
+    let contract_id = Contract::load_from(
+        "test_artifacts/auth_testing_contract/out/debug/auth_testing_contract.bin",
+        LoadConfiguration::default(),
+    )
+    .unwrap()
+    .deploy(&wallet, TxParameters::default())
+    .await
+    .unwrap();
+
+    let instance = AuthContract::new(contract_id.clone(), wallet.clone());
+
+    let handler = auth_instance.methods().returns_msg_sender_address(wallet.address());
+    let mut tx = handler.build_tx().await.unwrap();
+    add_message_input(&mut tx, wallet.clone()).await;
+    tx.precompute(*ChainId::default()).unwrap();
+
+    let receipts = wallet
+        .provider()
+        .unwrap()
+        .send_transaction(&tx)
+        .await
+        .unwrap();
+
+    // true = 1
+    assert_eq!(*receipts[1].data().unwrap(), [1u8]);
+}
+
+async fn add_message_input(tx: &mut ScriptTransaction, wallet: WalletUnlocked) {
+    let message = &wallet.get_messages().await.unwrap()[0];
+
+    let message_input = TxInput::message_data_signed(
+        message.sender.clone().into(),
+        message.recipient.clone().into(),
+        message.amount,
+        message.nonce,
+        0,
+        message.data.clone(),
+    );
+
+    tx.tx.inputs_mut().push(message_input);
 }
 
 async fn get_contracts() -> (


### PR DESCRIPTION
## Description

This change reflects an issue experienced by an internal contributor where `msg_sender().unwrap()` would revert when sending a message. Currently, the sender is only returned when the input is of type `Input::Coin`.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
