### PR TITLE
Fix diagnostics in multi file projects

### DIFF
--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -1,7 +1,7 @@
 use crate::{
     capabilities::{
         self,
-        diagnostic::{DiagnosticMap, Diagnostics},
+        diagnostic::DiagnosticMap,
         formatting::get_page_text_edit,
         runnable::{Runnable, RunnableMainFn, RunnableTestFn},
     },

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -25,7 +25,6 @@ use lsp_types::{
 use parking_lot::RwLock;
 use pkg::{manifest::ManifestFile, BuildPlan};
 use std::{
-    collections::HashMap,
     fs::File,
     io::Write,
     ops::Deref,
@@ -106,7 +105,7 @@ impl Session {
             engines: <_>::default(),
             sync: SyncWorkspace::new(),
             parse_permits: Arc::new(Semaphore::new(2)),
-            diagnostics: Arc::new(RwLock::new(HashMap::<PathBuf, Diagnostics>::new())),
+            diagnostics: Arc::new(RwLock::new(DiagnosticMap::new())),
         }
     }
 

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -1,7 +1,7 @@
 use crate::{
     capabilities::{
         self,
-        diagnostic::{get_diagnostics, Diagnostics},
+        diagnostic::{DiagnosticMap, Diagnostics},
         formatting::get_page_text_edit,
         runnable::{Runnable, RunnableMainFn, RunnableTestFn},
     },
@@ -25,6 +25,7 @@ use lsp_types::{
 use parking_lot::RwLock;
 use pkg::{manifest::ManifestFile, BuildPlan};
 use std::{
+    collections::HashMap,
     fs::File,
     io::Write,
     ops::Deref,
@@ -41,6 +42,7 @@ use sway_core::{
     },
     BuildTarget, Engines, Namespace, Programs,
 };
+use sway_error::{error::CompileError, warning::CompileWarning};
 use sway_types::{SourceEngine, Spanned};
 use sway_utils::helpers::get_sway_files;
 use tokio::sync::Semaphore;
@@ -61,7 +63,7 @@ pub struct CompiledProgram {
 /// the types in [Session] after successfully parsing.
 #[derive(Debug)]
 pub struct ParseResult {
-    pub(crate) diagnostics: Diagnostics,
+    pub(crate) diagnostics: (Vec<CompileError>, Vec<CompileWarning>),
     pub(crate) token_map: TokenMap,
     pub(crate) engines: Engines,
     pub(crate) lexed: LexedProgram,
@@ -85,7 +87,7 @@ pub struct Session {
     // and one thread can be waiting to start parsing. All others will return the cached diagnostics.
     pub parse_permits: Arc<Semaphore>,
     // Cached diagnostic results that require a lock to access. Readers will wait for writers to complete.
-    pub diagnostics: Arc<RwLock<Diagnostics>>,
+    pub diagnostics: Arc<RwLock<DiagnosticMap>>,
 }
 
 impl Default for Session {
@@ -104,7 +106,7 @@ impl Session {
             engines: <_>::default(),
             sync: SyncWorkspace::new(),
             parse_permits: Arc::new(Semaphore::new(2)),
-            diagnostics: Arc::new(RwLock::new(Diagnostics::default())),
+            diagnostics: Arc::new(RwLock::new(HashMap::<PathBuf, Diagnostics>::new())),
         }
     }
 
@@ -139,8 +141,8 @@ impl Session {
         &self.token_map
     }
 
-    /// Wait for the cached [Diagnostics] to be unlocked after parsing and return a copy.
-    pub fn wait_for_parsing(&self) -> Diagnostics {
+    /// Wait for the cached [DiagnosticMap] to be unlocked after parsing and return a copy.
+    pub fn wait_for_parsing(&self) -> DiagnosticMap {
         self.diagnostics.read().clone()
     }
 
@@ -427,7 +429,7 @@ fn build_plan(uri: &Url) -> Result<BuildPlan, LanguageServerError> {
 /// Parses the project and returns true if the compiler diagnostics are new and should be published.
 pub fn parse_project(uri: &Url) -> Result<ParseResult, LanguageServerError> {
     let build_plan = build_plan(uri)?;
-    let mut diagnostics = Diagnostics::default();
+    let mut diagnostics = (Vec::<CompileError>::new(), Vec::<CompileWarning>::new());
     let engines = Engines::default();
     let token_map = TokenMap::new();
     let tests_enabled = true;
@@ -445,12 +447,10 @@ pub fn parse_project(uri: &Url) -> Result<ParseResult, LanguageServerError> {
     let results_len = results.len();
     for (i, (value, handler)) in results.into_iter().enumerate() {
         // We can convert these destructured elements to a Vec<Diagnostic> later on.
-        let (errors, warnings) = handler.consume();
+        let current_diagnostics = handler.consume();
+        diagnostics = current_diagnostics;
 
         if value.is_none() {
-            // If there was an unrecoverable error in the parser
-            // make sure to still return the diagnostics.
-            diagnostics = get_diagnostics(&warnings, &errors);
             continue;
         }
         let Programs {
@@ -460,10 +460,10 @@ pub fn parse_project(uri: &Url) -> Result<ParseResult, LanguageServerError> {
         } = value.unwrap();
 
         // Get a reference to the typed program AST.
-        let typed_program = typed.as_ref().ok().ok_or_else(|| {
-            diagnostics = get_diagnostics(&warnings, &errors);
-            LanguageServerError::FailedToParse
-        })?;
+        let typed_program = typed
+            .as_ref()
+            .ok()
+            .ok_or_else(|| LanguageServerError::FailedToParse)?;
 
         // Create context with write guards to make readers wait until the update to token_map is complete.
         // This operation is fast because we already have the compile results.
@@ -487,7 +487,6 @@ pub fn parse_project(uri: &Url) -> Result<ParseResult, LanguageServerError> {
             });
 
             programs = Some((lexed, parsed, typed_program.clone()));
-            diagnostics = get_diagnostics(&warnings, &errors);
         } else {
             // Collect tokens from dependencies and the standard library prelude.
             parse_ast_to_tokens(&parsed, &ctx, |an, ctx| {

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -121,7 +121,7 @@ async fn run_blocking_parse_project(
         let parse_result = session::parse_project(&uri)?;
         let (errors, warnings) = parse_result.diagnostics.clone();
         session.write_parse_result(parse_result);
-        *diagnostics = get_diagnostics(&warnings, &errors, &session.engines.read().se());
+        *diagnostics = get_diagnostics(&warnings, &errors, session.engines.read().se());
         Ok(())
     })
     .await

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -1,6 +1,7 @@
 //! The context or environment in which the language server functions.
 
 use crate::{
+    capabilities::diagnostic::get_diagnostics,
     config::{Config, Warnings},
     core::session::{self, Session},
     error::{DirectoryError, DocumentError, LanguageServerError},
@@ -66,12 +67,14 @@ impl ServerState {
                 diagnostics_to_publish = debug::generate_warnings_for_typed_tokens(tokens)
             }
             Warnings::Default => {
-                let diagnostics = session.wait_for_parsing();
-                if config.diagnostic.show_warnings {
-                    diagnostics_to_publish.extend(diagnostics.warnings);
-                }
-                if config.diagnostic.show_errors {
-                    diagnostics_to_publish.extend(diagnostics.errors);
+                let diagnostics_map = session.wait_for_parsing();
+                if let Some(diagnostics) = diagnostics_map.get(&PathBuf::from(uri.path())) {
+                    if config.diagnostic.show_warnings {
+                        diagnostics_to_publish.extend(diagnostics.warnings.clone());
+                    }
+                    if config.diagnostic.show_errors {
+                        diagnostics_to_publish.extend(diagnostics.errors.clone());
+                    }
                 }
             }
         }
@@ -116,8 +119,9 @@ async fn run_blocking_parse_project(
         // Lock the diagnostics result to prevent multiple threads from parsing the project at the same time.
         let mut diagnostics = session.diagnostics.write();
         let parse_result = session::parse_project(&uri)?;
-        *diagnostics = parse_result.diagnostics.clone();
+        let (errors, warnings) = parse_result.diagnostics.clone();
         session.write_parse_result(parse_result);
+        *diagnostics = get_diagnostics(&warnings, &errors, &session.engines.read().se());
         Ok(())
     })
     .await

--- a/sway-lsp/tests/fixtures/diagnostics/multi_file/Forc.toml
+++ b/sway-lsp/tests/fixtures/diagnostics/multi_file/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "multi_file"
+entry = "main.sw"
+implicit-std = false
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/tests/fixtures/diagnostics/multi_file/expected.json
+++ b/sway-lsp/tests/fixtures/diagnostics/multi_file/expected.json
@@ -1,0 +1,7 @@
+{
+  "jsonrpc": "2.0",
+  "method": "textDocument/publishDiagnostics",
+  "params": {
+    "diagnostics": []
+  }
+}

--- a/sway-lsp/tests/fixtures/diagnostics/multi_file/src/adt_tests.sw
+++ b/sway-lsp/tests/fixtures/diagnostics/multi_file/src/adt_tests.sw
@@ -1,0 +1,58 @@
+library;
+
+struct Point {
+    x: u64,
+    y: u64
+}
+
+pub fn point_test() {
+    let p = Point {
+        x: 3,
+        y: 4,
+    };
+    // should fail
+    let foo = match p {
+        Point { x: 3, y } => { y },
+        Point { x: 3, y: 4 } => { 24 },
+    };
+    // should succeed
+    let foo = match p {
+        Point { x: 3, y } => { y },
+        Point { x: 3, y: 4 } => { 24 },
+        Point { x, y } => { x },
+    };
+    // should succeed
+    let foo = match p {
+        Point { x: 3, y } => { y },
+        Point { x: 3, y: 4 } => { 24 },
+        a => { 24 },
+    };
+    // should succeed
+    let foo = match p {
+        Point { x: 3, y } => { y },
+        Point { x: 3, y: 4 } => { 24 },
+        _ => { 24 },
+    };
+}
+
+struct CrazyPoint {
+    p1: Point,
+    p2: Point
+}
+
+pub fn crazy_point_test() {
+    let p = CrazyPoint {
+        p1: Point {
+            x: 100,
+            y: 200
+        },
+        p2: Point {
+            x: 300,
+            y: 400
+        }
+    };
+    // should fail
+    let foo = match p {
+        CrazyPoint { p1: Point { x: 0, y: 1 }, p2 } => { 42 },
+    };
+}

--- a/sway-lsp/tests/fixtures/diagnostics/multi_file/src/complex_tests.sw
+++ b/sway-lsp/tests/fixtures/diagnostics/multi_file/src/complex_tests.sw
@@ -1,0 +1,137 @@
+library;
+
+fn a(x: u64) -> u64 {
+    match x {
+        7 => { 0 },
+        _ => { 1 },
+    }
+}
+
+fn b(x: u64) -> u64 {
+    match x {
+        14 => { 7 },
+        _ => { 1 },
+    }
+}
+
+fn c(x: u64) -> u64 {
+    match x {
+        21 => { 7 },
+        _ => { 1 },
+    }
+}
+
+pub fn nested_match_tests() {
+    // should succeed
+    let foo = match (match 1 {
+            1 => { 1 },
+            _ => { 0 },
+        }) {
+        0 => { 42 },
+        _ => { 0 },
+    };
+    assert(foo == 0);
+
+    // should succeed
+    let q = 21;
+    let foo = match a(match q {
+        14 => { b(q) },
+        21 => { c(q) },
+        _ => { q },
+    }) {
+        0 => { 42 },
+        _ => { 24 },
+    };
+    assert(foo == 42);
+}
+
+const ORACLE_1: u64 = 1;
+const ORACLE_3: u64 = 3;
+
+struct MyAddress {
+    inner: u64,
+}
+
+struct MyContractId {
+    inner: bool
+}
+
+enum MyIdentity {
+    Address: MyAddress,
+    ContractId: MyContractId,
+}
+
+enum MyAuthError {
+    ReasonOne: (),
+    ReasonTwo: (),
+}
+
+pub fn enum_match_exp_bugfix_test() {
+    let a: Result<MyIdentity, MyAuthError> = Ok(
+        MyIdentity::Address(
+            MyAddress { inner: 7 }
+        )
+    );
+
+    // should fail with non-exhaustive
+    let b = match a {
+        Ok(MyIdentity::Address(_)) => 1,
+        // missing Ok(MyIdentity::ContractId(_))
+        Err(_) => 5,
+    };
+
+    // should succeed
+    let c = match a {
+        Ok(MyIdentity::Address(_)) => 1,
+        Ok(MyIdentity::ContractId(_)) => 4,
+        Err(_) => 5,
+    };
+    assert(c == 4);
+
+    // should fail with non-exhaustive
+    let d = match a {
+        Ok(MyIdentity::Address(MyAddress { inner: ORACLE_1 })) => 1,
+        // missing Ok(MyIdentity::Address(MyAddress { inner: 0, 2..MAX }))
+        Ok(MyIdentity::ContractId(_)) => 4,
+        Err(_) => 5,
+    };
+
+    // should fail with non-exhaustive
+    let e = match a {
+        Ok(MyIdentity::Address(MyAddress { inner: ORACLE_1 })) => 1,
+        // missing Ok(MyIdentity::ContractId(_))
+        Err(_) => 5,
+    };
+
+    // should fail with non-exhaustive
+    let f = match a {
+        Ok(MyIdentity::Address(MyAddress { inner: ORACLE_1 })) => 1,
+        Ok(MyIdentity::ContractId(_)) => 2,
+        // missing Ok(MyIdentity::Address(MyAddress { inner: 0, 2..MAX }))
+        Err(_) => 5,
+    };
+
+    // should fail with non-exhaustive
+    let g = match a {
+        Ok(MyIdentity::Address(MyAddress { inner: ORACLE_1 })) => 1,
+        Ok(MyIdentity::ContractId(_)) => 2,
+        Ok(MyIdentity::Address(MyAddress { inner: ORACLE_3 })) => 3,
+        // missing Ok(MyIdentity::Address(MyAddress { inner: 0, 2, 4..MAX }))
+        Err(_) => 5,
+    };
+}
+
+pub fn enum_match_exp_bugfix_test2() {
+    let a: Result<MyIdentity, MyAuthError> = Ok(
+        MyIdentity::ContractId(
+            MyContractId { inner: false }
+        )
+    );
+
+    // should succeed
+    let b = match a.unwrap() {
+        MyIdentity::Address(_) => 1,
+        MyIdentity::ContractId(_) => 2,
+    };
+    assert(b == 2);
+}

--- a/sway-lsp/tests/fixtures/diagnostics/multi_file/src/main.sw
+++ b/sway-lsp/tests/fixtures/diagnostics/multi_file/src/main.sw
@@ -1,0 +1,25 @@
+script;
+
+mod primitive_tests;
+mod adt_tests;
+mod complex_tests;
+mod or_patterns;
+
+use primitive_tests::*;
+use adt_tests::*;
+use complex_tests::*;
+use or_patterns::*;
+
+fn main() -> u64 {
+    simple_numbers_test();
+    simple_tuples_test();
+    point_test();
+    crazy_point_test();
+    variable_not_found_test();
+    nested_match_tests();
+    enum_match_exp_bugfix_test();
+    enum_match_exp_bugfix_test2();
+    or_patterns_test();
+
+    42u64
+}

--- a/sway-lsp/tests/fixtures/diagnostics/multi_file/src/or_patterns.sw
+++ b/sway-lsp/tests/fixtures/diagnostics/multi_file/src/or_patterns.sw
@@ -1,0 +1,61 @@
+library;
+
+struct A {
+    a: u64,
+    b: u64,
+}
+
+struct B {
+    a: A,
+    b: u64,
+}
+
+pub fn or_patterns_test() {
+    match 0 {
+        1 | 2 => (),
+        0 => (),
+    }
+
+    let a = A { a: 1, b: 2 };
+
+
+    match a {
+        A { a, b: 2 } => (),
+        A { a, b: 1 } => (),
+        A  { a: 1, b: _ } => (),
+    }
+
+    match a {
+        A { a, b: 2 } | A { a, b: 1 } => (),
+        A  { a: 1, b: 0 } => (),
+        A  { a: 2, b: _ } => (),
+        A { a, b: 3 } => (),
+    }
+
+    let b = B { a, b: 1 };
+
+    match b {
+        B {
+            a: A { a, b: 2 } | A { a, b: 1 },
+            b: _,
+        } => (),
+        B {
+            a: _,
+            b: 1,
+        } => (),
+    }
+
+    match b {
+        B {
+            a: A { a, b: 2 } ,
+            b: _,
+        } | B {
+            a: A { a, b: 1 },
+            b: _,
+        } => (),
+        B {
+            a: _,
+            b: 1,
+        } => (),
+    }
+}

--- a/sway-lsp/tests/fixtures/diagnostics/multi_file/src/primitive_tests.sw
+++ b/sway-lsp/tests/fixtures/diagnostics/multi_file/src/primitive_tests.sw
@@ -1,0 +1,61 @@
+library;
+
+pub fn simple_numbers_test() {
+    let x = 0;
+    // should fail
+    let y = match x {
+        0 => { 0 },
+        10 => { 0 },
+        5 => { 0 },
+        10 => { 0 },
+    };
+    // should succeed
+    let y = match x {
+        0 => { 0 },
+        1 => { 0 },
+        _ => { 0 },
+    };
+    // should succeed
+    let y = match x {
+        0 => { 0 },
+        1 => { 0 },
+        a => { a },
+    };
+}
+
+pub fn simple_tuples_test() {
+    let x = (1, 2);
+    // should fail
+    let y = match x {
+        (0, 0) => { 0 },
+        (1, 1) => { 0 },
+        (1, 1) => { 0 },
+        (1, 2) => { 0 },
+    };
+    // should succeed
+    let y = match x {
+        (0, 0) => { 0 },
+        (1, 1) => { 0 },
+        _ => { 0 },
+    };
+    // should succeed
+    let y = match x {
+        (0, 0) => { 0 },
+        (1, 1) => { 0 },
+        a => { 0 },
+    };
+    // should succeed
+    let y = match x {
+        (0, 0) => { 0 },
+        (1, 1) => { 0 },
+        (a, b) => { 0 },
+    };
+}
+
+pub fn variable_not_found_test() {
+    // should fail
+    let foo = match 42 {
+        0 => { newvariable},
+        foo => { foo },
+    };
+}

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -1643,6 +1643,23 @@ async fn publish_diagnostics_dead_code_warning() {
     shutdown_and_exit(&mut service).await;
 }
 
+#[tokio::test]
+async fn publish_diagnostics_multi_file() {
+    let (mut service, socket) = LspService::new(ServerState::new);
+    let fixture = get_fixture(test_fixtures_dir().join("diagnostics/multi_file/expected.json"));
+    let expected_requests = vec![fixture];
+    let socket_handle = assert_server_requests(socket, expected_requests).await;
+    let _ = init_and_open(
+        &mut service,
+        test_fixtures_dir().join("diagnostics/multi_file/src/main.sw"),
+    )
+    .await;
+    socket_handle
+        .await
+        .unwrap_or_else(|e| panic!("Test failed: {e:?}"));
+    shutdown_and_exit(&mut service).await;
+}
+
 // This macro allows us to spin up a server / client for testing
 // It initializes and performs the necessary handshake and then loads
 // the sway example that was passed into `example_dir`.


### PR DESCRIPTION
## Description

Closes https://github.com/FuelLabs/sway/issues/5027

Now instead of caching the `Diagnostics` object, we cache a mapping of file path -> `Diagnostics`

When we publish diagnostics, we only publishing the diagnostics for the given URI, not for the entire project. I added a test where there are no diagnostics in the main.sw file, but a bunch of diagnostics in the other files in the project.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
