### PR TITLE
LSP: Don't recompile workspace when moving between files

### DIFF
--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -15,9 +15,14 @@ pub async fn handle_did_open_text_document(
         .sessions
         .uri_and_session_from_workspace(&params.text_document.uri)?;
     session.handle_open_file(&uri);
-    state
-        .parse_project(uri, params.text_document.uri, session.clone())
-        .await;
+    // If the token map is empty, then we need to parse the project.
+    // Otherwise, don't recompile the project when a new file in the project is opened
+    // as the workspace is already compiled.
+    if session.token_map().is_empty() {
+        state
+            .parse_project(uri, params.text_document.uri, session.clone())
+            .await;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Description
We have been unnecessarily recompiling the whole workspace when a user moves between different files. As the whole workspace is already compiled and traversed this was hugely unnecessary. Feels so much nicer moving between files now. 

closes #5031

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
