### PR TITLE
Remove dummy spans

### DIFF
--- a/forc-plugins/forc-doc/src/doc/descriptor.rs
+++ b/forc-plugins/forc-doc/src/doc/descriptor.rs
@@ -58,12 +58,12 @@ impl Descriptor {
                         item_header: ItemHeader {
                             module_info: module_info.clone(),
                             friendly_name: ty_decl.friendly_type_name(),
-                            item_name: item_name.clone(),
+                            item_name: item_name.to_string(),
                         },
                         item_body: ItemBody {
                             module_info,
                             ty_decl: ty_decl.clone(),
-                            item_name,
+                            item_name: item_name.to_string(),
                             code_str: parse::parse_format::<sway_ast::ItemStruct>(
                                 struct_decl.span.as_str(),
                             )?,
@@ -95,12 +95,12 @@ impl Descriptor {
                         item_header: ItemHeader {
                             module_info: module_info.clone(),
                             friendly_name: ty_decl.friendly_type_name(),
-                            item_name: item_name.clone(),
+                            item_name: item_name.to_string(),
                         },
                         item_body: ItemBody {
                             module_info,
                             ty_decl: ty_decl.clone(),
-                            item_name,
+                            item_name: item_name.to_string(),
                             code_str: parse::parse_format::<sway_ast::ItemEnum>(
                                 enum_decl.span.as_str(),
                             )?,
@@ -119,7 +119,7 @@ impl Descriptor {
                 if !document_private_items && trait_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
                 } else {
-                    let item_name = trait_decl.name;
+                    let item_name = trait_decl.name.to_string();
                     let attrs_opt = (!trait_decl.attributes.is_empty())
                         .then(|| trait_decl.attributes.to_html_string());
                     let context =
@@ -143,7 +143,7 @@ impl Descriptor {
                         item_header: ItemHeader {
                             module_info: module_info.clone(),
                             friendly_name: ty_decl.friendly_type_name(),
-                            item_name: item_name.clone(),
+                            item_name: item_name.to_string(),
                         },
                         item_body: ItemBody {
                             module_info,
@@ -164,7 +164,7 @@ impl Descriptor {
             }
             ty::TyDecl::AbiDecl(ty::AbiDecl { decl_id, .. }) => {
                 let abi_decl = decl_engine.get_abi(decl_id);
-                let item_name = abi_decl.name;
+                let item_name = abi_decl.name.to_string();
                 let attrs_opt =
                     (!abi_decl.attributes.is_empty()).then(|| abi_decl.attributes.to_html_string());
                 let context = (!abi_decl.interface_surface.is_empty()).then_some(Context::new(
@@ -187,7 +187,7 @@ impl Descriptor {
                     item_header: ItemHeader {
                         module_info: module_info.clone(),
                         friendly_name: ty_decl.friendly_type_name(),
-                        item_name: item_name.clone(),
+                        item_name: item_name.to_string(),
                     },
                     item_body: ItemBody {
                         module_info,
@@ -205,9 +205,7 @@ impl Descriptor {
             }
             ty::TyDecl::StorageDecl(ty::StorageDecl { decl_id, .. }) => {
                 let storage_decl = decl_engine.get_storage(decl_id);
-                let item_name = sway_types::BaseIdent::new_no_trim(
-                    sway_types::span::Span::from_string(CONTRACT_STORAGE.to_string()),
-                );
+                let item_name = CONTRACT_STORAGE.to_string();
                 let attrs_opt = (!storage_decl.attributes.is_empty())
                     .then(|| storage_decl.attributes.to_html_string());
                 let context = (!storage_decl.fields.is_empty()).then_some(Context::new(
@@ -271,7 +269,7 @@ impl Descriptor {
                 if !document_private_items && fn_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
                 } else {
-                    let item_name = fn_decl.name;
+                    let item_name = fn_decl.name.to_string();
                     let attrs_opt = (!fn_decl.attributes.is_empty())
                         .then(|| fn_decl.attributes.to_html_string());
 
@@ -280,7 +278,7 @@ impl Descriptor {
                         item_header: ItemHeader {
                             module_info: module_info.clone(),
                             friendly_name: ty_decl.friendly_type_name(),
-                            item_name: item_name.clone(),
+                            item_name: item_name.to_string(),
                         },
                         item_body: ItemBody {
                             module_info,
@@ -304,7 +302,7 @@ impl Descriptor {
                 if !document_private_items && const_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
                 } else {
-                    let item_name = const_decl.call_path.suffix;
+                    let item_name = const_decl.call_path.suffix.to_string();
                     let attrs_opt = (!const_decl.attributes.is_empty())
                         .then(|| const_decl.attributes.to_html_string());
 
@@ -313,7 +311,7 @@ impl Descriptor {
                         item_header: ItemHeader {
                             module_info: module_info.clone(),
                             friendly_name: ty_decl.friendly_type_name(),
-                            item_name: item_name.clone(),
+                            item_name: item_name.to_string(),
                         },
                         item_body: ItemBody {
                             module_info,

--- a/forc-plugins/forc-doc/src/render/item/components.rs
+++ b/forc-plugins/forc-doc/src/render/item/components.rs
@@ -9,7 +9,6 @@ use crate::{
 use anyhow::Result;
 use horrorshow::{box_html, Raw, RenderBox};
 use sway_core::language::ty::TyDecl;
-use sway_types::BaseIdent;
 
 /// All necessary components to render the header portion of
 /// the item html doc.
@@ -17,7 +16,7 @@ use sway_types::BaseIdent;
 pub(crate) struct ItemHeader {
     pub(crate) module_info: ModuleInfo,
     pub(crate) friendly_name: &'static str,
-    pub(crate) item_name: BaseIdent,
+    pub(crate) item_name: String,
 }
 impl Renderable for ItemHeader {
     /// Basic HTML header component
@@ -73,7 +72,7 @@ pub(crate) struct ItemBody {
     /// The item name varies depending on type.
     /// We store it during info gathering to avoid
     /// multiple match statements.
-    pub(crate) item_name: BaseIdent,
+    pub(crate) item_name: String,
     pub(crate) code_str: String,
     pub(crate) attrs_opt: Option<String>,
     pub(crate) item_context: ItemContext,

--- a/forc-plugins/forc-doc/src/render/mod.rs
+++ b/forc-plugins/forc-doc/src/render/mod.rs
@@ -16,7 +16,6 @@ use anyhow::Result;
 use horrorshow::{box_html, helper::doctype, html, prelude::*};
 use std::collections::BTreeMap;
 use sway_core::{language::ty::TyProgramKind, transform::AttributesMap};
-use sway_types::BaseIdent;
 
 pub mod constant;
 mod index;
@@ -275,6 +274,6 @@ pub(crate) enum DocStyle {
     ModuleIndex,
     Item {
         title: Option<BlockTitle>,
-        name: Option<BaseIdent>,
+        name: Option<String>,
     },
 }

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -49,4 +49,4 @@ whoami = "1.1"
 default = []
 test = []
 util = []
-uwu = ["uwuify"]
+uwu = ["uwuify", "sway-error/uwu"]

--- a/sway-ast/src/item/item_configurable.rs
+++ b/sway-ast/src/item/item_configurable.rs
@@ -30,5 +30,6 @@ impl Spanned for ConfigurableField {
             self.eq_token.span(),
             self.initializer.span(),
         ])
+        .unwrap()
     }
 }

--- a/sway-ast/src/item/item_const.rs
+++ b/sway-ast/src/item/item_const.rs
@@ -8,7 +8,7 @@ pub struct ItemConst {
     pub ty_opt: Option<(ColonToken, Ty)>,
     pub eq_token_opt: Option<EqToken>,
     pub expr_opt: Option<Expr>,
-    pub semicolon_token: SemicolonToken,
+    pub semicolon_token: Option<SemicolonToken>,
 }
 
 impl Spanned for ItemConst {

--- a/sway-ast/src/item/item_storage.rs
+++ b/sway-ast/src/item/item_storage.rs
@@ -30,5 +30,6 @@ impl Spanned for StorageField {
             self.eq_token.span(),
             self.initializer.span(),
         ])
+        .unwrap()
     }
 }

--- a/sway-ast/src/item/item_trait.rs
+++ b/sway-ast/src/item/item_trait.rs
@@ -7,7 +7,7 @@ pub enum ItemTraitItem {
     Fn(FnSignature, Option<SemicolonToken>),
     Const(ItemConst, Option<SemicolonToken>),
     // to handle parser recovery: Error represents an incomplete trait item
-    Error(Box<[Span]>, #[serde(skip_serializing)] ErrorEmitted),
+    Error(Span, #[serde(skip_serializing)] ErrorEmitted),
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -49,7 +49,7 @@ impl Spanned for ItemTraitItem {
                     None => const_decl.span(),
                 }
             }
-            ItemTraitItem::Error(spans, _) => Span::join_all(spans.iter().cloned()),
+            ItemTraitItem::Error(span, _) => span.clone(),
         }
     }
 }

--- a/sway-ast/src/item/mod.rs
+++ b/sway-ast/src/item/mod.rs
@@ -41,7 +41,7 @@ pub enum ItemKind {
     Configurable(ItemConfigurable),
     TypeAlias(ItemTypeAlias),
     // to handle parser recovery: Error represents an incomplete item
-    Error(Box<[Span]>, #[serde(skip_serializing)] ErrorEmitted),
+    Error(Span, #[serde(skip_serializing)] ErrorEmitted),
 }
 
 impl Spanned for ItemKind {
@@ -59,7 +59,7 @@ impl Spanned for ItemKind {
             ItemKind::Storage(item_storage) => item_storage.span(),
             ItemKind::Configurable(item_configurable) => item_configurable.span(),
             ItemKind::TypeAlias(item_type_alias) => item_type_alias.span(),
-            ItemKind::Error(spans, _) => Span::join_all(spans.iter().cloned()),
+            ItemKind::Error(span, _) => span.clone(),
         }
     }
 }

--- a/sway-ast/src/keywords.rs
+++ b/sway-ast/src/keywords.rs
@@ -107,14 +107,6 @@ macro_rules! define_token (
             span: Span,
         }
 
-        impl Default for $ty_name {
-            fn default() -> Self {
-                Self {
-                    span: Span::dummy()
-                }
-            }
-        }
-
         impl Spanned for $ty_name {
             fn span(&self) -> Span {
                 self.span.clone()

--- a/sway-ast/src/statement.rs
+++ b/sway-ast/src/statement.rs
@@ -12,7 +12,7 @@ pub enum Statement {
         semicolon_token_opt: Option<SemicolonToken>,
     },
     // to handle parser recovery: Error represents an unknown statement
-    Error(Box<[Span]>, #[serde(skip_serializing)] ErrorEmitted),
+    Error(Span, #[serde(skip_serializing)] ErrorEmitted),
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -37,7 +37,7 @@ impl Spanned for Statement {
                 None => expr.span(),
                 Some(semicolon_token) => Span::join(expr.span(), semicolon_token.span()),
             },
-            Statement::Error(spans, _) => Span::join_all(spans.iter().cloned()),
+            Statement::Error(span, _) => span.clone(),
         }
     }
 }

--- a/sway-core/src/asm_generation/finalized_asm.rs
+++ b/sway-core/src/asm_generation/finalized_asm.rs
@@ -66,7 +66,7 @@ impl FinalizedAsm {
             InstructionSet::Evm { ops } => {
                 let mut assembler = Assembler::new();
                 if let Err(e) = assembler.push_all(ops.clone()) {
-                    Err(handler.emit_err(CompileError::InternalOwned(e.to_string(), Span::dummy())))
+                    Err(handler.emit_err(CompileError::InternalOwned(e.to_string(), None)))
                 } else {
                     Ok(CompiledBytecode {
                         bytecode: assembler.take(),

--- a/sway-core/src/asm_generation/fuel/abstract_instruction_set.rs
+++ b/sway-core/src/asm_generation/fuel/abstract_instruction_set.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 
 use sway_error::error::CompileError;
-use sway_types::Span;
 
 use std::{collections::HashSet, fmt};
 
@@ -154,7 +153,7 @@ impl AbstractInstructionSet {
                 .join(", ");
             Err(CompileError::InternalOwned(
                 format!("Program erroneously uses uninitialized virtual registers: {bad_regs}"),
-                Span::dummy(),
+                None,
             ))
         }
     }

--- a/sway-core/src/asm_generation/fuel/register_allocator.rs
+++ b/sway-core/src/asm_generation/fuel/register_allocator.rs
@@ -734,7 +734,7 @@ pub(crate) fn allocate_registers(
                                      Using #[inline(never)] on some functions may help.",
                             comment
                         ),
-                        Span::dummy(),
+                        None,
                     ));
                 }
                 try_count += 1;

--- a/sway-core/src/ir_generation.rs
+++ b/sway-core/src/ir_generation.rs
@@ -9,7 +9,6 @@ mod types;
 
 use sway_error::error::CompileError;
 use sway_ir::{Context, Kind};
-use sway_types::span::Span;
 
 pub(crate) use purity::{check_function_purity, PurityEnv};
 
@@ -101,9 +100,6 @@ pub fn compile_program<'eng>(
     //println!("{ctx}");
 
     ctx.verify().map_err(|ir_error: sway_ir::IrError| {
-        vec![CompileError::InternalOwned(
-            ir_error.to_string(),
-            Span::dummy(),
-        )]
+        vec![CompileError::InternalOwned(ir_error.to_string(), None)]
     })
 }

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -552,7 +552,7 @@ fn compile_abi_method(
                         "Cannot generate selector for ABI method: {}",
                         ast_fn_decl.name.as_str()
                     ),
-                    ast_fn_decl.name.span(),
+                    Some(ast_fn_decl.name.span()),
                 )])
             };
         }

--- a/sway-core/src/ir_generation/convert.rs
+++ b/sway-core/src/ir_generation/convert.rs
@@ -64,9 +64,9 @@ pub(super) fn convert_resolved_typeid(
         type_engine,
         decl_engine,
         context,
-        &type_engine
-            .to_typeinfo(*ast_type, span)
-            .map_err(|ty_err| CompileError::InternalOwned(format!("{ty_err:?}"), span.clone()))?,
+        &type_engine.to_typeinfo(*ast_type, span).map_err(|ty_err| {
+            CompileError::InternalOwned(format!("{ty_err:?}"), Some(span.clone()))
+        })?,
         span,
     )
 }

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -258,7 +258,7 @@ impl<'eng> FnCompiler<'eng> {
         let tmp_var = self
             .function
             .new_local_var(context, temp_name, ty, None, false)
-            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), Span::dummy()))?;
+            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), None))?;
         let tmp_val = self.current_block.ins(context).get_local(tmp_var);
         self.current_block.ins(context).store(tmp_val, val);
 
@@ -487,9 +487,7 @@ impl<'eng> FnCompiler<'eng> {
             let key_var = compiler
                 .function
                 .new_local_var(context, key_name, Type::get_b256(context), None, false)
-                .map_err(|ir_error| {
-                    CompileError::InternalOwned(ir_error.to_string(), Span::dummy())
-                })?;
+                .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), None))?;
 
             // Convert the key variable to a value using get_local.
             let key_val = compiler
@@ -918,9 +916,7 @@ impl<'eng> FnCompiler<'eng> {
                         None,
                         false,
                     )
-                    .map_err(|ir_error| {
-                        CompileError::InternalOwned(ir_error.to_string(), Span::dummy())
-                    })?;
+                    .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), None))?;
 
                 // Step 4: Convert the local variable into a value via `get_local`.
                 let message = self
@@ -1128,7 +1124,7 @@ impl<'eng> FnCompiler<'eng> {
                         .function
                         .new_local_var(context, temp_arg_name, arg0_type, None, false)
                         .map_err(|ir_error| {
-                            CompileError::InternalOwned(ir_error.to_string(), Span::dummy())
+                            CompileError::InternalOwned(ir_error.to_string(), None)
                         })?;
 
                     let temp_val = self.current_block.ins(context).get_local(temp_var);
@@ -1159,9 +1155,7 @@ impl<'eng> FnCompiler<'eng> {
                         None,
                         false,
                     )
-                    .map_err(|ir_error| {
-                        CompileError::InternalOwned(ir_error.to_string(), Span::dummy())
-                    })?;
+                    .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), None))?;
 
                 // Initialise each of the fields in the user args struct.
                 let user_args_struct_val = self
@@ -1212,7 +1206,7 @@ impl<'eng> FnCompiler<'eng> {
                 None,
                 false,
             )
-            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), Span::dummy()))?;
+            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), None))?;
 
         let ra_struct_ptr_val = self
             .current_block
@@ -1291,9 +1285,7 @@ impl<'eng> FnCompiler<'eng> {
                 let tmp_var = self
                     .function
                     .new_local_var(context, tmp_asset_id_name, b256_ty, None, false)
-                    .map_err(|ir_error| {
-                        CompileError::InternalOwned(ir_error.to_string(), Span::dummy())
-                    })?;
+                    .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), None))?;
                 let tmp_val = self.current_block.ins(context).get_local(tmp_var);
                 self.current_block.ins(context).store(tmp_val, asset_id_val);
                 tmp_val
@@ -1731,7 +1723,7 @@ impl<'eng> FnCompiler<'eng> {
         } else {
             Err(CompileError::InternalOwned(
                 format!("Unable to resolve variable '{}'.", name.as_str()),
-                Span::dummy(),
+                None,
             ))
         }
     }
@@ -1779,7 +1771,7 @@ impl<'eng> FnCompiler<'eng> {
         let local_var = self
             .function
             .new_local_var(context, local_name, return_type, None, mutable)
-            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), Span::dummy()))?;
+            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), None))?;
 
         // We can have empty aggregates, especially arrays, which shouldn't be initialised, but
         // otherwise use a store.
@@ -1851,9 +1843,7 @@ impl<'eng> FnCompiler<'eng> {
                 let local_var = self
                     .function
                     .new_local_var(context, local_name, return_type, None, false)
-                    .map_err(|ir_error| {
-                        CompileError::InternalOwned(ir_error.to_string(), Span::dummy())
-                    })?;
+                    .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), None))?;
 
                 // We can have empty aggregates, especially arrays, which shouldn't be initialised, but
                 // otherwise use a store.
@@ -1907,7 +1897,7 @@ impl<'eng> FnCompiler<'eng> {
             .ok_or_else(|| {
                 CompileError::InternalOwned(
                     format!("variable not found: {name}"),
-                    ast_reassignment.lhs_base_name.span(),
+                    Some(ast_reassignment.lhs_base_name.span()),
                 )
             })?;
 
@@ -1954,7 +1944,7 @@ impl<'eng> FnCompiler<'eng> {
                                                 in reassignment.",
                                             struct_call_path.suffix.as_str(),
                                         ),
-                                        ast_reassignment.lhs_base_name.span(),
+                                        Some(ast_reassignment.lhs_base_name.span()),
                                     )
                                 })
                                 .map(|(field_idx, field_type_id)| {
@@ -2024,7 +2014,7 @@ impl<'eng> FnCompiler<'eng> {
         let array_var = self
             .function
             .new_local_var(context, temp_name, array_type, None, false)
-            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), Span::dummy()))?;
+            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), None))?;
         let array_value = self
             .current_block
             .ins(context)
@@ -2158,7 +2148,7 @@ impl<'eng> FnCompiler<'eng> {
         let struct_var = self
             .function
             .new_local_var(context, temp_name, struct_type, None, false)
-            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), Span::dummy()))?;
+            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), None))?;
         let struct_val = self
             .current_block
             .ins(context)
@@ -2224,7 +2214,7 @@ impl<'eng> FnCompiler<'eng> {
                         struct_call_path.suffix.as_str(),
                         ast_field.name
                     ),
-                    ast_field.span.clone(),
+                    Some(ast_field.span.clone()),
                 )
             })?;
 
@@ -2272,7 +2262,7 @@ impl<'eng> FnCompiler<'eng> {
         let enum_var = self
             .function
             .new_local_var(context, temp_name, enum_type, None, false)
-            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), Span::dummy()))?;
+            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), None))?;
         let enum_ptr = self
             .current_block
             .ins(context)
@@ -2352,9 +2342,7 @@ impl<'eng> FnCompiler<'eng> {
             let tuple_var = self
                 .function
                 .new_local_var(context, temp_name, tuple_type, None, false)
-                .map_err(|ir_error| {
-                    CompileError::InternalOwned(ir_error.to_string(), Span::dummy())
-                })?;
+                .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), None))?;
             let tuple_val = self
                 .current_block
                 .ins(context)
@@ -2599,7 +2587,7 @@ impl<'eng> FnCompiler<'eng> {
                 None,
                 false,
             )
-            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), Span::dummy()))?;
+            .map_err(|ir_error| CompileError::InternalOwned(ir_error.to_string(), None))?;
         let storage_key = self
             .current_block
             .ins(context)

--- a/sway-core/src/ir_generation/types.rs
+++ b/sway-core/src/ir_generation/types.rs
@@ -161,7 +161,7 @@ pub(super) fn get_indices_for_struct_access(
                     Err(error) => {
                         return Err(CompileError::InternalOwned(
                             format!("type error resolving type for reassignment: {error}"),
-                            field_kind.span(),
+                            Some(field_kind.span()),
                         ));
                     }
                 };
@@ -187,7 +187,7 @@ pub(super) fn get_indices_for_struct_access(
                                         field_kind.pretty_print(),
                                         decl.call_path,
                                     ),
-                                    field_kind.span(),
+                                    Some(field_kind.span()),
                                 ));
                             }
                         };
@@ -205,7 +205,7 @@ pub(super) fn get_indices_for_struct_access(
                                         index,
                                         fields.len(),
                                     ),
-                                    field_kind.span(),
+                                    Some(field_kind.span()),
                                 ));
                             }
                         };

--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -59,7 +59,7 @@ impl<T: Spanned> Spanned for CallPath<T> {
                 })
                 .peekable();
             if prefixes_spans.peek().is_some() {
-                Span::join(Span::join_all(prefixes_spans), self.suffix.span())
+                Span::join(Span::join_all(prefixes_spans).unwrap(), self.suffix.span())
             } else {
                 self.suffix.span()
             }

--- a/sway-core/src/language/parsed/declaration/trait.rs
+++ b/sway-core/src/language/parsed/declaration/trait.rs
@@ -13,7 +13,7 @@ pub enum TraitItem {
     TraitFn(TraitFn),
     Constant(ConstantDeclaration),
     // to handle parser recovery: Error represents an incomplete trait item
-    Error(Box<[Span]>, ErrorEmitted),
+    Error(Span, ErrorEmitted),
 }
 
 #[derive(Debug, Clone)]

--- a/sway-core/src/language/parsed/mod.rs
+++ b/sway-core/src/language/parsed/mod.rs
@@ -63,9 +63,7 @@ pub enum AstNodeContent {
     /// A malformed statement.
     ///
     /// Used for parser recovery when we cannot form a more specific node.
-    /// The list of `Span`s are for consumption by the LSP and are,
-    /// when joined, the same as that stored in `statement.span`.
-    Error(Box<[Span]>, ErrorEmitted),
+    Error(Span, ErrorEmitted),
 }
 
 impl ParseTree {

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -334,7 +334,7 @@ pub enum TyAstNodeContent {
     ImplicitReturnExpression(TyExpression),
     // a no-op node used for something that just issues a side effect, like an import statement.
     SideEffect(TySideEffect),
-    Error(Box<[Span]>, ErrorEmitted),
+    Error(Span, ErrorEmitted),
 }
 
 impl EqWithEngines for TyAstNodeContent {}

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -773,10 +773,7 @@ pub(crate) fn compile_ast_to_ir_to_asm(
 
     // Run the passes.
     let res = if let Err(ir_error) = pass_mgr.run(&mut ir, &pass_group) {
-        Err(handler.emit_err(CompileError::InternalOwned(
-            ir_error.to_string(),
-            span::Span::dummy(),
-        )))
+        Err(handler.emit_err(CompileError::InternalOwned(ir_error.to_string(), None)))
     } else {
         Ok(())
     };

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -63,7 +63,7 @@ impl ty::TyFunctionDecl {
         if ctx.functions_disallowed() {
             return Err(handler.emit_err(CompileError::Unimplemented(
                 "Nested function definitions are not allowed at this time.",
-                span,
+                Some(span),
             )));
         }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -1007,7 +1007,7 @@ fn handle_supertraits(
                     if !trait_decl.type_parameters.is_empty() {
                         handler.emit_err(CompileError::Unimplemented(
                             "Using generic traits as supertraits is not supported yet.",
-                            supertrait.name.span(),
+                            Some(supertrait.name.span()),
                         ));
                         continue;
                     }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
@@ -55,7 +55,7 @@ pub(crate) fn insert_supertraits_into_namespace(
                     if !trait_decl.type_parameters.is_empty() {
                         handler.emit_err(CompileError::Unimplemented(
                             "Using generic traits as supertraits is not supported yet.",
-                            supertrait.name.span(),
+                            Some(supertrait.name.span()),
                         ));
                         continue;
                     }

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -157,7 +157,7 @@ fn type_check_variable(
                 None => {
                     return Err(handler.emit_err(CompileError::Unimplemented(
                         "constant values of this type are not supported yet",
-                        span,
+                        Some(span),
                     )));
                 }
             };

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -2,7 +2,7 @@ use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
 };
-use sway_types::{Ident, Span, Spanned};
+use sway_types::{Ident, MaybeSpanned, Span, Spanned};
 
 use crate::{
     decl_engine::DeclRefStruct,
@@ -40,7 +40,7 @@ pub(crate) fn struct_instantiation(
         return Err(
             handler.emit_err(CompileError::DoesNotTakeTypeArgumentsAsPrefix {
                 name: suffix,
-                span: type_arguments.span(),
+                span: type_arguments.try_span(),
             }),
         );
     }

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -156,7 +156,7 @@ impl ty::TyAstNode {
                         .unwrap_or_else(|err| ty::TyExpression::error(err, expr.span(), engines));
                     ty::TyAstNodeContent::ImplicitReturnExpression(typed_expr)
                 }
-                AstNodeContent::Error(spans, err) => ty::TyAstNodeContent::Error(spans, err),
+                AstNodeContent::Error(span, err) => ty::TyAstNodeContent::Error(span, err),
             },
             span: node.span,
         };

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -132,11 +132,8 @@ impl Items {
                             variable_or_constant: "Variable".to_string(),
                             name: name.clone(),
                             constant_span: constant_ident.span(),
-                            constant_decl: if is_imported_constant {
-                                constant_decl.decl_span.clone()
-                            } else {
-                                Span::dummy()
-                            },
+                            constant_decl: is_imported_constant
+                                .then_some(constant_decl.decl_span.clone()),
                             is_alias,
                         });
                     }
@@ -153,11 +150,8 @@ impl Items {
                             variable_or_constant: "Constant".to_string(),
                             name: name.clone(),
                             constant_span: constant_ident.span(),
-                            constant_decl: if is_imported_constant {
-                                constant_decl.decl_span.clone()
-                            } else {
-                                Span::dummy()
-                            },
+                            constant_decl: is_imported_constant
+                                .then_some(constant_decl.decl_span.clone()),
                             is_alias,
                         });
                     }

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -10,8 +10,8 @@ use crate::{
 use sway_error::error::CompileError;
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::integer_bits::IntegerBits;
-use sway_types::Spanned;
 use sway_types::{ident::Ident, span::Span};
+use sway_types::{MaybeSpanned, Spanned};
 
 // -------------------------------------------------------------------------------------------------
 /// Take a list of nodes and reorder them so that they may be semantically analysed without any
@@ -36,7 +36,7 @@ pub(crate) fn order_ast_nodes_by_dependency(
     handler.scope(|handler| {
         // Because we're pulling these errors out of a HashMap they'll probably be in a funny
         // order.  Here we'll sort them by span start.
-        errors.sort_by_key(|err| err.span().start());
+        errors.sort_by_key(|err| err.try_span().map(|s| s.start()).unwrap_or_default());
 
         for err in errors {
             handler.emit_err(err);

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -600,7 +600,7 @@ fn item_trait_to_trait_declaration(
                     context, handler, engines, const_decl, attributes, false,
                 )
                 .map(TraitItem::Constant),
-                ItemTraitItem::Error(spans, error) => Ok(TraitItem::Error(spans, error)),
+                ItemTraitItem::Error(span, error) => Ok(TraitItem::Error(span, error)),
             }?))
         })
         .filter_map_ok(|item| item)
@@ -2391,10 +2391,9 @@ fn statement_to_ast_nodes(
         Statement::Expr { expr, .. } => {
             vec![expr_to_ast_node(context, handler, engines, expr, true)?]
         }
-        Statement::Error(spans, error) => {
-            let span = Span::join_all(spans.iter().cloned());
+        Statement::Error(span, error) => {
             vec![AstNode {
-                content: AstNodeContent::Error(spans, error),
+                content: AstNodeContent::Error(span.clone(), error),
                 span,
             }]
         }
@@ -2556,7 +2555,7 @@ fn path_type_segment_to_ident(
 ) -> Result<Ident, ErrorEmitted> {
     if let Some((_, generic_args)) = generics_opt {
         let error = ConvertParseTreeError::GenericsNotSupportedHere {
-            span: generic_args.span(),
+            span: Some(generic_args.span()),
         };
         return Err(handler.emit_err(error.into()));
     }
@@ -2585,7 +2584,7 @@ fn path_expr_segment_to_ident(
 ) -> Result<Ident, ErrorEmitted> {
     if let Some((_, generic_args)) = generics_opt {
         let error = ConvertParseTreeError::GenericsNotSupportedHere {
-            span: generic_args.span(),
+            span: Some(generic_args.span()),
         };
         return Err(handler.emit_err(error.into()));
     }
@@ -3936,7 +3935,7 @@ fn path_type_to_type_info(
             }
             if let Some((_, generic_args)) = generics_opt {
                 let error = ConvertParseTreeError::GenericsNotSupportedHere {
-                    span: generic_args.span(),
+                    span: Some(generic_args.span()),
                 };
                 return Err(handler.emit_err(error.into()));
             }

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -1,5 +1,5 @@
 use sway_error::handler::{ErrorEmitted, Handler};
-use sway_types::{Span, Spanned};
+use sway_types::{MaybeSpanned, Span, Spanned};
 
 use crate::{
     decl_engine::*,
@@ -119,8 +119,8 @@ impl TypeArgs {
     }
 }
 
-impl Spanned for TypeArgs {
-    fn span(&self) -> Span {
+impl MaybeSpanned for TypeArgs {
+    fn try_span(&self) -> Option<Span> {
         Span::join_all(self.to_vec().iter().map(|t| t.span()))
     }
 }

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -7,7 +7,7 @@ use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
 };
-use sway_types::{Span, Spanned};
+use sway_types::{MaybeSpanned, Span, Spanned};
 
 use crate::{
     engine_threading::*,
@@ -141,8 +141,8 @@ impl TraitConstraint {
                 Span::join_all(
                     self.type_arguments
                         .iter()
-                        .map(|x| x.span())
-                        .collect::<Vec<_>>(),
+                        .filter_map(|x| x.try_span())
+                        .collect::<Vec<Span>>(),
                 ),
             )));
         }

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -1018,7 +1018,7 @@ impl TypeInfo {
             | TypeInfo::Placeholder(_)
             | TypeInfo::TypeParam(_) => Err(handler.emit_err(CompileError::Unimplemented(
                 "matching on this type is unsupported right now",
-                span.clone(),
+                Some(span.clone()),
             ))),
             TypeInfo::ErrorRecovery(err) => Err(*err),
         }
@@ -1056,7 +1056,7 @@ impl TypeInfo {
             | TypeInfo::Placeholder(_)
             | TypeInfo::TypeParam(_) => Err(handler.emit_err(CompileError::Unimplemented(
                 "implementing traits on this type is unsupported right now",
-                span.clone(),
+                Some(span.clone()),
             ))),
             TypeInfo::ErrorRecovery(err) => Err(*err),
         }

--- a/sway-error/src/convert_parse_tree_error.rs
+++ b/sway-error/src/convert_parse_tree_error.rs
@@ -1,4 +1,4 @@
-use sway_types::{Ident, Span, Spanned};
+use sway_types::{Ident, MaybeSpanned, Span};
 use thiserror::Error;
 
 #[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
@@ -8,7 +8,7 @@ pub enum ConvertParseTreeError {
     #[error("functions used in applications may not be arbitrary expressions")]
     FunctionArbitraryExpression { span: Span },
     #[error("generics are not supported here")]
-    GenericsNotSupportedHere { span: Span },
+    GenericsNotSupportedHere { span: Option<Span> },
     #[error("multiple generics are not supported")]
     MultipleGenericsNotSupported { span: Span },
     #[error("tuple index out of range")]
@@ -125,70 +125,74 @@ pub enum ConvertParseTreeError {
     UnexpectedCallPathPrefixAfterQualifiedRoot { span: Span },
 }
 
-impl Spanned for ConvertParseTreeError {
-    fn span(&self) -> Span {
+impl MaybeSpanned for ConvertParseTreeError {
+    fn try_span(&self) -> Option<Span> {
         match self {
-            ConvertParseTreeError::PubUseNotSupported { span } => span.clone(),
-            ConvertParseTreeError::FunctionArbitraryExpression { span } => span.clone(),
+            ConvertParseTreeError::PubUseNotSupported { span } => Some(span.clone()),
+            ConvertParseTreeError::FunctionArbitraryExpression { span } => Some(span.clone()),
             ConvertParseTreeError::GenericsNotSupportedHere { span } => span.clone(),
-            ConvertParseTreeError::MultipleGenericsNotSupported { span } => span.clone(),
-            ConvertParseTreeError::TupleIndexOutOfRange { span } => span.clone(),
-            ConvertParseTreeError::ShlNotImplemented { span } => span.clone(),
-            ConvertParseTreeError::ShrNotImplemented { span } => span.clone(),
-            ConvertParseTreeError::BitXorNotImplemented { span } => span.clone(),
-            ConvertParseTreeError::IntTySuffixNotSupported { span } => span.clone(),
-            ConvertParseTreeError::IntLiteralOutOfRange { span } => span.clone(),
-            ConvertParseTreeError::IntLiteralExpected { span } => span.clone(),
-            ConvertParseTreeError::QualifiedPathRootsNotImplemented { span } => span.clone(),
-            ConvertParseTreeError::CharLiteralsNotImplemented { span } => span.clone(),
-            ConvertParseTreeError::HexLiteralLength { span } => span.clone(),
-            ConvertParseTreeError::BinaryLiteralLength { span } => span.clone(),
-            ConvertParseTreeError::U8LiteralOutOfRange { span } => span.clone(),
-            ConvertParseTreeError::U16LiteralOutOfRange { span } => span.clone(),
-            ConvertParseTreeError::U32LiteralOutOfRange { span } => span.clone(),
-            ConvertParseTreeError::U64LiteralOutOfRange { span } => span.clone(),
-            ConvertParseTreeError::SignedIntegersNotSupported { span } => span.clone(),
-            ConvertParseTreeError::RefVariablesNotSupported { span } => span.clone(),
-            ConvertParseTreeError::LiteralPatternsNotSupportedHere { span } => span.clone(),
-            ConvertParseTreeError::ConstantPatternsNotSupportedHere { span } => span.clone(),
-            ConvertParseTreeError::ConstructorPatternsNotSupportedHere { span } => span.clone(),
-            ConvertParseTreeError::StructPatternsNotSupportedHere { span } => span.clone(),
-            ConvertParseTreeError::WildcardPatternsNotSupportedHere { span } => span.clone(),
-            ConvertParseTreeError::OrPatternsNotSupportedHere { span } => span.clone(),
-            ConvertParseTreeError::TuplePatternsNotSupportedHere { span } => span.clone(),
-            ConvertParseTreeError::RefPatternsNotSupportedHere { span } => span.clone(),
-            ConvertParseTreeError::ConstructorPatternOneArg { span } => span.clone(),
-            ConvertParseTreeError::ConstructorPatternSubPatterns { span } => span.clone(),
-            ConvertParseTreeError::PathsNotSupportedHere { span } => span.clone(),
-            ConvertParseTreeError::FullySpecifiedTypesNotSupported { span } => span.clone(),
-            ConvertParseTreeError::ContractCallerOneGenericArg { span } => span.clone(),
-            ConvertParseTreeError::ContractCallerNamedTypeGenericArg { span } => span.clone(),
-            ConvertParseTreeError::InvalidAttributeArgument { span, .. } => span.clone(),
-            ConvertParseTreeError::ConstrainedNonExistentType { span, .. } => span.clone(),
-            ConvertParseTreeError::GetStorageKeyTooManyArgs { span, .. } => span.clone(),
-            ConvertParseTreeError::RecursiveType { span } => span.clone(),
-            ConvertParseTreeError::DuplicateEnumVariant { span, .. } => span.clone(),
-            ConvertParseTreeError::DuplicateStorageField { span, .. } => span.clone(),
-            ConvertParseTreeError::DuplicateConfigurable { span, .. } => span.clone(),
-            ConvertParseTreeError::MultipleConfigurableBlocksInModule { span } => span.clone(),
-            ConvertParseTreeError::DuplicateStructField { span, .. } => span.clone(),
-            ConvertParseTreeError::DuplicateParameterIdentifier { span, .. } => span.clone(),
-            ConvertParseTreeError::SelfParameterNotAllowedForFn { span, .. } => span.clone(),
-            ConvertParseTreeError::TestFnOnlyAllowedAtModuleLevel { span } => span.clone(),
-            ConvertParseTreeError::SelfImplForContract { span, .. } => span.clone(),
-            ConvertParseTreeError::CannotDocCommentDependency { span } => span.clone(),
-            ConvertParseTreeError::CannotAnnotateDependency { span } => span.clone(),
-            ConvertParseTreeError::ExpectedDependencyAtBeginning { span } => span.clone(),
-            ConvertParseTreeError::RefExprNotYetSupported { span } => span.clone(),
-            ConvertParseTreeError::DerefExprNotYetSupported { span } => span.clone(),
-            ConvertParseTreeError::ConstantRequiresExpression { span } => span.clone(),
-            ConvertParseTreeError::ConstantRequiresTypeAscription { span } => span.clone(),
-            ConvertParseTreeError::InvalidCfgTargetArgValue { span, .. } => span.clone(),
-            ConvertParseTreeError::ExpectedCfgTargetArgValue { span } => span.clone(),
-            ConvertParseTreeError::InvalidCfgProgramTypeArgValue { span, .. } => span.clone(),
-            ConvertParseTreeError::ExpectedCfgProgramTypeArgValue { span } => span.clone(),
+            ConvertParseTreeError::MultipleGenericsNotSupported { span } => Some(span.clone()),
+            ConvertParseTreeError::TupleIndexOutOfRange { span } => Some(span.clone()),
+            ConvertParseTreeError::ShlNotImplemented { span } => Some(span.clone()),
+            ConvertParseTreeError::ShrNotImplemented { span } => Some(span.clone()),
+            ConvertParseTreeError::BitXorNotImplemented { span } => Some(span.clone()),
+            ConvertParseTreeError::IntTySuffixNotSupported { span } => Some(span.clone()),
+            ConvertParseTreeError::IntLiteralOutOfRange { span } => Some(span.clone()),
+            ConvertParseTreeError::IntLiteralExpected { span } => Some(span.clone()),
+            ConvertParseTreeError::QualifiedPathRootsNotImplemented { span } => Some(span.clone()),
+            ConvertParseTreeError::CharLiteralsNotImplemented { span } => Some(span.clone()),
+            ConvertParseTreeError::HexLiteralLength { span } => Some(span.clone()),
+            ConvertParseTreeError::BinaryLiteralLength { span } => Some(span.clone()),
+            ConvertParseTreeError::U8LiteralOutOfRange { span } => Some(span.clone()),
+            ConvertParseTreeError::U16LiteralOutOfRange { span } => Some(span.clone()),
+            ConvertParseTreeError::U32LiteralOutOfRange { span } => Some(span.clone()),
+            ConvertParseTreeError::U64LiteralOutOfRange { span } => Some(span.clone()),
+            ConvertParseTreeError::SignedIntegersNotSupported { span } => Some(span.clone()),
+            ConvertParseTreeError::RefVariablesNotSupported { span } => Some(span.clone()),
+            ConvertParseTreeError::LiteralPatternsNotSupportedHere { span } => Some(span.clone()),
+            ConvertParseTreeError::ConstantPatternsNotSupportedHere { span } => Some(span.clone()),
+            ConvertParseTreeError::ConstructorPatternsNotSupportedHere { span } => {
+                Some(span.clone())
+            }
+            ConvertParseTreeError::StructPatternsNotSupportedHere { span } => Some(span.clone()),
+            ConvertParseTreeError::WildcardPatternsNotSupportedHere { span } => Some(span.clone()),
+            ConvertParseTreeError::OrPatternsNotSupportedHere { span } => Some(span.clone()),
+            ConvertParseTreeError::TuplePatternsNotSupportedHere { span } => Some(span.clone()),
+            ConvertParseTreeError::RefPatternsNotSupportedHere { span } => Some(span.clone()),
+            ConvertParseTreeError::ConstructorPatternOneArg { span } => Some(span.clone()),
+            ConvertParseTreeError::ConstructorPatternSubPatterns { span } => Some(span.clone()),
+            ConvertParseTreeError::PathsNotSupportedHere { span } => Some(span.clone()),
+            ConvertParseTreeError::FullySpecifiedTypesNotSupported { span } => Some(span.clone()),
+            ConvertParseTreeError::ContractCallerOneGenericArg { span } => Some(span.clone()),
+            ConvertParseTreeError::ContractCallerNamedTypeGenericArg { span } => Some(span.clone()),
+            ConvertParseTreeError::InvalidAttributeArgument { span, .. } => Some(span.clone()),
+            ConvertParseTreeError::ConstrainedNonExistentType { span, .. } => Some(span.clone()),
+            ConvertParseTreeError::GetStorageKeyTooManyArgs { span, .. } => Some(span.clone()),
+            ConvertParseTreeError::RecursiveType { span } => Some(span.clone()),
+            ConvertParseTreeError::DuplicateEnumVariant { span, .. } => Some(span.clone()),
+            ConvertParseTreeError::DuplicateStorageField { span, .. } => Some(span.clone()),
+            ConvertParseTreeError::DuplicateConfigurable { span, .. } => Some(span.clone()),
+            ConvertParseTreeError::MultipleConfigurableBlocksInModule { span } => {
+                Some(span.clone())
+            }
+            ConvertParseTreeError::DuplicateStructField { span, .. } => Some(span.clone()),
+            ConvertParseTreeError::DuplicateParameterIdentifier { span, .. } => Some(span.clone()),
+            ConvertParseTreeError::SelfParameterNotAllowedForFn { span, .. } => Some(span.clone()),
+            ConvertParseTreeError::TestFnOnlyAllowedAtModuleLevel { span } => Some(span.clone()),
+            ConvertParseTreeError::SelfImplForContract { span, .. } => Some(span.clone()),
+            ConvertParseTreeError::CannotDocCommentDependency { span } => Some(span.clone()),
+            ConvertParseTreeError::CannotAnnotateDependency { span } => Some(span.clone()),
+            ConvertParseTreeError::ExpectedDependencyAtBeginning { span } => Some(span.clone()),
+            ConvertParseTreeError::RefExprNotYetSupported { span } => Some(span.clone()),
+            ConvertParseTreeError::DerefExprNotYetSupported { span } => Some(span.clone()),
+            ConvertParseTreeError::ConstantRequiresExpression { span } => Some(span.clone()),
+            ConvertParseTreeError::ConstantRequiresTypeAscription { span } => Some(span.clone()),
+            ConvertParseTreeError::InvalidCfgTargetArgValue { span, .. } => Some(span.clone()),
+            ConvertParseTreeError::ExpectedCfgTargetArgValue { span } => Some(span.clone()),
+            ConvertParseTreeError::InvalidCfgProgramTypeArgValue { span, .. } => Some(span.clone()),
+            ConvertParseTreeError::ExpectedCfgProgramTypeArgValue { span } => Some(span.clone()),
             ConvertParseTreeError::UnexpectedCallPathPrefixAfterQualifiedRoot { span } => {
-                span.clone()
+                Some(span.clone())
             }
         }
     }

--- a/sway-parse/src/attribute.rs
+++ b/sway-parse/src/attribute.rs
@@ -85,14 +85,11 @@ impl<T: Parse> Parse for Annotated<T> {
         }
     }
 
-    fn error(
-        spans: Box<[sway_types::Span]>,
-        error: sway_error::handler::ErrorEmitted,
-    ) -> Option<Self>
+    fn error(span: sway_types::Span, error: sway_error::handler::ErrorEmitted) -> Option<Self>
     where
         Self: Sized,
     {
-        T::error(spans, error).map(|value| Annotated {
+        T::error(span, error).map(|value| Annotated {
             attribute_list: vec![],
             value,
         })

--- a/sway-parse/src/expr/mod.rs
+++ b/sway-parse/src/expr/mod.rs
@@ -142,9 +142,9 @@ impl ParseToEnd for CodeBlockContents {
                 Ok(StmtOrTail::Stmt(s)) => statements.push(s),
                 Ok(StmtOrTail::Tail(e, c)) => break (Some(e), c),
                 Err(r) => {
-                    let (spans, error) = r
+                    let (span, error) = r
                         .recover_at_next_line_with_fallback_error(ParseErrorKind::InvalidStatement);
-                    statements.push(Statement::Error(spans, error));
+                    statements.push(Statement::Error(span, error));
                 }
             }
         };

--- a/sway-parse/src/item/item_const.rs
+++ b/sway-parse/src/item/item_const.rs
@@ -19,10 +19,7 @@ impl Parse for ItemConst {
             Some(_eq) => Some(parser.parse()?),
             None => None,
         };
-        // Use the default here since the braces parsing is expecting
-        // a semicolon, that allows us to re-use the same parsing code
-        // between associated consts and module-level consts.
-        let semicolon_token = parser.peek().unwrap_or_default();
+        let semicolon_token = parser.peek();
         Ok(ItemConst {
             visibility,
             const_token,

--- a/sway-parse/src/item/item_trait.rs
+++ b/sway-parse/src/item/item_trait.rs
@@ -20,14 +20,11 @@ impl Parse for ItemTraitItem {
         }
     }
 
-    fn error(
-        spans: Box<[sway_types::Span]>,
-        error: sway_error::handler::ErrorEmitted,
-    ) -> Option<Self>
+    fn error(span: sway_types::Span, error: sway_error::handler::ErrorEmitted) -> Option<Self>
     where
         Self: Sized,
     {
-        Some(ItemTraitItem::Error(spans, error))
+        Some(ItemTraitItem::Error(span, error))
     }
 }
 

--- a/sway-parse/src/item/mod.rs
+++ b/sway-parse/src/item/mod.rs
@@ -77,14 +77,11 @@ impl Parse for ItemKind {
         Ok(kind)
     }
 
-    fn error(
-        spans: Box<[sway_types::Span]>,
-        error: sway_error::handler::ErrorEmitted,
-    ) -> Option<Self>
+    fn error(span: sway_types::Span, error: sway_error::handler::ErrorEmitted) -> Option<Self>
     where
         Self: Sized,
     {
-        Some(ItemKind::Error(spans, error))
+        Some(ItemKind::Error(span, error))
     }
 }
 

--- a/sway-parse/src/parse.rs
+++ b/sway-parse/src/parse.rs
@@ -13,7 +13,7 @@ pub trait Parse {
         Self: Sized;
 
     fn error(
-        #[allow(clippy::boxed_local)] _spans: Box<[sway_types::Span]>,
+        #[allow(clippy::boxed_local)] _span: sway_types::Span,
         _error: sway_error::handler::ErrorEmitted,
     ) -> Option<Self>
     where

--- a/sway-types/src/span.rs
+++ b/sway-types/src/span.rs
@@ -191,11 +191,8 @@ impl Span {
         }
     }
 
-    pub fn join_all(spans: impl IntoIterator<Item = Span>) -> Span {
-        spans
-            .into_iter()
-            .reduce(Span::join)
-            .unwrap_or_else(Span::dummy)
+    pub fn join_all(spans: impl IntoIterator<Item = Span>) -> Option<Span> {
+        spans.into_iter().reduce(Span::join)
     }
 
     /// Returns the line and column start and end.
@@ -226,6 +223,19 @@ impl fmt::Debug for Span {
 
 pub trait Spanned {
     fn span(&self) -> Span;
+}
+
+pub trait MaybeSpanned {
+    fn try_span(&self) -> Option<Span>;
+}
+
+impl<T> MaybeSpanned for T
+where
+    T: Spanned,
+{
+    fn try_span(&self) -> Option<Span> {
+        Some(self.span())
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/swayfmt/src/items/item_const.rs
+++ b/swayfmt/src/items/item_const.rs
@@ -44,7 +44,9 @@ impl Format for ItemConst {
             expr.format(formatted_code, formatter)?;
         }
 
-        write!(formatted_code, "{}", self.semicolon_token.ident().as_str())?;
+        if let Some(semicolon_token) = &self.semicolon_token {
+            write!(formatted_code, "{}", semicolon_token.ident().as_str())?;
+        }
 
         rewrite_with_comments::<ItemConst>(
             formatter,
@@ -74,7 +76,9 @@ impl LeafSpans for ItemConst {
         if let Some(expr) = &self.expr_opt {
             collected_spans.append(&mut expr.leaf_spans());
         }
-        collected_spans.push(ByteSpan::from(self.semicolon_token.span()));
+        if let Some(semicolon_token) = &self.semicolon_token {
+            collected_spans.push(ByteSpan::from(semicolon_token.span()));
+        }
         collected_spans
     }
 }

--- a/swayfmt/src/items/item_trait/mod.rs
+++ b/swayfmt/src/items/item_trait/mod.rs
@@ -222,8 +222,8 @@ impl LeafSpans for ItemTraitItem {
                 collected_spans.append(&mut const_decl.leaf_spans());
                 collected_spans.extend(semicolon.as_ref().into_iter().flat_map(|x| x.leaf_spans()));
             }
-            ItemTraitItem::Error(spans, _) => {
-                collected_spans.extend(spans.iter().cloned().map(Into::into));
+            ItemTraitItem::Error(span, _) => {
+                collected_spans.push(span.clone().into());
             }
         };
         collected_spans

--- a/swayfmt/src/module/item.rs
+++ b/swayfmt/src/module/item.rs
@@ -43,9 +43,7 @@ impl LeafSpans for ItemKind {
             Use(item_use) => item_use.leaf_spans(),
             Configurable(item_configurable) => item_configurable.leaf_spans(),
             TypeAlias(item_type_alias) => item_type_alias.leaf_spans(),
-            Error(spans, _) => {
-                vec![sway_types::Span::join_all(spans.iter().cloned()).into()]
-            }
+            Error(span, _) => vec![span.clone().into()],
         }
     }
 }

--- a/swayfmt/src/utils/language/statement.rs
+++ b/swayfmt/src/utils/language/statement.rs
@@ -97,9 +97,7 @@ impl LeafSpans for Statement {
                 }
                 collected_spans
             }
-            Statement::Error(spans, _) => {
-                vec![sway_types::Span::join_all(spans.iter().cloned()).into()]
-            }
+            Statement::Error(span, _) => vec![span.clone().into()],
         }
     }
 }


### PR DESCRIPTION
## Description

Remove dummy spans in favor of explicit `Option` where appropriate.

Related to #4981, #3594, #5037, #5040

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
