### PR TITLE
udeps dont need nightly anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-udeps
         run: cargo install --locked cargo-udeps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,9 +397,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
-        with:
-          # `cargo-udeps` requires nightly to run
-          toolchain: ${{ env.NIGHTLY_RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-udeps
         run: cargo install --locked cargo-udeps


### PR DESCRIPTION
## Description

`cargo-udeps` stopped compiling with the hardcoded version. But it compiles in stable now.


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
