### PR TITLE
chore: bump to v1.72.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.71.0
-  NIGHTLY_RUST_VERSION: nightly-2023-04-01
+  RUST_VERSION: 1.72.0
+  NIGHTLY_RUST_VERSION: nightly-2023-08-27
 
 jobs:
   build-sway-lib-core:


### PR DESCRIPTION
## Description

Changes rust version CI uses to v1.72.0 and nightly to 2023-08-27
