### PR TITLE
Ensure generic values used with a `StorageMap` are hashable

### DIFF
--- a/sway-lib-std/src/storage/storage_map.sw
+++ b/sway-lib-std/src/storage/storage_map.sw
@@ -36,7 +36,7 @@ impl<K, V> StorageKey<StorageMap<K, V>> where K: Hash {
     /// }
     /// ```
     #[storage(read, write)]
-    pub fn insert(self, key: K, value: V) {
+    pub fn insert(self, key: K, value: V) where K: Hash {
         let key = sha256((key, self.field_id));
         write::<V>(key, 0, value);
     }
@@ -67,7 +67,7 @@ impl<K, V> StorageKey<StorageMap<K, V>> where K: Hash {
     ///     assert(value == retrieved_value);
     /// }
     /// ```
-    pub fn get(self, key: K) -> StorageKey<V> {
+    pub fn get(self, key: K) -> StorageKey<V> where K: Hash {
         StorageKey {
             slot: sha256((key, self.field_id)),
             offset: 0,
@@ -106,7 +106,7 @@ impl<K, V> StorageKey<StorageMap<K, V>> where K: Hash {
     /// }
     /// ```
     #[storage(write)]
-    pub fn remove(self, key: K) -> bool {
+    pub fn remove(self, key: K) -> bool where K: Hash {
         let key = sha256((key, self.slot));
         clear::<V>(key)
     }


### PR DESCRIPTION
## Description

Currently, any type may be included as a key value to the `StorageMap<K, V>` type. This presents an issue as the type must be hashable in order to generate the key. 

A where clause has been added to the function definition.

This should open the door for using heap types(`String`, `Bytes`) as key values for the `StorageMap` type however, this will require additional compiler changes.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
