### PR TITLE
Implements associated types

### DIFF
--- a/forc-plugins/forc-doc/src/render/item/context.rs
+++ b/forc-plugins/forc-doc/src/render/item/context.rs
@@ -448,6 +448,7 @@ impl Renderable for TyTraitItem {
         let item = match self {
             TyTraitItem::Fn(item_fn) => item_fn,
             TyTraitItem::Constant(_) => unimplemented!("Constant Trait items not yet implemented"),
+            TyTraitItem::Type(_) => unimplemented!("Type Trait items not yet implemented"),
         };
         let method = render_plan.engines.de().get_function(item.id());
         let attributes = method.attributes.to_html_string();

--- a/sway-ast/src/item/item_impl.rs
+++ b/sway-ast/src/item/item_impl.rs
@@ -4,6 +4,7 @@ use crate::priv_prelude::*;
 pub enum ItemImplItem {
     Fn(ItemFn),
     Const(ItemConst),
+    Type(TraitType),
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -27,6 +28,7 @@ impl Spanned for ItemImplItem {
         match self {
             ItemImplItem::Fn(fn_decl) => fn_decl.span(),
             ItemImplItem::Const(const_decl) => const_decl.span(),
+            ItemImplItem::Type(type_decl) => type_decl.span(),
         }
     }
 }

--- a/sway-ast/src/item/item_trait.rs
+++ b/sway-ast/src/item/item_trait.rs
@@ -4,6 +4,7 @@ use crate::priv_prelude::*;
 pub enum ItemTraitItem {
     Fn(FnSignature),
     Const(ItemConst),
+    Type(TraitType),
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -37,6 +38,7 @@ impl Spanned for ItemTraitItem {
         match self {
             ItemTraitItem::Fn(fn_decl) => fn_decl.span(),
             ItemTraitItem::Const(const_decl) => const_decl.span(),
+            ItemTraitItem::Type(type_decl) => type_decl.span(),
         }
     }
 }

--- a/sway-ast/src/item/mod.rs
+++ b/sway-ast/src/item/mod.rs
@@ -128,3 +128,22 @@ impl Spanned for FnSignature {
         Span::join(start, end)
     }
 }
+
+#[derive(Clone, Debug, Serialize)]
+pub struct TraitType {
+    pub name: Ident,
+    pub type_token: TypeToken,
+    pub eq_token_opt: Option<EqToken>,
+    pub ty_opt: Option<Ty>,
+}
+
+impl Spanned for TraitType {
+    fn span(&self) -> Span {
+        let start = self.type_token.span();
+        let end = match &self.ty_opt {
+            Some(ty_opt) => ty_opt.span(),
+            None => self.name.span(),
+        };
+        Span::join(start, end)
+    }
+}

--- a/sway-ast/src/lib.rs
+++ b/sway-ast/src/lib.rs
@@ -42,7 +42,7 @@ pub use crate::{
         item_trait::{ItemTrait, ItemTraitItem, Traits},
         item_type_alias::ItemTypeAlias,
         item_use::{ItemUse, UseTree},
-        FnArg, FnArgs, FnSignature, Item, ItemKind, TypeField,
+        FnArg, FnArgs, FnSignature, Item, ItemKind, TraitType, TypeField,
     },
     keywords::{CommaToken, DoubleColonToken, PubToken},
     literal::{LitInt, LitIntType, Literal},

--- a/sway-ast/src/priv_prelude.rs
+++ b/sway-ast/src/priv_prelude.rs
@@ -22,7 +22,7 @@ pub use {
             item_trait::{ItemTrait, Traits},
             item_type_alias::ItemTypeAlias,
             item_use::ItemUse,
-            FnSignature, Item, ItemKind, TypeField,
+            FnSignature, Item, ItemKind, TraitType, TypeField,
         },
         keywords::*,
         literal::{LitBool, LitBoolType, LitChar, LitInt, LitIntType, LitString, Literal},

--- a/sway-core/src/abi_generation/evm_abi.rs
+++ b/sway-core/src/abi_generation/evm_abi.rs
@@ -134,6 +134,10 @@ pub fn abi_str(type_info: &TypeInfo, type_engine: &TypeEngine, decl_engine: &Dec
             format!("__slice {}", abi_str_type_arg(ty, type_engine, decl_engine))
         }
         Alias { ty, .. } => abi_str_type_arg(ty, type_engine, decl_engine),
+        TraitType {
+            name,
+            trait_type_id: _,
+        } => format!("trait type {}", name),
     }
 }
 

--- a/sway-core/src/abi_generation/fuel_abi.rs
+++ b/sway-core/src/abi_generation/fuel_abi.rs
@@ -835,6 +835,10 @@ impl TypeInfo {
                 format!("__slice {}", ty.abi_str(ctx, type_engine, decl_engine))
             }
             Alias { ty, .. } => ty.abi_str(ctx, type_engine, decl_engine),
+            TraitType {
+                name,
+                trait_type_id: _,
+            } => format!("trait type {}", name),
         }
     }
 }

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -201,6 +201,7 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
         | ty::TyDecl::EnumVariantDecl(_)
         | ty::TyDecl::StorageDecl(_)
         | ty::TyDecl::TypeAliasDecl(_)
+        | ty::TyDecl::TypeDecl(_)
         | ty::TyDecl::GenericTypeForFunctionScope(_) => Ok(leaves.to_vec()),
         ty::TyDecl::VariableDecl(_) | ty::TyDecl::ConstantDecl(_) => {
             let entry_node = graph.add_node(ControlFlowGraphNode::from_node(node));
@@ -266,6 +267,7 @@ fn connect_impl_trait<'eng: 'cfg, 'cfg>(
                 methods_and_indexes.push((fn_decl.name.clone(), fn_decl_entry_node));
             }
             TyImplItem::Constant(_const_decl) => {}
+            TyImplItem::Type(_type_decl) => {}
         }
     }
     // Now, insert the methods into the trait method namespace.

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -565,6 +565,7 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             connect_type_alias_declaration(engines, &type_alias, graph, entry_node)?;
             Ok(leaves.to_vec())
         }
+        ty::TyDecl::TypeDecl(ty::TypeDecl { .. }) => Ok(leaves.to_vec()),
         ty::TyDecl::ErrorRecovery(..) | ty::TyDecl::GenericTypeForFunctionScope(_) => {
             Ok(leaves.to_vec())
         }
@@ -718,6 +719,7 @@ fn connect_impl_trait<'eng: 'cfg, 'cfg>(
                 methods_and_indexes.push((fn_decl.name.clone(), fn_decl_entry_node));
             }
             TyImplItem::Constant(_const_decl) => {}
+            TyImplItem::Type(_type_decl) => {}
         }
     }
     // we also want to add an edge from the methods back to the trait, so if a method gets called,
@@ -806,6 +808,7 @@ fn connect_abi_declaration(
                 }
             }
             ty::TyTraitInterfaceItem::Constant(_const_decl) => {}
+            ty::TyTraitInterfaceItem::Type(_type_decl) => {}
         }
     }
 
@@ -2227,6 +2230,9 @@ fn allow_dead_code_ast_node(decl_engine: &DeclEngine, node: &ty::TyAstNode) -> b
             ty::TyDecl::VariableDecl(_) => false,
             ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
                 allow_dead_code(decl_engine.get_constant(decl_id).attributes)
+            }
+            ty::TyDecl::TypeDecl(ty::TypeDecl { decl_id, .. }) => {
+                allow_dead_code(decl_engine.get_type(decl_id).attributes)
             }
             ty::TyDecl::FunctionDecl(ty::FunctionDecl { decl_id, .. }) => {
                 allow_dead_code(decl_engine.get_function(decl_id).attributes)

--- a/sway-core/src/decl_engine/associated_item_decl_id.rs
+++ b/sway-core/src/decl_engine/associated_item_decl_id.rs
@@ -11,6 +11,7 @@ pub enum AssociatedItemDeclId {
     TraitFn(DeclId<ty::TyTraitFn>),
     Function(DeclId<ty::TyFunctionDecl>),
     Constant(DeclId<ty::TyConstantDecl>),
+    Type(DeclId<ty::TyTraitType>),
 }
 
 impl From<DeclId<ty::TyFunctionDecl>> for AssociatedItemDeclId {
@@ -45,6 +46,22 @@ impl From<&mut DeclId<ty::TyTraitFn>> for AssociatedItemDeclId {
     }
 }
 
+impl From<DeclId<ty::TyTraitType>> for AssociatedItemDeclId {
+    fn from(val: DeclId<ty::TyTraitType>) -> Self {
+        Self::Type(val)
+    }
+}
+impl From<&DeclId<ty::TyTraitType>> for AssociatedItemDeclId {
+    fn from(val: &DeclId<ty::TyTraitType>) -> Self {
+        Self::Type(*val)
+    }
+}
+impl From<&mut DeclId<ty::TyTraitType>> for AssociatedItemDeclId {
+    fn from(val: &mut DeclId<ty::TyTraitType>) -> Self {
+        Self::Type(*val)
+    }
+}
+
 impl From<DeclId<ty::TyConstantDecl>> for AssociatedItemDeclId {
     fn from(val: DeclId<ty::TyConstantDecl>) -> Self {
         Self::Constant(val)
@@ -73,6 +90,9 @@ impl std::fmt::Display for AssociatedItemDeclId {
             Self::Constant(_) => {
                 write!(f, "decl(constant)",)
             }
+            Self::Type(_) => {
+                write!(f, "decl(type)",)
+            }
         }
     }
 }
@@ -91,6 +111,10 @@ impl TryFrom<DeclRefMixedFunctional> for DeclRefFunction {
                 span: value.decl_span().clone(),
             }),
             actually @ AssociatedItemDeclId::Constant(_) => Err(CompileError::DeclIsNotAFunction {
+                actually: actually.to_string(),
+                span: value.decl_span().clone(),
+            }),
+            actually @ AssociatedItemDeclId::Type(_) => Err(CompileError::DeclIsNotAFunction {
                 actually: actually.to_string(),
                 span: value.decl_span().clone(),
             }),
@@ -114,6 +138,10 @@ impl TryFrom<AssociatedItemDeclId> for DeclId<TyFunctionDecl> {
                 span: Span::dummy(), // FIXME
             }),
             actually @ AssociatedItemDeclId::Constant(_) => Err(CompileError::DeclIsNotAFunction {
+                actually: actually.to_string(),
+                span: Span::dummy(), // FIXME
+            }),
+            actually @ AssociatedItemDeclId::Type(_) => Err(CompileError::DeclIsNotAFunction {
                 actually: actually.to_string(),
                 span: Span::dummy(), // FIXME
             }),

--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -11,7 +11,7 @@ use crate::{
     engine_threading::*,
     language::ty::{
         self, TyAbiDecl, TyConstantDecl, TyEnumDecl, TyFunctionDecl, TyImplTrait, TyStorageDecl,
-        TyStructDecl, TyTraitDecl, TyTraitFn, TyTypeAliasDecl,
+        TyStructDecl, TyTraitDecl, TyTraitFn, TyTraitType, TyTypeAliasDecl,
     },
 };
 
@@ -21,6 +21,7 @@ pub struct DeclEngine {
     function_slab: ConcurrentSlab<TyFunctionDecl>,
     trait_slab: ConcurrentSlab<TyTraitDecl>,
     trait_fn_slab: ConcurrentSlab<TyTraitFn>,
+    trait_type_slab: ConcurrentSlab<TyTraitType>,
     impl_trait_slab: ConcurrentSlab<TyImplTrait>,
     struct_slab: ConcurrentSlab<TyStructDecl>,
     storage_slab: ConcurrentSlab<TyStorageDecl>,
@@ -72,6 +73,7 @@ macro_rules! decl_engine_get {
 decl_engine_get!(function_slab, ty::TyFunctionDecl);
 decl_engine_get!(trait_slab, ty::TyTraitDecl);
 decl_engine_get!(trait_fn_slab, ty::TyTraitFn);
+decl_engine_get!(trait_type_slab, ty::TyTraitType);
 decl_engine_get!(impl_trait_slab, ty::TyImplTrait);
 decl_engine_get!(struct_slab, ty::TyStructDecl);
 decl_engine_get!(storage_slab, ty::TyStorageDecl);
@@ -97,6 +99,7 @@ macro_rules! decl_engine_insert {
 decl_engine_insert!(function_slab, ty::TyFunctionDecl);
 decl_engine_insert!(trait_slab, ty::TyTraitDecl);
 decl_engine_insert!(trait_fn_slab, ty::TyTraitFn);
+decl_engine_insert!(trait_type_slab, ty::TyTraitType);
 decl_engine_insert!(impl_trait_slab, ty::TyImplTrait);
 decl_engine_insert!(struct_slab, ty::TyStructDecl);
 decl_engine_insert!(storage_slab, ty::TyStorageDecl);
@@ -117,6 +120,7 @@ macro_rules! decl_engine_replace {
 decl_engine_replace!(function_slab, ty::TyFunctionDecl);
 decl_engine_replace!(trait_slab, ty::TyTraitDecl);
 decl_engine_replace!(trait_fn_slab, ty::TyTraitFn);
+decl_engine_replace!(trait_type_slab, ty::TyTraitType);
 decl_engine_replace!(impl_trait_slab, ty::TyImplTrait);
 decl_engine_replace!(struct_slab, ty::TyStructDecl);
 decl_engine_replace!(storage_slab, ty::TyStorageDecl);
@@ -133,6 +137,7 @@ macro_rules! decl_engine_index {
 decl_engine_index!(function_slab, ty::TyFunctionDecl);
 decl_engine_index!(trait_slab, ty::TyTraitDecl);
 decl_engine_index!(trait_fn_slab, ty::TyTraitFn);
+decl_engine_index!(trait_type_slab, ty::TyTraitType);
 decl_engine_index!(impl_trait_slab, ty::TyImplTrait);
 decl_engine_index!(struct_slab, ty::TyStructDecl);
 decl_engine_index!(storage_slab, ty::TyStorageDecl);
@@ -294,6 +299,18 @@ impl DeclEngine {
     pub fn get_constant<I>(&self, index: &I) -> ty::TyConstantDecl
     where
         DeclEngine: DeclEngineGet<I, ty::TyConstantDecl>,
+    {
+        self.get(index)
+    }
+
+    /// Friendly helper method for calling the `get` method from the
+    /// implementation of [DeclEngineGet] for [DeclEngine]
+    ///
+    /// Calling [DeclEngine][get] directly is equivalent to this method, but
+    /// this method adds additional syntax that some users may find helpful.
+    pub fn get_type<I>(&self, index: &I) -> ty::TyTraitType
+    where
+        DeclEngine: DeclEngineGet<I, ty::TyTraitType>,
     {
         self.get(index)
     }

--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 use std::{fmt, hash::Hash};
 
+use crate::language::ty::TyTraitType;
 use crate::{
     decl_engine::*,
     engine_threading::*,
@@ -133,6 +134,14 @@ impl SubstTypes for DeclId<TyTypeAliasDecl> {
         decl_engine.replace(*self, decl);
     }
 }
+impl SubstTypes for DeclId<TyTraitType> {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+        let decl_engine = engines.de();
+        let mut decl = decl_engine.get(self);
+        decl.subst(type_mapping, engines);
+        decl_engine.replace(*self, decl);
+    }
+}
 
 impl ReplaceSelfType for DeclId<TyFunctionDecl> {
     fn replace_self_type(&mut self, engines: &Engines, self_type: TypeId) {
@@ -183,6 +192,14 @@ impl ReplaceSelfType for DeclId<TyEnumDecl> {
     }
 }
 impl ReplaceSelfType for DeclId<TyTypeAliasDecl> {
+    fn replace_self_type(&mut self, engines: &Engines, self_type: TypeId) {
+        let decl_engine = engines.de();
+        let mut decl = decl_engine.get(self);
+        decl.replace_self_type(engines, self_type);
+        decl_engine.replace(*self, decl);
+    }
+}
+impl ReplaceSelfType for DeclId<TyTraitType> {
     fn replace_self_type(&mut self, engines: &Engines, self_type: TypeId) {
         let decl_engine = engines.de();
         let mut decl = decl_engine.get(self);

--- a/sway-core/src/decl_engine/mapping.rs
+++ b/sway-core/src/decl_engine/mapping.rs
@@ -31,6 +31,7 @@ impl fmt::Display for DeclMapping {
                             AssociatedItemDeclId::TraitFn(decl_id) => decl_id.inner(),
                             AssociatedItemDeclId::Function(decl_id) => decl_id.inner(),
                             AssociatedItemDeclId::Constant(decl_id) => decl_id.inner(),
+                            AssociatedItemDeclId::Type(decl_id) => decl_id.inner(),
                         }
                     )
                 })
@@ -70,10 +71,12 @@ impl DeclMapping {
                 let interface_decl_ref = match interface_item {
                     TyTraitInterfaceItem::TraitFn(decl_ref) => decl_ref.id().into(),
                     TyTraitInterfaceItem::Constant(decl_ref) => decl_ref.id().into(),
+                    TyTraitInterfaceItem::Type(decl_ref) => decl_ref.id().into(),
                 };
                 let new_decl_ref = match new_item {
                     TyTraitItem::Fn(decl_ref) => decl_ref.id().into(),
                     TyTraitItem::Constant(decl_ref) => decl_ref.id().into(),
+                    TyTraitItem::Type(decl_ref) => decl_ref.id().into(),
                 };
                 mapping.push((interface_decl_ref, new_decl_ref));
             }
@@ -83,10 +86,12 @@ impl DeclMapping {
                 let interface_decl_ref = match item {
                     TyTraitItem::Fn(decl_ref) => decl_ref.id().into(),
                     TyTraitItem::Constant(decl_ref) => decl_ref.id().into(),
+                    TyTraitItem::Type(decl_ref) => decl_ref.id().into(),
                 };
                 let new_decl_ref = match new_item {
                     TyTraitItem::Fn(decl_ref) => decl_ref.id().into(),
                     TyTraitItem::Constant(decl_ref) => decl_ref.id().into(),
+                    TyTraitItem::Type(decl_ref) => decl_ref.id().into(),
                 };
                 mapping.push((interface_decl_ref, new_decl_ref));
             }
@@ -124,6 +129,7 @@ impl DeclMapping {
                     }
                 }
                 AssociatedItemDeclId::Constant(_) => mapping.push((source_decl_ref, dest_decl_ref)),
+                AssociatedItemDeclId::Type(_) => mapping.push((source_decl_ref, dest_decl_ref)),
             }
         }
         DeclMapping { mapping }

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -30,7 +30,7 @@ use crate::{
     engine_threading::*,
     language::ty::{
         self, TyAbiDecl, TyConstantDecl, TyEnumDecl, TyFunctionDecl, TyImplTrait, TyStorageDecl,
-        TyStructDecl, TyTraitDecl, TyTraitFn,
+        TyStructDecl, TyTraitDecl, TyTraitFn, TyTraitType,
     },
     semantic_analysis::TypeCheckContext,
     type_system::*,
@@ -39,6 +39,7 @@ use crate::{
 pub type DeclRefFunction = DeclRef<DeclId<TyFunctionDecl>>;
 pub type DeclRefTrait = DeclRef<DeclId<TyTraitDecl>>;
 pub type DeclRefTraitFn = DeclRef<DeclId<TyTraitFn>>;
+pub type DeclRefTraitType = DeclRef<DeclId<TyTraitType>>;
 pub type DeclRefImplTrait = DeclRef<DeclId<TyImplTrait>>;
 pub type DeclRefStruct = DeclRef<DeclId<TyStructDecl>>;
 pub type DeclRefStorage = DeclRef<DeclId<TyStorageDecl>>;

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -299,6 +299,7 @@ fn compile_declarations(
             | ty::TyDecl::GenericTypeForFunctionScope { .. }
             | ty::TyDecl::StorageDecl { .. }
             | ty::TyDecl::TypeAliasDecl { .. }
+            | ty::TyDecl::TypeDecl { .. }
             | ty::TyDecl::ErrorRecovery(..) => (),
         }
     }

--- a/sway-core/src/ir_generation/convert.rs
+++ b/sway-core/src/ir_generation/convert.rs
@@ -166,5 +166,6 @@ fn convert_resolved_type(
         TypeInfo::TypeParam(_) => reject_type!("TypeParam"),
         TypeInfo::ErrorRecovery(_) => reject_type!("Error recovery"),
         TypeInfo::Storage { .. } => reject_type!("Storage"),
+        TypeInfo::TraitType { .. } => reject_type!("TraitType"),
     })
 }

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -199,6 +199,7 @@ impl<'eng> FnCompiler<'eng> {
                 ty::TyDecl::ErrorRecovery { .. } => unexpected_decl("error recovery"),
                 ty::TyDecl::StorageDecl { .. } => unexpected_decl("storage"),
                 ty::TyDecl::EnumVariantDecl { .. } => unexpected_decl("enum variant"),
+                ty::TyDecl::TypeDecl { .. } => unexpected_decl("trait type"),
             },
             ty::TyAstNodeContent::Expression(te) => {
                 // An expression with an ignored return value... I assume.

--- a/sway-core/src/language/parsed/declaration.rs
+++ b/sway-core/src/language/parsed/declaration.rs
@@ -33,6 +33,7 @@ pub enum Declaration {
     ConstantDeclaration(ConstantDeclaration),
     StorageDeclaration(StorageDeclaration),
     TypeAliasDeclaration(TypeAliasDeclaration),
+    TraitTypeDeclaration(TraitTypeDeclaration),
 }
 
 impl Declaration {

--- a/sway-core/src/language/parsed/declaration/impl_trait.rs
+++ b/sway-core/src/language/parsed/declaration/impl_trait.rs
@@ -1,4 +1,4 @@
-use super::{ConstantDeclaration, FunctionDeclaration};
+use super::{ConstantDeclaration, FunctionDeclaration, TraitTypeDeclaration};
 use crate::{language::CallPath, type_system::TypeArgument, TypeParameter};
 
 use sway_types::span::Span;
@@ -7,6 +7,7 @@ use sway_types::span::Span;
 pub enum ImplItem {
     Fn(FunctionDeclaration),
     Constant(ConstantDeclaration),
+    Type(TraitTypeDeclaration),
 }
 
 #[derive(Debug, Clone)]

--- a/sway-core/src/language/parsed/declaration/trait.rs
+++ b/sway-core/src/language/parsed/declaration/trait.rs
@@ -11,6 +11,7 @@ use sway_types::{ident::Ident, span::Span, Spanned};
 pub enum TraitItem {
     TraitFn(TraitFn),
     Constant(ConstantDeclaration),
+    Type(TraitTypeDeclaration),
 }
 
 #[derive(Debug, Clone)]
@@ -68,4 +69,12 @@ pub struct TraitFn {
     pub purity: Purity,
     pub parameters: Vec<FunctionParameter>,
     pub return_type: TypeArgument,
+}
+
+#[derive(Debug, Clone)]
+pub struct TraitTypeDeclaration {
+    pub name: Ident,
+    pub attributes: transform::AttributesMap,
+    pub ty_opt: Option<TypeArgument>,
+    pub span: Span,
 }

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -21,6 +21,7 @@ use crate::{
 pub enum TyDecl {
     VariableDecl(Box<TyVariableDecl>),
     ConstantDecl(ConstantDecl),
+    TypeDecl(TypeDecl),
     FunctionDecl(FunctionDecl),
     TraitDecl(TraitDecl),
     StructDecl(StructDecl),
@@ -40,6 +41,13 @@ pub enum TyDecl {
 pub struct ConstantDecl {
     pub name: Ident,
     pub decl_id: DeclId<TyConstantDecl>,
+    pub decl_span: Span,
+}
+
+#[derive(Clone, Debug)]
+pub struct TypeDecl {
+    pub name: Ident,
+    pub decl_id: DeclId<TyTraitType>,
     pub decl_span: Span,
 }
 
@@ -243,6 +251,9 @@ impl HashWithEngines for TyDecl {
             TyDecl::ConstantDecl(ConstantDecl { decl_id, .. }) => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
+            TyDecl::TypeDecl(TypeDecl { decl_id, .. }) => {
+                decl_engine.get(decl_id).hash(state, engines);
+            }
             TyDecl::FunctionDecl(FunctionDecl { decl_id, .. }) => {
                 decl_engine.get(decl_id).hash(state, engines);
             }
@@ -323,6 +334,11 @@ impl SubstTypes for TyDecl {
             }) => {
                 decl_id.subst(type_mapping, engines);
             }
+            TyDecl::TypeDecl(TypeDecl {
+                ref mut decl_id, ..
+            }) => {
+                decl_id.subst(type_mapping, engines);
+            }
             // generics in an ABI is unsupported by design
             TyDecl::AbiDecl(_)
             | TyDecl::ConstantDecl(_)
@@ -360,6 +376,9 @@ impl ReplaceSelfType for TyDecl {
             TyDecl::TypeAliasDecl(TypeAliasDecl {
                 ref mut decl_id, ..
             }) => decl_id.replace_self_type(engines, self_type),
+            TyDecl::TypeDecl(TypeDecl {
+                ref mut decl_id, ..
+            }) => decl_id.replace_self_type(engines, self_type),
             // generics in an ABI is unsupported by design
             TyDecl::AbiDecl(_)
             | TyDecl::ConstantDecl(_)
@@ -394,6 +413,7 @@ impl Spanned for TyDecl {
             | TyDecl::TraitDecl(TraitDecl { decl_span, .. })
             | TyDecl::ImplTrait(ImplTrait { decl_span, .. })
             | TyDecl::ConstantDecl(ConstantDecl { decl_span, .. })
+            | TyDecl::TypeDecl(TypeDecl { decl_span, .. })
             | TyDecl::StorageDecl(StorageDecl { decl_span, .. })
             | TyDecl::TypeAliasDecl(TypeAliasDecl { decl_span, .. })
             | TyDecl::AbiDecl(AbiDecl { decl_span, .. })
@@ -540,6 +560,7 @@ impl CollectTypesMetadata for TyDecl {
             | TyDecl::ImplTrait(_)
             | TyDecl::AbiDecl(_)
             | TyDecl::TypeAliasDecl(_)
+            | TyDecl::TypeDecl(_)
             | TyDecl::GenericTypeForFunctionScope(_) => vec![],
         };
         Ok(metadata)
@@ -556,6 +577,7 @@ impl GetDeclIdent for TyDecl {
             | TyDecl::ImplTrait(ImplTrait { name, .. })
             | TyDecl::AbiDecl(AbiDecl { name, .. })
             | TyDecl::TypeAliasDecl(TypeAliasDecl { name, .. })
+            | TyDecl::TypeDecl(TypeDecl { name, .. })
             | TyDecl::GenericTypeForFunctionScope(GenericTypeForFunctionScope { name, .. })
             | TyDecl::StructDecl(StructDecl { name, .. })
             | TyDecl::EnumDecl(EnumDecl { name, .. }) => Some(name.clone()),
@@ -739,6 +761,7 @@ impl TyDecl {
         match self {
             VariableDecl(_) => "variable",
             ConstantDecl(_) => "constant",
+            TypeDecl(_) => "type",
             FunctionDecl(_) => "function",
             TraitDecl(_) => "trait",
             StructDecl(_) => "struct",
@@ -862,6 +885,7 @@ impl TyDecl {
             | TyDecl::ImplTrait(_)
             | TyDecl::StorageDecl(_)
             | TyDecl::AbiDecl(_)
+            | TyDecl::TypeDecl(_)
             | TyDecl::ErrorRecovery(_, _) => Visibility::Public,
             TyDecl::VariableDecl(decl) => decl.mutability.visibility(),
         }

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -892,6 +892,16 @@ impl TyDecl {
     }
 }
 
+impl From<DeclRef<DeclId<TyTraitType>>> for TyDecl {
+    fn from(decl_ref: DeclRef<DeclId<TyTraitType>>) -> Self {
+        TyDecl::TypeDecl(TypeDecl {
+            name: decl_ref.name().clone(),
+            decl_id: *decl_ref.id(),
+            decl_span: decl_ref.decl_span().clone(),
+        })
+    }
+}
+
 impl From<DeclRef<DeclId<TyConstantDecl>>> for TyDecl {
     fn from(decl_ref: DeclRef<DeclId<TyConstantDecl>>) -> Self {
         TyDecl::ConstantDecl(ConstantDecl {

--- a/sway-core/src/language/ty/declaration/mod.rs
+++ b/sway-core/src/language/ty/declaration/mod.rs
@@ -9,6 +9,7 @@ mod storage;
 mod r#struct;
 mod r#trait;
 mod trait_fn;
+mod trait_type;
 mod type_alias;
 mod variable;
 
@@ -22,6 +23,7 @@ pub use r#struct::*;
 pub use r#trait::*;
 pub use storage::*;
 pub use trait_fn::*;
+pub use trait_type::*;
 pub use type_alias::*;
 pub use variable::*;
 

--- a/sway-core/src/language/ty/declaration/trait_type.rs
+++ b/sway-core/src/language/ty/declaration/trait_type.rs
@@ -1,0 +1,63 @@
+use std::hash::{Hash, Hasher};
+
+use sway_types::{Ident, Named, Span, Spanned};
+
+use crate::{engine_threading::*, transform, type_system::*};
+
+#[derive(Clone, Debug)]
+pub struct TyTraitType {
+    pub name: Ident,
+    pub attributes: transform::AttributesMap,
+    pub ty: Option<TypeArgument>,
+    pub span: Span,
+}
+
+impl Named for TyTraitType {
+    fn name(&self) -> &Ident {
+        &self.name
+    }
+}
+
+impl EqWithEngines for TyTraitType {}
+impl PartialEqWithEngines for TyTraitType {
+    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+        self.name == other.name && self.ty.eq(&other.ty, engines)
+    }
+}
+
+impl HashWithEngines for TyTraitType {
+    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+        let TyTraitType {
+            name,
+            ty,
+            // these fields are not hashed because they aren't relevant/a
+            // reliable source of obj v. obj distinction
+            span: _,
+            attributes: _,
+        } = self;
+        name.hash(state);
+        ty.hash(state, engines);
+    }
+}
+
+impl SubstTypes for TyTraitType {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+        if let Some(ref mut ty) = self.ty {
+            ty.subst(type_mapping, engines);
+        }
+    }
+}
+
+impl ReplaceSelfType for TyTraitType {
+    fn replace_self_type(&mut self, engines: &Engines, self_type: TypeId) {
+        if let Some(ref mut ty) = self.ty {
+            ty.replace_self_type(engines, self_type);
+        }
+    }
+}
+
+impl Spanned for TyTraitType {
+    fn span(&self) -> Span {
+        self.span.clone()
+    }
+}

--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -123,6 +123,14 @@ impl TyProgram {
                                                 decl_span: const_decl.span,
                                             }));
                                         }
+                                        TyImplItem::Type(type_ref) => {
+                                            let type_decl = decl_engine.get_type(&type_ref);
+                                            declarations.push(TyDecl::TypeDecl(TypeDecl {
+                                                name: type_decl.name().clone(),
+                                                decl_id: *type_ref.id(),
+                                                decl_span: type_decl.span,
+                                            }));
+                                        }
                                     }
                                 }
                             }

--- a/sway-core/src/monomorphize/gather/declaration.rs
+++ b/sway-core/src/monomorphize/gather/declaration.rs
@@ -29,6 +29,7 @@ pub(crate) fn gather_from_decl(
         ty::TyDecl::StorageDecl(_) => todo!(),
         ty::TyDecl::ErrorRecovery(_, _) => {}
         ty::TyDecl::TypeAliasDecl(_) => todo!(),
+        ty::TyDecl::TypeDecl(_) => todo!(),
     }
 
     Ok(())

--- a/sway-core/src/monomorphize/instruct/declaration.rs
+++ b/sway-core/src/monomorphize/instruct/declaration.rs
@@ -29,6 +29,7 @@ pub(crate) fn instruct_decl(
         ty::TyDecl::StorageDecl(_) => todo!(),
         ty::TyDecl::ErrorRecovery(_, _) => {}
         ty::TyDecl::TypeAliasDecl(_) => todo!(),
+        ty::TyDecl::TypeDecl(_) => todo!(),
     }
     Ok(())
 }

--- a/sway-core/src/monomorphize/solve/solver.rs
+++ b/sway-core/src/monomorphize/solve/solver.rs
@@ -146,7 +146,8 @@ impl<'a> Solver<'a> {
             | TypeInfo::RawUntypedPtr
             | TypeInfo::RawUntypedSlice
             | TypeInfo::Ptr(..)
-            | TypeInfo::Slice(..) => {}
+            | TypeInfo::Slice(..)
+            | TypeInfo::TraitType { .. } => {}
         }
 
         Ok(InstructionResult::from_instructions(instructions))

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -67,7 +67,7 @@ impl ty::TyCodeBlock {
                     let never_decl_opt = ctx
                         .namespace
                         .root()
-                        .resolve_symbol(&Handler::default(), &never_mod_path, &never_ident)
+                        .resolve_symbol(&Handler::default(), engines, &never_mod_path, &never_ident)
                         .ok();
 
                     if let Some(ty::TyDecl::EnumDecl(ty::EnumDecl {
@@ -79,7 +79,7 @@ impl ty::TyCodeBlock {
                     {
                         return ctx.engines().te().insert(
                             engines,
-                            TypeInfo::Enum(DeclRef::new(name.clone(), *decl_id, decl_span.clone())),
+                            TypeInfo::Enum(DeclRef::new(name.clone(), decl_id, decl_span.clone())),
                         );
                     }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -133,6 +133,24 @@ impl ty::TyAbiDecl {
 
                     const_name
                 }
+                TraitItem::Type(type_decl) => {
+                    let type_decl = ty::TyTraitType::type_check(handler, ctx.by_ref(), type_decl)?;
+                    let decl_ref = ctx.engines().de().insert(type_decl.clone());
+                    new_interface_surface.push(ty::TyTraitInterfaceItem::Type(decl_ref.clone()));
+
+                    let type_name = type_decl.name.clone();
+                    ctx.insert_symbol(
+                        handler,
+                        type_name.clone(),
+                        ty::TyDecl::TypeDecl(ty::TypeDecl {
+                            name: type_name.clone(),
+                            decl_id: *decl_ref.id(),
+                            decl_span: type_decl.span.clone(),
+                        }),
+                    )?;
+
+                    type_name
+                }
             };
 
             if !ids.insert(decl_name.clone()) {
@@ -281,6 +299,22 @@ impl ty::TyAbiDecl {
                             const_shadowing_mode,
                         );
                     }
+                    ty::TyTraitInterfaceItem::Type(decl_ref) => {
+                        let type_decl = decl_engine.get_type(decl_ref);
+                        let type_name = type_decl.name;
+                        all_items.push(TyImplItem::Type(decl_ref.clone()));
+                        let const_shadowing_mode = ctx.const_shadowing_mode();
+                        let _ = ctx.namespace.insert_symbol(
+                            handler,
+                            type_name.clone(),
+                            ty::TyDecl::TypeDecl(ty::TypeDecl {
+                                name: type_name,
+                                decl_id: *decl_ref.id(),
+                                decl_span: type_decl.span.clone(),
+                            }),
+                            const_shadowing_mode,
+                        );
+                    }
                 }
             }
             for item in items.iter() {
@@ -331,6 +365,11 @@ impl ty::TyAbiDecl {
                         const_decl.replace_self_type(engines, type_id);
                         all_items.push(TyImplItem::Constant(ctx.engines.de().insert(const_decl)));
                     }
+                    ty::TyTraitItem::Type(decl_ref) => {
+                        let mut type_decl = decl_engine.get_type(decl_ref);
+                        type_decl.replace_self_type(engines, type_id);
+                        all_items.push(TyImplItem::Type(ctx.engines.de().insert(type_decl)));
+                    }
                 }
             }
             // Insert the methods of the ABI into the namespace.
@@ -347,6 +386,7 @@ impl ty::TyAbiDecl {
                 &all_items,
                 &self.span,
                 Some(self.span()),
+                false,
                 false,
                 ctx.engines,
             );

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -74,6 +74,16 @@ impl ty::TyDecl {
                 ctx.insert_symbol(handler, const_decl.name().clone(), typed_const_decl.clone())?;
                 typed_const_decl
             }
+            parsed::Declaration::TraitTypeDeclaration(decl) => {
+                let span = decl.span.clone();
+                let type_decl = match ty::TyTraitType::type_check(handler, ctx.by_ref(), decl) {
+                    Ok(res) => res,
+                    Err(err) => return Ok(ty::TyDecl::ErrorRecovery(span, err)),
+                };
+                let typed_type_decl: ty::TyDecl = decl_engine.insert(type_decl.clone()).into();
+                ctx.insert_symbol(handler, type_decl.name().clone(), typed_type_decl.clone())?;
+                typed_type_decl
+            }
             parsed::Declaration::EnumDeclaration(decl) => {
                 let span = decl.span.clone();
                 let enum_decl = match ty::TyEnumDecl::type_check(handler, ctx.by_ref(), decl) {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -117,8 +117,7 @@ impl ty::TyDecl {
                 for supertrait in trait_decl.supertraits.iter_mut() {
                     let _ = ctx
                         .namespace
-                        .resolve_call_path(handler, &supertrait.name)
-                        .cloned()
+                        .resolve_call_path(handler, engines, &supertrait.name)
                         .map(|supertrait_decl| {
                             if let ty::TyDecl::TraitDecl(ty::TraitDecl {
                                 name: supertrait_name,
@@ -159,11 +158,9 @@ impl ty::TyDecl {
                 // insert those since we do not allow calling contract methods
                 // from contract methods
                 let emp_vec = vec![];
-                let impl_trait_items = if let Some(ty::TyDecl::TraitDecl { .. }) = ctx
+                let impl_trait_items = if let Ok(ty::TyDecl::TraitDecl { .. }) = ctx
                     .namespace
-                    .resolve_call_path(&Handler::default(), &impl_trait.trait_name)
-                    .ok()
-                    .cloned()
+                    .resolve_call_path(&Handler::default(), engines, &impl_trait.trait_name)
                 {
                     &impl_trait.items
                 } else {
@@ -180,6 +177,7 @@ impl ty::TyDecl {
                         .trait_decl_ref
                         .as_ref()
                         .map(|decl_ref| decl_ref.decl_span().clone()),
+                    false,
                     false,
                     engines,
                 )?;
@@ -208,6 +206,7 @@ impl ty::TyDecl {
                         .as_ref()
                         .map(|decl_ref| decl_ref.decl_span().clone()),
                     true,
+                    false,
                     engines,
                 )?;
                 let impl_trait_decl: ty::TyDecl = decl_engine.insert(impl_trait.clone()).into();
@@ -245,8 +244,7 @@ impl ty::TyDecl {
                 for supertrait in abi_decl.supertraits.iter_mut() {
                     let _ = ctx
                         .namespace
-                        .resolve_call_path(handler, &supertrait.name)
-                        .cloned()
+                        .resolve_call_path(handler, engines, &supertrait.name)
                         .map(|supertrait_decl| {
                             if let ty::TyDecl::TraitDecl(ty::TraitDecl {
                                 name: supertrait_name,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/mod.rs
@@ -10,6 +10,7 @@ mod r#struct;
 mod supertrait;
 mod r#trait;
 mod trait_fn;
+mod trait_type;
 
 pub use abi::*;
 pub use function::*;
@@ -20,3 +21,4 @@ pub use r#trait::*;
 pub use storage::*;
 pub(crate) use supertrait::*;
 pub use trait_fn::*;
+pub use trait_type::*;

--- a/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
@@ -23,7 +23,8 @@ pub(crate) fn insert_supertraits_into_namespace(
     supertraits: &[parsed::Supertrait],
     supertraits_of: &SupertraitOf,
 ) -> Result<(), ErrorEmitted> {
-    let decl_engine = ctx.engines.de();
+    let engines = ctx.engines;
+    let decl_engine = engines.de();
 
     handler.scope(|handler| {
         for supertrait in supertraits.iter() {
@@ -41,9 +42,8 @@ pub(crate) fn insert_supertraits_into_namespace(
 
             let decl = ctx
                 .namespace
-                .resolve_call_path(handler, &supertrait.name)
-                .ok()
-                .cloned();
+                .resolve_call_path(handler, engines, &supertrait.name)
+                .ok();
 
             match (decl.clone(), supertraits_of) {
                 // a trait can be a supertrait of either a trait or a an ABI

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait_type.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait_type.rs
@@ -1,0 +1,70 @@
+use sway_error::handler::{ErrorEmitted, Handler};
+
+use crate::{
+    language::{
+        parsed,
+        ty::{self, TyTraitType},
+    },
+    semantic_analysis::TypeCheckContext,
+    type_system::*,
+    Engines,
+};
+
+impl ty::TyTraitType {
+    pub(crate) fn type_check(
+        handler: &Handler,
+        mut ctx: TypeCheckContext,
+        trait_type: parsed::TraitTypeDeclaration,
+    ) -> Result<Self, ErrorEmitted> {
+        let parsed::TraitTypeDeclaration {
+            name,
+            attributes,
+            ty_opt,
+            span,
+        } = trait_type;
+
+        let engines = ctx.engines();
+        let type_engine = engines.te();
+
+        let ty = if let Some(mut ty) = ty_opt {
+            ty.type_id = ctx
+                .resolve_type_with_self(
+                    handler,
+                    ty.type_id,
+                    &ty.span,
+                    EnforceTypeArguments::No,
+                    None,
+                )
+                .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err)));
+            Some(ty)
+        } else {
+            None
+        };
+
+        let trait_type = ty::TyTraitType {
+            name,
+            attributes,
+            ty,
+            span,
+        };
+
+        Ok(trait_type)
+    }
+
+    /// Used to create a stubbed out constant when the constant fails to
+    /// compile, preventing cascading namespace errors.
+    pub(crate) fn error(_engines: &Engines, decl: parsed::TraitTypeDeclaration) -> TyTraitType {
+        let parsed::TraitTypeDeclaration {
+            name,
+            attributes,
+            ty_opt,
+            span,
+        } = decl;
+        TyTraitType {
+            name,
+            attributes,
+            ty: ty_opt,
+            span,
+        }
+    }
+}

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -112,17 +112,18 @@ fn type_check_variable(
     name: Ident,
     span: Span,
 ) -> Result<ty::TyScrutinee, ErrorEmitted> {
-    let type_engine = ctx.engines.te();
-    let decl_engine = ctx.engines.de();
+    let engines = ctx.engines;
+    let type_engine = engines.te();
+    let decl_engine = engines.de();
 
     let typed_scrutinee = match ctx
         .namespace
-        .resolve_symbol(&Handler::default(), &name)
+        .resolve_symbol(&Handler::default(), engines, &name)
         .ok()
     {
         // If this variable is a constant, then we turn it into a [TyScrutinee::Constant](ty::TyScrutinee::Constant).
         Some(ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. })) => {
-            let constant_decl = decl_engine.get_constant(decl_id);
+            let constant_decl = decl_engine.get_constant(&decl_id);
             let value = match constant_decl.value {
                 Some(ref value) => value,
                 None => {
@@ -165,14 +166,14 @@ fn type_check_struct(
     fields: Vec<StructScrutineeField>,
     span: Span,
 ) -> Result<ty::TyScrutinee, ErrorEmitted> {
-    let type_engine = ctx.engines.te();
-    let decl_engine = ctx.engines.de();
+    let engines = ctx.engines;
+    let type_engine = engines.te();
+    let decl_engine = engines.de();
 
     // find the struct definition from the name
     let unknown_decl = ctx
         .namespace
-        .resolve_symbol(handler, &struct_name)
-        .cloned()?;
+        .resolve_symbol(handler, engines, &struct_name)?;
     let struct_ref = unknown_decl.to_struct_ref(handler, ctx.engines())?;
     let mut struct_decl = decl_engine.get_struct(&struct_ref);
 
@@ -274,8 +275,7 @@ fn type_check_enum(
             // find the enum definition from the name
             let unknown_decl = ctx
                 .namespace
-                .resolve_call_path(handler, &enum_callpath)
-                .cloned()?;
+                .resolve_call_path(handler, engines, &enum_callpath)?;
             let enum_ref = unknown_decl.to_enum_ref(handler, ctx.engines())?;
             (
                 enum_callpath.span(),
@@ -287,8 +287,7 @@ fn type_check_enum(
             // we may have an imported variant
             let decl = ctx
                 .namespace
-                .resolve_call_path(handler, &call_path)
-                .cloned()?;
+                .resolve_call_path(handler, engines, &call_path)?;
             if let TyDecl::EnumVariantDecl(ty::EnumVariantDecl { enum_ref, .. }) = decl.clone() {
                 (
                     call_path.suffix.span(),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -137,7 +137,7 @@ pub(crate) fn type_check_method_application(
         if let Some(coins_expr) = contract_call_params_map.get(CONTRACT_CALL_COINS_PARAMETER_NAME) {
             if coins_analysis::possibly_nonzero_u64_expression(
                 ctx.namespace,
-                decl_engine,
+                ctx.engines,
                 coins_expr,
             ) && !method
                 .attributes
@@ -198,10 +198,9 @@ pub(crate) fn type_check_method_application(
     ) -> Result<(), ErrorEmitted> {
         match exp {
             ty::TyExpressionVariant::VariableExpression { name, .. } => {
-                let unknown_decl = ctx
-                    .namespace
-                    .resolve_symbol(&Handler::default(), name)
-                    .cloned()?;
+                let unknown_decl =
+                    ctx.namespace
+                        .resolve_symbol(&Handler::default(), ctx.engines, name)?;
 
                 let is_decl_mutable = match unknown_decl {
                     ty::TyDecl::ConstantDecl { .. } => false,

--- a/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
+++ b/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
@@ -127,6 +127,7 @@ fn impl_trait_methods(
         .flat_map(|item| match item {
             ty::TyImplItem::Fn(fn_decl) => Some(fn_decl),
             ty::TyImplItem::Constant(_) => None,
+            ty::TyImplItem::Type(_) => None,
         })
         .flat_map(|fn_decl| decl_id_to_fn_decls(decl_engine, &fn_decl.id().clone()))
         .collect()

--- a/sway-core/src/semantic_analysis/coins_analysis.rs
+++ b/sway-core/src/semantic_analysis/coins_analysis.rs
@@ -1,6 +1,6 @@
 use sway_error::handler::Handler;
 
-use crate::{decl_engine::DeclEngine, language::ty, Namespace};
+use crate::{language::ty, Engines, Namespace};
 
 // This analysis checks if an expression is known statically to evaluate
 // to a non-zero value at runtime.
@@ -8,7 +8,7 @@ use crate::{decl_engine::DeclEngine, language::ty, Namespace};
 // method gets called with a non-zero amount of `coins`
 pub fn possibly_nonzero_u64_expression(
     namespace: &Namespace,
-    decl_engine: &DeclEngine,
+    engines: &Engines,
     expr: &ty::TyExpression,
 ) -> bool {
     use ty::TyExpressionVariant::*;
@@ -18,21 +18,24 @@ pub fn possibly_nonzero_u64_expression(
         // not a u64 literal, hence we return true to be on the safe side
         Literal(_) => true,
         ConstantExpression { const_decl, .. } => match &const_decl.value {
-            Some(expr) => possibly_nonzero_u64_expression(namespace, decl_engine, expr),
+            Some(expr) => possibly_nonzero_u64_expression(namespace, engines, expr),
             None => false,
         },
         VariableExpression { name, .. } => {
-            match namespace.resolve_symbol(&Handler::default(), name).ok() {
+            match namespace
+                .resolve_symbol(&Handler::default(), engines, name)
+                .ok()
+            {
                 Some(ty_decl) => {
                     match ty_decl {
                         ty::TyDecl::VariableDecl(var_decl) => {
-                            possibly_nonzero_u64_expression(namespace, decl_engine, &var_decl.body)
+                            possibly_nonzero_u64_expression(namespace, engines, &var_decl.body)
                         }
                         ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
-                            let const_decl = decl_engine.get_constant(decl_id);
+                            let const_decl = engines.de().get_constant(&decl_id);
                             match const_decl.value {
                                 Some(value) => {
-                                    possibly_nonzero_u64_expression(namespace, decl_engine, &value)
+                                    possibly_nonzero_u64_expression(namespace, engines, &value)
                                 }
                                 None => true,
                             }

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -291,6 +291,7 @@ impl Items {
             .filter_map(|item| match item {
                 ty::TyTraitItem::Fn(decl_ref) => Some(decl_ref),
                 ty::TyTraitItem::Constant(_decl_ref) => None,
+                ty::TyTraitItem::Type(_decl_ref) => None,
             })
             .collect::<Vec<_>>()
     }

--- a/sway-core/src/semantic_analysis/namespace/root.rs
+++ b/sway-core/src/semantic_analysis/namespace/root.rs
@@ -6,8 +6,12 @@ use sway_types::Spanned;
 use sway_utils::iter_prefixes;
 
 use crate::{
-    language::{ty, CallPath},
-    Engines, Ident,
+    decl_engine::DeclRef,
+    language::{
+        ty::{self, TypeDecl},
+        CallPath,
+    },
+    Engines, Ident, TypeId, TypeInfo,
 };
 
 use super::{module::Module, namespace::Namespace, Path};
@@ -33,15 +37,35 @@ impl Root {
     pub(crate) fn resolve_call_path(
         &self,
         handler: &Handler,
+        engines: &Engines,
         mod_path: &Path,
         call_path: &CallPath,
-    ) -> Result<&ty::TyDecl, ErrorEmitted> {
+    ) -> Result<ty::TyDecl, ErrorEmitted> {
+        let (decl, _) =
+            self.resolve_call_path_and_mod_path(handler, engines, mod_path, call_path, None)?;
+        Ok(decl)
+    }
+
+    fn resolve_call_path_and_mod_path(
+        &self,
+        handler: &Handler,
+        engines: &Engines,
+        mod_path: &Path,
+        call_path: &CallPath,
+        self_type: Option<TypeId>,
+    ) -> Result<(ty::TyDecl, Vec<Ident>), ErrorEmitted> {
         let symbol_path: Vec<_> = mod_path
             .iter()
             .chain(&call_path.prefixes)
             .cloned()
             .collect();
-        self.resolve_symbol(handler, &symbol_path, &call_path.suffix)
+        self.resolve_symbol_and_mod_path(
+            handler,
+            engines,
+            &symbol_path,
+            &call_path.suffix,
+            self_type,
+        )
     }
 
     /// Resolve a symbol that is potentially prefixed with some path, e.g. `foo::bar::symbol`.
@@ -58,17 +82,39 @@ impl Root {
         engines: &Engines,
         mod_path: &Path,
         call_path: &CallPath,
-    ) -> Result<&ty::TyDecl, ErrorEmitted> {
-        let decl = self.resolve_call_path(handler, mod_path, call_path)?;
+    ) -> Result<ty::TyDecl, ErrorEmitted> {
+        self.resolve_call_path_with_self_with_visibility_check(
+            handler, engines, mod_path, call_path, None,
+        )
+    }
+
+    /// Resolve a symbol that is potentially prefixed with some path, e.g. `foo::bar::symbol`.
+    ///
+    /// This will concatenate the `mod_path` with the `call_path`'s prefixes and
+    /// then calling `resolve_symbol` with the resulting path and call_path's suffix.
+    ///
+    /// The `mod_path` is significant here as we assume the resolution is done within the
+    /// context of the module pointed to by `mod_path` and will only check the call path prefixes
+    /// and the symbol's own visibility
+    pub(crate) fn resolve_call_path_with_self_with_visibility_check(
+        &self,
+        handler: &Handler,
+        engines: &Engines,
+        mod_path: &Path,
+        call_path: &CallPath,
+        self_type: Option<TypeId>,
+    ) -> Result<ty::TyDecl, ErrorEmitted> {
+        let (decl, mod_path) =
+            self.resolve_call_path_and_mod_path(handler, engines, mod_path, call_path, self_type)?;
 
         // In case there are no prefixes we don't need to check visibility
-        if call_path.prefixes.is_empty() {
+        if mod_path.is_empty() {
             return Ok(decl);
         }
 
         // check the visibility of the call path elements
         // we don't check the first prefix because direct children are always accessible
-        for prefix in iter_prefixes(&call_path.prefixes).skip(1) {
+        for prefix in iter_prefixes(&mod_path).skip(1) {
             let module = self.check_submodule(handler, prefix)?;
             if module.visibility.is_private() {
                 let prefix_last = prefix[prefix.len() - 1].clone();
@@ -98,25 +144,172 @@ impl Root {
     pub(crate) fn resolve_symbol(
         &self,
         handler: &Handler,
+        engines: &Engines,
         mod_path: &Path,
         symbol: &Ident,
-    ) -> Result<&ty::TyDecl, ErrorEmitted> {
-        self.check_submodule(handler, mod_path).and_then(|module| {
-            let true_symbol = self[mod_path]
-                .use_aliases
-                .get(symbol.as_str())
-                .unwrap_or(symbol);
-            match module.use_synonyms.get(symbol) {
-                Some((_, _, decl @ ty::TyDecl::EnumVariantDecl { .. }, _)) => Ok(decl),
-                Some((src_path, _, _, _)) if mod_path != src_path => {
-                    // TODO: check that the symbol import is public?
-                    self.resolve_symbol(handler, src_path, true_symbol)
+    ) -> Result<ty::TyDecl, ErrorEmitted> {
+        let (decl, _) =
+            self.resolve_symbol_and_mod_path(handler, engines, mod_path, symbol, None)?;
+        Ok(decl)
+    }
+
+    fn resolve_symbol_and_mod_path(
+        &self,
+        handler: &Handler,
+        engines: &Engines,
+        mod_path: &Path,
+        symbol: &Ident,
+        self_type: Option<TypeId>,
+    ) -> Result<(ty::TyDecl, Vec<Ident>), ErrorEmitted> {
+        // This block tries to resolve associated types
+        let mut module = &self.module;
+        let mut current_mod_path = vec![];
+        let mut decl_opt = None;
+        let mut type_id_opt = None;
+        for (ident_index, ident) in mod_path.iter().enumerate() {
+            if let Some(type_id) = type_id_opt {
+                type_id_opt = None;
+                decl_opt = Some(
+                    self.resolve_associated_type_from_type_id(handler, engines, ident, type_id)?,
+                );
+            } else if ident_index == 0 && ident.as_str() == "Self" {
+                if let Some(self_type) = self_type {
+                    type_id_opt = Some(self_type);
+                } else {
+                    return Err(handler.emit_err(CompileError::Internal(
+                        "Self type not specified",
+                        ident.span(),
+                    )));
                 }
-                _ => module
-                    .check_symbol(true_symbol)
-                    .map_err(|e| handler.emit_err(e)),
+            } else {
+                if let Some(decl) = decl_opt {
+                    decl_opt = Some(self.resolve_associated_type(handler, engines, ident, decl)?);
+                } else {
+                    match module.submodules.get(ident.as_str()) {
+                        Some(ns) => {
+                            module = ns;
+                            current_mod_path.push(ident.clone());
+                        }
+                        None => {
+                            decl_opt = Some(self.resolve_symbol_helper(
+                                handler,
+                                engines,
+                                &current_mod_path,
+                                ident,
+                                module,
+                            )?);
+                        }
+                    }
+                }
             }
+        }
+        if let Some(type_id) = type_id_opt {
+            let decl =
+                self.resolve_associated_type_from_type_id(handler, engines, symbol, type_id)?;
+            return Ok((decl, current_mod_path));
+        }
+        if let Some(decl) = decl_opt {
+            let decl = self.resolve_associated_type(handler, engines, symbol, decl)?;
+            return Ok((decl, current_mod_path));
+        }
+
+        self.check_submodule(handler, mod_path).and_then(|module| {
+            let decl = self.resolve_symbol_helper(handler, engines, mod_path, symbol, module)?;
+            Ok((decl, mod_path.to_vec()))
         })
+    }
+
+    fn resolve_associated_type(
+        &self,
+        handler: &Handler,
+        engines: &Engines,
+        symbol: &Ident,
+        decl: ty::TyDecl,
+    ) -> Result<ty::TyDecl, ErrorEmitted> {
+        let type_info = match decl.clone() {
+            ty::TyDecl::StructDecl(struct_decl) => TypeInfo::Struct(DeclRef::new(
+                struct_decl.name.clone(),
+                struct_decl.decl_id,
+                struct_decl.name.span(),
+            )),
+            ty::TyDecl::EnumDecl(enum_decl) => TypeInfo::Enum(DeclRef::new(
+                enum_decl.name.clone(),
+                enum_decl.decl_id,
+                enum_decl.name.span(),
+            )),
+            ty::TyDecl::TypeDecl(type_decl) => {
+                let type_decl = engines.de().get_type(&type_decl.decl_id);
+                engines.te().get(type_decl.ty.unwrap().type_id)
+            }
+            _ => {
+                return Err(handler.emit_err(CompileError::SymbolNotFound {
+                    name: symbol.clone(),
+                    span: symbol.span(),
+                }))
+            }
+        };
+
+        self.resolve_associated_type_from_type_id(
+            handler,
+            engines,
+            symbol,
+            engines.te().insert(engines, type_info),
+        )
+    }
+
+    fn resolve_associated_type_from_type_id(
+        &self,
+        handler: &Handler,
+        engines: &Engines,
+        symbol: &Ident,
+        type_id: TypeId,
+    ) -> Result<ty::TyDecl, ErrorEmitted> {
+        for trait_item in self.implemented_traits.get_items_for_type(engines, type_id) {
+            match trait_item {
+                ty::TyTraitItem::Fn(_) => {}
+                ty::TyTraitItem::Constant(_) => {}
+                ty::TyTraitItem::Type(type_ref) => {
+                    let type_decl = engines.de().get_type(type_ref.id());
+                    if type_decl.name.as_str() == symbol.as_str() {
+                        return Ok(ty::TyDecl::TypeDecl(TypeDecl {
+                            name: type_decl.name.clone(),
+                            decl_id: *type_ref.id(),
+                            decl_span: type_decl.name.span(),
+                        }));
+                    }
+                }
+            }
+        }
+
+        Err(handler.emit_err(CompileError::SymbolNotFound {
+            name: symbol.clone(),
+            span: symbol.span(),
+        }))
+    }
+
+    fn resolve_symbol_helper(
+        &self,
+        handler: &Handler,
+        engines: &Engines,
+        mod_path: &Path,
+        symbol: &Ident,
+        module: &Module,
+    ) -> Result<ty::TyDecl, ErrorEmitted> {
+        let true_symbol = self[mod_path]
+            .use_aliases
+            .get(symbol.as_str())
+            .unwrap_or(symbol);
+        match module.use_synonyms.get(symbol) {
+            Some((_, _, decl @ ty::TyDecl::EnumVariantDecl { .. }, _)) => Ok(decl.clone()),
+            Some((src_path, _, _, _)) if mod_path != src_path => {
+                // TODO: check that the symbol import is public?
+                self.resolve_symbol(handler, engines, src_path, true_symbol)
+            }
+            _ => module
+                .check_symbol(true_symbol)
+                .map_err(|e| handler.emit_err(e))
+                .cloned(),
+        }
     }
 }
 

--- a/sway-core/src/semantic_analysis/namespace/root.rs
+++ b/sway-core/src/semantic_analysis/namespace/root.rs
@@ -181,24 +181,22 @@ impl Root {
                         ident.span(),
                     )));
                 }
+            } else if let Some(decl) = decl_opt {
+                decl_opt = Some(self.resolve_associated_type(handler, engines, ident, decl)?);
             } else {
-                if let Some(decl) = decl_opt {
-                    decl_opt = Some(self.resolve_associated_type(handler, engines, ident, decl)?);
-                } else {
-                    match module.submodules.get(ident.as_str()) {
-                        Some(ns) => {
-                            module = ns;
-                            current_mod_path.push(ident.clone());
-                        }
-                        None => {
-                            decl_opt = Some(self.resolve_symbol_helper(
-                                handler,
-                                engines,
-                                &current_mod_path,
-                                ident,
-                                module,
-                            )?);
-                        }
+                match module.submodules.get(ident.as_str()) {
+                    Some(ns) => {
+                        module = ns;
+                        current_mod_path.push(ident.clone());
+                    }
+                    None => {
+                        decl_opt = Some(self.resolve_symbol_helper(
+                            handler,
+                            engines,
+                            &current_mod_path,
+                            ident,
+                            module,
+                        )?);
                     }
                 }
             }

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -308,6 +308,7 @@ impl Dependencies {
                 .gather_from_type_argument(engines, type_ascription)
                 .gather_from_expr(engines, body),
             Declaration::ConstantDeclaration(decl) => self.gather_from_constant_decl(engines, decl),
+            Declaration::TraitTypeDeclaration(decl) => self.gather_from_type_decl(engines, decl),
             Declaration::FunctionDeclaration(fn_decl) => self.gather_from_fn_decl(engines, fn_decl),
             Declaration::StructDeclaration(StructDeclaration {
                 fields,
@@ -806,6 +807,7 @@ fn decl_name(type_engine: &TypeEngine, decl: &Declaration) -> Option<DependentSy
             Some(decl.span.clone()),
         )),
         Declaration::ConstantDeclaration(decl) => dep_sym(decl.name.clone()),
+        Declaration::TraitTypeDeclaration(decl) => dep_sym(decl.name.clone()),
         Declaration::StructDeclaration(decl) => dep_sym(decl.name.clone()),
         Declaration::EnumDeclaration(decl) => dep_sym(decl.name.clone()),
         Declaration::TraitDeclaration(decl) => dep_sym(decl.name.clone()),

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -345,6 +345,7 @@ impl Dependencies {
                     TraitItem::Constant(const_decl) => {
                         deps.gather_from_constant_decl(engines, const_decl)
                     }
+                    TraitItem::Type(type_decl) => deps.gather_from_type_decl(engines, type_decl),
                 })
                 .gather_from_iter(methods.iter(), |deps, fn_decl| {
                     deps.gather_from_fn_decl(engines, fn_decl)
@@ -364,6 +365,7 @@ impl Dependencies {
                     ImplItem::Constant(const_decl) => {
                         deps.gather_from_constant_decl(engines, const_decl)
                     }
+                    ImplItem::Type(type_decl) => deps.gather_from_type_decl(engines, type_decl),
                 }),
             Declaration::ImplSelf(ImplSelf {
                 implementing_for,
@@ -376,6 +378,7 @@ impl Dependencies {
                     ImplItem::Constant(const_decl) => {
                         deps.gather_from_constant_decl(engines, const_decl)
                     }
+                    ImplItem::Type(type_decl) => deps.gather_from_type_decl(engines, type_decl),
                 }),
             Declaration::AbiDeclaration(AbiDeclaration {
                 interface_surface,
@@ -395,6 +398,7 @@ impl Dependencies {
                     TraitItem::Constant(const_decl) => {
                         deps.gather_from_constant_decl(engines, const_decl)
                     }
+                    TraitItem::Type(type_decl) => deps.gather_from_type_decl(engines, type_decl),
                 })
                 .gather_from_iter(methods.iter(), |deps, fn_decl| {
                     deps.gather_from_fn_decl(engines, fn_decl)
@@ -429,6 +433,14 @@ impl Dependencies {
             Some(value) => self
                 .gather_from_type_argument(engines, type_ascription)
                 .gather_from_expr(engines, value),
+            None => self,
+        }
+    }
+
+    fn gather_from_type_decl(self, engines: &Engines, type_decl: &TraitTypeDeclaration) -> Self {
+        let TraitTypeDeclaration { ty_opt, .. } = type_decl;
+        match ty_opt {
+            Some(value) => self.gather_from_type_argument(engines, value),
             None => self,
         }
     }
@@ -811,6 +823,7 @@ fn decl_name(type_engine: &TypeEngine, decl: &Declaration) -> Option<DependentSy
                     .map(|item| match item {
                         ImplItem::Fn(fn_decl) => fn_decl.name.as_str(),
                         ImplItem::Constant(const_decl) => const_decl.name.as_str(),
+                        ImplItem::Type(type_decl) => type_decl.name.as_str(),
                     })
                     .collect::<Vec<&str>>()
                     .join(""),
@@ -826,6 +839,7 @@ fn decl_name(type_engine: &TypeEngine, decl: &Declaration) -> Option<DependentSy
                         .map(|item| match item {
                             ImplItem::Fn(fn_decl) => fn_decl.name.as_str(),
                             ImplItem::Constant(const_decl) => const_decl.name.as_str(),
+                            ImplItem::Type(type_decl) => type_decl.name.as_str(),
                         })
                         .collect::<Vec<&str>>()
                         .join(""),
@@ -881,6 +895,7 @@ fn type_info_name(type_info: &TypeInfo) -> String {
         TypeInfo::Ptr(..) => "__ptr",
         TypeInfo::Slice(..) => "__slice",
         TypeInfo::Alias { .. } => "alias",
+        TypeInfo::TraitType { .. } => "trait type",
     }
     .to_string()
 }

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -17,7 +17,7 @@ use sway_ast::{
     ItemStorage, ItemStruct, ItemTrait, ItemTraitItem, ItemTypeAlias, ItemUse, LitInt, LitIntType,
     MatchBranchKind, Module, ModuleKind, Parens, PathExpr, PathExprSegment, PathType,
     PathTypeSegment, Pattern, PatternStructField, PubToken, Punctuated, QualifiedPathRoot,
-    Statement, StatementLet, Submodule, Traits, Ty, TypeField, UseTree, WhereClause,
+    Statement, StatementLet, Submodule, TraitType, Traits, Ty, TypeField, UseTree, WhereClause,
 };
 use sway_error::convert_parse_tree_error::ConvertParseTreeError;
 use sway_error::handler::{ErrorEmitted, Handler};
@@ -600,6 +600,10 @@ fn item_trait_to_trait_declaration(
                     context, handler, engines, const_decl, attributes, false,
                 )
                 .map(TraitItem::Constant),
+                ItemTraitItem::Type(trait_type) => trait_type_to_trait_type_declaration(
+                    context, handler, engines, trait_type, attributes,
+                )
+                .map(TraitItem::Type),
             }?))
         })
         .filter_map_ok(|item| item)
@@ -676,6 +680,10 @@ fn item_impl_to_declaration(
                     context, handler, engines, const_item, attributes, true,
                 )
                 .map(ImplItem::Constant),
+                sway_ast::ItemImplItem::Type(type_item) => trait_type_to_trait_type_declaration(
+                    context, handler, engines, type_item, attributes,
+                )
+                .map(ImplItem::Type),
             }?))
         })
         .filter_map_ok(|item| item)
@@ -787,6 +795,10 @@ fn item_abi_to_abi_declaration(
                             context, handler, engines, const_decl, attributes, false,
                         )
                         .map(TraitItem::Constant),
+                        ItemTraitItem::Type(type_decl) => trait_type_to_trait_type_declaration(
+                            context, handler, engines, type_decl, attributes,
+                        )
+                        .map(TraitItem::Type),
                     }?))
                 })
                 .filter_map_ok(|item| item)
@@ -876,6 +888,27 @@ pub(crate) fn item_const_to_constant_declaration(
         visibility: pub_token_opt_to_visibility(item_const.visibility),
         is_configurable: false,
         attributes,
+        span,
+    })
+}
+
+pub(crate) fn trait_type_to_trait_type_declaration(
+    context: &mut Context,
+    handler: &Handler,
+    engines: &Engines,
+    trait_type: TraitType,
+    attributes: AttributesMap,
+) -> Result<TraitTypeDeclaration, ErrorEmitted> {
+    let span = trait_type.span();
+
+    Ok(TraitTypeDeclaration {
+        name: trait_type.name.clone(),
+        attributes,
+        ty_opt: if let Some(ty) = trait_type.ty_opt {
+            Some(ty_to_type_argument(context, handler, engines, ty)?)
+        } else {
+            None
+        },
         span,
     })
 }
@@ -3927,6 +3960,23 @@ fn path_type_to_type_info(
     } = path_type.clone();
 
     let type_info = match type_name_to_type_info_opt(&name) {
+        Some(type_info @ TypeInfo::SelfType) => {
+            if root_opt.is_some() {
+                let error = ConvertParseTreeError::FullySpecifiedTypesNotSupported { span };
+                return Err(handler.emit_err(error.into()));
+            }
+            if !suffix.is_empty() {
+                let (call_path, type_arguments) = path_type_to_call_path_and_type_arguments(
+                    context, handler, engines, path_type,
+                )?;
+                TypeInfo::Custom {
+                    call_path,
+                    type_arguments: Some(type_arguments),
+                }
+            } else {
+                type_info
+            }
+        }
         Some(type_info) => {
             if root_opt.is_some() || !suffix.is_empty() {
                 let error = ConvertParseTreeError::FullySpecifiedTypesNotSupported { span };

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -231,10 +231,9 @@ impl TypeCheckTypeBinding<ty::TyFunctionDecl> for TypeBinding<CallPath> {
         let decl_engine = ctx.engines.de();
         let engines = ctx.engines();
         // Grab the declaration.
-        let unknown_decl = ctx
-            .namespace
-            .resolve_call_path_with_visibility_check(handler, engines, &self.inner)
-            .cloned()?;
+        let unknown_decl =
+            ctx.namespace
+                .resolve_call_path_with_visibility_check(handler, engines, &self.inner)?;
         // Check to see if this is a fn declaration.
         let fn_ref = unknown_decl.to_fn_ref(handler)?;
         // Get a new copy from the declaration engine.
@@ -293,10 +292,9 @@ impl TypeCheckTypeBinding<ty::TyStructDecl> for TypeBinding<CallPath> {
         let decl_engine = ctx.engines.de();
         let engines = ctx.engines();
         // Grab the declaration.
-        let unknown_decl = ctx
-            .namespace
-            .resolve_call_path_with_visibility_check(handler, engines, &self.inner)
-            .cloned()?;
+        let unknown_decl =
+            ctx.namespace
+                .resolve_call_path_with_visibility_check(handler, engines, &self.inner)?;
         // Check to see if this is a struct declaration.
         let struct_ref = unknown_decl.to_struct_ref(handler, engines)?;
         // Get a new copy from the declaration engine.
@@ -336,10 +334,9 @@ impl TypeCheckTypeBinding<ty::TyEnumDecl> for TypeBinding<CallPath> {
         let decl_engine = ctx.engines.de();
         let engines = ctx.engines();
         // Grab the declaration.
-        let unknown_decl = ctx
-            .namespace
-            .resolve_call_path_with_visibility_check(handler, engines, &self.inner)
-            .cloned()?;
+        let unknown_decl =
+            ctx.namespace
+                .resolve_call_path_with_visibility_check(handler, engines, &self.inner)?;
 
         // Get a new copy from the declaration engine.
         let mut new_copy = if let ty::TyDecl::EnumVariantDecl(ty::EnumVariantDecl {
@@ -388,10 +385,9 @@ impl TypeCheckTypeBinding<ty::TyConstantDecl> for TypeBinding<CallPath> {
         let engines = ctx.engines();
 
         // Grab the declaration.
-        let unknown_decl = ctx
-            .namespace
-            .resolve_call_path_with_visibility_check(handler, engines, &self.inner)
-            .cloned()?;
+        let unknown_decl =
+            ctx.namespace
+                .resolve_call_path_with_visibility_check(handler, engines, &self.inner)?;
 
         // Check to see if this is a const declaration.
         let const_ref = unknown_decl.to_const_ref(handler)?;

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -172,7 +172,8 @@ impl TraitConstraint {
         type_id: TypeId,
         trait_constraint: &TraitConstraint,
     ) -> Result<(), ErrorEmitted> {
-        let decl_engine = ctx.engines.de();
+        let engines = ctx.engines;
+        let decl_engine = engines.de();
 
         let TraitConstraint {
             trait_name,
@@ -183,9 +184,8 @@ impl TraitConstraint {
 
         match ctx
             .namespace
-            .resolve_call_path(handler, trait_name)
+            .resolve_call_path(handler, engines, trait_name)
             .ok()
-            .cloned()
         {
             Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
                 let mut trait_decl = decl_engine.get_trait(&decl_id);

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -342,7 +342,8 @@ fn handle_trait(
     trait_name: &CallPath,
     type_arguments: &[TypeArgument],
 ) -> Result<(InterfaceItemMap, ItemMap, ItemMap), ErrorEmitted> {
-    let decl_engine = ctx.engines.de();
+    let engines = ctx.engines;
+    let decl_engine = engines.de();
 
     let mut interface_item_refs: InterfaceItemMap = BTreeMap::new();
     let mut item_refs: ItemMap = BTreeMap::new();
@@ -351,9 +352,8 @@ fn handle_trait(
     handler.scope(|handler| {
         match ctx
             .namespace
-            .resolve_call_path(handler, trait_name)
+            .resolve_call_path(handler, engines, trait_name)
             .ok()
-            .cloned()
         {
             Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
                 let trait_decl = decl_engine.get_trait(&decl_id);

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -500,21 +500,19 @@ impl TypeEngine {
 
                         if let Some(ty) = decl_type.ty {
                             ty.type_id
+                        } else if let Some(self_type) = self_type {
+                            self.insert(
+                                engines,
+                                TypeInfo::TraitType {
+                                    name,
+                                    trait_type_id: self_type,
+                                },
+                            )
                         } else {
-                            if let Some(self_type) = self_type {
-                                self.insert(
-                                    engines,
-                                    TypeInfo::TraitType {
-                                        name,
-                                        trait_type_id: self_type,
-                                    },
-                                )
-                            } else {
-                                return Err(handler.emit_err(CompileError::Internal(
-                                    "Self type not specified",
-                                    decl_span,
-                                )));
-                            }
+                            return Err(handler.emit_err(CompileError::Internal(
+                                "Self type not specified",
+                                decl_span,
+                            )));
                         }
                     }
                     _ => {

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -223,6 +223,19 @@ impl ReplaceSelfType for TypeId {
                     ty.type_id = type_id;
                     type_engine.insert(engines, TypeInfo::Slice(ty))
                 }),
+                TypeInfo::TraitType {
+                    name,
+                    mut trait_type_id,
+                } => helper(trait_type_id, engines, self_type).map(|type_id| {
+                    trait_type_id = type_id;
+                    type_engine.insert(
+                        engines,
+                        TypeInfo::TraitType {
+                            name,
+                            trait_type_id,
+                        },
+                    )
+                }),
                 TypeInfo::Unknown
                 | TypeInfo::UnknownGeneric { .. }
                 | TypeInfo::Str(_)

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -348,8 +348,8 @@ impl PartialEqWithEngines for TypeInfo {
             ) => {
                 l_name == r_name
                     && type_engine
-                        .get(l_trait_type_id.clone())
-                        .eq(&type_engine.get(r_trait_type_id.clone()), engines)
+                        .get(*l_trait_type_id)
+                        .eq(&type_engine.get(*r_trait_type_id), engines)
             }
             (l, r) => l.discriminant_value() == r.discriminant_value(),
         }

--- a/sway-core/src/type_system/substitute/subst_map.rs
+++ b/sway-core/src/type_system/substitute/subst_map.rs
@@ -11,6 +11,7 @@ type DestinationType = TypeId;
 
 /// The [TypeSubstMap] is used to create a mapping between a [SourceType] (LHS)
 /// and a [DestinationType] (RHS).
+#[derive(Clone)]
 pub struct TypeSubstMap {
     mapping: BTreeMap<SourceType, DestinationType>,
 }
@@ -293,6 +294,10 @@ impl TypeSubstMap {
         TypeSubstMap { mapping }
     }
 
+    pub(crate) fn extend(&mut self, subst_map: TypeSubstMap) {
+        self.mapping.extend(subst_map.mapping.iter());
+    }
+
     /// Given a [TypeId] `type_id`, find (or create) a match for `type_id` in
     /// this [TypeSubstMap] and return it, if there is a match. Importantly, this
     /// function is recursive, so any `type_id` it's given will undergo
@@ -422,6 +427,7 @@ impl TypeSubstMap {
                 ty.type_id = type_id;
                 type_engine.insert(engines, TypeInfo::Slice(ty))
             }),
+            TypeInfo::TraitType { .. } => iter_for_match(engines, self, &type_info),
             TypeInfo::Unknown
             | TypeInfo::Str(..)
             | TypeInfo::UnsignedInteger(..)

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -72,6 +72,8 @@ pub enum CompileError {
     MultipleDefinitionsOfName { name: Ident, span: Span },
     #[error("Constant \"{name}\" was already defined in scope.")]
     MultipleDefinitionsOfConstant { name: Ident, span: Span },
+    #[error("Type \"{name}\" was already defined in scope.")]
+    MultipleDefinitionsOfType { name: Ident, span: Span },
     #[error("Assignment to immutable variable. Variable {name} is not declared as mutable.")]
     AssignmentToNonMutable { name: Ident, span: Span },
     #[error(
@@ -131,6 +133,12 @@ pub enum CompileError {
     },
     #[error("Constant \"{name}\" is not a part of {interface_name}'s interface surface.")]
     ConstantNotAPartOfInterfaceSurface {
+        name: Ident,
+        interface_name: InterfaceName,
+        span: Span,
+    },
+    #[error("Type \"{name}\" is not a part of {interface_name}'s interface surface.")]
+    TypeNotAPartOfInterfaceSurface {
         name: Ident,
         interface_name: InterfaceName,
         span: Span,
@@ -703,6 +711,7 @@ impl Spanned for CompileError {
             MultipleDefinitionsOfFunction { span, .. } => span.clone(),
             MultipleDefinitionsOfName { span, .. } => span.clone(),
             MultipleDefinitionsOfConstant { span, .. } => span.clone(),
+            MultipleDefinitionsOfType { span, .. } => span.clone(),
             AssignmentToNonMutable { span, .. } => span.clone(),
             MutableParameterNotSupported { span, .. } => span.clone(),
             ImmutableArgumentToMutableParameter { span } => span.clone(),
@@ -714,6 +723,7 @@ impl Spanned for CompileError {
             UnknownTrait { span, .. } => span.clone(),
             FunctionNotAPartOfInterfaceSurface { span, .. } => span.clone(),
             ConstantNotAPartOfInterfaceSurface { span, .. } => span.clone(),
+            TypeNotAPartOfInterfaceSurface { span, .. } => span.clone(),
             MissingInterfaceSurfaceConstants { span, .. } => span.clone(),
             MissingInterfaceSurfaceMethods { span, .. } => span.clone(),
             IncorrectNumberOfTypeArguments { span, .. } => span.clone(),

--- a/sway-lsp/src/capabilities/code_actions/abi_decl/abi_impl.rs
+++ b/sway-lsp/src/capabilities/code_actions/abi_decl/abi_impl.rs
@@ -86,6 +86,7 @@ impl AbiImplCodeAction<'_> {
                             )
                         }
                         ty::TyTraitInterfaceItem::Constant(_) => unreachable!(),
+                        ty::TyTraitInterfaceItem::Type(_) => unreachable!(),
                     }
                 })
                 .collect::<Vec<String>>()

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
@@ -119,6 +119,7 @@ impl<'a> CodeAction<'a, TyStructDecl> for StructNewCodeAction<'a> {
                     fn_decl.span().as_str().contains("fn new")
                 }
                 sway_core::language::ty::TyTraitItem::Constant(_) => false,
+                sway_core::language::ty::TyTraitItem::Type(_) => false,
             })
         {
             Some(CodeActionDisabled {

--- a/sway-lsp/src/capabilities/document_symbol.rs
+++ b/sway-lsp/src/capabilities/document_symbol.rs
@@ -37,6 +37,7 @@ pub(crate) fn symbol_kind(symbol_kind: &SymbolKind) -> lsp_types::SymbolKind {
         | SymbolKind::ByteLiteral
         | SymbolKind::Variable
         | SymbolKind::TypeAlias
+        | SymbolKind::TraiType
         | SymbolKind::Keyword
         | SymbolKind::SelfKeyword
         | SymbolKind::SelfTypeKeyword

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -156,6 +156,7 @@ fn semantic_token_type(kind: &SymbolKind) -> SemanticTokenType {
         SymbolKind::ByteLiteral | SymbolKind::NumericLiteral => SemanticTokenType::NUMBER,
         SymbolKind::BoolLiteral => SemanticTokenType::new("boolean"),
         SymbolKind::TypeAlias => SemanticTokenType::new("typeAlias"),
+        SymbolKind::TraiType => SemanticTokenType::new("traitType"),
         SymbolKind::Keyword => SemanticTokenType::new("keyword"),
         SymbolKind::Unknown => SemanticTokenType::new("generic"),
         SymbolKind::BuiltinType => SemanticTokenType::new("builtinType"),

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -63,6 +63,7 @@ pub enum TypedAstToken {
     TypedScrutinee(ty::TyScrutinee),
     TyStructScrutineeField(ty::TyStructScrutineeField),
     TypedConstantDeclaration(ty::TyConstantDecl),
+    TypedTraitTypeDeclaration(ty::TyTraitType),
     TypedFunctionDeclaration(ty::TyFunctionDecl),
     TypedFunctionParameter(ty::TyFunctionParameter),
     TypedStructField(ty::TyStructField),
@@ -118,6 +119,8 @@ pub enum SymbolKind {
     Struct,
     /// Emitted for traits.
     Trait,
+    /// Emitted for associated types.
+    TraiType,
     /// Emitted for type aliases.
     TypeAlias,
     /// Emitted for type parameters.

--- a/sway-lsp/src/traverse/lexed_tree.rs
+++ b/sway-lsp/src/traverse/lexed_tree.rs
@@ -8,7 +8,7 @@ use sway_ast::{
     IfCondition, IfExpr, ItemAbi, ItemConfigurable, ItemConst, ItemEnum, ItemFn, ItemImpl,
     ItemImplItem, ItemKind, ItemStorage, ItemStruct, ItemTrait, ItemTypeAlias, ItemUse,
     MatchBranchKind, ModuleKind, Pattern, PatternStructField, Statement, StatementLet,
-    StorageField, Ty, TypeField, UseTree,
+    StorageField, TraitType, Ty, TypeField, UseTree,
 };
 use sway_core::language::lexed::LexedProgram;
 use sway_types::{Ident, Span, Spanned};
@@ -303,6 +303,7 @@ impl Parse for ItemTrait {
             .for_each(|(annotated, _)| match &annotated.value {
                 sway_ast::ItemTraitItem::Fn(fn_sig) => fn_sig.parse(ctx),
                 sway_ast::ItemTraitItem::Const(item_const) => item_const.parse(ctx),
+                sway_ast::ItemTraitItem::Type(item_type) => item_type.parse(ctx),
             });
 
         if let Some(trait_defs_opt) = &self.trait_defs_opt {
@@ -334,6 +335,7 @@ impl Parse for ItemImpl {
             .for_each(|item| match &item.value {
                 ItemImplItem::Fn(fn_decl) => fn_decl.parse(ctx),
                 ItemImplItem::Const(const_decl) => const_decl.parse(ctx),
+                ItemImplItem::Type(type_decl) => type_decl.parse(ctx),
             });
     }
 }
@@ -348,6 +350,7 @@ impl Parse for ItemAbi {
             .for_each(|(annotated, _)| match &annotated.value {
                 sway_ast::ItemTraitItem::Fn(fn_sig) => fn_sig.parse(ctx),
                 sway_ast::ItemTraitItem::Const(item_const) => item_const.parse(ctx),
+                sway_ast::ItemTraitItem::Type(item_type) => item_type.parse(ctx),
             });
 
         if let Some(abi_defs_opt) = self.abi_defs_opt.as_ref() {
@@ -372,6 +375,16 @@ impl Parse for ItemConst {
 
         if let Some(expr) = self.expr_opt.as_ref() {
             expr.parse(ctx);
+        }
+    }
+}
+
+impl Parse for TraitType {
+    fn parse(&self, ctx: &ParseContext) {
+        insert_keyword(ctx, self.type_token.span());
+
+        if let Some(ty) = self.ty_opt.as_ref() {
+            ty.parse(ctx);
         }
     }
 }

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -23,7 +23,7 @@ use sway_core::{
             Scrutinee, StorageAccessExpression, StorageDeclaration, StorageField,
             StructDeclaration, StructExpression, StructExpressionField, StructField,
             StructScrutineeField, SubfieldExpression, Supertrait, TraitDeclaration, TraitFn,
-            TraitItem, TupleIndexExpression, TypeAliasDeclaration, UseStatement,
+            TraitItem, TupleIndexExpression, TypeAliasDeclaration, TypeDeclaration, UseStatement,
             VariableDeclaration, WhileLoopExpression,
         },
         CallPathTree, Literal,
@@ -127,6 +127,7 @@ impl Parse for Declaration {
             Declaration::ConstantDeclaration(decl) => decl.parse(ctx),
             Declaration::StorageDeclaration(decl) => decl.parse(ctx),
             Declaration::TypeAliasDeclaration(decl) => decl.parse(ctx),
+            Declaration::Type(decl) => decl.parse(ctx),
         }
     }
 }
@@ -732,6 +733,7 @@ impl Parse for TraitDeclaration {
         self.interface_surface.iter().for_each(|item| match item {
             TraitItem::TraitFn(trait_fn) => trait_fn.parse(ctx),
             TraitItem::Constant(const_decl) => const_decl.parse(ctx),
+            TraitItem::TraitType(trait_type) => trait_type.parse(ctx),
         });
         self.methods.iter().for_each(|func_dec| {
             func_dec.parse(ctx);

--- a/sway-parse/src/item/item_impl.rs
+++ b/sway-parse/src/item/item_impl.rs
@@ -1,7 +1,9 @@
 use crate::{Parse, ParseResult, Parser};
 
 use sway_ast::attribute::Annotated;
-use sway_ast::keywords::{ConstToken, FnToken, OpenAngleBracketToken, SemicolonToken, WhereToken};
+use sway_ast::keywords::{
+    ConstToken, FnToken, OpenAngleBracketToken, SemicolonToken, TypeToken, WhereToken,
+};
 use sway_ast::{Braces, ItemImpl, ItemImplItem, PubToken, Ty};
 use sway_error::parser_error::ParseErrorKind;
 
@@ -14,6 +16,10 @@ impl Parse for ItemImplItem {
             let const_decl = parser.parse()?;
             parser.parse::<SemicolonToken>()?;
             Ok(ItemImplItem::Const(const_decl))
+        } else if let Some(_type_keyword) = parser.peek::<TypeToken>() {
+            let type_decl = parser.parse()?;
+            parser.parse::<SemicolonToken>()?;
+            Ok(ItemImplItem::Type(type_decl))
         } else {
             Err(parser.emit_error(ParseErrorKind::ExpectedAnItem))
         }

--- a/sway-parse/src/item/item_trait.rs
+++ b/sway-parse/src/item/item_trait.rs
@@ -1,7 +1,7 @@
 use crate::{Parse, ParseBracket, ParseResult, Parser};
 
 use sway_ast::attribute::Annotated;
-use sway_ast::keywords::{ConstToken, FnToken, OpenAngleBracketToken, WhereToken};
+use sway_ast::keywords::{ConstToken, FnToken, OpenAngleBracketToken, TypeToken, WhereToken};
 use sway_ast::{Braces, ItemFn, ItemTrait, ItemTraitItem, PubToken, Traits};
 use sway_error::parser_error::ParseErrorKind;
 
@@ -13,6 +13,9 @@ impl Parse for ItemTraitItem {
         } else if let Some(_const_keyword) = parser.peek::<ConstToken>() {
             let const_decl = parser.parse()?;
             Ok(ItemTraitItem::Const(const_decl))
+        } else if let Some(_type_keyword) = parser.peek::<TypeToken>() {
+            let type_decl = parser.parse()?;
+            Ok(ItemTraitItem::Type(type_decl))
         } else {
             Err(parser.emit_error(ParseErrorKind::ExpectedAnItem))
         }

--- a/sway-parse/src/item/mod.rs
+++ b/sway-parse/src/item/mod.rs
@@ -7,7 +7,7 @@ use sway_ast::keywords::{
 };
 use sway_ast::{
     FnArg, FnArgs, FnSignature, ItemConst, ItemEnum, ItemFn, ItemKind, ItemStruct, ItemTrait,
-    ItemTypeAlias, ItemUse, Submodule, TypeField,
+    ItemTypeAlias, ItemUse, Submodule, TraitType, TypeField,
 };
 use sway_error::parser_error::ParseErrorKind;
 
@@ -173,6 +173,24 @@ impl Parse for FnSignature {
                 None => None,
             },
             where_clause_opt: parser.guarded_parse::<WhereToken, _>()?,
+        })
+    }
+}
+
+impl Parse for TraitType {
+    fn parse(parser: &mut Parser) -> ParseResult<TraitType> {
+        let type_token = parser.parse()?;
+        let name = parser.parse()?;
+        let eq_token_opt = parser.take();
+        let ty_opt = match &eq_token_opt {
+            Some(_eq) => Some(parser.parse()?),
+            None => None,
+        };
+        Ok(TraitType {
+            type_token,
+            name,
+            eq_token_opt,
+            ty_opt,
         })
     }
 }

--- a/swayfmt/src/items/item_impl/mod.rs
+++ b/swayfmt/src/items/item_impl/mod.rs
@@ -68,6 +68,7 @@ impl Format for ItemImplItem {
         match self {
             ItemImplItem::Fn(fn_decl) => fn_decl.format(formatted_code, formatter),
             ItemImplItem::Const(const_decl) => const_decl.format(formatted_code, formatter),
+            ItemImplItem::Type(type_decl) => type_decl.format(formatted_code, formatter),
         }
     }
 }
@@ -124,6 +125,7 @@ impl LeafSpans for ItemImplItem {
         match self {
             ItemImplItem::Fn(fn_decl) => collected_spans.append(&mut fn_decl.leaf_spans()),
             ItemImplItem::Const(const_decl) => collected_spans.append(&mut const_decl.leaf_spans()),
+            ItemImplItem::Type(type_decl) => collected_spans.append(&mut type_decl.leaf_spans()),
         }
         collected_spans
     }

--- a/swayfmt/src/items/item_trait/mod.rs
+++ b/swayfmt/src/items/item_trait/mod.rs
@@ -85,6 +85,11 @@ impl Format for ItemTrait {
                         const_decl.format(formatted_code, formatter)?;
                         writeln!(formatted_code, "{}", semicolon_token.ident().as_str())?;
                     }
+                    sway_ast::ItemTraitItem::Type(type_decl) => {
+                        write!(formatted_code, "{}", formatter.indent_str()?,)?;
+                        type_decl.format(formatted_code, formatter)?;
+                        writeln!(formatted_code, "{}", semicolon_token.ident().as_str())?;
+                    }
                 }
             }
         }
@@ -122,6 +127,7 @@ impl Format for ItemTraitItem {
         match self {
             ItemTraitItem::Fn(fn_decl) => fn_decl.format(formatted_code, formatter),
             ItemTraitItem::Const(const_decl) => const_decl.format(formatted_code, formatter),
+            ItemTraitItem::Type(type_decl) => type_decl.format(formatted_code, formatter),
         }
     }
 }
@@ -203,6 +209,7 @@ impl LeafSpans for ItemTraitItem {
             ItemTraitItem::Const(const_decl) => {
                 collected_spans.append(&mut const_decl.leaf_spans())
             }
+            ItemTraitItem::Type(type_decl) => collected_spans.append(&mut type_decl.leaf_spans()),
         };
         collected_spans
     }

--- a/swayfmt/src/items/item_trait_type.rs
+++ b/swayfmt/src/items/item_trait_type.rs
@@ -1,0 +1,59 @@
+use crate::{
+    comments::rewrite_with_comments,
+    formatter::*,
+    utils::map::byte_span::{ByteSpan, LeafSpans},
+};
+use std::fmt::Write;
+use sway_ast::{keywords::Token, TraitType};
+use sway_types::Spanned;
+
+impl Format for TraitType {
+    fn format(
+        &self,
+        formatted_code: &mut FormattedCode,
+        formatter: &mut Formatter,
+    ) -> Result<(), FormatterError> {
+        // Required for comment formatting
+        let start_len = formatted_code.len();
+
+        // Add the const token
+        write!(formatted_code, "{} ", self.type_token.span().as_str())?;
+
+        // Add name of the const
+        self.name.format(formatted_code, formatter)?;
+
+        // Check if ` = ` exists
+        if let Some(eq_token) = &self.eq_token_opt {
+            write!(formatted_code, " {} ", eq_token.ident().as_str())?;
+        }
+
+        // Check if ty exists
+        if let Some(ty) = &self.ty_opt {
+            ty.format(formatted_code, formatter)?;
+        }
+
+        rewrite_with_comments::<TraitType>(
+            formatter,
+            self.span(),
+            self.leaf_spans(),
+            formatted_code,
+            start_len,
+        )?;
+        Ok(())
+    }
+}
+
+impl LeafSpans for TraitType {
+    fn leaf_spans(&self) -> Vec<ByteSpan> {
+        let mut collected_spans = Vec::new();
+        collected_spans.push(ByteSpan::from(self.type_token.span()));
+        collected_spans.push(ByteSpan::from(self.name.span()));
+        if let Some(eq_token) = &self.eq_token_opt {
+            collected_spans.push(ByteSpan::from(eq_token.span()));
+        }
+        if let Some(ty) = &self.ty_opt {
+            collected_spans.append(&mut ty.leaf_spans());
+        }
+        collected_spans
+    }
+}

--- a/swayfmt/src/items/mod.rs
+++ b/swayfmt/src/items/mod.rs
@@ -7,5 +7,6 @@ mod item_impl;
 mod item_storage;
 mod item_struct;
 mod item_trait;
+mod item_trait_type;
 mod item_type_alias;
 mod item_use;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_ascription/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_ascription/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'associated_type_ascription'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_ascription/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_ascription/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "associated_type_ascription"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_ascription/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_ascription/src/main.sw
@@ -1,0 +1,27 @@
+script;
+
+trait TypeTrait {
+    type T;
+}
+
+struct Struct {}
+
+struct Struct2 {}
+
+struct Struct3 {}
+
+impl TypeTrait for Struct2 {
+  type T = Struct;
+}
+
+impl TypeTrait for Struct3 {
+  type T = Struct2;
+}
+
+fn main() -> u32 {
+  let _: Struct2::T = Struct {};
+  let _: Struct3::T = Struct2 {};
+  let _: Struct3::T::T = Struct {};
+
+  1
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_ascription/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_ascription/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+expected_warnings = 1

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_method/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_method/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'associated_type_method'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_method/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_method/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "associated_type_parameter"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_method/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_method/src/main.sw
@@ -1,0 +1,36 @@
+script;
+
+trait TypeTrait {
+    type T;
+
+    fn method(self, s1: Self::T) -> Self::T;
+}
+
+struct Struct {}
+
+struct Struct2 {}
+
+struct Struct3 {}
+
+impl TypeTrait for Struct2 {
+  type T = Struct;
+
+  fn method(self, s1: Self::T) -> Self::T {
+    s1
+  }
+}
+
+impl TypeTrait for Struct3 {
+  type T = Struct2;
+
+  fn method(self, s1: Self::T) -> Self::T {
+    s1
+  }
+}
+
+fn main() -> u32 {
+  Struct2 {}.method(Struct {});
+  Struct3 {}.method(Struct2 {});
+
+  1
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_method/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_method/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+expected_warnings = 1

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_parameter/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_parameter/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'associated_type_parameter'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_parameter/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_parameter/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "associated_type_parameter"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_parameter/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_parameter/src/main.sw
@@ -1,0 +1,29 @@
+script;
+
+trait TypeTrait {
+    type T;
+}
+
+struct Struct {}
+
+struct Struct2 {}
+
+struct Struct3 {}
+
+impl TypeTrait for Struct2 {
+  type T = Struct;
+}
+
+impl TypeTrait for Struct3 {
+  type T = Struct2;
+}
+
+fn func(_s1: Struct2::T, _s2: Struct3::T::T) {
+
+}
+
+fn main() -> u32 {
+  func(Struct {}, Struct {});
+
+  1
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_parameter/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_type_parameter/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+expected_warnings = 1


### PR DESCRIPTION
## Description

Implements associated types parsing.

Adds associated types to trait map.

Modifies resolve_symbol to handle associated types.

Support was added for type ascription, methods parameters, method return types, and function parameters.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
