### PR TITLE
Add `Eq` implementation for `String`

### DIFF
--- a/sway-lib-std/src/string.sw
+++ b/sway-lib-std/src/string.sw
@@ -259,6 +259,12 @@ impl From<raw_slice> for String {
     }
 }
 
+impl Eq for String {
+    fn eq(self, other: Self) -> bool {
+        self.bytes == other.bytes
+    }
+}
+
 // Tests
 
 #[test]
@@ -478,4 +484,14 @@ fn string_test_with_capacity() {
     let mut string = String::with_capacity(4);
 
     assert(string.capacity() == 4);
+}
+
+#[test]
+fn string_test_equal() {
+    let string1 = String::from_ascii_str("fuel");
+    let string2 = String::from_ascii_str("fuel");
+    let string3 = String::from_ascii_str("blazingly fast");
+
+    assert(string1 == string2);
+    assert(string1 != string3);
 }


### PR DESCRIPTION
## Description

The `Eq` implementation seems to have been missing since moving the `String` type from sway-libs to the standard library.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
