### PR TITLE
Rework server to use experimental mutable tower-lsp branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-weighted-semaphore"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c3c4e4764855498d3ee6554748ff2d9376bc4c937692e266a56dd4ac098cfb"
+
+[[package]]
 name = "atomic-polyfill"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6539,10 +6545,10 @@ checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 [[package]]
 name = "tower-lsp"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b38fb0e6ce037835174256518aace3ca621c4f96383c56bb846cfc11b341910"
+source = "git+https://github.com/ebkalderon/tower-lsp?branch=support-mutable-methods#8fe0f21e9d386b6bf2561ee2bf9590d89724cf5a"
 dependencies = [
  "async-trait",
+ "async-weighted-semaphore",
  "auto_impl",
  "bytes",
  "dashmap",
@@ -6562,8 +6568,7 @@ dependencies = [
 [[package]]
 name = "tower-lsp-macros"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34723c06344244474fdde365b76aebef8050bf6be61a935b91ee9ff7c4e91157"
+source = "git+https://github.com/ebkalderon/tower-lsp?branch=support-mutable-methods#8fe0f21e9d386b6bf2561ee2bf9590d89724cf5a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -256,7 +256,7 @@ fn format_pkg_at_dir(app: &App, dir: &Path, formatter: &mut Formatter) -> Result
         Some(path) => {
             let manifest_path = path.clone();
             let manifest_file = manifest_path.join(constants::MANIFEST_FILE_NAME);
-            let files = get_sway_files(path);
+            let files = get_sway_files(&path);
             let mut contains_edits = false;
 
             for file in files {

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -34,7 +34,7 @@ tempfile = "3"
 thiserror = "1.0.30"
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 toml_edit = "0.19"
-tower-lsp = { version = "0.19", features = ["proposed"] }
+tower-lsp = { git = "https://github.com/ebkalderon/tower-lsp", branch = "support-mutable-methods" }
 tracing = "0.1"
 urlencoding = "2.1.2"
 

--- a/sway-lsp/benches/lsp_benchmarks/mod.rs
+++ b/sway-lsp/benches/lsp_benchmarks/mod.rs
@@ -3,10 +3,10 @@ pub mod requests;
 pub mod token_map;
 
 use lsp_types::Url;
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 use sway_lsp::core::session::{self, Session};
 
-pub fn compile_test_project() -> (Url, Arc<Session>) {
+pub fn compile_test_project() -> (Url, Session) {
     let session = Session::new();
     // Load the test project
     let uri = Url::from_file_path(benchmark_dir().join("src/main.sw")).unwrap();
@@ -14,7 +14,7 @@ pub fn compile_test_project() -> (Url, Arc<Session>) {
     // Compile the project and write the parse result to the session
     let parse_result = session::parse_project(&uri).unwrap();
     session.write_parse_result(parse_result);
-    (uri, Arc::new(session))
+    (uri, session)
 }
 
 pub fn sway_workspace_dir() -> PathBuf {

--- a/sway-lsp/benches/lsp_benchmarks/mod.rs
+++ b/sway-lsp/benches/lsp_benchmarks/mod.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use sway_lsp::core::session::{self, Session};
 
 pub fn compile_test_project() -> (Url, Session) {
-    let session = Session::new();
+    let mut session = Session::new();
     // Load the test project
     let uri = Url::from_file_path(benchmark_dir().join("src/main.sw")).unwrap();
     session.handle_open_file(&uri);

--- a/sway-lsp/benches/lsp_benchmarks/requests.rs
+++ b/sway-lsp/benches/lsp_benchmarks/requests.rs
@@ -6,14 +6,14 @@ use lsp_types::{
 use sway_lsp::{capabilities, lsp_ext::OnEnterParams, utils::keyword_docs::KeywordDocs};
 
 fn benchmarks(c: &mut Criterion) {
-    let (uri, session) = black_box(super::compile_test_project());
+    let (uri, ref session) = black_box(super::compile_test_project());
     let config = sway_lsp::config::Config::default();
     let keyword_docs = KeywordDocs::new();
     let position = Position::new(1717, 24);
     let range = Range::new(Position::new(1628, 0), Position::new(1728, 0));
 
     c.bench_function("semantic_tokens", |b| {
-        b.iter(|| capabilities::semantic_tokens::semantic_tokens_full(session.clone(), &uri))
+        b.iter(|| capabilities::semantic_tokens::semantic_tokens_full(session, &uri))
     });
 
     c.bench_function("document_symbol", |b| {
@@ -34,13 +34,11 @@ fn benchmarks(c: &mut Criterion) {
     });
 
     c.bench_function("hover", |b| {
-        b.iter(|| {
-            capabilities::hover::hover_data(session.clone(), &keyword_docs, uri.clone(), position)
-        })
+        b.iter(|| capabilities::hover::hover_data(session, &keyword_docs, uri.clone(), position))
     });
 
     c.bench_function("highlight", |b| {
-        b.iter(|| capabilities::highlight::get_highlights(session.clone(), uri.clone(), position))
+        b.iter(|| capabilities::highlight::get_highlights(session, uri.clone(), position))
     });
 
     c.bench_function("goto_definition", |b| {
@@ -49,23 +47,18 @@ fn benchmarks(c: &mut Criterion) {
 
     c.bench_function("inlay_hints", |b| {
         b.iter(|| {
-            capabilities::inlay_hints::inlay_hints(
-                session.clone(),
-                &uri,
-                &range,
-                &config.inlay_hints,
-            )
+            capabilities::inlay_hints::inlay_hints(session, &uri, &range, &config.inlay_hints)
         })
     });
 
     c.bench_function("prepare_rename", |b| {
-        b.iter(|| capabilities::rename::prepare_rename(session.clone(), uri.clone(), position))
+        b.iter(|| capabilities::rename::prepare_rename(session, uri.clone(), position))
     });
 
     c.bench_function("rename", |b| {
         b.iter(|| {
             capabilities::rename::rename(
-                session.clone(),
+                session,
                 "new_token_name".to_string(),
                 uri.clone(),
                 position,
@@ -75,11 +68,11 @@ fn benchmarks(c: &mut Criterion) {
 
     c.bench_function("code_action", |b| {
         let range = Range::new(Position::new(4, 10), Position::new(4, 10));
-        b.iter(|| capabilities::code_actions::code_actions(session.clone(), &range, &uri, &uri))
+        b.iter(|| capabilities::code_actions::code_actions(session, &range, &uri, &uri))
     });
 
     c.bench_function("code_lens", |b| {
-        b.iter(|| capabilities::code_lens::code_lens(&session, &uri.clone()))
+        b.iter(|| capabilities::code_lens::code_lens(session, &uri.clone()))
     });
 
     c.bench_function("on_enter", |b| {
@@ -91,7 +84,7 @@ fn benchmarks(c: &mut Criterion) {
                 text: "\n".to_string(),
             }],
         };
-        b.iter(|| capabilities::on_enter::on_enter(&config.on_enter, &session, &uri, &params))
+        b.iter(|| capabilities::on_enter::on_enter(&config.on_enter, session, &uri, &params))
     });
 }
 

--- a/sway-lsp/benches/lsp_benchmarks/token_map.rs
+++ b/sway-lsp/benches/lsp_benchmarks/token_map.rs
@@ -3,7 +3,7 @@ use lsp_types::Position;
 
 fn benchmarks(c: &mut Criterion) {
     let (uri, session) = black_box(super::compile_test_project());
-    let engines = session.engines.read();
+    let engines = &session.engines;
     let position = Position::new(1716, 24);
 
     c.bench_function("tokens_for_file", |b| {

--- a/sway-lsp/src/capabilities/code_actions/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/mod.rs
@@ -37,7 +37,7 @@ pub(crate) struct CodeActionContext<'a> {
 }
 
 pub fn code_actions(
-    session: Arc<Session>,
+    session: &Session,
     range: &Range,
     uri: &Url,
     temp_uri: &Url,
@@ -48,7 +48,7 @@ pub fn code_actions(
         .token_at_position(temp_uri, range.start)?;
 
     let ctx = CodeActionContext {
-        engines: &engines,
+        engines: &session.engines,
         tokens: session.token_map(),
         token: &token,
         uri,

--- a/sway-lsp/src/capabilities/code_actions/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/mod.rs
@@ -20,7 +20,7 @@ use lsp_types::{
     CodeActionResponse, Position, Range, TextEdit, Url, WorkspaceEdit,
 };
 use serde_json::Value;
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 use sway_core::{language::ty, Engines};
 use sway_types::Spanned;
 

--- a/sway-lsp/src/capabilities/code_actions/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/mod.rs
@@ -42,13 +42,12 @@ pub fn code_actions(
     uri: &Url,
     temp_uri: &Url,
 ) -> Option<CodeActionResponse> {
-    let engines = session.engines.read();
     let (_, token) = session
         .token_map()
         .token_at_position(temp_uri, range.start)?;
 
     let ctx = CodeActionContext {
-        engines: &engines,
+        engines: &session.engines,
         tokens: session.token_map(),
         token: &token,
         uri,

--- a/sway-lsp/src/capabilities/code_actions/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/mod.rs
@@ -48,7 +48,7 @@ pub fn code_actions(
         .token_at_position(temp_uri, range.start)?;
 
     let ctx = CodeActionContext {
-        engines: &session.engines,
+        engines: &engines,
         tokens: session.token_map(),
         token: &token,
         uri,

--- a/sway-lsp/src/capabilities/code_lens.rs
+++ b/sway-lsp/src/capabilities/code_lens.rs
@@ -4,7 +4,7 @@ use lsp_types::{CodeLens, Url};
 
 use crate::core::session::Session;
 
-pub fn code_lens(session: &Arc<Session>, url: &Url) -> Vec<CodeLens> {
+pub fn code_lens(session: &Session, url: &Url) -> Vec<CodeLens> {
     let url_path = PathBuf::from(url.path());
 
     // Construct code lenses for runnable functions

--- a/sway-lsp/src/capabilities/code_lens.rs
+++ b/sway-lsp/src/capabilities/code_lens.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 
 use lsp_types::{CodeLens, Url};
 

--- a/sway-lsp/src/capabilities/diagnostic.rs
+++ b/sway-lsp/src/capabilities/diagnostic.rs
@@ -61,7 +61,6 @@ pub fn get_diagnostics(
                 .push(diagnostic);
         }
     }
-
     diagnostics
 }
 

--- a/sway-lsp/src/capabilities/highlight.rs
+++ b/sway-lsp/src/capabilities/highlight.rs
@@ -3,7 +3,7 @@ use lsp_types::{DocumentHighlight, Position, Url};
 use std::sync::Arc;
 
 pub fn get_highlights(
-    session: Arc<Session>,
+    session: &Session,
     url: Url,
     position: Position,
 ) -> Option<Vec<DocumentHighlight>> {

--- a/sway-lsp/src/capabilities/highlight.rs
+++ b/sway-lsp/src/capabilities/highlight.rs
@@ -1,6 +1,5 @@
 use crate::core::session::Session;
 use lsp_types::{DocumentHighlight, Position, Url};
-use std::sync::Arc;
 
 pub fn get_highlights(
     session: &Session,

--- a/sway-lsp/src/capabilities/hover/hover_link_contents.rs
+++ b/sway-lsp/src/capabilities/hover/hover_link_contents.rs
@@ -81,7 +81,7 @@ impl<'a> HoverLinkContents<'a> {
     /// Adds all implementations of the given [TyTraitDecl] to the list of implementations.
     pub fn add_implementations_for_trait(&mut self, trait_decl: &TyTraitDecl) {
         if let Some(namespace) = self.session.namespace() {
-            let call_path = CallPath::from(trait_decl.name.clone()).to_fullpath(&namespace);
+            let call_path = CallPath::from(trait_decl.name.clone()).to_fullpath(namespace);
             let impl_spans = namespace.get_impl_spans_for_trait_name(&call_path);
             self.add_implementations(&trait_decl.span(), impl_spans);
         }

--- a/sway-lsp/src/capabilities/hover/hover_link_contents.rs
+++ b/sway-lsp/src/capabilities/hover/hover_link_contents.rs
@@ -26,12 +26,12 @@ pub struct RelatedType {
 pub struct HoverLinkContents<'a> {
     pub related_types: Vec<RelatedType>,
     pub implementations: Vec<Span>,
-    session: Arc<Session>,
+    session: &'a Session,
     engines: &'a Engines,
 }
 
 impl<'a> HoverLinkContents<'a> {
-    pub fn new(session: Arc<Session>, engines: &'a Engines) -> Self {
+    pub fn new(session: &'a Session, engines: &'a Engines) -> Self {
         Self {
             related_types: Vec::new(),
             implementations: Vec::new(),

--- a/sway-lsp/src/capabilities/hover/hover_link_contents.rs
+++ b/sway-lsp/src/capabilities/hover/hover_link_contents.rs
@@ -2,7 +2,6 @@ use crate::{
     core::{session::Session, token::get_range_from_span},
     utils::document::get_url_from_span,
 };
-use std::sync::Arc;
 use sway_core::{
     language::{
         ty::{TyDecl, TyTraitDecl},

--- a/sway-lsp/src/capabilities/hover/mod.rs
+++ b/sway-lsp/src/capabilities/hover/mod.rs
@@ -22,7 +22,7 @@ use self::hover_link_contents::HoverLinkContents;
 
 /// Extracts the hover information for a token at the current position.
 pub fn hover_data(
-    session: Arc<Session>,
+    session: &Session,
     keyword_docs: &KeywordDocs,
     url: Url,
     position: Position,
@@ -62,7 +62,7 @@ pub fn hover_data(
         None => (ident.clone(), token),
     };
 
-    let contents = hover_format(session.clone(), &engines, &decl_token, &decl_ident.name);
+    let contents = hover_format(session.clone(), &session.engines, &decl_token, &decl_ident.name);
     Some(lsp_types::Hover {
         contents,
         range: Some(range),
@@ -120,7 +120,7 @@ fn markup_content(markup: Markup) -> lsp_types::MarkupContent {
 }
 
 fn hover_format(
-    session: Arc<Session>,
+    session: &Session,
     engines: &Engines,
     token: &Token,
     ident_name: &str,

--- a/sway-lsp/src/capabilities/hover/mod.rs
+++ b/sway-lsp/src/capabilities/hover/mod.rs
@@ -60,7 +60,12 @@ pub fn hover_data(
         None => (ident.clone(), token),
     };
 
-    let contents = hover_format(session.clone(), &session.engines, &decl_token, &decl_ident.name);
+    let contents = hover_format(
+        session.clone(),
+        &session.engines,
+        &decl_token,
+        &decl_ident.name,
+    );
     Some(lsp_types::Hover {
         contents,
         range: Some(range),

--- a/sway-lsp/src/capabilities/hover/mod.rs
+++ b/sway-lsp/src/capabilities/hover/mod.rs
@@ -46,8 +46,7 @@ pub fn hover_data(
         });
     }
 
-    let engines = session.engines.read();
-    let (decl_ident, decl_token) = match token.declared_token_ident(&engines) {
+    let (decl_ident, decl_token) = match token.declared_token_ident(&session.engines) {
         Some(decl_ident) => {
             let decl_token = session
                 .token_map()
@@ -61,7 +60,7 @@ pub fn hover_data(
         None => (ident.clone(), token),
     };
 
-    let contents = hover_format(session.clone(), &engines, &decl_token, &decl_ident.name);
+    let contents = hover_format(session.clone(), &session.engines, &decl_token, &decl_ident.name);
     Some(lsp_types::Hover {
         contents,
         range: Some(range),

--- a/sway-lsp/src/capabilities/hover/mod.rs
+++ b/sway-lsp/src/capabilities/hover/mod.rs
@@ -61,12 +61,7 @@ pub fn hover_data(
         None => (ident.clone(), token),
     };
 
-    let contents = hover_format(
-        session.clone(),
-        &session.engines,
-        &decl_token,
-        &decl_ident.name,
-    );
+    let contents = hover_format(session.clone(), &engines, &decl_token, &decl_ident.name);
     Some(lsp_types::Hover {
         contents,
         range: Some(range),

--- a/sway-lsp/src/capabilities/hover/mod.rs
+++ b/sway-lsp/src/capabilities/hover/mod.rs
@@ -9,7 +9,6 @@ use crate::{
         attributes::doc_comment_attributes, keyword_docs::KeywordDocs, markdown, markup::Markup,
     },
 };
-use std::sync::Arc;
 use sway_core::{
     language::{ty, Visibility},
     Engines, TypeId,
@@ -62,7 +61,12 @@ pub fn hover_data(
         None => (ident.clone(), token),
     };
 
-    let contents = hover_format(session.clone(), &session.engines, &decl_token, &decl_ident.name);
+    let contents = hover_format(
+        session.clone(),
+        &session.engines,
+        &decl_token,
+        &decl_ident.name,
+    );
     Some(lsp_types::Hover {
         contents,
         range: Some(range),

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -6,7 +6,6 @@ use crate::{
     },
 };
 use lsp_types::{self, Range, Url};
-use std::sync::Arc;
 use sway_core::{language::ty::TyDecl, type_system::TypeInfo};
 use sway_types::Spanned;
 

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -71,7 +71,7 @@ pub fn inlay_hints(
         .map(|var| {
             let range = get_range_from_span(&var.name.span());
             let kind = InlayKind::TypeHint;
-            let label = format!("{}", session.engines.help_out(var.type_ascription));
+            let label = format!("{}", engines.help_out(var.type_ascription));
             let inlay_hint = InlayHint { range, kind, label };
             self::inlay_hint(config.render_colons, inlay_hint)
         })

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -24,7 +24,7 @@ pub struct InlayHint {
 }
 
 pub fn inlay_hints(
-    session: Arc<Session>,
+    session: &Session,
     uri: &Url,
     range: &Range,
     config: &InlayHintsConfig,
@@ -72,7 +72,7 @@ pub fn inlay_hints(
         .map(|var| {
             let range = get_range_from_span(&var.name.span());
             let kind = InlayKind::TypeHint;
-            let label = format!("{}", engines.help_out(var.type_ascription));
+            let label = format!("{}", session.engines.help_out(var.type_ascription));
             let inlay_hint = InlayHint { range, kind, label };
             self::inlay_hint(config.render_colons, inlay_hint)
         })

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -37,9 +37,6 @@ pub fn inlay_hints(
         return None;
     }
 
-    let engines = session.engines.read();
-    let type_engine = engines.te();
-
     let hints: Vec<lsp_types::InlayHint> = session
         .token_map()
         .tokens_for_file(uri)
@@ -62,7 +59,7 @@ pub fn inlay_hints(
             })
         })
         .filter_map(|var| {
-            let type_info = type_engine.get(var.type_ascription.type_id);
+            let type_info = session.engines.te().get(var.type_ascription.type_id);
             match type_info {
                 TypeInfo::Unknown | TypeInfo::UnknownGeneric { .. } => None,
                 _ => Some(var),
@@ -71,7 +68,7 @@ pub fn inlay_hints(
         .map(|var| {
             let range = get_range_from_span(&var.name.span());
             let kind = InlayKind::TypeHint;
-            let label = format!("{}", engines.help_out(var.type_ascription));
+            let label = format!("{}", session.engines.help_out(var.type_ascription));
             let inlay_hint = InlayHint { range, kind, label };
             self::inlay_hint(config.render_colons, inlay_hint)
         })

--- a/sway-lsp/src/capabilities/on_enter.rs
+++ b/sway-lsp/src/capabilities/on_enter.rs
@@ -17,7 +17,7 @@ const DOC_COMMENT_START: &str = "///";
 /// with the appropriate comment start pattern (// or ///).
 pub fn on_enter(
     config: &OnEnterConfig,
-    session: &Arc<Session>,
+    session: &Session,
     temp_uri: &Url,
     params: &OnEnterParams,
 ) -> Option<WorkspaceEdit> {

--- a/sway-lsp/src/capabilities/on_enter.rs
+++ b/sway-lsp/src/capabilities/on_enter.rs
@@ -3,7 +3,6 @@ use crate::{
     core::{document::TextDocument, session::Session},
     lsp_ext::OnEnterParams,
 };
-use std::sync::Arc;
 use tower_lsp::lsp_types::{
     DocumentChanges, OneOf, OptionalVersionedTextDocumentIdentifier, Position, Range,
     TextDocumentEdit, TextEdit, Url, WorkspaceEdit,

--- a/sway-lsp/src/capabilities/on_enter.rs
+++ b/sway-lsp/src/capabilities/on_enter.rs
@@ -30,11 +30,11 @@ pub fn on_enter(
         .expect("could not get text document");
 
     if config.continue_doc_comments.unwrap_or(false) {
-        workspace_edit = get_comment_workspace_edit(DOC_COMMENT_START, params, &text_document);
+        workspace_edit = get_comment_workspace_edit(DOC_COMMENT_START, params, text_document);
     }
 
     if config.continue_comments.unwrap_or(false) && workspace_edit.is_none() {
-        workspace_edit = get_comment_workspace_edit(COMMENT_START, params, &text_document);
+        workspace_edit = get_comment_workspace_edit(COMMENT_START, params, text_document);
     }
 
     workspace_edit

--- a/sway-lsp/src/capabilities/rename.rs
+++ b/sway-lsp/src/capabilities/rename.rs
@@ -53,13 +53,13 @@ pub fn rename(
     // If the token is a function, find the parent declaration
     // and collect idents for all methods of ABI Decl, Trait Decl, and Impl Trait
     let map_of_changes: HashMap<Url, Vec<TextEdit>> = (if token.kind == SymbolKind::Function {
-        find_all_methods_for_decl(&session, &session.engines, &url, position)?
+        find_all_methods_for_decl(&session, &engines, &url, position)?
     } else {
         // otherwise, just find all references of the token in the token map
         session
             .token_map()
             .iter()
-            .all_references_of_token(&token, &session.engines)
+            .all_references_of_token(&token, &engines)
             .map(|(ident, _)| ident)
             .collect::<Vec<TokenIdent>>()
     })

--- a/sway-lsp/src/capabilities/rename.rs
+++ b/sway-lsp/src/capabilities/rename.rs
@@ -48,18 +48,16 @@ pub fn rename(
         ));
     }
 
-    let engines = session.engines.read();
-
     // If the token is a function, find the parent declaration
     // and collect idents for all methods of ABI Decl, Trait Decl, and Impl Trait
     let map_of_changes: HashMap<Url, Vec<TextEdit>> = (if token.kind == SymbolKind::Function {
-        find_all_methods_for_decl(&session, &engines, &url, position)?
+        find_all_methods_for_decl(&session, &session.engines, &url, position)?
     } else {
         // otherwise, just find all references of the token in the token map
         session
             .token_map()
             .iter()
-            .all_references_of_token(&token, &engines)
+            .all_references_of_token(&token, &session.engines)
             .map(|(ident, _)| ident)
             .collect::<Vec<TokenIdent>>()
     })
@@ -109,11 +107,9 @@ pub fn prepare_rename(
         .token_at_position(&url, position)
         .ok_or(RenameError::TokenNotFound)?;
 
-    let engines = session.engines.read();
-
     // Only let through tokens that are in the users workspace.
     // tokens that are external to the users workspace cannot be renamed.
-    let _ = is_token_in_workspace(&session, &engines, &token)?;
+    let _ = is_token_in_workspace(&session, &session.engines, &token)?;
 
     // Make sure we don't allow renaming of tokens that
     // are keywords or intrinsics.

--- a/sway-lsp/src/capabilities/rename.rs
+++ b/sway-lsp/src/capabilities/rename.rs
@@ -8,7 +8,7 @@ use crate::{
     utils::document::get_url_from_path,
 };
 use lsp_types::{Position, PrepareRenameResponse, TextEdit, Url, WorkspaceEdit};
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 use sway_core::{language::ty, Engines};
 use sway_types::SourceEngine;
 

--- a/sway-lsp/src/capabilities/rename.rs
+++ b/sway-lsp/src/capabilities/rename.rs
@@ -51,7 +51,7 @@ pub fn rename(
     // If the token is a function, find the parent declaration
     // and collect idents for all methods of ABI Decl, Trait Decl, and Impl Trait
     let map_of_changes: HashMap<Url, Vec<TextEdit>> = (if token.kind == SymbolKind::Function {
-        find_all_methods_for_decl(&session, &session.engines, &url, position)?
+        find_all_methods_for_decl(session, &session.engines, &url, position)?
     } else {
         // otherwise, just find all references of the token in the token map
         session
@@ -109,7 +109,7 @@ pub fn prepare_rename(
 
     // Only let through tokens that are in the users workspace.
     // tokens that are external to the users workspace cannot be renamed.
-    let _ = is_token_in_workspace(&session, &session.engines, &token)?;
+    let _ = is_token_in_workspace(session, &session.engines, &token)?;
 
     // Make sure we don't allow renaming of tokens that
     // are keywords or intrinsics.

--- a/sway-lsp/src/capabilities/rename.rs
+++ b/sway-lsp/src/capabilities/rename.rs
@@ -15,7 +15,7 @@ use sway_types::SourceEngine;
 const RAW_IDENTIFIER: &str = "r#";
 
 pub fn rename(
-    session: Arc<Session>,
+    session: &Session,
     new_name: String,
     url: Url,
     position: Position,
@@ -53,13 +53,13 @@ pub fn rename(
     // If the token is a function, find the parent declaration
     // and collect idents for all methods of ABI Decl, Trait Decl, and Impl Trait
     let map_of_changes: HashMap<Url, Vec<TextEdit>> = (if token.kind == SymbolKind::Function {
-        find_all_methods_for_decl(&session, &engines, &url, position)?
+        find_all_methods_for_decl(&session, &session.engines, &url, position)?
     } else {
         // otherwise, just find all references of the token in the token map
         session
             .token_map()
             .iter()
-            .all_references_of_token(&token, &engines)
+            .all_references_of_token(&token, &session.engines)
             .map(|(ident, _)| ident)
             .collect::<Vec<TokenIdent>>()
     })
@@ -100,7 +100,7 @@ pub fn rename(
 }
 
 pub fn prepare_rename(
-    session: Arc<Session>,
+    session: &Session,
     url: Url,
     position: Position,
 ) -> Result<PrepareRenameResponse, LanguageServerError> {
@@ -141,7 +141,7 @@ fn formatted_name(ident: &TokenIdent) -> String {
 
 /// Checks if the token is in the users workspace.
 fn is_token_in_workspace(
-    session: &Arc<Session>,
+    session: &Session,
     engines: &Engines,
     token: &Token,
 ) -> Result<bool, LanguageServerError> {

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -6,10 +6,7 @@ use lsp_types::{
     Range, SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
     SemanticTokensResult, Url,
 };
-use std::sync::{
-    atomic::{AtomicU32, Ordering},
-    Arc,
-};
+use std::sync::atomic::{AtomicU32, Ordering};
 
 // https://github.com/microsoft/vscode-extension-samples/blob/5ae1f7787122812dcc84e37427ca90af5ee09f14/semantic-tokens-sample/vscode.proposed.d.ts#L71
 pub fn semantic_tokens_full(session: &Session, url: &Url) -> Option<SemanticTokensResult> {

--- a/sway-lsp/src/capabilities/semantic_tokens.rs
+++ b/sway-lsp/src/capabilities/semantic_tokens.rs
@@ -12,7 +12,7 @@ use std::sync::{
 };
 
 // https://github.com/microsoft/vscode-extension-samples/blob/5ae1f7787122812dcc84e37427ca90af5ee09f14/semantic-tokens-sample/vscode.proposed.d.ts#L71
-pub fn semantic_tokens_full(session: Arc<Session>, url: &Url) -> Option<SemanticTokensResult> {
+pub fn semantic_tokens_full(session: &Session, url: &Url) -> Option<SemanticTokensResult> {
     // The tokens need sorting by their span so each token is sequential
     // If this step isn't done, then the bit offsets used for the lsp_types::SemanticToken are incorrect.
     let mut tokens_sorted: Vec<_> = session.token_map().tokens_for_file(url).collect();

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -120,12 +120,12 @@ impl Session {
         self.sync.manifest_dir().map_err(Into::into)
     }
 
-    pub fn shutdown(&self) {
+    pub fn shutdown(&mut self) {
         // Set the should_end flag to true
         self.sync.should_end.store(true, Ordering::Relaxed);
 
         // Wait for the thread to finish
-        let mut join_handle_option = self.sync.notify_join_handle.write();
+        let join_handle_option = &mut self.sync.notify_join_handle;
         if let Some(join_handle) = std::mem::take(&mut *join_handle_option) {
             let _ = join_handle.join();
         }

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -29,7 +29,7 @@ pub struct SyncWorkspace {
     pub directories: HashMap<Directory, PathBuf>,
     pub notify_join_handle: Option<JoinHandle<()>>,
     // if we should shutdown the thread watching the manifest file
-    pub should_end: Arc<AtomicBool>,
+    pub should_end: AtomicBool,
 }
 
 impl SyncWorkspace {
@@ -39,7 +39,7 @@ impl SyncWorkspace {
         Self {
             directories: HashMap::new(),
             notify_join_handle: None,
-            should_end: Arc::new(AtomicBool::new(false)),
+            should_end: AtomicBool::new(false),
         }
     }
 
@@ -236,7 +236,7 @@ impl SyncWorkspace {
             .ok_or(DirectoryError::TempDirNotFound)
     }
 
-    fn convert_url(&self, uri: &Url, from: &PathBuf, to: &PathBuf) -> Result<Url, DirectoryError> {
+    fn convert_url(&self, uri: &Url, from: &Path, to: &PathBuf) -> Result<Url, DirectoryError> {
         let path = from.join(
             PathBuf::from(uri.path())
                 .strip_prefix(to)

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -22,6 +22,8 @@ pub enum LanguageServerError {
     FormatError(FormatterError),
     #[error("Unable to acquire a semaphore permit for parsing")]
     UnableToAcquirePermit,
+    #[error("Session has not been initialized")]
+    SessionNotFound,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -22,7 +22,7 @@ pub async fn handle_did_open_text_document(
     // Otherwise, don't recompile the project when a new file in the project is opened
     // as the workspace is already compiled.
     if session.token_map().is_empty() {
-        let parse_result = server_state::parse_project(uri.clone(), &session).await?;
+        let parse_result = server_state::parse_project(uri.clone(), session).await?;
         session.write_parse_result(parse_result);
         server_state::publish_diagnostics(
             &state.config,
@@ -44,7 +44,7 @@ pub async fn handle_did_change_text_document(
         .sessions
         .uri_and_mut_session_from_workspace(&params.text_document.uri)?;
     session.write_changes_to_file(&uri, params.content_changes)?;
-    let parse_result = server_state::parse_project(uri.clone(), &session).await?;
+    let parse_result = server_state::parse_project(uri.clone(), session).await?;
     session.write_parse_result(parse_result);
     server_state::publish_diagnostics(
         &state.config,
@@ -65,7 +65,7 @@ pub(crate) async fn handle_did_save_text_document(
         .sessions
         .uri_and_mut_session_from_workspace(&params.text_document.uri)?;
     session.sync.resync()?;
-    let parse_result = server_state::parse_project(uri.clone(), &session).await?;
+    let parse_result = server_state::parse_project(uri.clone(), session).await?;
     session.write_parse_result(parse_result);
     server_state::publish_diagnostics(
         &state.config,

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -1,7 +1,7 @@
 //! This module is responsible for implementing handlers for Language Server
 //! Protocol. This module specifically handles notification messages sent by the Client.
 
-use crate::{error::LanguageServerError, server_state::ServerState};
+use crate::{error::LanguageServerError, server_state::{ServerState, self}};
 use lsp_types::{
     DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidOpenTextDocumentParams,
     DidSaveTextDocumentParams, FileChangeType,
@@ -13,15 +13,15 @@ pub async fn handle_did_open_text_document(
 ) -> Result<(), LanguageServerError> {
     let (uri, session) = state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)?;
+        .uri_and_mut_session_from_workspace(&params.text_document.uri)?;
     session.handle_open_file(&uri);
     // If the token map is empty, then we need to parse the project.
     // Otherwise, don't recompile the project when a new file in the project is opened
     // as the workspace is already compiled.
     if session.token_map().is_empty() {
-        state
-            .parse_project(uri, params.text_document.uri, session.clone())
-            .await?;
+        let parse_result = server_state::parse_project(uri.clone(), &session).await?;
+        session.write_parse_result(parse_result);
+        server_state::publish_diagnostics(&state.config, &state.client, uri, params.text_document.uri, session).await;
     }
     Ok(())
 }
@@ -32,11 +32,11 @@ pub async fn handle_did_change_text_document(
 ) -> Result<(), LanguageServerError> {
     let (uri, session) = state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)?;
+        .uri_and_mut_session_from_workspace(&params.text_document.uri)?;
     session.write_changes_to_file(&uri, params.content_changes)?;
-    state
-        .parse_project(uri, params.text_document.uri, session.clone())
-        .await?;
+    let parse_result = server_state::parse_project(uri.clone(), &session).await?;
+    session.write_parse_result(parse_result);
+    server_state::publish_diagnostics(&state.config, &state.client, uri, params.text_document.uri, session).await;
     Ok(())
 }
 
@@ -46,11 +46,11 @@ pub(crate) async fn handle_did_save_text_document(
 ) -> Result<(), LanguageServerError> {
     let (uri, session) = state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)?;
+        .uri_and_mut_session_from_workspace(&params.text_document.uri)?;
     session.sync.resync()?;
-    state
-        .parse_project(uri, params.text_document.uri, session.clone())
-        .await?;
+    let parse_result = server_state::parse_project(uri.clone(), &session).await?;
+    session.write_parse_result(parse_result);
+    server_state::publish_diagnostics(&state.config, &state.client, uri, params.text_document.uri, session).await;
     Ok(())
 }
 
@@ -60,7 +60,7 @@ pub(crate) fn handle_did_change_watched_files(
 ) {
     for event in params.changes {
         if event.typ == FileChangeType::DELETED {
-            match state.sessions.uri_and_session_from_workspace(&event.uri) {
+            match state.sessions.uri_and_mut_session_from_workspace(&event.uri) {
                 Ok((uri, session)) => {
                     let _ = session.remove_document(&uri);
                 }

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -8,7 +8,7 @@ use lsp_types::{
 };
 
 pub async fn handle_did_open_text_document(
-    state: &ServerState,
+    state: &mut ServerState,
     params: DidOpenTextDocumentParams,
 ) -> Result<(), LanguageServerError> {
     let (uri, session) = state
@@ -27,7 +27,7 @@ pub async fn handle_did_open_text_document(
 }
 
 pub async fn handle_did_change_text_document(
-    state: &ServerState,
+    state: &mut ServerState,
     params: DidChangeTextDocumentParams,
 ) -> Result<(), LanguageServerError> {
     let (uri, session) = state
@@ -41,7 +41,7 @@ pub async fn handle_did_change_text_document(
 }
 
 pub(crate) async fn handle_did_save_text_document(
-    state: &ServerState,
+    state: &mut ServerState,
     params: DidSaveTextDocumentParams,
 ) -> Result<(), LanguageServerError> {
     let (uri, session) = state
@@ -55,7 +55,7 @@ pub(crate) async fn handle_did_save_text_document(
 }
 
 pub(crate) fn handle_did_change_watched_files(
-    state: &ServerState,
+    state: &mut ServerState,
     params: DidChangeWatchedFilesParams,
 ) {
     for event in params.changes {

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -21,7 +21,7 @@ pub async fn handle_did_open_text_document(
     if session.token_map().is_empty() {
         state
             .parse_project(uri, params.text_document.uri, session.clone())
-            .await;
+            .await?;
     }
     Ok(())
 }
@@ -36,7 +36,7 @@ pub async fn handle_did_change_text_document(
     session.write_changes_to_file(&uri, params.content_changes)?;
     state
         .parse_project(uri, params.text_document.uri, session.clone())
-        .await;
+        .await?;
     Ok(())
 }
 
@@ -50,7 +50,7 @@ pub(crate) async fn handle_did_save_text_document(
     session.sync.resync()?;
     state
         .parse_project(uri, params.text_document.uri, session.clone())
-        .await;
+        .await?;
     Ok(())
 }
 

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -335,7 +335,11 @@ pub fn handle_show_ast(
 
             // Returns true if the current path matches the path of a submodule
             let path_is_submodule = |ident: &Ident, path: &Option<PathBuf>| -> bool {
-                ident.span().source_id().map(|p| session.engines.se().get_path(p)) == *path
+                ident
+                    .span()
+                    .source_id()
+                    .map(|p| session.engines.se().get_path(p))
+                    == *path
             };
 
             let ast_path = PathBuf::from(params.save_path.path());

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -341,7 +341,7 @@ pub fn handle_show_ast(
 
             let ast_path = PathBuf::from(params.save_path.path());
             {
-                let program = session.compiled_program.read();
+                let program = &session.compiled_program;
                 match params.ast_kind.as_str() {
                     "lexed" => {
                         Ok(program.lexed.as_ref().and_then(|lexed_program| {

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -335,8 +335,7 @@ pub fn handle_show_ast(
 
             // Returns true if the current path matches the path of a submodule
             let path_is_submodule = |ident: &Ident, path: &Option<PathBuf>| -> bool {
-                let engines = session.engines.read();
-                ident.span().source_id().map(|p| engines.se().get_path(p)) == *path
+                ident.span().source_id().map(|p| session.engines.se().get_path(p)) == *path
             };
 
             let ast_path = PathBuf::from(params.save_path.path());
@@ -375,14 +374,14 @@ pub fn handle_show_ast(
                             // Initialize the string with the AST from the root
                             let mut formatted_ast = debug::print_decl_engine_types(
                                 &typed_program.root.all_nodes,
-                                session.engines.read().de(),
+                                session.engines.de(),
                             );
                             for (ident, submodule) in &typed_program.root.submodules {
                                 if path_is_submodule(ident, &path) {
                                     // overwrite the root AST with the submodule AST
                                     formatted_ast = debug::print_decl_engine_types(
                                         &submodule.module.all_nodes,
-                                        session.engines.read().de(),
+                                        session.engines.de(),
                                     );
                                 }
                             }

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -412,7 +412,7 @@ pub(crate) fn on_enter(
     {
         Ok((uri, session)) => {
             // handle on_enter capabilities if they are enabled
-            Ok(capabilities::on_enter(config, &session, &uri, &params))
+            Ok(capabilities::on_enter(config, session, &uri, &params))
         }
         Err(err) => {
             tracing::error!("{}", err.to_string());

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -43,7 +43,7 @@ pub fn handle_initialize(
     })
 }
 
-pub fn handle_document_symbol(
+pub async fn handle_document_symbol(
     state: &ServerState,
     params: lsp_types::DocumentSymbolParams,
 ) -> Result<Option<lsp_types::DocumentSymbolResponse>> {
@@ -52,7 +52,7 @@ pub fn handle_document_symbol(
         .uri_and_session_from_workspace(&params.text_document.uri)
     {
         Ok((uri, session)) => {
-            let _ = session.wait_for_parsing();
+            let _ = session.wait_for_parsing().await;
             Ok(session
                 .symbol_information(&uri)
                 .map(DocumentSymbolResponse::Flat))
@@ -242,7 +242,7 @@ pub fn handle_code_lens(
         .sessions
         .uri_and_session_from_workspace(&params.text_document.uri)
     {
-        Ok((url, session)) => Ok(Some(capabilities::code_lens::code_lens(&session, &url))),
+        Ok((url, session)) => Ok(Some(capabilities::code_lens::code_lens(session, &url))),
         Err(err) => {
             tracing::error!("{}", err.to_string());
             Ok(None)
@@ -250,7 +250,7 @@ pub fn handle_code_lens(
     }
 }
 
-pub fn handle_semantic_tokens_full(
+pub async fn handle_semantic_tokens_full(
     state: &ServerState,
     params: SemanticTokensParams,
 ) -> Result<Option<SemanticTokensResult>> {
@@ -259,7 +259,7 @@ pub fn handle_semantic_tokens_full(
         .uri_and_session_from_workspace(&params.text_document.uri)
     {
         Ok((uri, session)) => {
-            let _ = session.wait_for_parsing();
+            let _ = session.wait_for_parsing().await;
             Ok(capabilities::semantic_tokens::semantic_tokens_full(
                 session, &uri,
             ))
@@ -271,7 +271,7 @@ pub fn handle_semantic_tokens_full(
     }
 }
 
-pub(crate) fn handle_inlay_hints(
+pub(crate) async fn handle_inlay_hints(
     state: &ServerState,
     params: InlayHintParams,
 ) -> Result<Option<Vec<InlayHint>>> {
@@ -280,7 +280,7 @@ pub(crate) fn handle_inlay_hints(
         .uri_and_session_from_workspace(&params.text_document.uri)
     {
         Ok((uri, session)) => {
-            let _ = session.wait_for_parsing();
+            let _ = session.wait_for_parsing().await;
             let config = &state.config.inlay_hints;
             Ok(capabilities::inlay_hints::inlay_hints(
                 session,

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -74,14 +74,14 @@ impl LanguageServer for ServerState {
         &self,
         params: DocumentSymbolParams,
     ) -> Result<Option<DocumentSymbolResponse>> {
-        request::handle_document_symbol(self, params)
+        request::handle_document_symbol(self, params).await
     }
 
     async fn semantic_tokens_full(
         &self,
         params: SemanticTokensParams,
     ) -> Result<Option<SemanticTokensResult>> {
-        request::handle_semantic_tokens_full(self, params)
+        request::handle_semantic_tokens_full(self, params).await
     }
 
     async fn document_highlight(
@@ -114,7 +114,7 @@ impl LanguageServer for ServerState {
     }
 
     async fn inlay_hint(&self, params: InlayHintParams) -> Result<Option<Vec<InlayHint>>> {
-        request::handle_inlay_hints(self, params)
+        request::handle_inlay_hints(self, params).await
     }
 }
 

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -18,39 +18,39 @@ use lsp_types::{
 };
 use tower_lsp::{jsonrpc::Result, LanguageServer};
 
-#[tower_lsp::async_trait]
+#[tower_lsp::async_trait(?Send)]
 impl LanguageServer for ServerState {
-    async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+    async fn initialize(&mut self, params: InitializeParams) -> Result<InitializeResult> {
         request::handle_initialize(self, params)
     }
 
-    async fn initialized(&self, _: InitializedParams) {
+    async fn initialized(&mut self, _: InitializedParams) {
         tracing::info!("Sway Language Server Initialized");
     }
 
-    async fn shutdown(&self) -> Result<()> {
+    async fn shutdown(&mut self) -> Result<()> {
         self.shutdown_server()
     }
 
-    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+    async fn did_open(&mut self, params: DidOpenTextDocumentParams) {
         if let Err(err) = notification::handle_did_open_text_document(self, params).await {
             tracing::error!("{}", err.to_string());
         }
     }
 
-    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+    async fn did_change(&mut self, params: DidChangeTextDocumentParams) {
         if let Err(err) = notification::handle_did_change_text_document(self, params).await {
             tracing::error!("{}", err.to_string());
         }
     }
 
-    async fn did_save(&self, params: DidSaveTextDocumentParams) {
+    async fn did_save(&mut self, params: DidSaveTextDocumentParams) {
         if let Err(err) = notification::handle_did_save_text_document(self, params).await {
             tracing::error!("{}", err.to_string());
         }
     }
 
-    async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
+    async fn did_change_watched_files(&mut self, params: DidChangeWatchedFilesParams) {
         notification::handle_did_change_watched_files(self, params);
     }
 
@@ -102,7 +102,7 @@ impl LanguageServer for ServerState {
         request::handle_formatting(self, params)
     }
 
-    async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+    async fn rename(&mut self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
         request::handle_rename(self, params)
     }
 

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -146,7 +146,7 @@ pub(crate) struct Sessions(HashMap<PathBuf, Session>);
 
 impl Sessions {
     fn init(&mut self, uri: &Url) -> Result<(), LanguageServerError> {
-        let session = Session::new();
+        let mut session = Session::new();
         let project_name = session.init(uri)?;
         self.insert(project_name, session);
         Ok(())

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -148,7 +148,7 @@ impl Sessions {
     fn init(&mut self, uri: &Url) -> Result<(), LanguageServerError> {
         let mut session = Session::new();
         let project_name = session.init(uri)?;
-        self.insert(project_name, session);
+        self.insert(project_name.clone(), session);
         Ok(())
     }
 

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -40,9 +40,9 @@ impl ServerState {
         }
     }
 
-    pub fn shutdown_server(&self) -> jsonrpc::Result<()> {
+    pub fn shutdown_server(&mut self) -> jsonrpc::Result<()> {
         tracing::info!("Shutting Down the Sway Language Server");
-        let _ = self.sessions.iter().map(|(_, session)| {
+        let _ = self.sessions.iter_mut().map(|(_, session)| {
             session.shutdown();
         });
         Ok(())
@@ -99,9 +99,7 @@ pub(crate) async fn publish_diagnostics(
 }
 
 pub(crate) async fn parse_project(
-    // &mut self,
     uri: Url,
-    // workspace_uri: Url,
     session: &Session,
 ) -> Result<ParseResult, LanguageServerError> {
     // Acquire a permit to parse the project. If there are none available, return false. This way,
@@ -113,13 +111,6 @@ pub(crate) async fn parse_project(
     let parse_result = run_blocking_parse_project(uri).await?;
     let (errors, warnings) = parse_result.diagnostics.clone();
     *diagnostics = get_diagnostics(&warnings, &errors, parse_result.engines.se());
-    // // Note: Even if the computed diagnostics vec is empty, we still have to push the empty Vec
-    // // in order to clear former diagnostics. Newly pushed diagnostics always replace previously pushed diagnostics.
-    // if let Some(client) = self.client.as_ref() {
-    //     client
-    //         .publish_diagnostics(workspace_uri.clone(), self.diagnostics(&uri, session), None)
-    //         .await;
-    // }
     Ok(parse_result)
 }
 

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -78,12 +78,22 @@ pub(crate) fn diagnostics(config: &Config, uri: &Url, session: &Session) -> Vec<
     diagnostics_to_publish
 }
 
-pub(crate) async fn publish_diagnostics(config: &Config, client: &Option<Client>, uri: Url, workspace_uri: Url, session: &Session) {
+pub(crate) async fn publish_diagnostics(
+    config: &Config,
+    client: &Option<Client>,
+    uri: Url,
+    workspace_uri: Url,
+    session: &Session,
+) {
     // Note: Even if the computed diagnostics vec is empty, we still have to push the empty Vec
     // in order to clear former diagnostics. Newly pushed diagnostics always replace previously pushed diagnostics.
     if let Some(client) = client.as_ref() {
         client
-            .publish_diagnostics(workspace_uri.clone(), diagnostics(config, &uri, session), None)
+            .publish_diagnostics(
+                workspace_uri.clone(),
+                diagnostics(config, &uri, session),
+                None,
+            )
             .await;
     }
 }
@@ -102,7 +112,7 @@ pub(crate) async fn parse_project(
     let mut diagnostics = session.diagnostics.write();
     let parse_result = run_blocking_parse_project(uri).await?;
     let (errors, warnings) = parse_result.diagnostics.clone();
-    *diagnostics = get_diagnostics(&warnings, &errors, session.engines.se());
+    *diagnostics = get_diagnostics(&warnings, &errors, parse_result.engines.se());
     // // Note: Even if the computed diagnostics vec is empty, we still have to push the empty Vec
     // // in order to clear former diagnostics. Newly pushed diagnostics always replace previously pushed diagnostics.
     // if let Some(client) = self.client.as_ref() {
@@ -112,7 +122,6 @@ pub(crate) async fn parse_project(
     // }
     Ok(parse_result)
 }
-
 
 fn try_acquire_parse_permit(session: &Session) -> Result<(), LanguageServerError> {
     if session.parse_permits.try_acquire().is_err() {
@@ -165,7 +174,9 @@ impl Sessions {
 
     fn url_to_session(&self, uri: &Url) -> Result<&Session, LanguageServerError> {
         let manifest_dir = get_manifest_dir_from_uri(&uri)?;
-        let session = self.get(&manifest_dir).ok_or(LanguageServerError::SessionNotFound)?;
+        let session = self
+            .get(&manifest_dir)
+            .ok_or(LanguageServerError::SessionNotFound)?;
         Ok(session)
     }
 
@@ -174,8 +185,10 @@ impl Sessions {
         if self.get(&manifest_dir).is_none() {
             // If no session can be found, then we need to call init and insert a new session into the map
             self.init(uri)?;
-        }        
-        let session = self.get_mut(&manifest_dir).expect("no session found even though it was just inserted into the map");
+        }
+        let session = self
+            .get_mut(&manifest_dir)
+            .expect("no session found even though it was just inserted into the map");
         Ok(session)
     }
 }
@@ -195,11 +208,10 @@ impl std::ops::DerefMut for Sessions {
 
 fn get_manifest_dir_from_uri(uri: &Url) -> Result<PathBuf, LanguageServerError> {
     let path = PathBuf::from(uri.path());
-    let manifest = PackageManifestFile::from_dir(&path).map_err(|_| {
-        DocumentError::ManifestFileNotFound {
+    let manifest =
+        PackageManifestFile::from_dir(&path).map_err(|_| DocumentError::ManifestFileNotFound {
             dir: path.to_string_lossy().to_string(),
-        }
-    })?;
+        })?;
 
     // Strip Forc.toml from the path to get the manifest directory
     let manifest_dir = manifest
@@ -210,4 +222,3 @@ fn get_manifest_dir_from_uri(uri: &Url) -> Result<PathBuf, LanguageServerError> 
 
     Ok(manifest_dir)
 }
-

--- a/sway-lsp/tests/integration/code_actions.rs
+++ b/sway-lsp/tests/integration/code_actions.rs
@@ -42,7 +42,7 @@ fn create_code_action_params(uri: Url, range: Range) -> CodeActionParams {
     }
 }
 
-pub(crate) fn code_action_abi_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_abi_request(server: &ServerState, uri: &Url) {
     let params = create_code_action_params(
         uri.clone(),
         Range {
@@ -83,7 +83,7 @@ pub(crate) fn code_action_abi_request(server: &ServerState, uri: &Url) {
     assert_eq!(res.unwrap().unwrap(), expected);
 }
 
-pub(crate) fn code_action_function_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_function_request(server: &ServerState, uri: &Url) {
     let params = create_code_action_params(
         uri.clone(),
         Range {
@@ -121,7 +121,7 @@ pub(crate) fn code_action_function_request(server: &ServerState, uri: &Url) {
     assert_eq!(res.unwrap().unwrap(), expected);
 }
 
-pub(crate) fn code_action_trait_fn_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_trait_fn_request(server: &ServerState, uri: &Url) {
     let params = create_code_action_params(
         uri.clone(),
         Range {
@@ -160,7 +160,7 @@ pub(crate) fn code_action_trait_fn_request(server: &ServerState, uri: &Url) {
     assert_eq!(res.unwrap().unwrap(), expected);
 }
 
-pub(crate) fn code_action_struct_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_struct_request(server: &ServerState, uri: &Url) {
     let params = create_code_action_params(
         uri.clone(),
         Range {
@@ -248,7 +248,7 @@ pub(crate) fn code_action_struct_request(server: &ServerState, uri: &Url) {
     assert_eq!(res.unwrap().unwrap(), expected);
 }
 
-pub(crate) fn code_action_struct_type_params_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_struct_type_params_request(server: &ServerState, uri: &Url) {
     let params = create_code_action_params(
         uri.clone(),
         Range {
@@ -340,7 +340,7 @@ pub(crate) fn code_action_struct_type_params_request(server: &ServerState, uri: 
     assert_eq!(res.unwrap().unwrap(), expected);
 }
 
-pub(crate) fn code_action_struct_existing_impl_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_struct_existing_impl_request(server: &ServerState, uri: &Url) {
     let params = create_code_action_params(
         uri.clone(),
         Range {

--- a/sway-lsp/tests/integration/lsp.rs
+++ b/sway-lsp/tests/integration/lsp.rs
@@ -147,7 +147,9 @@ pub(crate) fn semantic_tokens_request(server: &ServerState, uri: &Url) {
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
     };
-    let response = request::handle_semantic_tokens_full(server, params.clone()).unwrap();
+    let response = request::handle_semantic_tokens_full(server, params.clone())
+        .await
+        .unwrap();
     eprintln!("{:#?}", response);
     if let Some(SemanticTokensResult::Tokens(tokens)) = response {
         assert!(!tokens.data.is_empty());
@@ -160,7 +162,9 @@ pub(crate) fn document_symbol_request(server: &ServerState, uri: &Url) {
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
     };
-    let response = request::handle_document_symbol(server, params.clone()).unwrap();
+    let response = request::handle_document_symbol(server, params.clone())
+        .await
+        .unwrap();
     if let Some(DocumentSymbolResponse::Flat(res)) = response {
         assert!(!res.is_empty());
     }

--- a/sway-lsp/tests/integration/lsp.rs
+++ b/sway-lsp/tests/integration/lsp.rs
@@ -141,7 +141,7 @@ pub(crate) async fn show_ast_request(
     assert_eq!(expected, response.unwrap().unwrap());
 }
 
-pub(crate) fn semantic_tokens_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn semantic_tokens_request(server: &ServerState, uri: &Url) {
     let params = SemanticTokensParams {
         text_document: TextDocumentIdentifier { uri: uri.clone() },
         work_done_progress_params: Default::default(),
@@ -156,7 +156,7 @@ pub(crate) fn semantic_tokens_request(server: &ServerState, uri: &Url) {
     }
 }
 
-pub(crate) fn document_symbol_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn document_symbol_request(server: &ServerState, uri: &Url) {
     let params = DocumentSymbolParams {
         text_document: TextDocumentIdentifier { uri: uri.clone() },
         work_done_progress_params: Default::default(),
@@ -170,7 +170,7 @@ pub(crate) fn document_symbol_request(server: &ServerState, uri: &Url) {
     }
 }
 
-pub(crate) fn format_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn format_request(server: &ServerState, uri: &Url) {
     let params = DocumentFormattingParams {
         text_document: TextDocumentIdentifier { uri: uri.clone() },
         options: FormattingOptions {
@@ -184,7 +184,7 @@ pub(crate) fn format_request(server: &ServerState, uri: &Url) {
     assert!(!response.unwrap().is_empty());
 }
 
-pub(crate) fn highlight_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn highlight_request(server: &ServerState, uri: &Url) {
     let params = DocumentHighlightParams {
         text_document_position_params: TextDocumentPositionParams {
             text_document: TextDocumentIdentifier { uri: uri.clone() },
@@ -228,7 +228,7 @@ pub(crate) fn highlight_request(server: &ServerState, uri: &Url) {
     assert_eq!(expected, response.unwrap());
 }
 
-pub(crate) fn code_lens_empty_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_lens_empty_request(server: &ServerState, uri: &Url) {
     let params = CodeLensParams {
         text_document: TextDocumentIdentifier { uri: uri.clone() },
         work_done_progress_params: Default::default(),
@@ -238,7 +238,7 @@ pub(crate) fn code_lens_empty_request(server: &ServerState, uri: &Url) {
     assert_eq!(response.unwrap().len(), 0);
 }
 
-pub(crate) fn code_lens_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_lens_request(server: &ServerState, uri: &Url) {
     let params = CodeLensParams {
         text_document: TextDocumentIdentifier { uri: uri.clone() },
         work_done_progress_params: Default::default(),
@@ -308,7 +308,7 @@ pub(crate) fn code_lens_request(server: &ServerState, uri: &Url) {
     assert_eq!(expected, response.unwrap());
 }
 
-pub(crate) fn completion_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn completion_request(server: &ServerState, uri: &Url) {
     let params = CompletionParams {
         text_document_position: TextDocumentPositionParams {
             text_document: TextDocumentIdentifier { uri: uri.clone() },

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -108,10 +108,10 @@ async fn lsp_syncs_with_workspace_edits() {
         def_end_char: 11,
         def_path: uri.as_str(),
     };
-    lsp::definition_check(service.inner(), &go_to);
+    lsp::definition_check(&service.inner(), &go_to);
     let _ = lsp::did_change_request(&mut service, &uri).await;
     go_to.def_line = 20;
-    lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 45, 24);
+    lsp::definition_check_with_req_offset(&service.inner(), &mut go_to, 45, 24);
     shutdown_and_exit(&mut service).await;
 }
 

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -1687,7 +1687,7 @@ macro_rules! test_lsp_capability {
         let uri = open(&mut server, $entry_point).await;
 
         // Call the specific LSP capability function that was passed in.
-        let _ = $capability(&server, &uri);
+        let _ = $capability(&server, &uri).await;
         let _ = server.shutdown_server();
     }};
 }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -42,7 +42,7 @@ pub(crate) struct Rename<'a> {
     new_name: &'a str,
 }
 
-async fn open(server: &ServerState, entry_point: PathBuf) -> Url {
+async fn open(server: &mut ServerState, entry_point: PathBuf) -> Url {
     let (uri, sway_program) = load_sway_example(entry_point);
     let params = DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
@@ -72,18 +72,18 @@ async fn shutdown_and_exit(service: &mut LspService<ServerState>) {
 
 #[tokio::test]
 async fn initialize() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let params = InitializeParams {
         initialization_options: None,
         ..Default::default()
     };
-    let _ = request::handle_initialize(&server, params);
+    let _ = request::handle_initialize(&mut server, params);
 }
 
 #[tokio::test]
 async fn did_open() {
-    let server = ServerState::default();
-    let _ = open(&server, e2e_test_dir().join("src/main.sw")).await;
+    let mut server = ServerState::default();
+    let _ = open(&mut server, e2e_test_dir().join("src/main.sw")).await;
     let _ = server.shutdown_server();
 }
 
@@ -117,8 +117,8 @@ async fn lsp_syncs_with_workspace_edits() {
 
 #[tokio::test]
 async fn show_ast() {
-    let server = ServerState::default();
-    let uri = open(&server, e2e_test_dir().join("src/main.sw")).await;
+    let mut server = ServerState::default();
+    let uri = open(&mut server, e2e_test_dir().join("src/main.sw")).await;
     lsp::show_ast_request(&server, &uri, "typed", None).await;
     let _ = server.shutdown_server();
 }
@@ -127,8 +127,8 @@ async fn show_ast() {
 
 #[tokio::test]
 async fn go_to_definition() {
-    let server = ServerState::default();
-    let uri = open(&server, doc_comments_dir().join("src/main.sw")).await;
+    let mut server = ServerState::default();
+    let uri = open(&mut server, doc_comments_dir().join("src/main.sw")).await;
     let go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 44,
@@ -144,9 +144,9 @@ async fn go_to_definition() {
 
 #[tokio::test]
 async fn go_to_definition_for_fields() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/fields/src/main.sw"),
     )
     .await;
@@ -198,9 +198,9 @@ async fn go_to_definition_for_fields() {
 
 #[tokio::test]
 async fn go_to_definition_inside_turbofish() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/turbofish/src/main.sw"),
     )
     .await;
@@ -246,9 +246,9 @@ async fn go_to_definition_inside_turbofish() {
 
 #[tokio::test]
 async fn go_to_definition_for_matches() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/matches/src/main.sw"),
     )
     .await;
@@ -357,9 +357,9 @@ async fn go_to_definition_for_matches() {
 
 #[tokio::test]
 async fn go_to_definition_for_modules() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/modules/src/lib.sw"),
     )
     .await;
@@ -378,9 +378,9 @@ async fn go_to_definition_for_modules() {
 
     let _ = server.shutdown_server();
 
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/modules/src/test_mod.sw"),
     )
     .await;
@@ -402,9 +402,9 @@ async fn go_to_definition_for_modules() {
 
 #[tokio::test]
 async fn go_to_definition_for_paths() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/paths/src/main.sw"),
     )
     .await;
@@ -774,9 +774,9 @@ async fn go_to_definition_for_paths() {
 
 #[tokio::test]
 async fn go_to_definition_for_traits() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/traits/src/main.sw"),
     )
     .await;
@@ -803,9 +803,9 @@ async fn go_to_definition_for_traits() {
 
 #[tokio::test]
 async fn go_to_definition_for_variables() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/variables/src/main.sw"),
     )
     .await;
@@ -894,9 +894,9 @@ async fn go_to_definition_for_variables() {
 
 #[tokio::test]
 async fn go_to_definition_for_consts() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/consts/src/main.sw"),
     )
     .await;
@@ -969,9 +969,9 @@ async fn go_to_definition_for_consts() {
 
 #[tokio::test]
 async fn go_to_definition_for_functions() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/functions/src/main.sw"),
     )
     .await;
@@ -1019,9 +1019,9 @@ async fn go_to_definition_for_functions() {
 
 #[tokio::test]
 async fn go_to_definition_for_structs() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/structs/src/main.sw"),
     )
     .await;
@@ -1072,9 +1072,9 @@ async fn go_to_definition_for_structs() {
 
 #[tokio::test]
 async fn go_to_definition_for_impls() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/impls/src/main.sw"),
     )
     .await;
@@ -1109,9 +1109,9 @@ async fn go_to_definition_for_impls() {
 
 #[tokio::test]
 async fn go_to_definition_for_where_clause() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/where_clause/src/main.sw"),
     )
     .await;
@@ -1168,9 +1168,9 @@ async fn go_to_definition_for_where_clause() {
 
 #[tokio::test]
 async fn go_to_definition_for_enums() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/enums/src/main.sw"),
     )
     .await;
@@ -1211,8 +1211,12 @@ async fn go_to_definition_for_enums() {
 
 #[tokio::test]
 async fn go_to_definition_for_abi() {
-    let server = ServerState::default();
-    let uri = open(&server, test_fixtures_dir().join("tokens/abi/src/main.sw")).await;
+    let mut server = ServerState::default();
+    let uri = open(
+        &mut server,
+        test_fixtures_dir().join("tokens/abi/src/main.sw"),
+    )
+    .await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -1236,9 +1240,9 @@ async fn go_to_definition_for_abi() {
 
 #[tokio::test]
 async fn go_to_definition_for_storage() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/storage/src/main.sw"),
     )
     .await;
@@ -1326,9 +1330,9 @@ async fn go_to_definition_for_storage() {
 
 #[tokio::test]
 async fn hover_docs_for_consts() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/consts/src/main.sw"),
     )
     .await;
@@ -1349,9 +1353,9 @@ async fn hover_docs_for_consts() {
 
 #[tokio::test]
 async fn hover_docs_for_functions() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/functions/src/main.sw"),
     )
     .await;
@@ -1368,9 +1372,9 @@ async fn hover_docs_for_functions() {
 
 #[tokio::test]
 async fn hover_docs_for_structs() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/structs/src/main.sw"),
     )
     .await;
@@ -1405,9 +1409,9 @@ async fn hover_docs_for_structs() {
 
 #[tokio::test]
 async fn hover_docs_for_enums() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/enums/src/main.sw"),
     )
     .await;
@@ -1432,8 +1436,12 @@ async fn hover_docs_for_enums() {
 
 #[tokio::test]
 async fn hover_docs_for_abis() {
-    let server = ServerState::default();
-    let uri = open(&server, test_fixtures_dir().join("tokens/abi/src/main.sw")).await;
+    let mut server = ServerState::default();
+    let uri = open(
+        &mut server,
+        test_fixtures_dir().join("tokens/abi/src/main.sw"),
+    )
+    .await;
 
     let hover = HoverDocumentation {
         req_uri: &uri,
@@ -1447,9 +1455,9 @@ async fn hover_docs_for_abis() {
 
 #[tokio::test]
 async fn hover_docs_for_variables() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/variables/src/main.sw"),
     )
     .await;
@@ -1466,8 +1474,8 @@ async fn hover_docs_for_variables() {
 
 #[tokio::test]
 async fn hover_docs_with_code_examples() {
-    let server = ServerState::default();
-    let uri = open(&server, doc_comments_dir().join("src/main.sw")).await;
+    let mut server = ServerState::default();
+    let uri = open(&mut server, doc_comments_dir().join("src/main.sw")).await;
 
     let hover = HoverDocumentation {
             req_uri: &uri,
@@ -1481,8 +1489,12 @@ async fn hover_docs_with_code_examples() {
 
 #[tokio::test]
 async fn hover_docs_for_self_keywords() {
-    let server = ServerState::default();
-    let uri = open(&server, test_fixtures_dir().join("completion/src/main.sw")).await;
+    let mut server = ServerState::default();
+    let uri = open(
+        &mut server,
+        test_fixtures_dir().join("completion/src/main.sw"),
+    )
+    .await;
 
     let mut hover = HoverDocumentation {
         req_uri: &uri,
@@ -1500,9 +1512,9 @@ async fn hover_docs_for_self_keywords() {
 
 #[tokio::test]
 async fn hover_docs_for_boolean_keywords() {
-    let server = ServerState::default();
+    let mut server = ServerState::default();
     let uri = open(
-        &server,
+        &mut server,
         test_fixtures_dir().join("tokens/storage/src/main.sw"),
     )
     .await;
@@ -1524,8 +1536,12 @@ async fn hover_docs_for_boolean_keywords() {
 
 #[tokio::test]
 async fn rename() {
-    let server = ServerState::default();
-    let uri = open(&server, test_fixtures_dir().join("renaming/src/main.sw")).await;
+    let mut server = ServerState::default();
+    let uri = open(
+        &mut server,
+        test_fixtures_dir().join("renaming/src/main.sw"),
+    )
+    .await;
 
     // Struct expression variable
     let rename = Rename {
@@ -1667,8 +1683,8 @@ async fn publish_diagnostics_multi_file() {
 // The capability argument is an async function.
 macro_rules! test_lsp_capability {
     ($entry_point:expr, $capability:expr) => {{
-        let server = ServerState::default();
-        let uri = open(&server, $entry_point).await;
+        let mut server = ServerState::default();
+        let uri = open(&mut server, $entry_point).await;
 
         // Call the specific LSP capability function that was passed in.
         let _ = $capability(&server, &uri);
@@ -1779,7 +1795,7 @@ async fn write_all_example_asts() {
     // ordering is required the entries should be explicitly sorted.
     entries.sort();
 
-    let server = ServerState::default();
+    let mut server = ServerState::default();
 
     for entry in entries {
         let manifest_dir = entry;
@@ -1794,7 +1810,7 @@ async fn write_all_example_asts() {
                 Err(_) => continue,
             }
 
-            let uri = open(&server, manifest_dir.join("src/main.sw")).await;
+            let uri = open(&mut server, manifest_dir.join("src/main.sw")).await;
             let example_dir = Some(Url::from_file_path(example_dir).unwrap());
             lsp::show_ast_request(&server, &uri, "lexed", example_dir.clone()).await;
             lsp::show_ast_request(&server, &uri, "parsed", example_dir.clone()).await;

--- a/sway-lsp/tests/utils/Cargo.toml
+++ b/sway-lsp/tests/utils/Cargo.toml
@@ -17,4 +17,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.60"
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tower = { version = "0.4.12", default-features = false, features = ["util"] }
-tower-lsp = { version = "0.19", features = ["proposed"] }
+tower-lsp = { git = "https://github.com/ebkalderon/tower-lsp", branch = "support-mutable-methods" }

--- a/sway-utils/src/helpers.rs
+++ b/sway-utils/src/helpers.rs
@@ -4,9 +4,9 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-pub fn get_sway_files(path: &PathBuf) -> Vec<PathBuf> {
+pub fn get_sway_files(path: &Path) -> Vec<PathBuf> {
     let mut files = vec![];
-    let mut dir_entries = vec![path.clone()];
+    let mut dir_entries = vec![path.to_path_buf()];
 
     while let Some(next_dir) = dir_entries.pop() {
         if let Ok(read_dir) = fs::read_dir(next_dir) {

--- a/sway-utils/src/helpers.rs
+++ b/sway-utils/src/helpers.rs
@@ -4,9 +4,9 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-pub fn get_sway_files(path: PathBuf) -> Vec<PathBuf> {
+pub fn get_sway_files(path: &PathBuf) -> Vec<PathBuf> {
     let mut files = vec![];
-    let mut dir_entries = vec![path];
+    let mut dir_entries = vec![path.clone()];
 
     while let Some(next_dir) = dir_entries.pop() {
         if let Ok(read_dir) = fs::read_dir(next_dir) {


### PR DESCRIPTION
## Description
This PR uses the [experimental branch](https://github.com/ebkalderon/tower-lsp/tree/support-mutable-methods) in `tower-lsp` that allows notification methods to take `&mut self`.  This means we no longer need to wrap all of our types in `RwLock`'s as we have clear boundaries where we can mutate state owned by the server and where we just take a reference. 

Not looking to get this PR merged at this stage, just opening for visibility. I must say, it really does feel soooo much nicer than what we currently are doing. I'm going to reach out to @ebkalderon to see whats left to do before this branch can be merged into master in `tower-lsp`.

See [this issue](https://github.com/ebkalderon/tower-lsp/issues/284) for more context on the API change in `tower-lsp`


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
