### PR TITLE
feat: sway-test-rs load store config & beta-4 bump

### DIFF
--- a/templates/sway-test-rs/template/Cargo.toml
+++ b/templates/sway-test-rs/template/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["{{authors}}"]
 license = "Apache-2.0"
 
 [dev-dependencies]
-fuels = { version = "0.45", features = ["fuel-core-lib"] }
+fuels = { version = "0.47", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/templates/sway-test-rs/template/tests/harness.rs
+++ b/templates/sway-test-rs/template/tests/harness.rs
@@ -20,10 +20,12 @@ async fn get_contract_instance() -> (MyContract<WalletUnlocked>, ContractId) {
     .await;
     let wallet = wallets.pop().unwrap();
 
-    let id = Contract::load_from(
-        "./out/debug/{{project-name}}.bin",
-        LoadConfiguration::default(),
-    )
+    let storage_config =
+        StorageConfiguration::load_from("out/debug/{{project-name}}-storage_slots.json").unwrap();
+
+    let load_config = LoadConfiguration::default().with_storage_configuration(storage_config);
+
+    let id = Contract::load_from("./out/debug/{{project-name}}.bin", load_config)
     .unwrap()
     .deploy(&wallet, TxParameters::default())
     .await


### PR DESCRIPTION
## Description

- Bumps the test harness for the [quickstart](https://github.com/FuelLabs/fuel-docs/blob/master/src/quickstart/smart-contract.md) to match beta-4

- Adds [changes ](https://github.com/FuelLabs/fuel-docs/pull/102) suggested by @segfault-magnet for storage initialization on rust sdk testing. Due to the sdk storage initialization issue [fuels-rs/issues/111](https://github.com/FuelLabs/fuels-rs/issues/1117)

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
