### PR TITLE
Split compilation and traversal stages

### DIFF
--- a/sway-lsp/benches/lsp_benchmarks/compile.rs
+++ b/sway-lsp/benches/lsp_benchmarks/compile.rs
@@ -1,9 +1,26 @@
 use criterion::{black_box, criterion_group, Criterion};
+use lsp_types::Url;
+use sway_core::Engines;
+use sway_lsp::core::session::{self, Session};
 
 fn benchmarks(c: &mut Criterion) {
-    c.bench_function("compile_and_traverse", |b| {
+    // Load the test project
+    let uri = Url::from_file_path(super::benchmark_dir().join("src/main.sw")).unwrap();
+    let session = Session::new();
+    session.handle_open_file(&uri);
+
+    c.bench_function("compile", |b| {
         b.iter(|| {
-            let _ = black_box(super::compile_test_project());
+            let engines = Engines::default();
+            let _ = black_box(session::compile(&uri, &engines).unwrap());
+        })
+    });
+
+    c.bench_function("traverse", |b| {
+        let engines = Engines::default();
+        let results = black_box(session::compile(&uri, &engines).unwrap());
+        b.iter(|| {
+            let _ = black_box(session::traverse(results.clone(), &engines).unwrap());
         })
     });
 }

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -8,7 +8,7 @@ use crate::{
     core::{
         document::TextDocument,
         sync::SyncWorkspace,
-        token::TypedAstToken,
+        token::{self, TypedAstToken},
         token_map::{TokenMap, TokenMapExt},
     },
     error::{DocumentError, LanguageServerError},
@@ -45,8 +45,6 @@ use sway_error::{error::CompileError, handler::Handler, warning::CompileWarning}
 use sway_types::{SourceEngine, Spanned};
 use sway_utils::helpers::get_sway_files;
 use tokio::sync::Semaphore;
-
-use super::{token::get_range_from_span, token_map};
 
 pub type Documents = DashMap<String, TextDocument>;
 pub type ProjectDirectory = PathBuf;
@@ -355,7 +353,7 @@ impl Session {
             if let Some(source_id) = span.source_id() {
                 let path = source_engine.get_path(source_id);
                 let runnable = Box::new(RunnableTestFn {
-                    range: get_range_from_span(&span.clone()),
+                    range: token::get_range_from_span(&span.clone()),
                     tree_type: typed_program.kind.tree_type(),
                     test_name: Some(decl.name.to_string()),
                 });
@@ -375,7 +373,7 @@ impl Session {
             if let Some(source_id) = span.source_id() {
                 let path = source_engine.get_path(source_id);
                 let runnable = Box::new(RunnableMainFn {
-                    range: get_range_from_span(&span.clone()),
+                    range: token::get_range_from_span(&span.clone()),
                     tree_type: typed_program.kind.tree_type(),
                 });
                 self.runnables
@@ -436,7 +434,7 @@ pub fn compile(
         BuildTarget::default(),
         true,
         tests_enabled,
-        &engines,
+        engines,
     )
     .map_err(LanguageServerError::FailedToCompile)
 }


### PR DESCRIPTION
## Description
This PR splits the compilation and traversal stages into separate functions. This allows us to benchmark each part separately from the other. 

related to #5001 

The current measurements are below.

| Request Type/Method    | Time  
|------------------------|-----------|
| compile   | 2.4822s   |
traverse   | 422ms   |

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
