### PR TITLE
Synchronize code_lens request & provide better UX for `forc-fmt` <> `sway-lsp` interaction.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,9 +1689,9 @@ checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "fd-lock"
-version = "3.0.13"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+checksum = "0b0377f1edc77dbd1118507bc7a66e4ab64d2b90c66f90726dc801e73a8c68f9"
 dependencies = [
  "cfg-if",
  "rustix 0.38.13",
@@ -1903,7 +1903,6 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "cid",
- "fd-lock",
  "forc-tracing",
  "forc-util",
  "fuel-abi-types 0.1.0",
@@ -1980,6 +1979,7 @@ dependencies = [
  "anyhow",
  "clap 3.2.25",
  "dirs 3.0.2",
+ "fd-lock",
  "forc-tracing",
  "fuel-tx",
  "hex",
@@ -5872,8 +5872,10 @@ dependencies = [
  "criterion",
  "dashmap",
  "dirs 4.0.0",
+ "fd-lock",
  "forc-pkg",
  "forc-tracing",
+ "forc-util",
  "futures",
  "lsp-types",
  "notify",

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 ansi_term = "0.12"
 anyhow = "1"
 cid = "0.10"
-fd-lock = "3.0"
 forc-tracing = { version = "0.46.0", path = "../forc-tracing" }
 forc-util = { version = "0.46.0", path = "../forc-util" }
 fuel-abi-types = "0.1"

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -7,7 +7,7 @@ use crate::{
 use anyhow::{anyhow, bail, Context, Error, Result};
 use forc_util::{
     default_output_directory, find_file_name, kebab_to_snake_case, print_compiling,
-    print_on_failure, print_warnings, user_forc_directory,
+    print_on_failure, print_warnings,
 };
 use fuel_abi_types::program_abi;
 use petgraph::{
@@ -26,7 +26,6 @@ use std::{
     str::FromStr,
     sync::Arc,
 };
-use sway_core::fuel_prelude::fuel_types::ChainId;
 pub use sway_core::Programs;
 use sway_core::{
     abi_generation::{
@@ -38,6 +37,7 @@ use sway_core::{
     fuel_prelude::{
         fuel_crypto,
         fuel_tx::{self, Contract, ContractId, StorageSlot},
+        fuel_types::ChainId,
     },
     language::{parsed::TreeType, Visibility},
     semantic_analysis::namespace,
@@ -1514,48 +1514,6 @@ fn fetch_deps(
         )?);
     }
     Ok(added)
-}
-
-/// Given a path to a directory we wish to lock, produce a path for an associated lock file.
-///
-/// Note that the lock file itself is simply a placeholder for co-ordinating access. As a result,
-/// we want to create the lock file if it doesn't exist, but we can never reliably remove it
-/// without risking invalidation of an existing lock. As a result, we use a dedicated, hidden
-/// directory with a lock file named after the checkout path.
-///
-/// Note: This has nothing to do with `Forc.lock` files, rather this is about fd locks for
-/// coordinating access to particular paths (e.g. git checkout directories).
-fn fd_lock_path(path: &Path) -> PathBuf {
-    const LOCKS_DIR_NAME: &str = ".locks";
-    const LOCK_EXT: &str = "forc-lock";
-
-    // Hash the path to produce a file-system friendly lock file name.
-    // Append the file stem for improved readability.
-    let mut hasher = hash_map::DefaultHasher::default();
-    path.hash(&mut hasher);
-    let hash = hasher.finish();
-    let file_name = match path.file_stem().and_then(|s| s.to_str()) {
-        None => format!("{hash:X}"),
-        Some(stem) => format!("{hash:X}-{stem}"),
-    };
-
-    user_forc_directory()
-        .join(LOCKS_DIR_NAME)
-        .join(file_name)
-        .with_extension(LOCK_EXT)
-}
-
-/// Create an advisory lock over the given path.
-///
-/// See [fd_lock_path] for details.
-pub(crate) fn path_lock(path: &Path) -> Result<fd_lock::RwLock<File>> {
-    let lock_path = fd_lock_path(path);
-    let lock_dir = lock_path
-        .parent()
-        .expect("lock path has no parent directory");
-    std::fs::create_dir_all(lock_dir).context("failed to create forc advisory lock directory")?;
-    let lock_file = File::create(&lock_path).context("failed to create advisory lock file")?;
-    Ok(fd_lock::RwLock::new(lock_file))
 }
 
 /// Given a `forc_pkg::BuildProfile`, produce the necessary `sway_core::BuildConfig` required for

--- a/forc-pkg/src/source/git/mod.rs
+++ b/forc-pkg/src/source/git/mod.rs
@@ -185,7 +185,7 @@ impl source::Pin for Source {
 impl source::Fetch for Pinned {
     fn fetch(&self, ctx: source::PinCtx, repo_path: &Path) -> Result<PackageManifestFile> {
         // Co-ordinate access to the git checkout directory using an advisory file lock.
-        let mut lock = crate::pkg::path_lock(repo_path)?;
+        let mut lock = forc_util::path_lock(repo_path)?;
         // TODO: Here we assume that if the local path already exists, that it contains the
         // full and correct source for that commit and hasn't been tampered with. This is
         // probably fine for most cases as users should never be touching these
@@ -217,7 +217,7 @@ impl source::DepPath for Pinned {
     fn dep_path(&self, name: &str) -> anyhow::Result<source::DependencyPath> {
         let repo_path = commit_path(name, &self.source.repo, &self.commit_hash);
         // Co-ordinate access to the git checkout directory using an advisory file lock.
-        let lock = crate::pkg::path_lock(&repo_path)?;
+        let lock = forc_util::path_lock(&repo_path)?;
         let _guard = lock.read()?;
         let path = manifest::find_within(&repo_path, name)
             .ok_or_else(|| anyhow!("failed to find package `{}` in {}", name, self))?;

--- a/forc-pkg/src/source/ipfs.rs
+++ b/forc-pkg/src/source/ipfs.rs
@@ -62,7 +62,7 @@ impl source::Fetch for Pinned {
             anyhow::bail!("offline fetching for IPFS sources is not supported")
         }
 
-        let mut lock = crate::pkg::path_lock(repo_path)?;
+        let mut lock = forc_util::path_lock(repo_path)?;
         {
             let _guard = lock.write()?;
             if !repo_path.exists() {
@@ -111,7 +111,7 @@ impl source::DepPath for Pinned {
     fn dep_path(&self, name: &str) -> anyhow::Result<source::DependencyPath> {
         let repo_path = pkg_cache_dir(&self.0);
         // Co-ordinate access to the ipfs checkout directory using an advisory file lock.
-        let lock = crate::pkg::path_lock(&repo_path)?;
+        let lock = forc_util::path_lock(&repo_path)?;
         let _guard = lock.read()?;
         let path = manifest::find_within(&repo_path, name)
             .ok_or_else(|| anyhow::anyhow!("failed to find package `{}` in {}", name, self))?;

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -13,11 +13,8 @@ use std::{
 use taplo::formatter as taplo_fmt;
 use tracing::{debug, error, info};
 
-use forc_tracing::{
-    init_tracing_subscriber, println_error, println_green, println_red, println_warning,
-};
+use forc_tracing::{init_tracing_subscriber, println_error, println_green, println_red};
 use forc_util::{find_parent_manifest_dir, is_sway_file};
-use std::io::Write;
 use sway_core::{BuildConfig, BuildTarget};
 use sway_utils::{constants, get_sway_files};
 use swayfmt::Formatter;
@@ -55,9 +52,6 @@ fn main() {
 fn run() -> Result<()> {
     let app = App::parse();
 
-    // Check if the 'forc-lsp' process is running
-    is_lsp_running()?;
-
     let dir = match app.path.as_ref() {
         Some(path) => PathBuf::from(path),
         None => std::env::current_dir()?,
@@ -94,40 +88,6 @@ fn run() -> Result<()> {
         }
     }
 
-    Ok(())
-}
-
-/// Check if a code editor is running the 'forc-lsp' process.
-/// If so, prompt the user to save any unsaved changes before proceeding.
-///
-/// Unsaved edits exist in tempory memory, while formatting will edit the files on disk.
-fn is_lsp_running() -> Result<()> {
-    // Execute the "ps aux" command to retrieve details of all current processes
-    let output = std::process::Command::new("ps")
-        .arg("aux")
-        .output()
-        .expect("Failed to execute command");
-
-    // Convert the command output bytes to a string for easier parsing
-    let output_str = String::from_utf8_lossy(&output.stdout);
-
-    // Check if the output string contains the name of the process we're looking for
-    if output_str.contains("forc-lsp") {
-        // Print warning
-        println_warning("A code editor may have unsaved changes in this project. \nEnsure all changes are saved before proceeding to prevent potential data loss.");
-
-        // Prompt user for input
-        print!("Continue: (Y)es/(N)o: ");
-        std::io::stdout().flush()?; // Flush to ensure the prompt appears before waiting for input
-
-        let mut input = String::new();
-        std::io::stdin().read_line(&mut input)?;
-
-        // If user responds with 'N' or 'n', exit the program
-        if !input.trim().eq_ignore_ascii_case("y") {
-            std::process::exit(1);
-        }
-    }
     Ok(())
 }
 

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -14,6 +14,7 @@ ansi_term = "0.12"
 anyhow = "1"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 dirs = "3.0.2"
+fd-lock = "3.0"
 forc-tracing = { version = "0.46.0", path = "../forc-tracing" }
 fuel-tx = { workspace = true, features = ["serde"], optional = true }
 hex = "0.4.3"

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -14,7 +14,7 @@ ansi_term = "0.12"
 anyhow = "1"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 dirs = "3.0.2"
-fd-lock = "3.0"
+fd-lock = "4.0"
 forc-tracing = { version = "0.46.0", path = "../forc-tracing" }
 fuel-tx = { workspace = true, features = ["serde"], optional = true }
 hex = "0.4.3"

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -377,7 +377,6 @@ fn fd_lock_path(path: &Path) -> PathBuf {
 ///
 /// This function uses a hashed representation of the original path for uniqueness.
 pub fn is_dirty_path(path: &Path) -> PathBuf {
-    eprintln!("is_dirty_path: {:?}", path);
     const LOCKS_DIR_NAME: &str = ".lsp-locks";
     const LOCK_EXT: &str = "dirty";
     let file_name = hash_path(path);

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -5,12 +5,17 @@ use annotate_snippets::{
     snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
 };
 use ansi_term::Colour;
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use forc_tracing::{println_red_err, println_yellow_err};
-use std::{collections::HashSet, str};
+use std::{
+    collections::{hash_map, HashSet},
+    str,
+};
 use std::{ffi::OsStr, process::Termination};
 use std::{
     fmt::Display,
+    fs::File,
+    hash::{Hash, Hasher},
     path::{Path, PathBuf},
 };
 use sway_core::language::parsed::TreeType;
@@ -347,6 +352,48 @@ pub fn user_forc_directory() -> PathBuf {
 /// The location at which `forc` will checkout git repositories.
 pub fn git_checkouts_directory() -> PathBuf {
     user_forc_directory().join("git").join("checkouts")
+}
+
+/// Given a path to a directory we wish to lock, produce a path for an associated lock file.
+///
+/// Note that the lock file itself is simply a placeholder for co-ordinating access. As a result,
+/// we want to create the lock file if it doesn't exist, but we can never reliably remove it
+/// without risking invalidation of an existing lock. As a result, we use a dedicated, hidden
+/// directory with a lock file named after the checkout path.
+///
+/// Note: This has nothing to do with `Forc.lock` files, rather this is about fd locks for
+/// coordinating access to particular paths (e.g. git checkout directories).
+fn fd_lock_path(path: &Path) -> PathBuf {
+    const LOCKS_DIR_NAME: &str = ".locks";
+    const LOCK_EXT: &str = "forc-lock";
+
+    // Hash the path to produce a file-system friendly lock file name.
+    // Append the file stem for improved readability.
+    let mut hasher = hash_map::DefaultHasher::default();
+    path.hash(&mut hasher);
+    let hash = hasher.finish();
+    let file_name = match path.file_stem().and_then(|s| s.to_str()) {
+        None => format!("{hash:X}"),
+        Some(stem) => format!("{hash:X}-{stem}"),
+    };
+
+    user_forc_directory()
+        .join(LOCKS_DIR_NAME)
+        .join(file_name)
+        .with_extension(LOCK_EXT)
+}
+
+/// Create an advisory lock over the given path.
+///
+/// See [fd_lock_path] for details.
+pub fn path_lock(path: &Path) -> Result<fd_lock::RwLock<File>> {
+    let lock_path = fd_lock_path(path);
+    let lock_dir = lock_path
+        .parent()
+        .expect("lock path has no parent directory");
+    std::fs::create_dir_all(lock_dir).context("failed to create forc advisory lock directory")?;
+    let lock_file = File::create(&lock_path).context("failed to create advisory lock file")?;
+    Ok(fd_lock::RwLock::new(lock_file))
 }
 
 pub fn program_type_str(ty: &TreeType) -> &'static str {

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -366,9 +366,30 @@ pub fn git_checkouts_directory() -> PathBuf {
 fn fd_lock_path(path: &Path) -> PathBuf {
     const LOCKS_DIR_NAME: &str = ".locks";
     const LOCK_EXT: &str = "forc-lock";
+    let file_name = hash_path(path);
+    user_forc_directory()
+        .join(LOCKS_DIR_NAME)
+        .join(file_name)
+        .with_extension(LOCK_EXT)
+}
 
-    // Hash the path to produce a file-system friendly lock file name.
-    // Append the file stem for improved readability.
+/// Constructs the path for the "dirty" flag file corresponding to the specified file.
+///
+/// This function uses a hashed representation of the original path for uniqueness.
+pub fn is_dirty_path(path: &Path) -> PathBuf {
+    eprintln!("is_dirty_path: {:?}", path);
+    const LOCKS_DIR_NAME: &str = ".lsp-locks";
+    const LOCK_EXT: &str = "dirty";
+    let file_name = hash_path(path);
+    user_forc_directory()
+        .join(LOCKS_DIR_NAME)
+        .join(file_name)
+        .with_extension(LOCK_EXT)
+}
+
+/// Hash the path to produce a file-system friendly file name.
+/// Append the file stem for improved readability.
+fn hash_path(path: &Path) -> String {
     let mut hasher = hash_map::DefaultHasher::default();
     path.hash(&mut hasher);
     let hash = hasher.finish();
@@ -376,11 +397,7 @@ fn fd_lock_path(path: &Path) -> PathBuf {
         None => format!("{hash:X}"),
         Some(stem) => format!("{hash:X}-{stem}"),
     };
-
-    user_forc_directory()
-        .join(LOCKS_DIR_NAME)
-        .join(file_name)
-        .with_extension(LOCK_EXT)
+    file_name
 }
 
 /// Create an advisory lock over the given path.

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -11,8 +11,10 @@ repository.workspace = true
 [dependencies]
 anyhow = "1.0.41"
 dashmap = "5.4"
+fd-lock = "4.0"
 forc-pkg = { version = "0.46.0", path = "../forc-pkg" }
 forc-tracing = { version = "0.46.0", path = "../forc-tracing" }
+forc-util = { version = "0.46.0", path = "../forc-util" }
 lsp-types = { version = "0.94", features = ["proposed"] }
 notify = "5.0.0"
 notify-debouncer-mini = { version = "0.2.0" }

--- a/sway-lsp/benches/lsp_benchmarks/requests.rs
+++ b/sway-lsp/benches/lsp_benchmarks/requests.rs
@@ -93,6 +93,8 @@ fn benchmarks(c: &mut Criterion) {
         };
         b.iter(|| capabilities::on_enter::on_enter(&config.on_enter, &session, &uri, &params))
     });
+
+    c.bench_function("format", |b| b.iter(|| session.format_text(&uri)));
 }
 
 criterion_group! {

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -1,8 +1,10 @@
 #![allow(dead_code)]
-use crate::error::DocumentError;
-use lsp_types::{Position, Range, TextDocumentContentChangeEvent};
+use crate::{
+    error::{DirectoryError, DocumentError, LanguageServerError},
+    utils::document,
+};
+use lsp_types::{Position, Range, TextDocumentContentChangeEvent, Url};
 use ropey::Rope;
-use std::{fs::File, sync::Arc};
 
 #[derive(Debug, Clone)]
 pub struct TextDocument {
@@ -12,7 +14,6 @@ pub struct TextDocument {
     version: i32,
     uri: String,
     content: Rope,
-    is_dirty: Option<Arc<fd_lock::RwLock<File>>>,
 }
 
 impl TextDocument {
@@ -23,7 +24,6 @@ impl TextDocument {
                 version: 1,
                 uri: path.into(),
                 content: Rope::from_str(&content),
-                is_dirty: None,
             })
             .map_err(|_| DocumentError::DocumentNotFound { path: path.into() })
     }
@@ -45,19 +45,6 @@ impl TextDocument {
 
     pub fn get_text(&self) -> String {
         self.content.to_string()
-    }
-
-    pub fn mark_file_as_dirty(&mut self) {
-        match forc_util::path_lock(self.uri.as_ref()) {
-            Ok(lock) => self.is_dirty = Some(lock.into()),
-            Err(err) => {
-                tracing::error!("{}", err.to_string());
-            }
-        }
-    }
-
-    pub fn mark_file_as_clean(&mut self) {
-        self.is_dirty = None;
     }
 }
 
@@ -117,6 +104,40 @@ impl TextDocument {
 
         row_char_index + column_char_index
     }
+}
+
+/// Marks the specified file as "dirty" by creating a corresponding flag file.
+///
+/// This function ensures the necessary directory structure exists before creating the flag file.
+pub fn mark_file_as_dirty(uri: &Url) -> Result<(), LanguageServerError> {
+    let path = document::get_path_from_url(uri)?;
+    let dirty_file_path = forc_util::is_dirty_path(&path);
+    if let Some(dir) = dirty_file_path.parent() {
+        // Ensure the directory exists
+        std::fs::create_dir_all(dir).map_err(|_| DirectoryError::LspLocksDirFailed)?;
+    }
+    // Create an empty "dirty" file
+    std::fs::File::create(&dirty_file_path).map_err(|err| DocumentError::UnableToCreateFile {
+        path: uri.path().to_string(),
+        err: err.to_string(),
+    })?;
+    Ok(())
+}
+
+/// Removes the corresponding flag file for the specifed Url.
+///
+/// If the flag file does not exist, this function will do nothing.
+pub fn remove_dirty_flag(uri: &Url) -> Result<(), LanguageServerError> {
+    let path = document::get_path_from_url(uri)?;
+    let dirty_file_path = forc_util::is_dirty_path(&path);
+    if dirty_file_path.exists() {
+        // Remove the "dirty" file
+        std::fs::remove_file(dirty_file_path).map_err(|err| DocumentError::UnableToRemoveFile {
+            path: uri.path().to_string(),
+            err: err.to_string(),
+        })?;
+    }
+    Ok(())
 }
 
 #[derive(Debug)]

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -129,8 +129,11 @@ pub fn mark_file_as_dirty(uri: &Url) -> Result<(), LanguageServerError> {
 /// If the flag file does not exist, this function will do nothing.
 pub fn remove_dirty_flag(uri: &Url) -> Result<(), LanguageServerError> {
     let path = document::get_path_from_url(uri)?;
+    eprintln!("path to remove dirty flag: {:?}", path);
     let dirty_file_path = forc_util::is_dirty_path(&path);
+    eprintln!("dirty_file_path: {:?}", dirty_file_path);
     if dirty_file_path.exists() {
+        eprintln!("Removing dirty flag file: {:?}", dirty_file_path);
         // Remove the "dirty" file
         std::fs::remove_file(dirty_file_path).map_err(|err| DocumentError::UnableToRemoveFile {
             path: uri.path().to_string(),

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -129,11 +129,8 @@ pub fn mark_file_as_dirty(uri: &Url) -> Result<(), LanguageServerError> {
 /// If the flag file does not exist, this function will do nothing.
 pub fn remove_dirty_flag(uri: &Url) -> Result<(), LanguageServerError> {
     let path = document::get_path_from_url(uri)?;
-    eprintln!("path to remove dirty flag: {:?}", path);
     let dirty_file_path = forc_util::is_dirty_path(&path);
-    eprintln!("dirty_file_path: {:?}", dirty_file_path);
     if dirty_file_path.exists() {
-        eprintln!("Removing dirty flag file: {:?}", dirty_file_path);
         // Remove the "dirty" file
         std::fs::remove_file(dirty_file_path).map_err(|err| DocumentError::UnableToRemoveFile {
             path: uri.path().to_string(),

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -130,8 +130,6 @@ impl Session {
             let _ = join_handle.join();
         }
 
-        // TODO: clean up any remaining .dirty files
-
         // Delete the temporary directory.
         self.sync.remove_temp_dir();
     }
@@ -392,7 +390,10 @@ impl Session {
     fn store_sway_files(&self) -> Result<(), LanguageServerError> {
         let temp_dir = self.sync.temp_dir()?;
         // Store the documents.
-        for path in get_sway_files(temp_dir).iter().filter_map(|fp| fp.to_str()) {
+        for path in get_sway_files(&temp_dir)
+            .iter()
+            .filter_map(|fp| fp.to_str())
+        {
             self.store_document(TextDocument::build_from_path(path)?)?;
         }
         Ok(())

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -390,10 +390,7 @@ impl Session {
     fn store_sway_files(&self) -> Result<(), LanguageServerError> {
         let temp_dir = self.sync.temp_dir()?;
         // Store the documents.
-        for path in get_sway_files(&temp_dir)
-            .iter()
-            .filter_map(|fp| fp.to_str())
-        {
+        for path in get_sway_files(temp_dir).iter().filter_map(|fp| fp.to_str()) {
             self.store_document(TextDocument::build_from_path(path)?)?;
         }
         Ok(())

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -310,6 +310,7 @@ impl Session {
             .try_get_mut(url.path())
             .try_unwrap()
             .map(|mut document| {
+                document.mark_file_as_dirty();
                 changes.iter().for_each(|change| {
                     document.apply_change(change);
                 });
@@ -325,6 +326,19 @@ impl Session {
                 path: url.path().to_string(),
             })
             .map(|(_, text_document)| text_document)
+    }
+
+    /// Mark the file as saved so we can remove the is_dirty lock.
+    pub fn document_saved(&self, uri: &Url) -> Result<(), DocumentError> {
+        self.documents
+            .try_get_mut(uri.path())
+            .try_unwrap()
+            .map(|mut document| {
+                document.mark_file_as_clean();
+            })
+            .ok_or_else(|| DocumentError::DocumentNotFound {
+                path: uri.path().to_string(),
+            })
     }
 
     /// Store the text document in the session.

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -130,6 +130,8 @@ impl Session {
             let _ = join_handle.join();
         }
 
+        // TODO: clean up any remaining .dirty files
+
         // Delete the temporary directory.
         self.sync.remove_temp_dir();
     }

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -310,7 +310,6 @@ impl Session {
             .try_get_mut(url.path())
             .try_unwrap()
             .map(|mut document| {
-                document.mark_file_as_dirty();
                 changes.iter().for_each(|change| {
                     document.apply_change(change);
                 });
@@ -326,19 +325,6 @@ impl Session {
                 path: url.path().to_string(),
             })
             .map(|(_, text_document)| text_document)
-    }
-
-    /// Mark the file as saved so we can remove the is_dirty lock.
-    pub fn document_saved(&self, uri: &Url) -> Result<(), DocumentError> {
-        self.documents
-            .try_get_mut(uri.path())
-            .try_unwrap()
-            .map(|mut document| {
-                document.mark_file_as_clean();
-            })
-            .ok_or_else(|| DocumentError::DocumentNotFound {
-                path: uri.path().to_string(),
-            })
     }
 
     /// Store the text document in the session.

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -40,6 +40,8 @@ pub enum DocumentError {
     UnableToCreateFile { path: String, err: String },
     #[error("Unable to write string to file at {:?} : {:?}", path, err)]
     UnableToWriteFile { path: String, err: String },
+    #[error("File wasn't able to be removed at path {:?} : {:?}", path, err)]
+    UnableToRemoveFile { path: String, err: String },
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -50,6 +52,8 @@ pub enum DirectoryError {
     ManifestDirNotFound,
     #[error("Can't extract project name from {:?}", dir)]
     CantExtractProjectName { dir: String },
+    #[error("Failed to create hidden .lsp_locks directory")]
+    LspLocksDirFailed,
     #[error("Failed to create temp directory")]
     TempDirFailed,
     #[error("Failed to canonicalize path")]

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -1,7 +1,7 @@
 //! This module is responsible for implementing handlers for Language Server
 //! Protocol. This module specifically handles notification messages sent by the Client.
 
-use crate::{error::LanguageServerError, server_state::ServerState};
+use crate::{core::document, error::LanguageServerError, server_state::ServerState};
 use lsp_types::{
     DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidOpenTextDocumentParams,
     DidSaveTextDocumentParams, FileChangeType,
@@ -30,6 +30,7 @@ pub async fn handle_did_change_text_document(
     state: &ServerState,
     params: DidChangeTextDocumentParams,
 ) -> Result<(), LanguageServerError> {
+    document::mark_file_as_dirty(&params.text_document.uri)?;
     let (uri, session) = state
         .sessions
         .uri_and_session_from_workspace(&params.text_document.uri)?;
@@ -44,11 +45,11 @@ pub(crate) async fn handle_did_save_text_document(
     state: &ServerState,
     params: DidSaveTextDocumentParams,
 ) -> Result<(), LanguageServerError> {
+    document::remove_dirty_flag(&params.text_document.uri)?;
     let (uri, session) = state
         .sessions
         .uri_and_session_from_workspace(&params.text_document.uri)?;
     session.sync.resync()?;
-    session.document_saved(&uri)?;
     state
         .parse_project(uri, params.text_document.uri, session.clone())
         .await;
@@ -58,15 +59,13 @@ pub(crate) async fn handle_did_save_text_document(
 pub(crate) fn handle_did_change_watched_files(
     state: &ServerState,
     params: DidChangeWatchedFilesParams,
-) {
+) -> Result<(), LanguageServerError> {
     for event in params.changes {
-        if event.typ == FileChangeType::DELETED {
-            match state.sessions.uri_and_session_from_workspace(&event.uri) {
-                Ok((uri, session)) => {
-                    let _ = session.remove_document(&uri);
-                }
-                Err(err) => tracing::error!("{}", err.to_string()),
-            }
+        let (uri, session) = state.sessions.uri_and_session_from_workspace(&event.uri)?;
+        if let FileChangeType::DELETED = event.typ {
+            document::remove_dirty_flag(&event.uri)?;
+            let _ = session.remove_document(&uri);
         }
     }
+    Ok(())
 }

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -48,6 +48,7 @@ pub(crate) async fn handle_did_save_text_document(
         .sessions
         .uri_and_session_from_workspace(&params.text_document.uri)?;
     session.sync.resync()?;
+    session.document_saved(&uri)?;
     state
         .parse_project(uri, params.text_document.uri, session.clone())
         .await;

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -244,7 +244,10 @@ pub fn handle_code_lens(
         .sessions
         .uri_and_session_from_workspace(&params.text_document.uri)
     {
-        Ok((url, session)) => Ok(Some(capabilities::code_lens::code_lens(&session, &url))),
+        Ok((url, session)) => {
+            let _ = session.wait_for_parsing();
+            Ok(Some(capabilities::code_lens::code_lens(&session, &url)))
+        },
         Err(err) => {
             tracing::error!("{}", err.to_string());
             Ok(None)

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -247,7 +247,7 @@ pub fn handle_code_lens(
         Ok((url, session)) => {
             let _ = session.wait_for_parsing();
             Ok(Some(capabilities::code_lens::code_lens(&session, &url)))
-        },
+        }
         Err(err) => {
             tracing::error!("{}", err.to_string());
             Ok(None)

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -51,7 +51,9 @@ impl LanguageServer for ServerState {
     }
 
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
-        notification::handle_did_change_watched_files(self, params);
+        if let Err(err) = notification::handle_did_change_watched_files(self, params) {
+            tracing::error!("{}", err.to_string());
+        }
     }
 
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {

--- a/sway-lsp/tests/integration/lsp.rs
+++ b/sway-lsp/tests/integration/lsp.rs
@@ -148,7 +148,6 @@ pub(crate) fn semantic_tokens_request(server: &ServerState, uri: &Url) {
         partial_result_params: Default::default(),
     };
     let response = request::handle_semantic_tokens_full(server, params).unwrap();
-    eprintln!("{:#?}", response);
     if let Some(SemanticTokensResult::Tokens(tokens)) = response {
         assert!(!tokens.data.is_empty());
     }


### PR DESCRIPTION
## Description
This PR adds 3 things:

1. Adds a benchmark for the format LSP request.

2. Calls `session.wait_for_parsing();` before computing the `code_lens` request. This fixes the original issue reported in #4893 where run buttons where being placed incorrectly after formatting. 

3. If a file open in a code editor contains unsaved changes we write a lock file to `.forc/lsp_locks/`. This file is removed when the file is saved and there are no pending changes. If `forc-fmt` is run in a terminal we check if the path has a lock file associated with it. If unsaved changes are detected we bail from formatting with an error message instructing the user to save changes before continuing. See video below.

https://github.com/FuelLabs/sway/assets/1289413/75e6fddc-adbc-4796-aeb9-985574ae8dcc


closes #4893 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
