### PR TITLE
Add a "this" method to ContractId

### DIFF
--- a/sway-lib-std/src/call_frames.sw
+++ b/sway-lib-std/src/call_frames.sw
@@ -33,12 +33,12 @@ const SECOND_PARAMETER_OFFSET: u64 = 74;
 /// # Examples
 ///
 /// ```sway
-/// use std::{call_frames::contract_id, token::mint};
+/// use std::{call_frames::contract_id, constants::ZERO_B256, token::mint};
 ///
 /// fn foo() {
 ///     let this_contract = contract_id();
-///     mint(50);
-///     Address::from(ZERO_B256).transfer(50, this_contract);
+///     mint(ZERO_B256, 50);
+///     Address::from(ZERO_B256).transfer(AssetId::default(this_contract), 50);
 /// }
 /// ```
 pub fn contract_id() -> ContractId {

--- a/sway-lib-std/src/contract_id.sw
+++ b/sway-lib-std/src/contract_id.sw
@@ -233,6 +233,33 @@ impl AssetId {
 }
 
 impl ContractId {
+    /// Returns the ContractId of the currently executing contract.
+    ///
+    /// # Additional Information
+    ///
+    /// This is equivalent to std::callframes::contract_id().
+    ///
+    /// **_Note:_** If called in an external context, this will **not** return a ContractId.
+    /// If called externally, will actually return a pointer to the Transaction Id (Wrapped in the ContractId struct).
+    /// 
+    /// # Returns
+    ///
+    /// * [ContractId] - The contract id of this contract.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::{constants::ZERO_B256, token::mint};
+    ///
+    /// fn foo() {
+    ///     let this_contract = ContractId::this();
+    ///     mint(ZERO_B256, 50);
+    ///     Address::from(ZERO_B256).transfer(AssetId::default(this_contract), 50);
+    /// }
+    /// ```
+    pub fn this() -> ContractId {
+        ContractId::from(asm() { fp: b256 })
+    }
     /// UNCONDITIONAL transfer of `amount` coins of type `asset_id` to
     /// the ContractId.
     ///

--- a/test/src/sdk-harness/test_artifacts/call_frames_test_abi/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/call_frames_test_abi/src/main.sw
@@ -11,6 +11,7 @@ pub struct TestStruct2 {
 
 abi CallFramesTest {
     fn get_id() -> ContractId;
+    fn get_id_contract_id_this() -> ContractId;
     fn get_asset_id() -> AssetId;
     fn get_code_size() -> u64;
     fn get_first_param() -> u64;

--- a/test/src/sdk-harness/test_projects/call_frames/mod.rs
+++ b/test/src/sdk-harness/test_projects/call_frames/mod.rs
@@ -31,6 +31,13 @@ async fn can_get_contract_id() {
 }
 
 #[tokio::test]
+async fn can_get_id_contract_id_this() {
+    let (instance, id) = get_call_frames_instance().await;
+    let result = instance.methods().get_id_contract_id_this().call().await.unwrap();
+    assert_eq!(result.value, id);
+}
+
+#[tokio::test]
 async fn can_get_code_size() {
     let (instance, _id) = get_call_frames_instance().await;
     let result = instance.methods().get_code_size().call().await.unwrap();

--- a/test/src/sdk-harness/test_projects/call_frames/src/main.sw
+++ b/test/src/sdk-harness/test_projects/call_frames/src/main.sw
@@ -8,6 +8,10 @@ impl CallFramesTest for Contract {
         contract_id()
     }
 
+    fn get_id_contract_id_this() -> ContractId {
+        ContractId::this()
+    }
+
     fn get_asset_id() -> AssetId {
         msg_asset_id()
     }


### PR DESCRIPTION
## Description
Adds a `ContractId::this()` method, equivalent to `std::call_frames::contract_id()`. For ease of use.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
