### PR TITLE
Fixes generic types unification of empty structs.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1308,7 +1308,6 @@ impl ty::TyExpression {
                     args,
                     call_path_binding,
                     call_path_decl,
-                    &span,
                 )?
             }
             (false, Some((fn_ref, call_path_binding)), None, None) => {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -9,7 +9,7 @@ use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
 };
-use sway_types::{Ident, Span, Spanned};
+use sway_types::{Ident, Spanned};
 
 /// Given an enum declaration and the instantiation expression/type arguments, construct a valid
 /// [ty::TyExpression].
@@ -22,7 +22,6 @@ pub(crate) fn instantiate_enum(
     args_opt: Option<Vec<Expression>>,
     call_path_binding: TypeBinding<CallPath>,
     call_path_decl: ty::TyDecl,
-    span: &Span,
 ) -> Result<ty::TyExpression, ErrorEmitted> {
     let type_engine = ctx.engines.te();
     let decl_engine = ctx.engines.de();
@@ -73,7 +72,7 @@ pub(crate) fn instantiate_enum(
             let enum_ctx = ctx
                 .by_ref()
                 .with_help_text("Enum instantiator must match its declared variant type.")
-                .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown));
+                .with_type_annotation(enum_variant.type_argument.type_id);
             let typed_expr = ty::TyExpression::type_check(handler, enum_ctx, single_expr.clone())?;
 
             // unify the value of the argument with the variant
@@ -83,7 +82,7 @@ pub(crate) fn instantiate_enum(
                     engines,
                     typed_expr.return_type,
                     enum_variant.type_argument.type_id,
-                    span,
+                    &typed_expr.span,
                     "Enum instantiator must match its declared variant type.",
                     None,
                 );

--- a/test/src/e2e_vm_tests/test_programs/should_fail/binop_intrinsics/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/binop_intrinsics/test.toml
@@ -5,6 +5,13 @@ category = "fail"
 # nextln: $()Mismatched types
 # nextln: $()expected: numeric
 # nextln: $()found:    A.
+# nextln: $()help: Struct type must match the type specified in its declaration.
+
+# check: $()error
+# check: $()__add(A { a: 32 }, 32);
+# nextln: $()Mismatched types
+# nextln: $()expected: numeric
+# nextln: $()found:    A.
 # nextln: $()help: Incorrect argument type
 
 # check: $()error

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_empty_struct_with_constraint/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_empty_struct_with_constraint/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_empty_struct_with_constraint/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_empty_struct_with_constraint/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-151EC6D60D03100D"
+
+[[package]]
+name = "impl_with_constraint"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "std"
+source = "path+from-root-151EC6D60D03100D"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_empty_struct_with_constraint/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_empty_struct_with_constraint/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "impl_with_constraint"
+
+[dependencies]
+std = { path = "../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_empty_struct_with_constraint/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_empty_struct_with_constraint/src/main.sw
@@ -1,0 +1,16 @@
+script;
+
+use std::hash::*;
+
+// Does NOT have a Hash trait implementation
+pub struct NoHashStruct {
+    val: u64
+}
+
+// Where clause on empty struct
+pub struct GenericEmptyStruct<T> where T: Hash {}
+
+fn main() {
+    // Does not compile as expected
+    let _empty_no_hash: GenericEmptyStruct<NoHashStruct> = GenericEmptyStruct {};
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_empty_struct_with_constraint/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_empty_struct_with_constraint/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: let _empty_no_hash: GenericEmptyStruct<NoHashStruct> = GenericEmptyStruct {};
+# nextln: $()Trait "Hash" is not implemented for type "NoHashStruct".

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_unification/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_unification/test.toml
@@ -1,7 +1,7 @@
 category = "fail"
 
 # check: $()error
-# nextln: recursive_type_unification/src/main.sw:8:5
+# nextln: recursive_type_unification/src/main.sw:8:15
 # check: $()Some::<V>(foo::<V>(value))
 # nextln: $()Mismatched types.
 # nextln: $()expected: V

--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_mismatch_error_message/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_mismatch_error_message/test.toml
@@ -9,6 +9,17 @@ category = "fail"
 # nextln: $()Mismatched types.
 # nextln: $()expected: Item<I>
 # nextln: $()found:    Item<A>
+# nextln: $()help: Struct type must match the type specified in its declaration.
+
+# check: $()error
+# check: type_mismatch_error_message/src/main.sw:18:5
+# check: $()fn test<A, I>(arg: A) -> Item<I> {
+# check: $()Item {
+# check: $()item: arg
+# check: $()}
+# nextln: $()Mismatched types.
+# nextln: $()expected: Item<I>
+# nextln: $()found:    Item<A>
 # nextln: $()help: Implicit return must match up with block's type.
 
 # check: $()error

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/generic_empty_struct_with_constraint/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/generic_empty_struct_with_constraint/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-1137881413C24890"
+
+[[package]]
+name = "generic_empty_struct_with_constraint"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "std"
+source = "path+from-root-1137881413C24890"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/generic_empty_struct_with_constraint/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/generic_empty_struct_with_constraint/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "generic_empty_struct_with_constraint"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }
+

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/generic_empty_struct_with_constraint/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/generic_empty_struct_with_constraint/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": [],
+      "type": "()",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/generic_empty_struct_with_constraint/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/generic_empty_struct_with_constraint/src/main.sw
@@ -1,0 +1,33 @@
+script;
+
+use std::hash::*;
+
+// Where clause with value
+pub struct GenericValStruct<T> where T: Hash {
+    value: T
+}
+
+// Where clause on empty struct
+pub struct GenericEmptyStruct<T> where T: Hash {}
+
+fn test_fn(_a: GenericEmptyStruct<u64>) {}
+
+pub struct Struct {
+    s: GenericEmptyStruct<u64>
+}
+
+pub enum Enum {
+    E: GenericEmptyStruct<u64>
+}
+
+fn main() {
+    let _val_hash: GenericValStruct<u64> = GenericValStruct { value: 0 };
+    
+    let _empty_hash: GenericEmptyStruct<u64> = GenericEmptyStruct {};
+
+    test_fn(GenericEmptyStruct {});
+
+    let _s = Struct {s: GenericEmptyStruct {}};
+
+    let _e = Enum::E(GenericEmptyStruct {});
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/generic_empty_struct_with_constraint/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/generic_empty_struct_with_constraint/test.toml
@@ -1,0 +1,4 @@
+category = "run"
+expected_result = { action = "return", value = 0 }
+validate_abi = true
+expected_warnings = 2


### PR DESCRIPTION
## Description

Structs generic type were not unified with type annotation this caused the struct generic types not beeing resolved to the previous type annotations.

Example:
```let _empty_hash: GenericEmptyStruct<u64> = GenericEmptyStruct {};```

The example above would throw the error `Trait "Hash" is not implemented for type "T".`
While the compiler should know the generic type T is in fact u64.

The solution was to unify the struct type id with the type annotation.
This is now working for variables with type ascriptions, function parameters, struct fields instantiation and enum instantiation.

Closes #5105 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
