### PR TITLE
Implement TODO in Storage API 

### DIFF
--- a/sway-lib-std/src/inputs.sw
+++ b/sway-lib-std/src/inputs.sw
@@ -18,7 +18,6 @@ use ::tx::{
     tx_type,
 };
 use core::ops::Eq;
-use core::primitive_conversions::*;
 
 const GTF_INPUT_TYPE = 0x101;
 

--- a/sway-lib-std/src/storage/storage_api.sw
+++ b/sway-lib-std/src/storage/storage_api.sw
@@ -175,12 +175,9 @@ fn slot_calculator<T>(slot: b256, offset: u64) -> (b256, u64, u64) {
         false => 1,
     };
 
-    // TODO: Update when u256 <-> b256 conversions exist.
     // Determine which starting slot `T` will be stored based on the offset.
-    let mut u256_slot = asm(r1: slot) {r1: u256};
-    let u256_increment = asm(r1: (0, 0, 0, last_slot - number_of_slots)) { r1: u256 };
-    u256_slot += u256_increment;
-    let offset_slot = asm(r1: u256_slot) { r1: b256 };
+    let mut offset_slot = slot.as_u256();
+    offset_slot += last_slot.as_u256() - number_of_slots.as_u256();
 
-    (offset_slot, number_of_slots, place_in_slot)
+    (offset_slot.as_b256(), number_of_slots, place_in_slot)
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -2,7 +2,7 @@ script;
 use basic_storage_abi::{BasicStorage, Quad};
 
 fn main() -> u64 {
-    let addr = abi(BasicStorage, 0xf01862cb7b641c642815d71795e9ed7d7daf10158ef3a20e8e32045de97bee0a);
+    let addr = abi(BasicStorage, 0xc7b239ea8eee87d901dbce256b0652f098afb6aa660c343fec6f986d6ea258d3);
     let key = 0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
@@ -3,7 +3,7 @@ script;
 use increment_abi::Incrementor;
 
 fn main() -> bool {
-    let the_abi = abi(Incrementor, 0xdeb965022530a5e114faa0a5214c7f7a19feba73c5218938615186c60feb9813);
+    let the_abi = abi(Incrementor, 0x5dac7c9e1f06e227f90e5f8118c67d4e2e9436ffc1d1a724da092b0bcad3cc82);
     the_abi.increment(5);
     the_abi.increment(5);
     let result = the_abi.get();

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
@@ -4,7 +4,7 @@ use storage_access_abi::*;
 use std::hash::*;
 
 fn main() -> bool {
-    let contract_id = 0xcbaac3d1670ec094eef042052fb49479f639d0120709ac58dad46a6b80cb6550;
+    let contract_id = 0x07df46e19e6992fca171dbca03ac1964cbfc027ee6d20d17d301efa2bb445b16;
     let caller = abi(StorageAccess, contract_id);
 
     // Test initializers


### PR DESCRIPTION
## Description

There is a TODO in the storage API to use the appropriate conversions between b256 <-> u256 when available. This PR resolves this TODO and removes an unused import. 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
