### PR TITLE
Code quality updates for `Option` usage throughout the std lib

### DIFF
--- a/sway-lib-std/src/identity.sw
+++ b/sway-lib-std/src/identity.sw
@@ -9,7 +9,7 @@ use ::call_frames::contract_id;
 use ::constants::{ZERO_B256, BASE_ASSET_ID};
 use ::contract_id::{AssetId, ContractId};
 use ::hash::*;
-use ::option::Option;
+use ::option::Option::{self, *};
 
 /// The `Identity` type: either an `Address` or a `ContractId`.
 // ANCHOR: docs_identity
@@ -49,8 +49,8 @@ impl Identity {
     /// ```
     pub fn as_address(self) -> Option<Address> {
         match self {
-            Self::Address(addr) => Option::Some(addr),
-            Self::ContractId(_) => Option::None,
+            Self::Address(addr) => Some(addr),
+            Self::ContractId(_) => None,
         }
     }
 
@@ -73,8 +73,8 @@ impl Identity {
     /// ```
     pub fn as_contract_id(self) -> Option<ContractId> {
         match self {
-            Self::Address(_) => Option::None,
-            Self::ContractId(id) => Option::Some(id),
+            Self::Address(_) => None,
+            Self::ContractId(id) => Some(id),
         }
     }
 

--- a/sway-lib-std/src/outputs.sw
+++ b/sway-lib-std/src/outputs.sw
@@ -12,7 +12,7 @@ use ::tx::{
     Transaction,
     tx_type,
 };
-use ::option::*;
+use ::option::Option::{self, *};
 
 // GTF Opcode const selectors
 //
@@ -220,8 +220,8 @@ pub fn output_amount(index: u64) -> u64 {
 /// ```
 pub fn output_asset_id(index: u64) -> Option<AssetId> {
     match output_type(index) {
-        Output::Coin => Option::Some(AssetId::from(__gtf::<b256>(index, GTF_OUTPUT_COIN_ASSET_ID))),
-        _ => Option::None,
+        Output::Coin => Some(AssetId::from(__gtf::<b256>(index, GTF_OUTPUT_COIN_ASSET_ID))),
+        _ => None,
     }
 }
 
@@ -252,7 +252,7 @@ pub fn output_asset_id(index: u64) -> Option<AssetId> {
 /// ```
 pub fn output_asset_to(index: u64) -> Option<b256> {
     match output_type(index) {
-        Output::Coin => Option::Some(__gtf::<b256>(index, GTF_OUTPUT_COIN_TO)),
-        _ => Option::None,
+        Output::Coin => Some(__gtf::<b256>(index, GTF_OUTPUT_COIN_TO)),
+        _ => None,
     }
 }

--- a/sway-lib-std/src/storage/storage_string.sw
+++ b/sway-lib-std/src/storage/storage_string.sw
@@ -1,7 +1,7 @@
 library;
 
 use ::bytes::Bytes;
-use ::option::Option;
+use ::option::Option::{self, *};
 use ::storage::storable_slice::*;
 use ::storage::storage_api::read;
 use ::string::String;
@@ -78,10 +78,10 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     #[storage(read)]
     fn read_slice(self) -> Option<String> {
         match read_slice(self.slot) {
-            Option::Some(slice) => {
-                Option::Some(String::from(slice))
+            Some(slice) => {
+                Some(String::from(slice))
             },
-            Option::None => Option::None,
+            None => None,
         }
     }
 

--- a/sway-lib-std/src/vec.sw
+++ b/sway-lib-std/src/vec.sw
@@ -309,7 +309,7 @@ impl<T> Vec<T> {
     pub fn get(self, index: u64) -> Option<T> {
         // First check that index is within bounds.
         if self.len <= index {
-            return Option::None;
+            return None;
         };
 
         // Get a pointer to the desired element using `index`


### PR DESCRIPTION
## Description

Replaces instances of the syntax `Option::Some` and `Option::None` with `Some` and `None` respectively. This follows Rust syntax more closely and homogenizes the use of `Option`s throughout the std lib.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
