### PR TITLE
Fix fmt whitespaces between comments and doc comments

### DIFF
--- a/swayfmt/src/constants.rs
+++ b/swayfmt/src/constants.rs
@@ -48,6 +48,11 @@ pub(crate) const CARRIAGE_RETURN: char = '\r';
 pub(crate) const WINDOWS_NEWLINE: &str = "\r\n";
 pub(crate) const UNIX_NEWLINE: &str = "\n";
 
+#[cfg(target_os = "windows")]
+pub(crate) const NEW_LINE: &str = WINDOWS_NEWLINE;
+#[cfg(not(target_os = "windows"))]
+pub(crate) const NEW_LINE: &str = UNIX_NEWLINE;
+
 //INDENT_STYLE
 
 // INDENT_BUFFER.len() = 81

--- a/swayfmt/tests/mod.rs
+++ b/swayfmt/tests/mod.rs
@@ -1602,3 +1602,103 @@ impl MyContract for Contract {
 "#,
     );
 }
+
+#[test]
+fn empty_fn() {
+    check(
+        r#"
+library;
+fn test() {
+}
+        "#,
+        r#"library;
+fn test() {}
+"#,
+    );
+}
+
+#[test]
+fn empty_if() {
+    check(
+        r#"
+library;
+fn test() {
+    if ( something ( ) ) {
+    }
+}
+        "#,
+        r#"library;
+fn test() {
+    if (something()) {}
+}
+"#,
+    );
+}
+
+#[test]
+fn bug_whitespace_added_after_comment() {
+    check(
+        r#"
+library;
+// GTF Opcode const selectors
+//
+pub const GTF_OUTPUT_TYPE = 0x201;
+pub const GTF_OUTPUT_COIN_TO = 0x202;
+pub const GTF_OUTPUT_COIN_AMOUNT = 0x203;
+pub const GTF_OUTPUT_COIN_ASSET_ID = 0x204;
+// pub const GTF_OUTPUT_CONTRACT_INPUT_INDEX = 0x205;
+// pub const GTF_OUTPUT_CONTRACT_BALANCE_ROOT = 0x206;
+// pub const GTF_OUTPUT_CONTRACT_STATE_ROOT = 0x207;
+// pub const GTF_OUTPUT_CONTRACT_CREATED_CONTRACT_ID = 0x208;
+// pub const GTF_OUTPUT_CONTRACT_CREATED_STATE_ROOT = 0x209;
+
+
+
+/// The output type for a transaction.
+pub enum Output {
+    /// A coin output.
+    Coin: (), /// A contract output.
+    Contract: (),
+    /// Remaining "change" from spending of a coin.
+    Change: (),
+        /// A variable output.
+    Variable: (),
+}
+    /// The output type for a transaction.
+pub enum Input {
+        /// A variable output.
+            Variable: (),
+}
+        "#,
+        r#"library;
+// GTF Opcode const selectors
+//
+pub const GTF_OUTPUT_TYPE = 0x201;
+pub const GTF_OUTPUT_COIN_TO = 0x202;
+pub const GTF_OUTPUT_COIN_AMOUNT = 0x203;
+pub const GTF_OUTPUT_COIN_ASSET_ID = 0x204;
+// pub const GTF_OUTPUT_CONTRACT_INPUT_INDEX = 0x205;
+// pub const GTF_OUTPUT_CONTRACT_BALANCE_ROOT = 0x206;
+// pub const GTF_OUTPUT_CONTRACT_STATE_ROOT = 0x207;
+// pub const GTF_OUTPUT_CONTRACT_CREATED_CONTRACT_ID = 0x208;
+// pub const GTF_OUTPUT_CONTRACT_CREATED_STATE_ROOT = 0x209;
+
+/// The output type for a transaction.
+pub enum Output {
+    /// A coin output.
+    Coin: (),
+    /// A contract output.
+    Contract: (),
+    /// Remaining "change" from spending of a coin.
+    Change: (),
+    /// A variable output.
+    Variable: (),
+}
+/// The output type for a transaction.
+pub enum Input {
+    /// A variable output.
+    Variable: (),
+}
+"#,
+    );
+}


### PR DESCRIPTION
This is part of #5052

## Description

There was a bug in the formatter whenever a comment as followed by a doc-comment, this was due the `insert_after_span` was not allowed to return a negative offset (due types constraints). But sometimes this function should let their callee know to remove some bytes.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
