### PR TITLE
bug: Fix formatting for `ItemTraitItem` and `Annotated<T>`

### DIFF
--- a/swayfmt/src/comments.rs
+++ b/swayfmt/src/comments.rs
@@ -103,7 +103,7 @@ pub fn write_comments(
                     write!(
                         formatted_code,
                         "{}{}{}",
-                        formatter.indent_str()?,
+                        formatter.indent_to_str()?,
                         comment.span().as_str(),
                         newlines
                     )?;

--- a/swayfmt/src/formatter/mod.rs
+++ b/swayfmt/src/formatter/mod.rs
@@ -45,16 +45,31 @@ impl Formatter {
         })
     }
 
+    /// Adds a block to the indentation level of the current [`Shape`].
     pub fn indent(&mut self) {
         self.shape.block_indent(&self.config);
     }
 
+    /// Removes a block from the indentation level of the current [`Shape`].
     pub fn unindent(&mut self) {
         self.shape.block_unindent(&self.config);
     }
 
-    pub fn indent_str(&self) -> Result<Cow<'static, str>, FormatterError> {
+    /// Returns the [`Shape`]'s indentation blocks as a `Cow<'static, str>`.
+    pub fn indent_to_str(&self) -> Result<Cow<'static, str>, FormatterError> {
         self.shape.indent.to_string(&self.config)
+    }
+
+    /// Checks the current level of indentation before writing the indent str into the buffer.
+    pub fn write_indent_into_buffer(
+        &self,
+        formatted_code: &mut FormattedCode,
+    ) -> Result<(), FormatterError> {
+        let indent_str = self.indent_to_str()?;
+        if !formatted_code.ends_with(indent_str.as_ref()) {
+            write!(formatted_code, "{indent_str}")?
+        }
+        Ok(())
     }
 
     /// Collect a mapping of Span -> Comment from unformatted input.

--- a/swayfmt/src/items/item_abi/mod.rs
+++ b/swayfmt/src/items/item_abi/mod.rs
@@ -36,10 +36,8 @@ impl Format for ItemAbi {
         let abi_items = self.abi_items.get();
 
         // abi_items
-        for annotated in abi_items.iter() {
-            // add indent + format item
-            write!(formatted_code, "{}", formatter.indent_str()?)?;
-            annotated.format(formatted_code, formatter)?;
+        for trait_item in abi_items.iter() {
+            trait_item.format(formatted_code, formatter)?;
         }
 
         if abi_items.is_empty() {
@@ -56,8 +54,6 @@ impl Format for ItemAbi {
         if let Some(abi_defs) = self.abi_defs_opt.clone() {
             Self::open_curly_brace(formatted_code, formatter)?;
             for item in abi_defs.get().iter() {
-                // add indent + format item
-                write!(formatted_code, "{}", formatter.indent_str()?,)?;
                 item.format(formatted_code, formatter)?;
             }
             writeln!(formatted_code)?;

--- a/swayfmt/src/items/item_abi/mod.rs
+++ b/swayfmt/src/items/item_abi/mod.rs
@@ -57,7 +57,6 @@ impl Format for ItemAbi {
                 item.format(formatted_code, formatter)?;
             }
             writeln!(formatted_code)?;
-
             Self::close_curly_brace(formatted_code, formatter)?;
         }
 
@@ -103,7 +102,7 @@ impl CurlyBrace for ItemAbi {
         write!(
             line,
             "{}{}",
-            formatter.indent_str()?,
+            formatter.indent_to_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 

--- a/swayfmt/src/items/item_configurable/mod.rs
+++ b/swayfmt/src/items/item_configurable/mod.rs
@@ -74,7 +74,7 @@ impl Format for ItemConfigurable {
                         for (field_index, (configurable_field, comma_token)) in
                             value_pairs_iter.clone()
                         {
-                            write!(formatted_code, "{}", &formatter.indent_str()?)?;
+                            write!(formatted_code, "{}", &formatter.indent_to_str()?)?;
 
                             // Add name
                             configurable_field.name.format(formatted_code, formatter)?;
@@ -156,7 +156,7 @@ impl CurlyBrace for ItemConfigurable {
         write!(
             line,
             "{}{}",
-            formatter.indent_str()?,
+            formatter.indent_to_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 

--- a/swayfmt/src/items/item_enum/mod.rs
+++ b/swayfmt/src/items/item_enum/mod.rs
@@ -77,7 +77,7 @@ impl Format for ItemEnum {
 
                         let value_pairs_iter = value_pairs.iter().enumerate();
                         for (var_index, (type_field, comma_token)) in value_pairs_iter.clone() {
-                            write!(formatted_code, "{}", &formatter.indent_str()?)?;
+                            write!(formatted_code, "{}", &formatter.indent_to_str()?)?;
 
                             // Add name
                             type_field.name.format(formatted_code, formatter)?;
@@ -165,7 +165,7 @@ impl CurlyBrace for ItemEnum {
         write!(
             line,
             "{}{}",
-            formatter.indent_str()?,
+            formatter.indent_to_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 

--- a/swayfmt/src/items/item_fn/mod.rs
+++ b/swayfmt/src/items/item_fn/mod.rs
@@ -114,7 +114,7 @@ impl CurlyBrace for ItemFn {
         write!(
             line,
             "{}{}",
-            formatter.indent_str()?,
+            formatter.indent_to_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 
@@ -208,7 +208,7 @@ fn format_fn_args(
                     formatter.indent();
                     args.format(formatted_code, formatter)?;
                     formatter.unindent();
-                    write!(formatted_code, "{}", formatter.indent_str()?)?;
+                    write!(formatted_code, "{}", formatter.indent_to_str()?)?;
                 }
             }
             _ => args.format(formatted_code, formatter)?,
@@ -222,7 +222,7 @@ fn format_fn_args(
             match formatter.shape.code_line.line_style {
                 LineStyle::Multiline => {
                     formatter.indent();
-                    write!(formatted_code, "\n{}", formatter.indent_str()?)?;
+                    write!(formatted_code, "\n{}", formatter.indent_to_str()?)?;
                     format_self(self_token, ref_self, mutable_self, formatted_code)?;
                     // `args_opt`
                     if let Some((comma, args)) = args_opt {

--- a/swayfmt/src/items/item_impl/mod.rs
+++ b/swayfmt/src/items/item_impl/mod.rs
@@ -41,7 +41,7 @@ impl Format for ItemImpl {
         Self::open_curly_brace(formatted_code, formatter)?;
         let contents = self.contents.get();
         for item in contents.iter() {
-            write!(formatted_code, "{}", formatter.indent_str()?,)?;
+            write!(formatted_code, "{}", formatter.indent_to_str()?,)?;
             item.format(formatted_code, formatter)?;
             writeln!(formatted_code)?;
         }
@@ -111,7 +111,7 @@ impl CurlyBrace for ItemImpl {
         write!(
             line,
             "{}{}",
-            formatter.indent_str()?,
+            formatter.indent_to_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 

--- a/swayfmt/src/items/item_storage/mod.rs
+++ b/swayfmt/src/items/item_storage/mod.rs
@@ -70,7 +70,7 @@ impl Format for ItemStorage {
                         let value_pairs_iter = value_pairs.iter().enumerate();
                         for (field_index, (storage_field, comma_token)) in value_pairs_iter.clone()
                         {
-                            write!(formatted_code, "{}", formatter.indent_str()?)?;
+                            write!(formatted_code, "{}", formatter.indent_to_str()?)?;
                             // Add name
                             storage_field.name.format(formatted_code, formatter)?;
 
@@ -160,7 +160,7 @@ impl CurlyBrace for ItemStorage {
         write!(
             line,
             "{}{}",
-            formatter.indent_str()?,
+            formatter.indent_to_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 

--- a/swayfmt/src/items/item_storage/mod.rs
+++ b/swayfmt/src/items/item_storage/mod.rs
@@ -70,8 +70,7 @@ impl Format for ItemStorage {
                         let value_pairs_iter = value_pairs.iter().enumerate();
                         for (field_index, (storage_field, comma_token)) in value_pairs_iter.clone()
                         {
-                            write!(formatted_code, "{}", &formatter.indent_str()?)?;
-
+                            write!(formatted_code, "{}", formatter.indent_str()?)?;
                             // Add name
                             storage_field.name.format(formatted_code, formatter)?;
 

--- a/swayfmt/src/items/item_struct/mod.rs
+++ b/swayfmt/src/items/item_struct/mod.rs
@@ -79,7 +79,7 @@ impl Format for ItemStruct {
 
                         let value_pairs_iter = value_pairs.iter().enumerate();
                         for (var_index, (type_field, comma_token)) in value_pairs_iter.clone() {
-                            write!(formatted_code, "{}", formatter.indent_str()?)?;
+                            write!(formatted_code, "{}", formatter.indent_to_str()?)?;
                             // Add name
                             type_field.name.format(formatted_code, formatter)?;
                             let current_variant_length = variant_length[var_index];
@@ -161,7 +161,7 @@ impl CurlyBrace for ItemStruct {
         write!(
             line,
             "{}{}",
-            formatter.indent_str()?,
+            formatter.indent_to_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 

--- a/swayfmt/src/items/item_struct/mod.rs
+++ b/swayfmt/src/items/item_struct/mod.rs
@@ -79,8 +79,7 @@ impl Format for ItemStruct {
 
                         let value_pairs_iter = value_pairs.iter().enumerate();
                         for (var_index, (type_field, comma_token)) in value_pairs_iter.clone() {
-                            write!(formatted_code, "{}", &formatter.indent_str()?)?;
-
+                            write!(formatted_code, "{}", formatter.indent_str()?)?;
                             // Add name
                             type_field.name.format(formatted_code, formatter)?;
                             let current_variant_length = variant_length[var_index];

--- a/swayfmt/src/items/item_trait/mod.rs
+++ b/swayfmt/src/items/item_trait/mod.rs
@@ -9,10 +9,7 @@ use crate::{
 };
 use std::fmt::Write;
 use sway_ast::{keywords::Token, ItemTrait, ItemTraitItem, Traits};
-use sway_types::{
-    ast::{Delimiter, PunctKind},
-    Spanned,
-};
+use sway_types::{ast::Delimiter, Spanned};
 
 #[cfg(test)]
 mod tests;
@@ -68,7 +65,6 @@ impl Format for ItemTrait {
             write!(formatted_code, " ")?;
             Self::open_curly_brace(formatted_code, formatter)?;
             for trait_items in trait_defs.get() {
-                write!(formatted_code, "{}", formatter.indent_str()?)?;
                 // format `Annotated<ItemFn>`
                 trait_items.format(formatted_code, formatter)?;
             }

--- a/swayfmt/src/items/item_trait/mod.rs
+++ b/swayfmt/src/items/item_trait/mod.rs
@@ -59,29 +59,7 @@ impl Format for ItemTrait {
             write_comments(formatted_code, self.trait_items.span().into(), formatter)?;
         } else {
             for item in trait_items {
-                for attr in &item.attribute_list {
-                    write!(formatted_code, "{}", &formatter.indent_str()?)?;
-                    attr.format(formatted_code, formatter)?;
-                }
-                match &item.value {
-                    sway_ast::ItemTraitItem::Fn(fn_signature, _) => {
-                        write!(formatted_code, "{}", formatter.indent_str()?)?;
-                        fn_signature.format(formatted_code, formatter)?;
-                        write!(formatted_code, "{}", PunctKind::Semicolon.as_char())?;
-                    }
-                    sway_ast::ItemTraitItem::Const(const_decl, _) => {
-                        write!(formatted_code, "{}", formatter.indent_str()?)?;
-                        const_decl.format(formatted_code, formatter)?;
-                    }
-                    sway_ast::ItemTraitItem::Type(type_decl, _) => {
-                        write!(formatted_code, "{}", formatter.indent_str()?)?;
-                        type_decl.format(formatted_code, formatter)?;
-                    }
-                    ItemTraitItem::Error(_, _) => {
-                        return Err(FormatterError::SyntaxError);
-                    }
-                }
-                writeln!(formatted_code)?;
+                item.format(formatted_code, formatter)?;
             }
         }
 
@@ -120,20 +98,20 @@ impl Format for ItemTraitItem {
             ItemTraitItem::Fn(fn_decl, _) => {
                 fn_decl.format(formatted_code, formatter)?;
                 writeln!(formatted_code, ";")?;
-                Ok(())
             }
             ItemTraitItem::Const(const_decl, _) => {
                 const_decl.format(formatted_code, formatter)?;
                 writeln!(formatted_code)?;
-                Ok(())
             }
             ItemTraitItem::Type(type_decl, _) => {
                 type_decl.format(formatted_code, formatter)?;
                 writeln!(formatted_code)?;
-                Ok(())
             }
-            ItemTraitItem::Error(_, _) => Err(FormatterError::SyntaxError),
+            ItemTraitItem::Error(_, _) => {
+                return Err(FormatterError::SyntaxError);
+            }
         }
+        Ok(())
     }
 }
 

--- a/swayfmt/src/items/item_use/mod.rs
+++ b/swayfmt/src/items/item_use/mod.rs
@@ -107,8 +107,8 @@ impl Format for UseTree {
                             writeln!(
                                 formatted_code,
                                 "{}{}",
-                                formatter.indent_str()?,
-                                ord_vec.join(&format!("\n{}", formatter.indent_str()?)),
+                                formatter.indent_to_str()?,
+                                ord_vec.join(&format!("\n{}", formatter.indent_to_str()?)),
                             )?;
                         }
                         _ => {
@@ -182,7 +182,7 @@ impl CurlyBrace for UseTree {
                 write!(
                     line,
                     "{}{}",
-                    formatter.indent_str()?,
+                    formatter.indent_to_str()?,
                     Delimiter::Brace.as_close_char()
                 )?;
             }

--- a/swayfmt/src/utils/language/attribute.rs
+++ b/swayfmt/src/utils/language/attribute.rs
@@ -21,15 +21,11 @@ impl<T: Format + Spanned> Format for Annotated<T> {
     ) -> Result<(), FormatterError> {
         // format each `Attribute`
         for attr in &self.attribute_list {
-            if !formatted_code.ends_with(formatter.indent_str()?.as_ref()) {
-                write!(formatted_code, "{}", &formatter.indent_str()?)?;
-            }
+            formatter.write_indent_into_buffer(formatted_code)?;
             attr.format(formatted_code, formatter)?;
         }
         // format `ItemKind`
-        if !formatted_code.ends_with(formatter.indent_str()?.as_ref()) {
-            write!(formatted_code, "{}", &formatter.indent_str()?)?;
-        }
+        formatter.write_indent_into_buffer(formatted_code)?;
         self.value.format(formatted_code, formatter)?;
 
         Ok(())

--- a/swayfmt/src/utils/language/attribute.rs
+++ b/swayfmt/src/utils/language/attribute.rs
@@ -21,11 +21,15 @@ impl<T: Format + Spanned> Format for Annotated<T> {
     ) -> Result<(), FormatterError> {
         // format each `Attribute`
         for attr in &self.attribute_list {
+            if !formatted_code.ends_with(formatter.indent_str()?.as_ref()) {
+                write!(formatted_code, "{}", &formatter.indent_str()?)?;
+            }
             attr.format(formatted_code, formatter)?;
-
-            write!(formatted_code, "{}", &formatter.indent_str()?,)?;
         }
         // format `ItemKind`
+        if !formatted_code.ends_with(formatter.indent_str()?.as_ref()) {
+            write!(formatted_code, "{}", &formatter.indent_str()?)?;
+        }
         self.value.format(formatted_code, formatter)?;
 
         Ok(())

--- a/swayfmt/src/utils/language/expr/asm_block.rs
+++ b/swayfmt/src/utils/language/expr/asm_block.rs
@@ -125,7 +125,7 @@ impl CurlyBrace for AsmBlock {
                 write!(
                     line,
                     "{}{}",
-                    formatter.indent_str()?,
+                    formatter.indent_to_str()?,
                     Delimiter::Brace.as_close_char()
                 )?;
             }
@@ -174,13 +174,13 @@ impl Format for AsmBlockContents {
         formatter: &mut Formatter,
     ) -> Result<(), FormatterError> {
         for (instruction, semicolon_token) in self.instructions.iter() {
-            write!(formatted_code, "{}", formatter.indent_str()?)?;
+            write!(formatted_code, "{}", formatter.indent_to_str()?)?;
             instruction.format(formatted_code, formatter)?;
             writeln!(formatted_code, "{}", semicolon_token.span().as_str())?
         }
         if let Some(final_expr) = &self.final_expr_opt {
             if formatter.shape.code_line.line_style == LineStyle::Multiline {
-                write!(formatted_code, "{}", formatter.indent_str()?)?;
+                write!(formatted_code, "{}", formatter.indent_to_str()?)?;
                 final_expr.format(formatted_code, formatter)?;
                 writeln!(formatted_code)?;
             } else {

--- a/swayfmt/src/utils/language/expr/code_block.rs
+++ b/swayfmt/src/utils/language/expr/code_block.rs
@@ -32,14 +32,14 @@ impl Format for CodeBlockContents {
                 _ => {
                     writeln!(formatted_code)?;
                     for statement in self.statements.iter() {
-                        write!(formatted_code, "{}", formatter.indent_str()?)?;
+                        write!(formatted_code, "{}", formatter.indent_to_str()?)?;
                         statement.format(formatted_code, formatter)?;
                         if !formatted_code.ends_with('\n') {
                             writeln!(formatted_code)?;
                         }
                     }
                     if let Some(final_expr) = &self.final_expr_opt {
-                        write!(formatted_code, "{}", formatter.indent_str()?)?;
+                        write!(formatted_code, "{}", formatter.indent_to_str()?)?;
                         final_expr.format(formatted_code, formatter)?;
                         writeln!(formatted_code)?;
                     }
@@ -90,7 +90,7 @@ impl CurlyBrace for CodeBlockContents {
         write!(
             line,
             "{}{}",
-            formatter.indent_str()?,
+            formatter.indent_to_str()?,
             Delimiter::Brace.as_close_char()
         )?;
         Ok(())

--- a/swayfmt/src/utils/language/expr/collections.rs
+++ b/swayfmt/src/utils/language/expr/collections.rs
@@ -24,7 +24,7 @@ impl Format for ExprTupleDescriptor {
                 tail,
             } => match formatter.shape.code_line.line_style {
                 LineStyle::Multiline => {
-                    write!(formatted_code, "{}", formatter.indent_str()?)?;
+                    write!(formatted_code, "{}", formatter.indent_to_str()?)?;
                     head.format(formatted_code, formatter)?;
                     write!(formatted_code, "{}", comma_token.span().as_str())?;
                     tail.format(formatted_code, formatter)?;
@@ -67,7 +67,7 @@ impl Parenthesis for ExprTupleDescriptor {
                 write!(
                     line,
                     "{}{}",
-                    formatter.indent_str()?,
+                    formatter.indent_to_str()?,
                     Delimiter::Parenthesis.as_close_char()
                 )?;
             }
@@ -130,7 +130,7 @@ impl SquareBracket for ExprArrayDescriptor {
                 write!(
                     line,
                     "{}{}",
-                    formatter.indent_str()?,
+                    formatter.indent_to_str()?,
                     Delimiter::Bracket.as_close_char()
                 )?;
             }

--- a/swayfmt/src/utils/language/expr/conditional.rs
+++ b/swayfmt/src/utils/language/expr/conditional.rs
@@ -181,7 +181,7 @@ fn format_else_opt(
         )?;
 
         if comments_written {
-            write!(else_if_str, "{}", formatter.indent_str()?,)?;
+            write!(else_if_str, "{}", formatter.indent_to_str()?,)?;
         } else {
             write!(else_if_str, " ")?;
         }
@@ -215,7 +215,7 @@ impl CurlyBrace for IfExpr {
         match formatter.shape.code_line.line_style {
             LineStyle::Multiline => {
                 formatter.shape.code_line.reset_width();
-                write!(line, "\n{}{open_brace}", formatter.indent_str()?)?;
+                write!(line, "\n{}{open_brace}", formatter.indent_to_str()?)?;
                 formatter
                     .shape
                     .code_line
@@ -242,7 +242,7 @@ impl CurlyBrace for IfExpr {
                 write!(
                     line,
                     "{}{}",
-                    formatter.indent_str()?,
+                    formatter.indent_to_str()?,
                     Delimiter::Brace.as_close_char()
                 )?;
             }
@@ -315,7 +315,7 @@ impl CurlyBrace for MatchBranch {
         write!(
             line,
             "{}{}",
-            formatter.indent_str()?,
+            formatter.indent_to_str()?,
             Delimiter::Brace.as_close_char()
         )?;
 
@@ -345,7 +345,7 @@ impl Format for MatchBranchKind {
                     block.format(formatted_code, formatter)?;
                     // we handle this here to avoid needless indents
                     formatter.unindent();
-                    write!(formatted_code, "{}", formatter.indent_str()?)?;
+                    write!(formatted_code, "{}", formatter.indent_to_str()?)?;
                 }
                 Self::close_curly_brace(formatted_code, formatter)?;
                 if let Some(comma_token) = comma_token_opt {

--- a/swayfmt/src/utils/language/expr/mod.rs
+++ b/swayfmt/src/utils/language/expr/mod.rs
@@ -168,7 +168,7 @@ impl Format for Expr {
                     MatchBranch::open_curly_brace(formatted_code, formatter)?;
                     let branches = branches.get();
                     for match_branch in branches.iter() {
-                        write!(formatted_code, "{}", formatter.indent_str()?)?;
+                        write!(formatted_code, "{}", formatter.indent_to_str()?)?;
                         match_branch.format(formatted_code, formatter)?;
                         writeln!(formatted_code)?;
                     }
@@ -194,7 +194,7 @@ impl Format for Expr {
                     |formatter| -> Result<(), FormatterError> {
                         // don't indent unless on new line
                         if formatted_code.ends_with('\n') {
-                            write!(formatted_code, "{}", formatter.indent_str()?)?;
+                            write!(formatted_code, "{}", formatter.indent_to_str()?)?;
                         }
                         func.format(formatted_code, formatter)?;
                         Self::open_parenthesis(formatted_code, formatter)?;
@@ -387,7 +387,7 @@ impl Format for Expr {
                         write!(
                             formatted_code,
                             "\n{}{} ",
-                            formatter.indent_str()?,
+                            formatter.indent_to_str()?,
                             ampersand_token.span().as_str()
                         )?;
                     }
@@ -408,7 +408,7 @@ impl Format for Expr {
                         write!(
                             formatted_code,
                             "\n{}{} ",
-                            formatter.indent_str()?,
+                            formatter.indent_to_str()?,
                             caret_token.span().as_str()
                         )?;
                     }
@@ -429,7 +429,7 @@ impl Format for Expr {
                         write!(
                             formatted_code,
                             "\n{}{} ",
-                            formatter.indent_str()?,
+                            formatter.indent_to_str()?,
                             pipe_token.span().as_str()
                         )?;
                     }
@@ -508,7 +508,7 @@ impl Format for Expr {
                         write!(
                             formatted_code,
                             "\n{}{} ",
-                            formatter.indent_str()?,
+                            formatter.indent_to_str()?,
                             double_ampersand_token.span().as_str()
                         )?;
                     }
@@ -533,7 +533,7 @@ impl Format for Expr {
                         write!(
                             formatted_code,
                             "\n{}{} ",
-                            formatter.indent_str()?,
+                            formatter.indent_to_str()?,
                             double_pipe_token.span().as_str()
                         )?;
                     }
@@ -643,7 +643,7 @@ fn format_method_call(
 ) -> Result<(), FormatterError> {
     // don't indent unless on new line
     if formatted_code.ends_with('\n') {
-        write!(formatted_code, "{}", formatter.indent_str()?)?;
+        write!(formatted_code, "{}", formatter.indent_to_str()?)?;
     }
     target.format(formatted_code, formatter)?;
     write!(formatted_code, "{}", dot_token.span().as_str())?;

--- a/swayfmt/src/utils/language/expr/struct_field.rs
+++ b/swayfmt/src/utils/language/expr/struct_field.rs
@@ -59,7 +59,7 @@ impl CurlyBrace for ExprStructField {
             _ => write!(
                 line,
                 "{}{}",
-                formatter.indent_str()?,
+                formatter.indent_to_str()?,
                 Delimiter::Brace.as_close_char()
             )?,
         }

--- a/swayfmt/src/utils/language/pattern.rs
+++ b/swayfmt/src/utils/language/pattern.rs
@@ -183,7 +183,7 @@ impl CurlyBrace for Pattern {
             _ => write!(
                 line,
                 "{}{}",
-                formatter.indent_str()?,
+                formatter.indent_to_str()?,
                 Delimiter::Brace.as_close_char()
             )?,
         }

--- a/swayfmt/src/utils/language/punctuated.rs
+++ b/swayfmt/src/utils/language/punctuated.rs
@@ -49,14 +49,16 @@ where
                     }
                     let value_pairs_iter = self.value_separator_pairs.iter();
                     for (type_field, comma_token) in value_pairs_iter.clone() {
-                        write!(formatted_code, "{}", &formatter.indent_str()?)?;
+                        if !formatted_code.ends_with(formatter.indent_str()?.as_ref()) {
+                            write!(formatted_code, "{}", formatter.indent_str()?)?;
+                        }
                         type_field.format(formatted_code, formatter)?;
 
                         comma_token.format(formatted_code, formatter)?;
                         writeln!(formatted_code)?;
                     }
                     if let Some(final_value) = &self.final_value_opt {
-                        write!(formatted_code, "{}", &formatter.indent_str()?)?;
+                        write!(formatted_code, "{}", formatter.indent_str()?)?;
                         final_value.format(formatted_code, formatter)?;
                         writeln!(formatted_code, "{}", PunctKind::Comma.as_char())?;
                     }

--- a/swayfmt/src/utils/language/punctuated.rs
+++ b/swayfmt/src/utils/language/punctuated.rs
@@ -49,8 +49,8 @@ where
                     }
                     let value_pairs_iter = self.value_separator_pairs.iter();
                     for (type_field, comma_token) in value_pairs_iter.clone() {
-                        if !formatted_code.ends_with(formatter.indent_str()?.as_ref()) {
-                            write!(formatted_code, "{}", formatter.indent_str()?)?;
+                        if !formatted_code.ends_with(formatter.indent_to_str()?.as_ref()) {
+                            write!(formatted_code, "{}", formatter.indent_to_str()?)?;
                         }
                         type_field.format(formatted_code, formatter)?;
 
@@ -58,7 +58,7 @@ where
                         writeln!(formatted_code)?;
                     }
                     if let Some(final_value) = &self.final_value_opt {
-                        write!(formatted_code, "{}", formatter.indent_str()?)?;
+                        write!(formatted_code, "{}", formatter.indent_to_str()?)?;
                         final_value.format(formatted_code, formatter)?;
                         writeln!(formatted_code, "{}", PunctKind::Comma.as_char())?;
                     }

--- a/swayfmt/src/utils/language/punctuated.rs
+++ b/swayfmt/src/utils/language/punctuated.rs
@@ -49,9 +49,7 @@ where
                     }
                     let value_pairs_iter = self.value_separator_pairs.iter();
                     for (type_field, comma_token) in value_pairs_iter.clone() {
-                        if !formatted_code.ends_with(formatter.indent_to_str()?.as_ref()) {
-                            write!(formatted_code, "{}", formatter.indent_to_str()?)?;
-                        }
+                        formatter.write_indent_into_buffer(formatted_code)?;
                         type_field.format(formatted_code, formatter)?;
 
                         comma_token.format(formatted_code, formatter)?;

--- a/swayfmt/src/utils/language/where_clause.rs
+++ b/swayfmt/src/utils/language/where_clause.rs
@@ -15,7 +15,7 @@ impl Format for WhereClause {
         writeln!(
             formatted_code,
             "{}{}",
-            &formatter.indent_str()?,
+            &formatter.indent_to_str()?,
             self.where_token.span().as_str(),
         )?;
         formatter.indent();
@@ -52,7 +52,7 @@ impl Format for WhereBound {
         write!(
             formatted_code,
             "{}{}{} ",
-            &formatter.indent_str()?,         // `Indent`
+            &formatter.indent_to_str()?,      // `Indent`
             self.ty_name.span().as_str(),     // `Ident`
             self.colon_token.span().as_str(), // `ColonToken`
         )?;


### PR DESCRIPTION
Closes #5179 

What this does:
- Centralizes the use case of `ItemTraitItem`'s format method
- Fixes indentation problems around `Annotated<T>`
- Adds a `write_ident_into_buffer` method which checks if the buffer is already indented
- Adds documentation for methods the interact with the indentation of the formatter to avoid confusion on what they actually do
