### PR TITLE
Use `u32` as exponent in `Power` instead of `Self`

### DIFF
--- a/sway-lib-std/src/math.sw
+++ b/sway-lib-std/src/math.sw
@@ -48,11 +48,11 @@ impl Root for u8 {
 
 /// Calculates a number to a given power.
 pub trait Power {
-    fn pow(self, exponent: Self) -> Self;
+    fn pow(self, exponent: u32) -> Self;
 }
 
 impl Power for u64 {
-    fn pow(self, exponent: Self) -> Self {
+    fn pow(self, exponent: u32) -> Self {
         asm(r1: self, r2: exponent, r3) {
             exp r3 r1 r2;
             r3: Self
@@ -61,7 +61,7 @@ impl Power for u64 {
 }
 
 impl Power for u32 {
-    fn pow(self, exponent: Self) -> Self {
+    fn pow(self, exponent: u32) -> Self {
         asm(r1: self, r2: exponent, r3) {
             exp r3 r1 r2;
             r3: Self
@@ -70,7 +70,7 @@ impl Power for u32 {
 }
 
 impl Power for u16 {
-    fn pow(self, exponent: Self) -> Self {
+    fn pow(self, exponent: u32) -> Self {
         asm(r1: self, r2: exponent, r3) {
             exp r3 r1 r2;
             r3: Self
@@ -79,7 +79,7 @@ impl Power for u16 {
 }
 
 impl Power for u8 {
-    fn pow(self, exponent: Self) -> Self {
+    fn pow(self, exponent: u32) -> Self {
         asm(r1: self, r2: exponent, r3) {
             exp r3 r1 r2;
             r3: Self

--- a/sway-lib-std/src/u128.sw
+++ b/sway-lib-std/src/u128.sw
@@ -468,36 +468,34 @@ impl core::ops::Divide for U128 {
 }
 
 impl Power for U128 {
-    fn pow(self, exponent: Self) -> Self {
+    fn pow(self, exponent: u32) -> Self {
         let mut value = self;
         let mut exp = exponent;
-        let one = Self::from((0, 1));
-        let zero = Self::from((0, 0));
 
-        if exp == zero {
-            return one;
+        if exp == 0 {
+            return Self::from((0, 1));
         }
 
-        if exp == one {
+        if exp == 1 {
             // Manually clone `self`. Otherwise, we may have a `MemoryOverflow`
             // issue with code that looks like: `x = x.pow(other)`
             return Self::from((self.upper, self.lower));
         }
 
-        while exp & one == zero {
+        while exp & 1 == 0 {
             value = value * value;
             exp >>= 1;
         }
 
-        if exp == one {
+        if exp == 1 {
             return value;
         }
 
         let mut acc = value;
-        while exp > one {
+        while exp > 1 {
             exp >>= 1;
             value = value * value;
-            if exp & one == one {
+            if exp & 1 == 1 {
                 acc = acc * value;
             }
         }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/exponentiation_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/exponentiation_test/src/main.sw
@@ -57,60 +57,60 @@ fn main() -> bool {
     assert(0u32 ** 2u32 == 0u32);
 
     // u16
-    assert(2u16.pow(2u16) == 4u16);
-    assert(2u16 ** 2u16 == 4u16);
+    assert(2u16.pow(2u32) == 4u16);
+    assert(2u16 ** 2u32 == 4u16);
 
-    assert(2u16.pow(3u16) == 8u16);
-    assert(2u16 ** 3u16 == 8u16);
+    assert(2u16.pow(3u32) == 8u16);
+    assert(2u16 ** 3u32 == 8u16);
 
-    assert(42u16.pow(2u16) == 1764u16);
-    assert(42u16 ** 2u16 == 1764u16);
+    assert(42u16.pow(2u32) == 1764u16);
+    assert(42u16 ** 2u32 == 1764u16);
 
-    assert(20u16.pow(3u16) == 8000u16);
-    assert(20u16 ** 3u16 == 8000u16);
+    assert(20u16.pow(3u32) == 8000u16);
+    assert(20u16 ** 3u32 == 8000u16);
 
-    assert(15u16.pow(4u16) == 50625u16);
-    assert(15u16 ** 4u16 == 50625u16);
+    assert(15u16.pow(4u32) == 50625u16);
+    assert(15u16 ** 4u32 == 50625u16);
 
-    assert(2u16.pow(0u16) == 1u16);
-    assert(2u16 ** 0u16 == 1u16);
+    assert(2u16.pow(0u32) == 1u16);
+    assert(2u16 ** 0u32 == 1u16);
 
-    assert(0u16.pow(1u16) == 0u16);
-    assert(0u16 ** 1u16 == 0u16);
+    assert(0u16.pow(1u32) == 0u16);
+    assert(0u16 ** 1u32 == 0u16);
 
-    assert(0u16.pow(2u16) == 0u16);
-    assert(0u16 ** 2u16 == 0u16);
+    assert(0u16.pow(2u32) == 0u16);
+    assert(0u16 ** 2u32 == 0u16);
 
     // u8
-    assert(2u8.pow(2u8) == 4u8);
-    assert(2u8 ** 2u8 == 4u8);
+    assert(2u8.pow(2u32) == 4u8);
+    assert(2u8 ** 2u32 == 4u8);
 
-    assert(2u8.pow(3u8) == 8u8);
-    assert(2u8 ** 3u8 == 8u8);
+    assert(2u8.pow(3u32) == 8u8);
+    assert(2u8 ** 3u32 == 8u8);
 
-    assert(4u8.pow(3u8) == 64u8);
-    assert(4u8 ** 3u8 == 64u8);
+    assert(4u8.pow(3u32) == 64u8);
+    assert(4u8 ** 3u32 == 64u8);
 
-    assert(3u8.pow(4u8) == 81u8);
-    assert(3u8 ** 4u8 == 81u8);
+    assert(3u8.pow(4u32) == 81u8);
+    assert(3u8 ** 4u32 == 81u8);
 
-    assert(10u8.pow(2u8) == 100u8);
-    assert(10u8 ** 2u8 == 100u8);
+    assert(10u8.pow(2u32) == 100u8);
+    assert(10u8 ** 2u32 == 100u8);
 
-    assert(5u8.pow(3u8) == 125u8);
-    assert(5u8 ** 3u8 == 125u8);
+    assert(5u8.pow(3u32) == 125u8);
+    assert(5u8 ** 3u32 == 125u8);
 
-    assert(3u8.pow(5u8) == 243u8);
-    assert(3u8 ** 5u8 == 243u8);
+    assert(3u8.pow(5u32) == 243u8);
+    assert(3u8 ** 5u32 == 243u8);
 
-    assert(2u8.pow(0u8) == 1u8);
-    assert(2u8 ** 0u8 == 1u8);
+    assert(2u8.pow(0u32) == 1u8);
+    assert(2u8 ** 0u32 == 1u8);
 
-    assert(0u8.pow(1u8) == 0u8);
-    assert(0u8 ** 1u8 == 0u8);
+    assert(0u8.pow(1u32) == 0u8);
+    assert(0u8 ** 1u32 == 0u8);
 
-    assert(0u8.pow(2u8) == 0u8);
-    assert(0u8 ** 2u8 == 0u8);
+    assert(0u8.pow(2u32) == 0u8);
+    assert(0u8 ** 2u32 == 0u8);
 
     true
 }

--- a/test/src/sdk-harness/test_artifacts/pow/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/pow/src/main.sw
@@ -3,14 +3,14 @@ contract;
 use std::math::*;
 
 abi PowTest {
-    fn u64_overflow(a: u64, b: u64) -> u64;
+    fn u64_overflow(a: u64, b: u32) -> u64;
     fn u32_overflow(a: u32, b: u32) -> u32;
-    fn u16_overflow(a: u16, b: u16) -> u16;
-    fn u8_overflow(a: u8, b: u8) -> u8;
+    fn u16_overflow(a: u16, b: u32) -> u16;
+    fn u8_overflow(a: u8, b: u32) -> u8;
 }
 
 impl PowTest for Contract {
-    fn u64_overflow(a: u64, b: u64) -> u64 {
+    fn u64_overflow(a: u64, b: u32) -> u64 {
         a.pow(b)
     }
 
@@ -18,11 +18,11 @@ impl PowTest for Contract {
         a.pow(b)
     }
 
-    fn u16_overflow(a: u16, b: u16) -> u16 {
+    fn u16_overflow(a: u16, b: u32) -> u16 {
         a.pow(b)
     }
 
-    fn u8_overflow(a: u8, b: u8) -> u8 {
+    fn u8_overflow(a: u8, b: u32) -> u8 {
         a.pow(b)
     }
 }

--- a/test/src/sdk-harness/test_projects/exponentiation/mod.rs
+++ b/test/src/sdk-harness/test_projects/exponentiation/mod.rs
@@ -14,7 +14,7 @@ async fn overflowing_pow_u64_panics() {
     let (pow_instance, _) = get_pow_test_instance(wallet).await;
     pow_instance
         .methods()
-        .u64_overflow(100u64, 100u64)
+        .u64_overflow(100u64, 100u32)
         .call()
         .await
         .unwrap();
@@ -55,7 +55,7 @@ async fn overflowing_pow_u16_panics() {
     let (pow_instance, _) = get_pow_test_instance(wallet).await;
     pow_instance
         .methods()
-        .u16_overflow(10u16, 5u16)
+        .u16_overflow(10u16, 5u32)
         .call()
         .await
         .unwrap();
@@ -68,7 +68,7 @@ async fn overflowing_pow_u16_panics_max() {
     let (pow_instance, _) = get_pow_test_instance(wallet).await;
     pow_instance
         .methods()
-        .u16_overflow(u16::MAX, u16::MAX)
+        .u16_overflow(u16::MAX, u32::MAX)
         .call()
         .await
         .unwrap();
@@ -82,7 +82,7 @@ async fn overflowing_pow_u8_panics() {
     let (pow_instance, _) = get_pow_test_instance(wallet).await;
     pow_instance
         .methods()
-        .u8_overflow(10u8, 3u8)
+        .u8_overflow(10u8, 3u32)
         .call()
         .await
         .unwrap();
@@ -95,7 +95,7 @@ async fn overflowing_pow_u8_panics_max() {
     let (pow_instance, _) = get_pow_test_instance(wallet).await;
     pow_instance
         .methods()
-        .u8_overflow(u8::MAX, u8::MAX)
+        .u8_overflow(u8::MAX, u32::MAX)
         .call()
         .await
         .unwrap();


### PR DESCRIPTION

## Description

The exponent type should not mirror the type of the value being exponentiated and should be an unsigned integer. This follows the Rust convention of using `u32`.


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
