### PR TITLE
refactor: Move dir helpers from `forc-util` to `sway-utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6001,7 +6001,6 @@ version = "0.46.1"
 dependencies = [
  "anyhow",
  "forc-tracing",
- "forc-util",
  "paste",
  "prettydiff 0.6.4",
  "ropey",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,7 +2015,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-xid",
- "walkdir",
 ]
 
 [[package]]
@@ -5993,6 +5992,7 @@ name = "sway-utils"
 version = "0.46.1"
 dependencies = [
  "serde",
+ "walkdir",
 ]
 
 [[package]]
@@ -6012,6 +6012,7 @@ dependencies = [
  "sway-error",
  "sway-parse",
  "sway-types",
+ "sway-utils",
  "test-macros",
  "thiserror",
  "toml 0.7.8",

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -1,7 +1,7 @@
 use crate::pkg::{manifest_file_missing, parsing_failed, wrong_program_type};
 use anyhow::{anyhow, bail, Context, Result};
 use forc_tracing::println_warning;
-use forc_util::{find_nested_manifest_dir, find_parent_manifest_dir, validate_name};
+use forc_util::validate_name;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use std::{
@@ -11,7 +11,10 @@ use std::{
 };
 use sway_core::{fuel_prelude::fuel_tx, language::parsed::TreeType, parse_tree_type, BuildTarget};
 use sway_error::handler::Handler;
-use sway_utils::constants;
+use sway_utils::{
+    constants, find_nested_manifest_dir, find_parent_manifest_dir,
+    find_parent_manifest_dir_with_check,
+};
 
 /// The name of a workspace member package.
 pub type MemberName = String;
@@ -327,7 +330,7 @@ impl PackageManifestFile {
     /// file.
     pub fn from_dir<P: AsRef<Path>>(manifest_dir: P) -> Result<Self> {
         let manifest_dir = manifest_dir.as_ref();
-        let dir = forc_util::find_parent_manifest_dir(manifest_dir)
+        let dir = find_parent_manifest_dir(manifest_dir)
             .ok_or_else(|| manifest_file_missing(manifest_dir))?;
         let path = dir.join(constants::MANIFEST_FILE_NAME);
         Self::from_file(path)
@@ -841,25 +844,24 @@ impl WorkspaceManifestFile {
     /// file.
     pub fn from_dir<T: AsRef<Path>>(manifest_dir: T) -> Result<Self> {
         let manifest_dir = manifest_dir.as_ref();
-        let dir =
-            forc_util::find_parent_manifest_dir_with_check(manifest_dir, |possible_manifest_dir| {
-                // Check if the found manifest file is a workspace manifest file or a standalone
-                // package manifest file.
-                let possible_path = possible_manifest_dir.join(constants::MANIFEST_FILE_NAME);
-                // We should not continue to search if the given manifest is a workspace manifest with
-                // some issues.
-                //
-                // If the error is missing field `workspace` (which happens when trying to read a
-                // package manifest as a workspace manifest), look into the parent directories for a
-                // legitimate workspace manifest. If the error returned is something else this is a
-                // workspace manifest with errors, classify this as a workspace manifest but with
-                // errors so that the erros will be displayed to the user.
-                Self::from_file(possible_path)
-                    .err()
-                    .map(|e| !e.to_string().contains("missing field `workspace`"))
-                    .unwrap_or_else(|| true)
-            })
-            .ok_or_else(|| manifest_file_missing(manifest_dir))?;
+        let dir = find_parent_manifest_dir_with_check(manifest_dir, |possible_manifest_dir| {
+            // Check if the found manifest file is a workspace manifest file or a standalone
+            // package manifest file.
+            let possible_path = possible_manifest_dir.join(constants::MANIFEST_FILE_NAME);
+            // We should not continue to search if the given manifest is a workspace manifest with
+            // some issues.
+            //
+            // If the error is missing field `workspace` (which happens when trying to read a
+            // package manifest as a workspace manifest), look into the parent directories for a
+            // legitimate workspace manifest. If the error returned is something else this is a
+            // workspace manifest with errors, classify this as a workspace manifest but with
+            // errors so that the erros will be displayed to the user.
+            Self::from_file(possible_path)
+                .err()
+                .map(|e| !e.to_string().contains("missing field `workspace`"))
+                .unwrap_or_else(|| true)
+        })
+        .ok_or_else(|| manifest_file_missing(manifest_dir))?;
         let path = dir.join(constants::MANIFEST_FILE_NAME);
         Self::from_file(path)
     }

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -14,9 +14,8 @@ use taplo::formatter as taplo_fmt;
 use tracing::{debug, error, info};
 
 use forc_tracing::{init_tracing_subscriber, println_error, println_green, println_red};
-use forc_util::{find_parent_manifest_dir, is_sway_file};
 use sway_core::{BuildConfig, BuildTarget};
-use sway_utils::{constants, get_sway_files};
+use sway_utils::{constants, find_parent_manifest_dir, get_sway_files, is_sway_file};
 use swayfmt::Formatter;
 
 #[derive(Debug, Parser)]

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -27,7 +27,6 @@ sway-utils = { version = "0.46.1", path = "../sway-utils" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }
 unicode-xid = "0.2.2"
-walkdir = "2.3.3"
 
 [features]
 default = ["fuel-tx"]

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -9,14 +9,12 @@ use anyhow::{bail, Context, Result};
 use forc_tracing::{println_red_err, println_yellow_err};
 use std::{
     collections::{hash_map, HashSet},
-    str,
-};
-use std::{ffi::OsStr, process::Termination};
-use std::{
     fmt::Display,
     fs::File,
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
+    process::Termination,
+    str,
 };
 use sway_core::language::parsed::TreeType;
 use sway_error::{
@@ -192,87 +190,6 @@ pub mod tx_utils {
             Ok(serde_json::to_string(&receipt_to_json_array)?)
         }
     }
-}
-
-/// Continually go down in the file tree until a Forc manifest file is found.
-pub fn find_nested_manifest_dir(starter_path: &Path) -> Option<PathBuf> {
-    find_nested_dir_with_file(starter_path, constants::MANIFEST_FILE_NAME)
-}
-
-/// Continually go down in the file tree until a specified file is found.
-///
-/// Starts the search from child dirs of `starter_path`.
-pub fn find_nested_dir_with_file(starter_path: &Path, file_name: &str) -> Option<PathBuf> {
-    use walkdir::WalkDir;
-    let starter_dir = if starter_path.is_dir() {
-        starter_path
-    } else {
-        starter_path.parent()?
-    };
-    WalkDir::new(starter_path)
-        .into_iter()
-        .filter_map(|e| e.ok())
-        .filter(|entry| entry.path() != starter_dir.join(file_name))
-        .filter(|entry| entry.file_name().to_string_lossy() == file_name)
-        .map(|entry| {
-            let mut entry = entry.path().to_path_buf();
-            entry.pop();
-            entry
-        })
-        .next()
-}
-
-/// Continually go up in the file tree until a specified file is found.
-///
-/// Starts the search from `starter_path`.
-#[allow(clippy::branches_sharing_code)]
-pub fn find_parent_dir_with_file<P: AsRef<Path>>(
-    starter_path: P,
-    file_name: &str,
-) -> Option<PathBuf> {
-    let mut path = std::fs::canonicalize(starter_path).ok()?;
-    let empty_path = PathBuf::from("/");
-    while path != empty_path {
-        path.push(file_name);
-        if path.exists() {
-            path.pop();
-            return Some(path);
-        } else {
-            path.pop();
-            path.pop();
-        }
-    }
-    None
-}
-/// Continually go up in the file tree until a Forc manifest file is found.
-pub fn find_parent_manifest_dir<P: AsRef<Path>>(starter_path: P) -> Option<PathBuf> {
-    find_parent_dir_with_file(starter_path, constants::MANIFEST_FILE_NAME)
-}
-
-/// Continually go up in the file tree until a Forc manifest file is found and given predicate
-/// returns true.
-pub fn find_parent_manifest_dir_with_check<T: AsRef<Path>, F>(
-    starter_path: T,
-    f: F,
-) -> Option<PathBuf>
-where
-    F: Fn(&Path) -> bool,
-{
-    find_parent_manifest_dir(starter_path).and_then(|manifest_dir| {
-        // If given check satisifies return current dir otherwise start searching from the parent.
-        if f(&manifest_dir) {
-            Some(manifest_dir)
-        } else if let Some(parent_dir) = manifest_dir.parent() {
-            find_parent_manifest_dir_with_check(parent_dir, f)
-        } else {
-            None
-        }
-    })
-}
-
-pub fn is_sway_file(file: &Path) -> bool {
-    let res = file.extension();
-    file.is_file() && Some(OsStr::new(constants::SWAY_EXTENSION)) == res
 }
 
 pub fn find_file_name<'sc>(manifest_dir: &Path, entry_path: &'sc Path) -> Result<&'sc Path> {

--- a/forc/src/ops/forc_clean.rs
+++ b/forc/src/ops/forc_clean.rs
@@ -1,9 +1,9 @@
 use crate::cli::CleanCommand;
 use anyhow::{anyhow, bail, Result};
 use forc_pkg::manifest::ManifestFile;
-use forc_util::{default_output_directory, find_parent_manifest_dir};
+use forc_util::default_output_directory;
 use std::path::PathBuf;
-use sway_utils::MANIFEST_FILE_NAME;
+use sway_utils::{find_parent_manifest_dir, MANIFEST_FILE_NAME};
 
 pub fn clean(command: CleanCommand) -> Result<()> {
     let CleanCommand { path } = command;

--- a/sway-utils/Cargo.toml
+++ b/sway-utils/Cargo.toml
@@ -10,3 +10,4 @@ repository.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+walkdir = "2.3.3"

--- a/sway-utils/src/helpers.rs
+++ b/sway-utils/src/helpers.rs
@@ -1,8 +1,9 @@
 use crate::constants;
-use std::ffi::OsStr;
-
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+};
 
 pub fn get_sway_files(path: PathBuf) -> Vec<PathBuf> {
     let mut files = vec![];
@@ -27,7 +28,7 @@ pub fn get_sway_files(path: PathBuf) -> Vec<PathBuf> {
 
 pub fn is_sway_file(file: &Path) -> bool {
     let res = file.extension();
-    Some(OsStr::new(constants::SWAY_EXTENSION)) == res
+    file.is_file() && Some(OsStr::new(constants::SWAY_EXTENSION)) == res
 }
 
 /// create an iterator over all prefixes in a slice, smallest first
@@ -44,4 +45,80 @@ pub fn is_sway_file(file: &Path) -> bool {
 /// ```
 pub fn iter_prefixes<T>(slice: &[T]) -> impl Iterator<Item = &[T]> + DoubleEndedIterator {
     (1..=slice.len()).map(move |len| &slice[..len])
+}
+
+/// Continually go down in the file tree until a Forc manifest file is found.
+pub fn find_nested_manifest_dir(starter_path: &Path) -> Option<PathBuf> {
+    find_nested_dir_with_file(starter_path, constants::MANIFEST_FILE_NAME)
+}
+
+/// Continually go down in the file tree until a specified file is found.
+///
+/// Starts the search from child dirs of `starter_path`.
+pub fn find_nested_dir_with_file(starter_path: &Path, file_name: &str) -> Option<PathBuf> {
+    use walkdir::WalkDir;
+    let starter_dir = if starter_path.is_dir() {
+        starter_path
+    } else {
+        starter_path.parent()?
+    };
+    WalkDir::new(starter_path)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|entry| entry.path() != starter_dir.join(file_name))
+        .filter(|entry| entry.file_name().to_string_lossy() == file_name)
+        .map(|entry| {
+            let mut entry = entry.path().to_path_buf();
+            entry.pop();
+            entry
+        })
+        .next()
+}
+
+/// Continually go up in the file tree until a specified file is found.
+///
+/// Starts the search from `starter_path`.
+#[allow(clippy::branches_sharing_code)]
+pub fn find_parent_dir_with_file<P: AsRef<Path>>(
+    starter_path: P,
+    file_name: &str,
+) -> Option<PathBuf> {
+    let mut path = std::fs::canonicalize(starter_path).ok()?;
+    let empty_path = PathBuf::from("/");
+    while path != empty_path {
+        path.push(file_name);
+        if path.exists() {
+            path.pop();
+            return Some(path);
+        } else {
+            path.pop();
+            path.pop();
+        }
+    }
+    None
+}
+/// Continually go up in the file tree until a Forc manifest file is found.
+pub fn find_parent_manifest_dir<P: AsRef<Path>>(starter_path: P) -> Option<PathBuf> {
+    find_parent_dir_with_file(starter_path, constants::MANIFEST_FILE_NAME)
+}
+
+/// Continually go up in the file tree until a Forc manifest file is found and given predicate
+/// returns true.
+pub fn find_parent_manifest_dir_with_check<T: AsRef<Path>, F>(
+    starter_path: T,
+    f: F,
+) -> Option<PathBuf>
+where
+    F: Fn(&Path) -> bool,
+{
+    find_parent_manifest_dir(starter_path).and_then(|manifest_dir| {
+        // If given check satisifies return current dir otherwise start searching from the parent.
+        if f(&manifest_dir) {
+            Some(manifest_dir)
+        } else if let Some(parent_dir) = manifest_dir.parent() {
+            find_parent_manifest_dir_with_check(parent_dir, f)
+        } else {
+            None
+        }
+    })
 }

--- a/swayfmt/Cargo.toml
+++ b/swayfmt/Cargo.toml
@@ -11,7 +11,6 @@ repository.workspace = true
 [dependencies]
 anyhow = "1"
 forc-tracing = { version = "0.46.1", path = "../forc-tracing" }
-forc-util = { version = "0.46.1", path = "../forc-util" }
 ropey = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_ignored = "0.1.9"
@@ -20,6 +19,7 @@ sway-core = { version = "0.46.1", path = "../sway-core" }
 sway-error = { version = "0.46.1", path = "../sway-error" }
 sway-parse = { version = "0.46.1", path = "../sway-parse" }
 sway-types = { version = "0.46.1", path = "../sway-types" }
+sway-utils = { version = "0.46.1", path = "../sway-utils" }
 thiserror = "1.0.30"
 toml = { version = "0.7", features = ["parse"] }
 

--- a/swayfmt/Cargo.toml
+++ b/swayfmt/Cargo.toml
@@ -24,7 +24,6 @@ thiserror = "1.0.30"
 toml = { version = "0.7", features = ["parse"] }
 
 [dev-dependencies]
-forc-util = { path = "../forc-util" }
 paste = "1.0"
 prettydiff = "0.6"
 test-macros = { path = "test_macros" }

--- a/swayfmt/src/config/manifest.rs
+++ b/swayfmt/src/config/manifest.rs
@@ -9,9 +9,9 @@ use crate::{
     error::ConfigError,
 };
 use forc_tracing::println_yellow_err;
-use forc_util::find_parent_dir_with_file;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use sway_utils::find_parent_dir_with_file;
 
 /// A finalized `swayfmt` config.
 #[derive(Debug, Default, Clone)]


### PR DESCRIPTION
## Description
This PR just moves the dir helpers that were in `forc-util` to `sway-utils`. I need access to these methods in an upcoming PR and having them in `forc-util` introduces a mind field of circular dependencies. 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
