### PR TITLE
Optimize gas for `AssetId::new()` and `AssetId::default()` functions

### DIFF
--- a/sway-lib-std/src/contract_id.sw
+++ b/sway-lib-std/src/contract_id.sw
@@ -170,7 +170,11 @@ impl AssetId {
     /// }
     /// ```
     pub fn new(contract_id: ContractId, sub_id: SubId) -> Self {
-        let value = sha256((contract_id, sub_id));
+        let value = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(token_id: value, ptr: (contract_id, sub_id), bytes: 64) {
+            s256 token_id ptr bytes;
+        };
+        
         Self { value }
     }
 
@@ -199,7 +203,11 @@ impl AssetId {
     /// }
     /// ```
     pub fn default(contract_id: ContractId) -> Self {
-        let value = sha256((contract_id, 0x0000000000000000000000000000000000000000000000000000000000000000));
+        let value = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(token_id: value, ptr: (contract_id, 0x0000000000000000000000000000000000000000000000000000000000000000), bytes: 64) {
+            s256 token_id ptr bytes;
+        };
+        
         Self { value }
     }
 

--- a/sway-lib-std/src/contract_id.sw
+++ b/sway-lib-std/src/contract_id.sw
@@ -170,12 +170,12 @@ impl AssetId {
     /// }
     /// ```
     pub fn new(contract_id: ContractId, sub_id: SubId) -> Self {
-        let value = 0x0000000000000000000000000000000000000000000000000000000000000000;
-        asm(token_id: value, ptr: (contract_id, sub_id), bytes: 64) {
-            s256 token_id ptr bytes;
+        let result_buffer = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(asset_id: result_buffer, ptr: (contract_id, sub_id), bytes: 64) {
+            s256 asset_id ptr bytes;
         };
         
-        Self { value }
+        Self { value: result_buffer }
     }
 
     /// Creates a new AssetId from a ContractId and the zero SubId.
@@ -203,12 +203,12 @@ impl AssetId {
     /// }
     /// ```
     pub fn default(contract_id: ContractId) -> Self {
-        let value = 0x0000000000000000000000000000000000000000000000000000000000000000;
-        asm(token_id: value, ptr: (contract_id, 0x0000000000000000000000000000000000000000000000000000000000000000), bytes: 64) {
-            s256 token_id ptr bytes;
+        let result_buffer = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        asm(asset_id: result_buffer, ptr: (contract_id, 0x0000000000000000000000000000000000000000000000000000000000000000), bytes: 64) {
+            s256 asset_id ptr bytes;
         };
-        
-        Self { value }
+
+        Self { value: result_buffer }
     }
 
     /// The base_asset_id represents the base asset of a chain.


### PR DESCRIPTION
## Description

The following changes remove the use of the `std::hash::sha256` function in place of assembly to hash the `ContractId` and `SubId` of an asset. As the values hashed are of static length, we can perform the hashing in assembly avoiding the conversion to `Bytes` and concatenation of the two values done in `sha256()`

These changes result in a **93%** reduction in gas usage.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
