### PR TITLE
Initialise large enough, same-const-initialised, arrays using loops

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/Forc.lock
@@ -1,8 +1,16 @@
 [[package]]
-name = 'array_basics'
-source = 'member'
-dependencies = ['core']
+name = "array_basics"
+source = "member"
+dependencies = [
+    "core",
+    "std",
+]
 
 [[package]]
-name = 'core'
-source = 'path+from-root-E87F696D35D6ACBA'
+name = "core"
+source = "path+from-root-E87F696D35D6ACBA"
+
+[[package]]
+name = "std"
+source = "path+from-root-E87F696D35D6ACBA"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/Forc.toml
@@ -6,3 +6,4 @@ name = "array_basics"
 
 [dependencies]
 core = { path = "../../../../../../../sway-lib-core" }
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/array_basics/src/main.sw
@@ -1,5 +1,7 @@
 script;
 
+use std::assert::assert;
+
 struct S {
     foo: u64,
     bar: u64,
@@ -27,6 +29,8 @@ fn main() -> bool {
     ];
     let _h = i()[2];
 
+    assert(test_init() == 110);
+
     b[0] == b[9] && e[0][1] + e[1][2] == 9 && g[0].foo + g[1].bar == 12 && j(g) && /* a.len() == 5 && */
     true
 }
@@ -39,4 +43,16 @@ fn i() -> [u64;
 fn j(ary_arg: [S;
 2]) -> bool {
     ary_arg[0].foo + ary_arg[1].bar == 12
+}
+
+fn test_init() -> u64 {
+    let mut a: [u64;10] = [11;10];
+
+    let mut i = 0;
+    let mut m = 0;
+    while i < 10 {
+        m += a[i];
+        i += 1;
+    }
+    m
 }


### PR DESCRIPTION
## Description
Closes #5229 

Previously, these arrays were initialised with repeated "load index from data area, store initialise constant to array". Now we just use a loop to store the constant initialise to every element of the array. To avoid overheads of the loop, it's only done, currently, when the array size is greater than 5 (can be tuned later).