### PR TITLE
Fix hash.sw, replaced `#![foo]` for `#[foo]`

### DIFF
--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -169,7 +169,11 @@ fn format_file(
                 // TODO: Support formatting for incomplete/invalid sway code.
                 // https://github.com/FuelLabs/sway/issues/5012
                 debug!("{}", err);
-                bail!("Failed to compile: {:?}", file);
+                if let Some(file) = file.to_str() {
+                    bail!("Failed to compile {}\n{}", file, err);
+                } else {
+                    bail!("Failed to compile.\n{}", err);
+                }
             }
         }
     }

--- a/sway-lib-std/src/hash.sw
+++ b/sway-lib-std/src/hash.sw
@@ -47,7 +47,7 @@ impl Hasher {
         self.write(bytes);
     }
 
-    #![inline(never)]
+    #[inline(never)]
     pub fn write_str_array<S>(ref mut self, s: S) {
         __assert_is_str_array::<S>();
         let str_size = __size_of_str_array::<S>();
@@ -159,7 +159,7 @@ impl Hash for str {
 }
 
 impl<A, B> Hash for (A, B) where A: Hash, B: Hash  {
-    #![inline(never)]
+    #[inline(never)]
     fn hash(self, ref mut state: Hasher) {
         self.0.hash(state);
         self.1.hash(state);
@@ -318,7 +318,7 @@ impl<T> Hash for [T; 10] where T: Hash {
 ///     assert(result = 0xa80f942f4112036dfc2da86daf6d2ef6ede3164dd56d1000eb82fa87c992450f);
 /// }
 /// ```
-#![inline(never)]
+#[inline(never)]
 pub fn sha256<T>(s: T) -> b256 where T: Hash {
     let mut hasher = Hasher::new();
     s.hash(hasher);
@@ -338,7 +338,7 @@ pub fn sha256<T>(s: T) -> b256 where T: Hash {
 ///     assert(result = 0xa80f942f4112036dfc2da86daf6d2ef6ede3164dd56d1000eb82fa87c992450f);
 /// }
 /// ```
-#![inline(never)]
+#[inline(never)]
 pub fn sha256_str_array<S>(param: S) -> b256 {
      __assert_is_str_array::<S>();
     let str_size = __size_of_str_array::<S>();
@@ -374,7 +374,7 @@ pub fn sha256_str_array<S>(param: S) -> b256 {
 ///     assert(result = 0x4375c8bcdc904e5f51752581202ae9ae2bb6eddf8de05d5567d9a6b0ae4789ad);
 /// }
 /// ```
-#![inline(never)]
+#[inline(never)]
 pub fn keccak256<T>(s: T) -> b256 where T: Hash {
     let mut hasher = Hasher::new();
     s.hash(hasher);


### PR DESCRIPTION
## Description

Fixes #5059 

While doing this I also updated `forc-fmt` to have a better error message being printed to the stdout

Before:

```bash
error: Formatting skipped due to error.
error: Failed to compile /Users/cr-fuel/projects/fuel/sway/sway-lib-std/src/hash.sw
```

Now:

```bash
error: Formatting skipped due to error.
error: Failed to compile /Users/cr-fuel/projects/fuel/sway/sway-lib-std/src/hash.sw
Cannot format raw hashbang attribute,
If this is intended to be a doc comment try using the `//!` syntax instead
```

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
