### PR TITLE
allow implicit stdlib to be configured with env vars

### DIFF
--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -754,7 +754,19 @@ impl Default for BuildProfile {
 }
 
 /// The definition for the implicit `std` dependency.
+/// 
+/// This can be configured using environment variables:
+/// - use `FORC_IMPLICIT_STD_PATH` for the path for the std-lib;
+/// - use `FORC_IMPLICIT_STD_GIT`, `FORC_IMPLICIT_STD_GIT_TAG` and/or `FORC_IMPLICIT_STD_GIT_BRANCH` to configure
+/// the git repo of the std-lib.
 fn implicit_std_dep() -> Dependency {
+    if let Ok(path) = std::env::var("FORC_IMPLICIT_STD_PATH") {
+        return Dependency::Detailed(DependencyDetails {
+            path: Some(path),
+            ..Default::default()
+        });
+    }
+
     // Here, we use the `forc-pkg` crate version formatted with the `v` prefix (e.g. "v1.2.3"),
     // or the revision commit hash (e.g. "abcdefg").
     //
@@ -763,7 +775,9 @@ fn implicit_std_dep() -> Dependency {
     //
     // This is important to ensure that the version of `sway-core` that is baked into `forc-pkg` is
     // compatible with the version of the `std` lib.
-    const VERSION: &str = env!("CARGO_PKG_VERSION");
+    let tag = std::env::var("FORC_IMPLICIT_STD_GIT_TAG")
+        .ok()
+        .unwrap_or_else(|| format!("v{}", env!("CARGO_PKG_VERSION")));
     const SWAY_GIT_REPO_URL: &str = "https://github.com/fuellabs/sway";
 
     fn rev_from_build_metadata(build_metadata: &str) -> Option<String> {
@@ -771,15 +785,17 @@ fn implicit_std_dep() -> Dependency {
         build_metadata.split('.').last().map(|r| r.to_string())
     }
 
-    let sway_git_tag: String = "v".to_string() + VERSION;
-
     let mut det = DependencyDetails {
-        git: Some(SWAY_GIT_REPO_URL.to_string()),
-        tag: Some(sway_git_tag),
+        git: std::env::var("FORC_IMPLICIT_STD_GIT")
+            .ok()
+            .or_else(|| Some(SWAY_GIT_REPO_URL.to_string())),
+        tag: Some(tag),
+        branch: std::env::var("FORC_IMPLICIT_STD_GIT_BRANCH")
+            .ok(),
         ..Default::default()
     };
 
-    if let Some((_tag, build_metadata)) = VERSION.split_once('+') {
+    if let Some((_, build_metadata)) = det.tag.as_ref().unwrap().split_once('+') {
         let rev = rev_from_build_metadata(build_metadata);
 
         // If some revision is available and parsed from the 'nightly' build metadata,

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -754,7 +754,7 @@ impl Default for BuildProfile {
 }
 
 /// The definition for the implicit `std` dependency.
-/// 
+///
 /// This can be configured using environment variables:
 /// - use `FORC_IMPLICIT_STD_PATH` for the path for the std-lib;
 /// - use `FORC_IMPLICIT_STD_GIT`, `FORC_IMPLICIT_STD_GIT_TAG` and/or `FORC_IMPLICIT_STD_GIT_BRANCH` to configure
@@ -790,8 +790,7 @@ fn implicit_std_dep() -> Dependency {
             .ok()
             .or_else(|| Some(SWAY_GIT_REPO_URL.to_string())),
         tag: Some(tag),
-        branch: std::env::var("FORC_IMPLICIT_STD_GIT_BRANCH")
-            .ok(),
+        branch: std::env::var("FORC_IMPLICIT_STD_GIT_BRANCH").ok(),
         ..Default::default()
     };
 


### PR DESCRIPTION
## Description

This PR is needed to make https://github.com/FuelLabs/fuels-rs/pull/1163 green. We can configure the sway branch for the CI, but not the stdlib. With this, we will be able to edit github CI config and point to whichever sway version we want.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
