### PR TITLE
Improve inline arguments formatting

### DIFF
--- a/examples/cei_analysis/src/main.sw
+++ b/examples/cei_analysis/src/main.sw
@@ -24,7 +24,9 @@ impl MyContract for Contract {
 
         // External call
         let caller = abi(OtherContract, external_contract_id.into());
-        caller.external_call { coins: bal }();
+        caller.external_call {
+            coins: bal,
+        }();
 
         // Storage update _after_ external call
         storage.balances.insert(sender, 0);

--- a/examples/storage_vec/src/main.sw
+++ b/examples/storage_vec/src/main.sw
@@ -75,11 +75,9 @@ impl StorageVecContract for Contract {
         storage.row.push(TableCell::Int(3));
         storage
             .row
-            .push(
-                TableCell::B256(
-                    0x0101010101010101010101010101010101010101010101010101010101010101,
-                ),
-            );
+            .push(TableCell::B256(
+                0x0101010101010101010101010101010101010101010101010101010101010101,
+            ));
         storage.row.push(TableCell::Boolean(true));
     }
     // ANCHOR_END: storage_vec_multiple_types_fn

--- a/examples/vec/src/main.sw
+++ b/examples/vec/src/main.sw
@@ -39,12 +39,9 @@ fn main() {
 
     let mut row = Vec::new();
     row.push(TableCell::Int(3));
-    row
-        .push(
-            TableCell::B256(
-                0x0101010101010101010101010101010101010101010101010101010101010101,
-            ),
-        );
+    row.push(TableCell::B256(
+        0x0101010101010101010101010101010101010101010101010101010101010101,
+    ));
     row.push(TableCell::Boolean(true));
     // ANCHOR_END: vec_multiple_data_types
 }

--- a/swayfmt/src/utils/language/expr/mod.rs
+++ b/swayfmt/src/utils/language/expr/mod.rs
@@ -696,7 +696,7 @@ pub fn should_write_multiline(code: &str, formatter: &Formatter) -> bool {
     }
 }
 
-/// Weather this expression can be inlined if it is the sole argument of a
+/// Whether this expression can be inlined if it is the sole argument of a
 /// function/method call
 #[inline]
 fn same_line_if_only_argument(expr: &Expr) -> bool {

--- a/swayfmt/src/utils/language/statement.rs
+++ b/swayfmt/src/utils/language/statement.rs
@@ -3,8 +3,8 @@ use crate::{
     utils::map::byte_span::{ByteSpan, LeafSpans},
 };
 use std::fmt::Write;
-use sway_ast::{Statement, StatementLet};
-use sway_types::Spanned;
+use sway_ast::{Expr, Parens, Punctuated, Statement, StatementLet};
+use sway_types::{Span, Spanned};
 
 impl Format for Statement {
     fn format(
@@ -16,6 +16,60 @@ impl Format for Statement {
         format_statement(self, formatted_code, formatter)?;
 
         Ok(())
+    }
+}
+
+/// Remove arguments from the expression if the expression is a method call if
+/// the method is a simple two path call (foo.bar()). This needed because in
+/// method calls of two parts they are never broke into multiple lines.
+/// Arguments however can be be broken into multiple lines, and that is handled
+/// by `write_function_call_arguments`
+fn remove_arguments_from_expr(expr: Expr, formatter: &mut Formatter) -> Expr {
+    match expr {
+        Expr::MethodCall {
+            target,
+            dot_token,
+            path_seg,
+            contract_args_opt,
+            args,
+        } => {
+            let is_simple_call = match *target {
+                Expr::Path(_) => true,
+                _ => false,
+            };
+
+            let target = remove_arguments_from_expr(*target, formatter);
+            Expr::MethodCall {
+                target: Box::new(target),
+                dot_token,
+                path_seg,
+                contract_args_opt,
+                args: if is_simple_call {
+                    Parens::new(
+                        Punctuated {
+                            value_separator_pairs: vec![],
+                            final_value_opt: None,
+                        },
+                        Span::dummy(),
+                    )
+                } else {
+                    args
+                },
+            }
+        }
+        Expr::FieldProjection {
+            target,
+            dot_token,
+            name,
+        } => {
+            let target = remove_arguments_from_expr(*target, formatter);
+            Expr::FieldProjection {
+                target: Box::new(target),
+                dot_token,
+                name,
+            }
+        }
+        _ => expr,
     }
 }
 
@@ -32,14 +86,16 @@ fn format_statement(
             semicolon_token_opt,
         } => {
             let mut temp_expr = FormattedCode::new();
-            expr.format(&mut temp_expr, formatter)?;
+
+            remove_arguments_from_expr(expr.clone(), formatter)
+                .format(&mut temp_expr, formatter)?;
             if temp_expr.len() > formatter.shape.width_heuristics.chain_width {
                 formatter.shape.code_line.expr_new_line = true;
                 // reformat the expression adding a break
                 expr.format(formatted_code, formatter)?;
                 formatter.shape.code_line.expr_new_line = false;
             } else {
-                write!(formatted_code, "{}", temp_expr)?;
+                expr.format(formatted_code, formatter)?;
             }
             if let Some(semicolon) = semicolon_token_opt {
                 if formatter.shape.code_line.line_style == LineStyle::Inline {

--- a/swayfmt/src/utils/language/statement.rs
+++ b/swayfmt/src/utils/language/statement.rs
@@ -24,7 +24,7 @@ impl Format for Statement {
 /// method calls of two parts they are never broke into multiple lines.
 /// Arguments however can be be broken into multiple lines, and that is handled
 /// by `write_function_call_arguments`
-fn remove_arguments_from_expr(expr: Expr, formatter: &mut Formatter) -> Expr {
+fn remove_arguments_from_expr(expr: Expr) -> Expr {
     match expr {
         Expr::MethodCall {
             target,
@@ -33,12 +33,8 @@ fn remove_arguments_from_expr(expr: Expr, formatter: &mut Formatter) -> Expr {
             contract_args_opt,
             args,
         } => {
-            let is_simple_call = match *target {
-                Expr::Path(_) => true,
-                _ => false,
-            };
-
-            let target = remove_arguments_from_expr(*target, formatter);
+            let is_simple_call = matches!(*target, Expr::Path(_));
+            let target = remove_arguments_from_expr(*target);
             Expr::MethodCall {
                 target: Box::new(target),
                 dot_token,
@@ -62,7 +58,7 @@ fn remove_arguments_from_expr(expr: Expr, formatter: &mut Formatter) -> Expr {
             dot_token,
             name,
         } => {
-            let target = remove_arguments_from_expr(*target, formatter);
+            let target = remove_arguments_from_expr(*target);
             Expr::FieldProjection {
                 target: Box::new(target),
                 dot_token,
@@ -87,8 +83,7 @@ fn format_statement(
         } => {
             let mut temp_expr = FormattedCode::new();
 
-            remove_arguments_from_expr(expr.clone(), formatter)
-                .format(&mut temp_expr, formatter)?;
+            remove_arguments_from_expr(expr.clone()).format(&mut temp_expr, formatter)?;
             if temp_expr.len() > formatter.shape.width_heuristics.chain_width {
                 formatter.shape.code_line.expr_new_line = true;
                 // reformat the expression adding a break

--- a/swayfmt/tests/mod.rs
+++ b/swayfmt/tests/mod.rs
@@ -490,7 +490,9 @@ fn main() -> bool {
     fuelcoin_balance = balance_of(fuelcoin_id, fuelcoin_id);
     assert(fuelcoin_balance == 4);
 
-    fuel_coin.force_transfer { gas: default_gas }(3, fuelcoin_id, balance_test_id);
+    fuel_coin.force_transfer {
+        gas: default_gas,
+    }(3, fuelcoin_id, balance_test_id);
 
     fuelcoin_balance = balance_of(fuelcoin_id, fuelcoin_id);
     let balance_test_contract_balance = balance_of(fuelcoin_id, balance_test_id);
@@ -1960,12 +1962,11 @@ fn main() {
         amount: 2,
         id: 42,
     });
-    my_enum
-        .test(Item {
-            price: 5,
-            amount: 2,
-            id: 42,
-        });
+    my_enum.test(Item {
+        price: 5,
+        amount: 2,
+        id: 42,
+    });
 }
 "#,
     )
@@ -2075,17 +2076,16 @@ fn method_call_long_args_with_long_expr() {
 fn access_control_with_identity() {
     // ANCHOR: access_control_with_identity
     let sender = msg_sender().unwrap();
-    sender
-        .require(
-            sender == storage
-                .owner
-                .read()
-                .some_prop()
-                .that_is_too_long_to_fit_in_one_line()
-                .or_two_lines(),
-            MyError::UnauthorizedUser(sender),
-        );
-        // ANCHOR_END: access_control_with_identity
+    sender.require(
+        sender == storage
+            .owner
+            .read()
+            .some_prop()
+            .that_is_too_long_to_fit_in_one_line()
+            .or_two_lines(),
+        MyError::UnauthorizedUser(sender),
+    );
+    // ANCHOR_END: access_control_with_identity
 }
 "#,
     )
@@ -2230,4 +2230,36 @@ fn main() {
 }
 "#,
     )
+}
+
+#[test]
+fn method_call_3() {
+    check(
+        r#"library;
+
+fn enum_in_vec() -> Vec<Pasta> {
+   let mut vec: Vec<Pasta> = Vec::new();
+   vec.push(Pasta::Tortelini(Bimba {
+      bim: 1111,
+      bam: 2222_u32,
+   }));
+   vec.push(Pasta::Rigatoni(1987));
+   vec.push(Pasta::Spaghetti(true));
+   vec
+}
+       "#,
+        r#"library;
+
+fn enum_in_vec() -> Vec<Pasta> {
+    let mut vec: Vec<Pasta> = Vec::new();
+    vec.push(Pasta::Tortelini(Bimba {
+        bim: 1111,
+        bam: 2222_u32,
+    }));
+    vec.push(Pasta::Rigatoni(1987));
+    vec.push(Pasta::Spaghetti(true));
+    vec
+}
+"#,
+    );
 }


### PR DESCRIPTION
## Description

Improve breaking method calls into multiple lines following Rust rules.

A two parts method call is never broken into multiple lines, longer chains are broken if they are long enough (counting their arguments).

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
