### PR TITLE
Use type context when type_check enum instantiation

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -73,10 +73,23 @@ pub(crate) fn instantiate_enum(
             span: enum_variant_name.span(),
         }),
         ([single_expr], _) => {
+            // If type context is an enum, force `single_expr` to be the enum variant type
+            let start_type = match type_engine.get(ctx.type_annotation()) {
+                TypeInfo::Enum(e) => {
+                    let expected_enum_decl = decl_engine.get_enum(e.id());
+                    let expected_enum_variant = expected_enum_decl
+                        .expect_variant_from_name(handler, &enum_variant_name)
+                        .cloned()?;
+                    expected_enum_variant.type_argument.type_id
+                },
+                _ => enum_variant.type_argument.type_id,
+            };
+
             let enum_ctx = ctx
                 .by_ref()
                 .with_help_text("Enum instantiator must match its declared variant type.")
-                .with_type_annotation(enum_variant.type_argument.type_id);
+                .with_type_annotation(start_type);
+
             let typed_expr = ty::TyExpression::type_check(handler, enum_ctx, single_expr.clone())?;
 
             // unify the value of the argument with the variant

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -81,7 +81,7 @@ pub(crate) fn instantiate_enum(
                         .expect_variant_from_name(handler, &enum_variant_name)
                         .cloned()?;
                     expected_enum_variant.type_argument.type_id
-                },
+                }
                 _ => enum_variant.type_argument.type_id,
             };
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/integer_type_inference/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/integer_type_inference/src/main.sw
@@ -81,6 +81,7 @@ fn main() {
     let x3: u8 = 4u32.try_as_u8().unwrap();
     let x4: u8 = 4u64.try_as_u8().unwrap();
     let x5: u8 = 4;
+    let x6: Option<u8> = Option::Some(1);
 
     let y1: u16 = 4u8.as_u16();
     let y2: u16 = 4u16;


### PR DESCRIPTION
## Description

This PR fixes a internal compiler error when `Enum` instantiation infer literals as `Numeric` needlessly. This creates a problem because `u8` are not `u64` in the IR and `Numeric` automatically decays into `u64` ( see `decay_numeric`).

Example:

```
let a: Option<u8> = Option::Some(1); // Error
let b: Option<u8> = Option::Some(1u8); // OK
```

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
