### PR TITLE
fix fuel data section alignment

### DIFF
--- a/sway-lsp/tests/fixtures/auto_import/Forc.toml
+++ b/sway-lsp/tests/fixtures/auto_import/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "auto_import"
+implicit-std = false
 
 [dependencies]
 std = { path = "../../../../sway-lib-std" }

--- a/sway-lsp/tests/fixtures/benchmark/Forc.toml
+++ b/sway-lsp/tests/fixtures/benchmark/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "sway_project"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/completion/Forc.toml
+++ b/sway-lsp/tests/fixtures/completion/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "completion"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/diagnostics/dead_code/Forc.toml
+++ b/sway-lsp/tests/fixtures/diagnostics/dead_code/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "dead_code"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/diagnostics/multi_file/Forc.toml
+++ b/sway-lsp/tests/fixtures/diagnostics/multi_file/Forc.toml
@@ -6,4 +6,4 @@ entry = "main.sw"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/renaming/Forc.toml
+++ b/sway-lsp/tests/fixtures/renaming/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "renaming"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/runnables/Forc.toml
+++ b/sway-lsp/tests/fixtures/runnables/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "script_multi_test"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/abi/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/abi/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "abi"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/consts/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/consts/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "consts"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/enums/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/enums/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "enums"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/fields/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/fields/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "fields"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/functions/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/functions/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "functions"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/impls/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/impls/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "impls"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/matches/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/matches/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "matches"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/modules/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/modules/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "lib.sw"
 license = "Apache-2.0"
 name = "turbofish"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/paths/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/paths/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "paths"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/storage/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/storage/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "storage"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/structs/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/structs/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "structs"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/traits/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/traits/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "traits"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/turbofish/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/turbofish/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "turbofish"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/variables/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/variables/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "variables"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/sway-lsp/tests/fixtures/tokens/where_clause/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/where_clause/Forc.toml
@@ -3,6 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
 name = "where_clause"
+implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.47.0" }
+std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle.json
@@ -3,65 +3,65 @@
     {
       "configurableType": {
         "name": "",
-        "type": 3,
+        "type": 4,
         "typeArguments": null
       },
       "name": "C0",
-      "offset": 3460
+      "offset": 4988
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 8,
+        "typeArguments": null
+      },
+      "name": "C1",
+      "offset": 5004
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 3,
+        "typeArguments": null
+      },
+      "name": "C2",
+      "offset": 5020
     },
     {
       "configurableType": {
         "name": "",
         "type": 7,
-        "typeArguments": null
-      },
-      "name": "C1",
-      "offset": 3476
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 2,
-        "typeArguments": null
-      },
-      "name": "C2",
-      "offset": 3492
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 6,
         "typeArguments": []
       },
       "name": "C3",
-      "offset": 3524
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 4,
-        "typeArguments": []
-      },
-      "name": "C4",
-      "offset": 3540
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 4,
-        "typeArguments": []
-      },
-      "name": "C5",
-      "offset": 3556
+      "offset": 5052
     },
     {
       "configurableType": {
         "name": "",
         "type": 5,
+        "typeArguments": []
+      },
+      "name": "C4",
+      "offset": 5068
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 5,
+        "typeArguments": []
+      },
+      "name": "C5",
+      "offset": 5084
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 6,
         "typeArguments": null
       },
       "name": "C6",
-      "offset": 3572
+      "offset": 5100
     },
     {
       "configurableType": {
@@ -70,16 +70,25 @@
         "typeArguments": null
       },
       "name": "C7",
-      "offset": 3588
+      "offset": 5116
     },
     {
       "configurableType": {
         "name": "",
-        "type": 7,
+        "type": 2,
+        "typeArguments": null
+      },
+      "name": "C7_2",
+      "offset": 5188
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 8,
         "typeArguments": null
       },
       "name": "C9",
-      "offset": 3636
+      "offset": 5164
     }
   ],
   "functions": [
@@ -107,7 +116,7 @@
       "components": [
         {
           "name": "__array_element",
-          "type": 7,
+          "type": 8,
           "typeArguments": null
         }
       ],
@@ -116,61 +125,79 @@
       "typeParameters": null
     },
     {
-      "components": null,
-      "type": "b256",
+      "components": [
+        {
+          "name": "__array_element",
+          "type": 9,
+          "typeArguments": null
+        }
+      ],
+      "type": "[_; 4]",
       "typeId": 2,
       "typeParameters": null
     },
     {
       "components": null,
-      "type": "bool",
+      "type": "b256",
       "typeId": 3,
+      "typeParameters": null
+    },
+    {
+      "components": null,
+      "type": "bool",
+      "typeId": 4,
       "typeParameters": null
     },
     {
       "components": [
         {
           "name": "A",
-          "type": 7,
+          "type": 8,
           "typeArguments": null
         },
         {
           "name": "B",
-          "type": 3,
+          "type": 4,
           "typeArguments": null
         }
       ],
       "type": "enum MyEnum",
-      "typeId": 4,
+      "typeId": 5,
       "typeParameters": null
     },
     {
       "components": null,
       "type": "str[4]",
-      "typeId": 5,
+      "typeId": 6,
       "typeParameters": null
     },
     {
       "components": [
         {
           "name": "x",
-          "type": 7,
+          "type": 8,
           "typeArguments": null
         },
         {
           "name": "y",
-          "type": 3,
+          "type": 4,
           "typeArguments": null
         }
       ],
       "type": "struct MyStruct",
-      "typeId": 6,
+      "typeId": 7,
       "typeParameters": null
     },
     {
       "components": null,
       "type": "u64",
-      "typeId": 7,
+      "typeId": 8,
+      "typeParameters": null
+    },
+    {
+      "components": null,
+      "type": "u8",
+      "typeId": 9,
       "typeParameters": null
     }
   ]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/src/main.sw
@@ -31,6 +31,7 @@ configurable {
     C5: MyEnum = MyEnum::B(true),
     C6: str[4] = __to_str_array("fuel"),
     C7: [u64; 4] = [1, 2, 3, 4],
+    C7_2: [u8; 4] = [1, 2, 3, 4],
     C8: u64 = 0, // Unused - should not show up in the JSON file
     C9: u64 =  10 + 9 - 8 * 7 / 6 << 5 >> 4 ^ 3 | 2 & 1,
 }
@@ -66,6 +67,12 @@ fn test_second_use() {
     assert(C7[1] == 2);
     assert(C7[2] == 3);
     assert(C7[3] == 4);
+
+    assert(C7_2[0] == 1);
+    assert(C7_2[1] == 2);
+    assert(C7_2[2] == 3);
+    assert(C7_2[3] == 4);
+    
     assert(C9 == 23);
 }
 


### PR DESCRIPTION
## Description

This PR solves a problem that Data Section alignment was being calculated even for "internal" entries, like entries inside collections. This creates problems with things like 

```sway
const a: [u8; 4] = [1, 2, 3, 4];
```

See https://github.com/FuelLabs/fuels-ts/blob/309608dc9902a225f685327fc4107deee0349039/apps/docs-snippets/projects/echo-configurables/src/main.sw as an example.

Now the alignment is correctly calculated only for "root" entries , allowing "internal" entries to be as packed as they desire.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
