### PR TITLE
Provide useful error for "Cannot find trait Hash in this scope"

### DIFF
--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -261,6 +261,21 @@ impl DeclEngine {
         self.get(index)
     }
 
+    /// Returns all the [ty::TyTraitDecl]s whose name is the same as `trait_name`.
+    /// 
+    /// The method does a linear search over all the declared traits and is meant
+    /// to be used only for diagnostic purposes.
+    pub fn get_traits_by_name(&self, trait_name: &Ident) -> Vec<ty::TyTraitDecl>
+    {
+        self.trait_slab
+            .with_slice(|elems| elems
+                .into_iter()
+                .filter(|trait_decl| trait_decl.name == *trait_name)
+                .cloned()
+                .collect()
+            )
+    }
+
     /// Friendly helper method for calling the `get` method from the
     /// implementation of [DeclEngineGet] for [DeclEngine]
     ///

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -800,6 +800,7 @@ impl ReplaceDecls for TyExpressionVariant {
                             handler,
                             ctx.by_ref(),
                             &method.type_parameters,
+                            method.name.as_str(),
                             &method.name.span(),
                         )?;
                     method.replace_decls(&inner_decl_mapping, handler, ctx)?;

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -1425,7 +1425,8 @@ fn handle_supertraits(
 
             match ctx
                 .namespace
-                .resolve_call_path(handler, engines, &supertrait.name, ctx.self_type())
+                // Use the default Handler to avoid emitting the redundant SymbolNotFound error. 
+                .resolve_call_path(&Handler::default(), engines, &supertrait.name, ctx.self_type())
                 .ok()
             {
                 Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
@@ -43,7 +43,8 @@ pub(crate) fn insert_supertraits_into_namespace(
 
             let decl = ctx
                 .namespace
-                .resolve_call_path(handler, engines, &supertrait.name, ctx.self_type())
+                // Use the default Handler to avoid emitting the redundant SymbolNotFound error. 
+                .resolve_call_path(&Handler::default(), engines, &supertrait.name, ctx.self_type())
                 .ok();
 
             match (decl.clone(), supertraits_of) {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -69,6 +69,7 @@ pub(crate) fn instantiate_function_application(
         handler,
         ctx.by_ref(),
         &function_decl.type_parameters,
+        function_decl.name.as_str(),
         &call_path_binding.span(),
     )?;
     function_decl.replace_decls(&decl_mapping, handler, &mut ctx)?;

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -617,6 +617,7 @@ pub(crate) fn monomorphize_method_application(
             handler,
             ctx.by_ref(),
             &method.type_parameters,
+            method.name.as_str(),
             &call_path.span(),
         )?;
 

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -176,7 +176,8 @@ impl TraitConstraint {
 
         match ctx
             .namespace
-            .resolve_call_path(handler, engines, trait_name, ctx.self_type())
+            // Use the default Handler to avoid emitting the redundant SymbolNotFound error. 
+            .resolve_call_path(&Handler::default(), engines, trait_name, ctx.self_type())
             .ok()
         {
             Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -551,12 +551,18 @@ fn handle_trait(
                 }
             }
             _ => {
+                let trait_candidates = decl_engine
+                    .get_traits_by_name(&trait_name.suffix)
+                    .iter()
+                    .map(|trait_decl| trait_decl.call_path.to_string())
+                    .collect();
+
                 handler.emit_err(CompileError::TraitNotImportedAtFunctionApplication {
                     trait_name: trait_name.suffix.to_string(),
                     function_name: function_name.to_string(),
                     function_call_site_span: access_span.clone(),
                     trait_constraint_span: trait_name.suffix.span(),
-                    trait_candidates: vec![],
+                    trait_candidates,
                 });
             }
         }

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -554,7 +554,16 @@ fn handle_trait(
                 let trait_candidates = decl_engine
                     .get_traits_by_name(&trait_name.suffix)
                     .iter()
-                    .map(|trait_decl| trait_decl.call_path.to_string())
+                    .map(|trait_decl| {
+                        // In the case of an internal library, always add :: to the candidate call path.
+                        let import_path = trait_decl.call_path.to_import_path(ctx.namespace);
+                        if import_path == trait_decl.call_path { // If external library.
+                            import_path.to_string()
+                        }
+                        else {
+                            format!("::{import_path}")
+                        }
+                    })
                     .collect();
 
                 handler.emit_err(CompileError::TraitNotImportedAtFunctionApplication {

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -518,7 +518,7 @@ fn handle_trait(
     handler.scope(|handler| {
         match ctx
             .namespace
-            // Use the default Handler to avoid emitting the redundant symbol not found error. 
+            // Use the default Handler to avoid emitting the redundant SymbolNotFound error. 
             .resolve_call_path(&Handler::default(), engines, trait_name, ctx.self_type())
             .ok()
         {

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -1197,7 +1197,7 @@ impl ToDiagnostic for CompileError {
                             "  2. Detect which exact \"{trait_name}\" is used in the trait constraint in the \"{function_name}\"."
                         ));
                         help.push(format!(
-                            "  3. Import the same \"{trait_name}\"{}.",
+                            "  3. Import that \"{trait_name}\"{}.",
                             get_file_name(source_engine, function_call_site_span.source_id())
                                 .map_or("".to_string(), |file_name| format!(" into \"{file_name}\""))
                         ));

--- a/sway-types/src/source_engine.rs
+++ b/sway-types/src/source_engine.rs
@@ -81,4 +81,13 @@ impl SourceEngine {
     pub fn get_module_id(&self, path: &PathBuf) -> Option<ModuleId> {
         self.path_to_module_map.read().unwrap().get(path).cloned()
     }
+
+    /// This function provides the file name (with extension) corresponding to a specified source ID.
+    pub fn get_file_name(&self, source_id: &SourceId) -> Option<String> {
+        self.get_path(source_id)
+            .as_path()
+            .file_name()
+            .map(|file_name| file_name.to_string_lossy())
+            .map(|file_name| file_name.to_string())
+    }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/supertrait_does_not_exist/test.toml
@@ -1,3 +1,3 @@
 category = "fail"
 
-# check: $()Could not find symbol "C" in this scope.
+# check: $()Cannot find trait "C" in this scope.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-AC247AEA3D39B916"
+
+[[package]]
+name = "std"
+source = "git+https://github.com/fuellabs/sway?tag=v0.47.0#34265301c6037d51444899a99df1cfc563df6016"
+dependencies = ["core"]
+
+[[package]]
+name = "trait_cannot_find_in_scope_issue"
+source = "member"
+dependencies = ["std"]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "trait_cannot_find_in_scope_issue"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = true

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/src/lib.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/src/lib.sw
@@ -1,0 +1,27 @@
+library;
+
+use std::hash::Hash;
+
+pub trait FirstTrait {}
+
+pub trait SecondTrait<T> {
+    fn trait_method(self, t: T) where T: FirstTrait;
+    fn trait_associated_function(t: T) where T: FirstTrait;
+}
+
+pub trait GenericTrait<T> {}
+
+pub trait DuplicatedTrait {}
+
+pub struct A {}
+
+pub struct S {}
+
+impl S {
+    pub fn method_01<T>(self, t: T) where T: Hash { }
+    pub fn method_02<T>(self, t: T) where T: FirstTrait { }
+
+    pub fn associated_function<T>(t: T) where T: FirstTrait { }
+}
+
+pub fn function<T>(t: T) where T: FirstTrait + GenericTrait<u8> { }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/src/main.sw
@@ -1,0 +1,29 @@
+script;
+
+mod lib;
+mod other_lib;
+mod trait_impls;
+
+use std::hash::sha256;
+
+use ::lib::{S, A, function};
+use ::trait_impls::*;
+
+fn main() {
+    let _ = sha256(123u8);
+
+    let s = S {};
+    s.method_01(0u8);
+    s.method_02(A {});
+    S::associated_function(A {});
+
+    function(A {});
+
+    let a = A {};
+
+    a.trait_method(A {});
+
+    A::trait_associated_function(A {});
+
+    function_with_duplicated_trait(A {});
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/src/other_lib.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/src/other_lib.sw
@@ -1,0 +1,3 @@
+library;
+
+pub trait DuplicatedTrait {}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/src/trait_impls.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/src/trait_impls.sw
@@ -1,0 +1,23 @@
+library;
+
+use std::hash::Hash;
+use ::lib::{A, FirstTrait, SecondTrait, GenericTrait};
+
+impl FirstTrait for A {}
+
+impl GenericTrait<u8> for A {}
+
+impl<T> SecondTrait<T> for A {
+    fn trait_method(self, t: T) where T: FirstTrait { }
+    fn trait_associated_function(t: T) where T: FirstTrait { }
+}
+
+use ::lib::FirstTrait as FirstTraitAlias;
+
+pub fn function_with_trait_alias<T>(t: T) where T: FirstTraitAlias { }
+
+use ::other_lib::DuplicatedTrait;
+
+impl DuplicatedTrait for A {}
+
+pub fn function_with_duplicated_trait<T>(t: T) where T: DuplicatedTrait { }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_cannot_find_in_scope_issue/test.toml
@@ -1,0 +1,69 @@
+category = "fail"
+
+#check: $()Trait is not imported
+#check: $()let _ = sha256(123u8);
+#nextln: $()Trait "Hash" is not imported into "main.sw" when calling "sha256".
+#check: $()To import "Hash" into "main.sw" use: `use std::hash::Hash;`.
+#check: $()pub fn sha256<T>(s: T) -> b256 where T: Hash {
+#nextln: $()In the definition of "sha256", "Hash" is used in this trait constraint.
+
+#check: $()Trait is not imported
+#check: $()s.method_01(0u8);
+#nextln: $()Trait "Hash" is not imported into "main.sw" when calling "method_01".
+#check: $()To import "Hash" into "main.sw" use: `use std::hash::Hash;`.
+#check: $()pub fn method_01<T>(self, t: T) where T: Hash { }
+#nextln: $()In the definition of "method_01", "Hash" is used in this trait constraint.
+
+#check: $()Trait is not imported
+#check: $()s.method_02(A {});
+#nextln: $()Trait "FirstTrait" is not imported into "main.sw" when calling "method_02".
+#check: $()To import "FirstTrait" into "main.sw" use: `use ::lib::FirstTrait;`.
+#check: $()pub fn method_02<T>(self, t: T) where T: FirstTrait { }
+#nextln: $()In the definition of "method_02", "FirstTrait" is used in this trait constraint.
+
+#check: $()Trait is not imported
+#check: $()S::associated_function(A {});
+#nextln: $()Trait "FirstTrait" is not imported into "main.sw" when calling "associated_function".
+#check: $()To import "FirstTrait" into "main.sw" use: `use ::lib::FirstTrait;`.
+#check: $()pub fn associated_function<T>(t: T) where T: FirstTrait { }
+#nextln: $()In the definition of "associated_function", "FirstTrait" is used in this trait constraint.
+
+#check: $()Trait is not imported
+#check: $()function(A {});
+#nextln: $()Trait "FirstTrait" is not imported into "main.sw" when calling "function".
+#check: $()To import "FirstTrait" into "main.sw" use: `use ::lib::FirstTrait;`.
+#check: $()pub fn function<T>(t: T) where T: FirstTrait + GenericTrait<u8> { }
+#nextln: $()In the definition of "function", "FirstTrait" is used in this trait constraint.
+
+#check: $()Trait is not imported
+#check: $()function(A {});
+#nextln: $()Trait "GenericTrait" is not imported into "main.sw" when calling "function".
+#check: $()To import "GenericTrait" into "main.sw" use: `use ::lib::GenericTrait;`.
+#check: $()pub fn function<T>(t: T) where T: FirstTrait + GenericTrait<u8> { }
+#nextln: $()In the definition of "function", "GenericTrait" is used in this trait constraint.
+
+#check: $()Trait is not imported
+#check: $()a.trait_method(A {});
+#nextln: $()Trait "FirstTrait" is not imported into "main.sw" when calling "trait_method".
+#check: $()To import "FirstTrait" into "main.sw" use: `use ::lib::FirstTrait;`.
+#check: $()fn trait_method(self, t: T) where T: FirstTrait { }
+#nextln: $()In the definition of "trait_method", "FirstTrait" is used in this trait constraint.
+
+#check: $()Trait is not imported
+#check: $()A::trait_associated_function(A {});
+#nextln: $()Trait "FirstTrait" is not imported into "main.sw" when calling "trait_associated_function".
+#check: $()To import "FirstTrait" into "main.sw" use: `use ::lib::FirstTrait;`.
+#check: $()fn trait_associated_function(t: T) where T: FirstTrait { }
+#nextln: $()In the definition of "trait_associated_function", "FirstTrait" is used in this trait constraint.
+
+#check: $()Trait is not imported
+#check: $()function_with_duplicated_trait(A {});
+#nextln: $()Trait "DuplicatedTrait" is not imported into "main.sw" when calling "function_with_duplicated_trait".
+#check: $()To import the proper "DuplicatedTrait" into "main.sw" follow the detailed instructions given below.
+#check: $()pub fn function_with_duplicated_trait<T>(t: T) where T: DuplicatedTrait { }
+#nextln: $()In the definition of "function_with_duplicated_trait", "DuplicatedTrait" is used in this trait constraint.
+#check: $()There are these 2 traits with the name "DuplicatedTrait" available in the modules:
+#check: $()  - ::lib::DuplicatedTrait
+#check: $()  - ::other_lib::DuplicatedTrait
+#check: $()  1. Look at the definition of the "function_with_duplicated_trait" in the "trait_impls.sw".
+#check: $()     E.g., assuming it is the first one on the list, use: `use ::lib::DuplicatedTrait;`


### PR DESCRIPTION
## Description

This PR closes #5129 by providing a detailed guidelines to programmers on how to fix the "Cannot find trait XYZ in this scope". The issue is very prominent in the case of the `Hash` trait as demonstrated in the #5084.

We need to guide programmers at the moment because fixing the root cause will take some time.

The PR:
- replaces the current two misleading and redundant error messages with a clear instruction how to fix the issue at the call site.
- provides the guidelines in a general case, and not only for the prominent issue with the `Hash` trait.
- removes the redundant `SymbolNotFound` error in favor of more specific `TraitNotFound`

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
