### PR TITLE
Rename input_owner to input_coin_owner

### DIFF
--- a/sway-lib-std/src/auth.sw
+++ b/sway-lib-std/src/auth.sw
@@ -6,7 +6,7 @@ use ::contract_id::ContractId;
 use ::identity::Identity;
 use ::option::Option::{self, *};
 use ::result::Result::{self, *};
-use ::inputs::{Input, input_count, input_owner, input_type};
+use ::inputs::{Input, input_count, input_coin_owner, input_type};
 
 /// The error type used when an `Identity` cannot be determined.
 pub enum AuthError {
@@ -150,7 +150,7 @@ pub fn caller_address() -> Result<Address, AuthError> {
         }
 
         // type == InputCoin or InputMessage.
-        let owner_of_input = input_owner(i.as_u64());
+        let owner_of_input = input_coin_owner(i.as_u64());
         if candidate.is_none() {
             // This is the first input seen of the correct type.
             candidate = owner_of_input;
@@ -159,7 +159,7 @@ pub fn caller_address() -> Result<Address, AuthError> {
         }
 
         // Compare current input owner to candidate.
-        // `candidate` and `input_owner` must be `Some`.
+        // `candidate` and `input_coin_owner` must be `Some`.
         // at this point, so we can unwrap safely.
         if owner_of_input.unwrap() == candidate.unwrap() {
             // Owners are a match, continue looping.

--- a/sway-lib-std/src/inputs.sw
+++ b/sway-lib-std/src/inputs.sw
@@ -191,7 +191,7 @@ pub fn input_amount(index: u64) -> Option<u64> {
     }
 }
 
-/// Gets owner field from input at `index`.
+/// Gets owner field from input at `index` if it's a coin.
 ///
 /// # Arguments
 ///
@@ -204,14 +204,14 @@ pub fn input_amount(index: u64) -> Option<u64> {
 /// # Examples
 ///
 /// ```sway
-/// use std::inputs::input_owner;
+/// use std::inputs::input_coin_owner;
 ///
 /// fn foo() {
-///     let input_owner = input_owner(0);
-///     assert(input_owner.is_some()); // Ensure the input is a coin input.
+///     let input_coin_owner = input_coin_owner(0);
+///     assert(input_coin_owner.is_some()); // Ensure the input is a coin input.
 /// }
 /// ```
-pub fn input_owner(index: u64) -> Option<Address> {
+pub fn input_coin_owner(index: u64) -> Option<Address> {
     match input_type(index) {
         Input::Coin => Some(Address::from(__gtf::<b256>(index, GTF_INPUT_COIN_OWNER))),
         _ => None,

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_log/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_log/src/main.sw
@@ -1,12 +1,12 @@
 predicate;
 
 use std::{
-    inputs::input_owner,
+    inputs::input_coin_owner,
     logging::log,
 };
 
 fn main() -> bool {
-    log::<Address>(input_owner(0).unwrap());
+    log::<Address>(input_coin_owner(0).unwrap());
         
     true
 }

--- a/test/src/sdk-harness/test_artifacts/tx_contract/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/tx_contract/src/main.sw
@@ -35,7 +35,7 @@ abi TxContractTest {
 
     fn get_input_type(index: u64) -> Input;
     fn get_tx_input_pointer(index: u64) -> u64;
-    fn get_input_owner(index: u64) -> Address;
+    fn get_input_coin_owner(index: u64) -> Address;
     fn get_input_amount(index: u64) -> u64;
     fn get_tx_input_predicate_data_pointer(index: u64) -> u64;
     fn get_input_message_sender(index: u64) -> Address;
@@ -111,8 +111,8 @@ impl TxContractTest for Contract {
     fn get_input_type(index: u64) -> Input {
         input_type(index)
     }
-    fn get_input_owner(index: u64) -> Address {
-        input_owner(index).unwrap()
+    fn get_input_coin_owner(index: u64) -> Address {
+        input_coin_owner(index).unwrap()
     }
     fn get_input_amount(index: u64) -> u64 {
         input_amount(index).unwrap()

--- a/test/src/sdk-harness/test_projects/tx_fields/mod.rs
+++ b/test/src/sdk-harness/test_projects/tx_fields/mod.rs
@@ -559,7 +559,7 @@ mod inputs {
 
             let owner_result = contract_instance
                 .methods()
-                .get_input_owner(1)
+                .get_input_coin_owner(1)
                 .call()
                 .await
                 .unwrap();


### PR DESCRIPTION
close #5029

## Description
Changes the misleading name `input_owner` to `input_coin_owner`

Requesting a review and addition of the `Breaking` tag from @Braqzen 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
