### PR TITLE
Allow user to override initial storage slots in forc-deploy

### DIFF
--- a/forc-plugins/forc-client/src/cmd/deploy.rs
+++ b/forc-plugins/forc-client/src/cmd/deploy.rs
@@ -52,4 +52,24 @@ pub struct Command {
     /// Sign the deployment transaction manually.
     #[clap(long)]
     pub manual_signing: bool,
+    /// Override storage slot initialization.
+    ///
+    /// By default, storage slots are initialized with the values defined in the storage block in
+    /// the contract. You can override the initialization by providing the file path to a JSON file
+    /// containing the overriden values.
+    ///
+    /// The file format and key values should match the compiler-generated `*-storage_slots.json` file in the output
+    /// directory of the compiled contract.
+    ///
+    /// Example: `forc deploy --override-storage-slots my_override.json`
+    ///
+    /// my_override.json:
+    /// [
+    ///   {
+    ///     "key": "<key from out/debug/storage_slots.json>",
+    ///     "value": "0000000000000000000000000000000000000000000000000000000000000001"
+    ///   }
+    /// ]
+    #[clap(long, verbatim_doc_comment, name = "JSON_FILE_PATH")]
+    pub override_storage_slots: Option<String>,
 }

--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -215,7 +215,14 @@ pub async fn deploy_pkg(
 
     let bytecode = &compiled.bytecode.bytes;
 
-    let mut storage_slots = compiled.storage_slots.clone();
+    let mut storage_slots =
+        if let Some(storage_slot_override_file) = &command.override_storage_slots {
+            let storage_slots_file = std::fs::read_to_string(storage_slot_override_file)?;
+            let storage_slots: Vec<StorageSlot> = serde_json::from_str(&storage_slots_file)?;
+            storage_slots
+        } else {
+            compiled.storage_slots.clone()
+        };
     storage_slots.sort();
 
     let contract = Contract::from(bytecode.clone());


### PR DESCRIPTION
## Description

Closes https://github.com/FuelLabs/sway/issues/2010

Notes: 
- I couldn't use `from_reader` to deserialize the file contents due to this issue: https://github.com/FuelLabs/fuel-vm/pull/643

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
