### PR TITLE
Changes `ConcurrentSlab` to no longer clone values

### DIFF
--- a/forc-plugins/forc-doc/src/doc/descriptor.rs
+++ b/forc-plugins/forc-doc/src/doc/descriptor.rs
@@ -1,4 +1,6 @@
 //! Determine whether a [Declaration] is documentable.
+use std::ops::Deref;
+
 use crate::{
     doc::{module::ModuleInfo, Document},
     render::{
@@ -18,7 +20,7 @@ trait RequiredMethods {
 impl RequiredMethods for Vec<DeclRefTraitFn> {
     fn to_methods(&self, decl_engine: &DeclEngine) -> Vec<TyTraitFn> {
         self.iter()
-            .map(|decl_ref| decl_engine.get_trait_fn(decl_ref))
+            .map(|decl_ref| decl_engine.get_trait_fn(decl_ref).deref().clone())
             .collect()
     }
 }
@@ -45,12 +47,12 @@ impl Descriptor {
                 if !document_private_items && struct_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
                 } else {
-                    let item_name = struct_decl.call_path.suffix;
+                    let item_name = struct_decl.call_path.suffix.clone();
                     let attrs_opt = (!struct_decl.attributes.is_empty())
                         .then(|| struct_decl.attributes.to_html_string());
                     let context = (!struct_decl.fields.is_empty()).then_some(Context::new(
                         module_info.clone(),
-                        ContextType::StructFields(struct_decl.fields),
+                        ContextType::StructFields(struct_decl.fields.clone()),
                     ));
 
                     Ok(Descriptor::Documentable(Document {
@@ -82,12 +84,12 @@ impl Descriptor {
                 if !document_private_items && enum_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
                 } else {
-                    let item_name = enum_decl.call_path.suffix;
+                    let item_name = enum_decl.call_path.suffix.clone();
                     let attrs_opt = (!enum_decl.attributes.is_empty())
                         .then(|| enum_decl.attributes.to_html_string());
                     let context = (!enum_decl.variants.is_empty()).then_some(Context::new(
                         module_info.clone(),
-                        ContextType::EnumVariants(enum_decl.variants),
+                        ContextType::EnumVariants(enum_decl.variants.clone()),
                     ));
 
                     Ok(Descriptor::Documentable(Document {
@@ -115,7 +117,7 @@ impl Descriptor {
                 }
             }
             ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. }) => {
-                let trait_decl = decl_engine.get_trait(decl_id);
+                let trait_decl = decl_engine.get_trait(decl_id).deref().clone();
                 if !document_private_items && trait_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
                 } else {
@@ -163,7 +165,7 @@ impl Descriptor {
                 }
             }
             ty::TyDecl::AbiDecl(ty::AbiDecl { decl_id, .. }) => {
-                let abi_decl = decl_engine.get_abi(decl_id);
+                let abi_decl = decl_engine.get_abi(decl_id).deref().clone();
                 let item_name = abi_decl.name;
                 let attrs_opt =
                     (!abi_decl.attributes.is_empty()).then(|| abi_decl.attributes.to_html_string());
@@ -212,7 +214,7 @@ impl Descriptor {
                     .then(|| storage_decl.attributes.to_html_string());
                 let context = (!storage_decl.fields.is_empty()).then_some(Context::new(
                     module_info.clone(),
-                    ContextType::StorageFields(storage_decl.fields),
+                    ContextType::StorageFields(storage_decl.fields.clone()),
                 ));
 
                 Ok(Descriptor::Documentable(Document {
@@ -243,7 +245,7 @@ impl Descriptor {
                 if !document_private_items && fn_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
                 } else {
-                    let item_name = fn_decl.name;
+                    let item_name = fn_decl.name.clone();
                     let attrs_opt = (!fn_decl.attributes.is_empty())
                         .then(|| fn_decl.attributes.to_html_string());
 
@@ -276,7 +278,7 @@ impl Descriptor {
                 if !document_private_items && const_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
                 } else {
-                    let item_name = const_decl.call_path.suffix;
+                    let item_name = const_decl.call_path.suffix.clone();
                     let attrs_opt = (!const_decl.attributes.is_empty())
                         .then(|| const_decl.attributes.to_html_string());
 

--- a/forc-plugins/forc-doc/src/doc/descriptor.rs
+++ b/forc-plugins/forc-doc/src/doc/descriptor.rs
@@ -1,6 +1,4 @@
 //! Determine whether a [Declaration] is documentable.
-use std::ops::Deref;
-
 use crate::{
     doc::{module::ModuleInfo, Document},
     render::{
@@ -20,7 +18,7 @@ trait RequiredMethods {
 impl RequiredMethods for Vec<DeclRefTraitFn> {
     fn to_methods(&self, decl_engine: &DeclEngine) -> Vec<TyTraitFn> {
         self.iter()
-            .map(|decl_ref| decl_engine.get_trait_fn(decl_ref).deref().clone())
+            .map(|decl_ref| (*decl_engine.get_trait_fn(decl_ref)).clone())
             .collect()
     }
 }
@@ -117,7 +115,7 @@ impl Descriptor {
                 }
             }
             ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. }) => {
-                let trait_decl = decl_engine.get_trait(decl_id).deref().clone();
+                let trait_decl = (*decl_engine.get_trait(decl_id)).clone();
                 if !document_private_items && trait_decl.visibility.is_private() {
                     Ok(Descriptor::NonDocumentable)
                 } else {
@@ -165,7 +163,7 @@ impl Descriptor {
                 }
             }
             ty::TyDecl::AbiDecl(ty::AbiDecl { decl_id, .. }) => {
-                let abi_decl = decl_engine.get_abi(decl_id).deref().clone();
+                let abi_decl = (*decl_engine.get_abi(decl_id)).clone();
                 let item_name = abi_decl.name;
                 let attrs_opt =
                     (!abi_decl.attributes.is_empty()).then(|| abi_decl.attributes.to_html_string());

--- a/forc-plugins/forc-doc/src/doc/mod.rs
+++ b/forc-plugins/forc-doc/src/doc/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 use anyhow::Result;
-use std::{collections::HashMap, ops::Deref, option::Option};
+use std::{collections::HashMap, option::Option};
 use sway_core::{
     decl_engine::DeclEngine,
     language::ty::{TyAstNodeContent, TyDecl, TyImplTrait, TyModule, TyProgram, TySubmodule},
@@ -122,10 +122,7 @@ impl Documentation {
             if let TyAstNodeContent::Declaration(ref decl) = ast_node.content {
                 if let TyDecl::ImplTrait(impl_trait) = decl {
                     impl_traits.push((
-                        decl_engine
-                            .get_impl_trait(&impl_trait.decl_id)
-                            .deref()
-                            .clone(),
+                        (*decl_engine.get_impl_trait(&impl_trait.decl_id)).clone(),
                         module_info.clone(),
                     ))
                 } else {

--- a/forc-plugins/forc-doc/src/doc/mod.rs
+++ b/forc-plugins/forc-doc/src/doc/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 use anyhow::Result;
-use std::{collections::HashMap, option::Option};
+use std::{collections::HashMap, ops::Deref, option::Option};
 use sway_core::{
     decl_engine::DeclEngine,
     language::ty::{TyAstNodeContent, TyDecl, TyImplTrait, TyModule, TyProgram, TySubmodule},
@@ -122,7 +122,10 @@ impl Documentation {
             if let TyAstNodeContent::Declaration(ref decl) = ast_node.content {
                 if let TyDecl::ImplTrait(impl_trait) = decl {
                     impl_traits.push((
-                        decl_engine.get_impl_trait(&impl_trait.decl_id),
+                        decl_engine
+                            .get_impl_trait(&impl_trait.decl_id)
+                            .deref()
+                            .clone(),
                         module_info.clone(),
                     ))
                 } else {

--- a/forc-plugins/forc-doc/src/render/item/context.rs
+++ b/forc-plugins/forc-doc/src/render/item/context.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use anyhow::Result;
 use horrorshow::{box_html, Raw, RenderBox, Template};
-use std::{collections::BTreeMap, fmt::Write};
+use std::{collections::BTreeMap, fmt::Write, ops::Deref};
 use sway_core::language::ty::{
     TyEnumVariant, TyImplTrait, TyStorageField, TyStructField, TyTraitFn, TyTraitItem,
 };
@@ -53,7 +53,12 @@ impl Renderable for Context {
                 for field in fields {
                     let struct_field_id = format!("structfield.{}", field.name.as_str());
                     let type_anchor = render_type_anchor(
-                        render_plan.engines.te().get(field.type_argument.type_id),
+                        render_plan
+                            .engines
+                            .te()
+                            .get(field.type_argument.type_id)
+                            .deref()
+                            .clone(),
                         &render_plan,
                         &self.module_info,
                     );
@@ -81,7 +86,12 @@ impl Renderable for Context {
                 for field in fields {
                     let storage_field_id = format!("storagefield.{}", field.name.as_str());
                     let type_anchor = render_type_anchor(
-                        render_plan.engines.te().get(field.type_argument.type_id),
+                        render_plan
+                            .engines
+                            .te()
+                            .get(field.type_argument.type_id)
+                            .deref()
+                            .clone(),
                         &render_plan,
                         &self.module_info,
                     );
@@ -109,7 +119,12 @@ impl Renderable for Context {
                 for variant in variants {
                     let enum_variant_id = format!("variant.{}", variant.name.as_str());
                     let type_anchor = render_type_anchor(
-                        render_plan.engines.te().get(variant.type_argument.type_id),
+                        render_plan
+                            .engines
+                            .te()
+                            .get(variant.type_argument.type_id)
+                            .deref()
+                            .clone(),
                         &render_plan,
                         &self.module_info,
                     );

--- a/forc-plugins/forc-doc/src/render/item/context.rs
+++ b/forc-plugins/forc-doc/src/render/item/context.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use anyhow::Result;
 use horrorshow::{box_html, Raw, RenderBox, Template};
-use std::{collections::BTreeMap, fmt::Write, ops::Deref};
+use std::{collections::BTreeMap, fmt::Write};
 use sway_core::language::ty::{
     TyEnumVariant, TyImplTrait, TyStorageField, TyStructField, TyTraitFn, TyTraitItem,
 };
@@ -53,12 +53,7 @@ impl Renderable for Context {
                 for field in fields {
                     let struct_field_id = format!("structfield.{}", field.name.as_str());
                     let type_anchor = render_type_anchor(
-                        render_plan
-                            .engines
-                            .te()
-                            .get(field.type_argument.type_id)
-                            .deref()
-                            .clone(),
+                        (*render_plan.engines.te().get(field.type_argument.type_id)).clone(),
                         &render_plan,
                         &self.module_info,
                     );
@@ -86,12 +81,7 @@ impl Renderable for Context {
                 for field in fields {
                     let storage_field_id = format!("storagefield.{}", field.name.as_str());
                     let type_anchor = render_type_anchor(
-                        render_plan
-                            .engines
-                            .te()
-                            .get(field.type_argument.type_id)
-                            .deref()
-                            .clone(),
+                        (*render_plan.engines.te().get(field.type_argument.type_id)).clone(),
                         &render_plan,
                         &self.module_info,
                     );
@@ -119,12 +109,7 @@ impl Renderable for Context {
                 for variant in variants {
                     let enum_variant_id = format!("variant.{}", variant.name.as_str());
                     let type_anchor = render_type_anchor(
-                        render_plan
-                            .engines
-                            .te()
-                            .get(variant.type_argument.type_id)
-                            .deref()
-                            .clone(),
+                        (*render_plan.engines.te().get(variant.type_argument.type_id)).clone(),
                         &render_plan,
                         &self.module_info,
                     );

--- a/forc-plugins/forc-doc/src/render/item/type_anchor.rs
+++ b/forc-plugins/forc-doc/src/render/item/type_anchor.rs
@@ -1,6 +1,4 @@
 //! Creation of HTML anchors for types that can be linked.
-use std::ops::Deref;
-
 use crate::{doc::module::ModuleInfo, RenderPlan};
 use anyhow::{anyhow, Result};
 use horrorshow::{box_html, RenderBox};
@@ -25,7 +23,7 @@ pub(crate) fn render_type_anchor(
     match type_info {
         TypeInfo::Array(ty_arg, len) => {
             let inner = render_type_anchor(
-                render_plan.engines.te().get(ty_arg.type_id).deref().clone(),
+                (*render_plan.engines.te().get(ty_arg.type_id)).clone(),
                 render_plan,
                 current_module_info,
             )?;
@@ -39,7 +37,7 @@ pub(crate) fn render_type_anchor(
             let mut rendered_args: Vec<_> = Vec::new();
             for ty_arg in ty_args {
                 rendered_args.push(render_type_anchor(
-                    render_plan.engines.te().get(ty_arg.type_id).deref().clone(),
+                    (*render_plan.engines.te().get(ty_arg.type_id)).clone(),
                     render_plan,
                     current_module_info,
                 )?)

--- a/forc-plugins/forc-doc/src/render/item/type_anchor.rs
+++ b/forc-plugins/forc-doc/src/render/item/type_anchor.rs
@@ -1,4 +1,6 @@
 //! Creation of HTML anchors for types that can be linked.
+use std::ops::Deref;
+
 use crate::{doc::module::ModuleInfo, RenderPlan};
 use anyhow::{anyhow, Result};
 use horrorshow::{box_html, RenderBox};
@@ -23,7 +25,7 @@ pub(crate) fn render_type_anchor(
     match type_info {
         TypeInfo::Array(ty_arg, len) => {
             let inner = render_type_anchor(
-                render_plan.engines.te().get(ty_arg.type_id),
+                render_plan.engines.te().get(ty_arg.type_id).deref().clone(),
                 render_plan,
                 current_module_info,
             )?;
@@ -37,7 +39,7 @@ pub(crate) fn render_type_anchor(
             let mut rendered_args: Vec<_> = Vec::new();
             for ty_arg in ty_args {
                 rendered_args.push(render_type_anchor(
-                    render_plan.engines.te().get(ty_arg.type_id),
+                    render_plan.engines.te().get(ty_arg.type_id).deref().clone(),
                     render_plan,
                     current_module_info,
                 )?)

--- a/sway-core/src/abi_generation/evm_abi.rs
+++ b/sway-core/src/abi_generation/evm_abi.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use sway_types::integer_bits::IntegerBits;
 
 use crate::{
@@ -43,8 +41,8 @@ fn get_type_str(
         )
     } else {
         match (
-            type_engine.get(*type_id).deref(),
-            type_engine.get(resolved_type_id).deref(),
+            &*type_engine.get(*type_id),
+            &*type_engine.get(resolved_type_id),
         ) {
             (TypeInfo::Custom { .. }, TypeInfo::Struct { .. }) => {
                 format!(

--- a/sway-core/src/abi_generation/evm_abi.rs
+++ b/sway-core/src/abi_generation/evm_abi.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use sway_types::integer_bits::IntegerBits;
 
 use crate::{
@@ -40,7 +42,10 @@ fn get_type_str(
             abi_str(&type_engine.get(*type_id), type_engine, decl_engine)
         )
     } else {
-        match (type_engine.get(*type_id), type_engine.get(resolved_type_id)) {
+        match (
+            type_engine.get(*type_id).deref(),
+            type_engine.get(resolved_type_id).deref(),
+        ) {
             (TypeInfo::Custom { .. }, TypeInfo::Struct { .. }) => {
                 format!(
                     "struct {}",

--- a/sway-core/src/abi_generation/fuel_abi.rs
+++ b/sway-core/src/abi_generation/fuel_abi.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use fuel_abi_types::program_abi;
 use sway_types::integer_bits::IntegerBits;
 
@@ -269,8 +267,8 @@ impl TypeId {
             )
         } else {
             match (
-                type_engine.get(*self).deref(),
-                type_engine.get(resolved_type_id).deref(),
+                &*type_engine.get(*self),
+                &*type_engine.get(resolved_type_id),
             ) {
                 (TypeInfo::Custom { .. }, TypeInfo::Struct { .. }) => type_engine
                     .get(resolved_type_id)
@@ -344,7 +342,7 @@ impl TypeId {
         types: &mut Vec<program_abi::TypeDeclaration>,
         resolved_type_id: TypeId,
     ) -> Option<Vec<program_abi::TypeApplication>> {
-        match type_engine.get(*self).deref() {
+        match &*type_engine.get(*self) {
             TypeInfo::Enum(decl_ref) => {
                 let decl = decl_engine.get_enum(decl_ref);
                 // A list of all `program_abi::TypeDeclaration`s needed for the enum variants
@@ -449,7 +447,7 @@ impl TypeId {
                 )
             }
             TypeInfo::Array(..) => {
-                if let TypeInfo::Array(elem_ty, _) = type_engine.get(resolved_type_id).deref() {
+                if let TypeInfo::Array(elem_ty, _) = &*type_engine.get(resolved_type_id) {
                     // The `program_abi::TypeDeclaration`s needed for the array element type
                     let elem_abi_ty = program_abi::TypeDeclaration {
                         type_id: elem_ty.initial_type_id.index(),
@@ -494,7 +492,7 @@ impl TypeId {
                 }
             }
             TypeInfo::Tuple(_) => {
-                if let TypeInfo::Tuple(fields) = type_engine.get(resolved_type_id).deref() {
+                if let TypeInfo::Tuple(fields) = &*type_engine.get(resolved_type_id) {
                     // A list of all `program_abi::TypeDeclaration`s needed for the tuple fields
                     let fields_types = fields
                         .iter()
@@ -597,7 +595,7 @@ impl TypeId {
                 }
             }
             TypeInfo::Alias { .. } => {
-                if let TypeInfo::Alias { ty, .. } = type_engine.get(resolved_type_id).deref() {
+                if let TypeInfo::Alias { ty, .. } = &*type_engine.get(resolved_type_id) {
                     ty.initial_type_id.get_abi_type_components(
                         ctx,
                         type_engine,
@@ -627,7 +625,7 @@ impl TypeId {
         resolved_type_id: TypeId,
     ) -> Option<Vec<program_abi::TypeApplication>> {
         let resolved_params = resolved_type_id.get_type_parameters(type_engine, decl_engine);
-        match type_engine.get(*self).deref() {
+        match &*type_engine.get(*self) {
             TypeInfo::Custom {
                 type_arguments: Some(type_arguments),
                 ..

--- a/sway-core/src/concurrent_slab.rs
+++ b/sway-core/src/concurrent_slab.rs
@@ -53,8 +53,8 @@ where
     T: Clone,
 {
     pub fn len(&self) -> usize {
-        let lock = self.inner.read().unwrap();
-        lock.len()
+        let inner = self.inner.read().unwrap();
+        inner.len()
     }
 
     pub fn insert(&self, value: T) -> usize {

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -1,8 +1,6 @@
 //! This is the flow graph, a graph which contains edges that represent possible steps of program
 //! execution.
 
-use std::ops::Deref;
-
 use crate::{
     control_flow_analysis::*,
     language::{
@@ -225,7 +223,7 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             let impl_trait = decl_engine.get_impl_trait(decl_id);
             let ty::TyImplTrait {
                 trait_name, items, ..
-            } = impl_trait.deref();
+            } = &*impl_trait;
             let entry_node = graph.add_node(ControlFlowGraphNode::from_node(node));
             for leaf in leaves {
                 graph.add_edge(*leaf, entry_node, "".into());

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -1,6 +1,8 @@
 //! This is the flow graph, a graph which contains edges that represent possible steps of program
 //! execution.
 
+use std::ops::Deref;
+
 use crate::{
     control_flow_analysis::*,
     language::{
@@ -220,15 +222,16 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             Ok(leaves.to_vec())
         }
         ty::TyDecl::ImplTrait(ty::ImplTrait { decl_id, .. }) => {
+            let impl_trait = decl_engine.get_impl_trait(decl_id);
             let ty::TyImplTrait {
                 trait_name, items, ..
-            } = decl_engine.get_impl_trait(decl_id);
+            } = impl_trait.deref();
             let entry_node = graph.add_node(ControlFlowGraphNode::from_node(node));
             for leaf in leaves {
                 graph.add_edge(*leaf, entry_node, "".into());
             }
 
-            connect_impl_trait(engines, &trait_name, graph, &items, entry_node)?;
+            connect_impl_trait(engines, trait_name, graph, items, entry_node)?;
             Ok(leaves.to_vec())
         }
         ty::TyDecl::ErrorRecovery(..) => Ok(leaves.to_vec()),

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -2177,9 +2177,9 @@ fn connect_type_id<'eng: 'cfg, 'cfg>(
     let decl_engine = engines.de();
     let type_engine = engines.te();
 
-    match type_engine.get(type_id) {
+    match type_engine.get(type_id).deref() {
         TypeInfo::Enum(decl_ref) => {
-            let decl = decl_engine.get_enum(&decl_ref);
+            let decl = decl_engine.get_enum(decl_ref);
             let enum_idx = graph.namespace.find_enum(decl.name());
             if let Some(enum_idx) = enum_idx.cloned() {
                 graph.add_edge(entry_node, enum_idx, "".into());
@@ -2189,7 +2189,7 @@ fn connect_type_id<'eng: 'cfg, 'cfg>(
             }
         }
         TypeInfo::Struct(decl_ref) => {
-            let decl = decl_engine.get_struct(&decl_ref);
+            let decl = decl_engine.get_struct(decl_ref);
             let struct_idx = graph.namespace.find_struct_decl(decl.name().as_str());
             if let Some(struct_idx) = struct_idx.cloned() {
                 graph.add_edge(entry_node, struct_idx, "".into());
@@ -2199,7 +2199,7 @@ fn connect_type_id<'eng: 'cfg, 'cfg>(
             }
         }
         TypeInfo::Alias { name, .. } => {
-            let alias_idx = graph.namespace.get_alias(&name);
+            let alias_idx = graph.namespace.get_alias(name);
             if let Some(alias_idx) = alias_idx.cloned() {
                 graph.add_edge(entry_node, alias_idx, "".into());
             }

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -11,7 +11,10 @@ use crate::{
     Engines, TypeArgument, TypeEngine, TypeId,
 };
 use petgraph::{prelude::NodeIndex, visit::Dfs};
-use std::collections::{BTreeSet, HashMap};
+use std::{
+    collections::{BTreeSet, HashMap},
+    ops::Deref,
+};
 use sway_ast::Intrinsic;
 use sway_error::{error::CompileError, type_error::TypeError};
 use sway_error::{
@@ -484,12 +487,13 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             result
         }
         ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
+            let const_decl = decl_engine.get_constant(decl_id);
             let ty::TyConstantDecl {
                 call_path, value, ..
-            } = decl_engine.get_constant(decl_id);
+            } = const_decl.deref();
             graph
                 .namespace
-                .insert_global_constant(call_path.suffix, entry_node);
+                .insert_global_constant(call_path.suffix.clone(), entry_node);
             if let Some(value) = &value {
                 connect_expression(
                     engines,
@@ -539,19 +543,20 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             Ok(leaves.to_vec())
         }
         ty::TyDecl::ImplTrait(ty::ImplTrait { decl_id, .. }) => {
+            let impl_trait_decl = decl_engine.get_impl_trait(decl_id);
             let ty::TyImplTrait {
                 trait_name,
                 items,
                 trait_decl_ref,
                 implementing_for,
                 ..
-            } = decl_engine.get_impl_trait(decl_id);
+            } = impl_trait_decl.deref();
 
             connect_impl_trait(
                 engines,
-                &trait_name,
+                trait_name,
                 graph,
-                &items,
+                items,
                 entry_node,
                 tree_type,
                 trait_decl_ref,
@@ -641,8 +646,8 @@ fn connect_impl_trait<'eng: 'cfg, 'cfg>(
     items: &[TyImplItem],
     entry_node: NodeIndex,
     tree_type: &TreeType,
-    trait_decl_ref: Option<DeclRef<InterfaceDeclId>>,
-    implementing_for: TypeArgument,
+    trait_decl_ref: &Option<DeclRef<InterfaceDeclId>>,
+    implementing_for: &TypeArgument,
     options: NodeConnectionOptions,
 ) -> Result<(), CompileError> {
     let decl_engine = engines.de();
@@ -670,7 +675,7 @@ fn connect_impl_trait<'eng: 'cfg, 'cfg>(
     if let Some(trait_decl_ref) = trait_decl_ref {
         if let InterfaceDeclId::Trait(trait_decl_id) = &trait_decl_ref.id() {
             let trait_decl = decl_engine.get_trait(trait_decl_id);
-            for trait_item in trait_decl.items {
+            for trait_item in trait_decl.items.clone() {
                 if let ty::TyTraitItem::Fn(func_decl_ref) = trait_item {
                     let functional_decl_id = decl_engine.get_function(&func_decl_ref);
                     trait_items_method_names.push(functional_decl_id.name.as_str().to_string());
@@ -1060,31 +1065,31 @@ fn get_trait_fn_node_index<'a>(
 ) -> Result<Option<&'a NodeIndex>, CompileError> {
     let decl_engine = engines.de();
     let fn_decl = decl_engine.get_function(&function_decl_ref);
-    if let Some(implementing_type) = fn_decl.implementing_type {
+    if let Some(implementing_type) = &fn_decl.implementing_type {
         match implementing_type {
             ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. }) => {
-                let trait_decl = decl_engine.get_trait(&decl_id);
+                let trait_decl = decl_engine.get_trait(decl_id);
                 Ok(graph
                     .namespace
-                    .find_trait_method(&trait_decl.name.into(), &fn_decl.name))
+                    .find_trait_method(&trait_decl.name.clone().into(), &fn_decl.name))
             }
             ty::TyDecl::StructDecl(ty::StructDecl { decl_id, .. }) => {
-                let struct_decl = decl_engine.get_struct(&decl_id);
+                let struct_decl = decl_engine.get_struct(decl_id);
                 Ok(graph
                     .namespace
-                    .find_trait_method(&struct_decl.call_path.suffix.into(), &fn_decl.name))
+                    .find_trait_method(&struct_decl.call_path.suffix.clone().into(), &fn_decl.name))
             }
             ty::TyDecl::ImplTrait(ty::ImplTrait { decl_id, .. }) => {
-                let impl_trait = decl_engine.get_impl_trait(&decl_id);
+                let impl_trait = decl_engine.get_impl_trait(decl_id);
                 Ok(graph
                     .namespace
                     .find_trait_method(&impl_trait.trait_name, &fn_decl.name))
             }
             ty::TyDecl::AbiDecl(ty::AbiDecl { decl_id, .. }) => {
-                let abi_decl = decl_engine.get_abi(&decl_id);
+                let abi_decl = decl_engine.get_abi(decl_id);
                 Ok(graph
                     .namespace
-                    .find_trait_method(&abi_decl.name.into(), &fn_decl.name))
+                    .find_trait_method(&abi_decl.name.clone().into(), &fn_decl.name))
             }
             _ => Err(CompileError::Internal(
                 "Could not get node index for trait function",
@@ -1514,7 +1519,7 @@ fn connect_expression<'eng: 'cfg, 'cfg>(
                 .expect_struct(&Handler::default(), engines, field_instantiation_span)
                 .ok()
             {
-                Some(struct_decl_ref) => decl_engine.get_struct(&struct_decl_ref).call_path,
+                Some(struct_decl_ref) => decl_engine.get_struct(&struct_decl_ref).call_path.clone(),
                 None => {
                     return Err(CompileError::Internal(
                         "Called subfield on a non-struct",
@@ -2086,7 +2091,7 @@ fn construct_dead_code_warning_from_node(
                 })),
             span,
         } => {
-            let ty::TyImplTrait { .. } = decl_engine.get_impl_trait(decl_id);
+            let ty::TyImplTrait { .. } = decl_engine.get_impl_trait(decl_id).deref();
             CompileWarning {
                 span: span.clone(),
                 warning_content: Warning::DeadDeclaration,
@@ -2179,7 +2184,7 @@ fn connect_type_id<'eng: 'cfg, 'cfg>(
             if let Some(enum_idx) = enum_idx.cloned() {
                 graph.add_edge(entry_node, enum_idx, "".into());
             }
-            for type_param in decl.type_parameters {
+            for type_param in &decl.type_parameters {
                 connect_type_id(engines, type_param.type_id, graph, entry_node)?;
             }
         }
@@ -2189,7 +2194,7 @@ fn connect_type_id<'eng: 'cfg, 'cfg>(
             if let Some(struct_idx) = struct_idx.cloned() {
                 graph.add_edge(entry_node, struct_idx, "".into());
             }
-            for type_param in decl.type_parameters {
+            for type_param in &decl.type_parameters {
                 connect_type_id(engines, type_param.type_id, graph, entry_node)?;
             }
         }
@@ -2251,36 +2256,38 @@ fn allow_dead_code_ast_node(decl_engine: &DeclEngine, node: &ty::TyAstNode) -> b
         ty::TyAstNodeContent::Declaration(decl) => match &decl {
             ty::TyDecl::VariableDecl(_) => false,
             ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
-                allow_dead_code(decl_engine.get_constant(decl_id).attributes)
+                allow_dead_code(decl_engine.get_constant(decl_id).attributes.clone())
             }
             ty::TyDecl::TraitTypeDecl(ty::TraitTypeDecl { decl_id, .. }) => {
-                allow_dead_code(decl_engine.get_type(decl_id).attributes)
+                allow_dead_code(decl_engine.get_type(decl_id).attributes.clone())
             }
             ty::TyDecl::FunctionDecl(ty::FunctionDecl { decl_id, .. }) => {
-                allow_dead_code(decl_engine.get_function(decl_id).attributes)
+                allow_dead_code(decl_engine.get_function(decl_id).attributes.clone())
             }
             ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. }) => {
-                allow_dead_code(decl_engine.get_trait(decl_id).attributes)
+                allow_dead_code(decl_engine.get_trait(decl_id).attributes.clone())
             }
             ty::TyDecl::StructDecl(ty::StructDecl { decl_id, .. }) => {
-                allow_dead_code(decl_engine.get_struct(decl_id).attributes)
+                allow_dead_code(decl_engine.get_struct(decl_id).attributes.clone())
             }
             ty::TyDecl::EnumDecl(ty::EnumDecl { decl_id, .. }) => {
-                allow_dead_code(decl_engine.get_enum(decl_id).attributes)
+                allow_dead_code(decl_engine.get_enum(decl_id).attributes.clone())
             }
             ty::TyDecl::EnumVariantDecl(ty::EnumVariantDecl {
                 enum_ref,
                 variant_name,
                 ..
-            }) => decl_engine
-                .get_enum(enum_ref.id())
-                .variants
-                .into_iter()
-                .find(|v| v.name == *variant_name)
-                .map(|enum_variant| allow_dead_code(enum_variant.attributes))
-                .unwrap_or(false),
+            }) => {
+                let enum_decl = decl_engine.get_enum(enum_ref.id());
+                enum_decl
+                    .variants
+                    .iter()
+                    .find(|v| v.name == *variant_name)
+                    .map(|enum_variant| allow_dead_code(enum_variant.attributes.clone()))
+                    .unwrap_or(false)
+            }
             ty::TyDecl::TypeAliasDecl(ty::TypeAliasDecl { decl_id, .. }) => {
-                allow_dead_code(decl_engine.get_type_alias(decl_id).attributes)
+                allow_dead_code(decl_engine.get_type_alias(decl_id).attributes.clone())
             }
             ty::TyDecl::ImplTrait { .. } => false,
             ty::TyDecl::AbiDecl { .. } => false,
@@ -2312,11 +2319,11 @@ fn allow_dead_code_node(
             allow_dead_code_ast_node(decl_engine, node)
         }
         ControlFlowGraphNode::EnumVariant { enum_decl_id, .. } => {
-            allow_dead_code(decl_engine.get_enum(enum_decl_id).attributes)
+            allow_dead_code(decl_engine.get_enum(enum_decl_id).attributes.clone())
         }
         ControlFlowGraphNode::MethodDeclaration {
             method_decl_ref, ..
-        } => allow_dead_code(decl_engine.get_function(method_decl_ref).attributes),
+        } => allow_dead_code(decl_engine.get_function(method_decl_ref).attributes.clone()),
         ControlFlowGraphNode::StructField {
             struct_decl_id,
             attributes,
@@ -2325,7 +2332,7 @@ fn allow_dead_code_node(
             if allow_dead_code(attributes.clone()) {
                 true
             } else {
-                allow_dead_code(decl_engine.get_struct(struct_decl_id).attributes)
+                allow_dead_code(decl_engine.get_struct(struct_decl_id).attributes.clone())
             }
         }
         ControlFlowGraphNode::StorageField { .. } => false,

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -11,10 +11,7 @@ use crate::{
     Engines, TypeArgument, TypeEngine, TypeId,
 };
 use petgraph::{prelude::NodeIndex, visit::Dfs};
-use std::{
-    collections::{BTreeSet, HashMap},
-    ops::Deref,
-};
+use std::collections::{BTreeSet, HashMap};
 use sway_ast::Intrinsic;
 use sway_error::{error::CompileError, type_error::TypeError};
 use sway_error::{
@@ -490,7 +487,7 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             let const_decl = decl_engine.get_constant(decl_id);
             let ty::TyConstantDecl {
                 call_path, value, ..
-            } = const_decl.deref();
+            } = &*const_decl;
             graph
                 .namespace
                 .insert_global_constant(call_path.suffix.clone(), entry_node);
@@ -550,7 +547,7 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
                 trait_decl_ref,
                 implementing_for,
                 ..
-            } = impl_trait_decl.deref();
+            } = &*impl_trait_decl;
 
             connect_impl_trait(
                 engines,
@@ -2091,7 +2088,7 @@ fn construct_dead_code_warning_from_node(
                 })),
             span,
         } => {
-            let ty::TyImplTrait { .. } = decl_engine.get_impl_trait(decl_id).deref();
+            let ty::TyImplTrait { .. } = &*decl_engine.get_impl_trait(decl_id);
             CompileWarning {
                 span: span.clone(),
                 warning_content: Warning::DeadDeclaration,
@@ -2177,7 +2174,7 @@ fn connect_type_id<'eng: 'cfg, 'cfg>(
     let decl_engine = engines.de();
     let type_engine = engines.te();
 
-    match type_engine.get(type_id).deref() {
+    match &*type_engine.get(type_id) {
         TypeInfo::Enum(decl_ref) => {
             let decl = decl_engine.get_enum(decl_ref);
             let enum_idx = graph.namespace.find_enum(decl.name());

--- a/sway-core/src/control_flow_analysis/flow_graph/mod.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/mod.rs
@@ -143,7 +143,7 @@ impl<'cfg> DebugWithEngines for ControlFlowGraphNode<'cfg> {
             } => {
                 let decl_engines = engines.de();
                 let method = decl_engines.get_function(method_decl_ref);
-                if let Some(implementing_type) = method.implementing_type {
+                if let Some(implementing_type) = &method.implementing_type {
                     format!(
                         "Method {}.{}",
                         implementing_type.friendly_name(engines),

--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -131,7 +131,7 @@ macro_rules! decl_engine_replace {
     ($slab:ident, $decl:ty) => {
         impl DeclEngineReplace<$decl> for DeclEngine {
             fn replace(&self, index: DeclId<$decl>, decl: $decl) {
-                self.$slab.replace(index, decl);
+                self.$slab.replace(index.inner(), decl);
             }
         }
     };

--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -1,7 +1,8 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     fmt::Write,
-    sync::RwLock,
+    ops::Deref,
+    sync::{Arc, RwLock},
 };
 
 use sway_types::{ModuleId, Named, Spanned};
@@ -35,7 +36,7 @@ pub struct DeclEngine {
 }
 
 pub trait DeclEngineGet<I, U> {
-    fn get(&self, index: &I) -> U;
+    fn get(&self, index: &I) -> Arc<U>;
 }
 
 pub trait DeclEngineInsert<T>
@@ -43,6 +44,13 @@ where
     T: Named + Spanned,
 {
     fn insert(&self, decl: T) -> DeclRef<DeclId<T>>;
+}
+
+pub trait DeclEngineInsertArc<T>
+where
+    T: Named + Spanned,
+{
+    fn insert_arc(&self, decl: Arc<T>) -> DeclRef<DeclId<T>>;
 }
 
 pub trait DeclEngineReplace<T> {
@@ -59,13 +67,13 @@ where
 macro_rules! decl_engine_get {
     ($slab:ident, $decl:ty) => {
         impl DeclEngineGet<DeclId<$decl>, $decl> for DeclEngine {
-            fn get(&self, index: &DeclId<$decl>) -> $decl {
+            fn get(&self, index: &DeclId<$decl>) -> Arc<$decl> {
                 self.$slab.get(index.inner())
             }
         }
 
         impl DeclEngineGet<DeclRef<DeclId<$decl>>, $decl> for DeclEngine {
-            fn get(&self, index: &DeclRef<DeclId<$decl>>) -> $decl {
+            fn get(&self, index: &DeclRef<DeclId<$decl>>) -> Arc<$decl> {
                 self.$slab.get(index.id().inner())
             }
         }
@@ -91,6 +99,16 @@ macro_rules! decl_engine_insert {
                 DeclRef::new(
                     decl.name().clone(),
                     DeclId::new(self.$slab.insert(decl)),
+                    span,
+                )
+            }
+        }
+        impl DeclEngineInsertArc<$decl> for DeclEngine {
+            fn insert_arc(&self, decl: Arc<$decl>) -> DeclRef<DeclId<$decl>> {
+                let span = decl.span();
+                DeclRef::new(
+                    decl.name().clone(),
+                    DeclId::new(self.$slab.insert_arc(decl)),
                     span,
                 )
             }
@@ -242,7 +260,7 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_function<I>(&self, index: &I) -> ty::TyFunctionDecl
+    pub fn get_function<I>(&self, index: &I) -> Arc<ty::TyFunctionDecl>
     where
         DeclEngine: DeclEngineGet<I, ty::TyFunctionDecl>,
     {
@@ -254,7 +272,7 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_trait<I>(&self, index: &I) -> ty::TyTraitDecl
+    pub fn get_trait<I>(&self, index: &I) -> Arc<ty::TyTraitDecl>
     where
         DeclEngine: DeclEngineGet<I, ty::TyTraitDecl>,
     {
@@ -266,13 +284,14 @@ impl DeclEngine {
     /// The method does a linear search over all the declared traits and is meant
     /// to be used only for diagnostic purposes.
     pub fn get_traits_by_name(&self, trait_name: &Ident) -> Vec<ty::TyTraitDecl> {
-        self.trait_slab.with_slice(|elems| {
-            elems
-                .iter()
-                .filter(|trait_decl| trait_decl.name == *trait_name)
-                .cloned()
-                .collect()
-        })
+        let mut vec = vec![];
+        for i in 0..self.trait_slab.len() {
+            let trait_decl = self.trait_slab.get(i);
+            if trait_decl.name == *trait_name {
+                vec.push(trait_decl.deref().clone())
+            }
+        }
+        vec
     }
 
     /// Friendly helper method for calling the `get` method from the
@@ -280,7 +299,7 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_trait_fn<I>(&self, index: &I) -> ty::TyTraitFn
+    pub fn get_trait_fn<I>(&self, index: &I) -> Arc<ty::TyTraitFn>
     where
         DeclEngine: DeclEngineGet<I, ty::TyTraitFn>,
     {
@@ -292,7 +311,7 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_impl_trait<I>(&self, index: &I) -> ty::TyImplTrait
+    pub fn get_impl_trait<I>(&self, index: &I) -> Arc<ty::TyImplTrait>
     where
         DeclEngine: DeclEngineGet<I, ty::TyImplTrait>,
     {
@@ -304,7 +323,7 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_struct<I>(&self, index: &I) -> ty::TyStructDecl
+    pub fn get_struct<I>(&self, index: &I) -> Arc<ty::TyStructDecl>
     where
         DeclEngine: DeclEngineGet<I, ty::TyStructDecl>,
     {
@@ -316,7 +335,7 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_storage<I>(&self, index: &I) -> ty::TyStorageDecl
+    pub fn get_storage<I>(&self, index: &I) -> Arc<ty::TyStorageDecl>
     where
         DeclEngine: DeclEngineGet<I, ty::TyStorageDecl>,
     {
@@ -328,7 +347,7 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_abi<I>(&self, index: &I) -> ty::TyAbiDecl
+    pub fn get_abi<I>(&self, index: &I) -> Arc<ty::TyAbiDecl>
     where
         DeclEngine: DeclEngineGet<I, ty::TyAbiDecl>,
     {
@@ -340,7 +359,7 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_constant<I>(&self, index: &I) -> ty::TyConstantDecl
+    pub fn get_constant<I>(&self, index: &I) -> Arc<ty::TyConstantDecl>
     where
         DeclEngine: DeclEngineGet<I, ty::TyConstantDecl>,
     {
@@ -352,7 +371,7 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_type<I>(&self, index: &I) -> ty::TyTraitType
+    pub fn get_type<I>(&self, index: &I) -> Arc<ty::TyTraitType>
     where
         DeclEngine: DeclEngineGet<I, ty::TyTraitType>,
     {
@@ -364,7 +383,7 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_enum<I>(&self, index: &I) -> ty::TyEnumDecl
+    pub fn get_enum<I>(&self, index: &I) -> Arc<ty::TyEnumDecl>
     where
         DeclEngine: DeclEngineGet<I, ty::TyEnumDecl>,
     {
@@ -376,7 +395,7 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_type_alias<I>(&self, index: &I) -> ty::TyTypeAliasDecl
+    pub fn get_type_alias<I>(&self, index: &I) -> Arc<ty::TyTypeAliasDecl>
     where
         DeclEngine: DeclEngineGet<I, ty::TyTypeAliasDecl>,
     {
@@ -388,13 +407,15 @@ impl DeclEngine {
     /// [DisplayWithEngines].
     pub fn pretty_print(&self, engines: &Engines) -> String {
         let mut builder = String::new();
-        self.function_slab.with_slice(|elems| {
-            let list = elems
-                .iter()
-                .map(|type_info| format!("{:?}", engines.help_out(type_info)));
-            let list = ListDisplay { list };
-            write!(builder, "DeclEngine {{\n{list}\n}}").unwrap();
-        });
+        let mut list = vec![];
+        for i in 0..self.function_slab.len() {
+            list.push(format!(
+                "{:?}",
+                engines.help_out(self.function_slab.get(i).deref())
+            ));
+        }
+        let list = ListDisplay { list };
+        write!(builder, "DeclEngine {{\n{list}\n}}").unwrap();
         builder
     }
 }

--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     fmt::Write,
-    ops::Deref,
     sync::{Arc, RwLock},
 };
 
@@ -288,7 +287,7 @@ impl DeclEngine {
         for i in 0..self.trait_slab.len() {
             let trait_decl = self.trait_slab.get(i);
             if trait_decl.name == *trait_name {
-                vec.push(trait_decl.deref().clone())
+                vec.push((*trait_decl).clone())
             }
         }
         vec
@@ -411,7 +410,7 @@ impl DeclEngine {
         for i in 0..self.function_slab.len() {
             list.push(format!(
                 "{:?}",
-                engines.help_out(self.function_slab.get(i).deref())
+                engines.help_out(&*self.function_slab.get(i))
             ));
         }
         let list = ListDisplay { list };

--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -1,5 +1,4 @@
 use std::marker::PhantomData;
-use std::ops::Deref;
 use std::{fmt, hash::Hash};
 
 use crate::language::ty::TyTraitType;
@@ -84,7 +83,7 @@ impl<T> Into<usize> for DeclId<T> {
 impl SubstTypes for DeclId<TyFunctionDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self).deref().clone();
+        let mut decl = (*decl_engine.get(self)).clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -92,7 +91,7 @@ impl SubstTypes for DeclId<TyFunctionDecl> {
 impl SubstTypes for DeclId<TyTraitDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self).deref().clone();
+        let mut decl = (*decl_engine.get(self)).clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -100,7 +99,7 @@ impl SubstTypes for DeclId<TyTraitDecl> {
 impl SubstTypes for DeclId<TyTraitFn> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self).deref().clone();
+        let mut decl = (*decl_engine.get(self)).clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -108,7 +107,7 @@ impl SubstTypes for DeclId<TyTraitFn> {
 impl SubstTypes for DeclId<TyImplTrait> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self).deref().clone();
+        let mut decl = (*decl_engine.get(self)).clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -116,7 +115,7 @@ impl SubstTypes for DeclId<TyImplTrait> {
 impl SubstTypes for DeclId<TyStructDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self).deref().clone();
+        let mut decl = (*decl_engine.get(self)).clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -124,7 +123,7 @@ impl SubstTypes for DeclId<TyStructDecl> {
 impl SubstTypes for DeclId<TyEnumDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self).deref().clone();
+        let mut decl = (*decl_engine.get(self)).clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -132,7 +131,7 @@ impl SubstTypes for DeclId<TyEnumDecl> {
 impl SubstTypes for DeclId<TyTypeAliasDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self).deref().clone();
+        let mut decl = (*decl_engine.get(self)).clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -141,7 +140,7 @@ impl SubstTypes for DeclId<TyTypeAliasDecl> {
 impl SubstTypes for DeclId<TyTraitType> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self).deref().clone();
+        let mut decl = (*decl_engine.get(self)).clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }

--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::ops::Deref;
 use std::{fmt, hash::Hash};
 
 use crate::language::ty::TyTraitType;
@@ -83,7 +84,7 @@ impl<T> Into<usize> for DeclId<T> {
 impl SubstTypes for DeclId<TyFunctionDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self);
+        let mut decl = decl_engine.get(self).deref().clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -91,7 +92,7 @@ impl SubstTypes for DeclId<TyFunctionDecl> {
 impl SubstTypes for DeclId<TyTraitDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self);
+        let mut decl = decl_engine.get(self).deref().clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -99,7 +100,7 @@ impl SubstTypes for DeclId<TyTraitDecl> {
 impl SubstTypes for DeclId<TyTraitFn> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self);
+        let mut decl = decl_engine.get(self).deref().clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -107,7 +108,7 @@ impl SubstTypes for DeclId<TyTraitFn> {
 impl SubstTypes for DeclId<TyImplTrait> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self);
+        let mut decl = decl_engine.get(self).deref().clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -115,7 +116,7 @@ impl SubstTypes for DeclId<TyImplTrait> {
 impl SubstTypes for DeclId<TyStructDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self);
+        let mut decl = decl_engine.get(self).deref().clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -123,7 +124,7 @@ impl SubstTypes for DeclId<TyStructDecl> {
 impl SubstTypes for DeclId<TyEnumDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self);
+        let mut decl = decl_engine.get(self).deref().clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -131,7 +132,7 @@ impl SubstTypes for DeclId<TyEnumDecl> {
 impl SubstTypes for DeclId<TyTypeAliasDecl> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self);
+        let mut decl = decl_engine.get(self).deref().clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }
@@ -140,7 +141,7 @@ impl SubstTypes for DeclId<TyTypeAliasDecl> {
 impl SubstTypes for DeclId<TyTraitType> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(self);
+        let mut decl = decl_engine.get(self).deref().clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
     }

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -20,10 +20,7 @@
 //! `fn my_function() { .. }`, and to use [DeclRef] for cases like function
 //! application `my_function()`.
 
-use std::{
-    hash::{Hash, Hasher},
-    ops::Deref,
-};
+use std::hash::{Hash, Hasher};
 
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::{Ident, Named, Span, Spanned};
@@ -117,7 +114,7 @@ where
         engines: &Engines,
     ) -> Self {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(&self.id).deref().clone();
+        let mut decl = (*decl_engine.get(&self.id)).clone();
         decl.subst(type_mapping, engines);
         decl_engine.insert(decl)
     }
@@ -150,7 +147,7 @@ where
         engines: &Engines,
     ) -> Self {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(&self.id).deref().clone();
+        let mut decl = (*decl_engine.get(&self.id)).clone();
         decl.subst(type_mapping, engines);
         decl_engine
             .insert(decl)
@@ -171,7 +168,7 @@ where
         ctx: &mut TypeCheckContext,
     ) -> Result<Self, ErrorEmitted> {
         let decl_engine = ctx.engines().de();
-        let mut decl = decl_engine.get(&self.id).deref().clone();
+        let mut decl = (*decl_engine.get(&self.id)).clone();
         decl.replace_decls(decl_mapping, handler, ctx)?;
         Ok(decl_engine
             .insert(decl)
@@ -287,7 +284,7 @@ where
 {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(&self.id).deref().clone();
+        let mut decl = (*decl_engine.get(&self.id)).clone();
         decl.subst(type_mapping, engines);
         decl_engine.replace(self.id, decl);
     }
@@ -324,7 +321,7 @@ impl ReplaceDecls for DeclRefFunction {
 impl ReplaceFunctionImplementingType for DeclRefFunction {
     fn replace_implementing_type(&mut self, engines: &Engines, implementing_type: ty::TyDecl) {
         let decl_engine = engines.de();
-        let mut decl = decl_engine.get(&self.id).deref().clone();
+        let mut decl = (*decl_engine.get(&self.id)).clone();
         decl.set_implementing_type(implementing_type);
         decl_engine.replace(self.id, decl);
     }

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -18,7 +18,7 @@ use sway_error::{error::CompileError, handler::Handler};
 use sway_ir::{metadata::combine as md_combine, *};
 use sway_types::Spanned;
 
-use std::{collections::HashMap, ops::Deref, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn compile_script(
@@ -222,7 +222,7 @@ pub(crate) fn compile_constants(
                     lookup: compile_const_decl,
                 },
                 &call_path,
-                &Some(const_decl.deref().clone()),
+                &Some((*const_decl).clone()),
             )?;
         }
     }
@@ -267,7 +267,7 @@ fn compile_declarations(
                         lookup: compile_const_decl,
                     },
                     &call_path,
-                    &Some(decl.deref().clone()),
+                    &Some((*decl).clone()),
                 )?;
             }
 

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -18,7 +18,7 @@ use sway_error::{error::CompileError, handler::Handler};
 use sway_ir::{metadata::combine as md_combine, *};
 use sway_types::Spanned;
 
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Deref, sync::Arc};
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn compile_script(
@@ -29,7 +29,7 @@ pub(super) fn compile_script(
     declarations: &[ty::TyDecl],
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
-    test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
+    test_fns: &[(Arc<ty::TyFunctionDecl>, DeclRefFunction)],
 ) -> Result<Module, Vec<CompileError>> {
     let module = Module::new(context, Kind::Script);
     let mut md_mgr = MetadataManager::default();
@@ -76,7 +76,7 @@ pub(super) fn compile_predicate(
     declarations: &[ty::TyDecl],
     logged_types: &HashMap<TypeId, LogId>,
     messages_types: &HashMap<TypeId, MessageId>,
-    test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
+    test_fns: &[(Arc<ty::TyFunctionDecl>, DeclRefFunction)],
 ) -> Result<Module, Vec<CompileError>> {
     let module = Module::new(context, Kind::Predicate);
     let mut md_mgr = MetadataManager::default();
@@ -122,7 +122,7 @@ pub(super) fn compile_contract(
     declarations: &[ty::TyDecl],
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
-    test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
+    test_fns: &[(Arc<ty::TyFunctionDecl>, DeclRefFunction)],
     engines: &Engines,
 ) -> Result<Module, Vec<CompileError>> {
     let module = Module::new(context, Kind::Contract);
@@ -170,7 +170,7 @@ pub(super) fn compile_library(
     declarations: &[ty::TyDecl],
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
-    test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
+    test_fns: &[(Arc<ty::TyFunctionDecl>, DeclRefFunction)],
 ) -> Result<Module, Vec<CompileError>> {
     let module = Module::new(context, Kind::Library);
     let mut md_mgr = MetadataManager::default();
@@ -222,7 +222,7 @@ pub(crate) fn compile_constants(
                     lookup: compile_const_decl,
                 },
                 &call_path,
-                &Some(const_decl),
+                &Some(const_decl.deref().clone()),
             )?;
         }
     }
@@ -267,7 +267,7 @@ fn compile_declarations(
                         lookup: compile_const_decl,
                     },
                     &call_path,
-                    &Some(decl),
+                    &Some(decl.deref().clone()),
                 )?;
             }
 
@@ -373,7 +373,7 @@ pub(super) fn compile_tests(
     module: Module,
     logged_types_map: &HashMap<TypeId, LogId>,
     messages_types_map: &HashMap<TypeId, MessageId>,
-    test_fns: &[(ty::TyFunctionDecl, DeclRefFunction)],
+    test_fns: &[(Arc<ty::TyFunctionDecl>, DeclRefFunction)],
 ) -> Result<Vec<Function>, Vec<CompileError>> {
     test_fns
         .iter()

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -267,7 +267,7 @@ fn const_eval_typed_expr(
 ) -> Result<Option<Constant>, ConstEvalError> {
     Ok(match &expr.expression {
         ty::TyExpressionVariant::Literal(Literal::Numeric(n)) => {
-            let implied_lit = match lookup.engines.te().get(expr.return_type) {
+            let implied_lit = match lookup.engines.te().get(expr.return_type).deref() {
                 TypeInfo::UnsignedInteger(IntegerBits::Eight) => Literal::U8(*n as u8),
                 _ => Literal::U64(*n),
             };

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitAnd, BitOr, BitXor, Not, Rem};
+use std::ops::{BitAnd, BitOr, BitXor, Deref, Not, Rem};
 
 use crate::{
     engine_threading::*,
@@ -132,7 +132,7 @@ pub(crate) fn compile_const_decl(
             let const_decl = match decl {
                 Ok(decl) => match decl {
                     ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
-                        Some(env.engines.de().get_constant(decl_id))
+                        Some(env.engines.de().get_constant(decl_id).deref().clone())
                     }
                     _otherwise => const_decl.cloned(),
                 },
@@ -158,7 +158,7 @@ pub(crate) fn compile_const_decl(
                         env.module_ns,
                         env.function_compiler,
                         &call_path,
-                        &value.unwrap(),
+                        &value.clone().unwrap(),
                         is_configurable,
                     )?;
 
@@ -671,6 +671,7 @@ fn const_eval_codeblock(
                 let ty_const_decl = lookup.engines.de().get_constant(&const_decl.decl_id);
                 if let Some(constant) = ty_const_decl
                     .value
+                    .clone()
                     .and_then(|expr| const_eval_typed_expr(lookup, known_consts, &expr).ok())
                     .flatten()
                 {
@@ -1160,7 +1161,7 @@ mod tests {
             ty::TyAstNodeContent::Expression(expr_under_test) => expr_under_test.clone(),
             ty::TyAstNodeContent::Declaration(crate::language::ty::TyDecl::ConstantDecl(decl)) => {
                 let decl = engines.de().get_constant(&decl.decl_id);
-                decl.value.unwrap()
+                decl.value.clone().unwrap()
             }
             x => todo!("{x:?}"),
         };

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitAnd, BitOr, BitXor, Deref, Not, Rem};
+use std::ops::{BitAnd, BitOr, BitXor, Not, Rem};
 
 use crate::{
     engine_threading::*,
@@ -132,7 +132,7 @@ pub(crate) fn compile_const_decl(
             let const_decl = match decl {
                 Ok(decl) => match decl {
                     ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
-                        Some(env.engines.de().get_constant(decl_id).deref().clone())
+                        Some((*env.engines.de().get_constant(decl_id)).clone())
                     }
                     _otherwise => const_decl.cloned(),
                 },
@@ -267,7 +267,7 @@ fn const_eval_typed_expr(
 ) -> Result<Option<Constant>, ConstEvalError> {
     Ok(match &expr.expression {
         ty::TyExpressionVariant::Literal(Literal::Numeric(n)) => {
-            let implied_lit = match lookup.engines.te().get(expr.return_type).deref() {
+            let implied_lit = match &*lookup.engines.te().get(expr.return_type) {
                 TypeInfo::UnsignedInteger(IntegerBits::Eight) => Literal::U8(*n as u8),
                 _ => Literal::U64(*n),
             };

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -1,7 +1,6 @@
 use std::{
     fmt::{self, Debug},
     hash::{Hash, Hasher},
-    ops::Deref,
 };
 
 use sway_error::handler::{ErrorEmitted, Handler};
@@ -209,7 +208,7 @@ impl TyAstNode {
                 let fn_decl = decl_engine.get_function(decl_id);
                 let TyFunctionDecl {
                     type_parameters, ..
-                } = fn_decl.deref();
+                } = &*fn_decl;
                 !type_parameters.is_empty()
             }
             _ => false,
@@ -228,7 +227,7 @@ impl TyAstNode {
                 ..
             } => {
                 let fn_decl = decl_engine.get_function(decl_id);
-                let TyFunctionDecl { attributes, .. } = fn_decl.deref();
+                let TyFunctionDecl { attributes, .. } = &*fn_decl;
                 attributes.contains_key(&AttributeKind::Test)
             }
             _ => false,
@@ -324,10 +323,10 @@ impl TyAstNode {
         match &self.content {
             TyAstNodeContent::Declaration(_) => TypeInfo::Tuple(Vec::new()),
             TyAstNodeContent::Expression(TyExpression { return_type, .. }) => {
-                type_engine.get(*return_type).deref().clone()
+                (*type_engine.get(*return_type)).clone()
             }
             TyAstNodeContent::ImplicitReturnExpression(TyExpression { return_type, .. }) => {
-                type_engine.get(*return_type).deref().clone()
+                (*type_engine.get(*return_type)).clone()
             }
             TyAstNodeContent::SideEffect(_) => TypeInfo::Tuple(Vec::new()),
             TyAstNodeContent::Error(_, error) => TypeInfo::ErrorRecovery(*error),

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -324,10 +324,10 @@ impl TyAstNode {
         match &self.content {
             TyAstNodeContent::Declaration(_) => TypeInfo::Tuple(Vec::new()),
             TyAstNodeContent::Expression(TyExpression { return_type, .. }) => {
-                type_engine.get(*return_type)
+                type_engine.get(*return_type).deref().clone()
             }
             TyAstNodeContent::ImplicitReturnExpression(TyExpression { return_type, .. }) => {
-                type_engine.get(*return_type)
+                type_engine.get(*return_type).deref().clone()
             }
             TyAstNodeContent::SideEffect(_) => TypeInfo::Tuple(Vec::new()),
             TyAstNodeContent::Error(_, error) => TypeInfo::ErrorRecovery(*error),

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt::{self, Debug},
     hash::{Hash, Hasher},
+    ops::Deref,
 };
 
 use sway_error::handler::{ErrorEmitted, Handler};
@@ -205,9 +206,10 @@ impl TyAstNode {
                     })),
                 ..
             } => {
+                let fn_decl = decl_engine.get_function(decl_id);
                 let TyFunctionDecl {
                     type_parameters, ..
-                } = decl_engine.get_function(decl_id);
+                } = fn_decl.deref();
                 !type_parameters.is_empty()
             }
             _ => false,
@@ -225,7 +227,8 @@ impl TyAstNode {
                     })),
                 ..
             } => {
-                let TyFunctionDecl { attributes, .. } = decl_engine.get_function(decl_id);
+                let fn_decl = decl_engine.get_function(decl_id);
+                let TyFunctionDecl { attributes, .. } = fn_decl.deref();
                 attributes.contains_key(&AttributeKind::Test)
             }
             _ => false,
@@ -345,14 +348,14 @@ impl TyAstNode {
                 }
                 TyDecl::ConstantDecl(decl) => {
                     let decl = engines.de().get(&decl.decl_id);
-                    if let Some(value) = decl.value {
+                    if let Some(value) = &decl.value {
                         value.check_deprecated(engines, handler, allow_deprecated);
                     }
                 }
                 TyDecl::TraitTypeDecl(_) => {}
                 TyDecl::FunctionDecl(decl) => {
                     let decl = engines.de().get(&decl.decl_id);
-                    let token = allow_deprecated.enter(decl.attributes);
+                    let token = allow_deprecated.enter(decl.attributes.clone());
                     for node in decl.body.contents.iter() {
                         node.check_deprecated(engines, handler, allow_deprecated);
                     }
@@ -364,7 +367,7 @@ impl TyAstNode {
                         match item {
                             TyTraitItem::Fn(item) => {
                                 let decl = engines.de().get(item.id());
-                                let token = allow_deprecated.enter(decl.attributes);
+                                let token = allow_deprecated.enter(decl.attributes.clone());
                                 for node in decl.body.contents.iter() {
                                     node.check_deprecated(engines, handler, allow_deprecated);
                                 }

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -417,7 +417,7 @@ impl DisplayWithEngines for TyDecl {
                     builder.push_str(": ");
                     builder.push_str(
                         &engines
-                            .help_out(type_engine.get(type_ascription.type_id))
+                            .help_out(type_engine.get(type_ascription.type_id).deref())
                             .to_string(),
                     );
                     builder.push_str(" = ");
@@ -463,7 +463,7 @@ impl DebugWithEngines for TyDecl {
                     builder.push_str(
                         format!(
                             "{:?}",
-                            engines.help_out(type_engine.get(type_ascription.type_id))
+                            engines.help_out(type_engine.get(type_ascription.type_id).deref())
                         )
                         .as_str(),
                     );
@@ -579,8 +579,8 @@ impl TyDecl {
             // `Self` type parameter might resolve to an Enum
             TyDecl::GenericTypeForFunctionScope(GenericTypeForFunctionScope {
                 type_id, ..
-            }) => match engines.te().get(*type_id) {
-                TypeInfo::Enum(r) => Ok(r),
+            }) => match engines.te().get(*type_id).deref() {
+                TypeInfo::Enum(r) => Ok(r.clone()),
                 _ => Err(handler.emit_err(CompileError::DeclIsNotAnEnum {
                     actually: self.friendly_type_name().to_string(),
                     span: self.span(),
@@ -714,7 +714,8 @@ impl TyDecl {
         match self {
             TyDecl::ImplTrait(ImplTrait { decl_id, .. }) => {
                 let decl = decl_engine.get_impl_trait(decl_id);
-                let implementing_for_type_id = type_engine.get(decl.implementing_for.type_id);
+                let implementing_for_type_id_arc = type_engine.get(decl.implementing_for.type_id);
+                let implementing_for_type_id = implementing_for_type_id_arc.deref();
                 format!(
                     "{} for {:?}",
                     self.get_decl_ident()

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -1,7 +1,6 @@
 use std::{
     fmt,
     hash::{Hash, Hasher},
-    ops::Deref,
 };
 
 use sway_error::{
@@ -417,7 +416,7 @@ impl DisplayWithEngines for TyDecl {
                     builder.push_str(": ");
                     builder.push_str(
                         &engines
-                            .help_out(type_engine.get(type_ascription.type_id).deref())
+                            .help_out(&*type_engine.get(type_ascription.type_id))
                             .to_string(),
                     );
                     builder.push_str(" = ");
@@ -463,7 +462,7 @@ impl DebugWithEngines for TyDecl {
                     builder.push_str(
                         format!(
                             "{:?}",
-                            engines.help_out(type_engine.get(type_ascription.type_id).deref())
+                            engines.help_out(&*type_engine.get(type_ascription.type_id))
                         )
                         .as_str(),
                     );
@@ -506,7 +505,7 @@ impl CollectTypesMetadata for TyDecl {
             }
             TyDecl::ConstantDecl(ConstantDecl { decl_id, .. }) => {
                 let const_decl = decl_engine.get_constant(decl_id);
-                let TyConstantDecl { value, .. } = const_decl.deref();
+                let TyConstantDecl { value, .. } = &*const_decl;
                 if let Some(value) = value {
                     value.collect_types_metadata(handler, ctx)?
                 } else {
@@ -570,7 +569,7 @@ impl TyDecl {
             }) => Ok(DeclRef::new(name.clone(), *decl_id, decl_span.clone())),
             TyDecl::TypeAliasDecl(TypeAliasDecl { decl_id, .. }) => {
                 let alias_decl = engines.de().get_type_alias(decl_id);
-                let TyTypeAliasDecl { ty, span, .. } = alias_decl.deref();
+                let TyTypeAliasDecl { ty, span, .. } = &*alias_decl;
                 engines
                     .te()
                     .get(ty.type_id)
@@ -579,7 +578,7 @@ impl TyDecl {
             // `Self` type parameter might resolve to an Enum
             TyDecl::GenericTypeForFunctionScope(GenericTypeForFunctionScope {
                 type_id, ..
-            }) => match engines.te().get(*type_id).deref() {
+            }) => match &*engines.te().get(*type_id) {
                 TypeInfo::Enum(r) => Ok(r.clone()),
                 _ => Err(handler.emit_err(CompileError::DeclIsNotAnEnum {
                     actually: self.friendly_type_name().to_string(),
@@ -611,7 +610,7 @@ impl TyDecl {
             }) => Ok(DeclRef::new(name.clone(), *decl_id, decl_span.clone())),
             TyDecl::TypeAliasDecl(TypeAliasDecl { decl_id, .. }) => {
                 let alias_decl = engines.de().get_type_alias(decl_id);
-                let TyTypeAliasDecl { ty, span, .. } = alias_decl.deref();
+                let TyTypeAliasDecl { ty, span, .. } = &*alias_decl;
                 engines
                     .te()
                     .get(ty.type_id)
@@ -715,7 +714,7 @@ impl TyDecl {
             TyDecl::ImplTrait(ImplTrait { decl_id, .. }) => {
                 let decl = decl_engine.get_impl_trait(decl_id);
                 let implementing_for_type_id_arc = type_engine.get(decl.implementing_for.type_id);
-                let implementing_for_type_id = implementing_for_type_id_arc.deref();
+                let implementing_for_type_id = &*implementing_for_type_id_arc;
                 format!(
                     "{} for {:?}",
                     self.get_decl_ident()
@@ -832,23 +831,23 @@ impl TyDecl {
     pub(crate) fn visibility(&self, decl_engine: &DeclEngine) -> Visibility {
         match self {
             TyDecl::TraitDecl(TraitDecl { decl_id, .. }) => {
-                decl_engine.get_trait(decl_id).deref().visibility
+                decl_engine.get_trait(decl_id).visibility
             }
             TyDecl::ConstantDecl(ConstantDecl { decl_id, .. }) => {
-                decl_engine.get_constant(decl_id).deref().visibility
+                decl_engine.get_constant(decl_id).visibility
             }
             TyDecl::StructDecl(StructDecl { decl_id, .. }) => {
-                decl_engine.get_struct(decl_id).deref().visibility
+                decl_engine.get_struct(decl_id).visibility
             }
             TyDecl::EnumDecl(EnumDecl { decl_id, .. }) => decl_engine.get_enum(decl_id).visibility,
             TyDecl::EnumVariantDecl(EnumVariantDecl { enum_ref, .. }) => {
-                decl_engine.get_enum(enum_ref.id()).deref().visibility
+                decl_engine.get_enum(enum_ref.id()).visibility
             }
             TyDecl::FunctionDecl(FunctionDecl { decl_id, .. }) => {
-                decl_engine.get_function(decl_id).deref().visibility
+                decl_engine.get_function(decl_id).visibility
             }
             TyDecl::TypeAliasDecl(TypeAliasDecl { decl_id, .. }) => {
-                decl_engine.get_type_alias(decl_id).deref().visibility
+                decl_engine.get_type_alias(decl_id).visibility
             }
             TyDecl::GenericTypeForFunctionScope(_)
             | TyDecl::ImplTrait(_)

--- a/sway-core/src/language/ty/declaration/storage.rs
+++ b/sway-core/src/language/ty/declaration/storage.rs
@@ -1,4 +1,7 @@
-use std::hash::{Hash, Hasher};
+use std::{
+    hash::{Hash, Hasher},
+    ops::Deref,
+};
 
 use sway_error::{
     error::CompileError,
@@ -89,8 +92,8 @@ impl TyStorageDecl {
             span: first_field.span(),
         });
 
-        let update_available_struct_fields = |id: TypeId| match type_engine.get(id) {
-            TypeInfo::Struct(decl_ref) => decl_engine.get_struct(&decl_ref).fields.clone(),
+        let update_available_struct_fields = |id: TypeId| match type_engine.get(id).deref() {
+            TypeInfo::Struct(decl_ref) => decl_engine.get_struct(decl_ref).fields.clone(),
             _ => vec![],
         };
 

--- a/sway-core/src/language/ty/declaration/storage.rs
+++ b/sway-core/src/language/ty/declaration/storage.rs
@@ -1,7 +1,4 @@
-use std::{
-    hash::{Hash, Hasher},
-    ops::Deref,
-};
+use std::hash::{Hash, Hasher};
 
 use sway_error::{
     error::CompileError,
@@ -92,7 +89,7 @@ impl TyStorageDecl {
             span: first_field.span(),
         });
 
-        let update_available_struct_fields = |id: TypeId| match type_engine.get(id).deref() {
+        let update_available_struct_fields = |id: TypeId| match &*type_engine.get(id) {
             TypeInfo::Struct(decl_ref) => decl_engine.get_struct(decl_ref).fields.clone(),
             _ => vec![],
         };

--- a/sway-core/src/language/ty/declaration/storage.rs
+++ b/sway-core/src/language/ty/declaration/storage.rs
@@ -90,7 +90,7 @@ impl TyStorageDecl {
         });
 
         let update_available_struct_fields = |id: TypeId| match type_engine.get(id) {
-            TypeInfo::Struct(decl_ref) => decl_engine.get_struct(&decl_ref).fields,
+            TypeInfo::Struct(decl_ref) => decl_engine.get_struct(&decl_ref).fields.clone(),
             _ => vec![],
         };
 

--- a/sway-core/src/language/ty/declaration/trait.rs
+++ b/sway-core/src/language/ty/declaration/trait.rs
@@ -1,7 +1,6 @@
 use std::{
     fmt,
     hash::{Hash, Hasher},
-    ops::Deref,
 };
 
 use sway_error::handler::{ErrorEmitted, Handler};
@@ -66,15 +65,15 @@ impl DebugWithEngines for TyTraitItem {
             match self {
                 TyTraitItem::Fn(fn_ref) => format!(
                     "fn {:?}",
-                    engines.help_out(engines.de().get_function(fn_ref).deref())
+                    engines.help_out(&*engines.de().get_function(fn_ref))
                 ),
                 TyTraitItem::Constant(const_ref) => format!(
                     "const {:?}",
-                    engines.help_out(engines.de().get_constant(const_ref).deref())
+                    engines.help_out(&*engines.de().get_constant(const_ref))
                 ),
                 TyTraitItem::Type(type_ref) => format!(
                     "type {:?}",
-                    engines.help_out(engines.de().get_type(type_ref).deref())
+                    engines.help_out(&*engines.de().get_type(type_ref))
                 ),
             }
         )
@@ -214,12 +213,12 @@ impl TypeCheckFinalization for TyTraitItem {
         let decl_engine = ctx.engines.de();
         match self {
             TyTraitItem::Fn(node) => {
-                let mut item_fn = decl_engine.get_function(node).deref().clone();
+                let mut item_fn = (*decl_engine.get_function(node)).clone();
                 item_fn.type_check_finalize(handler, ctx)?;
                 decl_engine.replace(*node.id(), item_fn);
             }
             TyTraitItem::Constant(node) => {
-                let mut item_const = decl_engine.get_constant(node).deref().clone();
+                let mut item_const = (*decl_engine.get_constant(node)).clone();
                 item_const.type_check_finalize(handler, ctx)?;
                 decl_engine.replace(*node.id(), item_const);
             }

--- a/sway-core/src/language/ty/declaration/trait.rs
+++ b/sway-core/src/language/ty/declaration/trait.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt,
     hash::{Hash, Hasher},
+    ops::Deref,
 };
 
 use sway_error::handler::{ErrorEmitted, Handler};
@@ -65,15 +66,15 @@ impl DebugWithEngines for TyTraitItem {
             match self {
                 TyTraitItem::Fn(fn_ref) => format!(
                     "fn {:?}",
-                    engines.help_out(engines.de().get_function(fn_ref))
+                    engines.help_out(engines.de().get_function(fn_ref).deref())
                 ),
                 TyTraitItem::Constant(const_ref) => format!(
                     "const {:?}",
-                    engines.help_out(engines.de().get_constant(const_ref))
+                    engines.help_out(engines.de().get_constant(const_ref).deref())
                 ),
                 TyTraitItem::Type(type_ref) => format!(
                     "type {:?}",
-                    engines.help_out(engines.de().get_type(type_ref))
+                    engines.help_out(engines.de().get_type(type_ref).deref())
                 ),
             }
         )
@@ -213,12 +214,12 @@ impl TypeCheckFinalization for TyTraitItem {
         let decl_engine = ctx.engines.de();
         match self {
             TyTraitItem::Fn(node) => {
-                let mut item_fn = decl_engine.get_function(node);
+                let mut item_fn = decl_engine.get_function(node).deref().clone();
                 item_fn.type_check_finalize(handler, ctx)?;
                 decl_engine.replace(*node.id(), item_fn);
             }
             TyTraitItem::Constant(node) => {
-                let mut item_const = decl_engine.get_constant(node);
+                let mut item_const = decl_engine.get_constant(node).deref().clone();
                 item_const.type_check_finalize(handler, ctx)?;
                 decl_engine.replace(*node.id(), item_const);
             }

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -1,4 +1,4 @@
-use std::{fmt, hash::Hasher};
+use std::{fmt, hash::Hasher, ops::Deref};
 
 use sway_error::{
     handler::{ErrorEmitted, Handler},
@@ -177,8 +177,8 @@ impl CollectTypesMetadata for TyExpression {
                 for type_parameter in &struct_decl.type_parameters {
                     ctx.call_site_insert(type_parameter.type_id, instantiation_span.clone());
                 }
-                if let TypeInfo::Struct(decl_ref) = ctx.engines.te().get(self.return_type) {
-                    let decl = decl_engine.get_struct(&decl_ref);
+                if let TypeInfo::Struct(decl_ref) = ctx.engines.te().get(self.return_type).deref() {
+                    let decl = decl_engine.get_struct(decl_ref);
                     for type_parameter in &decl.type_parameters {
                         ctx.call_site_insert(type_parameter.type_id, instantiation_span.clone());
                     }
@@ -502,7 +502,7 @@ impl TyExpression {
             } => {
                 if let Some(TyDecl::ImplTrait(t)) = &engines.de().get(fn_ref).implementing_type {
                     let t = &engines.de().get(&t.decl_id).implementing_for;
-                    if let TypeInfo::Struct(struct_ref) = engines.te().get(t.type_id) {
+                    if let TypeInfo::Struct(struct_ref) = engines.te().get(t.type_id).deref() {
                         let s = engines.de().get(struct_ref.id());
                         emit_warning_if_deprecated(
                             &s.attributes,

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -1,4 +1,4 @@
-use std::{fmt, hash::Hasher, ops::Deref};
+use std::{fmt, hash::Hasher};
 
 use sway_error::{
     handler::{ErrorEmitted, Handler},
@@ -177,7 +177,7 @@ impl CollectTypesMetadata for TyExpression {
                 for type_parameter in &struct_decl.type_parameters {
                     ctx.call_site_insert(type_parameter.type_id, instantiation_span.clone());
                 }
-                if let TypeInfo::Struct(decl_ref) = ctx.engines.te().get(self.return_type).deref() {
+                if let TypeInfo::Struct(decl_ref) = &*ctx.engines.te().get(self.return_type) {
                     let decl = decl_engine.get_struct(decl_ref);
                     for type_parameter in &decl.type_parameters {
                         ctx.call_site_insert(type_parameter.type_id, instantiation_span.clone());
@@ -502,7 +502,7 @@ impl TyExpression {
             } => {
                 if let Some(TyDecl::ImplTrait(t)) = &engines.de().get(fn_ref).implementing_type {
                     let t = &engines.de().get(&t.decl_id).implementing_for;
-                    if let TypeInfo::Struct(struct_ref) = engines.te().get(t.type_id).deref() {
+                    if let TypeInfo::Struct(struct_ref) = &*engines.te().get(t.type_id) {
                         let s = engines.de().get(struct_ref.id());
                         emit_warning_if_deprecated(
                             &s.attributes,

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -146,7 +146,7 @@ impl CollectTypesMetadata for TyExpression {
                 let function_decl = decl_engine.get_function(fn_ref);
 
                 ctx.call_site_push();
-                for type_parameter in function_decl.type_parameters {
+                for type_parameter in &function_decl.type_parameters {
                     ctx.call_site_insert(type_parameter.type_id, call_path.span())
                 }
 
@@ -174,12 +174,12 @@ impl CollectTypesMetadata for TyExpression {
                 ..
             } => {
                 let struct_decl = decl_engine.get_struct(struct_ref);
-                for type_parameter in struct_decl.type_parameters {
+                for type_parameter in &struct_decl.type_parameters {
                     ctx.call_site_insert(type_parameter.type_id, instantiation_span.clone());
                 }
                 if let TypeInfo::Struct(decl_ref) = ctx.engines.te().get(self.return_type) {
                     let decl = decl_engine.get_struct(&decl_ref);
-                    for type_parameter in decl.type_parameters {
+                    for type_parameter in &decl.type_parameters {
                         ctx.call_site_insert(type_parameter.type_id, instantiation_span.clone());
                     }
                 }
@@ -500,8 +500,8 @@ impl TyExpression {
             TyExpressionVariant::FunctionApplication {
                 call_path, fn_ref, ..
             } => {
-                if let Some(TyDecl::ImplTrait(t)) = engines.de().get(fn_ref).implementing_type {
-                    let t = engines.de().get(&t.decl_id).implementing_for;
+                if let Some(TyDecl::ImplTrait(t)) = &engines.de().get(fn_ref).implementing_type {
+                    let t = &engines.de().get(&t.decl_id).implementing_for;
                     if let TypeInfo::Struct(struct_ref) = engines.te().get(t.type_id) {
                         let s = engines.de().get(struct_ref.id());
                         emit_warning_if_deprecated(

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap,
     fmt::{self, Write},
     hash::{Hash, Hasher},
+    ops::Deref,
 };
 
 use sway_error::handler::{ErrorEmitted, Handler};
@@ -791,7 +792,7 @@ impl ReplaceDecls for TyExpressionVariant {
                     }
 
                     let decl_engine = ctx.engines().de();
-                    let mut method = decl_engine.get(fn_ref);
+                    let mut method = decl_engine.get(fn_ref).deref().clone();
 
                     // Handle the trait constraints. This includes checking to see if the trait
                     // constraints are satisfied and replacing old decl ids based on the
@@ -1257,16 +1258,19 @@ fn find_const_decl_from_impl(
             let impl_trait = decl_engine.get_impl_trait(&decl_id.clone());
             impl_trait
                 .items
-                .into_iter()
+                .iter()
                 .find(|item| match item {
                     TyTraitItem::Constant(decl_id) => {
-                        let trait_const_decl = decl_engine.get_constant(&decl_id.clone());
+                        let trait_const_decl =
+                            decl_engine.get_constant(&decl_id.clone()).deref().clone();
                         const_decl.name().eq(trait_const_decl.name())
                     }
                     _ => false,
                 })
                 .map(|item| match item {
-                    TyTraitItem::Constant(decl_id) => decl_engine.get_constant(&decl_id),
+                    TyTraitItem::Constant(decl_id) => {
+                        decl_engine.get_constant(decl_id).deref().clone()
+                    }
                     _ => unreachable!(),
                 })
         }

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -2,7 +2,6 @@ use std::{
     collections::HashMap,
     fmt::{self, Write},
     hash::{Hash, Hasher},
-    ops::Deref,
 };
 
 use sway_error::handler::{ErrorEmitted, Handler};
@@ -792,7 +791,7 @@ impl ReplaceDecls for TyExpressionVariant {
                     }
 
                     let decl_engine = ctx.engines().de();
-                    let mut method = decl_engine.get(fn_ref).deref().clone();
+                    let mut method = (*decl_engine.get(fn_ref)).clone();
 
                     // Handle the trait constraints. This includes checking to see if the trait
                     // constraints are satisfied and replacing old decl ids based on the
@@ -1262,15 +1261,13 @@ fn find_const_decl_from_impl(
                 .find(|item| match item {
                     TyTraitItem::Constant(decl_id) => {
                         let trait_const_decl =
-                            decl_engine.get_constant(&decl_id.clone()).deref().clone();
+                            (*decl_engine.get_constant(&decl_id.clone())).clone();
                         const_decl.name().eq(trait_const_decl.name())
                     }
                     _ => false,
                 })
                 .map(|item| match item {
-                    TyTraitItem::Constant(decl_id) => {
-                        decl_engine.get_constant(decl_id).deref().clone()
-                    }
+                    TyTraitItem::Constant(decl_id) => (*decl_engine.get_constant(decl_id)).clone(),
                     _ => unreachable!(),
                 })
         }

--- a/sway-core/src/language/ty/module.rs
+++ b/sway-core/src/language/ty/module.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::Span;
 
@@ -49,7 +51,7 @@ impl TyModule {
     pub fn test_fns<'a: 'b, 'b>(
         &'b self,
         decl_engine: &'a DeclEngine,
-    ) -> impl '_ + Iterator<Item = (TyFunctionDecl, DeclRefFunction)> {
+    ) -> impl '_ + Iterator<Item = (Arc<TyFunctionDecl>, DeclRefFunction)> {
         self.all_nodes.iter().filter_map(|node| {
             if let TyAstNodeContent::Declaration(TyDecl::FunctionDecl(FunctionDecl {
                 decl_id,

--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -129,7 +129,10 @@ impl TyProgram {
                         trait_decl_ref,
                         ..
                     } = impl_trait_decl.deref();
-                    if matches!(ty_engine.get(implementing_for.type_id), TypeInfo::Contract) {
+                    if matches!(
+                        ty_engine.get(implementing_for.type_id).deref(),
+                        TypeInfo::Contract
+                    ) {
                         // add methods to the ABI only if they come from an ABI implementation
                         // and not a (super)trait implementation for Contract
                         if let Some(trait_decl_ref) = trait_decl_ref {
@@ -255,7 +258,7 @@ impl TyProgram {
                 }
                 let main_func_id = mains.remove(0);
                 let main_func = decl_engine.get_function(&main_func_id);
-                match ty_engine.get(main_func.return_type.type_id) {
+                match ty_engine.get(main_func.return_type.type_id).deref() {
                     TypeInfo::Boolean => (),
                     _ => {
                         handler.emit_err(CompileError::PredicateMainDoesNotReturnBool(
@@ -325,7 +328,7 @@ impl TyProgram {
                 ) {
                     // Let main return `raw_slice` directly
                     if !matches!(
-                        engines.te().get(main_func.return_type.type_id),
+                        engines.te().get(main_func.return_type.type_id).deref(),
                         TypeInfo::RawUntypedSlice
                     ) {
                         handler.emit_err(error);

--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 use crate::{
     decl_engine::*,
@@ -111,7 +111,7 @@ impl TyProgram {
                     decl_id,
                     ..
                 })) => {
-                    let config_decl = decl_engine.get_constant(decl_id).deref().clone();
+                    let config_decl = (*decl_engine.get_constant(decl_id)).clone();
                     if config_decl.is_configurable {
                         configurables.push(config_decl);
                     } else {
@@ -128,9 +128,9 @@ impl TyProgram {
                         implementing_for,
                         trait_decl_ref,
                         ..
-                    } = impl_trait_decl.deref();
+                    } = &*impl_trait_decl;
                     if matches!(
-                        ty_engine.get(implementing_for.type_id).deref(),
+                        &*ty_engine.get(implementing_for.type_id),
                         TypeInfo::Contract
                     ) {
                         // add methods to the ABI only if they come from an ABI implementation
@@ -258,7 +258,7 @@ impl TyProgram {
                 }
                 let main_func_id = mains.remove(0);
                 let main_func = decl_engine.get_function(&main_func_id);
-                match ty_engine.get(main_func.return_type.type_id).deref() {
+                match &*ty_engine.get(main_func.return_type.type_id) {
                     TypeInfo::Boolean => (),
                     _ => {
                         handler.emit_err(CompileError::PredicateMainDoesNotReturnBool(
@@ -328,7 +328,7 @@ impl TyProgram {
                 ) {
                     // Let main return `raw_slice` directly
                     if !matches!(
-                        engines.te().get(main_func.return_type.type_id).deref(),
+                        &*engines.te().get(main_func.return_type.type_id),
                         TypeInfo::RawUntypedSlice
                     ) {
                         handler.emit_err(error);
@@ -544,7 +544,7 @@ fn disallow_impure_functions(
     let mut err_purity = fn_decls
         .filter_map(|decl_id| {
             let fn_decl = decl_engine.get_function(&decl_id);
-            let TyFunctionDecl { purity, name, .. } = fn_decl.deref();
+            let TyFunctionDecl { purity, name, .. } = &*fn_decl;
             if *purity != Purity::Pure {
                 Some(CompileError::ImpureInNonContract { span: name.span() })
             } else {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use sway_error::{
     handler::{ErrorEmitted, Handler},
     warning::{CompileWarning, Warning},
@@ -79,7 +81,7 @@ impl ty::TyConstantDecl {
         // to get the type of the variable. The type of the variable *has* to follow
         // `type_ascription` if `type_ascription` is a concrete integer type that does not
         // conflict with the type of `expression` (i.e. passes the type checking above).
-        let return_type = match type_engine.get(type_ascription.type_id) {
+        let return_type = match type_engine.get(type_ascription.type_id).deref() {
             TypeInfo::UnsignedInteger(_) => type_ascription.type_id,
             _ => match &value {
                 Some(value) => value.return_type,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use sway_error::{
     handler::{ErrorEmitted, Handler},
     warning::{CompileWarning, Warning},
@@ -81,7 +79,7 @@ impl ty::TyConstantDecl {
         // to get the type of the variable. The type of the variable *has* to follow
         // `type_ascription` if `type_ascription` is a concrete integer type that does not
         // conflict with the type of `expression` (i.e. passes the type checking above).
-        let return_type = match type_engine.get(type_ascription.type_id).deref() {
+        let return_type = match &*type_engine.get(type_ascription.type_id) {
             TypeInfo::UnsignedInteger(_) => type_ascription.type_id,
             _ => match &value {
                 Some(value) => value.return_type,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::{Named, Spanned};
 
@@ -60,7 +58,7 @@ impl TyDecl {
                 // to get the type of the variable. The type of the variable *has* to follow
                 // `type_ascription` if `type_ascription` is a concrete integer type that does not
                 // conflict with the type of `body` (i.e. passes the type checking above).
-                let return_type = match type_engine.get(type_ascription.type_id).deref() {
+                let return_type = match &*type_engine.get(type_ascription.type_id) {
                     TypeInfo::UnsignedInteger(_) => type_ascription.type_id,
                     _ => body.return_type,
                 };
@@ -446,42 +444,42 @@ impl TypeCheckFinalization for TyDecl {
                 node.type_check_finalize(handler, ctx)?;
             }
             TyDecl::ConstantDecl(node) => {
-                let mut const_decl = ctx.engines.de().get_constant(&node.decl_id).deref().clone();
+                let mut const_decl = (*ctx.engines.de().get_constant(&node.decl_id)).clone();
                 const_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::FunctionDecl(node) => {
-                let mut fn_decl = ctx.engines.de().get_function(&node.decl_id).deref().clone();
+                let mut fn_decl = (*ctx.engines.de().get_function(&node.decl_id)).clone();
                 fn_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::TraitDecl(node) => {
-                let mut trait_decl = ctx.engines.de().get_trait(&node.decl_id).deref().clone();
+                let mut trait_decl = (*ctx.engines.de().get_trait(&node.decl_id)).clone();
                 trait_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::StructDecl(node) => {
-                let mut struct_decl = ctx.engines.de().get_struct(&node.decl_id).deref().clone();
+                let mut struct_decl = (*ctx.engines.de().get_struct(&node.decl_id)).clone();
                 struct_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::EnumDecl(node) => {
-                let mut enum_decl = ctx.engines.de().get_enum(&node.decl_id).deref().clone();
+                let mut enum_decl = (*ctx.engines.de().get_enum(&node.decl_id)).clone();
                 enum_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::EnumVariantDecl(_) => {}
             TyDecl::ImplTrait(node) => {
-                let mut impl_trait = decl_engine.get_impl_trait(&node.decl_id).deref().clone();
+                let mut impl_trait = (*decl_engine.get_impl_trait(&node.decl_id)).clone();
                 impl_trait.type_check_finalize(handler, ctx)?;
             }
             TyDecl::AbiDecl(node) => {
-                let mut abi_decl = decl_engine.get_abi(&node.decl_id).deref().clone();
+                let mut abi_decl = (*decl_engine.get_abi(&node.decl_id)).clone();
                 abi_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::GenericTypeForFunctionScope(_) => {}
             TyDecl::ErrorRecovery(_, _) => {}
             TyDecl::StorageDecl(node) => {
-                let mut storage_decl = decl_engine.get_storage(&node.decl_id).deref().clone();
+                let mut storage_decl = (*decl_engine.get_storage(&node.decl_id)).clone();
                 storage_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::TypeAliasDecl(node) => {
-                let mut type_alias_decl = decl_engine.get_type_alias(&node.decl_id).deref().clone();
+                let mut type_alias_decl = (*decl_engine.get_type_alias(&node.decl_id)).clone();
                 type_alias_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::TraitTypeDecl(_node) => {}

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -60,7 +60,7 @@ impl TyDecl {
                 // to get the type of the variable. The type of the variable *has* to follow
                 // `type_ascription` if `type_ascription` is a concrete integer type that does not
                 // conflict with the type of `body` (i.e. passes the type checking above).
-                let return_type = match type_engine.get(type_ascription.type_id) {
+                let return_type = match type_engine.get(type_ascription.type_id).deref() {
                     TypeInfo::UnsignedInteger(_) => type_ascription.type_id,
                     _ => body.return_type,
                 };

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::{Named, Spanned};
 
@@ -444,42 +446,42 @@ impl TypeCheckFinalization for TyDecl {
                 node.type_check_finalize(handler, ctx)?;
             }
             TyDecl::ConstantDecl(node) => {
-                let mut const_decl = ctx.engines.de().get_constant(&node.decl_id);
+                let mut const_decl = ctx.engines.de().get_constant(&node.decl_id).deref().clone();
                 const_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::FunctionDecl(node) => {
-                let mut fn_decl = ctx.engines.de().get_function(&node.decl_id);
+                let mut fn_decl = ctx.engines.de().get_function(&node.decl_id).deref().clone();
                 fn_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::TraitDecl(node) => {
-                let mut trait_decl = ctx.engines.de().get_trait(&node.decl_id);
+                let mut trait_decl = ctx.engines.de().get_trait(&node.decl_id).deref().clone();
                 trait_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::StructDecl(node) => {
-                let mut struct_decl = ctx.engines.de().get_struct(&node.decl_id);
+                let mut struct_decl = ctx.engines.de().get_struct(&node.decl_id).deref().clone();
                 struct_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::EnumDecl(node) => {
-                let mut enum_decl = ctx.engines.de().get_enum(&node.decl_id);
+                let mut enum_decl = ctx.engines.de().get_enum(&node.decl_id).deref().clone();
                 enum_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::EnumVariantDecl(_) => {}
             TyDecl::ImplTrait(node) => {
-                let mut impl_trait = decl_engine.get_impl_trait(&node.decl_id);
+                let mut impl_trait = decl_engine.get_impl_trait(&node.decl_id).deref().clone();
                 impl_trait.type_check_finalize(handler, ctx)?;
             }
             TyDecl::AbiDecl(node) => {
-                let mut abi_decl = decl_engine.get_abi(&node.decl_id);
+                let mut abi_decl = decl_engine.get_abi(&node.decl_id).deref().clone();
                 abi_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::GenericTypeForFunctionScope(_) => {}
             TyDecl::ErrorRecovery(_, _) => {}
             TyDecl::StorageDecl(node) => {
-                let mut storage_decl = decl_engine.get_storage(&node.decl_id);
+                let mut storage_decl = decl_engine.get_storage(&node.decl_id).deref().clone();
                 storage_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::TypeAliasDecl(node) => {
-                let mut type_alias_decl = decl_engine.get_type_alias(&node.decl_id);
+                let mut type_alias_decl = decl_engine.get_type_alias(&node.decl_id).deref().clone();
                 type_alias_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::TraitTypeDecl(_node) => {}

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -1,4 +1,8 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    ops::Deref,
+    sync::Arc,
+};
 
 use sway_error::{
     error::{CompileError, InterfaceName},
@@ -124,7 +128,7 @@ impl TyImplTrait {
             .ok()
         {
             Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
-                let mut trait_decl = decl_engine.get_trait(&decl_id);
+                let mut trait_decl = decl_engine.get_trait(&decl_id).deref().clone();
 
                 // the following essentially is needed to map `Self` to `implementing_for`
                 // during trait decl monomorphization
@@ -252,7 +256,11 @@ impl TyImplTrait {
                     impl_type_parameters: vec![], // this is empty because abi definitions don't support generics
                     trait_name,
                     trait_type_arguments: vec![], // this is empty because abi definitions don't support generics
-                    trait_decl_ref: Some(DeclRef::new(abi.name.clone(), decl_id.into(), abi.span)),
+                    trait_decl_ref: Some(DeclRef::new(
+                        abi.name.clone(),
+                        decl_id.into(),
+                        abi.span.clone(),
+                    )),
                     span: block_span,
                     items: new_items,
                     implementing_for,
@@ -454,7 +462,8 @@ impl TyImplTrait {
             for (item, new_item) in items.clone().into_iter().zip(new_items) {
                 match (item, new_item) {
                     (ImplItem::Fn(fn_decl), TyTraitItem::Fn(decl_ref)) => {
-                        let mut ty_fn_decl = decl_engine.get_function(decl_ref.id());
+                        let mut ty_fn_decl =
+                            decl_engine.get_function(decl_ref.id()).deref().clone();
                         let new_ty_fn_decl = match ty::TyFunctionDecl::type_check_body(
                             handler,
                             defer_ctx.by_ref(),
@@ -502,7 +511,8 @@ impl TyImplTrait {
             for idx in ordered_node_indices {
                 match (&items[idx], &new_items[idx]) {
                     (ImplItem::Fn(fn_decl), TyTraitItem::Fn(decl_ref)) => {
-                        let mut ty_fn_decl = decl_engine.get_function(decl_ref.id());
+                        let mut ty_fn_decl =
+                            decl_engine.get_function(decl_ref.id()).deref().clone();
                         let new_ty_fn_decl = match ty::TyFunctionDecl::type_check_body(
                             handler,
                             ctx.by_ref(),
@@ -530,12 +540,13 @@ impl TyImplTrait {
             for item in new_items {
                 match item {
                     TyTraitItem::Fn(decl_ref) => {
-                        let mut fn_decl = decl_engine.get_function(decl_ref.id());
+                        let mut fn_decl = decl_engine.get_function(decl_ref.id()).deref().clone();
                         let _ = fn_decl.type_check_finalize(handler, &mut finalizing_ctx);
                         decl_engine.replace(*decl_ref.id(), fn_decl);
                     }
                     TyTraitItem::Constant(decl_ref) => {
-                        let mut const_decl = decl_engine.get_constant(decl_ref.id());
+                        let mut const_decl =
+                            decl_engine.get_constant(decl_ref.id()).deref().clone();
                         let _ = const_decl.type_check_finalize(handler, &mut finalizing_ctx);
                         decl_engine.replace(*decl_ref.id(), const_decl);
                     }
@@ -633,15 +644,15 @@ fn type_check_trait_implementation(
 
     // This map keeps track of the remaining functions in the interface surface
     // that still need to be implemented for the trait to be fully implemented.
-    let mut method_checklist: BTreeMap<Ident, ty::TyTraitFn> = BTreeMap::new();
+    let mut method_checklist: BTreeMap<Ident, Arc<ty::TyTraitFn>> = BTreeMap::new();
 
     // This map keeps track of the remaining constants in the interface surface
     // that still need to be implemented for the trait to be fully implemented.
-    let mut constant_checklist: BTreeMap<Ident, ty::TyConstantDecl> = BTreeMap::new();
+    let mut constant_checklist: BTreeMap<Ident, Arc<ty::TyConstantDecl>> = BTreeMap::new();
 
     // This map keeps track of the remaining types in the interface surface
     // that still need to be implemented for the trait to be fully implemented.
-    let mut type_checklist: BTreeMap<Ident, ty::TyTraitType> = BTreeMap::new();
+    let mut type_checklist: BTreeMap<Ident, Arc<ty::TyTraitType>> = BTreeMap::new();
 
     // This map keeps track of the interface declaration id's of the trait
     // definition.
@@ -883,7 +894,7 @@ fn type_check_trait_implementation(
     for item in trait_items.iter() {
         match item {
             TyImplItem::Fn(decl_ref) => {
-                let mut method = decl_engine.get_function(decl_ref);
+                let mut method = decl_engine.get_function(decl_ref).deref().clone();
 
                 // We need to add impl type parameters to the method's type parameters
                 // so that in-line monomorphization can complete.
@@ -916,13 +927,13 @@ fn type_check_trait_implementation(
                 ));
             }
             TyImplItem::Constant(decl_ref) => {
-                let mut const_decl = decl_engine.get_constant(decl_ref);
+                let mut const_decl = decl_engine.get_constant(decl_ref).deref().clone();
                 const_decl.replace_decls(&decl_mapping, handler, &mut ctx)?;
                 const_decl.subst(&type_mapping, engines);
                 all_items_refs.push(TyImplItem::Constant(decl_engine.insert(const_decl)));
             }
             TyImplItem::Type(decl_ref) => {
-                let mut type_decl = decl_engine.get_type(decl_ref);
+                let mut type_decl = decl_engine.get_type(decl_ref).deref().clone();
                 type_decl.subst(&type_mapping, engines);
                 all_items_refs.push(TyImplItem::Type(decl_engine.insert(type_decl.clone())));
             }
@@ -966,7 +977,7 @@ fn type_check_impl_method(
     trait_name: &CallPath,
     is_contract: bool,
     impld_item_refs: &ItemMap,
-    method_checklist: &BTreeMap<Ident, ty::TyTraitFn>,
+    method_checklist: &BTreeMap<Ident, Arc<ty::TyTraitFn>>,
 ) -> Result<ty::TyFunctionDecl, ErrorEmitted> {
     let type_engine = ctx.engines.te();
     let engines = ctx.engines();
@@ -1000,7 +1011,7 @@ fn type_check_impl_method(
 
     // Ensure that the method checklist contains this function.
     let mut impl_method_signature = match method_checklist.get(&impl_method.name) {
-        Some(trait_fn) => trait_fn.clone(),
+        Some(trait_fn) => trait_fn.deref().clone(),
         None => {
             return Err(
                 handler.emit_err(CompileError::FunctionNotAPartOfInterfaceSurface {
@@ -1185,7 +1196,7 @@ fn type_check_const_decl(
     trait_name: &CallPath,
     is_contract: bool,
     impld_constant_ids: &ItemMap,
-    constant_checklist: &BTreeMap<Ident, ty::TyConstantDecl>,
+    constant_checklist: &BTreeMap<Ident, Arc<ty::TyConstantDecl>>,
 ) -> Result<ty::TyConstantDecl, ErrorEmitted> {
     let type_engine = ctx.engines.te();
     let engines = ctx.engines();
@@ -1271,7 +1282,7 @@ fn type_check_type_decl(
     self_type: TypeId,
     is_contract: bool,
     impld_type_ids: &ItemMap,
-    type_checklist: &BTreeMap<Ident, ty::TyTraitType>,
+    type_checklist: &BTreeMap<Ident, Arc<ty::TyTraitType>>,
 ) -> Result<ty::TyTraitType, ErrorEmitted> {
     let engines = ctx.engines();
     let type_engine = engines.te();

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -306,7 +306,7 @@ impl TyImplTrait {
         // create the trait name
         let trait_name = CallPath {
             prefixes: vec![],
-            suffix: match &type_engine.get(implementing_for.type_id) {
+            suffix: match &type_engine.get(implementing_for.type_id).deref() {
                 TypeInfo::Custom {
                     qualified_call_path: call_path,
                     ..
@@ -1376,7 +1376,7 @@ fn check_for_unconstrained_type_parameters(
     let mut defined_generics: HashMap<_, _> = HashMap::from_iter(
         type_parameters
             .iter()
-            .map(|x| (engines.te().get(x.type_id), x.span()))
+            .map(|x| (engines.te().get(x.type_id).deref().clone(), x.span()))
             .map(|(thing, sp)| (WithEngines::new(thing, engines), sp)),
     );
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use sway_error::error::CompileError;
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::{Span, Spanned};
@@ -57,7 +55,7 @@ pub(crate) fn insert_supertraits_into_namespace(
             match (decl.clone(), supertraits_of) {
                 // a trait can be a supertrait of either a trait or a an ABI
                 (Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })), _) => {
-                    let mut trait_decl = decl_engine.get_trait(&decl_id).deref().clone();
+                    let mut trait_decl = (*decl_engine.get_trait(&decl_id)).clone();
 
                     // Right now we don't parse type arguments for supertraits, so
                     // we should give this error message to users.

--- a/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use sway_error::error::CompileError;
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::{Span, Spanned};
@@ -55,7 +57,7 @@ pub(crate) fn insert_supertraits_into_namespace(
             match (decl.clone(), supertraits_of) {
                 // a trait can be a supertrait of either a trait or a an ABI
                 (Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })), _) => {
-                    let mut trait_decl = decl_engine.get_trait(&decl_id);
+                    let mut trait_decl = decl_engine.get_trait(&decl_id).deref().clone();
 
                     // Right now we don't parse type arguments for supertraits, so
                     // we should give this error message to users.

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashSet},
+    ops::Deref,
+};
 
 use sway_error::{
     error::CompileError,
@@ -350,7 +353,7 @@ impl TyTraitDecl {
         {
             match item {
                 ty::TyTraitItem::Fn(decl_ref) => {
-                    let mut method = decl_engine.get_function(&decl_ref);
+                    let mut method = decl_engine.get_function(&decl_ref).deref().clone();
                     method.subst(&type_mapping, engines);
                     impld_item_refs.insert(
                         (method.name.clone(), type_id),
@@ -362,7 +365,7 @@ impl TyTraitDecl {
                     );
                 }
                 ty::TyTraitItem::Constant(decl_ref) => {
-                    let mut const_decl = decl_engine.get_constant(&decl_ref);
+                    let mut const_decl = decl_engine.get_constant(&decl_ref).deref().clone();
                     const_decl.subst(&type_mapping, engines);
                     impld_item_refs.insert(
                         (const_decl.call_path.suffix.clone(), type_id),
@@ -370,7 +373,7 @@ impl TyTraitDecl {
                     );
                 }
                 ty::TyTraitItem::Type(decl_ref) => {
-                    let mut type_decl = decl_engine.get_type(&decl_ref);
+                    let mut type_decl = decl_engine.get_type(&decl_ref).deref().clone();
                     type_decl.subst(&type_mapping, engines);
                     impld_item_refs.insert(
                         (type_decl.name.clone(), type_id),
@@ -420,7 +423,7 @@ impl TyTraitDecl {
         for item in interface_surface.iter() {
             match item {
                 ty::TyTraitInterfaceItem::TraitFn(decl_ref) => {
-                    let mut method = decl_engine.get_trait_fn(decl_ref);
+                    let mut method = decl_engine.get_trait_fn(decl_ref).deref().clone();
                     method.subst(&type_mapping, engines);
                     all_items.push(TyImplItem::Fn(
                         ctx.engines
@@ -455,7 +458,7 @@ impl TyTraitDecl {
         for item in items.iter() {
             match item {
                 ty::TyTraitItem::Fn(decl_ref) => {
-                    let mut method = decl_engine.get_function(decl_ref);
+                    let mut method = decl_engine.get_function(decl_ref).deref().clone();
                     method.subst(&type_mapping, engines);
                     all_items.push(TyImplItem::Fn(
                         ctx.engines
@@ -465,12 +468,12 @@ impl TyTraitDecl {
                     ));
                 }
                 ty::TyTraitItem::Constant(decl_ref) => {
-                    let mut const_decl = decl_engine.get_constant(decl_ref);
+                    let mut const_decl = decl_engine.get_constant(decl_ref).deref().clone();
                     const_decl.subst(&type_mapping, engines);
                     all_items.push(TyImplItem::Constant(ctx.engines.de().insert(const_decl)));
                 }
                 ty::TyTraitItem::Type(decl_ref) => {
-                    let mut type_decl = decl_engine.get_type(decl_ref);
+                    let mut type_decl = decl_engine.get_type(decl_ref).deref().clone();
                     type_decl.subst(&type_mapping, engines);
                     all_items.push(TyImplItem::Type(ctx.engines.de().insert(type_decl)));
                 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{BTreeMap, HashSet},
-    ops::Deref,
-};
+use std::collections::{BTreeMap, HashSet};
 
 use sway_error::{
     error::CompileError,
@@ -353,7 +350,7 @@ impl TyTraitDecl {
         {
             match item {
                 ty::TyTraitItem::Fn(decl_ref) => {
-                    let mut method = decl_engine.get_function(&decl_ref).deref().clone();
+                    let mut method = (*decl_engine.get_function(&decl_ref)).clone();
                     method.subst(&type_mapping, engines);
                     impld_item_refs.insert(
                         (method.name.clone(), type_id),
@@ -365,7 +362,7 @@ impl TyTraitDecl {
                     );
                 }
                 ty::TyTraitItem::Constant(decl_ref) => {
-                    let mut const_decl = decl_engine.get_constant(&decl_ref).deref().clone();
+                    let mut const_decl = (*decl_engine.get_constant(&decl_ref)).clone();
                     const_decl.subst(&type_mapping, engines);
                     impld_item_refs.insert(
                         (const_decl.call_path.suffix.clone(), type_id),
@@ -373,7 +370,7 @@ impl TyTraitDecl {
                     );
                 }
                 ty::TyTraitItem::Type(decl_ref) => {
-                    let mut type_decl = decl_engine.get_type(&decl_ref).deref().clone();
+                    let mut type_decl = (*decl_engine.get_type(&decl_ref)).clone();
                     type_decl.subst(&type_mapping, engines);
                     impld_item_refs.insert(
                         (type_decl.name.clone(), type_id),
@@ -423,7 +420,7 @@ impl TyTraitDecl {
         for item in interface_surface.iter() {
             match item {
                 ty::TyTraitInterfaceItem::TraitFn(decl_ref) => {
-                    let mut method = decl_engine.get_trait_fn(decl_ref).deref().clone();
+                    let mut method = (*decl_engine.get_trait_fn(decl_ref)).clone();
                     method.subst(&type_mapping, engines);
                     all_items.push(TyImplItem::Fn(
                         ctx.engines
@@ -458,7 +455,7 @@ impl TyTraitDecl {
         for item in items.iter() {
             match item {
                 ty::TyTraitItem::Fn(decl_ref) => {
-                    let mut method = decl_engine.get_function(decl_ref).deref().clone();
+                    let mut method = (*decl_engine.get_function(decl_ref)).clone();
                     method.subst(&type_mapping, engines);
                     all_items.push(TyImplItem::Fn(
                         ctx.engines
@@ -468,12 +465,12 @@ impl TyTraitDecl {
                     ));
                 }
                 ty::TyTraitItem::Constant(decl_ref) => {
-                    let mut const_decl = decl_engine.get_constant(decl_ref).deref().clone();
+                    let mut const_decl = (*decl_engine.get_constant(decl_ref)).clone();
                     const_decl.subst(&type_mapping, engines);
                     all_items.push(TyImplItem::Constant(ctx.engines.de().insert(const_decl)));
                 }
                 ty::TyTraitItem::Type(decl_ref) => {
-                    let mut type_decl = decl_engine.get_type(decl_ref).deref().clone();
+                    let mut type_decl = (*decl_engine.get_type(decl_ref)).clone();
                     type_decl.subst(&type_mapping, engines);
                     all_items.push(TyImplItem::Type(ctx.engines.de().insert(type_decl)));
                 }

--- a/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use sway_ast::intrinsics::Intrinsic;
 use sway_error::{
     error::CompileError,
@@ -119,7 +117,7 @@ fn type_check_not(
     let operand_expr = ty::TyExpression::type_check(handler, ctx.by_ref(), operand)?;
 
     let t_arc = engines.te().get(operand_expr.return_type);
-    let t = t_arc.deref();
+    let t = &*t_arc;
     match t {
         TypeInfo::B256 | TypeInfo::UnsignedInteger(_) | TypeInfo::Numeric => Ok((
             ty::TyIntrinsicFunctionKind {
@@ -1027,7 +1025,7 @@ fn type_check_bitwise_binary_op(
     let rhs = ty::TyExpression::type_check(handler, ctx, rhs)?;
 
     let t_arc = engines.te().get(lhs.return_type);
-    let t = t_arc.deref();
+    let t = &*t_arc;
     match t {
         TypeInfo::B256 | TypeInfo::UnsignedInteger(_) | TypeInfo::Numeric => Ok((
             ty::TyIntrinsicFunctionKind {
@@ -1101,7 +1099,7 @@ fn type_check_shift_binary_op(
     )?;
 
     let t_arc = engines.te().get(lhs.return_type);
-    let t = t_arc.deref();
+    let t = &*t_arc;
     match t {
         TypeInfo::B256 | TypeInfo::UnsignedInteger(_) | TypeInfo::Numeric => Ok((
             ty::TyIntrinsicFunctionKind {

--- a/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use sway_ast::intrinsics::Intrinsic;
 use sway_error::{
     error::CompileError,
@@ -116,7 +118,8 @@ fn type_check_not(
     let operand = arguments[0].clone();
     let operand_expr = ty::TyExpression::type_check(handler, ctx.by_ref(), operand)?;
 
-    let t = engines.te().get(operand_expr.return_type);
+    let t_arc = engines.te().get(operand_expr.return_type);
+    let t = t_arc.deref();
     match t {
         TypeInfo::B256 | TypeInfo::UnsignedInteger(_) | TypeInfo::Numeric => Ok((
             ty::TyIntrinsicFunctionKind {
@@ -1023,7 +1026,8 @@ fn type_check_bitwise_binary_op(
     let rhs = arguments[1].clone();
     let rhs = ty::TyExpression::type_check(handler, ctx, rhs)?;
 
-    let t = engines.te().get(lhs.return_type);
+    let t_arc = engines.te().get(lhs.return_type);
+    let t = t_arc.deref();
     match t {
         TypeInfo::B256 | TypeInfo::UnsignedInteger(_) | TypeInfo::Numeric => Ok((
             ty::TyIntrinsicFunctionKind {
@@ -1096,7 +1100,8 @@ fn type_check_shift_binary_op(
         rhs,
     )?;
 
-    let t = engines.te().get(lhs.return_type);
+    let t_arc = engines.te().get(lhs.return_type);
+    let t = t_arc.deref();
     match t {
         TypeInfo::B256 | TypeInfo::UnsignedInteger(_) | TypeInfo::Numeric => Ok((
             ty::TyIntrinsicFunctionKind {

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/constructor_factory.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/constructor_factory.rs
@@ -223,12 +223,12 @@ impl ConstructorFactory {
                 let enum_decl = engines
                     .de()
                     .get_enum(&type_info.expect_enum(handler, engines, "", span)?);
-                let enum_name = enum_decl.call_path.suffix;
-                let enum_variants = enum_decl.variants;
+                let enum_name = &enum_decl.call_path.suffix;
+                let enum_variants = &enum_decl.variants;
                 let (all_variants, variant_tracker) = ConstructorFactory::resolve_enum(
                     handler,
-                    &enum_name,
-                    &enum_variants,
+                    enum_name,
+                    enum_variants,
                     enum_pattern,
                     rest,
                     span,
@@ -452,12 +452,12 @@ impl ConstructorFactory {
                 let enum_decl = engines
                     .de()
                     .get_enum(&type_info.expect_enum(handler, engines, "", span)?);
-                let enum_name = enum_decl.call_path.suffix;
-                let enum_variants = enum_decl.variants;
+                let enum_name = &enum_decl.call_path.suffix;
+                let enum_variants = &enum_decl.variants;
                 let (all_variants, variant_tracker) = ConstructorFactory::resolve_enum(
                     handler,
-                    &enum_name,
-                    &enum_variants,
+                    enum_name,
+                    enum_variants,
                     enum_pattern,
                     rest,
                     span,

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
@@ -170,7 +172,7 @@ fn type_check_variable(
     {
         // If this variable is a constant, then we turn it into a [TyScrutinee::Constant](ty::TyScrutinee::Constant).
         Some(ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. })) => {
-            let constant_decl = decl_engine.get_constant(&decl_id);
+            let constant_decl = decl_engine.get_constant(&decl_id).deref().clone();
             let value = match constant_decl.value {
                 Some(ref value) => value,
                 None => {
@@ -222,7 +224,7 @@ fn type_check_struct(
         ctx.namespace
             .resolve_symbol(handler, engines, &struct_name, ctx.self_type())?;
     let struct_ref = unknown_decl.to_struct_ref(handler, ctx.engines())?;
-    let mut struct_decl = decl_engine.get_struct(&struct_ref);
+    let mut struct_decl = decl_engine.get_struct(&struct_ref).deref().clone();
 
     // monomorphize the struct definition
     ctx.monomorphize(
@@ -343,7 +345,7 @@ fn type_check_enum(
             let enum_ref = unknown_decl.to_enum_ref(handler, ctx.engines())?;
             (
                 enum_callpath.span(),
-                decl_engine.get_enum(&enum_ref),
+                decl_engine.get_enum(&enum_ref).deref().clone(),
                 unknown_decl,
             )
         }
@@ -355,7 +357,7 @@ fn type_check_enum(
             if let TyDecl::EnumVariantDecl(ty::EnumVariantDecl { enum_ref, .. }) = decl.clone() {
                 (
                     call_path.suffix.span(),
-                    decl_engine.get_enum(enum_ref.id()),
+                    decl_engine.get_enum(enum_ref.id()).deref().clone(),
                     decl,
                 )
             } else {

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
@@ -172,7 +170,7 @@ fn type_check_variable(
     {
         // If this variable is a constant, then we turn it into a [TyScrutinee::Constant](ty::TyScrutinee::Constant).
         Some(ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. })) => {
-            let constant_decl = decl_engine.get_constant(&decl_id).deref().clone();
+            let constant_decl = (*decl_engine.get_constant(&decl_id)).clone();
             let value = match constant_decl.value {
                 Some(ref value) => value,
                 None => {
@@ -224,7 +222,7 @@ fn type_check_struct(
         ctx.namespace
             .resolve_symbol(handler, engines, &struct_name, ctx.self_type())?;
     let struct_ref = unknown_decl.to_struct_ref(handler, ctx.engines())?;
-    let mut struct_decl = decl_engine.get_struct(&struct_ref).deref().clone();
+    let mut struct_decl = (*decl_engine.get_struct(&struct_ref)).clone();
 
     // monomorphize the struct definition
     ctx.monomorphize(
@@ -345,7 +343,7 @@ fn type_check_enum(
             let enum_ref = unknown_decl.to_enum_ref(handler, ctx.engines())?;
             (
                 enum_callpath.span(),
-                decl_engine.get_enum(&enum_ref).deref().clone(),
+                (*decl_engine.get_enum(&enum_ref)).clone(),
                 unknown_decl,
             )
         }
@@ -357,7 +355,7 @@ fn type_check_enum(
             if let TyDecl::EnumVariantDecl(ty::EnumVariantDecl { enum_ref, .. }) = decl.clone() {
                 (
                     call_path.suffix.span(),
-                    decl_engine.get_enum(enum_ref.id()).deref().clone(),
+                    (*decl_engine.get_enum(enum_ref.id())).clone(),
                     decl,
                 )
             } else {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/constant_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/constant_expression.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use sway_types::Spanned;
 
 use crate::{
@@ -14,12 +12,7 @@ pub(crate) fn instantiate_constant_expression(
     const_ref: DeclRefConstant,
     call_path_binding: TypeBinding<CallPath>,
 ) -> ty::TyExpression {
-    let const_decl = ctx
-        .engines
-        .de()
-        .get_constant(const_ref.id())
-        .deref()
-        .clone();
+    let const_decl = (*ctx.engines.de().get_constant(const_ref.id())).clone();
     ty::TyExpression {
         return_type: const_decl.return_type,
         span: call_path_binding.span(),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/constant_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/constant_expression.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use sway_types::Spanned;
 
 use crate::{
@@ -12,7 +14,12 @@ pub(crate) fn instantiate_constant_expression(
     const_ref: DeclRefConstant,
     call_path_binding: TypeBinding<CallPath>,
 ) -> ty::TyExpression {
-    let const_decl = ctx.engines.de().get_constant(const_ref.id());
+    let const_decl = ctx
+        .engines
+        .de()
+        .get_constant(const_ref.id())
+        .deref()
+        .clone();
     ty::TyExpression {
         return_type: const_decl.return_type,
         span: call_path_binding.span(),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use crate::{
     decl_engine::DeclRefEnum,
     language::{parsed::*, ty, CallPath},
@@ -55,7 +53,7 @@ pub(crate) fn instantiate_enum(
 
     match (
         &args[..],
-        type_engine.get(enum_variant.type_argument.type_id).deref(),
+        &*type_engine.get(enum_variant.type_argument.type_id),
     ) {
         ([], ty) if ty.is_unit() => Ok(ty::TyExpression {
             return_type: type_engine.insert(
@@ -76,7 +74,7 @@ pub(crate) fn instantiate_enum(
         }),
         ([single_expr], _) => {
             // If type context is an enum, force `single_expr` to be the enum variant type
-            let start_type = match type_engine.get(ctx.type_annotation()).deref() {
+            let start_type = match &*type_engine.get(ctx.type_annotation()) {
                 TypeInfo::Enum(e) => {
                     let expected_enum_decl = decl_engine.get_enum(e.id());
                     let expected_enum_variant = expected_enum_decl

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::{
     decl_engine::DeclRefEnum,
     language::{parsed::*, ty, CallPath},
@@ -53,7 +55,7 @@ pub(crate) fn instantiate_enum(
 
     match (
         &args[..],
-        type_engine.get(enum_variant.type_argument.type_id),
+        type_engine.get(enum_variant.type_argument.type_id).deref(),
     ) {
         ([], ty) if ty.is_unit() => Ok(ty::TyExpression {
             return_type: type_engine.insert(
@@ -74,7 +76,7 @@ pub(crate) fn instantiate_enum(
         }),
         ([single_expr], _) => {
             // If type context is an enum, force `single_expr` to be the enum variant type
-            let start_type = match type_engine.get(ctx.type_annotation()) {
+            let start_type = match type_engine.get(ctx.type_annotation()).deref() {
                 TypeInfo::Enum(e) => {
                     let expected_enum_decl = decl_engine.get_enum(e.id());
                     let expected_enum_variant = expected_enum_decl

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -3,7 +3,7 @@ use crate::{
     language::{ty, *},
     semantic_analysis::{ast_node::*, TypeCheckContext},
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Deref};
 use sway_error::error::CompileError;
 use sway_types::Spanned;
 
@@ -23,7 +23,7 @@ pub(crate) fn instantiate_function_application(
 ) -> Result<ty::TyExpression, ErrorEmitted> {
     let decl_engine = ctx.engines.de();
 
-    let mut function_decl = decl_engine.get_function(&function_decl_ref);
+    let mut function_decl = decl_engine.get_function(&function_decl_ref).deref().clone();
 
     if arguments.is_none() {
         return Err(

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -3,7 +3,7 @@ use crate::{
     language::{ty, *},
     semantic_analysis::{ast_node::*, TypeCheckContext},
 };
-use std::{collections::HashMap, ops::Deref};
+use std::collections::HashMap;
 use sway_error::error::CompileError;
 use sway_types::Spanned;
 
@@ -23,7 +23,7 @@ pub(crate) fn instantiate_function_application(
 ) -> Result<ty::TyExpression, ErrorEmitted> {
     let decl_engine = ctx.engines.de();
 
-    let mut function_decl = decl_engine.get_function(&function_decl_ref).deref().clone();
+    let mut function_decl = (*decl_engine.get_function(&function_decl_ref)).clone();
 
     if arguments.is_none() {
         return Err(

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -13,10 +13,7 @@ use crate::{
     type_system::*,
 };
 use ast_node::typed_expression::check_function_arguments_arity;
-use std::{
-    collections::{HashMap, VecDeque},
-    ops::Deref,
-};
+use std::collections::{HashMap, VecDeque};
 use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
@@ -173,9 +170,7 @@ pub(crate) fn type_check_method_application(
             if let Some(first_arg) = args_buf.get(0) {
                 // check if the user calls an ABI supertrait's method (those are private)
                 // as a contract method
-                if let TypeInfo::ContractCaller { .. } =
-                    type_engine.get(first_arg.return_type).deref()
-                {
+                if let TypeInfo::ContractCaller { .. } = &*type_engine.get(first_arg.return_type) {
                     return Err(handler.emit_err(
                         CompileError::AbiSupertraitMethodCallAsContractCall {
                             fn_name: method_name.clone(),
@@ -298,7 +293,7 @@ pub(crate) fn type_check_method_application(
         let contract_caller = args_buf.pop_front();
         let contract_address = match contract_caller
             .clone()
-            .map(|x| type_engine.get(x.return_type).deref().clone())
+            .map(|x| (*type_engine.get(x.return_type)).clone())
         {
             Some(TypeInfo::ContractCaller { address, .. }) => match address {
                 Some(address) => address,
@@ -574,7 +569,7 @@ pub(crate) fn monomorphize_method_application(
             fn_ref.clone(),
             type_binding.as_mut().unwrap().type_arguments.to_vec_mut(),
         )?;
-        let mut method = decl_engine.get_function(fn_ref).deref().clone();
+        let mut method = (*decl_engine.get_function(fn_ref)).clone();
 
         // unify the types of the arguments with the types of the parameters from the function declaration
         *arguments =
@@ -601,7 +596,7 @@ pub(crate) fn monomorphize_method_application(
                 qualified_call_path,
                 type_arguments: _,
                 root_type_id: _,
-            } = type_engine.get(t.initial_type_id).deref()
+            } = &*type_engine.get(t.initial_type_id)
             {
                 for p in method.type_parameters.clone() {
                     if p.name_ident.as_str() == qualified_call_path.call_path.suffix.as_str() {
@@ -649,7 +644,7 @@ pub(crate) fn monomorphize_method(
 ) -> Result<DeclRefFunction, ErrorEmitted> {
     let engines = ctx.engines();
     let decl_engine = engines.de();
-    let mut func_decl = decl_engine.get_function(&decl_ref).deref().clone();
+    let mut func_decl = (*decl_engine.get_function(&decl_ref)).clone();
 
     // monomorphize the function declaration
     ctx.monomorphize(

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
@@ -91,7 +93,7 @@ pub(crate) fn struct_instantiation(
     // extract the struct name and fields from the type info
     let type_info = type_engine.get(type_id);
     let struct_ref = type_info.expect_struct(handler, engines, &span)?;
-    let struct_decl = decl_engine.get_struct(&struct_ref);
+    let struct_decl = decl_engine.get_struct(&struct_ref).deref().clone();
     let struct_name = struct_decl.call_path.suffix;
     let struct_fields = struct_decl.fields;
     let mut struct_fields = struct_fields;

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
@@ -93,7 +91,7 @@ pub(crate) fn struct_instantiation(
     // extract the struct name and fields from the type info
     let type_info = type_engine.get(type_id);
     let struct_ref = type_info.expect_struct(handler, engines, &span)?;
-    let struct_decl = decl_engine.get_struct(&struct_ref).deref().clone();
+    let struct_decl = (*decl_engine.get_struct(&struct_ref)).clone();
     let struct_name = struct_decl.call_path.suffix;
     let struct_fields = struct_decl.fields;
     let mut struct_fields = struct_fields;

--- a/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
+++ b/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
@@ -16,8 +16,8 @@ use crate::{
     },
     Engines,
 };
+use std::fmt;
 use std::{collections::HashSet, sync::Arc};
-use std::{fmt, ops::Deref};
 use sway_error::warning::{CompileWarning, Warning};
 use sway_types::{Ident, Span, Spanned};
 
@@ -502,7 +502,7 @@ fn effects_of_expression(engines: &Engines, expr: &ty::TyExpression) -> HashSet<
         | AbiName(_) => HashSet::new(),
         // this type of assignment only mutates local variables and not storage
         Reassignment(reassgn) => effects_of_expression(engines, &reassgn.rhs),
-        StorageAccess(_) => match type_engine.get(expr.return_type).deref() {
+        StorageAccess(_) => match &*type_engine.get(expr.return_type) {
             // accessing a storage map's method (or a storage vector's method),
             // which is represented using a struct with empty fields
             // does not result in a storage read

--- a/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
+++ b/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
@@ -16,8 +16,8 @@ use crate::{
     },
     Engines,
 };
-use std::collections::HashSet;
 use std::fmt;
+use std::{collections::HashSet, sync::Arc};
 use sway_error::warning::{CompileWarning, Warning};
 use sway_types::{Ident, Span, Spanned};
 
@@ -93,7 +93,7 @@ fn analyze_contract(engines: &Engines, ast_nodes: &[ty::TyAstNode]) -> Vec<Compi
 fn contract_entry_points(
     decl_engine: &DeclEngine,
     ast_nodes: &[ty::TyAstNode],
-) -> Vec<ty::TyFunctionDecl> {
+) -> Vec<Arc<ty::TyFunctionDecl>> {
     use crate::ty::TyAstNodeContent::Declaration;
     ast_nodes
         .iter()
@@ -112,14 +112,14 @@ fn contract_entry_points(
 fn decl_id_to_fn_decls(
     decl_engine: &DeclEngine,
     decl_id: &DeclId<TyFunctionDecl>,
-) -> Vec<TyFunctionDecl> {
+) -> Vec<Arc<TyFunctionDecl>> {
     vec![decl_engine.get_function(decl_id)]
 }
 
 fn impl_trait_methods(
     decl_engine: &DeclEngine,
     impl_trait_decl_id: &DeclId<TyImplTrait>,
-) -> Vec<ty::TyFunctionDecl> {
+) -> Vec<Arc<ty::TyFunctionDecl>> {
     let impl_trait = decl_engine.get_impl_trait(impl_trait_decl_id);
     impl_trait
         .items
@@ -576,8 +576,8 @@ fn effects_of_expression(engines: &Engines, expr: &ty::TyExpression) -> HashSet<
             selector,
             ..
         } => {
-            let fn_body = decl_engine.get_function(fn_ref).body;
-            let mut effs = effects_of_codeblock(engines, &fn_body);
+            let fn_body = &decl_engine.get_function(fn_ref).body;
+            let mut effs = effects_of_codeblock(engines, fn_body);
             let args_effs = map_hashsets_union(arguments, |e| effects_of_expression(engines, &e.1));
             effs.extend(args_effs);
             if selector.is_some() {

--- a/sway-core/src/semantic_analysis/coins_analysis.rs
+++ b/sway-core/src/semantic_analysis/coins_analysis.rs
@@ -33,9 +33,9 @@ pub fn possibly_nonzero_u64_expression(
                         }
                         ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
                             let const_decl = engines.de().get_constant(&decl_id);
-                            match const_decl.value {
+                            match &const_decl.value {
                                 Some(value) => {
-                                    possibly_nonzero_u64_expression(namespace, engines, &value)
+                                    possibly_nonzero_u64_expression(namespace, engines, value)
                                 }
                                 None => true,
                             }

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -18,7 +18,7 @@ use sway_error::{
 };
 use sway_types::{span::Span, Spanned};
 
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
 /// Is this a glob (`use foo::*;`) import?
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -309,7 +309,7 @@ impl Items {
     pub fn get_declared_storage(&self, decl_engine: &DeclEngine) -> Option<TyStorageDecl> {
         self.declared_storage
             .as_ref()
-            .map(|decl_ref| decl_engine.get_storage(decl_ref))
+            .map(|decl_ref| decl_engine.get_storage(decl_ref).deref().clone())
     }
 
     pub(crate) fn get_storage_field_descriptors(
@@ -318,7 +318,7 @@ impl Items {
         decl_engine: &DeclEngine,
     ) -> Result<Vec<ty::TyStorageField>, ErrorEmitted> {
         match self.get_declared_storage(decl_engine) {
-            Some(storage) => Ok(storage.fields),
+            Some(storage) => Ok(storage.fields.clone()),
             None => {
                 let msg = "unknown source location";
                 let span = Span::new(Arc::from(msg), 0, msg.len(), None).unwrap();
@@ -393,7 +393,7 @@ impl Items {
 
                             return Err(handler.emit_err(CompileError::FieldNotFound {
                                 field_name: field_name.clone(),
-                                struct_name: struct_decl.call_path.suffix,
+                                struct_name: struct_decl.call_path.suffix.clone(),
                                 available_fields: available_fields.join(", "),
                                 span: field_name.span(),
                             }));

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -18,7 +18,7 @@ use sway_error::{
 };
 use sway_types::{span::Span, Spanned};
 
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 /// Is this a glob (`use foo::*;`) import?
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -309,7 +309,7 @@ impl Items {
     pub fn get_declared_storage(&self, decl_engine: &DeclEngine) -> Option<TyStorageDecl> {
         self.declared_storage
             .as_ref()
-            .map(|decl_ref| decl_engine.get_storage(decl_ref).deref().clone())
+            .map(|decl_ref| (*decl_engine.get_storage(decl_ref)).clone())
     }
 
     pub(crate) fn get_storage_field_descriptors(

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -596,8 +596,8 @@ impl Module {
                         enum_decl.span(),
                     );
 
-                    for variant_decl in enum_decl.variants {
-                        let variant_name = variant_decl.name;
+                    for variant_decl in enum_decl.variants.iter() {
+                        let variant_name = &variant_decl.name;
 
                         // import it this way.
                         let dst_ns = &mut self[dst];
@@ -608,7 +608,7 @@ impl Module {
                                 GlobImport::Yes,
                                 TyDecl::EnumVariantDecl(ty::EnumVariantDecl {
                                     enum_ref: enum_ref.clone(),
-                                    variant_name,
+                                    variant_name: variant_name.clone(),
                                     variant_decl_span: variant_decl.span.clone(),
                                 }),
                                 is_src_absolute,

--- a/sway-core/src/semantic_analysis/namespace/root.rs
+++ b/sway-core/src/semantic_analysis/namespace/root.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
@@ -263,7 +265,11 @@ impl Root {
             )),
             ty::TyDecl::TraitTypeDecl(type_decl) => {
                 let type_decl = engines.de().get_type(&type_decl.decl_id);
-                engines.te().get(type_decl.ty.clone().unwrap().type_id)
+                engines
+                    .te()
+                    .get(type_decl.ty.clone().unwrap().type_id)
+                    .deref()
+                    .clone()
             }
             _ => {
                 return Err(handler.emit_err(CompileError::SymbolNotFound {

--- a/sway-core/src/semantic_analysis/namespace/root.rs
+++ b/sway-core/src/semantic_analysis/namespace/root.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
@@ -265,11 +263,7 @@ impl Root {
             )),
             ty::TyDecl::TraitTypeDecl(type_decl) => {
                 let type_decl = engines.de().get_type(&type_decl.decl_id);
-                engines
-                    .te()
-                    .get(type_decl.ty.clone().unwrap().type_id)
-                    .deref()
-                    .clone()
+                (*engines.te().get(type_decl.ty.clone().unwrap().type_id)).clone()
             }
             _ => {
                 return Err(handler.emit_err(CompileError::SymbolNotFound {

--- a/sway-core/src/semantic_analysis/namespace/root.rs
+++ b/sway-core/src/semantic_analysis/namespace/root.rs
@@ -263,7 +263,7 @@ impl Root {
             )),
             ty::TyDecl::TraitTypeDecl(type_decl) => {
                 let type_decl = engines.de().get_type(&type_decl.decl_id);
-                engines.te().get(type_decl.ty.unwrap().type_id)
+                engines.te().get(type_decl.ty.clone().unwrap().type_id)
             }
             _ => {
                 return Err(handler.emit_err(CompileError::SymbolNotFound {

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -2,6 +2,7 @@ use std::{
     cmp::Ordering,
     collections::{BTreeSet, HashMap},
     fmt,
+    ops::Deref,
 };
 
 use sway_error::{
@@ -735,7 +736,7 @@ impl TraitMap {
                         .into_iter()
                         .map(|(name, item)| match &item {
                             ty::TyTraitItem::Fn(decl_ref) => {
-                                let mut decl = decl_engine.get(decl_ref.id());
+                                let mut decl = decl_engine.get(decl_ref.id()).deref().clone();
                                 decl.subst(&type_mapping, engines);
                                 let new_ref = decl_engine
                                     .insert(decl)
@@ -743,13 +744,13 @@ impl TraitMap {
                                 (name, TyImplItem::Fn(new_ref))
                             }
                             ty::TyTraitItem::Constant(decl_ref) => {
-                                let mut decl = decl_engine.get(decl_ref.id());
+                                let mut decl = decl_engine.get(decl_ref.id()).deref().clone();
                                 decl.subst(&type_mapping, engines);
                                 let new_ref = decl_engine.insert(decl);
                                 (name, TyImplItem::Constant(new_ref))
                             }
                             ty::TyTraitItem::Type(decl_ref) => {
-                                let mut decl = decl_engine.get(decl_ref.id());
+                                let mut decl = decl_engine.get(decl_ref.id()).deref().clone();
                                 decl.subst(&type_mapping, engines);
                                 let new_ref = decl_engine.insert(decl);
                                 (name, TyImplItem::Type(new_ref))

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -801,7 +801,7 @@ impl TraitMap {
 
         let mut items = vec![];
         // small performance gain in bad case
-        if matches!(type_engine.get(type_id), TypeInfo::ErrorRecovery(_)) {
+        if matches!(type_engine.get(type_id).deref(), TypeInfo::ErrorRecovery(_)) {
             return items;
         }
         for entry in self.trait_impls.iter() {
@@ -834,7 +834,10 @@ impl TraitMap {
 
         let mut spans = vec![];
         // small performance gain in bad case
-        if matches!(type_engine.get(*type_id), TypeInfo::ErrorRecovery(_)) {
+        if matches!(
+            type_engine.get(*type_id).deref(),
+            TypeInfo::ErrorRecovery(_)
+        ) {
             return spans;
         }
         for entry in self.trait_impls.iter() {
@@ -885,7 +888,7 @@ impl TraitMap {
         let unify_check = UnifyCheck::non_dynamic_equality(engines);
         let mut items = vec![];
         // small performance gain in bad case
-        if matches!(type_engine.get(type_id), TypeInfo::ErrorRecovery(_)) {
+        if matches!(type_engine.get(type_id).deref(), TypeInfo::ErrorRecovery(_)) {
             return items;
         }
         for e in self.trait_impls.iter() {
@@ -918,7 +921,7 @@ impl TraitMap {
         let unify_check = UnifyCheck::non_dynamic_equality(engines);
         let mut trait_names = vec![];
         // small performance gain in bad case
-        if matches!(type_engine.get(type_id), TypeInfo::ErrorRecovery(_)) {
+        if matches!(type_engine.get(type_id).deref(), TypeInfo::ErrorRecovery(_)) {
             return trait_names;
         }
         for entry in self.trait_impls.iter() {
@@ -1107,7 +1110,7 @@ impl TraitMap {
                         qualified_call_path: _,
                         type_arguments: Some(type_arguments),
                         root_type_id: _,
-                    } = type_engine.get(*constraint_type_id)
+                    } = type_engine.get(*constraint_type_id).deref()
                     {
                         type_arguments_string = format!("<{}>", engines.help_out(type_arguments));
                     }

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -2,7 +2,6 @@ use std::{
     cmp::Ordering,
     collections::{BTreeSet, HashMap},
     fmt,
-    ops::Deref,
 };
 
 use sway_error::{
@@ -736,7 +735,7 @@ impl TraitMap {
                         .into_iter()
                         .map(|(name, item)| match &item {
                             ty::TyTraitItem::Fn(decl_ref) => {
-                                let mut decl = decl_engine.get(decl_ref.id()).deref().clone();
+                                let mut decl = (*decl_engine.get(decl_ref.id())).clone();
                                 decl.subst(&type_mapping, engines);
                                 let new_ref = decl_engine
                                     .insert(decl)
@@ -744,13 +743,13 @@ impl TraitMap {
                                 (name, TyImplItem::Fn(new_ref))
                             }
                             ty::TyTraitItem::Constant(decl_ref) => {
-                                let mut decl = decl_engine.get(decl_ref.id()).deref().clone();
+                                let mut decl = (*decl_engine.get(decl_ref.id())).clone();
                                 decl.subst(&type_mapping, engines);
                                 let new_ref = decl_engine.insert(decl);
                                 (name, TyImplItem::Constant(new_ref))
                             }
                             ty::TyTraitItem::Type(decl_ref) => {
-                                let mut decl = decl_engine.get(decl_ref.id()).deref().clone();
+                                let mut decl = (*decl_engine.get(decl_ref.id())).clone();
                                 decl.subst(&type_mapping, engines);
                                 let new_ref = decl_engine.insert(decl);
                                 (name, TyImplItem::Type(new_ref))
@@ -801,7 +800,7 @@ impl TraitMap {
 
         let mut items = vec![];
         // small performance gain in bad case
-        if matches!(type_engine.get(type_id).deref(), TypeInfo::ErrorRecovery(_)) {
+        if matches!(&*type_engine.get(type_id), TypeInfo::ErrorRecovery(_)) {
             return items;
         }
         for entry in self.trait_impls.iter() {
@@ -834,10 +833,7 @@ impl TraitMap {
 
         let mut spans = vec![];
         // small performance gain in bad case
-        if matches!(
-            type_engine.get(*type_id).deref(),
-            TypeInfo::ErrorRecovery(_)
-        ) {
+        if matches!(&*type_engine.get(*type_id), TypeInfo::ErrorRecovery(_)) {
             return spans;
         }
         for entry in self.trait_impls.iter() {
@@ -888,7 +884,7 @@ impl TraitMap {
         let unify_check = UnifyCheck::non_dynamic_equality(engines);
         let mut items = vec![];
         // small performance gain in bad case
-        if matches!(type_engine.get(type_id).deref(), TypeInfo::ErrorRecovery(_)) {
+        if matches!(&*type_engine.get(type_id), TypeInfo::ErrorRecovery(_)) {
             return items;
         }
         for e in self.trait_impls.iter() {
@@ -921,7 +917,7 @@ impl TraitMap {
         let unify_check = UnifyCheck::non_dynamic_equality(engines);
         let mut trait_names = vec![];
         // small performance gain in bad case
-        if matches!(type_engine.get(type_id).deref(), TypeInfo::ErrorRecovery(_)) {
+        if matches!(&*type_engine.get(type_id), TypeInfo::ErrorRecovery(_)) {
             return trait_names;
         }
         for entry in self.trait_impls.iter() {
@@ -1110,7 +1106,7 @@ impl TraitMap {
                         qualified_call_path: _,
                         type_arguments: Some(type_arguments),
                         root_type_id: _,
-                    } = type_engine.get(*constraint_type_id).deref()
+                    } = &*type_engine.get(*constraint_type_id)
                     {
                         type_arguments_string = format!("<{}>", engines.help_out(type_arguments));
                     }

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, VecDeque};
+use std::{
+    collections::{HashMap, VecDeque},
+    ops::Deref,
+};
 
 use crate::{
     decl_engine::{DeclEngineInsert, DeclRefFunction},
@@ -525,7 +528,7 @@ impl<'a> TypeCheckContext<'a> {
                     .get_trait_item_for_type(handler, self.engines, &name, trait_type_id, None)?;
                 if let TyTraitItem::Type(type_ref) = item_ref {
                     let type_decl = self.engines.de().get_type(type_ref.id());
-                    if let Some(ty) = type_decl.ty {
+                    if let Some(ty) = &type_decl.ty {
                         ty.type_id
                     } else {
                         type_id
@@ -748,7 +751,7 @@ impl<'a> TypeCheckContext<'a> {
                 ..
             })) => {
                 // get the copy from the declaration engine
-                let mut new_copy = decl_engine.get_struct(&original_id);
+                let mut new_copy = decl_engine.get_struct(&original_id).deref().clone();
 
                 // monomorphize the copy, in place
                 self.monomorphize_with_modpath(
@@ -775,7 +778,7 @@ impl<'a> TypeCheckContext<'a> {
                 ..
             })) => {
                 // get the copy from the declaration engine
-                let mut new_copy = decl_engine.get_enum(&original_id);
+                let mut new_copy = decl_engine.get_enum(&original_id).deref().clone();
 
                 // monomorphize the copy, in place
                 self.monomorphize_with_modpath(
@@ -819,7 +822,7 @@ impl<'a> TypeCheckContext<'a> {
             })) => {
                 let decl_type = decl_engine.get_type(&decl_id);
 
-                if let Some(ty) = decl_type.ty {
+                if let Some(ty) = &decl_type.ty {
                     ty.type_id
                 } else if let Some(implementing_type) = self.self_type() {
                     type_engine.insert(
@@ -1055,7 +1058,7 @@ impl<'a> TypeCheckContext<'a> {
                         if !skip_insert {
                             trait_methods.insert(
                                 (
-                                    trait_decl.trait_name,
+                                    trait_decl.trait_name.clone(),
                                     trait_decl
                                         .trait_type_arguments
                                         .iter()

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -43,6 +43,7 @@ use std::{
     convert::TryFrom,
     iter,
     mem::MaybeUninit,
+    ops::Deref,
     str::FromStr,
     sync::Arc,
 };
@@ -364,7 +365,7 @@ fn item_struct_to_struct_declaration(
         .collect::<Result<Vec<_>, _>>()?;
 
     if fields.iter().any(
-        |field| matches!(&engines.te().get(field.type_argument.type_id), TypeInfo::Custom { qualified_call_path, ..} if qualified_call_path.call_path.suffix == item_struct.name),
+        |field| matches!(&engines.te().get(field.type_argument.type_id).deref(), TypeInfo::Custom { qualified_call_path, ..} if qualified_call_path.call_path.suffix == item_struct.name),
     ) {
         errors.push(ConvertParseTreeError::RecursiveType { span: span.clone() });
     }
@@ -433,7 +434,7 @@ fn item_enum_to_enum_declaration(
         .collect::<Result<Vec<_>, _>>()?;
 
     if variants.iter().any(|variant| {
-       matches!(&engines.te().get(variant.type_argument.type_id), TypeInfo::Custom { qualified_call_path, ..} if qualified_call_path.call_path.suffix == item_enum.name)
+       matches!(&engines.te().get(variant.type_argument.type_id).deref(), TypeInfo::Custom { qualified_call_path, ..} if qualified_call_path.call_path.suffix == item_enum.name)
     }) {
         errors.push(ConvertParseTreeError::RecursiveType { span: span.clone() });
     }
@@ -727,7 +728,7 @@ fn item_impl_to_declaration(
             };
             Ok(Declaration::ImplTrait(impl_trait))
         }
-        None => match engines.te().get(implementing_for.type_id) {
+        None => match engines.te().get(implementing_for.type_id).deref() {
             TypeInfo::Contract => Err(handler
                 .emit_err(ConvertParseTreeError::SelfImplForContract { span: block_span }.into())),
             _ => {

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -43,7 +43,6 @@ use std::{
     convert::TryFrom,
     iter,
     mem::MaybeUninit,
-    ops::Deref,
     str::FromStr,
     sync::Arc,
 };
@@ -365,7 +364,7 @@ fn item_struct_to_struct_declaration(
         .collect::<Result<Vec<_>, _>>()?;
 
     if fields.iter().any(
-        |field| matches!(&engines.te().get(field.type_argument.type_id).deref(), TypeInfo::Custom { qualified_call_path, ..} if qualified_call_path.call_path.suffix == item_struct.name),
+        |field| matches!(&&*engines.te().get(field.type_argument.type_id), TypeInfo::Custom { qualified_call_path, ..} if qualified_call_path.call_path.suffix == item_struct.name),
     ) {
         errors.push(ConvertParseTreeError::RecursiveType { span: span.clone() });
     }
@@ -434,7 +433,7 @@ fn item_enum_to_enum_declaration(
         .collect::<Result<Vec<_>, _>>()?;
 
     if variants.iter().any(|variant| {
-       matches!(&engines.te().get(variant.type_argument.type_id).deref(), TypeInfo::Custom { qualified_call_path, ..} if qualified_call_path.call_path.suffix == item_enum.name)
+       matches!(&&*engines.te().get(variant.type_argument.type_id), TypeInfo::Custom { qualified_call_path, ..} if qualified_call_path.call_path.suffix == item_enum.name)
     }) {
         errors.push(ConvertParseTreeError::RecursiveType { span: span.clone() });
     }
@@ -728,7 +727,7 @@ fn item_impl_to_declaration(
             };
             Ok(Declaration::ImplTrait(impl_trait))
         }
-        None => match engines.te().get(implementing_for.type_id).deref() {
+        None => match &*engines.te().get(implementing_for.type_id) {
             TypeInfo::Contract => Err(handler
                 .emit_err(ConvertParseTreeError::SelfImplForContract { span: block_span }.into())),
             _ => {

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::{Span, Spanned};
 
@@ -235,7 +237,7 @@ impl TypeCheckTypeBinding<ty::TyFunctionDecl> for TypeBinding<CallPath> {
         // Check to see if this is a fn declaration.
         let fn_ref = unknown_decl.to_fn_ref(handler)?;
         // Get a new copy from the declaration engine.
-        let mut new_copy = decl_engine.get_function(fn_ref.id());
+        let mut new_copy = decl_engine.get_function(fn_ref.id()).deref().clone();
         match self.type_arguments {
             // Monomorphize the copy, in place.
             TypeArgs::Regular(_) => {
@@ -294,7 +296,7 @@ impl TypeCheckTypeBinding<ty::TyStructDecl> for TypeBinding<CallPath> {
         // Check to see if this is a struct declaration.
         let struct_ref = unknown_decl.to_struct_ref(handler, engines)?;
         // Get a new copy from the declaration engine.
-        let mut new_copy = decl_engine.get_struct(struct_ref.id());
+        let mut new_copy = decl_engine.get_struct(struct_ref.id()).deref().clone();
         // Monomorphize the copy, in place.
         ctx.monomorphize(
             handler,
@@ -339,11 +341,11 @@ impl TypeCheckTypeBinding<ty::TyEnumDecl> for TypeBinding<CallPath> {
             ..
         }) = &unknown_decl
         {
-            decl_engine.get_enum(enum_ref.id())
+            decl_engine.get_enum(enum_ref.id()).deref().clone()
         } else {
             // Check to see if this is a enum declaration.
             let enum_ref = unknown_decl.to_enum_ref(handler, engines)?;
-            decl_engine.get_enum(enum_ref.id())
+            decl_engine.get_enum(enum_ref.id()).deref().clone()
         };
 
         // Monomorphize the copy, in place.

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::{Span, Spanned};
 
@@ -237,7 +235,7 @@ impl TypeCheckTypeBinding<ty::TyFunctionDecl> for TypeBinding<CallPath> {
         // Check to see if this is a fn declaration.
         let fn_ref = unknown_decl.to_fn_ref(handler)?;
         // Get a new copy from the declaration engine.
-        let mut new_copy = decl_engine.get_function(fn_ref.id()).deref().clone();
+        let mut new_copy = (*decl_engine.get_function(fn_ref.id())).clone();
         match self.type_arguments {
             // Monomorphize the copy, in place.
             TypeArgs::Regular(_) => {
@@ -296,7 +294,7 @@ impl TypeCheckTypeBinding<ty::TyStructDecl> for TypeBinding<CallPath> {
         // Check to see if this is a struct declaration.
         let struct_ref = unknown_decl.to_struct_ref(handler, engines)?;
         // Get a new copy from the declaration engine.
-        let mut new_copy = decl_engine.get_struct(struct_ref.id()).deref().clone();
+        let mut new_copy = (*decl_engine.get_struct(struct_ref.id())).clone();
         // Monomorphize the copy, in place.
         ctx.monomorphize(
             handler,
@@ -341,11 +339,11 @@ impl TypeCheckTypeBinding<ty::TyEnumDecl> for TypeBinding<CallPath> {
             ..
         }) = &unknown_decl
         {
-            decl_engine.get_enum(enum_ref.id()).deref().clone()
+            (*decl_engine.get_enum(enum_ref.id())).clone()
         } else {
             // Check to see if this is a enum declaration.
             let enum_ref = unknown_decl.to_enum_ref(handler, engines)?;
-            decl_engine.get_enum(enum_ref.id()).deref().clone()
+            (*decl_engine.get_enum(enum_ref.id())).clone()
         };
 
         // Monomorphize the copy, in place.

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -2,6 +2,7 @@ use std::{
     cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
+    ops::Deref,
 };
 
 use sway_error::{
@@ -181,7 +182,7 @@ impl TraitConstraint {
             .ok()
         {
             Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
-                let mut trait_decl = decl_engine.get_trait(&decl_id);
+                let mut trait_decl = decl_engine.get_trait(&decl_id).deref().clone();
 
                 // the following essentially is needed to map `Self` to the right type
                 // during trait decl monomorphization

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -2,7 +2,6 @@ use std::{
     cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
-    ops::Deref,
 };
 
 use sway_error::{
@@ -182,7 +181,7 @@ impl TraitConstraint {
             .ok()
         {
             Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
-                let mut trait_decl = decl_engine.get_trait(&decl_id).deref().clone();
+                let mut trait_decl = (*decl_engine.get_trait(&decl_id)).clone();
 
                 // the following essentially is needed to map `Self` to the right type
                 // during trait decl monomorphization

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -1,5 +1,5 @@
 use crate::{engine_threading::*, language::CallPathTree, type_system::priv_prelude::*};
-use std::{cmp::Ordering, fmt, hash::Hasher};
+use std::{cmp::Ordering, fmt, hash::Hasher, ops::Deref};
 use sway_types::{Span, Spanned};
 
 #[derive(Debug, Clone)]
@@ -80,13 +80,21 @@ impl OrdWithEngines for TypeArgument {
 
 impl DisplayWithEngines for TypeArgument {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, engines: &Engines) -> fmt::Result {
-        write!(f, "{}", engines.help_out(engines.te().get(self.type_id)))
+        write!(
+            f,
+            "{}",
+            engines.help_out(engines.te().get(self.type_id).deref())
+        )
     }
 }
 
 impl DebugWithEngines for TypeArgument {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, engines: &Engines) -> fmt::Result {
-        write!(f, "{:?}", engines.help_out(engines.te().get(self.type_id)))
+        write!(
+            f,
+            "{:?}",
+            engines.help_out(engines.te().get(self.type_id).deref())
+        )
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -1,5 +1,5 @@
 use crate::{engine_threading::*, language::CallPathTree, type_system::priv_prelude::*};
-use std::{cmp::Ordering, fmt, hash::Hasher, ops::Deref};
+use std::{cmp::Ordering, fmt, hash::Hasher};
 use sway_types::{Span, Spanned};
 
 #[derive(Debug, Clone)]
@@ -80,11 +80,7 @@ impl OrdWithEngines for TypeArgument {
 
 impl DisplayWithEngines for TypeArgument {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, engines: &Engines) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            engines.help_out(engines.te().get(self.type_id).deref())
-        )
+        write!(f, "{}", engines.help_out(&*engines.te().get(self.type_id)))
     }
 }
 
@@ -93,7 +89,7 @@ impl DebugWithEngines for TypeArgument {
         write!(
             f,
             "{:?}",
-            engines.help_out(engines.te().get(self.type_id).deref())
+            engines.help_out(&*engines.te().get(self.type_id))
         )
     }
 }

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -315,7 +315,6 @@ impl TypeParameter {
         type_parameter: TypeParameter,
     ) -> Result<(), ErrorEmitted> {
         let type_engine = ctx.engines.te();
-        let engines = ctx.engines();
 
         let mut trait_constraints_with_supertraits: Vec<TraitConstraint> = type_parameter
             .trait_constraints
@@ -333,7 +332,6 @@ impl TypeParameter {
         // Trait constraints mutate so we replace the previous type id associated TypeInfo.
         type_engine.replace(
             type_parameter.type_id,
-            engines,
             TypeSourceInfo {
                 type_info: TypeInfo::UnknownGeneric {
                     name: type_parameter.name_ident.clone(),

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -6,7 +6,10 @@ use crate::{
 };
 use core::fmt::Write;
 use hashbrown::{hash_map::RawEntryMut, HashMap};
-use std::sync::RwLock;
+use std::{
+    ops::Deref,
+    sync::{Arc, RwLock},
+};
 use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
@@ -18,7 +21,8 @@ use super::unify::unifier::UnifyKind;
 
 #[derive(Debug, Default)]
 pub struct TypeEngine {
-    pub(super) slab: ConcurrentSlab<TypeSourceInfo>,
+    slab: ConcurrentSlab<TypeInfo>,
+    slab_source_ids: ConcurrentSlab<Option<SourceId>>,
     id_map: RwLock<HashMap<TypeSourceInfo, TypeId>>,
 }
 
@@ -34,26 +38,32 @@ impl TypeEngine {
         let source_id = source_id
             .map(Clone::clone)
             .or_else(|| info_to_source_id(&ty));
-        let ty = TypeSourceInfo {
-            type_info: ty,
+        let tsi = TypeSourceInfo {
+            type_info: ty.clone(),
             source_id,
         };
         let mut id_map = self.id_map.write().unwrap();
 
         let hash_builder = id_map.hasher().clone();
-        let ty_hash = make_hasher(&hash_builder, engines)(&ty);
+        let ty_hash = make_hasher(&hash_builder, engines)(&tsi);
 
         let raw_entry = id_map
             .raw_entry_mut()
-            .from_hash(ty_hash, |x| x.eq(&ty, engines));
+            .from_hash(ty_hash, |x| x.eq(&tsi, engines));
         match raw_entry {
             RawEntryMut::Occupied(o) => return *o.get(),
-            RawEntryMut::Vacant(_) if ty.type_info.can_change(engines.de()) => {
-                TypeId::new(self.slab.insert(ty))
+            RawEntryMut::Vacant(_) if ty.can_change(engines.de()) => {
+                let t1 = self.slab.insert(ty);
+                let t2 = self.slab_source_ids.insert(source_id);
+                assert!(t1 == t2);
+                TypeId::new(t1)
             }
             RawEntryMut::Vacant(v) => {
-                let type_id = TypeId::new(self.slab.insert(ty.clone()));
-                v.insert_with_hasher(ty_hash, ty, type_id, make_hasher(&hash_builder, engines));
+                let t1 = self.slab.insert(ty);
+                let t2 = self.slab_source_ids.insert(source_id);
+                assert!(t1 == t2);
+                let type_id = TypeId::new(t1);
+                v.insert_with_hasher(ty_hash, tsi, type_id, make_hasher(&hash_builder, engines));
                 type_id
             }
         }
@@ -61,30 +71,33 @@ impl TypeEngine {
 
     /// Removes all data associated with `module_id` from the type engine.
     pub fn clear_module(&mut self, module_id: &ModuleId) {
-        self.slab.retain(|ty| match &ty.source_id {
-            Some(source_id) => &source_id.module_id() != module_id,
-            None => false,
-        });
+        self.slab_source_ids
+            .retain(|source_id| match source_id.deref() {
+                Some(source_id) => &source_id.module_id() != module_id,
+                None => false,
+            });
     }
 
-    pub fn replace(&self, id: TypeId, engines: &Engines, new_value: TypeSourceInfo) {
-        let prev_value = self.slab.get(id.index());
-        self.slab.replace(id, &prev_value, new_value, engines);
+    pub fn replace(&self, id: TypeId, new_value: TypeSourceInfo) {
+        self.slab.replace(id.index(), new_value.type_info);
+        self.slab_source_ids
+            .replace(id.index(), new_value.source_id);
     }
 
     /// Performs a lookup of `id` into the [TypeEngine].
-    pub fn get(&self, id: TypeId) -> TypeInfo {
-        self.slab.get(id.index()).type_info.clone()
+    pub fn get(&self, id: TypeId) -> Arc<TypeInfo> {
+        self.slab.get(id.index())
     }
 
     /// Performs a lookup of `id` into the [TypeEngine] recursing when finding a
     /// [TypeInfo::Alias].
-    pub fn get_unaliased(&self, id: TypeId) -> TypeInfo {
+    pub fn get_unaliased(&self, id: TypeId) -> Arc<TypeInfo> {
         // A slight infinite loop concern if we somehow have self-referential aliases, but that
         // shouldn't be possible.
-        match self.slab.get(id.index()).type_info.clone() {
+        let type_info = self.slab.get(id.index());
+        match type_info.deref() {
             TypeInfo::Alias { ty, .. } => self.get_unaliased(ty.type_id),
-            ty_info => ty_info,
+            _ => type_info,
         }
     }
 
@@ -221,17 +234,17 @@ impl TypeEngine {
     }
 
     pub(crate) fn to_typeinfo(&self, id: TypeId, error_span: &Span) -> Result<TypeInfo, TypeError> {
-        match self.get(id) {
+        match self.get(id).deref() {
             TypeInfo::Unknown => Err(TypeError::UnknownType {
                 span: error_span.clone(),
             }),
-            ty => Ok(ty),
+            ty => Ok(ty.clone()),
         }
     }
 
     /// Return whether a given type still contains undecayed references to [TypeInfo::Numeric]
     pub(crate) fn contains_numeric(&self, decl_engine: &DeclEngine, type_id: TypeId) -> bool {
-        match &self.get(type_id) {
+        match &self.get(type_id).deref() {
             TypeInfo::Enum(decl_ref) => {
                 decl_engine
                     .get_enum(decl_ref)
@@ -286,7 +299,7 @@ impl TypeEngine {
     ) -> Result<(), ErrorEmitted> {
         let decl_engine = engines.de();
 
-        match &self.get(type_id) {
+        match &self.get(type_id).deref() {
             TypeInfo::Enum(decl_ref) => {
                 for variant_type in decl_engine.get_enum(decl_ref).variants.iter() {
                     self.decay_numeric(handler, engines, variant_type.type_argument.type_id, span)?;
@@ -352,10 +365,7 @@ impl TypeEngine {
         let mut builder = String::new();
         let mut list = vec![];
         for i in 0..self.slab.len() {
-            list.push(format!(
-                "{:?}",
-                engines.help_out(self.slab.get(i).type_info.clone())
-            ));
+            list.push(format!("{:?}", engines.help_out(self.slab.get(i).deref())));
         }
         let list = ListDisplay { list };
         write!(builder, "TypeEngine {{\n{list}\n}}").unwrap();

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -116,11 +116,11 @@ impl TypeId {
         match type_engine.get(*self) {
             TypeInfo::Enum(decl_ref) => {
                 let decl = decl_engine.get_enum(&decl_ref);
-                (!decl.type_parameters.is_empty()).then_some(decl.type_parameters)
+                (!decl.type_parameters.is_empty()).then_some(decl.type_parameters.clone())
             }
             TypeInfo::Struct(decl_ref) => {
                 let decl = decl_engine.get_struct(&decl_ref);
-                (!decl.type_parameters.is_empty()).then_some(decl.type_parameters)
+                (!decl.type_parameters.is_empty()).then_some(decl.type_parameters.clone())
             }
             _ => None,
         }

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -13,6 +13,7 @@ use crate::{
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     fmt,
+    ops::Deref,
 };
 
 /// A identifier to uniquely refer to our type terms
@@ -21,13 +22,13 @@ pub struct TypeId(usize);
 
 impl DisplayWithEngines for TypeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, engines: &Engines) -> fmt::Result {
-        write!(f, "{}", engines.help_out(engines.te().get(*self)))
+        write!(f, "{}", engines.help_out(engines.te().get(*self).deref()))
     }
 }
 
 impl DebugWithEngines for TypeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, engines: &Engines) -> fmt::Result {
-        write!(f, "{:?}", engines.help_out(engines.te().get(*self)))
+        write!(f, "{:?}", engines.help_out(engines.te().get(*self).deref()))
     }
 }
 
@@ -51,16 +52,16 @@ impl CollectTypesMetadata for TypeId {
         let possible = self.extract_any_including_self(engines, &filter_fn, vec![]);
         let mut res = vec![];
         for (type_id, _) in possible.into_iter() {
-            match ctx.engines.te().get(type_id) {
+            match ctx.engines.te().get(type_id).deref() {
                 TypeInfo::UnknownGeneric { name, .. } => {
                     res.push(TypeMetadata::UnresolvedType(
-                        name,
+                        name.clone(),
                         ctx.call_site_get(&type_id),
                     ));
                 }
                 TypeInfo::Placeholder(type_param) => {
                     res.push(TypeMetadata::UnresolvedType(
-                        type_param.name_ident,
+                        type_param.name_ident.clone(),
                         ctx.call_site_get(self),
                     ));
                 }
@@ -75,7 +76,10 @@ impl SubstTypes for TypeId {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
         let type_engine = engines.te();
         if let Some(matching_id) = type_mapping.find_match(*self, engines) {
-            if !matches!(type_engine.get(matching_id), TypeInfo::ErrorRecovery(_)) {
+            if !matches!(
+                type_engine.get(matching_id).deref(),
+                TypeInfo::ErrorRecovery(_)
+            ) {
                 *self = matching_id;
             }
         }
@@ -113,13 +117,13 @@ impl TypeId {
         type_engine: &TypeEngine,
         decl_engine: &DeclEngine,
     ) -> Option<Vec<TypeParameter>> {
-        match type_engine.get(*self) {
+        match type_engine.get(*self).deref() {
             TypeInfo::Enum(decl_ref) => {
-                let decl = decl_engine.get_enum(&decl_ref);
+                let decl = decl_engine.get_enum(decl_ref);
                 (!decl.type_parameters.is_empty()).then_some(decl.type_parameters.clone())
             }
             TypeInfo::Struct(decl_ref) => {
-                let decl = decl_engine.get_struct(&decl_ref);
+                let decl = decl_engine.get_struct(decl_ref);
                 (!decl.type_parameters.is_empty()).then_some(decl.type_parameters.clone())
             }
             _ => None,
@@ -135,28 +139,31 @@ impl TypeId {
         decl_engine: &DeclEngine,
         resolved_type_id: TypeId,
     ) -> bool {
-        match (type_engine.get(self), type_engine.get(resolved_type_id)) {
+        match (
+            type_engine.get(self).deref(),
+            type_engine.get(resolved_type_id).deref(),
+        ) {
             (
                 TypeInfo::Custom {
                     qualified_call_path: call_path,
                     ..
                 },
                 TypeInfo::Enum(decl_ref),
-            ) => call_path.call_path.suffix != decl_engine.get_enum(&decl_ref).call_path.suffix,
+            ) => call_path.call_path.suffix != decl_engine.get_enum(decl_ref).call_path.suffix,
             (
                 TypeInfo::Custom {
                     qualified_call_path: call_path,
                     ..
                 },
                 TypeInfo::Struct(decl_ref),
-            ) => call_path.call_path.suffix != decl_engine.get_struct(&decl_ref).call_path.suffix,
+            ) => call_path.call_path.suffix != decl_engine.get_struct(decl_ref).call_path.suffix,
             (
                 TypeInfo::Custom {
                     qualified_call_path: call_path,
                     ..
                 },
                 TypeInfo::Alias { name, .. },
-            ) => call_path.call_path.suffix != name,
+            ) => call_path.call_path.suffix != name.clone(),
             (TypeInfo::Custom { .. }, _) => true,
             _ => false,
         }
@@ -203,7 +210,7 @@ impl TypeId {
 
         let decl_engine = engines.de();
         let mut found: HashMap<TypeId, Vec<TraitConstraint>> = HashMap::new();
-        match engines.te().get(*self) {
+        match engines.te().get(*self).deref() {
             TypeInfo::Unknown
             | TypeInfo::Placeholder(_)
             | TypeInfo::TypeParam(_)
@@ -219,7 +226,7 @@ impl TypeId {
             | TypeInfo::ErrorRecovery(_)
             | TypeInfo::TraitType { .. } => {}
             TypeInfo::Enum(enum_ref) => {
-                let enum_decl = decl_engine.get_enum(&enum_ref);
+                let enum_decl = decl_engine.get_enum(enum_ref);
                 for type_param in enum_decl.type_parameters.iter() {
                     extend(
                         &mut found,
@@ -242,7 +249,7 @@ impl TypeId {
                 }
             }
             TypeInfo::Struct(struct_ref) => {
-                let struct_decl = decl_engine.get_struct(&struct_ref);
+                let struct_decl = decl_engine.get_struct(struct_ref);
                 for type_param in struct_decl.type_parameters.iter() {
                     extend(
                         &mut found,
@@ -397,9 +404,9 @@ impl TypeId {
         let mut inner_types: Vec<TypeInfo> = self
             .extract_inner_types(engines)
             .into_iter()
-            .map(|type_id| type_engine.get(type_id))
+            .map(|type_id| type_engine.get(type_id).deref().clone())
             .collect();
-        inner_types.push(type_engine.get(self));
+        inner_types.push(type_engine.get(self).deref().clone());
         inner_types
     }
 
@@ -466,10 +473,10 @@ impl TypeId {
 
                 let structure_type_info = engines.te().get(*structure_type_id);
                 let structure_type_info_with_engines =
-                    engines.help_out(structure_type_info.clone());
+                    engines.help_out(structure_type_info.deref());
                 if let TypeInfo::UnknownGeneric {
                     trait_constraints, ..
-                } = &structure_type_info
+                } = structure_type_info.deref()
                 {
                     let mut generic_trait_constraints_trait_names: Vec<CallPath<BaseIdent>> =
                         vec![];

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -953,7 +953,7 @@ impl TypeInfo {
             TypeInfo::Enum(decl_ref) => {
                 let decl = decl_engine.get_enum(decl_ref);
                 let mut found_unit_variant = false;
-                for variant_type in decl.variants {
+                for variant_type in decl.variants.iter() {
                     let type_info = type_engine.get(variant_type.type_argument.type_id);
                     if type_info.is_uninhabited(type_engine, decl_engine) {
                         continue;
@@ -969,7 +969,7 @@ impl TypeInfo {
             TypeInfo::Struct(decl_ref) => {
                 let decl = decl_engine.get_struct(decl_ref);
                 let mut all_zero_sized = true;
-                for field in decl.fields {
+                for field in decl.fields.iter() {
                     let type_info = type_engine.get(field.type_argument.type_id);
                     if type_info.is_uninhabited(type_engine, decl_engine) {
                         return true;

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -6,6 +6,9 @@ mod priv_prelude;
 mod substitute;
 mod unify;
 
+#[allow(unused)]
+use std::ops::Deref;
+
 pub use priv_prelude::*;
 #[cfg(test)]
 use sway_error::handler::Handler;
@@ -131,11 +134,14 @@ fn generic_enum_resolution() {
     let (_, errors) = h.consume();
     assert!(errors.is_empty());
 
-    if let TypeInfo::Enum(decl_ref_1) = engines.te().get(ty_1) {
-        let decl = engines.de().get_enum(&decl_ref_1);
+    if let TypeInfo::Enum(decl_ref_1) = engines.te().get(ty_1).deref() {
+        let decl = engines.de().get_enum(decl_ref_1);
         assert_eq!(decl.call_path.suffix.as_str(), "Result");
         assert!(matches!(
-            engines.te().get(variant_types[0].type_argument.type_id),
+            engines
+                .te()
+                .get(variant_types[0].type_argument.type_id)
+                .deref(),
             TypeInfo::Boolean
         ));
     } else {

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -134,14 +134,11 @@ fn generic_enum_resolution() {
     let (_, errors) = h.consume();
     assert!(errors.is_empty());
 
-    if let TypeInfo::Enum(decl_ref_1) = engines.te().get(ty_1).deref() {
+    if let TypeInfo::Enum(decl_ref_1) = &*engines.te().get(ty_1) {
         let decl = engines.de().get_enum(decl_ref_1);
         assert_eq!(decl.call_path.suffix.as_str(), "Result");
         assert!(matches!(
-            engines
-                .te()
-                .get(variant_types[0].type_argument.type_id)
-                .deref(),
+            &*engines.te().get(variant_types[0].type_argument.type_id),
             TypeInfo::Boolean
         ));
     } else {

--- a/sway-core/src/type_system/substitute/subst_map.rs
+++ b/sway-core/src/type_system/substitute/subst_map.rs
@@ -3,7 +3,7 @@ use crate::{
     engine_threading::*,
     type_system::priv_prelude::*,
 };
-use std::{collections::BTreeMap, fmt};
+use std::{collections::BTreeMap, fmt, ops::Deref};
 use sway_types::Spanned;
 
 type SourceType = TypeId;
@@ -336,7 +336,7 @@ impl TypeSubstMap {
             TypeInfo::Placeholder(_) => iter_for_match(engines, self, &type_info),
             TypeInfo::TypeParam(_) => None,
             TypeInfo::Struct(decl_ref) => {
-                let mut decl = decl_engine.get_struct(&decl_ref);
+                let mut decl = decl_engine.get_struct(&decl_ref).deref().clone();
                 let mut need_to_create_new = false;
                 for field in decl.fields.iter_mut() {
                     if let Some(type_id) = self.find_match(field.type_argument.type_id, engines) {
@@ -362,7 +362,7 @@ impl TypeSubstMap {
                 }
             }
             TypeInfo::Enum(decl_ref) => {
-                let mut decl = decl_engine.get_enum(&decl_ref);
+                let mut decl = decl_engine.get_enum(&decl_ref).deref().clone();
                 let mut need_to_create_new = false;
 
                 for variant in decl.variants.iter_mut() {

--- a/sway-core/src/type_system/substitute/subst_map.rs
+++ b/sway-core/src/type_system/substitute/subst_map.rs
@@ -3,7 +3,7 @@ use crate::{
     engine_threading::*,
     type_system::priv_prelude::*,
 };
-use std::{collections::BTreeMap, fmt, ops::Deref};
+use std::{collections::BTreeMap, fmt};
 use sway_types::Spanned;
 
 type SourceType = TypeId;
@@ -141,10 +141,7 @@ impl TypeSubstMap {
         superset: TypeId,
         subset: TypeId,
     ) -> TypeSubstMap {
-        match (
-            type_engine.get(superset).deref(),
-            type_engine.get(subset).deref(),
-        ) {
+        match (&*type_engine.get(superset), &*type_engine.get(subset)) {
             (TypeInfo::UnknownGeneric { .. }, _) => TypeSubstMap {
                 mapping: BTreeMap::from([(superset, subset)]),
             },
@@ -335,13 +332,13 @@ impl TypeSubstMap {
         let type_engine = engines.te();
         let decl_engine = engines.de();
         let type_info = type_engine.get(type_id);
-        match type_info.deref().clone() {
+        match (*type_info).clone() {
             TypeInfo::Custom { .. } => iter_for_match(engines, self, &type_info),
             TypeInfo::UnknownGeneric { .. } => iter_for_match(engines, self, &type_info),
             TypeInfo::Placeholder(_) => iter_for_match(engines, self, &type_info),
             TypeInfo::TypeParam(_) => None,
             TypeInfo::Struct(decl_ref) => {
-                let mut decl = decl_engine.get_struct(&decl_ref).deref().clone();
+                let mut decl = (*decl_engine.get_struct(&decl_ref)).clone();
                 let mut need_to_create_new = false;
                 for field in decl.fields.iter_mut() {
                     if let Some(type_id) = self.find_match(field.type_argument.type_id, engines) {
@@ -367,7 +364,7 @@ impl TypeSubstMap {
                 }
             }
             TypeInfo::Enum(decl_ref) => {
-                let mut decl = decl_engine.get_enum(&decl_ref).deref().clone();
+                let mut decl = (*decl_engine.get_enum(&decl_ref)).clone();
                 let mut need_to_create_new = false;
 
                 for variant in decl.variants.iter_mut() {

--- a/sway-core/src/type_system/unify/occurs_check.rs
+++ b/sway-core/src/type_system/unify/occurs_check.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::{engine_threading::*, type_system::priv_prelude::*};
 
 /// Helper struct to perform the occurs check.
@@ -32,6 +34,10 @@ impl<'a> OccursCheck<'a> {
     /// unification.
     pub(super) fn check(&self, generic: TypeId, other: TypeId) -> bool {
         let other_generics = other.extract_nested_generics(self.engines);
-        other_generics.contains(&self.engines.help_out(self.engines.te().get(generic)))
+        other_generics.contains(
+            &self
+                .engines
+                .help_out(self.engines.te().get(generic).deref().clone()),
+        )
     }
 }

--- a/sway-core/src/type_system/unify/occurs_check.rs
+++ b/sway-core/src/type_system/unify/occurs_check.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use crate::{engine_threading::*, type_system::priv_prelude::*};
 
 /// Helper struct to perform the occurs check.
@@ -37,7 +35,7 @@ impl<'a> OccursCheck<'a> {
         other_generics.contains(
             &self
                 .engines
-                .help_out(self.engines.te().get(generic).deref().clone()),
+                .help_out((*self.engines.te().get(generic)).clone()),
         )
     }
 }

--- a/sway-core/src/type_system/unify/unifier.rs
+++ b/sway-core/src/type_system/unify/unifier.rs
@@ -1,4 +1,4 @@
-use std::{fmt, ops::Deref};
+use std::fmt;
 
 use sway_error::{handler::Handler, type_error::TypeError};
 use sway_types::{Ident, Span};
@@ -96,7 +96,7 @@ impl<'a> Unifier<'a> {
         let r_type_source_info = self.engines.te().get(received);
         let l_type_source_info = self.engines.te().get(expected);
 
-        match (r_type_source_info.deref(), l_type_source_info.deref()) {
+        match (&*r_type_source_info, &*l_type_source_info) {
             // If they have the same `TypeInfo`, then we either compare them for
             // correctness or perform further unification.
             (Boolean, Boolean) => (),
@@ -168,7 +168,7 @@ impl<'a> Unifier<'a> {
                 if !self.occurs_check(received, expected)
                     && (matches!(self.unify_kind, UnifyKind::WithGeneric)
                         || !matches!(
-                            self.engines.te().get(expected).deref(),
+                            &*self.engines.te().get(expected),
                             TypeInfo::UnknownGeneric { .. }
                         )) =>
             {
@@ -235,7 +235,7 @@ impl<'a> Unifier<'a> {
                 // if one address is empty, coerce to the other one
                 self.replace_received_with_expected(
                     received,
-                    self.engines.te().get(expected).deref(),
+                    &self.engines.te().get(expected),
                     span,
                 )
             }
@@ -251,7 +251,7 @@ impl<'a> Unifier<'a> {
                 // if one address is empty, coerce to the other one
                 self.replace_expected_with_received(
                     expected,
-                    self.engines.te().get(received).deref(),
+                    &self.engines.te().get(received),
                     span,
                 )
             }

--- a/sway-core/src/type_system/unify/unifier.rs
+++ b/sway-core/src/type_system/unify/unifier.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, ops::Deref};
 
 use sway_error::{handler::Handler, type_error::TypeError};
 use sway_types::{Ident, Span};
@@ -52,65 +52,37 @@ impl<'a> Unifier<'a> {
     /// Helper method for replacing the values in the [TypeEngine].
     fn replace_received_with_expected(
         &self,
-        handler: &Handler,
         received: TypeId,
-        expected: TypeId,
-        received_type_info: &TypeInfo,
-        expected_type_info: TypeInfo,
-        span: &Span,
-    ) {
-        let type_engine = self.engines.te();
-        let source_id = span.source_id().cloned();
-        if type_engine
-            .slab
-            .replace(
-                received,
-                &TypeSourceInfo {
-                    type_info: received_type_info.clone(),
-                    source_id,
-                },
-                TypeSourceInfo {
-                    type_info: expected_type_info.clone(),
-                    source_id,
-                },
-                self.engines,
-            )
-            .is_some()
-        {
-            self.unify(handler, received, expected, span);
-        }
-    }
-
-    /// Helper method for replacing the values in the [TypeEngine].
-    fn replace_expected_with_received(
-        &self,
-        handler: &Handler,
-        received: TypeId,
-        expected: TypeId,
-        received_type_info: TypeInfo,
         expected_type_info: &TypeInfo,
         span: &Span,
     ) {
         let type_engine = self.engines.te();
         let source_id = span.source_id().cloned();
-        if type_engine
-            .slab
-            .replace(
-                expected,
-                &TypeSourceInfo {
-                    type_info: expected_type_info.clone(),
-                    source_id,
-                },
-                TypeSourceInfo {
-                    type_info: received_type_info.clone(),
-                    source_id,
-                },
-                self.engines,
-            )
-            .is_some()
-        {
-            self.unify(handler, received, expected, span);
-        }
+        type_engine.replace(
+            received,
+            TypeSourceInfo {
+                type_info: expected_type_info.clone(),
+                source_id,
+            },
+        );
+    }
+
+    /// Helper method for replacing the values in the [TypeEngine].
+    fn replace_expected_with_received(
+        &self,
+        expected: TypeId,
+        received_type_info: &TypeInfo,
+        span: &Span,
+    ) {
+        let type_engine = self.engines.te();
+        let source_id = span.source_id().cloned();
+        type_engine.replace(
+            expected,
+            TypeSourceInfo {
+                type_info: received_type_info.clone(),
+                source_id,
+            },
+        );
     }
 
     /// Performs type unification with `received` and `expected`.
@@ -121,13 +93,10 @@ impl<'a> Unifier<'a> {
             return;
         }
 
-        let r_type_source_info = self.engines.te().slab.get(received.index());
-        let l_type_source_info = self.engines.te().slab.get(expected.index());
+        let r_type_source_info = self.engines.te().get(received);
+        let l_type_source_info = self.engines.te().get(expected);
 
-        match (
-            r_type_source_info.type_info.clone(),
-            l_type_source_info.type_info.clone(),
-        ) {
+        match (r_type_source_info.deref(), l_type_source_info.deref()) {
             // If they have the same `TypeInfo`, then we either compare them for
             // correctness or perform further unification.
             (Boolean, Boolean) => (),
@@ -147,8 +116,8 @@ impl<'a> Unifier<'a> {
                 self.unify_arrays(handler, received, expected, span, re.type_id, ee.type_id)
             }
             (Struct(r_decl_ref), Struct(e_decl_ref)) => {
-                let r_decl = self.engines.de().get_struct(&r_decl_ref);
-                let e_decl = self.engines.de().get_struct(&e_decl_ref);
+                let r_decl = self.engines.de().get_struct(r_decl_ref);
+                let e_decl = self.engines.de().get_struct(e_decl_ref);
 
                 self.unify_structs(
                     handler,
@@ -172,22 +141,14 @@ impl<'a> Unifier<'a> {
             // they match and make the one we know nothing about reference the
             // one we may know something about.
             (Unknown, Unknown) => (),
-            (Unknown, e) => {
-                self.replace_received_with_expected(handler, received, expected, &Unknown, e, span)
-            }
-            (r, Unknown) => {
-                self.replace_expected_with_received(handler, received, expected, r, &Unknown, span)
-            }
+            (Unknown, e) => self.replace_received_with_expected(received, e, span),
+            (r, Unknown) => self.replace_expected_with_received(expected, r, span),
 
-            (r @ Placeholder(_), e @ Placeholder(_)) => {
-                self.replace_expected_with_received(handler, received, expected, r, &e, span)
+            (r @ Placeholder(_), _e @ Placeholder(_)) => {
+                self.replace_expected_with_received(expected, r, span)
             }
-            (r @ Placeholder(_), e) => {
-                self.replace_received_with_expected(handler, received, expected, &r, e, span)
-            }
-            (r, e @ Placeholder(_)) => {
-                self.replace_expected_with_received(handler, received, expected, r, &e, span)
-            }
+            (_r @ Placeholder(_), e) => self.replace_received_with_expected(received, e, span),
+            (r, _e @ Placeholder(_)) => self.replace_expected_with_received(expected, r, span),
 
             // Generics are handled similarly to the case for unknowns, except
             // we take more careful consideration for the type/purpose for the
@@ -201,36 +162,36 @@ impl<'a> Unifier<'a> {
                     name: en,
                     trait_constraints: etc,
                 },
-            ) if rn.as_str() == en.as_str() && rtc.eq(&etc, self.engines) => (),
+            ) if rn.as_str() == en.as_str() && rtc.eq(etc, self.engines) => (),
 
-            (r @ UnknownGeneric { .. }, e)
+            (_r @ UnknownGeneric { .. }, e)
                 if !self.occurs_check(received, expected)
                     && (matches!(self.unify_kind, UnifyKind::WithGeneric)
                         || !matches!(
-                            self.engines.te().get(expected),
+                            self.engines.te().get(expected).deref(),
                             TypeInfo::UnknownGeneric { .. }
                         )) =>
             {
-                self.replace_received_with_expected(handler, received, expected, &r, e, span)
+                self.replace_received_with_expected(received, e, span)
             }
             (r, e @ UnknownGeneric { .. })
                 if !self.occurs_check(expected, received)
                     && e.is_self_type()
                     && matches!(self.unify_kind, UnifyKind::WithSelf) =>
             {
-                self.replace_expected_with_received(handler, received, expected, r, &e, span)
+                self.replace_expected_with_received(expected, r, span)
             }
             // Type aliases and the types they encapsulate coerce to each other.
             (Alias { ty, .. }, _) => self.unify(handler, ty.type_id, expected, span),
             (_, Alias { ty, .. }) => self.unify(handler, received, ty.type_id, span),
 
             // Let empty enums to coerce to any other type. This is useful for Never enum.
-            (Enum(r_decl_ref), _)
-                if self.engines.de().get_enum(&r_decl_ref).variants.is_empty() => {}
+            (Enum(r_decl_ref), _) if self.engines.de().get_enum(r_decl_ref).variants.is_empty() => {
+            }
 
             (Enum(r_decl_ref), Enum(e_decl_ref)) => {
-                let r_decl = self.engines.de().get_enum(&r_decl_ref);
-                let e_decl = self.engines.de().get_enum(&e_decl_ref);
+                let r_decl = self.engines.de().get_enum(r_decl_ref);
+                let e_decl = self.engines.de().get_enum(e_decl_ref);
 
                 self.unify_enums(
                     handler,
@@ -254,16 +215,16 @@ impl<'a> Unifier<'a> {
             // with the integer.
             (UnsignedInteger(r), UnsignedInteger(e)) if r == e => (),
             (Numeric, e @ UnsignedInteger(_)) => {
-                self.replace_received_with_expected(handler, received, expected, &Numeric, e, span)
+                self.replace_received_with_expected(received, e, span)
             }
             (r @ UnsignedInteger(_), Numeric) => {
-                self.replace_expected_with_received(handler, received, expected, r, &Numeric, span)
+                self.replace_expected_with_received(expected, r, span)
             }
 
             // For contract callers, we (potentially) unify them if they have
             // the same name and their address is `None`
             (
-                ref r @ TypeInfo::ContractCaller {
+                _r @ TypeInfo::ContractCaller {
                     abi_name: ref ran,
                     address: ref rra,
                 },
@@ -273,16 +234,8 @@ impl<'a> Unifier<'a> {
             ) if (ran == ean && rra.is_none()) || matches!(ran, AbiName::Deferred) => {
                 // if one address is empty, coerce to the other one
                 self.replace_received_with_expected(
-                    handler,
                     received,
-                    expected,
-                    r,
-                    self.engines
-                        .te()
-                        .slab
-                        .get(expected.index())
-                        .type_info
-                        .clone(),
+                    self.engines.te().get(expected).deref(),
                     span,
                 )
             }
@@ -290,23 +243,15 @@ impl<'a> Unifier<'a> {
                 TypeInfo::ContractCaller {
                     abi_name: ref ran, ..
                 },
-                ref e @ TypeInfo::ContractCaller {
+                _e @ TypeInfo::ContractCaller {
                     abi_name: ref ean,
                     address: ref ea,
                 },
             ) if (ran == ean && ea.is_none()) || matches!(ean, AbiName::Deferred) => {
                 // if one address is empty, coerce to the other one
                 self.replace_expected_with_received(
-                    handler,
-                    received,
                     expected,
-                    self.engines
-                        .te()
-                        .slab
-                        .get(received.index())
-                        .type_info
-                        .clone(),
-                    e,
+                    self.engines.te().get(received).deref(),
                     span,
                 )
             }
@@ -361,7 +306,7 @@ impl<'a> Unifier<'a> {
         }
     }
 
-    fn unify_tuples(&self, handler: &Handler, rfs: Vec<TypeArgument>, efs: Vec<TypeArgument>) {
+    fn unify_tuples(&self, handler: &Handler, rfs: &[TypeArgument], efs: &[TypeArgument]) {
         for (rf, ef) in rfs.iter().zip(efs.iter()) {
             self.unify(handler, rf.type_id, ef.type_id, &rf.span);
         }

--- a/sway-core/src/type_system/unify/unifier.rs
+++ b/sway-core/src/type_system/unify/unifier.rs
@@ -121,9 +121,12 @@ impl<'a> Unifier<'a> {
             return;
         }
 
+        let r_type_source_info = self.engines.te().slab.get(received.index());
+        let l_type_source_info = self.engines.te().slab.get(expected.index());
+
         match (
-            self.engines.te().slab.get(received.index()).type_info,
-            self.engines.te().slab.get(expected.index()).type_info,
+            r_type_source_info.type_info.clone(),
+            l_type_source_info.type_info.clone(),
         ) {
             // If they have the same `TypeInfo`, then we either compare them for
             // correctness or perform further unification.
@@ -153,14 +156,14 @@ impl<'a> Unifier<'a> {
                     expected,
                     span,
                     (
-                        r_decl.call_path.suffix,
-                        r_decl.type_parameters,
-                        r_decl.fields,
+                        r_decl.call_path.suffix.clone(),
+                        r_decl.type_parameters.clone(),
+                        r_decl.fields.clone(),
                     ),
                     (
-                        e_decl.call_path.suffix,
-                        e_decl.type_parameters,
-                        e_decl.fields,
+                        e_decl.call_path.suffix.clone(),
+                        e_decl.type_parameters.clone(),
+                        e_decl.fields.clone(),
                     ),
                 )
             }
@@ -235,14 +238,14 @@ impl<'a> Unifier<'a> {
                     expected,
                     span,
                     (
-                        r_decl.call_path.suffix,
-                        r_decl.type_parameters,
-                        r_decl.variants,
+                        r_decl.call_path.suffix.clone(),
+                        r_decl.type_parameters.clone(),
+                        r_decl.variants.clone(),
                     ),
                     (
-                        e_decl.call_path.suffix,
-                        e_decl.type_parameters,
-                        e_decl.variants,
+                        e_decl.call_path.suffix.clone(),
+                        e_decl.type_parameters.clone(),
+                        e_decl.variants.clone(),
                     ),
                 )
             }
@@ -274,7 +277,12 @@ impl<'a> Unifier<'a> {
                     received,
                     expected,
                     r,
-                    self.engines.te().slab.get(expected.index()).type_info,
+                    self.engines
+                        .te()
+                        .slab
+                        .get(expected.index())
+                        .type_info
+                        .clone(),
                     span,
                 )
             }
@@ -292,7 +300,12 @@ impl<'a> Unifier<'a> {
                     handler,
                     received,
                     expected,
-                    self.engines.te().slab.get(received.index()).type_info,
+                    self.engines
+                        .te()
+                        .slab
+                        .get(received.index())
+                        .type_info
+                        .clone(),
                     e,
                     span,
                 )

--- a/sway-core/src/type_system/unify/unify_check.rs
+++ b/sway-core/src/type_system/unify/unify_check.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use crate::{
     engine_threading::*,
     type_system::{priv_prelude::*, unify::occurs_check::OccursCheck},
@@ -215,7 +213,7 @@ impl<'a> UnifyCheck<'a> {
 
         // override top level generics with simple equality but only at top level
         if let NonGenericConstraintSubset = self.mode {
-            if let UnknownGeneric { .. } = right_info.deref() {
+            if let UnknownGeneric { .. } = &*right_info {
                 return left_info.eq(&right_info, self.engines);
             }
         }
@@ -234,7 +232,7 @@ impl<'a> UnifyCheck<'a> {
         let right_info = self.engines.te().get(right);
 
         // common recursion patterns
-        match (left_info.deref(), right_info.deref()) {
+        match (&*left_info, &*right_info) {
             (Array(l0, l1), Array(r0, r1)) => {
                 return self.check_inner(l0.type_id, r0.type_id) && l1.val() == r1.val();
             }
@@ -332,7 +330,7 @@ impl<'a> UnifyCheck<'a> {
 
         match self.mode {
             Coercion => {
-                match (left_info.deref(), right_info.deref()) {
+                match (&*left_info, &*right_info) {
                     (r @ UnknownGeneric { .. }, e @ UnknownGeneric { .. })
                         if TypeInfo::is_self_type(r) || TypeInfo::is_self_type(e) =>
                     {
@@ -434,7 +432,7 @@ impl<'a> UnifyCheck<'a> {
                 }
             }
             ConstraintSubset | NonGenericConstraintSubset => {
-                match (left_info.deref(), right_info.deref()) {
+                match (&*left_info, &*right_info) {
                     (
                         UnknownGeneric {
                             name: _,
@@ -487,7 +485,7 @@ impl<'a> UnifyCheck<'a> {
                     (a, b) => a.eq(b, self.engines),
                 }
             }
-            NonDynamicEquality => match (left_info.deref(), right_info.deref()) {
+            NonDynamicEquality => match (&*left_info, &*right_info) {
                 // when a type alias is encoutered, defer the decision to the type it contains (i.e. the
                 // type it aliases with)
                 (Alias { ty, .. }, _) => self.check_inner(ty.type_id, right),
@@ -679,7 +677,7 @@ impl<'a> UnifyCheck<'a> {
                         let b = right_types.get(j).unwrap();
                         if matches!(&self.mode, Coercion)
                             && (matches!(
-                                (a.deref(), b.deref()),
+                                (&**a, &**b),
                                 (_, Placeholder(_))
                                     | (Placeholder(_), _)
                                     | (UnsignedInteger(_), Numeric)
@@ -699,7 +697,7 @@ impl<'a> UnifyCheck<'a> {
                     let b = left_types.get(j).unwrap();
                     if matches!(&self.mode, Coercion)
                         && (matches!(
-                            (a.deref(), b.deref()),
+                            (&**a, &**b),
                             (_, Placeholder(_))
                                 | (Placeholder(_), _)
                                 | (UnsignedInteger(_), Numeric)

--- a/sway-lsp/src/capabilities/code_actions/enum_decl/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/enum_decl/mod.rs
@@ -1,7 +1,5 @@
 pub(crate) mod enum_impl;
 
-use std::ops::Deref;
-
 use self::enum_impl::EnumImplCodeAction;
 use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
 use lsp_types::CodeActionOrCommand;
@@ -13,7 +11,7 @@ pub(crate) fn code_actions(
     decl_id: &DeclId<ty::TyEnumDecl>,
     ctx: &CodeActionContext,
 ) -> Option<Vec<CodeActionOrCommand>> {
-    let decl = ctx.engines.de().get_enum(decl_id).deref().clone();
+    let decl = (*ctx.engines.de().get_enum(decl_id)).clone();
     Some(vec![
         EnumImplCodeAction::new(ctx, &decl).code_action(),
         BasicDocCommentCodeAction::new(ctx, &decl).code_action(),

--- a/sway-lsp/src/capabilities/code_actions/enum_decl/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/enum_decl/mod.rs
@@ -1,5 +1,7 @@
 pub(crate) mod enum_impl;
 
+use std::ops::Deref;
+
 use self::enum_impl::EnumImplCodeAction;
 use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
 use lsp_types::CodeActionOrCommand;
@@ -11,7 +13,7 @@ pub(crate) fn code_actions(
     decl_id: &DeclId<ty::TyEnumDecl>,
     ctx: &CodeActionContext,
 ) -> Option<Vec<CodeActionOrCommand>> {
-    let decl = ctx.engines.de().get_enum(decl_id);
+    let decl = ctx.engines.de().get_enum(decl_id).deref().clone();
     Some(vec![
         EnumImplCodeAction::new(ctx, &decl).code_action(),
         BasicDocCommentCodeAction::new(ctx, &decl).code_action(),

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/mod.rs
@@ -1,8 +1,6 @@
 pub(crate) mod struct_impl;
 pub(crate) mod struct_new;
 
-use std::ops::Deref;
-
 use self::{struct_impl::StructImplCodeAction, struct_new::StructNewCodeAction};
 use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
 use lsp_types::CodeActionOrCommand;
@@ -14,7 +12,7 @@ pub(crate) fn code_actions(
     decl_id: &DeclId<ty::TyStructDecl>,
     ctx: &CodeActionContext,
 ) -> Option<Vec<CodeActionOrCommand>> {
-    let decl = ctx.engines.de().get_struct(decl_id).deref().clone();
+    let decl = (*ctx.engines.de().get_struct(decl_id)).clone();
     Some(vec![
         StructImplCodeAction::new(ctx, &decl).code_action(),
         StructNewCodeAction::new(ctx, &decl).code_action(),

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/mod.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/mod.rs
@@ -1,6 +1,8 @@
 pub(crate) mod struct_impl;
 pub(crate) mod struct_new;
 
+use std::ops::Deref;
+
 use self::{struct_impl::StructImplCodeAction, struct_new::StructNewCodeAction};
 use crate::capabilities::code_actions::{CodeAction, CodeActionContext};
 use lsp_types::CodeActionOrCommand;
@@ -12,7 +14,7 @@ pub(crate) fn code_actions(
     decl_id: &DeclId<ty::TyStructDecl>,
     ctx: &CodeActionContext,
 ) -> Option<Vec<CodeActionOrCommand>> {
-    let decl = ctx.engines.de().get_struct(decl_id);
+    let decl = ctx.engines.de().get_struct(decl_id).deref().clone();
     Some(vec![
         StructImplCodeAction::new(ctx, &decl).code_action(),
         StructNewCodeAction::new(ctx, &decl).code_action(),

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::{
     capabilities::code_actions::{
         common::generate_impl::GenerateImplCodeAction, CodeAction, CodeActionContext,
@@ -35,7 +37,7 @@ impl<'a> CodeAction<'a, TyStructDecl> for StructNewCodeAction<'a> {
                     ty::ImplTrait { decl_id, .. },
                 ))) = token.typed
                 {
-                    Some(ctx.engines.de().get_impl_trait(&decl_id))
+                    Some(ctx.engines.de().get_impl_trait(&decl_id).deref().clone())
                 } else {
                     None
                 }

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use crate::{
     capabilities::code_actions::{
         common::generate_impl::GenerateImplCodeAction, CodeAction, CodeActionContext,
@@ -37,7 +35,7 @@ impl<'a> CodeAction<'a, TyStructDecl> for StructNewCodeAction<'a> {
                     ty::ImplTrait { decl_id, .. },
                 ))) = token.typed
                 {
-                    Some(ctx.engines.de().get_impl_trait(&decl_id).deref().clone())
+                    Some((*ctx.engines.de().get_impl_trait(&decl_id)).clone())
                 } else {
                     None
                 }

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::core::token::TokenIdent;
 use lsp_types::{
     CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionTextEdit, Position,
@@ -30,7 +32,7 @@ fn completion_items_for_type_id(
 ) -> Vec<CompletionItem> {
     let mut completion_items = vec![];
     let type_info = engines.te().get(type_id);
-    if let TypeInfo::Struct(decl_ref) = type_info {
+    if let TypeInfo::Struct(decl_ref) = type_info.deref() {
         let struct_decl = engines.de().get_struct(&decl_ref.id().clone());
         for field in struct_decl.fields.iter() {
             let item = CompletionItem {
@@ -164,7 +166,7 @@ fn type_id_of_raw_ident(
                     }
                     None
                 });
-        } else if let TypeInfo::Struct(decl_ref) = engines.te().get(curr_type_id.unwrap()) {
+        } else if let TypeInfo::Struct(decl_ref) = engines.te().get(curr_type_id.unwrap()).deref() {
             let struct_decl = engines.de().get_struct(&decl_ref.id().clone());
             curr_type_id = struct_decl
                 .fields

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -32,12 +32,12 @@ fn completion_items_for_type_id(
     let type_info = engines.te().get(type_id);
     if let TypeInfo::Struct(decl_ref) = type_info {
         let struct_decl = engines.de().get_struct(&decl_ref.id().clone());
-        for field in struct_decl.fields {
+        for field in struct_decl.fields.iter() {
             let item = CompletionItem {
                 kind: Some(CompletionItemKind::FIELD),
                 label: field.name.as_str().to_string(),
                 label_details: Some(CompletionItemLabelDetails {
-                    description: Some(field.type_argument.span.str()),
+                    description: Some(field.type_argument.span.clone().str()),
                     detail: None,
                 }),
                 ..Default::default()
@@ -48,7 +48,7 @@ fn completion_items_for_type_id(
 
     for method in namespace.get_methods_for_type(engines, type_id) {
         let fn_decl = engines.de().get_function(&method.id().clone());
-        let params = fn_decl.clone().parameters;
+        let params = &fn_decl.parameters;
 
         // Only show methods that take `self` as the first parameter.
         if params.first().map(|p| p.is_self()).unwrap_or(false) {

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use crate::core::token::TokenIdent;
 use lsp_types::{
     CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionTextEdit, Position,
@@ -32,7 +30,7 @@ fn completion_items_for_type_id(
 ) -> Vec<CompletionItem> {
     let mut completion_items = vec![];
     let type_info = engines.te().get(type_id);
-    if let TypeInfo::Struct(decl_ref) = type_info.deref() {
+    if let TypeInfo::Struct(decl_ref) = &*type_info {
         let struct_decl = engines.de().get_struct(&decl_ref.id().clone());
         for field in struct_decl.fields.iter() {
             let item = CompletionItem {
@@ -166,7 +164,7 @@ fn type_id_of_raw_ident(
                     }
                     None
                 });
-        } else if let TypeInfo::Struct(decl_ref) = engines.te().get(curr_type_id.unwrap()).deref() {
+        } else if let TypeInfo::Struct(decl_ref) = &*engines.te().get(curr_type_id.unwrap()) {
             let struct_decl = engines.de().get_struct(&decl_ref.id().clone());
             curr_type_id = struct_decl
                 .fields

--- a/sway-lsp/src/capabilities/hover/hover_link_contents.rs
+++ b/sway-lsp/src/capabilities/hover/hover_link_contents.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{session::Session, token::get_range_from_span},
     utils::document::get_url_from_span,
 };
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 use sway_core::{
     language::{
         ty::{TyDecl, TyTraitDecl},
@@ -43,7 +43,7 @@ impl<'a> HoverLinkContents<'a> {
     /// Adds the given type and any related type parameters to the list of related types.
     pub fn add_related_types(&mut self, type_id: &TypeId) {
         let type_info = self.engines.te().get(*type_id);
-        match type_info.deref() {
+        match &*type_info {
             TypeInfo::Enum(decl_ref) => {
                 let decl = self.engines.de().get_enum(decl_ref);
                 self.add_related_type(

--- a/sway-lsp/src/capabilities/hover/hover_link_contents.rs
+++ b/sway-lsp/src/capabilities/hover/hover_link_contents.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{session::Session, token::get_range_from_span},
     utils::document::get_url_from_span,
 };
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 use sway_core::{
     language::{
         ty::{TyDecl, TyTraitDecl},
@@ -43,9 +43,9 @@ impl<'a> HoverLinkContents<'a> {
     /// Adds the given type and any related type parameters to the list of related types.
     pub fn add_related_types(&mut self, type_id: &TypeId) {
         let type_info = self.engines.te().get(*type_id);
-        match type_info {
+        match type_info.deref() {
             TypeInfo::Enum(decl_ref) => {
-                let decl = self.engines.de().get_enum(&decl_ref);
+                let decl = self.engines.de().get_enum(decl_ref);
                 self.add_related_type(
                     decl_ref.name().to_string(),
                     &decl.span(),
@@ -56,7 +56,7 @@ impl<'a> HoverLinkContents<'a> {
                     .for_each(|type_param| self.add_related_types(&type_param.type_id));
             }
             TypeInfo::Struct(decl_ref) => {
-                let decl = self.engines.de().get_struct(&decl_ref);
+                let decl = self.engines.de().get_struct(decl_ref);
                 self.add_related_type(
                     decl_ref.name().to_string(),
                     &decl.span(),

--- a/sway-lsp/src/capabilities/hover/hover_link_contents.rs
+++ b/sway-lsp/src/capabilities/hover/hover_link_contents.rs
@@ -46,14 +46,22 @@ impl<'a> HoverLinkContents<'a> {
         match type_info {
             TypeInfo::Enum(decl_ref) => {
                 let decl = self.engines.de().get_enum(&decl_ref);
-                self.add_related_type(decl_ref.name().to_string(), &decl.span(), decl.call_path);
+                self.add_related_type(
+                    decl_ref.name().to_string(),
+                    &decl.span(),
+                    decl.call_path.clone(),
+                );
                 decl.type_parameters
                     .iter()
                     .for_each(|type_param| self.add_related_types(&type_param.type_id));
             }
             TypeInfo::Struct(decl_ref) => {
                 let decl = self.engines.de().get_struct(&decl_ref);
-                self.add_related_type(decl_ref.name().to_string(), &decl.span(), decl.call_path);
+                self.add_related_type(
+                    decl_ref.name().to_string(),
+                    &decl.span(),
+                    decl.call_path.clone(),
+                );
                 decl.type_parameters
                     .iter()
                     .for_each(|type_param| self.add_related_types(&type_param.type_id));

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -6,7 +6,7 @@ use crate::{
     },
 };
 use lsp_types::{self, Range, Url};
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 use sway_core::{language::ty::TyDecl, type_system::TypeInfo};
 use sway_types::Spanned;
 
@@ -64,7 +64,7 @@ pub fn inlay_hints(
         })
         .filter_map(|var| {
             let type_info = type_engine.get(var.type_ascription.type_id);
-            match type_info {
+            match type_info.deref() {
                 TypeInfo::Unknown | TypeInfo::UnknownGeneric { .. } => None,
                 _ => Some(var),
             }

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -6,7 +6,7 @@ use crate::{
     },
 };
 use lsp_types::{self, Range, Url};
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 use sway_core::{language::ty::TyDecl, type_system::TypeInfo};
 use sway_types::Spanned;
 
@@ -64,7 +64,7 @@ pub fn inlay_hints(
         })
         .filter_map(|var| {
             let type_info = type_engine.get(var.type_ascription.type_id);
-            match type_info.deref() {
+            match &*type_info {
                 TypeInfo::Unknown | TypeInfo::UnknownGeneric { .. } => None,
                 _ => Some(var),
             }

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -1,5 +1,5 @@
 use lsp_types::{Position, Range};
-use std::path::PathBuf;
+use std::{ops::Deref, path::PathBuf};
 use sway_ast::Intrinsic;
 use sway_core::{
     language::{
@@ -239,15 +239,15 @@ pub fn desugared_op(prefixes: &[Ident]) -> bool {
 
 /// Use the [TypeId] to look up the associated [TypeInfo] and return the [TokenIdent] if one is found.
 pub fn ident_of_type_id(engines: &Engines, type_id: &TypeId) -> Option<TokenIdent> {
-    let ident = match engines.te().get(*type_id) {
-        TypeInfo::UnknownGeneric { name, .. } => name,
-        TypeInfo::Enum(decl_ref) => engines.de().get_enum(&decl_ref).call_path.suffix.clone(),
-        TypeInfo::Struct(decl_ref) => engines.de().get_struct(&decl_ref).call_path.suffix.clone(),
-        TypeInfo::Alias { name, .. } => name,
+    let ident = match engines.te().get(*type_id).deref() {
+        TypeInfo::UnknownGeneric { name, .. } => name.clone(),
+        TypeInfo::Enum(decl_ref) => engines.de().get_enum(decl_ref).call_path.suffix.clone(),
+        TypeInfo::Struct(decl_ref) => engines.de().get_struct(decl_ref).call_path.suffix.clone(),
+        TypeInfo::Alias { name, .. } => name.clone(),
         TypeInfo::Custom {
             qualified_call_path,
             ..
-        } => qualified_call_path.call_path.suffix,
+        } => qualified_call_path.call_path.suffix.clone(),
         _ => return None,
     };
     Some(TokenIdent::new(&ident, engines.se()))

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -241,8 +241,8 @@ pub fn desugared_op(prefixes: &[Ident]) -> bool {
 pub fn ident_of_type_id(engines: &Engines, type_id: &TypeId) -> Option<TokenIdent> {
     let ident = match engines.te().get(*type_id) {
         TypeInfo::UnknownGeneric { name, .. } => name,
-        TypeInfo::Enum(decl_ref) => engines.de().get_enum(&decl_ref).call_path.suffix,
-        TypeInfo::Struct(decl_ref) => engines.de().get_struct(&decl_ref).call_path.suffix,
+        TypeInfo::Enum(decl_ref) => engines.de().get_enum(&decl_ref).call_path.suffix.clone(),
+        TypeInfo::Struct(decl_ref) => engines.de().get_struct(&decl_ref).call_path.suffix.clone(),
         TypeInfo::Alias { name, .. } => name,
         TypeInfo::Custom {
             qualified_call_path,

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -1,5 +1,5 @@
 use lsp_types::{Position, Range};
-use std::{ops::Deref, path::PathBuf};
+use std::path::PathBuf;
 use sway_ast::Intrinsic;
 use sway_core::{
     language::{
@@ -239,7 +239,7 @@ pub fn desugared_op(prefixes: &[Ident]) -> bool {
 
 /// Use the [TypeId] to look up the associated [TypeInfo] and return the [TokenIdent] if one is found.
 pub fn ident_of_type_id(engines: &Engines, type_id: &TypeId) -> Option<TokenIdent> {
-    let ident = match engines.te().get(*type_id).deref() {
+    let ident = match &*engines.te().get(*type_id) {
         TypeInfo::UnknownGeneric { name, .. } => name.clone(),
         TypeInfo::Enum(decl_ref) => engines.de().get_enum(decl_ref).call_path.suffix.clone(),
         TypeInfo::Struct(decl_ref) => engines.de().get_struct(decl_ref).call_path.suffix.clone(),

--- a/sway-lsp/src/core/token_map.rs
+++ b/sway-lsp/src/core/token_map.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::core::token::{self, Token, TokenIdent, TypedAstToken};
 use dashmap::DashMap;
 use lsp_types::{Position, Url};
@@ -186,7 +188,7 @@ impl TokenMap {
         self.declaration_of_type_id(engines, type_id)
             .and_then(|decl| match decl {
                 ty::TyDecl::StructDecl(ty::StructDecl { decl_id, .. }) => {
-                    Some(engines.de().get_struct(&decl_id))
+                    Some(engines.de().get_struct(&decl_id).deref().clone())
                 }
                 _ => None,
             })

--- a/sway-lsp/src/core/token_map.rs
+++ b/sway-lsp/src/core/token_map.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use crate::core::token::{self, Token, TokenIdent, TypedAstToken};
 use dashmap::DashMap;
 use lsp_types::{Position, Url};
@@ -188,7 +186,7 @@ impl TokenMap {
         self.declaration_of_type_id(engines, type_id)
             .and_then(|decl| match decl {
                 ty::TyDecl::StructDecl(ty::StructDecl { decl_id, .. }) => {
-                    Some(engines.de().get_struct(&decl_id).deref().clone())
+                    Some((*engines.de().get_struct(&decl_id)).clone())
                 }
                 _ => None,
             })

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-use std::ops::Deref;
-
 use crate::{
     core::{
         token::{
@@ -845,7 +843,7 @@ impl Parse for ImplSelf {
             qualified_call_path,
             type_arguments,
             root_type_id: _,
-        } = &ctx.engines.te().get(self.implementing_for.type_id).deref()
+        } = &&*ctx.engines.te().get(self.implementing_for.type_id)
         {
             ctx.tokens.insert(
                 ctx.ident(&qualified_call_path.call_path.suffix),
@@ -1043,7 +1041,7 @@ impl Parse for TypeParameter {
 impl Parse for TypeArgument {
     fn parse(&self, ctx: &ParseContext) {
         let type_info = ctx.engines.te().get(self.type_id);
-        match type_info.deref() {
+        match &*type_info {
             TypeInfo::Array(type_arg, length) => {
                 let ident = Ident::new(length.span());
                 ctx.tokens.insert(

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+use std::ops::Deref;
+
 use crate::{
     core::{
         token::{
@@ -843,7 +845,7 @@ impl Parse for ImplSelf {
             qualified_call_path,
             type_arguments,
             root_type_id: _,
-        } = &ctx.engines.te().get(self.implementing_for.type_id)
+        } = &ctx.engines.te().get(self.implementing_for.type_id).deref()
         {
             ctx.tokens.insert(
                 ctx.ident(&qualified_call_path.call_path.suffix),
@@ -1041,7 +1043,7 @@ impl Parse for TypeParameter {
 impl Parse for TypeArgument {
     fn parse(&self, ctx: &ParseContext) {
         let type_info = ctx.engines.te().get(self.type_id);
-        match &type_info {
+        match type_info.deref() {
             TypeInfo::Array(type_arg, length) => {
                 let ident = Ident::new(length.span());
                 ctx.tokens.insert(

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -541,12 +541,12 @@ impl Parse for ty::TyExpression {
                             ctx.tokens.try_get_mut(&ctx.ident(&field.name)).try_unwrap()
                         {
                             token.typed = Some(TypedAstToken::Ident(field.name.clone()));
-                            match ctx.engines.te().get(container_type_id) {
+                            match ctx.engines.te().get(container_type_id).deref() {
                                 TypeInfo::Struct(decl_ref) => {
                                     if let Some(field_name) = ctx
                                         .engines
                                         .de()
-                                        .get_struct(&decl_ref)
+                                        .get_struct(decl_ref)
                                         .fields
                                         .iter()
                                         .find(|struct_field| {
@@ -1158,7 +1158,7 @@ fn collect_call_path_tree(ctx: &ParseContext, tree: &CallPathTree, type_arg: &Ty
         &TypedAstToken::TypedArgument(type_arg.clone()),
         tree.qualified_call_path.call_path.suffix.span(),
     );
-    match &type_info {
+    match type_info.deref() {
         TypeInfo::Enum(decl_ref) => {
             let decl = ctx.engines.de().get_enum(decl_ref);
             let child_type_args = decl.type_parameters.iter().map(TypeArgument::from);
@@ -1262,7 +1262,7 @@ fn collect_type_id(
 ) {
     let type_info = ctx.engines.te().get(type_id);
     let symbol_kind = type_info_to_symbol_kind(ctx.engines.te(), &type_info, Some(&type_span));
-    match &type_info {
+    match type_info.deref() {
         TypeInfo::Array(type_arg, ..) => {
             collect_type_argument(ctx, type_arg);
         }

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -1,6 +1,4 @@
 #![allow(dead_code)]
-use std::ops::Deref;
-
 use crate::{
     core::token::{
         type_info_to_symbol_kind, SymbolKind, Token, TokenIdent, TypeDefinition, TypedAstToken,
@@ -235,11 +233,7 @@ impl Parse for ty::TyExpression {
                             collect_type_argument(ctx, type_arg);
                         });
                 }
-                let implementing_type_name = ctx
-                    .engines
-                    .de()
-                    .get_function(fn_ref)
-                    .deref()
+                let implementing_type_name = (*ctx.engines.de().get_function(fn_ref))
                     .clone()
                     .implementing_type
                     .and_then(|impl_type| impl_type.get_decl_ident());
@@ -541,7 +535,7 @@ impl Parse for ty::TyExpression {
                             ctx.tokens.try_get_mut(&ctx.ident(&field.name)).try_unwrap()
                         {
                             token.typed = Some(TypedAstToken::Ident(field.name.clone()));
-                            match ctx.engines.te().get(container_type_id).deref() {
+                            match &*ctx.engines.te().get(container_type_id) {
                                 TypeInfo::Struct(decl_ref) => {
                                     if let Some(field_name) = ctx
                                         .engines
@@ -635,7 +629,7 @@ impl Parse for ty::TraitTypeDecl {
 impl Parse for ty::FunctionDecl {
     fn parse(&self, ctx: &ParseContext) {
         let func_decl = ctx.engines.de().get_function(&self.decl_id);
-        let typed_token = TypedAstToken::TypedFunctionDeclaration(func_decl.deref().clone());
+        let typed_token = TypedAstToken::TypedFunctionDeclaration((*func_decl).clone());
         if let Some(mut token) = ctx
             .tokens
             .try_get_mut(&ctx.ident(&func_decl.name))
@@ -757,7 +751,7 @@ impl Parse for ty::ImplTrait {
             items,
             implementing_for,
             ..
-        } = impl_trait_decl.deref();
+        } = &*impl_trait_decl;
         impl_type_parameters.iter().for_each(|param| {
             collect_type_id(
                 ctx,
@@ -1158,7 +1152,7 @@ fn collect_call_path_tree(ctx: &ParseContext, tree: &CallPathTree, type_arg: &Ty
         &TypedAstToken::TypedArgument(type_arg.clone()),
         tree.qualified_call_path.call_path.suffix.span(),
     );
-    match type_info.deref() {
+    match &*type_info {
         TypeInfo::Enum(decl_ref) => {
             let decl = ctx.engines.de().get_enum(decl_ref);
             let child_type_args = decl.type_parameters.iter().map(TypeArgument::from);
@@ -1262,7 +1256,7 @@ fn collect_type_id(
 ) {
     let type_info = ctx.engines.te().get(type_id);
     let symbol_kind = type_info_to_symbol_kind(ctx.engines.te(), &type_info, Some(&type_span));
-    match type_info.deref() {
+    match &*type_info {
         TypeInfo::Array(type_arg, ..) => {
             collect_type_argument(ctx, type_arg);
         }


### PR DESCRIPTION
## Description

`ConcurrentSlab` now stores and returns an Arc, and on `get` it only clones an Arc which is much cheaper than cloning the whole values.

The type engine is still cloning every TypeInfo we should be able to also avoid that and get further improvements in speed.

With these changes core + std-lib compilation improved from around 3 secs to 1.5 secs.
`cargo run --bin test --release` is running in around  8min versus 16min in master. 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
