### PR TITLE
Update LSP tests to use std lib v0.48.1

### DIFF
--- a/sway-lsp/tests/fixtures/benchmark/Forc.toml
+++ b/sway-lsp/tests/fixtures/benchmark/Forc.toml
@@ -6,4 +6,4 @@ name = "sway_project"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/completion/Forc.toml
+++ b/sway-lsp/tests/fixtures/completion/Forc.toml
@@ -6,4 +6,4 @@ name = "completion"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/diagnostics/dead_code/Forc.toml
+++ b/sway-lsp/tests/fixtures/diagnostics/dead_code/Forc.toml
@@ -6,4 +6,4 @@ name = "dead_code"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/diagnostics/multi_file/Forc.toml
+++ b/sway-lsp/tests/fixtures/diagnostics/multi_file/Forc.toml
@@ -6,4 +6,4 @@ entry = "main.sw"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/renaming/Forc.toml
+++ b/sway-lsp/tests/fixtures/renaming/Forc.toml
@@ -6,4 +6,4 @@ name = "renaming"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/runnables/Forc.toml
+++ b/sway-lsp/tests/fixtures/runnables/Forc.toml
@@ -6,4 +6,4 @@ name = "script_multi_test"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/abi/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/abi/Forc.toml
@@ -6,4 +6,4 @@ name = "abi"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/consts/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/consts/Forc.toml
@@ -6,4 +6,4 @@ name = "consts"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/enums/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/enums/Forc.toml
@@ -6,4 +6,4 @@ name = "enums"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/fields/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/fields/Forc.toml
@@ -6,4 +6,4 @@ name = "fields"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/functions/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/functions/Forc.toml
@@ -6,4 +6,4 @@ name = "functions"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/impls/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/impls/Forc.toml
@@ -6,4 +6,4 @@ name = "impls"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/matches/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/matches/Forc.toml
@@ -6,4 +6,4 @@ name = "matches"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/modules/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/modules/Forc.toml
@@ -6,4 +6,4 @@ name = "turbofish"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/paths/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/paths/Forc.toml
@@ -6,4 +6,4 @@ name = "paths"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/storage/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/storage/Forc.toml
@@ -6,4 +6,4 @@ name = "storage"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/structs/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/structs/Forc.toml
@@ -6,4 +6,4 @@ name = "structs"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/traits/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/traits/Forc.toml
@@ -6,4 +6,4 @@ name = "traits"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/turbofish/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/turbofish/Forc.toml
@@ -6,4 +6,4 @@ name = "turbofish"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/variables/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/variables/Forc.toml
@@ -6,4 +6,4 @@ name = "variables"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }

--- a/sway-lsp/tests/fixtures/tokens/where_clause/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/where_clause/Forc.toml
@@ -6,4 +6,4 @@ name = "where_clause"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", commit = "194b5943dfc13e1b4fba7ea27678b4c3ab37ac84" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }


### PR DESCRIPTION
## Description
LSP tests now use the most recent release of the std lib.
