### PR TITLE
Use Jemalloc in `forc-lsp` and LSP benchmarks for greater performance.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,7 @@ dependencies = [
  "anyhow",
  "clap 3.2.25",
  "sway-lsp",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -6361,6 +6362,7 @@ dependencies = [
  "syn 1.0.109",
  "tempfile",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "toml_edit 0.19.15",
  "tower",
@@ -6774,6 +6776,26 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/forc-plugins/forc-lsp/Cargo.toml
+++ b/forc-plugins/forc-lsp/Cargo.toml
@@ -12,4 +12,5 @@ repository.workspace = true
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
 sway-lsp = { version = "0.48.1", path = "../../sway-lsp" }
+tikv-jemallocator = "0.5"
 tokio = { version = "1.8" }

--- a/forc-plugins/forc-lsp/src/main.rs
+++ b/forc-plugins/forc-lsp/src/main.rs
@@ -2,6 +2,10 @@
 //!
 //! Once installed and available via `PATH`, can be executed via `forc lsp`.
 
+// Use Jemalloc for main binary
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use clap::Parser;
 
 #[derive(Debug, Parser)]
@@ -15,6 +19,5 @@ struct App {}
 #[tokio::main]
 async fn main() {
     App::parse();
-
     sway_lsp::start().await
 }

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -60,6 +60,7 @@ futures = { version = "0.3", default-features = false, features = [
 pretty_assertions = "1.4.0"
 regex = "^1.10.2"
 sway-lsp-test-utils = { path = "tests/utils" }
+tikv-jemallocator = "0.5"
 tower = { version = "0.4.12", default-features = false, features = ["util"] }
 
 [[bench]]

--- a/sway-lsp/benches/bench_main.rs
+++ b/sway-lsp/benches/bench_main.rs
@@ -1,6 +1,10 @@
 mod lsp_benchmarks;
 use criterion::criterion_main;
 
+// Use Jemalloc during benchmarks
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 criterion_main! {
     lsp_benchmarks::token_map::benches,
     lsp_benchmarks::requests::benches,

--- a/sway-lsp/benches/lsp_benchmarks/compile.rs
+++ b/sway-lsp/benches/lsp_benchmarks/compile.rs
@@ -3,7 +3,7 @@ use lsp_types::Url;
 use sway_core::Engines;
 use sway_lsp::core::session::{self, Session};
 
-const NUM_DID_CHANGE_ITERATIONS: usize = 20;
+const NUM_DID_CHANGE_ITERATIONS: usize = 4;
 
 fn benchmarks(c: &mut Criterion) {
     // Load the test project
@@ -28,9 +28,8 @@ fn benchmarks(c: &mut Criterion) {
 
     c.bench_function("did_change_with_caching", |b| {
         b.iter(|| {
-            let engines = Engines::default();
             for _ in 0..NUM_DID_CHANGE_ITERATIONS {
-                let _ = black_box(session::compile(&uri, &engines).unwrap());
+                let _ = black_box(session::compile(&uri, &session.engines.read()).unwrap());
             }
         })
     });
@@ -38,6 +37,6 @@ fn benchmarks(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().measurement_time(std::time::Duration::from_secs(10));
+    config = Criterion::default().measurement_time(std::time::Duration::from_secs(10)).sample_size(10);
     targets = benchmarks
 }

--- a/sway-lsp/benches/lsp_benchmarks/mod.rs
+++ b/sway-lsp/benches/lsp_benchmarks/mod.rs
@@ -4,7 +4,6 @@ pub mod token_map;
 
 use lsp_types::Url;
 use std::{path::PathBuf, sync::Arc};
-use sway_core::Engines;
 use sway_lsp::core::session::{self, Session};
 
 pub fn compile_test_project() -> (Url, Arc<Session>) {
@@ -13,8 +12,7 @@ pub fn compile_test_project() -> (Url, Arc<Session>) {
     let uri = Url::from_file_path(benchmark_dir().join("src/main.sw")).unwrap();
     session.handle_open_file(&uri);
     // Compile the project and write the parse result to the session
-    let engines = Engines::default();
-    let parse_result = session::parse_project(&uri, &engines).unwrap();
+    let parse_result = session::parse_project(&uri, &session.engines.read()).unwrap();
     session.write_parse_result(parse_result);
     (uri, Arc::new(session))
 }


### PR DESCRIPTION
## Description

closes #5372

Thanks for the idea @Voxelot , we seem to be getting nice performance wins across all our benchmarks with this change!

| Benchmark                | Avg Duration Before (ms or s) | Avg Duration After (ms or s) | Speed Increase (%) |
|--------------------------|-------------------------------|------------------------------|--------------------|
| compile                  | 5.53213 s                     | 4.64997 s                    | 15.931             |
| traverse                 | 170.646 ms                    | 162.067 ms                   | 5.0397             |
| did_change_with_caching  | 15.332 s                      | 15.4923 s                    | -1.04545           |
| semantic_tokens          | 20.766 ms                     | 15.981 ms                    | 23.053             |
| document_symbol          | 7.9145 ms                     | 5.99825 ms                   | 24.2205            |
| completion               | 49.685 ms                     | 48.5775 ms                   | 2.22975            |
| hover                    | 7.42155 ms                    | 6.23545 ms                   | 15.952             |
| highlight                | 113.75 ms                     | 108.503 ms                   | 4.6195             |
| goto_definition          | 7.99853 ms                    | 6.53863 ms                   | 18.3765            |
| inlay_hints              | 10.6885 ms                    | 8.99667 ms                   | 15.814             |
| prepare_rename           | 7.9312 ms                     | 6.38533 ms                   | 19.4985            |
| rename                   | 119.68 ms                     | 113.803 ms                   | 4.9071             |
| code_action              | 60.1105 ms                    | 55.44 ms                     | 7.7762             |
| code_lens                | 0.365733 ms                   | 0.2341 ms                    | 35.989             |
| on_enter                 | 0.604733 ms                   | 0.3105 ms                    | 48.676             |
| format                   | 51.57 ms                      | 44.6735 ms                   | 13.3765            |
| tokens_for_file          | 10.3933 ms                    | 8.85676 ms                   | 14.723             |
| idents_at_position       | 3.81803 ms                    | 3.1588 ms                    | 17.261             |
| tokens_at_position       | 42.2257 ms                    | 40.9237 ms                   | 3.0873             |
| token_at_position        | 7.67043 ms                    | 6.2267 ms                    | 18.811             |
| parent_decl_at_position  | 42.87 ms                      | 40.8167 ms                   | 4.7931             |
