### PR TITLE
Refactor Language Server I/O to Use Tokio Async Primitives

### DIFF
--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -36,6 +36,7 @@ syn = { version = "1.0.73", features = ["full"] }
 tempfile = "3"
 thiserror = "1.0.30"
 tokio = { version = "1.3", features = [
+    "fs",
     "io-std",
     "io-util",
     "macros",

--- a/sway-lsp/benches/lsp_benchmarks/compile.rs
+++ b/sway-lsp/benches/lsp_benchmarks/compile.rs
@@ -2,14 +2,18 @@ use criterion::{black_box, criterion_group, Criterion};
 use lsp_types::Url;
 use sway_core::Engines;
 use sway_lsp::core::session::{self, Session};
+use tokio::runtime::Runtime;
 
 const NUM_DID_CHANGE_ITERATIONS: usize = 4;
 
 fn benchmarks(c: &mut Criterion) {
     // Load the test project
     let uri = Url::from_file_path(super::benchmark_dir().join("src/main.sw")).unwrap();
-    let session = Session::new();
-    session.handle_open_file(&uri);
+    let session = Runtime::new().unwrap().block_on(async {
+        let session = Session::new();
+        session.handle_open_file(&uri).await;
+        session
+    });
 
     c.bench_function("compile", |b| {
         b.iter(|| {

--- a/sway-lsp/benches/lsp_benchmarks/mod.rs
+++ b/sway-lsp/benches/lsp_benchmarks/mod.rs
@@ -6,11 +6,11 @@ use lsp_types::Url;
 use std::{path::PathBuf, sync::Arc};
 use sway_lsp::core::session::{self, Session};
 
-pub fn compile_test_project() -> (Url, Arc<Session>) {
+pub async fn compile_test_project() -> (Url, Arc<Session>) {
     let session = Session::new();
     // Load the test project
     let uri = Url::from_file_path(benchmark_dir().join("src/main.sw")).unwrap();
-    session.handle_open_file(&uri);
+    session.handle_open_file(&uri).await;
     // Compile the project and write the parse result to the session
     let parse_result = session::parse_project(&uri, &session.engines.read()).unwrap();
     session.write_parse_result(parse_result);

--- a/sway-lsp/benches/lsp_benchmarks/requests.rs
+++ b/sway-lsp/benches/lsp_benchmarks/requests.rs
@@ -4,9 +4,12 @@ use lsp_types::{
     TextDocumentIdentifier,
 };
 use sway_lsp::{capabilities, lsp_ext::OnEnterParams, utils::keyword_docs::KeywordDocs};
+use tokio::runtime::Runtime;
 
 fn benchmarks(c: &mut Criterion) {
-    let (uri, session) = black_box(super::compile_test_project());
+    let (uri, session) = Runtime::new()
+        .unwrap()
+        .block_on(async { black_box(super::compile_test_project().await) });
     let config = sway_lsp::config::Config::default();
     let keyword_docs = KeywordDocs::new();
     let position = Position::new(1717, 24);

--- a/sway-lsp/benches/lsp_benchmarks/token_map.rs
+++ b/sway-lsp/benches/lsp_benchmarks/token_map.rs
@@ -1,8 +1,11 @@
 use criterion::{black_box, criterion_group, Criterion};
 use lsp_types::Position;
+use tokio::runtime::Runtime;
 
 fn benchmarks(c: &mut Criterion) {
-    let (uri, session) = black_box(super::compile_test_project());
+    let (uri, session) = Runtime::new()
+        .unwrap()
+        .block_on(async { black_box(super::compile_test_project().await) });
     let engines = session.engines.read();
     let position = Position::new(1716, 24);
 

--- a/sway-lsp/src/capabilities/on_enter.rs
+++ b/sway-lsp/src/capabilities/on_enter.rs
@@ -123,8 +123,9 @@ mod tests {
     async fn get_comment_workspace_edit_double_slash_indented() {
         let path = get_absolute_path("sway-lsp/tests/fixtures/diagnostics/dead_code/src/main.sw");
         let uri = Url::from_file_path(path.clone()).unwrap();
-        let text_document =
-            TextDocument::build_from_path(path.as_str()).await.expect("failed to build document");
+        let text_document = TextDocument::build_from_path(path.as_str())
+            .await
+            .expect("failed to build document");
         let params = OnEnterParams {
             text_document: TextDocumentIdentifier { uri },
             content_changes: vec![TextDocumentContentChangeEvent {
@@ -160,8 +161,9 @@ mod tests {
     async fn get_comment_workspace_edit_triple_slash_paste() {
         let path = get_absolute_path("sway-lsp/tests/fixtures/diagnostics/dead_code/src/main.sw");
         let uri = Url::from_file_path(path.clone()).unwrap();
-        let text_document =
-            TextDocument::build_from_path(path.as_str()).await.expect("failed to build document");
+        let text_document = TextDocument::build_from_path(path.as_str())
+            .await
+            .expect("failed to build document");
         let params = OnEnterParams {
             text_document: TextDocumentIdentifier { uri },
             content_changes: vec![TextDocumentContentChangeEvent {

--- a/sway-lsp/src/capabilities/on_enter.rs
+++ b/sway-lsp/src/capabilities/on_enter.rs
@@ -119,12 +119,12 @@ mod tests {
         }
     }
 
-    #[test]
-    fn get_comment_workspace_edit_double_slash_indented() {
+    #[tokio::test]
+    async fn get_comment_workspace_edit_double_slash_indented() {
         let path = get_absolute_path("sway-lsp/tests/fixtures/diagnostics/dead_code/src/main.sw");
         let uri = Url::from_file_path(path.clone()).unwrap();
         let text_document =
-            TextDocument::build_from_path(path.as_str()).expect("failed to build document");
+            TextDocument::build_from_path(path.as_str()).await.expect("failed to build document");
         let params = OnEnterParams {
             text_document: TextDocumentIdentifier { uri },
             content_changes: vec![TextDocumentContentChangeEvent {
@@ -156,12 +156,12 @@ mod tests {
         assert_text_edit(&edits[0].edits[0], "// ".to_string(), 48, 4);
     }
 
-    #[test]
-    fn get_comment_workspace_edit_triple_slash_paste() {
+    #[tokio::test]
+    async fn get_comment_workspace_edit_triple_slash_paste() {
         let path = get_absolute_path("sway-lsp/tests/fixtures/diagnostics/dead_code/src/main.sw");
         let uri = Url::from_file_path(path.clone()).unwrap();
         let text_document =
-            TextDocument::build_from_path(path.as_str()).expect("failed to build document");
+            TextDocument::build_from_path(path.as_str()).await.expect("failed to build document");
         let params = OnEnterParams {
             text_document: TextDocumentIdentifier { uri },
             content_changes: vec![TextDocumentContentChangeEvent {

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -116,13 +116,17 @@ pub async fn mark_file_as_dirty(uri: &Url) -> Result<(), LanguageServerError> {
     let dirty_file_path = forc_util::is_dirty_path(&path);
     if let Some(dir) = dirty_file_path.parent() {
         // Ensure the directory exists
-        tokio::fs::create_dir_all(dir).await.map_err(|_| DirectoryError::LspLocksDirFailed)?;
+        tokio::fs::create_dir_all(dir)
+            .await
+            .map_err(|_| DirectoryError::LspLocksDirFailed)?;
     }
     // Create an empty "dirty" file
-    File::create(&dirty_file_path).await.map_err(|err| DocumentError::UnableToCreateFile {
-        path: uri.path().to_string(),
-        err: err.to_string(),
-    })?;
+    File::create(&dirty_file_path)
+        .await
+        .map_err(|err| DocumentError::UnableToCreateFile {
+            path: uri.path().to_string(),
+            err: err.to_string(),
+        })?;
     Ok(())
 }
 
@@ -134,10 +138,12 @@ pub async fn remove_dirty_flag(uri: &Url) -> Result<(), LanguageServerError> {
     let dirty_file_path = forc_util::is_dirty_path(&path);
     if dirty_file_path.exists() {
         // Remove the "dirty" file
-        tokio::fs::remove_file(dirty_file_path).await.map_err(|err| DocumentError::UnableToRemoveFile {
-            path: uri.path().to_string(),
-            err: err.to_string(),
-        })?;
+        tokio::fs::remove_file(dirty_file_path)
+            .await
+            .map_err(|err| DocumentError::UnableToRemoveFile {
+                path: uri.path().to_string(),
+                err: err.to_string(),
+            })?;
     }
     Ok(())
 }
@@ -164,7 +170,9 @@ mod tests {
     #[tokio::test]
     async fn build_from_path_returns_document_not_found_error() {
         let path = get_absolute_path("not/a/real/file/path");
-        let result = TextDocument::build_from_path(&path).await.expect_err("expected DocumentNotFound");
+        let result = TextDocument::build_from_path(&path)
+            .await
+            .expect_err("expected DocumentNotFound");
         assert_eq!(result, DocumentError::DocumentNotFound { path });
     }
 }

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use lsp_types::{Position, Range, TextDocumentContentChangeEvent, Url};
 use ropey::Rope;
+use tokio::fs::File;
 
 #[derive(Debug, Clone)]
 pub struct TextDocument {
@@ -17,8 +18,9 @@ pub struct TextDocument {
 }
 
 impl TextDocument {
-    pub fn build_from_path(path: &str) -> Result<Self, DocumentError> {
-        std::fs::read_to_string(path)
+    pub async fn build_from_path(path: &str) -> Result<Self, DocumentError> {
+        tokio::fs::read_to_string(path)
+            .await
             .map(|content| Self {
                 language_id: "sway".into(),
                 version: 1,
@@ -109,15 +111,15 @@ impl TextDocument {
 /// Marks the specified file as "dirty" by creating a corresponding flag file.
 ///
 /// This function ensures the necessary directory structure exists before creating the flag file.
-pub fn mark_file_as_dirty(uri: &Url) -> Result<(), LanguageServerError> {
+pub async fn mark_file_as_dirty(uri: &Url) -> Result<(), LanguageServerError> {
     let path = document::get_path_from_url(uri)?;
     let dirty_file_path = forc_util::is_dirty_path(&path);
     if let Some(dir) = dirty_file_path.parent() {
         // Ensure the directory exists
-        std::fs::create_dir_all(dir).map_err(|_| DirectoryError::LspLocksDirFailed)?;
+        tokio::fs::create_dir_all(dir).await.map_err(|_| DirectoryError::LspLocksDirFailed)?;
     }
     // Create an empty "dirty" file
-    std::fs::File::create(&dirty_file_path).map_err(|err| DocumentError::UnableToCreateFile {
+    File::create(&dirty_file_path).await.map_err(|err| DocumentError::UnableToCreateFile {
         path: uri.path().to_string(),
         err: err.to_string(),
     })?;
@@ -127,12 +129,12 @@ pub fn mark_file_as_dirty(uri: &Url) -> Result<(), LanguageServerError> {
 /// Removes the corresponding flag file for the specifed Url.
 ///
 /// If the flag file does not exist, this function will do nothing.
-pub fn remove_dirty_flag(uri: &Url) -> Result<(), LanguageServerError> {
+pub async fn remove_dirty_flag(uri: &Url) -> Result<(), LanguageServerError> {
     let path = document::get_path_from_url(uri)?;
     let dirty_file_path = forc_util::is_dirty_path(&path);
     if dirty_file_path.exists() {
         // Remove the "dirty" file
-        std::fs::remove_file(dirty_file_path).map_err(|err| DocumentError::UnableToRemoveFile {
+        tokio::fs::remove_file(dirty_file_path).await.map_err(|err| DocumentError::UnableToRemoveFile {
             path: uri.path().to_string(),
             err: err.to_string(),
         })?;
@@ -152,17 +154,17 @@ mod tests {
     use super::*;
     use sway_lsp_test_utils::get_absolute_path;
 
-    #[test]
-    fn build_from_path_returns_text_document() {
+    #[tokio::test]
+    async fn build_from_path_returns_text_document() {
         let path = get_absolute_path("sway-lsp/tests/fixtures/cats.txt");
-        let result = TextDocument::build_from_path(&path);
+        let result = TextDocument::build_from_path(&path).await;
         assert!(result.is_ok(), "result = {result:?}");
     }
 
-    #[test]
-    fn build_from_path_returns_document_not_found_error() {
+    #[tokio::test]
+    async fn build_from_path_returns_document_not_found_error() {
         let path = get_absolute_path("not/a/real/file/path");
-        let result = TextDocument::build_from_path(&path).expect_err("expected DocumentNotFound");
+        let result = TextDocument::build_from_path(&path).await.expect_err("expected DocumentNotFound");
         assert_eq!(result, DocumentError::DocumentNotFound { path });
     }
 }

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -104,14 +104,14 @@ impl Session {
         }
     }
 
-    pub fn init(&self, uri: &Url) -> Result<ProjectDirectory, LanguageServerError> {
+    pub async fn init(&self, uri: &Url) -> Result<ProjectDirectory, LanguageServerError> {
         let manifest_dir = PathBuf::from(uri.path());
         // Create a new temp dir that clones the current workspace
         // and store manifest and temp paths
         self.sync.create_temp_dir_from_workspace(&manifest_dir)?;
         self.sync.clone_manifest_dir_to_temp()?;
         // iterate over the project dir, parse all sway files
-        let _ = self.store_sway_files();
+        let _ = self.store_sway_files().await;
         self.sync.watch_and_sync_manifest();
         self.sync.manifest_dir().map_err(Into::into)
     }

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -26,8 +26,6 @@ use parking_lot::RwLock;
 use pkg::{manifest::ManifestFile, BuildPlan};
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use std::{
-    fs::File,
-    io::Write,
     ops::Deref,
     path::PathBuf,
     sync::{atomic::Ordering, Arc},
@@ -46,7 +44,10 @@ use sway_core::{
 use sway_error::{error::CompileError, handler::Handler, warning::CompileWarning};
 use sway_types::{SourceEngine, SourceId, Spanned};
 use sway_utils::{helpers::get_sway_files, PerformanceData};
-use tokio::sync::Semaphore;
+use tokio::{
+    fs::File, io::AsyncWriteExt,
+    sync::Semaphore,
+};
 
 pub type Documents = DashMap<String, TextDocument>;
 pub type ProjectDirectory = PathBuf;
@@ -276,16 +277,16 @@ impl Session {
             .map(|page_text_edit| vec![page_text_edit])
     }
 
-    pub fn handle_open_file(&self, uri: &Url) {
+    pub async fn handle_open_file(&self, uri: &Url) {
         if !self.documents.contains_key(uri.path()) {
-            if let Ok(text_document) = TextDocument::build_from_path(uri.path()) {
+            if let Ok(text_document) = TextDocument::build_from_path(uri.path()).await {
                 let _ = self.store_document(text_document);
             }
         }
     }
 
-    /// Writes the changes to the file and updates the document.
-    pub fn write_changes_to_file(
+    /// Asynchronously writes the changes to the file and updates the document.
+    pub async fn write_changes_to_file(
         &self,
         uri: &Url,
         changes: Vec<TextDocumentContentChangeEvent>,
@@ -295,15 +296,21 @@ impl Session {
                 path: uri.path().to_string(),
             }
         })?;
-        let mut file =
-            File::create(uri.path()).map_err(|err| DocumentError::UnableToCreateFile {
+
+        let mut file = File::create(uri.path())
+            .await
+            .map_err(|err| DocumentError::UnableToCreateFile {
                 path: uri.path().to_string(),
                 err: err.to_string(),
             })?;
-        writeln!(&mut file, "{src}").map_err(|err| DocumentError::UnableToWriteFile {
-            path: uri.path().to_string(),
-            err: err.to_string(),
-        })?;
+
+        file.write_all(src.as_bytes())
+            .await
+            .map_err(|err| DocumentError::UnableToWriteFile {
+                path: uri.path().to_string(),
+                err: err.to_string(),
+            })?;
+
         Ok(())
     }
 
@@ -399,11 +406,11 @@ impl Session {
     }
 
     /// Populate [Documents] with sway files found in the workspace.
-    fn store_sway_files(&self) -> Result<(), LanguageServerError> {
+    async fn store_sway_files(&self) -> Result<(), LanguageServerError> {
         let temp_dir = self.sync.temp_dir()?;
         // Store the documents.
         for path in get_sway_files(temp_dir).iter().filter_map(|fp| fp.to_str()) {
-            self.store_document(TextDocument::build_from_path(path)?)?;
+            self.store_document(TextDocument::build_from_path(path).await?)?;
         }
         Ok(())
     }
@@ -594,22 +601,22 @@ mod tests {
     use super::*;
     use sway_lsp_test_utils::{get_absolute_path, get_url};
 
-    #[test]
-    fn store_document_returns_empty_tuple() {
+    #[tokio::test]
+    async fn store_document_returns_empty_tuple() {
         let session = Session::new();
         let path = get_absolute_path("sway-lsp/tests/fixtures/cats.txt");
-        let document = TextDocument::build_from_path(&path).unwrap();
+        let document = TextDocument::build_from_path(&path).await.unwrap();
         let result = Session::store_document(&session, document);
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn store_document_returns_document_already_stored_error() {
+    #[tokio::test]
+    async fn store_document_returns_document_already_stored_error() {
         let session = Session::new();
         let path = get_absolute_path("sway-lsp/tests/fixtures/cats.txt");
-        let document = TextDocument::build_from_path(&path).unwrap();
+        let document = TextDocument::build_from_path(&path).await.unwrap();
         Session::store_document(&session, document).expect("expected successfully stored");
-        let document = TextDocument::build_from_path(&path).unwrap();
+        let document = TextDocument::build_from_path(&path).await.unwrap();
         let result = Session::store_document(&session, document)
             .expect_err("expected DocumentAlreadyStored");
         assert_eq!(result, DocumentError::DocumentAlreadyStored { path });

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -13,7 +13,7 @@ pub async fn handle_did_open_text_document(
 ) -> Result<(), LanguageServerError> {
     let (uri, session) = state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)?;
+        .uri_and_session_from_workspace(&params.text_document.uri).await?;
     session.handle_open_file(&uri).await;
     // If the token map is empty, then we need to parse the project.
     // Otherwise, don't recompile the project when a new file in the project is opened
@@ -33,7 +33,7 @@ pub async fn handle_did_change_text_document(
     document::mark_file_as_dirty(&params.text_document.uri).await?;
     let (uri, session) = state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)?;
+        .uri_and_session_from_workspace(&params.text_document.uri).await?;
     session
         .write_changes_to_file(&uri, params.content_changes)
         .await?;
@@ -55,7 +55,7 @@ pub(crate) async fn handle_did_save_text_document(
     document::remove_dirty_flag(&params.text_document.uri).await?;
     let (uri, session) = state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)?;
+        .uri_and_session_from_workspace(&params.text_document.uri).await?;
     session.sync.resync()?;
     state
         .parse_project(uri, params.text_document.uri, None, session.clone())
@@ -68,7 +68,7 @@ pub(crate) async fn handle_did_change_watched_files(
     params: DidChangeWatchedFilesParams,
 ) -> Result<(), LanguageServerError> {
     for event in params.changes {
-        let (uri, session) = state.sessions.uri_and_session_from_workspace(&event.uri)?;
+        let (uri, session) = state.sessions.uri_and_session_from_workspace(&event.uri).await?;
         if let FileChangeType::DELETED = event.typ {
             document::remove_dirty_flag(&event.uri).await?;
             let _ = session.remove_document(&uri);

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -13,7 +13,8 @@ pub async fn handle_did_open_text_document(
 ) -> Result<(), LanguageServerError> {
     let (uri, session) = state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri).await?;
+        .uri_and_session_from_workspace(&params.text_document.uri)
+        .await?;
     session.handle_open_file(&uri).await;
     // If the token map is empty, then we need to parse the project.
     // Otherwise, don't recompile the project when a new file in the project is opened
@@ -33,7 +34,8 @@ pub async fn handle_did_change_text_document(
     document::mark_file_as_dirty(&params.text_document.uri).await?;
     let (uri, session) = state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri).await?;
+        .uri_and_session_from_workspace(&params.text_document.uri)
+        .await?;
     session
         .write_changes_to_file(&uri, params.content_changes)
         .await?;
@@ -55,7 +57,8 @@ pub(crate) async fn handle_did_save_text_document(
     document::remove_dirty_flag(&params.text_document.uri).await?;
     let (uri, session) = state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri).await?;
+        .uri_and_session_from_workspace(&params.text_document.uri)
+        .await?;
     session.sync.resync()?;
     state
         .parse_project(uri, params.text_document.uri, None, session.clone())
@@ -68,7 +71,10 @@ pub(crate) async fn handle_did_change_watched_files(
     params: DidChangeWatchedFilesParams,
 ) -> Result<(), LanguageServerError> {
     for event in params.changes {
-        let (uri, session) = state.sessions.uri_and_session_from_workspace(&event.uri).await?;
+        let (uri, session) = state
+            .sessions
+            .uri_and_session_from_workspace(&event.uri)
+            .await?;
         if let FileChangeType::DELETED = event.typ {
             document::remove_dirty_flag(&event.uri).await?;
             let _ = session.remove_document(&uri);

--- a/sway-lsp/src/handlers/notification.rs
+++ b/sway-lsp/src/handlers/notification.rs
@@ -34,7 +34,9 @@ pub async fn handle_did_change_text_document(
     let (uri, session) = state
         .sessions
         .uri_and_session_from_workspace(&params.text_document.uri)?;
-    session.write_changes_to_file(&uri, params.content_changes).await?;
+    session
+        .write_changes_to_file(&uri, params.content_changes)
+        .await?;
     state
         .parse_project(
             uri,

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -54,7 +54,8 @@ pub async fn handle_document_symbol(
 ) -> Result<Option<lsp_types::DocumentSymbolResponse>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document.uri)
+        .await
     {
         Ok((uri, session)) => {
             let _ = session.wait_for_parsing();
@@ -75,7 +76,8 @@ pub async fn handle_goto_definition(
 ) -> Result<Option<lsp_types::GotoDefinitionResponse>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document_position_params.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document_position_params.text_document.uri)
+        .await
     {
         Ok((uri, session)) => {
             let position = params.text_document_position_params.position;
@@ -100,7 +102,8 @@ pub async fn handle_completion(
     let position = params.text_document_position.position;
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document_position.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document_position.text_document.uri)
+        .await
     {
         Ok((uri, session)) => Ok(session
             .completion_items(&uri, position, trigger_char)
@@ -118,7 +121,8 @@ pub async fn handle_hover(
 ) -> Result<Option<lsp_types::Hover>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document_position_params.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document_position_params.text_document.uri)
+        .await
     {
         Ok((uri, session)) => {
             let position = params.text_document_position_params.position;
@@ -142,7 +146,8 @@ pub async fn handle_prepare_rename(
 ) -> Result<Option<PrepareRenameResponse>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document.uri)
+        .await
     {
         Ok((uri, session)) => {
             match capabilities::rename::prepare_rename(session, uri, params.position) {
@@ -160,10 +165,14 @@ pub async fn handle_prepare_rename(
     }
 }
 
-pub async fn handle_rename(state: &ServerState, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+pub async fn handle_rename(
+    state: &ServerState,
+    params: RenameParams,
+) -> Result<Option<WorkspaceEdit>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document_position.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document_position.text_document.uri)
+        .await
     {
         Ok((uri, session)) => {
             let new_name = params.new_name;
@@ -189,7 +198,8 @@ pub async fn handle_document_highlight(
 ) -> Result<Option<Vec<lsp_types::DocumentHighlight>>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document_position_params.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document_position_params.text_document.uri)
+        .await
     {
         Ok((uri, session)) => {
             let position = params.text_document_position_params.position;
@@ -210,7 +220,8 @@ pub async fn handle_formatting(
 ) -> Result<Option<Vec<lsp_types::TextEdit>>> {
     state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document.uri)
+        .await
         .and_then(|(uri, session)| session.format_text(&uri).map(Some))
         .or_else(|err| {
             tracing::error!("{}", err.to_string());
@@ -224,7 +235,8 @@ pub async fn handle_code_action(
 ) -> Result<Option<lsp_types::CodeActionResponse>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document.uri)
+        .await
     {
         Ok((temp_uri, session)) => Ok(capabilities::code_actions(
             session,
@@ -246,7 +258,8 @@ pub async fn handle_code_lens(
 ) -> Result<Option<Vec<CodeLens>>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document.uri)
+        .await
     {
         Ok((url, session)) => {
             let _ = session.wait_for_parsing();
@@ -265,7 +278,8 @@ pub async fn handle_semantic_tokens_full(
 ) -> Result<Option<SemanticTokensResult>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document.uri)
+        .await
     {
         Ok((uri, session)) => {
             let _ = session.wait_for_parsing();
@@ -286,7 +300,8 @@ pub(crate) async fn handle_inlay_hints(
 ) -> Result<Option<Vec<InlayHint>>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document.uri)
+        .await
     {
         Ok((uri, session)) => {
             let _ = session.wait_for_parsing();
@@ -323,7 +338,8 @@ pub async fn handle_show_ast(
 ) -> Result<Option<TextDocumentIdentifier>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document.uri)
+        .await
     {
         Ok((_, session)) => {
             let current_open_file = params.text_document.uri;
@@ -416,11 +432,17 @@ pub async fn handle_on_enter(
 ) -> Result<Option<WorkspaceEdit>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document.uri)
+        .await
     {
         Ok((uri, session)) => {
             // handle on_enter capabilities if they are enabled
-            Ok(capabilities::on_enter(&state.config.read().on_enter, &session, &uri, &params))
+            Ok(capabilities::on_enter(
+                &state.config.read().on_enter,
+                &session,
+                &uri,
+                &params,
+            ))
         }
         Err(err) => {
             tracing::error!("{}", err.to_string());
@@ -455,7 +477,8 @@ pub(crate) async fn metrics(
 ) -> Result<Option<Vec<(String, PerformanceData)>>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri).await
+        .uri_and_session_from_workspace(&params.text_document.uri)
+        .await
     {
         Ok((_, session)) => {
             let engines = session.engines.read();

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -48,13 +48,13 @@ pub fn handle_initialize(
     })
 }
 
-pub fn handle_document_symbol(
+pub async fn handle_document_symbol(
     state: &ServerState,
     params: lsp_types::DocumentSymbolParams,
 ) -> Result<Option<lsp_types::DocumentSymbolResponse>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document.uri).await
     {
         Ok((uri, session)) => {
             let _ = session.wait_for_parsing();
@@ -69,13 +69,13 @@ pub fn handle_document_symbol(
     }
 }
 
-pub fn handle_goto_definition(
+pub async fn handle_goto_definition(
     state: &ServerState,
     params: lsp_types::GotoDefinitionParams,
 ) -> Result<Option<lsp_types::GotoDefinitionResponse>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document_position_params.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document_position_params.text_document.uri).await
     {
         Ok((uri, session)) => {
             let position = params.text_document_position_params.position;
@@ -88,7 +88,7 @@ pub fn handle_goto_definition(
     }
 }
 
-pub fn handle_completion(
+pub async fn handle_completion(
     state: &ServerState,
     params: lsp_types::CompletionParams,
 ) -> Result<Option<lsp_types::CompletionResponse>> {
@@ -100,7 +100,7 @@ pub fn handle_completion(
     let position = params.text_document_position.position;
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document_position.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document_position.text_document.uri).await
     {
         Ok((uri, session)) => Ok(session
             .completion_items(&uri, position, trigger_char)
@@ -112,13 +112,13 @@ pub fn handle_completion(
     }
 }
 
-pub fn handle_hover(
+pub async fn handle_hover(
     state: &ServerState,
     params: lsp_types::HoverParams,
 ) -> Result<Option<lsp_types::Hover>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document_position_params.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document_position_params.text_document.uri).await
     {
         Ok((uri, session)) => {
             let position = params.text_document_position_params.position;
@@ -136,13 +136,13 @@ pub fn handle_hover(
     }
 }
 
-pub fn handle_prepare_rename(
+pub async fn handle_prepare_rename(
     state: &ServerState,
     params: lsp_types::TextDocumentPositionParams,
 ) -> Result<Option<PrepareRenameResponse>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document.uri).await
     {
         Ok((uri, session)) => {
             match capabilities::rename::prepare_rename(session, uri, params.position) {
@@ -160,10 +160,10 @@ pub fn handle_prepare_rename(
     }
 }
 
-pub fn handle_rename(state: &ServerState, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+pub async fn handle_rename(state: &ServerState, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document_position.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document_position.text_document.uri).await
     {
         Ok((uri, session)) => {
             let new_name = params.new_name;
@@ -183,13 +183,13 @@ pub fn handle_rename(state: &ServerState, params: RenameParams) -> Result<Option
     }
 }
 
-pub fn handle_document_highlight(
+pub async fn handle_document_highlight(
     state: &ServerState,
     params: lsp_types::DocumentHighlightParams,
 ) -> Result<Option<Vec<lsp_types::DocumentHighlight>>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document_position_params.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document_position_params.text_document.uri).await
     {
         Ok((uri, session)) => {
             let position = params.text_document_position_params.position;
@@ -204,13 +204,13 @@ pub fn handle_document_highlight(
     }
 }
 
-pub fn handle_formatting(
+pub async fn handle_formatting(
     state: &ServerState,
     params: DocumentFormattingParams,
 ) -> Result<Option<Vec<lsp_types::TextEdit>>> {
     state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document.uri).await
         .and_then(|(uri, session)| session.format_text(&uri).map(Some))
         .or_else(|err| {
             tracing::error!("{}", err.to_string());
@@ -218,13 +218,13 @@ pub fn handle_formatting(
         })
 }
 
-pub fn handle_code_action(
+pub async fn handle_code_action(
     state: &ServerState,
     params: lsp_types::CodeActionParams,
 ) -> Result<Option<lsp_types::CodeActionResponse>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document.uri).await
     {
         Ok((temp_uri, session)) => Ok(capabilities::code_actions(
             session,
@@ -240,13 +240,13 @@ pub fn handle_code_action(
     }
 }
 
-pub fn handle_code_lens(
+pub async fn handle_code_lens(
     state: &ServerState,
     params: lsp_types::CodeLensParams,
 ) -> Result<Option<Vec<CodeLens>>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document.uri).await
     {
         Ok((url, session)) => {
             let _ = session.wait_for_parsing();
@@ -259,13 +259,13 @@ pub fn handle_code_lens(
     }
 }
 
-pub fn handle_semantic_tokens_full(
+pub async fn handle_semantic_tokens_full(
     state: &ServerState,
     params: SemanticTokensParams,
 ) -> Result<Option<SemanticTokensResult>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document.uri).await
     {
         Ok((uri, session)) => {
             let _ = session.wait_for_parsing();
@@ -280,13 +280,13 @@ pub fn handle_semantic_tokens_full(
     }
 }
 
-pub(crate) fn handle_inlay_hints(
+pub(crate) async fn handle_inlay_hints(
     state: &ServerState,
     params: InlayHintParams,
 ) -> Result<Option<Vec<InlayHint>>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document.uri).await
     {
         Ok((uri, session)) => {
             let _ = session.wait_for_parsing();
@@ -317,13 +317,13 @@ pub(crate) fn handle_inlay_hints(
 /// A formatted AST is written to a temporary file and the URI is
 /// returned to the client so it can be opened and displayed in a
 /// seperate side panel.
-pub fn handle_show_ast(
+pub async fn handle_show_ast(
     state: &ServerState,
     params: lsp_ext::ShowAstParams,
 ) -> Result<Option<TextDocumentIdentifier>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document.uri).await
     {
         Ok((_, session)) => {
             let current_open_file = params.text_document.uri;
@@ -410,18 +410,17 @@ pub fn handle_show_ast(
 }
 
 /// This method is triggered when the use hits enter or pastes a newline in the editor.
-pub(crate) fn handle_on_enter(
+pub async fn handle_on_enter(
     state: &ServerState,
     params: lsp_ext::OnEnterParams,
 ) -> Result<Option<WorkspaceEdit>> {
-    let config = &state.config.read().on_enter;
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document.uri).await
     {
         Ok((uri, session)) => {
             // handle on_enter capabilities if they are enabled
-            Ok(capabilities::on_enter(config, &session, &uri, &params))
+            Ok(capabilities::on_enter(&state.config.read().on_enter, &session, &uri, &params))
         }
         Err(err) => {
             tracing::error!("{}", err.to_string());
@@ -450,13 +449,13 @@ pub fn handle_visualize(
 }
 
 /// This method is triggered by the test suite to request the latest compilation metrics.
-pub(crate) fn metrics(
+pub(crate) async fn metrics(
     state: &ServerState,
     params: lsp_ext::MetricsParams,
 ) -> Result<Option<Vec<(String, PerformanceData)>>> {
     match state
         .sessions
-        .uri_and_session_from_workspace(&params.text_document.uri)
+        .uri_and_session_from_workspace(&params.text_document.uri).await
     {
         Ok((_, session)) => {
             let engines = session.engines.read();

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -41,7 +41,7 @@ impl LanguageServer for ServerState {
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
-        if let Err(err) = document::remove_dirty_flag(&params.text_document.uri) {
+        if let Err(err) = document::remove_dirty_flag(&params.text_document.uri).await {
             tracing::error!("{}", err.to_string());
         }
     }
@@ -59,7 +59,7 @@ impl LanguageServer for ServerState {
     }
 
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
-        if let Err(err) = notification::handle_did_change_watched_files(self, params) {
+        if let Err(err) = notification::handle_did_change_watched_files(self, params).await {
             tracing::error!("{}", err.to_string());
         }
     }

--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -65,77 +65,77 @@ impl LanguageServer for ServerState {
     }
 
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
-        request::handle_hover(self, params)
+        request::handle_hover(self, params).await
     }
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
-        request::handle_code_action(self, params)
+        request::handle_code_action(self, params).await
     }
 
     async fn code_lens(&self, params: CodeLensParams) -> Result<Option<Vec<CodeLens>>> {
-        request::handle_code_lens(self, params)
+        request::handle_code_lens(self, params).await
     }
 
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
-        request::handle_completion(self, params)
+        request::handle_completion(self, params).await
     }
 
     async fn document_symbol(
         &self,
         params: DocumentSymbolParams,
     ) -> Result<Option<DocumentSymbolResponse>> {
-        request::handle_document_symbol(self, params)
+        request::handle_document_symbol(self, params).await
     }
 
     async fn semantic_tokens_full(
         &self,
         params: SemanticTokensParams,
     ) -> Result<Option<SemanticTokensResult>> {
-        request::handle_semantic_tokens_full(self, params)
+        request::handle_semantic_tokens_full(self, params).await
     }
 
     async fn document_highlight(
         &self,
         params: DocumentHighlightParams,
     ) -> Result<Option<Vec<DocumentHighlight>>> {
-        request::handle_document_highlight(self, params)
+        request::handle_document_highlight(self, params).await
     }
 
     async fn goto_definition(
         &self,
         params: GotoDefinitionParams,
     ) -> Result<Option<GotoDefinitionResponse>> {
-        request::handle_goto_definition(self, params)
+        request::handle_goto_definition(self, params).await
     }
 
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
-        request::handle_formatting(self, params)
+        request::handle_formatting(self, params).await
     }
 
     async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
-        request::handle_rename(self, params)
+        request::handle_rename(self, params).await
     }
 
     async fn prepare_rename(
         &self,
         params: TextDocumentPositionParams,
     ) -> Result<Option<PrepareRenameResponse>> {
-        request::handle_prepare_rename(self, params)
+        request::handle_prepare_rename(self, params).await
     }
 
     async fn inlay_hint(&self, params: InlayHintParams) -> Result<Option<Vec<InlayHint>>> {
-        request::handle_inlay_hints(self, params)
+        request::handle_inlay_hints(self, params).await
     }
 }
 
 // Custom LSP-Server Methods
 impl ServerState {
     pub async fn show_ast(&self, params: ShowAstParams) -> Result<Option<TextDocumentIdentifier>> {
-        request::handle_show_ast(self, params)
+        request::handle_show_ast(self, params).await
     }
 
     pub async fn on_enter(&self, params: OnEnterParams) -> Result<Option<WorkspaceEdit>> {
-        request::handle_on_enter(self, params)
+        request::handle_on_enter(self, params).await
     }
 
     pub async fn visualize(&self, params: VisualizeParams) -> Result<Option<String>> {
@@ -146,6 +146,6 @@ impl ServerState {
         &self,
         params: MetricsParams,
     ) -> Result<Option<Vec<(String, PerformanceData)>>> {
-        request::metrics(self, params)
+        request::metrics(self, params).await
     }
 }

--- a/sway-lsp/src/utils/keyword_docs.rs
+++ b/sway-lsp/src/utils/keyword_docs.rs
@@ -837,8 +837,8 @@ fn extract_lit(tokens: TokenStream) -> String {
     res
 }
 
-#[test]
-fn keywords_in_sync() {
+#[tokio::test]
+async fn keywords_in_sync() {
     let keyword_docs = KeywordDocs::new();
     let lsp_keywords: Vec<_> = keyword_docs.keys().collect();
     let compiler_keywords: Vec<_> = sway_parse::RESERVED_KEYWORDS

--- a/sway-lsp/tests/integration/code_actions.rs
+++ b/sway-lsp/tests/integration/code_actions.rs
@@ -106,13 +106,14 @@ fn create_changes_for_qualify(
     create_changes_map(uri, range, call_path)
 }
 
-fn send_request(server: &ServerState, params: &CodeActionParams) -> Vec<CodeActionOrCommand> {
+async fn send_request(server: &ServerState, params: &CodeActionParams) -> Vec<CodeActionOrCommand> {
     request::handle_code_action(server, params.clone())
+        .await
         .unwrap()
         .unwrap_or_else(|| panic!("Empty response from server for request: {:?}", params))
 }
 
-pub(crate) fn code_action_abi_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_abi_request(server: &ServerState, uri: &Url) {
     let params = create_code_action_params(
         uri.clone(),
         Range {
@@ -150,11 +151,11 @@ pub(crate) fn code_action_abi_request(server: &ServerState, uri: &Url) {
         Some(CodeActionKind::REFACTOR),
     )];
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 }
 
-pub(crate) fn code_action_function_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_function_request(server: &ServerState, uri: &Url) {
     let params = create_code_action_params(
         uri.clone(),
         Range {
@@ -189,11 +190,11 @@ pub(crate) fn code_action_function_request(server: &ServerState, uri: &Url) {
         Some(CodeActionKind::REFACTOR),
     )];
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 }
 
-pub(crate) fn code_action_trait_fn_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_trait_fn_request(server: &ServerState, uri: &Url) {
     let params = create_code_action_params(
         uri.clone(),
         Range {
@@ -228,11 +229,11 @@ pub(crate) fn code_action_trait_fn_request(server: &ServerState, uri: &Url) {
         Some(CodeActionKind::REFACTOR),
     )];
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 }
 
-pub(crate) fn code_action_struct_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_struct_request(server: &ServerState, uri: &Url) {
     let params = create_code_action_params(
         uri.clone(),
         Range {
@@ -310,11 +311,11 @@ pub(crate) fn code_action_struct_request(server: &ServerState, uri: &Url) {
         Some(CodeActionKind::REFACTOR),
     ));
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 }
 
-pub(crate) fn code_action_struct_type_params_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_struct_type_params_request(server: &ServerState, uri: &Url) {
     let params = create_code_action_params(
         uri.clone(),
         Range {
@@ -398,11 +399,11 @@ pub(crate) fn code_action_struct_type_params_request(server: &ServerState, uri: 
         Some(CodeActionKind::REFACTOR),
     ));
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 }
 
-pub(crate) fn code_action_struct_existing_impl_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_struct_existing_impl_request(server: &ServerState, uri: &Url) {
     let params = create_code_action_params(
         uri.clone(),
         Range {
@@ -482,11 +483,11 @@ pub(crate) fn code_action_struct_existing_impl_request(server: &ServerState, uri
         Some(CodeActionKind::REFACTOR),
     ));
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 }
 
-pub(crate) fn code_action_auto_import_struct_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_auto_import_struct_request(server: &ServerState, uri: &Url) {
     // EvmAddress: external library
     let range = Range {
         start: Position {
@@ -527,7 +528,7 @@ pub(crate) fn code_action_auto_import_struct_request(server: &ServerState, uri: 
         ),
     ];
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 
     // DeepStruct: local library
@@ -570,11 +571,11 @@ pub(crate) fn code_action_auto_import_struct_request(server: &ServerState, uri: 
         ),
     ];
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 }
 
-pub(crate) fn code_action_auto_import_enum_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_auto_import_enum_request(server: &ServerState, uri: &Url) {
     // TODO: Add a test for an enum variant when https://github.com/FuelLabs/sway/issues/5188 is fixed.
 
     // AuthError: external library
@@ -617,7 +618,7 @@ pub(crate) fn code_action_auto_import_enum_request(server: &ServerState, uri: &U
         ),
     ];
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 
     // DeepEnum: local library
@@ -660,11 +661,11 @@ pub(crate) fn code_action_auto_import_enum_request(server: &ServerState, uri: &U
         ),
     ];
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 }
 
-pub(crate) fn code_action_auto_import_function_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_auto_import_function_request(server: &ServerState, uri: &Url) {
     // TODO: external library, test with `overflow``
     // Tracking issue: https://github.com/FuelLabs/sway/issues/5191
 
@@ -708,11 +709,11 @@ pub(crate) fn code_action_auto_import_function_request(server: &ServerState, uri
         ),
     ];
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 }
 
-pub(crate) fn code_action_auto_import_constant_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_auto_import_constant_request(server: &ServerState, uri: &Url) {
     // TODO: external library, test with ZERO_B256
     // Tracking issue: https://github.com/FuelLabs/sway/issues/5192
 
@@ -756,11 +757,11 @@ pub(crate) fn code_action_auto_import_constant_request(server: &ServerState, uri
         ),
     ];
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 }
 
-pub(crate) fn code_action_auto_import_trait_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_auto_import_trait_request(server: &ServerState, uri: &Url) {
     // TryFrom: external library
     let range = Range {
         start: Position {
@@ -801,7 +802,7 @@ pub(crate) fn code_action_auto_import_trait_request(server: &ServerState, uri: &
         ),
     ];
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 
     // DeepTrait: local library
@@ -844,11 +845,11 @@ pub(crate) fn code_action_auto_import_trait_request(server: &ServerState, uri: &
         ),
     ];
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 }
 
-pub(crate) fn code_action_auto_import_alias_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_action_auto_import_alias_request(server: &ServerState, uri: &Url) {
     // TODO: find an example in an external library
     // A: local library with multiple possible imports
     let range = Range {
@@ -905,6 +906,6 @@ pub(crate) fn code_action_auto_import_alias_request(server: &ServerState, uri: &
         ),
     ];
 
-    let actual = send_request(server, &params);
+    let actual = send_request(server, &params).await;
     assert_eq!(expected, actual);
 }

--- a/sway-lsp/tests/integration/lsp.rs
+++ b/sway-lsp/tests/integration/lsp.rs
@@ -140,7 +140,7 @@ pub(crate) async fn show_ast_request(
         save_path: save_path.clone(),
     };
 
-    let response = request::handle_show_ast(server, params);
+    let response = request::handle_show_ast(server, params).await;
     let expected = TextDocumentIdentifier {
         uri: Url::parse(&format!("{save_path}/{ast_kind}.rs")).unwrap(),
     };
@@ -187,31 +187,31 @@ pub(crate) async fn metrics_request(
     res
 }
 
-pub(crate) fn semantic_tokens_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn semantic_tokens_request(server: &ServerState, uri: &Url) {
     let params = SemanticTokensParams {
         text_document: TextDocumentIdentifier { uri: uri.clone() },
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
     };
-    let response = request::handle_semantic_tokens_full(server, params).unwrap();
+    let response = request::handle_semantic_tokens_full(server, params).await.unwrap();
     if let Some(SemanticTokensResult::Tokens(tokens)) = response {
         assert!(!tokens.data.is_empty());
     }
 }
 
-pub(crate) fn document_symbol_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn document_symbol_request(server: &ServerState, uri: &Url) {
     let params = DocumentSymbolParams {
         text_document: TextDocumentIdentifier { uri: uri.clone() },
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
     };
-    let response = request::handle_document_symbol(server, params).unwrap();
+    let response = request::handle_document_symbol(server, params).await.unwrap();
     if let Some(DocumentSymbolResponse::Flat(res)) = response {
         assert!(!res.is_empty());
     }
 }
 
-pub(crate) fn format_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn format_request(server: &ServerState, uri: &Url) {
     let params = DocumentFormattingParams {
         text_document: TextDocumentIdentifier { uri: uri.clone() },
         options: FormattingOptions {
@@ -221,11 +221,11 @@ pub(crate) fn format_request(server: &ServerState, uri: &Url) {
         },
         work_done_progress_params: Default::default(),
     };
-    let response = request::handle_formatting(server, params).unwrap();
+    let response = request::handle_formatting(server, params).await.unwrap();
     assert!(!response.unwrap().is_empty());
 }
 
-pub(crate) fn highlight_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn highlight_request(server: &ServerState, uri: &Url) {
     let params = DocumentHighlightParams {
         text_document_position_params: TextDocumentPositionParams {
             text_document: TextDocumentIdentifier { uri: uri.clone() },
@@ -237,7 +237,7 @@ pub(crate) fn highlight_request(server: &ServerState, uri: &Url) {
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
     };
-    let response = request::handle_document_highlight(server, params).unwrap();
+    let response = request::handle_document_highlight(server, params).await.unwrap();
     let expected = vec![
         DocumentHighlight {
             range: Range {
@@ -269,23 +269,23 @@ pub(crate) fn highlight_request(server: &ServerState, uri: &Url) {
     assert_eq!(expected, response.unwrap());
 }
 
-pub(crate) fn code_lens_empty_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_lens_empty_request(server: &ServerState, uri: &Url) {
     let params = CodeLensParams {
         text_document: TextDocumentIdentifier { uri: uri.clone() },
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
     };
-    let response = request::handle_code_lens(server, params).unwrap();
+    let response = request::handle_code_lens(server, params).await.unwrap();
     assert_eq!(response.unwrap().len(), 0);
 }
 
-pub(crate) fn code_lens_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn code_lens_request(server: &ServerState, uri: &Url) {
     let params = CodeLensParams {
         text_document: TextDocumentIdentifier { uri: uri.clone() },
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
     };
-    let response = request::handle_code_lens(server, params).unwrap();
+    let response = request::handle_code_lens(server, params).await.unwrap();
     let expected = vec![
         CodeLens {
             range: Range {
@@ -349,7 +349,7 @@ pub(crate) fn code_lens_request(server: &ServerState, uri: &Url) {
     assert_eq!(expected, response.unwrap());
 }
 
-pub(crate) fn completion_request(server: &ServerState, uri: &Url) {
+pub(crate) async fn completion_request(server: &ServerState, uri: &Url) {
     let params = CompletionParams {
         text_document_position: TextDocumentPositionParams {
             text_document: TextDocumentIdentifier { uri: uri.clone() },
@@ -365,7 +365,7 @@ pub(crate) fn completion_request(server: &ServerState, uri: &Url) {
             trigger_character: Some(".".to_string()),
         }),
     };
-    let res = request::handle_completion(server, params).unwrap();
+    let res = request::handle_completion(server, params).await.unwrap();
     let expected = CompletionResponse::Array(vec![
         CompletionItem {
             label: "a".to_string(),
@@ -402,7 +402,7 @@ pub(crate) fn completion_request(server: &ServerState, uri: &Url) {
     assert_eq!(expected, res.unwrap());
 }
 
-pub(crate) fn definition_check<'a>(server: &ServerState, go_to: &'a GotoDefinition<'a>) {
+pub(crate) async fn definition_check<'a>(server: &ServerState, go_to: &'a GotoDefinition<'a>) {
     let params = GotoDefinitionParams {
         text_document_position_params: TextDocumentPositionParams {
             text_document: TextDocumentIdentifier {
@@ -416,7 +416,7 @@ pub(crate) fn definition_check<'a>(server: &ServerState, go_to: &'a GotoDefiniti
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
     };
-    let res = request::handle_goto_definition(server, params.clone()).unwrap();
+    let res = request::handle_goto_definition(server, params.clone()).await.unwrap();
     let unwrapped_response = res.as_ref().unwrap_or_else(|| {
         panic!(
             "Failed to deserialize response: {:?} input: {:#?}",
@@ -452,7 +452,7 @@ pub(crate) fn definition_check<'a>(server: &ServerState, go_to: &'a GotoDefiniti
     }
 }
 
-pub(crate) fn definition_check_with_req_offset(
+pub(crate) async fn definition_check_with_req_offset(
     server: &ServerState,
     go_to: &mut GotoDefinition<'_>,
     req_line: u32,
@@ -460,10 +460,10 @@ pub(crate) fn definition_check_with_req_offset(
 ) {
     go_to.req_line = req_line;
     go_to.req_char = req_char;
-    definition_check(server, go_to);
+    definition_check(server, go_to).await;
 }
 
-pub(crate) fn hover_request<'a>(server: &ServerState, hover_docs: &'a HoverDocumentation<'a>) {
+pub(crate) async fn hover_request<'a>(server: &ServerState, hover_docs: &'a HoverDocumentation<'a>) {
     let params = HoverParams {
         text_document_position_params: TextDocumentPositionParams {
             text_document: TextDocumentIdentifier {
@@ -476,7 +476,7 @@ pub(crate) fn hover_request<'a>(server: &ServerState, hover_docs: &'a HoverDocum
         },
         work_done_progress_params: Default::default(),
     };
-    let res = request::handle_hover(server, params.clone()).unwrap();
+    let res = request::handle_hover(server, params.clone()).await.unwrap();
     let unwrapped_response = res.as_ref().unwrap_or_else(|| {
         panic!(
             "Failed to deserialize hover: {:?} input: {:#?}",
@@ -498,7 +498,7 @@ pub(crate) fn hover_request<'a>(server: &ServerState, hover_docs: &'a HoverDocum
     }
 }
 
-pub(crate) fn prepare_rename_request<'a>(
+pub(crate) async fn prepare_rename_request<'a>(
     server: &ServerState,
     rename: &'a Rename<'a>,
 ) -> Option<PrepareRenameResponse> {
@@ -511,10 +511,10 @@ pub(crate) fn prepare_rename_request<'a>(
             character: rename.req_char,
         },
     };
-    request::handle_prepare_rename(server, params).unwrap()
+    request::handle_prepare_rename(server, params).await.unwrap()
 }
 
-pub(crate) fn rename_request<'a>(server: &ServerState, rename: &'a Rename<'a>) -> WorkspaceEdit {
+pub(crate) async fn rename_request<'a>(server: &ServerState, rename: &'a Rename<'a>) -> WorkspaceEdit {
     let params = RenameParams {
         text_document_position: TextDocumentPositionParams {
             text_document: TextDocumentIdentifier {
@@ -528,6 +528,6 @@ pub(crate) fn rename_request<'a>(server: &ServerState, rename: &'a Rename<'a>) -
         new_name: rename.new_name.to_string(),
         work_done_progress_params: Default::default(),
     };
-    let worspace_edit = request::handle_rename(server, params).unwrap();
+    let worspace_edit = request::handle_rename(server, params).await.unwrap();
     worspace_edit.unwrap()
 }

--- a/sway-lsp/tests/integration/lsp.rs
+++ b/sway-lsp/tests/integration/lsp.rs
@@ -193,7 +193,9 @@ pub(crate) async fn semantic_tokens_request(server: &ServerState, uri: &Url) {
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
     };
-    let response = request::handle_semantic_tokens_full(server, params).await.unwrap();
+    let response = request::handle_semantic_tokens_full(server, params)
+        .await
+        .unwrap();
     if let Some(SemanticTokensResult::Tokens(tokens)) = response {
         assert!(!tokens.data.is_empty());
     }
@@ -205,7 +207,9 @@ pub(crate) async fn document_symbol_request(server: &ServerState, uri: &Url) {
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
     };
-    let response = request::handle_document_symbol(server, params).await.unwrap();
+    let response = request::handle_document_symbol(server, params)
+        .await
+        .unwrap();
     if let Some(DocumentSymbolResponse::Flat(res)) = response {
         assert!(!res.is_empty());
     }
@@ -237,7 +241,9 @@ pub(crate) async fn highlight_request(server: &ServerState, uri: &Url) {
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
     };
-    let response = request::handle_document_highlight(server, params).await.unwrap();
+    let response = request::handle_document_highlight(server, params)
+        .await
+        .unwrap();
     let expected = vec![
         DocumentHighlight {
             range: Range {
@@ -416,7 +422,9 @@ pub(crate) async fn definition_check<'a>(server: &ServerState, go_to: &'a GotoDe
         work_done_progress_params: Default::default(),
         partial_result_params: Default::default(),
     };
-    let res = request::handle_goto_definition(server, params.clone()).await.unwrap();
+    let res = request::handle_goto_definition(server, params.clone())
+        .await
+        .unwrap();
     let unwrapped_response = res.as_ref().unwrap_or_else(|| {
         panic!(
             "Failed to deserialize response: {:?} input: {:#?}",
@@ -463,7 +471,10 @@ pub(crate) async fn definition_check_with_req_offset(
     definition_check(server, go_to).await;
 }
 
-pub(crate) async fn hover_request<'a>(server: &ServerState, hover_docs: &'a HoverDocumentation<'a>) {
+pub(crate) async fn hover_request<'a>(
+    server: &ServerState,
+    hover_docs: &'a HoverDocumentation<'a>,
+) {
     let params = HoverParams {
         text_document_position_params: TextDocumentPositionParams {
             text_document: TextDocumentIdentifier {
@@ -511,10 +522,15 @@ pub(crate) async fn prepare_rename_request<'a>(
             character: rename.req_char,
         },
     };
-    request::handle_prepare_rename(server, params).await.unwrap()
+    request::handle_prepare_rename(server, params)
+        .await
+        .unwrap()
 }
 
-pub(crate) async fn rename_request<'a>(server: &ServerState, rename: &'a Rename<'a>) -> WorkspaceEdit {
+pub(crate) async fn rename_request<'a>(
+    server: &ServerState,
+    rename: &'a Rename<'a>,
+) -> WorkspaceEdit {
     let params = RenameParams {
         text_document_position: TextDocumentPositionParams {
             text_document: TextDocumentIdentifier {

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -145,10 +145,10 @@ async fn lsp_syncs_with_workspace_edits() {
         def_end_char: 11,
         def_path: uri.as_str(),
     };
-    lsp::definition_check(service.inner(), &go_to);
+    lsp::definition_check(service.inner(), &go_to).await;
     let _ = lsp::did_change_request(&mut service, &uri).await;
     go_to.def_line = 20;
-    lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 45, 24);
+    lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 45, 24).await;
     shutdown_and_exit(&mut service).await;
 }
 
@@ -183,7 +183,7 @@ async fn go_to_definition() {
         def_end_char: 11,
         def_path: uri.as_str(),
     };
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
     let _ = server.shutdown_server();
 }
 
@@ -205,14 +205,14 @@ async fn go_to_definition_for_fields() {
         def_path: "sway-lib-std/src/option.sw",
     };
     // Option
-    lsp::definition_check(&server, &opt_go_to);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 5, 16);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 9, 9);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 9, 16);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 13, 12);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 13, 19);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 13, 34);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 13, 47);
+    lsp::definition_check(&server, &opt_go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 5, 16).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 9, 9).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 9, 16).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 13, 12).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 13, 19).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 13, 34).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 13, 47).await;
 
     let opt_go_to = GotoDefinition {
         req_uri: &uri,
@@ -224,7 +224,7 @@ async fn go_to_definition_for_fields() {
         def_path: "sway-lsp/tests/fixtures/tokens/fields/src/foo.sw",
     };
     // foo
-    lsp::definition_check(&server, &opt_go_to);
+    lsp::definition_check(&server, &opt_go_to).await;
 
     let opt_go_to = GotoDefinition {
         req_uri: &uri,
@@ -236,7 +236,7 @@ async fn go_to_definition_for_fields() {
         def_path: "sway-lsp/tests/fixtures/tokens/fields/src/foo.sw",
     };
     // Foo
-    lsp::definition_check(&server, &opt_go_to);
+    lsp::definition_check(&server, &opt_go_to).await;
 
     let _ = server.shutdown_server();
 }
@@ -260,15 +260,15 @@ async fn go_to_definition_inside_turbofish() {
         def_path: "sway-lib-std/src/option.sw",
     };
     // option.sw
-    lsp::definition_check(&server, &opt_go_to);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 16, 17);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 17, 29);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 18, 19);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 20, 13);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 21, 19);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 22, 29);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 23, 18);
-    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 24, 26);
+    lsp::definition_check(&server, &opt_go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 16, 17).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 17, 29).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 18, 19).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 20, 13).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 21, 19).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 22, 29).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 23, 18).await;
+    lsp::definition_check_with_req_offset(&server, &mut opt_go_to, 24, 26).await;
 
     let mut res_go_to = GotoDefinition {
         req_uri: &uri,
@@ -280,11 +280,11 @@ async fn go_to_definition_inside_turbofish() {
         def_path: "sway-lib-std/src/result.sw",
     };
     // result.sw
-    lsp::definition_check(&server, &res_go_to);
-    lsp::definition_check_with_req_offset(&server, &mut res_go_to, 21, 25);
-    lsp::definition_check_with_req_offset(&server, &mut res_go_to, 22, 36);
-    lsp::definition_check_with_req_offset(&server, &mut res_go_to, 23, 27);
-    lsp::definition_check_with_req_offset(&server, &mut res_go_to, 24, 33);
+    lsp::definition_check(&server, &res_go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut res_go_to, 21, 25).await;
+    lsp::definition_check_with_req_offset(&server, &mut res_go_to, 22, 36).await;
+    lsp::definition_check_with_req_offset(&server, &mut res_go_to, 23, 27).await;
+    lsp::definition_check_with_req_offset(&server, &mut res_go_to, 24, 33).await;
 
     let _ = server.shutdown_server();
 }
@@ -308,13 +308,13 @@ async fn go_to_definition_for_matches() {
         def_path: "sway-lsp/tests/fixtures/tokens/matches/src/main.sw",
     };
     // EXAMPLE_CONST
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 19, 18);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 22, 18);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 19, 18).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 22, 18).await;
     // TODO: Enable the below check once this issue is fixed: https://github.com/FuelLabs/sway/issues/5221
     // lsp::definition_check_with_req_offset(&server, &mut go_to, 22, 30);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 23, 16);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 38);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 23, 16).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 38).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -326,7 +326,7 @@ async fn go_to_definition_for_matches() {
         def_path: "sway-lsp/tests/fixtures/tokens/matches/src/main.sw",
     };
     // a => a + 1
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -338,13 +338,13 @@ async fn go_to_definition_for_matches() {
         def_path: "sway-lib-std/src/option.sw",
     };
     // Option
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 33);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 26, 11);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 27, 11);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 27, 22);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 11);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 22);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 33).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 26, 11).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 27, 11).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 27, 22).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 11).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 22).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -356,10 +356,10 @@ async fn go_to_definition_for_matches() {
         def_path: "sway-lib-std/src/option.sw",
     };
     // Some
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 27, 17);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 17);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 30);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 27, 17).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 17).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 30).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -371,8 +371,8 @@ async fn go_to_definition_for_matches() {
         def_path: "sway-lib-std/src/option.sw",
     };
     // None
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 27, 30);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 27, 30).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -384,7 +384,7 @@ async fn go_to_definition_for_matches() {
         def_path: "sway-lsp/tests/fixtures/tokens/matches/src/main.sw",
     };
     // ExampleStruct
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -396,7 +396,7 @@ async fn go_to_definition_for_matches() {
         def_path: "sway-lsp/tests/fixtures/tokens/matches/src/main.sw",
     };
     // ExampleStruct.variable
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let _ = server.shutdown_server();
 }
@@ -420,7 +420,7 @@ async fn go_to_definition_for_modules() {
         def_path: "sway-lsp/tests/fixtures/tokens/modules/src/test_mod.sw",
     };
     // mod test_mod;
-    lsp::definition_check(&server, &opt_go_to);
+    lsp::definition_check(&server, &opt_go_to).await;
 
     let _ = server.shutdown_server();
 
@@ -441,7 +441,7 @@ async fn go_to_definition_for_modules() {
         def_path: "sway-lsp/tests/fixtures/tokens/modules/src/test_mod/deep_mod.sw",
     };
     // mod deep_mod;
-    lsp::definition_check(&server, &opt_go_to);
+    lsp::definition_check(&server, &opt_go_to).await;
 
     let _ = server.shutdown_server();
 }
@@ -465,11 +465,11 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/lib.sw",
     };
     // std
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 12, 14);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 18, 5);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 24, 13);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 5);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 12, 14).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 18, 5).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 24, 13).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 5).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -481,7 +481,7 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/option.sw",
     };
     // option
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -493,8 +493,8 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/option.sw",
     };
     // Option
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 14);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 14).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -506,7 +506,7 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/vm.sw",
     };
     // vm
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -518,7 +518,7 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/vm/evm.sw",
     };
     // evm
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -530,7 +530,7 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/vm/evm/evm_address.sw",
     };
     // evm_address
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -542,7 +542,7 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/vm/evm/evm_address.sw",
     };
     // EvmAddress
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -554,9 +554,9 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
     };
     // test_mod
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 22, 7);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 5, 5);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 22, 7).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 5, 5).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -568,7 +568,7 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
     };
     // test_fun
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -580,14 +580,14 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod.sw",
     };
     // deep_mod
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 6, 6);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 27, 16);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 16);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 29, 16);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 30, 16);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 32, 16);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 16);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 6, 6).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 27, 16).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 16).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 29, 16).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 30, 16).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 32, 16).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 16).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -599,14 +599,14 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
     };
     // deeper_mod
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 6, 16);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 27, 28);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 28);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 29, 28);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 30, 28);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 32, 28);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 28);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 6, 16).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 27, 28).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 28).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 29, 28).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 30, 28).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 32, 28).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 28).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -618,10 +618,10 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
     };
     // DeepEnum
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 38);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 29, 38);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 30, 38);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 38).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 29, 38).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 30, 38).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -633,8 +633,8 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
     };
     // DeepStruct
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 37);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 37).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -646,8 +646,8 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
     };
     // DeepEnum::Variant
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 48);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 48).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -659,8 +659,8 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
     };
     // DeepEnum::Number
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 30, 48);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 30, 48).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -672,8 +672,8 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
     };
     // deep_fun
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 6, 28);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 6, 28).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -685,7 +685,7 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/assert.sw",
     };
     // assert
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -697,7 +697,7 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-core/src/lib.sw",
     };
     // core
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -709,8 +709,8 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-core/src/primitives.sw",
     };
     // primitives
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 20);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 20).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -722,7 +722,7 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
     };
     // A def
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -734,8 +734,8 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
     };
     // A impl
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 22, 14);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 22, 14).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -747,8 +747,8 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lsp/tests/fixtures/tokens/paths/src/test_mod.sw",
     };
     // fun
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 22, 18);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 22, 18).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -760,9 +760,9 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/constants.sw",
     };
     // constants
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 11);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 23);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 11).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 23).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -774,8 +774,8 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-std/src/constants.sw",
     };
     // ZERO_B256
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 31);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 31).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -787,7 +787,7 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-core/src/primitives.sw",
     };
     // u64::min()
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -799,8 +799,8 @@ async fn go_to_definition_for_paths() {
         def_path: "sway-lib-core/src/primitives.sw",
     };
     // b256::min()
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 38);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 38).await;
 
     // TODO: Uncomment when https://github.com/FuelLabs/sway/issues/4211 is fixed.
     // let go_to = GotoDefinition {
@@ -813,7 +813,7 @@ async fn go_to_definition_for_paths() {
     //     def_path: "sway-lsp/tests/fixtures/tokens/paths/src/deep_mod/deeper_mod.sw",
     // };
     // dfun
-    // lsp::definition_check(&server, &go_to);
+    // lsp::definition_check(&server, &go_to).await;
 
     let _ = server.shutdown_server();
 }
@@ -837,13 +837,13 @@ async fn go_to_definition_for_traits() {
         def_path: "sway-lsp/tests/fixtures/tokens/traits/src/traits.sw",
     };
 
-    lsp::definition_check(&server, &trait_go_to);
-    lsp::definition_check_with_req_offset(&server, &mut trait_go_to, 7, 10);
-    lsp::definition_check_with_req_offset(&server, &mut trait_go_to, 10, 6);
+    lsp::definition_check(&server, &trait_go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut trait_go_to, 7, 10).await;
+    lsp::definition_check_with_req_offset(&server, &mut trait_go_to, 10, 6).await;
     trait_go_to.req_line = 7;
     trait_go_to.req_char = 20;
     trait_go_to.def_line = 3;
-    lsp::definition_check(&server, &trait_go_to);
+    lsp::definition_check(&server, &trait_go_to).await;
     let _ = server.shutdown_server();
 }
 
@@ -866,74 +866,74 @@ async fn go_to_definition_for_variables() {
         def_path: uri.as_str(),
     };
     // Variable expressions
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     // Function arguments
     go_to.def_line = 20;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 35);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 35).await;
 
     // Struct fields
     go_to.def_line = 19;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 45);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 28, 45).await;
 
     // Enum fields
     go_to.def_line = 19;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 31, 39);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 31, 39).await;
 
     // Tuple elements
     go_to.def_line = 21;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 34, 20);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 34, 20).await;
 
     // Array elements
     go_to.def_line = 22;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 37, 20);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 37, 20).await;
 
     // Scoped declarations
     go_to.def_line = 41;
     go_to.def_start_char = 12;
     go_to.def_end_char = 21;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 42, 13);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 42, 13).await;
 
     // If let scopes
     go_to.def_line = 47;
     go_to.def_start_char = 38;
     go_to.def_end_char = 39;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 47, 47);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 47, 47).await;
 
     // Shadowing
     go_to.def_line = 47;
     go_to.def_start_char = 8;
     go_to.def_end_char = 17;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 50, 29);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 50, 29).await;
 
     // Variable type ascriptions
     go_to.def_line = 6;
     go_to.def_start_char = 5;
     go_to.def_end_char = 16;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 53, 21);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 53, 21).await;
 
     // Complex type ascriptions
     go_to.def_line = 61;
     go_to.def_start_char = 9;
     go_to.def_end_char = 15;
     go_to.def_path = "sway-lib-std/src/result.sw";
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 56, 22);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 31);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 60);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 56, 22).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 31).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 60).await;
     go_to.def_line = 81;
     go_to.def_path = "sway-lib-std/src/option.sw";
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 56, 28);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 39);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 68);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 56, 28).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 39).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 68).await;
 
     // ContractCaller
     go_to.def_line = 15;
     go_to.def_start_char = 4;
     go_to.def_end_char = 11;
     go_to.def_path = uri.as_str();
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 60, 34);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 60, 50);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 61, 50);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 60, 34).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 60, 50).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 61, 50).await;
 
     let _ = server.shutdown_server();
 }
@@ -957,13 +957,13 @@ async fn go_to_definition_for_consts() {
         def_end_char: 21,
         def_path: "sway-lib-std/src/contract_id.sw",
     };
-    lsp::definition_check(&server, &contract_go_to);
+    lsp::definition_check(&server, &contract_go_to).await;
 
     contract_go_to.req_char = 34;
     contract_go_to.def_line = 40;
     contract_go_to.def_start_char = 7;
     contract_go_to.def_end_char = 11;
-    lsp::definition_check(&server, &contract_go_to);
+    lsp::definition_check(&server, &contract_go_to).await;
 
     // Constants defined in the same module
     let mut go_to = GotoDefinition {
@@ -975,10 +975,10 @@ async fn go_to_definition_for_consts() {
         def_end_char: 16,
         def_path: uri.as_str(),
     };
-    lsp::definition_check(&server, &contract_go_to);
+    lsp::definition_check(&server, &contract_go_to).await;
 
     go_to.def_line = 9;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 21, 29);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 21, 29).await;
 
     // Constants defined in a different module
     go_to = GotoDefinition {
@@ -990,27 +990,27 @@ async fn go_to_definition_for_consts() {
         def_end_char: 20,
         def_path: "consts/src/more_consts.sw",
     };
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     go_to.def_line = 13;
     go_to.def_start_char = 10;
     go_to.def_end_char = 18;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 31);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 31).await;
 
     // Constants with type ascriptions
     go_to.def_line = 6;
     go_to.def_start_char = 5;
     go_to.def_end_char = 9;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 10, 17);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 10, 17).await;
 
     // Complex type ascriptions
     go_to.def_line = 81;
     go_to.def_start_char = 9;
     go_to.def_end_char = 15;
     go_to.def_path = "sway-lib-std/src/option.sw";
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 17);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 24);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 38);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 17).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 24).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 38).await;
 }
 
 #[tokio::test]
@@ -1032,35 +1032,35 @@ async fn go_to_definition_for_functions() {
         def_path: uri.as_str(),
     };
     // Return type
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
     go_to.def_line = 23;
     go_to.def_start_char = 9;
     go_to.def_end_char = 15;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 42);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 42).await;
     go_to.def_line = 28;
     go_to.def_start_char = 9;
     go_to.def_end_char = 18;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 55);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 55).await;
 
     // Function parameters
     go_to.def_line = 2;
     go_to.def_start_char = 7;
     go_to.def_end_char = 12;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 13, 16);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 13, 16).await;
     go_to.def_line = 23;
     go_to.def_start_char = 9;
     go_to.def_end_char = 15;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 18);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 18).await;
     go_to.def_line = 28;
     go_to.def_start_char = 9;
     go_to.def_end_char = 18;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 28);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 33, 28).await;
 
     // Functions expression
     go_to.def_line = 8;
     go_to.def_start_char = 3;
     go_to.def_end_char = 6;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 19, 13);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 19, 13).await;
 }
 
 #[tokio::test]
@@ -1082,15 +1082,15 @@ async fn go_to_definition_for_structs() {
         def_path: uri.as_str(),
     };
     // Type Params
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
     go_to.def_line = 3;
     go_to.def_start_char = 5;
     go_to.def_end_char = 9;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 12, 8);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 13, 16);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 14, 9);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 15, 16);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 15, 23);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 12, 8).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 13, 16).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 14, 9).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 15, 16).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 15, 23).await;
     go_to = GotoDefinition {
         req_uri: &uri,
         req_line: 16,
@@ -1101,7 +1101,7 @@ async fn go_to_definition_for_structs() {
         def_path: "sway-lib-std/src/option.sw",
     };
     // Type Params
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     // Call Path
     go_to = GotoDefinition {
@@ -1113,7 +1113,7 @@ async fn go_to_definition_for_structs() {
         def_end_char: 13,
         def_path: uri.as_str(),
     };
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 }
 
 #[tokio::test]
@@ -1135,10 +1135,10 @@ async fn go_to_definition_for_impls() {
         def_path: uri.as_str(),
     };
     // TestStruct
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 33);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 8, 17);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 8, 27);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 33).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 8, 17).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 8, 27).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -1150,7 +1150,7 @@ async fn go_to_definition_for_impls() {
         def_path: uri.as_str(),
     };
     // TestTrait
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 }
 
 #[tokio::test]
@@ -1172,8 +1172,8 @@ async fn go_to_definition_for_where_clause() {
         def_path: uri.as_str(),
     };
     // Trait1
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 8);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 8).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -1185,7 +1185,7 @@ async fn go_to_definition_for_where_clause() {
         def_path: uri.as_str(),
     };
     // Trait2
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -1197,7 +1197,7 @@ async fn go_to_definition_for_where_clause() {
         def_path: uri.as_str(),
     };
     // A
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -1209,7 +1209,7 @@ async fn go_to_definition_for_where_clause() {
         def_path: uri.as_str(),
     };
     // B
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 }
 
 #[tokio::test]
@@ -1231,28 +1231,28 @@ async fn go_to_definition_for_enums() {
         def_path: uri.as_str(),
     };
     // Type Params
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
     go_to.def_line = 8;
     go_to.def_start_char = 5;
     go_to.def_end_char = 10;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 17, 15);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 18, 20);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 17, 15).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 18, 20).await;
 
     // Variants
     go_to.def_line = 9;
     go_to.def_start_char = 4;
     go_to.def_end_char = 7;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 24, 21);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 24, 21).await;
     go_to.def_line = 20;
     go_to.def_start_char = 4;
     go_to.def_end_char = 10;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 31);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 31).await;
 
     // Call Path
     go_to.def_line = 15;
     go_to.def_start_char = 9;
     go_to.def_end_char = 15;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 23);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 23).await;
 }
 
 #[tokio::test]
@@ -1270,14 +1270,14 @@ async fn go_to_definition_for_abi() {
         def_path: uri.as_str(),
     };
     // Return type
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     // Abi name
     go_to.def_line = 5;
     go_to.def_start_char = 4;
     go_to.def_end_char = 14;
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 9, 11);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 16, 15);
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 9, 11).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 16, 15).await;
 }
 
 #[tokio::test]
@@ -1299,9 +1299,9 @@ async fn go_to_definition_for_storage() {
         def_path: "sway-lsp/tests/fixtures/tokens/storage/src/main.sw",
     };
     // storage
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 8);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 26, 8);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 8).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 26, 8).await;
 
     let mut go_to = GotoDefinition {
         req_uri: &uri,
@@ -1313,9 +1313,9 @@ async fn go_to_definition_for_storage() {
         def_path: "sway-lsp/tests/fixtures/tokens/storage/src/main.sw",
     };
     // storage.var1
-    lsp::definition_check(&server, &go_to);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 17);
-    lsp::definition_check_with_req_offset(&server, &mut go_to, 26, 17);
+    lsp::definition_check(&server, &go_to).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 17).await;
+    lsp::definition_check_with_req_offset(&server, &mut go_to, 26, 17).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -1327,7 +1327,7 @@ async fn go_to_definition_for_storage() {
         def_path: "sway-lsp/tests/fixtures/tokens/storage/src/main.sw",
     };
     // storage.var1.x
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -1339,7 +1339,7 @@ async fn go_to_definition_for_storage() {
         def_path: "sway-lsp/tests/fixtures/tokens/storage/src/main.sw",
     };
     // storage.var1.y
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -1351,7 +1351,7 @@ async fn go_to_definition_for_storage() {
         def_path: "sway-lsp/tests/fixtures/tokens/storage/src/main.sw",
     };
     // storage.var1.z
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let go_to = GotoDefinition {
         req_uri: &uri,
@@ -1363,7 +1363,7 @@ async fn go_to_definition_for_storage() {
         def_path: "sway-lsp/tests/fixtures/tokens/storage/src/main.sw",
     };
     // storage.var1.z.x
-    lsp::definition_check(&server, &go_to);
+    lsp::definition_check(&server, &go_to).await;
 
     let _ = server.shutdown_server();
 }
@@ -1386,10 +1386,10 @@ async fn hover_docs_for_consts() {
         documentation: vec![" documentation for CONSTANT_1"],
     };
 
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     hover.req_char = 49;
     hover.documentation = vec![" CONSTANT_2 has a value of 200"];
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     let _ = server.shutdown_server();
 }
 
@@ -1408,7 +1408,7 @@ async fn hover_docs_for_functions() {
         req_char: 14,
         documentation: vec!["```sway\npub fn bar(p: Point) -> Point\n```\n---\n A function declaration with struct as a function parameter\n\n---\nGo to [Point](command:sway.goToLocation?%5B%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A5%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A2%7D%7D%2C%22uri%22%3A%22file","sway%2Fsway-lsp%2Ftests%2Ffixtures%2Ftokens%2Ffunctions%2Fsrc%2Fmain.sw%22%7D%5D \"functions::Point\")"],
     };
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     let _ = server.shutdown_server();
 }
 
@@ -1428,16 +1428,16 @@ async fn hover_docs_for_structs() {
         req_char: 10,
         documentation: vec![data_documention],
     };
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     hover.req_line = 13;
     hover.req_char = 15;
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     hover.req_line = 14;
     hover.req_char = 10;
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     hover.req_line = 15;
     hover.req_char = 16;
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
 
     hover = HoverDocumentation {
         req_uri: &uri,
@@ -1445,7 +1445,7 @@ async fn hover_docs_for_structs() {
         req_char: 8,
         documentation: vec!["```sway\nstruct MyStruct\n```\n---\n My struct type"],
     };
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     let _ = server.shutdown_server();
 }
 
@@ -1464,15 +1464,15 @@ async fn hover_docs_for_enums() {
         req_char: 19,
         documentation: vec!["```sway\nstruct TestStruct\n```\n---\n Test Struct Docs"],
     };
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     hover.req_line = 18;
     hover.req_char = 20;
     hover.documentation = vec!["```sway\nenum Color\n```\n---\n Color enum with RGB variants"];
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     hover.req_line = 25;
     hover.req_char = 29;
     hover.documentation = vec![" Docs for variants"];
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     let _ = server.shutdown_server();
 }
 
@@ -1487,7 +1487,7 @@ async fn hover_docs_for_abis() {
         req_char: 14,
         documentation: vec!["```sway\nabi MyContract\n```\n---\n Docs for MyContract"],
     };
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     let _ = server.shutdown_server();
 }
 
@@ -1506,7 +1506,7 @@ async fn hover_docs_for_variables() {
         req_char: 14,
         documentation: vec!["```sway\nlet variable8: ContractCaller<TestAbi>\n```\n---"],
     };
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     let _ = server.shutdown_server();
 }
 
@@ -1521,7 +1521,7 @@ async fn hover_docs_with_code_examples() {
             req_char: 24,
             documentation: vec!["```sway\nstruct Data\n```\n---\n Struct holding:\n\n 1. A `value` of type `NumberOrString`\n 2. An `address` of type `u64`"],
         };
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     let _ = server.shutdown_server();
 }
 
@@ -1537,10 +1537,10 @@ async fn hover_docs_for_self_keywords() {
         documentation: vec!["\n```sway\nself\n```\n\n---\n\n The receiver of a method, or the current module.\n\n `self` is used in two situations: referencing the current module and marking\n the receiver of a method.\n\n In paths, `self` can be used to refer to the current module, either in a\n [`use`] statement or in a path to access an element:\n\n ```sway\n use std::contract_id::{self, ContractId};\n ```\n\n Is functionally the same as:\n\n ```sway\n use std::contract_id;\n use std::contract_id::ContractId;\n ```\n\n `self` as the current receiver for a method allows to omit the parameter\n type most of the time. With the exception of this particularity, `self` is\n used much like any other parameter:\n\n ```sway\n struct Foo(u32);\n\n impl Foo {\n     // No `self`.\n     fn new() -> Self {\n         Self(0)\n     }\n\n     // Borrowing `self`.\n     fn value(&self) -> u32 {\n         self.0\n     }\n\n     // Updating `self` mutably.\n     fn clear(ref mut self) {\n         self.0 = 0\n     }\n }\n ```"],
     };
 
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     hover.req_char = 24;
     hover.documentation = vec!["```sway\nstruct MyStruct\n```\n---\n\n---\n[2 implementations](command:sway.peekLocations?%5B%7B%22locations%22%3A%5B%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A4%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A2%7D%7D%2C%22uri%22%3A%22file","sway%2Fsway-lsp%2Ftests%2Ffixtures%2Fcompletion%2Fsrc%2Fmain.sw%22%7D%2C%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A14%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A6%7D%7D%2C%22uri%22%3A%22file","sway%2Fsway-lsp%2Ftests%2Ffixtures%2Fcompletion%2Fsrc%2Fmain.sw%22%7D%5D%7D%5D \"Go to implementations\")"];
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     let _ = server.shutdown_server();
 }
 
@@ -1560,11 +1560,11 @@ async fn hover_docs_for_boolean_keywords() {
         documentation: vec!["\n```sway\nfalse\n```\n\n---\n\n A value of type [`bool`] representing logical **false**.\n\n `false` is the logical opposite of [`true`].\n\n See the documentation for [`true`] for more information."],
     };
 
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     hover.req_line = 25;
     hover.req_char = 31;
     hover.documentation = vec!["\n```sway\ntrue\n```\n\n---\n\n A value of type [`bool`] representing logical **true**.\n\n Logically `true` is not equal to [`false`].\n\n ## Control structures that check for **true**\n\n Several of Sway's control structures will check for a `bool` condition evaluating to **true**.\n\n   * The condition in an [`if`] expression must be of type `bool`.\n     Whenever that condition evaluates to **true**, the `if` expression takes\n     on the value of the first block. If however, the condition evaluates\n     to `false`, the expression takes on value of the `else` block if there is one.\n\n   * [`while`] is another control flow construct expecting a `bool`-typed condition.\n     As long as the condition evaluates to **true**, the `while` loop will continually\n     evaluate its associated block.\n\n   * [`match`] arms can have guard clauses on them."];
-    lsp::hover_request(&server, &hover);
+    lsp::hover_request(&server, &hover).await;
     let _ = server.shutdown_server();
 }
 
@@ -1580,8 +1580,8 @@ async fn rename() {
         req_char: 19,
         new_name: "pnt", // from "point"
     };
-    let _ = lsp::prepare_rename_request(&server, &rename);
-    let _ = lsp::rename_request(&server, &rename);
+    let _ = lsp::prepare_rename_request(&server, &rename).await;
+    let _ = lsp::rename_request(&server, &rename).await;
 
     // Enum
     let rename = Rename {
@@ -1590,8 +1590,8 @@ async fn rename() {
         req_char: 17,
         new_name: "MyEnum", // from "Color"
     };
-    let _ = lsp::prepare_rename_request(&server, &rename);
-    let _ = lsp::rename_request(&server, &rename);
+    let _ = lsp::prepare_rename_request(&server, &rename).await;
+    let _ = lsp::rename_request(&server, &rename).await;
 
     // Enum Variant
     let rename = Rename {
@@ -1600,8 +1600,8 @@ async fn rename() {
         req_char: 20,
         new_name: "Pink", // from "Red"
     };
-    let _ = lsp::prepare_rename_request(&server, &rename);
-    let _ = lsp::rename_request(&server, &rename);
+    let _ = lsp::prepare_rename_request(&server, &rename).await;
+    let _ = lsp::rename_request(&server, &rename).await;
 
     // raw identifier syntax
     let rename = Rename {
@@ -1610,8 +1610,8 @@ async fn rename() {
         req_char: 16,
         new_name: "new_var_name", // from r#struct
     };
-    let _ = lsp::prepare_rename_request(&server, &rename);
-    let _ = lsp::rename_request(&server, &rename);
+    let _ = lsp::prepare_rename_request(&server, &rename).await;
+    let _ = lsp::rename_request(&server, &rename).await;
 
     // Function name defined in external module
     let rename = Rename {
@@ -1620,8 +1620,8 @@ async fn rename() {
         req_char: 25,
         new_name: "better_func_name", // from test_fun
     };
-    let _ = lsp::prepare_rename_request(&server, &rename);
-    let _ = lsp::rename_request(&server, &rename);
+    let _ = lsp::prepare_rename_request(&server, &rename).await;
+    let _ = lsp::rename_request(&server, &rename).await;
 
     // Function method in ABI declaration
     let rename = Rename {
@@ -1630,8 +1630,8 @@ async fn rename() {
         req_char: 16,
         new_name: "name_func_name", // from test_function
     };
-    let _ = lsp::prepare_rename_request(&server, &rename);
-    let _ = lsp::rename_request(&server, &rename);
+    let _ = lsp::prepare_rename_request(&server, &rename).await;
+    let _ = lsp::rename_request(&server, &rename).await;
 
     // Function method in ABI implementation
     let rename = Rename {
@@ -1640,8 +1640,8 @@ async fn rename() {
         req_char: 16,
         new_name: "name_func_name", // from test_function
     };
-    let _ = lsp::prepare_rename_request(&server, &rename);
-    let _ = lsp::rename_request(&server, &rename);
+    let _ = lsp::prepare_rename_request(&server, &rename).await;
+    let _ = lsp::rename_request(&server, &rename).await;
 
     // Type alias used in function call
     let rename = Rename {
@@ -1650,8 +1650,8 @@ async fn rename() {
         req_char: 8,
         new_name: "Alias11", // from Alias1
     };
-    let _ = lsp::prepare_rename_request(&server, &rename);
-    let result = lsp::rename_request(&server, &rename);
+    let _ = lsp::prepare_rename_request(&server, &rename).await;
+    let result = lsp::rename_request(&server, &rename).await;
     assert_eq!(result.changes.unwrap().values().next().unwrap().len(), 3);
 
     // Fail to rename keyword
@@ -1661,7 +1661,7 @@ async fn rename() {
         req_char: 2,
         new_name: "StruCt", // from struct
     };
-    assert_eq!(lsp::prepare_rename_request(&server, &rename), None);
+    assert_eq!(lsp::prepare_rename_request(&server, &rename).await, None);
 
     // Fail to rename module
     let rename = Rename {
@@ -1670,7 +1670,7 @@ async fn rename() {
         req_char: 13,
         new_name: "new_mod_name", // from std
     };
-    assert_eq!(lsp::prepare_rename_request(&server, &rename), None);
+    assert_eq!(lsp::prepare_rename_request(&server, &rename).await, None);
 
     // Fail to rename a type defined in a module outside of the users workspace
     let rename = Rename {
@@ -1679,7 +1679,7 @@ async fn rename() {
         req_char: 33,
         new_name: "NEW_TYPE_NAME", // from ZERO_B256
     };
-    assert_eq!(lsp::prepare_rename_request(&server, &rename), None);
+    assert_eq!(lsp::prepare_rename_request(&server, &rename).await, None);
     let _ = server.shutdown_server();
 }
 
@@ -1728,7 +1728,7 @@ macro_rules! test_lsp_capability {
         let uri = open(&server, $entry_point).await;
 
         // Call the specific LSP capability function that was passed in.
-        let _ = $capability(&server, &uri);
+        let _ = $capability(&server, &uri).await;
         let _ = server.shutdown_server();
     }};
 }
@@ -1744,7 +1744,7 @@ macro_rules! lsp_capability_test {
 
 lsp_capability_test!(
     semantic_tokens,
-    lsp::semantic_tokens_request,
+    lsp::semantic_tokens_request, // These need to be futures! 
     doc_comments_dir().join("src/main.sw")
 );
 lsp_capability_test!(

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -1744,7 +1744,7 @@ macro_rules! lsp_capability_test {
 
 lsp_capability_test!(
     semantic_tokens,
-    lsp::semantic_tokens_request, // These need to be futures! 
+    lsp::semantic_tokens_request, // These need to be futures!
     doc_comments_dir().join("src/main.sw")
 );
 lsp_capability_test!(

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -1744,7 +1744,7 @@ macro_rules! lsp_capability_test {
 
 lsp_capability_test!(
     semantic_tokens,
-    lsp::semantic_tokens_request, // These need to be futures!
+    lsp::semantic_tokens_request,
     doc_comments_dir().join("src/main.sw")
 );
 lsp_capability_test!(


### PR DESCRIPTION
## Description
Aligned the language server's I/O operations with the `tower-lsp` async framework by adopting Tokio's asynchronous I/O primitives instead of ones from `std::fs`.
