### PR TITLE
Ignore Forc.lock in LSP tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ benchmarks/
 
 # .DS_Store
 .DS_Store
+
+# Generated files in test directories
+sway-lsp/tests/**/Forc.lock


### PR DESCRIPTION
## Description

Prevent people from accidentally checking in the Forc.lock files in sway LSP tests.

Follow up to https://github.com/FuelLabs/sway/pull/5294

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
