### PR TITLE
Improve the selection of plugin binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,6 +1961,8 @@ dependencies = [
  "fs_extra",
  "fuel-asm",
  "hex",
+ "regex",
+ "semver",
  "serde",
  "serde_json",
  "sway-core",

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -29,6 +29,8 @@ forc-util = { version = "0.48.1", path = "../forc-util" }
 fs_extra = "1.2"
 fuel-asm = { workspace = true }
 hex = "0.4.3"
+regex = "1.10.2"
+semver = "1.0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.73"
 sway-core = { version = "0.48.1", path = "../sway-core" }

--- a/forc/src/cli/plugin.rs
+++ b/forc/src/cli/plugin.rs
@@ -1,7 +1,10 @@
 //! Items related to plugin support for `forc`.
 
 use anyhow::{bail, Result};
+use regex::Regex;
+use semver::Version;
 use std::{
+    cmp::Ordering,
     env, fs,
     path::{Path, PathBuf},
     process,
@@ -17,7 +20,7 @@ use std::{
 pub(crate) fn execute_external_subcommand(args: Vec<String>) -> Result<process::Output> {
     let cmd = args.get(0).expect("`args` must not be empty");
     let args = &args[1..];
-    let path = find_external_subcommand(cmd);
+    let path = find_external_subcommand(cmd, std::env::current_exe().ok());
     let command = match path {
         Some(command) => command,
         None => bail!("no such subcommand: `{}`", cmd),
@@ -31,13 +34,72 @@ pub(crate) fn execute_external_subcommand(args: Vec<String>) -> Result<process::
     Ok(output)
 }
 
+/// Find the versions of the given plugin's stdout text.
+fn get_version_from_text(stdout: &str) -> Option<Version> {
+    Regex::new(r"(\d+\.\d+\.\d+)")
+        .map(|pattern| {
+            pattern
+                .captures(stdout)
+                .and_then(|captures| captures.get(1))
+                .and_then(|version| Version::parse(version.as_str()).ok())
+        })
+        .ok()
+        .flatten()
+}
+
+/// Callback to sort a set of versions.
+fn sort_versions(a: &Option<Version>, b: &Option<Version>) -> Ordering {
+    match (a, b) {
+        (Some(a), Some(b)) => b.cmp(a),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    }
+}
+
 /// Find an exe called `forc-<cmd>` and return its path.
-fn find_external_subcommand(cmd: &str) -> Option<PathBuf> {
+///
+/// The algorithm to select a plugin is as follows:
+/// 1. If a plugin with the same name as the command exists in the same
+///    directory as the forc exe, use it.
+/// 2. Find all plugins in the user's `PATH` and select the one with the, sort
+///    them based on their versions. No version found is considered to be the
+///    oldest version.
+/// 3. Use the newer plugin that is found.
+fn find_external_subcommand(cmd: &str, current_exec: Option<PathBuf>) -> Option<PathBuf> {
     let command_exe = format!("forc-{}{}", cmd, env::consts::EXE_SUFFIX);
-    search_directories()
-        .iter()
+    if let Some(path) = current_exec {
+        if let Some(parent) = path.parent() {
+            let command_full_path = parent.join(&command_exe);
+            if is_executable(&command_full_path) {
+                return Some(command_full_path);
+            }
+        }
+    }
+
+    let mut candidates = search_directories()
+        .into_iter()
         .map(|dir| dir.join(&command_exe))
-        .find(|file| is_executable(file))
+        .filter(|path| is_executable(path))
+        .collect::<Vec<_>>()
+        .into_iter()
+        .map(|path| {
+            use std::process::Command;
+            (
+                Command::new(&path)
+                    .arg("--version")
+                    .output()
+                    .map(|output| get_version_from_text(&String::from_utf8_lossy(&output.stdout)))
+                    .ok()
+                    .flatten(),
+                path,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    candidates.sort_by(|(a, _), (b, _)| sort_versions(a, b));
+
+    candidates.get(0).map(|(_, path)| path.to_owned())
 }
 
 /// Search the user's `PATH` for `forc-*` exes.
@@ -49,7 +111,7 @@ fn search_directories() -> Vec<PathBuf> {
 }
 
 #[cfg(unix)]
-fn is_executable(path: &Path) -> bool {
+fn is_executable<P: AsRef<Path>>(path: P) -> bool {
     use std::os::unix::prelude::*;
     fs::metadata(path)
         .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
@@ -57,7 +119,7 @@ fn is_executable(path: &Path) -> bool {
 }
 
 #[cfg(windows)]
-fn is_executable(path: &Path) -> bool {
+fn is_executable<P: AsRef<Path>>(path: P) -> bool {
     path.is_file()
 }
 
@@ -79,4 +141,50 @@ pub(crate) fn find_all() -> impl Iterator<Item = PathBuf> {
         .filter_map(Result::ok)
         .map(|entry| entry.path().to_path_buf())
         .filter(|p| is_plugin(p))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn version_parsing() {
+        let stdout = "forc 0.1.0";
+        let version = get_version_from_text(stdout);
+        assert_eq!(version, Version::parse("0.1.0").ok());
+
+        let stdout = "forc 0.1";
+        let version = get_version_from_text(stdout);
+        assert_eq!(version, None);
+
+        let stdout =
+            "forc with some long text and having the version (0.1.11) somewhere in the middle";
+        let version = get_version_from_text(stdout);
+        assert_eq!(version, Version::parse("0.1.11").ok());
+    }
+
+    #[test]
+    fn sort_version() {
+        let mut versions = vec![
+            Version::parse("1.9.0").ok(),
+            Version::parse("1.9.1").ok(),
+            Version::parse("1.9.99").ok(),
+            Version::parse("1.19.1").ok(),
+            Version::parse("9.19.1").ok(),
+            None,
+        ];
+        versions.sort_by(sort_versions);
+
+        assert_eq!(
+            versions,
+            vec![
+                Version::parse("9.19.1").ok(),
+                Version::parse("1.19.1").ok(),
+                Version::parse("1.9.99").ok(),
+                Version::parse("1.9.1").ok(),
+                Version::parse("1.9.0").ok(),
+                None,
+            ]
+        )
+    }
 }


### PR DESCRIPTION
## Description

Fixes #5402

If several plugin names are found in $PATH, prior to this commit the first binary to be found is being used.

This PR enhances the process by adding some heuristics. The algorithm works as follows:

1. Check if a binary exists in the same directory as the current forc binary.
2. Otherwise find all occurrences of the forc-plugin in the $PATH. Sort them by their version.
3. Use the newest (greater version) binary that is found. If no version can be parsed it is assumed to be the oldest available.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
