### PR TITLE
Return type of output_asset_to changed to Address

### DIFF
--- a/sway-lib-std/src/outputs.sw
+++ b/sway-lib-std/src/outputs.sw
@@ -2,6 +2,7 @@
 //! This includes `Output::Coins`, `Input::Messages` and `Input::Contracts`.
 library;
 
+use ::address::Address;
 use ::contract_id::{AssetId, ContractId};
 use ::revert::revert;
 use ::tx::{
@@ -225,8 +226,7 @@ pub fn output_asset_id(index: u64) -> Option<AssetId> {
     }
 }
 
-// TODO: Update to `Identity` when https://github.com/FuelLabs/sway/issues/4569 is resolved
-/// Returns the receiver of the output if it is a `Output::Coin`. Represents the receiver as a `b256`.
+/// Returns the receiver of the output if it is a `Output::Coin`.
 ///
 /// # Arguments
 ///
@@ -234,7 +234,7 @@ pub fn output_asset_id(index: u64) -> Option<AssetId> {
 ///
 /// # Returns
 ///
-/// * [Option<b256>] - The receiver of the output if it is a `Output::Coin`. None otherwise.
+/// * [Option<Address>] - The receiver of the output if it is a `Output::Coin`. None otherwise.
 ///
 /// # Reverts
 ///
@@ -250,9 +250,9 @@ pub fn output_asset_id(index: u64) -> Option<AssetId> {
 ///     log(output_receiver);
 /// }
 /// ```
-pub fn output_asset_to(index: u64) -> Option<b256> {
+pub fn output_asset_to(index: u64) -> Option<Address> {
     match output_type(index) {
-        Output::Coin => Some(__gtf::<b256>(index, GTF_OUTPUT_COIN_TO)),
+        Output::Coin => Some(Address::from(__gtf::<Address>(index, GTF_OUTPUT_COIN_TO))),
         _ => None,
     }
 }


### PR DESCRIPTION
## Description
When `output_asset_to` was added in #4694, it used `b256` as the return type, instead of an `Address`. It referenced #4569, which describes the confusion developers face between `Address` and `Identity`.

While that confusion _is_ an issue, I don't believe that's relevant to this function type. An output coin can _only_ be an address, not a contract, since contract balances are stored in the contract UTXO itself. Furthermore, the standard lib API will need to be frozen soon, and there's no plans in place to change anything in regards to #4569.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
