### PR TITLE
Added `assert_ne(x, y)` function

### DIFF
--- a/docs/book/src/introduction/standard_library.md
+++ b/docs/book/src/introduction/standard_library.md
@@ -41,7 +41,7 @@ The current version of the prelude lives in [`std::prelude`](https://github.com/
 - [`std::result::Result`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/result.sw), an enum for functions that may succeed or fail.
 - [`std::assert::assert`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/assert.sw), a function that reverts the VM if the condition provided to it is `false`.
 - [`std::assert::assert_eq`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/assert.sw), a function that reverts the VM and logs its two inputs `v1` and `v2` if the condition `v1` == `v2` is `false`.
-- - [`std::assert::assert_ne`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/assert.sw), a function that reverts the VM and logs its two inputs `v1` and `v2` if the condition `v1` != `v2` is `false`.
+- [`std::assert::assert_ne`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/assert.sw), a function that reverts the VM and logs its two inputs `v1` and `v2` if the condition `v1` != `v2` is `false`.
 - [`std::revert::require`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/revert.sw), a function that reverts the VM and logs a given value if the condition provided to it is `false`.
 - [`std::revert::revert`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/revert.sw), a function that reverts the VM.
 - [`std::logging::log`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/logging.sw), a function that logs arbitrary stack types.

--- a/docs/book/src/introduction/standard_library.md
+++ b/docs/book/src/introduction/standard_library.md
@@ -41,6 +41,7 @@ The current version of the prelude lives in [`std::prelude`](https://github.com/
 - [`std::result::Result`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/result.sw), an enum for functions that may succeed or fail.
 - [`std::assert::assert`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/assert.sw), a function that reverts the VM if the condition provided to it is `false`.
 - [`std::assert::assert_eq`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/assert.sw), a function that reverts the VM and logs its two inputs `v1` and `v2` if the condition `v1` == `v2` is `false`.
+- - [`std::assert::assert_ne`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/assert.sw), a function that reverts the VM and logs its two inputs `v1` and `v2` if the condition `v1` != `v2` is `false`.
 - [`std::revert::require`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/revert.sw), a function that reverts the VM and logs a given value if the condition provided to it is `false`.
 - [`std::revert::revert`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/revert.sw), a function that reverts the VM.
 - [`std::logging::log`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/logging.sw), a function that logs arbitrary stack types.

--- a/docs/reference/src/SUMMARY.md
+++ b/docs/reference/src/SUMMARY.md
@@ -89,6 +89,7 @@
   - [require](./documentation/operations/assertions/require.md)
   - [revert](./documentation/operations/assertions/revert.md)
   - [assert_eq](./documentation/operations/assertions/assert-eq.md)
+  - [assert_ne](./documentation/operations/assertions/assert-ne.md)
 - [Address Namespace](./documentation/operations/namespace/index.md)
   - [Address](./documentation/operations/namespace/address.md)
   - [ContractId](./documentation/operations/namespace/contract-id.md)

--- a/docs/reference/src/code/operations/assertions/src/lib.sw
+++ b/docs/reference/src/code/operations/assertions/src/lib.sw
@@ -19,8 +19,16 @@ fn reverts() {
 
 #[allow(dead_code)]
 // ANCHOR: assert_eq
-fn compare(a: u64, b: u64) {
+fn compare_eq(a: u64, b: u64) {
     assert_eq(a, b);
     // code
 }
 // ANCHOR_END: assert_eq
+
+#[allow(dead_code)]
+// ANCHOR: assert_ne
+fn compare_ne(a: u64, b: u64) {
+    assert_ne(a, b);
+    // code
+}
+// ANCHOR_END: assert_ne

--- a/docs/reference/src/documentation/misc/prelude.md
+++ b/docs/reference/src/documentation/misc/prelude.md
@@ -18,6 +18,7 @@ The prelude contains the following:
 - [`assert`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/assert.sw): A module containing
   - `assert`: A function that reverts the VM if the condition provided to it is false
   - `assert_eq`: A function that reverts the VM and logs its two inputs v1 and v2 if the condition v1 == v2 is false
+  - `assert_ne`: A function that reverts the VM and logs its two inputs v1 and v2 if the condition v1 != v2 is false
 - [`revert`](https://github.com/FuelLabs/sway/blob/master/sway-lib-std/src/revert.sw): A module containing
   - `require`: A function that reverts and logs a given value if the condition is `false`
   - `revert`: A function that reverts

--- a/docs/reference/src/documentation/operations/assertions/assert-ne.md
+++ b/docs/reference/src/documentation/operations/assertions/assert-ne.md
@@ -1,0 +1,11 @@
+# assert_ne
+
+The `assert_ne` function is automatically imported into every program from the [prelude](../../misc/prelude.md). It takes two expressions which are compared and the result is a [Boolean](../../language/built-ins/boolean.md). If the value is `false` then the virtual machine will revert.
+
+## Example
+
+Here is a function which asserts that `a` and `b` must not be equal.
+
+```sway
+{{#include ../../../code/operations/assertions/src/lib.sw:assert_ne}}
+```

--- a/docs/reference/src/documentation/operations/assertions/index.md
+++ b/docs/reference/src/documentation/operations/assertions/index.md
@@ -13,3 +13,4 @@ Handling exceptions may be done through [if expressions](../../language/control-
 - [`require`](require.md): Checks if a `condition` is `true` otherwise logs a `value` and reverts
 - [`revert`](revert.md): Reverts the virtual machine with the provided exit code
 - [`assert_eq`](assert-eq.md): Checks if `a` and `b` are equal otherwise reverts
+- [`assert_ne`](assert-ne.md): Checks if `a` and `b` are not equal otherwise reverts

--- a/sway-lib-std/src/assert.sw
+++ b/sway-lib-std/src/assert.sw
@@ -3,7 +3,7 @@ library;
 
 use ::logging::log;
 use ::revert::revert;
-use ::error_signals::{FAILED_ASSERT_SIGNAL, FAILED_ASSERT_EQ_SIGNAL};
+use ::error_signals::{FAILED_ASSERT_SIGNAL, FAILED_ASSERT_EQ_SIGNAL, FAILED_ASSERT_NE_SIGNAL};
 
 
 /// Asserts that the given `condition` will always be `true` during runtime.
@@ -61,5 +61,33 @@ pub fn assert_eq<T>(v1: T, v2: T) where T: Eq {
         log(v1);
         log(v2);
         revert(FAILED_ASSERT_EQ_SIGNAL);
+    }
+}
+
+/// Asserts that the given values `v1` & `v2` will never be equal during runtime.
+///
+/// # Arguments
+///
+/// * `v1`: [T] - The first value to compare.
+/// * `v2`: [T] - The second value to compare.
+///
+/// # Reverts
+///
+/// * Reverts when `v1` == `v2`.
+///
+/// # Examples
+///
+/// ```sway
+/// fn foo(a: u64, b: u64) {
+///     assert_ne(a, b);
+///     // if code execution continues, that means `a` is not equal to `b`
+///     log("a is not equal to b");
+/// }
+/// ```
+pub fn assert_ne<T>(v1: T, v2: T) where T: Eq {
+    if (v1 == v2) {
+        log(v1);
+        log(v2);
+        revert(FAILED_ASSERT_NE_SIGNAL);
     }
 }

--- a/sway-lib-std/src/error_signals.sw
+++ b/sway-lib-std/src/error_signals.sw
@@ -28,3 +28,10 @@ pub const FAILED_ASSERT_EQ_SIGNAL = 0xffff_ffff_ffff_0003;
 ///
 /// The value is: 18446744073709486084
 pub const FAILED_ASSERT_SIGNAL = 0xffff_ffff_ffff_0004;
+
+/// A revert with this value signals that it was caused by a failing call to `std::assert::assert_ne`.
+///
+/// # Additional Information
+///
+/// The value is: 18446744073709486085
+pub const FAILED_ASSERT_NE_SIGNAL = 0xffff_ffff_ffff_0005;

--- a/sway-lib-std/src/prelude.sw
+++ b/sway-lib-std/src/prelude.sw
@@ -17,7 +17,7 @@ use ::storage::storage_map::*;
 use ::vec::Vec;
 
 // Error handling
-use ::assert::{assert, assert_eq};
+use ::assert::{assert, assert_eq, assert_ne};
 use ::option::Option::{self, *};
 use ::result::Result::{self, *};
 use ::revert::{require, revert};

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/.gitignore
@@ -1,0 +1,4 @@
+out
+target
+out
+target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "assert_ne"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "core"
+source = "path+from-root-075F52DB87742EF3"
+
+[[package]]
+name = "std"
+source = "path+from-root-075F52DB87742EF3"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "assert_ne"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/json_abi_oracle.json
@@ -1,0 +1,337 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 2,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [
+    {
+      "logId": 0,
+      "loggedType": {
+        "name": "",
+        "type": 12,
+        "typeArguments": null
+      }
+    },
+    {
+      "logId": 1,
+      "loggedType": {
+        "name": "",
+        "type": 12,
+        "typeArguments": null
+      }
+    },
+    {
+      "logId": 2,
+      "loggedType": {
+        "name": "",
+        "type": 11,
+        "typeArguments": null
+      }
+    },
+    {
+      "logId": 3,
+      "loggedType": {
+        "name": "",
+        "type": 11,
+        "typeArguments": null
+      }
+    },
+    {
+      "logId": 4,
+      "loggedType": {
+        "name": "",
+        "type": 10,
+        "typeArguments": null
+      }
+    },
+    {
+      "logId": 5,
+      "loggedType": {
+        "name": "",
+        "type": 10,
+        "typeArguments": null
+      }
+    },
+    {
+      "logId": 6,
+      "loggedType": {
+        "name": "",
+        "type": 13,
+        "typeArguments": null
+      }
+    },
+    {
+      "logId": 7,
+      "loggedType": {
+        "name": "",
+        "type": 13,
+        "typeArguments": null
+      }
+    },
+    {
+      "logId": 8,
+      "loggedType": {
+        "name": "",
+        "type": 1,
+        "typeArguments": null
+      }
+    },
+    {
+      "logId": 9,
+      "loggedType": {
+        "name": "",
+        "type": 1,
+        "typeArguments": null
+      }
+    },
+    {
+      "logId": 10,
+      "loggedType": {
+        "name": "",
+        "type": 5,
+        "typeArguments": []
+      }
+    },
+    {
+      "logId": 11,
+      "loggedType": {
+        "name": "",
+        "type": 5,
+        "typeArguments": []
+      }
+    },
+    {
+      "logId": 12,
+      "loggedType": {
+        "name": "",
+        "type": 9,
+        "typeArguments": []
+      }
+    },
+    {
+      "logId": 13,
+      "loggedType": {
+        "name": "",
+        "type": 9,
+        "typeArguments": []
+      }
+    },
+    {
+      "logId": 14,
+      "loggedType": {
+        "name": "",
+        "type": 7,
+        "typeArguments": []
+      }
+    },
+    {
+      "logId": 15,
+      "loggedType": {
+        "name": "",
+        "type": 7,
+        "typeArguments": []
+      }
+    },
+    {
+      "logId": 16,
+      "loggedType": {
+        "name": "",
+        "type": 6,
+        "typeArguments": []
+      }
+    },
+    {
+      "logId": 17,
+      "loggedType": {
+        "name": "",
+        "type": 6,
+        "typeArguments": []
+      }
+    },
+    {
+      "logId": 18,
+      "loggedType": {
+        "name": "",
+        "type": 3,
+        "typeArguments": []
+      }
+    },
+    {
+      "logId": 19,
+      "loggedType": {
+        "name": "",
+        "type": 3,
+        "typeArguments": []
+      }
+    },
+    {
+      "logId": 20,
+      "loggedType": {
+        "name": "",
+        "type": 3,
+        "typeArguments": []
+      }
+    },
+    {
+      "logId": 21,
+      "loggedType": {
+        "name": "",
+        "type": 3,
+        "typeArguments": []
+      }
+    }
+  ],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": [
+        {
+          "name": "__array_element",
+          "type": 1,
+          "typeArguments": null
+        }
+      ],
+      "type": "[_; 2]",
+      "typeId": 0,
+      "typeParameters": null
+    },
+    {
+      "components": null,
+      "type": "b256",
+      "typeId": 1,
+      "typeParameters": null
+    },
+    {
+      "components": null,
+      "type": "bool",
+      "typeId": 2,
+      "typeParameters": null
+    },
+    {
+      "components": [
+        {
+          "name": "Address",
+          "type": 5,
+          "typeArguments": null
+        },
+        {
+          "name": "ContractId",
+          "type": 9,
+          "typeArguments": null
+        }
+      ],
+      "type": "enum std::identity::Identity",
+      "typeId": 3,
+      "typeParameters": null
+    },
+    {
+      "components": null,
+      "type": "raw untyped ptr",
+      "typeId": 4,
+      "typeParameters": null
+    },
+    {
+      "components": [
+        {
+          "name": "value",
+          "type": 1,
+          "typeArguments": null
+        }
+      ],
+      "type": "struct std::address::Address",
+      "typeId": 5,
+      "typeParameters": null
+    },
+    {
+      "components": [
+        {
+          "name": "bytes",
+          "type": 0,
+          "typeArguments": null
+        }
+      ],
+      "type": "struct std::b512::B512",
+      "typeId": 6,
+      "typeParameters": null
+    },
+    {
+      "components": [
+        {
+          "name": "buf",
+          "type": 8,
+          "typeArguments": null
+        },
+        {
+          "name": "len",
+          "type": 12,
+          "typeArguments": null
+        }
+      ],
+      "type": "struct std::bytes::Bytes",
+      "typeId": 7,
+      "typeParameters": null
+    },
+    {
+      "components": [
+        {
+          "name": "ptr",
+          "type": 4,
+          "typeArguments": null
+        },
+        {
+          "name": "cap",
+          "type": 12,
+          "typeArguments": null
+        }
+      ],
+      "type": "struct std::bytes::RawBytes",
+      "typeId": 8,
+      "typeParameters": null
+    },
+    {
+      "components": [
+        {
+          "name": "value",
+          "type": 1,
+          "typeArguments": null
+        }
+      ],
+      "type": "struct std::contract_id::ContractId",
+      "typeId": 9,
+      "typeParameters": null
+    },
+    {
+      "components": null,
+      "type": "u16",
+      "typeId": 10,
+      "typeParameters": null
+    },
+    {
+      "components": null,
+      "type": "u32",
+      "typeId": 11,
+      "typeParameters": null
+    },
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 12,
+      "typeParameters": null
+    },
+    {
+      "components": null,
+      "type": "u8",
+      "typeId": 13,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/src/main.sw
@@ -1,0 +1,74 @@
+script;
+
+use std::bytes::Bytes;
+use std::b512::B512;
+
+fn main() -> bool {
+
+    // test_assert_ne_u64
+    let a = 42;
+    let b = 40;
+    assert_ne(a, b);
+
+    // test_assert_ne_u32
+    let c = 42u32;
+    let d = 40u32;
+    assert_ne(c, d);
+
+    // test_assert_ne_u16
+    let e = 42u16;
+    let f = 40u16;
+    assert_ne(e, f);
+
+    // test_assert_ne_u8
+    let g = 42u8;
+    let h = 40u8;
+    assert_ne(g, h);
+
+    // test_assert_ne_b256
+    let i: b256 = 0b0000000000000000000000000000000000000000000000000000000000000001_0000000000000000000000000000000000000000000000000000000000000001_0000000000000000000000000000000000000000000000000000000000000001_0000000000000000000000000000000000000000000000000000000000000010;
+    let j: b256 = 0b1000000000000000000000000000000000000000000000000000000000000000_1000000000000000000000000000000000000000000000000000000000000000_1000000000000000000000000000000000000000000000000000000000000000_1000000000000000000000000000000000000000000000000000000000000001;
+    assert_ne(i, j);
+
+    // test_assert_ne_address
+    let value = 0xBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEF;
+    let value2 = 0xBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEE;
+    let k = Address::from(value);
+    let l = Address::from(value2);
+    assert_ne(k, l);
+
+    // test_assert_ne_contract_id
+    let m = ContractId::from(value);
+    let n = ContractId::from(value2);
+    assert_ne(m, n);
+
+    // test_assert_ne_bytes
+    let mut q = Bytes::new();
+    let mut r = Bytes::new();
+    q.push(42u8);
+    q.push(11u8);
+    q.push(69u8);
+    r.push(42u8);
+    r.push(11u8);
+    r.push(70u8);
+    assert_ne(q, r);
+
+    // test_assert_ne_b512
+    let value = 0xBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEF;
+    let value2 = 0xBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEE;
+    let s = B512::from((value, value));
+    let t = B512::from((value2, value2));
+    assert_ne(s, t);
+
+    // test_assert_ne_identity
+    let value = 0xBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEF;
+    let value2 = 0xBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEFBEEE;
+    let u = Identity::Address(Address::from(value));
+    let v = Identity::Address(Address::from(value2));
+    let w = Identity::ContractId(ContractId::from(value));
+    let x = Identity::ContractId(ContractId::from(value2));
+    assert_ne(u, v);
+    assert_ne(w, x);
+
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+validate_abi = true

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/.gitignore
@@ -1,0 +1,8 @@
+out
+target
+out
+target
+out
+target
+out
+target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "assert_ne_revert"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "core"
+source = "path+from-root-57A6C488795FD4D0"
+
+[[package]]
+name = "std"
+source = "path+from-root-57A6C488795FD4D0"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "assert_ne_revert"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/json_abi_oracle.json
@@ -1,0 +1,48 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [
+    {
+      "logId": 0,
+      "loggedType": {
+        "name": "",
+        "type": 1,
+        "typeArguments": null
+      }
+    },
+    {
+      "logId": 1,
+      "loggedType": {
+        "name": "",
+        "type": 1,
+        "typeArguments": null
+      }
+    }
+  ],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": [],
+      "type": "()",
+      "typeId": 0,
+      "typeParameters": null
+    },
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 1,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/src/main.sw
@@ -1,0 +1,5 @@
+script;
+
+fn main() {
+    assert_ne(1, 1);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "revert", value =  -65531} # 0xffffffffffff0005 as i64
+validate_abi = true


### PR DESCRIPTION
## Description
Closes #5321

Added an assertion that mirrors the existing `assert_eq(x, y)` function. The `assert_ne(x, y)` function asserts that the two passed values are not equal. This removes the need for the workaround `assert(x != y)`. 

Documentation was updated in all areas that `assert_eq()` is referenced. Tests were created similarly to the `assert_eq()` tests. The function was also added to [`prelude.sw`](https://github.com/brandonsurh/sway/blob/9ee4b7a85d54cf19aea29ad63fdfb992d17d95ce/sway-lib-std/src/prelude.sw#L20). 


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
