### PR TITLE
Revert TE `slab` to hold `TypeSourceInfo` and perform GC on DE `parents` and TE `id_map`

### DIFF
--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -190,7 +190,7 @@ macro_rules! decl_engine_clear_module {
                         Some(source_id) => &source_id.module_id() != module_id,
                         None => false,
                     });
-                )*                
+                )*
             }
         }
     };

--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -168,13 +168,6 @@ macro_rules! decl_engine_clear_module {
     ($($slab:ident, $decl:ty);* $(;)?) => {
         impl DeclEngine {
             pub fn clear_module(&mut self, module_id: &ModuleId) {
-                $(
-                    self.$slab.retain(|_k, ty| match ty.span().source_id() {
-                        Some(source_id) => &source_id.module_id() != module_id,
-                        None => false,
-                    });
-                )*
-
                 self.parents.write().unwrap().retain(|key, _| {
                     match key {
                         AssociatedItemDeclId::TraitFn(decl_id) => {
@@ -191,6 +184,13 @@ macro_rules! decl_engine_clear_module {
                         },
                     }
                 });
+
+                $(
+                    self.$slab.retain(|_k, ty| match ty.span().source_id() {
+                        Some(source_id) => &source_id.module_id() != module_id,
+                        None => false,
+                    });
+                )*                
             }
         }
     };

--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -174,6 +174,23 @@ macro_rules! decl_engine_clear_module {
                         None => false,
                     });
                 )*
+
+                self.parents.write().unwrap().retain(|key, _| {
+                    match key {
+                        AssociatedItemDeclId::TraitFn(decl_id) => {
+                            self.get_trait_fn(decl_id).span().source_id().map_or(false, |src_id| &src_id.module_id() != module_id)
+                        },
+                        AssociatedItemDeclId::Function(decl_id) => {
+                            self.get_function(decl_id).span().source_id().map_or(false, |src_id| &src_id.module_id() != module_id)
+                        },
+                        AssociatedItemDeclId::Type(decl_id) => {
+                            self.get_type(decl_id).span().source_id().map_or(false, |src_id| &src_id.module_id() != module_id)
+                        },
+                        AssociatedItemDeclId::Constant(decl_id) => {
+                            self.get_constant(decl_id).span().source_id().map_or(false, |src_id| &src_id.module_id() != module_id)
+                        },
+                    }
+                });
             }
         }
     };

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -336,7 +336,8 @@ impl TypeParameter {
                 type_info: TypeInfo::UnknownGeneric {
                     name: type_parameter.name_ident.clone(),
                     trait_constraints: VecSet(trait_constraints_with_supertraits.clone()),
-                },
+                }
+                .into(),
                 source_id: type_parameter.name_ident.span().source_id().cloned(),
             },
         );

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -65,6 +65,13 @@ impl TypeEngine {
             Some(source_id) => &source_id.module_id() != module_id,
             None => false,
         });
+        self.id_map
+            .write()
+            .unwrap()
+            .retain(|tsi, _| match tsi.source_id {
+                Some(source_id) => &source_id.module_id() != module_id,
+                None => false,
+            });
     }
 
     pub fn replace(&self, id: TypeId, new_value: TypeSourceInfo) {

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -18,8 +18,7 @@ use super::unify::unifier::UnifyKind;
 
 #[derive(Debug, Default)]
 pub struct TypeEngine {
-    slab: ConcurrentSlab<TypeInfo>,
-    slab_source_ids: ConcurrentSlab<Option<SourceId>>,
+    slab: ConcurrentSlab<TypeSourceInfo>,
     id_map: RwLock<HashMap<TypeSourceInfo, TypeId>>,
 }
 
@@ -36,7 +35,7 @@ impl TypeEngine {
             .map(Clone::clone)
             .or_else(|| info_to_source_id(&ty));
         let tsi = TypeSourceInfo {
-            type_info: ty.clone(),
+            type_info: ty.clone().into(),
             source_id,
         };
         let mut id_map = self.id_map.write().unwrap();
@@ -50,16 +49,10 @@ impl TypeEngine {
         match raw_entry {
             RawEntryMut::Occupied(o) => return *o.get(),
             RawEntryMut::Vacant(_) if ty.can_change(engines.de()) => {
-                let t1 = self.slab.insert(ty);
-                let t2 = self.slab_source_ids.insert(source_id);
-                assert!(t1 == t2);
-                TypeId::new(t1)
+                TypeId::new(self.slab.insert(tsi))
             }
             RawEntryMut::Vacant(v) => {
-                let t1 = self.slab.insert(ty);
-                let t2 = self.slab_source_ids.insert(source_id);
-                assert!(t1 == t2);
-                let type_id = TypeId::new(t1);
+                let type_id = TypeId::new(self.slab.insert(tsi.clone()));
                 v.insert_with_hasher(ty_hash, tsi, type_id, make_hasher(&hash_builder, engines));
                 type_id
             }
@@ -68,29 +61,19 @@ impl TypeEngine {
 
     /// Removes all data associated with `module_id` from the type engine.
     pub fn clear_module(&mut self, module_id: &ModuleId) {
-        self.slab.retain(|key, _type_info| {
-            let source_id = self.slab_source_ids.get(*key);
-            match *source_id {
-                Some(source_id) => &source_id.module_id() != module_id,
-                None => false,
-            }
+        self.slab.retain(|_, tsi| match tsi.source_id {
+            Some(source_id) => &source_id.module_id() != module_id,
+            None => false,
         });
-        self.slab_source_ids
-            .retain(|_key, source_id| match **source_id {
-                Some(source_id) => &source_id.module_id() != module_id,
-                None => false,
-            });
     }
 
     pub fn replace(&self, id: TypeId, new_value: TypeSourceInfo) {
-        self.slab.replace(id.index(), new_value.type_info);
-        self.slab_source_ids
-            .replace(id.index(), new_value.source_id);
+        self.slab.replace(id.index(), new_value);
     }
 
     /// Performs a lookup of `id` into the [TypeEngine].
     pub fn get(&self, id: TypeId) -> Arc<TypeInfo> {
-        self.slab.get(id.index())
+        self.slab.get(id.index()).type_info.clone()
     }
 
     /// Performs a lookup of `id` into the [TypeEngine] recursing when finding a
@@ -98,10 +81,10 @@ impl TypeEngine {
     pub fn get_unaliased(&self, id: TypeId) -> Arc<TypeInfo> {
         // A slight infinite loop concern if we somehow have self-referential aliases, but that
         // shouldn't be possible.
-        let type_info = self.slab.get(id.index());
-        match &*type_info {
+        let tsi = self.slab.get(id.index());
+        match &*tsi.type_info {
             TypeInfo::Alias { ty, .. } => self.get_unaliased(ty.type_id),
-            _ => type_info,
+            _ => tsi.type_info.clone(),
         }
     }
 
@@ -368,8 +351,8 @@ impl TypeEngine {
     pub fn pretty_print(&self, _decl_engine: &DeclEngine, engines: &Engines) -> String {
         let mut builder = String::new();
         let mut list = vec![];
-        for type_info in self.slab.values() {
-            list.push(format!("{:?}", engines.help_out(&*type_info)));
+        for tsi in self.slab.values() {
+            list.push(format!("{:?}", engines.help_out(&*tsi.type_info)));
         }
         let list = ListDisplay { list };
         write!(builder, "TypeEngine {{\n{list}\n}}").unwrap();

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -15,6 +15,7 @@ use std::{
     cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
+    sync::Arc,
 };
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
@@ -70,7 +71,7 @@ impl<T: PartialEqWithEngines> PartialEqWithEngines for VecSet<T> {
 /// Encapsulates type information and its optional source identifier.
 #[derive(Debug, Default, Clone)]
 pub struct TypeSourceInfo {
-    pub(crate) type_info: TypeInfo,
+    pub(crate) type_info: Arc<TypeInfo>,
     /// The source id that created this type.
     pub(crate) source_id: Option<SourceId>,
 }

--- a/sway-core/src/type_system/unify/unifier.rs
+++ b/sway-core/src/type_system/unify/unifier.rs
@@ -61,7 +61,7 @@ impl<'a> Unifier<'a> {
         type_engine.replace(
             received,
             TypeSourceInfo {
-                type_info: expected_type_info.clone(),
+                type_info: expected_type_info.clone().into(),
                 source_id,
             },
         );
@@ -79,7 +79,7 @@ impl<'a> Unifier<'a> {
         type_engine.replace(
             expected,
             TypeSourceInfo {
-                type_info: received_type_info.clone(),
+                type_info: received_type_info.clone().into(),
                 source_id,
             },
         );


### PR DESCRIPTION
## Description
The current GC implementation was not cleaning up `parents` in the decl engine and also was missing the `id_map` in the type engine. This also changes the `slab` in the type engine to hold a `TypeSourceInfo` instead of having seperate maps. 

The `type_info` in the `TypeSourceInfo` is now an `Arc`.
