### PR TITLE
Major Performance Boost in `line_col` Function with `bytecount` Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
+name = "bytecount"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6595,6 +6601,7 @@ dependencies = [
 name = "sway-types"
 version = "0.48.1"
 dependencies = [
+ "bytecount",
  "fuel-asm",
  "fuel-crypto",
  "fuel-tx",

--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+bytecount = "0.6"
 fuel-asm = { workspace = true }
 fuel-crypto = { workspace = true }
 fuel-tx = { workspace = true }

--- a/sway-types/src/span.rs
+++ b/sway-types/src/span.rs
@@ -21,17 +21,24 @@ impl<'a> Position<'a> {
         input.get(pos..).map(|_| Position { input, pos })
     }
 
-    #[inline]
     pub fn line_col(&self) -> (usize, usize) {
         if self.pos > self.input.len() {
             panic!("position out of bounds");
         }
 
-        let slice = &self.input[..self.pos];
-        let lines = slice.split('\n').collect::<Vec<_>>();
-        let line_count = lines.len();
-        let last_line_len = lines.last().unwrap_or(&"").chars().count() + 1;
-        (line_count, last_line_len)
+        // This is performance critical, so we use bytecount instead of a naive implementation.
+        let newlines_up_to_pos = bytecount::count(&self.input.as_bytes()[..self.pos], b'\n');
+        let line = newlines_up_to_pos + 1;
+
+        // Find the last newline character before the position
+        let last_newline_pos = match self.input[..self.pos].rfind('\n') {
+            Some(pos) => pos + 1, // Start after the newline
+            None => 0,            // If no newline, start is at the beginning
+        };
+
+        // Column number should start from 1, not 0
+        let col = self.pos - last_newline_pos + 1;
+        (line, col)
     }
 }
 


### PR DESCRIPTION
## Description
This PR introduces a significant performance improvement to the `line_col` function by integrating the `bytecount` crate, leading to more efficient newline character counting in strings. Here are the results of the `sway-lsp` benchmarks. 🚀 

| Type                      | Previous Duration | Current Duration | Speedup        | Improvement % |
|---------------------------|-------------------|------------------|----------------|---------------|
| highlight                 | 108.30 ms         | 14.704 ms        | 7.36x          | +86.44%       |
| tokens_at_position        | 41.317 ms         | 6.9646 ms        | 5.93x          | +83.14%       |
| parent_decl_at_position   | 41.319 ms         | 6.9321 ms        | 5.96x          | +83.22%       |
| traverse                  | 165.60 ms         | 28.811 ms        | 5.75x          | +82.60%       |
| code_action               | 58.034 ms         | 10.734 ms        | 5.41x          | +81.52%       |
| rename                    | 119.33 ms         | 11.773 ms        | 10.14x         | +90.14%       |
| completion                | 48.597 ms         | 13.809 ms        | 3.52x          | +71.59%       |
| inlay_hints               | 8.6783 ms         | 6.0263 ms        | 1.44x          | +30.52%       |
| format                    | 46.893 ms         | 43.834 ms        | 1.07x          | +6.52%        |
| compile                   | 1.1505 s          | 1.0962 s         | 1.05x          | +4.71%        |
| code_lens                 | 231.30 ns         | 221.57 ns        | 1.04x          | +4.21%        |
| hover                     | 6.1517 ms         | 5.9984 ms        | 1.03x          | +2.49%        |
| tokens_for_file           | 8.2928 ms         | 8.0658 ms        | 1.03x          | +2.73%        |
| on_enter                  | 307.96 ns         | 300.81 ns        | 1.02x          | +2.32%        |
| document_symbol           | 6.1988 ms         | 6.7087 ms        | 0.92x          | -7.90%        |
| token_at_position         | 6.0207 ms         | 5.9769 ms        | 1.01x          | +0.73%        |
| idents_at_position        | 3.2212 ms         | 3.1946 ms        | 1.01x          | +0.83%        |
| did_change_with_caching   | 175.55 ms         | 174.16 ms        | 1.01x          | +0.79%        |
| prepare_rename            | 6.0136 ms         | 6.0365 ms        | 1.00x          | -0.38%        |
| semantic_tokens           | 16.790 ms         | 17.340 ms        | 0.97x          | -3.28%        |
| goto_definition           | 5.9613 ms         | 6.0710 ms        | 0.98x          | -1.84%        |


