### PR TITLE
fix: fix `forc build` panic when sway package folder contains dot

### DIFF
--- a/sway-core/src/build_config.rs
+++ b/sway-core/src/build_config.rs
@@ -72,7 +72,7 @@ impl BuildConfig {
             true => root_module,
             false => {
                 assert!(
-                    root_module.starts_with(canonical_manifest_dir.file_stem().unwrap()),
+                    root_module.starts_with(canonical_manifest_dir.file_name().unwrap()),
                     "file_name must be either absolute or relative to manifest directory",
                 );
                 canonical_manifest_dir


### PR DESCRIPTION
## Description

Close #5434

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
