### PR TITLE
fix: point std to local version for forc-client cli tests

### DIFF
--- a/forc-plugins/forc-client/tests/Forc.lock
+++ b/forc-plugins/forc-client/tests/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-F252333F9C4A5D78"
+
+[[package]]
+name = "std"
+source = "path+from-root-F252333F9C4A5D78"
+dependencies = ["core"]
+
+[[package]]
+name = "tests"
+source = "member"
+dependencies = ["std"]

--- a/forc-plugins/forc-client/tests/Forc.toml
+++ b/forc-plugins/forc-client/tests/Forc.toml
@@ -5,3 +5,4 @@ license = "Apache-2.0"
 name = "tests"
 
 [dependencies]
+std = { path = "../../../sway-lib-std/" }


### PR DESCRIPTION
## Description

It seems like we accidentally depend on released version of std in forc-client deployment cli tests (more specifically the test folder https://github.com/FuelLabs/sway/tree/master/forc-plugins/forc-client/tests). This PR fixes it to point local version of std so that release PRs such as #5452 won't get blocked.