### PR TITLE
LSP Optimization: Wrap `programs_cache` in an `Arc`

### DIFF
--- a/sway-core/src/query_engine/mod.rs
+++ b/sway-core/src/query_engine/mod.rs
@@ -48,14 +48,14 @@ pub type ProgramsCacheMap = HashMap<ModulePath, ProgramsCacheEntry>;
 #[derive(Debug, Default)]
 pub struct QueryEngine {
     parse_module_cache: RwLock<ModuleCacheMap>,
-    programs_cache: RwLock<ProgramsCacheMap>,
+    programs_cache: Arc<RwLock<ProgramsCacheMap>>,
 }
 
 impl Clone for QueryEngine {
     fn clone(&self) -> Self {
         Self {
             parse_module_cache: RwLock::new(self.parse_module_cache.read().unwrap().clone()),
-            programs_cache: RwLock::new(self.programs_cache.read().unwrap().clone()),
+            programs_cache: self.programs_cache.clone(),
         }
     }
 }


### PR DESCRIPTION
## Description
We clone the `Engines` before each keystroke in the language server. We shouldn't need to clone anything other than a pointer for the `programs_cache`. Measured against the `benchmark` example in `sway-lsp` tests, this saves us `23.015ms`.

related to #5445 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
