### PR TITLE
Introduce the `PredicateId` type to the std-lib

### DIFF
--- a/sway-lib-std/src/auth.sw
+++ b/sway-lib-std/src/auth.sw
@@ -7,6 +7,7 @@ use ::identity::Identity;
 use ::option::Option::{self, *};
 use ::result::Result::{self, *};
 use ::inputs::{Input, input_coin_owner, input_count, input_type};
+use ::predicate_id::PredicateId;
 
 /// The error type used when an `Identity` cannot be determined.
 pub enum AuthError {
@@ -182,7 +183,7 @@ pub fn caller_address() -> Result<Address, AuthError> {
 ///
 /// # Returns
 ///
-/// * [Address] - The address of this predicate.
+/// * [PredicateId] - The address of this predicate.
 ///
 /// # Reverts
 ///
@@ -198,7 +199,7 @@ pub fn caller_address() -> Result<Address, AuthError> {
 ///     log(this_predicate);
 /// }
 /// ```
-pub fn predicate_id() -> Address {
+pub fn predicate_id() -> PredicateId {
     // Get index of current predicate.
     // i3 = GM_GET_VERIFYING_PREDICATE
     let predicate_index = asm(r1) {
@@ -206,5 +207,6 @@ pub fn predicate_id() -> Address {
         r1: u64
     };
 
-    input_coin_owner(predicate_index).unwrap()
+    let result_b256: b256 = input_coin_owner(predicate_index).unwrap().into();
+    PredicateId::from(result_b256)
 }

--- a/sway-lib-std/src/lib.sw
+++ b/sway-lib-std/src/lib.sw
@@ -29,6 +29,7 @@ pub mod b512;
 pub mod tx;
 pub mod outputs;
 pub mod address;
+pub mod predicate_id;
 pub mod identity;
 pub mod ecr;
 pub mod vm;

--- a/sway-lib-std/src/predicate_id.sw
+++ b/sway-lib-std/src/predicate_id.sw
@@ -1,0 +1,72 @@
+//! A wrapper around the `b256` type to help enhance type-safety.
+library;
+
+use ::convert::From;
+use ::hash::{Hash, Hasher};
+
+/// The `PredicateId` type, a struct wrapper around the inner `b256` value.
+pub struct PredicateId {
+    /// The underlying raw `b256` data of the predicate.
+    value: b256,
+}
+
+impl core::ops::Eq for PredicateId {
+    fn eq(self, other: Self) -> bool {
+        self.value == other.value
+    }
+}
+
+/// Functions for casting between the `b256` and `PredicateId` types.
+impl From<b256> for PredicateId {
+    /// Casts raw `b256` data to an `PredicateId`.
+    ///
+    /// # Arguments
+    ///
+    /// * `bits`: [b256] - The raw `b256` data to be casted.
+    ///
+    /// # Returns
+    ///
+    /// * [PredicateId] - The newly created `PredicateId` from the raw `b256`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::constants::ZERO_B256;
+    ///
+    /// fn foo() {
+    ///    let predicate_id = PredicateId::from(ZERO_B256);
+    /// }
+    /// ```
+    fn from(bits: b256) -> Self {
+        Self { value: bits }
+    }
+
+    /// Casts an `PredicateId` to raw `b256` data.
+    ///
+    /// # Returns
+    ///
+    /// * [b256] - The underlying raw `b256` data of the `PredicateId`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::constants::ZERO_B256;
+    ///
+    /// fn foo() {
+    ///     let predicate_id = PredicateId::from(ZERO_B256);
+    ///     let b256_data = predicate_id.into();
+    ///     assert(b256_data == ZERO_B256);
+    /// }
+    /// ```
+    fn into(self) -> b256 {
+        self.value
+    }
+}
+
+impl Hash for PredicateId {
+    fn hash(self, ref mut state: Hasher) {
+        let PredicateId { value } = self;
+        value.hash(state);
+    }
+}
+

--- a/sway-lib-std/src/prelude.sw
+++ b/sway-lib-std/src/prelude.sw
@@ -8,6 +8,7 @@ use ::address::Address;
 use ::alias::SubId;
 use ::asset_id::AssetId;
 use ::contract_id::ContractId;
+use ::predicate_id::PredicateId;
 use ::identity::Identity;
 
 // `StorageKey` API

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/contract_with_type_aliases/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/contract_with_type_aliases/json_abi_oracle.json
@@ -141,6 +141,11 @@
           "name": "ContractId",
           "type": 10,
           "typeArguments": null
+        },
+        {
+          "name": "PredicateId",
+          "type": 11,
+          "typeArguments": null
         }
       ],
       "type": "enum std::identity::Identity",
@@ -207,6 +212,18 @@
       ],
       "type": "struct std::contract_id::ContractId",
       "typeId": 10,
+      "typeParameters": null
+    },
+    {
+      "components": [
+        {
+          "name": "value",
+          "type": 3,
+          "typeArguments": null
+        }
+      ],
+      "type": "struct std::predicate_id::PredicateId",
+      "typeId": 11,
       "typeParameters": null
     }
   ]

--- a/test/src/sdk-harness/Forc.lock
+++ b/test/src/sdk-harness/Forc.lock
@@ -47,6 +47,11 @@ source = "member"
 dependencies = ["std"]
 
 [[package]]
+name = "barebones_predicate"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
 name = "block"
 source = "member"
 dependencies = [

--- a/test/src/sdk-harness/Forc.toml
+++ b/test/src/sdk-harness/Forc.toml
@@ -47,6 +47,7 @@ members = [
   "test_artifacts/auth_testing_abi",
   "test_artifacts/auth_testing_contract",
   "test_artifacts/balance_contract",
+  "test_artifacts/barebones_predicate",
   "test_artifacts/block_test_abi",
   "test_artifacts/call_frames_test_abi",
   "test_artifacts/context_caller_contract",

--- a/test/src/sdk-harness/test_artifacts/auth_predicate/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/auth_predicate/src/main.sw
@@ -3,6 +3,8 @@ predicate;
 use std::auth::predicate_id;
 
 fn main(predicate_address: Address) -> bool {
-    predicate_address == predicate_id()
+    // TODO: Converts an `Address` to a `PredicateId` until SDK supports the `PredicateId` type.
+    let result_b256: b256 = predicate_address.into();
+    PredicateId::from(result_b256) == predicate_id()
 }
 

--- a/test/src/sdk-harness/test_artifacts/barebones_predicate/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/barebones_predicate/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/sdk-harness/test_artifacts/barebones_predicate/Forc.toml
+++ b/test/src/sdk-harness/test_artifacts/barebones_predicate/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "barebones_predicate"
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/test/src/sdk-harness/test_artifacts/barebones_predicate/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/barebones_predicate/src/main.sw
@@ -1,0 +1,5 @@
+predicate;
+
+fn main() -> bool {
+    true
+}

--- a/test/src/sdk-harness/test_projects/asset_ops/src/main.sw
+++ b/test/src/sdk-harness/test_projects/asset_ops/src/main.sw
@@ -7,9 +7,11 @@ abi TestFuelCoin {
     fn burn_coins(burn_amount: u64, sub_id: b256);
     fn force_transfer_coins(coins: u64, asset_id: b256, target: ContractId);
     fn transfer_coins_to_address(coins: u64, asset_id: b256, to: Address);
+    fn transfer_coins_to_predicate(coins: u64, asset_id: b256, to: Address);
     fn get_balance(asset_id: b256, target: ContractId) -> u64;
     fn mint_and_send_to_contract(amount: u64, to: ContractId, sub_id: b256);
     fn mint_and_send_to_address(amount: u64, to: Address, sub_id: b256);
+    fn mint_and_send_to_predicate(amount: u64, to: Address, sub_id: b256);
     fn generic_mint_to(amount: u64, to: Identity, sub_id: b256);
     fn generic_transfer(amount: u64, asset_id: b256, to: Identity);
     fn send_message(recipient: b256, msg_data: Vec<u64>, coins: u64);
@@ -34,6 +36,14 @@ impl TestFuelCoin for Contract {
         transfer_to_address(to, asset_id, coins);
     }
 
+    fn transfer_coins_to_predicate(coins: u64, asset_id: b256, to: Address) {
+        let asset_id = AssetId { value: asset_id };
+        // TODO: Converts an `Address` to a `PredicateId` until SDK supports the `PredicateId` type.
+        let result_b256: b256 = to.into();
+        let predicate_id = PredicateId::from(result_b256);
+        transfer_to_predicate(predicate_id, asset_id, coins);
+    }
+
     fn get_balance(asset_id: b256, target: ContractId) -> u64 {
         let asset_id = AssetId { value: asset_id };
         balance_of(target, asset_id)
@@ -45,6 +55,13 @@ impl TestFuelCoin for Contract {
 
     fn mint_and_send_to_address(amount: u64, to: Address, sub_id: b256) {
         mint_to_address(to, sub_id, amount);
+    }
+
+    fn mint_and_send_to_predicate(amount: u64, to: Address, sub_id: b256) {
+        // TODO: Converts an `Address` to a `PredicateId` until SDK supports the `PredicateId` type.
+        let result_b256: b256 = to.into();
+        let predicate_id = PredicateId::from(result_b256);
+        mint_to_predicate(predicate_id, sub_id, amount);
     }
 
     fn generic_mint_to(amount: u64, to: Identity, sub_id: b256) {

--- a/test/src/sdk-harness/test_projects/auth/mod.rs
+++ b/test/src/sdk-harness/test_projects/auth/mod.rs
@@ -123,7 +123,7 @@ async fn can_get_predicate_id() {
 
     // Setup Predciate
     let hex_predicate_address: &str =
-        "0x76bae6a88c3f54a9aee40ee5390696dd9edaf1b2a16d96a75adbcaac2ec6584f";
+        "0xf7b5855a221eca4a803fd1ed8d0178a5c5d2ba6aa2f94f59ad11aa946345aae8";
     let predicate_address =
         Address::from_str(hex_predicate_address).expect("failed to create Address from string");
     let predicate_bech32_address = Bech32Address::from(predicate_address);


### PR DESCRIPTION
## Description

This PR adds the `PredicateId` type to the std-lib, outlined in https://github.com/FuelLabs/sway/issues/5476

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
