### PR TITLE
Convert numeric literals to U256 based on inferred expression type

### DIFF
--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -27,6 +27,7 @@ use sway_types::{
     integer_bits::IntegerBits,
     span::{Span, Spanned},
     state::StateIndex,
+    u256::U256,
     Named,
 };
 
@@ -365,7 +366,13 @@ impl<'eng> FnCompiler<'eng> {
             ty::TyExpressionVariant::Literal(Literal::Numeric(n)) => {
                 let implied_lit = match &*self.engines.te().get(ast_expr.return_type) {
                     TypeInfo::UnsignedInteger(IntegerBits::Eight) => Literal::U8(*n as u8),
-                    _ => Literal::U64(*n),
+                    TypeInfo::UnsignedInteger(IntegerBits::V256) => Literal::U256(U256::from(*n)),
+                    _ =>
+                    // Anything more than a byte needs a u64 (except U256 of course).
+                    // (This is how convert_literal_to_value treats it too).
+                    {
+                        Literal::U64(*n)
+                    }
                 };
                 Ok(convert_literal_to_value(context, &implied_lit)
                     .add_metadatum(context, span_md_idx))

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_operators/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_operators/src/main.sw
@@ -162,3 +162,17 @@ fn should_revert_on_div_zero() -> u256 {
     let a = 0x0000000000000000000000000000000000000000000000000000000000000000u256;
     a / 0x0000000000000000000000000000000000000000000000000000000000000000u256
 }
+
+#[test]
+fn type_inference_numeric_1() -> u256 {
+    let a = 1;
+    let b = 0x2u256;
+    b * a
+}
+
+#[test]
+fn type_inference_numeric_2() -> u256 {
+   let mut result = 0;
+   result = 3.as_u256();
+   result
+}


### PR DESCRIPTION
Fixes #5453,
Fixes #5454
