### PR TITLE
ci: switch katyo/publish-crates@v2 to xgreenx/publish-crates@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,7 +564,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Publish crate
-        uses: katyo/publish-crates@v2
+        uses: xgreenx/publish-crates@v1
         with:
           publish-delay: 30000
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Description
Due to an upstream issue, publish crates step is failing this is changing the step to our fork.