### PR TITLE
Forbid configurables in constants

### DIFF
--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -741,6 +741,7 @@ impl<'eng> FnCompiler<'eng> {
                     None,
                     None,
                     &arguments[1],
+                    false,
                 )?;
                 let tx_field_id = match tx_field_id_constant.value {
                     ConstantValue::Uint(n) => n,
@@ -2444,6 +2445,7 @@ impl<'eng> FnCompiler<'eng> {
             None,
             Some(self),
             index_expr,
+            false,
         ) {
             let count = array_type.get_array_len(context).unwrap();
             if constant_value >= count {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/storage.rs
@@ -67,6 +67,7 @@ impl ty::TyStorageField {
             None,
             None,
             &self.initializer,
+            true,
         )
         .map(|constant| serialize_to_storage_slots(&constant, context, ix, &constant.ty, &[]))
     }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_not_const/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_not_const/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = 'configurables_are_not_const'
+source = 'member'

--- a/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_not_const/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_not_const/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "configurables_are_not_const"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_not_const/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_not_const/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+configurable {
+    VALUE: u64 = 42,
+}
+
+fn main() {
+    const CONSTANT: u64 = VALUE;
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_not_const/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/configurables_are_not_const/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+#check: $()const CONSTANT: u64 = VALUE;
+#nextln: $()Could not evaluate initializer to a const declaration.


### PR DESCRIPTION
## Description

Don't allow configurables to be used in const expressions except as
storage and configurable initializers.

Fix #5272
Fix #5261


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
