### PR TITLE
Change auto_import test to use git tag of std lib

### DIFF
--- a/sway-lsp/tests/fixtures/auto_import/Forc.toml
+++ b/sway-lsp/tests/fixtures/auto_import/Forc.toml
@@ -6,5 +6,4 @@ name = "auto_import"
 implicit-std = false
 
 [dependencies]
-std = { path = "../../../../sway-lib-std" }
-core = { path = "../../../../sway-lib-core" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }


### PR DESCRIPTION
## Description
There isn't a good reason to target the local std-lib for these tests, targeting the git tag helps reduce churn on people working on the std-lib. 
