### PR TITLE
Partially fixes stack overflow when using recursive trait.

### DIFF
--- a/sway-core/src/decl_engine/replace_decls.rs
+++ b/sway-core/src/decl_engine/replace_decls.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+
 use sway_error::handler::{ErrorEmitted, Handler};
+use sway_types::Span;
 
 use crate::{
     engine_threading::Engines,
@@ -14,6 +17,7 @@ pub trait ReplaceDecls {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
+        already_replaced: &mut HashMap<(usize, std::any::TypeId), (usize, Span)>,
     ) -> Result<(), ErrorEmitted>;
 
     fn replace_decls(
@@ -21,9 +25,10 @@ pub trait ReplaceDecls {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
+        already_replaced: &mut HashMap<(usize, std::any::TypeId), (usize, Span)>,
     ) -> Result<(), ErrorEmitted> {
         if !decl_mapping.is_empty() {
-            self.replace_decls_inner(decl_mapping, handler, ctx)?;
+            self.replace_decls_inner(decl_mapping, handler, ctx, already_replaced)?;
         }
 
         Ok(())

--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp::Ordering,
+    collections::HashSet,
     fmt,
     hash::{Hash, Hasher},
     sync::Arc,
@@ -28,13 +29,18 @@ pub struct CallPathTree {
 }
 
 impl HashWithEngines for CallPathTree {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let CallPathTree {
             qualified_call_path,
             children,
         } = self;
-        qualified_call_path.hash(state, engines);
-        children.hash(state, engines);
+        qualified_call_path.hash(state, engines, already_hashed);
+        children.hash(state, engines, already_hashed);
     }
 }
 
@@ -109,13 +115,18 @@ impl QualifiedCallPath {
 }
 
 impl HashWithEngines for QualifiedCallPath {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let QualifiedCallPath {
             call_path,
             qualified_path_root,
         } = self;
         call_path.hash(state);
-        qualified_path_root.hash(state, engines);
+        qualified_path_root.hash(state, engines, already_hashed);
     }
 }
 

--- a/sway-core/src/language/parsed/declaration/trait.rs
+++ b/sway-core/src/language/parsed/declaration/trait.rs
@@ -1,4 +1,7 @@
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::HashSet,
+    hash::{Hash, Hasher},
+};
 
 use super::{ConstantDeclaration, FunctionDeclaration, FunctionParameter};
 
@@ -57,10 +60,15 @@ impl PartialEqWithEngines for Supertrait {
 }
 
 impl HashWithEngines for Supertrait {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let Supertrait { name, decl_ref } = self;
         name.hash(state);
-        decl_ref.hash(state, engines);
+        decl_ref.hash(state, engines, already_hashed);
     }
 }
 

--- a/sway-core/src/language/parsed/expression/mod.rs
+++ b/sway-core/src/language/parsed/expression/mod.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, fmt, hash::Hasher};
+use std::{cmp::Ordering, collections::HashSet, fmt, hash::Hasher};
 
 use crate::{
     engine_threading::{
@@ -119,15 +119,23 @@ pub struct QualifiedPathRootTypes {
 }
 
 impl HashWithEngines for QualifiedPathRootTypes {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let QualifiedPathRootTypes {
             ty,
             as_trait,
             // ignored fields
             as_trait_span: _,
         } = self;
-        ty.hash(state, engines);
-        engines.te().get(*as_trait).hash(state, engines);
+        ty.hash(state, engines, already_hashed);
+        engines
+            .te()
+            .get(*as_trait)
+            .hash(state, engines, already_hashed);
     }
 }
 

--- a/sway-core/src/language/ty/declaration/abi.rs
+++ b/sway-core/src/language/ty/declaration/abi.rs
@@ -1,5 +1,8 @@
 use crate::{engine_threading::*, language::parsed, transform, type_system::*};
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::HashSet,
+    hash::{Hash, Hasher},
+};
 
 use sway_types::{Ident, Named, Span, Spanned};
 
@@ -47,7 +50,12 @@ impl PartialEqWithEngines for TyAbiDecl {
 }
 
 impl HashWithEngines for TyAbiDecl {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyAbiDecl {
             name,
             interface_surface,
@@ -59,9 +67,9 @@ impl HashWithEngines for TyAbiDecl {
             span: _,
         } = self;
         name.hash(state);
-        interface_surface.hash(state, engines);
-        items.hash(state, engines);
-        supertraits.hash(state, engines);
+        interface_surface.hash(state, engines, already_hashed);
+        items.hash(state, engines, already_hashed);
+        supertraits.hash(state, engines, already_hashed);
     }
 }
 

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp::Ordering,
+    collections::HashSet,
     hash::{Hash, Hasher},
 };
 
@@ -44,7 +45,12 @@ impl PartialEqWithEngines for TyEnumDecl {
 }
 
 impl HashWithEngines for TyEnumDecl {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyEnumDecl {
             call_path,
             type_parameters,
@@ -56,8 +62,8 @@ impl HashWithEngines for TyEnumDecl {
             attributes: _,
         } = self;
         call_path.suffix.hash(state);
-        variants.hash(state, engines);
-        type_parameters.hash(state, engines);
+        variants.hash(state, engines, already_hashed);
+        type_parameters.hash(state, engines, already_hashed);
         visibility.hash(state);
     }
 }
@@ -130,9 +136,14 @@ pub struct TyEnumVariant {
 }
 
 impl HashWithEngines for TyEnumVariant {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         self.name.hash(state);
-        self.type_argument.hash(state, engines);
+        self.type_argument.hash(state, engines, already_hashed);
         self.tag.hash(state);
     }
 }

--- a/sway-core/src/language/ty/declaration/impl_trait.rs
+++ b/sway-core/src/language/ty/declaration/impl_trait.rs
@@ -1,4 +1,7 @@
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::HashSet,
+    hash::{Hash, Hasher},
+};
 
 use sway_types::{Ident, Named, Span, Spanned};
 
@@ -50,7 +53,12 @@ impl PartialEqWithEngines for TyImplTrait {
 }
 
 impl HashWithEngines for TyImplTrait {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyImplTrait {
             impl_type_parameters,
             trait_name,
@@ -63,11 +71,11 @@ impl HashWithEngines for TyImplTrait {
             span: _,
         } = self;
         trait_name.hash(state);
-        impl_type_parameters.hash(state, engines);
-        trait_type_arguments.hash(state, engines);
-        items.hash(state, engines);
-        implementing_for.hash(state, engines);
-        trait_decl_ref.hash(state, engines);
+        impl_type_parameters.hash(state, engines, already_hashed);
+        trait_type_arguments.hash(state, engines, already_hashed);
+        items.hash(state, engines, already_hashed);
+        implementing_for.hash(state, engines, already_hashed);
+        trait_decl_ref.hash(state, engines, already_hashed);
     }
 }
 

--- a/sway-core/src/language/ty/declaration/storage.rs
+++ b/sway-core/src/language/ty/declaration/storage.rs
@@ -1,4 +1,7 @@
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::HashSet,
+    hash::{Hash, Hasher},
+};
 
 use sway_error::{
     error::CompileError,
@@ -32,7 +35,12 @@ impl PartialEqWithEngines for TyStorageDecl {
 }
 
 impl HashWithEngines for TyStorageDecl {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyStorageDecl {
             fields,
             // these fields are not hashed because they aren't relevant/a
@@ -41,7 +49,7 @@ impl HashWithEngines for TyStorageDecl {
             attributes: _,
             storage_keyword: _,
         } = self;
-        fields.hash(state, engines);
+        fields.hash(state, engines, already_hashed);
     }
 }
 
@@ -187,7 +195,12 @@ impl PartialEqWithEngines for TyStorageField {
 }
 
 impl HashWithEngines for TyStorageField {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyStorageField {
             name,
             type_argument,
@@ -198,7 +211,7 @@ impl HashWithEngines for TyStorageField {
             attributes: _,
         } = self;
         name.hash(state);
-        type_argument.hash(state, engines);
-        initializer.hash(state, engines);
+        type_argument.hash(state, engines, already_hashed);
+        initializer.hash(state, engines, already_hashed);
     }
 }

--- a/sway-core/src/language/ty/declaration/struct.rs
+++ b/sway-core/src/language/ty/declaration/struct.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp::Ordering,
+    collections::HashSet,
     hash::{Hash, Hasher},
 };
 
@@ -44,7 +45,12 @@ impl PartialEqWithEngines for TyStructDecl {
 }
 
 impl HashWithEngines for TyStructDecl {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyStructDecl {
             call_path,
             fields,
@@ -56,8 +62,8 @@ impl HashWithEngines for TyStructDecl {
             attributes: _,
         } = self;
         call_path.suffix.hash(state);
-        fields.hash(state, engines);
-        type_parameters.hash(state, engines);
+        fields.hash(state, engines, already_hashed);
+        type_parameters.hash(state, engines, already_hashed);
         visibility.hash(state);
     }
 }
@@ -151,7 +157,12 @@ pub struct TyStructField {
 }
 
 impl HashWithEngines for TyStructField {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyStructField {
             name,
             type_argument,
@@ -161,7 +172,7 @@ impl HashWithEngines for TyStructField {
             attributes: _,
         } = self;
         name.hash(state);
-        type_argument.hash(state, engines);
+        type_argument.hash(state, engines, already_hashed);
     }
 }
 

--- a/sway-core/src/language/ty/declaration/trait.rs
+++ b/sway-core/src/language/ty/declaration/trait.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     fmt,
     hash::{Hash, Hasher},
 };
@@ -105,7 +106,12 @@ impl PartialEqWithEngines for TyTraitDecl {
 }
 
 impl HashWithEngines for TyTraitDecl {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyTraitDecl {
             name,
             type_parameters,
@@ -121,11 +127,11 @@ impl HashWithEngines for TyTraitDecl {
             call_path: _,
         } = self;
         name.hash(state);
-        type_parameters.hash(state, engines);
-        self_type.hash(state, engines);
-        interface_surface.hash(state, engines);
-        items.hash(state, engines);
-        supertraits.hash(state, engines);
+        type_parameters.hash(state, engines, already_hashed);
+        self_type.hash(state, engines, already_hashed);
+        interface_surface.hash(state, engines, already_hashed);
+        items.hash(state, engines, already_hashed);
+        supertraits.hash(state, engines, already_hashed);
         visibility.hash(state);
     }
 }
@@ -159,21 +165,33 @@ impl PartialEqWithEngines for TyTraitItem {
 }
 
 impl HashWithEngines for TyTraitInterfaceItem {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         match self {
-            TyTraitInterfaceItem::TraitFn(fn_decl) => fn_decl.hash(state, engines),
-            TyTraitInterfaceItem::Constant(const_decl) => const_decl.hash(state, engines),
-            TyTraitInterfaceItem::Type(type_decl) => type_decl.hash(state, engines),
+            TyTraitInterfaceItem::TraitFn(fn_decl) => fn_decl.hash(state, engines, already_hashed),
+            TyTraitInterfaceItem::Constant(const_decl) => {
+                const_decl.hash(state, engines, already_hashed)
+            }
+            TyTraitInterfaceItem::Type(type_decl) => type_decl.hash(state, engines, already_hashed),
         }
     }
 }
 
 impl HashWithEngines for TyTraitItem {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         match self {
-            TyTraitItem::Fn(fn_decl) => fn_decl.hash(state, engines),
-            TyTraitItem::Constant(const_decl) => const_decl.hash(state, engines),
-            TyTraitItem::Type(type_decl) => type_decl.hash(state, engines),
+            TyTraitItem::Fn(fn_decl) => fn_decl.hash(state, engines, already_hashed),
+            TyTraitItem::Constant(const_decl) => const_decl.hash(state, engines, already_hashed),
+            TyTraitItem::Type(type_decl) => type_decl.hash(state, engines, already_hashed),
         }
     }
 }

--- a/sway-core/src/language/ty/declaration/trait_fn.rs
+++ b/sway-core/src/language/ty/declaration/trait_fn.rs
@@ -1,4 +1,7 @@
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::HashSet,
+    hash::{Hash, Hasher},
+};
 
 use sway_types::{Ident, Named, Span, Spanned};
 
@@ -57,7 +60,12 @@ impl PartialEqWithEngines for TyTraitFn {
 }
 
 impl HashWithEngines for TyTraitFn {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyTraitFn {
             name,
             purity,
@@ -70,8 +78,10 @@ impl HashWithEngines for TyTraitFn {
         } = self;
         let type_engine = engines.te();
         name.hash(state);
-        parameters.hash(state, engines);
-        type_engine.get(return_type.type_id).hash(state, engines);
+        parameters.hash(state, engines, already_hashed);
+        type_engine
+            .get(return_type.type_id)
+            .hash(state, engines, already_hashed);
         purity.hash(state);
     }
 }

--- a/sway-core/src/language/ty/declaration/trait_type.rs
+++ b/sway-core/src/language/ty/declaration/trait_type.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     fmt,
     hash::{Hash, Hasher},
 };
@@ -38,7 +39,12 @@ impl PartialEqWithEngines for TyTraitType {
 }
 
 impl HashWithEngines for TyTraitType {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyTraitType {
             name,
             ty,
@@ -49,7 +55,7 @@ impl HashWithEngines for TyTraitType {
             attributes: _,
         } = self;
         name.hash(state);
-        ty.hash(state, engines);
+        ty.hash(state, engines, already_hashed);
         implementing_type.hash(state);
     }
 }

--- a/sway-core/src/language/ty/declaration/type_alias.rs
+++ b/sway-core/src/language/ty/declaration/type_alias.rs
@@ -1,4 +1,7 @@
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::HashSet,
+    hash::{Hash, Hasher},
+};
 
 use sway_types::{Ident, Named, Span, Spanned};
 
@@ -35,7 +38,12 @@ impl PartialEqWithEngines for TyTypeAliasDecl {
 }
 
 impl HashWithEngines for TyTypeAliasDecl {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyTypeAliasDecl {
             name,
             ty,
@@ -47,7 +55,7 @@ impl HashWithEngines for TyTypeAliasDecl {
             attributes: _,
         } = self;
         name.hash(state);
-        ty.hash(state, engines);
+        ty.hash(state, engines, already_hashed);
         visibility.hash(state);
     }
 }

--- a/sway-core/src/language/ty/declaration/variable.rs
+++ b/sway-core/src/language/ty/declaration/variable.rs
@@ -1,4 +1,7 @@
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::HashSet,
+    hash::{Hash, Hasher},
+};
 
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::Ident;
@@ -37,7 +40,12 @@ impl PartialEqWithEngines for TyVariableDecl {
 }
 
 impl HashWithEngines for TyVariableDecl {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyVariableDecl {
             name,
             body,
@@ -47,9 +55,11 @@ impl HashWithEngines for TyVariableDecl {
         } = self;
         let type_engine = engines.te();
         name.hash(state);
-        body.hash(state, engines);
-        type_engine.get(*return_type).hash(state, engines);
-        type_ascription.hash(state, engines);
+        body.hash(state, engines, already_hashed);
+        type_engine
+            .get(*return_type)
+            .hash(state, engines, already_hashed);
+        type_ascription.hash(state, engines, already_hashed);
         mutability.hash(state);
     }
 }

--- a/sway-core/src/language/ty/expression/asm.rs
+++ b/sway-core/src/language/ty/expression/asm.rs
@@ -1,4 +1,7 @@
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::HashSet,
+    hash::{Hash, Hasher},
+};
 
 use sway_types::Ident;
 
@@ -22,11 +25,16 @@ impl PartialEqWithEngines for TyAsmRegisterDeclaration {
 }
 
 impl HashWithEngines for TyAsmRegisterDeclaration {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyAsmRegisterDeclaration { initializer, name } = self;
         name.hash(state);
         if let Some(x) = initializer.as_ref() {
-            x.hash(state, engines)
+            x.hash(state, engines, already_hashed)
         }
     }
 }

--- a/sway-core/src/language/ty/expression/storage.rs
+++ b/sway-core/src/language/ty/expression/storage.rs
@@ -1,4 +1,7 @@
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::HashSet,
+    hash::{Hash, Hasher},
+};
 
 use sway_types::{state::StateIndex, Ident, Span, Spanned};
 
@@ -22,13 +25,18 @@ impl PartialEqWithEngines for TyStorageAccess {
 }
 
 impl HashWithEngines for TyStorageAccess {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyStorageAccess {
             fields,
             ix,
             storage_keyword_span,
         } = self;
-        fields.hash(state, engines);
+        fields.hash(state, engines, already_hashed);
         ix.hash(state);
         storage_keyword_span.hash(state);
     }
@@ -71,7 +79,12 @@ impl PartialEqWithEngines for TyStorageAccessDescriptor {
 }
 
 impl HashWithEngines for TyStorageAccessDescriptor {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyStorageAccessDescriptor {
             name,
             type_id,
@@ -81,6 +94,8 @@ impl HashWithEngines for TyStorageAccessDescriptor {
         } = self;
         let type_engine = engines.te();
         name.hash(state);
-        type_engine.get(*type_id).hash(state, engines);
+        type_engine
+            .get(*type_id)
+            .hash(state, engines, already_hashed);
     }
 }

--- a/sway-core/src/language/ty/expression/struct_exp_field.rs
+++ b/sway-core/src/language/ty/expression/struct_exp_field.rs
@@ -1,7 +1,10 @@
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::{HashMap, HashSet},
+    hash::{Hash, Hasher},
+};
 
 use sway_error::handler::{ErrorEmitted, Handler};
-use sway_types::Ident;
+use sway_types::{Ident, Span};
 
 use crate::{
     decl_engine::*,
@@ -25,10 +28,15 @@ impl PartialEqWithEngines for TyStructExpressionField {
 }
 
 impl HashWithEngines for TyStructExpressionField {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TyStructExpressionField { name, value } = self;
         name.hash(state);
-        value.hash(state, engines);
+        value.hash(state, engines, already_hashed);
     }
 }
 
@@ -44,8 +52,10 @@ impl ReplaceDecls for TyStructExpressionField {
         decl_mapping: &DeclMapping,
         handler: &Handler,
         ctx: &mut TypeCheckContext,
+        already_replaced: &mut HashMap<(usize, std::any::TypeId), (usize, Span)>,
     ) -> Result<(), ErrorEmitted> {
-        self.value.replace_decls(decl_mapping, handler, ctx)
+        self.value
+            .replace_decls(decl_mapping, handler, ctx, already_replaced)
     }
 }
 

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -32,7 +32,7 @@ use control_flow_analysis::ControlFlowGraph;
 use metadata::MetadataManager;
 use query_engine::{ModuleCacheKey, ModulePath, ProgramsCacheEntry};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -511,6 +511,7 @@ pub fn parsed_to_ast(
     let types_metadata_result = typed_program.collect_types_metadata(
         handler,
         &mut CollectTypesMetadataContext::new(engines, experimental),
+        &mut HashSet::<(usize, std::any::TypeId)>::new(),
     );
     let types_metadata = match types_metadata_result {
         Ok(types_metadata) => types_metadata,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -914,7 +914,12 @@ fn type_check_trait_implementation(
                         .collect::<Vec<_>>(),
                 );
 
-                method.replace_decls(&decl_mapping, handler, &mut ctx)?;
+                method.replace_decls(
+                    &decl_mapping,
+                    handler,
+                    &mut ctx,
+                    &mut HashMap::<(usize, std::any::TypeId), (usize, Span)>::new(),
+                )?;
                 method.subst(&type_mapping, engines);
                 all_items_refs.push(TyImplItem::Fn(
                     decl_engine
@@ -924,7 +929,12 @@ fn type_check_trait_implementation(
             }
             TyImplItem::Constant(decl_ref) => {
                 let mut const_decl = (*decl_engine.get_constant(decl_ref)).clone();
-                const_decl.replace_decls(&decl_mapping, handler, &mut ctx)?;
+                const_decl.replace_decls(
+                    &decl_mapping,
+                    handler,
+                    &mut ctx,
+                    &mut HashMap::<(usize, std::any::TypeId), (usize, Span)>::new(),
+                )?;
                 const_decl.subst(&type_mapping, engines);
                 all_items_refs.push(TyImplItem::Constant(decl_engine.insert(const_decl)));
             }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -72,7 +72,12 @@ pub(crate) fn instantiate_function_application(
         function_decl.name.as_str(),
         &call_path_binding.span(),
     )?;
-    function_decl.replace_decls(&decl_mapping, handler, &mut ctx)?;
+    function_decl.replace_decls(
+        &decl_mapping,
+        handler,
+        &mut ctx,
+        &mut HashMap::<(usize, std::any::TypeId), (usize, Span)>::new(),
+    )?;
     let return_type = function_decl.return_type.clone();
     let new_decl_ref = decl_engine
         .insert(function_decl)

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -622,7 +622,12 @@ pub(crate) fn monomorphize_method_application(
         )?;
 
         if !ctx.defer_monomorphization() {
-            method.replace_decls(&decl_mapping, handler, &mut ctx)?;
+            method.replace_decls(
+                &decl_mapping,
+                handler,
+                &mut ctx,
+                &mut HashMap::<(usize, std::any::TypeId), (usize, Span)>::new(),
+            )?;
         }
 
         decl_engine.replace(*fn_ref.id(), method);

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -1,5 +1,5 @@
 use crate::{engine_threading::*, language::CallPathTree, type_system::priv_prelude::*};
-use std::{cmp::Ordering, fmt, hash::Hasher};
+use std::{cmp::Ordering, collections::HashSet, fmt, hash::Hasher};
 use sway_types::{Span, Spanned};
 
 #[derive(Debug, Clone)]
@@ -28,7 +28,12 @@ impl Spanned for TypeArgument {
 }
 
 impl HashWithEngines for TypeArgument {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TypeArgument {
             type_id,
             // these fields are not hashed because they aren't relevant/a
@@ -38,7 +43,9 @@ impl HashWithEngines for TypeArgument {
             call_path_tree: _,
         } = self;
         let type_engine = engines.te();
-        type_engine.get(*type_id).hash(state, engines);
+        type_engine
+            .get(*type_id)
+            .hash(state, engines, already_hashed);
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -18,7 +18,7 @@ use sway_types::{ident::Ident, span::Span, Spanned};
 
 use std::{
     cmp::Ordering,
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     fmt,
     hash::{Hash, Hasher},
 };
@@ -34,7 +34,12 @@ pub struct TypeParameter {
 }
 
 impl HashWithEngines for TypeParameter {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
         let TypeParameter {
             type_id,
             name_ident,
@@ -46,9 +51,11 @@ impl HashWithEngines for TypeParameter {
             is_from_parent: _,
         } = self;
         let type_engine = engines.te();
-        type_engine.get(*type_id).hash(state, engines);
+        type_engine
+            .get(*type_id)
+            .hash(state, engines, already_hashed);
         name_ident.hash(state);
-        trait_constraints.hash(state, engines);
+        trait_constraints.hash(state, engines, already_hashed);
     }
 }
 

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -42,6 +42,7 @@ impl CollectTypesMetadata for TypeId {
         &self,
         _handler: &Handler,
         ctx: &mut CollectTypesMetadataContext,
+        _already_collected: &mut HashSet<(usize, std::any::TypeId)>,
     ) -> Result<Vec<TypeMetadata>, ErrorEmitted> {
         fn filter_fn(type_info: &TypeInfo) -> bool {
             matches!(type_info, TypeInfo::UnknownGeneric { .. })

--- a/sway-core/src/type_system/substitute/subst_list.rs
+++ b/sway-core/src/type_system/substitute/subst_list.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     hash::Hasher,
     slice::{Iter, IterMut},
     vec::IntoIter,
@@ -66,8 +67,13 @@ impl PartialEqWithEngines for SubstList {
 }
 
 impl HashWithEngines for SubstList {
-    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
-        self.list.hash(state, engines);
+    fn hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        engines: &Engines,
+        already_hashed: &mut HashSet<(usize, std::any::TypeId)>,
+    ) {
+        self.list.hash(state, engines, already_hashed);
     }
 }
 

--- a/sway-core/src/types/collect_types_metadata.rs
+++ b/sway-core/src/types/collect_types_metadata.rs
@@ -4,7 +4,7 @@
 //! that is not the case.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
 };
 
@@ -137,5 +137,6 @@ pub(crate) trait CollectTypesMetadata {
         &self,
         handler: &Handler,
         ctx: &mut CollectTypesMetadataContext,
+        already_collected: &mut HashSet<(usize, std::any::TypeId)>,
     ) -> Result<Vec<TypeMetadata>, ErrorEmitted>;
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_recursive/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_recursive/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-52814126C16198E0"
+
+[[package]]
+name = "std"
+source = "path+from-root-52814126C16198E0"
+dependencies = ["core"]
+
+[[package]]
+name = "trait_recursive"
+source = "member"
+dependencies = ["std"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_recursive/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_recursive/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "trait_recursive"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_recursive/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_recursive/src/main.sw
@@ -1,0 +1,31 @@
+script;
+
+trait T1 {
+    fn trait_fn() -> Self;
+}
+
+impl T1 for u64 {
+    fn trait_fn() -> u64 {
+        0
+    }
+}
+
+impl<A> T1 for (A, ) 
+where
+    A: T1
+{
+    fn trait_fn() -> (A, ) {
+        (A::trait_fn(), )
+    }
+}
+
+fn f<T> () 
+where
+    T: T1
+{
+    T::trait_fn();
+}
+
+fn main() {
+    let a = f::<(u64, )>();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_recursive/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_recursive/test.toml
@@ -1,0 +1,4 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+validate_abi = false
+expected_warnings = 3


### PR DESCRIPTION
ReplaceDecls, CollectTypesMetadata, HashWithEngines now have a mechanism that interrupts recursive visiting.

The mechanism works by adding TypeIds or DeclIds to a HashMap or HashSet and no longer revisiting TypeIds or DeclIds on the passed collection.

This was necessary because in some cases while visiting a declaration we can go back to the beginning because of recursive DeclIds.

I suspect these changes will also be useful to #3018

This partially fixes #5504, which is still failing because we have yet to fix a recursion problem in the IR side of the compiler.

## Description


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
