### PR TITLE
Dereferencing operator index `[]`

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/tuple_index_access.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/tuple_index_access.rs
@@ -14,7 +14,7 @@ pub(crate) fn instantiate_tuple_index_access(
     let type_engine = engines.te();
     let mut tuple_type_arg_to_access = None;
     let type_info = type_engine.get(parent.return_type);
-    let type_args = type_info.expect_tuple(handler, engines, parent.span.as_str(), &parent.span)?;
+    let type_args = type_info.expect_tuple(handler, engines, &parent.span)?;
     for (pos, type_arg) in type_args.iter().enumerate() {
         if pos == index {
             tuple_type_arg_to_access = Some(type_arg.clone());

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -353,7 +353,6 @@ impl Items {
         let mut symbol = symbol.return_type(handler, engines)?;
         let mut symbol_span = base_name.span();
         let mut parent_rover = symbol;
-        let mut full_name_for_error = base_name.to_string();
         let mut full_span_for_error = base_name.span();
         for projection in projections {
             let resolved_type = match type_engine.to_typeinfo(symbol, &symbol_span) {
@@ -412,7 +411,6 @@ impl Items {
                     parent_rover = symbol;
                     symbol = field_type_id;
                     symbol_span = field_name.span().clone();
-                    full_name_for_error.push_str(field_name.as_str());
                     full_span_for_error =
                         Span::join(full_span_for_error, field_name.span().clone());
                 }
@@ -435,7 +433,6 @@ impl Items {
                     parent_rover = symbol;
                     symbol = *field_type;
                     symbol_span = index_span.clone();
-                    full_name_for_error.push_str(&index.to_string());
                     full_span_for_error = Span::join(full_span_for_error, index_span.clone());
                 }
                 (
@@ -445,7 +442,14 @@ impl Items {
                     parent_rover = symbol;
                     symbol = elem_ty.type_id;
                     symbol_span = index_span.clone();
-                    full_span_for_error = index_span.clone();
+                    // `index_span` does not contain the enclosing square brackets.
+                    // Which means, if this array index access is the last one before the
+                    // erroneous expression, the `full_span_for_error` will be missing the
+                    // closing `]`. We can live with this small glitch so far. To fix it,
+                    // we would need to bring the full span of the index all the way from
+                    // the parsing stage. An effort that doesn't pay off at the moment.
+                    // TODO: Include the closing square bracket into the error span.
+                    full_span_for_error = Span::join(full_span_for_error, index_span.clone());
                 }
                 (actually, ty::ProjectionKind::StructField { .. }) => {
                     return Err(handler.emit_err(CompileError::FieldAccessOnNonStruct {
@@ -455,16 +459,14 @@ impl Items {
                 }
                 (actually, ty::ProjectionKind::TupleField { .. }) => {
                     return Err(handler.emit_err(CompileError::NotATuple {
-                        name: full_name_for_error,
-                        span: full_span_for_error,
                         actually: engines.help_out(actually).to_string(),
+                        span: full_span_for_error,
                     }));
                 }
                 (actually, ty::ProjectionKind::ArrayIndex { .. }) => {
                     return Err(handler.emit_err(CompileError::NotIndexable {
-                        name: full_name_for_error,
-                        span: full_span_for_error,
                         actually: engines.help_out(actually).to_string(),
+                        span: full_span_for_error,
                     }));
                 }
             }

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -1092,6 +1092,10 @@ impl TypeInfo {
         matches!(self, TypeInfo::Ref(_))
     }
 
+    pub fn is_array(&self) -> bool {
+        matches!(self, TypeInfo::Array(_, _))
+    }
+
     pub(crate) fn apply_type_arguments(
         self,
         handler: &Handler,
@@ -1409,7 +1413,6 @@ impl TypeInfo {
         &self,
         handler: &Handler,
         engines: &Engines,
-        debug_string: impl Into<String>,
         debug_span: &Span,
     ) -> Result<Vec<TypeArgument>, ErrorEmitted> {
         match self {
@@ -1421,13 +1424,12 @@ impl TypeInfo {
                 engines
                     .te()
                     .get(*type_id)
-                    .expect_tuple(handler, engines, debug_string, debug_span)
+                    .expect_tuple(handler, engines, debug_span)
             }
             TypeInfo::ErrorRecovery(err) => Err(*err),
             a => Err(handler.emit_err(CompileError::NotATuple {
-                name: debug_string.into(),
-                span: debug_span.clone(),
                 actually: engines.help_out(a).to_string(),
+                span: debug_span.clone(),
             })),
         }
     }

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -287,17 +287,15 @@ pub enum CompileError {
     ModuleNotFound { span: Span, name: String },
     #[error("This is a {actually}, not a struct. Fields can only be accessed on structs.")]
     FieldAccessOnNonStruct { actually: String, span: Span },
-    #[error("\"{name}\" is a {actually}, not a tuple. Elements can only be access on tuples.")]
+    #[error("This is a {actually}, not a tuple. Elements can only be access on tuples.")]
     NotATuple {
-        name: String,
-        span: Span,
         actually: String,
+        span: Span,
     },
-    #[error("\"{name}\" is a {actually}, which is not an indexable expression.")]
+    #[error("This expression has type \"{actually}\", which is not an indexable type.")]
     NotIndexable {
-        name: String,
-        span: Span,
         actually: String,
+        span: Span,
     },
     #[error("\"{name}\" is a {actually}, not an enum.")]
     NotAnEnum {
@@ -1712,6 +1710,21 @@ impl ToDiagnostic for CompileError {
                     hints
                 },
                 help: vec![],
+            },
+            NotIndexable { actually, span } => Diagnostic {
+                reason: Some(Reason::new(code(1), "Type is not indexable".to_string())),
+                issue: Issue::error(
+                    source_engine,
+                    span.clone(),
+                    format!("This expression has type \"{actually}\", which is not an indexable type.")
+                ),
+                hints: vec![],
+                help: vec![
+                    "Index operator `[]` can be used only on indexable types.".to_string(),
+                    "In Sway, indexable types are:".to_string(),
+                    format!("{}- arrays. E.g., `[u64;3]`.", Indent::Single),
+                    format!("{}- references, direct or indirect, to arrays. E.g., `&[u64;3]` or `&&&[u64;3]`.", Indent::Single),
+                ],
             },
            _ => Diagnostic {
                     // TODO: Temporary we use self here to achieve backward compatibility.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/diverging_never/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/diverging_never/test.toml
@@ -1,4 +1,5 @@
 category = "fail"
 
+# check: $()Type is not indexable
 # check: $()}[0];
-# nextln: $()No method named "index" found for type "Never".
+# nextln: $()This expression has type "Never", which is not an indexable type.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/mutable_arrays/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/mutable_arrays/test.toml
@@ -1,6 +1,8 @@
 category = "fail"
 
-# check: $()"b" is a bool, which is not an indexable expression.
+# check: $()Type is not indexable
+# check: $()b[0] = true;
+# nextln: $()This expression has type "bool", which is not an indexable type.
 
 # check: $()Assignment to immutable variable. Variable my_array is not declared as mutable.
 
@@ -8,4 +10,6 @@ category = "fail"
 
 # check: $()Mismatched types.
 
-# check: $()"my_array_2" is a u64, which is not an indexable expression.
+# check: $()Type is not indexable
+# check: $()my_array_2[0][1] = false;
+# nextln: $()This expression has type "u64", which is not an indexable type.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/non_indexable_types/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/non_indexable_types/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "non_indexable_types"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/non_indexable_types/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/non_indexable_types/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "non_indexable_types"
+entry = "main.sw"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/non_indexable_types/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/non_indexable_types/src/main.sw
@@ -1,0 +1,36 @@
+script;
+
+struct S {
+    x: u8,
+    u8_field: u8,
+}
+
+fn main() {
+    let mut not_array = 0;
+    let _ = not_array[0];
+    not_array[0] = 1;
+
+    let mut s = S { x: 0, u8_field: 0 };
+    let _ = s[0];
+    s[0] = 1;
+
+    let _ = s.x[0];
+    s.x[0] = 1;
+
+    let mut array = [s, s];
+    let _ = array[0].x[0];
+    array[0].x[0] = 1;
+
+    let _= array[0].u8_field[0];
+    array[0].u8_field[0] = 1;
+
+    let _ = array[0][0];
+    array[0][0] = 1;
+
+    let mut tuple = (1, 2);
+    let _ = tuple[0];
+    tuple[0] = 1;
+
+    let _ = tuple.1[0];
+    tuple.1[0] = 1;
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/non_indexable_types/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/non_indexable_types/test.toml
@@ -1,0 +1,84 @@
+category = "fail"
+
+# We want to check for ^^^^ to have at least the check for the expected length of the error span.
+# The reason is the bug in the error span for this error, that we had before.
+
+#check: $()Type is not indexable
+#check: $()let _ = not_array[0];
+#nextln: $()^^^^^^^^^
+#sameln: $()This expression has type "numeric", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()not_array[0] = 1;
+#nextln: $()^^^^^^^^^
+#sameln: $()This expression has type "numeric", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()let _ = s[0];
+#nextln: $()^
+#sameln: $()This expression has type "S", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()s[0] = 1;
+#nextln: $()^
+#sameln: $()This expression has type "S", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()let _ = s.x[0];
+#nextln: $()^^^
+#sameln: $()This expression has type "u8", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()s.x[0] = 1;
+#nextln: $()^^^
+#sameln: $()This expression has type "u8", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()let _ = array[0].x[0];
+#nextln: $()^^^^^^^^^^
+#sameln: $()This expression has type "u8", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()array[0].x[0] = 1;
+#nextln: $()^^^^^^^^^^
+#sameln: $()This expression has type "u8", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()let _= array[0].u8_field[0];
+#nextln: $()^^^^^^^^^^^^^^^^^
+#sameln: $()This expression has type "u8", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()array[0].u8_field[0] = 1;
+#nextln: $()^^^^^^^^^^^^^^^^^
+#sameln: $()This expression has type "u8", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()let _ = array[0][0];
+#nextln: $()^^^^^^^^
+#sameln: $()This expression has type "S", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()array[0][0] = 1;
+#nextln: $()^^^^^^^
+#sameln: $()This expression has type "S", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()let _ = tuple[0];
+#nextln: $()^^^^^
+#sameln: $()This expression has type "(numeric, numeric)", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()tuple[0] = 1;
+#nextln: $()^^^^^
+#sameln: $()This expression has type "(numeric, numeric)", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()let _ = tuple.1[0];
+#nextln: $()^^^^^^^
+#sameln: $()This expression has type "numeric", which is not an indexable type.
+
+#check: $()Type is not indexable
+#check: $()tuple.1[0] = 1;
+#nextln: $()^^^^^^^
+#sameln: $()This expression has type "numeric", which is not an indexable type.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_index/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_index/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-F936EAA5128B67EA"
+
+[[package]]
+name = "dereferencing_operator_index"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "std"
+source = "path+from-root-F936EAA5128B67EA"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_index/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_index/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "dereferencing_operator_index"
+
+[dependencies]
+std = { path = "../../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_index/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_index/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_index/src/impls.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_index/src/impls.sw
@@ -1,0 +1,258 @@
+library;
+
+use core::ops::Eq;
+use std::bytes_conversions::u256::*;
+use std::bytes_conversions::b256::*;
+
+pub trait TestInstance {
+    fn new() -> Self;
+    fn different() -> Self;
+}
+
+impl TestInstance for bool {
+    fn new() -> Self {
+        true
+    }
+    fn different() -> Self {
+        false
+    }
+}
+
+impl TestInstance for u8 {
+    fn new() -> Self {
+        123
+    }
+    fn different() -> Self {
+        223
+    }
+}
+
+impl TestInstance for u16 {
+    fn new() -> Self {
+        1234
+    }
+    fn different() -> Self {
+        4321
+    }
+}
+
+impl TestInstance for u32 {
+    fn new() -> Self {
+        12345
+    }
+    fn different() -> Self {
+        54321
+    }
+}
+
+impl TestInstance for u64 {
+    fn new() -> Self {
+        123456
+    }
+    fn different() -> Self {
+        654321
+    }
+}
+
+impl TestInstance for u256 {
+    fn new() -> Self {
+        0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20u256
+    }
+    fn different() -> Self {
+        0x0203040405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1f1a20u256
+    }
+}
+
+impl TestInstance for str {
+    fn new() -> Self {
+        "1a2B3c"
+    }
+    fn different() -> Self {
+        "3A2b1C"
+    }
+}
+
+impl Eq for str[6] {
+    fn eq(self, other: Self) -> bool {
+        let mut i = 0;
+        while i < 6 {
+            let ptr_self = __addr_of(self).add::<u8>(i);
+            let ptr_other = __addr_of(other).add::<u8>(i);
+
+            if ptr_self.read::<u8>() != ptr_other.read::<u8>() {
+                return false;
+            }
+
+            i = i + 1;
+        };
+        
+        true
+    }
+}
+
+impl TestInstance for str[6] {
+    fn new() -> Self {
+        __to_str_array("1a2B3c")
+    }
+    fn different() -> Self {
+        __to_str_array("3A2b1C")
+    }
+}
+
+impl Eq for [u64;2] {
+    fn eq(self, other: Self) -> bool {
+        self[0] == other[0] && self[1] == other[1] 
+    }
+}
+
+impl TestInstance for [u64;2] {
+    fn new() -> Self {
+        [123456, 654321]
+    }
+    fn different() -> Self {
+        [654321, 123456]
+    }
+}
+
+pub struct Struct {
+    x: u64,
+}
+
+impl Eq for Struct {
+    fn eq(self, other: Self) -> bool {
+        self.x == other.x
+    }
+}
+
+impl TestInstance for Struct {
+    fn new() -> Self {
+        Self { x: 98765 }
+    }
+    fn different() -> Self {
+        Self { x: 56789 }
+    }
+}
+
+pub struct EmptyStruct { }
+
+impl Eq for EmptyStruct {
+    fn eq(self, other: Self) -> bool {
+        true
+    }
+}
+
+impl TestInstance for EmptyStruct {
+    fn new() -> Self {
+        EmptyStruct { }
+    }
+    fn different() -> Self {
+        EmptyStruct { }
+    }
+}
+
+pub enum Enum {
+    A: u64,
+}
+
+impl Eq for Enum {
+    fn eq(self, other: Self) -> bool {
+        match (self, other) {
+            (Enum::A(l), Enum::A(r)) => l == r,
+        }
+    }
+}
+
+impl TestInstance for Enum {
+    fn new() -> Self {
+        Self::A(123456)
+    }
+    fn different() -> Self {
+        Self::A(654321)
+    }
+}
+
+impl Eq for (u8, u32) {
+    fn eq(self, other: Self) -> bool {
+        self.0 == other.0 && self.1 == other.1
+    }
+}
+
+impl TestInstance for (u8, u32) {
+    fn new() -> Self {
+        (123, 12345)
+    }
+    fn different() -> Self {
+        (223, 54321)
+    }
+}
+
+impl TestInstance for b256 {
+    fn new() -> Self {
+        0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20
+    }
+    fn different() -> Self {
+        0x0202020405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1f1a20
+    }
+}
+
+impl TestInstance for raw_ptr {
+    fn new() -> Self {
+        let null_ptr = asm() { zero: raw_ptr };
+
+        null_ptr.add::<u64>(42)
+    }
+    fn different() -> Self {
+        let null_ptr = asm() { zero: raw_ptr };
+
+        null_ptr.add::<u64>(42*2)
+    }
+}
+
+impl TestInstance for raw_slice {
+    fn new() -> Self {
+        let null_ptr = asm() { zero: raw_ptr };
+        
+        std::raw_slice::from_parts::<u64>(null_ptr, 42)
+    }
+    fn different() -> Self {
+        let null_ptr = asm() { zero: raw_ptr };
+        
+        std::raw_slice::from_parts::<u64>(null_ptr, 42*2)
+    }
+}
+
+impl Eq for raw_slice {
+    fn eq(self, other: Self) -> bool {
+        self.ptr() == other.ptr() && self.number_of_bytes() == other.number_of_bytes()
+    }
+}
+
+impl TestInstance for () {
+    fn new() -> Self {
+        ()
+    }
+    fn different() -> Self {
+        ()
+    }
+}
+
+impl Eq for () {
+    fn eq(self, other: Self) -> bool {
+        true
+    }
+}
+
+impl TestInstance for [u64;0] {
+    fn new() -> Self {
+        []
+    }
+    fn different() -> Self {
+        []
+    }
+}
+
+impl Eq for [u64;0] {
+    fn eq(self, other: Self) -> bool {
+        true
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_index/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_index/src/main.sw
@@ -1,0 +1,196 @@
+script;
+
+mod impls;
+use impls::*;
+use core::ops::Eq;
+
+#[inline(always)]
+fn dereference_array<T>()
+    where T: TestInstance + Eq
+{
+    let mut array = [T::new(), T::different()];
+    let r_array = &array;
+    let r_r_array = &r_array;
+    let r_r_r_array = &r_r_array;
+
+    assert(r_array[0] == array[0]);
+    assert(r_array[1] == array[1]);
+
+    assert(r_r_array[0] == array[0]);
+    assert(r_r_array[1] == array[1]);
+
+    assert(r_r_r_array[0] == array[0]);
+    assert(r_r_r_array[1] == array[1]);
+
+    array[0] = T::different();
+    array[1] = T::new();
+
+    assert(r_array[0] == array[0]);
+    assert(r_array[1] == array[1]);
+
+    assert(r_r_array[0] == array[0]);
+    assert(r_r_array[1] == array[1]);
+
+    assert(r_r_r_array[0] == array[0]);
+    assert(r_r_r_array[1] == array[1]);
+}
+
+#[inline(never)]
+fn dereference_array_not_inlined<T>()
+    where T: TestInstance + Eq
+{
+    dereference_array::<T>()
+}
+
+#[inline(always)]
+fn dereference_array_of_refs<T>()
+    where T: TestInstance + Eq
+{
+    let mut array = [T::new(), T::different()];
+    let mut array_of_refs = [&array, &array];
+
+    let r_array_of_refs = &array_of_refs;
+    let r_r_array_of_refs = &r_array_of_refs;
+    let r_r_r_array_of_refs = &r_r_array_of_refs;
+
+    assert(r_array_of_refs[0][0] == array_of_refs[0][0]);
+    assert(r_array_of_refs[0][0] == array[0]);
+    assert(r_array_of_refs[1][1] == array_of_refs[1][1]);
+    assert(r_array_of_refs[1][1] == array[1]);
+
+    assert(r_r_array_of_refs[0][0] == array_of_refs[0][0]);
+    assert(r_r_array_of_refs[0][0] == array[0]);
+    assert(r_r_array_of_refs[1][1] == array_of_refs[1][1]);
+    assert(r_r_array_of_refs[1][1] == array[1]);
+
+    assert(r_r_r_array_of_refs[0][0] == array_of_refs[0][0]);
+    assert(r_r_r_array_of_refs[0][0] == array[0]);
+    assert(r_r_r_array_of_refs[1][1] == array_of_refs[1][1]);
+    assert(r_r_r_array_of_refs[1][1] == array[1]);
+
+    array[0] = T::different();
+    array[1] = T::new();
+
+    assert(r_array_of_refs[0][0] == array_of_refs[0][0]);
+    assert(r_array_of_refs[0][0] == array[0]);
+    assert(r_array_of_refs[1][1] == array_of_refs[1][1]);
+    assert(r_array_of_refs[1][1] == array[1]);
+
+    assert(r_r_array_of_refs[0][0] == array_of_refs[0][0]);
+    assert(r_r_array_of_refs[0][0] == array[0]);
+    assert(r_r_array_of_refs[1][1] == array_of_refs[1][1]);
+    assert(r_r_array_of_refs[1][1] == array[1]);
+
+    assert(r_r_r_array_of_refs[0][0] == array_of_refs[0][0]);
+    assert(r_r_r_array_of_refs[0][0] == array[0]);
+    assert(r_r_r_array_of_refs[1][1] == array_of_refs[1][1]);
+    assert(r_r_r_array_of_refs[1][1] == array[1]);
+
+    let r = & & & & &[& & &array, & & &array, & & &array];
+
+    let mut j = 0;
+    let mut k = 0;
+    while j < 3 {
+        while k < 2 {
+            assert(r[j][k] == array[k]);
+            k += 1;
+        }
+        j += 1;
+    } 
+}
+
+#[inline(never)]
+fn dereference_array_of_refs_not_inlined<T>()
+    where T: TestInstance + Eq
+{
+    dereference_array_of_refs::<T>()
+}
+
+#[inline(never)]
+fn test_all_inlined() {
+    dereference_array::<()>();
+    dereference_array::<bool>();
+    dereference_array::<u8>();
+    dereference_array::<u16>();
+    dereference_array::<u32>();
+    dereference_array::<u64>();
+    dereference_array::<u256>();
+    dereference_array::<[u64;2]>();
+    dereference_array::<[u64;0]>();
+    dereference_array::<Struct>();
+    dereference_array::<EmptyStruct>();
+    dereference_array::<str>();
+    dereference_array::<str[6]>();
+    dereference_array::<Enum>();
+    dereference_array::<(u8, u32)>();
+    dereference_array::<b256>();
+    dereference_array::<raw_ptr>();
+    dereference_array::<raw_slice>();
+
+    dereference_array_of_refs::<()>();
+    dereference_array_of_refs::<bool>();
+    dereference_array_of_refs::<u8>();
+    dereference_array_of_refs::<u16>();
+    dereference_array_of_refs::<u32>();
+    dereference_array_of_refs::<u64>();
+    dereference_array_of_refs::<u256>();
+    dereference_array_of_refs::<[u64;2]>();
+    dereference_array_of_refs::<[u64;0]>();
+    dereference_array_of_refs::<Struct>();
+    dereference_array_of_refs::<EmptyStruct>();
+    dereference_array_of_refs::<str>();
+    dereference_array_of_refs::<str[6]>();
+    dereference_array_of_refs::<Enum>();
+    dereference_array_of_refs::<(u8, u32)>();
+    dereference_array_of_refs::<b256>();
+    dereference_array_of_refs::<raw_ptr>();
+    dereference_array_of_refs::<raw_slice>();
+}
+
+#[inline(never)]
+fn test_not_inlined() {
+    dereference_array_not_inlined::<()>();
+    dereference_array_not_inlined::<bool>();
+    dereference_array_not_inlined::<u8>();
+    dereference_array_not_inlined::<u16>();
+    dereference_array_not_inlined::<u32>();
+    dereference_array_not_inlined::<u64>();
+    dereference_array_not_inlined::<u256>();
+    dereference_array_not_inlined::<[u64;2]>();
+    dereference_array_not_inlined::<[u64;0]>();
+    dereference_array_not_inlined::<Struct>();
+    dereference_array_not_inlined::<EmptyStruct>();
+    dereference_array_not_inlined::<str>();
+    dereference_array_not_inlined::<str[6]>();
+    dereference_array_not_inlined::<Enum>();
+    dereference_array_not_inlined::<(u8, u32)>();
+    dereference_array_not_inlined::<b256>();
+    dereference_array_not_inlined::<raw_ptr>();
+    dereference_array_not_inlined::<raw_slice>();
+
+    dereference_array_of_refs_not_inlined::<()>();
+    dereference_array_of_refs_not_inlined::<bool>();
+    dereference_array_of_refs_not_inlined::<u8>();
+    dereference_array_of_refs_not_inlined::<u16>();
+    dereference_array_of_refs_not_inlined::<u32>();
+    dereference_array_of_refs_not_inlined::<u64>();
+    dereference_array_of_refs_not_inlined::<u256>();
+    dereference_array_of_refs_not_inlined::<[u64;2]>();
+    dereference_array_of_refs_not_inlined::<[u64;0]>();
+    dereference_array_of_refs_not_inlined::<Struct>();
+    dereference_array_of_refs_not_inlined::<EmptyStruct>();
+    dereference_array_of_refs_not_inlined::<str>();
+    dereference_array_of_refs_not_inlined::<str[6]>();
+    dereference_array_of_refs_not_inlined::<Enum>();
+    dereference_array_of_refs_not_inlined::<(u8, u32)>();
+    dereference_array_of_refs_not_inlined::<b256>();
+    dereference_array_of_refs_not_inlined::<raw_ptr>();
+    dereference_array_of_refs_not_inlined::<raw_slice>();
+}
+
+fn main() -> u64 {
+    test_all_inlined();
+    test_not_inlined();
+
+    42
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_index/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_index/test.toml
@@ -1,0 +1,4 @@
+category = "run"
+expected_result = { action = "return", value = 42 }
+validate_abi = true
+expected_warnings = 1000 # TODO-IG: Set the proper number

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_star/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_star/src/main.sw
@@ -258,10 +258,7 @@ fn test_all_inlined() {
     dereference_array::<u16>();
     dereference_array::<u32>();
     dereference_array::<u64>();
-    // TODO-IG: Uncomment once this issue is solved: https://github.com/FuelLabs/sway/issues/5377 
-    // thread 'main' panicked at sway-ir/src/optimize/sroa.rs:174:25:
-    // assertion failed: ty.is_aggregate(context)
-    //dereference_array::<u256>();
+    dereference_array::<u256>();
     dereference_array::<[u64;2]>();
     dereference_array::<[u64;0]>();
     dereference_array::<Struct>();
@@ -280,8 +277,7 @@ fn test_all_inlined() {
     dereference_tuple::<u16>();
     dereference_tuple::<u32>();
     dereference_tuple::<u64>();
-    // TODO-IG: Uncomment once this issue is solved: https://github.com/FuelLabs/sway/issues/5377 
-    //dereference_tuple::<u256>();
+    dereference_tuple::<u256>();
     dereference_tuple::<[u64;2]>();
     dereference_tuple::<[u64;0]>();
     dereference_tuple::<Struct>();
@@ -300,8 +296,7 @@ fn test_all_inlined() {
     dereference_struct::<u16>();
     dereference_struct::<u32>();
     dereference_struct::<u64>();
-    // TODO-IG: Uncomment once this issue is solved: https://github.com/FuelLabs/sway/issues/5377 
-    //dereference_struct::<u256>();
+    dereference_struct::<u256>();
     dereference_struct::<[u64;2]>();
     dereference_struct::<[u64;0]>();
     dereference_struct::<Struct>();
@@ -361,8 +356,7 @@ fn test_not_inlined() {
     dereference_array_not_inlined::<u16>();
     dereference_array_not_inlined::<u32>();
     dereference_array_not_inlined::<u64>();
-    // TODO-IG: Uncomment once this issue is solved: https://github.com/FuelLabs/sway/issues/5377 
-    //dereference_array_not_inlined::<u256>();
+    dereference_array_not_inlined::<u256>();
     dereference_array_not_inlined::<[u64;2]>();
     dereference_array_not_inlined::<[u64;0]>();
     dereference_array_not_inlined::<Struct>();
@@ -381,8 +375,7 @@ fn test_not_inlined() {
     dereference_tuple_not_inlined::<u16>();
     dereference_tuple_not_inlined::<u32>();
     dereference_tuple_not_inlined::<u64>();
-    // TODO-IG: Uncomment once this issue is solved: https://github.com/FuelLabs/sway/issues/5377 
-    //dereference_tuple_not_inlined::<u256>();
+    dereference_tuple_not_inlined::<u256>();
     dereference_tuple_not_inlined::<[u64;2]>();
     dereference_tuple_not_inlined::<[u64;0]>();
     dereference_tuple_not_inlined::<Struct>();
@@ -401,8 +394,7 @@ fn test_not_inlined() {
     dereference_struct_not_inlined::<u16>();
     dereference_struct_not_inlined::<u32>();
     dereference_struct_not_inlined::<u64>();
-    // TODO-IG: Uncomment once this issue is solved: https://github.com/FuelLabs/sway/issues/5377 
-    //dereference_struct_not_inlined::<u256>();
+    dereference_struct_not_inlined::<u256>();
     dereference_struct_not_inlined::<[u64;2]>();
     dereference_struct_not_inlined::<[u64;0]>();
     dereference_struct_not_inlined::<Struct>();

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/references_in_aggregates/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/references_in_aggregates/src/main.sw
@@ -59,6 +59,10 @@ fn in_structs() {
     assert((*&array)[0] == (*a.r_array)[0]);
     assert((*&array)[1] == (*a.r_array)[1]);
     assert((*&array)[2] == (*a.r_array)[2]);
+    
+    assert((&array)[0] == a.r_array[0]);
+    assert((&array)[1] == a.r_array[1]);
+    assert((&array)[2] == a.r_array[2]);
 
     let b_r_a_ptr = asm(r: b.r_a) { r: raw_ptr };
 
@@ -81,6 +85,10 @@ fn in_structs() {
     assert((*((*(*b.r_array)[0]).r_array))[0] == (*a.r_array)[0]);
     assert((*((*(*b.r_array)[0]).r_array))[1] == (*a.r_array)[1]);
     assert((*((*(*b.r_array)[0]).r_array))[2] == (*a.r_array)[2]);
+    
+    assert(((*(b.r_array)[0]).r_array)[0] == a.r_array[0]);
+    assert(((*(b.r_array)[0]).r_array)[1] == a.r_array[1]);
+    assert(((*(b.r_array)[0]).r_array)[2] == a.r_array[2]);
 }
 
 #[inline(never)]
@@ -121,6 +129,10 @@ fn in_enums() {
             assert((*(*local_r_a).r_array)[0] == (*&array)[0]);
             assert((*(*local_r_a).r_array)[1] == (*&array)[1]);
             assert((*(*local_r_a).r_array)[2] == (*&array)[2]);
+            
+            assert((*local_r_a).r_array[0] == (&array)[0]);
+            assert((*local_r_a).r_array[1] == (&array)[1]);
+            assert((*local_r_a).r_array[2] == (&array)[2]);
         }
         _ => assert(false),
     }
@@ -137,6 +149,10 @@ fn in_enums() {
             assert((*(*(*(*local_r_b).r_array)[0]).r_array)[0] == (*&array)[0]);
             assert((*(*(*(*local_r_b).r_array)[0]).r_array)[1] == (*&array)[1]);
             assert((*(*(*(*local_r_b).r_array)[0]).r_array)[2] == (*&array)[2]);
+            
+            assert((*(*local_r_b).r_array[0]).r_array[0] == (&array)[0]);
+            assert((*(*local_r_b).r_array[0]).r_array[1] == (&array)[1]);
+            assert((*(*local_r_b).r_array[0]).r_array[2] == (&array)[2]);
         }
         _ => assert(false),
     }
@@ -172,6 +188,10 @@ fn in_arrays() {
     assert((*(*((*(*arr[1]).r_array)[2])).r_array)[0] == (*&array)[0]);
     assert((*(*((*(*arr[1]).r_array)[2])).r_array)[1] == (*&array)[1]);
     assert((*(*((*(*arr[1]).r_array)[2])).r_array)[2] == (*&array)[2]);
+    
+    assert((*((*arr[1]).r_array[2])).r_array[0] == (&array)[0]);
+    assert((*((*arr[1]).r_array[2])).r_array[1] == (&array)[1]);
+    assert((*((*arr[1]).r_array[2])).r_array[2] == (&array)[2]);
 }
 
 #[inline(never)]
@@ -204,6 +224,10 @@ fn in_tuples() {
     assert((*(*((*(*tuple.1).r_array)[2])).r_array)[0] == (*&array)[0]);
     assert((*(*((*(*tuple.1).r_array)[2])).r_array)[1] == (*&array)[1]);
     assert((*(*((*(*tuple.1).r_array)[2])).r_array)[2] == (*&array)[2]);
+    
+    assert((*((*tuple.1).r_array[2])).r_array[0] == (&array)[0]);
+    assert((*((*tuple.1).r_array[2])).r_array[1] == (&array)[1]);
+    assert((*((*tuple.1).r_array[2])).r_array[2] == (&array)[2]);
 }
 
 #[inline(never)]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/referencing_function_parameters/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/referencing_function_parameters/src/main.sw
@@ -64,6 +64,9 @@ fn array_parameter(p: [u64;2]) {
     assert(p_ptr.read::<[u64;2]>() == p);
 
     assert(*r_p_1 == *r_p_2);
+    
+    assert(r_p_1[0] == r_p_2[0]);
+    assert(r_p_1[1] == r_p_2[1]);
 }
 
 #[inline(never)]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/referencing_parts_of_aggregates/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/referencing_parts_of_aggregates/src/main.sw
@@ -48,7 +48,7 @@ impl C {
     }
 }
 
-// TODO-IG: Add tests for accessing via reference chains once dereferencing operators `[]` and `.` are implemented.
+// TODO-IG: Add tests for accessing via reference chains once dereferencing operator `.` is implemented.
 
 #[inline(always)]
 fn struct_fields() {
@@ -128,7 +128,6 @@ fn tuple_fields_not_inlined() {
 
 #[inline(always)]
 fn array_elements() {
-    // TODO-IG: Add tests for arrays of references once dereferencing operator `[]` is implemented.
     let x1 = 111u8;
     let x2 = 222u8;
 
@@ -159,6 +158,18 @@ fn array_elements() {
 
     assert(*r_a3_a2_a1_x1 == x1);
     assert(*r_a3_a2_a1_x2 == x2);
+
+    let a_r1 = [&x1, &x2];
+    let a_r2 = [&a_r1, &a_r1];
+    let a_r3 = [&a_r2, &a_r2];
+
+    let r_a_r3_a_r2_a_r1_x1: & &u8 = &a_r3[0][1][0];
+    assert(**r_a_r3_a_r2_a_r1_x1 == x1);
+
+    assert(*(&a_r3)[0][0][0] == x1);
+    assert(*(& &a_r3)[0][1][0] == x1);
+    assert(*(& & &a_r3)[0][0][1] == x2);
+    assert(*(& & & &a_r3)[0][1][1] == x2);
 }
 
 #[inline(never)]


### PR DESCRIPTION
## Description

This PR implements index operator `[]` for [references](https://github.com/FuelLabs/sway-rfcs/blob/ironcev/amend-references/files/0010-references.sw). The overall effort related to references is tracked in #5063.

`[]` is defined for references using this recursive definition: `<reference>[<index>] := (*<reference>)[<index>]`.

This eliminates the need for the dereferencing operator `*` when working with references to arrays:

```Sway
let array = [1, 2, 3];

let r = &&&array;

assert((***r)[0] == r[0]);
```
```Sway
let r = &&&[ &&[1, 2, 3], &&[4, 5, 6] ];
assert(r[0][2] == 3);
assert(r[1][0] == 4);
```

Additionally, the PR fixes two previously existing issues (see below screenshots):
- the misleading error message on type not implementing the "index" method when indexing a non-indexable type.
- the broken error span and expression text when indexing a non-indexable type in reassignments.

Before:
![No method named index found for type](https://github.com/FuelLabs/sway/assets/4142833/4693510d-bcb4-45ca-8f41-7988a8d87b3e)

![Not an indexable expression - Before](https://github.com/FuelLabs/sway/assets/4142833/6b8f28f0-25db-4ba8-b6a5-3d5468c70cdc)

After:
![Type is not indexable](https://github.com/FuelLabs/sway/assets/4142833/df160b3b-312e-40dc-b32f-71786ee382ea)

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
