### PR TITLE
"i.e." -> "e.g."

### DIFF
--- a/docs/book/src/basics/built_in_types.md
+++ b/docs/book/src/basics/built_in_types.md
@@ -21,7 +21,7 @@ Sway has the following primitive types:
 1. `str[]` (fixed-length string)
 1. `str` (string slices)
 1. `bool` (Boolean `true` or `false`)
-1. `b256` (256 bits (32 bytes), i.e. a hash)
+1. `b256` (256 bits (32 bytes), e.g. a hash)
 
 All other types in Sway are built up of these primitive types, or references to these primitive types. You may notice that there are no signed integers&mdash;this is by design. In the blockchain domain that Sway occupies, floating-point values and negative numbers have smaller utility, so their implementation has been left up to libraries for specific use cases.
 <!-- prim_types:example:end -->


### PR DESCRIPTION
Fix a small typo in built_in_types.md.