### PR TITLE
Support for criterion-compare-prs gh action

### DIFF
--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -68,3 +68,6 @@ tower = { version = "0.4.12", default-features = false, features = ["util"] }
 [[bench]]
 name = "bench_main"
 harness = false
+
+[lib]
+bench = false


### PR DESCRIPTION
## Description

The extra config in Cargo.toml is because of this issue: bheisler/criterion.rs#275

Once merged, this PR should be working: https://github.com/FuelLabs/sway/pull/5546

This doesn't affect running benchmarks locally.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
