### PR TITLE
Dereferencing operator `.` on tuple element access

### DIFF
--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -1345,7 +1345,7 @@ impl<'eng> FnCompiler<'eng> {
 
         let referenced_type = self.engines.te().get_unaliased(referenced_ast_type);
 
-        let result = if referenced_type.is_copy_type() || referenced_type.is_reference_type() {
+        let result = if referenced_type.is_copy_type() || referenced_type.is_reference() {
             // For non aggregates, we need to return the value.
             // This means, loading the value the `ptr` is pointing to.
             self.current_block.append(context).load(ptr)
@@ -3005,7 +3005,7 @@ impl<'eng> FnCompiler<'eng> {
                     if initializer_val
                         .get_type(context)
                         .map_or(false, |ty| ty.is_ptr(context))
-                        && (init_type.is_copy_type() || init_type.is_reference_type())
+                        && (init_type.is_copy_type() || init_type.is_reference())
                     {
                         // It's a pointer to a copy type, or a reference behind a pointer. We need to dereference it.
                         // We can get a reference behind a pointer if a reference variable is passed to the ASM block.

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -103,6 +103,13 @@ pub enum TyExpressionVariant {
     TupleElemAccess {
         prefix: Box<TyExpression>,
         elem_to_access_num: usize,
+        /// Final resolved type of the `prefix` part
+        /// of the expression. This will always be
+        /// a [TypeId] of a tuple, never an alias
+        /// or a reference to a tuple.
+        /// The original parent might be an alias
+        /// or a direct or indirect reference to a
+        /// tuple.
         resolved_type_of_parent: TypeId,
         elem_to_access_span: Span,
     },

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1855,7 +1855,7 @@ impl ty::TyExpression {
                 _ => {
                     return Err(handler.emit_err(CompileError::NotIndexable {
                         actually: engines.help_out(prefix_type_id).to_string(),
-                        span: prefix_span.clone(),
+                        span: prefix_span,
                     }))
                 }
             };

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_field_access.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_field_access.rs
@@ -52,7 +52,7 @@ pub(crate) fn instantiate_struct_field_access(
                     actually: engines.help_out(prefix_type_id).to_string(),
                     storage_variable: None,
                     field_name: (&field_to_access).into(),
-                    span: prefix_span.clone(),
+                    span: prefix_span,
                 }))
             }
         };

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/tuple_index_access.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/tuple_index_access.rs
@@ -41,12 +41,14 @@ pub(crate) fn instantiate_tuple_index_access(
             }
             TypeInfo::ErrorRecovery(err) => return Err(*err),
             _ => {
-                return Err(handler.emit_err(CompileError::TupleElementAccessOnNonTuple {
-                    actually: engines.help_out(prefix_type_id).to_string(),
-                    span: prefix_span,
-                    index,
-                    index_span,
-                }))
+                return Err(
+                    handler.emit_err(CompileError::TupleElementAccessOnNonTuple {
+                        actually: engines.help_out(prefix_type_id).to_string(),
+                        span: prefix_span,
+                        index,
+                        index_span,
+                    }),
+                )
             }
         };
     }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/tuple_index_access.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/tuple_index_access.rs
@@ -1,7 +1,7 @@
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::Span;
 
-use crate::{language::ty, CompileError, Engines};
+use crate::{language::ty, CompileError, Engines, TypeInfo};
 
 pub(crate) fn instantiate_tuple_index_access(
     handler: &Handler,
@@ -12,33 +12,68 @@ pub(crate) fn instantiate_tuple_index_access(
     span: Span,
 ) -> Result<ty::TyExpression, ErrorEmitted> {
     let type_engine = engines.te();
-    let mut tuple_type_arg_to_access = None;
-    let type_info = type_engine.get(parent.return_type);
-    let type_args = type_info.expect_tuple(handler, engines, &parent.span)?;
-    for (pos, type_arg) in type_args.iter().enumerate() {
-        if pos == index {
-            tuple_type_arg_to_access = Some(type_arg.clone());
-        }
+
+    let mut current_prefix_te = Box::new(parent);
+    let mut current_type = type_engine.get_unaliased(current_prefix_te.return_type);
+
+    let prefix_type_id = current_prefix_te.return_type;
+    let prefix_span = current_prefix_te.span.clone();
+
+    // Create the prefix part of the final tuple element access expression.
+    // This might be an expression that directly evaluates to a tuple type,
+    // or an arbitrary number of dereferencing expressions where the last one
+    // dereference to a tuple type.
+    //
+    // We will either hit a tuple at the end or return an error, so the
+    // loop cannot be endless.
+    while !current_type.is_tuple() {
+        match &*current_type {
+            TypeInfo::Ref(referenced_type) => {
+                let referenced_type_id = referenced_type.type_id;
+
+                current_prefix_te = Box::new(ty::TyExpression {
+                    expression: ty::TyExpressionVariant::Deref(current_prefix_te),
+                    return_type: referenced_type_id,
+                    span: prefix_span.clone(),
+                });
+
+                current_type = type_engine.get_unaliased(referenced_type_id);
+            }
+            TypeInfo::ErrorRecovery(err) => return Err(*err),
+            _ => {
+                return Err(handler.emit_err(CompileError::TupleElementAccessOnNonTuple {
+                    actually: engines.help_out(prefix_type_id).to_string(),
+                    span: prefix_span,
+                    index,
+                    index_span,
+                }))
+            }
+        };
     }
-    let tuple_type_arg_to_access = match tuple_type_arg_to_access {
-        Some(tuple_type_arg_to_access) => tuple_type_arg_to_access,
-        None => {
-            return Err(handler.emit_err(CompileError::TupleIndexOutOfBounds {
-                index,
-                count: type_args.len(),
-                span: index_span,
-            }));
-        }
+
+    let TypeInfo::Tuple(type_args) = &*current_type else {
+        panic!("The current type must be a tuple.");
     };
-    let exp = ty::TyExpression {
+
+    if type_args.len() <= index {
+        return Err(handler.emit_err(CompileError::TupleIndexOutOfBounds {
+            index,
+            count: type_args.len(),
+            tuple_type: engines.help_out(prefix_type_id).to_string(),
+            referencing_level: type_engine.get_referencing_level(prefix_type_id),
+            span: index_span,
+            prefix_span,
+        }));
+    }
+
+    Ok(ty::TyExpression {
         expression: ty::TyExpressionVariant::TupleElemAccess {
-            resolved_type_of_parent: parent.return_type,
-            prefix: Box::new(parent),
+            resolved_type_of_parent: current_prefix_te.return_type,
+            prefix: current_prefix_te,
             elem_to_access_num: index,
             elem_to_access_span: index_span,
         },
-        return_type: tuple_type_arg_to_access.type_id,
+        return_type: type_args[index].type_id,
         span,
-    };
-    Ok(exp)
+    })
 }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/tuple_index_access.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/tuple_index_access.rs
@@ -62,7 +62,6 @@ pub(crate) fn instantiate_tuple_index_access(
             index,
             count: type_args.len(),
             tuple_type: engines.help_out(prefix_type_id).to_string(),
-            referencing_level: type_engine.get_referencing_level(prefix_type_id),
             span: index_span,
             prefix_span,
         }));

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -427,7 +427,10 @@ impl Items {
                             return Err(handler.emit_err(CompileError::TupleIndexOutOfBounds {
                                 index: *index,
                                 count: fields.len(),
-                                span: Span::join(full_span_for_error, index_span.clone()),
+                                tuple_type: engines.help_out(symbol).to_string(),
+                                referencing_level: type_engine.get_referencing_level(symbol),
+                                span:  index_span.clone(),
+                                prefix_span: full_span_for_error.clone(),
                             }));
                         }
                     };
@@ -460,10 +463,12 @@ impl Items {
                         span: full_span_for_error,
                     }));
                 }
-                (actually, ty::ProjectionKind::TupleField { .. }) => {
-                    return Err(handler.emit_err(CompileError::NotATuple {
+                (actually, ty::ProjectionKind::TupleField { index, index_span, .. }) => {
+                    return Err(handler.emit_err(CompileError::TupleElementAccessOnNonTuple {
                         actually: engines.help_out(actually).to_string(),
                         span: full_span_for_error,
+                        index: *index,
+                        index_span: index_span.clone(),
                     }));
                 }
                 (actually, ty::ProjectionKind::ArrayIndex { .. }) => {

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -429,7 +429,7 @@ impl Items {
                                 count: fields.len(),
                                 tuple_type: engines.help_out(symbol).to_string(),
                                 referencing_level: type_engine.get_referencing_level(symbol),
-                                span:  index_span.clone(),
+                                span: index_span.clone(),
                                 prefix_span: full_span_for_error.clone(),
                             }));
                         }
@@ -463,13 +463,20 @@ impl Items {
                         span: full_span_for_error,
                     }));
                 }
-                (actually, ty::ProjectionKind::TupleField { index, index_span, .. }) => {
-                    return Err(handler.emit_err(CompileError::TupleElementAccessOnNonTuple {
-                        actually: engines.help_out(actually).to_string(),
-                        span: full_span_for_error,
-                        index: *index,
-                        index_span: index_span.clone(),
-                    }));
+                (
+                    actually,
+                    ty::ProjectionKind::TupleField {
+                        index, index_span, ..
+                    },
+                ) => {
+                    return Err(
+                        handler.emit_err(CompileError::TupleElementAccessOnNonTuple {
+                            actually: engines.help_out(actually).to_string(),
+                            span: full_span_for_error,
+                            index: *index,
+                            index_span: index_span.clone(),
+                        }),
+                    );
                 }
                 (actually, ty::ProjectionKind::ArrayIndex { .. }) => {
                     return Err(handler.emit_err(CompileError::NotIndexable {

--- a/sway-core/src/semantic_analysis/namespace/items.rs
+++ b/sway-core/src/semantic_analysis/namespace/items.rs
@@ -428,7 +428,6 @@ impl Items {
                                 index: *index,
                                 count: fields.len(),
                                 tuple_type: engines.help_out(symbol).to_string(),
-                                referencing_level: type_engine.get_referencing_level(symbol),
                                 span: index_span.clone(),
                                 prefix_span: full_span_for_error.clone(),
                             }));

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -104,31 +104,6 @@ impl TypeEngine {
         }
     }
 
-    /// Returns the number of dereferencing operations needed to come from the type
-    /// specified with [TypeId] `id` to a type which is not a [TypeInfo::Ref].
-    /// If the type specified by `id` is not a reference, zero is returned.
-    /// In general, assuming the `T` is not a reference, the method returns:
-    ///       T -> 0
-    ///      &T -> 1
-    ///     &&T -> 2
-    ///  &...&T -> n, where n is the number of referencing operations
-    ///
-    /// Aliases are unaliased, and seen either as a [TypeInfo::Ref]
-    /// or a non-reference.
-    pub fn get_referencing_level(&self, id: TypeId) -> usize {
-        let mut referencing_level = 0;
-        let mut type_info = self.get_unaliased(id);
-
-        // We cannot have self-referencing references, so this loop always ends.
-        while let TypeInfo::Ref(referenced_type) = &*type_info {
-            referencing_level += 1;
-
-            type_info = self.get_unaliased(referenced_type.type_id);
-        }
-
-        referencing_level
-    }
-
     /// Make the types of `received` and `expected` equivalent (or produce an
     /// error if there is a conflict between them).
     ///

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -104,6 +104,31 @@ impl TypeEngine {
         }
     }
 
+    /// Returns the number of dereferencing operations needed to come from the type
+    /// specified with [TypeId] `id` to a type which is not a [TypeInfo::Ref].
+    /// If the type specified by `id` is not a reference, zero is returned.
+    /// In general, assuming the `T` is not a reference, the method returns:
+    ///       T -> 0
+    ///      &T -> 1
+    ///     &&T -> 2
+    ///  &...&T -> n, where n is the number of referencing operations
+    ///
+    /// Aliases are unaliased, and seen either as a [TypeInfo::Ref]
+    /// or a non-reference.
+    pub fn get_referencing_level(&self, id: TypeId) -> usize {
+        let mut referencing_level = 0;
+        let mut type_info = self.get_unaliased(id);
+
+        // We cannot have self-referencing references, so this loop always ends.
+        while let TypeInfo::Ref(referenced_type) = &*type_info {
+            referencing_level += 1;
+
+            type_info = self.get_unaliased(referenced_type.type_id);
+        }
+
+        referencing_level
+    }
+
     /// Make the types of `received` and `expected` equivalent (or produce an
     /// error if there is a conflict between them).
     ///

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -303,7 +303,7 @@ pub enum CompileError {
         field_name: IdentUnique,
         span: Span,
     },
-    #[error("This expression has type \"{actually}\", which is not a tuple. Elements can be access only on tuples.")]
+    #[error("This expression has type \"{actually}\", which is not a tuple. Elements can only be accessed on tuples.")]
     TupleElementAccessOnNonTuple {
         actually: String,
         span: Span,

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -565,12 +565,6 @@ pub enum CompileError {
         index: usize,
         count: usize,
         tuple_type: String,
-        /// Denotes if the tuple element access occurs over
-        /// references. The meaning of the `referencing_level` is:
-        ///   0 - no referencing. Element access directly on a tuple type.
-        ///   1 - single referencing. Element access over a reference to a tuple type.
-        ///   n - n levels of referencing. Element access over a reference to a reference ... to a tuple type.
-        referencing_level: usize,
         span: Span,
         prefix_span: Span,
     },
@@ -1831,19 +1825,12 @@ impl ToDiagnostic for CompileError {
                 },
                 help: vec![],
             },
-            TupleIndexOutOfBounds { index, count, tuple_type, referencing_level, span, prefix_span } => Diagnostic {
+            TupleIndexOutOfBounds { index, count, tuple_type, span, prefix_span } => Diagnostic {
                 reason: Some(Reason::new(code(1), "Tuple index is out of bounds".to_string())),
                 issue: Issue::error(
                     source_engine,
                     span.clone(),
-                    format!("Tuple index {index} is out of bounds. The {}tuple has only {count} element{}.",
-                        if *referencing_level > 0 {
-                            "referenced "
-                        } else {
-                            ""
-                        },
-                        plural_s(*count)
-                    )
+                    format!("Tuple index {index} is out of bounds. The tuple has only {count} element{}.", plural_s(*count))
                 ),
                 hints: vec![
                     Hint::info(
@@ -1851,19 +1838,6 @@ impl ToDiagnostic for CompileError {
                         prefix_span.clone(),
                         format!("This expression has type \"{tuple_type}\".")
                     ),
-                    Hint::info(
-                        source_engine,
-                        prefix_span.clone(),
-                        format!("That is {} tuple of only {} element{}.",
-                            match *referencing_level {
-                                0 => "a",
-                                1 => "a reference to a",
-                                _ => "an indirect reference to a",
-                            },
-                            number_to_str(*count),
-                            plural_s(*count)
-                        )
-                    )
                 ],
                 help: vec![],
             },

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -303,8 +303,13 @@ pub enum CompileError {
         field_name: IdentUnique,
         span: Span,
     },
-    #[error("This is a {actually}, not a tuple. Elements can only be access on tuples.")]
-    NotATuple { actually: String, span: Span },
+    #[error("This expression has type \"{actually}\", which is not a tuple. Elements can be access only on tuples.")]
+    TupleElementAccessOnNonTuple {
+        actually: String,
+        span: Span,
+        index: usize,
+        index_span: Span,
+    },
     #[error("This expression has type \"{actually}\", which is not an indexable type.")]
     NotIndexable { actually: String, span: Span },
     #[error("\"{name}\" is a {actually}, not an enum.")]
@@ -555,11 +560,19 @@ pub enum CompileError {
     InvalidOpcodeFromPredicate { opcode: String, span: Span },
     #[error("Array index out of bounds; the length is {count} but the index is {index}.")]
     ArrayOutOfBounds { index: u64, count: u64, span: Span },
-    #[error("Tuple index out of bounds; the arity is {count} but the index is {index}.")]
+    #[error("Tuple index {index} is out of bounds. The tuple has {count} element{}.", plural_s(*count))]
     TupleIndexOutOfBounds {
         index: usize,
         count: usize,
+        tuple_type: String,
+        /// Denotes if the tuple element access occurs over
+        /// references. The meaning of the `referencing_level` is:
+        ///   0 - no referencing. Element access directly on a tuple type.
+        ///   1 - single referencing. Element access over a reference to a tuple type.
+        ///   n - n levels of referencing. Element access over a reference to a reference ... to a tuple type.
+        referencing_level: usize,
         span: Span,
+        prefix_span: Span,
     },
     #[error("Constants cannot be shadowed. {variable_or_constant} \"{name}\" shadows constant with the same name.")]
     ConstantsCannotBeShadowed {
@@ -894,7 +907,7 @@ impl Spanned for CompileError {
             StructFieldDoesNotExist { field_name, .. } => field_name.span(),
             MethodNotFound { span, .. } => span.clone(),
             ModuleNotFound { span, .. } => span.clone(),
-            NotATuple { span, .. } => span.clone(),
+            TupleElementAccessOnNonTuple { span, .. } => span.clone(),
             NotAStruct { span, .. } => span.clone(),
             NotIndexable { span, .. } => span.clone(),
             FieldAccessOnNonStruct { span, .. } => span.clone(),
@@ -1818,6 +1831,62 @@ impl ToDiagnostic for CompileError {
                 },
                 help: vec![],
             },
+            TupleIndexOutOfBounds { index, count, tuple_type, referencing_level, span, prefix_span } => Diagnostic {
+                reason: Some(Reason::new(code(1), "Tuple index is out of bounds".to_string())),
+                issue: Issue::error(
+                    source_engine,
+                    span.clone(),
+                    format!("Tuple index {index} is out of bounds. The {}tuple has only {count} element{}.",
+                        if *referencing_level > 0 {
+                            "referenced "
+                        } else {
+                            ""
+                        },
+                        plural_s(*count)
+                    )
+                ),
+                hints: vec![
+                    Hint::info(
+                        source_engine,
+                        prefix_span.clone(),
+                        format!("This expression has type \"{tuple_type}\".")
+                    ),
+                    Hint::info(
+                        source_engine,
+                        prefix_span.clone(),
+                        format!("That is {} tuple of only {} element{}.",
+                            match *referencing_level {
+                                0 => "a",
+                                1 => "a reference to a",
+                                _ => "an indirect reference to a",
+                            },
+                            number_to_str(*count),
+                            plural_s(*count)
+                        )
+                    )
+                ],
+                help: vec![],
+            },
+            TupleElementAccessOnNonTuple { actually, span, index, index_span } => Diagnostic {
+                reason: Some(Reason::new(code(1), "Tuple element access requires a tuple".to_string())),
+                issue: Issue::error(
+                    source_engine,
+                    span.clone(),
+                    format!("This expression has type \"{actually}\", which is not a tuple or a reference to a tuple.")
+                ),
+                hints: vec![
+                    Hint::info(
+                        source_engine,
+                        index_span.clone(),
+                        format!("Tuple element access happens here, on the index {index}.")
+                    )
+                ],
+                help: vec![
+                    "In Sway, tuple elements can be accessed on:".to_string(),
+                    format!("{}- tuples. E.g., `my_tuple.1`.", Indent::Single),
+                    format!("{}- references, direct or indirect, to tuples. E.g., `(&my_tuple).1` or `(&&&my_tuple).1`.", Indent::Single),
+                ],
+            },
            _ => Diagnostic {
                     // TODO: Temporary we use self here to achieve backward compatibility.
                     //       In general, self must not be used and will not be used once we
@@ -1861,7 +1930,7 @@ pub enum StructFieldUsageContext {
     StorageAccess,
     PatternMatching { has_rest_pattern: bool },
     StructFieldAccess,
-    // TODO: Distinguish between struct filed access and destructing
+    // TODO: Distinguish between struct field access and destructing
     //       once https://github.com/FuelLabs/sway/issues/5478 is implemented
     //       and provide specific suggestions for these two cases.
     //       (Destructing desugars to plain struct field access.)

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_dot_on_tuples/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_dot_on_tuples/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-F898797E7BC715F8"
+
+[[package]]
+name = "dereferencing_operator_dot_on_tuples"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "std"
+source = "path+from-root-F898797E7BC715F8"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_dot_on_tuples/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_dot_on_tuples/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "dereferencing_operator_dot_on_tuples"
+
+[dependencies]
+std = { path = "../../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_dot_on_tuples/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_dot_on_tuples/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_dot_on_tuples/src/impls.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_dot_on_tuples/src/impls.sw
@@ -1,0 +1,258 @@
+library;
+
+use core::ops::Eq;
+use std::bytes_conversions::u256::*;
+use std::bytes_conversions::b256::*;
+
+pub trait TestInstance {
+    fn new() -> Self;
+    fn different() -> Self;
+}
+
+impl TestInstance for bool {
+    fn new() -> Self {
+        true
+    }
+    fn different() -> Self {
+        false
+    }
+}
+
+impl TestInstance for u8 {
+    fn new() -> Self {
+        123
+    }
+    fn different() -> Self {
+        223
+    }
+}
+
+impl TestInstance for u16 {
+    fn new() -> Self {
+        1234
+    }
+    fn different() -> Self {
+        4321
+    }
+}
+
+impl TestInstance for u32 {
+    fn new() -> Self {
+        12345
+    }
+    fn different() -> Self {
+        54321
+    }
+}
+
+impl TestInstance for u64 {
+    fn new() -> Self {
+        123456
+    }
+    fn different() -> Self {
+        654321
+    }
+}
+
+impl TestInstance for u256 {
+    fn new() -> Self {
+        0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20u256
+    }
+    fn different() -> Self {
+        0x0203040405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1f1a20u256
+    }
+}
+
+impl TestInstance for str {
+    fn new() -> Self {
+        "1a2B3c"
+    }
+    fn different() -> Self {
+        "3A2b1C"
+    }
+}
+
+impl Eq for str[6] {
+    fn eq(self, other: Self) -> bool {
+        let mut i = 0;
+        while i < 6 {
+            let ptr_self = __addr_of(self).add::<u8>(i);
+            let ptr_other = __addr_of(other).add::<u8>(i);
+
+            if ptr_self.read::<u8>() != ptr_other.read::<u8>() {
+                return false;
+            }
+
+            i = i + 1;
+        };
+        
+        true
+    }
+}
+
+impl TestInstance for str[6] {
+    fn new() -> Self {
+        __to_str_array("1a2B3c")
+    }
+    fn different() -> Self {
+        __to_str_array("3A2b1C")
+    }
+}
+
+impl Eq for [u64;2] {
+    fn eq(self, other: Self) -> bool {
+        self[0] == other[0] && self[1] == other[1] 
+    }
+}
+
+impl TestInstance for [u64;2] {
+    fn new() -> Self {
+        [123456, 654321]
+    }
+    fn different() -> Self {
+        [654321, 123456]
+    }
+}
+
+pub struct Struct {
+    x: u64,
+}
+
+impl Eq for Struct {
+    fn eq(self, other: Self) -> bool {
+        self.x == other.x
+    }
+}
+
+impl TestInstance for Struct {
+    fn new() -> Self {
+        Self { x: 98765 }
+    }
+    fn different() -> Self {
+        Self { x: 56789 }
+    }
+}
+
+pub struct EmptyStruct { }
+
+impl Eq for EmptyStruct {
+    fn eq(self, other: Self) -> bool {
+        true
+    }
+}
+
+impl TestInstance for EmptyStruct {
+    fn new() -> Self {
+        EmptyStruct { }
+    }
+    fn different() -> Self {
+        EmptyStruct { }
+    }
+}
+
+pub enum Enum {
+    A: u64,
+}
+
+impl Eq for Enum {
+    fn eq(self, other: Self) -> bool {
+        match (self, other) {
+            (Enum::A(l), Enum::A(r)) => l == r,
+        }
+    }
+}
+
+impl TestInstance for Enum {
+    fn new() -> Self {
+        Self::A(123456)
+    }
+    fn different() -> Self {
+        Self::A(654321)
+    }
+}
+
+impl Eq for (u8, u32) {
+    fn eq(self, other: Self) -> bool {
+        self.0 == other.0 && self.1 == other.1
+    }
+}
+
+impl TestInstance for (u8, u32) {
+    fn new() -> Self {
+        (123, 12345)
+    }
+    fn different() -> Self {
+        (223, 54321)
+    }
+}
+
+impl TestInstance for b256 {
+    fn new() -> Self {
+        0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20
+    }
+    fn different() -> Self {
+        0x0202020405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1f1a20
+    }
+}
+
+impl TestInstance for raw_ptr {
+    fn new() -> Self {
+        let null_ptr = asm() { zero: raw_ptr };
+
+        null_ptr.add::<u64>(42)
+    }
+    fn different() -> Self {
+        let null_ptr = asm() { zero: raw_ptr };
+
+        null_ptr.add::<u64>(42*2)
+    }
+}
+
+impl TestInstance for raw_slice {
+    fn new() -> Self {
+        let null_ptr = asm() { zero: raw_ptr };
+        
+        std::raw_slice::from_parts::<u64>(null_ptr, 42)
+    }
+    fn different() -> Self {
+        let null_ptr = asm() { zero: raw_ptr };
+        
+        std::raw_slice::from_parts::<u64>(null_ptr, 42*2)
+    }
+}
+
+impl Eq for raw_slice {
+    fn eq(self, other: Self) -> bool {
+        self.ptr() == other.ptr() && self.number_of_bytes() == other.number_of_bytes()
+    }
+}
+
+impl TestInstance for () {
+    fn new() -> Self {
+        ()
+    }
+    fn different() -> Self {
+        ()
+    }
+}
+
+impl Eq for () {
+    fn eq(self, other: Self) -> bool {
+        true
+    }
+}
+
+impl TestInstance for [u64;0] {
+    fn new() -> Self {
+        []
+    }
+    fn different() -> Self {
+        []
+    }
+}
+
+impl Eq for [u64;0] {
+    fn eq(self, other: Self) -> bool {
+        true
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_dot_on_tuples/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_dot_on_tuples/src/main.sw
@@ -1,0 +1,220 @@
+script;
+
+mod impls;
+use impls::*;
+use core::ops::Eq;
+
+impl<T> Eq for & &T
+    where T: TestInstance + Eq
+{
+    fn eq(self, other: Self) -> bool {
+        **self == **other
+    }
+}
+
+impl<T> Eq for & & &T
+    where T: TestInstance + Eq
+{
+    fn eq(self, other: Self) -> bool {
+        ***self == ***other
+    }
+}
+
+#[inline(always)]
+fn dereference_tuple<T>()
+    where T: TestInstance + Eq
+{
+    let mut x = (T::new(), T::different());
+    let r_x = &x;
+    let r_r_x = &r_x;
+    let r_r_r_x = &r_r_x;
+
+    assert((*r_x).0 == T::new());
+    assert((*r_x).0 == r_x.0);
+    assert((*r_x).1 == T::different());
+    assert((*r_x).1 == r_x.1);
+
+    assert((**r_r_x).0 == T::new());
+    assert((**r_r_x).0 == r_r_x.0);
+    assert((**r_r_x).1 == T::different());
+    assert((**r_r_x).1 == r_r_x.1);
+
+    assert((***r_r_r_x).0 == T::new());
+    assert((***r_r_r_x).0 == r_r_r_x.0);
+    assert((***r_r_r_x).1 == T::different());
+    assert((***r_r_r_x).1 == r_r_r_x.1);
+
+    x.0 = T::different();
+    x.1 = T::new();
+
+    assert((*r_x).0 == T::different());
+    assert((*r_x).0 == r_x.0);
+    assert((*r_x).1 == T::new());
+    assert((*r_x).1 == r_x.1);
+
+    assert((**r_r_x).0 == T::different());
+    assert((**r_r_x).0 == r_r_x.0);
+    assert((**r_r_x).1 == T::new());
+    assert((**r_r_x).1 == r_r_x.1);
+
+    assert((***r_r_r_x).0 == T::different());
+    assert((***r_r_r_x).0 == r_r_r_x.0);
+    assert((***r_r_r_x).1 == T::new());
+    assert((***r_r_r_x).1 == r_r_r_x.1);
+}
+
+#[inline(never)]
+fn dereference_tuple_not_inlined<T>()
+    where T: TestInstance + Eq
+{
+    dereference_tuple::<T>()
+}
+
+#[inline(always)]
+fn dereference_tuple_of_refs<T>()
+    where T: TestInstance + Eq
+{
+    let mut x1 = (T::new(), T::different());
+    let mut x2 = (T::new(), T::different());
+    let embed = (& & &x1, & &x2);
+    let r_embed = &embed;
+    let r_r_embed = &r_embed;
+    let r_r_r_embed = &r_r_embed;
+
+    assert(r_embed.0.0 == T::new());
+    assert(r_embed.0.1 == T::different());
+    assert(r_embed.1.0 == T::new());
+    assert(r_embed.1.1 == T::different());
+
+    assert(r_r_embed.0.0 == T::new());
+    assert(r_r_embed.0.1 == T::different());
+    assert(r_r_embed.1.0 == T::new());
+    assert(r_r_embed.1.1 == T::different());
+
+    assert(r_r_r_embed.0.0 == T::new());
+    assert(r_r_r_embed.0.1 == T::different());
+    assert(r_r_r_embed.1.0 == T::new());
+    assert(r_r_r_embed.1.1 == T::different());
+
+    x1.0 = T::different();
+    x1.1 = T::new();
+
+    x2.0 = T::different();
+    x2.1 = T::new();
+
+    assert(r_embed.0.0 == T::different());
+    assert(r_embed.0.1 == T::new());
+    assert(r_embed.1.0 == T::different());
+    assert(r_embed.1.1 == T::new());
+
+    assert(r_r_embed.0.0 == T::different());
+    assert(r_r_embed.0.1 == T::new());
+    assert(r_r_embed.1.0 == T::different());
+    assert(r_r_embed.1.1 == T::new());
+
+    assert(r_r_r_embed.0.0 == T::different());
+    assert(r_r_r_embed.0.1 == T::new());
+    assert(r_r_r_embed.1.0 == T::different());
+    assert(r_r_r_embed.1.1 == T::new());
+
+    let r = & & & & &(& & &T::new(), & &T::different());
+
+    assert(r.0 == & & &T::new());
+    assert(r.1 == & &T::different());
+}
+
+#[inline(never)]
+fn dereference_tuple_of_refs_not_inlined<T>()
+    where T: TestInstance + Eq
+{
+    dereference_tuple_of_refs::<T>()
+}
+
+#[inline(never)]
+fn test_all_inlined() {
+    dereference_tuple::<()>();
+    dereference_tuple::<bool>();
+    dereference_tuple::<u8>();
+    dereference_tuple::<u16>();
+    dereference_tuple::<u32>();
+    dereference_tuple::<u64>();
+    dereference_tuple::<u256>();
+    dereference_tuple::<[u64;2]>();
+    dereference_tuple::<[u64;0]>();
+    dereference_tuple::<Struct>();
+    dereference_tuple::<EmptyStruct>();
+    dereference_tuple::<str>();
+    dereference_tuple::<str[6]>();
+    dereference_tuple::<Enum>();
+    dereference_tuple::<(u8, u32)>();
+    dereference_tuple::<b256>();
+    dereference_tuple::<raw_ptr>();
+    dereference_tuple::<raw_slice>();
+    
+    dereference_tuple_of_refs::<()>();
+    dereference_tuple_of_refs::<bool>();
+    dereference_tuple_of_refs::<u8>();
+    dereference_tuple_of_refs::<u16>();
+    dereference_tuple_of_refs::<u32>();
+    dereference_tuple_of_refs::<u64>();
+    dereference_tuple_of_refs::<u256>();
+    dereference_tuple_of_refs::<[u64;2]>();
+    dereference_tuple_of_refs::<[u64;0]>();
+    dereference_tuple_of_refs::<Struct>();
+    dereference_tuple_of_refs::<EmptyStruct>();
+    dereference_tuple_of_refs::<str>();
+    dereference_tuple_of_refs::<str[6]>();
+    dereference_tuple_of_refs::<Enum>();
+    dereference_tuple_of_refs::<(u8, u32)>();
+    dereference_tuple_of_refs::<b256>();
+    dereference_tuple_of_refs::<raw_ptr>();
+    dereference_tuple_of_refs::<raw_slice>();
+}
+
+#[inline(never)]
+fn test_not_inlined() {
+    dereference_tuple_not_inlined::<()>();
+    dereference_tuple_not_inlined::<bool>();
+    dereference_tuple_not_inlined::<u8>();
+    dereference_tuple_not_inlined::<u16>();
+    dereference_tuple_not_inlined::<u32>();
+    dereference_tuple_not_inlined::<u64>();
+    dereference_tuple_not_inlined::<u256>();
+    dereference_tuple_not_inlined::<[u64;2]>();
+    dereference_tuple_not_inlined::<[u64;0]>();
+    dereference_tuple_not_inlined::<Struct>();
+    dereference_tuple_not_inlined::<EmptyStruct>();
+    dereference_tuple_not_inlined::<str>();
+    dereference_tuple_not_inlined::<str[6]>();
+    dereference_tuple_not_inlined::<Enum>();
+    dereference_tuple_not_inlined::<(u8, u32)>();
+    dereference_tuple_not_inlined::<b256>();
+    dereference_tuple_not_inlined::<raw_ptr>();
+    dereference_tuple_not_inlined::<raw_slice>();
+    
+    dereference_tuple_of_refs_not_inlined::<()>();
+    dereference_tuple_of_refs_not_inlined::<bool>();
+    dereference_tuple_of_refs_not_inlined::<u8>();
+    dereference_tuple_of_refs_not_inlined::<u16>();
+    dereference_tuple_of_refs_not_inlined::<u32>();
+    dereference_tuple_of_refs_not_inlined::<u64>();
+    dereference_tuple_of_refs_not_inlined::<u256>();
+    dereference_tuple_of_refs_not_inlined::<[u64;2]>();
+    dereference_tuple_of_refs_not_inlined::<[u64;0]>();
+    dereference_tuple_of_refs_not_inlined::<Struct>();
+    dereference_tuple_of_refs_not_inlined::<EmptyStruct>();
+    dereference_tuple_of_refs_not_inlined::<str>();
+    dereference_tuple_of_refs_not_inlined::<str[6]>();
+    dereference_tuple_of_refs_not_inlined::<Enum>();
+    dereference_tuple_of_refs_not_inlined::<(u8, u32)>();
+    dereference_tuple_of_refs_not_inlined::<b256>();
+    dereference_tuple_of_refs_not_inlined::<raw_ptr>();
+    dereference_tuple_of_refs_not_inlined::<raw_slice>();
+}
+
+fn main() -> u64 {
+    test_all_inlined();
+    test_not_inlined();
+
+    42
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_dot_on_tuples/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_dot_on_tuples/test.toml
@@ -1,0 +1,4 @@
+category = "run"
+expected_result = { action = "return", value = 42 }
+validate_abi = true
+expected_warnings = 50

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_star/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/dereferencing_operator_star/src/main.sw
@@ -106,24 +106,36 @@ fn dereference_tuple<T>()
 
     assert((*r_x).0 == T::new());
     assert((*r_x).1 == T::different());
+    assert((*r_x).0 == r_x.0);
+    assert((*r_x).1 == r_x.1);
 
     assert((**r_r_x).0 == T::new());
     assert((**r_r_x).1 == T::different());
+    assert((**r_r_x).0 == r_r_x.0);
+    assert((**r_r_x).1 == r_r_x.1);
 
     assert((***r_r_r_x).0 == T::new());
     assert((***r_r_r_x).1 == T::different());
+    assert((***r_r_r_x).0 == r_r_r_x.0);
+    assert((***r_r_r_x).1 == r_r_r_x.1);
 
     x.0 = T::different();
     x.1 = T::new();
 
     assert((*r_x).0 == T::different());
     assert((*r_x).1 == T::new());
+    assert((*r_x).0 == r_x.0);
+    assert((*r_x).1 == r_x.1);
 
     assert((**r_r_x).0 == T::different());
     assert((**r_r_x).1 == T::new());
+    assert((**r_r_x).0 == r_r_x.0);
+    assert((**r_r_x).1 == r_r_x.1);
 
     assert((***r_r_r_x).0 == T::different());
     assert((***r_r_r_x).1 == T::new());
+    assert((***r_r_r_x).0 == r_r_r_x.0);
+    assert((***r_r_r_x).1 == r_r_r_x.1);
 }
 
 #[inline(never)]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/references/referencing_function_parameters/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/references/referencing_function_parameters/src/main.sw
@@ -128,6 +128,37 @@ fn struct_parameter_not_inlined(p: S) {
     struct_parameter(p)
 }
 
+impl Eq for (u64, u64) {
+    fn eq(self, other: Self) -> bool {
+        self.0 == other.0 && self.1 == other.1
+    }
+}
+
+#[inline(always)]
+fn tuple_parameter(p: (u64, u64)) {
+    let r_p_1 = &p;
+    let r_p_2 = &p;
+    
+    let p_ptr = asm(r: &p) { r: raw_ptr };
+    let r_p_1_ptr = asm(r: r_p_1) { r: raw_ptr };
+    let r_p_2_ptr = asm(r: r_p_2) { r: raw_ptr };
+
+    assert(p_ptr == r_p_1_ptr);
+    assert(p_ptr == r_p_2_ptr);
+
+    assert(p_ptr.read::<(u64, u64)>() == p);
+
+    assert(*r_p_1 == *r_p_2);
+    
+    assert(r_p_1.0 == r_p_2.0);
+    assert(r_p_1.1 == r_p_2.1);
+}
+
+#[inline(never)]
+fn tuple_parameter_not_inlined(p: (u64, u64)) {
+    tuple_parameter(p)
+}
+
 enum E {
     A: u8,
 }
@@ -208,6 +239,7 @@ fn test_all_inlined() {
     array_parameter([111u64, 222u64]);
     empty_struct_parameter(EmptyStruct { });
     struct_parameter(S { x: 123u8 });
+    tuple_parameter((111u64, 222u64));
     enum_parameter(E::A(123u8));
     generic_parameter();
 }
@@ -218,6 +250,7 @@ fn test_not_inlined() {
     array_parameter_not_inlined([111u64, 222u64]);
     empty_struct_parameter_not_inlined(EmptyStruct { });
     struct_parameter_not_inlined(S { x: 123u8 });
+    tuple_parameter_not_inlined((111u64, 222u64));
     enum_parameter_not_inlined(E::A(123u8));
     generic_parameter_not_inlined();
 }


### PR DESCRIPTION
## Description

This PR implements tuple element access operator `.` for [references](https://github.com/FuelLabs/sway-rfcs/blob/ironcev/amend-references/files/0010-references.sw). The overall effort related to references is tracked in #5063.

`.` is defined for references to tuples using this recursive definition: `<reference>.<element index> := (*<reference>).<element index>`.

This eliminates the need for the dereferencing operator `*` when working with references to tuples:

```Sway
let t = (1, 2, 3);

let r = &&&t;

assert((***r).0 == r.0);
```
```Sway
let r = &&& ( &&(1, 2), &(3, 4) );
assert(r.0.0 == 1);
assert(r.1.1 == 4);
```

Additionally, the PR:
- creates `Diagnostic` for the `TupleIndexOutOfBounds` error.
- harmonizes the appearance of the `TupleIndexOutOfBounds` error in the element access and reassignments.

## Demo

`TupleIndexOutOfBounds` in element access and reassignments before:

![Tuple index out of bounds - Before](https://github.com/FuelLabs/sway/assets/4142833/38dc610e-c9c2-4ae9-a638-d3da3fc38ada)

New errors:

![Tuple index out of bounds - After](https://github.com/FuelLabs/sway/assets/4142833/d1668f7d-15b6-4d76-8644-301d3871568d)

![Tuple element access requires a tuple](https://github.com/FuelLabs/sway/assets/4142833/15c41cea-ccac-417c-9b7b-758dccbc43f8)

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
