### PR TITLE
Disable DCA and writing diagnostics on did_change events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6575,6 +6575,7 @@ dependencies = [
  "pretty_assertions",
  "proc-macro2",
  "quote",
+ "rand",
  "rayon",
  "regex",
  "ropey",

--- a/forc-pkg/src/manifest.rs
+++ b/forc-pkg/src/manifest.rs
@@ -238,7 +238,6 @@ pub struct BuildProfile {
     pub optimization_level: OptLevel,
     #[serde(default)]
     pub experimental: ExperimentalFlags,
-    pub lsp_mode: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
@@ -734,7 +733,6 @@ impl BuildProfile {
             experimental: ExperimentalFlags {
                 new_encoding: false,
             },
-            lsp_mode: false,
         }
     }
 
@@ -757,7 +755,6 @@ impl BuildProfile {
             experimental: ExperimentalFlags {
                 new_encoding: false,
             },
-            lsp_mode: false,
         }
     }
 }

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -33,10 +33,18 @@ use sway_core::{
     abi_generation::{
         evm_abi,
         fuel_abi::{self, AbiContext},
-    }, asm_generation::ProgramABI, decl_engine::DeclRefFunction, fuel_prelude::{
+    },
+    asm_generation::ProgramABI,
+    decl_engine::DeclRefFunction,
+    fuel_prelude::{
         fuel_crypto,
         fuel_tx::{self, Contract, ContractId, StorageSlot},
-    }, language::{parsed::TreeType, Visibility}, semantic_analysis::namespace, source_map::SourceMap, transform::AttributeKind, BuildTarget, Engines, FinalizedEntry, LspConfig
+    },
+    language::{parsed::TreeType, Visibility},
+    semantic_analysis::namespace,
+    source_map::SourceMap,
+    transform::AttributeKind,
+    BuildTarget, Engines, FinalizedEntry, LspConfig,
 };
 use sway_error::{error::CompileError, handler::Handler, warning::CompileWarning};
 use sway_types::constants::{CORE, PRELUDE, STD};

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -33,18 +33,10 @@ use sway_core::{
     abi_generation::{
         evm_abi,
         fuel_abi::{self, AbiContext},
-    },
-    asm_generation::ProgramABI,
-    decl_engine::DeclRefFunction,
-    fuel_prelude::{
+    }, asm_generation::ProgramABI, decl_engine::DeclRefFunction, fuel_prelude::{
         fuel_crypto,
         fuel_tx::{self, Contract, ContractId, StorageSlot},
-    },
-    language::{parsed::TreeType, Visibility},
-    semantic_analysis::namespace,
-    source_map::SourceMap,
-    transform::AttributeKind,
-    BuildTarget, Engines, FinalizedEntry,
+    }, language::{parsed::TreeType, Visibility}, semantic_analysis::namespace, source_map::SourceMap, transform::AttributeKind, BuildTarget, Engines, FinalizedEntry, LspConfig
 };
 use sway_error::{error::CompileError, handler::Handler, warning::CompileWarning};
 use sway_types::constants::{CORE, PRELUDE, STD};
@@ -1567,8 +1559,7 @@ pub fn sway_build_config(
     .with_optimization_level(build_profile.optimization_level)
     .with_experimental(sway_core::ExperimentalFlags {
         new_encoding: build_profile.experimental.new_encoding,
-    })
-    .with_lsp_mode(build_profile.lsp_mode);
+    });
     Ok(build_config)
 }
 
@@ -2598,7 +2589,7 @@ pub fn check(
     plan: &BuildPlan,
     build_target: BuildTarget,
     terse_mode: bool,
-    lsp_mode: bool,
+    lsp_mode: Option<LspConfig>,
     include_tests: bool,
     engines: &Engines,
     retrigger_compilation: Option<Arc<AtomicBool>>,
@@ -2647,7 +2638,7 @@ pub fn check(
             &profile,
         )?
         .with_include_tests(include_tests)
-        .with_lsp_mode(lsp_mode);
+        .with_lsp_mode(lsp_mode.clone());
 
         let input = manifest.entry_string()?;
         let handler = Handler::default();

--- a/forc-plugins/forc-doc/src/main.rs
+++ b/forc-plugins/forc-doc/src/main.rs
@@ -216,8 +216,8 @@ pub fn compile_html(
         &plan,
         BuildTarget::default(),
         build_instructions.silent,
+        None,
         tests_enabled,
-        false,
         &engines,
         None,
     )?;

--- a/forc/src/ops/forc_check.rs
+++ b/forc/src/ops/forc_check.rs
@@ -38,7 +38,7 @@ pub fn check(command: CheckCommand, engines: &Engines) -> Result<(Option<ty::TyP
         &plan,
         build_target,
         terse_mode,
-        false,
+        None,
         tests_enabled,
         engines,
         None,

--- a/sway-core/src/build_config.rs
+++ b/sway-core/src/build_config.rs
@@ -201,7 +201,6 @@ pub struct ExperimentalFlags {
 
 #[derive(Clone, Debug, Default)]
 pub struct LspConfig {
-    pub retrigger_compilation: Option<Arc<AtomicBool>>,
     // This is set to true if compilation was triggered by a didChange LSP event. In this case, we
     // bypass collecting type metadata and skip DCA.
     //

--- a/sway-core/src/build_config.rs
+++ b/sway-core/src/build_config.rs
@@ -1,7 +1,4 @@
-use std::{
-    path::PathBuf,
-    sync::{atomic::AtomicBool, Arc},
-};
+use std::{path::PathBuf, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 use strum::EnumString;

--- a/sway-core/src/build_config.rs
+++ b/sway-core/src/build_config.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, sync::{atomic::AtomicBool, Arc}};
+use std::{
+    path::PathBuf,
+    sync::{atomic::AtomicBool, Arc},
+};
 
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
@@ -195,7 +198,6 @@ impl BuildConfig {
 pub struct ExperimentalFlags {
     pub new_encoding: bool,
 }
-
 
 #[derive(Clone, Debug, Default)]
 pub struct LspConfig {

--- a/sway-core/src/build_config.rs
+++ b/sway-core/src/build_config.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::{atomic::AtomicBool, Arc}};
 
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
@@ -56,7 +56,7 @@ pub struct BuildConfig {
     pub time_phases: bool,
     pub metrics_outfile: Option<String>,
     pub experimental: ExperimentalFlags,
-    pub lsp_mode: bool,
+    pub lsp_mode: Option<LspConfig>,
 }
 
 impl BuildConfig {
@@ -103,7 +103,7 @@ impl BuildConfig {
             metrics_outfile: None,
             optimization_level: OptLevel::Opt0,
             experimental: ExperimentalFlags::default(),
-            lsp_mode: false,
+            lsp_mode: None,
         }
     }
 
@@ -182,7 +182,7 @@ impl BuildConfig {
         }
     }
 
-    pub fn with_lsp_mode(self, lsp_mode: bool) -> Self {
+    pub fn with_lsp_mode(self, lsp_mode: Option<LspConfig>) -> Self {
         Self { lsp_mode, ..self }
     }
 
@@ -194,6 +194,17 @@ impl BuildConfig {
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ExperimentalFlags {
     pub new_encoding: bool,
+}
+
+
+#[derive(Clone, Debug, Default)]
+pub struct LspConfig {
+    pub retrigger_compilation: Option<Arc<AtomicBool>>,
+    // This is set to true if compilation was triggered by a didChange LSP event. In this case, we
+    // bypass collecting type metadata and skip DCA.
+    //
+    // This is set to false if compilation was triggered by a didSave or didOpen LSP event.
+    pub optimized_build: bool,
 }
 
 #[cfg(test)]

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -27,7 +27,7 @@ use crate::source_map::SourceMap;
 pub use asm_generation::from_ir::compile_ir_to_asm;
 use asm_generation::FinalizedAsm;
 pub use asm_generation::{CompiledBytecode, FinalizedEntry};
-pub use build_config::{BuildConfig, BuildTarget, OptLevel, LspConfig};
+pub use build_config::{BuildConfig, BuildTarget, LspConfig, OptLevel};
 use control_flow_analysis::ControlFlowGraph;
 use metadata::MetadataManager;
 use query_engine::{ModuleCacheKey, ModulePath, ProgramsCacheEntry};
@@ -480,6 +480,11 @@ pub fn parsed_to_ast(
     retrigger_compilation: Option<Arc<AtomicBool>>,
 ) -> Result<ty::TyProgram, ErrorEmitted> {
     let experimental = build_config.map(|x| x.experimental).unwrap_or_default();
+    let lsp_config = build_config.map(|x| x.lsp_mode.clone()).unwrap_or_default();
+    let (retrigger_compilation, optimized_build) = lsp_config
+        .as_ref()
+        .map(|lsp| (lsp.retrigger_compilation.clone(), lsp.optimized_build))
+        .unwrap_or((None, false));
 
     // Type check the program.
     let typed_program_opt = ty::TyProgram::type_check(
@@ -491,15 +496,14 @@ pub fn parsed_to_ast(
         build_config,
     );
 
+    check_should_abort(handler, retrigger_compilation.clone())?;
+
     // Only clear the parsed AST nodes if we are running a regular compilation pipeline.
     // LSP needs these to build its token map, and they are cleared by `clear_module` as
     // part of the LSP garbage collection functionality instead.
-    let lsp_mode = build_config.map(|x| x.lsp_mode.clone()).unwrap_or_default();
-    if lsp_mode.is_none() {
+    if lsp_config.is_none() {
         engines.pe().clear();
     }
-
-    check_should_abort(handler, retrigger_compilation.clone())?;
 
     let mut typed_program = match typed_program_opt {
         Ok(typed_program) => typed_program,
@@ -516,51 +520,58 @@ pub fn parsed_to_ast(
         }
     };
 
-    // Collect information about the types used in this program
-    let types_metadata_result = typed_program.collect_types_metadata(
-        handler,
-        &mut CollectTypesMetadataContext::new(engines, experimental),
-    );
-    let types_metadata = match types_metadata_result {
-        Ok(types_metadata) => types_metadata,
-        Err(e) => {
-            handler.dedup();
-            return Err(e);
-        }
+    // Skip collecting metadata if we triggered an optimised build from LSP.
+    let types_metadata = if !optimized_build {
+        // Collect information about the types used in this program
+        let types_metadata_result = typed_program.collect_types_metadata(
+            handler,
+            &mut CollectTypesMetadataContext::new(engines, experimental),
+        );
+        let types_metadata = match types_metadata_result {
+            Ok(types_metadata) => types_metadata,
+            Err(e) => {
+                handler.dedup();
+                return Err(e);
+            }
+        };
+
+        typed_program
+            .logged_types
+            .extend(types_metadata.iter().filter_map(|m| match m {
+                TypeMetadata::LoggedType(log_id, type_id) => Some((*log_id, *type_id)),
+                _ => None,
+            }));
+
+        typed_program
+            .messages_types
+            .extend(types_metadata.iter().filter_map(|m| match m {
+                TypeMetadata::MessageType(message_id, type_id) => Some((*message_id, *type_id)),
+                _ => None,
+            }));
+
+        let (print_graph, print_graph_url_format) = match build_config {
+            Some(cfg) => (
+                cfg.print_dca_graph.clone(),
+                cfg.print_dca_graph_url_format.clone(),
+            ),
+            None => (None, None),
+        };
+
+        check_should_abort(handler, retrigger_compilation.clone())?;
+
+        // Perform control flow analysis and extend with any errors.
+        let _ = perform_control_flow_analysis(
+            handler,
+            engines,
+            &typed_program,
+            print_graph,
+            print_graph_url_format,
+        );
+
+        types_metadata
+    } else {
+        vec![]
     };
-
-    typed_program
-        .logged_types
-        .extend(types_metadata.iter().filter_map(|m| match m {
-            TypeMetadata::LoggedType(log_id, type_id) => Some((*log_id, *type_id)),
-            _ => None,
-        }));
-
-    typed_program
-        .messages_types
-        .extend(types_metadata.iter().filter_map(|m| match m {
-            TypeMetadata::MessageType(message_id, type_id) => Some((*message_id, *type_id)),
-            _ => None,
-        }));
-
-    let (print_graph, print_graph_url_format) = match build_config {
-        Some(cfg) => (
-            cfg.print_dca_graph.clone(),
-            cfg.print_dca_graph_url_format.clone(),
-        ),
-        None => (None, None),
-    };
-
-    check_should_abort(handler, retrigger_compilation.clone())?;
-
-    // Perform control flow analysis and extend with any errors.
-    let _ = perform_control_flow_analysis(
-        handler,
-        engines,
-        &typed_program,
-        print_graph,
-        print_graph_url_format,
-    );
 
     // Evaluate const declarations, to allow storage slots initialization with consts.
     let mut ctx = Context::new(
@@ -632,6 +643,11 @@ pub fn compile_to_ast(
     package_name: &str,
     retrigger_compilation: Option<Arc<AtomicBool>>,
 ) -> Result<Programs, ErrorEmitted> {
+    let lsp_config = build_config.map(|x| x.lsp_mode.clone()).unwrap_or_default();
+    let retrigger_compilation = lsp_config
+        .as_ref()
+        .map_or(None, |config| config.retrigger_compilation.clone());
+
     check_should_abort(handler, retrigger_compilation.clone())?;
 
     let query_engine = engines.qe();
@@ -712,6 +728,8 @@ pub fn compile_to_ast(
         };
         query_engine.insert_programs_cache_entry(cache_entry);
     }
+
+    check_should_abort(handler, retrigger_compilation.clone())?;
 
     Ok(programs)
 }

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -27,7 +27,7 @@ use crate::source_map::SourceMap;
 pub use asm_generation::from_ir::compile_ir_to_asm;
 use asm_generation::FinalizedAsm;
 pub use asm_generation::{CompiledBytecode, FinalizedEntry};
-pub use build_config::{BuildConfig, BuildTarget, OptLevel};
+pub use build_config::{BuildConfig, BuildTarget, OptLevel, LspConfig};
 use control_flow_analysis::ControlFlowGraph;
 use metadata::MetadataManager;
 use query_engine::{ModuleCacheKey, ModulePath, ProgramsCacheEntry};
@@ -494,8 +494,8 @@ pub fn parsed_to_ast(
     // Only clear the parsed AST nodes if we are running a regular compilation pipeline.
     // LSP needs these to build its token map, and they are cleared by `clear_module` as
     // part of the LSP garbage collection functionality instead.
-    let lsp_mode = build_config.map(|x| x.lsp_mode).unwrap_or_default();
-    if !lsp_mode {
+    let lsp_mode = build_config.map(|x| x.lsp_mode.clone()).unwrap_or_default();
+    if lsp_mode.is_none() {
         engines.pe().clear();
     }
 

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -40,8 +40,8 @@ use std::sync::Arc;
 use sway_ast::AttributeDecl;
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_ir::{
-    create_o1_pass_group, optimize, register_known_passes, Context, Kind, Module, PassGroup,
-    PassManager, ARGDEMOTION_NAME, CONSTDEMOTION_NAME, DCE_NAME, INLINE_MODULE_NAME, MEM2REG_NAME,
+    create_o1_pass_group, register_known_passes, Context, Kind, Module, PassGroup, PassManager,
+    ARGDEMOTION_NAME, CONSTDEMOTION_NAME, DCE_NAME, INLINE_MODULE_NAME, MEM2REG_NAME,
     MEMCPYOPT_NAME, MISCDEMOTION_NAME, MODULEPRINTER_NAME, RETDEMOTION_NAME, SIMPLIFYCFG_NAME,
     SROA_NAME,
 };

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -40,7 +40,10 @@ use std::sync::Arc;
 use sway_ast::AttributeDecl;
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_ir::{
-    create_o1_pass_group, optimize, register_known_passes, Context, Kind, Module, PassGroup, PassManager, ARGDEMOTION_NAME, CONSTDEMOTION_NAME, DCE_NAME, INLINE_MODULE_NAME, MEM2REG_NAME, MEMCPYOPT_NAME, MISCDEMOTION_NAME, MODULEPRINTER_NAME, RETDEMOTION_NAME, SIMPLIFYCFG_NAME, SROA_NAME
+    create_o1_pass_group, optimize, register_known_passes, Context, Kind, Module, PassGroup,
+    PassManager, ARGDEMOTION_NAME, CONSTDEMOTION_NAME, DCE_NAME, INLINE_MODULE_NAME, MEM2REG_NAME,
+    MEMCPYOPT_NAME, MISCDEMOTION_NAME, MODULEPRINTER_NAME, RETDEMOTION_NAME, SIMPLIFYCFG_NAME,
+    SROA_NAME,
 };
 use sway_types::constants::DOC_COMMENT_ATTRIBUTE_NAME;
 use sway_types::SourceEngine;
@@ -517,7 +520,8 @@ pub fn parsed_to_ast(
     let types_metadata = if !lsp_config
         .as_ref()
         .map(|lsp| lsp.optimized_build)
-        .unwrap_or(false) {
+        .unwrap_or(false)
+    {
         // Collect information about the types used in this program
         let types_metadata_result = typed_program.collect_types_metadata(
             handler,

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -60,6 +60,7 @@ futures = { version = "0.3", default-features = false, features = [
     "async-await",
 ] }
 pretty_assertions = "1.4.0"
+rand = "0.8"
 regex = "^1.10.2"
 sway-lsp-test-utils = { path = "tests/utils" }
 tikv-jemallocator = "0.5"

--- a/sway-lsp/benches/lsp_benchmarks/mod.rs
+++ b/sway-lsp/benches/lsp_benchmarks/mod.rs
@@ -8,11 +8,21 @@ use sway_lsp::core::session::{self, Session};
 
 pub async fn compile_test_project() -> (Url, Arc<Session>) {
     let session = Arc::new(Session::new());
+    let lsp_mode = Some(sway_core::LspConfig {
+        optimized_build: false,
+    });
     // Load the test project
     let uri = Url::from_file_path(benchmark_dir().join("src/main.sw")).unwrap();
     session.handle_open_file(&uri).await;
     // Compile the project
-    session::parse_project(&uri, &session.engines.read(), None, session.clone()).unwrap();
+    session::parse_project(
+        &uri,
+        &session.engines.read(),
+        None,
+        lsp_mode,
+        session.clone(),
+    )
+    .unwrap();
     (uri, session)
 }
 

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -30,12 +30,14 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 use sway_core::{
-    decl_engine::DeclEngine, language::{
+    decl_engine::DeclEngine,
+    language::{
         lexed::LexedProgram,
         parsed::{AstNode, ParseProgram},
         ty::{self},
         HasSubmodules,
-    }, BuildTarget, Engines, LspConfig, Namespace, Programs
+    },
+    BuildTarget, Engines, LspConfig, Namespace, Programs,
 };
 use sway_error::{error::CompileError, handler::Handler, warning::CompileWarning};
 use sway_types::{SourceEngine, SourceId, Spanned};
@@ -452,15 +454,9 @@ pub fn parse_project(
         return Err(LanguageServerError::ProgramsIsNone);
     }
     let diagnostics = traverse(results, engines, session.clone())?;
-    // if let Some((errors, warnings)) = &diagnostics {
-    //     *session.diagnostics.write() =
-    //         capabilities::diagnostic::get_diagnostics(warnings, errors, engines.se());
-    // }
-    // Only write the diagnostics results on didSave or didOpen.
     if let Some(config) = &lsp_mode {
-        eprintln!("optimization: {}", config.optimized_build);
+        // Only write the diagnostics results on didSave or didOpen.
         if !config.optimized_build {
-            eprintln!("Publishing diagnostics");
             if let Some((errors, warnings)) = &diagnostics {
                 *session.diagnostics.write() =
                     capabilities::diagnostic::get_diagnostics(warnings, errors, engines.se());

--- a/sway-lsp/src/core/token_map.rs
+++ b/sway-lsp/src/core/token_map.rs
@@ -51,16 +51,11 @@ impl<'a> TokenMap {
             500_000_000,
             1_000_000_000,
         ]; // Backoff times in nanoseconds
-        for (i, sleep) in backoff_times.iter().enumerate().take(MAX_RETRIES) {
+        for sleep in backoff_times.iter().take(MAX_RETRIES) {
             match self.try_get_mut(ident) {
                 TryResult::Present(token) => return Some(token),
                 TryResult::Absent => return None,
                 TryResult::Locked => {
-                    tracing::warn!(
-                        "Failed to get token, retrying attmpt {}: {:#?}",
-                        i,
-                        ident.name
-                    );
                     // Wait for the specified backoff time before retrying
                     let backoff_time = Duration::from_nanos(*sleep);
                     thread::sleep(backoff_time);

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -12,6 +12,7 @@ use dashmap::DashMap;
 use forc_pkg::PackageManifestFile;
 use lsp_types::{Diagnostic, Url};
 use parking_lot::RwLock;
+use sway_core::LspConfig;
 use std::{
     mem,
     path::PathBuf,
@@ -82,6 +83,7 @@ pub struct CompilationContext {
     pub session: Option<Arc<Session>>,
     pub uri: Option<Url>,
     pub version: Option<i32>,
+    pub optimized_build: bool,
 }
 
 impl ServerState {
@@ -125,12 +127,18 @@ impl ServerState {
                             }
                         }
 
+                        let lsp_mode = Some(LspConfig {
+                            retrigger_compilation: Some(retrigger_compilation.clone()),
+                            optimized_build: ctx.optimized_build,
+                        });
+
                         // Set the is_compiling flag to true so that the wait_for_parsing function knows that we are compiling
                         is_compiling.store(true, Ordering::SeqCst);
                         match session::parse_project(
                             &uri,
                             &engines_clone,
                             Some(retrigger_compilation.clone()),
+                            lsp_mode,
                             session.clone(),
                         ) {
                             Ok(_) => {

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -105,7 +105,9 @@ impl ServerState {
         let finished_compilation = self.finished_compilation.clone();
         let rx = self.cb_rx.clone();
         let last_compilation_state = self.last_compilation_state.clone();
-        std::thread::spawn(move || {
+        // Create a new thread with a 4MB stack size
+        let builder = std::thread::Builder::new().stack_size(4 * 1024 * 1024);
+        builder.spawn(move || {
             while let Ok(msg) = rx.recv() {
                 match msg {
                     TaskMessage::CompilationContext(ctx) => {
@@ -166,7 +168,7 @@ impl ServerState {
                     }
                 }
             }
-        });
+        }).unwrap();
     }
 
     /// Waits asynchronously for the `is_compiling` flag to become false.

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -114,9 +114,9 @@ impl ServerState {
                         let mut engines_clone = session.engines.read().clone();
 
                         if let Some(version) = ctx.version {
-                            // Garbage collection is fairly expsensive so we only clear on every 4th keystroke.
+                            // Garbage collection is fairly expsensive so we only clear on every 3rd keystroke.
                             // Waiting too long to clear can cause a stack overflow to occur.
-                            if version % 4 == 0 {
+                            if version % 3 == 0 {
                                 // Call this on the engines clone so we don't clear types that are still in use
                                 // and might be needed in the case cancel compilation was triggered.
                                 if let Err(err) = session.garbage_collect(&mut engines_clone) {
@@ -129,7 +129,6 @@ impl ServerState {
                         }
 
                         let lsp_mode = Some(LspConfig {
-                            retrigger_compilation: Some(retrigger_compilation.clone()),
                             optimized_build: ctx.optimized_build,
                         });
 

--- a/sway-lsp/tests/fixtures/benchmark/src/main.sw
+++ b/sway-lsp/tests/fixtures/benchmark/src/main.sw
@@ -8,7 +8,7 @@ struct Struct1 {
     /// I am a random doc comment.
     field2: u16,
     /// I am a random doc comment.
-    field3: u32,
+    field3: u16,
     /// I am a random doc comment.
     field4: u64,
 }

--- a/sway-lsp/tests/fixtures/benchmark/src/main.sw
+++ b/sway-lsp/tests/fixtures/benchmark/src/main.sw
@@ -8,7 +8,7 @@ struct Struct1 {
     /// I am a random doc comment.
     field2: u16,
     /// I am a random doc comment.
-    field3: u16,
+    field3: u32,
     /// I am a random doc comment.
     field4: u64,
 }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -138,7 +138,6 @@ async fn did_change_stress_test() {
     shutdown_and_exit(&mut service).await;
 }
 
-
 #[tokio::test]
 #[allow(dead_code)]
 async fn did_change_stress_test_random() {

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -138,6 +138,57 @@ async fn did_change_stress_test() {
     shutdown_and_exit(&mut service).await;
 }
 
+
+#[tokio::test]
+#[allow(dead_code)]
+async fn did_change_stress_test_random() {
+    set_panic_hook();
+
+    let (mut service, _) = LspService::build(ServerState::new)
+        .custom_method("sway/metrics", ServerState::metrics)
+        .finish();
+    let bench_dir = sway_workspace_dir().join("sway-lsp/tests/fixtures/benchmark");
+    let uri = init_and_open(&mut service, bench_dir.join("src/main.sw")).await;
+    let times = 40000;
+    for version in 0..times {
+        eprintln!("version: {}", version);
+        let _ = lsp::did_change_request(&mut service, &uri, version + 1).await;
+        if version == 0 {
+            service.inner().wait_for_parsing().await;
+        }
+        let metrics = lsp::metrics_request(&mut service, &uri).await;
+        for (path, metrics) in metrics {
+            if path.contains("sway-lib-core") || path.contains("sway-lib-std") {
+                assert!(metrics.reused_modules >= 1);
+            }
+        }
+        // wait for a random amount of time between 1-30ms
+        let wait_time = rand::random::<u64>() % 30 + 1;
+        tokio::time::sleep(tokio::time::Duration::from_millis(wait_time)).await;
+
+        // there is a 10% chance that a longer 300-1000ms wait will be added
+        if rand::random::<u64>() % 10 < 1 {
+            let wait_time = rand::random::<u64>() % 700 + 300;
+            tokio::time::sleep(tokio::time::Duration::from_millis(wait_time)).await;
+        }
+    }
+    shutdown_and_exit(&mut service).await;
+}
+
+fn set_panic_hook() {
+    std::env::set_var("RUST_BACKTRACE", "1");
+    let default_panic = std::panic::take_hook();
+
+    std::panic::set_hook(Box::new(move |panic_info| {
+        eprintln!("PANIC!!!!!!!!!!!!!!!");
+        // Print the panic message
+        default_panic(panic_info);
+
+        eprintln!("exiting");
+        std::process::exit(1);
+    }));
+}
+
 #[tokio::test]
 async fn lsp_syncs_with_workspace_edits() {
     let (mut service, _) = LspService::new(ServerState::new);


### PR DESCRIPTION
## Description
This PR does 3 optimizations. The timings below are measured against the LSP benchmarking project.

1. Disable running DCA & control flow analysis, for did_change events `39.544ms`
2. Disable running collect_types_metadata for did_change events `3.522ms`
3. Only write the diagnostics res to self.diagnostics.write() on did_open & did_save `21.135ms`

I also had to increase the frequency that we are calling GC to every 3rd keystroke as during stress tests I was occasionally getting stack overflows otherwise.

related to #5445

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
