### PR TITLE
Only run docs CI checks when docs have changed

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,9 @@
 name: Docs
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
-  release:
-    types: [published]
+    paths:
+      - docs/**
 
 jobs:
   test:


### PR DESCRIPTION
## Description

This makes it so the Docs CI checks only happen when a PR includes changes to files under `docs/`

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
