### PR TITLE
Fix build-mdbook CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Forc
-        run: cargo install --locked --debug --path ./forc
+        run: cargo install --force --locked --debug --path ./forc
       - name: Install Forc plugins
         run: |
           cargo install --locked --debug --path ./forc-plugins/forc-fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,14 +152,11 @@ jobs:
       - uses: buildjet/cache@v3
         with:
           path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
+            ~/.cargo/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Forc
-        run: cargo install --force --locked --debug --path ./forc
+        run: cargo install --locked --debug --path ./forc
       - name: Install Forc plugins
         run: |
           cargo install --locked --debug --path ./forc-plugins/forc-fmt
@@ -376,10 +373,7 @@ jobs:
       - uses: buildjet/cache@v3
         with:
           path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
+            ~/.cargo/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Build All Tests


### PR DESCRIPTION
## Description

`build-mdbook` was failing on multiple PRs with 

```
Run cargo install --locked --debug --path ./forc
error: binary `forc` already exists in destination
Add --force to overwrite
```

https://github.com/FuelLabs/sway/actions/runs/7819113568/attempts/1?pr=5569
https://github.com/FuelLabs/sway/actions/runs/7816891674/job/21336246772?pr=5565

`cargo install` keeps track of which binaries it has installed in ~/.cargo/crates.toml and ~/.cargo.crates2.json. By using the entire cached `cargo` directory, cargo is able to tell that it has previously installed the binaries and install correctly.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
