### PR TITLE
Enforce deterministic order in hashmaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.75.0
-  NIGHTLY_RUST_VERSION: nightly-2023-12-27
+  RUST_VERSION: 1.76.0
+  NIGHTLY_RUST_VERSION: nightly-2024-02-07
 
 jobs:
   get-fuel-core-version:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -254,14 +254,13 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
+checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -353,9 +352,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
@@ -407,9 +406,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 dependencies = [
  "serde",
 ]
@@ -537,7 +536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
 dependencies = [
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.5",
  "serde",
 ]
 
@@ -604,9 +603,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -614,14 +613,14 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -630,15 +629,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
@@ -701,24 +700,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.14"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e92c5c1a78c62968ec57dbc2440366a2d6e5a23faf829970ff1585dc6b18e2"
+checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
 dependencies = [
  "clap_builder",
- "clap_derive 4.4.7",
+ "clap_derive 4.5.0",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.14"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4323769dc8a61e2c39ad7dc26f6f2800524691a44d74fe3d1071a5c24db6370"
+checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.6.0",
- "strsim 0.10.0",
+ "clap_lex 0.7.0",
+ "strsim 0.11.0",
  "terminal_size",
 ]
 
@@ -733,11 +732,11 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.4.6"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97aeaa95557bd02f23fbb662f981670c3d20c5a26e69f7354b28f57092437fcd"
+checksum = "299353be8209bd133b049bf1c63582d184a8b39fd9c04f15fe65f50f88bdfe6c"
 dependencies = [
- "clap 4.4.14",
+ "clap 4.5.0",
 ]
 
 [[package]]
@@ -755,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -776,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clipboard-win"
@@ -835,7 +834,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "bech32",
  "bs58",
  "digest 0.10.7",
@@ -900,7 +899,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784836d0812dade01579cc0cc9b1684847044e716fd7aa6bffbc172e42199500"
 dependencies = [
- "clap 4.4.14",
+ "clap 4.5.0",
  "entities",
  "memchr",
  "once_cell",
@@ -953,9 +952,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
 dependencies = [
  "percent-encoding",
  "time",
@@ -964,12 +963,12 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.16.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d606d0fba62e13cf04db20536c05cb7f13673c161cb47a47a82b9b9e7d3f1daa"
+checksum = "387461abbc748185c3a6e1673d826918b450b87ff22639429c694619a83b6cf6"
 dependencies = [
  "cookie",
- "idna 0.2.3",
+ "idna 0.3.0",
  "log",
  "publicsuffix",
  "serde",
@@ -1046,7 +1045,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.4.14",
+ "clap 4.5.0",
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
@@ -1192,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -1269,12 +1268,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+ "darling_core 0.20.5",
+ "darling_macro 0.20.5",
 ]
 
 [[package]]
@@ -1293,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1318,11 +1317,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core 0.20.5",
  "quote",
  "syn 2.0.48",
 ]
@@ -1576,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1676,16 +1675,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.1"
+name = "env_filter"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
 dependencies = [
- "humantime",
- "is-terminal",
  "log",
  "regex",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e7cf40684ae96ade6232ed84582f40ce0a66efcd43a5117aef610534f8e0b8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -1876,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
 
 [[package]]
 name = "filecheck"
@@ -2064,7 +2073,7 @@ name = "forc-doc"
 version = "0.50.0"
 dependencies = [
  "anyhow",
- "clap 4.4.14",
+ "clap 4.5.0",
  "colored",
  "comrak",
  "dir_indexer",
@@ -2134,7 +2143,7 @@ dependencies = [
  "serde",
  "serde_ignored",
  "serde_json",
- "serde_with 3.4.0",
+ "serde_with 3.6.1",
  "sway-core",
  "sway-error",
  "sway-types",
@@ -2232,7 +2241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec33476fc17ae778231373c911b7782b1f64b820decac07861fb6578cdcf4408"
 dependencies = [
  "anyhow",
- "clap 4.4.14",
+ "clap 4.5.0",
  "eth-keystore",
  "forc-tracing 0.47.0",
  "fuel-crypto",
@@ -2330,7 +2339,7 @@ version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea884860261efdc7300b63db7972cb0e08e8f5379495ad7cdd2bdb7c0cc4623"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "fuel-types",
  "serde",
  "strum",
@@ -2525,7 +2534,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
- "synstructure 0.13.0",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -2626,7 +2635,7 @@ version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f65e363e5e9a5412cea204f2d2357043327a0c3da5482c3b38b9da045f20e"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "derivative",
  "derive_more",
  "fuel-asm",
@@ -2662,7 +2671,7 @@ checksum = "aed5ba0cde904f16cd748dc9b33e62f4b3dc5fd0a72ec867c973e687cd7347ba"
 dependencies = [
  "async-trait",
  "backtrace",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "derivative",
  "derive_more",
  "ethnum",
@@ -2734,7 +2743,7 @@ checksum = "aa5acfe0ef24e12137786072a182dc5f0de9d51e79a6023183466f4eaecf7512"
 dependencies = [
  "Inflector",
  "fuel-abi-types 0.3.0",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -2761,7 +2770,7 @@ dependencies = [
  "fuel-vm",
  "fuels-macros",
  "hex",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -2777,7 +2786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0dcdf41ccc7090bec4848d680d16cdc0c6cd37b749e518084caa8e6b730053"
 dependencies = [
  "fuels-code-gen",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "rand",
@@ -2798,7 +2807,7 @@ dependencies = [
  "fuel-types",
  "fuels-accounts",
  "fuels-core",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "rand",
  "serde_json",
  "tokio",
@@ -2824,7 +2833,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "serde_with 3.4.0",
+ "serde_with 3.6.1",
  "tempfile",
  "tokio",
  "which",
@@ -3083,9 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -3093,7 +3102,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -3102,15 +3111,19 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crunchy",
+]
 
 [[package]]
 name = "handlebars"
-version = "4.5.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa67bab9ff362228eb3d00bd024a4965d8231bbb7921167f0cfa66c6626b225"
+checksum = "ab283476b99e66691dee3f1640fea91487a8d81f50fb5ecc75538f8f8879a1e4"
 dependencies = [
  "log",
  "pest",
@@ -3201,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
 
 [[package]]
 name = "hex"
@@ -3412,9 +3425,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.59"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -3438,17 +3451,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -3554,12 +3556,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "rayon",
  "serde",
 ]
 
@@ -3667,12 +3670,12 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "fe8f25ce1159c7740ff0b9b2f5cdf4a8428742ba7c112b9f20f22cd5219c7dab"
 dependencies = [
- "hermit-abi 0.3.3",
- "rustix",
+ "hermit-abi 0.3.5",
+ "libc",
  "windows-sys 0.52.0",
 ]
 
@@ -3687,9 +3690,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -3702,18 +3705,18 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3734,9 +3737,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
 ]
@@ -3772,9 +3775,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libgit2-sys"
@@ -3820,7 +3823,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -3831,7 +3834,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -3900,9 +3903,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.14"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050"
+checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
 dependencies = [
  "cc",
  "libc",
@@ -3927,9 +3930,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -3993,12 +3996,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
 name = "matchit"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4006,21 +4003,20 @@ checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "mdbook"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80992cb0e05f22cc052c99f8e883f1593b891014b96a8b4637fd274d7030c85e"
+checksum = "0c33564061c3c640bed5ace7d6a2a1b65f2c64257d1ac930c15e94ed0fb561d3"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.4.14",
- "clap_complete 4.4.6",
+ "clap 4.5.0",
+ "clap_complete 4.5.0",
  "env_logger",
  "handlebars",
  "log",
  "memchr",
  "once_cell",
  "opener 0.6.1",
- "pathdiff",
  "pulldown-cmark",
  "regex",
  "serde",
@@ -4176,9 +4172,9 @@ checksum = "95bbbf96b9ac3482c2a25450b67a15ed851319bc5fabf3b40742ea9066e84282"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -4413,28 +4409,33 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
+name = "num-conv"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -4455,9 +4456,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -4468,7 +4469,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi 0.3.5",
  "libc",
 ]
 
@@ -4571,11 +4572,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.62"
+version = "0.10.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
+checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -4603,18 +4604,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.1+3.2.0"
+version = "300.2.2+3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
+checksum = "8bbfad0063610ac26ee79f7484739e2b07555a75c42453b89263830b5c8103bc"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.98"
+version = "0.9.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
+checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",
@@ -4743,12 +4744,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-
-[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4802,9 +4797,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.6"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f200d8d83c44a45b21764d1916299752ca035d15ecd46faca3e9a2a2bf6ad06"
+checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4813,9 +4808,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.6"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd6ab1236bbdb3a49027e920e693192ebfe8913f6d60e294de57463a493cfde"
+checksum = "22e1288dbd7786462961e69bfd4df7848c1e37e8b74303dbdab82c3a9cdd2809"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4823,9 +4818,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.6"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a31940305ffc96863a735bef7c7994a00b325a7138fdbc5bda0f1a0476d3275"
+checksum = "1381c29a877c6d34b8c176e734f35d7f7f5b3adaefe940cb4d1bb7af94678e2e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4836,9 +4831,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.6"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ff62f5259e53b78d1af898941cdcdccfae7385cf7d793a6e55de5d05bb4b7d"
+checksum = "d0934d6907f148c22a3acbda520c7eed243ad7487a30f51f6ce52b58b7077a8a"
 dependencies = [
  "once_cell",
  "pest",
@@ -4852,7 +4847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "serde",
  "serde_derive",
 ]
@@ -4903,18 +4898,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4945,9 +4940,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "platforms"
@@ -4961,8 +4956,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5699cc8a63d1aa2b1ee8e12b9ad70ac790d65788cd36101fa37f87ea46c4cef"
 dependencies = [
- "base64 0.21.6",
- "indexmap 2.1.0",
+ "base64 0.21.7",
+ "indexmap 2.2.2",
  "line-wrap",
  "quick-xml",
  "serde",
@@ -5164,9 +5159,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -5235,14 +5230,21 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+checksum = "dce76ce678ffc8e5675b22aa1405de0b7037e2fdf8913fea40d1926c6fe1e6e7"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "memchr",
+ "pulldown-cmark-escape",
  "unicase",
 ]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d8f9aa0e3cbcfaf8bf00300004ee3b72f74770f9cbac93f6928771f613276b"
 
 [[package]]
 name = "quick-protobuf"
@@ -5328,9 +5330,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
  "either",
  "rayon-core",
@@ -5338,9 +5340,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -5400,13 +5402,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.5",
  "regex-syntax 0.8.2",
 ]
 
@@ -5421,9 +5423,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5438,23 +5440,17 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
-
-[[package]]
-name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.23"
+version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "bytes",
  "cookie",
  "cookie_store",
@@ -5480,6 +5476,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -5694,11 +5691,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5760,7 +5757,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -6000,18 +5997,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6029,9 +6026,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -6082,18 +6079,19 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.4.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "serde",
+ "serde_derive",
  "serde_json",
- "serde_with_macros 3.4.0",
+ "serde_with_macros 3.6.1",
  "time",
 ]
 
@@ -6111,11 +6109,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.4.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.5",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -6123,11 +6121,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.30"
+version = "0.9.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
+checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "itoa",
  "ryu",
  "serde",
@@ -6223,9 +6221,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -6289,9 +6287,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smawk"
@@ -6394,6 +6392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6488,7 +6492,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "hex",
  "im",
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "itertools 0.10.5",
  "lazy_static",
  "miden-core",
@@ -6533,6 +6537,7 @@ dependencies = [
  "downcast-rs",
  "filecheck",
  "generational-arena",
+ "indexmap 2.2.2",
  "itertools 0.10.5",
  "once_cell",
  "peg",
@@ -6568,6 +6573,7 @@ dependencies = [
  "forc-tracing 0.50.0",
  "forc-util",
  "futures",
+ "indexmap 2.2.2",
  "lsp-types",
  "notify",
  "notify-debouncer-mini",
@@ -6641,9 +6647,11 @@ dependencies = [
  "fuel-asm",
  "fuel-crypto",
  "fuel-tx",
+ "indexmap 2.2.2",
  "lazy_static",
  "num-bigint",
  "num-traits",
+ "rustc-hash",
  "serde",
  "sway-utils",
  "thiserror",
@@ -6722,21 +6730,20 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285ba80e733fac80aa4270fbcdf83772a79b80aa35c97075320abfee4a915b06"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
- "unicode-xid",
 ]
 
 [[package]]
 name = "syntect"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02b4b303bf8d08bfeb0445cba5068a3d306b6baece1d5582171a9bf49188f91"
+checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
 dependencies = [
  "bincode",
  "bitflags 1.3.2",
@@ -6746,8 +6753,9 @@ dependencies = [
  "once_cell",
  "onig",
  "plist",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
  "serde",
+ "serde_derive",
  "serde_json",
  "thiserror",
  "walkdir",
@@ -6835,13 +6843,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall 0.4.1",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -6917,7 +6924,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "bytes",
- "clap 4.4.14",
+ "clap 4.5.0",
  "colored",
  "filecheck",
  "forc",
@@ -7032,12 +7039,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -7052,10 +7060,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -7114,9 +7123,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7244,7 +7253,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7257,7 +7266,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.2",
  "toml_datetime",
  "winnow",
 ]
@@ -7482,9 +7491,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -7509,9 +7518,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -7679,9 +7688,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -7691,9 +7700,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
@@ -7706,9 +7715,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -7718,9 +7727,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7728,9 +7737,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7741,15 +7750,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7767,9 +7776,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "which"
@@ -8034,9 +8043,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.34"
+version = "0.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
 dependencies = [
  "memchr",
 ]
@@ -8139,9 +8148,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914566e6413e7fa959cc394fb30e563ba80f3541fbd40816d4c05a0fc3f2a0f1"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
  "linux-raw-sys",

--- a/forc/src/ops/forc_init.rs
+++ b/forc/src/ops/forc_init.rs
@@ -160,7 +160,6 @@ pub fn init(command: InitCommand) -> ForcResult<()> {
     let gitignore_path = Path::new(&project_dir).join(".gitignore");
     // Append to existing gitignore if it exists otherwise create a new one.
     let mut gitignore_file = fs::OpenOptions::new()
-        .write(true)
         .append(true)
         .create(true)
         .open(&gitignore_path)?;

--- a/sway-ast/Cargo.toml
+++ b/sway-ast/Cargo.toml
@@ -15,3 +15,6 @@ num-traits = "0.2.14"
 serde = { version = "1.0", features = ["derive"] }
 sway-error = { version = "0.50.0", path = "../sway-error" }
 sway-types = { version = "0.50.0", path = "../sway-types" }
+
+[lints.clippy]
+iter_over_hash_type = "deny"

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -50,3 +50,6 @@ vec1 = "1.8.0"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 sysinfo = "0.29.0"
+
+[lints.clippy]
+iter_over_hash_type = "deny"

--- a/sway-core/src/asm_generation/finalized_asm.rs
+++ b/sway-core/src/asm_generation/finalized_asm.rs
@@ -99,7 +99,7 @@ impl fmt::Display for FinalizedAsm {
 
 fn to_bytecode_mut(
     handler: &Handler,
-    ops: &Vec<AllocatedOp>,
+    ops: &[AllocatedOp],
     data_section: &mut DataSection,
     source_map: &mut SourceMap,
     source_engine: &SourceEngine,

--- a/sway-core/src/asm_generation/fuel/allocated_abstract_instruction_set.rs
+++ b/sway-core/src/asm_generation/fuel/allocated_abstract_instruction_set.rs
@@ -10,6 +10,7 @@ use super::{
     data_section::{DataSection, Entry},
 };
 
+use indexmap::{IndexMap, IndexSet};
 use sway_types::span::Span;
 
 use std::{
@@ -47,7 +48,7 @@ impl AllocatedAbstractInstructionSet {
             .ops
             .iter()
             .fold(
-                (HashMap::new(), HashSet::new()),
+                (IndexMap::new(), IndexSet::new()),
                 |(mut reg_sets, mut active_sets), op| {
                     let reg = match &op.opcode {
                         Either::Right(ControlFlowOp::PushAll(label)) => {
@@ -55,7 +56,7 @@ impl AllocatedAbstractInstructionSet {
                             None
                         }
                         Either::Right(ControlFlowOp::PopAll(label)) => {
-                            active_sets.remove(label);
+                            active_sets.swap_remove(label);
                             None
                         }
 

--- a/sway-core/src/asm_generation/fuel/analyses.rs
+++ b/sway-core/src/asm_generation/fuel/analyses.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeSet, HashMap};
 
 use either::Either;
-use rustc_hash::FxHashSet;
+use indexmap::IndexSet;
+use sway_types::FxIndexSet;
 
 use crate::asm_lang::{ControlFlowOp, Label, Op, VirtualRegister};
 
@@ -53,7 +54,7 @@ pub(crate) fn liveness_analysis(
 ) -> Vec<BTreeSet<VirtualRegister>> {
     // Vectors representing maps that will represent the live_in and live_out tables. Each entry
     // corresponds to an instruction in `ops`.
-    let mut live_in: Vec<FxHashSet<VirtualRegister>> = vec![FxHashSet::default(); ops.len()];
+    let mut live_in: Vec<FxIndexSet<VirtualRegister>> = vec![IndexSet::default(); ops.len()];
     let mut live_out: Vec<BTreeSet<VirtualRegister>> = vec![BTreeSet::default(); ops.len()];
     let mut label_to_index: HashMap<Label, usize> = HashMap::new();
 

--- a/sway-core/src/asm_generation/fuel/register_allocator.rs
+++ b/sway-core/src/asm_generation/fuel/register_allocator.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 use either::Either;
+use indexmap::IndexMap;
 use petgraph::{
     stable_graph::NodeIndex,
     visit::EdgeRef,
@@ -16,7 +17,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::{hash_map, BTreeSet, HashMap};
 use sway_error::error::CompileError;
 use sway_ir::size_bytes_round_up_to_word_alignment;
-use sway_types::Span;
+use sway_types::{FxIndexSet, Span};
 
 use super::allocated_abstract_instruction_set::AllocatedAbstractInstructionSet;
 
@@ -201,7 +202,7 @@ pub(crate) fn coalesce_registers(
 ) -> (Vec<Op>, Vec<BTreeSet<VirtualRegister>>) {
     // A map from the virtual registers that are removed to the virtual registers that they are
     // replaced with during the coalescing process.
-    let mut reg_to_reg_map: HashMap<&VirtualRegister, &VirtualRegister> = HashMap::new();
+    let mut reg_to_reg_map = IndexMap::<&VirtualRegister, &VirtualRegister>::new();
 
     // To hold the final *reduced* list of ops
     let mut reduced_ops: Vec<Op> = Vec::with_capacity(ops.len());
@@ -237,10 +238,10 @@ pub(crate) fn coalesce_registers(
 
                         let r1_neighbours = interference_graph
                             .neighbors_undirected(*ix1)
-                            .collect::<FxHashSet<_>>();
+                            .collect::<FxIndexSet<_>>();
                         let r2_neighbours = interference_graph
                             .neighbors_undirected(*ix2)
-                            .collect::<FxHashSet<_>>();
+                            .collect::<FxIndexSet<_>>();
 
                         // Using either of the two safety conditions below, it's guaranteed
                         // that we aren't turning a k-colourable graph into one that's not,
@@ -315,7 +316,7 @@ pub(crate) fn coalesce_registers(
 
     // Create a *final* reg-to-reg map that We keep looking for mappings within reg_to_reg_map
     // until we find a register that doesn't map to any other.
-    let mut final_reg_to_reg_map: HashMap<&VirtualRegister, &VirtualRegister> = HashMap::new();
+    let mut final_reg_to_reg_map = IndexMap::<&VirtualRegister, &VirtualRegister>::new();
     for reg in reg_to_reg_map.keys() {
         let mut temp = reg;
         while let Some(t) = reg_to_reg_map.get(temp) {

--- a/sway-core/src/asm_generation/miden_vm/miden_vm_asm_builder.rs
+++ b/sway-core/src/asm_generation/miden_vm/miden_vm_asm_builder.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use std::{collections::HashMap, sync::Arc};
 mod miden_op;
+use indexmap::IndexMap;
 pub use miden_op::MidenAsmOp;
 
 use crate::{
@@ -59,7 +60,7 @@ impl StackManager {
 // for now, we can use function names for readability
 pub type ProcedureName = String;
 
-pub type ProcedureMap = HashMap<ProcedureName, Procedure>;
+pub type ProcedureMap = IndexMap<ProcedureName, Procedure>;
 
 /// MidenVM Asm is built in the following way:
 /// Function bodies are abstracted into [Procedures]

--- a/sway-core/src/asm_lang/mod.rs
+++ b/sway-core/src/asm_lang/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod allocated_ops;
 pub(crate) mod virtual_immediate;
 pub(crate) mod virtual_ops;
 pub(crate) mod virtual_register;
+use indexmap::IndexMap;
 pub(crate) use virtual_immediate::*;
 pub(crate) use virtual_ops::*;
 pub(crate) use virtual_register::*;
@@ -638,7 +639,7 @@ impl Op {
 
     pub(crate) fn update_register(
         &self,
-        reg_to_reg_map: &HashMap<&VirtualRegister, &VirtualRegister>,
+        reg_to_reg_map: &IndexMap<&VirtualRegister, &VirtualRegister>,
     ) -> Self {
         Op {
             opcode: match &self.opcode {
@@ -1238,7 +1239,7 @@ impl<Reg: Clone + Eq + Ord + Hash> ControlFlowOp<Reg> {
         BTreeSet::new()
     }
 
-    pub(crate) fn update_register(&self, reg_to_reg_map: &HashMap<&Reg, &Reg>) -> Self {
+    pub(crate) fn update_register(&self, reg_to_reg_map: &IndexMap<&Reg, &Reg>) -> Self {
         let update_reg = |reg: &Reg| -> Reg { (*reg_to_reg_map.get(reg).unwrap_or(&reg)).clone() };
 
         use ControlFlowOp::*;

--- a/sway-core/src/asm_lang/virtual_ops.rs
+++ b/sway-core/src/asm_lang/virtual_ops.rs
@@ -4,6 +4,8 @@
 //! The immediate types are used to safely construct numbers that are within their bounds, and the
 //! ops are clones of the actual opcodes, but with the safe primitives as arguments.
 
+use indexmap::IndexMap;
+
 use super::{
     allocated_ops::{AllocatedOpcode, AllocatedRegister},
     virtual_immediate::*,
@@ -795,7 +797,7 @@ impl VirtualOp {
 
     pub(crate) fn update_register(
         &self,
-        reg_to_reg_map: &HashMap<&VirtualRegister, &VirtualRegister>,
+        reg_to_reg_map: &IndexMap<&VirtualRegister, &VirtualRegister>,
     ) -> Self {
         use VirtualOp::*;
         match self {
@@ -1667,7 +1669,7 @@ fn map_reg(
 }
 
 fn update_reg(
-    reg_to_reg_map: &HashMap<&VirtualRegister, &VirtualRegister>,
+    reg_to_reg_map: &IndexMap<&VirtualRegister, &VirtualRegister>,
     reg: &VirtualRegister,
 ) -> VirtualRegister {
     if let Some(r) = reg_to_reg_map.get(reg) {

--- a/sway-core/src/control_flow_analysis/flow_graph/namespace.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/namespace.rs
@@ -8,6 +8,7 @@ use crate::{
     type_system::TypeInfo,
     Ident,
 };
+use indexmap::IndexMap;
 use petgraph::prelude::NodeIndex;
 use std::collections::HashMap;
 use sway_types::{IdentUnique, Named};
@@ -25,7 +26,7 @@ pub(crate) struct FunctionNamespaceEntry {
 #[derive(Default, Clone)]
 pub(crate) struct StructNamespaceEntry {
     pub(crate) struct_decl_ix: NodeIndex,
-    pub(crate) fields: HashMap<String, NodeIndex>,
+    pub(crate) fields: IndexMap<String, NodeIndex>,
 }
 
 #[derive(Clone, Debug)]
@@ -47,7 +48,7 @@ pub(crate) struct VariableNamespaceEntry {
 /// of scope at this point, as that would have been caught earlier and aborted the compilation
 /// process.
 pub struct ControlFlowNamespace {
-    pub(crate) function_namespace: HashMap<(IdentUnique, TyFunctionSig), FunctionNamespaceEntry>,
+    pub(crate) function_namespace: IndexMap<(IdentUnique, TyFunctionSig), FunctionNamespaceEntry>,
     pub(crate) enum_namespace: HashMap<IdentUnique, (NodeIndex, HashMap<Ident, NodeIndex>)>,
     pub(crate) trait_namespace: HashMap<CallPath, TraitNamespaceEntry>,
     /// This is a mapping from trait name to method names and their node indexes

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -18,6 +18,7 @@ use crate::{
     type_system::*,
     types::*,
 };
+use indexmap::IndexMap;
 use sway_ast::intrinsics::Intrinsic;
 use sway_error::error::CompileError;
 use sway_ir::{Context, *};
@@ -1421,7 +1422,7 @@ impl<'eng> FnCompiler<'eng> {
         context: &mut Context,
         md_mgr: &mut MetadataManager,
         call_params: &ty::ContractCallParams,
-        contract_call_parameters: &HashMap<String, ty::TyExpression>,
+        contract_call_parameters: &IndexMap<String, ty::TyExpression>,
         ast_name: &str,
         ast_args: &[(Ident, ty::TyExpression)],
         ast_return_type: TypeId,

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -1,9 +1,9 @@
 use std::{
-    collections::HashMap,
     fmt::{self, Write},
     hash::{Hash, Hasher},
 };
 
+use indexmap::IndexMap;
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::{Ident, Named, Span, Spanned};
 
@@ -23,7 +23,7 @@ pub enum TyExpressionVariant {
     Literal(Literal),
     FunctionApplication {
         call_path: CallPath,
-        contract_call_params: HashMap<String, TyExpression>,
+        contract_call_params: IndexMap<String, TyExpression>,
         arguments: Vec<(Ident, TyExpression)>,
         fn_ref: DeclRefFunction,
         selector: Option<ContractCallParams>,

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -29,10 +29,10 @@ use asm_generation::FinalizedAsm;
 pub use asm_generation::{CompiledBytecode, FinalizedEntry};
 pub use build_config::{BuildConfig, BuildTarget, LspConfig, OptLevel};
 use control_flow_analysis::ControlFlowGraph;
+use indexmap::IndexMap;
 use metadata::MetadataManager;
 use query_engine::{ModuleCacheKey, ModulePath, ProgramsCacheEntry};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -137,7 +137,7 @@ fn module_attrs_to_map(
     handler: &Handler,
     attribute_list: &[AttributeDecl],
 ) -> Result<AttributesMap, ErrorEmitted> {
-    let mut attrs_map: HashMap<_, Vec<Attribute>> = HashMap::new();
+    let mut attrs_map: IndexMap<_, Vec<Attribute>> = IndexMap::new();
     for attr_decl in attribute_list {
         let attrs = attr_decl.attribute.get().into_iter();
         for attr in attrs {

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/duplicates.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/analysis/duplicates.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use indexmap::IndexMap;
 use sway_types::{Ident, Span, Spanned};
 
 use crate::language::ty::{self, TyScrutinee};
@@ -143,7 +142,7 @@ pub(crate) struct MatchVariableDuplicate {
 pub(crate) fn collect_duplicate_match_pattern_variables(
     scrutinee: &TyScrutinee,
 ) -> Vec<MatchVariableDuplicate> {
-    let mut left_most_branch = HashMap::new();
+    let mut left_most_branch = IndexMap::new();
     let mut branches = vec![];
 
     recursively_collect_duplicate_variables(&mut branches, &mut left_most_branch, scrutinee);
@@ -167,8 +166,8 @@ pub(crate) fn collect_duplicate_match_pattern_variables(
     return result;
 
     fn recursively_collect_duplicate_variables(
-        branches: &mut Vec<HashMap<Ident, (bool, Vec<MatchVariable>)>>,
-        left_most_branch: &mut HashMap<Ident, (bool, Vec<MatchVariable>)>,
+        branches: &mut Vec<IndexMap<Ident, (bool, Vec<MatchVariable>)>>,
+        left_most_branch: &mut IndexMap<Ident, (bool, Vec<MatchVariable>)>,
         scrutinee: &TyScrutinee,
     ) {
         match &scrutinee.variant {
@@ -198,7 +197,7 @@ pub(crate) fn collect_duplicate_match_pattern_variables(
                 // The new branch contains the identifiers collected so far in the left-most branch,
                 // but without duplicates collected so far. We want to have only unique duplicates in each branch.
                 for scrutinee in others {
-                    let mut branch: HashMap<Ident, (bool, Vec<(bool, Span)>)> = left_most_branch
+                    let mut branch: IndexMap<Ident, (bool, Vec<(bool, Span)>)> = left_most_branch
                         .iter()
                         .map(|(ident, (is_struct_field, _))| {
                             (
@@ -236,7 +235,7 @@ pub(crate) fn collect_duplicate_match_pattern_variables(
         }
 
         fn add_variable(
-            duplicate_variables: &mut HashMap<Ident, (bool, Vec<MatchVariable>)>,
+            duplicate_variables: &mut IndexMap<Ident, (bool, Vec<MatchVariable>)>,
             ident: &Ident,
             is_struct_field: bool,
         ) {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 
 use ast_node::declaration::{insert_supertraits_into_namespace, SupertraitOf};
+use indexmap::IndexMap;
 use sway_ast::intrinsics::Intrinsic;
 use sway_error::{
     convert_parse_tree_error::ConvertParseTreeError,
@@ -122,7 +123,7 @@ impl ty::TyExpression {
         let exp = ty::TyExpression {
             expression: ty::TyExpressionVariant::FunctionApplication {
                 call_path,
-                contract_call_params: HashMap::new(),
+                contract_call_params: IndexMap::new(),
                 arguments: args_and_names,
                 fn_ref: decl_ref,
                 selector: None,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -3,7 +3,7 @@ use crate::{
     language::{ty, *},
     semantic_analysis::{ast_node::*, TypeCheckContext},
 };
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use sway_error::error::CompileError;
 use sway_types::Spanned;
 
@@ -81,7 +81,7 @@ pub(crate) fn instantiate_function_application(
     let exp = ty::TyExpression {
         expression: ty::TyExpressionVariant::FunctionApplication {
             call_path: call_path_binding.inner.clone(),
-            contract_call_params: HashMap::new(),
+            contract_call_params: IndexMap::new(),
             arguments: typed_arguments_with_names,
             fn_ref: new_decl_ref,
             selector: None,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -13,7 +13,8 @@ use crate::{
     type_system::*,
 };
 use ast_node::typed_expression::check_function_arguments_arity;
-use std::collections::{HashMap, VecDeque};
+use indexmap::IndexMap;
+use std::collections::VecDeque;
 use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
@@ -83,7 +84,7 @@ pub(crate) fn type_check_method_application(
     }
 
     // generate the map of the contract call params
-    let mut contract_call_params_map = HashMap::new();
+    let mut contract_call_params_map = IndexMap::new();
     if method.is_contract_call {
         for param_name in &[
             constants::CONTRACT_CALL_GAS_PARAMETER_NAME,

--- a/sway-core/src/transform/attribute.rs
+++ b/sway-core/src/transform/attribute.rs
@@ -20,6 +20,7 @@
 //!
 //!   #[foo(bar, bar)]
 
+use indexmap::IndexMap;
 use sway_ast::Literal;
 use sway_types::{
     constants::{
@@ -29,7 +30,7 @@ use sway_types::{
     Ident, Span, Spanned,
 };
 
-use std::{collections::HashMap, hash::Hash, sync::Arc};
+use std::{hash::Hash, sync::Arc};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AttributeArg {
@@ -110,11 +111,11 @@ impl AttributeKind {
 
 /// Stores the attributes associated with the type.
 #[derive(Default, Clone, Debug, Eq, PartialEq)]
-pub struct AttributesMap(Arc<HashMap<AttributeKind, Vec<Attribute>>>);
+pub struct AttributesMap(Arc<IndexMap<AttributeKind, Vec<Attribute>>>);
 
 impl AttributesMap {
     /// Create a new attributes map.
-    pub fn new(attrs_map: Arc<HashMap<AttributeKind, Vec<Attribute>>>) -> AttributesMap {
+    pub fn new(attrs_map: Arc<IndexMap<AttributeKind, Vec<Attribute>>>) -> AttributesMap {
         AttributesMap(attrs_map)
     }
 
@@ -135,13 +136,13 @@ impl AttributesMap {
         first
     }
 
-    pub fn inner(&self) -> &HashMap<AttributeKind, Vec<Attribute>> {
+    pub fn inner(&self) -> &IndexMap<AttributeKind, Vec<Attribute>> {
         &self.0
     }
 }
 
 impl std::ops::Deref for AttributesMap {
-    type Target = Arc<HashMap<AttributeKind, Vec<Attribute>>>;
+    type Target = Arc<IndexMap<AttributeKind, Vec<Attribute>>>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -10,6 +10,7 @@ use crate::{
     BuildTarget, Engines, ExperimentalFlags,
 };
 
+use indexmap::IndexMap;
 use itertools::Itertools;
 use sway_ast::{
     attribute::Annotated,
@@ -40,12 +41,7 @@ use sway_types::{
 use sway_types::{Ident, Span, Spanned};
 
 use std::{
-    collections::{HashMap, HashSet},
-    convert::TryFrom,
-    iter,
-    mem::MaybeUninit,
-    str::FromStr,
-    sync::Arc,
+    collections::HashSet, convert::TryFrom, iter, mem::MaybeUninit, str::FromStr, sync::Arc,
 };
 
 pub fn convert_parse_tree(
@@ -4363,11 +4359,9 @@ fn path_type_to_type_info(
                     let error = ConvertParseTreeError::FullySpecifiedTypesNotSupported { span };
                     return Err(handler.emit_err(error.into()));
                 }
-                let generic_ty = match {
-                    generics_opt.and_then(|(_, generic_args)| {
-                        iter_to_array(generic_args.parameters.into_inner())
-                    })
-                } {
+                let generic_ty = match generics_opt.and_then(|(_, generic_args)| {
+                    iter_to_array(generic_args.parameters.into_inner())
+                }) {
                     Some([ty]) => ty,
                     None => {
                         let error = ConvertParseTreeError::ContractCallerOneGenericArg { span };
@@ -4443,7 +4437,7 @@ fn item_attrs_to_map(
     handler: &Handler,
     attribute_list: &[AttributeDecl],
 ) -> Result<AttributesMap, ErrorEmitted> {
-    let mut attrs_map: HashMap<_, Vec<Attribute>> = HashMap::new();
+    let mut attrs_map: IndexMap<_, Vec<Attribute>> = IndexMap::new();
 
     for attr_decl in attribute_list {
         let attrs = attr_decl.attribute.get().into_iter();

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
@@ -11,7 +12,7 @@ use crate::{
 };
 
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashSet},
     fmt,
 };
 
@@ -170,7 +171,7 @@ impl TypeId {
         filter_fn: &F,
         trait_constraints: Vec<TraitConstraint>,
         depth: usize,
-    ) -> HashMap<TypeId, Vec<TraitConstraint>>
+    ) -> IndexMap<TypeId, Vec<TraitConstraint>>
     where
         F: Fn(&TypeInfo) -> bool,
     {
@@ -188,7 +189,7 @@ impl TypeId {
         engines: &Engines,
         filter_fn: &F,
         depth: usize,
-    ) -> HashMap<TypeId, Vec<TraitConstraint>>
+    ) -> IndexMap<TypeId, Vec<TraitConstraint>>
     where
         F: Fn(&TypeInfo) -> bool,
     {
@@ -197,8 +198,8 @@ impl TypeId {
         }
 
         fn extend(
-            hashmap: &mut HashMap<TypeId, Vec<TraitConstraint>>,
-            hashmap_other: HashMap<TypeId, Vec<TraitConstraint>>,
+            hashmap: &mut IndexMap<TypeId, Vec<TraitConstraint>>,
+            hashmap_other: IndexMap<TypeId, Vec<TraitConstraint>>,
         ) {
             for (type_id, trait_constraints) in hashmap_other {
                 if let Some(existing_trait_constraints) = hashmap.get_mut(&type_id) {
@@ -210,7 +211,7 @@ impl TypeId {
         }
 
         let decl_engine = engines.de();
-        let mut found: HashMap<TypeId, Vec<TraitConstraint>> = HashMap::new();
+        let mut found: IndexMap<TypeId, Vec<TraitConstraint>> = IndexMap::new();
         match &*engines.te().get(*self) {
             TypeInfo::Unknown
             | TypeInfo::Placeholder(_)
@@ -414,7 +415,7 @@ impl TypeId {
     pub(crate) fn extract_inner_types_with_trait_constraints(
         &self,
         engines: &Engines,
-    ) -> HashMap<TypeId, Vec<TraitConstraint>> {
+    ) -> IndexMap<TypeId, Vec<TraitConstraint>> {
         fn filter_fn(_type_info: &TypeInfo) -> bool {
             true
         }

--- a/sway-error/Cargo.toml
+++ b/sway-error/Cargo.toml
@@ -19,3 +19,6 @@ uwuify = { version = "^0.2", optional = true }
 [features]
 default = []
 uwu = ["uwuify"]
+
+[lints.clippy]
+iter_over_hash_type = "deny"

--- a/sway-ir/Cargo.toml
+++ b/sway-ir/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0"
 downcast-rs = "1.2.0"
 filecheck = "0.5"
 generational-arena = "0.2"
+indexmap = { version = "2.0.0", features = ["rayon"] }
 itertools = "0.10.3"
 once_cell = "1.18.0"
 peg = "0.7"
@@ -21,3 +22,6 @@ rustc-hash = "1.1.0"
 sway-ir-macros = { version = "0.50.0", path = "sway-ir-macros" }
 sway-types = { version = "0.50.0", path = "../sway-types" }
 sway-utils = { version = "0.50.0", path = "../sway-utils" }
+
+[lints.clippy]
+iter_over_hash_type = "deny"

--- a/sway-ir/src/analysis/call_graph.rs
+++ b/sway-ir/src/analysis/call_graph.rs
@@ -3,16 +3,17 @@
 /// graph has an edge F1->F2.
 use crate::{Context, Function, InstOp, Instruction, ValueDatum};
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use indexmap::IndexSet;
+use sway_types::{FxIndexMap, FxIndexSet};
 
-pub type CallGraph = FxHashMap<Function, FxHashSet<Function>>;
+pub type CallGraph = FxIndexMap<Function, FxIndexSet<Function>>;
 
 /// Build call graph considering all providing functions.
 pub fn build_call_graph(ctx: &Context, functions: &[Function]) -> CallGraph {
     let mut res = CallGraph::default();
     for function in functions {
         let entry = res.entry(*function);
-        let entry = entry.or_insert_with(FxHashSet::default);
+        let entry = entry.or_insert_with(IndexSet::default);
         for (_, inst) in function.instruction_iter(ctx) {
             if let ValueDatum::Instruction(Instruction {
                 op: InstOp::Call(callee, _),
@@ -32,10 +33,10 @@ pub fn build_call_graph(ctx: &Context, functions: &[Function]) -> CallGraph {
 pub fn callee_first_order(cg: &CallGraph) -> Vec<Function> {
     let mut res = Vec::new();
 
-    let mut visited = FxHashSet::<Function>::default();
+    let mut visited = FxIndexSet::<Function>::default();
     fn post_order_visitor(
         cg: &CallGraph,
-        visited: &mut FxHashSet<Function>,
+        visited: &mut FxIndexSet<Function>,
         res: &mut Vec<Function>,
         node: Function,
     ) {

--- a/sway-ir/src/analysis/memory_utils.rs
+++ b/sway-ir/src/analysis/memory_utils.rs
@@ -1,7 +1,10 @@
 //! An analysis to compute symbols that escape out from a function.
 //! This could be into another function, or via ptr_to_int etc.
 //! Any transformations involving such symbols are unsafe.
-use rustc_hash::{FxHashMap, FxHashSet};
+
+use indexmap::IndexSet;
+use rustc_hash::FxHashSet;
+use sway_types::{FxIndexMap, FxIndexSet};
 
 use crate::{
     AnalysisResult, AnalysisResultT, AnalysisResults, BlockArgument, Context, FuelVmInstruction,
@@ -43,12 +46,12 @@ impl Symbol {
 }
 
 // A value may (indirectly) refer to one or more symbols.
-pub fn get_symbols(context: &Context, val: Value) -> FxHashSet<Symbol> {
+pub fn get_symbols(context: &Context, val: Value) -> FxIndexSet<Symbol> {
     let mut visited = FxHashSet::default();
-    let mut symbols = FxHashSet::<Symbol>::default();
+    let mut symbols = IndexSet::default();
     fn get_symbols_rec(
         context: &Context,
-        symbols: &mut FxHashSet<Symbol>,
+        symbols: &mut FxIndexSet<Symbol>,
         visited: &mut FxHashSet<Value>,
         val: Value,
     ) {
@@ -211,8 +214,8 @@ pub fn get_loaded_ptr_values(context: &Context, val: Value) -> Vec<Value> {
 }
 
 /// Symbols that may possibly be loaded from.
-pub fn get_loaded_symbols(context: &Context, val: Value) -> FxHashSet<Symbol> {
-    let mut res = FxHashSet::default();
+pub fn get_loaded_symbols(context: &Context, val: Value) -> FxIndexSet<Symbol> {
+    let mut res = IndexSet::default();
     for val in get_loaded_ptr_values(context, val) {
         for sym in get_symbols(context, val) {
             res.insert(sym);
@@ -265,8 +268,8 @@ pub fn get_stored_ptr_values(context: &Context, val: Value) -> Vec<Value> {
 }
 
 /// Symbols that may possibly be stored to.
-pub fn get_stored_symbols(context: &Context, val: Value) -> FxHashSet<Symbol> {
-    let mut res = FxHashSet::default();
+pub fn get_stored_symbols(context: &Context, val: Value) -> FxIndexSet<Symbol> {
+    let mut res = IndexSet::default();
     for val in get_stored_ptr_values(context, val) {
         for sym in get_symbols(context, val) {
             res.insert(sym);
@@ -302,7 +305,7 @@ pub fn combine_indices(context: &Context, val: Value) -> Option<Vec<Value>> {
 
 /// Given a memory pointer instruction, compute the offset of indexed element,
 /// for each symbol that this may alias to.
-pub fn get_memory_offsets(context: &Context, val: Value) -> FxHashMap<Symbol, u64> {
+pub fn get_memory_offsets(context: &Context, val: Value) -> FxIndexMap<Symbol, u64> {
     get_symbols(context, val)
         .into_iter()
         .filter_map(|sym| {

--- a/sway-ir/src/optimize/const_demotion.rs
+++ b/sway-ir/src/optimize/const_demotion.rs
@@ -1,5 +1,3 @@
-use std::collections::hash_map::Entry;
-
 /// Constant value demotion.
 ///
 /// This pass demotes 'by-value' constant types to 'by-reference` pointer types, based on target
@@ -13,6 +11,7 @@ use crate::{
 };
 
 use rustc_hash::FxHashMap;
+use sway_types::FxIndexMap;
 
 pub const CONSTDEMOTION_NAME: &str = "constdemotion";
 
@@ -31,7 +30,7 @@ pub fn const_demotion(
     function: Function,
 ) -> Result<bool, IrError> {
     // Find all candidate constant values and their wrapped constants.
-    let mut candidate_values: FxHashMap<Block, Vec<(Value, Constant)>> = FxHashMap::default();
+    let mut candidate_values: FxIndexMap<Block, Vec<(Value, Constant)>> = FxIndexMap::default();
 
     for (block, inst) in function.instruction_iter(context) {
         let operands = inst.get_instruction(context).unwrap().op.get_operands();
@@ -40,10 +39,10 @@ pub fn const_demotion(
                 if super::target_fuel::is_demotable_type(context, &c.ty) {
                     let dem = (*val, c.clone());
                     match candidate_values.entry(block) {
-                        Entry::Occupied(mut occ) => {
+                        indexmap::map::Entry::Occupied(mut occ) => {
                             occ.get_mut().push(dem);
                         }
-                        Entry::Vacant(vac) => {
+                        indexmap::map::Entry::Vacant(vac) => {
                             vac.insert(vec![dem]);
                         }
                     }

--- a/sway-ir/src/optimize/mem2reg.rs
+++ b/sway-ir/src/optimize/mem2reg.rs
@@ -1,10 +1,11 @@
+use indexmap::IndexMap;
 /// Promote local memory to SSA registers.
 /// This pass is essentially SSA construction. A good readable reference is:
 /// https://www.cs.princeton.edu/~appel/modern/c/
 /// We use block arguments instead of explicit PHI nodes. Conceptually,
 /// they are both the same.
 use rustc_hash::FxHashMap;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use sway_utils::mapped_stack::MappedStack;
 
 use crate::{
@@ -223,7 +224,7 @@ pub fn promote_to_registers(
     ) {
         // Whatever new definitions we find in this block, they must be popped
         // when we're done. So let's keep track of that locally as a count.
-        let mut num_local_pushes = HashMap::<String, u32>::new();
+        let mut num_local_pushes = IndexMap::<String, u32>::new();
 
         // Start with relevant block args, they are new definitions.
         for arg in node.arg_iter(context) {

--- a/sway-ir/sway-ir-macros/Cargo.toml
+++ b/sway-ir/sway-ir-macros/Cargo.toml
@@ -16,3 +16,6 @@ itertools = "0.10.3"
 proc-macro2 = "1.0.43"
 quote = "1.0.21"
 syn = { version = "1.0.99", features = ["derive", "extra-traits"] }
+
+[lints.clippy]
+iter_over_hash_type = "deny"

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -16,6 +16,7 @@ fd-lock = "4.0"
 forc-pkg = { version = "0.50.0", path = "../forc-pkg" }
 forc-tracing = { version = "0.50.0", path = "../forc-tracing" }
 forc-util = { version = "0.50.0", path = "../forc-util" }
+indexmap = { version = "2.0.0", features = ["rayon"] }
 lsp-types = { version = "0.94", features = ["proposed"] }
 notify = "5.0.0"
 notify-debouncer-mini = { version = "0.2.0" }
@@ -72,3 +73,6 @@ harness = false
 
 [lib]
 bench = false
+
+[lints.clippy]
+iter_over_hash_type = "deny"

--- a/sway-lsp/src/capabilities/code_actions/common/generate_impl.rs
+++ b/sway-lsp/src/capabilities/code_actions/common/generate_impl.rs
@@ -14,7 +14,7 @@ pub(crate) trait GenerateImplCodeAction<'a, T: Spanned>: CodeAction<'a, T> {
     fn decl_name(&self) -> String;
 
     /// Returns an optional [String] of the type parameters for the given [TypeParameter] vector.
-    fn type_param_string(&self, type_params: &Vec<TypeParameter>) -> Option<String> {
+    fn type_param_string(&self, type_params: &[TypeParameter]) -> Option<String> {
         if type_params.is_empty() {
             None
         } else {

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -4,12 +4,12 @@ use crate::{
 };
 use dashmap::DashMap;
 use forc_pkg::{manifest::Dependency, PackageManifestFile};
+use indexmap::IndexMap;
 use lsp_types::Url;
 use notify::RecursiveMode;
 use notify_debouncer_mini::new_debouncer;
 use parking_lot::RwLock;
 use std::{
-    collections::HashMap,
     fs::{self, File},
     io::{Read, Write},
     path::{Path, PathBuf},
@@ -263,7 +263,7 @@ pub(crate) fn edit_manifest_dependency_paths(
 ) {
     // Key = name of the dependancy that has been specified will a relative path
     // Value = the absolute path that should be used to overwrite the relateive path
-    let mut dependency_map: HashMap<String, PathBuf> = HashMap::new();
+    let mut dependency_map: IndexMap<String, PathBuf> = IndexMap::new();
 
     if let Some(deps) = &manifest.dependencies {
         for (name, dep) in deps.iter() {

--- a/sway-parse/Cargo.toml
+++ b/sway-parse/Cargo.toml
@@ -23,3 +23,6 @@ unicode-xid = "0.2.2"
 [dev-dependencies]
 assert_matches = "1.5.0"
 insta = { version = "1.28.0", features = ["ron"] }
+
+[lints.clippy]
+iter_over_hash_type = "deny"

--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -13,12 +13,17 @@ bytecount = "0.6"
 fuel-asm = { workspace = true }
 fuel-crypto = { workspace = true }
 fuel-tx = { workspace = true }
+indexmap = "2.0.0"
 lazy_static = "1.4"
 num-bigint = "0.4.3"
 num-traits = "0.2.16"
+rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 sway-utils = { version = "0.50.0", path = "../sway-utils" }
 thiserror = "1"
 
 [features]
 no-span-debug = []
+
+[lints.clippy]
+iter_over_hash_type = "deny"

--- a/sway-types/src/lib.rs
+++ b/sway-types/src/lib.rs
@@ -397,3 +397,7 @@ impl Context {
         }
     }
 }
+
+pub type FxBuildHasher = std::hash::BuildHasherDefault<rustc_hash::FxHasher>;
+pub type FxIndexMap<K, V> = indexmap::IndexMap<K, V, FxBuildHasher>;
+pub type FxIndexSet<K> = indexmap::IndexSet<K, FxBuildHasher>;

--- a/sway-utils/Cargo.toml
+++ b/sway-utils/Cargo.toml
@@ -11,3 +11,6 @@ repository.workspace = true
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 walkdir = "2.3.3"
+
+[lints.clippy]
+iter_over_hash_type = "deny"

--- a/sway-utils/src/helpers.rs
+++ b/sway-utils/src/helpers.rs
@@ -43,7 +43,7 @@ pub fn is_sway_file(file: &Path) -> bool {
 /// assert_eq!(it.next(), None);
 ///
 /// ```
-pub fn iter_prefixes<T>(slice: &[T]) -> impl Iterator<Item = &[T]> + DoubleEndedIterator {
+pub fn iter_prefixes<T>(slice: &[T]) -> impl DoubleEndedIterator<Item = &[T]> {
     (1..=slice.len()).map(move |len| &slice[..len])
 }
 
@@ -62,21 +62,18 @@ pub fn find_nested_dir_with_file(starter_path: &Path, file_name: &str) -> Option
     } else {
         starter_path.parent()?
     };
-    WalkDir::new(starter_path)
-        .into_iter()
-        .filter_map(|e| {
-            let entry = e.ok()?;
-            if entry.path() != starter_dir.join(file_name)
-                && entry.file_name().to_string_lossy() == file_name
-            {
-                let mut entry = entry.path().to_path_buf();
-                entry.pop();
-                Some(entry)
-            } else {
-                None
-            }
-        })
-        .next()
+    WalkDir::new(starter_path).into_iter().find_map(|e| {
+        let entry = e.ok()?;
+        if entry.path() != starter_dir.join(file_name)
+            && entry.file_name().to_string_lossy() == file_name
+        {
+            let mut entry = entry.path().to_path_buf();
+            entry.pop();
+            Some(entry)
+        } else {
+            None
+        }
+    })
 }
 
 /// Continually go up in the file tree until a specified file is found.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle.json
@@ -79,7 +79,7 @@
         "typeArguments": null
       },
       "name": "C7_2",
-      "offset": 4804
+      "offset": 4796
     },
     {
       "configurableType": {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -2,7 +2,7 @@ script;
 use basic_storage_abi::{BasicStorage, Quad};
 
 fn main() -> u64 {
-    let addr = abi(BasicStorage, 0xae7f9f2c90c7d0ef5295b1fcd1a7a1c75e080438ca86311b34271eebbb934593);
+    let addr = abi(BasicStorage, 0x1cb4847c0c736d7bc3a904728b3695b6a8e83be195ec6652cf9047bbe94f3b64);
     let key = 0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
@@ -3,7 +3,7 @@ script;
 use storage_enum_abi::*;
 
 fn main() -> u64 {
-    let contract_id = 0x98847a788b7eb370581f902c5395ba999d7d16b4762fc31f4719cbf88f2c1dcb;
+    let contract_id = 0x2c6686f3a059e41298f5680c92a8effdc628cf86ac293b84ea9fc10fa1fd7906;
     let caller = abi(StorageEnum, contract_id);
 
     let res = caller.read_write_enums();


### PR DESCRIPTION
## Description

This PR does three things:

1. use Rust 1.76.0
2. enable the new `iter_over_hash_type` Clippy lint on relevant crates
3. use `indexmap::IndexMap` to replace any equivalent `HashMap` being iterated upon with a deterministically ordered alternative


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
