### PR TITLE
Enhance autocomplete generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_fig"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed37b4c0c1214673eba6ad8ea31666626bf72be98ffb323067d973c48b4964b9"
+dependencies = [
+ "clap 3.2.25",
+ "clap_complete 3.2.5",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +1986,7 @@ dependencies = [
  "anyhow",
  "clap 3.2.25",
  "clap_complete 3.2.5",
+ "clap_complete_fig",
  "forc-pkg",
  "forc-test",
  "forc-tracing 0.50.0",
@@ -2091,7 +2102,7 @@ name = "forc-doc"
 version = "0.50.0"
 dependencies = [
  "anyhow",
- "clap 4.5.0",
+ "clap 3.2.25",
  "colored",
  "comrak",
  "dir_indexer",
@@ -2242,7 +2253,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serial_test",
  "sway-core",
  "sway-error",
  "sway-types",
@@ -6099,31 +6109,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ad9342b3aaca7cb43c45c097dd008d4907070394bd0751a0aa8817e5a018d"
-dependencies = [
- "dashmap",
- "futures",
- "lazy_static",
- "log",
- "parking_lot 0.12.1",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,6 +2083,7 @@ dependencies = [
  "escargot",
  "forc-pkg",
  "forc-test",
+ "forc-util",
  "fuel-core-client",
  "fuel-types",
  "fuel-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,6 +1994,7 @@ dependencies = [
  "fs_extra",
  "fuel-asm",
  "hex",
+ "home",
  "serde",
  "serde_json",
  "sway-core",

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "forc-client"
 version = "0.50.0"
-description = "A `forc` plugin for interacting with a Fuel node."
+description = "A `forc` plugin for interacting with a Fuel node"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/forc-plugins/forc-client/src/bin/deploy.rs
+++ b/forc-plugins/forc-client/src/bin/deploy.rs
@@ -1,8 +1,9 @@
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use forc_tracing::{init_tracing_subscriber, println_error};
 
 #[tokio::main]
 async fn main() {
+    forc_util::cli::register(forc_client::cmd::Deploy::into_app());
     init_tracing_subscriber(Default::default());
     let command = forc_client::cmd::Deploy::parse();
     if let Err(err) = forc_client::op::deploy(command).await {

--- a/forc-plugins/forc-client/src/bin/run.rs
+++ b/forc-plugins/forc-client/src/bin/run.rs
@@ -1,8 +1,9 @@
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use forc_tracing::{init_tracing_subscriber, println_error};
 
 #[tokio::main]
 async fn main() {
+    forc_util::cli::register(forc_client::cmd::Run::into_app());
     init_tracing_subscriber(Default::default());
     let command = forc_client::cmd::Run::parse();
     if let Err(err) = forc_client::op::run(command).await {

--- a/forc-plugins/forc-client/src/bin/submit.rs
+++ b/forc-plugins/forc-client/src/bin/submit.rs
@@ -1,8 +1,9 @@
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use forc_tracing::{init_tracing_subscriber, println_error};
 
 #[tokio::main]
 async fn main() {
+    forc_util::cli::register(forc_client::cmd::Submit::into_app());
     init_tracing_subscriber(Default::default());
     let command = forc_client::cmd::Submit::parse();
     if let Err(err) = forc_client::op::submit(command).await {

--- a/forc-plugins/forc-crypto/src/main.rs
+++ b/forc-plugins/forc-crypto/src/main.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use atty::Stream;
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use forc_tracing::{init_tracing_subscriber, println_error};
 use std::{
     default::Default,
@@ -57,6 +57,7 @@ fn main() {
 }
 
 fn run() -> Result<()> {
+    forc_util::cli::register(Command::into_app());
     let app = Command::parse();
     let content = match app {
         Command::Keccak256(arg) => keccak256::hash(arg)?,

--- a/forc-plugins/forc-crypto/src/main.rs
+++ b/forc-plugins/forc-crypto/src/main.rs
@@ -16,7 +16,7 @@ mod keccak256;
 mod keys;
 mod sha256;
 
-const ABOUT: &str = "Forc plugin for hashing arbitrary data.";
+const ABOUT: &str = "Forc plugin for hashing arbitrary data";
 
 fn help() -> &'static str {
     Box::leak(

--- a/forc-plugins/forc-debug/Cargo.toml
+++ b/forc-plugins/forc-debug/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "3", features = ["env", "derive"] }
 dap = "0.4.1-alpha1"
 forc-pkg = { version = "0.50.0", path = "../../forc-pkg" }
 forc-test = { version = "0.50.0", path = "../../forc-test" }
+forc-util = { version = "0.50.0", path = "../../forc-util" }
 fuel-core-client = { workspace = true }
 fuel-types = { workspace = true, features = ["serde"] }
 fuel-vm = { workspace = true, features = ["serde"] }

--- a/forc-plugins/forc-debug/src/main.rs
+++ b/forc-plugins/forc-debug/src/main.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use forc_debug::{
     names::{register_index, register_name},
     server::DapServer,
@@ -20,6 +20,7 @@ pub struct Opt {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    forc_util::cli::register(Opt::into_app());
     let config = Opt::parse();
 
     if config.serve {

--- a/forc-plugins/forc-doc/Cargo.toml
+++ b/forc-plugins/forc-doc/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow = "1.0.65"
-clap = { version = "4.0.18", features = ["derive"] }
+clap = { version = "3", features = ["derive"] }
 colored = "2.0.0"
 comrak = "0.16"
 forc-pkg = { version = "0.50.0", path = "../../forc-pkg" }

--- a/forc-plugins/forc-doc/src/main.rs
+++ b/forc-plugins/forc-doc/src/main.rs
@@ -4,7 +4,7 @@ use crate::{
     search::write_search_index,
 };
 use anyhow::{bail, Result};
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use cli::Command;
 use colored::*;
 use forc_pkg as pkg;
@@ -51,6 +51,7 @@ struct ProgramInfo<'a> {
 }
 
 pub fn main() -> Result<()> {
+    forc_util::cli::register(Command::into_app());
     let build_instructions = Command::parse();
 
     let (doc_path, pkg_manifest) = compile_html(&build_instructions, &get_doc_dir)?;

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -35,7 +35,7 @@ forc_util::cli_examples! {
 #[derive(Debug, Parser)]
 #[clap(
     name = "forc-fmt",
-    about = "Forc plugin for running the Sway code formatter.",
+    about = "Forc plugin for running the Sway code formatter",
     after_help = help(),
     version
 )]

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -1,7 +1,7 @@
 //! A `forc` plugin for running the Sway code formatter.
 
 use anyhow::{bail, Result};
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use forc_pkg::{
     manifest::{GenericManifestFile, ManifestFile},
     WorkspaceManifestFile,
@@ -51,7 +51,8 @@ pub struct App {
     pub path: Option<String>,
     #[clap(short, long)]
     /// Formats a single .sw file with the default settings.
-    /// If not specified, current working directory will be formatted using a Forc.toml configuration.
+    /// If not specified, current working directory will be formatted using a Forc.toml
+    /// configuration.
     pub file: Option<String>,
 }
 
@@ -65,6 +66,7 @@ fn main() {
 }
 
 fn run() -> Result<()> {
+    forc_util::cli::register(App::into_app());
     let app = App::parse();
 
     let dir = match app.path.as_ref() {

--- a/forc-plugins/forc-tx/src/lib.rs
+++ b/forc-plugins/forc-tx/src/lib.rs
@@ -14,6 +14,9 @@ use thiserror::Error;
 
 forc_util::cli_examples! {
     {
+        None
+    }
+    {
         // This parser has a custom parser
         super::Command::try_parse_from_args
     } {

--- a/forc-plugins/forc-tx/src/lib.rs
+++ b/forc-plugins/forc-tx/src/lib.rs
@@ -14,9 +14,6 @@ use thiserror::Error;
 
 forc_util::cli_examples! {
     {
-        None
-    }
-    {
         // This parser has a custom parser
         super::Command::try_parse_from_args
     } {
@@ -728,7 +725,8 @@ impl TryFrom<Script> for fuel_tx::Script {
             script_tx.set_script_gas_limit(script_gas_limit)
         } else {
             let consensus_params = ConsensusParameters::default();
-            // Get `max_gas` used by everything except the script execution. Add `1` because of rounding.
+            // Get `max_gas` used by everything except the script execution. Add `1` because of
+            // rounding.
             let max_gas =
                 script_tx.max_gas(consensus_params.gas_costs(), consensus_params.fee_params()) + 1;
             // Increase `script_gas_limit` to the maximum allowed value.

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -21,8 +21,7 @@ hex = "0.4.3"
 paste = "1.0.14"
 regex = "1.10.2"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.73"
-serial_test = "3.0.0"
+serde_json = "1.0"
 sway-core = { version = "0.50.0", path = "../sway-core" }
 sway-error = { version = "0.50.0", path = "../sway-error" }
 sway-types = { version = "0.50.0", path = "../sway-types" }

--- a/forc-util/src/cli.rs
+++ b/forc-util/src/cli.rs
@@ -1,9 +1,145 @@
+use clap::{ArgAction, Command};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CommandInfo {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub long_help: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub subcommands: Vec<CommandInfo>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub args: Vec<ArgInfo>,
+}
+
+impl CommandInfo {
+    pub fn new(cmd: &Command) -> Self {
+        CommandInfo {
+            name: cmd.get_name().to_owned(),
+            long_help: cmd.get_after_long_help().map(|s| s.to_string()),
+            description: cmd.get_about().map(|s| s.to_string()),
+            subcommands: Self::get_subcommands(cmd),
+            args: Self::get_args(cmd),
+        }
+    }
+
+    pub fn to_clap(&self) -> clap::App<'_> {
+        let mut cmd = Command::new(self.name.as_str());
+        if let Some(desc) = &self.description {
+            cmd = cmd.about(desc.as_str());
+        }
+        if let Some(long_help) = &self.long_help {
+            cmd = cmd.after_long_help(long_help.as_str());
+        }
+        for subcommand in &self.subcommands {
+            cmd = cmd.subcommand(subcommand.to_clap());
+        }
+        for arg in &self.args {
+            cmd = cmd.arg(arg.to_clap());
+        }
+        cmd
+    }
+
+    fn get_subcommands(cmd: &Command) -> Vec<CommandInfo> {
+        cmd.get_subcommands()
+            .map(|subcommand| CommandInfo::new(subcommand))
+            .collect::<Vec<_>>()
+    }
+
+    fn arg_conflicts(cmd: &Command, arg: &clap::Arg) -> Vec<String> {
+        let mut res = vec![];
+
+        for conflict in cmd.get_arg_conflicts_with(arg) {
+            if let Some(s) = conflict.get_short() {
+                res.push(format!("-{}", s));
+            }
+
+            if let Some(l) = conflict.get_long() {
+                res.push(format!("--{}", l));
+            }
+        }
+
+        res
+    }
+
+    fn get_args(cmd: &Command) -> Vec<ArgInfo> {
+        cmd.get_arguments()
+            .map(|opt| ArgInfo {
+                name: opt.get_name().to_string(),
+                short: opt.get_short_and_visible_aliases(),
+                aliases: opt
+                    .get_long_and_visible_aliases()
+                    .map(|c| c.iter().map(|x| x.to_string()).collect::<Vec<_>>())
+                    .unwrap_or_default(),
+                help: opt.get_help().map(|s| s.to_string()),
+                long_help: opt.get_long_help().map(|s| s.to_string()),
+                conflicts: Self::arg_conflicts(cmd, opt),
+                is_repeatable: matches!(
+                    opt.get_action(),
+                    ArgAction::Set | ArgAction::Append | ArgAction::Count,
+                ),
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ArgInfo {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub short: Option<Vec<char>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub help: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub long_help: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub conflicts: Vec<String>,
+    pub is_repeatable: bool,
+}
+
+impl ArgInfo {
+    pub fn to_clap(&self) -> clap::Arg<'_> {
+        let mut arg = clap::Arg::with_name(self.name.as_str());
+        if let Some(short) = &self.short {
+            arg = arg.short(short[0]);
+        }
+        if let Some(help) = &self.help {
+            arg = arg.help(help.as_str());
+        }
+        if let Some(long_help) = &self.long_help {
+            arg = arg.long_help(long_help.as_str());
+        }
+        if self.is_repeatable {
+            arg = arg.multiple(true);
+        }
+        arg
+    }
+}
+
 #[macro_export]
 // Let the user format the help and parse it from that string into arguments to create the unit test
 macro_rules! cli_examples {
     ($st:path { $( [ $($description:ident)* => $command:stmt ] )* }) => {
         forc_util::cli_examples! {
             {
+                $crate::paste::paste! {
+                    use clap::IntoApp;
+                    Some($st::into_app())
+                }
+            } {
                 $crate::paste::paste! {
                     use clap::Parser;
                     $st::try_parse_from
@@ -13,15 +149,14 @@ macro_rules! cli_examples {
             }
         }
     };
-    ( $code:block { $( [ $($description:ident)* => $command:stmt ] )* }) => {
+    ( $into_app:block $parser:block { $( [ $($description:ident)* => $command:stmt ] )* }) => {
         $crate::paste::paste! {
         #[cfg(test)]
         mod cli_parsing {
             $(
             #[test]
             fn [<$($description:lower _)*:snake example>] () {
-
-                let cli_parser = $code;
+                let cli_parser = $parser;
                 let mut args = parse_args($command);
                 if cli_parser(args.clone()).is_err() {
                     // Failed to parse, it maybe a plugin. To execute a plugin the first argument needs to be removed, `forc`.
@@ -101,11 +236,34 @@ macro_rules! cli_examples {
         }
         }
 
+        mod cli_definition {
+            /// Dump the CLI definition to the stdout
+            pub(crate) fn dump() {
+                std::env::set_var("CLI_DUMP_DEFINITION", "");
 
+                if let Some(mut cmd) = $into_app {
+                    forc_util::serde_json::to_writer_pretty(
+                        std::io::stdout(),
+                        &forc_util::cli::CommandInfo::new(&cmd)
+                    ).unwrap();
+                    std::process::exit(0);
+                }
+            }
+        }
+
+        /// Show the long help for the current app
+        ///
+        /// This function is being called automatically, so if CLI_DUMP_DEFINITION is set to 1, it
+        /// will dump the definition of the CLI. Otherwise, it would have to be manually invoked by
+        /// the developer
         fn help() -> &'static str {
+            if std::env::var("CLI_DUMP_DEFINITION") == Ok("1".to_string()) {
+                cli_definition::dump();
+            }
             Box::leak(format!("{}\n{}", forc_util::ansi_term::Colour::Yellow.paint("EXAMPLES:"), examples()).into_boxed_str())
         }
 
+        /// Returns the examples for the command
         pub fn examples() -> &'static str {
             Box::leak( [
             $(

--- a/forc-util/src/cli.rs
+++ b/forc-util/src/cli.rs
@@ -165,6 +165,35 @@ impl ArgInfo {
     }
 }
 
+pub fn dump_cli_definition<X: clap::IntoApp>(app: X) {
+    let cmd = app.into_app();
+    serde_json::to_writer_pretty(std::io::stdout(), &CommandInfo::new(&cmd)).unwrap();
+    std::process::exit(0);
+}
+
+macro_rules! clap_completions {
+    ($st:path) => {
+        use clap::IntoApp;
+        $st::into_app()
+
+        mod cli_definition {
+            /// Dump the CLI definition to the stdout
+            pub(crate) fn dump() {
+                std::env::set_var("CLI_DUMP_DEFINITION", "");
+
+                if let Some(mut cmd) = $into_app {
+                    forc_util::serde_json::to_writer_pretty(
+                        std::io::stdout(),
+                        &forc_util::cli::CommandInfo::new(&cmd)
+                    ).unwrap();
+                    std::process::exit(0);
+                }
+            }
+        }
+
+    };
+}
+
 #[macro_export]
 // Let the user format the help and parse it from that string into arguments to create the unit test
 macro_rules! cli_examples {

--- a/forc-util/src/cli.rs
+++ b/forc-util/src/cli.rs
@@ -53,19 +53,16 @@ impl CommandInfo {
     }
 
     fn arg_conflicts(cmd: &Command, arg: &clap::Arg) -> Vec<String> {
-        let mut res = vec![];
-
-        for conflict in cmd.get_arg_conflicts_with(arg) {
-            if let Some(s) = conflict.get_short() {
-                res.push(format!("-{}", s));
-            }
-
-            if let Some(l) = conflict.get_long() {
-                res.push(format!("--{}", l));
-            }
-        }
-
-        res
+        cmd.get_arg_conflicts_with(arg)
+            .iter()
+            .flat_map(|conflict| {
+                vec![
+                    conflict.get_short().map(|s| format!("-{}", s)),
+                    conflict.get_long().map(|l| format!("--{}", l)),
+                ]
+            })
+            .filter_map(|opt| opt)
+            .collect()
     }
 
     fn get_args(cmd: &Command) -> Vec<ArgInfo> {

--- a/forc-util/src/cli.rs
+++ b/forc-util/src/cli.rs
@@ -61,7 +61,7 @@ impl CommandInfo {
                     conflict.get_long().map(|l| format!("--{}", l)),
                 ]
             })
-            .filter_map(|opt| opt)
+            .flatten()
             .collect()
     }
 
@@ -81,14 +81,18 @@ impl CommandInfo {
 
     fn arg_alias(arg: &clap::Arg<'_>) -> Vec<String> {
         arg.get_long_and_visible_aliases()
-            .map(|c| c.iter().map(|x| x.to_string()).collect::<Vec<_>>())
+            .map(|c| c.iter().map(|x| format!("--{}", x)).collect::<Vec<_>>())
             .unwrap_or_default()
     }
 
     fn get_args(cmd: &Command) -> Vec<ArgInfo> {
         cmd.get_arguments()
             .map(|arg| ArgInfo {
-                name: arg.get_name().to_string(),
+                name: if arg.get_long().is_some() {
+                    format!("--{}", arg.get_name())
+                } else {
+                    arg.get_name().to_string()
+                },
                 possible_values: Self::arg_possible_values(arg),
                 short: arg.get_short_and_visible_aliases(),
                 aliases: Self::arg_alias(arg),

--- a/forc-util/src/cli.rs
+++ b/forc-util/src/cli.rs
@@ -65,31 +65,38 @@ impl CommandInfo {
             .collect()
     }
 
+    fn arg_possible_values(arg: &clap::Arg<'_>) -> Vec<PossibleValues> {
+        arg.get_possible_values()
+            .map(|possible_values| {
+                possible_values
+                    .iter()
+                    .map(|x| PossibleValues {
+                        name: x.get_name().to_owned(),
+                        help: x.get_help().unwrap_or_default().to_owned(),
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+    }
+
+    fn arg_alias(arg: &clap::Arg<'_>) -> Vec<String> {
+        arg.get_long_and_visible_aliases()
+            .map(|c| c.iter().map(|x| x.to_string()).collect::<Vec<_>>())
+            .unwrap_or_default()
+    }
+
     fn get_args(cmd: &Command) -> Vec<ArgInfo> {
         cmd.get_arguments()
-            .map(|opt| ArgInfo {
-                name: opt.get_name().to_string(),
-                possible_values: opt
-                    .get_possible_values()
-                    .map(|x| {
-                        x.iter()
-                            .map(|x| PossibleValues {
-                                name: x.get_name().to_owned(),
-                                help: x.get_help().unwrap_or_default().to_owned(),
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                    .unwrap_or_default(),
-                short: opt.get_short_and_visible_aliases(),
-                aliases: opt
-                    .get_long_and_visible_aliases()
-                    .map(|c| c.iter().map(|x| x.to_string()).collect::<Vec<_>>())
-                    .unwrap_or_default(),
-                help: opt.get_help().map(|s| s.to_string()),
-                long_help: opt.get_long_help().map(|s| s.to_string()),
-                conflicts: Self::arg_conflicts(cmd, opt),
+            .map(|arg| ArgInfo {
+                name: arg.get_name().to_string(),
+                possible_values: Self::arg_possible_values(arg),
+                short: arg.get_short_and_visible_aliases(),
+                aliases: Self::arg_alias(arg),
+                help: arg.get_help().map(|s| s.to_string()),
+                long_help: arg.get_long_help().map(|s| s.to_string()),
+                conflicts: Self::arg_conflicts(cmd, arg),
                 is_repeatable: matches!(
-                    opt.get_action(),
+                    arg.get_action(),
                     ArgAction::Set | ArgAction::Append | ArgAction::Count,
                 ),
             })

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -34,7 +34,7 @@ pub mod cli;
 pub use ansi_term;
 pub use paste;
 pub use regex::Regex;
-pub use serial_test;
+pub use serde_json;
 
 pub const DEFAULT_OUTPUT_DIRECTORY: &str = "out";
 pub const DEFAULT_ERROR_EXIT_CODE: u8 = 1;

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -30,6 +30,7 @@ forc-util = { version = "0.50.0", path = "../forc-util" }
 fs_extra = "1.2"
 fuel-asm = { workspace = true }
 hex = "0.4.3"
+home = "0.5.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 sway-core = { version = "0.50.0", path = "../sway-core" }

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -22,6 +22,7 @@ ansi_term = "0.12"
 anyhow = "1.0.41"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 clap_complete = "3.1"
+clap_complete_fig = "3.1"
 forc-pkg = { version = "0.50.0", path = "../forc-pkg" }
 forc-test = { version = "0.50.0", path = "../forc-test" }
 forc-tracing = { version = "0.50.0", path = "../forc-tracing" }
@@ -30,7 +31,7 @@ fs_extra = "1.2"
 fuel-asm = { workspace = true }
 hex = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.73"
+serde_json = "1"
 sway-core = { version = "0.50.0", path = "../sway-core" }
 sway-error = { version = "0.50.0", path = "../sway-error" }
 sway-types = { version = "0.50.0", path = "../sway-types" }

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -4,7 +4,7 @@ use clap_complete::{generate, Generator, Shell as BuiltInShell};
 use forc_util::cli::CommandInfo;
 use forc_util::ForcResult;
 use std::collections::HashMap;
-use std::str::FromStr;
+use std::{fmt::Display, str::FromStr};
 
 use crate::cli::plugin::find_all;
 
@@ -13,6 +13,15 @@ use crate::cli::plugin::find_all;
 enum Target {
     BuiltIn(BuiltInShell),
     Fig,
+}
+
+impl Display for Target {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.to_possible_value()
+            .expect("no values are skipped")
+            .get_name()
+            .fmt(f)
+    }
 }
 
 impl FromStr for Target {

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -1,58 +1,39 @@
-use clap::{Command as ClapCommand, ValueEnum};
-use clap::{CommandFactory, Parser};
-use clap_complete::{generate, Generator, Shell as BuiltInShell};
-use forc_util::cli::CommandInfo;
-use forc_util::ForcResult;
-use std::collections::HashMap;
-use std::{fmt::Display, str::FromStr};
-
 use crate::cli::plugin::find_all;
+use clap::{Command as ClapCommand, CommandFactory, Parser};
+use clap_complete::{generate, Generator};
+use forc_util::{cli::CommandInfo, ForcResult};
+use std::{
+    collections::HashMap,
+    fs::{metadata, File, OpenOptions},
+    io::{BufRead, BufReader, Write},
+    path::Path,
+};
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum)]
 enum Target {
-    BuiltIn(BuiltInShell),
+    /// Bourne Again SHell (bash)
+    Bash,
+    /// Elvish shell
+    Elvish,
+    /// Friendly Interactive SHell (fish)
+    Fish,
+    /// PowerShell
+    PowerShell,
+    /// Z SHell (zsh)
+    Zsh,
+    /// Fig
     Fig,
 }
 
-impl Display for Target {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.to_possible_value()
-            .expect("no values are skipped")
-            .get_name()
-            .fmt(f)
-    }
-}
-
-impl FromStr for Target {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "fig" => Ok(Target::Fig),
-            other => Ok(Target::BuiltIn(
-                <clap_complete::Shell as FromStr>::from_str(other)?,
-            )),
-        }
-    }
-}
-
-impl ValueEnum for Target {
-    fn value_variants<'a>() -> &'a [Self] {
-        &[
-            Target::BuiltIn(BuiltInShell::Bash),
-            Target::BuiltIn(BuiltInShell::Elvish),
-            Target::BuiltIn(BuiltInShell::Fish),
-            Target::BuiltIn(BuiltInShell::PowerShell),
-            Target::BuiltIn(BuiltInShell::Zsh),
-            Target::Fig,
-        ]
-    }
-
-    fn to_possible_value<'a>(&self) -> Option<clap::PossibleValue<'a>> {
+impl ToString for Target {
+    fn to_string(&self) -> String {
         match self {
-            Target::BuiltIn(shell) => shell.to_possible_value(),
-            Target::Fig => Some(clap::PossibleValue::new("fig")),
+            Target::Bash => "bash".to_string(),
+            Target::Elvish => "elvish".to_string(),
+            Target::Fish => "fish".to_string(),
+            Target::PowerShell => "powershell".to_string(),
+            Target::Zsh => "zsh".to_string(),
+            Target::Fig => "fig".to_string(),
         }
     }
 }
@@ -65,13 +46,12 @@ pub struct Command {
     /// [possible values: zsh, bash, fish, powershell, elvish]
     ///
     /// For more info: https://fuellabs.github.io/sway/latest/forc/commands/forc_completions.html
-    #[clap(short = 'T', long)]
-    target: Target,
+    #[clap(short = 'T', long, value_enum)]
+    target: Option<Target>,
 }
 
-pub(crate) fn exec(command: Command) -> ForcResult<()> {
+fn generate_autocomplete_script(target: Target, writer: &mut dyn Write) {
     let mut cmd = CommandInfo::new(&super::super::Opt::command());
-
     let mut plugins = HashMap::new();
     find_all().for_each(|path| {
         let mut proc = std::process::Command::new(path.clone());
@@ -83,7 +63,9 @@ pub(crate) fn exec(command: Command) -> ForcResult<()> {
                 } else {
                     command_info.name
                 };
-                plugins.insert(command_info.name.to_owned(), command_info);
+                if !plugins.contains_key(&command_info.name) {
+                    plugins.insert(command_info.name.to_owned(), command_info);
+                }
             }
         }
     });
@@ -92,13 +74,105 @@ pub(crate) fn exec(command: Command) -> ForcResult<()> {
     cmd.subcommands.append(&mut plugins);
 
     let mut cmd = cmd.to_clap();
-    match command.target {
-        Target::Fig => print_completions(clap_complete_fig::Fig, &mut cmd),
-        Target::BuiltIn(shell) => print_completions(shell, &mut cmd),
+    match target {
+        Target::Bash => print_completions(clap_complete::Shell::Bash, &mut cmd, writer),
+        Target::Zsh => print_completions(clap_complete::Shell::Zsh, &mut cmd, writer),
+        Target::Fish => print_completions(clap_complete::Shell::Fish, &mut cmd, writer),
+        Target::Elvish => print_completions(clap_complete::Shell::Elvish, &mut cmd, writer),
+        Target::PowerShell => print_completions(clap_complete::Shell::PowerShell, &mut cmd, writer),
+        Target::Fig => print_completions(clap_complete_fig::Fig, &mut cmd, writer),
     }
+}
+
+fn is_writable<P: AsRef<Path>>(path: P) -> bool {
+    if let Ok(metadata) = metadata(path) {
+        return !metadata.permissions().readonly();
+    }
+    false
+}
+
+pub(crate) fn exec(command: Command) -> ForcResult<()> {
+    let target = command.target.unwrap_or_else(|| {
+        if let Ok(shell) = std::env::var("SHELL") {
+            match Path::new(shell.as_str())
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+            {
+                "bash" => Target::Bash,
+                "zsh" => Target::Zsh,
+                "fish" => Target::Fish,
+                "pwsh" => Target::PowerShell,
+                "elvish" => Target::Elvish,
+                _ => Target::Bash,
+            }
+        } else {
+            Target::Bash
+        }
+    });
+
+    let dir = home::home_dir().map(|p| p.display().to_string()).unwrap();
+    let forc_autocomplete_path = match target {
+        Target::Zsh => {
+            let x = std::process::Command::new("zsh")
+                .arg("-c")
+                .arg("echo $fpath")
+                .output()
+                .expect("Cannot read $FPATH env variable")
+                .stdout;
+            let paths = String::from_utf8_lossy(&x)
+                .split(' ')
+                .filter(|path| is_writable(Path::new(path)))
+                .map(|x| x.to_owned())
+                .collect::<Vec<_>>();
+            format!(
+                "{}/_forc",
+                paths.get(0).expect("No writable path found for zsh")
+            )
+        }
+        _ => format!("{}/.forc.autocomplete", dir),
+    };
+
+    let mut file = File::create(&forc_autocomplete_path).expect("Open the shell config file");
+    generate_autocomplete_script(target, &mut file);
+
+    let user_shell_config = match target {
+        Target::Fish => Some(format!("{}/.config/fish/config.fish", dir)),
+        Target::Elvish => Some(format!("{}/.elvish/rc.elv", dir)),
+        Target::PowerShell => Some(format!(
+            "{}/.config/powershell/Microsoft.PowerShell_profile.ps1",
+            dir
+        )),
+        Target::Bash => Some(format!("{}/.bashrc", dir)),
+        Target::Fig => Some(format!("{}/.config/fig/fig.fish", dir)),
+        _ => None,
+    };
+
+    if let Some(file_path) = user_shell_config {
+        let file = File::open(&file_path).expect("Open the shell config file");
+        let reader = BufReader::new(file);
+
+        for line in reader.lines() {
+            if let Ok(line) = line {
+                if line.contains(&forc_autocomplete_path) {
+                    println!("Forc completions is already installed");
+                    return Ok(());
+                }
+            }
+        }
+
+        let mut file = OpenOptions::new().append(true).open(&file_path)?;
+        writeln!(file, "source {}", forc_autocomplete_path,).unwrap();
+    }
+
+    println!("Forc completions is installed successfully");
+    println!("\t The script is stored in {}", forc_autocomplete_path);
+
     Ok(())
 }
 
-fn print_completions<G: Generator>(gen: G, cmd: &mut ClapCommand) {
-    generate(gen, cmd, cmd.get_name().to_string(), &mut std::io::stdout());
+#[inline]
+fn print_completions<G: Generator>(gen: G, cmd: &mut ClapCommand, writer: &mut dyn Write) {
+    generate(gen, cmd, cmd.get_name().to_string(), writer);
 }

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -128,7 +128,7 @@ pub(crate) fn exec(command: Command) -> ForcResult<()> {
                 .collect::<Vec<_>>();
             format!(
                 "{}/_forc",
-                paths.get(0).expect("No writable path found for zsh")
+                paths.first().expect("No writable path found for zsh")
             )
         }
         _ => format!("{}/.forc.autocomplete", dir),
@@ -153,12 +153,10 @@ pub(crate) fn exec(command: Command) -> ForcResult<()> {
         let file = File::open(&file_path).expect("Open the shell config file");
         let reader = BufReader::new(file);
 
-        for line in reader.lines() {
-            if let Ok(line) = line {
-                if line.contains(&forc_autocomplete_path) {
-                    println!("Forc completions is already installed");
-                    return Ok(());
-                }
+        for line in reader.lines().map_while(Result::ok) {
+            if line.contains(&forc_autocomplete_path) {
+                println!("Forc completions is already installed");
+                return Ok(());
             }
         }
 

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -1,7 +1,52 @@
-use clap::Command as ClapCommand;
+use clap::{Command as ClapCommand, ValueEnum};
 use clap::{CommandFactory, Parser};
-use clap_complete::{generate, Generator, Shell};
+use clap_complete::{generate, Generator, Shell as BuiltInShell};
+use forc_util::cli::CommandInfo;
 use forc_util::ForcResult;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use crate::cli::plugin::find_all;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+enum Shell {
+    BuiltIn(BuiltInShell),
+    Fig,
+}
+
+impl FromStr for Shell {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "fig" => Ok(Shell::Fig),
+            other => Ok(Shell::BuiltIn(<clap_complete::Shell as FromStr>::from_str(
+                other,
+            )?)),
+        }
+    }
+}
+
+impl ValueEnum for Shell {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            Shell::BuiltIn(BuiltInShell::Bash),
+            Shell::BuiltIn(BuiltInShell::Elvish),
+            Shell::BuiltIn(BuiltInShell::Fish),
+            Shell::BuiltIn(BuiltInShell::PowerShell),
+            Shell::BuiltIn(BuiltInShell::Zsh),
+            Shell::Fig,
+        ]
+    }
+
+    fn to_possible_value<'a>(&self) -> Option<clap::PossibleValue<'a>> {
+        match self {
+            Shell::BuiltIn(shell) => shell.to_possible_value(),
+            Shell::Fig => Some(clap::PossibleValue::new("fig")),
+        }
+    }
+}
 
 /// Generate tab-completion scripts for your shell
 #[derive(Debug, Parser)]
@@ -16,8 +61,32 @@ pub struct Command {
 }
 
 pub(crate) fn exec(command: Command) -> ForcResult<()> {
-    let mut cmd = super::super::Opt::command();
-    print_completions(command.shell, &mut cmd);
+    let mut cmd = CommandInfo::new(&super::super::Opt::command());
+
+    let mut plugins = HashMap::new();
+    find_all().for_each(|path| {
+        let mut proc = std::process::Command::new(path.clone());
+        proc.env("CLI_DUMP_DEFINITION", "1");
+        if let Ok(proc) = proc.output() {
+            if let Ok(mut command_info) = serde_json::from_slice::<CommandInfo>(&proc.stdout) {
+                command_info.name = if let Some(name) = command_info.name.strip_prefix("forc-") {
+                    name.to_string()
+                } else {
+                    command_info.name
+                };
+                plugins.insert(command_info.name.to_owned(), command_info);
+            }
+        }
+    });
+
+    let mut plugins = plugins.into_values().collect::<Vec<_>>();
+    cmd.subcommands.append(&mut plugins);
+
+    let mut cmd = cmd.to_clap();
+    match command.shell {
+        Shell::Fig => print_completions(clap_complete_fig::Fig, &mut cmd),
+        Shell::BuiltIn(shell) => print_completions(shell, &mut cmd),
+    }
     Ok(())
 }
 

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -150,7 +150,7 @@ pub(crate) fn exec(command: Command) -> ForcResult<()> {
             "{}/.config/powershell/Microsoft.PowerShell_profile.ps1",
             dir
         )),
-        Target::Bash => Some(format!("{}/.bashrc", dir)),
+        Target::Bash => Some(format!("{}/.bash_profile", dir)),
         Target::Fig => Some(format!("{}/.config/fig/fig.fish", dir)),
         _ => None,
     };
@@ -169,9 +169,9 @@ pub(crate) fn exec(command: Command) -> ForcResult<()> {
 
         let mut file = OpenOptions::new().append(true).open(&file_path)?;
         writeln!(file, "source {}", forc_autocomplete_path,).unwrap();
+        println!("Forc completions were installed successfully at {file_path}");
     }
 
-    println!("Forc completions were installed successfully at {shell_config_path}");
     println!("\t The script is stored at {}", forc_autocomplete_path);
 
     Ok(())

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -10,40 +10,40 @@ use crate::cli::plugin::find_all;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
-enum Shell {
+enum Target {
     BuiltIn(BuiltInShell),
     Fig,
 }
 
-impl FromStr for Shell {
+impl FromStr for Target {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "fig" => Ok(Shell::Fig),
-            other => Ok(Shell::BuiltIn(<clap_complete::Shell as FromStr>::from_str(
-                other,
-            )?)),
+            "fig" => Ok(Target::Fig),
+            other => Ok(Target::BuiltIn(
+                <clap_complete::Shell as FromStr>::from_str(other)?,
+            )),
         }
     }
 }
 
-impl ValueEnum for Shell {
+impl ValueEnum for Target {
     fn value_variants<'a>() -> &'a [Self] {
         &[
-            Shell::BuiltIn(BuiltInShell::Bash),
-            Shell::BuiltIn(BuiltInShell::Elvish),
-            Shell::BuiltIn(BuiltInShell::Fish),
-            Shell::BuiltIn(BuiltInShell::PowerShell),
-            Shell::BuiltIn(BuiltInShell::Zsh),
-            Shell::Fig,
+            Target::BuiltIn(BuiltInShell::Bash),
+            Target::BuiltIn(BuiltInShell::Elvish),
+            Target::BuiltIn(BuiltInShell::Fish),
+            Target::BuiltIn(BuiltInShell::PowerShell),
+            Target::BuiltIn(BuiltInShell::Zsh),
+            Target::Fig,
         ]
     }
 
     fn to_possible_value<'a>(&self) -> Option<clap::PossibleValue<'a>> {
         match self {
-            Shell::BuiltIn(shell) => shell.to_possible_value(),
-            Shell::Fig => Some(clap::PossibleValue::new("fig")),
+            Target::BuiltIn(shell) => shell.to_possible_value(),
+            Target::Fig => Some(clap::PossibleValue::new("fig")),
         }
     }
 }
@@ -56,8 +56,8 @@ pub struct Command {
     /// [possible values: zsh, bash, fish, powershell, elvish]
     ///
     /// For more info: https://fuellabs.github.io/sway/latest/forc/commands/forc_completions.html
-    #[clap(short = 'S', long)]
-    shell: Shell,
+    #[clap(short = 'T', long)]
+    target: Target,
 }
 
 pub(crate) fn exec(command: Command) -> ForcResult<()> {
@@ -83,9 +83,9 @@ pub(crate) fn exec(command: Command) -> ForcResult<()> {
     cmd.subcommands.append(&mut plugins);
 
     let mut cmd = cmd.to_clap();
-    match command.shell {
-        Shell::Fig => print_completions(clap_complete_fig::Fig, &mut cmd),
-        Shell::BuiltIn(shell) => print_completions(shell, &mut cmd),
+    match command.target {
+        Target::Fig => print_completions(clap_complete_fig::Fig, &mut cmd),
+        Target::BuiltIn(shell) => print_completions(shell, &mut cmd),
     }
     Ok(())
 }

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -171,8 +171,8 @@ pub(crate) fn exec(command: Command) -> ForcResult<()> {
         writeln!(file, "source {}", forc_autocomplete_path,).unwrap();
     }
 
-    println!("Forc completions is installed successfully");
-    println!("\t The script is stored in {}", forc_autocomplete_path);
+    println!("Forc completions were installed successfully at {shell_config_path}");
+    println!("\t The script is stored at {}", forc_autocomplete_path);
 
     Ok(())
 }

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -54,19 +54,16 @@ fn generate_autocomplete_script(target: Target, writer: &mut dyn Write) {
     let mut cmd = CommandInfo::new(&super::super::Opt::command());
     let mut plugins = HashMap::new();
     find_all().for_each(|path| {
-        let mut proc = std::process::Command::new(path.clone());
-        proc.env("CLI_DUMP_DEFINITION", "1");
-        if let Ok(proc) = proc.output() {
+        if let Ok(proc) = std::process::Command::new(path.clone())
+            .arg("--cli-definition")
+            .output()
+        {
             if let Ok(mut command_info) = serde_json::from_slice::<CommandInfo>(&proc.stdout) {
-                command_info.name = if let Some(name) = path
-                    .file_name()
-                    .map(|x| {
-                        x.to_string_lossy()
-                            .strip_prefix("forc-")
-                            .map(|x| x.to_owned())
-                    })
-                    .flatten()
-                {
+                command_info.name = if let Some(name) = path.file_name().and_then(|x| {
+                    x.to_string_lossy()
+                        .strip_prefix("forc-")
+                        .map(|x| x.to_owned())
+                }) {
                     name
                 } else {
                     command_info.name

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -58,8 +58,16 @@ fn generate_autocomplete_script(target: Target, writer: &mut dyn Write) {
         proc.env("CLI_DUMP_DEFINITION", "1");
         if let Ok(proc) = proc.output() {
             if let Ok(mut command_info) = serde_json::from_slice::<CommandInfo>(&proc.stdout) {
-                command_info.name = if let Some(name) = command_info.name.strip_prefix("forc-") {
-                    name.to_string()
+                command_info.name = if let Some(name) = path
+                    .file_name()
+                    .map(|x| {
+                        x.to_string_lossy()
+                            .strip_prefix("forc-")
+                            .map(|x| x.to_owned())
+                    })
+                    .flatten()
+                {
+                    name
                 } else {
                     command_info.name
                 };


### PR DESCRIPTION
This PR fixes #5474,

This PR enhances the autocomplete feature that is built-in ly forc. The first enhancement is to add support to generate a script for [fig](https://fig.io).

The second enhancement is to add support to let each plugin (automatically through cli_examples) dump its clap configuration. This configuration is shared to the main `forc` binary which creates a single autocomplete script for the requested shell that is also aware of every `plugin`. If a plugin uses `cli_examples!` macro this will automatically inherit this feature without any additional change.

~The third improvement, still under development, is to install automatically the autocomplete feature instead of printing to the stdout (to address https://github.com/FuelLabs/fuelup/issues/548)~ (This feature has been added on c7015d0c0ad13cd0fd9a88ea2ef8c4b19ad38f26)

## Description


## Checklist

- [x] I have linked to any relevant issues.
- [x]  I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
