### PR TITLE
Encapsulation for Heap Types

### DIFF
--- a/sway-lib-std/src/bytes.sw
+++ b/sway-lib-std/src/bytes.sw
@@ -50,7 +50,7 @@ impl RawBytes {
     }
 }
 
-impl From<raw_slice> for RawBytes {    
+impl From<raw_slice> for RawBytes {
     /// Creates a `RawBytes` from a `raw_slice`.
     ///
     /// ### Examples
@@ -707,7 +707,10 @@ impl Bytes {
 
         // reallocate with combined capacity, write `other`, set buffer capacity
         if self.buf.capacity() < both_len {
-            let new_slice = raw_slice::from_parts::<u8>(realloc_bytes(self.buf.ptr(), self.buf.capacity(), both_len), both_len);
+            let new_slice = raw_slice::from_parts::<u8>(
+                realloc_bytes(self.buf.ptr(), self.buf.capacity(), both_len),
+                both_len,
+            );
             self.buf = RawBytes::from(new_slice);
         }
 

--- a/sway-lib-std/src/bytes.sw
+++ b/sway-lib-std/src/bytes.sw
@@ -70,7 +70,7 @@ impl From<raw_slice> for RawBytes {
     /// let vec_as_raw_slice = vec.as_raw_slice();
     /// let raw_bytes = RawBytes::from(vec_as_raw_slice);
     ///
-    /// assert(bytes.capacity == 3);
+    /// assert(raw_bytes.capacity == 3);
     /// ```
     fn from(slice: raw_slice) -> Self {
         Self {

--- a/sway-lib-std/src/bytes.sw
+++ b/sway-lib-std/src/bytes.sw
@@ -8,7 +8,7 @@ use ::option::Option::{self, *};
 use ::convert::{From, Into, *};
 
 struct RawBytes {
-    pub ptr: raw_ptr,
+    ptr: raw_ptr,
     cap: u64,
 }
 
@@ -50,12 +50,42 @@ impl RawBytes {
     }
 }
 
+impl From<raw_slice> for RawBytes {    
+    /// Creates a `RawBytes` from a `raw_slice`.
+    ///
+    /// ### Examples
+    ///
+    /// ```sway
+    /// use std:bytes::RawBytes;
+    ///
+    /// let mut vec = Vec::new();
+    /// let a = 5u8;
+    /// let b = 7u8;
+    /// let c = 9u8
+    ///
+    /// vec.push(a);
+    /// vec.push(b);
+    /// vec.push(c);
+    ///
+    /// let vec_as_raw_slice = vec.as_raw_slice();
+    /// let raw_bytes = RawBytes::from(vec_as_raw_slice);
+    ///
+    /// assert(bytes.capacity == 3);
+    /// ```
+    fn from(slice: raw_slice) -> Self {
+        Self {
+            ptr: slice.ptr(),
+            cap: slice.number_of_bytes(),
+        }
+    }
+}
+
 /// A type used to represent raw bytes.
 pub struct Bytes {
     /// A barebones struct for the bytes.
-    pub buf: RawBytes,
+    buf: RawBytes,
     /// The number of bytes being stored.
-    pub len: u64,
+    len: u64,
 }
 
 impl Bytes {
@@ -111,7 +141,7 @@ impl Bytes {
     /// use std::bytes::Bytes;
     ///
     /// fn foo() {
-    ///     let bytes = Bytes::with_capacity(2);
+    ///     let mut bytes = Bytes::with_capacity(2);
     ///     // does not allocate
     ///     bytes.push(5);
     ///     // does not re-allocate
@@ -175,7 +205,7 @@ impl Bytes {
     /// use std::bytes::Bytes;
     ///
     /// fn foo() {
-    ///     let bytes = Bytes::new();
+    ///     let mut bytes = Bytes::new();
     ///
     ///     let res = bytes.pop();
     ///     assert(res.is_none());
@@ -214,7 +244,7 @@ impl Bytes {
     /// use std::bytes::Byte;
     ///
     /// fn foo() {
-    ///     let bytes = Bytes::new();
+    ///     let mut bytes = Bytes::new();
     ///     bytes.push(5u8);
     ///     bytes.push(10u8);
     ///     bytes.push(15u8);
@@ -252,7 +282,7 @@ impl Bytes {
     /// use std::bytes::Bytes;
     ///
     /// fn foo() {
-    ///     let bytes = Bytes::new();
+    ///     let mut bytes = Bytes::new();
     ///     let a = 5u8;
     ///     let b = 7u8;
     ///     let c = 9u8;
@@ -296,7 +326,7 @@ impl Bytes {
     /// use std::bytes::Byte;
     ///
     /// fn foo() {
-    ///     let bytes = Bytes::new();
+    ///     let mut bytes = Bytes::new();
     ///     let a = 11u8;
     ///     let b = 11u8;
     ///     let c = 11u8;
@@ -316,7 +346,7 @@ impl Bytes {
         assert(index <= self.len);
 
         // If there is insufficient capacity, grow the buffer.
-        if self.len == self.buf.cap {
+        if self.len == self.buf.capacity() {
             self.buf.grow();
         }
 
@@ -362,7 +392,7 @@ impl Bytes {
     /// use std::bytes::Byte;
     ///
     /// fn foo() {
-    ///     let bytes = Byte::new();
+    ///     let mut bytes = Byte::new();
     ///     bytes.push(5);
     ///     bytes.push(10);
     ///     bytes.push(15);
@@ -413,7 +443,7 @@ impl Bytes {
     /// use std::bytes::Bytes;
     ///
     /// fn foo() {
-    ///     let bytes = Bytes::new();
+    ///     let mut bytes = Bytes::new();
     ///     let a = 5u8;
     ///     let b = 7u8;
     ///     let c = 9u8;
@@ -464,7 +494,7 @@ impl Bytes {
     /// }
     /// ```
     pub fn capacity(self) -> u64 {
-        self.buf.cap
+        self.buf.capacity()
     }
 
     /// Gets the length of the `Bytes`.
@@ -479,7 +509,7 @@ impl Bytes {
     /// use std::bytes::Bytes;
     ///
     /// fn foo() {
-    ///     let bytes = Bytes::new();
+    ///     let mut bytes = Bytes::new();
     ///     assert(bytes.len() == 0);
     ///     bytes.push(5);
     ///     assert(bytes.len() == 1);
@@ -502,16 +532,15 @@ impl Bytes {
     /// use std:bytes::Bytes;
     ///
     /// fn foo() {
-    ///     let bytes = Bytes::new();
+    ///     let mut bytes = Bytes::new();
     ///     bytes.push(5);
     ///     bytes.clear()
     ///     assert(bytes.is_empty());
     /// }
     /// ```
     pub fn clear(ref mut self) {
-        self.buf.ptr = alloc_bytes(0);
+        self.buf = RawBytes::new();
         self.len = 0;
-        self.buf.cap = 0;
     }
 
     /// Returns `true` if the type contains no elements.
@@ -526,7 +555,7 @@ impl Bytes {
     /// use std:bytes::Bytes;
     ///
     /// fn foo() {
-    ///     let bytes = Bytes::new();
+    ///     let mut bytes = Bytes::new();
     ///     assert(bytes.is_empty());
     ///     bytes.push(5);
     ///     assert(!bytes.is_empty());
@@ -536,6 +565,26 @@ impl Bytes {
     /// ```
     pub fn is_empty(self) -> bool {
         self.len == 0
+    }
+
+    /// Gets the pointer of the allocation.
+    ///
+    /// # Returns
+    ///
+    /// [raw_ptr] - The location in memory that the allocated bytes live.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::bytes::Bytes;
+    ///
+    /// fn foo() {
+    ///     let bytes = Bytes::new();
+    ///     assert(!bytes.ptr().is_null());
+    /// }
+    /// ```
+    pub fn ptr(self) -> raw_ptr {
+        self.buf.ptr()
     }
 }
 
@@ -592,13 +641,13 @@ impl Bytes {
         };
 
         if mid > 0 {
-            self.buf.ptr().copy_bytes_to(left_bytes.buf.ptr(), left_len);
+            self.buf.ptr().copy_bytes_to(left_bytes.ptr(), left_len);
         };
         if mid != self.len {
             self.buf
                 .ptr()
                 .add_uint_offset(mid)
-                .copy_bytes_to(right_bytes.buf.ptr(), right_len);
+                .copy_bytes_to(right_bytes.ptr(), right_len);
         };
 
         left_bytes.len = left_len;
@@ -641,7 +690,8 @@ impl Bytes {
     /// }
     /// ```
     pub fn append(ref mut self, ref mut other: self) {
-        if other.len == 0 {
+        let other_len = other.len();
+        if other_len == 0 {
             return
         };
 
@@ -652,23 +702,19 @@ impl Bytes {
             return;
         };
 
-        let both_len = self.len + other.len;
+        let both_len = self.len + other_len;
         let other_start = self.len;
 
         // reallocate with combined capacity, write `other`, set buffer capacity
-        self.buf.ptr = realloc_bytes(self.buf.ptr(), self.buf.capacity(), both_len);
-
-        let mut i = 0;
-        while i < other.len {
-            let new_ptr = self.buf.ptr().add_uint_offset(other_start);
-            new_ptr
-                .add_uint_offset(i)
-                .write_byte(other.buf.ptr.add_uint_offset(i).read_byte());
-            i += 1;
+        if self.buf.capacity() < both_len {
+            let new_slice = raw_slice::from_parts::<u8>(realloc_bytes(self.buf.ptr(), self.buf.capacity(), both_len), both_len);
+            self.buf = RawBytes::from(new_slice);
         }
 
+        let new_ptr = self.buf.ptr().add_uint_offset(other_start);
+        other.ptr().copy_bytes_to(new_ptr, other_len);
+
         // set capacity and length
-        self.buf.cap = both_len;
         self.len = both_len;
 
         // clear `other`
@@ -678,11 +724,11 @@ impl Bytes {
 
 impl core::ops::Eq for Bytes {
     fn eq(self, other: Self) -> bool {
-        if self.len != other.len {
+        if self.len != other.len() {
             return false;
         }
 
-        asm(result, r2: self.buf.ptr, r3: other.buf.ptr, r4: self.len) {
+        asm(result, r2: self.buf.ptr(), r3: other.ptr(), r4: self.len) {
             meq result r2 r3 r4;
             result: bool
         }
@@ -705,7 +751,7 @@ impl From<b256> for Bytes {
         let mut bytes = Self::with_capacity(32);
         bytes.len = 32;
         // Copy bytes from contract_id into the buffer of the target bytes
-        __addr_of(b).copy_bytes_to(bytes.buf.ptr, 32);
+        __addr_of(b).copy_bytes_to(bytes.buf.ptr(), 32);
 
         bytes
     }
@@ -751,13 +797,9 @@ impl From<raw_slice> for Bytes {
     /// assert(bytes.get(2).unwrap() == c);
     /// ```
     fn from(slice: raw_slice) -> Self {
-        let number_of_bytes = slice.number_of_bytes();
         Self {
-            buf: RawBytes {
-                ptr: slice.ptr(),
-                cap: number_of_bytes,
-            },
-            len: number_of_bytes,
+            buf: RawBytes::from(slice),
+            len: slice.number_of_bytes(),
         }
     }
 }

--- a/sway-lib-std/src/bytes_conversions/u16.sw
+++ b/sway-lib-std/src/bytes_conversions/u16.sw
@@ -70,7 +70,7 @@ impl u16 {
     /// ```
     pub fn from_le_bytes(bytes: Bytes) -> Self {
         assert(bytes.len() == 2);
-        let ptr = bytes.buf.ptr();
+        let ptr = bytes.ptr();
         let a = ptr.read_byte();
         let b = (ptr.add_uint_offset(1)).read_byte();
         let i = 0x8;
@@ -147,7 +147,7 @@ impl u16 {
     /// ```
     pub fn from_be_bytes(bytes: Bytes) -> Self {
         assert(bytes.len() == 2);
-        let ptr = bytes.buf.ptr();
+        let ptr = bytes.ptr();
         let a = ptr.read_byte();
         let b = (ptr.add_uint_offset(1)).read_byte();
 

--- a/sway-lib-std/src/bytes_conversions/u32.sw
+++ b/sway-lib-std/src/bytes_conversions/u32.sw
@@ -94,7 +94,7 @@ impl u32 {
     /// ```
     pub fn from_le_bytes(bytes: Bytes) -> Self {
         assert(bytes.len() == 4);
-        let ptr = bytes.buf.ptr();
+        let ptr = bytes.ptr();
         let a = ptr.read_byte();
         let b = (ptr.add_uint_offset(1)).read_byte();
         let c = (ptr.add_uint_offset(2)).read_byte();
@@ -199,7 +199,7 @@ impl u32 {
     /// ```
     pub fn from_be_bytes(bytes: Bytes) -> Self {
         assert(bytes.len() == 4);
-        let ptr = bytes.buf.ptr();
+        let ptr = bytes.ptr();
         let a = ptr.read_byte();
         let b = (ptr.add_uint_offset(1)).read_byte();
         let c = (ptr.add_uint_offset(2)).read_byte();

--- a/sway-lib-std/src/bytes_conversions/u64.sw
+++ b/sway-lib-std/src/bytes_conversions/u64.sw
@@ -122,7 +122,7 @@ impl u64 {
     /// ```
     pub fn from_le_bytes(bytes: Bytes) -> Self {
         assert(bytes.len() == 8);
-        let ptr = bytes.buf.ptr();
+        let ptr = bytes.ptr();
         let a = ptr.read_byte();
         let b = (ptr.add_uint_offset(1)).read_byte();
         let c = (ptr.add_uint_offset(2)).read_byte();
@@ -271,7 +271,7 @@ impl u64 {
     /// ```
     pub fn from_be_bytes(bytes: Bytes) -> Self {
         assert(bytes.len() == 8);
-        let ptr = bytes.buf.ptr();
+        let ptr = bytes.ptr();
         let h = ptr.read_byte();
         let g = (ptr.add_uint_offset(1)).read_byte();
         let f = (ptr.add_uint_offset(2)).read_byte();

--- a/sway-lib-std/src/hash.sw
+++ b/sway-lib-std/src/hash.sw
@@ -1,6 +1,7 @@
 //! Utility functions for cryptographic hashing.
 library;
 
+use ::alloc::alloc_bytes;
 use ::bytes::*;
 
 pub struct Hasher {
@@ -23,8 +24,8 @@ impl Hasher {
         let mut result_buffer = b256::min();
         asm(
             hash: result_buffer,
-            ptr: self.bytes.buf.ptr,
-            bytes: self.bytes.len,
+            ptr: self.bytes.ptr(),
+            bytes: self.bytes.len(),
         ) {
             s256 hash ptr bytes;
             hash: b256
@@ -35,8 +36,8 @@ impl Hasher {
         let mut result_buffer = b256::min();
         asm(
             hash: result_buffer,
-            ptr: self.bytes.buf.ptr,
-            bytes: self.bytes.len,
+            ptr: self.bytes.ptr(),
+            bytes: self.bytes.len(),
         ) {
             k256 hash ptr bytes;
             hash: b256
@@ -50,11 +51,7 @@ impl Hasher {
         let str_size = s.len();
         let str_ptr = s.as_ptr();
 
-        let mut bytes = Bytes::with_capacity(str_size);
-        bytes.len = str_size;
-
-        str_ptr.copy_bytes_to(bytes.buf.ptr(), str_size);
-        self.write(bytes);
+        self.write(Bytes::from(raw_slice::from_parts::<u8>(str_ptr, str_size)));
     }
 
     #[inline(never)]
@@ -63,12 +60,7 @@ impl Hasher {
         let str_size = __size_of_str_array::<S>();
         let str_ptr = __addr_of(s);
 
-        let mut bytes = Bytes::with_capacity(str_size);
-        bytes.len = str_size;
-
-        str_ptr.copy_bytes_to(bytes.buf.ptr(), str_size);
-
-        self.write(bytes);
+        self.write(Bytes::from(raw_slice::from_parts::<u8>(str_ptr, str_size)));
     }
 }
 
@@ -86,56 +78,52 @@ impl Hash for u8 {
 
 impl Hash for u16 {
     fn hash(self, ref mut state: Hasher) {
-        let mut bytes = Bytes::with_capacity(8); // one word capacity
-        bytes.len = 2;
+        let ptr = alloc_bytes(8); // one word capacity
 
-        asm(ptr: bytes.buf.ptr(), val: self, r1) {
+        asm(ptr: ptr, val: self, r1) {
             slli r1 val i48;
             sw ptr r1 i0;
         };
 
-        state.write(bytes);
+        state.write(Bytes::from(raw_slice::from_parts::<u8>(ptr, 2)));
     }
 }
 
 impl Hash for u32 {
     fn hash(self, ref mut state: Hasher) {
-        let mut bytes = Bytes::with_capacity(8); // one word capacity
-        bytes.len = 4;
+        let ptr = alloc_bytes(8); // one word capacity
 
-        asm(ptr: bytes.buf.ptr(), val: self, r1) {
+        asm(ptr: ptr, val: self, r1) {
             slli r1 val i32;
             sw ptr r1 i0;
         };
 
-        state.write(bytes);
+        state.write(Bytes::from(raw_slice::from_parts::<u8>(ptr, 4)));
     }
 }
 
 impl Hash for u64 {
     fn hash(self, ref mut state: Hasher) {
-        let mut bytes = Bytes::with_capacity(8); // one word capacity
-        bytes.len = 8;
+        let ptr = alloc_bytes(8); // one word capacity
 
-        asm(ptr: bytes.buf.ptr(), val: self) {
+        asm(ptr: ptr, val: self) {
             sw ptr val i0;
         };
 
-        state.write(bytes);
+        state.write(Bytes::from(raw_slice::from_parts::<u8>(ptr, 8)));
     }
 }
 
 impl Hash for b256 {
     fn hash(self, ref mut state: Hasher) {
-        let mut bytes = Bytes::with_capacity(32); // four word capacity
-        bytes.len = 32;
+        let ptr = alloc_bytes(32); // four word capacity
 
         let (word_1, word_2, word_3, word_4) = asm(r1: self) {
             r1: (u64, u64, u64, u64)
         };
 
         asm(
-            ptr: bytes.buf.ptr(),
+            ptr: ptr,
             val_1: word_1,
             val_2: word_2,
             val_3: word_3,
@@ -147,21 +135,20 @@ impl Hash for b256 {
             sw ptr val_4 i3;
         };
 
-        state.write(bytes);
+        state.write(Bytes::from(raw_slice::from_parts::<u8>(ptr, 32)));
     }
 }
 
 impl Hash for u256 {
     fn hash(self, ref mut state: Hasher) {
-        let mut bytes = Bytes::with_capacity(32); // four word capacity
-        bytes.len = 32;
+        let ptr = alloc_bytes(32); // four word capacity
 
         let (word_1, word_2, word_3, word_4) = asm(r1: self) {
             r1: (u64, u64, u64, u64)
         };
 
         asm(
-            ptr: bytes.buf.ptr(),
+            ptr: ptr,
             val_1: word_1,
             val_2: word_2,
             val_3: word_3,
@@ -173,7 +160,7 @@ impl Hash for u256 {
             sw ptr val_4 i3;
         };
 
-        state.write(bytes);
+        state.write(Bytes::from(raw_slice::from_parts::<u8>(ptr, 32)));
     }
 }
 
@@ -442,13 +429,11 @@ pub fn sha256_str_array<S>(param: S) -> b256 {
     let str_size = __size_of_str_array::<S>();
     let str_ptr = __addr_of(param);
 
-    let mut bytes = Bytes::with_capacity(str_size);
-    bytes.len = str_size;
-
-    str_ptr.copy_bytes_to(bytes.buf.ptr(), str_size);
+    let ptr = alloc_bytes(str_size);
+    str_ptr.copy_bytes_to(ptr, str_size);
 
     let mut hasher = Hasher::new();
-    hasher.write(bytes);
+    hasher.write(Bytes::from(raw_slice::from_parts::<u8>(ptr, str_size)));
     hasher.sha256()
 }
 

--- a/sway-lib-std/src/hash.sw
+++ b/sway-lib-std/src/hash.sw
@@ -79,7 +79,6 @@ impl Hash for u8 {
 impl Hash for u16 {
     fn hash(self, ref mut state: Hasher) {
         let ptr = alloc_bytes(8); // one word capacity
-
         asm(ptr: ptr, val: self, r1) {
             slli r1 val i48;
             sw ptr r1 i0;
@@ -92,7 +91,6 @@ impl Hash for u16 {
 impl Hash for u32 {
     fn hash(self, ref mut state: Hasher) {
         let ptr = alloc_bytes(8); // one word capacity
-
         asm(ptr: ptr, val: self, r1) {
             slli r1 val i32;
             sw ptr r1 i0;
@@ -105,7 +103,6 @@ impl Hash for u32 {
 impl Hash for u64 {
     fn hash(self, ref mut state: Hasher) {
         let ptr = alloc_bytes(8); // one word capacity
-
         asm(ptr: ptr, val: self) {
             sw ptr val i0;
         };
@@ -117,7 +114,6 @@ impl Hash for u64 {
 impl Hash for b256 {
     fn hash(self, ref mut state: Hasher) {
         let ptr = alloc_bytes(32); // four word capacity
-
         let (word_1, word_2, word_3, word_4) = asm(r1: self) {
             r1: (u64, u64, u64, u64)
         };
@@ -142,7 +138,6 @@ impl Hash for b256 {
 impl Hash for u256 {
     fn hash(self, ref mut state: Hasher) {
         let ptr = alloc_bytes(32); // four word capacity
-
         let (word_1, word_2, word_3, word_4) = asm(r1: self) {
             r1: (u64, u64, u64, u64)
         };

--- a/sway-lib-std/src/inputs.sw
+++ b/sway-lib-std/src/inputs.sw
@@ -3,6 +3,7 @@
 library;
 
 use ::address::Address;
+use ::alloc::alloc_bytes;
 use ::assert::assert;
 use ::asset_id::AssetId;
 use ::bytes::Bytes;
@@ -411,12 +412,11 @@ pub fn input_predicate(index: u64) -> Bytes {
         revert(0);
     };
     let length = wrapped.unwrap().as_u64();
-    let mut data_bytes = Bytes::with_capacity(length);
+    let new_ptr = alloc_bytes(length);
     match input_predicate_pointer(index) {
         Some(d) => {
-            data_bytes.len = length;
-            d.copy_bytes_to(data_bytes.buf.ptr, length);
-            data_bytes
+            d.copy_bytes_to(new_ptr, length);
+            Bytes::from(raw_slice::from_parts::<u8>(new_ptr, length))
         },
         None => revert(0),
     }
@@ -610,10 +610,10 @@ pub fn input_message_data(index: u64, offset: u64) -> Bytes {
     let data = __gtf::<raw_ptr>(index, GTF_INPUT_MESSAGE_DATA);
     let data_with_offset = data.add_uint_offset(offset);
     let length = input_message_data_length(index).as_u64();
-    let mut data_bytes = Bytes::with_capacity(length);
-    data_bytes.len = length;
-    data_with_offset.copy_bytes_to(data_bytes.buf.ptr, length);
-    data_bytes
+    let new_ptr = alloc_bytes(length);
+
+    data_with_offset.copy_bytes_to(new_ptr, length);
+    Bytes::from(raw_slice::from_parts::<u8>(new_ptr, length))
 }
 
 fn valid_input_type(index: u64, expected_type: Input) -> bool {

--- a/sway-lib-std/src/low_level_call.sw
+++ b/sway-lib-std/src/low_level_call.sw
@@ -65,8 +65,7 @@ pub struct CallParams {
 fn contract_id_to_bytes(contract_id: ContractId) -> Bytes {
     let target_ptr = alloc_bytes(32);
 
-    __addr_of(contract_id)
-        .copy_bytes_to(target_ptr, 32);
+    __addr_of(contract_id).copy_bytes_to(target_ptr, 32);
 
     Bytes::from(raw_slice::from_parts::<u8>(target_ptr, 32))
 }

--- a/sway-lib-std/src/message.sw
+++ b/sway-lib-std/src/message.sw
@@ -38,7 +38,7 @@ pub fn send_message(recipient: b256, msg_data: Bytes, coins: u64) {
     // If msg_data is empty, we just ignore it and pass `smo` a pointer to the inner value of recipient.
     if !msg_data.is_empty() {
         size = msg_data.len();
-        msg_data_pointer = msg_data.buf.ptr;
+        msg_data_pointer = msg_data.ptr();
     }
 
     asm(

--- a/sway-lib-std/src/primitive_conversions/b256.sw
+++ b/sway-lib-std/src/primitive_conversions/b256.sw
@@ -11,7 +11,7 @@ impl TryFrom<Bytes> for b256 {
         } else {
             let mut val = 0x0000000000000000000000000000000000000000000000000000000000000000;
             let ptr = __addr_of(val);
-            b.buf.ptr().copy_to::<b256>(ptr, 1);
+            b.ptr().copy_to::<b256>(ptr, 1);
             Some(val)
         }
     }

--- a/sway-lib-std/src/string.sw
+++ b/sway-lib-std/src/string.sw
@@ -138,7 +138,9 @@ impl String {
         let str_size = s.len();
         let str_ptr = s.as_ptr();
 
-        Self { bytes: Bytes::from(raw_slice::from_parts::<u8>(str_ptr, str_size)) }
+        Self {
+            bytes: Bytes::from(raw_slice::from_parts::<u8>(str_ptr, str_size)),
+        }
     }
 
     /// Returns a `bool` indicating whether the `String` is empty.
@@ -233,9 +235,7 @@ impl String {
 
 impl From<Bytes> for String {
     fn from(b: Bytes) -> Self {
-        Self {
-            bytes: b
-        }
+        Self { bytes: b }
     }
 }
 

--- a/sway-lib-std/src/vec.sw
+++ b/sway-lib-std/src/vec.sw
@@ -138,7 +138,6 @@ impl<T> From<raw_slice> for RawVec<T> {
     }
 }
 
-
 /// A contiguous growable array type, written as `Vec<T>`, short for 'vector'.
 pub struct Vec<T> {
     buf: RawVec<T>,

--- a/sway-lib-std/src/vec.sw
+++ b/sway-lib-std/src/vec.sw
@@ -8,7 +8,7 @@ use ::convert::From;
 use ::iterator::*;
 
 struct RawVec<T> {
-    pub ptr: raw_ptr,
+    ptr: raw_ptr,
     cap: u64,
 }
 
@@ -129,9 +129,19 @@ impl<T> RawVec<T> {
     }
 }
 
+impl<T> From<raw_slice> for RawVec<T> {
+    fn from(slice: raw_slice) -> Self {
+        Self {
+            ptr: slice.ptr(),
+            cap: slice.len::<T>(),
+        }
+    }
+}
+
+
 /// A contiguous growable array type, written as `Vec<T>`, short for 'vector'.
 pub struct Vec<T> {
-    pub buf: RawVec<T>,
+    buf: RawVec<T>,
     len: u64,
 }
 
@@ -257,7 +267,7 @@ impl<T> Vec<T> {
     /// }
     /// ```
     pub fn capacity(self) -> u64 {
-        self.buf.cap
+        self.buf.capacity()
     }
 
     /// Clears the vector, removing all values.
@@ -456,7 +466,7 @@ impl<T> Vec<T> {
         assert(index <= self.len);
 
         // If there is insufficient capacity, grow the buffer.
-        if self.len == self.buf.cap {
+        if self.len == self.buf.capacity() {
             self.buf.grow();
         }
 
@@ -595,6 +605,24 @@ impl<T> Vec<T> {
             index: 0,
         }
     }
+
+    /// Gets the pointer of the allocation.
+    ///
+    /// # Returns
+    ///
+    /// [raw_ptr] - The location in memory that the allocated vec lives.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// fn foo() {
+    ///     let vec = Vec::new();
+    ///     assert(!vec.ptr().is_null());
+    /// }
+    /// ```
+    pub fn ptr(self) -> raw_ptr {
+        self.buf.ptr()
+    }
 }
 
 impl<T> AsRawSlice for Vec<T> {
@@ -605,20 +633,16 @@ impl<T> AsRawSlice for Vec<T> {
 
 impl<T> From<raw_slice> for Vec<T> {
     fn from(slice: raw_slice) -> Self {
-        let buf = RawVec {
-            ptr: slice.ptr(),
-            cap: slice.len::<T>(),
-        };
         Self {
-            buf,
-            len: buf.cap,
+            buf: RawVec::from(slice),
+            len: slice.len::<T>(),
         }
     }
 }
 
 impl<T> From<Vec<T>> for raw_slice {
     fn from(vec: Vec<T>) -> Self {
-        asm(ptr: (vec.buf.ptr(), vec.len)) {
+        asm(ptr: (vec.ptr(), vec.len())) {
             ptr: raw_slice
         }
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/raw_ptr/raw_ptr_ret/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/raw_ptr/raw_ptr_ret/src/main.sw
@@ -5,5 +5,5 @@ use std::vec::Vec;
 fn main() -> raw_ptr {
     let mut a : Vec<u64> = Vec::new();
     a.push(1234);
-    a.buf.ptr
+    a.ptr()
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/return_into/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/return_into/src/main.sw
@@ -1,6 +1,6 @@
 script;
 
-use std::bytes::Bytes;
+use std::{alloc::alloc_bytes, bytes::Bytes};
 
 pub trait MyFrom<T> {
     fn my_from(b: T) -> Self;
@@ -10,18 +10,18 @@ pub trait MyFrom<T> {
 impl MyFrom<b256> for Bytes {
     fn my_from(b: b256) -> Self {
         // Artificially create bytes with capacity and len
-        let mut bytes = Self::with_capacity(32);
-        bytes.len = 32;
-        // Copy bytes from contract_id into the buffer of the target bytes
-        __addr_of(b).copy_bytes_to(bytes.buf.ptr, 32);
+        let new_ptr = alloc_bytes(32);
 
-        bytes
+        // Copy bytes from contract_id into the buffer of the target bytes
+        __addr_of(b).copy_bytes_to(new_ptr, 32);
+
+        Bytes::from(raw_slice::from_parts::<u8>(new_ptr, 32))
     }
 
     fn my_into(self) -> b256 {
         let mut value = 0x0000000000000000000000000000000000000000000000000000000000000000;
         let ptr = __addr_of(value);
-        self.buf.ptr().copy_to::<b256>(ptr, 1);
+        self.ptr().copy_to::<b256>(ptr, 1);
 
         value
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/src/main.sw
@@ -59,13 +59,13 @@ impl BasicStorage for Contract {
             i += 1;
         }
 
-        let _ = __state_load_quad(key, values.buf.ptr(), slots);
+        let _ = __state_load_quad(key, values.ptr(), slots);
         values
     }
 
     #[storage(write)]
     fn intrinsic_store_quad(key: b256, values: Vec<Quad>) {
-        let _ = __state_store_quad(key, values.buf.ptr(), values.len());
+        let _ = __state_store_quad(key, values.ptr(), values.len());
     }
 
     #[storage(read, write)]

--- a/test/src/sdk-harness/test_projects/storage_string/src/main.sw
+++ b/test/src/sdk-harness/test_projects/storage_string/src/main.sw
@@ -29,7 +29,7 @@ impl MyContract for Contract {
     fn get_string() -> Bytes {
         match storage.stored_string.read_slice() {
             Option::Some(string) => {
-                string.bytes
+                string.as_bytes()
             },
             Option::None => Bytes::new(),
         }


### PR DESCRIPTION
## Description

Updates the following heap types to have private struct variables:

- `Bytes`
- `RawBytes`
- `Vec`
- `RawVec`
- `String`

Note: This PR merges into a staging branch

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
