### PR TITLE
Encapsulation of Storage Types

### DIFF
--- a/sway-lib-core/src/storage.sw
+++ b/sway-lib-core/src/storage.sw
@@ -12,9 +12,107 @@ library;
 /// represent different storage constructs.
 pub struct StorageKey<T> {
     /// The assigned location in storage.
-    pub slot: b256,
+    slot: b256,
     /// The assigned offset based on the data structure `T`.
-    pub offset: u64,
+    offset: u64,
     /// A unique identifier.
-    pub field_id: b256,
+    field_id: b256,
+}
+
+impl<T> StorageKey<T> {
+    /// Create a new `StorageKey`.
+    ///
+    /// # Arguments
+    ///
+    /// * `slot`: [b256] - The assigned location in storage for the new `StorageKey`.
+    /// * `offset`: [u64] - The assigned offset based on the data structure `T` for the new `StorageKey`.
+    /// * `field_id`: [b256] - A unique identifier for the new `StorageKey`.
+    ///
+    /// # Returns
+    ///
+    /// * [StorageKey] - The newly create `StorageKey`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::{constants::ZERO_B256, hash::sha256};
+    ///
+    /// fn foo() {
+    ///     let my_key = StorageKey::<u64>::new(ZERO_B256, 0, sha256(ZERO_B256));
+    ///     assert(my_key.slot() == ZERO_B256);
+    /// }
+    /// ```
+    pub fn new(slot: b256, offset: u64, field_id: b256) -> Self {
+        Self {
+            slot,
+            offset,
+            field_id,
+        }
+    }
+
+    /// Returns the storage slot address.
+    ///
+    /// # Returns
+    ///
+    /// * [b256] - The address in storage that this storage slot points to.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::{constants::ZERO_B256, hash::sha256};
+    ///
+    /// fn foo() {
+    ///     let my_key = StorageKey::<u64>::new(ZERO_B256, 0, sha256(ZERO_B256));
+    ///     assert(my_key.slot() == ZERO_B256);
+    /// }
+    /// ```
+    pub fn slot(self) -> b256 {
+        self.slot
+    }
+
+    /// Returns the offset on the storage slot.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The offset in storage that this storage slot points to.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::{constants::ZERO_B256, hash::sha256};
+    ///
+    /// fn foo() {
+    ///     let my_key = StorageKey::<u64>::new(ZERO_B256, 0, sha256(ZERO_B256));
+    ///     assert(my_key.offset() == 0);
+    /// }
+    /// ```
+    pub fn offset(self) -> u64 {
+        self.offset
+    }
+
+    /// Returns the storage slot field id.
+    ///
+    /// # Additional Information
+    ///
+    /// The field id is a unique identifier for the storage field being referred to, it is different even
+    /// for multiple zero sized fields that might live at the same location but
+    /// represent different storage constructs.
+    ///
+    /// # Returns
+    ///
+    /// * [b256] - The field id for this storage slot.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::{constants::ZERO_B256, hash::sha256};
+    ///
+    /// fn foo() {
+    ///     let my_key = StorageKey::<u64>::new(ZERO_B256, 0, sha256(ZERO_B256));
+    ///     assert(my_key.field_id() == sha256(ZERO_B256));
+    /// }
+    /// ```
+    pub fn field_id(self) -> b256 {
+        self.field_id
+    }
 }

--- a/sway-lib-std/src/storage/storage_bytes.sw
+++ b/sway-lib-std/src/storage/storage_bytes.sw
@@ -39,7 +39,7 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
     /// ```
     #[storage(read, write)]
     fn write_slice(self, bytes: Bytes) {
-        write_slice(self.field_id, bytes.as_raw_slice());
+        write_slice(self.field_id(), bytes.as_raw_slice());
     }
 
     /// Constructs a `Bytes` type from a collection of tightly packed bytes in storage.
@@ -75,7 +75,7 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
     /// ```
     #[storage(read)]
     fn read_slice(self) -> Option<Bytes> {
-        match read_slice(self.field_id) {
+        match read_slice(self.field_id()) {
             Some(slice) => {
                 Some(Bytes::from(slice))
             },
@@ -119,7 +119,7 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
     /// ```
     #[storage(read, write)]
     fn clear(self) -> bool {
-        clear_slice(self.field_id)
+        clear_slice(self.field_id())
     }
 
     /// Returns the length of tightly packed bytes in storage.
@@ -154,6 +154,6 @@ impl StorableSlice<Bytes> for StorageKey<StorageBytes> {
     /// ```
     #[storage(read)]
     fn len(self) -> u64 {
-        read::<u64>(self.field_id, 0).unwrap_or(0)
+        read::<u64>(self.field_id(), 0).unwrap_or(0)
     }
 }

--- a/sway-lib-std/src/storage/storage_key.sw
+++ b/sway-lib-std/src/storage/storage_key.sw
@@ -32,7 +32,7 @@ impl<T> StorageKey<T> {
     /// ```
     #[storage(read)]
     pub fn read(self) -> T {
-        read::<T>(self.slot, self.offset).unwrap()
+        read::<T>(self.slot(), self.offset()).unwrap()
     }
 
     /// Reads a value of type `T` starting at the location specified by `self`. If the value
@@ -63,7 +63,7 @@ impl<T> StorageKey<T> {
     /// ```
     #[storage(read)]
     pub fn try_read(self) -> Option<T> {
-        read(self.slot, self.offset)
+        read(self.slot(), self.offset())
     }
 
     /// Writes a value of type `T` starting at the location specified by `self`. If the value
@@ -95,7 +95,7 @@ impl<T> StorageKey<T> {
     /// ```
     #[storage(read, write)]
     pub fn write(self, value: T) {
-        write(self.slot, self.offset, value);
+        write(self.slot(), self.offset(), value);
     }
 
     /// Clears the value at `self`.
@@ -125,39 +125,9 @@ impl<T> StorageKey<T> {
             // If the generic doesn't have a size, this is an empty struct and nothing can be stored at the slot.
             // This clears the length value for StorageVec, StorageString, and StorageBytes 
             // or any other Storage type.
-            clear::<u64>(self.field_id, 0)
+            clear::<u64>(self.field_id(), 0)
         } else {
-            clear::<T>(self.slot, self.offset)
-        }
-    }
-
-    /// Create a new `StorageKey`.
-    ///
-    /// # Arguments
-    ///
-    /// * `slot`: [b256] - The assigned location in storage for the new `StorageKey`.
-    /// * `offset`: [u64] - The assigned offset based on the data structure `T` for the new `StorageKey`.
-    /// * `field_id`: [b256] - A unique identifier for the new `StorageKey`.
-    ///
-    /// # Returns
-    ///
-    /// * [StorageKey] - The newly create `StorageKey`.
-    ///
-    /// # Examples
-    ///
-    /// ```sway
-    /// use std::{constants::ZERO_B256, hash::sha256};
-    ///
-    /// fn foo() {
-    ///     let my_key = StorageKey::<u64>::new(ZERO_B256, 0, sha256(ZERO_B256));
-    ///     assert(my_key.slot == ZERO_B256);
-    /// }
-    /// ```
-    pub fn new(slot: b256, offset: u64, field_id: b256) -> Self {
-        Self {
-            slot,
-            offset,
-            field_id,
+            clear::<T>(self.slot(), self.offset())
         }
     }
 }
@@ -168,7 +138,7 @@ fn test_storage_key_new() {
     use ::assert::assert;
 
     let key = StorageKey::<u64>::new(ZERO_B256, 0, ZERO_B256);
-    assert(key.slot == ZERO_B256);
-    assert(key.offset == 0);
-    assert(key.field_id == ZERO_B256);
+    assert(key.slot() == ZERO_B256);
+    assert(key.offset() == 0);
+    assert(key.field_id() == ZERO_B256);
 }

--- a/sway-lib-std/src/storage/storage_map.sw
+++ b/sway-lib-std/src/storage/storage_map.sw
@@ -54,7 +54,7 @@ where
     where
         K: Hash,
     {
-        let key = sha256((key, self.field_id));
+        let key = sha256((key, self.field_id()));
         write::<V>(key, 0, value);
     }
 
@@ -89,9 +89,9 @@ where
         K: Hash,
     {
         StorageKey::<V>::new(
-            sha256((key, self.field_id)),
+            sha256((key, self.field_id())),
             0,
-            sha256((key, self.field_id)),
+            sha256((key, self.field_id())),
         )
     }
 
@@ -130,7 +130,7 @@ where
     where
         K: Hash,
     {
-        let key = sha256((key, self.slot));
+        let key = sha256((key, self.slot()));
         clear::<V>(key, 0)
     }
 
@@ -181,7 +181,7 @@ where
     where
         K: Hash,
     {
-        let key = sha256((key, self.field_id));
+        let key = sha256((key, self.field_id()));
 
         let val = read::<V>(key, 0);
 

--- a/sway-lib-std/src/storage/storage_string.sw
+++ b/sway-lib-std/src/storage/storage_string.sw
@@ -40,7 +40,7 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     /// ```
     #[storage(read, write)]
     fn write_slice(self, string: String) {
-        write_slice(self.slot, string.as_raw_slice());
+        write_slice(self.slot(), string.as_raw_slice());
     }
 
     /// Constructs a `String` type from storage.
@@ -77,7 +77,7 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     /// ```
     #[storage(read)]
     fn read_slice(self) -> Option<String> {
-        match read_slice(self.slot) {
+        match read_slice(self.slot()) {
             Some(slice) => {
                 Some(String::from(slice))
             },
@@ -123,7 +123,7 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     /// ```
     #[storage(read, write)]
     fn clear(self) -> bool {
-        clear_slice(self.slot)
+        clear_slice(self.slot())
     }
 
     /// Returns the length of `String` in storage.
@@ -159,6 +159,6 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     /// ```
     #[storage(read)]
     fn len(self) -> u64 {
-        read::<u64>(self.slot, 0).unwrap_or(0)
+        read::<u64>(self.slot(), 0).unwrap_or(0)
     }
 }

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -40,15 +40,15 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read, write)]
     pub fn push(self, value: V) {
-        let len = read::<u64>(self.field_id, 0).unwrap_or(0);
+        let len = read::<u64>(self.field_id(), 0).unwrap_or(0);
 
         // Storing the value at the current length index (if this is the first item, starts off at 0)
-        let key = sha256(self.field_id);
+        let key = sha256(self.field_id());
         let offset = offset_calculator::<V>(len);
         write::<V>(key, offset, value);
 
         // Incrementing the length
-        write(self.field_id, 0, len + 1);
+        write(self.field_id(), 0, len + 1);
     }
 
     /// Removes the last element of the vector and returns it, `None` if empty.
@@ -82,7 +82,7 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read, write)]
     pub fn pop(self) -> Option<V> {
-        let len = read::<u64>(self.field_id, 0).unwrap_or(0);
+        let len = read::<u64>(self.field_id(), 0).unwrap_or(0);
 
         // if the length is 0, there is no item to pop from the vec
         if len == 0 {
@@ -90,9 +90,9 @@ impl<V> StorageKey<StorageVec<V>> {
         }
 
         // reduces len by 1, effectively removing the last item in the vec
-        write(self.field_id, 0, len - 1);
+        write(self.field_id(), 0, len - 1);
 
-        let key = sha256(self.field_id);
+        let key = sha256(self.field_id());
         let offset = offset_calculator::<V>(len - 1);
         read::<V>(key, offset)
     }
@@ -130,14 +130,14 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read)]
     pub fn get(self, index: u64) -> Option<StorageKey<V>> {
-        let len = read::<u64>(self.field_id, 0).unwrap_or(0);
+        let len = read::<u64>(self.field_id(), 0).unwrap_or(0);
 
         // if the index is larger or equal to len, there is no item to return
         if len <= index {
             return None;
         }
 
-        let key = sha256(self.field_id);
+        let key = sha256(self.field_id());
         let offset = offset_calculator::<V>(index);
         // This StorageKey can be read by the standard storage api.
         // Field Id must be unique such that nested storage vecs work as they have a 
@@ -189,13 +189,13 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read, write)]
     pub fn remove(self, index: u64) -> V {
-        let len = read::<u64>(self.field_id, 0).unwrap_or(0);
+        let len = read::<u64>(self.field_id(), 0).unwrap_or(0);
 
         // if the index is larger or equal to len, there is no item to remove
         assert(index < len);
 
         // gets the element before removing it, so it can be returned
-        let key = sha256(self.field_id);
+        let key = sha256(self.field_id());
         let removed_offset = offset_calculator::<V>(index);
         let removed_element = read::<V>(key, removed_offset).unwrap();
 
@@ -213,7 +213,7 @@ impl<V> StorageKey<StorageVec<V>> {
         }
 
         // decrements len by 1
-        write(self.field_id, 0, len - 1);
+        write(self.field_id(), 0, len - 1);
 
         removed_element
     }
@@ -259,12 +259,12 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read, write)]
     pub fn swap_remove(self, index: u64) -> V {
-        let len = read::<u64>(self.field_id, 0).unwrap_or(0);
+        let len = read::<u64>(self.field_id(), 0).unwrap_or(0);
 
         // if the index is larger or equal to len, there is no item to remove
         assert(index < len);
 
-        let key = sha256(self.field_id);
+        let key = sha256(self.field_id());
         // gets the element before removing it, so it can be returned
         let element_offset = offset_calculator::<V>(index);
         let element_to_be_removed = read::<V>(key, element_offset).unwrap();
@@ -275,7 +275,7 @@ impl<V> StorageKey<StorageVec<V>> {
         write::<V>(key, element_offset, last_element);
 
         // decrements len by 1
-        write(self.field_id, 0, len - 1);
+        write(self.field_id(), 0, len - 1);
 
         element_to_be_removed
     }
@@ -317,12 +317,12 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read, write)]
     pub fn set(self, index: u64, value: V) {
-        let len = read::<u64>(self.field_id, 0).unwrap_or(0);
+        let len = read::<u64>(self.field_id(), 0).unwrap_or(0);
 
         // if the index is higher than or equal len, there is no element to set
         assert(index < len);
 
-        let key = sha256(self.field_id);
+        let key = sha256(self.field_id());
         let offset = offset_calculator::<V>(index);
         write::<V>(key, offset, value);
     }
@@ -370,19 +370,19 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read, write)]
     pub fn insert(self, index: u64, value: V) {
-        let len = read::<u64>(self.field_id, 0).unwrap_or(0);
+        let len = read::<u64>(self.field_id(), 0).unwrap_or(0);
 
         // if the index is larger than len, there is no space to insert
         assert(index <= len);
 
         // if len is 0, index must also be 0 due to above check
-        let key = sha256(self.field_id);
+        let key = sha256(self.field_id());
         if len == index {
             let offset = offset_calculator::<V>(index);
             write::<V>(key, offset, value);
 
             // increments len by 1
-            write(self.field_id, 0, len + 1);
+            write(self.field_id(), 0, len + 1);
 
             return;
         }
@@ -408,7 +408,7 @@ impl<V> StorageKey<StorageVec<V>> {
         write::<V>(key, offset, value);
 
         // increments len by 1
-        write(self.field_id, 0, len + 1);
+        write(self.field_id(), 0, len + 1);
     }
 
     /// Returns the length of the vector.
@@ -440,7 +440,7 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read)]
     pub fn len(self) -> u64 {
-        read::<u64>(self.field_id, 0).unwrap_or(0)
+        read::<u64>(self.field_id(), 0).unwrap_or(0)
     }
 
     /// Checks whether the len is zero or not.
@@ -476,7 +476,7 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read)]
     pub fn is_empty(self) -> bool {
-        read::<u64>(self.field_id, 0).unwrap_or(0) == 0
+        read::<u64>(self.field_id(), 0).unwrap_or(0) == 0
     }
 
     /// Swaps two elements.
@@ -516,7 +516,7 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read, write)]
     pub fn swap(self, element1_index: u64, element2_index: u64) {
-        let len = read::<u64>(self.field_id, 0).unwrap_or(0);
+        let len = read::<u64>(self.field_id(), 0).unwrap_or(0);
         assert(element1_index < len);
         assert(element2_index < len);
 
@@ -524,7 +524,7 @@ impl<V> StorageKey<StorageVec<V>> {
             return;
         }
 
-        let key = sha256(self.field_id);
+        let key = sha256(self.field_id());
         let element1_offset = offset_calculator::<V>(element1_index);
         let element2_offset = offset_calculator::<V>(element2_index);
 
@@ -567,8 +567,8 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read)]
     pub fn first(self) -> Option<StorageKey<V>> {
-        let key = sha256(self.field_id);
-        match read::<u64>(self.field_id, 0).unwrap_or(0) {
+        let key = sha256(self.field_id());
+        match read::<u64>(self.field_id(), 0).unwrap_or(0) {
             0 => None,
             _ => Some(StorageKey::<V>::new(key, 0, sha256((0, key)))),
         }
@@ -603,8 +603,8 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read)]
     pub fn last(self) -> Option<StorageKey<V>> {
-        let key = sha256(self.field_id);
-        match read::<u64>(self.field_id, 0).unwrap_or(0) {
+        let key = sha256(self.field_id());
+        match read::<u64>(self.field_id(), 0).unwrap_or(0) {
             0 => None,
             len => {
                 let offset = offset_calculator::<V>(len - 1);
@@ -640,13 +640,13 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read, write)]
     pub fn reverse(self) {
-        let len = read::<u64>(self.field_id, 0).unwrap_or(0);
+        let len = read::<u64>(self.field_id(), 0).unwrap_or(0);
 
         if len < 2 {
             return;
         }
 
-        let key = sha256(self.field_id);
+        let key = sha256(self.field_id());
         let mid = len / 2;
         let mut i = 0;
         while i < mid {
@@ -693,9 +693,9 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read, write)]
     pub fn fill(self, value: V) {
-        let len = read::<u64>(self.field_id, 0).unwrap_or(0);
+        let len = read::<u64>(self.field_id(), 0).unwrap_or(0);
 
-        let key = sha256(self.field_id);
+        let key = sha256(self.field_id());
         let mut i = 0;
         while i < len {
             let offset = offset_calculator::<V>(i);
@@ -749,14 +749,14 @@ impl<V> StorageKey<StorageVec<V>> {
     /// ```
     #[storage(read, write)]
     pub fn resize(self, new_len: u64, value: V) {
-        let mut len = read::<u64>(self.field_id, 0).unwrap_or(0);
-        let key = sha256(self.field_id);
+        let mut len = read::<u64>(self.field_id(), 0).unwrap_or(0);
+        let key = sha256(self.field_id());
         while len < new_len {
             let offset = offset_calculator::<V>(len);
             write::<V>(key, offset, value);
             len += 1;
         }
-        write::<u64>(self.field_id, 0, new_len);
+        write::<u64>(self.field_id(), 0, new_len);
     }
 
     // TODO: This should be moved into the vec.sw file and `From<StorageKey<StorageVec>> for Vec`
@@ -820,11 +820,11 @@ impl<V> StorageKey<StorageVec<V>> {
         ptr = realloc_bytes(ptr, number_of_bytes, number_of_slots * 32);
 
         // Store `number_of_slots * 32` bytes starting at storage slot `key`.
-        let _ = __state_store_quad(sha256(self.field_id), ptr, number_of_slots);
+        let _ = __state_store_quad(sha256(self.field_id()), ptr, number_of_slots);
 
         // Store the length, NOT the bytes. 
         // This differs from the existing `write_slice()` function to be compatible with `StorageVec`.
-        write::<u64>(self.field_id, 0, number_of_bytes / __size_of::<V>());
+        write::<u64>(self.field_id(), 0, number_of_bytes / __size_of::<V>());
     }
 
     /// Load a `Vec` from the `StorageVec`.
@@ -861,7 +861,7 @@ impl<V> StorageKey<StorageVec<V>> {
     #[storage(read)]
     pub fn load_vec(self) -> Vec<V> {
         // Get the length of the slice that is stored.
-        match read::<u64>(self.field_id, 0).unwrap_or(0) {
+        match read::<u64>(self.field_id(), 0).unwrap_or(0) {
             0 => Vec::new(),
             len => {
                 // Get the number of storage slots needed based on the size.
@@ -869,7 +869,7 @@ impl<V> StorageKey<StorageVec<V>> {
                 let number_of_slots = (bytes + 31) >> 5;
                 let ptr = alloc_bytes(number_of_slots * 32);
                 // Load the stored slice into the pointer.
-                let _ = __state_load_quad(sha256(self.field_id), ptr, number_of_slots);
+                let _ = __state_load_quad(sha256(self.field_id()), ptr, number_of_slots);
                 Vec::from(asm(ptr: (ptr, bytes)) {
                     ptr: raw_slice
                 })

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generics_in_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generics_in_contract/src/main.sw
@@ -9,12 +9,12 @@ impl<K, V> StorageKey<MyStorageMap<K, V>> where K: Hash {
     // annotated with `Vec<V>`.
     #[storage(read)]
     fn to_vec1(self, key: K) -> Vec<V> {
-        let k = sha256((key, self.slot));
+        let k = sha256((key, self.slot()));
         let len = read::<u64>(k, 0).unwrap_or(0);
         let mut i = 0;
         let mut vec: Vec<V> = Vec::new();
         while len > i {
-            let k = sha256((key, i, self.slot));
+            let k = sha256((key, i, self.slot()));
             let item = read::<K>(k, 0).unwrap();
             vec.push(item); // <-----
             i += 1;
@@ -26,12 +26,12 @@ impl<K, V> StorageKey<MyStorageMap<K, V>> where K: Hash {
     // the type of `vec` (`Vec<K>`) is taken from the `vec.push` statement.
     #[storage(read)]
     fn to_vec2(self, key: K) -> Vec<V> {
-        let k = sha256((key, self.slot));
+        let k = sha256((key, self.slot()));
         let len = read::<u64>(k, 0).unwrap_or(0);
         let mut i = 0;
         let mut vec/*: Vec<V>*/ = Vec::new();
         while len > i {
-            let k = sha256((key, i, self.slot));
+            let k = sha256((key, i, self.slot()));
             let item = read::<K>(k, 0).unwrap();
             vec.push(item); // <-----
             i += 1;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -2,7 +2,7 @@ script;
 use basic_storage_abi::{BasicStorage, Quad};
 
 fn main() -> u64 {
-    let addr = abi(BasicStorage, 0x7ee9d721777c523e408a966d97605116e1f2bbad1c16403446c6d734d46258a6);
+    let addr = abi(BasicStorage, 0xc366a3d257f985bf9e3f3571e9ed5c4fbfc56ca8b91d3af9afdeafa628f0fb9a);
     let key = 0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -2,7 +2,7 @@ script;
 use basic_storage_abi::{BasicStorage, Quad};
 
 fn main() -> u64 {
-    let addr = abi(BasicStorage, 0xbe6118636efb556a7bfec50072f3d2eb3d1b2c047a71971dcc3d966c2ea851b3);
+    let addr = abi(BasicStorage, 0xd24a4462a2567bc7c6703afe2cd02cd16e6b279002d5530e4d0ba22648225621);
     let key = 0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     let value = 4242;
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
@@ -3,7 +3,7 @@ script;
 use storage_enum_abi::*;
 
 fn main() -> u64 {
-    let contract_id = 0x097ea9a771b69bf349375a0d6db542e9c730194de4bcd27e4e6665ffb107dfaf;
+    let contract_id = 0x68e2d67cc9ba503882c931ad2425d9fe91bfe78b1b59d039a6e2f06e2c9ce130;
     let caller = abi(StorageEnum, contract_id);
 
     let res = caller.read_write_enums();


### PR DESCRIPTION
## Description

Updates the following heap types to have private struct variables:

- `StorageSlot`

As private fields can only be accessed from within the same file, the `new()`, `slot()`, `offset()`, and `field_id()` functions have been moved to core.

Note: This PR merges into a staging branch

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
