### PR TITLE
Temporarily disable `test_server_launch_mode`

### DIFF
--- a/forc-plugins/forc-debug/tests/server_integration.rs
+++ b/forc-plugins/forc-debug/tests/server_integration.rs
@@ -70,6 +70,8 @@ fn test_server_attach_mode() {
     assert_not_supported_event(output_capture.take_event());
 }
 
+// TODO: re-enable this test once fixed
+#[ignore]
 #[test]
 fn test_server_launch_mode() {
     let output_capture = EventCapture::default();


### PR DESCRIPTION
## Description

This test is failing on PRs. Disabling for now while I investigate the root cause.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
