### PR TITLE
Use v0.48 tag in debugger test

### DIFF
--- a/forc-plugins/forc-debug/tests/fixtures/simple/Forc.toml
+++ b/forc-plugins/forc-debug/tests/fixtures/simple/Forc.toml
@@ -6,4 +6,4 @@ name = "simple"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.50.0" }
+std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }


### PR DESCRIPTION
## Description

Attempting to fix a test that started failing in CI. Most of the other tests are using this tag.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
