### PR TITLE
Encapsulation Numeric Types

### DIFF
--- a/sway-lib-std/src/b512.sw
+++ b/sway-lib-std/src/b512.sw
@@ -9,12 +9,12 @@ use ::convert::From;
 /// Guaranteed to be contiguous for use with ec-recover: `std::ecr::ec_recover`.
 pub struct B512 {
     /// The two `b256`s that make up the `B512`.
-    pub bytes: [b256; 2],
+    bits: [b256; 2],
 }
 
 impl core::ops::Eq for B512 {
     fn eq(self, other: Self) -> bool {
-        (self.bytes)[0] == (other.bytes)[0] && (self.bytes)[1] == (other.bytes)[1]
+        (self.bits)[0] == (other.bits)[0] && (self.bits)[1] == (other.bits)[1]
     }
 }
 
@@ -22,14 +22,14 @@ impl core::ops::Eq for B512 {
 impl From<(b256, b256)> for B512 {
     fn from(components: (b256, b256)) -> Self {
         Self {
-            bytes: [components.0, components.1],
+            bits: [components.0, components.1],
         }
     }
 }
 
 impl From<B512> for (b256, b256) {
     fn from(val: B512) -> (b256, b256) {
-        ((val.bytes)[0], (val.bytes)[1])
+        ((val.bits)[0], (val.bits)[1])
     }
 }
 
@@ -52,7 +52,27 @@ impl B512 {
     /// ```
     pub fn new() -> Self {
         Self {
-            bytes: [ZERO_B256, ZERO_B256],
+            bits: [ZERO_B256, ZERO_B256],
         }
+    }
+
+    /// Returns the underlying bits for the B512 type.
+    ///
+    /// # Returns
+    ///
+    /// * [[b256; 2]] - The two `b256`s that make up the `B512`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::{b512::B512, constants::ZERO_B256);
+    ///
+    /// fn foo() {
+    ///     let zero = B512::new();
+    ///     assert(zero.bits() == [ZERO_B256, ZERO_B256]);
+    /// }
+    /// ```
+    pub fn bits(self) -> [b256; 2] {
+        self.bits
     }
 }

--- a/sway-lib-std/src/ecr.sw
+++ b/sway-lib-std/src/ecr.sw
@@ -159,7 +159,11 @@ pub fn ed_verify(
     signature: B512,
     msg_hash: b256,
 ) -> Result<bool, EcRecoverError> {
-    let was_error = asm(buffer: public_key, sig: __addr_of(signature), hash: msg_hash) {
+    let was_error = asm(
+        buffer: public_key,
+        sig: __addr_of(signature),
+        hash: msg_hash,
+    ) {
         ed19 buffer sig hash;
         err
     };

--- a/sway-lib-std/src/ecr.sw
+++ b/sway-lib-std/src/ecr.sw
@@ -44,15 +44,15 @@ pub enum EcRecoverError {
 ///     // A recovered public key pair.
 ///     let public_key = ec_recover(signature, msg_hash).unwrap();
 ///
-///     assert(public_key.bytes[0] == pub_hi);
-///     assert(public_key.bytes[1] == pub_lo);
+///     assert(public_key.bits()[0] == pub_hi);
+///     assert(public_key.bits()[1] == pub_lo);
 /// }
 /// ```
 pub fn ec_recover(signature: B512, msg_hash: b256) -> Result<B512, EcRecoverError> {
     let public_key = B512::new();
     let was_error = asm(
-        buffer: public_key.bytes,
-        sig: signature.bytes,
+        buffer: public_key.bits(),
+        sig: signature.bits(),
         hash: msg_hash,
     ) {
         eck1 buffer sig hash;
@@ -97,15 +97,15 @@ pub fn ec_recover(signature: B512, msg_hash: b256) -> Result<B512, EcRecoverErro
 ///     // A recovered public key pair.
 ///     let public_key = ec_recover_r1(signature, msg_hash).unwrap();
 ///
-///     assert(public_key.bytes[0] == pub_hi);
-///     assert(public_key.bytes[1] == pub_lo);
+///     assert(public_key.bits()[0] == pub_hi);
+///     assert(public_key.bits()[1] == pub_lo);
 /// }
 /// ```
 pub fn ec_recover_r1(signature: B512, msg_hash: b256) -> Result<B512, EcRecoverError> {
     let public_key = B512::new();
     let was_error = asm(
-        buffer: public_key.bytes,
-        sig: signature.bytes,
+        buffer: public_key.bits(),
+        sig: signature.bits(),
         hash: msg_hash,
     ) {
         ecr1 buffer sig hash;
@@ -159,7 +159,7 @@ pub fn ed_verify(
     signature: B512,
     msg_hash: b256,
 ) -> Result<bool, EcRecoverError> {
-    let was_error = asm(buffer: public_key, sig: signature.bytes, hash: msg_hash) {
+    let was_error = asm(buffer: public_key, sig: signature.bits(), hash: msg_hash) {
         ed19 buffer sig hash;
         err
     };
@@ -211,7 +211,7 @@ pub fn ec_recover_address(signature: B512, msg_hash: b256) -> Result<Address, Ec
         Err(e)
     } else {
         let pub_key = pub_key_result.unwrap();
-        let address = sha256(((pub_key.bytes)[0], (pub_key.bytes)[1]));
+        let address = sha256(((pub_key.bits())[0], (pub_key.bits())[1]));
         Ok(Address::from(address))
     }
 }
@@ -256,7 +256,7 @@ pub fn ec_recover_address_r1(signature: B512, msg_hash: b256) -> Result<Address,
         Err(e)
     } else {
         let pub_key = pub_key_result.unwrap();
-        let address = sha256(((pub_key.bytes)[0], (pub_key.bytes)[1]));
+        let address = sha256(((pub_key.bits())[0], (pub_key.bits())[1]));
         Ok(Address::from(address))
     }
 }
@@ -274,8 +274,8 @@ fn test_ec_recover_r1() {
     // A recovered public key pair.
     let public_key = ec_recover_r1(signature, msg_hash).unwrap();
 
-    assert(public_key.bytes[0] == pub_hi);
-    assert(public_key.bytes[1] == pub_lo);
+    assert(public_key.bits()[0] == pub_hi);
+    assert(public_key.bits()[1] == pub_lo);
 }
 
 #[test(should_revert = "0")]

--- a/sway-lib-std/src/ecr.sw
+++ b/sway-lib-std/src/ecr.sw
@@ -51,8 +51,8 @@ pub enum EcRecoverError {
 pub fn ec_recover(signature: B512, msg_hash: b256) -> Result<B512, EcRecoverError> {
     let public_key = B512::new();
     let was_error = asm(
-        buffer: public_key.bits(),
-        sig: signature.bits(),
+        buffer: __addr_of(public_key),
+        sig: __addr_of(signature),
         hash: msg_hash,
     ) {
         eck1 buffer sig hash;
@@ -104,8 +104,8 @@ pub fn ec_recover(signature: B512, msg_hash: b256) -> Result<B512, EcRecoverErro
 pub fn ec_recover_r1(signature: B512, msg_hash: b256) -> Result<B512, EcRecoverError> {
     let public_key = B512::new();
     let was_error = asm(
-        buffer: public_key.bits(),
-        sig: signature.bits(),
+        buffer: __addr_of(public_key),
+        sig: __addr_of(signature),
         hash: msg_hash,
     ) {
         ecr1 buffer sig hash;
@@ -159,7 +159,7 @@ pub fn ed_verify(
     signature: B512,
     msg_hash: b256,
 ) -> Result<bool, EcRecoverError> {
-    let was_error = asm(buffer: public_key, sig: signature.bits(), hash: msg_hash) {
+    let was_error = asm(buffer: public_key, sig: __addr_of(signature), hash: msg_hash) {
         ed19 buffer sig hash;
         err
     };

--- a/sway-lib-std/src/u128.sw
+++ b/sway-lib-std/src/u128.sw
@@ -14,9 +14,9 @@ use ::result::Result::{self, *};
 /// Represented as two 64-bit components: `(upper, lower)`, where `value = (upper << 64) + lower`.
 pub struct U128 {
     /// The most significant 64 bits of the `U128`.
-    pub upper: u64,
+    upper: u64,
     /// The least significant 64 bits of the `U128`.
-    pub lower: u64,
+    lower: u64,
 }
 
 /// The error type used for `U128` type errors.
@@ -84,7 +84,7 @@ impl u64 {
     ///     let y = u64::max();
     ///     let z = x.overflowing_add(y);
     ///
-    ///     assert(z == U128 { upper: 1, lower: 18446744073709551614 });
+    ///     assert(z == U128::from(1, 18446744073709551614));
     /// }
     /// ```
     pub fn overflowing_add(self, right: Self) -> U128 {
@@ -131,7 +131,7 @@ impl u64 {
     ///     let y = u64::max();
     ///     let z = x.overflowing_mul(y);
     ///
-    ///     assert(z == U128 { upper: 18446744073709551615, lower: 1 });
+    ///     assert(z == U128::from(18446744073709551615, 1));
     /// }
     /// ```
     pub fn overflowing_mul(self, right: Self) -> U128 {
@@ -175,7 +175,7 @@ impl U128 {
     ///
     /// fn foo() {
     ///     let new_u128 = U128::new();
-    ///     let zero_u128 = U128 { upper: 0, lower: 0 };
+    ///     let zero_u128 = U128::from(0, 0);
     ///
     ///     assert(new_u128 == zero_u128);
     /// }
@@ -203,7 +203,7 @@ impl U128 {
     /// use std::u128::{U128, U128Error};
     ///
     /// fn foo() {
-    ///     let zero_u128 = U128 { upper: 0, lower: 0 };
+    ///     let zero_u128 = U128::from(0, 0);
     ///     let zero_u64 = zero_u128.as_u64().unwrap();
     ///
     ///     assert(zero_u64 == 0);
@@ -234,7 +234,7 @@ impl U128 {
     ///
     /// fn foo() {
     ///     let min_u128 = U128::min();
-    ///     let zero_u128 = U128 { upper: 0, lower: 0 };
+    ///     let zero_u128 = U128::from(0, 0);
     ///
     ///     assert(min_u128 == zero_u128);
     /// }
@@ -259,7 +259,7 @@ impl U128 {
     ///
     /// fn foo() {
     ///     let max_u128 = U128::max();
-    ///     let maxed_u128 = U128 { upper: u64::max(), lower: u64::max() };
+    ///     let maxed_u128 = U128::from(u64::max(), u64::max());
     ///
     ///     assert(max_u128 == maxed_u128);
     /// }
@@ -290,6 +290,48 @@ impl U128 {
     /// ```
     pub fn bits() -> u32 {
         128
+    }
+
+    /// Returns the underlying upper u64 representing the most significant 64 bits of the `U128`.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The most significant 64 bits of the `U128`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::u128::U128;
+    ///
+    /// fn foo() {
+    ///     let maxed_u128 = U128::from(u64::max(), u64::min());
+    ///
+    ///     assert(maxed_u128.upper() == u64::max());
+    /// }
+    /// ```
+    pub fn upper(self) -> u64 {
+        self.upper
+    }
+
+    /// Returns the underlying lower u64 representing the least significant 64 bits of the `U128`.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The least significant 64 bits of the `U128`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::u128::U128;
+    ///
+    /// fn foo() {
+    ///     let maxed_u128 = U128::from(u64::max(), u64::min());
+    ///
+    ///     assert(maxed_u128.lower() == u64::min());
+    /// }
+    /// ```
+    pub fn lower(self) -> u64 {
+        self.lower
     }
 }
 

--- a/sway-lib-std/src/u256.sw
+++ b/sway-lib-std/src/u256.sw
@@ -198,7 +198,7 @@ impl U256 {
     ///     let zero_u256 = U256 { a: 0, b: 0, c: 0, d: 0 };
     ///     let zero_u128 = zero_u256.as_u128().unwrap();
     ///
-    ///     assert(zero_u128 == U128 { upper: 0, lower: 0 });
+    ///     assert(zero_u128 == U128::from(0, 0));
     ///
     ///     let max_u256 = U256::max();
     ///     let result = U256.as_u64();
@@ -462,21 +462,21 @@ impl core::ops::Add for U256 {
 
         let mut overflow = 0;
         let mut local_res = U128::from((0, word_4)) + U128::from((0, other_word_4));
-        let result_d = local_res.lower;
-        overflow = local_res.upper;
+        let result_d = local_res.lower();
+        overflow = local_res.upper();
 
         local_res = U128::from((0, word_3)) + U128::from((0, other_word_3)) + U128::from((0, overflow));
-        let result_c = local_res.lower;
-        overflow = local_res.upper;
+        let result_c = local_res.lower();
+        overflow = local_res.upper();
 
         local_res = U128::from((0, word_2)) + U128::from((0, other_word_2)) + U128::from((0, overflow));
-        let result_b = local_res.lower;
-        overflow = local_res.upper;
+        let result_b = local_res.lower();
+        overflow = local_res.upper();
 
         local_res = U128::from((0, word_1)) + U128::from((0, other_word_1)) + U128::from((0, overflow));
-        let result_a = local_res.lower;
+        let result_a = local_res.lower();
         // panic on overflow
-        assert(local_res.upper == 0);
+        assert(local_res.upper() == 0);
         Self::from((result_a, result_b, result_c, result_d))
     }
 }
@@ -573,20 +573,20 @@ impl core::ops::Multiply for U256 {
                 let result_d_c = self.d.overflowing_mul(other.c);
                 let result_d_d = self.d.overflowing_mul(other.d);
 
-                let (overflow_of_c_to_b_1, mut c): (u64, u64) = result_d_d.upper.overflowing_add(result_c_d.lower).into();
-                let (mut overflow_of_c_to_b_2, c): (u64, u64) = c.overflowing_add(result_d_c.lower).into();
+                let (overflow_of_c_to_b_1, mut c): (u64, u64) = result_d_d.upper().overflowing_add(result_c_d.lower()).into();
+                let (mut overflow_of_c_to_b_2, c): (u64, u64) = c.overflowing_add(result_d_c.lower()).into();
 
                 let (overflow_of_b_to_a_0, overflow_of_c_to_b_2): (u64, u64) = overflow_of_c_to_b_1.overflowing_add(overflow_of_c_to_b_2).into();
 
-                let (overflow_of_b_to_a_1, mut b): (u64, u64) = result_b_d.lower.overflowing_add(result_c_d.upper).into();
-                let (overflow_of_b_to_a_2, b): (u64, u64) = b.overflowing_add(result_d_c.upper).into();
+                let (overflow_of_b_to_a_1, mut b): (u64, u64) = result_b_d.lower().overflowing_add(result_c_d.upper()).into();
+                let (overflow_of_b_to_a_2, b): (u64, u64) = b.overflowing_add(result_d_c.upper()).into();
                 let (overflow_of_b_to_a_3, b): (u64, u64) = b.overflowing_add(overflow_of_c_to_b_2).into();
 
                 Self::from((
-                    self.b * other.c + result_b_d.upper + overflow_of_b_to_a_3 + overflow_of_b_to_a_2 + overflow_of_b_to_a_1 + overflow_of_b_to_a_0,
+                    self.b * other.c + result_b_d.upper() + overflow_of_b_to_a_3 + overflow_of_b_to_a_2 + overflow_of_b_to_a_1 + overflow_of_b_to_a_0,
                     b,
                     c,
-                    result_d_d.lower,
+                    result_d_d.lower(),
                 ))
             } else if other.b != 0 {
                 // If `other.b` is nonzero, `self.b` has to be zero. Otherwise, overflow is
@@ -598,20 +598,20 @@ impl core::ops::Multiply for U256 {
                 let result_d_c = other.d.overflowing_mul(self.c);
                 let result_d_d = other.d.overflowing_mul(self.d);
 
-                let (overflow_of_c_to_b_1, mut c): (u64, u64) = result_d_d.upper.overflowing_add(result_c_d.lower).into();
-                let (mut overflow_of_c_to_b_2, c): (u64, u64) = c.overflowing_add(result_d_c.lower).into();
+                let (overflow_of_c_to_b_1, mut c): (u64, u64) = result_d_d.upper().overflowing_add(result_c_d.lower()).into();
+                let (mut overflow_of_c_to_b_2, c): (u64, u64) = c.overflowing_add(result_d_c.lower()).into();
 
                 let (overflow_of_b_to_a_0, overflow_of_c_to_b_2): (u64, u64) = overflow_of_c_to_b_1.overflowing_add(overflow_of_c_to_b_2).into();
 
-                let (overflow_of_b_to_a_1, mut b): (u64, u64) = result_b_d.lower.overflowing_add(result_c_d.upper).into();
-                let (overflow_of_b_to_a_2, b): (u64, u64) = b.overflowing_add(result_d_c.upper).into();
+                let (overflow_of_b_to_a_1, mut b): (u64, u64) = result_b_d.lower().overflowing_add(result_c_d.upper()).into();
+                let (overflow_of_b_to_a_2, b): (u64, u64) = b.overflowing_add(result_d_c.upper()).into();
                 let (overflow_of_b_to_a_3, b): (u64, u64) = b.overflowing_add(overflow_of_c_to_b_2).into();
 
                 Self::from((
-                    other.b * self.c + result_b_d.upper + overflow_of_b_to_a_3 + overflow_of_b_to_a_2 + overflow_of_b_to_a_1 + overflow_of_b_to_a_0,
+                    other.b * self.c + result_b_d.upper() + overflow_of_b_to_a_3 + overflow_of_b_to_a_2 + overflow_of_b_to_a_1 + overflow_of_b_to_a_0,
                     b,
                     c,
-                    result_d_d.lower,
+                    result_d_d.lower(),
                 ))
             } else {
                 // note, that `self.a`, `self.b`, `other.a`, `other.b` are all equal to 0
@@ -620,22 +620,22 @@ impl core::ops::Multiply for U256 {
                 let result_d_c = self.d.overflowing_mul(other.c);
                 let result_d_d = self.d.overflowing_mul(other.d);
 
-                let (overflow_of_c_to_b_1, mut c): (u64, u64) = result_d_d.upper.overflowing_add(result_c_d.lower).into();
+                let (overflow_of_c_to_b_1, mut c): (u64, u64) = result_d_d.upper().overflowing_add(result_c_d.lower()).into();
 
-                let (mut overflow_of_c_to_b_2, c): (u64, u64) = c.overflowing_add(result_d_c.lower).into();
+                let (mut overflow_of_c_to_b_2, c): (u64, u64) = c.overflowing_add(result_d_c.lower()).into();
 
                 let (overflow_of_b_to_a_0, overflow_of_c_to_b_2): (u64, u64) = overflow_of_c_to_b_1.overflowing_add(overflow_of_c_to_b_2).into();
 
-                let (overflow_of_b_to_a_1, mut b): (u64, u64) = result_c_c.lower.overflowing_add(result_c_d.upper).into();
-                let (overflow_of_b_to_a_2, b): (u64, u64) = b.overflowing_add(result_d_c.upper).into();
+                let (overflow_of_b_to_a_1, mut b): (u64, u64) = result_c_c.lower().overflowing_add(result_c_d.upper()).into();
+                let (overflow_of_b_to_a_2, b): (u64, u64) = b.overflowing_add(result_d_c.upper()).into();
                 let (overflow_of_b_to_a_3, b): (u64, u64) = b.overflowing_add(overflow_of_c_to_b_2).into();
 
                 Self::from((
                     // as overflow for a means overflow for the whole number, we are adding as is, not using `overflowing_add`
-                    result_c_c.upper + overflow_of_b_to_a_3 + overflow_of_b_to_a_2 + overflow_of_b_to_a_1 + overflow_of_b_to_a_0,
+                    result_c_c.upper() + overflow_of_b_to_a_3 + overflow_of_b_to_a_2 + overflow_of_b_to_a_1 + overflow_of_b_to_a_0,
                     b,
                     c,
-                    result_d_d.lower,
+                    result_d_d.lower(),
                 ))
             }
         }
@@ -657,7 +657,7 @@ impl core::ops::Divide for U256 {
             && divisor.b == 0
         {
             let res = U128::from((self.c, self.d)) / U128::from((divisor.c, divisor.d));
-            return Self::from((0, 0, res.upper, res.lower));
+            return Self::from((0, 0, res.upper(), res.lower()));
         }
 
         let mut quotient = Self::from((0, 0, 0, 0));

--- a/sway-lib-std/src/vm/evm/ecr.sw
+++ b/sway-lib-std/src/vm/evm/ecr.sw
@@ -47,7 +47,7 @@ pub fn ec_recover_evm_address(
         _ => {
             let pub_key = pub_key_result.unwrap();
             // Note that EVM addresses are derived from the Keccak256 hash of the pubkey (not sha256)
-            let pubkey_hash = keccak256(((pub_key.bytes)[0], (pub_key.bytes)[1]));
+            let pubkey_hash = keccak256(((pub_key.bits())[0], (pub_key.bits())[1]));
             Ok(EvmAddress::from(pubkey_hash))
         }
     }

--- a/sway-lib-std/src/vm/evm/evm_address.sw
+++ b/sway-lib-std/src/vm/evm/evm_address.sw
@@ -8,12 +8,34 @@ use ::hash::*;
 /// The `EvmAddress` type, a struct wrapper around the inner `b256` value.
 pub struct EvmAddress {
     /// The underlying evm address data.
-    value: b256,
+    bits: b256,
+}
+
+impl EvmAddress {
+    /// Returns the underlying bits for the EvmAddress type.
+    ///
+    /// # Returns
+    ///
+    /// * [b256] - The `b256` that make up the EvmAddress.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::{evm::EvmAddress, constants::ZERO_B256);
+    ///
+    /// fn foo() {
+    ///     let evm_address = EvmAddress::from(ZERO_B256);
+    ///     assert(evm_address.bits() == ZERO_B256);
+    /// }
+    /// ```
+    pub fn bits(self) -> b256 {
+        self.bits
+    }
 }
 
 impl core::ops::Eq for EvmAddress {
     fn eq(self, other: Self) -> bool {
-        self.value == other.value
+        self.bits == other.bits
     }
 }
 
@@ -28,20 +50,20 @@ impl From<b256> for EvmAddress {
         };
 
         Self {
-            value: local_bits,
+            bits: local_bits,
         }
     }
 }
 
 impl From<EvmAddress> for b256 {
     fn from(addr: EvmAddress) -> b256 {
-        addr.value
+        addr.bits
     }
 }
 
 impl Hash for EvmAddress {
     fn hash(self, ref mut state: Hasher) {
-        let Address { value } = self;
-        value.hash(state);
+        let Address { bits } = self;
+        bits.hash(state);
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/complex_cfg/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/complex_cfg/src/main.sw
@@ -7,10 +7,7 @@ pub enum Error {
 }
 
 fn main() {
-    let x = U128 {
-        upper: 0,
-        lower: 0,
-    };
+    let x = U128::from(0, 0);
     let cond = false;
     require(cond || (x < U128::from((1, 1)) || x == U128::from((1, 1))), Error::Overflow);
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/complex_cfg/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/complex_cfg/src/main.sw
@@ -7,7 +7,7 @@ pub enum Error {
 }
 
 fn main() {
-    let x = U128::from(0, 0);
+    let x = U128::from((0, 0));
     let cond = false;
     require(cond || (x < U128::from((1, 1)) || x == U128::from((1, 1))), Error::Overflow);
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/empty_method_initializer/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/empty_method_initializer/src/main.sw
@@ -8,5 +8,5 @@ fn main() -> bool {
 
     let b = B512::from((hi_bits, lo_bits));
     let other_b = B512::new();
-    ((b.bytes)[0] != (other_b.bytes)[0]) && ((b.bytes)[1] == (other_b.bytes)[1])
+    ((b.bits())[0] != (other_b.bits())[0]) && ((b.bits())[1] == (other_b.bits())[1])
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_eq/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_eq/json_abi_oracle.json
@@ -254,7 +254,7 @@
     {
       "components": [
         {
-          "name": "bytes",
+          "name": "bits",
           "type": 0,
           "typeArguments": null
         }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/json_abi_oracle.json
@@ -254,7 +254,7 @@
     {
       "components": [
         {
-          "name": "bytes",
+          "name": "bits",
           "type": 0,
           "typeArguments": null
         }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_struct_alignment/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_struct_alignment/src/main.sw
@@ -8,5 +8,5 @@ fn main() -> bool {
 
     let b: B512 = B512::from((hi_bits, lo_bits));
 
-    (b.bytes)[1] == lo_bits && (b.bytes)[0] == hi_bits
+    (b.bits())[1] == lo_bits && (b.bits())[0] == hi_bits
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_test/src/main.sw
@@ -4,7 +4,7 @@ use std::b512::*;
 
 // helper to prove contiguity of memory in B512 type's hi & lo fields.
 fn are_fields_contiguous(big_value: B512) -> bool {
-    asm(r1: (big_value.bytes)[0], r2: (big_value.bytes)[1], r3, r4, r5, r6) {
+    asm(r1: (big_value.bits())[0], r2: (big_value.bits())[1], r3, r4, r5, r6) {
         move r3 sp; // Save a copy of SP in R3.
         cfei i64; // Reserve 512 bits of stack space.  SP is now R3+64.
         mcpi r3 r1 i64; // Copy 64 bytes *starting at* big_value.hi (includes big_value.lo)
@@ -24,23 +24,14 @@ fn main() -> bool {
 
     // it allows creation of new empty type:
     let mut a = B512::new();
-    assert(((a.bytes)[0] == zero) && ((a.bytes)[1] == zero));
-
-    // it allows reassignment of fields:
-    a.bytes = [hi_bits, lo_bits];
-    assert(((a.bytes)[0] == hi_bits) && ((a.bytes)[1] == lo_bits));
+    assert(((a.bits())[0] == zero) && ((a.bits())[1] == zero));
 
     // it allows building from 2 b256's:
     let mut b = B512::from((hi_bits, lo_bits));
-    assert(((b.bytes)[0] == hi_bits) && ((b.bytes)[1] == lo_bits));
-
-    // it allows reassignment of fields:
-    b.bytes = [modified, modified];
-    assert(((b.bytes)[0] == modified) && ((b.bytes)[1] == modified));
+    assert(((b.bits())[0] == hi_bits) && ((b.bits())[1] == lo_bits));
 
     // it guarantees memory contiguity:
-    let mut c = B512::new();
-    c.bytes = [hi_bits, lo_bits];
+    let mut c = B512::from(hi_bits, lo_bits);
     assert(are_fields_contiguous(c));
 
     // it allows direct comparison of equality:

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/b512_test/src/main.sw
@@ -31,7 +31,7 @@ fn main() -> bool {
     assert(((b.bits())[0] == hi_bits) && ((b.bits())[1] == lo_bits));
 
     // it guarantees memory contiguity:
-    let mut c = B512::from(hi_bits, lo_bits);
+    let mut c = B512::from((hi_bits, lo_bits));
     assert(are_fields_contiguous(c));
 
     // it allows direct comparison of equality:

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_div_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_div_test/src/main.sw
@@ -10,14 +10,14 @@ fn main() -> bool {
     let _one_upper = U128::from((1, 0));
 
     let div_max_two = max_u64 / two;
-    assert(div_max_two.upper == 0);
-    assert(div_max_two.lower == u64::max() >> 1);
+    assert(div_max_two.upper() == 0);
+    assert(div_max_two.lower() == u64::max() >> 1);
 
     // Product of u64::MAX and u64::MAX.
     let dividend = U128::from((u64::max() - 1, 1));
     let div_max_max = dividend / max_u64;
-    assert(div_max_max.upper == 0);
-    assert(div_max_max.lower == u64::max());
+    assert(div_max_max.upper() == 0);
+    assert(div_max_max.lower() == u64::max());
 
     true
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_mul_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_mul_test/src/main.sw
@@ -9,16 +9,16 @@ fn main() -> bool {
     let _one_upper = U128::from((1, 0));
 
     let mul_128_of_two = max_u64 * two;
-    assert(mul_128_of_two.upper == 1);
-    assert(mul_128_of_two.lower == u64::max() - 1);
+    assert(mul_128_of_two.upper() == 1);
+    assert(mul_128_of_two.lower() == u64::max() - 1);
 
     let mul_128_of_four = mul_128_of_two * two;
-    assert(mul_128_of_four.upper == 3);
-    assert(mul_128_of_four.lower == u64::max() - 3);
+    assert(mul_128_of_four.upper() == 3);
+    assert(mul_128_of_four.lower() == u64::max() - 3);
 
     let mul_128_max = max_u64 * max_u64;
-    assert(mul_128_max.upper == u64::max() - 1);
-    assert(mul_128_max.lower == 1);
+    assert(mul_128_max.upper() == u64::max() - 1);
+    assert(mul_128_max.lower() == 1);
 
     true
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_test/src/main.sw
@@ -8,85 +8,85 @@ fn main() -> bool {
     let max_u64 = U128::from((0, u64::max()));
 
     let one = first + second;
-    assert(one.upper == 0);
-    assert(one.lower == 1);
+    assert(one.upper() == 0);
+    assert(one.lower() == 1);
 
     let two = one + one;
-    assert(two.upper == 0);
-    assert(two.lower == 2);
+    assert(two.upper() == 0);
+    assert(two.lower() == 2);
 
     let add_of_one = max_u64 + one;
-    assert(add_of_one.upper == 1);
-    assert(add_of_one.lower == 0);
+    assert(add_of_one.upper() == 1);
+    assert(add_of_one.lower() == 0);
 
     let add_of_two = max_u64 + two;
-    assert(add_of_two.upper == 1);
-    assert(add_of_two.lower == 1);
+    assert(add_of_two.upper() == 1);
+    assert(add_of_two.lower() == 1);
 
     let add_max = max_u64 + max_u64;
-    assert(add_max.upper == 1);
-    assert(add_max.lower == u64::max() - 1);
+    assert(add_max.upper() == 1);
+    assert(add_max.lower() == u64::max() - 1);
 
     let sub_one = second - first;
-    assert(sub_one.upper == 0);
-    assert(sub_one.lower == 1);
+    assert(sub_one.upper() == 0);
+    assert(sub_one.lower() == 1);
 
     let sub_zero = first - first;
-    assert(sub_zero.upper == 0);
-    assert(sub_zero.lower == 0);
+    assert(sub_zero.upper() == 0);
+    assert(sub_zero.lower() == 0);
 
     let sub_max_again = add_of_two - two;
-    assert(sub_max_again.upper == 0);
-    assert(sub_max_again.lower == u64::max());
+    assert(sub_max_again.upper() == 0);
+    assert(sub_max_again.lower() == u64::max());
 
     let mul_four = 2.overflowing_mul(2);
-    assert(mul_four.upper == 0);
-    assert(mul_four.lower == 4);
+    assert(mul_four.upper() == 0);
+    assert(mul_four.lower() == 4);
 
     let mul_eight = 4.overflowing_mul(2);
-    assert(mul_eight.upper == 0);
-    assert(mul_eight.lower == 8);
+    assert(mul_eight.upper() == 0);
+    assert(mul_eight.lower() == 8);
 
     let mul_of_two = u64::max().overflowing_mul(2);
-    assert(mul_of_two.upper == 1);
-    assert(mul_of_two.lower == u64::max() - 1);
+    assert(mul_of_two.upper() == 1);
+    assert(mul_of_two.lower() == u64::max() - 1);
 
     let mul_of_four = u64::max().overflowing_mul(4);
-    assert(mul_of_four.upper == 3);
-    assert(mul_of_four.lower == u64::max() - 3);
+    assert(mul_of_four.upper() == 3);
+    assert(mul_of_four.lower() == u64::max() - 3);
 
     let mul_max = u64::max().overflowing_mul(u64::max());
-    assert(mul_max.upper == u64::max() - 1);
-    assert(mul_max.lower == 1);
+    assert(mul_max.upper() == u64::max() - 1);
+    assert(mul_max.lower() == 1);
 
     let one_upper = U128::from((1, 0));
 
     let right_shift_one_upper = one_upper >> 1;
-    assert(right_shift_one_upper.upper == 0);
-    assert(right_shift_one_upper.lower == (1 << 63));
+    assert(right_shift_one_upper.upper() == 0);
+    assert(right_shift_one_upper.lower() == (1 << 63));
 
     let left_shift_one_upper_right_shift = right_shift_one_upper << 1;
     assert(left_shift_one_upper_right_shift == one_upper);
 
     let one_left_shift_64 = one << 64;
-    assert(one_left_shift_64.upper == 1);
-    assert(one_left_shift_64.lower == 0);
+    assert(one_left_shift_64.upper() == 1);
+    assert(one_left_shift_64.lower() == 0);
 
     let three_left_shift_one = U128::from((0, 3)) << 1;
-    assert(three_left_shift_one.upper == 0);
-    assert(three_left_shift_one.lower == 6);
+    assert(three_left_shift_one.upper() == 0);
+    assert(three_left_shift_one.lower() == 6);
 
     let not_0_3 = !U128::from((0, 3));
-    assert(not_0_3.upper == u64::max());
-    assert(not_0_3.lower == u64::max() - 3);
+    assert(not_0_3.upper() == u64::max());
+    assert(not_0_3.lower() == u64::max() - 3);
 
     let not_3_3 = !U128::from((3, 3));
-    assert(not_3_3.upper == u64::max() - 3);
-    assert(not_3_3.lower == u64::max() - 3);
+    assert(not_3_3.upper() == u64::max() - 3);
+    assert(not_3_3.lower() == u64::max() - 3);
 
     let not_3_0 = !U128::from((3, 0));
-    assert(not_3_0.upper == u64::max() - 3);
-    assert(not_3_0.lower == u64::max());
+    assert(not_3_0.upper() == u64::max() - 3);
+    assert(not_3_0.lower() == u64::max());
 
     // test as_u64()
     let eleven = U128::from((0, 11));


### PR DESCRIPTION
## Description

Updates the following numeric types to have private struct variables:

- `B512`
- `U128`

As `U256` is deprecated this type has not been updated. 

This PR also renames the `B512` field from `bytes` to `bits` and renames the `EvmAddress` field from `bytes` to `bits` with a field accessor function.

Note: This PR merges into a staging branch

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
