### PR TITLE
Adds reuse of enum variant TypeId.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -90,7 +90,8 @@ pub(crate) fn instantiate_enum(
                 .with_help_text("Enum instantiator must match its declared variant type.")
                 .with_type_annotation(start_type);
 
-            let typed_expr = ty::TyExpression::type_check(handler, enum_ctx, single_expr.clone())?;
+            let mut typed_expr =
+                ty::TyExpression::type_check(handler, enum_ctx, single_expr.clone())?;
 
             // unify the value of the argument with the variant
             handler.scope(|handler| {
@@ -105,6 +106,9 @@ pub(crate) fn instantiate_enum(
                 );
                 Ok(())
             })?;
+
+            // Reuse the TypeId so further unification in typed_expr.return_type also affect enum_variant.type_argument.type_id
+            typed_expr.return_type = enum_variant.type_argument.type_id;
 
             // we now know that the instantiator type matches the declared type, via the above tpe
             // check

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_variant_unification/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_variant_unification/Forc.lock
@@ -1,0 +1,16 @@
+[[package]]
+name = "core"
+source = "path+from-root-F6BA7257B3F9949F"
+
+[[package]]
+name = "enum_variant_unification"
+source = "member"
+dependencies = [
+    "core",
+    "std",
+]
+
+[[package]]
+name = "std"
+source = "path+from-root-F6BA7257B3F9949F"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_variant_unification/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_variant_unification/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "enum_variant_unification"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_variant_unification/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_variant_unification/src/main.sw
@@ -1,0 +1,33 @@
+script;
+
+struct S<T> {
+    x: T,
+}
+
+fn main() -> u64 {
+  // https://github.com/FuelLabs/sway/issues/5492
+  let _ = foo();
+  let _ = bar(true);
+
+  // https://github.com/FuelLabs/sway/issues/5581
+  let _: S<Option<u8>>  = S { x: Option::Some(1) };
+
+  0
+}
+
+#[inline(never)]
+fn foo() -> Option<u8> {
+  match Some(true) {
+    Option::Some(_b) => Option::Some(17),
+    Option::None => Option::None,
+  }
+}
+
+#[inline(never)]
+fn bar(b: bool) -> Option<u8> {
+   if(b) {
+     Option::Some(19)
+   } else {
+     Option::None
+   }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_variant_unification/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/enum_variant_unification/test.toml
@@ -1,0 +1,4 @@
+category = "run"
+expected_result = { action = "return", value = 0 }
+validate_abi = false
+expected_warnings = 3


### PR DESCRIPTION
## Description

We already do unification of expressions with type annotation when necessary, but these were not affecting enum variants because we used separate TypeIds for the expression and for the enum variant.

With this change the enum variant and the expressions will share the same TypeId, making unification to the expression to also affect the enum variant.

Fixes #5492
Fixes #5581

Probably helpful for #5559

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
