### PR TITLE
Forc completions sub commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_fig"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed37b4c0c1214673eba6ad8ea31666626bf72be98ffb323067d973c48b4964b9"
+dependencies = [
+ "clap 3.2.25",
+ "clap_complete 3.2.5",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +1986,7 @@ dependencies = [
  "anyhow",
  "clap 3.2.25",
  "clap_complete 3.2.5",
+ "clap_complete_fig",
  "forc-pkg",
  "forc-test",
  "forc-tracing 0.51.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,6 +2082,7 @@ dependencies = [
  "escargot",
  "forc-pkg",
  "forc-test",
+ "forc-util",
  "fuel-core-client",
  "fuel-types",
  "fuel-vm",
@@ -2102,7 +2103,7 @@ name = "forc-doc"
 version = "0.51.1"
 dependencies = [
  "anyhow",
- "clap 4.5.1",
+ "clap 3.2.25",
  "colored",
  "comrak",
  "dir_indexer",

--- a/forc-plugins/forc-client/src/bin/deploy.rs
+++ b/forc-plugins/forc-client/src/bin/deploy.rs
@@ -1,8 +1,9 @@
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use forc_tracing::{init_tracing_subscriber, println_error};
 
 #[tokio::main]
 async fn main() {
+    forc_util::cli::register(forc_client::cmd::Deploy::into_app());
     init_tracing_subscriber(Default::default());
     let command = forc_client::cmd::Deploy::parse();
     if let Err(err) = forc_client::op::deploy(command).await {

--- a/forc-plugins/forc-client/src/bin/run.rs
+++ b/forc-plugins/forc-client/src/bin/run.rs
@@ -1,8 +1,9 @@
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use forc_tracing::{init_tracing_subscriber, println_error};
 
 #[tokio::main]
 async fn main() {
+    forc_util::cli::register(forc_client::cmd::Run::into_app());
     init_tracing_subscriber(Default::default());
     let command = forc_client::cmd::Run::parse();
     if let Err(err) = forc_client::op::run(command).await {

--- a/forc-plugins/forc-client/src/bin/submit.rs
+++ b/forc-plugins/forc-client/src/bin/submit.rs
@@ -1,8 +1,9 @@
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use forc_tracing::{init_tracing_subscriber, println_error};
 
 #[tokio::main]
 async fn main() {
+    forc_util::cli::register(forc_client::cmd::Submit::into_app());
     init_tracing_subscriber(Default::default());
     let command = forc_client::cmd::Submit::parse();
     if let Err(err) = forc_client::op::submit(command).await {

--- a/forc-plugins/forc-crypto/src/main.rs
+++ b/forc-plugins/forc-crypto/src/main.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use atty::Stream;
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use forc_tracing::{init_tracing_subscriber, println_error};
 use std::{
     default::Default,
@@ -57,6 +57,7 @@ fn main() {
 }
 
 fn run() -> Result<()> {
+    forc_util::cli::register(Command::into_app());
     let app = Command::parse();
     let content = match app {
         Command::Keccak256(arg) => keccak256::hash(arg)?,

--- a/forc-plugins/forc-crypto/src/main.rs
+++ b/forc-plugins/forc-crypto/src/main.rs
@@ -16,7 +16,7 @@ mod keccak256;
 mod keys;
 mod sha256;
 
-const ABOUT: &str = "Forc plugin for hashing arbitrary data.";
+const ABOUT: &str = "Forc plugin for hashing arbitrary data";
 
 fn help() -> &'static str {
     Box::leak(

--- a/forc-plugins/forc-debug/Cargo.toml
+++ b/forc-plugins/forc-debug/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "3", features = ["env", "derive"] }
 dap = "0.4.1-alpha1"
 forc-pkg = { version = "0.51.1", path = "../../forc-pkg" }
 forc-test = { version = "0.51.1", path = "../../forc-test" }
+forc-util = { version = "0.51.1", path = "../../forc-util" }
 fuel-core-client = { workspace = true }
 fuel-types = { workspace = true, features = ["serde"] }
 fuel-vm = { workspace = true, features = ["serde"] }

--- a/forc-plugins/forc-debug/src/main.rs
+++ b/forc-plugins/forc-debug/src/main.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use forc_debug::{
     names::{register_index, register_name},
     server::DapServer,
@@ -20,6 +20,7 @@ pub struct Opt {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    forc_util::cli::register(Opt::into_app());
     let config = Opt::parse();
 
     if config.serve {

--- a/forc-plugins/forc-doc/Cargo.toml
+++ b/forc-plugins/forc-doc/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow = "1.0.65"
-clap = { version = "4.0.18", features = ["derive"] }
+clap = { version = "3.1", features = ["derive"] }
 colored = "2.0.0"
 comrak = "0.16"
 forc-pkg = { version = "0.51.1", path = "../../forc-pkg" }

--- a/forc-plugins/forc-doc/src/main.rs
+++ b/forc-plugins/forc-doc/src/main.rs
@@ -4,7 +4,7 @@ use crate::{
     search::write_search_index,
 };
 use anyhow::{bail, Result};
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use cli::Command;
 use colored::*;
 use forc_pkg as pkg;
@@ -51,6 +51,7 @@ struct ProgramInfo<'a> {
 }
 
 pub fn main() -> Result<()> {
+    forc_util::cli::register(Command::into_app());
     let build_instructions = Command::parse();
 
     let (doc_path, pkg_manifest) = compile_html(&build_instructions, &get_doc_dir)?;

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -35,7 +35,7 @@ forc_util::cli_examples! {
 #[derive(Debug, Parser)]
 #[clap(
     name = "forc-fmt",
-    about = "Forc plugin for running the Sway code formatter.",
+    about = "Forc plugin for running the Sway code formatter",
     after_help = help(),
     version
 )]
@@ -51,7 +51,8 @@ pub struct App {
     pub path: Option<String>,
     #[clap(short, long)]
     /// Formats a single .sw file with the default settings.
-    /// If not specified, current working directory will be formatted using a Forc.toml configuration.
+    /// If not specified, current working directory will be formatted using a Forc.toml
+    /// configuration.
     pub file: Option<String>,
 }
 

--- a/forc-plugins/forc-fmt/src/main.rs
+++ b/forc-plugins/forc-fmt/src/main.rs
@@ -1,7 +1,7 @@
 //! A `forc` plugin for running the Sway code formatter.
 
 use anyhow::{bail, Result};
-use clap::Parser;
+use clap::{IntoApp, Parser};
 use forc_pkg::{
     manifest::{GenericManifestFile, ManifestFile},
     WorkspaceManifestFile,
@@ -66,6 +66,7 @@ fn main() {
 }
 
 fn run() -> Result<()> {
+    forc_util::cli::register(App::into_app());
     let app = App::parse();
 
     let dir = match app.path.as_ref() {

--- a/forc-plugins/forc-lsp/src/main.rs
+++ b/forc-plugins/forc-lsp/src/main.rs
@@ -11,7 +11,7 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 #[clap(
     name = "forc-lsp",
-    about = "Forc plugin for the Sway LSP (Language Server Protocol) implementation.",
+    about = "Forc plugin for the Sway LSP (Language Server Protocol) implementation",
     version
 )]
 struct App {}

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -21,7 +21,7 @@ hex = "0.4.3"
 paste = "1.0.14"
 regex = "1.10.2"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.73"
+serde_json = "1"
 serial_test = "3.0.0"
 sway-core = { version = "0.51.1", path = "../sway-core" }
 sway-error = { version = "0.51.1", path = "../sway-error" }

--- a/forc-util/src/cli.rs
+++ b/forc-util/src/cli.rs
@@ -1,3 +1,186 @@
+use clap::{ArgAction, Command};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CommandInfo {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub long_help: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub subcommands: Vec<CommandInfo>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub args: Vec<ArgInfo>,
+}
+
+impl CommandInfo {
+    pub fn new(cmd: &Command) -> Self {
+        CommandInfo {
+            name: cmd.get_name().to_owned(),
+            long_help: cmd.get_after_long_help().map(|s| s.to_string()),
+            description: cmd.get_about().map(|s| s.to_string()),
+            subcommands: Self::get_subcommands(cmd),
+            args: Self::get_args(cmd),
+        }
+    }
+
+    pub fn to_clap(&self) -> clap::App<'_> {
+        let mut cmd = Command::new(self.name.as_str());
+        if let Some(desc) = &self.description {
+            cmd = cmd.about(desc.as_str());
+        }
+        if let Some(long_help) = &self.long_help {
+            cmd = cmd.after_long_help(long_help.as_str());
+        }
+        for subcommand in &self.subcommands {
+            cmd = cmd.subcommand(subcommand.to_clap());
+        }
+        for arg in &self.args {
+            cmd = cmd.arg(arg.to_clap());
+        }
+        cmd
+    }
+
+    fn get_subcommands(cmd: &Command) -> Vec<CommandInfo> {
+        cmd.get_subcommands()
+            .map(|subcommand| CommandInfo::new(subcommand))
+            .collect::<Vec<_>>()
+    }
+
+    fn arg_conflicts(cmd: &Command, arg: &clap::Arg) -> Vec<String> {
+        cmd.get_arg_conflicts_with(arg)
+            .iter()
+            .flat_map(|conflict| {
+                vec![
+                    conflict.get_short().map(|s| format!("-{}", s)),
+                    conflict.get_long().map(|l| format!("--{}", l)),
+                ]
+            })
+            .flatten()
+            .collect()
+    }
+
+    fn arg_possible_values(arg: &clap::Arg<'_>) -> Vec<PossibleValues> {
+        arg.get_possible_values()
+            .map(|possible_values| {
+                possible_values
+                    .iter()
+                    .map(|x| PossibleValues {
+                        name: x.get_name().to_owned(),
+                        help: x.get_help().unwrap_or_default().to_owned(),
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+    }
+
+    fn arg_alias(arg: &clap::Arg<'_>) -> Vec<String> {
+        arg.get_long_and_visible_aliases()
+            .map(|c| c.iter().map(|x| format!("--{}", x)).collect::<Vec<_>>())
+            .unwrap_or_default()
+    }
+
+    fn get_args(cmd: &Command) -> Vec<ArgInfo> {
+        cmd.get_arguments()
+            .map(|arg| ArgInfo {
+                name: if arg.get_long().is_some() {
+                    format!("--{}", arg.get_name())
+                } else {
+                    arg.get_name().to_string()
+                },
+                possible_values: Self::arg_possible_values(arg),
+                short: arg.get_short_and_visible_aliases(),
+                aliases: Self::arg_alias(arg),
+                help: arg.get_help().map(|s| s.to_string()),
+                long_help: arg.get_long_help().map(|s| s.to_string()),
+                conflicts: Self::arg_conflicts(cmd, arg),
+                is_repeatable: matches!(
+                    arg.get_action(),
+                    ArgAction::Set | ArgAction::Append | ArgAction::Count,
+                ),
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PossibleValues {
+    pub name: String,
+    pub help: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ArgInfo {
+    pub name: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub possible_values: Vec<PossibleValues>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub short: Option<Vec<char>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub help: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub long_help: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub conflicts: Vec<String>,
+    pub is_repeatable: bool,
+}
+
+impl ArgInfo {
+    pub fn to_clap(&self) -> clap::Arg<'_> {
+        let mut arg = clap::Arg::with_name(self.name.as_str());
+        if let Some(short) = &self.short {
+            arg = arg.short(short[0]);
+        }
+        if let Some(help) = &self.help {
+            arg = arg.help(help.as_str());
+        }
+        if let Some(long_help) = &self.long_help {
+            arg = arg.long_help(long_help.as_str());
+        }
+        if !self.possible_values.is_empty() {
+            arg = arg.possible_values(
+                self.possible_values
+                    .iter()
+                    .map(|pv| clap::PossibleValue::new(pv.name.as_str()).help(pv.help.as_str()))
+                    .collect::<Vec<_>>(),
+            );
+        }
+        if self.is_repeatable {
+            arg = arg.multiple(true);
+        }
+        arg
+    }
+}
+
+/// Registers the current command to print the CLI definition, if the `--cli-definition` argument is
+/// passed.
+///
+/// The existance of --cli-definition is arbitrary, a convention that is used by forc and is
+/// probably not defined inside the clap struct. Because of this, the `--cli-definition` argument,
+/// the function should be called *before* the `clap::App` is built to parse the arguments.
+pub fn register(cmd: clap::App<'_>) {
+    std::env::args().skip(1).for_each(|arg| {
+        if arg == "--cli-definition" {
+            let cmd_info = CommandInfo::new(&cmd);
+            serde_json::to_writer_pretty(std::io::stdout(), &cmd_info).unwrap();
+            std::process::exit(0);
+        }
+    });
+}
+
 #[macro_export]
 // Let the user format the help and parse it from that string into arguments to create the unit test
 macro_rules! cli_examples {

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -31,7 +31,7 @@ fs_extra = "1.2"
 fuel-asm = { workspace = true }
 hex = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.73"
+serde_json = "1"
 sway-core = { version = "0.51.1", path = "../sway-core" }
 sway-error = { version = "0.51.1", path = "../sway-error" }
 sway-types = { version = "0.51.1", path = "../sway-types" }

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -22,6 +22,7 @@ ansi_term = "0.12"
 anyhow = "1.0.41"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
 clap_complete = "3.1"
+clap_complete_fig = "3.1"
 forc-pkg = { version = "0.51.1", path = "../forc-pkg" }
 forc-test = { version = "0.51.1", path = "../forc-test" }
 forc-tracing = { version = "0.51.1", path = "../forc-tracing" }

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -1,6 +1,10 @@
+use std::collections::HashMap;
+
 use clap::{Command as ClapCommand, CommandFactory, Parser};
 use clap_complete::{generate, Generator, Shell};
-use forc_util::ForcResult;
+use forc_util::{cli::CommandInfo, ForcResult};
+
+use crate::cli::plugin::find_all;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum)]
 enum Target {
@@ -44,7 +48,34 @@ pub struct Command {
 }
 
 pub(crate) fn exec(command: Command) -> ForcResult<()> {
-    let mut cmd = super::super::Opt::command();
+    let mut cmd = CommandInfo::new(&super::super::Opt::command());
+    let mut plugins = HashMap::new();
+    find_all().for_each(|path| {
+        if let Ok(proc) = std::process::Command::new(path.clone())
+            .arg("--cli-definition")
+            .output()
+        {
+            if let Ok(mut command_info) = serde_json::from_slice::<CommandInfo>(&proc.stdout) {
+                command_info.name = if let Some(name) = path.file_name().and_then(|x| {
+                    x.to_string_lossy()
+                        .strip_prefix("forc-")
+                        .map(|x| x.to_owned())
+                }) {
+                    name
+                } else {
+                    command_info.name
+                };
+                if !plugins.contains_key(&command_info.name) {
+                    plugins.insert(command_info.name.to_owned(), command_info);
+                }
+            }
+        }
+    });
+
+    let mut plugins = plugins.into_values().collect::<Vec<_>>();
+    cmd.subcommands.append(&mut plugins);
+    let mut cmd = cmd.to_clap();
+
     match command.target {
         Target::Fig => print_completions(clap_complete_fig::Fig, &mut cmd),
         Target::Bash => print_completions(Shell::Bash, &mut cmd),

--- a/forc/src/cli/commands/completions.rs
+++ b/forc/src/cli/commands/completions.rs
@@ -1,7 +1,35 @@
-use clap::Command as ClapCommand;
-use clap::{CommandFactory, Parser};
+use clap::{Command as ClapCommand, CommandFactory, Parser};
 use clap_complete::{generate, Generator, Shell};
 use forc_util::ForcResult;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, clap::ValueEnum)]
+enum Target {
+    /// Bourne Again SHell (bash)
+    Bash,
+    /// Elvish shell
+    Elvish,
+    /// Friendly Interactive SHell (fish)
+    Fish,
+    /// PowerShell
+    PowerShell,
+    /// Z SHell (zsh)
+    Zsh,
+    /// Fig
+    Fig,
+}
+
+impl ToString for Target {
+    fn to_string(&self) -> String {
+        match self {
+            Target::Bash => "bash".to_string(),
+            Target::Elvish => "elvish".to_string(),
+            Target::Fish => "fish".to_string(),
+            Target::PowerShell => "powershell".to_string(),
+            Target::Zsh => "zsh".to_string(),
+            Target::Fig => "fig".to_string(),
+        }
+    }
+}
 
 /// Generate tab-completion scripts for your shell
 #[derive(Debug, Parser)]
@@ -11,13 +39,20 @@ pub struct Command {
     /// [possible values: zsh, bash, fish, powershell, elvish]
     ///
     /// For more info: https://fuellabs.github.io/sway/latest/forc/commands/forc_completions.html
-    #[clap(short = 'S', long)]
-    shell: Shell,
+    #[clap(short = 'T', long, value_enum)]
+    target: Target,
 }
 
 pub(crate) fn exec(command: Command) -> ForcResult<()> {
     let mut cmd = super::super::Opt::command();
-    print_completions(command.shell, &mut cmd);
+    match command.target {
+        Target::Fig => print_completions(clap_complete_fig::Fig, &mut cmd),
+        Target::Bash => print_completions(Shell::Bash, &mut cmd),
+        Target::Elvish => print_completions(Shell::Elvish, &mut cmd),
+        Target::PowerShell => print_completions(Shell::PowerShell, &mut cmd),
+        Target::Zsh => print_completions(Shell::Zsh, &mut cmd),
+        Target::Fish => print_completions(Shell::Fish, &mut cmd),
+    }
     Ok(())
 }
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -26,7 +26,7 @@ prettydiff = "0.6"
 rand = "0.8"
 regex = "1.7"
 revm = "2.3.1"
-serde_json = "1.0.73"
+serde_json = "1"
 sway-core = { path = "../sway-core" }
 sway-error = { path = "../sway-error" }
 sway-ir = { path = "../sway-ir" }


### PR DESCRIPTION
## Description

Fixes #5670

Add the ability to generate completions for subcommands

Subcommands may generate completions code optionally.

 ## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
