### PR TITLE
Temporarily disable garbage collection

### DIFF
--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -124,12 +124,14 @@ impl ServerState {
                             if version % 3 == 0 {
                                 // Call this on the engines clone so we don't clear types that are still in use
                                 // and might be needed in the case cancel compilation was triggered.
-                                if let Err(err) = session.garbage_collect(&mut engines_clone) {
-                                    tracing::error!(
-                                        "Unable to perform garbage collection: {}",
-                                        err.to_string()
-                                    );
-                                }
+
+                                // Temporarily disable garbage collection until this issue is solved: https://github.com/FuelLabs/sway/issues/5698
+                                // if let Err(err) = session.garbage_collect(&mut engines_clone) {
+                                //     tracing::error!(
+                                //         "Unable to perform garbage collection: {}",
+                                //         err.to_string()
+                                //     );
+                                // }
                             }
                         }
 


### PR DESCRIPTION
## Description
Disabling GC for now so we can do a patch release to stop LSP from crashing. 

This should be re-enabled asap as soon as #5698 is resolved. 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
