### PR TITLE
Tweak the `did_change_stress_test_random_wait` test

### DIFF
--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -138,43 +138,43 @@ async fn did_change_stress_test() {
     shutdown_and_exit(&mut service).await;
 }
 
-#[tokio::test]
-#[allow(dead_code)]
-async fn did_change_stress_test_random_wait() {
-    std::env::set_var("RUST_BACKTRACE", "1");
-    let default_panic = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |panic_info| {
-        default_panic(panic_info); // Print the panic message
-        std::process::exit(1);
-    }));
-    let (mut service, _) = LspService::build(ServerState::new)
-        .custom_method("sway/metrics", ServerState::metrics)
-        .finish();
-    let example_dir = sway_workspace_dir()
-        .join(e2e_language_dir())
-        .join("generics_in_contract");
-    let uri = init_and_open(&mut service, example_dir.join("src/main.sw")).await;
-    let times = 400;
-    for version in 0..times {
-        //eprintln!("version: {}", version);
-        let _ = lsp::did_change_request(&mut service, &uri, version + 1).await;
-        if version == 0 {
-            service.inner().wait_for_parsing().await;
-        }
-        // wait for a random amount of time between 1-30ms
-        tokio::time::sleep(tokio::time::Duration::from_millis(
-            rand::random::<u64>() % 30 + 1,
-        ))
-        .await;
-        // there is a 10% chance that a longer 300-1000ms wait will be added
-        if rand::random::<u64>() % 10 < 1 {
+#[test]
+fn did_change_stress_test_random_wait() {
+    let rt = tokio::runtime::Runtime::new().expect("Failed to create a runtime");
+    rt.block_on(async {
+        std::env::set_var("RUST_BACKTRACE", "1");
+        let default_panic = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |panic_info| {
+            default_panic(panic_info); // Print the panic message
+            std::process::exit(1);
+        }));
+        let (mut service, _) = LspService::new(ServerState::new);
+        let example_dir = sway_workspace_dir()
+            .join(e2e_language_dir())
+            .join("generics_in_contract");
+        let uri = init_and_open(&mut service, example_dir.join("src/main.sw")).await;
+        let times = 60;
+        for version in 0..times {
+            //eprintln!("version: {}", version);
+            let _ = lsp::did_change_request(&mut service, &uri, version + 1).await;
+            if version == 0 {
+                service.inner().wait_for_parsing().await;
+            }
+            // wait for a random amount of time between 1-30ms
             tokio::time::sleep(tokio::time::Duration::from_millis(
-                rand::random::<u64>() % 700 + 300,
+                rand::random::<u64>() % 30 + 1,
             ))
             .await;
+            // there is a 10% chance that a longer 100-800ms wait will be added
+            if rand::random::<u64>() % 10 < 1 {
+                tokio::time::sleep(tokio::time::Duration::from_millis(
+                    rand::random::<u64>() % 700 + 100,
+                ))
+                .await;
+            }
         }
-    }
-    shutdown_and_exit(&mut service).await;
+        shutdown_and_exit(&mut service).await;
+    });
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description
This test was originally added in #5704. However, compiling 400 times seems to be a bit too ambitious as it was causing issues like stack overflows when all tests were run concurrently. I've reduced this to 60 so it finishes a lot quicker now. It should still be enough to test if any issues affect the garbage collector. 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
