### PR TITLE
chore:bump sdk to v0.56, fuel-core to 0.23.0, fuel-vm to 0.47.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
       - name: Install fuel-core from Cargo
         run: cargo install fuel-core-bin --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
       - name: Run fuel-core
-        run: fuel-core run --db-type in-memory --debug 
+        run: fuel-core run --db-type in-memory --debug & 
       - uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
@@ -325,7 +325,7 @@ jobs:
       - name: Install fuel-core from Cargo
         run: cargo install fuel-core-bin --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
       - name: Run fuel-core
-        run: fuel-core run --db-type in-memory --debug 
+        run: fuel-core run --db-type in-memory --debug & 
       - uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,7 @@ jobs:
         image: ghcr.io/fuellabs/fuel-core:v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
         ports:
           - 4000:4000
+        options: --debug
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -327,6 +328,7 @@ jobs:
         image: ghcr.io/fuellabs/fuel-core:v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
         ports:
           - 4000:4000
+        options: --debug
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -480,6 +482,7 @@ jobs:
         with:
           crate: fuel-core-bin
           version: ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
+          options: --debug
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --locked --release -p forc-debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,8 +309,12 @@ jobs:
         image: ghcr.io/fuellabs/fuel-core:v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
         ports:
           - 4000:4000
-        options: >-
-          --debug
+        env:
+          IP: "0.0.0.0"
+          PORT: "4000"
+          DB_PATH: "./mnt/db/"
+        command: ["./fuel-core", "run", "--ip", "0.0.0.0", "--port", "4000", "--db-path", "./mnt/db/", "--debug"]
+
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -329,8 +333,12 @@ jobs:
         image: ghcr.io/fuellabs/fuel-core:v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
         ports:
           - 4000:4000
-        options: >-
-          --debug
+        env:
+          IP: "0.0.0.0"
+          PORT: "4000"
+          DB_PATH: "./mnt/db/"
+        command: ["./fuel-core", "run", "--ip", "0.0.0.0", "--port", "4000", "--db-path", "./mnt/db/", "--debug"]
+
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,8 @@ jobs:
         image: ghcr.io/fuellabs/fuel-core:v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
         ports:
           - 4000:4000
+        options: >-
+          --debug
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -327,6 +329,8 @@ jobs:
         image: ghcr.io/fuellabs/fuel-core:v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
         ports:
           - 4000:4000
+        options: >-
+          --debug
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,9 +306,9 @@ jobs:
     needs: get-fuel-core-version
     steps:
       - name: Install fuel-core from Cargo
-        run: cargo install fuel-core --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
+        run: cargo install fuel-core-client-bin --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
       - name: Run fuel-core
-        run: fuel-core --db-type in-memory --debug 
+        run: fuel-core run --db-type in-memory --debug 
       - uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
@@ -323,9 +323,9 @@ jobs:
     needs: get-fuel-core-version
     steps:
       - name: Install fuel-core from Cargo
-        run: cargo install fuel-core --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
+        run: cargo install fuel-core-client-bin --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
       - name: Run fuel-core
-        run: fuel-core --db-type in-memory --debug 
+        run: fuel-core run --db-type in-memory --debug 
       - uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,10 +305,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: get-fuel-core-version
     steps:
-      - name: Install fuel-core from Cargo
-        run: cargo install fuel-core-bin --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
-      - name: Run fuel-core
-        run: fuel-core run --db-type in-memory --debug & 
+      - name: Install fuel-core for tests
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: fuel-core-bin
+          version: ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
       - uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
@@ -316,16 +317,20 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
       - name: Cargo Run E2E Tests (Fuel VM)
-        run: cargo run --locked --release --bin test -- --locked
+        run: |
+          fuel-core run --db-type in-memory --debug & 
+          sleep 5 &&
+          cargo run --locked --release --bin test -- --locked
 
   cargo-run-e2e-test-release:
     runs-on: ubuntu-latest
     needs: get-fuel-core-version
     steps:
-      - name: Install fuel-core from Cargo
-        run: cargo install fuel-core-bin --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
-      - name: Run fuel-core
-        run: fuel-core run --db-type in-memory --debug & 
+      - name: Install fuel-core for tests
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: fuel-core-bin
+          version: ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
       - uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
@@ -333,7 +338,10 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
       - name: Cargo Run E2E Tests (Fuel VM)
-        run: cargo run --locked --release --bin test -- --locked --release
+        run: |
+          fuel-core run --db-type in-memory --debug & 
+          sleep 5 &&
+          cargo run --locked --release --bin test -- --locked --release
 
   cargo-run-e2e-test-evm:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,18 +304,11 @@ jobs:
   cargo-run-e2e-test:
     runs-on: ubuntu-latest
     needs: get-fuel-core-version
-    services:
-      fuel-core:
-        image: ghcr.io/fuellabs/fuel-core:v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
-        ports:
-          - 4000:4000
-        env:
-          IP: "0.0.0.0"
-          PORT: "4000"
-          DB_PATH: "./mnt/db/"
-        command: ["./fuel-core", "run", "--ip", "0.0.0.0", "--port", "4000", "--db-path", "./mnt/db/", "--debug"]
-
     steps:
+      - name: Install fuel-core from Cargo
+        run: cargo install fuel-core --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
+      - name: Run fuel-core
+        run: fuel-core --db-type in-memory --debug 
       - uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
@@ -328,18 +321,11 @@ jobs:
   cargo-run-e2e-test-release:
     runs-on: ubuntu-latest
     needs: get-fuel-core-version
-    services:
-      fuel-core:
-        image: ghcr.io/fuellabs/fuel-core:v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
-        ports:
-          - 4000:4000
-        env:
-          IP: "0.0.0.0"
-          PORT: "4000"
-          DB_PATH: "./mnt/db/"
-        command: ["./fuel-core", "run", "--ip", "0.0.0.0", "--port", "4000", "--db-path", "./mnt/db/", "--debug"]
-
     steps:
+      - name: Install fuel-core from Cargo
+        run: cargo install fuel-core --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
+      - name: Run fuel-core
+        run: fuel-core --db-type in-memory --debug 
       - uses: actions/checkout@v3
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,6 @@ jobs:
         image: ghcr.io/fuellabs/fuel-core:v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
         ports:
           - 4000:4000
-        options: --debug
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -328,7 +327,6 @@ jobs:
         image: ghcr.io/fuellabs/fuel-core:v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
         ports:
           - 4000:4000
-        options: --debug
     steps:
       - uses: actions/checkout@v3
       - name: Install toolchain
@@ -482,7 +480,6 @@ jobs:
         with:
           crate: fuel-core-bin
           version: ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
-          options: --debug
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --locked --release -p forc-debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
     needs: get-fuel-core-version
     steps:
       - name: Install fuel-core from Cargo
-        run: cargo install fuel-core-client-bin --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
+        run: cargo install fuel-core-bin --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
       - name: Run fuel-core
         run: fuel-core run --db-type in-memory --debug 
       - uses: actions/checkout@v3
@@ -323,7 +323,7 @@ jobs:
     needs: get-fuel-core-version
     steps:
       - name: Install fuel-core from Cargo
-        run: cargo install fuel-core-client-bin --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
+        run: cargo install fuel-core-bin --version ${{ needs.get-fuel-core-version.outputs.fuel_core_version }}
       - name: Run fuel-core
         run: fuel-core run --db-type in-memory --debug 
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,8 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "forc-wallet"
-version = "0.4.3"
-source = "git+https://github.com/FuelLabs/forc-wallet?branch=kayagokalp/sdk-0.56#7b63680f9d4a04b7dd1f7b618819cf37e8b8c82f"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9501ef5fe13259c6e094521fc8af77805e99d113c3986375575551e4ddf0b858"
 dependencies = [
  "anyhow",
  "clap 4.5.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,7 +2007,7 @@ dependencies = [
  "forc-tracing 0.52.0",
  "forc-util",
  "fs_extra",
- "fuel-asm 0.47.1",
+ "fuel-asm",
  "hex",
  "serde",
  "serde_json",
@@ -2041,13 +2041,13 @@ dependencies = [
  "forc-tx",
  "forc-util",
  "forc-wallet",
- "fuel-abi-types 0.4.0",
- "fuel-core-client 0.23.0",
- "fuel-crypto 0.47.1",
- "fuel-tx 0.47.1",
- "fuel-vm 0.47.1",
- "fuels-accounts 0.56.0",
- "fuels-core 0.56.0",
+ "fuel-abi-types",
+ "fuel-core-client",
+ "fuel-crypto",
+ "fuel-tx",
+ "fuel-vm",
+ "fuels-accounts",
+ "fuels-core",
  "futures",
  "hex",
  "rand",
@@ -2071,9 +2071,9 @@ dependencies = [
  "clap 3.2.25",
  "forc-tracing 0.52.0",
  "forc-util",
- "fuel-core-types 0.23.0",
- "fuel-crypto 0.47.1",
- "fuels-core 0.56.0",
+ "fuel-core-types",
+ "fuel-crypto",
+ "fuels-core",
  "futures",
  "hex",
  "libp2p-identity",
@@ -2097,9 +2097,9 @@ dependencies = [
  "escargot",
  "forc-pkg",
  "forc-test",
- "fuel-core-client 0.23.0",
- "fuel-types 0.47.1",
- "fuel-vm 0.47.1",
+ "fuel-core-client",
+ "fuel-types",
+ "fuel-vm",
  "portpicker",
  "rayon",
  "rexpect",
@@ -2174,7 +2174,7 @@ dependencies = [
  "cid",
  "forc-tracing 0.52.0",
  "forc-util",
- "fuel-abi-types 0.4.0",
+ "fuel-abi-types",
  "futures",
  "git2",
  "gix-url",
@@ -2207,9 +2207,9 @@ version = "0.52.0"
 dependencies = [
  "anyhow",
  "forc-pkg",
- "fuel-abi-types 0.4.0",
- "fuel-tx 0.47.1",
- "fuel-vm 0.47.1",
+ "fuel-abi-types",
+ "fuel-tx",
+ "fuel-vm",
  "rand",
  "rayon",
  "sway-core",
@@ -2244,8 +2244,8 @@ dependencies = [
  "clap 3.2.25",
  "devault",
  "forc-util",
- "fuel-tx 0.47.1",
- "fuel-types 0.47.1",
+ "fuel-tx",
+ "fuel-types",
  "serde",
  "serde_json",
  "thiserror",
@@ -2261,8 +2261,13 @@ dependencies = [
  "clap 3.2.25",
  "dirs 3.0.2",
  "fd-lock 4.0.2",
+<<<<<<< HEAD
  "forc-tracing 0.52.0",
  "fuel-tx 0.47.1",
+=======
+ "forc-tracing 0.51.1",
+ "fuel-tx",
+>>>>>>> 74ce1d417 (use unreleased wallet)
  "hex",
  "paste",
  "regex",
@@ -2281,17 +2286,16 @@ dependencies = [
 [[package]]
 name = "forc-wallet"
 version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8892d98dd6b2e6fb47b23ef027e5e14653b82229d40b1b47c528fbccaf453c60"
+source = "git+https://github.com/FuelLabs/forc-wallet?branch=kayagokalp/sdk-0.56#7b63680f9d4a04b7dd1f7b618819cf37e8b8c82f"
 dependencies = [
  "anyhow",
  "clap 4.5.4",
  "eth-keystore",
  "forc-tracing 0.47.0",
- "fuel-crypto 0.43.2",
- "fuel-types 0.43.2",
+ "fuel-crypto",
+ "fuel-types",
  "fuels",
- "fuels-core 0.54.0",
+ "fuels-core",
  "futures",
  "hex",
  "home",
@@ -2345,6 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-abi-types"
+<<<<<<< HEAD
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8118789261e77d67569859a06a886d53dbf7bd00ea23a18a2dfae26a1f5be25"
@@ -2362,6 +2367,8 @@ dependencies = [
 
 [[package]]
 name = "fuel-abi-types"
+=======
+>>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2351bb0b743c23ac13ac2559756b3929502cd6e29091f2e5302fb9a1bdddaf35"
@@ -2379,6 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
+<<<<<<< HEAD
 version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea884860261efdc7300b63db7972cb0e08e8f5379495ad7cdd2bdb7c0cc4623"
@@ -2391,18 +2399,26 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
+=======
+>>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1b088ac4762d59736b90803db239f96c66f2a1a2c616715ef0a9c196b58edc9"
 dependencies = [
+<<<<<<< HEAD
  "bitflags 2.5.0",
  "fuel-types 0.47.1",
+=======
+ "bitflags 2.4.2",
+ "fuel-types",
+>>>>>>> 74ce1d417 (use unreleased wallet)
  "serde",
  "strum 0.24.1",
 ]
 
 [[package]]
 name = "fuel-core-chain-config"
+<<<<<<< HEAD
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62ab93dc93c87c0c380e94a6a8d1b65e791151d2f6a567c4970fc8cf76faaa05"
@@ -2421,14 +2437,16 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
+=======
+>>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc2032184b86cd7e54d0ca6f7c7db7419552048484e2cfa6d7dc346eefb4907"
 dependencies = [
  "anyhow",
  "bech32",
- "fuel-core-storage 0.23.0",
- "fuel-core-types 0.23.0",
+ "fuel-core-storage",
+ "fuel-core-types",
  "hex",
  "itertools 0.10.5",
  "postcard",
@@ -2439,6 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
+<<<<<<< HEAD
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a10b6a6e2dcc651f52961ef3c1bf44ab28434fdb437789bf17f4389d19041f4"
@@ -2463,6 +2482,8 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
+=======
+>>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19e4fe4535372749e5b38d58c29a7904b3bc95e0429e6ae2544cfa8417a39c4"
@@ -2471,7 +2492,7 @@ dependencies = [
  "cynic",
  "derive_more",
  "eventsource-client",
- "fuel-core-types 0.23.0",
+ "fuel-core-types",
  "futures",
  "hex",
  "hyper-rustls 0.24.2",
@@ -2487,21 +2508,27 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
+<<<<<<< HEAD
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08d775335cdfee3717faa083714c75da294508a1244fe7b229748c9926d91c3"
+=======
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b5f5336984cdbb3f7f8b3cf2d3ac0928d4b058dcdca061c49563764a5366be4"
+>>>>>>> 74ce1d417 (use unreleased wallet)
 dependencies = [
  "axum",
  "once_cell",
  "pin-project-lite",
- "prometheus-client 0.18.1",
- "prometheus-client 0.20.0",
+ "prometheus-client",
  "regex",
  "tracing",
 ]
 
 [[package]]
 name = "fuel-core-poa"
+<<<<<<< HEAD
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e99ef1eaab07450c327abb4809246f851cc0dc5d52650662a239bc66c26ded41"
@@ -2512,6 +2539,18 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage 0.22.4",
  "fuel-core-types 0.22.4",
+=======
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb6af0c9289fc3273c5c45fa4d5894a914acbc175c0001f5b6bbb336546e1e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "fuel-core-chain-config",
+ "fuel-core-services",
+ "fuel-core-storage",
+ "fuel-core-types",
+>>>>>>> 74ce1d417 (use unreleased wallet)
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2519,9 +2558,15 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
+<<<<<<< HEAD
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a42f05bc2ab4a91afd2db6556521002119e29de49744bd29c8f43b5f561d89"
+=======
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66cbc7c3958d00f28578a7f8343b1344fe7e866643f16cdfe280e5d90bc4541"
+>>>>>>> 74ce1d417 (use unreleased wallet)
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2534,6 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
+<<<<<<< HEAD
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95d4d9ede89f97c779433e389739410a946e8b94f379a0048a49670bef73e602"
@@ -2547,6 +2593,8 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
+=======
+>>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "481343e6501f5205f742fae3b745402dc7f7c3a5038e64c598ba5217dcf17033"
@@ -2554,8 +2602,8 @@ dependencies = [
  "anyhow",
  "derive_more",
  "enum-iterator",
- "fuel-core-types 0.23.0",
- "fuel-vm 0.47.1",
+ "fuel-core-types",
+ "fuel-vm",
  "impl-tools",
  "itertools 0.10.5",
  "paste",
@@ -2568,6 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
+<<<<<<< HEAD
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75785b3a26f7c2c05e73e5cef2f59912751c4821b40225e089199c7fb8712d7"
@@ -2585,6 +2634,8 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
+=======
+>>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e855f688cf9a6f61f60663f03e217d821c4ade7a08d15ce21b54348612c873"
@@ -2593,32 +2644,11 @@ dependencies = [
  "bs58",
  "derivative",
  "derive_more",
- "fuel-vm 0.47.1",
+ "fuel-vm",
  "secrecy",
  "serde",
  "tai64",
  "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "fuel-crypto"
-version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0efe99de550a5b5c12a6a4d2eadd26bc5571cfba82d0133baa2805d485ad8c"
-dependencies = [
- "coins-bip32",
- "coins-bip39",
- "ecdsa",
- "ed25519-dalek",
- "fuel-types 0.43.2",
- "k256",
- "lazy_static",
- "p256",
- "rand",
- "secp256k1 0.26.0",
- "serde",
- "sha2 0.10.8",
  "zeroize",
 ]
 
@@ -2632,7 +2662,7 @@ dependencies = [
  "coins-bip39",
  "ecdsa",
  "ed25519-dalek",
- "fuel-types 0.47.1",
+ "fuel-types",
  "k256",
  "lazy_static",
  "p256",
@@ -2645,6 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
+<<<<<<< HEAD
 version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff58cf4d01a4fb9440c63a8764154dfd3b07c74e4b3639cce8eea77d67e63a7a"
@@ -2657,6 +2688,8 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
+=======
+>>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9b265467fe9d3d613a5bae9b8d3005d558d3e830dc416c9836bc16609a000f"
@@ -2740,39 +2773,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89143dd80b29dda305fbb033bc7f868834445ef6b361bf920f0077938fb6c0bc"
-dependencies = [
- "derive_more",
- "digest 0.10.7",
- "fuel-storage 0.43.2",
- "hashbrown 0.13.2",
- "hex",
- "serde",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "fuel-merkle"
 version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b21ea035ff06a28791c862496c3b03cfb2d87778476c419724796e945e282ad"
 dependencies = [
  "derive_more",
  "digest 0.10.7",
- "fuel-storage 0.47.1",
+ "fuel-storage",
  "hashbrown 0.13.2",
  "hex",
  "serde",
  "sha2 0.10.8",
 ]
-
-[[package]]
-name = "fuel-storage"
-version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901aee4b46684e483d2c04d40e5ac1b8ccda737ac5a363507b44b9eb23b0fdaa"
 
 [[package]]
 name = "fuel-storage"
@@ -2782,6 +2794,7 @@ checksum = "1048957b744e448840eb9a09cb58c4647dec32e1cf49c0029e5445cbdc86f6d2"
 
 [[package]]
 name = "fuel-tx"
+<<<<<<< HEAD
 version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f65e363e5e9a5412cea204f2d2357043327a0c3da5482c3b38b9da045f20e"
@@ -2804,6 +2817,8 @@ dependencies = [
 
 [[package]]
 name = "fuel-tx"
+=======
+>>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dc917bb2d1892ef6792624782bed7cee5670f3f836b344f06c4233bb1124aff"
@@ -2811,10 +2826,10 @@ dependencies = [
  "bitflags 2.5.0",
  "derivative",
  "derive_more",
- "fuel-asm 0.47.1",
- "fuel-crypto 0.47.1",
- "fuel-merkle 0.47.1",
- "fuel-types 0.47.1",
+ "fuel-asm",
+ "fuel-crypto",
+ "fuel-merkle",
+ "fuel-types",
  "hashbrown 0.14.3",
  "itertools 0.10.5",
  "rand",
@@ -2826,23 +2841,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148b59be5c54bafff692310663cbce3f097a2a7ff5533224dcfdf387578a72b0"
-dependencies = [
- "fuel-derive 0.43.2",
- "hex",
- "rand",
- "serde",
-]
-
-[[package]]
-name = "fuel-types"
 version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2444c92791b02016aa1cbab6cfa38e34920e61ec61d564f7bdb3ad8ddfae35de"
 dependencies = [
- "fuel-derive 0.47.1",
+ "fuel-derive",
  "hex",
  "rand",
  "serde",
@@ -2850,6 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
+<<<<<<< HEAD
 version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed5ba0cde904f16cd748dc9b33e62f4b3dc5fd0a72ec867c973e687cd7347ba"
@@ -2881,6 +2885,8 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
+=======
+>>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e29c2333edbf3c55906b92a5f3dfb9639e2b0eabc7fd754e7a8e18d67ded3c2"
@@ -2891,12 +2897,12 @@ dependencies = [
  "derivative",
  "derive_more",
  "ethnum",
- "fuel-asm 0.47.1",
- "fuel-crypto 0.47.1",
- "fuel-merkle 0.47.1",
- "fuel-storage 0.47.1",
- "fuel-tx 0.47.1",
- "fuel-types 0.47.1",
+ "fuel-asm",
+ "fuel-crypto",
+ "fuel-merkle",
+ "fuel-storage",
+ "fuel-tx",
+ "fuel-types",
  "hashbrown 0.14.3",
  "itertools 0.10.5",
  "libm",
@@ -2913,21 +2919,31 @@ dependencies = [
 
 [[package]]
 name = "fuels"
-version = "0.54.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550689758e7cae90e76b11f40dc4a3d817a6f4b62541df134a9a26391011eb53"
+checksum = "b21f3e84f5aa46e69a6415daf717e572dfacaf1540243e6458d033d35a6f9fe0"
 dependencies = [
+<<<<<<< HEAD
  "fuel-core-client 0.22.4",
  "fuel-tx 0.43.2",
  "fuels-accounts 0.54.0",
  "fuels-core 0.54.0",
  "fuels-macros 0.54.0",
+=======
+ "fuel-core-client",
+ "fuel-crypto",
+ "fuel-tx",
+ "fuels-accounts",
+ "fuels-core",
+ "fuels-macros",
+>>>>>>> 74ce1d417 (use unreleased wallet)
  "fuels-programs",
  "fuels-test-helpers",
 ]
 
 [[package]]
 name = "fuels-accounts"
+<<<<<<< HEAD
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf897206616d15e284dba7641f95d2b3a119639705b4909828af5008699f6352"
@@ -2953,6 +2969,8 @@ dependencies = [
 
 [[package]]
 name = "fuels-accounts"
+=======
+>>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e3eff2a1756fa81aa7e218b8ecefe4c70d44b38011db73d3181c99f3388259"
@@ -2961,12 +2979,12 @@ dependencies = [
  "chrono",
  "elliptic-curve",
  "eth-keystore",
- "fuel-core-client 0.23.0",
- "fuel-core-types 0.23.0",
- "fuel-crypto 0.47.1",
- "fuel-tx 0.47.1",
- "fuel-types 0.47.1",
- "fuels-core 0.56.0",
+ "fuel-core-client",
+ "fuel-core-types",
+ "fuel-crypto",
+ "fuel-tx",
+ "fuel-types",
+ "fuels-core",
  "rand",
  "semver",
  "tai64",
@@ -2978,6 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
+<<<<<<< HEAD
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa5acfe0ef24e12137786072a182dc5f0de9d51e79a6023183466f4eaecf7512"
@@ -2994,12 +3013,14 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
+=======
+>>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cf2c8670901a44f89a983a27b2fa831e1af19f6788cea1186c9b48514cc2a4"
 dependencies = [
  "Inflector",
- "fuel-abi-types 0.4.0",
+ "fuel-abi-types",
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
@@ -3010,6 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
+<<<<<<< HEAD
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c716030842d8c4eef2191a9c93ed0cb3cdae7927a4b2f07d87db0020293db893"
@@ -3038,6 +3060,8 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
+=======
+>>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5af00939974c1796cc05f44f20b0e31b8d6a03e9aeb1195fb2a9b68cef59920"
@@ -3045,15 +3069,15 @@ dependencies = [
  "async-trait",
  "bech32",
  "chrono",
- "fuel-abi-types 0.4.0",
- "fuel-asm 0.47.1",
- "fuel-core-chain-config 0.23.0",
- "fuel-core-client 0.23.0",
- "fuel-crypto 0.47.1",
- "fuel-tx 0.47.1",
- "fuel-types 0.47.1",
- "fuel-vm 0.47.1",
- "fuels-macros 0.56.0",
+ "fuel-abi-types",
+ "fuel-asm",
+ "fuel-core-chain-config",
+ "fuel-core-client",
+ "fuel-crypto",
+ "fuel-tx",
+ "fuel-types",
+ "fuel-vm",
+ "fuels-macros",
  "hex",
  "itertools 0.12.1",
  "serde",
@@ -3065,6 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "fuels-macros"
+<<<<<<< HEAD
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0dcdf41ccc7090bec4848d680d16cdc0c6cd37b749e518084caa8e6b730053"
@@ -3079,11 +3104,13 @@ dependencies = [
 
 [[package]]
 name = "fuels-macros"
+=======
+>>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "652003ee5a73e3674c818d9175e61c17311593e40d8281e00f08e64d7d29a076"
 dependencies = [
- "fuels-code-gen 0.56.0",
+ "fuels-code-gen",
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
@@ -3093,18 +3120,18 @@ dependencies = [
 
 [[package]]
 name = "fuels-programs"
-version = "0.54.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2401c796ced3e64ef58156d3c1aeeb61937d5078b87abccbafe1fc60f25faeca"
+checksum = "d1d779783fc8c194864a596bfca82fda107a425398b49ad330de7b41f2622fd4"
 dependencies = [
  "async-trait",
  "bytes",
- "fuel-abi-types 0.3.0",
- "fuel-asm 0.43.2",
- "fuel-tx 0.43.2",
- "fuel-types 0.43.2",
- "fuels-accounts 0.54.0",
- "fuels-core 0.54.0",
+ "fuel-abi-types",
+ "fuel-asm",
+ "fuel-tx",
+ "fuel-types",
+ "fuels-accounts",
+ "fuels-core",
  "itertools 0.12.1",
  "rand",
  "serde_json",
@@ -3113,18 +3140,24 @@ dependencies = [
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.54.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c79e02208b3ebb75d37d27161ff7c96847feb88ccd640a027105d1669c0c37"
+checksum = "99e1a8ed34d466df259afb3c210270fca59c8d66be77c00f428c49e61f35baeb"
 dependencies = [
+<<<<<<< HEAD
  "fuel-core-chain-config 0.22.4",
  "fuel-core-client 0.22.4",
+=======
+ "fuel-core-chain-config",
+ "fuel-core-client",
+>>>>>>> 74ce1d417 (use unreleased wallet)
  "fuel-core-poa",
  "fuel-core-services",
- "fuel-tx 0.43.2",
- "fuel-types 0.43.2",
- "fuels-accounts 0.54.0",
- "fuels-core 0.54.0",
+ "fuel-crypto",
+ "fuel-tx",
+ "fuel-types",
+ "fuels-accounts",
+ "fuels-core",
  "futures",
  "hex",
  "portpicker",
@@ -5502,21 +5535,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.18.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cd1b99916654a69008fd66b4f9397fbe08e6e51dfe23d4417acf5d3b8cb87c"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot 0.12.1",
- "prometheus-client-derive-text-encode",
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e227aeb6c2cfec819e999c4773b35f8c7fa37298a203ff46420095458eee567e"
+checksum = "c1ca959da22a332509f2a73ae9e5f23f9dcfc31fd3a54d71f159495bd5909baa"
 dependencies = [
  "dtoa",
  "itoa",
@@ -5533,17 +5554,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.55",
-]
-
-[[package]]
-name = "prometheus-client-derive-text-encode"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a455fbcb954c1a7decf3c586e860fd7889cddf4b8e164be736dbac95a953cd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -6861,12 +6871,12 @@ dependencies = [
  "derivative",
  "dirs 3.0.2",
  "either",
- "fuel-abi-types 0.4.0",
+ "fuel-abi-types",
  "fuel-ethabi",
  "fuel-etk-asm",
  "fuel-etk-dasm",
  "fuel-etk-ops",
- "fuel-vm 0.47.1",
+ "fuel-vm",
  "gimli",
  "graph-cycles",
  "hashbrown 0.13.2",
@@ -7026,10 +7036,17 @@ name = "sway-types"
 version = "0.52.0"
 dependencies = [
  "bytecount",
+<<<<<<< HEAD
  "fuel-asm 0.47.1",
  "fuel-crypto 0.47.1",
  "fuel-tx 0.47.1",
  "indexmap 2.2.6",
+=======
+ "fuel-asm",
+ "fuel-crypto",
+ "fuel-tx",
+ "indexmap 2.2.5",
+>>>>>>> 74ce1d417 (use unreleased wallet)
  "lazy_static",
  "num-bigint",
  "num-traits",
@@ -7312,8 +7329,13 @@ dependencies = [
  "forc-client",
  "forc-pkg",
  "forc-test",
+<<<<<<< HEAD
  "forc-tracing 0.52.0",
  "fuel-vm 0.47.1",
+=======
+ "forc-tracing 0.51.1",
+ "fuel-vm",
+>>>>>>> 74ce1d417 (use unreleased wallet)
  "futures",
  "gag",
  "hex",
@@ -8179,15 +8201,15 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "which"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
+checksum = "7fa5e0c10bf77f44aac573e498d1a82d5fbd5e91f6fc0a99e7be4b38e85e101c"
 dependencies = [
  "either",
  "home",
  "once_cell",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,13 +2261,8 @@ dependencies = [
  "clap 3.2.25",
  "dirs 3.0.2",
  "fd-lock 4.0.2",
-<<<<<<< HEAD
  "forc-tracing 0.52.0",
- "fuel-tx 0.47.1",
-=======
- "forc-tracing 0.51.1",
  "fuel-tx",
->>>>>>> 74ce1d417 (use unreleased wallet)
  "hex",
  "paste",
  "regex",
@@ -2350,26 +2345,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-abi-types"
-<<<<<<< HEAD
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8118789261e77d67569859a06a886d53dbf7bd00ea23a18a2dfae26a1f5be25"
-dependencies = [
- "itertools 0.10.5",
- "lazy_static",
- "proc-macro2",
- "quote",
- "regex",
- "serde",
- "serde_json",
- "syn 2.0.55",
- "thiserror",
-]
-
-[[package]]
-name = "fuel-abi-types"
-=======
->>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2351bb0b743c23ac13ac2559756b3929502cd6e29091f2e5302fb9a1bdddaf35"
@@ -2387,59 +2362,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
-<<<<<<< HEAD
-version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea884860261efdc7300b63db7972cb0e08e8f5379495ad7cdd2bdb7c0cc4623"
-dependencies = [
- "bitflags 2.5.0",
- "fuel-types 0.43.2",
- "serde",
- "strum 0.24.1",
-]
-
-[[package]]
-name = "fuel-asm"
-=======
->>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1b088ac4762d59736b90803db239f96c66f2a1a2c616715ef0a9c196b58edc9"
 dependencies = [
-<<<<<<< HEAD
  "bitflags 2.5.0",
- "fuel-types 0.47.1",
-=======
- "bitflags 2.4.2",
  "fuel-types",
->>>>>>> 74ce1d417 (use unreleased wallet)
  "serde",
  "strum 0.24.1",
 ]
 
 [[package]]
 name = "fuel-core-chain-config"
-<<<<<<< HEAD
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ab93dc93c87c0c380e94a6a8d1b65e791151d2f6a567c4970fc8cf76faaa05"
-dependencies = [
- "anyhow",
- "bech32",
- "fuel-core-storage 0.22.4",
- "fuel-core-types 0.22.4",
- "hex",
- "itertools 0.10.5",
- "postcard",
- "serde",
- "serde_with 1.14.0",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-chain-config"
-=======
->>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc2032184b86cd7e54d0ca6f7c7db7419552048484e2cfa6d7dc346eefb4907"
@@ -2458,33 +2392,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-<<<<<<< HEAD
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a10b6a6e2dcc651f52961ef3c1bf44ab28434fdb437789bf17f4389d19041f4"
-dependencies = [
- "anyhow",
- "cynic",
- "derive_more",
- "eventsource-client",
- "fuel-core-types 0.22.4",
- "futures",
- "hex",
- "hyper-rustls 0.24.2",
- "itertools 0.10.5",
- "reqwest",
- "schemafy_lib",
- "serde",
- "serde_json",
- "tai64",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-client"
-=======
->>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19e4fe4535372749e5b38d58c29a7904b3bc95e0429e6ae2544cfa8417a39c4"
@@ -2509,15 +2416,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-<<<<<<< HEAD
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08d775335cdfee3717faa083714c75da294508a1244fe7b229748c9926d91c3"
-=======
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b5f5336984cdbb3f7f8b3cf2d3ac0928d4b058dcdca061c49563764a5366be4"
->>>>>>> 74ce1d417 (use unreleased wallet)
 dependencies = [
  "axum",
  "once_cell",
@@ -2529,18 +2430,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-<<<<<<< HEAD
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99ef1eaab07450c327abb4809246f851cc0dc5d52650662a239bc66c26ded41"
-dependencies = [
- "anyhow",
- "async-trait",
- "fuel-core-chain-config 0.22.4",
- "fuel-core-services",
- "fuel-core-storage 0.22.4",
- "fuel-core-types 0.22.4",
-=======
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17bb6af0c9289fc3273c5c45fa4d5894a914acbc175c0001f5b6bbb336546e1e"
@@ -2551,7 +2440,6 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-types",
->>>>>>> 74ce1d417 (use unreleased wallet)
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2559,15 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-<<<<<<< HEAD
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a42f05bc2ab4a91afd2db6556521002119e29de49744bd29c8f43b5f561d89"
-=======
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a66cbc7c3958d00f28578a7f8343b1344fe7e866643f16cdfe280e5d90bc4541"
->>>>>>> 74ce1d417 (use unreleased wallet)
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2580,22 +2462,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-<<<<<<< HEAD
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d4d9ede89f97c779433e389739410a946e8b94f379a0048a49670bef73e602"
-dependencies = [
- "anyhow",
- "derive_more",
- "fuel-core-types 0.22.4",
- "fuel-vm 0.43.2",
- "primitive-types",
-]
-
-[[package]]
-name = "fuel-core-storage"
-=======
->>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "481343e6501f5205f742fae3b745402dc7f7c3a5038e64c598ba5217dcf17033"
@@ -2617,26 +2483,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-<<<<<<< HEAD
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75785b3a26f7c2c05e73e5cef2f59912751c4821b40225e089199c7fb8712d7"
-dependencies = [
- "anyhow",
- "bs58",
- "derive_more",
- "fuel-vm 0.43.2",
- "secrecy",
- "serde",
- "tai64",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "fuel-core-types"
-=======
->>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e855f688cf9a6f61f60663f03e217d821c4ade7a08d15ce21b54348612c873"
@@ -2676,21 +2522,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
-<<<<<<< HEAD
-version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff58cf4d01a4fb9440c63a8764154dfd3b07c74e4b3639cce8eea77d67e63a7a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.55",
- "synstructure 0.13.1",
-]
-
-[[package]]
-name = "fuel-derive"
-=======
->>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9b265467fe9d3d613a5bae9b8d3005d558d3e830dc416c9836bc16609a000f"
@@ -2795,31 +2626,6 @@ checksum = "1048957b744e448840eb9a09cb58c4647dec32e1cf49c0029e5445cbdc86f6d2"
 
 [[package]]
 name = "fuel-tx"
-<<<<<<< HEAD
-version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f65e363e5e9a5412cea204f2d2357043327a0c3da5482c3b38b9da045f20e"
-dependencies = [
- "bitflags 2.5.0",
- "derivative",
- "derive_more",
- "fuel-asm 0.43.2",
- "fuel-crypto 0.43.2",
- "fuel-merkle 0.43.2",
- "fuel-types 0.43.2",
- "hashbrown 0.14.3",
- "itertools 0.10.5",
- "rand",
- "serde",
- "serde_json",
- "strum 0.24.1",
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "fuel-tx"
-=======
->>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dc917bb2d1892ef6792624782bed7cee5670f3f836b344f06c4233bb1124aff"
@@ -2854,40 +2660,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-<<<<<<< HEAD
-version = "0.43.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed5ba0cde904f16cd748dc9b33e62f4b3dc5fd0a72ec867c973e687cd7347ba"
-dependencies = [
- "async-trait",
- "backtrace",
- "bitflags 2.5.0",
- "derivative",
- "derive_more",
- "ethnum",
- "fuel-asm 0.43.2",
- "fuel-crypto 0.43.2",
- "fuel-merkle 0.43.2",
- "fuel-storage 0.43.2",
- "fuel-tx 0.43.2",
- "fuel-types 0.43.2",
- "hashbrown 0.14.3",
- "itertools 0.10.5",
- "libm",
- "paste",
- "percent-encoding",
- "primitive-types",
- "serde",
- "sha3",
- "static_assertions",
- "strum 0.24.1",
- "tai64",
-]
-
-[[package]]
-name = "fuel-vm"
-=======
->>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e29c2333edbf3c55906b92a5f3dfb9639e2b0eabc7fd754e7a8e18d67ded3c2"
@@ -2924,54 +2696,18 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b21f3e84f5aa46e69a6415daf717e572dfacaf1540243e6458d033d35a6f9fe0"
 dependencies = [
-<<<<<<< HEAD
- "fuel-core-client 0.22.4",
- "fuel-tx 0.43.2",
- "fuels-accounts 0.54.0",
- "fuels-core 0.54.0",
- "fuels-macros 0.54.0",
-=======
  "fuel-core-client",
  "fuel-crypto",
  "fuel-tx",
  "fuels-accounts",
  "fuels-core",
  "fuels-macros",
->>>>>>> 74ce1d417 (use unreleased wallet)
  "fuels-programs",
  "fuels-test-helpers",
 ]
 
 [[package]]
 name = "fuels-accounts"
-<<<<<<< HEAD
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf897206616d15e284dba7641f95d2b3a119639705b4909828af5008699f6352"
-dependencies = [
- "async-trait",
- "chrono",
- "elliptic-curve",
- "eth-keystore",
- "fuel-core-client 0.22.4",
- "fuel-crypto 0.43.2",
- "fuel-tx 0.43.2",
- "fuel-types 0.43.2",
- "fuels-core 0.54.0",
- "hex",
- "rand",
- "semver",
- "tai64",
- "thiserror",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "fuels-accounts"
-=======
->>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e3eff2a1756fa81aa7e218b8ecefe4c70d44b38011db73d3181c99f3388259"
@@ -2997,25 +2733,6 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
-<<<<<<< HEAD
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5acfe0ef24e12137786072a182dc5f0de9d51e79a6023183466f4eaecf7512"
-dependencies = [
- "Inflector",
- "fuel-abi-types 0.3.0",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "regex",
- "serde_json",
- "syn 2.0.55",
-]
-
-[[package]]
-name = "fuels-code-gen"
-=======
->>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cf2c8670901a44f89a983a27b2fa831e1af19f6788cea1186c9b48514cc2a4"
@@ -3032,37 +2749,6 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-<<<<<<< HEAD
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c716030842d8c4eef2191a9c93ed0cb3cdae7927a4b2f07d87db0020293db893"
-dependencies = [
- "async-trait",
- "bech32",
- "chrono",
- "fuel-abi-types 0.3.0",
- "fuel-asm 0.43.2",
- "fuel-core-chain-config 0.22.4",
- "fuel-core-client 0.22.4",
- "fuel-crypto 0.43.2",
- "fuel-tx 0.43.2",
- "fuel-types 0.43.2",
- "fuel-vm 0.43.2",
- "fuels-macros 0.54.0",
- "hex",
- "itertools 0.12.1",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "thiserror",
- "uint",
- "zeroize",
-]
-
-[[package]]
-name = "fuels-core"
-=======
->>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5af00939974c1796cc05f44f20b0e31b8d6a03e9aeb1195fb2a9b68cef59920"
@@ -3090,23 +2776,6 @@ dependencies = [
 
 [[package]]
 name = "fuels-macros"
-<<<<<<< HEAD
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0dcdf41ccc7090bec4848d680d16cdc0c6cd37b749e518084caa8e6b730053"
-dependencies = [
- "fuels-code-gen 0.54.0",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "rand",
- "syn 2.0.55",
-]
-
-[[package]]
-name = "fuels-macros"
-=======
->>>>>>> 74ce1d417 (use unreleased wallet)
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "652003ee5a73e3674c818d9175e61c17311593e40d8281e00f08e64d7d29a076"
@@ -3145,13 +2814,8 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e1a8ed34d466df259afb3c210270fca59c8d66be77c00f428c49e61f35baeb"
 dependencies = [
-<<<<<<< HEAD
- "fuel-core-chain-config 0.22.4",
- "fuel-core-client 0.22.4",
-=======
  "fuel-core-chain-config",
  "fuel-core-client",
->>>>>>> 74ce1d417 (use unreleased wallet)
  "fuel-core-poa",
  "fuel-core-services",
  "fuel-crypto",
@@ -7037,17 +6701,10 @@ name = "sway-types"
 version = "0.52.0"
 dependencies = [
  "bytecount",
-<<<<<<< HEAD
- "fuel-asm 0.47.1",
- "fuel-crypto 0.47.1",
- "fuel-tx 0.47.1",
- "indexmap 2.2.6",
-=======
  "fuel-asm",
  "fuel-crypto",
  "fuel-tx",
- "indexmap 2.2.5",
->>>>>>> 74ce1d417 (use unreleased wallet)
+ "indexmap 2.2.6",
  "lazy_static",
  "num-bigint",
  "num-traits",
@@ -7330,13 +6987,8 @@ dependencies = [
  "forc-client",
  "forc-pkg",
  "forc-test",
-<<<<<<< HEAD
  "forc-tracing 0.52.0",
- "fuel-vm 0.47.1",
-=======
- "forc-tracing 0.51.1",
  "fuel-vm",
->>>>>>> 74ce1d417 (use unreleased wallet)
  "futures",
  "gag",
  "hex",
@@ -8202,15 +7854,14 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "which"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa5e0c10bf77f44aac573e498d1a82d5fbd5e91f6fc0a99e7be4b38e85e101c"
+checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
 dependencies = [
  "either",
  "home",
- "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "winsafe",
 ]
 
 [[package]]
@@ -8480,6 +8131,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "winter-air"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,9 +603,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1673,6 +1673,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
+name = "enum-iterator"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd242f399be1da0a5354aa462d57b4ab2b4ee0683cc552f7c007d2d12d36e94"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03cdc46ec28bd728e67540c528013c6a10eb69a02eb31078a1bda695438cbfb8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1987,7 +2007,7 @@ dependencies = [
  "forc-tracing 0.52.0",
  "forc-util",
  "fs_extra",
- "fuel-asm",
+ "fuel-asm 0.47.1",
  "hex",
  "serde",
  "serde_json",
@@ -2022,12 +2042,12 @@ dependencies = [
  "forc-util",
  "forc-wallet",
  "fuel-abi-types 0.4.0",
- "fuel-core-client",
- "fuel-crypto",
- "fuel-tx",
- "fuel-vm",
- "fuels-accounts",
- "fuels-core",
+ "fuel-core-client 0.23.0",
+ "fuel-crypto 0.47.1",
+ "fuel-tx 0.47.1",
+ "fuel-vm 0.47.1",
+ "fuels-accounts 0.56.0",
+ "fuels-core 0.56.0",
  "futures",
  "hex",
  "rand",
@@ -2051,9 +2071,9 @@ dependencies = [
  "clap 3.2.25",
  "forc-tracing 0.52.0",
  "forc-util",
- "fuel-core-types",
- "fuel-crypto",
- "fuels-core",
+ "fuel-core-types 0.23.0",
+ "fuel-crypto 0.47.1",
+ "fuels-core 0.56.0",
  "futures",
  "hex",
  "libp2p-identity",
@@ -2077,9 +2097,9 @@ dependencies = [
  "escargot",
  "forc-pkg",
  "forc-test",
- "fuel-core-client",
- "fuel-types",
- "fuel-vm",
+ "fuel-core-client 0.23.0",
+ "fuel-types 0.47.1",
+ "fuel-vm 0.47.1",
  "portpicker",
  "rayon",
  "rexpect",
@@ -2188,8 +2208,8 @@ dependencies = [
  "anyhow",
  "forc-pkg",
  "fuel-abi-types 0.4.0",
- "fuel-tx",
- "fuel-vm",
+ "fuel-tx 0.47.1",
+ "fuel-vm 0.47.1",
  "rand",
  "rayon",
  "sway-core",
@@ -2224,8 +2244,8 @@ dependencies = [
  "clap 3.2.25",
  "devault",
  "forc-util",
- "fuel-tx",
- "fuel-types",
+ "fuel-tx 0.47.1",
+ "fuel-types 0.47.1",
  "serde",
  "serde_json",
  "thiserror",
@@ -2242,7 +2262,7 @@ dependencies = [
  "dirs 3.0.2",
  "fd-lock 4.0.2",
  "forc-tracing 0.52.0",
- "fuel-tx",
+ "fuel-tx 0.47.1",
  "hex",
  "paste",
  "regex",
@@ -2268,10 +2288,10 @@ dependencies = [
  "clap 4.5.4",
  "eth-keystore",
  "forc-tracing 0.47.0",
- "fuel-crypto",
- "fuel-types",
+ "fuel-crypto 0.43.2",
+ "fuel-types 0.43.2",
  "fuels",
- "fuels-core",
+ "fuels-core 0.54.0",
  "futures",
  "hex",
  "home",
@@ -2364,9 +2384,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea884860261efdc7300b63db7972cb0e08e8f5379495ad7cdd2bdb7c0cc4623"
 dependencies = [
  "bitflags 2.5.0",
- "fuel-types",
+ "fuel-types 0.43.2",
  "serde",
- "strum",
+ "strum 0.24.1",
+]
+
+[[package]]
+name = "fuel-asm"
+version = "0.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b088ac4762d59736b90803db239f96c66f2a1a2c616715ef0a9c196b58edc9"
+dependencies = [
+ "bitflags 2.5.0",
+ "fuel-types 0.47.1",
+ "serde",
+ "strum 0.24.1",
 ]
 
 [[package]]
@@ -2377,8 +2409,26 @@ checksum = "62ab93dc93c87c0c380e94a6a8d1b65e791151d2f6a567c4970fc8cf76faaa05"
 dependencies = [
  "anyhow",
  "bech32",
- "fuel-core-storage",
- "fuel-core-types",
+ "fuel-core-storage 0.22.4",
+ "fuel-core-types 0.22.4",
+ "hex",
+ "itertools 0.10.5",
+ "postcard",
+ "serde",
+ "serde_with 1.14.0",
+ "tracing",
+]
+
+[[package]]
+name = "fuel-core-chain-config"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc2032184b86cd7e54d0ca6f7c7db7419552048484e2cfa6d7dc346eefb4907"
+dependencies = [
+ "anyhow",
+ "bech32",
+ "fuel-core-storage 0.23.0",
+ "fuel-core-types 0.23.0",
  "hex",
  "itertools 0.10.5",
  "postcard",
@@ -2397,7 +2447,31 @@ dependencies = [
  "cynic",
  "derive_more",
  "eventsource-client",
- "fuel-core-types",
+ "fuel-core-types 0.22.4",
+ "futures",
+ "hex",
+ "hyper-rustls 0.24.2",
+ "itertools 0.10.5",
+ "reqwest",
+ "schemafy_lib",
+ "serde",
+ "serde_json",
+ "tai64",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "fuel-core-client"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19e4fe4535372749e5b38d58c29a7904b3bc95e0429e6ae2544cfa8417a39c4"
+dependencies = [
+ "anyhow",
+ "cynic",
+ "derive_more",
+ "eventsource-client",
+ "fuel-core-types 0.23.0",
  "futures",
  "hex",
  "hyper-rustls 0.24.2",
@@ -2434,10 +2508,10 @@ checksum = "e99ef1eaab07450c327abb4809246f851cc0dc5d52650662a239bc66c26ded41"
 dependencies = [
  "anyhow",
  "async-trait",
- "fuel-core-chain-config",
+ "fuel-core-chain-config 0.22.4",
  "fuel-core-services",
- "fuel-core-storage",
- "fuel-core-types",
+ "fuel-core-storage 0.22.4",
+ "fuel-core-types 0.22.4",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2466,9 +2540,30 @@ checksum = "95d4d9ede89f97c779433e389739410a946e8b94f379a0048a49670bef73e602"
 dependencies = [
  "anyhow",
  "derive_more",
- "fuel-core-types",
- "fuel-vm",
+ "fuel-core-types 0.22.4",
+ "fuel-vm 0.43.2",
  "primitive-types",
+]
+
+[[package]]
+name = "fuel-core-storage"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "481343e6501f5205f742fae3b745402dc7f7c3a5038e64c598ba5217dcf17033"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "enum-iterator",
+ "fuel-core-types 0.23.0",
+ "fuel-vm 0.47.1",
+ "impl-tools",
+ "itertools 0.10.5",
+ "paste",
+ "postcard",
+ "primitive-types",
+ "serde",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
 ]
 
 [[package]]
@@ -2480,7 +2575,25 @@ dependencies = [
  "anyhow",
  "bs58",
  "derive_more",
- "fuel-vm",
+ "fuel-vm 0.43.2",
+ "secrecy",
+ "serde",
+ "tai64",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "fuel-core-types"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e855f688cf9a6f61f60663f03e217d821c4ade7a08d15ce21b54348612c873"
+dependencies = [
+ "anyhow",
+ "bs58",
+ "derivative",
+ "derive_more",
+ "fuel-vm 0.47.1",
  "secrecy",
  "serde",
  "tai64",
@@ -2498,7 +2611,28 @@ dependencies = [
  "coins-bip39",
  "ecdsa",
  "ed25519-dalek",
- "fuel-types",
+ "fuel-types 0.43.2",
+ "k256",
+ "lazy_static",
+ "p256",
+ "rand",
+ "secp256k1 0.26.0",
+ "serde",
+ "sha2 0.10.8",
+ "zeroize",
+]
+
+[[package]]
+name = "fuel-crypto"
+version = "0.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f00ba92f0e13a0dd06a7ad4e9a61221dc43d665519b50bfdb18755aebfdcf0"
+dependencies = [
+ "coins-bip32",
+ "coins-bip39",
+ "ecdsa",
+ "ed25519-dalek",
+ "fuel-types 0.47.1",
  "k256",
  "lazy_static",
  "p256",
@@ -2514,6 +2648,18 @@ name = "fuel-derive"
 version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff58cf4d01a4fb9440c63a8764154dfd3b07c74e4b3639cce8eea77d67e63a7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+ "synstructure 0.13.1",
+]
+
+[[package]]
+name = "fuel-derive"
+version = "0.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9b265467fe9d3d613a5bae9b8d3005d558d3e830dc416c9836bc16609a000f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2600,7 +2746,22 @@ checksum = "89143dd80b29dda305fbb033bc7f868834445ef6b361bf920f0077938fb6c0bc"
 dependencies = [
  "derive_more",
  "digest 0.10.7",
- "fuel-storage",
+ "fuel-storage 0.43.2",
+ "hashbrown 0.13.2",
+ "hex",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "fuel-merkle"
+version = "0.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b21ea035ff06a28791c862496c3b03cfb2d87778476c419724796e945e282ad"
+dependencies = [
+ "derive_more",
+ "digest 0.10.7",
+ "fuel-storage 0.47.1",
  "hashbrown 0.13.2",
  "hex",
  "serde",
@@ -2614,6 +2775,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "901aee4b46684e483d2c04d40e5ac1b8ccda737ac5a363507b44b9eb23b0fdaa"
 
 [[package]]
+name = "fuel-storage"
+version = "0.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1048957b744e448840eb9a09cb58c4647dec32e1cf49c0029e5445cbdc86f6d2"
+
+[[package]]
 name = "fuel-tx"
 version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,17 +2789,39 @@ dependencies = [
  "bitflags 2.5.0",
  "derivative",
  "derive_more",
- "fuel-asm",
- "fuel-crypto",
- "fuel-merkle",
- "fuel-types",
+ "fuel-asm 0.43.2",
+ "fuel-crypto 0.43.2",
+ "fuel-merkle 0.43.2",
+ "fuel-types 0.43.2",
  "hashbrown 0.14.3",
  "itertools 0.10.5",
  "rand",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+]
+
+[[package]]
+name = "fuel-tx"
+version = "0.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc917bb2d1892ef6792624782bed7cee5670f3f836b344f06c4233bb1124aff"
+dependencies = [
+ "bitflags 2.5.0",
+ "derivative",
+ "derive_more",
+ "fuel-asm 0.47.1",
+ "fuel-crypto 0.47.1",
+ "fuel-merkle 0.47.1",
+ "fuel-types 0.47.1",
+ "hashbrown 0.14.3",
+ "itertools 0.10.5",
+ "rand",
+ "serde",
+ "serde_json",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
 ]
 
 [[package]]
@@ -2641,7 +2830,19 @@ version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "148b59be5c54bafff692310663cbce3f097a2a7ff5533224dcfdf387578a72b0"
 dependencies = [
- "fuel-derive",
+ "fuel-derive 0.43.2",
+ "hex",
+ "rand",
+ "serde",
+]
+
+[[package]]
+name = "fuel-types"
+version = "0.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2444c92791b02016aa1cbab6cfa38e34920e61ec61d564f7bdb3ad8ddfae35de"
+dependencies = [
+ "fuel-derive 0.47.1",
  "hex",
  "rand",
  "serde",
@@ -2659,12 +2860,43 @@ dependencies = [
  "derivative",
  "derive_more",
  "ethnum",
- "fuel-asm",
- "fuel-crypto",
- "fuel-merkle",
- "fuel-storage",
- "fuel-tx",
- "fuel-types",
+ "fuel-asm 0.43.2",
+ "fuel-crypto 0.43.2",
+ "fuel-merkle 0.43.2",
+ "fuel-storage 0.43.2",
+ "fuel-tx 0.43.2",
+ "fuel-types 0.43.2",
+ "hashbrown 0.14.3",
+ "itertools 0.10.5",
+ "libm",
+ "paste",
+ "percent-encoding",
+ "primitive-types",
+ "serde",
+ "sha3",
+ "static_assertions",
+ "strum 0.24.1",
+ "tai64",
+]
+
+[[package]]
+name = "fuel-vm"
+version = "0.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e29c2333edbf3c55906b92a5f3dfb9639e2b0eabc7fd754e7a8e18d67ded3c2"
+dependencies = [
+ "async-trait",
+ "backtrace",
+ "bitflags 2.5.0",
+ "derivative",
+ "derive_more",
+ "ethnum",
+ "fuel-asm 0.47.1",
+ "fuel-crypto 0.47.1",
+ "fuel-merkle 0.47.1",
+ "fuel-storage 0.47.1",
+ "fuel-tx 0.47.1",
+ "fuel-types 0.47.1",
  "hashbrown 0.14.3",
  "itertools 0.10.5",
  "libm",
@@ -2675,7 +2907,7 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
- "strum",
+ "strum 0.24.1",
  "tai64",
 ]
 
@@ -2685,11 +2917,11 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "550689758e7cae90e76b11f40dc4a3d817a6f4b62541df134a9a26391011eb53"
 dependencies = [
- "fuel-core-client",
- "fuel-tx",
- "fuels-accounts",
- "fuels-core",
- "fuels-macros",
+ "fuel-core-client 0.22.4",
+ "fuel-tx 0.43.2",
+ "fuels-accounts 0.54.0",
+ "fuels-core 0.54.0",
+ "fuels-macros 0.54.0",
  "fuels-programs",
  "fuels-test-helpers",
 ]
@@ -2704,12 +2936,37 @@ dependencies = [
  "chrono",
  "elliptic-curve",
  "eth-keystore",
- "fuel-core-client",
- "fuel-crypto",
- "fuel-tx",
- "fuel-types",
- "fuels-core",
+ "fuel-core-client 0.22.4",
+ "fuel-crypto 0.43.2",
+ "fuel-tx 0.43.2",
+ "fuel-types 0.43.2",
+ "fuels-core 0.54.0",
  "hex",
+ "rand",
+ "semver",
+ "tai64",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "fuels-accounts"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e3eff2a1756fa81aa7e218b8ecefe4c70d44b38011db73d3181c99f3388259"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "elliptic-curve",
+ "eth-keystore",
+ "fuel-core-client 0.23.0",
+ "fuel-core-types 0.23.0",
+ "fuel-crypto 0.47.1",
+ "fuel-tx 0.47.1",
+ "fuel-types 0.47.1",
+ "fuels-core 0.56.0",
  "rand",
  "semver",
  "tai64",
@@ -2736,6 +2993,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuels-code-gen"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cf2c8670901a44f89a983a27b2fa831e1af19f6788cea1186c9b48514cc2a4"
+dependencies = [
+ "Inflector",
+ "fuel-abi-types 0.4.0",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde_json",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "fuels-core"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2745,14 +3018,14 @@ dependencies = [
  "bech32",
  "chrono",
  "fuel-abi-types 0.3.0",
- "fuel-asm",
- "fuel-core-chain-config",
- "fuel-core-client",
- "fuel-crypto",
- "fuel-tx",
- "fuel-types",
- "fuel-vm",
- "fuels-macros",
+ "fuel-asm 0.43.2",
+ "fuel-core-chain-config 0.22.4",
+ "fuel-core-client 0.22.4",
+ "fuel-crypto 0.43.2",
+ "fuel-tx 0.43.2",
+ "fuel-types 0.43.2",
+ "fuel-vm 0.43.2",
+ "fuels-macros 0.54.0",
  "hex",
  "itertools 0.12.1",
  "serde",
@@ -2764,12 +3037,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuels-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5af00939974c1796cc05f44f20b0e31b8d6a03e9aeb1195fb2a9b68cef59920"
+dependencies = [
+ "async-trait",
+ "bech32",
+ "chrono",
+ "fuel-abi-types 0.4.0",
+ "fuel-asm 0.47.1",
+ "fuel-core-chain-config 0.23.0",
+ "fuel-core-client 0.23.0",
+ "fuel-crypto 0.47.1",
+ "fuel-tx 0.47.1",
+ "fuel-types 0.47.1",
+ "fuel-vm 0.47.1",
+ "fuels-macros 0.56.0",
+ "hex",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
 name = "fuels-macros"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0dcdf41ccc7090bec4848d680d16cdc0c6cd37b749e518084caa8e6b730053"
 dependencies = [
- "fuels-code-gen",
+ "fuels-code-gen 0.54.0",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "rand",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "fuels-macros"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "652003ee5a73e3674c818d9175e61c17311593e40d8281e00f08e64d7d29a076"
+dependencies = [
+ "fuels-code-gen 0.56.0",
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
@@ -2786,11 +3100,11 @@ dependencies = [
  "async-trait",
  "bytes",
  "fuel-abi-types 0.3.0",
- "fuel-asm",
- "fuel-tx",
- "fuel-types",
- "fuels-accounts",
- "fuels-core",
+ "fuel-asm 0.43.2",
+ "fuel-tx 0.43.2",
+ "fuel-types 0.43.2",
+ "fuels-accounts 0.54.0",
+ "fuels-core 0.54.0",
  "itertools 0.12.1",
  "rand",
  "serde_json",
@@ -2803,14 +3117,14 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c79e02208b3ebb75d37d27161ff7c96847feb88ccd640a027105d1669c0c37"
 dependencies = [
- "fuel-core-chain-config",
- "fuel-core-client",
+ "fuel-core-chain-config 0.22.4",
+ "fuel-core-client 0.22.4",
  "fuel-core-poa",
  "fuel-core-services",
- "fuel-tx",
- "fuel-types",
- "fuels-accounts",
- "fuels-core",
+ "fuel-tx 0.43.2",
+ "fuel-types 0.43.2",
+ "fuels-accounts 0.54.0",
+ "fuels-core 0.54.0",
  "futures",
  "hex",
  "portpicker",
@@ -3500,6 +3814,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-tools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82c305b1081f1a99fda262883c788e50ab57d36c00830bdd7e0a82894ad965c"
+dependencies = [
+ "autocfg",
+ "impl-tools-lib",
+ "proc-macro-error",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "impl-tools-lib"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85d3946d886eaab0702fa0c6585adcced581513223fa9df7ccfabbd9fa331a88"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3583,9 +3921,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1718b3f2b85bb5054baf8ce406e36401f27c3169205f4175504c4b1d98252d3f"
+checksum = "3eab73f58e59ca6526037208f0e98851159ec1633cf17b6cd2e1f2c3fd5d53cc"
 dependencies = [
  "console",
  "lazy_static",
@@ -4032,9 +4370,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memoffset"
@@ -4609,9 +4947,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.101"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -4914,9 +5252,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -6259,9 +6597,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
 
 [[package]]
 name = "siphasher"
@@ -6449,8 +6787,14 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
 ]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
@@ -6463,6 +6807,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -6509,7 +6866,7 @@ dependencies = [
  "fuel-etk-asm",
  "fuel-etk-dasm",
  "fuel-etk-ops",
- "fuel-vm",
+ "fuel-vm 0.47.1",
  "gimli",
  "graph-cycles",
  "hashbrown 0.13.2",
@@ -6527,7 +6884,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.9.9",
- "strum",
+ "strum 0.24.1",
  "sway-ast",
  "sway-error",
  "sway-ir",
@@ -6669,9 +7026,9 @@ name = "sway-types"
 version = "0.52.0"
 dependencies = [
  "bytecount",
- "fuel-asm",
- "fuel-crypto",
- "fuel-tx",
+ "fuel-asm 0.47.1",
+ "fuel-crypto 0.47.1",
+ "fuel-tx 0.47.1",
  "indexmap 2.2.6",
  "lazy_static",
  "num-bigint",
@@ -6956,7 +7313,7 @@ dependencies = [
  "forc-pkg",
  "forc-test",
  "forc-tracing 0.52.0",
- "fuel-vm",
+ "fuel-vm 0.47.1",
  "futures",
  "gag",
  "hex",
@@ -7147,9 +7504,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7667,9 +8024,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec1"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d26f532c492acf7d7f1b03dcbfa81ff820ab26f69207da3e152f4e1bb4e0274"
+checksum = "ffb60dcfffc189bfd4e2a81333c268619fee9db53da71bce2bcbd8e129c56936"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,19 +34,19 @@ exclude = [
 
 [workspace.dependencies]
 # Dependencies from the `fuel-core` repository:
-fuel-core-client = { version = "0.22.0", default-features = false }
-fuel-core-types = { version = "0.22.0", default-features = false }
+fuel-core-client = { version = "0.23.0", default-features = false }
+fuel-core-types = { version = "0.23.0", default-features = false }
 
 # Dependencies from the `fuel-vm` repository:
-fuel-asm = "0.43.1"
-fuel-crypto = "0.43.1"
-fuel-types = "0.43.1"
-fuel-tx = "0.43.1"
-fuel-vm = "0.43.1"
+fuel-asm = "0.47.1"
+fuel-crypto = "0.47.1"
+fuel-types = "0.47.1"
+fuel-tx = "0.47.1"
+fuel-vm = "0.47.1"
 
 # Dependencies from the `fuels-rs` repository:
-fuels-core = "0.54.0"
-fuels-accounts = "0.54.0"
+fuels-core = "0.56.0"
+fuels-accounts = "0.56.0"
 
 # Dependencies from the `forc-wallet` repository:
 forc-wallet = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ fuels-core = "0.56.0"
 fuels-accounts = "0.56.0"
 
 # Dependencies from the `forc-wallet` repository:
-forc-wallet = { git = "https://github.com/FuelLabs/forc-wallet", branch = "kayagokalp/sdk-0.56" }
+forc-wallet = "0.5.0" 
 
 # Dependencies from the `fuel-abi-types` repository:
 fuel-abi-types = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ fuels-core = "0.56.0"
 fuels-accounts = "0.56.0"
 
 # Dependencies from the `forc-wallet` repository:
-forc-wallet = "0.4.2"
+forc-wallet = { git = "https://github.com/FuelLabs/forc-wallet", branch = "kayagokalp/sdk-0.56" }
 
 # Dependencies from the `fuel-abi-types` repository:
 fuel-abi-types = "0.4.0"

--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -238,7 +238,6 @@ pub async fn deploy_pkg(
     };
 
     let tx = TransactionBuilder::create(bytecode.as_slice().into(), salt, storage_slots.clone())
-        //.gas_price(get_gas_price(&command.gas, client.node_info().await?))
         .maturity(command.maturity.maturity.into())
         .add_output(Output::contract_created(contract_id, state_root))
         .finalize_signed(

--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -1,7 +1,6 @@
 use crate::{
     cmd,
     util::{
-        gas::get_gas_price,
         node_url::get_node_url,
         pkg::built_pkgs,
         tx::{TransactionBuilderExt, WalletSelectionMode, TX_SUBMIT_TIMEOUT_MS},
@@ -43,7 +42,7 @@ pub struct DeploymentArtifact {
     chain_id: ChainId,
     contract_id: String,
     deployment_size: usize,
-    deployed_block_id: String,
+    deployed_block_height: u32,
 }
 
 impl DeploymentArtifact {
@@ -239,7 +238,7 @@ pub async fn deploy_pkg(
     };
 
     let tx = TransactionBuilder::create(bytecode.as_slice().into(), salt, storage_slots.clone())
-        .gas_price(get_gas_price(&command.gas, client.node_info().await?))
+        //.gas_price(get_gas_price(&command.gas, client.node_info().await?))
         .maturity(command.maturity.maturity.into())
         .add_output(Output::contract_created(contract_id, state_root))
         .finalize_signed(
@@ -258,13 +257,13 @@ pub async fn deploy_pkg(
             TransactionStatus::Submitted { .. } => {
                 bail!("contract {} deployment timed out", &contract_id);
             }
-            TransactionStatus::Success { block_id, .. } => {
+            TransactionStatus::Success { block_height, .. } => {
                 let pkg_name = manifest.project_name();
                 info!("\n\nContract {pkg_name} Deployed!");
 
                 info!("\nNetwork: {node_url}");
                 info!("Contract ID: 0x{contract_id}");
-                info!("Deployed in block {}", &block_id);
+                info!("Deployed in block {}", &block_height);
 
                 // Create a deployment artifact.
                 let deployment_size = bytecode.len();
@@ -275,7 +274,7 @@ pub async fn deploy_pkg(
                     chain_id,
                     contract_id: format!("0x{}", contract_id),
                     deployment_size,
-                    deployed_block_id: block_id,
+                    deployed_block_height: *block_height,
                 };
 
                 let output_dir = command

--- a/forc-plugins/forc-client/src/op/run/encode.rs
+++ b/forc-plugins/forc-client/src/op/run/encode.rs
@@ -1,6 +1,9 @@
 use crate::util::encode::{Token, Type};
 use fuel_abi_types::abi::full_program::FullProgramABI;
-use fuels_core::{codec::ABIEncoder, types::unresolved_bytes::UnresolvedBytes};
+use fuels_core::{
+    codec::{ABIEncoder, EncoderConfig},
+    types::unresolved_bytes::UnresolvedBytes,
+};
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct ScriptCallHandler {
@@ -53,7 +56,8 @@ impl ScriptCallHandler {
             .map(|(ty, val)| Token::from_type_and_value(ty, val).map(|token| token.0))
             .collect::<anyhow::Result<Vec<_>>>()?;
 
-        Ok(ABIEncoder::encode(tokens.as_slice())?)
+        let abi_encoder = ABIEncoder::new(EncoderConfig::default());
+        Ok(abi_encoder.encode(tokens.as_slice())?)
     }
 }
 

--- a/forc-plugins/forc-client/src/op/run/mod.rs
+++ b/forc-plugins/forc-client/src/op/run/mod.rs
@@ -110,7 +110,6 @@ pub async fn run_pkg(
 
     let mut tb = TransactionBuilder::script(compiled.bytecode.bytes.clone(), script_data);
     tb
-        //.gas_price(get_gas_price(&command.gas, client.node_info().await?))
         .maturity(command.maturity.maturity.into())
         .add_contracts(contract_ids);
 

--- a/forc-plugins/forc-client/src/op/run/mod.rs
+++ b/forc-plugins/forc-client/src/op/run/mod.rs
@@ -192,7 +192,7 @@ async fn send_tx(
             let txs = vec![tx.clone()];
             let receipts = client.dry_run(txs.as_slice()).await?;
             let receipts = receipts
-                .get(0)
+                .first()
                 .map(|tx| &tx.result)
                 .map(|res| res.receipts());
             match receipts {

--- a/forc-plugins/forc-client/src/op/run/mod.rs
+++ b/forc-plugins/forc-client/src/op/run/mod.rs
@@ -109,8 +109,7 @@ pub async fn run_pkg(
     };
 
     let mut tb = TransactionBuilder::script(compiled.bytecode.bytes.clone(), script_data);
-    tb
-        .maturity(command.maturity.maturity.into())
+    tb.maturity(command.maturity.maturity.into())
         .add_contracts(contract_ids);
 
     let provider = Provider::connect(node_url.clone()).await?;

--- a/forc-plugins/forc-client/src/op/submit.rs
+++ b/forc-plugins/forc-client/src/op/submit.rs
@@ -52,14 +52,14 @@ pub fn fmt_status(status: &TransactionStatus, s: &mut String) -> anyhow::Result<
             writeln!(s, "Transaction Submitted at {:?}", submitted_at.0)?;
         }
         TransactionStatus::Success {
-            block_id,
+            block_height,
             time,
             program_state,
             ..
         } => {
             let utc = chrono::Utc.timestamp_nanos(time.to_unix());
             writeln!(s, "Transaction Succeeded")?;
-            writeln!(s, "  Block ID:      {block_id}")?;
+            writeln!(s, "  Block ID:      {block_height}")?;
             writeln!(s, "  Time:          {utc}",)?;
             writeln!(s, "  Program State: {program_state:?}")?;
         }
@@ -67,7 +67,7 @@ pub fn fmt_status(status: &TransactionStatus, s: &mut String) -> anyhow::Result<
             writeln!(s, "Transaction Squeezed Out: {reason}")?;
         }
         TransactionStatus::Failure {
-            block_id,
+            block_height,
             time,
             reason,
             program_state,
@@ -76,7 +76,7 @@ pub fn fmt_status(status: &TransactionStatus, s: &mut String) -> anyhow::Result<
             let utc = chrono::Utc.timestamp_nanos(time.to_unix());
             writeln!(s, "Transaction Failed")?;
             writeln!(s, "  Reason: {reason}")?;
-            writeln!(s, "  Block ID:      {block_id}")?;
+            writeln!(s, "  Block ID:      {block_height}")?;
             writeln!(s, "  Time:          {utc}")?;
             writeln!(s, "  Program State: {program_state:?}")?;
         }

--- a/forc-plugins/forc-client/src/util/gas.rs
+++ b/forc-plugins/forc-client/src/util/gas.rs
@@ -1,22 +1,10 @@
 use anyhow::Result;
-use forc_tx::Gas;
-use fuel_core_client::client::types::NodeInfo;
 use fuel_tx::{
     field::{Inputs, Witnesses},
     Buildable, Chargeable, Input, Script, TxPointer,
 };
 use fuels_accounts::provider::Provider;
 use fuels_core::types::transaction_builders::DryRunner;
-
-/// Returns the gas to use for deployment, overriding default values if necessary.
-pub fn get_gas_price(gas: &Gas, node_info: NodeInfo) -> u64 {
-    // TODO: write unit tests for this function once https://github.com/FuelLabs/fuel-core/issues/1312 is resolved.
-    if let Some(gas_price) = gas.price {
-        gas_price
-    } else {
-        node_info.min_gas_price
-    }
-}
 
 fn no_spendable_input<'a, I: IntoIterator<Item = &'a Input>>(inputs: I) -> bool {
     !inputs.into_iter().any(|i| {

--- a/forc-plugins/forc-client/src/util/gas.rs
+++ b/forc-plugins/forc-client/src/util/gas.rs
@@ -40,7 +40,6 @@ pub(crate) async fn get_gas_used(mut tx: Script, provider: &Provider) -> Result<
             Default::default(),
             TxPointer::default(),
             0,
-            0u32.into(),
         ));
 
         // Add an empty `Witness` for the `coin_signed` we just added
@@ -49,11 +48,11 @@ pub(crate) async fn get_gas_used(mut tx: Script, provider: &Provider) -> Result<
     }
 
     // Get `max_gas` used by everything except the script execution. Add `1` because of rounding.
-    let network_info = provider.network_info().await?;
-    let consensus_params = &network_info.consensus_parameters;
+    let consensus_params = provider.consensus_parameters();
+    let max_gas_per_tx = consensus_params.tx_params().max_gas_per_tx;
     let max_gas = tx.max_gas(consensus_params.gas_costs(), consensus_params.fee_params()) + 1;
     // Increase `script_gas_limit` to the maximum allowed value.
-    tx.set_script_gas_limit(network_info.max_gas_per_tx() - max_gas);
+    tx.set_script_gas_limit(max_gas_per_tx - max_gas);
 
     let tolerance = 0.1;
     let gas_used = provider

--- a/forc-plugins/forc-debug/docs/walkthrough.md
+++ b/forc-plugins/forc-debug/docs/walkthrough.md
@@ -84,7 +84,7 @@ Now we would like to inspect the program while it's running. To do this, we firs
         "script": [],
         "script_data": [],
         "policies": {
-            "bits": "GasPrice",
+            "bits": "MaxFee",
             "values": [0,0,0,0]
         },
         "inputs": [

--- a/forc-plugins/forc-debug/examples/example_tx.json
+++ b/forc-plugins/forc-debug/examples/example_tx.json
@@ -81,7 +81,7 @@
         ],
         "script_data": [],
         "policies": {
-            "bits": "GasPrice",
+            "bits": "MaxFee",
             "values": [
                 0,
                 0,

--- a/forc-plugins/forc-debug/src/server/handlers/handle_launch.rs
+++ b/forc-plugins/forc-debug/src/server/handlers/handle_launch.rs
@@ -30,13 +30,14 @@ impl DapServer {
                     return None;
                 }
 
-                Some(TestExecutor::new(
+                TestExecutor::build(
                     &pkg_to_debug.bytecode.bytes,
                     offset,
                     test_setup.clone(),
                     test_entry,
                     name.clone(),
-                ))
+                )
+                .ok()
             })
             .collect();
         self.state.init_executors(executors);

--- a/forc-plugins/forc-tx/src/lib.rs
+++ b/forc-plugins/forc-tx/src/lib.rs
@@ -662,7 +662,7 @@ impl TryFrom<Create> for fuel_tx::Create {
 
         let maturity = (create.maturity.maturity != 0).then_some(create.maturity.maturity.into());
         let mut policies = Policies::default();
-        policies.set(PolicyType::GasPrice, create.gas.price);
+        policies.set(PolicyType::Tip, create.gas.price);
         policies.set(PolicyType::Maturity, maturity);
 
         let create = fuel_tx::Transaction::create(
@@ -710,7 +710,7 @@ impl TryFrom<Script> for fuel_tx::Script {
             .collect();
 
         let mut policies = Policies::default().with_maturity(script.maturity.maturity.into());
-        policies.set(PolicyType::GasPrice, script.gas.price);
+        policies.set(PolicyType::Tip, script.gas.price);
         let mut script_tx = fuel_tx::Transaction::script(
             0, // Temporary value. Will be replaced below
             script_bytecode,
@@ -749,7 +749,7 @@ impl TryFrom<Input> for fuel_tx::Input {
                     amount,
                     asset_id,
                     tx_ptr: tx_pointer,
-                    maturity,
+                    maturity: _,
                     predicate_gas_used,
                     predicate,
                     witness_ix,
@@ -762,7 +762,6 @@ impl TryFrom<Input> for fuel_tx::Input {
                         asset_id,
                         tx_pointer,
                         witness_index,
-                        maturity.into(),
                     ),
                     (None, Some(predicate), Some(predicate_data)) => {
                         fuel_tx::Input::coin_predicate(
@@ -771,7 +770,6 @@ impl TryFrom<Input> for fuel_tx::Input {
                             amount,
                             asset_id,
                             tx_pointer,
-                            maturity.into(),
                             predicate_gas_used,
                             std::fs::read(&predicate).map_err(|err| {
                                 ConvertInputError::PredicateRead {

--- a/forc-test/src/execute.rs
+++ b/forc-test/src/execute.rs
@@ -37,13 +37,13 @@ pub enum DebugResult {
 }
 
 impl TestExecutor {
-    pub fn new(
+    pub fn build(
         bytecode: &[u8],
         test_offset: u32,
         test_setup: TestSetup,
         test_entry: &PkgTestEntry,
         name: String,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let storage = test_setup.storage().clone();
 
         // Patch the bytecode to jump to the relevant test.
@@ -103,16 +103,16 @@ impl TestExecutor {
                 consensus_params.gas_costs(),
                 consensus_params.fee_params(),
             )
-            .unwrap();
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         let interpreter_params = InterpreterParams::new(gas_price, &consensus_params);
 
-        TestExecutor {
+        Ok(TestExecutor {
             interpreter: Interpreter::with_storage(storage, interpreter_params),
             tx,
             test_entry: test_entry.clone(),
             name,
-        }
+        })
     }
 
     /// Execute the test with breakpoints enabled.

--- a/forc-test/src/execute.rs
+++ b/forc-test/src/execute.rs
@@ -61,7 +61,7 @@ impl TestExecutor {
         let asset_id = rng.gen();
         let tx_pointer = rng.gen();
         let block_height = (u32::MAX >> 1).into();
-        let gas_price = 1;
+        let gas_price = 0;
 
         let mut tx_builder = tx::TransactionBuilder::script(bytecode, script_input_data);
 

--- a/forc-test/src/lib.rs
+++ b/forc-test/src/lib.rs
@@ -386,13 +386,13 @@ impl<'a> PackageTests {
                         .expect("test instruction offset out of range");
                     let name = entry.finalized.fn_name.clone();
                     let test_setup = self.setup()?;
-                    TestExecutor::new(
+                    TestExecutor::build(
                         &pkg_with_tests.bytecode.bytes,
                         offset,
                         test_setup,
                         test_entry,
                         name,
-                    )
+                    )?
                     .execute()
                 })
                 .collect::<anyhow::Result<_>>()

--- a/forc-test/src/lib.rs
+++ b/forc-test/src/lib.rs
@@ -195,7 +195,7 @@ impl PackageWithDeploymentToTest {
     /// For contract deploys all contract dependencies and the root contract itself.
     fn deploy(&self) -> anyhow::Result<TestSetup> {
         // Setup the interpreter for deployment.
-        let gas_price = 1;
+        let gas_price = 0;
         let params = tx::ConsensusParameters::default();
         let storage = vm::storage::MemoryStorage::default();
         let interpreter_params = InterpreterParams::new(gas_price, params.clone());

--- a/forc-test/src/lib.rs
+++ b/forc-test/src/lib.rs
@@ -18,6 +18,7 @@ use rayon::prelude::*;
 use std::{collections::HashMap, fs, path::PathBuf, sync::Arc};
 use sway_core::BuildTarget;
 use sway_types::Span;
+use vm::interpreter::InterpreterParams;
 use vm::prelude::SecretKey;
 
 /// The result of a `forc test` invocation.
@@ -194,21 +195,26 @@ impl PackageWithDeploymentToTest {
     /// For contract deploys all contract dependencies and the root contract itself.
     fn deploy(&self) -> anyhow::Result<TestSetup> {
         // Setup the interpreter for deployment.
+        let gas_price = 1;
         let params = tx::ConsensusParameters::default();
         let storage = vm::storage::MemoryStorage::default();
+        let interpreter_params = InterpreterParams::new(gas_price, params.clone());
         let mut interpreter: vm::prelude::Interpreter<_, _, vm::interpreter::NotSupportedEcal> =
-            vm::interpreter::Interpreter::with_storage(storage, params.clone().into());
+            vm::interpreter::Interpreter::with_storage(storage, interpreter_params);
 
         // Iterate and create deployment transactions for contract dependencies of the root
         // contract.
-        let contract_dependency_setups = self.contract_dependencies().map(|built_pkg| {
-            deployment_transaction(built_pkg, &built_pkg.bytecode, params.clone())
-        });
+        let contract_dependency_setups = self
+            .contract_dependencies()
+            .map(|built_pkg| deployment_transaction(built_pkg, &built_pkg.bytecode, &params));
 
         // Deploy contract dependencies of the root contract and collect their ids.
         let contract_dependency_ids = contract_dependency_setups
             .map(|(contract_id, tx)| {
                 // Transact the deployment transaction constructed for this contract dependency.
+                let tx = tx
+                    .into_ready(gas_price, params.gas_costs(), params.fee_params())
+                    .unwrap();
                 interpreter.transact(tx).map_err(anyhow::Error::msg)?;
                 Ok(contract_id)
             })
@@ -221,8 +227,11 @@ impl PackageWithDeploymentToTest {
             let (root_contract_id, root_contract_tx) = deployment_transaction(
                 &contract_to_test.pkg,
                 &contract_to_test.without_tests_bytecode,
-                params,
+                &params,
             );
+            let root_contract_tx = root_contract_tx
+                .into_ready(gas_price, params.gas_costs(), params.fee_params())
+                .unwrap();
             // Deploy the root contract.
             interpreter
                 .transact(root_contract_tx)
@@ -589,7 +598,7 @@ pub fn build(opts: TestOpts) -> anyhow::Result<BuiltTests> {
 fn deployment_transaction(
     built_pkg: &pkg::BuiltPackage,
     without_tests_bytecode: &pkg::BuiltPackageBytecode,
-    params: tx::ConsensusParameters,
+    params: &tx::ConsensusParameters,
 ) -> ContractDeploymentSetup {
     // Obtain the contract id for deployment.
     let mut storage_slots = built_pkg.storage_slots.clone();
@@ -614,8 +623,8 @@ fn deployment_transaction(
     let block_height = (u32::MAX >> 1).into();
 
     let tx = tx::TransactionBuilder::create(bytecode.as_slice().into(), salt, storage_slots)
-        .with_params(params)
-        .add_unsigned_coin_input(secret_key, utxo_id, amount, asset_id, tx_pointer, maturity)
+        .with_params(params.clone())
+        .add_unsigned_coin_input(secret_key, utxo_id, amount, asset_id, tx_pointer)
         .add_output(tx::Output::contract_created(contract_id, state_root))
         .maturity(maturity)
         .finalize_checked(block_height);

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -185,7 +185,7 @@ pub(crate) fn runs_in_vm(
                 }
             }
             // Smallest non-zero value used for gas-price
-            let gas_price = 1;
+            let gas_price = 0;
             let consensus_params = tb.get_params().clone();
 
             let params = ConsensusParameters::default();

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -176,7 +176,6 @@ pub(crate) fn runs_in_vm(
                     1,
                     Default::default(),
                     rng.gen(),
-                    0u32.into(),
                 )
                 .maturity(maturity);
 
@@ -185,8 +184,11 @@ pub(crate) fn runs_in_vm(
                     tb.add_witness(witness.into());
                 }
             }
+            // Smallest non-zero value used for gas-price
+            let gas_price = 1;
             let consensus_params = tb.get_params().clone();
 
+            let params = ConsensusParameters::default();
             // Temporarily finalize to calculate `script_gas_limit`
             let tmp_tx = tb.clone().finalize();
             // Get `max_gas` used by everything except the script execution. Add `1` because of rounding.
@@ -195,7 +197,8 @@ pub(crate) fn runs_in_vm(
             // Increase `script_gas_limit` to the maximum allowed value.
             tb.script_gas_limit(consensus_params.tx_params().max_gas_per_tx - max_gas);
 
-            let tx = tb.finalize_checked(block_height);
+            let tx = tb.finalize_checked(block_height)
+                .into_ready(gas_price, params.gas_costs(), params.fee_params()).map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
             let mut i: Interpreter<_, _, NotSupportedEcal> =
                 Interpreter::with_storage(storage, Default::default());

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -184,7 +184,6 @@ pub(crate) fn runs_in_vm(
                     tb.add_witness(witness.into());
                 }
             }
-            // Smallest non-zero value used for gas-price
             let gas_price = 0;
             let consensus_params = tb.get_params().clone();
 

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -197,8 +197,10 @@ pub(crate) fn runs_in_vm(
             // Increase `script_gas_limit` to the maximum allowed value.
             tb.script_gas_limit(consensus_params.tx_params().max_gas_per_tx - max_gas);
 
-            let tx = tb.finalize_checked(block_height)
-                .into_ready(gas_price, params.gas_costs(), params.fee_params()).map_err(|e| anyhow::anyhow!("{e:?}"))?;
+            let tx = tb
+                .finalize_checked(block_height)
+                .into_ready(gas_price, params.gas_costs(), params.fee_params())
+                .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
             let mut i: Interpreter<_, _, NotSupportedEcal> =
                 Interpreter::with_storage(storage, Default::default());

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/raw_ptr/raw_ptr_ret/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/raw_ptr/raw_ptr_ret/test.toml
@@ -1,2 +1,2 @@
 category = "run"
-expected_result = { action = "return", value = 10656 }
+expected_result = { action = "return", value = 10648 }


### PR DESCRIPTION
## Description

Update rust sdk to v0.56, fuel-core to v0.23.0 and fuel-vm to v0.47.1