### PR TITLE
Fix for performance problem with `MegaExample`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,12 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0453232ace82dee0dd0b4c87a59bd90f7b53b314f3e0f61fe2ee7c8a16482289"
+
+[[package]]
+name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -1379,6 +1385,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0047d07f2c89b17dd631c80450d69841a6b5d7fb17278cbc43d7e4cfcf2576f3"
 dependencies = [
  "data-encoding",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "deepsize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb987ec36f6bf7bfbea3f928b75590b736fc42af8e54d97592481351b2b96c"
+dependencies = [
+ "deepsize_derive",
+ "hashbrown 0.9.1",
+ "indexmap 1.9.3",
+]
+
+[[package]]
+name = "deepsize_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990101d41f3bc8c1a45641024377ee284ecc338e5ecf3ea0f0e236d897c72796"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3050,7 +3078,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a6ad932c6dd3cfaf16b66754a42f87bbeefd591530c4b6a8334270a7df3e853"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "petgraph",
  "thiserror",
 ]
@@ -3130,6 +3158,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.8",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -3146,7 +3183,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -3155,7 +3192,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "allocator-api2",
  "serde",
 ]
@@ -3312,6 +3349,18 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "human_bytes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
+
+[[package]]
+name = "human_format"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3b1f728c459d27b12448862017b96ad4767b1ec2ec5e6434e99f1577f085b8"
 
 [[package]]
 name = "humantime"
@@ -6504,6 +6553,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 name = "sway-ast"
 version = "0.52.0"
 dependencies = [
+ "deepsize",
  "extension-trait",
  "num-bigint",
  "num-traits",
@@ -6517,6 +6567,7 @@ name = "sway-core"
 version = "0.52.0"
 dependencies = [
  "clap 3.2.25",
+ "deepsize",
  "derivative",
  "dirs 3.0.2",
  "either",
@@ -6530,6 +6581,8 @@ dependencies = [
  "graph-cycles",
  "hashbrown 0.13.2",
  "hex",
+ "human_bytes",
+ "human_format",
  "im",
  "indexmap 2.2.6",
  "itertools 0.10.5",
@@ -6562,6 +6615,7 @@ dependencies = [
 name = "sway-error"
 version = "0.52.0"
 dependencies = [
+ "deepsize",
  "either",
  "num-traits",
  "smallvec",
@@ -6686,6 +6740,7 @@ name = "sway-types"
 version = "0.52.0"
 dependencies = [
  "bytecount",
+ "deepsize",
  "fuel-asm",
  "fuel-crypto",
  "fuel-tx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,6 +559,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
+name = "bytemuck"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5604,6 +5610,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1c77081a55300e016cb86f2864415b7518741879db925b8d488a0ee0d2da6bf"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "ron"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6523,6 +6539,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "petgraph",
+ "roaring",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,12 +565,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
-name = "bytemuck"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3351,18 +3345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "human_bytes"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
-
-[[package]]
-name = "human_format"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3b1f728c459d27b12448862017b96ad4767b1ec2ec5e6434e99f1577f085b8"
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5659,16 +5641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "roaring"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c77081a55300e016cb86f2864415b7518741879db925b8d488a0ee0d2da6bf"
-dependencies = [
- "bytemuck",
- "byteorder",
-]
-
-[[package]]
 name = "ron"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6581,8 +6553,6 @@ dependencies = [
  "graph-cycles",
  "hashbrown 0.13.2",
  "hex",
- "human_bytes",
- "human_format",
  "im",
  "indexmap 2.2.6",
  "itertools 0.10.5",
@@ -6592,7 +6562,6 @@ dependencies = [
  "pest",
  "pest_derive",
  "petgraph",
- "roaring",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2488,6 +2488,7 @@ pub fn build(
         }
     }
 
+    engines.print_stats();
     Ok(built_packages)
 }
 

--- a/sway-ast/Cargo.toml
+++ b/sway-ast/Cargo.toml
@@ -9,13 +9,13 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+deepsize = { version = "0.2.0", features = ["std", "indexmap", "hashbrown"] }
 extension-trait = "1.0.1"
 num-bigint = { version = "0.4.3", features = ["serde"] }
 num-traits = "0.2.14"
 serde = { version = "1.0", features = ["derive"] }
 sway-error = { version = "0.52.0", path = "../sway-error" }
 sway-types = { version = "0.52.0", path = "../sway-types" }
-deepsize = { version = "0.2.0", features = ["std", "indexmap", "hashbrown"] }
 
 [lints.clippy]
 iter_over_hash_type = "deny"

--- a/sway-ast/Cargo.toml
+++ b/sway-ast/Cargo.toml
@@ -15,6 +15,7 @@ num-traits = "0.2.14"
 serde = { version = "1.0", features = ["derive"] }
 sway-error = { version = "0.52.0", path = "../sway-error" }
 sway-types = { version = "0.52.0", path = "../sway-types" }
+deepsize = { version = "0.2.0", features = ["std", "indexmap", "hashbrown"] }
 
 [lints.clippy]
 iter_over_hash_type = "deny"

--- a/sway-ast/src/intrinsics.rs
+++ b/sway-ast/src/intrinsics.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Eq, PartialEq, Debug, Clone, Hash)]
+#[derive(Eq, PartialEq, Debug, Clone, Hash, deepsize::DeepSizeOf)]
 pub enum Intrinsic {
     IsReferenceType,
     IsStrArray,

--- a/sway-ast/src/literal.rs
+++ b/sway-ast/src/literal.rs
@@ -21,7 +21,7 @@ pub struct LitInt {
 
 impl ::deepsize::DeepSizeOf for LitInt {
     fn deep_size_of_children(&self, context: &mut ::deepsize::Context) -> usize {
-        0 + ::deepsize::DeepSizeOf::deep_size_of_children(&self.span, context)
+        ::deepsize::DeepSizeOf::deep_size_of_children(&self.span, context)
             + self.parsed.iter_u64_digits().count() * std::mem::size_of::<u64>()
             + ::deepsize::DeepSizeOf::deep_size_of_children(&self.ty_opt, context)
     }

--- a/sway-ast/src/literal.rs
+++ b/sway-ast/src/literal.rs
@@ -1,12 +1,12 @@
 use crate::priv_prelude::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize, deepsize::DeepSizeOf)]
 pub struct LitString {
     pub span: Span,
     pub parsed: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize, deepsize::DeepSizeOf)]
 pub struct LitChar {
     pub span: Span,
     pub parsed: char,
@@ -19,7 +19,15 @@ pub struct LitInt {
     pub ty_opt: Option<(LitIntType, Span)>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize)]
+impl ::deepsize::DeepSizeOf for LitInt {
+    fn deep_size_of_children(&self, context: &mut ::deepsize::Context) -> usize {
+        0 + ::deepsize::DeepSizeOf::deep_size_of_children(&self.span, context)
+            + self.parsed.iter_u64_digits().count() * std::mem::size_of::<u64>()
+            + ::deepsize::DeepSizeOf::deep_size_of_children(&self.ty_opt, context)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize, deepsize::DeepSizeOf)]
 pub enum LitIntType {
     U8,
     U16,
@@ -32,13 +40,13 @@ pub enum LitIntType {
     I64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize, deepsize::DeepSizeOf)]
 pub struct LitBool {
     pub span: Span,
     pub kind: LitBoolType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize, deepsize::DeepSizeOf)]
 pub enum LitBoolType {
     True,
     False,
@@ -53,7 +61,7 @@ impl From<LitBoolType> for bool {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash, Serialize, deepsize::DeepSizeOf)]
 pub enum Literal {
     String(LitString),
     Char(LitChar),

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 
 [dependencies]
 clap = { version = "3.1", features = ["derive"] }
+deepsize = { version = "0.2.0", features = ["std", "indexmap", "hashbrown"] }
 derivative = "2.2.0"
 dirs = "3.0"
 either = "1.9.0"
@@ -49,10 +50,6 @@ thiserror = "1.0"
 tracing = "0.1"
 uint = "0.9"
 vec1 = "1.8.0"
-roaring = "0.10.3"
-human_format = "1.1.0"
-deepsize = { version = "0.2.0", features = ["std", "indexmap", "hashbrown"] }
-human_bytes = "0.4.3"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 sysinfo = "0.29.0"

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -49,6 +49,7 @@ thiserror = "1.0"
 tracing = "0.1"
 uint = "0.9"
 vec1 = "1.8.0"
+roaring = "0.10.3"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 sysinfo = "0.29.0"

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -50,6 +50,9 @@ tracing = "0.1"
 uint = "0.9"
 vec1 = "1.8.0"
 roaring = "0.10.3"
+human_format = "1.1.0"
+deepsize = { version = "0.2.0", features = ["std", "indexmap", "hashbrown"] }
+human_bytes = "0.4.3"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 sysinfo = "0.29.0"

--- a/sway-core/src/concurrent_slab.rs
+++ b/sway-core/src/concurrent_slab.rs
@@ -1,11 +1,9 @@
 use std::{
-    collections::HashMap,
     fmt,
     sync::{Arc, RwLock},
 };
 
 use deepsize::DeepSizeOf;
-use itertools::Itertools;
 
 #[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct Inner<T> {
@@ -71,6 +69,7 @@ impl<T> ConcurrentSlab<T>
 where
     T: Clone,
 {
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         let inner = self.inner.read().unwrap();
         inner.items.len()
@@ -94,17 +93,14 @@ where
     {
         let mut inner = self.inner.write().unwrap();
 
-        let r = if let Some(free) = inner.free_list.pop() {
-            let free = free as usize;
+        if let Some(free) = inner.free_list.pop() {
             assert!(inner.items[free].is_none());
             inner.items[free] = Some(value);
             free
         } else {
             inner.items.push(Some(value));
             inner.items.len() - 1
-        };
-
-        r
+        }
     }
 
     pub fn replace(&self, index: usize, new_value: T) -> Option<T> {

--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -1,5 +1,4 @@
 use std::{
-    backtrace::Backtrace,
     collections::{HashMap, HashSet, VecDeque},
     fmt::Write,
     sync::{Arc, RwLock},
@@ -20,7 +19,7 @@ use crate::{
 /// Used inside of type inference to store declarations.
 #[derive(Debug, Default)]
 pub struct DeclEngine {
-    pub function_slab: ConcurrentSlab<TyFunctionDecl>,
+    function_slab: ConcurrentSlab<TyFunctionDecl>,
     trait_slab: ConcurrentSlab<TyTraitDecl>,
     trait_fn_slab: ConcurrentSlab<TyTraitFn>,
     trait_type_slab: ConcurrentSlab<TyTraitType>,

--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -98,67 +98,75 @@ impl<T> Into<usize> for DeclId<T> {
 }
 
 impl SubstTypes for DeclId<TyFunctionDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
+        let has_changes = decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
+        has_changes
     }
 }
 impl SubstTypes for DeclId<TyTraitDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
+        let has_changes = decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
+        has_changes
     }
 }
 impl SubstTypes for DeclId<TyTraitFn> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
+        let has_changes = decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
+        has_changes
     }
 }
 impl SubstTypes for DeclId<TyImplTrait> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
+        let has_changes = decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
+        has_changes
     }
 }
 impl SubstTypes for DeclId<TyStructDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
+        let has_changes = decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
+        has_changes
     }
 }
 impl SubstTypes for DeclId<TyEnumDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
+        let has_changes = decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
+        has_changes
     }
 }
 impl SubstTypes for DeclId<TyTypeAliasDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
+        let has_changes = decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
+        has_changes
     }
 }
 
 impl SubstTypes for DeclId<TyTraitType> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
+        let has_changes = decl.subst(type_mapping, engines);
         decl_engine.replace(*self, decl);
+        has_changes
     }
 }

--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -17,6 +17,7 @@ use crate::{
 pub type DeclIdIndexType = usize;
 
 /// An ID used to refer to an item in the [DeclEngine](super::decl_engine::DeclEngine)
+#[derive(deepsize::DeepSizeOf)]
 pub struct DeclId<T>(DeclIdIndexType, PhantomData<T>);
 
 impl<T> fmt::Debug for DeclId<T> {

--- a/sway-core/src/decl_engine/interface_decl_id.rs
+++ b/sway-core/src/decl_engine/interface_decl_id.rs
@@ -1,6 +1,6 @@
 use crate::{decl_engine::*, language::ty};
 
-#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone, deepsize::DeepSizeOf)]
 pub enum InterfaceDeclId {
     Abi(DeclId<ty::TyAbiDecl>),
     Trait(DeclId<ty::TyTraitDecl>),

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -53,7 +53,7 @@ pub type DeclRefMixedInterface = DeclRef<InterfaceDeclId>;
 /// Represents the use of / syntactic reference to a declaration. A
 /// smart-wrapper around a [DeclId], containing additional information about a
 /// declaration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct DeclRef<I> {
     /// The name of the declaration.
     // NOTE: In the case of storage, the name is "storage".
@@ -300,6 +300,7 @@ where
 }
 
 impl ReplaceDecls for DeclRefFunction {
+    #[inline(never)]
     fn replace_decls_inner(
         &mut self,
         decl_mapping: &DeclMapping,

--- a/sway-core/src/decl_engine/template.rs
+++ b/sway-core/src/decl_engine/template.rs
@@ -7,7 +7,7 @@
 /// [SubstList](crate::type_system::SubstList) contained in this field is simply
 /// a template for usages of the declaration declared in that particular
 /// [TyDecl](crate::language::ty::TyDecl) node.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, deepsize::DeepSizeOf)]
 pub struct Template<T>(T)
 where
     T: Clone;

--- a/sway-core/src/engine_threading.rs
+++ b/sway-core/src/engine_threading.rs
@@ -3,6 +3,7 @@ use crate::{
     query_engine::QueryEngine,
     type_system::TypeEngine,
 };
+use deepsize::DeepSizeOf;
 use std::{
     cmp::Ordering,
     fmt,
@@ -49,6 +50,52 @@ impl Engines {
     //         source_engine,
     //     }
     // }
+
+    pub fn print_stats(&self) {
+        println!("Engine Stats");
+        println!("------------");
+
+        println!("    Type Engine");
+        println!(
+            "        Slab: {} items ({})",
+            self.type_engine.slab.len(),
+            human_format::Formatter::new().format(self.type_engine.slab.len() as f64)
+        );
+        let size = self.type_engine.slab.deep_size_of();
+        println!(
+            "        Slab Size: {} bytes ({})",
+            size,
+            human_bytes::human_bytes(size as f64)
+        );
+
+        println!("    Decl Engine");
+        println!(
+            "        Function Decl Slab: {} items ({})",
+            self.decl_engine.function_slab.len(),
+            human_format::Formatter::new().format(self.decl_engine.function_slab.len() as f64)
+        );
+        let size = self.decl_engine.function_slab.deep_size_of();
+        println!(
+            "        Function Decl Slab: {} bytes ({})",
+            size,
+            human_bytes::human_bytes(size as f64)
+        );
+
+        // Count by name
+        // let items = self.decl_engine.function_slab.inner.read().unwrap();
+        // let map = items.items.iter().filter_map(|x| x.clone()).fold(
+        //     hashbrown::HashMap::<String, usize>::new(),
+        //     |mut map, item| {
+        //         *(map.entry(item.name.as_str().to_string()).or_default()) += 1;
+        //         map
+        //     },
+        // );
+        // let mut map = map.into_iter().collect::<Vec<_>>();
+        // map.sort_by(|a, b| a.1.cmp(&b.1));
+        // for (k, v) in map {
+        //     println!("{} -> {}", k, v);
+        // }
+    }
 
     pub fn te(&self) -> &TypeEngine {
         &self.type_engine

--- a/sway-core/src/engine_threading.rs
+++ b/sway-core/src/engine_threading.rs
@@ -3,7 +3,6 @@ use crate::{
     query_engine::QueryEngine,
     type_system::TypeEngine,
 };
-use deepsize::DeepSizeOf;
 use std::{
     cmp::Ordering,
     fmt,
@@ -52,34 +51,34 @@ impl Engines {
     // }
 
     pub fn print_stats(&self) {
-        println!("Engine Stats");
-        println!("------------");
+        // println!("Engine Stats");
+        // println!("------------");
 
-        println!("    Type Engine");
-        println!(
-            "        Slab: {} items ({})",
-            self.type_engine.slab.len(),
-            human_format::Formatter::new().format(self.type_engine.slab.len() as f64)
-        );
-        let size = self.type_engine.slab.deep_size_of();
-        println!(
-            "        Slab Size: {} bytes ({})",
-            size,
-            human_bytes::human_bytes(size as f64)
-        );
+        // println!("    Type Engine");
+        // println!(
+        //     "        Slab: {} items ({})",
+        //     self.type_engine.slab.len(),
+        //     human_format::Formatter::new().format(self.type_engine.slab.len() as f64)
+        // );
+        // let size = self.type_engine.slab.deep_size_of();
+        // println!(
+        //     "        Slab Size: {} bytes ({})",
+        //     size,
+        //     human_bytes::human_bytes(size as f64)
+        // );
 
-        println!("    Decl Engine");
-        println!(
-            "        Function Decl Slab: {} items ({})",
-            self.decl_engine.function_slab.len(),
-            human_format::Formatter::new().format(self.decl_engine.function_slab.len() as f64)
-        );
-        let size = self.decl_engine.function_slab.deep_size_of();
-        println!(
-            "        Function Decl Slab: {} bytes ({})",
-            size,
-            human_bytes::human_bytes(size as f64)
-        );
+        // println!("    Decl Engine");
+        // println!(
+        //     "        Function Decl Slab: {} items ({})",
+        //     self.decl_engine.function_slab.len(),
+        //     human_format::Formatter::new().format(self.decl_engine.function_slab.len() as f64)
+        // );
+        // let size = self.decl_engine.function_slab.deep_size_of();
+        // println!(
+        //     "        Function Decl Slab: {} bytes ({})",
+        //     size,
+        //     human_bytes::human_bytes(size as f64)
+        // );
 
         // Count by name
         // let items = self.decl_engine.function_slab.inner.read().unwrap();

--- a/sway-core/src/engine_threading.rs
+++ b/sway-core/src/engine_threading.rs
@@ -10,7 +10,7 @@ use std::{
 };
 use sway_types::SourceEngine;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Engines {
     type_engine: TypeEngine,
     decl_engine: DeclEngine,
@@ -19,22 +19,36 @@ pub struct Engines {
     source_engine: SourceEngine,
 }
 
-impl Engines {
-    pub fn new(
-        type_engine: TypeEngine,
-        decl_engine: DeclEngine,
-        parsed_decl_engine: ParsedDeclEngine,
-        query_engine: QueryEngine,
-        source_engine: SourceEngine,
-    ) -> Engines {
-        Engines {
-            type_engine,
-            decl_engine,
-            parsed_decl_engine,
-            query_engine,
-            source_engine,
-        }
+impl Default for Engines {
+    fn default() -> Self {
+        let engines = Self {
+            type_engine: Default::default(),
+            decl_engine: Default::default(),
+            parsed_decl_engine: Default::default(),
+            query_engine: Default::default(),
+            source_engine: Default::default(),
+        };
+        engines.te().init(&engines);
+        engines
     }
+}
+
+impl Engines {
+    // pub fn new(
+    //     type_engine: TypeEngine,
+    //     decl_engine: DeclEngine,
+    //     parsed_decl_engine: ParsedDeclEngine,
+    //     query_engine: QueryEngine,
+    //     source_engine: SourceEngine,
+    // ) -> Engines {
+    //     Engines {
+    //         type_engine,
+    //         decl_engine,
+    //         parsed_decl_engine,
+    //         query_engine,
+    //         source_engine,
+    //     }
+    // }
 
     pub fn te(&self) -> &TypeEngine {
         &self.type_engine

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -30,6 +30,7 @@ use sway_ir::{
 use sway_types::{ident::Ident, integer_bits::IntegerBits, span::Spanned, Span};
 use sway_utils::mapped_stack::MappedStack;
 
+#[allow(dead_code)]
 enum ConstEvalError {
     CompileError(CompileError),
     CannotBeEvaluatedToConst {

--- a/sway-core/src/language/asm.rs
+++ b/sway-core/src/language/asm.rs
@@ -2,7 +2,7 @@ use std::hash::{Hash, Hasher};
 
 use sway_types::{BaseIdent, Ident, Span};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct AsmOp {
     pub(crate) op_name: Ident,
     pub(crate) op_args: Vec<Ident>,
@@ -43,7 +43,7 @@ impl PartialEq for AsmOp {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, deepsize::DeepSizeOf)]
 pub struct AsmRegister {
     pub(crate) name: String,
 }

--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -21,7 +21,7 @@ use sway_types::{span::Span, Spanned};
 
 use super::parsed::QualifiedPathType;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct CallPathTree {
     pub qualified_call_path: QualifiedCallPath,
     pub children: Vec<CallPathTree>,
@@ -66,7 +66,7 @@ impl OrdWithEngines for CallPathTree {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 
 pub struct QualifiedCallPath {
     pub call_path: CallPath,
@@ -170,7 +170,7 @@ impl DebugWithEngines for QualifiedCallPath {
 
 /// In the expression `a::b::c()`, `a` and `b` are the prefixes and `c` is the suffix.
 /// `c` can be any type `T`, but in practice `c` is either an `Ident` or a `TypeInfo`.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, deepsize::DeepSizeOf)]
 pub struct CallPath<T = Ident> {
     pub prefixes: Vec<Ident>,
     pub suffix: T,

--- a/sway-core/src/language/lazy_op.rs
+++ b/sway-core/src/language/lazy_op.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, deepsize::DeepSizeOf)]
 pub enum LazyOp {
     And,
     Or,

--- a/sway-core/src/language/literal.rs
+++ b/sway-core/src/language/literal.rs
@@ -9,7 +9,7 @@ use std::{
     num::{IntErrorKind, ParseIntError},
 };
 
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Clone, Eq, deepsize::DeepSizeOf)]
 pub enum Literal {
     U8(u8),
     U16(u16),

--- a/sway-core/src/language/parsed/code_block.rs
+++ b/sway-core/src/language/parsed/code_block.rs
@@ -2,7 +2,7 @@ use crate::language::parsed::AstNode;
 
 use sway_types::{span::Span, Spanned};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct CodeBlock {
     pub contents: Vec<AstNode>,
     pub(crate) whole_block_span: Span,

--- a/sway-core/src/language/parsed/declaration/abi.rs
+++ b/sway-core/src/language/parsed/declaration/abi.rs
@@ -18,3 +18,9 @@ pub struct AbiDeclaration {
     pub(crate) span: Span,
     pub attributes: transform::AttributesMap,
 }
+
+impl deepsize::DeepSizeOf for AbiDeclaration {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        0
+    }
+}

--- a/sway-core/src/language/parsed/declaration/abi.rs
+++ b/sway-core/src/language/parsed/declaration/abi.rs
@@ -20,7 +20,7 @@ pub struct AbiDeclaration {
 }
 
 impl deepsize::DeepSizeOf for AbiDeclaration {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         0
     }
 }

--- a/sway-core/src/language/parsed/declaration/constant.rs
+++ b/sway-core/src/language/parsed/declaration/constant.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use sway_types::{Ident, Span};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct ConstantDeclaration {
     pub name: Ident,
     pub attributes: transform::AttributesMap,

--- a/sway-core/src/language/parsed/declaration/enum.rs
+++ b/sway-core/src/language/parsed/declaration/enum.rs
@@ -1,7 +1,7 @@
 use crate::{language::Visibility, transform, type_system::*};
 use sway_types::{ident::Ident, span::Span};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct EnumDeclaration {
     pub name: Ident,
     pub attributes: transform::AttributesMap,
@@ -11,7 +11,7 @@ pub struct EnumDeclaration {
     pub visibility: Visibility,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct EnumVariant {
     pub name: Ident,
     pub attributes: transform::AttributesMap,

--- a/sway-core/src/language/parsed/declaration/function.rs
+++ b/sway-core/src/language/parsed/declaration/function.rs
@@ -29,13 +29,19 @@ pub struct FunctionDeclaration {
     pub kind: FunctionDeclarationKind,
 }
 
+impl deepsize::DeepSizeOf for FunctionDeclaration {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        0
+    }
+}
+
 impl DebugWithEngines for FunctionDeclaration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, _engines: &Engines) -> std::fmt::Result {
         f.write_fmt(format_args!("{}", self.name))
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct FunctionParameter {
     pub name: Ident,
     pub is_reference: bool,

--- a/sway-core/src/language/parsed/declaration/function.rs
+++ b/sway-core/src/language/parsed/declaration/function.rs
@@ -30,7 +30,7 @@ pub struct FunctionDeclaration {
 }
 
 impl deepsize::DeepSizeOf for FunctionDeclaration {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         0
     }
 }

--- a/sway-core/src/language/parsed/declaration/impl_trait.rs
+++ b/sway-core/src/language/parsed/declaration/impl_trait.rs
@@ -44,7 +44,7 @@ pub struct ImplTrait {
 }
 
 impl deepsize::DeepSizeOf for ImplTrait {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         0
     }
 }
@@ -71,7 +71,7 @@ pub struct ImplSelf {
 }
 
 impl deepsize::DeepSizeOf for ImplSelf {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         0
     }
 }

--- a/sway-core/src/language/parsed/declaration/impl_trait.rs
+++ b/sway-core/src/language/parsed/declaration/impl_trait.rs
@@ -43,6 +43,12 @@ pub struct ImplTrait {
     pub(crate) block_span: Span,
 }
 
+impl deepsize::DeepSizeOf for ImplTrait {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        0
+    }
+}
+
 impl DebugWithEngines for ImplTrait {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, engines: &Engines) -> std::fmt::Result {
         f.write_fmt(format_args!(
@@ -62,6 +68,12 @@ pub struct ImplSelf {
     pub items: Vec<ImplItem>,
     // the span of the whole impl trait and block
     pub(crate) block_span: Span,
+}
+
+impl deepsize::DeepSizeOf for ImplSelf {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        0
+    }
 }
 
 impl DebugWithEngines for ImplSelf {

--- a/sway-core/src/language/parsed/declaration/storage.rs
+++ b/sway-core/src/language/parsed/declaration/storage.rs
@@ -11,6 +11,12 @@ pub struct StorageDeclaration {
     pub storage_keyword: Ident,
 }
 
+impl deepsize::DeepSizeOf for StorageDeclaration {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        0
+    }
+}
+
 /// An individual field in a storage declaration.
 /// A type annotation _and_ initializer value must be provided. The initializer value must be a
 /// constant expression. For now, that basically means just a literal, but as constant folding

--- a/sway-core/src/language/parsed/declaration/storage.rs
+++ b/sway-core/src/language/parsed/declaration/storage.rs
@@ -12,7 +12,7 @@ pub struct StorageDeclaration {
 }
 
 impl deepsize::DeepSizeOf for StorageDeclaration {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         0
     }
 }

--- a/sway-core/src/language/parsed/declaration/struct.rs
+++ b/sway-core/src/language/parsed/declaration/struct.rs
@@ -12,7 +12,7 @@ pub struct StructDeclaration {
 }
 
 impl deepsize::DeepSizeOf for StructDeclaration {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         0
     }
 }

--- a/sway-core/src/language/parsed/declaration/struct.rs
+++ b/sway-core/src/language/parsed/declaration/struct.rs
@@ -11,6 +11,12 @@ pub struct StructDeclaration {
     pub(crate) span: Span,
 }
 
+impl deepsize::DeepSizeOf for StructDeclaration {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        0
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StructField {
     pub visibility: Visibility,

--- a/sway-core/src/language/parsed/declaration/trait.rs
+++ b/sway-core/src/language/parsed/declaration/trait.rs
@@ -22,7 +22,7 @@ pub enum TraitItem {
 }
 
 impl deepsize::DeepSizeOf for TraitItem {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         0
     }
 }
@@ -40,7 +40,7 @@ pub struct TraitDeclaration {
 }
 
 impl deepsize::DeepSizeOf for TraitDeclaration {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         0
     }
 }
@@ -99,7 +99,7 @@ pub struct TraitTypeDeclaration {
 }
 
 impl deepsize::DeepSizeOf for TraitTypeDeclaration {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         0
     }
 }

--- a/sway-core/src/language/parsed/declaration/trait.rs
+++ b/sway-core/src/language/parsed/declaration/trait.rs
@@ -21,6 +21,12 @@ pub enum TraitItem {
     Error(Box<[Span]>, ErrorEmitted),
 }
 
+impl deepsize::DeepSizeOf for TraitItem {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        0
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TraitDeclaration {
     pub name: Ident,
@@ -33,7 +39,13 @@ pub struct TraitDeclaration {
     pub span: Span,
 }
 
-#[derive(Debug, Clone)]
+impl deepsize::DeepSizeOf for TraitDeclaration {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        0
+    }
+}
+
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct Supertrait {
     pub name: CallPath,
     pub decl_ref: Option<DeclRefTrait>,
@@ -68,7 +80,7 @@ impl HashWithEngines for Supertrait {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct TraitFn {
     pub name: Ident,
     pub span: Span,
@@ -84,6 +96,12 @@ pub struct TraitTypeDeclaration {
     pub attributes: transform::AttributesMap,
     pub ty_opt: Option<TypeArgument>,
     pub span: Span,
+}
+
+impl deepsize::DeepSizeOf for TraitTypeDeclaration {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        0
+    }
 }
 
 impl DebugWithEngines for TraitTypeDeclaration {

--- a/sway-core/src/language/parsed/declaration/type_alias.rs
+++ b/sway-core/src/language/parsed/declaration/type_alias.rs
@@ -2,7 +2,7 @@ use crate::{language::Visibility, transform, type_system::*};
 
 use sway_types::{ident::Ident, span::Span};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct TypeAliasDeclaration {
     pub name: Ident,
     pub attributes: transform::AttributesMap,

--- a/sway-core/src/language/parsed/declaration/variable.rs
+++ b/sway-core/src/language/parsed/declaration/variable.rs
@@ -7,3 +7,9 @@ pub struct VariableDeclaration {
     pub body: Expression, // will be codeblock variant
     pub is_mutable: bool,
 }
+
+impl deepsize::DeepSizeOf for VariableDeclaration {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        0
+    }
+}

--- a/sway-core/src/language/parsed/declaration/variable.rs
+++ b/sway-core/src/language/parsed/declaration/variable.rs
@@ -9,7 +9,7 @@ pub struct VariableDeclaration {
 }
 
 impl deepsize::DeepSizeOf for VariableDeclaration {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         0
     }
 }

--- a/sway-core/src/language/parsed/expression/mod.rs
+++ b/sway-core/src/language/parsed/expression/mod.rs
@@ -326,7 +326,7 @@ pub enum ExpressionKind {
 }
 
 impl deepsize::DeepSizeOf for ExpressionKind {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         0
     }
 }

--- a/sway-core/src/language/parsed/expression/mod.rs
+++ b/sway-core/src/language/parsed/expression/mod.rs
@@ -23,7 +23,7 @@ pub use scrutinee::*;
 use sway_ast::intrinsics::Intrinsic;
 
 /// Represents a parsed, but not yet type checked, [Expression](https://en.wikipedia.org/wiki/Expression_(computer_science)).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct Expression {
     pub kind: ExpressionKind,
     pub span: Span,
@@ -87,7 +87,7 @@ pub struct SubfieldExpression {
     pub field_to_access: Ident,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct AmbiguousSuffix {
     /// If the suffix is a pair, the ambiguous part of the suffix.
     ///
@@ -111,7 +111,7 @@ impl Spanned for AmbiguousSuffix {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct QualifiedPathType {
     pub ty: TypeArgument,
     pub as_trait: TypeId,
@@ -188,7 +188,7 @@ impl DebugWithEngines for QualifiedPathType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct AmbiguousPathExpression {
     pub qualified_path_root: Option<QualifiedPathType>,
     pub call_path_binding: TypeBinding<CallPath<AmbiguousSuffix>>,
@@ -229,18 +229,18 @@ pub struct IntrinsicFunctionExpression {
     pub arguments: Vec<Expression>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct WhileLoopExpression {
     pub condition: Box<Expression>,
     pub body: CodeBlock,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct ForLoopExpression {
     pub desugared: Box<Expression>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct ReassignmentExpression {
     pub lhs: ReassignmentTarget,
     pub rhs: Box<Expression>,
@@ -325,14 +325,20 @@ pub enum ExpressionKind {
     Deref(Box<Expression>),
 }
 
-#[derive(Debug, Clone)]
+impl deepsize::DeepSizeOf for ExpressionKind {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        0
+    }
+}
+
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct RefExpression {
     /// True if the reference is a reference to a mutable `value`.
     pub to_mutable_value: bool,
     pub value: Box<Expression>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub enum ReassignmentTarget {
     VariableExpression(Box<Expression>),
 }

--- a/sway-core/src/language/parsed/mod.rs
+++ b/sway-core/src/language/parsed/mod.rs
@@ -31,7 +31,7 @@ pub struct ParseTree {
 
 /// A single [AstNode] represents a node in the parse tree. Note that [AstNode]
 /// is a recursive type and can contain other [AstNode], thus populating the tree.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct AstNode {
     /// The content of this ast node, which could be any control flow structure or other
     /// basic organizational component.
@@ -59,6 +59,12 @@ pub enum AstNodeContent {
     /// The list of `Span`s are for consumption by the LSP and are,
     /// when joined, the same as that stored in `statement.span`.
     Error(Box<[Span]>, ErrorEmitted),
+}
+
+impl deepsize::DeepSizeOf for AstNodeContent {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        0
+    }
 }
 
 impl ParseTree {

--- a/sway-core/src/language/parsed/mod.rs
+++ b/sway-core/src/language/parsed/mod.rs
@@ -62,7 +62,7 @@ pub enum AstNodeContent {
 }
 
 impl deepsize::DeepSizeOf for AstNodeContent {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         0
     }
 }

--- a/sway-core/src/language/parsed/use_statement.rs
+++ b/sway-core/src/language/parsed/use_statement.rs
@@ -1,7 +1,7 @@
 use crate::parsed::Span;
 use sway_types::ident::Ident;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, deepsize::DeepSizeOf)]
 pub enum ImportType {
     Star,
     SelfImport(Span),

--- a/sway-core/src/language/purity.rs
+++ b/sway-core/src/language/purity.rs
@@ -1,7 +1,7 @@
 /// The purity of a function is related to its access of contract storage. If a function accesses
 /// or could potentially access contract storage, it is [Purity::Impure]. If a function does not utilize any
 /// any accesses (reads _or_ writes) of storage, then it is [Purity::Pure].
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, Default, deepsize::DeepSizeOf)]
 pub enum Purity {
     #[default]
     Pure,

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -23,7 +23,7 @@ pub trait GetDeclIdent {
     fn get_decl_ident(&self) -> Option<Ident>;
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyAstNode {
     pub content: TyAstNodeContent,
     pub span: Span,
@@ -72,6 +72,7 @@ impl SubstTypes for TyAstNode {
 }
 
 impl ReplaceDecls for TyAstNode {
+    #[inline(never)]
     fn replace_decls_inner(
         &mut self,
         decl_mapping: &DeclMapping,
@@ -330,7 +331,7 @@ impl TyAstNode {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub enum TyAstNodeContent {
     Declaration(TyDecl),
     Expression(TyExpression),

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -61,12 +61,12 @@ impl DebugWithEngines for TyAstNode {
 }
 
 impl SubstTypes for TyAstNode {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         match self.content {
             TyAstNodeContent::Declaration(ref mut decl) => decl.subst(type_mapping, engines),
             TyAstNodeContent::Expression(ref mut expr) => expr.subst(type_mapping, engines),
-            TyAstNodeContent::SideEffect(_) => (),
-            TyAstNodeContent::Error(_, _) => (),
+            TyAstNodeContent::SideEffect(_) => false,
+            TyAstNodeContent::Error(_, _) => false,
         }
     }
 }

--- a/sway-core/src/language/ty/code_block.rs
+++ b/sway-core/src/language/ty/code_block.rs
@@ -38,10 +38,14 @@ impl HashWithEngines for TyCodeBlock {
 }
 
 impl SubstTypes for TyCodeBlock {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.contents
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = false;
+
+        for x in self.contents.iter_mut() {
+            has_change |= x.subst(type_mapping, engines);
+        }
+
+        has_change
     }
 }
 

--- a/sway-core/src/language/ty/code_block.rs
+++ b/sway-core/src/language/ty/code_block.rs
@@ -8,7 +8,7 @@ use crate::{
     type_system::*,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyCodeBlock {
     pub contents: Vec<TyAstNode>,
     pub(crate) whole_block_span: Span,
@@ -46,6 +46,7 @@ impl SubstTypes for TyCodeBlock {
 }
 
 impl ReplaceDecls for TyCodeBlock {
+    #[inline(never)]
     fn replace_decls_inner(
         &mut self,
         decl_mapping: &DeclMapping,

--- a/sway-core/src/language/ty/declaration/abi.rs
+++ b/sway-core/src/language/ty/declaration/abi.rs
@@ -7,7 +7,7 @@ use super::{TyTraitInterfaceItem, TyTraitItem};
 
 /// A [TyAbiDecl] contains the type-checked version of the parse tree's
 /// `AbiDeclaration`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyAbiDecl {
     /// The name of the abi trait (also known as a "contract trait")
     pub name: Ident,

--- a/sway-core/src/language/ty/declaration/constant.rs
+++ b/sway-core/src/language/ty/declaration/constant.rs
@@ -94,12 +94,13 @@ impl Spanned for TyConstantDecl {
 }
 
 impl SubstTypes for TyConstantDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.return_type.subst(type_mapping, engines);
-        self.type_ascription.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = self.return_type.subst(type_mapping, engines);
+        has_change |= self.type_ascription.subst(type_mapping, engines);
         if let Some(expr) = &mut self.value {
-            expr.subst(type_mapping, engines);
+            has_change |= expr.subst(type_mapping, engines);
         }
+        has_change
     }
 }
 

--- a/sway-core/src/language/ty/declaration/constant.rs
+++ b/sway-core/src/language/ty/declaration/constant.rs
@@ -15,7 +15,7 @@ use crate::{
     type_system::*,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyConstantDecl {
     pub call_path: CallPath,
     pub value: Option<TyExpression>,
@@ -104,6 +104,7 @@ impl SubstTypes for TyConstantDecl {
 }
 
 impl ReplaceDecls for TyConstantDecl {
+    #[inline(never)]
     fn replace_decls_inner(
         &mut self,
         decl_mapping: &DeclMapping,

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -296,55 +296,39 @@ impl HashWithEngines for TyDecl {
 }
 
 impl SubstTypes for TyDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         match self {
             TyDecl::VariableDecl(ref mut var_decl) => var_decl.subst(type_mapping, engines),
             TyDecl::FunctionDecl(FunctionDecl {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             TyDecl::TraitDecl(TraitDecl {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             TyDecl::StructDecl(StructDecl {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             TyDecl::EnumDecl(EnumDecl {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             TyDecl::EnumVariantDecl(EnumVariantDecl {
                 ref mut enum_ref, ..
-            }) => {
-                enum_ref.subst(type_mapping, engines);
-            }
+            }) => enum_ref.subst(type_mapping, engines),
             TyDecl::ImplTrait(ImplTrait {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             TyDecl::TypeAliasDecl(TypeAliasDecl {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             TyDecl::TraitTypeDecl(TraitTypeDecl {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             // generics in an ABI is unsupported by design
             TyDecl::AbiDecl(_)
             | TyDecl::ConstantDecl(_)
             | TyDecl::StorageDecl(_)
             | TyDecl::GenericTypeForFunctionScope(_)
-            | TyDecl::ErrorRecovery(..) => (),
+            | TyDecl::ErrorRecovery(..) => false,
         }
     }
 }

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -17,7 +17,7 @@ use crate::{
     types::*,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub enum TyDecl {
     VariableDecl(Box<TyVariableDecl>),
     ConstantDecl(ConstantDecl),
@@ -37,21 +37,21 @@ pub enum TyDecl {
     TypeAliasDecl(TypeAliasDecl),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct ConstantDecl {
     pub name: Ident,
     pub decl_id: DeclId<TyConstantDecl>,
     pub decl_span: Span,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TraitTypeDecl {
     pub name: Ident,
     pub decl_id: DeclId<TyTraitType>,
     pub decl_span: Span,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct FunctionDecl {
     pub name: Ident,
     pub decl_id: DeclId<TyFunctionDecl>,
@@ -59,7 +59,7 @@ pub struct FunctionDecl {
     pub decl_span: Span,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TraitDecl {
     pub name: Ident,
     pub decl_id: DeclId<TyTraitDecl>,
@@ -67,7 +67,7 @@ pub struct TraitDecl {
     pub decl_span: Span,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct StructDecl {
     pub name: Ident,
     pub decl_id: DeclId<TyStructDecl>,
@@ -75,7 +75,7 @@ pub struct StructDecl {
     pub decl_span: Span,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct EnumDecl {
     pub name: Ident,
     pub decl_id: DeclId<TyEnumDecl>,
@@ -83,14 +83,14 @@ pub struct EnumDecl {
     pub decl_span: Span,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct EnumVariantDecl {
     pub enum_ref: DeclRefEnum,
     pub variant_name: Ident,
     pub variant_decl_span: Span,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct ImplTrait {
     pub name: Ident,
     pub decl_id: DeclId<TyImplTrait>,
@@ -98,26 +98,26 @@ pub struct ImplTrait {
     pub decl_span: Span,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct AbiDecl {
     pub name: Ident,
     pub decl_id: DeclId<TyAbiDecl>,
     pub decl_span: Span,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct GenericTypeForFunctionScope {
     pub name: Ident,
     pub type_id: TypeId,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct StorageDecl {
     pub decl_id: DeclId<TyStorageDecl>,
     pub decl_span: Span,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TypeAliasDecl {
     pub name: Ident,
     pub decl_id: DeclId<TyTypeAliasDecl>,

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -17,7 +17,7 @@ use crate::{
     type_system::*,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyEnumDecl {
     pub call_path: CallPath,
     pub type_parameters: Vec<TypeParameter>,
@@ -120,7 +120,7 @@ impl Spanned for TyEnumVariant {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct TyEnumVariant {
     pub name: Ident,
     pub type_argument: TypeArgument,

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -63,13 +63,18 @@ impl HashWithEngines for TyEnumDecl {
 }
 
 impl SubstTypes for TyEnumDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.variants
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
-        self.type_parameters
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = false;
+
+        for x in self.variants.iter_mut() {
+            has_change |= x.subst(type_mapping, engines)
+        }
+
+        for x in self.type_parameters.iter_mut() {
+            has_change |= x.subst(type_mapping, engines)
+        }
+
+        has_change
     }
 }
 
@@ -173,7 +178,7 @@ impl OrdWithEngines for TyEnumVariant {
 }
 
 impl SubstTypes for TyEnumVariant {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_argument.subst_inner(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.type_argument.subst_inner(type_mapping, engines)
     }
 }

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -195,18 +195,25 @@ impl HashWithEngines for TyFunctionDecl {
 }
 
 impl SubstTypes for TyFunctionDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_parameters
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
-        self.parameters
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
-        self.return_type.subst(type_mapping, engines);
-        self.body.subst(type_mapping, engines);
-        if let Some(implementing_for) = self.implementing_for_typeid.as_mut() {
-            implementing_for.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = false;
+
+        for x in self.type_parameters.iter_mut() {
+            has_change |= x.subst(type_mapping, engines)
         }
+
+        for x in self.parameters.iter_mut() {
+            has_change |= x.subst(type_mapping, engines);
+        }
+
+        has_change |= self.return_type.subst(type_mapping, engines);
+        has_change |= self.body.subst(type_mapping, engines);
+
+        if let Some(implementing_for) = self.implementing_for_typeid.as_mut() {
+            has_change |= implementing_for.subst(type_mapping, engines);
+        }
+
+        has_change
     }
 }
 
@@ -523,8 +530,8 @@ impl HashWithEngines for TyFunctionParameter {
 }
 
 impl SubstTypes for TyFunctionParameter {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_argument.type_id.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.type_argument.type_id.subst(type_mapping, engines)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -28,7 +28,7 @@ use sway_types::{
     Ident, Named, Span, Spanned,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub enum TyFunctionDeclKind {
     Default,
     Entry,
@@ -36,7 +36,7 @@ pub enum TyFunctionDeclKind {
     Test,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyFunctionDecl {
     pub name: Ident,
     pub body: TyCodeBlock,
@@ -211,6 +211,7 @@ impl SubstTypes for TyFunctionDecl {
 }
 
 impl ReplaceDecls for TyFunctionDecl {
+    #[inline(never)]
     fn replace_decls_inner(
         &mut self,
         decl_mapping: &DeclMapping,
@@ -484,7 +485,7 @@ impl TyFunctionDecl {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct TyFunctionParameter {
     pub name: Ident,
     pub is_reference: bool,

--- a/sway-core/src/language/ty/declaration/impl_trait.rs
+++ b/sway-core/src/language/ty/declaration/impl_trait.rs
@@ -11,7 +11,7 @@ use super::TyTraitItem;
 pub type TyImplItem = TyTraitItem;
 
 // impl <A, B, C> Trait<Arg, Arg> for Type<Arg, Arg>
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyImplTrait {
     pub impl_type_parameters: Vec<TypeParameter>,
     pub trait_name: CallPath,

--- a/sway-core/src/language/ty/declaration/impl_trait.rs
+++ b/sway-core/src/language/ty/declaration/impl_trait.rs
@@ -78,13 +78,19 @@ impl HashWithEngines for TyImplTrait {
 }
 
 impl SubstTypes for TyImplTrait {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.impl_type_parameters
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
-        self.implementing_for.subst_inner(type_mapping, engines);
-        self.items
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = false;
+
+        for x in self.impl_type_parameters.iter_mut() {
+            has_change |= x.subst(type_mapping, engines);
+        }
+
+        has_change |= self.implementing_for.subst_inner(type_mapping, engines);
+
+        for x in self.items.iter_mut() {
+            has_change |= x.subst(type_mapping, engines)
+        }
+
+        has_change
     }
 }

--- a/sway-core/src/language/ty/declaration/storage.rs
+++ b/sway-core/src/language/ty/declaration/storage.rs
@@ -14,7 +14,7 @@ use crate::{
     Namespace,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyStorageDecl {
     pub fields: Vec<TyStorageField>,
     pub span: Span,
@@ -244,7 +244,7 @@ impl Spanned for TyStorageField {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyStorageField {
     pub name: Ident,
     pub type_argument: TypeArgument,

--- a/sway-core/src/language/ty/declaration/struct.rs
+++ b/sway-core/src/language/ty/declaration/struct.rs
@@ -15,7 +15,7 @@ use crate::{
     Namespace,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyStructDecl {
     pub call_path: CallPath,
     pub fields: Vec<TyStructField>,
@@ -177,7 +177,7 @@ impl From<StructAccessInfo> for (bool, bool) {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct TyStructField {
     pub visibility: Visibility,
     pub name: Ident,

--- a/sway-core/src/language/ty/declaration/struct.rs
+++ b/sway-core/src/language/ty/declaration/struct.rs
@@ -61,13 +61,18 @@ impl HashWithEngines for TyStructDecl {
 }
 
 impl SubstTypes for TyStructDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.fields
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
-        self.type_parameters
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = false;
+
+        for x in self.fields.iter_mut() {
+            has_change |= x.subst(type_mapping, engines)
+        }
+
+        for x in self.type_parameters.iter_mut() {
+            has_change |= x.subst(type_mapping, engines)
+        }
+
+        has_change
     }
 }
 
@@ -274,7 +279,7 @@ impl OrdWithEngines for TyStructField {
 }
 
 impl SubstTypes for TyStructField {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_argument.subst_inner(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.type_argument.subst_inner(type_mapping, engines)
     }
 }

--- a/sway-core/src/language/ty/declaration/trait.rs
+++ b/sway-core/src/language/ty/declaration/trait.rs
@@ -270,57 +270,82 @@ impl Spanned for TyTraitItem {
 }
 
 impl SubstTypes for TyTraitDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_parameters
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
-        self.interface_surface
-            .iter_mut()
-            .for_each(|item| match item {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = false;
+        for x in self.type_parameters.iter_mut() {
+            has_change |= x.subst(type_mapping, engines)
+        }
+
+        for item in self.interface_surface.iter_mut() {
+            match item {
                 TyTraitInterfaceItem::TraitFn(item_ref) => {
-                    let new_item_ref = item_ref
+                    if let Some(new_item_ref) = item_ref
                         .clone()
-                        .subst_types_and_insert_new_with_parent(type_mapping, engines);
-                    item_ref.replace_id(*new_item_ref.id());
+                        .subst_types_and_insert_new_with_parent(type_mapping, engines)
+                    {
+                        item_ref.replace_id(*new_item_ref.id());
+                        has_change = true;
+                    }
                 }
                 TyTraitInterfaceItem::Constant(decl_ref) => {
-                    let new_decl_ref = decl_ref
+                    if let Some(new_decl_ref) = decl_ref
                         .clone()
-                        .subst_types_and_insert_new(type_mapping, engines);
-                    decl_ref.replace_id(*new_decl_ref.id());
+                        .subst_types_and_insert_new(type_mapping, engines)
+                    {
+                        decl_ref.replace_id(*new_decl_ref.id());
+                        has_change = true;
+                    }
                 }
                 TyTraitInterfaceItem::Type(decl_ref) => {
-                    let new_decl_ref = decl_ref
+                    if let Some(new_decl_ref) = decl_ref
                         .clone()
-                        .subst_types_and_insert_new(type_mapping, engines);
-                    decl_ref.replace_id(*new_decl_ref.id());
+                        .subst_types_and_insert_new(type_mapping, engines)
+                    {
+                        decl_ref.replace_id(*new_decl_ref.id());
+                        has_change = true;
+                    }
                 }
-            });
-        self.items.iter_mut().for_each(|item| match item {
-            TyTraitItem::Fn(item_ref) => {
-                let new_item_ref = item_ref
-                    .clone()
-                    .subst_types_and_insert_new_with_parent(type_mapping, engines);
-                item_ref.replace_id(*new_item_ref.id());
             }
-            TyTraitItem::Constant(item_ref) => {
-                let new_decl_ref = item_ref
-                    .clone()
-                    .subst_types_and_insert_new_with_parent(type_mapping, engines);
-                item_ref.replace_id(*new_decl_ref.id());
+        }
+
+        for item in self.items.iter_mut() {
+            match item {
+                TyTraitItem::Fn(item_ref) => {
+                    if let Some(new_item_ref) = item_ref
+                        .clone()
+                        .subst_types_and_insert_new_with_parent(type_mapping, engines)
+                    {
+                        item_ref.replace_id(*new_item_ref.id());
+                        has_change = true;
+                    }
+                }
+                TyTraitItem::Constant(item_ref) => {
+                    if let Some(new_decl_ref) = item_ref
+                        .clone()
+                        .subst_types_and_insert_new_with_parent(type_mapping, engines)
+                    {
+                        item_ref.replace_id(*new_decl_ref.id());
+                        has_change = true;
+                    }
+                }
+                TyTraitItem::Type(item_ref) => {
+                    if let Some(new_decl_ref) = item_ref
+                        .clone()
+                        .subst_types_and_insert_new_with_parent(type_mapping, engines)
+                    {
+                        item_ref.replace_id(*new_decl_ref.id());
+                        has_change = true;
+                    }
+                }
             }
-            TyTraitItem::Type(item_ref) => {
-                let new_decl_ref = item_ref
-                    .clone()
-                    .subst_types_and_insert_new_with_parent(type_mapping, engines);
-                item_ref.replace_id(*new_decl_ref.id());
-            }
-        });
+        }
+
+        has_change
     }
 }
 
 impl SubstTypes for TyTraitItem {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         match self {
             TyTraitItem::Fn(fn_decl) => fn_decl.subst(type_mapping, engines),
             TyTraitItem::Constant(const_decl) => const_decl.subst(type_mapping, engines),

--- a/sway-core/src/language/ty/declaration/trait.rs
+++ b/sway-core/src/language/ty/declaration/trait.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use super::TyDecl;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyTraitDecl {
     pub name: Ident,
     pub type_parameters: Vec<TypeParameter>,
@@ -37,7 +37,7 @@ pub struct TyTraitDecl {
     pub span: Span,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub enum TyTraitInterfaceItem {
     TraitFn(DeclRefTraitFn),
     Constant(DeclRefConstant),
@@ -73,7 +73,7 @@ impl DebugWithEngines for TyTraitInterfaceItem {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub enum TyTraitItem {
     Fn(DeclRefFunction),
     Constant(DeclRefConstant),

--- a/sway-core/src/language/ty/declaration/trait_fn.rs
+++ b/sway-core/src/language/ty/declaration/trait_fn.rs
@@ -13,7 +13,7 @@ use crate::{
     type_system::*,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyTraitFn {
     pub name: Ident,
     pub(crate) span: Span,

--- a/sway-core/src/language/ty/declaration/trait_fn.rs
+++ b/sway-core/src/language/ty/declaration/trait_fn.rs
@@ -100,11 +100,13 @@ impl HashWithEngines for TyTraitFn {
 }
 
 impl SubstTypes for TyTraitFn {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.parameters
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
-        self.return_type.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = false;
+        for x in self.parameters.iter_mut() {
+            has_change |= x.subst(type_mapping, engines)
+        }
+        has_change |= self.return_type.subst(type_mapping, engines);
+        has_change
     }
 }
 

--- a/sway-core/src/language/ty/declaration/trait_type.rs
+++ b/sway-core/src/language/ty/declaration/trait_type.rs
@@ -55,11 +55,13 @@ impl HashWithEngines for TyTraitType {
 }
 
 impl SubstTypes for TyTraitType {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = false;
         if let Some(ref mut ty) = self.ty {
-            ty.subst(type_mapping, engines);
+            has_change |= ty.subst(type_mapping, engines);
         }
-        self.implementing_type.subst(type_mapping, engines);
+        has_change |= self.implementing_type.subst(type_mapping, engines);
+        has_change
     }
 }
 

--- a/sway-core/src/language/ty/declaration/trait_type.rs
+++ b/sway-core/src/language/ty/declaration/trait_type.rs
@@ -7,7 +7,7 @@ use sway_types::{Ident, Named, Span, Spanned};
 
 use crate::{engine_threading::*, transform, type_system::*};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyTraitType {
     pub name: Ident,
     pub attributes: transform::AttributesMap,

--- a/sway-core/src/language/ty/declaration/type_alias.rs
+++ b/sway-core/src/language/ty/declaration/type_alias.rs
@@ -53,8 +53,8 @@ impl HashWithEngines for TyTypeAliasDecl {
 }
 
 impl SubstTypes for TyTypeAliasDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.ty.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.ty.subst(type_mapping, engines)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/type_alias.rs
+++ b/sway-core/src/language/ty/declaration/type_alias.rs
@@ -9,7 +9,7 @@ use crate::{
     type_system::*,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyTypeAliasDecl {
     pub name: Ident,
     pub call_path: CallPath,

--- a/sway-core/src/language/ty/declaration/variable.rs
+++ b/sway-core/src/language/ty/declaration/variable.rs
@@ -13,7 +13,7 @@ use crate::{
     type_system::*,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyVariableDecl {
     pub name: Ident,
     pub body: TyExpression,

--- a/sway-core/src/language/ty/declaration/variable.rs
+++ b/sway-core/src/language/ty/declaration/variable.rs
@@ -55,10 +55,11 @@ impl HashWithEngines for TyVariableDecl {
 }
 
 impl SubstTypes for TyVariableDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.return_type.subst(type_mapping, engines);
-        self.type_ascription.subst(type_mapping, engines);
-        self.body.subst(type_mapping, engines)
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = self.return_type.subst(type_mapping, engines);
+        has_change |= self.type_ascription.subst(type_mapping, engines);
+        has_change |= self.body.subst(type_mapping, engines);
+        has_change
     }
 }
 

--- a/sway-core/src/language/ty/expression/asm.rs
+++ b/sway-core/src/language/ty/expression/asm.rs
@@ -4,7 +4,7 @@ use sway_types::Ident;
 
 use crate::{engine_threading::*, language::ty::*, type_system::*};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyAsmRegisterDeclaration {
     pub initializer: Option<TyExpression>,
     pub(crate) name: Ident,

--- a/sway-core/src/language/ty/expression/asm.rs
+++ b/sway-core/src/language/ty/expression/asm.rs
@@ -32,9 +32,11 @@ impl HashWithEngines for TyAsmRegisterDeclaration {
 }
 
 impl SubstTypes for TyAsmRegisterDeclaration {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         if let Some(ref mut initializer) = self.initializer {
             initializer.subst(type_mapping, engines)
+        } else {
+            false
         }
     }
 }

--- a/sway-core/src/language/ty/expression/contract.rs
+++ b/sway-core/src/language/ty/expression/contract.rs
@@ -1,6 +1,6 @@
 use crate::language::ty::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct ContractCallParams {
     pub(crate) func_selector: [u8; 4],
     pub(crate) contract_address: Box<TyExpression>,

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -53,9 +53,11 @@ impl HashWithEngines for TyExpression {
 }
 
 impl SubstTypes for TyExpression {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.return_type.subst(type_mapping, engines);
-        self.expression.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = false;
+        has_change |= self.return_type.subst(type_mapping, engines);
+        has_change |= self.expression.subst(type_mapping, engines);
+        has_change
     }
 }
 

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -19,7 +19,7 @@ use crate::{
     types::*,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyExpression {
     pub expression: TyExpressionVariant,
     pub return_type: TypeId,
@@ -60,6 +60,7 @@ impl SubstTypes for TyExpression {
 }
 
 impl ReplaceDecls for TyExpression {
+    #[inline(never)]
     fn replace_decls_inner(
         &mut self,
         decl_mapping: &DeclMapping,

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -171,8 +171,8 @@ pub enum TyExpressionVariant {
 impl ::deepsize::DeepSizeOf for TyExpressionVariant {
     fn deep_size_of_children(&self, context: &mut ::deepsize::Context) -> usize {
         match self {
-            TyExpressionVariant::Literal(_0) => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            TyExpressionVariant::Literal(x) => {
+                ::deepsize::DeepSizeOf::deep_size_of_children(x, context)
             }
             TyExpressionVariant::FunctionApplication {
                 call_path,
@@ -193,7 +193,7 @@ impl ::deepsize::DeepSizeOf for TyExpressionVariant {
                         + std::mem::size_of::<usize>());
                 let contract_call_params_size = child_sizes + map_size;
 
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(call_path, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(call_path, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(arguments, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(fn_ref, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(selector, context)
@@ -207,7 +207,7 @@ impl ::deepsize::DeepSizeOf for TyExpressionVariant {
                     + ::deepsize::DeepSizeOf::deep_size_of_children(contract_caller, context)
             }
             TyExpressionVariant::LazyOperator { op, lhs, rhs } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(op, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(op, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(lhs, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(rhs, context)
             }
@@ -216,7 +216,7 @@ impl ::deepsize::DeepSizeOf for TyExpressionVariant {
                 const_decl,
                 call_path,
             } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(span, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(span, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(const_decl, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(call_path, context)
             }
@@ -226,23 +226,23 @@ impl ::deepsize::DeepSizeOf for TyExpressionVariant {
                 mutability,
                 call_path,
             } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(name, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(name, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(span, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(mutability, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(call_path, context)
             }
             TyExpressionVariant::Tuple { fields } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(fields, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(fields, context)
             }
             TyExpressionVariant::Array {
                 elem_type,
                 contents,
             } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(elem_type, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(elem_type, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(contents, context)
             }
             TyExpressionVariant::ArrayIndex { prefix, index } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(prefix, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(prefix, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(index, context)
             }
             TyExpressionVariant::StructExpression {
@@ -251,20 +251,20 @@ impl ::deepsize::DeepSizeOf for TyExpressionVariant {
                 instantiation_span,
                 call_path_binding,
             } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(struct_ref, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(struct_ref, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(fields, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(instantiation_span, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(call_path_binding, context)
             }
-            TyExpressionVariant::CodeBlock(_0) => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            TyExpressionVariant::CodeBlock(x) => {
+                ::deepsize::DeepSizeOf::deep_size_of_children(x, context)
             }
             TyExpressionVariant::FunctionParameter => 0,
             TyExpressionVariant::MatchExp {
                 desugared,
                 scrutinees,
             } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(desugared, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(desugared, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(scrutinees, context)
             }
             TyExpressionVariant::IfExp {
@@ -272,7 +272,7 @@ impl ::deepsize::DeepSizeOf for TyExpressionVariant {
                 then,
                 r#else,
             } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(condition, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(condition, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(then, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(r#else, context)
             }
@@ -282,7 +282,7 @@ impl ::deepsize::DeepSizeOf for TyExpressionVariant {
                 returns,
                 whole_block_span,
             } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(registers, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(registers, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(body, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(returns, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(whole_block_span, context)
@@ -293,7 +293,7 @@ impl ::deepsize::DeepSizeOf for TyExpressionVariant {
                 field_instantiation_span,
                 resolved_type_of_parent,
             } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(prefix, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(prefix, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(field_to_access, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(
                         field_instantiation_span,
@@ -310,7 +310,7 @@ impl ::deepsize::DeepSizeOf for TyExpressionVariant {
                 resolved_type_of_parent,
                 elem_to_access_span,
             } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(prefix, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(prefix, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(elem_to_access_num, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(
                         resolved_type_of_parent,
@@ -327,7 +327,7 @@ impl ::deepsize::DeepSizeOf for TyExpressionVariant {
                 call_path_binding,
                 call_path_decl,
             } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(enum_ref, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(enum_ref, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(variant_name, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(tag, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(contents, context)
@@ -343,56 +343,55 @@ impl ::deepsize::DeepSizeOf for TyExpressionVariant {
                 address,
                 span,
             } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(abi_name, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(abi_name, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(address, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(span, context)
             }
-            TyExpressionVariant::StorageAccess(_0) => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            TyExpressionVariant::StorageAccess(x) => {
+                ::deepsize::DeepSizeOf::deep_size_of_children(x, context)
             }
-            TyExpressionVariant::IntrinsicFunction(_0) => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            TyExpressionVariant::IntrinsicFunction(x) => {
+                ::deepsize::DeepSizeOf::deep_size_of_children(x, context)
             }
-            TyExpressionVariant::AbiName(_0) => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            TyExpressionVariant::AbiName(x) => {
+                ::deepsize::DeepSizeOf::deep_size_of_children(x, context)
             }
             TyExpressionVariant::EnumTag { exp } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(exp, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(exp, context)
             }
             TyExpressionVariant::UnsafeDowncast {
                 exp,
                 variant,
                 call_path_decl,
             } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(exp, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(exp, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(variant, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(call_path_decl, context)
             }
             TyExpressionVariant::WhileLoop { condition, body } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(condition, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(condition, context)
                     + ::deepsize::DeepSizeOf::deep_size_of_children(body, context)
             }
             TyExpressionVariant::ForLoop { desugared } => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(desugared, context)
+                ::deepsize::DeepSizeOf::deep_size_of_children(desugared, context)
             }
             TyExpressionVariant::Break => 0,
             TyExpressionVariant::Continue => 0,
-            TyExpressionVariant::Reassignment(_0) => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            TyExpressionVariant::Reassignment(x) => {
+                ::deepsize::DeepSizeOf::deep_size_of_children(x, context)
             }
-            TyExpressionVariant::ImplicitReturn(_0) => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            TyExpressionVariant::ImplicitReturn(x) => {
+                ::deepsize::DeepSizeOf::deep_size_of_children(x, context)
             }
-            TyExpressionVariant::Return(_0) => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            TyExpressionVariant::Return(x) => {
+                ::deepsize::DeepSizeOf::deep_size_of_children(x, context)
             }
-            TyExpressionVariant::Ref(_0) => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            TyExpressionVariant::Ref(x) => {
+                ::deepsize::DeepSizeOf::deep_size_of_children(x, context)
             }
-            TyExpressionVariant::Deref(_0) => {
-                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            TyExpressionVariant::Deref(x) => {
+                ::deepsize::DeepSizeOf::deep_size_of_children(x, context)
             }
-            _ => 0,
         }
     }
 }

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -168,6 +168,235 @@ pub enum TyExpressionVariant {
     Deref(Box<TyExpression>),
 }
 
+impl ::deepsize::DeepSizeOf for TyExpressionVariant {
+    fn deep_size_of_children(&self, context: &mut ::deepsize::Context) -> usize {
+        match self {
+            TyExpressionVariant::Literal(_0) => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            }
+            TyExpressionVariant::FunctionApplication {
+                call_path,
+                arguments,
+                fn_ref,
+                selector,
+                type_binding,
+                call_path_typeid,
+                deferred_monomorphization,
+                contract_call_params,
+                contract_caller,
+            } => {
+                let child_sizes = contract_call_params.iter().fold(0, |sum, (key, val)| {
+                    sum + key.deep_size_of_children(context) + val.deep_size_of_children(context)
+                });
+                let map_size = contract_call_params.capacity()
+                    * (std::mem::size_of::<(usize, String, TyExpression)>()
+                        + std::mem::size_of::<usize>());
+                let contract_call_params_size = child_sizes + map_size;
+
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(call_path, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(arguments, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(fn_ref, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(selector, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(type_binding, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(call_path_typeid, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(
+                        deferred_monomorphization,
+                        context,
+                    )
+                    + contract_call_params_size
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(contract_caller, context)
+            }
+            TyExpressionVariant::LazyOperator { op, lhs, rhs } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(op, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(lhs, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(rhs, context)
+            }
+            TyExpressionVariant::ConstantExpression {
+                span,
+                const_decl,
+                call_path,
+            } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(span, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(const_decl, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(call_path, context)
+            }
+            TyExpressionVariant::VariableExpression {
+                name,
+                span,
+                mutability,
+                call_path,
+            } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(name, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(span, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(mutability, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(call_path, context)
+            }
+            TyExpressionVariant::Tuple { fields } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(fields, context)
+            }
+            TyExpressionVariant::Array {
+                elem_type,
+                contents,
+            } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(elem_type, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(contents, context)
+            }
+            TyExpressionVariant::ArrayIndex { prefix, index } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(prefix, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(index, context)
+            }
+            TyExpressionVariant::StructExpression {
+                struct_ref,
+                fields,
+                instantiation_span,
+                call_path_binding,
+            } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(struct_ref, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(fields, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(instantiation_span, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(call_path_binding, context)
+            }
+            TyExpressionVariant::CodeBlock(_0) => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            }
+            TyExpressionVariant::FunctionParameter => 0,
+            TyExpressionVariant::MatchExp {
+                desugared,
+                scrutinees,
+            } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(desugared, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(scrutinees, context)
+            }
+            TyExpressionVariant::IfExp {
+                condition,
+                then,
+                r#else,
+            } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(condition, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(then, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(r#else, context)
+            }
+            TyExpressionVariant::AsmExpression {
+                registers,
+                body,
+                returns,
+                whole_block_span,
+            } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(registers, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(body, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(returns, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(whole_block_span, context)
+            }
+            TyExpressionVariant::StructFieldAccess {
+                prefix,
+                field_to_access,
+                field_instantiation_span,
+                resolved_type_of_parent,
+            } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(prefix, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(field_to_access, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(
+                        field_instantiation_span,
+                        context,
+                    )
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(
+                        resolved_type_of_parent,
+                        context,
+                    )
+            }
+            TyExpressionVariant::TupleElemAccess {
+                prefix,
+                elem_to_access_num,
+                resolved_type_of_parent,
+                elem_to_access_span,
+            } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(prefix, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(elem_to_access_num, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(
+                        resolved_type_of_parent,
+                        context,
+                    )
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(elem_to_access_span, context)
+            }
+            TyExpressionVariant::EnumInstantiation {
+                enum_ref,
+                variant_name,
+                tag,
+                contents,
+                variant_instantiation_span,
+                call_path_binding,
+                call_path_decl,
+            } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(enum_ref, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(variant_name, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(tag, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(contents, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(
+                        variant_instantiation_span,
+                        context,
+                    )
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(call_path_binding, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(call_path_decl, context)
+            }
+            TyExpressionVariant::AbiCast {
+                abi_name,
+                address,
+                span,
+            } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(abi_name, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(address, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(span, context)
+            }
+            TyExpressionVariant::StorageAccess(_0) => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            }
+            TyExpressionVariant::IntrinsicFunction(_0) => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            }
+            TyExpressionVariant::AbiName(_0) => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            }
+            TyExpressionVariant::EnumTag { exp } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(exp, context)
+            }
+            TyExpressionVariant::UnsafeDowncast {
+                exp,
+                variant,
+                call_path_decl,
+            } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(exp, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(variant, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(call_path_decl, context)
+            }
+            TyExpressionVariant::WhileLoop { condition, body } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(condition, context)
+                    + ::deepsize::DeepSizeOf::deep_size_of_children(body, context)
+            }
+            TyExpressionVariant::ForLoop { desugared } => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(desugared, context)
+            }
+            TyExpressionVariant::Break => 0,
+            TyExpressionVariant::Continue => 0,
+            TyExpressionVariant::Reassignment(_0) => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            }
+            TyExpressionVariant::ImplicitReturn(_0) => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            }
+            TyExpressionVariant::Return(_0) => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            }
+            TyExpressionVariant::Ref(_0) => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            }
+            TyExpressionVariant::Deref(_0) => {
+                0 + ::deepsize::DeepSizeOf::deep_size_of_children(_0, context)
+            }
+            _ => 0,
+        }
+    }
+}
+
 impl EqWithEngines for TyExpressionVariant {}
 impl PartialEqWithEngines for TyExpressionVariant {
     fn eq(&self, other: &Self, engines: &Engines) -> bool {
@@ -788,6 +1017,7 @@ impl SubstTypes for TyExpressionVariant {
 }
 
 impl ReplaceDecls for TyExpressionVariant {
+    #[inline(never)]
     fn replace_decls_inner(
         &mut self,
         decl_mapping: &DeclMapping,

--- a/sway-core/src/language/ty/expression/intrinsic_function.rs
+++ b/sway-core/src/language/ty/expression/intrinsic_function.rs
@@ -70,13 +70,18 @@ impl HashWithEngines for TyIntrinsicFunctionKind {
 }
 
 impl SubstTypes for TyIntrinsicFunctionKind {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = false;
+
         for arg in &mut self.arguments {
-            arg.subst(type_mapping, engines);
+            has_change |= arg.subst(type_mapping, engines);
         }
+
         for targ in &mut self.type_arguments {
-            targ.type_id.subst(type_mapping, engines);
+            has_change |= targ.type_id.subst(type_mapping, engines);
         }
+
+        has_change
     }
 }
 

--- a/sway-core/src/language/ty/expression/intrinsic_function.rs
+++ b/sway-core/src/language/ty/expression/intrinsic_function.rs
@@ -9,7 +9,7 @@ use sway_ast::Intrinsic;
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::Span;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct TyIntrinsicFunctionKind {
     pub kind: Intrinsic,
     pub arguments: Vec<TyExpression>,

--- a/sway-core/src/language/ty/expression/reassignment.rs
+++ b/sway-core/src/language/ty/expression/reassignment.rs
@@ -57,9 +57,11 @@ impl HashWithEngines for TyReassignment {
 }
 
 impl SubstTypes for TyReassignment {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.rhs.subst(type_mapping, engines);
-        self.lhs_type.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = false;
+        has_change |= self.rhs.subst(type_mapping, engines);
+        has_change |= self.lhs_type.subst(type_mapping, engines);
+        has_change
     }
 }
 

--- a/sway-core/src/language/ty/expression/reassignment.rs
+++ b/sway-core/src/language/ty/expression/reassignment.rs
@@ -17,7 +17,7 @@ use crate::{
     type_system::*,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyReassignment {
     // either a direct variable, so length of 1, or
     // at series of struct fields/array indices (array syntax)
@@ -64,6 +64,7 @@ impl SubstTypes for TyReassignment {
 }
 
 impl ReplaceDecls for TyReassignment {
+    #[inline(never)]
     fn replace_decls_inner(
         &mut self,
         decl_mapping: &DeclMapping,
@@ -101,7 +102,7 @@ impl UpdateConstantExpression for TyReassignment {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub enum ProjectionKind {
     StructField {
         name: Ident,

--- a/sway-core/src/language/ty/expression/scrutinee.rs
+++ b/sway-core/src/language/ty/expression/scrutinee.rs
@@ -6,14 +6,14 @@ use crate::{
     type_system::*,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct TyScrutinee {
     pub variant: TyScrutineeVariant,
     pub type_id: TypeId,
     pub span: Span,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub enum TyScrutineeVariant {
     Or(Vec<TyScrutinee>),
     CatchAll,
@@ -36,7 +36,7 @@ pub enum TyScrutineeVariant {
     Tuple(Vec<TyScrutinee>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct TyStructScrutineeField {
     pub field: Ident,
     pub scrutinee: Option<TyScrutinee>,

--- a/sway-core/src/language/ty/expression/storage.rs
+++ b/sway-core/src/language/ty/expression/storage.rs
@@ -5,7 +5,7 @@ use sway_types::{state::StateIndex, Ident, Span, Spanned};
 use crate::{engine_threading::*, type_system::TypeId};
 
 /// Describes the full storage access including all the subfields
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyStorageAccess {
     pub fields: Vec<TyStorageAccessDescriptor>,
     pub(crate) namespace: Option<Ident>,
@@ -55,7 +55,7 @@ impl TyStorageAccess {
 }
 
 /// Describes a single subfield access in the sequence when accessing a subfield within storage.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyStorageAccessDescriptor {
     pub name: Ident,
     pub type_id: TypeId,

--- a/sway-core/src/language/ty/expression/struct_exp_field.rs
+++ b/sway-core/src/language/ty/expression/struct_exp_field.rs
@@ -33,8 +33,8 @@ impl HashWithEngines for TyStructExpressionField {
 }
 
 impl SubstTypes for TyStructExpressionField {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.value.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.value.subst(type_mapping, engines)
     }
 }
 

--- a/sway-core/src/language/ty/expression/struct_exp_field.rs
+++ b/sway-core/src/language/ty/expression/struct_exp_field.rs
@@ -11,7 +11,7 @@ use crate::{
     type_system::*,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, deepsize::DeepSizeOf)]
 pub struct TyStructExpressionField {
     pub name: Ident,
     pub value: TyExpression,
@@ -39,6 +39,7 @@ impl SubstTypes for TyStructExpressionField {
 }
 
 impl ReplaceDecls for TyStructExpressionField {
+    #[inline(never)]
     fn replace_decls_inner(
         &mut self,
         decl_mapping: &DeclMapping,

--- a/sway-core/src/language/ty/side_effect/include_statement.rs
+++ b/sway-core/src/language/ty/side_effect/include_statement.rs
@@ -2,7 +2,7 @@ use crate::language::Visibility;
 
 use sway_types::{ident::Ident, Span, Spanned};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, deepsize::DeepSizeOf)]
 pub struct TyIncludeStatement {
     pub span: Span,
     pub visibility: Visibility,

--- a/sway-core/src/language/ty/side_effect/side_effect.rs
+++ b/sway-core/src/language/ty/side_effect/side_effect.rs
@@ -1,11 +1,11 @@
 use super::{TyIncludeStatement, TyUseStatement};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, deepsize::DeepSizeOf)]
 pub struct TySideEffect {
     pub side_effect: TySideEffectVariant,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, deepsize::DeepSizeOf)]
 pub enum TySideEffectVariant {
     IncludeStatement(TyIncludeStatement),
     UseStatement(TyUseStatement),

--- a/sway-core/src/language/ty/side_effect/use_statement.rs
+++ b/sway-core/src/language/ty/side_effect/use_statement.rs
@@ -1,7 +1,7 @@
 use crate::language::parsed;
 use sway_types::{ident::Ident, Span, Spanned};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, deepsize::DeepSizeOf)]
 pub struct TyUseStatement {
     pub call_path: Vec<Ident>,
     pub span: Span,

--- a/sway-core/src/language/ty/variable_mutability.rs
+++ b/sway-core/src/language/ty/variable_mutability.rs
@@ -1,6 +1,6 @@
 use crate::language::Visibility;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, deepsize::DeepSizeOf)]
 pub enum VariableMutability {
     // mutable
     Mutable,

--- a/sway-core/src/language/visibility.rs
+++ b/sway-core/src/language/visibility.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, deepsize::DeepSizeOf)]
 pub enum Visibility {
     Private,
     Public,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -359,31 +359,38 @@ impl TyTraitDecl {
             match item {
                 ty::TyTraitItem::Fn(decl_ref) => {
                     let mut method = (*decl_engine.get_function(&decl_ref)).clone();
-                    method.subst(&type_mapping, engines);
-                    impld_item_refs.insert(
-                        (method.name.clone(), type_id),
-                        TyTraitItem::Fn(
-                            decl_engine
-                                .insert(method)
-                                .with_parent(decl_engine, (*decl_ref.id()).into()),
-                        ),
-                    );
+                    let has_changes = method.subst(&type_mapping, engines);
+                    let name = method.name.clone();
+                    let item = if has_changes {
+                        decl_engine
+                            .insert(method)
+                            .with_parent(decl_engine, (*decl_ref.id()).into())
+                    } else {
+                        decl_ref.clone()
+                    };
+                    impld_item_refs.insert((name, type_id), TyTraitItem::Fn(item));
                 }
                 ty::TyTraitItem::Constant(decl_ref) => {
                     let mut const_decl = (*decl_engine.get_constant(&decl_ref)).clone();
-                    const_decl.subst(&type_mapping, engines);
-                    impld_item_refs.insert(
-                        (const_decl.call_path.suffix.clone(), type_id),
-                        TyTraitItem::Constant(decl_engine.insert(const_decl)),
-                    );
+                    let has_change = const_decl.subst(&type_mapping, engines);
+                    let name = const_decl.call_path.suffix.clone();
+                    let item = if has_change {
+                        decl_engine.insert(const_decl)
+                    } else {
+                        decl_ref.clone()
+                    };
+                    impld_item_refs.insert((name, type_id), TyTraitItem::Constant(item));
                 }
                 ty::TyTraitItem::Type(decl_ref) => {
                     let mut type_decl = (*decl_engine.get_type(&decl_ref)).clone();
-                    type_decl.subst(&type_mapping, engines);
-                    impld_item_refs.insert(
-                        (type_decl.name.clone(), type_id),
-                        TyTraitItem::Type(decl_engine.insert(type_decl)),
-                    );
+                    let has_change = type_decl.subst(&type_mapping, engines);
+                    let name = type_decl.name.clone();
+                    let item = if has_change {
+                        decl_engine.insert(type_decl)
+                    } else {
+                        decl_ref.clone()
+                    };
+                    impld_item_refs.insert((name, type_id), TyTraitItem::Type(item));
                 }
             }
         }

--- a/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
@@ -1190,7 +1190,6 @@ fn type_check_jmp_mem(
     span: Span,
 ) -> Result<(ty::TyIntrinsicFunctionKind, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
-    let engines = ctx.engines();
 
     if !arguments.is_empty() {
         return Err(handler.emit_err(CompileError::IntrinsicIncorrectNumArgs {

--- a/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
@@ -297,10 +297,7 @@ fn type_check_is_reference_type(
         }],
         span,
     };
-    Ok((
-        intrinsic_function,
-        type_engine.insert(engines, TypeInfo::Boolean, None),
-    ))
+    Ok((intrinsic_function, type_engine.get_bool_type()))
 }
 
 /// Signature: `__assert_is_str_array<T>()`
@@ -469,7 +466,7 @@ fn type_check_cmp(
             type_arguments: vec![],
             span,
         },
-        type_engine.insert(engines, TypeInfo::Boolean, None),
+        type_engine.get_bool_type(),
     ))
 }
 
@@ -655,7 +652,7 @@ fn type_check_state_clear(
         type_arguments: vec![],
         span,
     };
-    let return_type = type_engine.insert(engines, TypeInfo::Boolean, None);
+    let return_type = type_engine.get_bool_type();
     Ok((intrinsic_function, return_type))
 }
 
@@ -789,7 +786,7 @@ fn type_check_state_store_word(
         type_arguments: type_argument.map_or(vec![], |ta| vec![ta]),
         span,
     };
-    let return_type = type_engine.insert(engines, TypeInfo::Boolean, None);
+    let return_type = type_engine.get_bool_type();
     Ok((intrinsic_function, return_type))
 }
 
@@ -883,7 +880,7 @@ fn type_check_state_quad(
         type_arguments: type_argument.map_or(vec![], |ta| vec![ta]),
         span,
     };
-    let return_type = type_engine.insert(engines, TypeInfo::Boolean, None);
+    let return_type = type_engine.get_bool_type();
     Ok((intrinsic_function, return_type))
 }
 
@@ -1178,7 +1175,7 @@ fn type_check_revert(
             type_arguments: vec![],
             span,
         },
-        type_engine.insert(engines, TypeInfo::Never, None),
+        type_engine.get_never_type(),
     ))
 }
 
@@ -1218,7 +1215,7 @@ fn type_check_jmp_mem(
             type_arguments: vec![],
             span,
         },
-        type_engine.insert(engines, TypeInfo::Never, None),
+        type_engine.get_never_type(),
     ))
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/instantiate.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/instantiate.rs
@@ -28,8 +28,8 @@ impl Instantiate {
             TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
             None,
         );
-        let boolean_type = type_engine.insert(engines, TypeInfo::Boolean, None);
-        let revert_type = type_engine.insert(engines, TypeInfo::Never, None);
+        let boolean_type = type_engine.get_bool_type();
+        let revert_type = type_engine.get_never_type();
 
         Self {
             span,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -366,7 +366,7 @@ impl ty::TyExpression {
             ExpressionKind::Break => {
                 let expr = ty::TyExpression {
                     expression: ty::TyExpressionVariant::Break,
-                    return_type: type_engine.insert(engines, TypeInfo::Never, None),
+                    return_type: type_engine.get_never_type(),
                     span,
                 };
                 Ok(expr)
@@ -374,7 +374,7 @@ impl ty::TyExpression {
             ExpressionKind::Continue => {
                 let expr = ty::TyExpression {
                     expression: ty::TyExpressionVariant::Continue,
-                    return_type: type_engine.insert(engines, TypeInfo::Never, None),
+                    return_type: type_engine.get_never_type(),
                     span,
                 };
                 Ok(expr)
@@ -410,7 +410,7 @@ impl ty::TyExpression {
                     .unwrap_or_else(|err| ty::TyExpression::error(err, expr_span, engines));
                 let typed_expr = ty::TyExpression {
                     expression: ty::TyExpressionVariant::Return(Box::new(expr)),
-                    return_type: type_engine.insert(engines, TypeInfo::Never, None),
+                    return_type: type_engine.get_never_type(),
                     span,
                 };
                 Ok(typed_expr)
@@ -648,7 +648,7 @@ impl ty::TyExpression {
             let ctx = ctx
                 .by_ref()
                 .with_help_text("The condition of an if expression must be a boolean expression.")
-                .with_type_annotation(type_engine.insert(engines, TypeInfo::Boolean, None));
+                .with_type_annotation(type_engine.get_bool_type());
             ty::TyExpression::type_check(handler, ctx, condition.clone())
                 .unwrap_or_else(|err| ty::TyExpression::error(err, condition.span(), engines))
         };
@@ -1762,7 +1762,7 @@ impl ty::TyExpression {
         let engines = ctx.engines();
 
         if contents.is_empty() {
-            let never_type = type_engine.insert(engines, TypeInfo::Never, None);
+            let never_type = type_engine.get_never_type();
             return Ok(ty::TyExpression {
                 expression: ty::TyExpressionVariant::Array {
                     elem_type: never_type,
@@ -1946,7 +1946,7 @@ impl ty::TyExpression {
         let typed_condition = {
             let ctx = ctx
                 .by_ref()
-                .with_type_annotation(type_engine.insert(engines, TypeInfo::Boolean, None))
+                .with_type_annotation(type_engine.get_bool_type())
                 .with_help_text("A while loop's loop condition must be a boolean expression.");
             ty::TyExpression::type_check(handler, ctx, condition)?
         };

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -943,8 +943,7 @@ impl TraitMap {
                     .zip(e.key.name.suffix.args.iter())
                     .all(|(t1, t2)| unify_check.check(t1.type_id, t2.type_id))
             {
-                let mut trait_items = e.value.trait_items.values().cloned().collect::<Vec<_>>();
-                items.append(&mut trait_items);
+                items.extend(e.value.trait_items.values().cloned());
             }
         }
         items

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -10,7 +10,6 @@ use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
 };
-use sway_ir::DebugWithContext;
 use sway_types::{BaseIdent, Ident, Span, Spanned};
 
 use crate::{

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -69,7 +69,7 @@ use crate::{
 /// - `data4` has a type ascription and has type arguments in the `TypeBinding`,
 ///     so, with the type from the value passed to `value`, all three are unified
 ///     together
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct TypeBinding<T> {
     pub inner: T,
     pub type_arguments: TypeArgs,
@@ -94,7 +94,7 @@ pub struct TypeBinding<T> {
 /// ```
 /// So we can have type parameters in the `Prefix` or `Regular` variant but not
 /// in both.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub enum TypeArgs {
     /// `Regular` variant indicates the type arguments are located after the suffix.
     Regular(Vec<TypeArgument>),

--- a/sway-core/src/type_system/ast_elements/length.rs
+++ b/sway-core/src/type_system/ast_elements/length.rs
@@ -1,7 +1,7 @@
 use sway_types::{span::Span, Spanned};
 
 /// Describes a fixed length for types that needs it such as arrays and strings
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, deepsize::DeepSizeOf)]
 pub struct Length {
     val: usize,
     span: Span,

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -22,7 +22,7 @@ use crate::{
     types::*,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct TraitConstraint {
     pub trait_name: CallPath,
     pub type_arguments: Vec<TypeArgument>,

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -84,10 +84,12 @@ impl Spanned for TraitConstraint {
 }
 
 impl SubstTypes for TraitConstraint {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_arguments
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_changes = false;
+        for x in self.type_arguments.iter_mut() {
+            has_changes |= x.subst(type_mapping, engines);
+        }
+        has_changes
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -2,7 +2,7 @@ use crate::{engine_threading::*, language::CallPathTree, type_system::priv_prelu
 use std::{cmp::Ordering, fmt, hash::Hasher};
 use sway_types::{Span, Spanned};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, deepsize::DeepSizeOf)]
 pub struct TypeArgument {
     pub type_id: TypeId,
     pub initial_type_id: TypeId,

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -106,7 +106,7 @@ impl From<&TypeParameter> for TypeArgument {
 }
 
 impl SubstTypes for TypeArgument {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_id.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.type_id.subst(type_mapping, engines)
     }
 }

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -23,7 +23,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-#[derive(Clone)]
+#[derive(Clone, deepsize::DeepSizeOf)]
 pub struct TypeParameter {
     pub type_id: TypeId,
     pub(crate) initial_type_id: TypeId,

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -93,11 +93,12 @@ impl OrdWithEngines for TypeParameter {
 }
 
 impl SubstTypes for TypeParameter {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_id.subst(type_mapping, engines);
-        self.trait_constraints
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_changes = self.type_id.subst(type_mapping, engines);
+        for x in self.trait_constraints.iter_mut() {
+            has_changes |= x.subst(type_mapping, engines);
+        }
+        has_changes
     }
 }
 

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -18,7 +18,7 @@ use super::unify::unifier::UnifyKind;
 
 #[derive(Debug, Default)]
 pub struct TypeEngine {
-    slab: ConcurrentSlab<TypeSourceInfo>,
+    pub slab: ConcurrentSlab<TypeSourceInfo>,
     id_map: RwLock<HashMap<TypeSourceInfo, TypeId>>,
     never_id: RwLock<Option<TypeId>>,
     bool_id: RwLock<Option<TypeId>>,

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -18,7 +18,7 @@ use super::unify::unifier::UnifyKind;
 
 #[derive(Debug, Default)]
 pub struct TypeEngine {
-    pub slab: ConcurrentSlab<TypeSourceInfo>,
+    slab: ConcurrentSlab<TypeSourceInfo>,
     id_map: RwLock<HashMap<TypeSourceInfo, TypeId>>,
     never_id: RwLock<Option<TypeId>>,
     bool_id: RwLock<Option<TypeId>>,
@@ -36,7 +36,7 @@ impl ::deepsize::DeepSizeOf for TypeEngine {
                 + std::mem::size_of::<usize>());
         let id_map_size = child_sizes + map_size;
 
-        0 + ::deepsize::DeepSizeOf::deep_size_of_children(&self.slab, context)
+        ::deepsize::DeepSizeOf::deep_size_of_children(&self.slab, context)
             + id_map_size
             + ::deepsize::DeepSizeOf::deep_size_of_children(&self.never_id, context)
             + ::deepsize::DeepSizeOf::deep_size_of_children(&self.bool_id, context)
@@ -90,9 +90,7 @@ impl TypeEngine {
         ty: TypeInfo,
         source_id: Option<&SourceId>,
     ) -> TypeId {
-        let source_id = source_id
-            .map(Clone::clone)
-            .or_else(|| info_to_source_id(&ty));
+        let source_id = source_id.copied().or_else(|| info_to_source_id(&ty));
         let tsi = TypeSourceInfo {
             type_info: ty.clone().into(),
             source_id,

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -75,13 +75,18 @@ impl CollectTypesMetadata for TypeId {
 }
 
 impl SubstTypes for TypeId {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_change = false;
+
         let type_engine = engines.te();
         if let Some(matching_id) = type_mapping.find_match(*self, engines) {
             if !matches!(&*type_engine.get(matching_id), TypeInfo::ErrorRecovery(_)) {
                 *self = matching_id;
+                has_change = true;
             }
         }
+
+        has_change
     }
 }
 

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -19,7 +19,7 @@ use std::{
 const EXTRACT_ANY_MAX_DEPTH: usize = 128;
 
 /// A identifier to uniquely refer to our type terms
-#[derive(PartialEq, Eq, Hash, Clone, Copy, Ord, PartialOrd, Debug)]
+#[derive(PartialEq, Eq, Hash, Clone, Copy, Ord, PartialOrd, Debug, deepsize::DeepSizeOf)]
 pub struct TypeId(usize);
 
 impl DisplayWithEngines for TypeId {

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -18,7 +18,7 @@ use std::{
     sync::Arc,
 };
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, deepsize::DeepSizeOf)]
 pub enum AbiName {
     Deferred,
     Known(CallPath),
@@ -36,7 +36,7 @@ impl fmt::Display for AbiName {
 }
 
 /// A slow set primitive using `==` to check for containment.
-#[derive(Clone)]
+#[derive(Clone, deepsize::DeepSizeOf)]
 pub struct VecSet<T>(pub Vec<T>);
 
 impl<T: fmt::Debug> fmt::Debug for VecSet<T> {
@@ -69,7 +69,7 @@ impl<T: PartialEqWithEngines> PartialEqWithEngines for VecSet<T> {
 }
 
 /// Encapsulates type information and its optional source identifier.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, deepsize::DeepSizeOf)]
 pub struct TypeSourceInfo {
     pub(crate) type_info: Arc<TypeInfo>,
     /// The source id that created this type.
@@ -91,7 +91,7 @@ impl PartialEqWithEngines for TypeSourceInfo {
 }
 
 /// Type information without an associated value, used for type inferencing and definition.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, deepsize::DeepSizeOf)]
 pub enum TypeInfo {
     #[default]
     Unknown,

--- a/sway-core/src/type_system/substitute/subst_list.rs
+++ b/sway-core/src/type_system/substitute/subst_list.rs
@@ -80,9 +80,11 @@ impl OrdWithEngines for SubstList {
 }
 
 impl SubstTypes for SubstList {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.list
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        let mut has_changes = false;
+        for x in self.list.iter_mut() {
+            has_changes |= x.subst(type_mapping, engines);
+        }
+        has_changes
     }
 }

--- a/sway-core/src/type_system/substitute/subst_list.rs
+++ b/sway-core/src/type_system/substitute/subst_list.rs
@@ -9,7 +9,7 @@ use crate::{engine_threading::*, type_system::priv_prelude::*};
 /// A list of types that serve as the list of type params for type substitution.
 /// Any types of the [TypeParam][TypeInfo::TypeParam] variant will point to an
 /// index in this list.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, deepsize::DeepSizeOf)]
 pub struct SubstList {
     list: Vec<TypeParameter>,
 }

--- a/sway-core/src/type_system/substitute/subst_types.rs
+++ b/sway-core/src/type_system/substitute/subst_types.rs
@@ -1,11 +1,13 @@
 use crate::{engine_threading::*, type_system::priv_prelude::*};
 
 pub trait SubstTypes {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool;
 
-    fn subst(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         if !type_mapping.is_empty() {
-            self.subst_inner(type_mapping, engines);
+            self.subst_inner(type_mapping, engines)
+        } else {
+            false
         }
     }
 }

--- a/sway-core/src/type_system/unify/unify_check.rs
+++ b/sway-core/src/type_system/unify/unify_check.rs
@@ -209,11 +209,10 @@ impl<'a> UnifyCheck<'a> {
             return true;
         }
 
-        let left_info = self.engines.te().get(left);
-        let right_info = self.engines.te().get(right);
-
         // override top level generics with simple equality but only at top level
         if let NonGenericConstraintSubset = self.mode {
+            let left_info = self.engines.te().get(left);
+            let right_info = self.engines.te().get(right);
             if let UnknownGeneric { .. } = &*right_info {
                 return left_info.eq(&right_info, self.engines);
             }

--- a/sway-error/Cargo.toml
+++ b/sway-error/Cargo.toml
@@ -15,6 +15,7 @@ smallvec = "1.7"
 sway-types = { version = "0.52.0", path = "../sway-types" }
 thiserror = "1.0"
 uwuify = { version = "^0.2", optional = true }
+deepsize = { version = "0.2.0", features = ["std", "indexmap", "hashbrown"] }
 
 [features]
 default = []

--- a/sway-error/Cargo.toml
+++ b/sway-error/Cargo.toml
@@ -9,13 +9,13 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+deepsize = { version = "0.2.0", features = ["std", "indexmap", "hashbrown"] }
 either = "1.9.0"
 num-traits = "0.2.14"
 smallvec = "1.7"
 sway-types = { version = "0.52.0", path = "../sway-types" }
 thiserror = "1.0"
 uwuify = { version = "^0.2", optional = true }
-deepsize = { version = "0.2.0", features = ["std", "indexmap", "hashbrown"] }
 
 [features]
 default = []

--- a/sway-error/src/handler.rs
+++ b/sway-error/src/handler.rs
@@ -93,7 +93,7 @@ impl Handler {
 }
 
 /// Proof that an error was emitted through a `Handler`.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, deepsize::DeepSizeOf)]
 pub struct ErrorEmitted {
     _priv: (),
 }

--- a/sway-ir/src/parser.rs
+++ b/sway-ir/src/parser.rs
@@ -762,6 +762,7 @@ mod ir_builder {
         meta_idx: Option<MdIdxRef>,
     }
 
+    #[allow(dead_code)]
     #[derive(Debug)]
     enum IrAstConstValue {
         Undef(IrAstTy),

--- a/sway-parse/src/attribute.rs
+++ b/sway-parse/src/attribute.rs
@@ -14,7 +14,7 @@ use sway_types::{Ident, Spanned};
 
 impl Peek for DocComment {
     fn peek(peeker: Peeker<'_>) -> Option<DocComment> {
-        peeker.peek_doc_comment().ok().map(Clone::clone)
+        peeker.peek_doc_comment().ok().cloned()
     }
 }
 

--- a/sway-parse/src/parse.rs
+++ b/sway-parse/src/parse.rs
@@ -125,7 +125,7 @@ where
 
 impl Peek for Ident {
     fn peek(peeker: Peeker<'_>) -> Option<Ident> {
-        peeker.peek_ident().ok().map(Ident::clone)
+        peeker.peek_ident().ok().cloned()
     }
 }
 

--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -21,6 +21,7 @@ rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 sway-utils = { version = "0.52.0", path = "../sway-utils" }
 thiserror = "1"
+deepsize = { version = "0.2.0", features = ["std", "indexmap", "hashbrown"] }
 
 [features]
 no-span-debug = []

--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 
 [dependencies]
 bytecount = "0.6"
+deepsize = { version = "0.2.0", features = ["std", "indexmap", "hashbrown"] }
 fuel-asm = { workspace = true }
 fuel-crypto = { workspace = true }
 fuel-tx = { workspace = true }
@@ -21,7 +22,6 @@ rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 sway-utils = { version = "0.52.0", path = "../sway-utils" }
 thiserror = "1"
-deepsize = { version = "0.2.0", features = ["std", "indexmap", "hashbrown"] }
 
 [features]
 no-span-debug = []

--- a/sway-types/src/ident.rs
+++ b/sway-types/src/ident.rs
@@ -12,7 +12,7 @@ pub trait Named {
     fn name(&self) -> &BaseIdent;
 }
 
-#[derive(Clone)]
+#[derive(Clone, deepsize::DeepSizeOf)]
 pub struct BaseIdent {
     name_override_opt: Option<String>,
     span: Span,

--- a/sway-types/src/integer_bits.rs
+++ b/sway-types/src/integer_bits.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Eq, PartialEq, Hash, Debug, Clone, Copy, PartialOrd, Ord)]
+#[derive(Eq, PartialEq, Hash, Debug, Clone, Copy, PartialOrd, Ord, deepsize::DeepSizeOf)]
 pub enum IntegerBits {
     Eight,
     Sixteen,

--- a/sway-types/src/lib.rs
+++ b/sway-types/src/lib.rs
@@ -100,7 +100,19 @@ impl ModuleId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialOrd,
+    Ord,
+    deepsize::DeepSizeOf,
+)]
 pub struct SourceId {
     id: u32,
 }

--- a/sway-types/src/span.rs
+++ b/sway-types/src/span.rs
@@ -43,7 +43,7 @@ impl<'a> Position<'a> {
 }
 
 /// Represents a span of the source code in a specific file.
-#[derive(Clone, Ord, PartialOrd)]
+#[derive(Clone, Ord, PartialOrd, deepsize::DeepSizeOf)]
 pub struct Span {
     // The original source code.
     src: Arc<str>,

--- a/sway-types/src/state.rs
+++ b/sway-types/src/state.rs
@@ -17,7 +17,7 @@
 ///
 /// `bar`'s [StorageSlot] is `sha256(format!("{}{}", STORAGE_DOMAIN_SEPARATOR, 1))` or
 /// `DE9090CB50E71C2588C773487D1DA7066D0C719849A7E58DC8B6397A25C567C0`.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, deepsize::DeepSizeOf)]
 pub struct StateIndex(usize);
 
 impl StateIndex {

--- a/sway-types/src/u256.rs
+++ b/sway-types/src/u256.rs
@@ -8,8 +8,8 @@ use thiserror::Error;
 pub struct U256(BigUint);
 
 impl ::deepsize::DeepSizeOf for U256 {
-    fn deep_size_of_children(&self, context: &mut ::deepsize::Context) -> usize {
-        self.0.to_u64_digits().iter().count() * std::mem::size_of::<u64>()
+    fn deep_size_of_children(&self, _context: &mut ::deepsize::Context) -> usize {
+        self.0.to_u64_digits().len() * std::mem::size_of::<u64>()
     }
 }
 

--- a/sway-types/src/u256.rs
+++ b/sway-types/src/u256.rs
@@ -7,6 +7,12 @@ use thiserror::Error;
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub struct U256(BigUint);
 
+impl ::deepsize::DeepSizeOf for U256 {
+    fn deep_size_of_children(&self, context: &mut ::deepsize::Context) -> usize {
+        self.0.to_u64_digits().iter().count() * std::mem::size_of::<u64>()
+    }
+}
+
 impl U256 {
     pub fn from_be_bytes(bytes: &[u8; 32]) -> Self {
         let v = BigUint::from_bytes_be(bytes.as_slice());

--- a/swayfmt/src/utils/map/byte_span.rs
+++ b/swayfmt/src/utils/map/byte_span.rs
@@ -233,7 +233,7 @@ mod tests {
         let second_span = ByteSpan { start: 2, end: 4 };
         let third_span = ByteSpan { start: 4, end: 7 };
 
-        let mut vec = vec![second_span.clone(), third_span.clone(), first_span.clone()];
+        let mut vec = [second_span.clone(), third_span.clone(), first_span.clone()];
         vec.sort();
 
         assert_eq!(vec[0], first_span);


### PR DESCRIPTION
## Description

This PR is still incomplete.
Fixes https://github.com/FuelLabs/sway/issues/5781.


Callee map for `replace_decls_and_insert_new_with_parent` seems to be spending time doing actual work:

![image](https://github.com/FuelLabs/sway/assets/83425/b1781cb7-85bb-49a4-bba7-ff98b0a524cd)

The problem seems to be that we are creating A LOT of types and functions. It also seems that we do not remove unused items. The PR now logs at `ConcurrentSlab::insert` of every 1M items and this is very close to the end of the `MegaExample`

```
ConcurrentSlab of [sway_core::language::ty::declaration::function::TyFunctionDecl] has [4.00 M] items (28.2 GiB)
ConcurrentSlab of [sway_core::type_system::info::TypeSourceInfo] has [34.00 M] items (12 GiB)
``` 

Or, 40 GB only for types and functions.

## Cache in front of `check_if_trait_constraints_are_satisfied_for_type`

This PR also eliminates (not ideally) the problem of `TypeInfo` proliferation. Before we were creating 35 million of them... Now it doesn´t appear in the logs, which means less than one million. In the `MegaExample`, it is saving 12 gigabytes of memory and makes the whole compilation 1 minute faster.

```
     Running `target/release/forc build --path /home/xunilrj/github/fuels-rs/packages/fuels --experimental-new-encoding`
ConcurrentSlab of [sway_core::language::ty::declaration::function::TyFunctionDecl] has [1.00 M] items (8.1 GiB)
ConcurrentSlab of [sway_core::language::ty::declaration::function::TyFunctionDecl] has [2.00 M] items (14.8 GiB)
ConcurrentSlab of [sway_core::language::ty::declaration::function::TyFunctionDecl] has [3.00 M] items (21.5 GiB)
ConcurrentSlab of [sway_core::language::ty::declaration::function::TyFunctionDecl] has [4.00 M] items (28.2 GiB)
```

The problem here is that `check_if_trait_constraints_are_satisfied_for_type` creates a bunch of `TypeInfo` to verify if all constraints of a type are satisfied. But these TypeInfo are not returned and not used afterwards. They only use is to unify with the info inside the current `TraitMap`.

## SubsType returning true/false

One of the problems with the proliferation of `TyFunctionDecl` is at `retrieve_interface_surface_and_items_and_implemented_items_for_type`. It applies `SubsType` and inserts new declarations, even when no substitution happens.

Making `SubstTypes` return true/false and only inserting on changes, substantially improved things. Before it was creating 4M TyFunctionDecl. Now it is "only" 155k, with a lot of space to improve still:

```
Decl Engine
        Function Decl Slab: 155289 items (155.29 K)
        Function Decl Slab: 2692644053 bytes (2.5 GiB)
```

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
