### PR TITLE
Fail nicely on imports without callpaths

### DIFF
--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -268,7 +268,7 @@ fn item_use_to_use_statements(
         };
         return Err(handler.emit_err(error.into()));
     };
-    
+
     let mut ret = Vec::new();
     let mut prefix = Vec::new();
     let item_span = item_use.span();
@@ -284,14 +284,14 @@ fn item_use_to_use_statements(
     // Check that all use statements have a call_path
     // This is not the case for `use foo;`, which is currently not supported
     for use_stmt in ret.iter() {
-	if use_stmt.call_path.len() == 0 {
-	    let error = ConvertParseTreeError::ImportsWithoutItemsNotSupports{
-		span: use_stmt.span.clone(),
-	    };
-	    return Err(handler.emit_err(error.into()));
-	}
+        if use_stmt.call_path.is_empty() {
+            let error = ConvertParseTreeError::ImportsWithoutItemsNotSupports {
+                span: use_stmt.span.clone(),
+            };
+            return Err(handler.emit_err(error.into()));
+        }
     }
-    
+
     debug_assert!(prefix.is_empty());
     Ok(ret)
 }

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -267,7 +267,8 @@ fn item_use_to_use_statements(
             span: pub_token.span(),
         };
         return Err(handler.emit_err(error.into()));
-    }
+    };
+    
     let mut ret = Vec::new();
     let mut prefix = Vec::new();
     let item_span = item_use.span();
@@ -279,6 +280,18 @@ fn item_use_to_use_statements(
         &mut ret,
         item_span,
     );
+
+    // Check that all use statements have a call_path
+    // This is not the case for `use foo;`, which is currently not supported
+    for use_stmt in ret.iter() {
+	if use_stmt.call_path.len() == 0 {
+	    let error = ConvertParseTreeError::ImportsWithoutItemsNotSupports{
+		span: use_stmt.span.clone(),
+	    };
+	    return Err(handler.emit_err(error.into()));
+	}
+    }
+    
     debug_assert!(prefix.is_empty());
     Ok(ret)
 }

--- a/sway-error/src/convert_parse_tree_error.rs
+++ b/sway-error/src/convert_parse_tree_error.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 pub enum ConvertParseTreeError {
     #[error("pub use imports are not supported")]
     PubUseNotSupported { span: Span },
+    #[error("Imports without items are not supported")]
+    ImportsWithoutItemsNotSupports { span: Span },
     #[error("functions used in applications may not be arbitrary expressions")]
     FunctionArbitraryExpression { span: Span },
     #[error("generics are not supported here")]
@@ -125,6 +127,7 @@ impl Spanned for ConvertParseTreeError {
     fn span(&self) -> Span {
         match self {
             ConvertParseTreeError::PubUseNotSupported { span } => span.clone(),
+	    ConvertParseTreeError::ImportsWithoutItemsNotSupports { span } => span.clone(),
             ConvertParseTreeError::FunctionArbitraryExpression { span } => span.clone(),
             ConvertParseTreeError::GenericsNotSupportedHere { span } => span.clone(),
             ConvertParseTreeError::MultipleGenericsNotSupported { span } => span.clone(),

--- a/sway-error/src/convert_parse_tree_error.rs
+++ b/sway-error/src/convert_parse_tree_error.rs
@@ -127,7 +127,7 @@ impl Spanned for ConvertParseTreeError {
     fn span(&self) -> Span {
         match self {
             ConvertParseTreeError::PubUseNotSupported { span } => span.clone(),
-	    ConvertParseTreeError::ImportsWithoutItemsNotSupports { span } => span.clone(),
+            ConvertParseTreeError::ImportsWithoutItemsNotSupports { span } => span.clone(),
             ConvertParseTreeError::FunctionArbitraryExpression { span } => span.clone(),
             ConvertParseTreeError::GenericsNotSupportedHere { span } => span.clone(),
             ConvertParseTreeError::MultipleGenericsNotSupported { span } => span.clone(),

--- a/test/src/e2e_vm_tests/test_programs/should_fail/import_non_item/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/import_non_item/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = "core"
+source = "path+from-root-EDF14A16D4AB69C3"
+
+[[package]]
+name = "import_non_item"
+source = "member"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/import_non_item/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/import_non_item/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "import_non_item"
+entry = "main.sw"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/import_non_item/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/import_non_item/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/import_non_item/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/import_non_item/src/main.sw
@@ -1,0 +1,7 @@
+script;
+
+use my_internal_mod;
+
+fn main() {
+    assert(true);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/import_non_item/src/my_internal_mod.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/import_non_item/src/my_internal_mod.sw
@@ -1,0 +1,5 @@
+library;
+
+fn foo() -> u32 {
+    42
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/import_non_item/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/import_non_item/test.toml
@@ -1,0 +1,5 @@
+category = "fail"
+
+# check: $()error
+# check: $()Imports without items are not supported
+# check: $()Aborting due to 1 error


### PR DESCRIPTION
## Description

`use` statements without a call path such as

```
use foo;
```

causes the compiler to crash during semantic analysis.

This PR causes the compiler to fail nicely instead.

These types of imports should be allowed, but I am in the process of reworking the import logic, so I'm postponing an actual fix.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
