### PR TITLE
Fixes ignored where clause. 

### DIFF
--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -261,11 +261,17 @@ impl DeclEngine {
                         (
                             AssociatedItemDeclId::TraitFn(x_id),
                             AssociatedItemDeclId::TraitFn(curr_parent_id),
-                        ) => self.get(x_id).eq(&self.get(curr_parent_id), engines),
+                        ) => self.get(x_id).eq(
+                            &self.get(curr_parent_id),
+                            &PartialEqWithEnginesContext::new(engines),
+                        ),
                         (
                             AssociatedItemDeclId::Function(x_id),
                             AssociatedItemDeclId::Function(curr_parent_id),
-                        ) => self.get(x_id).eq(&self.get(curr_parent_id), engines),
+                        ) => self.get(x_id).eq(
+                            &self.get(curr_parent_id),
+                            &PartialEqWithEnginesContext::new(engines),
+                        ),
                         _ => false,
                     }) {
                         left_to_check.push_back(curr_parent.clone());

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -196,8 +196,8 @@ where
     DeclEngine: DeclEngineIndex<T>,
     T: Named + Spanned + PartialEqWithEngines,
 {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        let decl_engine = engines.de();
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        let decl_engine = ctx.engines().de();
         let DeclRef {
             name: ln,
             id: lid,
@@ -216,7 +216,7 @@ where
             // temporarily omitted
             subst_list: _,
         } = other;
-        ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines)
+        ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), ctx)
     }
 }
 
@@ -243,18 +243,18 @@ where
 
 impl EqWithEngines for DeclRefMixedInterface {}
 impl PartialEqWithEngines for DeclRefMixedInterface {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        let decl_engine = engines.de();
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        let decl_engine = ctx.engines().de();
         match (&self.id, &other.id) {
             (InterfaceDeclId::Abi(self_id), InterfaceDeclId::Abi(other_id)) => {
                 let left = decl_engine.get(self_id);
                 let right = decl_engine.get(other_id);
-                self.name == other.name && left.eq(&right, engines)
+                self.name == other.name && left.eq(&right, ctx)
             }
             (InterfaceDeclId::Trait(self_id), InterfaceDeclId::Trait(other_id)) => {
                 let left = decl_engine.get(self_id);
                 let right = decl_engine.get(other_id);
-                self.name == other.name && left.eq(&right, engines)
+                self.name == other.name && left.eq(&right, ctx)
             }
             _ => false,
         }

--- a/sway-core/src/engine_threading.rs
+++ b/sway-core/src/engine_threading.rs
@@ -107,7 +107,8 @@ impl<T: HashWithEngines> Hash for WithEngines<'_, T> {
 
 impl<T: PartialEqWithEngines> PartialEq for WithEngines<'_, T> {
     fn eq(&self, rhs: &Self) -> bool {
-        self.thing.eq(&rhs.thing, self.engines)
+        self.thing
+            .eq(&rhs.thing, &PartialEqWithEnginesContext::new(self.engines))
     }
 }
 
@@ -246,18 +247,58 @@ impl<T: HashWithEngines> HashWithEngines for Box<T> {
 
 pub trait EqWithEngines: PartialEqWithEngines {}
 
+pub struct PartialEqWithEnginesContext<'a> {
+    engines: &'a Engines,
+    is_inside_trait_constraint: bool,
+}
+
+impl<'a> PartialEqWithEnginesContext<'a> {
+    pub(crate) fn new(engines: &'a Engines) -> Self {
+        Self {
+            engines,
+            is_inside_trait_constraint: false,
+        }
+    }
+
+    pub fn by_ref(&self) -> PartialEqWithEnginesContext<'_> {
+        PartialEqWithEnginesContext {
+            engines: self.engines,
+            is_inside_trait_constraint: self.is_inside_trait_constraint,
+        }
+    }
+
+    pub(crate) fn with_is_inside_trait_constraint(&self) -> Self {
+        Self {
+            is_inside_trait_constraint: true,
+            ..*self
+        }
+    }
+
+    pub(crate) fn engines(&self) -> &Engines {
+        self.engines
+    }
+
+    pub(crate) fn is_inside_trait_constraint(&self) -> bool {
+        self.is_inside_trait_constraint
+    }
+}
+
 pub trait PartialEqWithEngines {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool;
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool;
 }
 
 pub trait OrdWithEngines {
-    fn cmp(&self, other: &Self, engines: &Engines) -> Ordering;
+    fn cmp(
+        &self,
+        other: &Self,
+        engines: &Engines, /* , ctx: &mut OrdWithEnginesContext*/
+    ) -> Ordering;
 }
 
 impl<T: EqWithEngines + ?Sized> EqWithEngines for &T {}
 impl<T: PartialEqWithEngines + ?Sized> PartialEqWithEngines for &T {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        (*self).eq(*other, engines)
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        (*self).eq(*other, ctx)
     }
 }
 impl<T: OrdWithEngines + ?Sized> OrdWithEngines for &T {
@@ -285,10 +326,10 @@ impl<T: OrdWithEngines> OrdWithEngines for Box<T> {
 
 impl<T: EqWithEngines> EqWithEngines for Option<T> {}
 impl<T: PartialEqWithEngines> PartialEqWithEngines for Option<T> {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         match (self, other) {
             (None, None) => true,
-            (Some(x), Some(y)) => x.eq(y, engines),
+            (Some(x), Some(y)) => x.eq(y, ctx),
             _ => false,
         }
     }
@@ -296,15 +337,15 @@ impl<T: PartialEqWithEngines> PartialEqWithEngines for Option<T> {
 
 impl<T: EqWithEngines> EqWithEngines for Box<T> {}
 impl<T: PartialEqWithEngines> PartialEqWithEngines for Box<T> {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        (**self).eq(&(**other), engines)
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        (**self).eq(&(**other), ctx)
     }
 }
 
 impl<T: EqWithEngines> EqWithEngines for [T] {}
 impl<T: PartialEqWithEngines> PartialEqWithEngines for [T] {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        self.len() == other.len() && self.iter().zip(other.iter()).all(|(x, y)| x.eq(y, engines))
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        self.len() == other.len() && self.iter().zip(other.iter()).all(|(x, y)| x.eq(y, ctx))
     }
 }
 impl<T: OrdWithEngines> OrdWithEngines for [T] {

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -952,7 +952,10 @@ impl<'eng> FnCompiler<'eng> {
                 // Validate that the val_exp is of the right type. We couldn't do it
                 // earlier during type checking as the type arguments may not have been resolved.
                 let val_ty = engines.te().get_unaliased(val_exp.return_type);
-                if !val_ty.eq(&TypeInfo::RawUntypedPtr, engines) {
+                if !val_ty.eq(
+                    &TypeInfo::RawUntypedPtr,
+                    &PartialEqWithEnginesContext::new(engines),
+                ) {
                     return Err(CompileError::IntrinsicUnsupportedArgType {
                         name: kind.to_string(),
                         span,

--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::{
     engine_threading::{
         DebugWithEngines, DisplayWithEngines, EqWithEngines, HashWithEngines, OrdWithEngines,
-        PartialEqWithEngines, PartialEqWithEnginesContext,
+        OrdWithEnginesContext, PartialEqWithEngines, PartialEqWithEnginesContext,
     },
     Engines, Ident, Namespace,
 };
@@ -50,7 +50,7 @@ impl PartialEqWithEngines for CallPathTree {
 }
 
 impl OrdWithEngines for CallPathTree {
-    fn cmp(&self, other: &Self, engines: &Engines) -> Ordering {
+    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> Ordering {
         let CallPathTree {
             qualified_call_path: l_call_path,
             children: l_children,
@@ -60,8 +60,8 @@ impl OrdWithEngines for CallPathTree {
             children: r_children,
         } = other;
         l_call_path
-            .cmp(r_call_path, engines)
-            .then_with(|| l_children.cmp(r_children, engines))
+            .cmp(r_call_path, ctx)
+            .then_with(|| l_children.cmp(r_children, ctx))
     }
 }
 
@@ -130,7 +130,7 @@ impl PartialEqWithEngines for QualifiedCallPath {
 }
 
 impl OrdWithEngines for QualifiedCallPath {
-    fn cmp(&self, other: &Self, engines: &Engines) -> Ordering {
+    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> Ordering {
         let QualifiedCallPath {
             call_path: l_call_path,
             qualified_path_root: l_qualified_path_root,
@@ -141,7 +141,7 @@ impl OrdWithEngines for QualifiedCallPath {
         } = other;
         l_call_path
             .cmp(r_call_path)
-            .then_with(|| l_qualified_path_root.cmp(r_qualified_path_root, engines))
+            .then_with(|| l_qualified_path_root.cmp(r_qualified_path_root, ctx))
     }
 }
 

--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::{
     engine_threading::{
         DebugWithEngines, DisplayWithEngines, EqWithEngines, HashWithEngines, OrdWithEngines,
-        PartialEqWithEngines,
+        PartialEqWithEngines, PartialEqWithEnginesContext,
     },
     Engines, Ident, Namespace,
 };
@@ -40,13 +40,12 @@ impl HashWithEngines for CallPathTree {
 
 impl EqWithEngines for CallPathTree {}
 impl PartialEqWithEngines for CallPathTree {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         let CallPathTree {
             qualified_call_path,
             children,
         } = self;
-        qualified_call_path.eq(&other.qualified_call_path, engines)
-            && children.eq(&other.children, engines)
+        qualified_call_path.eq(&other.qualified_call_path, ctx) && children.eq(&other.children, ctx)
     }
 }
 
@@ -121,13 +120,12 @@ impl HashWithEngines for QualifiedCallPath {
 
 impl EqWithEngines for QualifiedCallPath {}
 impl PartialEqWithEngines for QualifiedCallPath {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         let QualifiedCallPath {
             call_path,
             qualified_path_root,
         } = self;
-        call_path.eq(&other.call_path)
-            && qualified_path_root.eq(&other.qualified_path_root, engines)
+        call_path.eq(&other.call_path) && qualified_path_root.eq(&other.qualified_path_root, ctx)
     }
 }
 

--- a/sway-core/src/language/parsed/declaration/function.rs
+++ b/sway-core/src/language/parsed/declaration/function.rs
@@ -46,12 +46,12 @@ pub struct FunctionParameter {
 
 impl EqWithEngines for FunctionParameter {}
 impl PartialEqWithEngines for FunctionParameter {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.name == other.name
             && self.is_reference == other.is_reference
             && self.is_mutable == other.is_mutable
             && self.mutability_span == other.mutability_span
-            && self.type_argument.eq(&other.type_argument, engines)
+            && self.type_argument.eq(&other.type_argument, ctx)
     }
 }
 

--- a/sway-core/src/language/parsed/declaration/trait.rs
+++ b/sway-core/src/language/parsed/declaration/trait.rs
@@ -47,7 +47,7 @@ impl Spanned for Supertrait {
 
 impl EqWithEngines for Supertrait {}
 impl PartialEqWithEngines for Supertrait {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         let Supertrait {
             name: ln,
             decl_ref: ldr,
@@ -56,7 +56,7 @@ impl PartialEqWithEngines for Supertrait {
             name: rn,
             decl_ref: rdr,
         } = other;
-        ln == rn && ldr.eq(rdr, engines)
+        ln == rn && ldr.eq(rdr, ctx)
     }
 }
 

--- a/sway-core/src/language/parsed/expression/mod.rs
+++ b/sway-core/src/language/parsed/expression/mod.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fmt, hash::Hasher};
 use crate::{
     engine_threading::{
         DebugWithEngines, DisplayWithEngines, EqWithEngines, HashWithEngines, OrdWithEngines,
-        PartialEqWithEngines, PartialEqWithEnginesContext,
+        OrdWithEnginesContext, PartialEqWithEngines, PartialEqWithEnginesContext,
     },
     language::{parsed::CodeBlock, *},
     type_system::TypeBinding,
@@ -150,7 +150,7 @@ impl PartialEqWithEngines for QualifiedPathType {
 }
 
 impl OrdWithEngines for QualifiedPathType {
-    fn cmp(&self, other: &Self, engines: &Engines) -> Ordering {
+    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> Ordering {
         let QualifiedPathType {
             ty: l_ty,
             as_trait: l_as_trait,
@@ -163,11 +163,11 @@ impl OrdWithEngines for QualifiedPathType {
             // ignored fields
             as_trait_span: _,
         } = other;
-        l_ty.cmp(r_ty, engines).then_with(|| {
-            engines
+        l_ty.cmp(r_ty, ctx).then_with(|| {
+            ctx.engines()
                 .te()
                 .get(*l_as_trait)
-                .cmp(&engines.te().get(*r_as_trait), engines)
+                .cmp(&ctx.engines().te().get(*r_as_trait), ctx)
         })
     }
 }

--- a/sway-core/src/language/parsed/expression/mod.rs
+++ b/sway-core/src/language/parsed/expression/mod.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fmt, hash::Hasher};
 use crate::{
     engine_threading::{
         DebugWithEngines, DisplayWithEngines, EqWithEngines, HashWithEngines, OrdWithEngines,
-        PartialEqWithEngines,
+        PartialEqWithEngines, PartialEqWithEnginesContext,
     },
     language::{parsed::CodeBlock, *},
     type_system::TypeBinding,
@@ -133,18 +133,19 @@ impl HashWithEngines for QualifiedPathType {
 
 impl EqWithEngines for QualifiedPathType {}
 impl PartialEqWithEngines for QualifiedPathType {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         let QualifiedPathType {
             ty,
             as_trait,
             // ignored fields
             as_trait_span: _,
         } = self;
-        ty.eq(&other.ty, engines)
-            && engines
+        ty.eq(&other.ty, ctx)
+            && ctx
+                .engines()
                 .te()
                 .get(*as_trait)
-                .eq(&engines.te().get(other.as_trait), engines)
+                .eq(&ctx.engines().te().get(other.as_trait), ctx)
     }
 }
 

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -31,8 +31,8 @@ pub struct TyAstNode {
 
 impl EqWithEngines for TyAstNode {}
 impl PartialEqWithEngines for TyAstNode {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        self.content.eq(&other.content, engines)
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        self.content.eq(&other.content, ctx)
     }
 }
 
@@ -341,10 +341,10 @@ pub enum TyAstNodeContent {
 
 impl EqWithEngines for TyAstNodeContent {}
 impl PartialEqWithEngines for TyAstNodeContent {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         match (self, other) {
-            (Self::Declaration(x), Self::Declaration(y)) => x.eq(y, engines),
-            (Self::Expression(x), Self::Expression(y)) => x.eq(y, engines),
+            (Self::Declaration(x), Self::Declaration(y)) => x.eq(y, ctx),
+            (Self::Expression(x), Self::Expression(y)) => x.eq(y, ctx),
             (Self::SideEffect(_), Self::SideEffect(_)) => true,
             _ => false,
         }

--- a/sway-core/src/language/ty/code_block.rs
+++ b/sway-core/src/language/ty/code_block.rs
@@ -25,8 +25,8 @@ impl Default for TyCodeBlock {
 
 impl EqWithEngines for TyCodeBlock {}
 impl PartialEqWithEngines for TyCodeBlock {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        self.contents.eq(&other.contents, engines)
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        self.contents.eq(&other.contents, ctx)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/abi.rs
+++ b/sway-core/src/language/ty/declaration/abi.rs
@@ -21,7 +21,7 @@ pub struct TyAbiDecl {
 
 impl EqWithEngines for TyAbiDecl {}
 impl PartialEqWithEngines for TyAbiDecl {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         let TyAbiDecl {
             name: ln,
             interface_surface: lis,
@@ -42,7 +42,7 @@ impl PartialEqWithEngines for TyAbiDecl {
             attributes: _,
             span: _,
         } = other;
-        ln == rn && lis.eq(ris, engines) && li.eq(ri, engines) && ls.eq(rs, engines)
+        ln == rn && lis.eq(ris, ctx) && li.eq(ri, ctx) && ls.eq(rs, ctx)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/constant.rs
+++ b/sway-core/src/language/ty/declaration/constant.rs
@@ -36,18 +36,18 @@ impl DebugWithEngines for TyConstantDecl {
 
 impl EqWithEngines for TyConstantDecl {}
 impl PartialEqWithEngines for TyConstantDecl {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        let type_engine = engines.te();
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        let type_engine = ctx.engines().te();
         self.call_path == other.call_path
-            && self.value.eq(&other.value, engines)
+            && self.value.eq(&other.value, ctx)
             && self.visibility == other.visibility
-            && self.type_ascription.eq(&other.type_ascription, engines)
+            && self.type_ascription.eq(&other.type_ascription, ctx)
             && self.is_configurable == other.is_configurable
             && type_engine
                 .get(self.return_type)
-                .eq(&type_engine.get(other.return_type), engines)
+                .eq(&type_engine.get(other.return_type), ctx)
             && match (&self.implementing_type, &other.implementing_type) {
-                (Some(self_), Some(other)) => self_.eq(other, engines),
+                (Some(self_), Some(other)) => self_.eq(other, ctx),
                 _ => false,
             }
     }

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -126,11 +126,11 @@ pub struct TypeAliasDecl {
 
 impl EqWithEngines for TyDecl {}
 impl PartialEqWithEngines for TyDecl {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        let decl_engine = engines.de();
-        let type_engine = engines.te();
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        let decl_engine = ctx.engines().de();
+        let type_engine = ctx.engines().te();
         match (self, other) {
-            (TyDecl::VariableDecl(x), TyDecl::VariableDecl(y)) => x.eq(y, engines),
+            (TyDecl::VariableDecl(x), TyDecl::VariableDecl(y)) => x.eq(y, ctx),
             (
                 TyDecl::ConstantDecl(ConstantDecl {
                     name: ln,
@@ -142,7 +142,7 @@ impl PartialEqWithEngines for TyDecl {
                     decl_id: rid,
                     ..
                 }),
-            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), ctx),
             (
                 TyDecl::FunctionDecl(FunctionDecl {
                     name: ln,
@@ -154,7 +154,7 @@ impl PartialEqWithEngines for TyDecl {
                     decl_id: rid,
                     ..
                 }),
-            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), ctx),
             (
                 TyDecl::TraitDecl(TraitDecl {
                     name: ln,
@@ -166,7 +166,7 @@ impl PartialEqWithEngines for TyDecl {
                     decl_id: rid,
                     ..
                 }),
-            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), ctx),
             (
                 TyDecl::StructDecl(StructDecl {
                     name: ln,
@@ -178,7 +178,7 @@ impl PartialEqWithEngines for TyDecl {
                     decl_id: rid,
                     ..
                 }),
-            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), ctx),
             (
                 TyDecl::EnumDecl(EnumDecl {
                     name: ln,
@@ -190,7 +190,7 @@ impl PartialEqWithEngines for TyDecl {
                     decl_id: rid,
                     ..
                 }),
-            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), ctx),
             (
                 TyDecl::ImplTrait(ImplTrait {
                     name: ln,
@@ -202,7 +202,7 @@ impl PartialEqWithEngines for TyDecl {
                     decl_id: rid,
                     ..
                 }),
-            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), ctx),
             (
                 TyDecl::AbiDecl(AbiDecl {
                     name: ln,
@@ -214,15 +214,15 @@ impl PartialEqWithEngines for TyDecl {
                     decl_id: rid,
                     ..
                 }),
-            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
+            ) => ln == rn && decl_engine.get(lid).eq(&decl_engine.get(rid), ctx),
             (
                 TyDecl::StorageDecl(StorageDecl { decl_id: lid, .. }),
                 TyDecl::StorageDecl(StorageDecl { decl_id: rid, .. }),
-            ) => decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
+            ) => decl_engine.get(lid).eq(&decl_engine.get(rid), ctx),
             (
                 TyDecl::TypeAliasDecl(TypeAliasDecl { decl_id: lid, .. }),
                 TyDecl::TypeAliasDecl(TypeAliasDecl { decl_id: rid, .. }),
-            ) => decl_engine.get(lid).eq(&decl_engine.get(rid), engines),
+            ) => decl_engine.get(lid).eq(&decl_engine.get(rid), ctx),
             (
                 TyDecl::GenericTypeForFunctionScope(GenericTypeForFunctionScope {
                     name: xn,
@@ -232,7 +232,7 @@ impl PartialEqWithEngines for TyDecl {
                     name: yn,
                     type_id: yti,
                 }),
-            ) => xn == yn && type_engine.get(*xti).eq(&type_engine.get(*yti), engines),
+            ) => xn == yn && type_engine.get(*xti).eq(&type_engine.get(*yti), ctx),
             (TyDecl::ErrorRecovery(x, _), TyDecl::ErrorRecovery(y, _)) => x == y,
             _ => false,
         }

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -147,7 +147,7 @@ impl PartialEqWithEngines for TyEnumVariant {
 }
 
 impl OrdWithEngines for TyEnumVariant {
-    fn cmp(&self, other: &Self, engines: &Engines) -> Ordering {
+    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> Ordering {
         let TyEnumVariant {
             name: ln,
             type_argument: lta,
@@ -167,7 +167,7 @@ impl OrdWithEngines for TyEnumVariant {
             attributes: _,
         } = other;
         ln.cmp(rn)
-            .then_with(|| lta.cmp(rta, engines))
+            .then_with(|| lta.cmp(rta, ctx))
             .then_with(|| lt.cmp(rt))
     }
 }

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -35,10 +35,10 @@ impl Named for TyEnumDecl {
 
 impl EqWithEngines for TyEnumDecl {}
 impl PartialEqWithEngines for TyEnumDecl {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.call_path == other.call_path
-            && self.type_parameters.eq(&other.type_parameters, engines)
-            && self.variants.eq(&other.variants, engines)
+            && self.type_parameters.eq(&other.type_parameters, ctx)
+            && self.variants.eq(&other.variants, ctx)
             && self.visibility == other.visibility
     }
 }
@@ -139,9 +139,9 @@ impl HashWithEngines for TyEnumVariant {
 
 impl EqWithEngines for TyEnumVariant {}
 impl PartialEqWithEngines for TyEnumVariant {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.name == other.name
-            && self.type_argument.eq(&other.type_argument, engines)
+            && self.type_argument.eq(&other.type_argument, ctx)
             && self.tag == other.tag
     }
 }

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -149,12 +149,12 @@ impl declaration::FunctionSignature for TyFunctionDecl {
 
 impl EqWithEngines for TyFunctionDecl {}
 impl PartialEqWithEngines for TyFunctionDecl {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.name == other.name
-            && self.body.eq(&other.body, engines)
-            && self.parameters.eq(&other.parameters, engines)
-            && self.return_type.eq(&other.return_type, engines)
-            && self.type_parameters.eq(&other.type_parameters, engines)
+            && self.body.eq(&other.body, ctx)
+            && self.parameters.eq(&other.parameters, ctx)
+            && self.return_type.eq(&other.return_type, ctx)
+            && self.type_parameters.eq(&other.type_parameters, ctx)
             && self.visibility == other.visibility
             && self.is_contract_call == other.is_contract_call
             && self.purity == other.purity
@@ -263,9 +263,12 @@ impl UnconstrainedTypeParameters for TyFunctionDecl {
         all_types.extend(self.return_type.type_id.extract_inner_types(engines));
         all_types.insert(self.return_type.type_id);
         let type_parameter_info = type_engine.get(type_parameter.type_id);
-        all_types
-            .iter()
-            .any(|type_id| type_engine.get(*type_id).eq(&type_parameter_info, engines))
+        all_types.iter().any(|type_id| {
+            type_engine.get(*type_id).eq(
+                &type_parameter_info,
+                &PartialEqWithEnginesContext::new(engines),
+            )
+        })
     }
 }
 
@@ -495,9 +498,9 @@ pub struct TyFunctionParameter {
 
 impl EqWithEngines for TyFunctionParameter {}
 impl PartialEqWithEngines for TyFunctionParameter {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.name == other.name
-            && self.type_argument.eq(&other.type_argument, engines)
+            && self.type_argument.eq(&other.type_argument, ctx)
             && self.is_reference == other.is_reference
             && self.is_mutable == other.is_mutable
     }

--- a/sway-core/src/language/ty/declaration/impl_trait.rs
+++ b/sway-core/src/language/ty/declaration/impl_trait.rs
@@ -42,16 +42,16 @@ impl Spanned for TyImplTrait {
 
 impl EqWithEngines for TyImplTrait {}
 impl PartialEqWithEngines for TyImplTrait {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.impl_type_parameters
-            .eq(&other.impl_type_parameters, engines)
+            .eq(&other.impl_type_parameters, ctx)
             && self.trait_name == other.trait_name
             && self
                 .trait_type_arguments
-                .eq(&other.trait_type_arguments, engines)
-            && self.items.eq(&other.items, engines)
-            && self.implementing_for.eq(&other.implementing_for, engines)
-            && self.trait_decl_ref.eq(&other.trait_decl_ref, engines)
+                .eq(&other.trait_type_arguments, ctx)
+            && self.items.eq(&other.items, ctx)
+            && self.implementing_for.eq(&other.implementing_for, ctx)
+            && self.trait_decl_ref.eq(&other.trait_decl_ref, ctx)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/storage.rs
+++ b/sway-core/src/language/ty/declaration/storage.rs
@@ -30,8 +30,8 @@ impl Named for TyStorageDecl {
 
 impl EqWithEngines for TyStorageDecl {}
 impl PartialEqWithEngines for TyStorageDecl {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        self.fields.eq(&other.fields, engines) && self.attributes == other.attributes
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        self.fields.eq(&other.fields, ctx) && self.attributes == other.attributes
     }
 }
 
@@ -255,10 +255,10 @@ pub struct TyStorageField {
 
 impl EqWithEngines for TyStorageField {}
 impl PartialEqWithEngines for TyStorageField {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.name == other.name
-            && self.type_argument.eq(&other.type_argument, engines)
-            && self.initializer.eq(&other.initializer, engines)
+            && self.type_argument.eq(&other.type_argument, ctx)
+            && self.initializer.eq(&other.initializer, ctx)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/struct.rs
+++ b/sway-core/src/language/ty/declaration/struct.rs
@@ -33,10 +33,10 @@ impl Named for TyStructDecl {
 
 impl EqWithEngines for TyStructDecl {}
 impl PartialEqWithEngines for TyStructDecl {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.call_path == other.call_path
-            && self.fields.eq(&other.fields, engines)
-            && self.type_parameters.eq(&other.type_parameters, engines)
+            && self.fields.eq(&other.fields, ctx)
+            && self.type_parameters.eq(&other.type_parameters, ctx)
             && self.visibility == other.visibility
     }
 }
@@ -246,8 +246,8 @@ impl HashWithEngines for TyStructField {
 
 impl EqWithEngines for TyStructField {}
 impl PartialEqWithEngines for TyStructField {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        self.name == other.name && self.type_argument.eq(&other.type_argument, engines)
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        self.name == other.name && self.type_argument.eq(&other.type_argument, ctx)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/struct.rs
+++ b/sway-core/src/language/ty/declaration/struct.rs
@@ -252,7 +252,7 @@ impl PartialEqWithEngines for TyStructField {
 }
 
 impl OrdWithEngines for TyStructField {
-    fn cmp(&self, other: &Self, engines: &Engines) -> Ordering {
+    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> Ordering {
         let TyStructField {
             name: ln,
             type_argument: lta,
@@ -269,7 +269,7 @@ impl OrdWithEngines for TyStructField {
             attributes: _,
             visibility: _,
         } = other;
-        ln.cmp(rn).then_with(|| lta.cmp(rta, engines))
+        ln.cmp(rn).then_with(|| lta.cmp(rta, ctx))
     }
 }
 

--- a/sway-core/src/language/ty/declaration/trait.rs
+++ b/sway-core/src/language/ty/declaration/trait.rs
@@ -123,12 +123,12 @@ impl Spanned for TyTraitDecl {
 
 impl EqWithEngines for TyTraitDecl {}
 impl PartialEqWithEngines for TyTraitDecl {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.name == other.name
-            && self.type_parameters.eq(&other.type_parameters, engines)
-            && self.interface_surface.eq(&other.interface_surface, engines)
-            && self.items.eq(&other.items, engines)
-            && self.supertraits.eq(&other.supertraits, engines)
+            && self.type_parameters.eq(&other.type_parameters, ctx)
+            && self.interface_surface.eq(&other.interface_surface, ctx)
+            && self.items.eq(&other.items, ctx)
+            && self.supertraits.eq(&other.supertraits, ctx)
             && self.visibility == other.visibility
     }
 }
@@ -161,13 +161,13 @@ impl HashWithEngines for TyTraitDecl {
 
 impl EqWithEngines for TyTraitInterfaceItem {}
 impl PartialEqWithEngines for TyTraitInterfaceItem {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         match (self, other) {
             (TyTraitInterfaceItem::TraitFn(id), TyTraitInterfaceItem::TraitFn(other_id)) => {
-                id.eq(other_id, engines)
+                id.eq(other_id, ctx)
             }
             (TyTraitInterfaceItem::Constant(id), TyTraitInterfaceItem::Constant(other_id)) => {
-                id.eq(other_id, engines)
+                id.eq(other_id, ctx)
             }
             _ => false,
         }
@@ -176,12 +176,10 @@ impl PartialEqWithEngines for TyTraitInterfaceItem {
 
 impl EqWithEngines for TyTraitItem {}
 impl PartialEqWithEngines for TyTraitItem {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         match (self, other) {
-            (TyTraitItem::Fn(id), TyTraitItem::Fn(other_id)) => id.eq(other_id, engines),
-            (TyTraitItem::Constant(id), TyTraitItem::Constant(other_id)) => {
-                id.eq(other_id, engines)
-            }
+            (TyTraitItem::Fn(id), TyTraitItem::Fn(other_id)) => id.eq(other_id, ctx),
+            (TyTraitItem::Constant(id), TyTraitItem::Constant(other_id)) => id.eq(other_id, ctx),
             _ => false,
         }
     }

--- a/sway-core/src/language/ty/declaration/trait_fn.rs
+++ b/sway-core/src/language/ty/declaration/trait_fn.rs
@@ -67,14 +67,14 @@ impl declaration::FunctionSignature for TyTraitFn {
 
 impl EqWithEngines for TyTraitFn {}
 impl PartialEqWithEngines for TyTraitFn {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        let type_engine = engines.te();
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        let type_engine = ctx.engines().te();
         self.name == other.name
             && self.purity == other.purity
-            && self.parameters.eq(&other.parameters, engines)
+            && self.parameters.eq(&other.parameters, ctx)
             && type_engine
                 .get(self.return_type.type_id)
-                .eq(&type_engine.get(other.return_type.type_id), engines)
+                .eq(&type_engine.get(other.return_type.type_id), ctx)
             && self.attributes == other.attributes
     }
 }

--- a/sway-core/src/language/ty/declaration/trait_type.rs
+++ b/sway-core/src/language/ty/declaration/trait_type.rs
@@ -30,9 +30,9 @@ impl Named for TyTraitType {
 
 impl EqWithEngines for TyTraitType {}
 impl PartialEqWithEngines for TyTraitType {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.name == other.name
-            && self.ty.eq(&other.ty, engines)
+            && self.ty.eq(&other.ty, ctx)
             && self.implementing_type.eq(&other.implementing_type)
     }
 }

--- a/sway-core/src/language/ty/declaration/type_alias.rs
+++ b/sway-core/src/language/ty/declaration/type_alias.rs
@@ -27,10 +27,8 @@ impl Named for TyTypeAliasDecl {
 
 impl EqWithEngines for TyTypeAliasDecl {}
 impl PartialEqWithEngines for TyTypeAliasDecl {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        self.name == other.name
-            && self.ty.eq(&other.ty, engines)
-            && self.visibility == other.visibility
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        self.name == other.name && self.ty.eq(&other.ty, ctx) && self.visibility == other.visibility
     }
 }
 

--- a/sway-core/src/language/ty/declaration/variable.rs
+++ b/sway-core/src/language/ty/declaration/variable.rs
@@ -24,15 +24,15 @@ pub struct TyVariableDecl {
 
 impl EqWithEngines for TyVariableDecl {}
 impl PartialEqWithEngines for TyVariableDecl {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        let type_engine = engines.te();
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        let type_engine = ctx.engines().te();
         self.name == other.name
-            && self.body.eq(&other.body, engines)
+            && self.body.eq(&other.body, ctx)
             && self.mutability == other.mutability
             && type_engine
                 .get(self.return_type)
-                .eq(&type_engine.get(other.return_type), engines)
-            && self.type_ascription.eq(&other.type_ascription, engines)
+                .eq(&type_engine.get(other.return_type), ctx)
+            && self.type_ascription.eq(&other.type_ascription, ctx)
     }
 }
 

--- a/sway-core/src/language/ty/expression/asm.rs
+++ b/sway-core/src/language/ty/expression/asm.rs
@@ -11,10 +11,10 @@ pub struct TyAsmRegisterDeclaration {
 }
 
 impl PartialEqWithEngines for TyAsmRegisterDeclaration {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.name == other.name
             && if let (Some(l), Some(r)) = (&self.initializer, &other.initializer) {
-                l.eq(r, engines)
+                l.eq(r, ctx)
             } else {
                 true
             }

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -28,12 +28,12 @@ pub struct TyExpression {
 
 impl EqWithEngines for TyExpression {}
 impl PartialEqWithEngines for TyExpression {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        let type_engine = engines.te();
-        self.expression.eq(&other.expression, engines)
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        let type_engine = ctx.engines().te();
+        self.expression.eq(&other.expression, ctx)
             && type_engine
                 .get(self.return_type)
-                .eq(&type_engine.get(other.return_type), engines)
+                .eq(&type_engine.get(other.return_type), ctx)
     }
 }
 

--- a/sway-core/src/language/ty/expression/intrinsic_function.rs
+++ b/sway-core/src/language/ty/expression/intrinsic_function.rs
@@ -46,10 +46,10 @@ impl TyIntrinsicFunctionKind {
 
 impl EqWithEngines for TyIntrinsicFunctionKind {}
 impl PartialEqWithEngines for TyIntrinsicFunctionKind {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.kind == other.kind
-            && self.arguments.eq(&other.arguments, engines)
-            && self.type_arguments.eq(&other.type_arguments, engines)
+            && self.arguments.eq(&other.arguments, ctx)
+            && self.type_arguments.eq(&other.type_arguments, ctx)
     }
 }
 

--- a/sway-core/src/language/ty/expression/reassignment.rs
+++ b/sway-core/src/language/ty/expression/reassignment.rs
@@ -29,14 +29,14 @@ pub struct TyReassignment {
 
 impl EqWithEngines for TyReassignment {}
 impl PartialEqWithEngines for TyReassignment {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        let type_engine = engines.te();
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        let type_engine = ctx.engines().te();
         self.lhs_base_name == other.lhs_base_name
             && type_engine
                 .get(self.lhs_type)
-                .eq(&type_engine.get(other.lhs_type), engines)
-            && self.lhs_indices.eq(&other.lhs_indices, engines)
-            && self.rhs.eq(&other.rhs, engines)
+                .eq(&type_engine.get(other.lhs_type), ctx)
+            && self.lhs_indices.eq(&other.lhs_indices, ctx)
+            && self.rhs.eq(&other.rhs, ctx)
     }
 }
 
@@ -118,7 +118,7 @@ pub enum ProjectionKind {
 
 impl EqWithEngines for ProjectionKind {}
 impl PartialEqWithEngines for ProjectionKind {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         match (self, other) {
             (
                 ProjectionKind::StructField { name: l_name },
@@ -143,7 +143,7 @@ impl PartialEqWithEngines for ProjectionKind {
                     index: r_index,
                     index_span: r_index_span,
                 },
-            ) => l_index.eq(r_index, engines) && l_index_span == r_index_span,
+            ) => l_index.eq(r_index, ctx) && l_index_span == r_index_span,
             _ => false,
         }
     }

--- a/sway-core/src/language/ty/expression/storage.rs
+++ b/sway-core/src/language/ty/expression/storage.rs
@@ -15,10 +15,10 @@ pub struct TyStorageAccess {
 
 impl EqWithEngines for TyStorageAccess {}
 impl PartialEqWithEngines for TyStorageAccess {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.ix == other.ix
             && self.fields.len() == other.fields.len()
-            && self.fields.eq(&other.fields, engines)
+            && self.fields.eq(&other.fields, ctx)
     }
 }
 
@@ -64,12 +64,12 @@ pub struct TyStorageAccessDescriptor {
 
 impl EqWithEngines for TyStorageAccessDescriptor {}
 impl PartialEqWithEngines for TyStorageAccessDescriptor {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        let type_engine = engines.te();
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        let type_engine = ctx.engines().te();
         self.name == other.name
             && type_engine
                 .get(self.type_id)
-                .eq(&type_engine.get(other.type_id), engines)
+                .eq(&type_engine.get(other.type_id), ctx)
     }
 }
 

--- a/sway-core/src/language/ty/expression/struct_exp_field.rs
+++ b/sway-core/src/language/ty/expression/struct_exp_field.rs
@@ -19,8 +19,8 @@ pub struct TyStructExpressionField {
 
 impl EqWithEngines for TyStructExpressionField {}
 impl PartialEqWithEngines for TyStructExpressionField {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        self.name == other.name && self.value.eq(&other.value, engines)
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        self.name == other.name && self.value.eq(&other.value, ctx)
     }
 }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -1094,9 +1094,9 @@ fn type_check_impl_method(
                 impl_method_signature_param.type_argument.type_id;
             impl_method_signature_param_type_id.subst(&ctx.type_subst(), engines);
 
-            if !type_engine.get(impl_method_param_type_id).eq(
-                &type_engine.get(impl_method_signature_param_type_id),
-                &PartialEqWithEnginesContext::new(engines),
+            if !UnifyCheck::non_dynamic_equality(engines).check(
+                impl_method_param_type_id,
+                impl_method_signature_param_type_id,
             ) {
                 handler.emit_err(CompileError::MismatchedTypeInInterfaceSurface {
                     interface_name: interface_name(),
@@ -1168,9 +1168,9 @@ fn type_check_impl_method(
             impl_method_signature.return_type.type_id;
         impl_method_signature_return_type_type_id.subst(&ctx.type_subst(), engines);
 
-        if !type_engine.get(impl_method_return_type_id).eq(
-            &type_engine.get(impl_method_signature_return_type_type_id),
-            &PartialEqWithEnginesContext::new(engines),
+        if !UnifyCheck::non_dynamic_equality(engines).check(
+            impl_method_return_type_id,
+            impl_method_signature_return_type_type_id,
         ) {
             return Err(
                 handler.emit_err(CompileError::MismatchedTypeInInterfaceSurface {
@@ -1278,10 +1278,9 @@ fn type_check_const_decl(
     const_decl_signature_type_id.subst(&ctx.type_subst(), engines);
 
     // unify the types from the constant with the constant signature
-    if !type_engine.get(const_decl_type_id).eq(
-        &type_engine.get(const_decl_signature_type_id),
-        &PartialEqWithEnginesContext::new(engines),
-    ) {
+    if !UnifyCheck::non_dynamic_equality(engines)
+        .check(const_decl_type_id, const_decl_signature_type_id)
+    {
         return Err(
             handler.emit_err(CompileError::MismatchedTypeInInterfaceSurface {
                 interface_name: interface_name(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -801,6 +801,7 @@ fn type_check_trait_implementation(
                             // Using Span::dummy just to match the type substitution, type is not used anywhere else.
                             name: Ident::new_with_override("Self".into(), Span::dummy()),
                             trait_constraints: VecSet(vec![]),
+                            parent: None,
                         },
                         None,
                     ),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -194,10 +194,10 @@ impl TyImplTrait {
 
                         let abi = decl_engine.get_abi(&decl_id);
 
-                        if !type_engine
-                            .get(implementing_for.type_id)
-                            .eq(&TypeInfo::Contract, engines)
-                        {
+                        if !type_engine.get(implementing_for.type_id).eq(
+                            &TypeInfo::Contract,
+                            &PartialEqWithEnginesContext::new(engines),
+                        ) {
                             handler.emit_err(CompileError::ImplAbiForNonContract {
                                 span: implementing_for.span(),
                                 ty: engines.help_out(implementing_for.type_id).to_string(),
@@ -1095,7 +1095,7 @@ fn type_check_impl_method(
 
             if !type_engine.get(impl_method_param_type_id).eq(
                 &type_engine.get(impl_method_signature_param_type_id),
-                engines,
+                &PartialEqWithEnginesContext::new(engines),
             ) {
                 handler.emit_err(CompileError::MismatchedTypeInInterfaceSurface {
                     interface_name: interface_name(),
@@ -1169,7 +1169,7 @@ fn type_check_impl_method(
 
         if !type_engine.get(impl_method_return_type_id).eq(
             &type_engine.get(impl_method_signature_return_type_type_id),
-            engines,
+            &PartialEqWithEnginesContext::new(engines),
         ) {
             return Err(
                 handler.emit_err(CompileError::MismatchedTypeInInterfaceSurface {
@@ -1277,10 +1277,10 @@ fn type_check_const_decl(
     const_decl_signature_type_id.subst(&ctx.type_subst(), engines);
 
     // unify the types from the constant with the constant signature
-    if !type_engine
-        .get(const_decl_type_id)
-        .eq(&type_engine.get(const_decl_signature_type_id), engines)
-    {
+    if !type_engine.get(const_decl_type_id).eq(
+        &type_engine.get(const_decl_signature_type_id),
+        &PartialEqWithEnginesContext::new(engines),
+    ) {
         return Err(
             handler.emit_err(CompileError::MismatchedTypeInInterfaceSurface {
                 interface_name: interface_name(),

--- a/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
@@ -631,7 +631,10 @@ fn type_check_state_clear(
         .to_typeinfo(key_exp.return_type, &span)
         .map_err(|e| handler.emit_err(e.into()))
         .unwrap_or_else(TypeInfo::ErrorRecovery);
-    if !key_ty.eq(&TypeInfo::B256, ctx.engines()) {
+    if !key_ty.eq(
+        &TypeInfo::B256,
+        &PartialEqWithEnginesContext::new(ctx.engines()),
+    ) {
         return Err(handler.emit_err(CompileError::IntrinsicUnsupportedArgType {
             name: kind.to_string(),
             span,
@@ -687,7 +690,7 @@ fn type_check_state_load_word(
         .to_typeinfo(exp.return_type, &span)
         .map_err(|e| handler.emit_err(e.into()))
         .unwrap_or_else(TypeInfo::ErrorRecovery);
-    if !key_ty.eq(&TypeInfo::B256, engines) {
+    if !key_ty.eq(&TypeInfo::B256, &PartialEqWithEnginesContext::new(engines)) {
         return Err(handler.emit_err(CompileError::IntrinsicUnsupportedArgType {
             name: kind.to_string(),
             span,
@@ -745,7 +748,10 @@ fn type_check_state_store_word(
         .to_typeinfo(key_exp.return_type, &span)
         .map_err(|e| handler.emit_err(e.into()))
         .unwrap_or_else(TypeInfo::ErrorRecovery);
-    if !key_ty.eq(&TypeInfo::B256, ctx.engines()) {
+    if !key_ty.eq(
+        &TypeInfo::B256,
+        &PartialEqWithEnginesContext::new(ctx.engines()),
+    ) {
         return Err(handler.emit_err(CompileError::IntrinsicUnsupportedArgType {
             name: kind.to_string(),
             span,
@@ -837,7 +843,10 @@ fn type_check_state_quad(
         .to_typeinfo(key_exp.return_type, &span)
         .map_err(|e| handler.emit_err(e.into()))
         .unwrap_or_else(TypeInfo::ErrorRecovery);
-    if !key_ty.eq(&TypeInfo::B256, ctx.engines()) {
+    if !key_ty.eq(
+        &TypeInfo::B256,
+        &PartialEqWithEnginesContext::new(ctx.engines()),
+    ) {
         return Err(handler.emit_err(CompileError::IntrinsicUnsupportedArgType {
             name: kind.to_string(),
             span,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -275,7 +275,7 @@ pub(crate) fn struct_instantiation(
         // Short-circuit if the unification fails, by checking if the scoped handler
         // has collected any errors.
         handler.scope(|handler| {
-            type_engine.unify(
+            type_engine.unify_with_generic(
                 handler,
                 engines,
                 context_expected_type_id,

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -29,8 +29,8 @@ struct TraitSuffix {
     args: Vec<TypeArgument>,
 }
 impl PartialEqWithEngines for TraitSuffix {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        self.name == other.name && self.args.eq(&other.args, engines)
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        self.name == other.name && self.args.eq(&other.args, ctx)
     }
 }
 impl OrdWithEngines for TraitSuffix {
@@ -42,9 +42,9 @@ impl OrdWithEngines for TraitSuffix {
 }
 
 impl<T: PartialEqWithEngines> PartialEqWithEngines for CallPath<T> {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.prefixes == other.prefixes
-            && self.suffix.eq(&other.suffix, engines)
+            && self.suffix.eq(&other.suffix, ctx)
             && self.is_absolute == other.is_absolute
     }
 }
@@ -1059,9 +1059,9 @@ impl TraitMap {
                 trait_constraints, ..
             } => {
                 let all = constraints.iter().all(|required| {
-                    trait_constraints
-                        .iter()
-                        .any(|constraint| constraint.eq(required, engines))
+                    trait_constraints.iter().any(|constraint| {
+                        constraint.eq(required, &PartialEqWithEnginesContext::new(engines))
+                    })
                 });
                 if all {
                     return Ok(());
@@ -1069,9 +1069,9 @@ impl TraitMap {
             }
             TypeInfo::Placeholder(p) => {
                 let all = constraints.iter().all(|required| {
-                    p.trait_constraints
-                        .iter()
-                        .any(|constraint| constraint.eq(required, engines))
+                    p.trait_constraints.iter().any(|constraint| {
+                        constraint.eq(required, &PartialEqWithEnginesContext::new(engines))
+                    })
                 });
                 if all {
                     return Ok(());

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -34,10 +34,10 @@ impl PartialEqWithEngines for TraitSuffix {
     }
 }
 impl OrdWithEngines for TraitSuffix {
-    fn cmp(&self, other: &Self, engines: &Engines) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> std::cmp::Ordering {
         self.name
             .cmp(&other.name)
-            .then_with(|| self.args.cmp(&other.args, engines))
+            .then_with(|| self.args.cmp(&other.args, ctx))
     }
 }
 
@@ -49,10 +49,10 @@ impl<T: PartialEqWithEngines> PartialEqWithEngines for CallPath<T> {
     }
 }
 impl<T: OrdWithEngines> OrdWithEngines for CallPath<T> {
-    fn cmp(&self, other: &Self, engines: &Engines) -> Ordering {
+    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> Ordering {
         self.prefixes
             .cmp(&other.prefixes)
-            .then_with(|| self.suffix.cmp(&other.suffix, engines))
+            .then_with(|| self.suffix.cmp(&other.suffix, ctx))
             .then_with(|| self.is_absolute.cmp(&other.is_absolute))
     }
 }
@@ -92,9 +92,9 @@ struct TraitKey {
 }
 
 impl OrdWithEngines for TraitKey {
-    fn cmp(&self, other: &Self, engines: &Engines) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> std::cmp::Ordering {
         self.name
-            .cmp(&other.name, engines)
+            .cmp(&other.name, ctx)
             .then_with(|| self.type_id.cmp(&other.type_id))
     }
 }
@@ -491,7 +491,7 @@ impl TraitMap {
         for oe in other.trait_impls.into_iter() {
             let pos = self
                 .trait_impls
-                .binary_search_by(|se| se.key.cmp(&oe.key, engines));
+                .binary_search_by(|se| se.key.cmp(&oe.key, &OrdWithEnginesContext::new(engines)));
 
             match pos {
                 Ok(pos) => self.trait_impls[pos]

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -126,10 +126,10 @@ impl Spanned for TypeArgs {
 }
 
 impl PartialEqWithEngines for TypeArgs {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         match (self, other) {
-            (TypeArgs::Regular(vec1), TypeArgs::Regular(vec2)) => vec1.eq(vec2, engines),
-            (TypeArgs::Prefix(vec1), TypeArgs::Prefix(vec2)) => vec1.eq(vec2, engines),
+            (TypeArgs::Regular(vec1), TypeArgs::Regular(vec2)) => vec1.eq(vec2, ctx),
+            (TypeArgs::Prefix(vec1), TypeArgs::Prefix(vec2)) => vec1.eq(vec2, ctx),
             _ => false,
         }
     }
@@ -142,8 +142,8 @@ impl<T> Spanned for TypeBinding<T> {
 }
 
 impl PartialEqWithEngines for TypeBinding<()> {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        self.span == other.span && self.type_arguments.eq(&other.type_arguments, engines)
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        self.span == other.span && self.type_arguments.eq(&other.type_arguments, ctx)
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -37,9 +37,15 @@ impl HashWithEngines for TraitConstraint {
 
 impl EqWithEngines for TraitConstraint {}
 impl PartialEqWithEngines for TraitConstraint {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.trait_name == other.trait_name
-            && self.type_arguments.eq(&other.type_arguments, engines)
+            // Check if eq is already inside of a trait constraint, if it is we don't compare type arguments.
+            // This breaks the recursion when we use a where clause such as `T:MyTrait<T>`.
+            && (ctx.is_inside_trait_constraint()
+                || self.type_arguments.eq(
+                    &other.type_arguments,
+                    &(ctx.with_is_inside_trait_constraint()),
+                ))
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -50,7 +50,7 @@ impl PartialEqWithEngines for TraitConstraint {
 }
 
 impl OrdWithEngines for TraitConstraint {
-    fn cmp(&self, other: &Self, engines: &Engines) -> Ordering {
+    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> Ordering {
         let TraitConstraint {
             trait_name: ltn,
             type_arguments: lta,
@@ -59,7 +59,15 @@ impl OrdWithEngines for TraitConstraint {
             trait_name: rtn,
             type_arguments: rta,
         } = other;
-        ltn.cmp(rtn).then_with(|| lta.cmp(rta, engines))
+        let mut res = ltn.cmp(rtn);
+
+        // Check if cmp is already inside of a trait constraint, if it is we don't compare type arguments.
+        // This breaks the recursion when we use a where clause such as `T:MyTrait<T>`.
+        if !ctx.is_inside_trait_constraint() {
+            res = res.then_with(|| lta.cmp(rta, &ctx.with_is_inside_trait_constraint()))
+        }
+
+        res
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -54,7 +54,7 @@ impl PartialEqWithEngines for TypeArgument {
 }
 
 impl OrdWithEngines for TypeArgument {
-    fn cmp(&self, other: &Self, engines: &Engines) -> Ordering {
+    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> Ordering {
         let TypeArgument {
             type_id: lti,
             // these fields are not compared because they aren't relevant/a
@@ -74,7 +74,10 @@ impl OrdWithEngines for TypeArgument {
         if lti == rti {
             return Ordering::Equal;
         }
-        engines.te().get(*lti).cmp(&engines.te().get(*rti), engines)
+        ctx.engines()
+            .te()
+            .get(*lti)
+            .cmp(&ctx.engines().te().get(*rti), ctx)
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -44,12 +44,12 @@ impl HashWithEngines for TypeArgument {
 
 impl EqWithEngines for TypeArgument {}
 impl PartialEqWithEngines for TypeArgument {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        let type_engine = engines.te();
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        let type_engine = ctx.engines().te();
         self.type_id == other.type_id
             || type_engine
                 .get(self.type_id)
-                .eq(&type_engine.get(other.type_id), engines)
+                .eq(&type_engine.get(other.type_id), ctx)
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -14,7 +14,7 @@ use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
 };
-use sway_types::{ident::Ident, span::Span, BaseIdent, Spanned};
+use sway_types::{ident::Ident, span::Span, Spanned};
 
 use std::{
     cmp::Ordering,
@@ -65,7 +65,7 @@ impl PartialEqWithEngines for TypeParameter {
 }
 
 impl OrdWithEngines for TypeParameter {
-    fn cmp(&self, other: &Self, engines: &Engines) -> Ordering {
+    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> Ordering {
         let TypeParameter {
             type_id: lti,
             name_ident: ln,
@@ -87,8 +87,13 @@ impl OrdWithEngines for TypeParameter {
             is_from_parent: _,
         } = other;
         ln.cmp(rn)
-            .then_with(|| engines.te().get(*lti).cmp(&engines.te().get(*rti), engines))
-            .then_with(|| ltc.cmp(rtc, engines))
+            .then_with(|| {
+                ctx.engines()
+                    .te()
+                    .get(*lti)
+                    .cmp(&ctx.engines().te().get(*rti), ctx)
+            })
+            .then_with(|| ltc.cmp(rtc, ctx))
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -54,13 +54,13 @@ impl HashWithEngines for TypeParameter {
 
 impl EqWithEngines for TypeParameter {}
 impl PartialEqWithEngines for TypeParameter {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        let type_engine = engines.te();
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        let type_engine = ctx.engines().te();
         type_engine
             .get(self.type_id)
-            .eq(&type_engine.get(other.type_id), engines)
+            .eq(&type_engine.get(other.type_id), ctx)
             && self.name_ident == other.name_ident
-            && self.trait_constraints.eq(&other.trait_constraints, engines)
+            && self.trait_constraints.eq(&other.trait_constraints, ctx)
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -309,7 +309,7 @@ impl TypeParameter {
             parent,
         } = &*type_engine.get(type_id)
         {
-            parent.clone()
+            *parent
         } else {
             None
         };
@@ -369,7 +369,7 @@ impl TypeParameter {
             parent,
         } = &*type_engine.get(type_parameter.type_id)
         {
-            parent.clone()
+            *parent
         } else {
             None
         };
@@ -444,7 +444,7 @@ impl TypeParameter {
                 .module()
                 .current_items()
                 .symbols
-                .get(&name_ident)
+                .get(name_ident)
                 .unwrap();
 
             match sy {

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -14,7 +14,7 @@ use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
 };
-use sway_types::{ident::Ident, span::Span, Spanned};
+use sway_types::{ident::Ident, span::Span, BaseIdent, Spanned};
 
 use std::{
     cmp::Ordering,
@@ -441,17 +441,18 @@ impl TypeParameter {
             ..
         } = self;
 
-        if !is_from_parent {
-            // Insert the type parameter into the namespace as a dummy type
-            // declaration.
-            let type_parameter_decl =
-                ty::TyDecl::GenericTypeForFunctionScope(ty::GenericTypeForFunctionScope {
-                    name: name_ident.clone(),
-                    type_id: *type_id,
-                });
-            ctx.insert_symbol(handler, name_ident.clone(), type_parameter_decl)
-                .ok();
+        // Insert the type parameter into the namespace as a dummy type
+        // declaration.
+        let type_parameter_decl =
+            ty::TyDecl::GenericTypeForFunctionScope(ty::GenericTypeForFunctionScope {
+                name: name_ident.clone(),
+                type_id: *type_id,
+            });
+        if *is_from_parent {
+            ctx = ctx.with_generic_shadowing_mode(GenericShadowingMode::Allow);
         }
+        ctx.insert_symbol(handler, name_ident.clone(), type_parameter_decl)
+            .ok();
 
         Ok(())
     }

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -52,9 +52,9 @@ impl TypeEngine {
         let hash_builder = id_map.hasher().clone();
         let ty_hash = make_hasher(&hash_builder, engines)(&tsi);
 
-        let raw_entry = id_map
-            .raw_entry_mut()
-            .from_hash(ty_hash, |x| x.eq(&tsi, engines));
+        let raw_entry = id_map.raw_entry_mut().from_hash(ty_hash, |x| {
+            x.eq(&tsi, &PartialEqWithEnginesContext::new(engines))
+        });
         match raw_entry {
             RawEntryMut::Occupied(o) => return *o.get(),
             RawEntryMut::Vacant(_) if ty.can_change(engines.de()) => {

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -95,9 +95,12 @@ impl UnconstrainedTypeParameters for TypeId {
         let mut all_types: BTreeSet<TypeId> = self.extract_inner_types(engines);
         all_types.insert(*self);
         let type_parameter_info = type_engine.get(type_parameter.type_id);
-        all_types
-            .iter()
-            .any(|type_id| type_engine.get(*type_id).eq(&type_parameter_info, engines))
+        all_types.iter().any(|type_id| {
+            type_engine.get(*type_id).eq(
+                &type_parameter_info,
+                &PartialEqWithEnginesContext::new(engines),
+            )
+        })
     }
 }
 

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -359,6 +359,7 @@ impl TypeId {
             TypeInfo::UnknownGeneric {
                 name: _,
                 trait_constraints,
+                parent: _,
             } => {
                 found.insert(*self, trait_constraints.to_vec());
                 for trait_constraint in trait_constraints.iter() {

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -44,6 +44,7 @@ fn generic_enum_resolution() {
         TypeInfo::UnknownGeneric {
             name: generic_name.clone(),
             trait_constraints: VecSet(Vec::new()),
+            parent: None,
         },
         None,
     );

--- a/sway-core/src/type_system/substitute/subst_list.rs
+++ b/sway-core/src/type_system/substitute/subst_list.rs
@@ -60,8 +60,8 @@ impl std::iter::FromIterator<TypeParameter> for SubstList {
 
 impl EqWithEngines for SubstList {}
 impl PartialEqWithEngines for SubstList {
-    fn eq(&self, other: &Self, engines: &Engines) -> bool {
-        self.list.eq(&other.list, engines)
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        self.list.eq(&other.list, ctx)
     }
 }
 

--- a/sway-core/src/type_system/substitute/subst_list.rs
+++ b/sway-core/src/type_system/substitute/subst_list.rs
@@ -72,10 +72,10 @@ impl HashWithEngines for SubstList {
 }
 
 impl OrdWithEngines for SubstList {
-    fn cmp(&self, other: &Self, engines: &Engines) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> std::cmp::Ordering {
         let SubstList { list: ll } = self;
         let SubstList { list: rl } = other;
-        ll.cmp(rl, engines)
+        ll.cmp(rl, ctx)
     }
 }
 

--- a/sway-core/src/type_system/substitute/subst_map.rs
+++ b/sway-core/src/type_system/substitute/subst_map.rs
@@ -509,7 +509,10 @@ fn iter_for_match(
 ) -> Option<TypeId> {
     let type_engine = engines.te();
     for (source_type, dest_type) in type_mapping.mapping.iter() {
-        if type_engine.get(*source_type).eq(type_info, engines) {
+        if type_engine
+            .get(*source_type)
+            .eq(type_info, &PartialEqWithEnginesContext::new(engines))
+        {
             return Some(*dest_type);
         }
     }

--- a/sway-core/src/type_system/unify/unifier.rs
+++ b/sway-core/src/type_system/unify/unifier.rs
@@ -165,7 +165,11 @@ impl<'a> Unifier<'a> {
                     name: en,
                     trait_constraints: etc,
                 },
-            ) if rn.as_str() == en.as_str() && rtc.eq(etc, self.engines) => (),
+            ) if rn.as_str() == en.as_str()
+                && rtc.eq(etc, &PartialEqWithEnginesContext::new(self.engines)) =>
+            {
+                ()
+            }
 
             (_r @ UnknownGeneric { .. }, e)
                 if !self.occurs_check(received, expected)
@@ -260,7 +264,7 @@ impl<'a> Unifier<'a> {
                 )
             }
             (ref r @ TypeInfo::ContractCaller { .. }, ref e @ TypeInfo::ContractCaller { .. })
-                if r.eq(e, self.engines) =>
+                if r.eq(e, &PartialEqWithEnginesContext::new(self.engines)) =>
             {
                 // if they are the same, then it's ok
             }

--- a/sway-core/src/type_system/unify/unifier.rs
+++ b/sway-core/src/type_system/unify/unifier.rs
@@ -162,30 +162,21 @@ impl<'a> Unifier<'a> {
                         .engines
                         .te()
                         .get(rp.unwrap())
-                        .eq(e, &PartialEqWithEnginesContext::new(self.engines)) =>
-            {
-                ()
-            }
+                        .eq(e, &PartialEqWithEnginesContext::new(self.engines)) => {}
             (r, UnknownGeneric { parent: ep, .. })
                 if ep.is_some()
                     && self
                         .engines
                         .te()
                         .get(ep.unwrap())
-                        .eq(r, &PartialEqWithEnginesContext::new(self.engines)) =>
-            {
-                ()
-            }
+                        .eq(r, &PartialEqWithEnginesContext::new(self.engines)) => {}
             (UnknownGeneric { parent: rp, .. }, UnknownGeneric { parent: ep, .. })
                 if rp.is_some()
                     && ep.is_some()
                     && self.engines.te().get(ep.unwrap()).eq(
                         &*self.engines.te().get(rp.unwrap()),
                         &PartialEqWithEnginesContext::new(self.engines),
-                    ) =>
-            {
-                ()
-            }
+                    ) => {}
 
             (
                 UnknownGeneric {
@@ -199,10 +190,7 @@ impl<'a> Unifier<'a> {
                     parent: _,
                 },
             ) if rn.as_str() == en.as_str()
-                && rtc.eq(etc, &PartialEqWithEnginesContext::new(self.engines)) =>
-            {
-                ()
-            }
+                && rtc.eq(etc, &PartialEqWithEnginesContext::new(self.engines)) => {}
 
             (_r @ UnknownGeneric { .. }, e)
                 if !self.occurs_check(received, expected)

--- a/sway-core/src/type_system/unify/unifier.rs
+++ b/sway-core/src/type_system/unify/unifier.rs
@@ -156,14 +156,47 @@ impl<'a> Unifier<'a> {
             // Generics are handled similarly to the case for unknowns, except
             // we take more careful consideration for the type/purpose for the
             // unification that we are performing.
+            (UnknownGeneric { parent: rp, .. }, e)
+                if rp.is_some()
+                    && self
+                        .engines
+                        .te()
+                        .get(rp.unwrap())
+                        .eq(e, &PartialEqWithEnginesContext::new(self.engines)) =>
+            {
+                ()
+            }
+            (r, UnknownGeneric { parent: ep, .. })
+                if ep.is_some()
+                    && self
+                        .engines
+                        .te()
+                        .get(ep.unwrap())
+                        .eq(r, &PartialEqWithEnginesContext::new(self.engines)) =>
+            {
+                ()
+            }
+            (UnknownGeneric { parent: rp, .. }, UnknownGeneric { parent: ep, .. })
+                if rp.is_some()
+                    && ep.is_some()
+                    && self.engines.te().get(ep.unwrap()).eq(
+                        &*self.engines.te().get(rp.unwrap()),
+                        &PartialEqWithEnginesContext::new(self.engines),
+                    ) =>
+            {
+                ()
+            }
+
             (
                 UnknownGeneric {
                     name: rn,
                     trait_constraints: rtc,
+                    parent: _,
                 },
                 UnknownGeneric {
                     name: en,
                     trait_constraints: etc,
+                    parent: _,
                 },
             ) if rn.as_str() == en.as_str()
                 && rtc.eq(etc, &PartialEqWithEnginesContext::new(self.engines)) =>

--- a/sway-core/src/type_system/unify/unify_check.rs
+++ b/sway-core/src/type_system/unify/unify_check.rs
@@ -494,7 +494,7 @@ impl<'a> UnifyCheck<'a> {
                     TypeInfo::UnknownGeneric {
                         name: rn,
                         trait_constraints: rtc,
-                        parent: rp,
+                        parent: _,
                     },
                     TypeInfo::UnknownGeneric {
                         name: en,

--- a/sway-core/src/type_system/unify/unify_check.rs
+++ b/sway-core/src/type_system/unify/unify_check.rs
@@ -215,7 +215,7 @@ impl<'a> UnifyCheck<'a> {
         // override top level generics with simple equality but only at top level
         if let NonGenericConstraintSubset = self.mode {
             if let UnknownGeneric { .. } = &*right_info {
-                return left_info.eq(&right_info, self.engines);
+                return left_info.eq(&right_info, &PartialEqWithEnginesContext::new(self.engines));
             }
         }
         self.check_inner(left, right)
@@ -353,7 +353,7 @@ impl<'a> UnifyCheck<'a> {
                             name: rn,
                             trait_constraints: rtc,
                         },
-                    ) => ln == rn && rtc.eq(ltc, self.engines),
+                    ) => ln == rn && rtc.eq(ltc, &PartialEqWithEnginesContext::new(self.engines)),
                     // any type can be coerced into a generic,
                     // except if the type already contains the generic
                     (_e, _g @ UnknownGeneric { .. }) => {
@@ -394,7 +394,7 @@ impl<'a> UnifyCheck<'a> {
                             address: ref ea,
                         },
                     ) => {
-                        r.eq(e, self.engines)
+                        r.eq(e, &PartialEqWithEnginesContext::new(self.engines))
                             || (ran == ean && ra.is_none())
                             || matches!(ran, AbiName::Deferred)
                             || (ran == ean && ea.is_none())
@@ -404,7 +404,7 @@ impl<'a> UnifyCheck<'a> {
                     (ErrorRecovery(_), _) => true,
                     (_, ErrorRecovery(_)) => true,
 
-                    (a, b) => a.eq(b, self.engines),
+                    (a, b) => a.eq(b, &PartialEqWithEnginesContext::new(self.engines)),
                 }
             }
             ConstraintSubset | NonGenericConstraintSubset => {
@@ -418,7 +418,7 @@ impl<'a> UnifyCheck<'a> {
                             name: _,
                             trait_constraints: rtc,
                         },
-                    ) => rtc.eq(ltc, self.engines),
+                    ) => rtc.eq(ltc, &PartialEqWithEnginesContext::new(self.engines)),
 
                     // any type can be coerced into a generic,
                     // except if the type already contains the generic
@@ -429,7 +429,7 @@ impl<'a> UnifyCheck<'a> {
                     (Alias { ty: l_ty, .. }, Alias { ty: r_ty, .. }) => {
                         self.check_inner(l_ty.type_id, r_ty.type_id)
                     }
-                    (a, b) => a.eq(b, self.engines),
+                    (a, b) => a.eq(b, &PartialEqWithEnginesContext::new(self.engines)),
                 }
             }
             NonDynamicEquality => match (&*left_info, &*right_info) {
@@ -464,7 +464,10 @@ impl<'a> UnifyCheck<'a> {
                         name: en,
                         trait_constraints: etc,
                     },
-                ) => rn.as_str() == en.as_str() && rtc.eq(etc, self.engines),
+                ) => {
+                    rn.as_str() == en.as_str()
+                        && rtc.eq(etc, &PartialEqWithEnginesContext::new(self.engines))
+                }
                 (TypeInfo::Placeholder(_), TypeInfo::Placeholder(_)) => false,
                 (
                     TypeInfo::ContractCaller {
@@ -605,7 +608,7 @@ impl<'a> UnifyCheck<'a> {
                         {
                             continue;
                         }
-                        if a.eq(b, self.engines) {
+                        if a.eq(b, &PartialEqWithEnginesContext::new(self.engines)) {
                             // if a and b are the same type
                             constraints.push((i, j));
                         }
@@ -627,7 +630,7 @@ impl<'a> UnifyCheck<'a> {
                     {
                         continue;
                     }
-                    if !a.eq(b, self.engines) {
+                    if !a.eq(b, &PartialEqWithEnginesContext::new(self.engines)) {
                         return false;
                     }
                 }

--- a/sway-core/src/type_system/unify/unify_check.rs
+++ b/sway-core/src/type_system/unify/unify_check.rs
@@ -234,6 +234,9 @@ impl<'a> UnifyCheck<'a> {
 
         // common recursion patterns
         match (&*left_info, &*right_info) {
+            (Never, Never) => {
+                return true;
+            }
             (Array(l0, l1), Array(r0, r1)) => {
                 return self.check_inner(l0.type_id, r0.type_id) && l1.val() == r1.val();
             }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_generic_tuple/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_generic_tuple/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-15BAB98A466EA65D"
+
+[[package]]
+name = "std"
+source = "path+from-root-15BAB98A466EA65D"
+dependencies = ["core"]
+
+[[package]]
+name = "where_clause_generic_tuple"
+source = "member"
+dependencies = ["std"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_generic_tuple/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_generic_tuple/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+name = "where_clause_generic_tuple"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_generic_tuple/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_generic_tuple/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "u64",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_generic_tuple/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_generic_tuple/src/main.sw
@@ -1,0 +1,34 @@
+script;
+
+trait MyTrait {
+    fn call_trait(self) -> Self;
+}
+
+impl<A, B> MyTrait for (A, B) where A:MyTrait, B:MyTrait  {
+    fn call_trait(self) -> Self {
+        self
+    }
+}
+
+impl MyTrait for u64 {
+    fn call_trait(self) -> Self {
+        0
+    }
+}
+
+struct MyStruct<T> {
+    x: T,
+}
+
+impl<T> MyStruct<T> {
+    fn call_trait<M>(self, b: MyStruct<T>, c: MyStruct<M>) where T: MyTrait, M:MyTrait{
+        let _ = (b.x, c.x).call_trait();
+    }
+}
+
+fn main() -> u64 {
+    let s = MyStruct { x: 0u64 };
+    s.call_trait(s, s);
+
+    42
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_generic_tuple/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_generic_tuple/test.toml
@@ -1,0 +1,5 @@
+category = "run"
+expected_result = { action = "return", value = 42 }
+validate_abi = true
+
+expected_warnings = 8

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/src/main.sw
@@ -143,9 +143,7 @@ impl<T> MyPoint<T> {
 
 impl<T> MyPoint<T> where T: MyMath {
     fn do_math4(self, b: MyPoint<T>) -> MyPoint<T> {
-        // As reported in https://github.com/FuelLabs/sway/issues/5693
-        // Remove the `::<T>` after the issue is fixed.
-        MyPoint::<T> {
+        MyPoint {
             x: self.x.my_double().my_mul(b.x.my_double()),
             y: self.y.my_pow_2().my_add(b.y.my_pow_2()),
         }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/where_clause_methods/src/main.sw
@@ -139,6 +139,13 @@ impl<T> MyPoint<T> {
             y: self.y.my_pow_2().my_add(b.y.my_pow_2()),
         }
     }
+
+    fn do_math31<M>(self, b: MyPoint<T>, c: MyPoint<M>) -> MyPoint<T> where T: MyMath, M:MyMath{
+        MyPoint {
+            x: self.x.my_double().my_mul(b.x.my_double()),
+            y: self.y.my_pow_2().my_add(b.y.my_pow_2()),
+        }
+    }
 }
 
 impl<T> MyPoint<T> where T: MyMath {
@@ -217,6 +224,10 @@ fn main() -> u64 {
     let m = a.do_math3(b);
     assert(m.x == 12u64);
     assert(m.y == 20u64);
+
+    let m1 = a.do_math31(b, b);
+    assert(m1.x == 12u64);
+    assert(m1.y == 20u64);
 
     let n = a.do_math4(b);
     assert(n.x == 12u64);


### PR DESCRIPTION
## Description

When we have a impl type parameter that has a method where clause, the type
parameter in the namespace would not include the method where clause.

This fix shadows the impl type parameter with a new method type parameter that
contains the where clause.

PartialEqWithEnginesContext is now used to pass down engines and other variables in PartialEqWithEngines.
OrdWithEnginesContext is now used to pass down engines and other variables in OrdWithEngines.
This allows us to pass the variable is_inside_trait_constraint and break
the infinite recursion when where clauses such as `T:MyTrait<T>` are used.

Fixes https://github.com/FuelLabs/sway/issues/5735
Also fixes #5693 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
