### PR TITLE
Fixes compiler asking for unnecessary disambiguation for trait methods.

### DIFF
--- a/sway-core/src/type_system/unify/unify_check.rs
+++ b/sway-core/src/type_system/unify/unify_check.rs
@@ -375,7 +375,7 @@ impl<'a> UnifyCheck<'a> {
                     (Unknown, _) => true,
                     (_, Unknown) => true,
 
-                    (UnsignedInteger(_), UnsignedInteger(_)) => true,
+                    (UnsignedInteger(lb), UnsignedInteger(rb)) => lb == rb,
                     (Numeric, UnsignedInteger(_)) => true,
                     (UnsignedInteger(_), Numeric) => true,
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/method_unambiguous/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/method_unambiguous/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-13393DAFAC4DB2CA"
+
+[[package]]
+name = "method_unambiguous"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "std"
+source = "path+from-root-13393DAFAC4DB2CA"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/method_unambiguous/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/method_unambiguous/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "method_unambiguous"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/method_unambiguous/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/method_unambiguous/src/main.sw
@@ -1,0 +1,27 @@
+script;
+
+use std::convert::From;
+
+impl From<u8> for u256 {
+    fn from(num: u8) -> Self {
+        num.as_u256()
+    }
+}
+
+impl From<u16> for u256 {
+    fn from(num: u16) -> Self {
+        num.as_u256()
+    }
+}
+
+fn main() -> u64 {
+    use std::assert::assert;
+
+    let u256_value = u256::from(255_u8);
+    assert(u256_value == 0x00000000000000000000000000000000000000000000000000000000000000ff_u256);
+
+    let u256_value = u256::from(65535_u16);
+    assert(u256_value == 0x000000000000000000000000000000000000000000000000000000000000ffff_u256);
+
+    1
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/method_unambiguous/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/method_unambiguous/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+validate_abi = false


### PR DESCRIPTION
## Description

`find_method_for_type` was throwing an error when multiple implementations of a method exist receiving different kinds of unsigned int. This was caused by the coercion comparison which returned true while comparing any uint size to any other uint size.

The solution was to change the UnifyCheck on Coercion to only return true to same size uints.

Fixes #5798

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
