### PR TITLE
Refactor trait map and module symbol resolution code to allow usage for parsed declarations

### DIFF
--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -130,9 +130,9 @@ pub(crate) fn compile_const_decl(
                 None => None,
             };
             let const_decl = match decl {
-                Ok(decl) => match decl {
+                Ok(decl) => match decl.expect_typed() {
                     ty::TyDecl::ConstantDecl(ty::ConstantDecl { decl_id, .. }) => {
-                        Some((*env.engines.de().get_constant(decl_id)).clone())
+                        Some((*env.engines.de().get_constant(&decl_id)).clone())
                     }
                     _otherwise => const_decl.cloned(),
                 },

--- a/sway-core/src/language/parsed/declaration.rs
+++ b/sway-core/src/language/parsed/declaration.rs
@@ -17,6 +17,7 @@ pub use r#enum::*;
 pub use r#struct::*;
 pub use r#trait::*;
 pub use storage::*;
+use sway_types::Spanned;
 pub use type_alias::*;
 pub use variable::*;
 
@@ -46,6 +47,26 @@ impl Declaration {
             fn_decl.is_test()
         } else {
             false
+        }
+    }
+
+    #[allow(dead_code)]
+    fn span(&self, engines: &Engines) -> sway_types::Span {
+        use Declaration::*;
+        let pe = engines.pe();
+        match self {
+            VariableDeclaration(decl_id) => pe.get_variable(decl_id).span(),
+            FunctionDeclaration(decl_id) => pe.get_function(decl_id).span(),
+            TraitDeclaration(decl_id) => pe.get_trait(decl_id).span(),
+            StructDeclaration(decl_id) => pe.get_struct(decl_id).span(),
+            EnumDeclaration(decl_id) => pe.get_enum(decl_id).span(),
+            ImplTrait(decl_id) => pe.get_impl_trait(decl_id).span(),
+            ImplSelf(decl_id) => pe.get_impl_self(decl_id).span(),
+            AbiDeclaration(decl_id) => pe.get_abi(decl_id).span(),
+            ConstantDeclaration(decl_id) => pe.get_constant(decl_id).span(),
+            StorageDeclaration(decl_id) => pe.get_storage(decl_id).span(),
+            TypeAliasDeclaration(decl_id) => pe.get_type_alias(decl_id).span(),
+            TraitTypeDeclaration(decl_id) => pe.get_trait_type(decl_id).span(),
         }
     }
 }

--- a/sway-core/src/language/parsed/declaration/abi.rs
+++ b/sway-core/src/language/parsed/declaration/abi.rs
@@ -2,7 +2,7 @@ use crate::{decl_engine::parsed_id::ParsedDeclId, transform};
 
 use super::{FunctionDeclaration, Supertrait, TraitItem};
 
-use sway_types::{ident::Ident, span::Span};
+use sway_types::{ident::Ident, span::Span, Named, Spanned};
 
 /// An `abi` declaration, which declares an interface for a contract
 /// to implement or for a caller to use to call a contract.
@@ -17,4 +17,16 @@ pub struct AbiDeclaration {
     pub methods: Vec<ParsedDeclId<FunctionDeclaration>>,
     pub(crate) span: Span,
     pub attributes: transform::AttributesMap,
+}
+
+impl Named for AbiDeclaration {
+    fn name(&self) -> &sway_types::BaseIdent {
+        &self.name
+    }
+}
+
+impl Spanned for AbiDeclaration {
+    fn span(&self) -> sway_types::Span {
+        self.span.clone()
+    }
 }

--- a/sway-core/src/language/parsed/declaration/constant.rs
+++ b/sway-core/src/language/parsed/declaration/constant.rs
@@ -3,7 +3,7 @@ use crate::{
     language::{parsed::Expression, Visibility},
     transform, Engines, TypeArgument,
 };
-use sway_types::{Ident, Span};
+use sway_types::{Ident, Named, Span, Spanned};
 
 #[derive(Debug, Clone)]
 pub struct ConstantDeclaration {
@@ -14,6 +14,18 @@ pub struct ConstantDeclaration {
     pub visibility: Visibility,
     pub is_configurable: bool,
     pub span: Span,
+}
+
+impl Named for ConstantDeclaration {
+    fn name(&self) -> &sway_types::BaseIdent {
+        &self.name
+    }
+}
+
+impl Spanned for ConstantDeclaration {
+    fn span(&self) -> sway_types::Span {
+        self.span.clone()
+    }
 }
 
 impl DebugWithEngines for ConstantDeclaration {

--- a/sway-core/src/language/parsed/declaration/enum.rs
+++ b/sway-core/src/language/parsed/declaration/enum.rs
@@ -1,5 +1,5 @@
 use crate::{language::Visibility, transform, type_system::*};
-use sway_types::{ident::Ident, span::Span};
+use sway_types::{ident::Ident, span::Span, Named, Spanned};
 
 #[derive(Debug, Clone)]
 pub struct EnumDeclaration {
@@ -9,6 +9,18 @@ pub struct EnumDeclaration {
     pub variants: Vec<EnumVariant>,
     pub(crate) span: Span,
     pub visibility: Visibility,
+}
+
+impl Named for EnumDeclaration {
+    fn name(&self) -> &sway_types::BaseIdent {
+        &self.name
+    }
+}
+
+impl Spanned for EnumDeclaration {
+    fn span(&self) -> sway_types::Span {
+        self.span.clone()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/sway-core/src/language/parsed/declaration/function.rs
+++ b/sway-core/src/language/parsed/declaration/function.rs
@@ -4,7 +4,7 @@ use crate::{
     transform::{self, AttributeKind},
     type_system::*,
 };
-use sway_types::{ident::Ident, span::Span};
+use sway_types::{ident::Ident, span::Span, Named, Spanned};
 
 #[derive(Debug, Clone)]
 pub enum FunctionDeclarationKind {
@@ -32,6 +32,18 @@ pub struct FunctionDeclaration {
 impl DebugWithEngines for FunctionDeclaration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, _engines: &Engines) -> std::fmt::Result {
         f.write_fmt(format_args!("{}", self.name))
+    }
+}
+
+impl Named for FunctionDeclaration {
+    fn name(&self) -> &sway_types::BaseIdent {
+        &self.name
+    }
+}
+
+impl Spanned for FunctionDeclaration {
+    fn span(&self) -> sway_types::Span {
+        self.span.clone()
     }
 }
 

--- a/sway-core/src/language/parsed/declaration/impl_trait.rs
+++ b/sway-core/src/language/parsed/declaration/impl_trait.rs
@@ -4,13 +4,23 @@ use crate::{
     type_system::TypeArgument, Engines, TypeParameter,
 };
 
-use sway_types::span::Span;
+use sway_types::{span::Span, Named, Spanned};
 
 #[derive(Debug, Clone)]
 pub enum ImplItem {
     Fn(ParsedDeclId<FunctionDeclaration>),
     Constant(ParsedDeclId<ConstantDeclaration>),
     Type(ParsedDeclId<TraitTypeDeclaration>),
+}
+
+impl ImplItem {
+    pub fn span(&self, engines: &Engines) -> Span {
+        match self {
+            ImplItem::Fn(id) => engines.pe().get_function(id).span(),
+            ImplItem::Constant(id) => engines.pe().get_constant(id).span(),
+            ImplItem::Type(id) => engines.pe().get_trait_type(id).span(),
+        }
+    }
 }
 
 impl DebugWithEngines for ImplItem {
@@ -43,6 +53,18 @@ pub struct ImplTrait {
     pub(crate) block_span: Span,
 }
 
+impl Named for ImplTrait {
+    fn name(&self) -> &sway_types::BaseIdent {
+        &self.trait_name.suffix
+    }
+}
+
+impl Spanned for ImplTrait {
+    fn span(&self) -> sway_types::Span {
+        self.block_span.clone()
+    }
+}
+
 impl DebugWithEngines for ImplTrait {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, engines: &Engines) -> std::fmt::Result {
         f.write_fmt(format_args!(
@@ -62,6 +84,12 @@ pub struct ImplSelf {
     pub items: Vec<ImplItem>,
     // the span of the whole impl trait and block
     pub(crate) block_span: Span,
+}
+
+impl Spanned for ImplSelf {
+    fn span(&self) -> sway_types::Span {
+        self.block_span.clone()
+    }
 }
 
 impl DebugWithEngines for ImplSelf {

--- a/sway-core/src/language/parsed/declaration/storage.rs
+++ b/sway-core/src/language/parsed/declaration/storage.rs
@@ -1,5 +1,5 @@
 use crate::{language::parsed::Expression, transform, type_system::*};
-use sway_types::{ident::Ident, span::Span};
+use sway_types::{ident::Ident, span::Span, Spanned};
 
 #[derive(Debug, Clone)]
 /// A declaration of contract storage. Only valid within contract contexts.
@@ -9,6 +9,12 @@ pub struct StorageDeclaration {
     pub fields: Vec<StorageField>,
     pub span: Span,
     pub storage_keyword: Ident,
+}
+
+impl Spanned for StorageDeclaration {
+    fn span(&self) -> sway_types::Span {
+        self.span.clone()
+    }
 }
 
 /// An individual field in a storage declaration.

--- a/sway-core/src/language/parsed/declaration/struct.rs
+++ b/sway-core/src/language/parsed/declaration/struct.rs
@@ -1,5 +1,5 @@
 use crate::{language::Visibility, transform, type_system::TypeParameter, TypeArgument};
-use sway_types::{ident::Ident, span::Span};
+use sway_types::{ident::Ident, span::Span, Named, Spanned};
 
 #[derive(Debug, Clone)]
 pub struct StructDeclaration {
@@ -9,6 +9,18 @@ pub struct StructDeclaration {
     pub type_parameters: Vec<TypeParameter>,
     pub visibility: Visibility,
     pub(crate) span: Span,
+}
+
+impl Named for StructDeclaration {
+    fn name(&self) -> &sway_types::BaseIdent {
+        &self.name
+    }
+}
+
+impl Spanned for StructDeclaration {
+    fn span(&self) -> sway_types::Span {
+        self.span.clone()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/sway-core/src/language/parsed/declaration/trait.rs
+++ b/sway-core/src/language/parsed/declaration/trait.rs
@@ -10,7 +10,7 @@ use crate::{
     type_system::*,
 };
 use sway_error::handler::ErrorEmitted;
-use sway_types::{ident::Ident, span::Span, Spanned};
+use sway_types::{ident::Ident, span::Span, Named, Spanned};
 
 #[derive(Debug, Clone)]
 pub enum TraitItem {
@@ -31,6 +31,18 @@ pub struct TraitDeclaration {
     pub supertraits: Vec<Supertrait>,
     pub visibility: Visibility,
     pub span: Span,
+}
+
+impl Named for TraitDeclaration {
+    fn name(&self) -> &sway_types::BaseIdent {
+        &self.name
+    }
+}
+
+impl Spanned for TraitDeclaration {
+    fn span(&self) -> sway_types::Span {
+        self.span.clone()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -84,6 +96,18 @@ pub struct TraitTypeDeclaration {
     pub attributes: transform::AttributesMap,
     pub ty_opt: Option<TypeArgument>,
     pub span: Span,
+}
+
+impl Named for TraitTypeDeclaration {
+    fn name(&self) -> &sway_types::BaseIdent {
+        &self.name
+    }
+}
+
+impl Spanned for TraitTypeDeclaration {
+    fn span(&self) -> sway_types::Span {
+        self.span.clone()
+    }
 }
 
 impl DebugWithEngines for TraitTypeDeclaration {

--- a/sway-core/src/language/parsed/declaration/type_alias.rs
+++ b/sway-core/src/language/parsed/declaration/type_alias.rs
@@ -1,6 +1,6 @@
 use crate::{language::Visibility, transform, type_system::*};
 
-use sway_types::{ident::Ident, span::Span};
+use sway_types::{ident::Ident, span::Span, Named, Spanned};
 
 #[derive(Debug, Clone)]
 pub struct TypeAliasDeclaration {
@@ -9,4 +9,16 @@ pub struct TypeAliasDeclaration {
     pub ty: TypeArgument,
     pub visibility: Visibility,
     pub span: Span,
+}
+
+impl Named for TypeAliasDeclaration {
+    fn name(&self) -> &sway_types::BaseIdent {
+        &self.name
+    }
+}
+
+impl Spanned for TypeAliasDeclaration {
+    fn span(&self) -> sway_types::Span {
+        self.span.clone()
+    }
 }

--- a/sway-core/src/language/parsed/declaration/variable.rs
+++ b/sway-core/src/language/parsed/declaration/variable.rs
@@ -1,3 +1,5 @@
+use sway_types::{Named, Spanned};
+
 use crate::{language::parsed::Expression, Ident, TypeArgument};
 
 #[derive(Debug, Clone)]
@@ -6,4 +8,16 @@ pub struct VariableDeclaration {
     pub type_ascription: TypeArgument,
     pub body: Expression, // will be codeblock variant
     pub is_mutable: bool,
+}
+
+impl Named for VariableDeclaration {
+    fn name(&self) -> &sway_types::BaseIdent {
+        &self.name
+    }
+}
+
+impl Spanned for VariableDeclaration {
+    fn span(&self) -> sway_types::Span {
+        self.name.span()
+    }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -230,7 +230,12 @@ impl TyDecl {
                 for supertrait in trait_decl.supertraits.iter_mut() {
                     let _ = ctx
                         .namespace()
-                        .resolve_call_path(handler, engines, &supertrait.name, ctx.self_type())
+                        .resolve_call_path_typed(
+                            handler,
+                            engines,
+                            &supertrait.name,
+                            ctx.self_type(),
+                        )
                         .map(|supertrait_decl| {
                             if let ty::TyDecl::TraitDecl(ty::TraitDecl {
                                 name: supertrait_name,
@@ -273,7 +278,7 @@ impl TyDecl {
                 // we insert its methods with a prefix
                 let emp_vec = vec![];
                 let impl_trait_items = if let Ok(ty::TyDecl::TraitDecl { .. }) =
-                    ctx.namespace().resolve_call_path(
+                    ctx.namespace().resolve_call_path_typed(
                         &Handler::default(),
                         engines,
                         &impl_trait.trait_name,
@@ -392,7 +397,12 @@ impl TyDecl {
                 for supertrait in abi_decl.supertraits.iter_mut() {
                     let _ = ctx
                         .namespace()
-                        .resolve_call_path(handler, engines, &supertrait.name, ctx.self_type())
+                        .resolve_call_path_typed(
+                            handler,
+                            engines,
+                            &supertrait.name,
+                            ctx.self_type(),
+                        )
                         .map(|supertrait_decl| {
                             if let ty::TyDecl::TraitDecl(ty::TraitDecl {
                                 name: supertrait_name,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -120,7 +120,7 @@ impl TyImplTrait {
 
                 let impl_trait = match ctx
                     .namespace()
-                    .resolve_call_path(handler, engines, &trait_name, ctx.self_type())
+                    .resolve_call_path_typed(handler, engines, &trait_name, ctx.self_type())
                     .ok()
                 {
                     Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
@@ -1459,7 +1459,7 @@ fn handle_supertraits(
             match ctx
                 .namespace()
                 // Use the default Handler to avoid emitting the redundant SymbolNotFound error.
-                .resolve_call_path(
+                .resolve_call_path_typed(
                     &Handler::default(),
                     engines,
                     &supertrait.name,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/supertrait.rs
@@ -44,7 +44,7 @@ pub(crate) fn insert_supertraits_into_namespace(
             let decl = ctx
                 .namespace()
                 // Use the default Handler to avoid emitting the redundant SymbolNotFound error.
-                .resolve_call_path(
+                .resolve_call_path_typed(
                     &Handler::default(),
                     engines,
                     &supertrait.name,

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -166,7 +166,7 @@ fn type_check_variable(
 
     let typed_scrutinee = match ctx
         .namespace()
-        .resolve_symbol(&Handler::default(), engines, &name, ctx.self_type())
+        .resolve_symbol_typed(&Handler::default(), engines, &name, ctx.self_type())
         .ok()
     {
         // If this variable is a constant, then we turn it into a [TyScrutinee::Constant](ty::TyScrutinee::Constant).
@@ -221,7 +221,7 @@ fn type_check_struct(
     // find the struct definition from the name
     let unknown_decl =
         ctx.namespace()
-            .resolve_symbol(handler, engines, &struct_name, ctx.self_type())?;
+            .resolve_symbol_typed(handler, engines, &struct_name, ctx.self_type())?;
     let struct_ref = unknown_decl.to_struct_ref(handler, ctx.engines())?;
     let mut struct_decl = (*decl_engine.get_struct(&struct_ref)).clone();
 
@@ -485,7 +485,7 @@ fn type_check_enum(
                 is_absolute: call_path.is_absolute,
             };
             // find the enum definition from the name
-            let unknown_decl = ctx.namespace().resolve_call_path(
+            let unknown_decl = ctx.namespace().resolve_call_path_typed(
                 handler,
                 engines,
                 &enum_callpath,
@@ -500,9 +500,12 @@ fn type_check_enum(
         }
         None => {
             // we may have an imported variant
-            let decl =
-                ctx.namespace()
-                    .resolve_call_path(handler, engines, &call_path, ctx.self_type())?;
+            let decl = ctx.namespace().resolve_call_path_typed(
+                handler,
+                engines,
+                &call_path,
+                ctx.self_type(),
+            )?;
             if let TyDecl::EnumVariantDecl(ty::EnumVariantDecl { enum_ref, .. }) = decl.clone() {
                 (
                     call_path.suffix.span(),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -267,7 +267,7 @@ pub(crate) fn type_check_method_application(
     ) -> Result<(), ErrorEmitted> {
         match exp {
             ty::TyExpressionVariant::VariableExpression { name, .. } => {
-                let unknown_decl = ctx.namespace().resolve_symbol(
+                let unknown_decl = ctx.namespace().resolve_symbol_typed(
                     &Handler::default(),
                     ctx.engines,
                     name,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -12,6 +12,7 @@ use crate::{
         ty::{self, StructAccessInfo, TyStructField},
         CallPath, Visibility,
     },
+    namespace::ResolvedTraitImplItem,
     semantic_analysis::{
         type_check_context::EnforceTypeArguments, GenericShadowingMode, TypeCheckContext,
     },
@@ -332,8 +333,11 @@ fn collect_struct_constructors(
         .get_items_for_type(engines, struct_type_id)
         .iter()
         .filter_map(|item| match item {
-            ty::TyTraitItem::Fn(fn_decl_id) => Some(fn_decl_id),
-            _ => None,
+            ResolvedTraitImplItem::Parsed(_) => unreachable!(),
+            ResolvedTraitImplItem::Typed(item) => match item {
+                ty::TyTraitItem::Fn(fn_decl_id) => Some(fn_decl_id),
+                _ => None,
+            },
         })
         .map(|fn_decl_id| engines.de().get_function(fn_decl_id))
         .filter(|fn_decl| {

--- a/sway-core/src/semantic_analysis/coins_analysis.rs
+++ b/sway-core/src/semantic_analysis/coins_analysis.rs
@@ -23,7 +23,7 @@ pub fn possibly_nonzero_u64_expression(
         },
         VariableExpression { name, .. } => {
             match namespace
-                .resolve_symbol(&Handler::default(), engines, name, None)
+                .resolve_symbol_typed(&Handler::default(), engines, name, None)
                 .ok()
             {
                 Some(ty_decl) => {

--- a/sway-core/src/semantic_analysis/namespace/lexical_scope.rs
+++ b/sway-core/src/semantic_analysis/namespace/lexical_scope.rs
@@ -11,7 +11,7 @@ use crate::{
     type_system::*,
 };
 
-use super::TraitMap;
+use super::{module::ResolvedDeclaration, TraitMap};
 
 use sway_error::{
     error::{CompileError, StructFieldUsageContext},
@@ -291,9 +291,10 @@ impl Items {
         Ok(())
     }
 
-    pub(crate) fn check_symbol(&self, name: &Ident) -> Result<&ty::TyDecl, CompileError> {
+    pub(crate) fn check_symbol(&self, name: &Ident) -> Result<ResolvedDeclaration, CompileError> {
         self.symbols
             .get(name)
+            .map(|ty_decl| ResolvedDeclaration::Typed(ty_decl.clone()))
             .ok_or_else(|| CompileError::SymbolNotFound {
                 name: name.clone(),
                 span: name.span(),

--- a/sway-core/src/semantic_analysis/namespace/lexical_scope.rs
+++ b/sway-core/src/semantic_analysis/namespace/lexical_scope.rs
@@ -1,8 +1,8 @@
 use crate::{
-    decl_engine::*,
+    decl_engine::{parsed_id::ParsedDeclId, *},
     engine_threading::Engines,
     language::{
-        parsed::Declaration,
+        parsed::{Declaration, FunctionDeclaration},
         ty::{self, StructAccessInfo, TyDecl, TyStorageDecl},
         CallPath,
     },
@@ -26,6 +26,20 @@ use std::sync::Arc;
 pub(crate) enum GlobImport {
     Yes,
     No,
+}
+
+pub enum ResolvedFunctionDecl {
+    Parsed(ParsedDeclId<FunctionDeclaration>),
+    Typed(DeclRefFunction),
+}
+
+impl ResolvedFunctionDecl {
+    pub fn expect_typed(self) -> DeclRefFunction {
+        match self {
+            ResolvedFunctionDecl::Parsed(_) => panic!(),
+            ResolvedFunctionDecl::Typed(fn_ref) => fn_ref,
+        }
+    }
 }
 
 pub(super) type ParsedSymbolMap = im::OrdMap<Ident, Declaration>;
@@ -301,7 +315,11 @@ impl Items {
             })
     }
 
-    pub fn get_items_for_type(&self, engines: &Engines, type_id: TypeId) -> Vec<ty::TyTraitItem> {
+    pub fn get_items_for_type(
+        &self,
+        engines: &Engines,
+        type_id: TypeId,
+    ) -> Vec<ResolvedTraitImplItem> {
         self.implemented_traits.get_items_for_type(engines, type_id)
     }
 
@@ -326,13 +344,20 @@ impl Items {
             .get_impl_spans_for_trait_name(trait_name)
     }
 
-    pub fn get_methods_for_type(&self, engines: &Engines, type_id: TypeId) -> Vec<DeclRefFunction> {
+    pub fn get_methods_for_type(
+        &self,
+        engines: &Engines,
+        type_id: TypeId,
+    ) -> Vec<ResolvedFunctionDecl> {
         self.get_items_for_type(engines, type_id)
             .into_iter()
             .filter_map(|item| match item {
-                ty::TyTraitItem::Fn(decl_ref) => Some(decl_ref),
-                ty::TyTraitItem::Constant(_decl_ref) => None,
-                ty::TyTraitItem::Type(_decl_ref) => None,
+                ResolvedTraitImplItem::Parsed(_) => todo!(),
+                ResolvedTraitImplItem::Typed(item) => match item {
+                    ty::TyTraitItem::Fn(decl_ref) => Some(ResolvedFunctionDecl::Typed(decl_ref)),
+                    ty::TyTraitItem::Constant(_decl_ref) => None,
+                    ty::TyTraitItem::Type(_decl_ref) => None,
+                },
             })
             .collect::<Vec<_>>()
     }

--- a/sway-core/src/semantic_analysis/namespace/mod.rs
+++ b/sway-core/src/semantic_analysis/namespace/mod.rs
@@ -13,6 +13,7 @@ pub use namespace::TryInsertingTraitImplOnFailure;
 pub use root::Root;
 pub(super) use trait_map::IsExtendingExistingImpl;
 pub(super) use trait_map::IsImplSelf;
+pub(super) use trait_map::ResolvedTraitImplItem;
 pub(super) use trait_map::TraitMap;
 
 use sway_types::Ident;

--- a/sway-core/src/semantic_analysis/namespace/namespace.rs
+++ b/sway-core/src/semantic_analysis/namespace/namespace.rs
@@ -1,5 +1,5 @@
 use crate::{
-    language::{ty, ty::TyTraitItem, CallPath, Visibility},
+    language::{ty, CallPath, Visibility},
     Engines, Ident, TypeId,
 };
 
@@ -7,6 +7,7 @@ use super::{
     module::{Module, ResolvedDeclaration},
     root::Root,
     submodule_namespace::SubmoduleNamespace,
+    trait_map::ResolvedTraitImplItem,
     ModulePath, ModulePathBuf,
 };
 
@@ -170,7 +171,7 @@ impl Namespace {
         name: &Ident,
         type_id: TypeId,
         as_trait: Option<CallPath>,
-    ) -> Result<TyTraitItem, ErrorEmitted> {
+    ) -> Result<ResolvedTraitImplItem, ErrorEmitted> {
         self.root
             .module
             .current_items()

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -14,6 +14,7 @@ use crate::{
     decl_engine::{DeclEngineGet, DeclEngineInsert},
     engine_threading::*,
     language::{
+        parsed::ImplItem,
         ty::{self, TyImplItem, TyTraitItem},
         CallPath,
     },
@@ -99,8 +100,30 @@ impl OrdWithEngines for TraitKey {
     }
 }
 
-/// Map of name to [TyImplItem](ty::TyImplItem)
-type TraitItems = im::HashMap<String, TyImplItem>;
+#[derive(Clone, Debug)]
+pub enum ResolvedTraitImplItem {
+    Parsed(ImplItem),
+    Typed(TyImplItem),
+}
+
+impl ResolvedTraitImplItem {
+    fn expect_typed(self) -> TyImplItem {
+        match self {
+            ResolvedTraitImplItem::Parsed(_) => panic!(),
+            ResolvedTraitImplItem::Typed(ty) => ty,
+        }
+    }
+
+    pub fn span(&self, engines: &Engines) -> Span {
+        match self {
+            ResolvedTraitImplItem::Parsed(item) => item.span(engines),
+            ResolvedTraitImplItem::Typed(item) => item.span(),
+        }
+    }
+}
+
+/// Map of name to [ResolvedTraitImplItem](ResolvedTraitImplItem)
+type TraitItems = im::HashMap<String, ResolvedTraitImplItem>;
 
 #[derive(Clone, Debug)]
 struct TraitValue {
@@ -152,7 +175,7 @@ impl TraitMap {
         trait_name: CallPath,
         trait_type_args: Vec<TypeArgument>,
         type_id: TypeId,
-        items: &[TyImplItem],
+        items: &[ResolvedTraitImplItem],
         impl_span: &Span,
         trait_decl_span: Option<Span>,
         is_impl_self: IsImplSelf,
@@ -163,24 +186,27 @@ impl TraitMap {
             let mut trait_items: TraitItems = im::HashMap::new();
             for item in items.iter() {
                 match item {
-                    TyImplItem::Fn(decl_ref) => {
-                        if trait_items
-                            .insert(decl_ref.name().clone().to_string(), item.clone())
-                            .is_some()
-                        {
-                            // duplicate method name
-                            handler.emit_err(CompileError::MultipleDefinitionsOfName {
-                                name: decl_ref.name().clone(),
-                                span: decl_ref.span(),
-                            });
+                    ResolvedTraitImplItem::Parsed(_) => todo!(),
+                    ResolvedTraitImplItem::Typed(ty_item) => match ty_item {
+                        TyImplItem::Fn(decl_ref) => {
+                            if trait_items
+                                .insert(decl_ref.name().clone().to_string(), item.clone())
+                                .is_some()
+                            {
+                                // duplicate method name
+                                handler.emit_err(CompileError::MultipleDefinitionsOfName {
+                                    name: decl_ref.name().clone(),
+                                    span: decl_ref.span(),
+                                });
+                            }
                         }
-                    }
-                    TyImplItem::Constant(decl_ref) => {
-                        trait_items.insert(decl_ref.name().to_string(), item.clone());
-                    }
-                    TyImplItem::Type(decl_ref) => {
-                        trait_items.insert(decl_ref.name().to_string(), item.clone());
-                    }
+                        TyImplItem::Constant(decl_ref) => {
+                            trait_items.insert(decl_ref.name().to_string(), item.clone());
+                        }
+                        TyImplItem::Type(decl_ref) => {
+                            trait_items.insert(decl_ref.name().to_string(), item.clone());
+                        }
+                    },
                 }
             }
 
@@ -307,42 +333,51 @@ impl TraitMap {
                 {
                     for (name, item) in trait_items.iter() {
                         match item {
-                            ty::TyTraitItem::Fn(decl_ref) => {
-                                if map_trait_items.get(name).is_some() {
-                                    handler.emit_err(CompileError::DuplicateDeclDefinedForType {
-                                        decl_kind: "method".into(),
-                                        decl_name: decl_ref.name().to_string(),
-                                        type_implementing_for: engines
-                                            .help_out(type_id)
-                                            .to_string(),
-                                        span: decl_ref.name().span(),
-                                    });
+                            ResolvedTraitImplItem::Parsed(_item) => todo!(),
+                            ResolvedTraitImplItem::Typed(item) => match item {
+                                ty::TyTraitItem::Fn(decl_ref) => {
+                                    if map_trait_items.get(name).is_some() {
+                                        handler.emit_err(
+                                            CompileError::DuplicateDeclDefinedForType {
+                                                decl_kind: "method".into(),
+                                                decl_name: decl_ref.name().to_string(),
+                                                type_implementing_for: engines
+                                                    .help_out(type_id)
+                                                    .to_string(),
+                                                span: decl_ref.name().span(),
+                                            },
+                                        );
+                                    }
                                 }
-                            }
-                            ty::TyTraitItem::Constant(decl_ref) => {
-                                if map_trait_items.get(name).is_some() {
-                                    handler.emit_err(CompileError::DuplicateDeclDefinedForType {
-                                        decl_kind: "constant".into(),
-                                        decl_name: decl_ref.name().to_string(),
-                                        type_implementing_for: engines
-                                            .help_out(type_id)
-                                            .to_string(),
-                                        span: decl_ref.name().span(),
-                                    });
+                                ty::TyTraitItem::Constant(decl_ref) => {
+                                    if map_trait_items.get(name).is_some() {
+                                        handler.emit_err(
+                                            CompileError::DuplicateDeclDefinedForType {
+                                                decl_kind: "constant".into(),
+                                                decl_name: decl_ref.name().to_string(),
+                                                type_implementing_for: engines
+                                                    .help_out(type_id)
+                                                    .to_string(),
+                                                span: decl_ref.name().span(),
+                                            },
+                                        );
+                                    }
                                 }
-                            }
-                            ty::TyTraitItem::Type(decl_ref) => {
-                                if map_trait_items.get(name).is_some() {
-                                    handler.emit_err(CompileError::DuplicateDeclDefinedForType {
-                                        decl_kind: "type".into(),
-                                        decl_name: decl_ref.name().to_string(),
-                                        type_implementing_for: engines
-                                            .help_out(type_id)
-                                            .to_string(),
-                                        span: decl_ref.name().span(),
-                                    });
+                                ty::TyTraitItem::Type(decl_ref) => {
+                                    if map_trait_items.get(name).is_some() {
+                                        handler.emit_err(
+                                            CompileError::DuplicateDeclDefinedForType {
+                                                decl_kind: "type".into(),
+                                                decl_name: decl_ref.name().to_string(),
+                                                type_implementing_for: engines
+                                                    .help_out(type_id)
+                                                    .to_string(),
+                                                span: decl_ref.name().span(),
+                                            },
+                                        );
+                                    }
                                 }
-                            }
+                            },
                         }
                     }
                 }
@@ -769,26 +804,35 @@ impl TraitMap {
                         .clone()
                         .into_iter()
                         .map(|(name, item)| match &item {
-                            ty::TyTraitItem::Fn(decl_ref) => {
-                                let mut decl = (*decl_engine.get(decl_ref.id())).clone();
-                                decl.subst(&type_mapping, engines);
-                                let new_ref = decl_engine
-                                    .insert(decl)
-                                    .with_parent(decl_engine, decl_ref.id().into());
-                                (name, TyImplItem::Fn(new_ref))
-                            }
-                            ty::TyTraitItem::Constant(decl_ref) => {
-                                let mut decl = (*decl_engine.get(decl_ref.id())).clone();
-                                decl.subst(&type_mapping, engines);
-                                let new_ref = decl_engine.insert(decl);
-                                (name, TyImplItem::Constant(new_ref))
-                            }
-                            ty::TyTraitItem::Type(decl_ref) => {
-                                let mut decl = (*decl_engine.get(decl_ref.id())).clone();
-                                decl.subst(&type_mapping, engines);
-                                let new_ref = decl_engine.insert(decl);
-                                (name, TyImplItem::Type(new_ref))
-                            }
+                            ResolvedTraitImplItem::Parsed(_item) => todo!(),
+                            ResolvedTraitImplItem::Typed(item) => match item {
+                                ty::TyTraitItem::Fn(decl_ref) => {
+                                    let mut decl = (*decl_engine.get(decl_ref.id())).clone();
+                                    decl.subst(&type_mapping, engines);
+                                    let new_ref = decl_engine
+                                        .insert(decl)
+                                        .with_parent(decl_engine, decl_ref.id().into());
+                                    (name, ResolvedTraitImplItem::Typed(TyImplItem::Fn(new_ref)))
+                                }
+                                ty::TyTraitItem::Constant(decl_ref) => {
+                                    let mut decl = (*decl_engine.get(decl_ref.id())).clone();
+                                    decl.subst(&type_mapping, engines);
+                                    let new_ref = decl_engine.insert(decl);
+                                    (
+                                        name,
+                                        ResolvedTraitImplItem::Typed(TyImplItem::Constant(new_ref)),
+                                    )
+                                }
+                                ty::TyTraitItem::Type(decl_ref) => {
+                                    let mut decl = (*decl_engine.get(decl_ref.id())).clone();
+                                    decl.subst(&type_mapping, engines);
+                                    let new_ref = decl_engine.insert(decl);
+                                    (
+                                        name,
+                                        ResolvedTraitImplItem::Typed(TyImplItem::Type(new_ref)),
+                                    )
+                                }
+                            },
                         })
                         .collect();
                     trait_map.insert_inner(
@@ -818,7 +862,7 @@ impl TraitMap {
         &self,
         engines: &Engines,
         type_id: TypeId,
-    ) -> Vec<ty::TyTraitItem> {
+    ) -> Vec<ResolvedTraitImplItem> {
         self.get_items_and_trait_key_for_type(engines, type_id)
             .iter()
             .map(|i| i.0.clone())
@@ -829,7 +873,7 @@ impl TraitMap {
         &self,
         engines: &Engines,
         type_id: TypeId,
-    ) -> Vec<(ty::TyTraitItem, TraitKey)> {
+    ) -> Vec<(ResolvedTraitImplItem, TraitKey)> {
         let type_engine = engines.te();
         let unify_check = UnifyCheck::non_dynamic_equality(engines);
 
@@ -914,7 +958,7 @@ impl TraitMap {
         type_id: TypeId,
         trait_name: &CallPath,
         trait_type_args: Vec<TypeArgument>,
-    ) -> Vec<ty::TyTraitItem> {
+    ) -> Vec<ResolvedTraitImplItem> {
         let type_engine = engines.te();
         let unify_check = UnifyCheck::non_dynamic_equality(engines);
         let mut items = vec![];
@@ -941,6 +985,34 @@ impl TraitMap {
             }
         }
         items
+    }
+
+    /// Find the entries in `self` that are equivalent to `type_id` with trait
+    /// name `trait_name` and with trait type arguments.
+    ///
+    /// Notes:
+    /// - equivalency is defined (1) based on whether the types contains types
+    ///     that are dynamic and can change and (2) whether the types hold
+    ///     equivalency after (1) is fulfilled
+    /// - this method does not translate types from the found entries to the
+    ///     `type_id` (like in `filter_by_type()`). This is because the only
+    ///     entries that qualify as hits are equivalents of `type_id`
+    pub(crate) fn get_items_for_type_and_trait_name_and_trait_type_arguments_typed(
+        &self,
+        engines: &Engines,
+        type_id: TypeId,
+        trait_name: &CallPath,
+        trait_type_args: Vec<TypeArgument>,
+    ) -> Vec<ty::TyTraitItem> {
+        self.get_items_for_type_and_trait_name_and_trait_type_arguments(
+            engines,
+            type_id,
+            trait_name,
+            trait_type_args,
+        )
+        .into_iter()
+        .map(|item| item.expect_typed())
+        .collect::<Vec<_>>()
     }
 
     pub(crate) fn get_trait_names_and_type_arguments_for_type(
@@ -975,40 +1047,92 @@ impl TraitMap {
         symbol: &Ident,
         type_id: TypeId,
         as_trait: Option<CallPath>,
-    ) -> Result<TyTraitItem, ErrorEmitted> {
-        let mut candidates = HashMap::<String, TyTraitItem>::new();
+    ) -> Result<ResolvedTraitImplItem, ErrorEmitted> {
+        let mut candidates = HashMap::<String, ResolvedTraitImplItem>::new();
         for (trait_item, trait_key) in self.get_items_and_trait_key_for_type(engines, type_id) {
             match trait_item {
-                ty::TyTraitItem::Fn(fn_ref) => {
-                    let decl = engines.de().get_function(&fn_ref);
-                    let trait_call_path_string = engines.help_out(trait_key.name).to_string();
-                    if decl.name.as_str() == symbol.as_str()
-                        && (as_trait.is_none()
-                            || as_trait.clone().unwrap().to_string() == trait_call_path_string)
-                    {
-                        candidates.insert(trait_call_path_string, TyTraitItem::Fn(fn_ref));
+                ResolvedTraitImplItem::Parsed(impl_item) => match impl_item {
+                    ImplItem::Fn(fn_ref) => {
+                        let decl = engines.pe().get_function(&fn_ref);
+                        let trait_call_path_string = engines.help_out(trait_key.name).to_string();
+                        if decl.name.as_str() == symbol.as_str()
+                            && (as_trait.is_none()
+                                || as_trait.clone().unwrap().to_string() == trait_call_path_string)
+                        {
+                            candidates.insert(
+                                trait_call_path_string,
+                                ResolvedTraitImplItem::Parsed(ImplItem::Fn(fn_ref)),
+                            );
+                        }
                     }
-                }
-                ty::TyTraitItem::Constant(const_ref) => {
-                    let decl = engines.de().get_constant(&const_ref);
-                    let trait_call_path_string = engines.help_out(trait_key.name).to_string();
-                    if decl.call_path.suffix.as_str() == symbol.as_str()
-                        && (as_trait.is_none()
-                            || as_trait.clone().unwrap().to_string() == trait_call_path_string)
-                    {
-                        candidates.insert(trait_call_path_string, TyTraitItem::Constant(const_ref));
+                    ImplItem::Constant(const_ref) => {
+                        let decl = engines.pe().get_constant(&const_ref);
+                        let trait_call_path_string = engines.help_out(trait_key.name).to_string();
+                        if decl.name.as_str() == symbol.as_str()
+                            && (as_trait.is_none()
+                                || as_trait.clone().unwrap().to_string() == trait_call_path_string)
+                        {
+                            candidates.insert(
+                                trait_call_path_string,
+                                ResolvedTraitImplItem::Parsed(ImplItem::Constant(const_ref)),
+                            );
+                        }
                     }
-                }
-                ty::TyTraitItem::Type(type_ref) => {
-                    let decl = engines.de().get_type(&type_ref);
-                    let trait_call_path_string = engines.help_out(trait_key.name).to_string();
-                    if decl.name.as_str() == symbol.as_str()
-                        && (as_trait.is_none()
-                            || as_trait.clone().unwrap().to_string() == trait_call_path_string)
-                    {
-                        candidates.insert(trait_call_path_string, TyTraitItem::Type(type_ref));
+                    ImplItem::Type(type_ref) => {
+                        let decl = engines.pe().get_trait_type(&type_ref);
+                        let trait_call_path_string = engines.help_out(trait_key.name).to_string();
+                        if decl.name.as_str() == symbol.as_str()
+                            && (as_trait.is_none()
+                                || as_trait.clone().unwrap().to_string() == trait_call_path_string)
+                        {
+                            candidates.insert(
+                                trait_call_path_string,
+                                ResolvedTraitImplItem::Parsed(ImplItem::Type(type_ref)),
+                            );
+                        }
                     }
-                }
+                },
+                ResolvedTraitImplItem::Typed(ty_impl_item) => match ty_impl_item {
+                    ty::TyTraitItem::Fn(fn_ref) => {
+                        let decl = engines.de().get_function(&fn_ref);
+                        let trait_call_path_string = engines.help_out(trait_key.name).to_string();
+                        if decl.name.as_str() == symbol.as_str()
+                            && (as_trait.is_none()
+                                || as_trait.clone().unwrap().to_string() == trait_call_path_string)
+                        {
+                            candidates.insert(
+                                trait_call_path_string,
+                                ResolvedTraitImplItem::Typed(TyTraitItem::Fn(fn_ref)),
+                            );
+                        }
+                    }
+                    ty::TyTraitItem::Constant(const_ref) => {
+                        let decl = engines.de().get_constant(&const_ref);
+                        let trait_call_path_string = engines.help_out(trait_key.name).to_string();
+                        if decl.call_path.suffix.as_str() == symbol.as_str()
+                            && (as_trait.is_none()
+                                || as_trait.clone().unwrap().to_string() == trait_call_path_string)
+                        {
+                            candidates.insert(
+                                trait_call_path_string,
+                                ResolvedTraitImplItem::Typed(TyTraitItem::Constant(const_ref)),
+                            );
+                        }
+                    }
+                    ty::TyTraitItem::Type(type_ref) => {
+                        let decl = engines.de().get_type(&type_ref);
+                        let trait_call_path_string = engines.help_out(trait_key.name).to_string();
+                        if decl.name.as_str() == symbol.as_str()
+                            && (as_trait.is_none()
+                                || as_trait.clone().unwrap().to_string() == trait_call_path_string)
+                        {
+                            candidates.insert(
+                                trait_call_path_string,
+                                ResolvedTraitImplItem::Typed(TyTraitItem::Type(type_ref)),
+                            );
+                        }
+                    }
+                },
             }
         }
 

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -755,6 +755,7 @@ impl<'a> TypeCheckContext<'a> {
                 call_path,
                 self.self_type,
             )?;
+        let decl = decl.expect_typed();
 
         // In case there is no mod path we don't need to check visibility
         if mod_path.is_empty() {

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -177,7 +177,7 @@ impl TraitConstraint {
         match ctx
             .namespace()
             // Use the default Handler to avoid emitting the redundant SymbolNotFound error.
-            .resolve_call_path(&Handler::default(), engines, trait_name, ctx.self_type())
+            .resolve_call_path_typed(&Handler::default(), engines, trait_name, ctx.self_type())
             .ok()
         {
             Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -247,7 +247,7 @@ impl TypeParameter {
     ) -> Vec<TraitConstraint> {
         match ctx
             .namespace()
-            .resolve_call_path(handler, ctx.engines, &tc.trait_name, ctx.self_type())
+            .resolve_call_path_typed(handler, ctx.engines, &tc.trait_name, ctx.self_type())
             .ok()
         {
             Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
@@ -551,7 +551,7 @@ fn handle_trait(
         match ctx
             .namespace()
             // Use the default Handler to avoid emitting the redundant SymbolNotFound error.
-            .resolve_call_path(&Handler::default(), engines, trait_name, ctx.self_type())
+            .resolve_call_path_typed(&Handler::default(), engines, trait_name, ctx.self_type())
             .ok()
         {
             Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -47,6 +47,7 @@ fn completion_items_for_type_id(
     }
 
     for method in namespace.get_methods_for_type(engines, type_id) {
+        let method = method.expect_typed();
         let fn_decl = engines.de().get_function(&method.id().clone());
         let params = &fn_decl.parameters;
 
@@ -151,13 +152,14 @@ fn type_id_of_raw_ident(
             let method_name = parts[i].split_at(parts[i].find('(').unwrap_or(0)).0;
             curr_type_id = namespace
                 .get_methods_for_type(engines, curr_type_id?)
-                .iter()
-                .find_map(|decl_ref| {
-                    if decl_ref.name().clone().as_str() == method_name {
+                .into_iter()
+                .find_map(|method| {
+                    let method = method.expect_typed();
+                    if method.name().clone().as_str() == method_name {
                         return Some(
                             engines
                                 .de()
-                                .get_function(&decl_ref.id().clone())
+                                .get_function(&method.id().clone())
                                 .return_type
                                 .type_id,
                         );


### PR DESCRIPTION
## Description

This PR unifies the codepaths in trait map and name resolution code so they can work for both parsed and typed declarations.
It does this by introducing wrapper types for the output of resolving of names.

This is an intermediate step to being able to use this code on the new symbol resolving pass.

While this adds a little bit of minor bloat to the code, I think it's an acceptable further step to be able to do re-use the code in steps before type-checking. 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
