### PR TITLE
From<u8, u16, u32> for u64 implementations

### DIFF
--- a/sway-lib-std/src/primitive_conversions/u64.sw
+++ b/sway-lib-std/src/primitive_conversions/u64.sw
@@ -35,6 +35,72 @@ impl u64 {
     }
 }
 
+impl From<u8> for u64 {
+    /// Casts a `u8` to a `u64`.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The `u64` representation of the `u8` value.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    ///
+    /// fn foo() {
+    ///     let u64_value = u64::from(0u8);
+    /// }
+    /// ```
+    fn from(u: u8) -> Self {
+        asm(r1: u) {
+            r1: u64
+        }
+    }
+}
+
+impl From<u16> for u64 {
+    /// Casts a `u16` to a `u64`.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The `u64` representation of the `u16` value.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    ///
+    /// fn foo() {
+    ///     let u64_value = u64::from(0u16);
+    /// }
+    /// ```
+    fn from(u: u16) -> Self {
+        asm(r1: u) {
+            r1: u64
+        }
+    }
+}
+
+impl From<u32> for u64 {
+    /// Casts a `u32` to a `u64`.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The `u64` representation of the `u32` value.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    ///
+    /// fn foo() {
+    ///     let u64_value = u64::from(0u32);
+    /// }
+    /// ```
+    fn from(u: u32) -> Self {
+        asm(r1: u) {
+            r1: u64
+        }
+    }
+}
+
 impl TryFrom<u256> for u64 {
     fn try_from(u: u256) -> Option<Self> {
         let parts = asm(r1: u) {
@@ -47,6 +113,48 @@ impl TryFrom<u256> for u64 {
             Some(parts.3)
         }
     }
+}
+
+#[test]
+fn test_u64_from_u8() {
+    use ::assert::assert;
+
+    let u8_1: u8 = 0u8;
+    let u8_2: u8 = 255u8;
+
+    let u64_1 = u64::from(u8_1);
+    let u64_2 = u64::from(u8_2);
+
+    assert(u64_1 == 0u64);
+    assert(u64_2 == 255u64);
+}
+
+#[test]
+fn test_u64_from_u16() {
+    use ::assert::assert;
+
+    let u16_1: u16 = 0u16;
+    let u16_2: u16 = 65535u16;
+
+    let u64_1 = u64::from(u16_1);
+    let u64_2 = u64::from(u16_2);
+
+    assert(u64_1 == 0u64);
+    assert(u64_2 == 65535u64);
+}
+
+#[test]
+fn test_u64_from_u32() {
+    use ::assert::assert;
+
+    let u32_1: u32 = 0u32;
+    let u32_2: u32 = 4294967295u32;
+
+    let u64_1 = u64::from(u32_1);
+    let u64_2 = u64::from(u32_2);
+
+    assert(u64_1 == 0u64);
+    assert(u64_2 == 4294967295u64);
 }
 
 #[test]

--- a/sway-lib-std/src/primitive_conversions/u64.sw
+++ b/sway-lib-std/src/primitive_conversions/u64.sw
@@ -115,6 +115,7 @@ impl TryFrom<u256> for u64 {
     }
 }
 
+// TODO: Replace <u64 as From<T>> with u64::from when https://github.com/FuelLabs/sway/issues/5798 is resolved.
 #[test]
 fn test_u64_from_u8() {
     use ::assert::assert;
@@ -122,8 +123,8 @@ fn test_u64_from_u8() {
     let u8_1: u8 = 0u8;
     let u8_2: u8 = 255u8;
 
-    let u64_1 = u64::from(u8_1);
-    let u64_2 = u64::from(u8_2);
+    let u64_1 = <u64 as From<u8>>::from(u8_1);
+    let u64_2 = <u64 as From<u8>>::from(u8_2);
 
     assert(u64_1 == 0u64);
     assert(u64_2 == 255u64);
@@ -136,8 +137,8 @@ fn test_u64_from_u16() {
     let u16_1: u16 = 0u16;
     let u16_2: u16 = 65535u16;
 
-    let u64_1 = u64::from(u16_1);
-    let u64_2 = u64::from(u16_2);
+    let u64_1 = <u64 as From<u16>>::from(u16_1);
+    let u64_2 = <u64 as From<u16>>::from(u16_2);
 
     assert(u64_1 == 0u64);
     assert(u64_2 == 65535u64);
@@ -150,8 +151,8 @@ fn test_u64_from_u32() {
     let u32_1: u32 = 0u32;
     let u32_2: u32 = 4294967295u32;
 
-    let u64_1 = u64::from(u32_1);
-    let u64_2 = u64::from(u32_2);
+    let u64_1 = <u64 as From<u32>>::from(u32_1);
+    let u64_2 = <u64 as From<u32>>::from(u32_2);
 
     assert(u64_1 == 0u64);
     assert(u64_2 == 4294967295u64);


### PR DESCRIPTION
## Description
Adds implementations for From<u8>, From<u16>, From<u32> for u64

Partially addresses #5797 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
