### PR TITLE
fix: make sure to check std is taken from sway-lib-std folder

### DIFF
--- a/forc-pkg/src/manifest/mod.rs
+++ b/forc-pkg/src/manifest/mod.rs
@@ -992,6 +992,8 @@ impl std::ops::Deref for WorkspaceManifestFile {
 ///
 /// Returns the path to the package on success, or `None` in the case it could not be found.
 pub fn find_within(dir: &Path, pkg_name: &str) -> Option<PathBuf> {
+    use sway_types::constants::STD;
+    const SWAY_LIB_FOLDER: &str = "sway-lib-std";
     walkdir::WalkDir::new(dir)
         .into_iter()
         .filter_map(|entry| {
@@ -1002,7 +1004,13 @@ pub fn find_within(dir: &Path, pkg_name: &str) -> Option<PathBuf> {
         .find_map(|entry| {
             let path = entry.path();
             let manifest = PackageManifest::from_file(path).ok()?;
-            if manifest.project.name == pkg_name {
+            // If the package is STD, make sure it is coming from correct folder.
+            if (manifest.project.name == pkg_name && pkg_name != STD)
+                || (manifest.project.name == STD
+                    && path
+                        .components()
+                        .any(|comp| comp.as_os_str() == SWAY_LIB_FOLDER))
+            {
                 Some(path.to_path_buf())
             } else {
                 None

--- a/forc-pkg/src/manifest/mod.rs
+++ b/forc-pkg/src/manifest/mod.rs
@@ -993,7 +993,7 @@ impl std::ops::Deref for WorkspaceManifestFile {
 /// Returns the path to the package on success, or `None` in the case it could not be found.
 pub fn find_within(dir: &Path, pkg_name: &str) -> Option<PathBuf> {
     use sway_types::constants::STD;
-    const SWAY_LIB_FOLDER: &str = "sway-lib-std";
+    const SWAY_STD_FOLDER: &str = "sway-lib-std";
     walkdir::WalkDir::new(dir)
         .into_iter()
         .filter_map(|entry| {
@@ -1009,7 +1009,7 @@ pub fn find_within(dir: &Path, pkg_name: &str) -> Option<PathBuf> {
                 || (manifest.project.name == STD
                     && path
                         .components()
-                        .any(|comp| comp.as_os_str() == SWAY_LIB_FOLDER))
+                        .any(|comp| comp.as_os_str() == SWAY_STD_FOLDER))
             {
                 Some(path.to_path_buf())
             } else {


### PR DESCRIPTION
## Description

This PR adds a ad-hoc solution for #5811. Basically checks if the fetched package is 'std' and if so, only package from 'sway-lib-std' folder is accepted for that package.