### PR TITLE
Fixes type inference on inlined method applications.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -92,18 +92,15 @@ pub(crate) fn type_check_method_application(
     let mut method = (*decl_engine.get_function(&fn_ref)).clone();
 
     // unify method return type with current ctx.type_annotation().
-    handler.scope(|handler| {
-        type_engine.unify_with_generic(
-            handler,
-            engines,
-            method.return_type.type_id,
-            ctx.type_annotation(),
-            &method_name_binding.span(),
-            "Function return type does not match up with local type annotation.",
-            None,
-        );
-        Ok(())
-    })?;
+    type_engine.unify_with_generic(
+        handler,
+        engines,
+        method.return_type.type_id,
+        ctx.type_annotation(),
+        &method_name_binding.span(),
+        "Function return type does not match up with local type annotation.",
+        None,
+    );
 
     // type check the function arguments (2nd pass)
     let mut args_buf = VecDeque::new();

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -28,7 +28,7 @@ use sway_types::{Ident, Span};
 pub(crate) fn type_check_method_application(
     handler: &Handler,
     mut ctx: TypeCheckContext,
-    method_name_binding: TypeBinding<MethodName>,
+    mut method_name_binding: TypeBinding<MethodName>,
     contract_call_params: Vec<StructExpressionField>,
     arguments: Vec<Expression>,
     span: Span,
@@ -46,19 +46,27 @@ pub(crate) fn type_check_method_application(
             .by_ref()
             .with_help_text("")
             .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+        // Ignore errors in method parameters
+        // On the second pass we will throw the errors if they persist.
+        let arg_handler = Handler::default();
+        let arg_opt = ty::TyExpression::type_check(&arg_handler, ctx, arg.clone()).ok();
+        let has_errors = arg_handler.has_errors();
         if index == 0 {
-            args_opt_buf.push_back(ty::TyExpression::type_check(handler, ctx, arg.clone()).ok());
-        } else {
-            // Ignore errors in method parameters
-            // On the second pass we will throw the errors if they persist.
-            let arg_handler = Handler::default();
-            let arg_opt = ty::TyExpression::type_check(&arg_handler, ctx, arg.clone()).ok();
-            if arg_handler.has_errors() {
-                args_opt_buf.push_back(None);
-            } else {
-                args_opt_buf.push_back(arg_opt);
-            }
-        };
+            // We want to emit errors in the self parameter and ignore TraitConstraintNotSatisfied with Placeholder
+            // which may be recoverable on the second pass.
+            arg_handler.retain_err(|e| {
+                if let CompileError::TraitConstraintNotSatisfied { type_id, .. } = e {
+                    !matches!(
+                        *type_engine.get(TypeId::from(*type_id)),
+                        TypeInfo::Placeholder(_)
+                    )
+                } else {
+                    true
+                }
+            });
+            handler.append(arg_handler);
+        }
+        args_opt_buf.push_back((arg_opt, has_errors));
     }
 
     // resolve the method name to a typed function declaration and type_check
@@ -68,19 +76,39 @@ pub(crate) fn type_check_method_application(
         &method_name_binding,
         args_opt_buf
             .iter()
-            .map(|arg| match arg {
+            .map(|(arg, _has_errors)| match arg {
                 Some(arg) => arg.return_type,
                 None => type_engine.insert(engines, TypeInfo::Unknown, None),
             })
             .collect(),
     )?;
 
-    let method = decl_engine.get_function(&original_decl_ref);
+    let fn_ref = monomorphize_method(
+        handler,
+        ctx.by_ref(),
+        original_decl_ref.clone(),
+        method_name_binding.type_arguments.to_vec_mut(),
+    )?;
+    let mut method = (*decl_engine.get_function(&fn_ref)).clone();
+
+    // unify method return type with current ctx.type_annotation().
+    handler.scope(|handler| {
+        type_engine.unify_with_generic(
+            handler,
+            engines,
+            method.return_type.type_id,
+            ctx.type_annotation(),
+            &method_name_binding.span(),
+            "Function return type does not match up with local type annotation.",
+            None,
+        );
+        Ok(())
+    })?;
 
     // type check the function arguments (2nd pass)
     let mut args_buf = VecDeque::new();
     for (arg, index, arg_opt) in izip!(arguments.iter(), 0.., args_opt_buf.iter().cloned()) {
-        if let Some(arg) = arg_opt {
+        if let (Some(arg), false) = arg_opt {
             args_buf.push_back(arg);
         } else {
             let param_index = if method.is_contract_call {
@@ -90,24 +118,19 @@ pub(crate) fn type_check_method_application(
             };
             // This arg_opt is None because it failed in the first pass.
             // We now try to type check it again, this time with the type annotation.
-            let ctx = if param_index > 0 {
-                ctx.by_ref()
-                    .with_help_text(
-                        "Function application argument type must match function parameter type.",
-                    )
-                    .with_type_annotation(
-                        method
-                            .parameters
-                            .get(param_index)
-                            .unwrap()
-                            .type_argument
-                            .type_id,
-                    )
-            } else {
-                ctx.by_ref()
-                    .with_help_text("")
-                    .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None))
-            };
+            let ctx = ctx
+                .by_ref()
+                .with_help_text(
+                    "Function application argument type must match function parameter type.",
+                )
+                .with_type_annotation(
+                    method
+                        .parameters
+                        .get(param_index)
+                        .unwrap()
+                        .type_argument
+                        .type_id,
+                );
             args_buf.push_back(
                 ty::TyExpression::type_check(handler, ctx, arg.clone())
                     .unwrap_or_else(|err| ty::TyExpression::error(err, span.clone(), engines)),
@@ -540,10 +563,109 @@ pub(crate) fn type_check_method_application(
         return Ok(expr);
     }
 
-    let mut fn_app = ty::TyExpressionVariant::FunctionApplication {
+    // Unify method type parameters with implementing type type parameters.
+    if let Some(implementing_for_typeid) = method.implementing_for_typeid {
+        if let Some(TyDecl::ImplTrait(t)) = method.clone().implementing_type {
+            let t = &engines.de().get(&t.decl_id).implementing_for;
+            if let TypeInfo::Custom {
+                type_arguments: Some(type_arguments),
+                ..
+            } = &*type_engine.get(t.initial_type_id)
+            {
+                // Method type parameters that have is_from_parent set to true use the base ident as defined in
+                // in the impl trait. The type parameter name may be different in the Struct or Enum.
+                // Thus we use the index in the Struct's or Enum's type parameter the impl trait type parameter
+                // was used on.
+                let mut names_index = HashMap::<Ident, usize>::new();
+                for (index, t_arg) in type_arguments.iter().enumerate() {
+                    if let TypeInfo::Custom {
+                        qualified_call_path,
+                        ..
+                    } = &*type_engine.get(t_arg.initial_type_id)
+                    {
+                        names_index.insert(qualified_call_path.call_path.suffix.clone(), index);
+                    }
+                }
+                let implementing_type_parameters =
+                    implementing_for_typeid.get_type_parameters(type_engine, decl_engine);
+                if let Some(implementing_type_parameters) = implementing_type_parameters {
+                    for p in method.type_parameters.clone() {
+                        if p.is_from_parent {
+                            if let Some(type_param_index) = names_index.get(&p.name_ident) {
+                                if let Some(impl_type_param) =
+                                    implementing_type_parameters.get(*type_param_index)
+                                {
+                                    handler.scope(|handler| {
+                                        type_engine.unify_with_generic(
+                                            handler,
+                                            engines,
+                                            p.type_id,
+                                            impl_type_param.type_id,
+                                            &call_path.span(),
+                                            "Function type parameter does not match up with implementing type type parameter.",
+                                            None,
+                                        );
+                                        Ok(())
+                                    })?;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // unify the types of the arguments with the types of the parameters from the function declaration
+    let arguments =
+        unify_arguments_and_parameters(handler, ctx.by_ref(), &arguments, &method.parameters)?;
+
+    // This handles the case of substituting the generic blanket type by call_path_typeid.
+    if let Some(TyDecl::ImplTrait(t)) = method.clone().implementing_type {
+        let t = &engines.de().get(&t.decl_id).implementing_for;
+        if let TypeInfo::Custom {
+            qualified_call_path,
+            type_arguments: _,
+            root_type_id: _,
+        } = &*type_engine.get(t.initial_type_id)
+        {
+            for p in method.type_parameters.clone() {
+                if p.name_ident.as_str() == qualified_call_path.call_path.suffix.as_str() {
+                    let type_subst = TypeSubstMap::from_type_parameters_and_type_arguments(
+                        vec![t.initial_type_id],
+                        vec![call_path_typeid],
+                    );
+                    method.subst(&type_subst, engines);
+                }
+            }
+        }
+    }
+
+    // Handle the trait constraints. This includes checking to see if the trait
+    // constraints are satisfied and replacing old decl ids based on the
+    // constraint with new decl ids based on the new type.
+    let decl_mapping = TypeParameter::gather_decl_mapping_from_trait_constraints(
+        handler,
+        ctx.by_ref(),
+        &method.type_parameters,
+        method.name.as_str(),
+        &call_path.span(),
+    )
+    .ok();
+
+    if let Some(decl_mapping) = decl_mapping {
+        if !ctx.defer_monomorphization() {
+            method.replace_decls(&decl_mapping, handler, &mut ctx)?;
+        }
+    }
+
+    let method_return_type_id = method.return_type.type_id;
+    decl_engine.replace(*fn_ref.id(), method);
+
+    let fn_app = ty::TyExpressionVariant::FunctionApplication {
         call_path: call_path.clone(),
         arguments,
-        fn_ref: original_decl_ref,
+        fn_ref,
         selector,
         type_binding: Some(method_name_binding.strip_inner()),
         call_path_typeid: Some(call_path_typeid),
@@ -552,19 +674,11 @@ pub(crate) fn type_check_method_application(
         contract_caller: None,
     };
 
-    let mut exp = ty::TyExpression {
+    let exp = ty::TyExpression {
         expression: fn_app.clone(),
-        return_type: method.return_type.type_id,
+        return_type: method_return_type_id,
         span,
     };
-
-    monomorphize_method_application(&mut fn_app, handler, ctx)?;
-
-    if let ty::TyExpressionVariant::FunctionApplication { ref fn_ref, .. } = &fn_app {
-        let method = decl_engine.get_function(fn_ref);
-        exp.return_type = method.return_type.type_id;
-        exp.expression = fn_app;
-    }
 
     Ok(exp)
 }
@@ -745,150 +859,6 @@ pub(crate) fn resolve_method_name(
     };
 
     Ok((decl_ref, type_id))
-}
-
-pub(crate) fn monomorphize_method_application(
-    expr: &mut ty::TyExpressionVariant,
-    handler: &Handler,
-    mut ctx: TypeCheckContext,
-) -> Result<(), ErrorEmitted> {
-    if let ty::TyExpressionVariant::FunctionApplication {
-        ref mut fn_ref,
-        ref call_path,
-        ref mut arguments,
-        ref mut type_binding,
-        call_path_typeid,
-        ..
-    } = expr
-    {
-        let decl_engine = ctx.engines.de();
-        let type_engine = ctx.engines.te();
-        let engines = ctx.engines();
-
-        *fn_ref = monomorphize_method(
-            handler,
-            ctx.by_ref(),
-            fn_ref.clone(),
-            type_binding.as_mut().unwrap().type_arguments.to_vec_mut(),
-        )?;
-        let mut method = (*decl_engine.get_function(fn_ref)).clone();
-
-        // Unify method type parameters with implementing type type parameters.
-        if let Some(implementing_for_typeid) = method.implementing_for_typeid {
-            if let Some(TyDecl::ImplTrait(t)) = method.clone().implementing_type {
-                let t = &engines.de().get(&t.decl_id).implementing_for;
-                if let TypeInfo::Custom {
-                    type_arguments: Some(type_arguments),
-                    ..
-                } = &*type_engine.get(t.initial_type_id)
-                {
-                    // Method type parameters that have is_from_parent set to true use the base ident as defined in
-                    // in the impl trait. The type parameter name may be different in the Struct or Enum.
-                    // Thus we use the index in the Struct's or Enum's type parameter the impl trait type parameter
-                    // was used on.
-                    let mut names_index = HashMap::<Ident, usize>::new();
-                    for (index, t_arg) in type_arguments.iter().enumerate() {
-                        if let TypeInfo::Custom {
-                            qualified_call_path,
-                            ..
-                        } = &*type_engine.get(t_arg.initial_type_id)
-                        {
-                            names_index.insert(qualified_call_path.call_path.suffix.clone(), index);
-                        }
-                    }
-                    let implementing_type_parameters =
-                        implementing_for_typeid.get_type_parameters(engines);
-                    if let Some(implementing_type_parameters) = implementing_type_parameters {
-                        for p in method.type_parameters.clone() {
-                            if p.is_from_parent {
-                                if let Some(type_param_index) = names_index.get(&p.name_ident) {
-                                    if let Some(impl_type_param) =
-                                        implementing_type_parameters.get(*type_param_index)
-                                    {
-                                        handler.scope(|handler| {
-                                            type_engine.unify_with_generic(
-                                                handler,
-                                                engines,
-                                                p.type_id,
-                                                impl_type_param.type_id,
-                                                &call_path.span(),
-                                                "Function type parameter does not match up with implementing type type parameter.",
-                                                None,
-                                            );
-                                            Ok(())
-                                        })?;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // unify the types of the arguments with the types of the parameters from the function declaration
-        *arguments =
-            unify_arguments_and_parameters(handler, ctx.by_ref(), arguments, &method.parameters)?;
-
-        // unify method return type with current ctx.type_annotation().
-        handler.scope(|handler| {
-            type_engine.unify_with_generic(
-                handler,
-                engines,
-                method.return_type.type_id,
-                ctx.type_annotation(),
-                &call_path.span(),
-                "Function return type does not match up with local type annotation.",
-                None,
-            );
-            Ok(())
-        })?;
-
-        // This handles the case of substituting the generic blanket type by call_path_typeid.
-        if let Some(TyDecl::ImplTrait(t)) = method.clone().implementing_type {
-            let t = &engines.de().get(&t.decl_id).implementing_for;
-            if let TypeInfo::Custom {
-                qualified_call_path,
-                type_arguments: _,
-                root_type_id: _,
-            } = &*type_engine.get(t.initial_type_id)
-            {
-                for p in method.type_parameters.clone() {
-                    if p.name_ident.as_str() == qualified_call_path.call_path.suffix.as_str() {
-                        let type_subst = TypeSubstMap::from_type_parameters_and_type_arguments(
-                            vec![t.initial_type_id],
-                            vec![call_path_typeid.unwrap()],
-                        );
-                        method.subst(&type_subst, engines);
-                    }
-                }
-            }
-        }
-
-        // Handle the trait constraints. This includes checking to see if the trait
-        // constraints are satisfied and replacing old decl ids based on the
-        // constraint with new decl ids based on the new type.
-        let decl_mapping = TypeParameter::gather_decl_mapping_from_trait_constraints(
-            handler,
-            ctx.by_ref(),
-            &method.type_parameters,
-            method.name.as_str(),
-            &call_path.span(),
-        )?;
-
-        if !ctx.defer_monomorphization() {
-            method.replace_decls(&decl_mapping, handler, &mut ctx)?;
-        }
-
-        decl_engine.replace(*fn_ref.id(), method);
-
-        Ok(())
-    } else {
-        Err(handler.emit_err(CompileError::Internal(
-            "Unexpected expression variant, expecting a function application",
-            Span::dummy(),
-        )))
-    }
 }
 
 pub(crate) fn monomorphize_method(

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -584,27 +584,27 @@ pub(crate) fn type_check_method_application(
                     }
                 }
                 let implementing_type_parameters =
-                    implementing_for_typeid.get_type_parameters(type_engine, decl_engine);
+                    implementing_for_typeid.get_type_parameters(engines);
                 if let Some(implementing_type_parameters) = implementing_type_parameters {
                     for p in method.type_parameters.clone() {
                         if p.is_from_parent {
-                            if let Some(type_param_index) = names_index.get(&p.name_ident) {
-                                if let Some(impl_type_param) =
+                            if let Some(impl_type_param) =
+                                names_index.get(&p.name_ident).and_then(|type_param_index| {
                                     implementing_type_parameters.get(*type_param_index)
-                                {
-                                    handler.scope(|handler| {
-                                        type_engine.unify_with_generic(
-                                            handler,
-                                            engines,
-                                            p.type_id,
-                                            impl_type_param.type_id,
-                                            &call_path.span(),
-                                            "Function type parameter does not match up with implementing type type parameter.",
-                                            None,
-                                        );
-                                        Ok(())
-                                    })?;
-                                }
+                                })
+                            {
+                                handler.scope(|handler| {
+                                    type_engine.unify_with_generic(
+                                        handler,
+                                        engines,
+                                        p.type_id,
+                                        impl_type_param.type_id,
+                                        &call_path.span(),
+                                        "Function type parameter does not match up with implementing type type parameter.",
+                                        None,
+                                    );
+                                    Ok(())
+                                })?;
                             }
                         }
                     }

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -1370,6 +1370,7 @@ impl TraitMap {
 
                     // TODO: use a better span
                     handler.emit_err(CompileError::TraitConstraintNotSatisfied {
+                        type_id: type_id.index(),
                         ty: engines.help_out(type_id).to_string(),
                         trait_name: format!("{}{}", trait_name, type_arguments_string),
                         span: access_span.clone(),

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -560,6 +560,7 @@ impl TypeId {
                                     );
                                 }
                                 handler.emit_err(CompileError::TraitConstraintNotSatisfied {
+                                    type_id: structure_type_id.index(),
                                     ty: structure_type_info_with_engines.to_string(),
                                     trait_name: format!(
                                         "{}{}",

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -429,6 +429,7 @@ pub enum CompileError {
     UnconstrainedGenericParameter { ty: String, span: Span },
     #[error("Trait \"{trait_name}\" is not implemented for type \"{ty}\".")]
     TraitConstraintNotSatisfied {
+        type_id: usize, // Used to filter errors in method application type check.
         ty: String,
         trait_name: String,
         span: Span,

--- a/sway-error/src/handler.rs
+++ b/sway-error/src/handler.rs
@@ -90,6 +90,18 @@ impl Handler {
         inner.errors = dedup_unsorted(inner.errors.clone());
         inner.warnings = dedup_unsorted(inner.warnings.clone());
     }
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all elements `e` for which `f(&e)` returns `false`.
+    /// This method operates in place, visiting each element exactly once in the
+    /// original order, and preserves the order of the retained elements.
+    pub fn retain_err<F>(&self, f: F)
+    where
+        F: FnMut(&CompileError) -> bool,
+    {
+        self.inner.borrow_mut().errors.retain(f)
+    }
 }
 
 /// Proof that an error was emitted through a `Handler`.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/struct_field_privacy_storage/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/struct_field_privacy_storage/Forc.toml
@@ -5,5 +5,5 @@ name = "struct_field_privacy_storage"
 entry = "main.sw"
 
 [dependencies]
-std = { path = "../../../reduced_std_libs/sway-lib-std-assert" }
+std = { path = "../../../../../../sway-lib-std" }
 

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_method_and_generic_trait_impl/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_method_and_generic_trait_impl/src/main.sw
@@ -24,11 +24,11 @@ fn main() -> bool {
 
     // Calling foo() gives us the following expected error:
     // Trait "MyTrait" is not implemented for type "u64".
-    my_struct_1.foo(my_struct_2);
+    let _ = my_struct_1.foo(my_struct_2);
 
     // Calling bar() gives us the following expected error:
     // Trait "MyTrait" is not implemented for type "u64".
-    my_struct_1.bar(my_struct_2);
+    let _ = my_struct_1.bar(my_struct_2);
 
     true
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/trait_method_and_generic_trait_impl/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/trait_method_and_generic_trait_impl/test.toml
@@ -1,7 +1,7 @@
 category = "fail"
 
-# check: $()my_struct_1.foo(my_struct_2);
+# check: $()let _ = my_struct_1.foo(my_struct_2);
 # nextln: $()Trait "MyTrait" is not implemented for type "u64".
 
-# check: $()my_struct_1.bar(my_struct_2);
+# check: $()let _ = my_struct_1.bar(my_struct_2);
 # nextln: $()Trait "MyTrait" is not implemented for type "u64".

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/method_indirect_inference/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/method_indirect_inference/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-8A4F7B6E8B2D2456"
+
+[[package]]
+name = "method_indirect_inference"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "std"
+source = "path+from-root-8A4F7B6E8B2D2456"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/method_indirect_inference/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/method_indirect_inference/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "method_indirect_inference"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/method_indirect_inference/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/method_indirect_inference/src/main.sw
@@ -1,0 +1,12 @@
+script;
+
+fn main() -> u64 {
+    use std::bytes::Bytes;
+    use std::convert::TryFrom;
+    use std::primitive_conversions::u8::*;
+
+    let mut bytes = Bytes::new();
+    bytes.push(1_u64.try_into().unwrap());
+
+    1
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/method_indirect_inference/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/method_indirect_inference/test.toml
@@ -1,0 +1,3 @@
+category = "run"
+expected_result = { action = "return", value = 1 }
+validate_abi = false


### PR DESCRIPTION
## Description

We now do the return type unification before doing the second pass of arguments type checking in method application type checking.

Doing the unification sooner fixes the problem we were having while doing:
```
let mut bytes = Bytes::new();
bytes.push(1_u64.try_into().unwrap());
```
With the unification sooner we will unify the return of unwarp with the type annotation of the push argument before we do the type checking of `1_u64.try_into()`. By the time we do `1_u64.try_into()` we will already have the type parameter `U` unified with u8.

Fixes #5802.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
