### PR TITLE
Cache in front of check_if_trait_constraints_are_satisfied_for_type

### DIFF
--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -1181,6 +1181,8 @@ impl TraitMap {
         try_inserting_trait_impl_on_failure: TryInsertingTraitImplOnFailure,
     ) -> Result<(), ErrorEmitted> {
         let type_engine = engines.te();
+
+        // resolving trait constraints require a concrete type, we need to default numeric to u64
         type_engine.decay_numeric(handler, engines, type_id, access_span)?;
 
         if constraints.is_empty() {
@@ -1257,8 +1259,6 @@ impl TraitMap {
 
         let _decl_engine = engines.de();
         let unify_check = UnifyCheck::non_dynamic_equality(engines);
-
-        // resolving trait constraints require a concrete type, we need to default numeric to u64
 
         let all_impld_traits: BTreeSet<(Ident, TypeId)> = self
             .trait_impls

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -2,8 +2,10 @@ use std::{
     cmp::Ordering,
     collections::{BTreeSet, HashMap},
     fmt,
+    hash::{DefaultHasher, Hash, Hasher},
 };
 
+use hashbrown::HashSet;
 use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
@@ -148,6 +150,7 @@ type TraitImpls = Vec<TraitEntry>;
 #[derive(Clone, Debug, Default)]
 pub(crate) struct TraitMap {
     trait_impls: TraitImpls,
+    satisfied_cache: hashbrown::HashSet<u64>,
 }
 
 pub(crate) enum IsImplSelf {
@@ -425,7 +428,10 @@ impl TraitMap {
         };
         let entry = TraitEntry { key, value };
         let trait_impls: TraitImpls = vec![entry];
-        let trait_map = TraitMap { trait_impls };
+        let trait_map = TraitMap {
+            trait_impls,
+            satisfied_cache: HashSet::default(),
+        };
 
         self.extend(trait_map, engines);
     }
@@ -1175,6 +1181,51 @@ impl TraitMap {
         try_inserting_trait_impl_on_failure: TryInsertingTraitImplOnFailure,
     ) -> Result<(), ErrorEmitted> {
         let type_engine = engines.te();
+        type_engine.decay_numeric(handler, engines, type_id, access_span)?;
+
+        if constraints.is_empty() {
+            return Ok(());
+        }
+
+        // Check we can use the cache
+        let mut hasher = DefaultHasher::default();
+        type_id.hash(&mut hasher);
+        for c in constraints {
+            c.hash(&mut hasher, engines);
+        }
+        let hash = hasher.finish();
+
+        if self.satisfied_cache.contains(&hash) {
+            return Ok(());
+        }
+
+        // Call the real implementation and cache when true
+        match self.check_if_trait_constraints_are_satisfied_for_type_inner(
+            handler,
+            type_id,
+            constraints,
+            access_span,
+            engines,
+            try_inserting_trait_impl_on_failure,
+        ) {
+            Ok(()) => {
+                self.satisfied_cache.insert(hash);
+                Ok(())
+            }
+            r => r,
+        }
+    }
+
+    fn check_if_trait_constraints_are_satisfied_for_type_inner(
+        &mut self,
+        handler: &Handler,
+        type_id: TypeId,
+        constraints: &[TraitConstraint],
+        access_span: &Span,
+        engines: &Engines,
+        try_inserting_trait_impl_on_failure: TryInsertingTraitImplOnFailure,
+    ) -> Result<(), ErrorEmitted> {
+        let type_engine = engines.te();
 
         // If the type is generic/placeholder, its definition needs to contains all
         // constraints
@@ -1208,7 +1259,6 @@ impl TraitMap {
         let unify_check = UnifyCheck::non_dynamic_equality(engines);
 
         // resolving trait constraints require a concrete type, we need to default numeric to u64
-        type_engine.decay_numeric(handler, engines, type_id, access_span)?;
 
         let all_impld_traits: BTreeSet<(Ident, TypeId)> = self
             .trait_impls
@@ -1307,6 +1357,7 @@ impl TraitMap {
                     });
                 }
             }
+
             Ok(())
         })
     }

--- a/test/src/e2e_vm_tests/reduced_std_libs/sway-lib-std-vec/reduced_lib.config
+++ b/test/src/e2e_vm_tests/reduced_std_libs/sway-lib-std-vec/reduced_lib.config
@@ -8,4 +8,3 @@ revert.sw
 vec.sw
 iterator.sw
 convert.sw
-


### PR DESCRIPTION
## Description

Partially fixes https://github.com/FuelLabs/sway/issues/5781.

This reduces the problem of millions of `TypeInfo`s being created.
For more details see: https://github.com/FuelLabs/sway/pull/5782

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
