### PR TITLE
Fixes FQP root type not found when inside a library.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -721,13 +721,15 @@ pub(crate) fn resolve_method_name(
         } => {
             // type check the call path
             let type_id = ty.type_id;
-            let type_info_prefix = vec![];
+
+            // find the module that the symbol is in
+            let module_path = ctx.namespace().prepend_module_path(vec![]);
 
             // find the method
             let decl_ref = ctx.find_method_for_type(
                 handler,
                 type_id,
-                &type_info_prefix,
+                &module_path,
                 method_name,
                 ctx.type_annotation(),
                 &arguments_types,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/fqp_in_lib/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/fqp_in_lib/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-4CB0CAB2B0E9CCD6"
+
+[[package]]
+name = "fqp_in_lib"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "std"
+source = "path+from-root-4CB0CAB2B0E9CCD6"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/fqp_in_lib/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/fqp_in_lib/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "fqp_in_lib"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/fqp_in_lib/src/lib.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/fqp_in_lib/src/lib.sw
@@ -1,0 +1,32 @@
+library;
+use std::convert::{From, Into};
+use std::primitive_conversions::u64::*;
+
+pub struct U128_2 {
+    upper: u64,
+    lower: u64,
+}
+
+impl U128_2 {
+    fn associated_fn(){}
+}
+impl From<u8> for U128_2 {
+    fn from(val: u8) -> Self {
+        Self {
+            upper: 0,
+            lower: val.into(),
+        }
+    }
+}
+
+pub fn test_u128_from_u8() {
+    let u8_1: u8 = 0u8;
+    let u8_2: u8 = 255u8;
+
+    //Symbol U128_2 is found here
+    U128_2::associated_fn();
+
+    //Symbol U128_2 is found inside fully qualified path
+    let _u128_1 = <U128_2 as From<u8>>::from(u8_1);
+    let _u128_2 = <U128_2 as From<u8>>::from(u8_2);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/fqp_in_lib/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/fqp_in_lib/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+pub mod lib;
+
+use ::lib::*;
+
+fn main() {
+    test_u128_from_u8();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/fqp_in_lib/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/fqp_in_lib/test.toml
@@ -1,0 +1,4 @@
+category = "compile"
+
+# not: $()Unknown attribute: "test".
+# not: $()This function is never called.


### PR DESCRIPTION
## Description

When a fully qualified path was used inside a library using a type within the same file the symbol would not be found.

Fixes #5826

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
