### PR TITLE
Fix ZERO_B256 docs

### DIFF
--- a/sway-lib-std/src/constants.sw
+++ b/sway-lib-std/src/constants.sw
@@ -20,7 +20,7 @@ use ::asset_id::AssetId;
 /// ```
 pub const BASE_ASSET_ID: AssetId = AssetId::from(ZERO_B256);
 
-/// A B256 of zero value.
+/// A b256 of zero value.
 ///
 /// # Examples
 ///
@@ -28,7 +28,7 @@ pub const BASE_ASSET_ID: AssetId = AssetId::from(ZERO_B256);
 /// use std::{call_frames::msg_asset_id, constants::ZERO_B256};
 ///
 /// fn foo() {
-///     assert(ZERO_B256 == msg_asset_id());
+///     assert(ZERO_B256 == msg_asset_id().bits());
 /// }
 /// ```
 pub const ZERO_B256 = 0x0000000000000000000000000000000000000000000000000000000000000000;


### PR DESCRIPTION
## Description
The example wont compile as the function returns a assetid instead of b256, the proposed changes fixes it so the example should compile now.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
