### PR TITLE
Optimize retrieve_interface_surface_and_items_and_implemented_items_for_type

### DIFF
--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -97,99 +97,99 @@ impl<T> Into<usize> for DeclId<T> {
 }
 
 impl SubstTypes for DeclId<TyFunctionDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        if decl.subst(type_mapping, engines) {
+        if decl.subst(type_mapping, engines).has_changes() {
             decl_engine.replace(*self, decl);
-            true
+            HasChanges::Yes
         } else {
-            false
+            HasChanges::No
         }
     }
 }
 impl SubstTypes for DeclId<TyTraitDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        if decl.subst(type_mapping, engines) {
+        if decl.subst(type_mapping, engines).has_changes() {
             decl_engine.replace(*self, decl);
-            true
+            HasChanges::Yes
         } else {
-            false
+            HasChanges::No
         }
     }
 }
 impl SubstTypes for DeclId<TyTraitFn> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        if decl.subst(type_mapping, engines) {
+        if decl.subst(type_mapping, engines).has_changes() {
             decl_engine.replace(*self, decl);
-            true
+            HasChanges::Yes
         } else {
-            false
+            HasChanges::No
         }
     }
 }
 impl SubstTypes for DeclId<TyImplTrait> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        if decl.subst(type_mapping, engines) {
+        if decl.subst(type_mapping, engines).has_changes() {
             decl_engine.replace(*self, decl);
-            true
+            HasChanges::Yes
         } else {
-            false
+            HasChanges::No
         }
     }
 }
 impl SubstTypes for DeclId<TyStructDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        if decl.subst(type_mapping, engines) {
+        if decl.subst(type_mapping, engines).has_changes() {
             decl_engine.replace(*self, decl);
-            true
+            HasChanges::Yes
         } else {
-            false
+            HasChanges::No
         }
     }
 }
 impl SubstTypes for DeclId<TyEnumDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        if decl.subst(type_mapping, engines) {
+        if decl.subst(type_mapping, engines).has_changes() {
             decl_engine.replace(*self, decl);
-            true
+            HasChanges::Yes
         } else {
-            false
+            HasChanges::No
         }
     }
 }
 impl SubstTypes for DeclId<TyTypeAliasDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        if decl.subst(type_mapping, engines) {
+        if decl.subst(type_mapping, engines).has_changes() {
             decl_engine.replace(*self, decl);
-            true
+            HasChanges::Yes
         } else {
-            false
+            HasChanges::No
         }
     }
 }
 
 impl SubstTypes for DeclId<TyTraitType> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        if decl.subst(type_mapping, engines) {
+        if decl.subst(type_mapping, engines).has_changes() {
             decl_engine.replace(*self, decl);
-            true
+            HasChanges::Yes
         } else {
-            false
+            HasChanges::No
         }
     }
 }

--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -97,67 +97,99 @@ impl<T> Into<usize> for DeclId<T> {
 }
 
 impl SubstTypes for DeclId<TyFunctionDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
-        decl_engine.replace(*self, decl);
+        if decl.subst(type_mapping, engines) {
+            decl_engine.replace(*self, decl);
+            true
+        } else {
+            false
+        }
     }
 }
 impl SubstTypes for DeclId<TyTraitDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
-        decl_engine.replace(*self, decl);
+        if decl.subst(type_mapping, engines) {
+            decl_engine.replace(*self, decl);
+            true
+        } else {
+            false
+        }
     }
 }
 impl SubstTypes for DeclId<TyTraitFn> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
-        decl_engine.replace(*self, decl);
+        if decl.subst(type_mapping, engines) {
+            decl_engine.replace(*self, decl);
+            true
+        } else {
+            false
+        }
     }
 }
 impl SubstTypes for DeclId<TyImplTrait> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
-        decl_engine.replace(*self, decl);
+        if decl.subst(type_mapping, engines) {
+            decl_engine.replace(*self, decl);
+            true
+        } else {
+            false
+        }
     }
 }
 impl SubstTypes for DeclId<TyStructDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
-        decl_engine.replace(*self, decl);
+        if decl.subst(type_mapping, engines) {
+            decl_engine.replace(*self, decl);
+            true
+        } else {
+            false
+        }
     }
 }
 impl SubstTypes for DeclId<TyEnumDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
-        decl_engine.replace(*self, decl);
+        if decl.subst(type_mapping, engines) {
+            decl_engine.replace(*self, decl);
+            true
+        } else {
+            false
+        }
     }
 }
 impl SubstTypes for DeclId<TyTypeAliasDecl> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
-        decl_engine.replace(*self, decl);
+        if decl.subst(type_mapping, engines) {
+            decl_engine.replace(*self, decl);
+            true
+        } else {
+            false
+        }
     }
 }
 
 impl SubstTypes for DeclId<TyTraitType> {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();
-        decl.subst(type_mapping, engines);
-        decl_engine.replace(*self, decl);
+        if decl.subst(type_mapping, engines) {
+            decl_engine.replace(*self, decl);
+            true
+        } else {
+            false
+        }
     }
 }

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -115,7 +115,7 @@ where
     ) -> Option<Self> {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(&self.id)).clone();
-        if decl.subst(type_mapping, engines) {
+        if decl.subst(type_mapping, engines).has_changes() {
             Some(decl_engine.insert(decl))
         } else {
             None
@@ -151,7 +151,7 @@ where
     ) -> Option<Self> {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(&self.id)).clone();
-        if decl.subst(type_mapping, engines) {
+        if decl.subst(type_mapping, engines).has_changes() {
             Some(
                 decl_engine
                     .insert(decl)
@@ -299,14 +299,14 @@ where
     DeclEngine: DeclEngineIndex<T>,
     T: Named + Spanned + SubstTypes + Clone,
 {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(&self.id)).clone();
-        if decl.subst(type_mapping, engines) {
+        if decl.subst(type_mapping, engines).has_changes() {
             decl_engine.replace(self.id, decl);
-            true
+            HasChanges::Yes
         } else {
-            false
+            HasChanges::No
         }
     }
 }

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -112,11 +112,14 @@ where
         &self,
         type_mapping: &TypeSubstMap,
         engines: &Engines,
-    ) -> Self {
+    ) -> Option<Self> {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(&self.id)).clone();
-        decl.subst(type_mapping, engines);
-        decl_engine.insert(decl)
+        if decl.subst(type_mapping, engines) {
+            Some(decl_engine.insert(decl))
+        } else {
+            None
+        }
     }
 }
 
@@ -145,13 +148,18 @@ where
         &self,
         type_mapping: &TypeSubstMap,
         engines: &Engines,
-    ) -> Self {
+    ) -> Option<Self> {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(&self.id)).clone();
-        decl.subst(type_mapping, engines);
-        decl_engine
-            .insert(decl)
-            .with_parent(decl_engine, self.id.into())
+        if decl.subst(type_mapping, engines) {
+            Some(
+                decl_engine
+                    .insert(decl)
+                    .with_parent(decl_engine, self.id.into()),
+            )
+        } else {
+            None
+        }
     }
 }
 
@@ -291,11 +299,15 @@ where
     DeclEngine: DeclEngineIndex<T>,
     T: Named + Spanned + SubstTypes + Clone,
 {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(&self.id)).clone();
-        decl.subst(type_mapping, engines);
-        decl_engine.replace(self.id, decl);
+        if decl.subst(type_mapping, engines) {
+            decl_engine.replace(self.id, decl);
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -240,26 +240,23 @@ pub(crate) fn compile_constant_expression_to_constant(
         lookup: compile_const_decl,
     };
 
-    let err = |inner| match &const_expr.expression {
+    let err = match &const_expr.expression {
         // Special case functions because the span in `const_expr` is to the inlined function
         // definition, rather than the actual call site.
         ty::TyExpressionVariant::FunctionApplication { call_path, .. } => {
             Err(CompileError::NonConstantDeclValue {
                 span: call_path.span(),
-                inner,
             })
         }
         _otherwise => Err(CompileError::NonConstantDeclValue {
             span: const_expr.span.clone(),
-            inner,
         }),
     };
     let mut known_consts = MappedStack::<Ident, Constant>::new();
 
     match const_eval_typed_expr(lookup, &mut known_consts, const_expr, allow_configurables) {
         Ok(Some(constant)) => Ok(constant),
-        Err(ConstEvalError::CompileError(inner)) => err(Some(Box::new(inner))),
-        _ => err(None),
+        _ => err,
     }
 }
 

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -240,23 +240,26 @@ pub(crate) fn compile_constant_expression_to_constant(
         lookup: compile_const_decl,
     };
 
-    let err = match &const_expr.expression {
+    let err = |inner| match &const_expr.expression {
         // Special case functions because the span in `const_expr` is to the inlined function
         // definition, rather than the actual call site.
         ty::TyExpressionVariant::FunctionApplication { call_path, .. } => {
             Err(CompileError::NonConstantDeclValue {
                 span: call_path.span(),
+                inner,
             })
         }
         _otherwise => Err(CompileError::NonConstantDeclValue {
             span: const_expr.span.clone(),
+            inner,
         }),
     };
     let mut known_consts = MappedStack::<Ident, Constant>::new();
 
     match const_eval_typed_expr(lookup, &mut known_consts, const_expr, allow_configurables) {
         Ok(Some(constant)) => Ok(constant),
-        _ => err,
+        Err(ConstEvalError::CompileError(inner)) => err(Some(Box::new(inner))),
+        _ => err(None),
     }
 }
 

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -61,11 +61,11 @@ impl DebugWithEngines for TyAstNode {
 }
 
 impl SubstTypes for TyAstNode {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         match self.content {
             TyAstNodeContent::Declaration(ref mut decl) => decl.subst(type_mapping, engines),
             TyAstNodeContent::Expression(ref mut expr) => expr.subst(type_mapping, engines),
-            TyAstNodeContent::SideEffect(_) | TyAstNodeContent::Error(_, _) => false,
+            TyAstNodeContent::SideEffect(_) | TyAstNodeContent::Error(_, _) => HasChanges::No,
         }
     }
 }

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -61,12 +61,11 @@ impl DebugWithEngines for TyAstNode {
 }
 
 impl SubstTypes for TyAstNode {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         match self.content {
             TyAstNodeContent::Declaration(ref mut decl) => decl.subst(type_mapping, engines),
             TyAstNodeContent::Expression(ref mut expr) => expr.subst(type_mapping, engines),
-            TyAstNodeContent::SideEffect(_) => (),
-            TyAstNodeContent::Error(_, _) => (),
+            TyAstNodeContent::SideEffect(_) | TyAstNodeContent::Error(_, _) => false,
         }
     }
 }

--- a/sway-core/src/language/ty/code_block.rs
+++ b/sway-core/src/language/ty/code_block.rs
@@ -38,10 +38,8 @@ impl HashWithEngines for TyCodeBlock {
 }
 
 impl SubstTypes for TyCodeBlock {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.contents
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.contents.subst(type_mapping, engines)
     }
 }
 

--- a/sway-core/src/language/ty/code_block.rs
+++ b/sway-core/src/language/ty/code_block.rs
@@ -38,7 +38,7 @@ impl HashWithEngines for TyCodeBlock {
 }
 
 impl SubstTypes for TyCodeBlock {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         self.contents.subst(type_mapping, engines)
     }
 }

--- a/sway-core/src/language/ty/declaration/constant.rs
+++ b/sway-core/src/language/ty/declaration/constant.rs
@@ -95,7 +95,7 @@ impl Spanned for TyConstantDecl {
 }
 
 impl SubstTypes for TyConstantDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         has_changes! {
             self.return_type.subst(type_mapping, engines);
             self.type_ascription.subst(type_mapping, engines);

--- a/sway-core/src/language/ty/declaration/constant.rs
+++ b/sway-core/src/language/ty/declaration/constant.rs
@@ -9,6 +9,7 @@ use sway_types::{Ident, Named, Span, Spanned};
 use crate::{
     decl_engine::{DeclMapping, ReplaceDecls},
     engine_threading::*,
+    has_changes,
     language::{ty::*, CallPath, Visibility},
     semantic_analysis::TypeCheckContext,
     transform,
@@ -94,11 +95,11 @@ impl Spanned for TyConstantDecl {
 }
 
 impl SubstTypes for TyConstantDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.return_type.subst(type_mapping, engines);
-        self.type_ascription.subst(type_mapping, engines);
-        if let Some(expr) = &mut self.value {
-            expr.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        has_changes! {
+            self.return_type.subst(type_mapping, engines);
+            self.type_ascription.subst(type_mapping, engines);
+            self.value.subst(type_mapping, engines);
         }
     }
 }

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -296,7 +296,7 @@ impl HashWithEngines for TyDecl {
 }
 
 impl SubstTypes for TyDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         match self {
             TyDecl::VariableDecl(ref mut var_decl) => var_decl.subst(type_mapping, engines),
             TyDecl::FunctionDecl(FunctionDecl {
@@ -328,7 +328,7 @@ impl SubstTypes for TyDecl {
             | TyDecl::ConstantDecl(_)
             | TyDecl::StorageDecl(_)
             | TyDecl::GenericTypeForFunctionScope(_)
-            | TyDecl::ErrorRecovery(..) => false,
+            | TyDecl::ErrorRecovery(..) => HasChanges::No,
         }
     }
 }

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -296,55 +296,39 @@ impl HashWithEngines for TyDecl {
 }
 
 impl SubstTypes for TyDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         match self {
             TyDecl::VariableDecl(ref mut var_decl) => var_decl.subst(type_mapping, engines),
             TyDecl::FunctionDecl(FunctionDecl {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             TyDecl::TraitDecl(TraitDecl {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             TyDecl::StructDecl(StructDecl {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             TyDecl::EnumDecl(EnumDecl {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             TyDecl::EnumVariantDecl(EnumVariantDecl {
                 ref mut enum_ref, ..
-            }) => {
-                enum_ref.subst(type_mapping, engines);
-            }
+            }) => enum_ref.subst(type_mapping, engines),
             TyDecl::ImplTrait(ImplTrait {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             TyDecl::TypeAliasDecl(TypeAliasDecl {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             TyDecl::TraitTypeDecl(TraitTypeDecl {
                 ref mut decl_id, ..
-            }) => {
-                decl_id.subst(type_mapping, engines);
-            }
+            }) => decl_id.subst(type_mapping, engines),
             // generics in an ABI is unsupported by design
             TyDecl::AbiDecl(_)
             | TyDecl::ConstantDecl(_)
             | TyDecl::StorageDecl(_)
             | TyDecl::GenericTypeForFunctionScope(_)
-            | TyDecl::ErrorRecovery(..) => (),
+            | TyDecl::ErrorRecovery(..) => false,
         }
     }
 }

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -64,7 +64,7 @@ impl HashWithEngines for TyEnumDecl {
 }
 
 impl SubstTypes for TyEnumDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         has_changes! {
             self.variants.subst(type_mapping, engines);
             self.type_parameters.subst(type_mapping, engines);
@@ -172,7 +172,7 @@ impl OrdWithEngines for TyEnumVariant {
 }
 
 impl SubstTypes for TyEnumVariant {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         self.type_argument.subst_inner(type_mapping, engines)
     }
 }

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -11,6 +11,7 @@ use sway_types::{Ident, Named, Span, Spanned};
 
 use crate::{
     engine_threading::*,
+    has_changes,
     language::{CallPath, Visibility},
     semantic_analysis::type_check_context::MonomorphizeHelper,
     transform,
@@ -63,13 +64,11 @@ impl HashWithEngines for TyEnumDecl {
 }
 
 impl SubstTypes for TyEnumDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.variants
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
-        self.type_parameters
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        has_changes! {
+            self.variants.subst(type_mapping, engines);
+            self.type_parameters.subst(type_mapping, engines);
+        }
     }
 }
 
@@ -173,7 +172,7 @@ impl OrdWithEngines for TyEnumVariant {
 }
 
 impl SubstTypes for TyEnumVariant {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_argument.subst_inner(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.type_argument.subst_inner(type_mapping, engines)
     }
 }

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -196,7 +196,7 @@ impl HashWithEngines for TyFunctionDecl {
 }
 
 impl SubstTypes for TyFunctionDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         has_changes! {
             self.type_parameters.subst(type_mapping, engines);
             self.parameters.subst(type_mapping, engines);
@@ -522,7 +522,7 @@ impl HashWithEngines for TyFunctionParameter {
 }
 
 impl SubstTypes for TyFunctionParameter {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         self.type_argument.type_id.subst(type_mapping, engines)
     }
 }

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -8,6 +8,7 @@ use sha2::{Digest, Sha256};
 use sway_error::handler::{ErrorEmitted, Handler};
 
 use crate::{
+    has_changes,
     language::{parsed::FunctionDeclarationKind, CallPath},
     semantic_analysis::type_check_context::MonomorphizeHelper,
     transform::AttributeKind,
@@ -195,17 +196,13 @@ impl HashWithEngines for TyFunctionDecl {
 }
 
 impl SubstTypes for TyFunctionDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_parameters
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
-        self.parameters
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
-        self.return_type.subst(type_mapping, engines);
-        self.body.subst(type_mapping, engines);
-        if let Some(implementing_for) = self.implementing_for_typeid.as_mut() {
-            implementing_for.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        has_changes! {
+            self.type_parameters.subst(type_mapping, engines);
+            self.parameters.subst(type_mapping, engines);
+            self.return_type.subst(type_mapping, engines);
+            self.body.subst(type_mapping, engines);
+            self.implementing_for_typeid.subst(type_mapping, engines);
         }
     }
 }
@@ -525,8 +522,8 @@ impl HashWithEngines for TyFunctionParameter {
 }
 
 impl SubstTypes for TyFunctionParameter {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_argument.type_id.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.type_argument.type_id.subst(type_mapping, engines)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/impl_trait.rs
+++ b/sway-core/src/language/ty/declaration/impl_trait.rs
@@ -79,7 +79,7 @@ impl HashWithEngines for TyImplTrait {
 }
 
 impl SubstTypes for TyImplTrait {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         has_changes! {
             self.impl_type_parameters.subst(type_mapping, engines);
             self.implementing_for.subst_inner(type_mapping, engines);

--- a/sway-core/src/language/ty/declaration/impl_trait.rs
+++ b/sway-core/src/language/ty/declaration/impl_trait.rs
@@ -3,7 +3,8 @@ use std::hash::{Hash, Hasher};
 use sway_types::{Ident, Named, Span, Spanned};
 
 use crate::{
-    decl_engine::DeclRefMixedInterface, engine_threading::*, language::CallPath, type_system::*,
+    decl_engine::DeclRefMixedInterface, engine_threading::*, has_changes, language::CallPath,
+    type_system::*,
 };
 
 use super::TyTraitItem;
@@ -78,13 +79,11 @@ impl HashWithEngines for TyImplTrait {
 }
 
 impl SubstTypes for TyImplTrait {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.impl_type_parameters
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
-        self.implementing_for.subst_inner(type_mapping, engines);
-        self.items
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        has_changes! {
+            self.impl_type_parameters.subst(type_mapping, engines);
+            self.implementing_for.subst_inner(type_mapping, engines);
+            self.items.subst(type_mapping, engines);
+        }
     }
 }

--- a/sway-core/src/language/ty/declaration/struct.rs
+++ b/sway-core/src/language/ty/declaration/struct.rs
@@ -62,7 +62,7 @@ impl HashWithEngines for TyStructDecl {
 }
 
 impl SubstTypes for TyStructDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         has_changes! {
             self.fields.subst(type_mapping, engines);
             self.type_parameters.subst(type_mapping, engines);
@@ -273,7 +273,7 @@ impl OrdWithEngines for TyStructField {
 }
 
 impl SubstTypes for TyStructField {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         self.type_argument.subst_inner(type_mapping, engines)
     }
 }

--- a/sway-core/src/language/ty/declaration/struct.rs
+++ b/sway-core/src/language/ty/declaration/struct.rs
@@ -8,6 +8,7 @@ use sway_types::{Ident, Named, Span, Spanned};
 use crate::{
     engine_threading::*,
     error::module_can_be_changed,
+    has_changes,
     language::{CallPath, Visibility},
     semantic_analysis::type_check_context::MonomorphizeHelper,
     transform,
@@ -61,13 +62,11 @@ impl HashWithEngines for TyStructDecl {
 }
 
 impl SubstTypes for TyStructDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.fields
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
-        self.type_parameters
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        has_changes! {
+            self.fields.subst(type_mapping, engines);
+            self.type_parameters.subst(type_mapping, engines);
+        }
     }
 }
 
@@ -274,7 +273,7 @@ impl OrdWithEngines for TyStructField {
 }
 
 impl SubstTypes for TyStructField {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_argument.subst_inner(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.type_argument.subst_inner(type_mapping, engines)
     }
 }

--- a/sway-core/src/language/ty/declaration/trait.rs
+++ b/sway-core/src/language/ty/declaration/trait.rs
@@ -340,7 +340,7 @@ impl SubstTypes for TyTraitDecl {
                         false
                     }
                 }
-            });
+            } || has_changes);
         }
     }
 }

--- a/sway-core/src/language/ty/declaration/trait.rs
+++ b/sway-core/src/language/ty/declaration/trait.rs
@@ -269,20 +269,20 @@ impl Spanned for TyTraitItem {
 }
 
 impl SubstTypes for TyTraitDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         has_changes! {
             self.type_parameters.subst(type_mapping, engines);
             self.interface_surface
                 .iter_mut()
-                .fold(false, |has_changes, item| match item {
+                .fold(HasChanges::No, |has_changes, item| match item {
                     TyTraitInterfaceItem::TraitFn(item_ref) => {
                         if let Some(new_item_ref) = item_ref
                             .clone()
                             .subst_types_and_insert_new_with_parent(type_mapping, engines) {
                             item_ref.replace_id(*new_item_ref.id());
-                            true
+                            HasChanges::Yes
                         } else{
-                            false
+                            HasChanges::No
                         }
                     }
                     TyTraitInterfaceItem::Constant(decl_ref) => {
@@ -290,9 +290,9 @@ impl SubstTypes for TyTraitDecl {
                             .clone()
                             .subst_types_and_insert_new(type_mapping, engines) {
                             decl_ref.replace_id(*new_decl_ref.id());
-                            true
+                            HasChanges::Yes
                         } else{
-                            false
+                            HasChanges::No
                         }
                     }
                     TyTraitInterfaceItem::Type(decl_ref) => {
@@ -300,22 +300,22 @@ impl SubstTypes for TyTraitDecl {
                             .clone()
                             .subst_types_and_insert_new(type_mapping, engines) {
                             decl_ref.replace_id(*new_decl_ref.id());
-                            true
+                            HasChanges::Yes
                         } else{
-                            false
+                            HasChanges::No
                         }
                     }
-                } || has_changes);
-            self.items.iter_mut().fold(false, |has_changes, item| match item {
+                } | has_changes);
+            self.items.iter_mut().fold(HasChanges::No, |has_changes, item| match item {
                 TyTraitItem::Fn(item_ref) => {
                     if let Some(new_item_ref) = item_ref
                         .clone()
                         .subst_types_and_insert_new_with_parent(type_mapping, engines)
                     {
                         item_ref.replace_id(*new_item_ref.id());
-                        true
+                        HasChanges::Yes
                     } else {
-                        false
+                        HasChanges::No
                     }
                 }
                 TyTraitItem::Constant(item_ref) => {
@@ -324,9 +324,9 @@ impl SubstTypes for TyTraitDecl {
                         .subst_types_and_insert_new_with_parent(type_mapping, engines)
                     {
                         item_ref.replace_id(*new_decl_ref.id());
-                        true
+                        HasChanges::Yes
                     } else {
-                        false
+                        HasChanges::No
                     }
                 }
                 TyTraitItem::Type(item_ref) => {
@@ -335,18 +335,18 @@ impl SubstTypes for TyTraitDecl {
                         .subst_types_and_insert_new_with_parent(type_mapping, engines)
                     {
                         item_ref.replace_id(*new_decl_ref.id());
-                        true
+                        HasChanges::Yes
                     } else {
-                        false
+                        HasChanges::No
                     }
                 }
-            } || has_changes);
+            } | has_changes);
         }
     }
 }
 
 impl SubstTypes for TyTraitItem {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         match self {
             TyTraitItem::Fn(fn_decl) => fn_decl.subst(type_mapping, engines),
             TyTraitItem::Constant(const_decl) => const_decl.subst(type_mapping, engines),

--- a/sway-core/src/language/ty/declaration/trait_fn.rs
+++ b/sway-core/src/language/ty/declaration/trait_fn.rs
@@ -101,7 +101,7 @@ impl HashWithEngines for TyTraitFn {
 }
 
 impl SubstTypes for TyTraitFn {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         has_changes! {
             self.parameters.subst(type_mapping, engines);
             self.return_type.subst(type_mapping, engines);

--- a/sway-core/src/language/ty/declaration/trait_fn.rs
+++ b/sway-core/src/language/ty/declaration/trait_fn.rs
@@ -7,6 +7,7 @@ use sway_types::{Ident, Named, Span, Spanned};
 
 use crate::{
     engine_threading::*,
+    has_changes,
     language::{ty::*, Purity},
     semantic_analysis::type_check_context::MonomorphizeHelper,
     transform,
@@ -100,11 +101,11 @@ impl HashWithEngines for TyTraitFn {
 }
 
 impl SubstTypes for TyTraitFn {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.parameters
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
-        self.return_type.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        has_changes! {
+            self.parameters.subst(type_mapping, engines);
+            self.return_type.subst(type_mapping, engines);
+        }
     }
 }
 

--- a/sway-core/src/language/ty/declaration/trait_type.rs
+++ b/sway-core/src/language/ty/declaration/trait_type.rs
@@ -55,7 +55,7 @@ impl HashWithEngines for TyTraitType {
 }
 
 impl SubstTypes for TyTraitType {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         has_changes! {
             self.ty.subst(type_mapping, engines);
             self.implementing_type.subst(type_mapping, engines);

--- a/sway-core/src/language/ty/declaration/trait_type.rs
+++ b/sway-core/src/language/ty/declaration/trait_type.rs
@@ -5,7 +5,7 @@ use std::{
 
 use sway_types::{Ident, Named, Span, Spanned};
 
-use crate::{engine_threading::*, transform, type_system::*};
+use crate::{engine_threading::*, has_changes, transform, type_system::*};
 
 #[derive(Clone, Debug)]
 pub struct TyTraitType {
@@ -55,11 +55,11 @@ impl HashWithEngines for TyTraitType {
 }
 
 impl SubstTypes for TyTraitType {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        if let Some(ref mut ty) = self.ty {
-            ty.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        has_changes! {
+            self.ty.subst(type_mapping, engines);
+            self.implementing_type.subst(type_mapping, engines);
         }
-        self.implementing_type.subst(type_mapping, engines);
     }
 }
 

--- a/sway-core/src/language/ty/declaration/type_alias.rs
+++ b/sway-core/src/language/ty/declaration/type_alias.rs
@@ -51,7 +51,7 @@ impl HashWithEngines for TyTypeAliasDecl {
 }
 
 impl SubstTypes for TyTypeAliasDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         self.ty.subst(type_mapping, engines)
     }
 }

--- a/sway-core/src/language/ty/declaration/type_alias.rs
+++ b/sway-core/src/language/ty/declaration/type_alias.rs
@@ -51,8 +51,8 @@ impl HashWithEngines for TyTypeAliasDecl {
 }
 
 impl SubstTypes for TyTypeAliasDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.ty.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.ty.subst(type_mapping, engines)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/variable.rs
+++ b/sway-core/src/language/ty/declaration/variable.rs
@@ -55,7 +55,7 @@ impl HashWithEngines for TyVariableDecl {
 }
 
 impl SubstTypes for TyVariableDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         self.return_type.subst(type_mapping, engines);
         self.type_ascription.subst(type_mapping, engines);
         self.body.subst(type_mapping, engines)

--- a/sway-core/src/language/ty/declaration/variable.rs
+++ b/sway-core/src/language/ty/declaration/variable.rs
@@ -55,7 +55,7 @@ impl HashWithEngines for TyVariableDecl {
 }
 
 impl SubstTypes for TyVariableDecl {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         self.return_type.subst(type_mapping, engines);
         self.type_ascription.subst(type_mapping, engines);
         self.body.subst(type_mapping, engines)

--- a/sway-core/src/language/ty/expression/asm.rs
+++ b/sway-core/src/language/ty/expression/asm.rs
@@ -32,7 +32,7 @@ impl HashWithEngines for TyAsmRegisterDeclaration {
 }
 
 impl SubstTypes for TyAsmRegisterDeclaration {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         self.initializer.subst(type_mapping, engines)
     }
 }

--- a/sway-core/src/language/ty/expression/asm.rs
+++ b/sway-core/src/language/ty/expression/asm.rs
@@ -32,9 +32,7 @@ impl HashWithEngines for TyAsmRegisterDeclaration {
 }
 
 impl SubstTypes for TyAsmRegisterDeclaration {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        if let Some(ref mut initializer) = self.initializer {
-            initializer.subst(type_mapping, engines)
-        }
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.initializer.subst(type_mapping, engines)
     }
 }

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -9,6 +9,7 @@ use sway_types::{Span, Spanned};
 use crate::{
     decl_engine::*,
     engine_threading::*,
+    has_changes,
     language::{ty::*, Literal},
     semantic_analysis::{
         TypeCheckAnalysis, TypeCheckAnalysisContext, TypeCheckContext, TypeCheckFinalization,
@@ -53,9 +54,11 @@ impl HashWithEngines for TyExpression {
 }
 
 impl SubstTypes for TyExpression {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.return_type.subst(type_mapping, engines);
-        self.expression.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        has_changes! {
+            self.return_type.subst(type_mapping, engines);
+            self.expression.subst(type_mapping, engines);
+        }
     }
 }
 

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -54,7 +54,7 @@ impl HashWithEngines for TyExpression {
 }
 
 impl SubstTypes for TyExpression {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         has_changes! {
             self.return_type.subst(type_mapping, engines);
             self.expression.subst(type_mapping, engines);

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -11,6 +11,7 @@ use sway_types::{Ident, Named, Span, Spanned};
 use crate::{
     decl_engine::*,
     engine_threading::*,
+    has_changes,
     language::{ty::*, *},
     namespace::TryInsertingTraitImplOnFailure,
     semantic_analysis::{
@@ -628,89 +629,78 @@ impl HashWithEngines for TyExpressionVariant {
 }
 
 impl SubstTypes for TyExpressionVariant {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         use TyExpressionVariant::*;
         match self {
-            Literal(..) => (),
+            Literal(..) => false,
             FunctionApplication {
                 arguments,
                 ref mut fn_ref,
                 ref mut call_path_typeid,
                 ..
-            } => {
-                arguments
-                    .iter_mut()
-                    .for_each(|(_ident, expr)| expr.subst(type_mapping, engines));
-                let new_decl_ref = fn_ref
+            } => has_changes! {
+                arguments.subst(type_mapping, engines);
+                if let Some(new_decl_ref) = fn_ref
                     .clone()
-                    .subst_types_and_insert_new_with_parent(type_mapping, engines);
-                fn_ref.replace_id(*new_decl_ref.id());
-                if let Some(call_path_typeid) = call_path_typeid {
-                    call_path_typeid.subst(type_mapping, engines);
-                }
-            }
-            LazyOperator { lhs, rhs, .. } => {
-                (*lhs).subst(type_mapping, engines);
-                (*rhs).subst(type_mapping, engines);
-            }
-            ConstantExpression { const_decl, .. } => {
-                const_decl.subst(type_mapping, engines);
-            }
-            VariableExpression { .. } => (),
-            Tuple { fields } => fields
-                .iter_mut()
-                .for_each(|x| x.subst(type_mapping, engines)),
+                    .subst_types_and_insert_new_with_parent(type_mapping, engines)
+                {
+                    fn_ref.replace_id(*new_decl_ref.id());
+                    true
+                } else {
+                    false
+                };
+                call_path_typeid.subst(type_mapping, engines);
+            },
+            LazyOperator { lhs, rhs, .. } => has_changes! {
+                lhs.subst(type_mapping, engines);
+                rhs.subst(type_mapping, engines);
+            },
+            ConstantExpression { const_decl, .. } => const_decl.subst(type_mapping, engines),
+            VariableExpression { .. } => false,
+            Tuple { fields } => fields.subst(type_mapping, engines),
             Array {
                 ref mut elem_type,
                 contents,
-            } => {
+            } => has_changes! {
                 elem_type.subst(type_mapping, engines);
-                contents
-                    .iter_mut()
-                    .for_each(|x| x.subst(type_mapping, engines))
-            }
-            ArrayIndex { prefix, index } => {
-                (*prefix).subst(type_mapping, engines);
-                (*index).subst(type_mapping, engines);
-            }
+                contents.subst(type_mapping, engines);
+            },
+            ArrayIndex { prefix, index } => has_changes! {
+                prefix.subst(type_mapping, engines);
+                index.subst(type_mapping, engines);
+            },
             StructExpression {
                 struct_ref,
                 fields,
                 instantiation_span: _,
                 call_path_binding: _,
-            } => {
-                let new_struct_ref = struct_ref
+            } => has_changes! {
+                if let Some(new_struct_ref) = struct_ref
                     .clone()
-                    .subst_types_and_insert_new(type_mapping, engines);
-                struct_ref.replace_id(*new_struct_ref.id());
-                fields
-                    .iter_mut()
-                    .for_each(|x| x.subst(type_mapping, engines));
-            }
-            CodeBlock(block) => {
-                block.subst(type_mapping, engines);
-            }
-            FunctionParameter => (),
+                    .subst_types_and_insert_new(type_mapping, engines) {
+                    struct_ref.replace_id(*new_struct_ref.id());
+                    true
+                } else {
+                    false
+                };
+                fields.subst(type_mapping, engines);
+            },
+            CodeBlock(block) => block.subst(type_mapping, engines),
+            FunctionParameter => false,
             MatchExp { desugared, .. } => desugared.subst(type_mapping, engines),
             IfExp {
                 condition,
                 then,
                 r#else,
-            } => {
+            } => has_changes! {
                 condition.subst(type_mapping, engines);
                 then.subst(type_mapping, engines);
-                if let Some(ref mut r#else) = r#else {
-                    r#else.subst(type_mapping, engines);
-                }
-            }
+                r#else.subst(type_mapping, engines);
+            },
             AsmExpression {
                 registers, //: Vec<TyAsmRegisterDeclaration>,
                 ..
-            } => {
-                registers
-                    .iter_mut()
-                    .for_each(|x| x.subst(type_mapping, engines));
-            }
+            } => registers.subst(type_mapping, engines),
             // like a variable expression but it has multiple parts,
             // like looking up a field in a struct
             StructFieldAccess {
@@ -718,60 +708,57 @@ impl SubstTypes for TyExpressionVariant {
                 field_to_access,
                 ref mut resolved_type_of_parent,
                 ..
-            } => {
+            } => has_changes! {
                 resolved_type_of_parent.subst(type_mapping, engines);
                 field_to_access.subst(type_mapping, engines);
                 prefix.subst(type_mapping, engines);
-            }
+            },
             TupleElemAccess {
                 prefix,
                 ref mut resolved_type_of_parent,
                 ..
-            } => {
+            } => has_changes! {
                 resolved_type_of_parent.subst(type_mapping, engines);
                 prefix.subst(type_mapping, engines);
-            }
+            },
             EnumInstantiation {
                 enum_ref, contents, ..
-            } => {
-                let new_enum_ref = enum_ref
+            } => has_changes! {
+                if let Some(new_enum_ref) = enum_ref
                     .clone()
-                    .subst_types_and_insert_new(type_mapping, engines);
-                enum_ref.replace_id(*new_enum_ref.id());
-                if let Some(ref mut contents) = contents {
-                    contents.subst(type_mapping, engines)
+                    .subst_types_and_insert_new(type_mapping, engines)
+                {
+                    enum_ref.replace_id(*new_enum_ref.id());
+                    true
+                } else {
+                    false
                 };
-            }
+                contents.subst(type_mapping, engines);
+            },
             AbiCast { address, .. } => address.subst(type_mapping, engines),
             // storage is never generic and cannot be monomorphized
-            StorageAccess { .. } => (),
-            IntrinsicFunction(kind) => {
-                kind.subst(type_mapping, engines);
-            }
-            EnumTag { exp } => {
-                exp.subst(type_mapping, engines);
-            }
+            StorageAccess { .. } => false,
+            IntrinsicFunction(kind) => kind.subst(type_mapping, engines),
+            EnumTag { exp } => exp.subst(type_mapping, engines),
             UnsafeDowncast {
                 exp,
                 variant,
                 call_path_decl: _,
-            } => {
+            } => has_changes! {
                 exp.subst(type_mapping, engines);
                 variant.subst(type_mapping, engines);
-            }
-            AbiName(_) => (),
+            },
+            AbiName(_) => false,
             WhileLoop {
                 ref mut condition,
                 ref mut body,
             } => {
                 condition.subst(type_mapping, engines);
-                body.subst(type_mapping, engines);
+                body.subst(type_mapping, engines)
             }
-            ForLoop { ref mut desugared } => {
-                desugared.subst(type_mapping, engines);
-            }
-            Break => (),
-            Continue => (),
+            ForLoop { ref mut desugared } => desugared.subst(type_mapping, engines),
+            Break => false,
+            Continue => false,
             Reassignment(reassignment) => reassignment.subst(type_mapping, engines),
             ImplicitReturn(expr) | Return(expr) => expr.subst(type_mapping, engines),
             Ref(exp) | Deref(exp) => exp.subst(type_mapping, engines),

--- a/sway-core/src/language/ty/expression/intrinsic_function.rs
+++ b/sway-core/src/language/ty/expression/intrinsic_function.rs
@@ -70,7 +70,7 @@ impl HashWithEngines for TyIntrinsicFunctionKind {
 }
 
 impl SubstTypes for TyIntrinsicFunctionKind {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         has_changes! {
             self.arguments.subst(type_mapping, engines);
             self.type_arguments.subst(type_mapping, engines);

--- a/sway-core/src/language/ty/expression/intrinsic_function.rs
+++ b/sway-core/src/language/ty/expression/intrinsic_function.rs
@@ -3,7 +3,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use crate::{engine_threading::*, language::ty::*, type_system::*, types::*};
+use crate::{engine_threading::*, has_changes, language::ty::*, type_system::*, types::*};
 use itertools::Itertools;
 use sway_ast::Intrinsic;
 use sway_error::handler::{ErrorEmitted, Handler};
@@ -70,12 +70,10 @@ impl HashWithEngines for TyIntrinsicFunctionKind {
 }
 
 impl SubstTypes for TyIntrinsicFunctionKind {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        for arg in &mut self.arguments {
-            arg.subst(type_mapping, engines);
-        }
-        for targ in &mut self.type_arguments {
-            targ.type_id.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        has_changes! {
+            self.arguments.subst(type_mapping, engines);
+            self.type_arguments.subst(type_mapping, engines);
         }
     }
 }

--- a/sway-core/src/language/ty/expression/reassignment.rs
+++ b/sway-core/src/language/ty/expression/reassignment.rs
@@ -9,6 +9,7 @@ use sway_types::{Ident, Span, Spanned};
 use crate::{
     decl_engine::*,
     engine_threading::*,
+    has_changes,
     language::ty::*,
     semantic_analysis::{
         TypeCheckAnalysis, TypeCheckAnalysisContext, TypeCheckContext, TypeCheckFinalization,
@@ -57,9 +58,11 @@ impl HashWithEngines for TyReassignment {
 }
 
 impl SubstTypes for TyReassignment {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.rhs.subst(type_mapping, engines);
-        self.lhs_type.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        has_changes! {
+            self.rhs.subst(type_mapping, engines);
+            self.lhs_type.subst(type_mapping, engines);
+        }
     }
 }
 

--- a/sway-core/src/language/ty/expression/reassignment.rs
+++ b/sway-core/src/language/ty/expression/reassignment.rs
@@ -58,7 +58,7 @@ impl HashWithEngines for TyReassignment {
 }
 
 impl SubstTypes for TyReassignment {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         has_changes! {
             self.rhs.subst(type_mapping, engines);
             self.lhs_type.subst(type_mapping, engines);

--- a/sway-core/src/language/ty/expression/struct_exp_field.rs
+++ b/sway-core/src/language/ty/expression/struct_exp_field.rs
@@ -33,8 +33,8 @@ impl HashWithEngines for TyStructExpressionField {
 }
 
 impl SubstTypes for TyStructExpressionField {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.value.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.value.subst(type_mapping, engines)
     }
 }
 

--- a/sway-core/src/language/ty/expression/struct_exp_field.rs
+++ b/sway-core/src/language/ty/expression/struct_exp_field.rs
@@ -33,7 +33,7 @@ impl HashWithEngines for TyStructExpressionField {
 }
 
 impl SubstTypes for TyStructExpressionField {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         self.value.subst(type_mapping, engines)
     }
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -360,7 +360,7 @@ impl TyTraitDecl {
                 ty::TyTraitItem::Fn(decl_ref) => {
                     let mut method = (*decl_engine.get_function(&decl_ref)).clone();
                     let name = method.name.clone();
-                    let r = if method.subst(&type_mapping, engines) {
+                    let r = if method.subst(&type_mapping, engines).has_changes() {
                         let new_ref = decl_engine
                             .insert(method)
                             .with_parent(decl_engine, (*decl_ref.id()).into());
@@ -373,7 +373,7 @@ impl TyTraitDecl {
                 ty::TyTraitItem::Constant(decl_ref) => {
                     let mut const_decl = (*decl_engine.get_constant(&decl_ref)).clone();
                     let name = const_decl.call_path.suffix.clone();
-                    let r = if const_decl.subst(&type_mapping, engines) {
+                    let r = if const_decl.subst(&type_mapping, engines).has_changes() {
                         decl_engine.insert(const_decl)
                     } else {
                         decl_ref.clone()
@@ -383,7 +383,7 @@ impl TyTraitDecl {
                 ty::TyTraitItem::Type(decl_ref) => {
                     let mut t = (*decl_engine.get_type(&decl_ref)).clone();
                     let name = t.name.clone();
-                    let r = if t.subst(&type_mapping, engines) {
+                    let r = if t.subst(&type_mapping, engines).has_changes() {
                         decl_engine.insert(t)
                     } else {
                         decl_ref.clone()

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -359,31 +359,38 @@ impl TyTraitDecl {
             match item {
                 ty::TyTraitItem::Fn(decl_ref) => {
                     let mut method = (*decl_engine.get_function(&decl_ref)).clone();
-                    method.subst(&type_mapping, engines);
-                    impld_item_refs.insert(
-                        (method.name.clone(), type_id),
-                        TyTraitItem::Fn(
-                            decl_engine
-                                .insert(method)
-                                .with_parent(decl_engine, (*decl_ref.id()).into()),
-                        ),
-                    );
+                    let name = method.name.clone();
+                    let r = if method.subst(&type_mapping, engines) {
+                        let new_ref = decl_engine
+                            .insert(method)
+                            .with_parent(decl_engine, (*decl_ref.id()).into());
+                        new_ref
+                    } else {
+                        decl_ref.clone()
+                    };
+                    impld_item_refs.insert((name, type_id), TyTraitItem::Fn(r));
                 }
                 ty::TyTraitItem::Constant(decl_ref) => {
                     let mut const_decl = (*decl_engine.get_constant(&decl_ref)).clone();
-                    const_decl.subst(&type_mapping, engines);
-                    impld_item_refs.insert(
-                        (const_decl.call_path.suffix.clone(), type_id),
-                        TyTraitItem::Constant(decl_engine.insert(const_decl)),
-                    );
+                    let name = const_decl.call_path.suffix.clone();
+                    let r = if const_decl.subst(&type_mapping, engines) {
+                        let new_ref = decl_engine.insert(const_decl);
+                        new_ref
+                    } else {
+                        decl_ref.clone()
+                    };
+                    impld_item_refs.insert((name, type_id), TyTraitItem::Constant(r));
                 }
                 ty::TyTraitItem::Type(decl_ref) => {
-                    let mut type_decl = (*decl_engine.get_type(&decl_ref)).clone();
-                    type_decl.subst(&type_mapping, engines);
-                    impld_item_refs.insert(
-                        (type_decl.name.clone(), type_id),
-                        TyTraitItem::Type(decl_engine.insert(type_decl)),
-                    );
+                    let mut t = (*decl_engine.get_type(&decl_ref)).clone();
+                    let name = t.name.clone();
+                    let r = if t.subst(&type_mapping, engines) {
+                        let new_ref = decl_engine.insert(t);
+                        new_ref
+                    } else {
+                        decl_ref.clone()
+                    };
+                    impld_item_refs.insert((name, type_id), TyTraitItem::Type(r));
                 }
             }
         }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -374,8 +374,7 @@ impl TyTraitDecl {
                     let mut const_decl = (*decl_engine.get_constant(&decl_ref)).clone();
                     let name = const_decl.call_path.suffix.clone();
                     let r = if const_decl.subst(&type_mapping, engines) {
-                        let new_ref = decl_engine.insert(const_decl);
-                        new_ref
+                        decl_engine.insert(const_decl)
                     } else {
                         decl_ref.clone()
                     };
@@ -385,8 +384,7 @@ impl TyTraitDecl {
                     let mut t = (*decl_engine.get_type(&decl_ref)).clone();
                     let name = t.name.clone();
                     let r = if t.subst(&type_mapping, engines) {
-                        let new_ref = decl_engine.insert(t);
-                        new_ref
+                        decl_engine.insert(t)
                     } else {
                         decl_ref.clone()
                     };

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -98,7 +98,7 @@ impl Spanned for TraitConstraint {
 }
 
 impl SubstTypes for TraitConstraint {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         self.type_arguments.subst(type_mapping, engines)
     }
 }

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -98,10 +98,8 @@ impl Spanned for TraitConstraint {
 }
 
 impl SubstTypes for TraitConstraint {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_arguments
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.type_arguments.subst(type_mapping, engines)
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -109,7 +109,7 @@ impl From<&TypeParameter> for TypeArgument {
 }
 
 impl SubstTypes for TypeArgument {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_id.subst(type_mapping, engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.type_id.subst(type_mapping, engines)
     }
 }

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -109,7 +109,7 @@ impl From<&TypeParameter> for TypeArgument {
 }
 
 impl SubstTypes for TypeArgument {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         self.type_id.subst(type_mapping, engines)
     }
 }

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -1,10 +1,8 @@
 use crate::{
     decl_engine::*,
     engine_threading::*,
-    language::{
-        ty::{self},
-        CallPath,
-    },
+    has_changes,
+    language::{ty, CallPath},
     namespace::TryInsertingTraitImplOnFailure,
     semantic_analysis::*,
     type_system::priv_prelude::*,
@@ -98,11 +96,11 @@ impl OrdWithEngines for TypeParameter {
 }
 
 impl SubstTypes for TypeParameter {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.type_id.subst(type_mapping, engines);
-        self.trait_constraints
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        has_changes! {
+            self.type_id.subst(type_mapping, engines);
+            self.trait_constraints.subst(type_mapping, engines);
+        }
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -96,7 +96,7 @@ impl OrdWithEngines for TypeParameter {
 }
 
 impl SubstTypes for TypeParameter {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         has_changes! {
             self.type_id.subst(type_mapping, engines);
             self.trait_constraints.subst(type_mapping, engines);

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -75,17 +75,17 @@ impl CollectTypesMetadata for TypeId {
 }
 
 impl SubstTypes for TypeId {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         let type_engine = engines.te();
         if let Some(matching_id) = type_mapping.find_match(*self, engines) {
             if !matches!(&*type_engine.get(matching_id), TypeInfo::ErrorRecovery(_)) {
                 *self = matching_id;
-                true
+                HasChanges::Yes
             } else {
-                false
+                HasChanges::No
             }
         } else {
-            false
+            HasChanges::No
         }
     }
 }

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -75,12 +75,17 @@ impl CollectTypesMetadata for TypeId {
 }
 
 impl SubstTypes for TypeId {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         let type_engine = engines.te();
         if let Some(matching_id) = type_mapping.find_match(*self, engines) {
             if !matches!(&*type_engine.get(matching_id), TypeInfo::ErrorRecovery(_)) {
                 *self = matching_id;
+                true
+            } else {
+                false
             }
+        } else {
+            false
         }
     }
 }

--- a/sway-core/src/type_system/priv_prelude.rs
+++ b/sway-core/src/type_system/priv_prelude.rs
@@ -6,7 +6,10 @@ pub(crate) use super::{
         create_type_id::CreateTypeId,
     },
     info::VecSet,
-    substitute::{subst_list::SubstList, subst_map::TypeSubstMap, subst_types::SubstTypes},
+    substitute::{
+        subst_list::SubstList, subst_map::TypeSubstMap, subst_types::HasChanges,
+        subst_types::SubstTypes,
+    },
     unify::unify_check::UnifyCheck,
 };
 

--- a/sway-core/src/type_system/substitute/subst_list.rs
+++ b/sway-core/src/type_system/substitute/subst_list.rs
@@ -80,7 +80,7 @@ impl OrdWithEngines for SubstList {
 }
 
 impl SubstTypes for SubstList {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         self.list.subst(type_mapping, engines)
     }
 }

--- a/sway-core/src/type_system/substitute/subst_list.rs
+++ b/sway-core/src/type_system/substitute/subst_list.rs
@@ -80,9 +80,7 @@ impl OrdWithEngines for SubstList {
 }
 
 impl SubstTypes for SubstList {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
-        self.list
-            .iter_mut()
-            .for_each(|x| x.subst(type_mapping, engines));
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.list.subst(type_mapping, engines)
     }
 }

--- a/sway-core/src/type_system/substitute/subst_types.rs
+++ b/sway-core/src/type_system/substitute/subst_types.rs
@@ -34,7 +34,7 @@ impl<T: SubstTypes> SubstTypes for Option<T> {
 
 impl<T: SubstTypes> SubstTypes for Vec<T> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
-        self.iter_mut().fold(false, |mut has_change, x| {
+        self.iter_mut().fold(false, |has_change, x| {
             x.subst(type_mapping, engines) || has_change
         })
     }

--- a/sway-core/src/type_system/substitute/subst_types.rs
+++ b/sway-core/src/type_system/substitute/subst_types.rs
@@ -1,19 +1,15 @@
 use crate::{engine_threading::*, type_system::priv_prelude::*};
 
+#[derive(Default)]
 pub enum HasChanges {
     Yes,
+    #[default]
     No,
 }
 
 impl HasChanges {
     pub fn has_changes(&self) -> bool {
         matches!(self, HasChanges::Yes)
-    }
-}
-
-impl Default for HasChanges {
-    fn default() -> Self {
-        HasChanges::No
     }
 }
 
@@ -71,7 +67,7 @@ impl<T: SubstTypes> SubstTypes for Vec<T> {
 #[macro_export]
 macro_rules! has_changes {
     ($($stmts:expr);* ;) => {{
-        let mut has_change = crate::type_system::HasChanges::No;
+        let mut has_change = $crate::type_system::HasChanges::No;
         $(
             has_change = $stmts | has_change;
         )*

--- a/sway-core/src/type_system/substitute/subst_types.rs
+++ b/sway-core/src/type_system/substitute/subst_types.rs
@@ -1,11 +1,52 @@
 use crate::{engine_threading::*, type_system::priv_prelude::*};
 
 pub trait SubstTypes {
-    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines);
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool;
 
-    fn subst(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) {
+    fn subst(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
         if !type_mapping.is_empty() {
-            self.subst_inner(type_mapping, engines);
+            self.subst_inner(type_mapping, engines)
+        } else {
+            false
         }
     }
+}
+
+impl<A, B: SubstTypes> SubstTypes for (A, B) {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.1.subst(type_mapping, engines)
+    }
+}
+
+impl<T: SubstTypes> SubstTypes for Box<T> {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.as_mut().subst(type_mapping, engines)
+    }
+}
+
+impl<T: SubstTypes> SubstTypes for Option<T> {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.as_mut()
+            .map(|x| x.subst(type_mapping, engines))
+            .unwrap_or_default()
+    }
+}
+
+impl<T: SubstTypes> SubstTypes for Vec<T> {
+    fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> bool {
+        self.iter_mut().fold(false, |mut has_change, x| {
+            x.subst(type_mapping, engines) || has_change
+        })
+    }
+}
+
+#[macro_export]
+macro_rules! has_changes {
+    ($($stmts:expr);* ;) => {{
+        let mut has_change = false;
+        $(
+            has_change |= $stmts;
+        )*
+        has_change
+    }};
 }

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -749,7 +749,10 @@ pub enum CompileError {
     #[error("{}", error)]
     Parse { error: ParseError },
     #[error("Could not evaluate initializer to a const declaration.")]
-    NonConstantDeclValue { span: Span },
+    NonConstantDeclValue {
+        span: Span,
+        inner: Option<Box<CompileError>>,
+    },
     #[error("Declaring storage in a {program_kind} is not allowed.")]
     StorageDeclarationInNonContract { program_kind: String, span: Span },
     #[error("Unsupported argument type to intrinsic \"{name}\".{}", if hint.is_empty() { "".to_string() } else { format!(" Hint: {hint}") })]
@@ -1037,7 +1040,7 @@ impl Spanned for CompileError {
             Parse { error } => error.span.clone(),
             EnumNotFound { span, .. } => span.clone(),
             TupleIndexOutOfBounds { span, .. } => span.clone(),
-            NonConstantDeclValue { span } => span.clone(),
+            NonConstantDeclValue { span, .. } => span.clone(),
             StorageDeclarationInNonContract { span, .. } => span.clone(),
             IntrinsicUnsupportedArgType { span, .. } => span.clone(),
             IntrinsicIncorrectNumArgs { span, .. } => span.clone(),

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -749,10 +749,7 @@ pub enum CompileError {
     #[error("{}", error)]
     Parse { error: ParseError },
     #[error("Could not evaluate initializer to a const declaration.")]
-    NonConstantDeclValue {
-        span: Span,
-        inner: Option<Box<CompileError>>,
-    },
+    NonConstantDeclValue { span: Span },
     #[error("Declaring storage in a {program_kind} is not allowed.")]
     StorageDeclarationInNonContract { program_kind: String, span: Span },
     #[error("Unsupported argument type to intrinsic \"{name}\".{}", if hint.is_empty() { "".to_string() } else { format!(" Hint: {hint}") })]

--- a/sway-ir/src/parser.rs
+++ b/sway-ir/src/parser.rs
@@ -522,7 +522,7 @@ mod ir_builder {
                     (ty, cv)
                 }
                 / ty:ast_ty() "undef" _ {
-                    (ty.clone(), IrAstConst { value: IrAstConstValue::Undef(ty), meta_idx: None })
+                    (ty.clone(), IrAstConst { value: IrAstConstValue::Undef, meta_idx: None })
                 }
 
             rule ast_ty() -> IrAstTy
@@ -764,8 +764,7 @@ mod ir_builder {
 
     #[derive(Debug)]
     enum IrAstConstValue {
-        #[allow(dead_code)]
-        Undef(IrAstTy),
+        Undef,
         Unit,
         Bool(bool),
         Hex256([u8; 32]),
@@ -792,7 +791,7 @@ mod ir_builder {
     impl IrAstConstValue {
         fn as_constant_value(&self, context: &mut Context, val_ty: IrAstTy) -> ConstantValue {
             match self {
-                IrAstConstValue::Undef(_) => ConstantValue::Undef,
+                IrAstConstValue::Undef => ConstantValue::Undef,
                 IrAstConstValue::Unit => ConstantValue::Unit,
                 IrAstConstValue::Bool(b) => ConstantValue::Bool(*b),
                 IrAstConstValue::Hex256(bs) => match val_ty {
@@ -834,7 +833,7 @@ mod ir_builder {
 
         fn as_value(&self, context: &mut Context, val_ty: IrAstTy) -> Value {
             match self {
-                IrAstConstValue::Undef(_) => unreachable!("Can't convert 'undef' to a value."),
+                IrAstConstValue::Undef => unreachable!("Can't convert 'undef' to a value."),
                 IrAstConstValue::Unit => Constant::get_unit(context),
                 IrAstConstValue::Bool(b) => Constant::get_bool(context, *b),
                 IrAstConstValue::Hex256(bs) => match val_ty {


### PR DESCRIPTION
## Description

Partially addresses https://github.com/FuelLabs/sway/issues/5781.

This reduces the problem of millions of TyFunctionDecl being created.
For more details see: https://github.com/FuelLabs/sway/pull/5782

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
