### PR TITLE
change ConcurrentSlab to use Vec

### DIFF
--- a/sway-core/src/concurrent_slab.rs
+++ b/sway-core/src/concurrent_slab.rs
@@ -1,15 +1,26 @@
 use std::{
-    collections::HashMap,
     fmt,
     sync::{Arc, RwLock},
 };
 
-use itertools::Itertools;
+#[derive(Debug, Clone)]
+pub struct Inner<T> {
+    pub items: Vec<Option<Arc<T>>>,
+    pub free_list: Vec<usize>,
+}
+
+impl<T> Default for Inner<T> {
+    fn default() -> Self {
+        Self {
+            items: Default::default(),
+            free_list: Default::default(),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct ConcurrentSlab<T> {
-    inner: RwLock<HashMap<usize, Arc<T>>>,
-    last_id: Arc<RwLock<usize>>,
+    pub inner: RwLock<Inner<T>>,
 }
 
 impl<T> Clone for ConcurrentSlab<T>
@@ -20,7 +31,6 @@ where
         let inner = self.inner.read().unwrap();
         Self {
             inner: RwLock::new(inner.clone()),
-            last_id: self.last_id.clone(),
         }
     }
 }
@@ -29,7 +39,6 @@ impl<T> Default for ConcurrentSlab<T> {
     fn default() -> Self {
         Self {
             inner: Default::default(),
-            last_id: Default::default(),
         }
     }
 }
@@ -58,46 +67,69 @@ impl<T> ConcurrentSlab<T>
 where
     T: Clone,
 {
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        let inner = self.inner.read().unwrap();
+        inner.items.len()
+    }
+
     pub fn values(&self) -> Vec<Arc<T>> {
         let inner = self.inner.read().unwrap();
-        inner.values().cloned().collect_vec()
+        inner.items.iter().filter_map(|x| x.clone()).collect()
     }
 
     pub fn insert(&self, value: T) -> usize {
-        let mut inner = self.inner.write().unwrap();
-        let mut last_id = self.last_id.write().unwrap();
-        *last_id += 1;
-        inner.insert(*last_id, Arc::new(value));
-        *last_id
+        self.insert_arc(Arc::new(value))
     }
 
     pub fn insert_arc(&self, value: Arc<T>) -> usize {
         let mut inner = self.inner.write().unwrap();
-        let mut last_id = self.last_id.write().unwrap();
-        *last_id += 1;
-        inner.insert(*last_id, value);
-        *last_id
+
+        if let Some(free) = inner.free_list.pop() {
+            assert!(inner.items[free].is_none());
+            inner.items[free] = Some(value);
+            free
+        } else {
+            inner.items.push(Some(value));
+            inner.items.len() - 1
+        }
     }
 
     pub fn replace(&self, index: usize, new_value: T) -> Option<T> {
         let mut inner = self.inner.write().unwrap();
-        inner.insert(index, Arc::new(new_value));
-        None
+        let item = inner.items.get_mut(index)?;
+        let old = item.replace(Arc::new(new_value))?;
+        Arc::into_inner(old)
     }
 
     pub fn get(&self, index: usize) -> Arc<T> {
         let inner = self.inner.read().unwrap();
-        inner[&index].clone()
+        inner.items[index]
+            .as_ref()
+            .expect("invalid slab index for ConcurrentSlab::get")
+            .clone()
     }
 
     pub fn retain(&self, predicate: impl Fn(&usize, &mut Arc<T>) -> bool) {
         let mut inner = self.inner.write().unwrap();
-        inner.retain(predicate);
+
+        let Inner { items, free_list } = &mut *inner;
+        for (idx, item) in items.iter_mut().enumerate() {
+            if let Some(arc) = item {
+                if !predicate(&idx, arc) {
+                    free_list.push(idx);
+                    item.take();
+                }
+            }
+        }
     }
 
     pub fn clear(&self) {
         let mut inner = self.inner.write().unwrap();
-        inner.clear();
-        inner.shrink_to(0);
+        inner.items.clear();
+        inner.items.shrink_to(0);
+
+        inner.free_list.clear();
+        inner.free_list.shrink_to(0);
     }
 }


### PR DESCRIPTION
## Description

Partially addresses https://github.com/FuelLabs/sway/issues/5781.

This reduces the time spent retrieving items in slabs.
For more details see: https://github.com/FuelLabs/sway/pull/5782

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
