### PR TITLE
Fixes compiler performance in mega_example.

### DIFF
--- a/sway-core/src/decl_engine/mapping.rs
+++ b/sway-core/src/decl_engine/mapping.rs
@@ -84,6 +84,10 @@ impl DeclMapping {
         self.mapping.is_empty()
     }
 
+    pub(crate) fn extend(&mut self, other: &DeclMapping) {
+        self.mapping.extend(other.mapping.clone());
+    }
+
     pub(crate) fn from_interface_and_item_and_impld_decl_refs(
         interface_decl_refs: InterfaceItemMap,
         item_decl_refs: ItemMap,

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -163,36 +163,6 @@ where
     }
 }
 
-impl<T> DeclRef<DeclId<T>>
-where
-    AssociatedItemDeclId: From<DeclId<T>>,
-    DeclEngine: DeclEngineIndex<T>,
-    T: Named + Spanned + ReplaceDecls + std::fmt::Debug + Clone,
-{
-    /// Returns Ok(None), if nothing was replaced.
-    /// Ok(true), if something was replaced.
-    /// and errors when appropriated.
-    pub(crate) fn replace_decls_and_insert_new_with_parent(
-        &self,
-        decl_mapping: &DeclMapping,
-        handler: &Handler,
-        ctx: &mut TypeCheckContext,
-    ) -> Result<Option<Self>, ErrorEmitted> {
-        let decl_engine = ctx.engines().de();
-
-        let original = decl_engine.get(&self.id);
-
-        let mut new = (*original).clone();
-        let changed = new.replace_decls(decl_mapping, handler, ctx)?;
-
-        Ok(changed.then(|| {
-            decl_engine
-                .insert(new)
-                .with_parent(decl_engine, self.id.into())
-        }))
-    }
-}
-
 impl<T> EqWithEngines for DeclRef<DeclId<T>>
 where
     DeclEngine: DeclEngineIndex<T>,

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -784,17 +784,7 @@ impl ReplaceDecls for TyExpressionVariant {
                 } => {
                     let mut has_changes = false;
 
-                    // TODO do we need this call?
-                    // The next call seems to make this one redundant
                     has_changes |= fn_ref.replace_decls(decl_mapping, handler, ctx)?;
-
-                    if let Some(new_decl_ref) = fn_ref
-                        .clone()
-                        .replace_decls_and_insert_new_with_parent(decl_mapping, handler, ctx)?
-                    {
-                        fn_ref.replace_id(*new_decl_ref.id());
-                        has_changes = true;
-                    };
 
                     for (_, arg) in arguments.iter_mut() {
                         if let Ok(r) = arg.replace_decls(decl_mapping, handler, ctx) {
@@ -830,7 +820,7 @@ impl ReplaceDecls for TyExpressionVariant {
 
                     // Handle the trait constraints. This includes checking to see if the trait
                     // constraints are satisfied and replacing old decl ids based on the
-                    let inner_decl_mapping =
+                    let mut inner_decl_mapping =
                         TypeParameter::gather_decl_mapping_from_trait_constraints(
                             handler,
                             ctx.by_ref(),
@@ -838,6 +828,8 @@ impl ReplaceDecls for TyExpressionVariant {
                             method.name.as_str(),
                             &method.name.span(),
                         )?;
+
+                    inner_decl_mapping.extend(decl_mapping);
 
                     if method.replace_decls(&inner_decl_mapping, handler, ctx)? {
                         decl_engine.replace(*fn_ref.id(), method);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/mega_example/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/mega_example/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-A63EC0723332CE0D"
+
+[[package]]
+name = "mega_example"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "std"
+source = "path+from-root-A63EC0723332CE0D"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/mega_example/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/mega_example/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "mega_example"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/mega_example/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/mega_example/src/main.sw
@@ -1,0 +1,117 @@
+contract;
+
+use std::hash::*;
+
+struct SimpleGeneric<T> {
+    single_generic_param: T,
+}
+
+struct PassTheGenericOn<K> {
+    one: SimpleGeneric<K>,
+}
+
+struct StructWArrayGeneric<L> {
+    a: [L; 2],
+}
+
+struct StructWTupleGeneric<M> {
+    a: (M, M),
+}
+
+struct StructWDiffTupleGeneric<M, N> {
+    a: (M, N),
+}
+
+enum EnumWGeneric<N> {
+    a: u64,
+    b: N,
+}
+
+struct MegaExample<T, U> {
+    a: ([U; 2], T),
+    b: Vec<([EnumWGeneric<StructWTupleGeneric<StructWArrayGeneric<PassTheGenericOn<T>>>>; 1], u32)>,
+}
+
+abi MyContract {
+    fn struct_w_generic(arg1: SimpleGeneric<u64>) -> SimpleGeneric<u64>;
+    fn struct_delegating_generic(arg1: PassTheGenericOn<str[3]>) -> PassTheGenericOn<str[3]>;
+    fn struct_w_generic_in_array(arg1: StructWArrayGeneric<u32>) -> StructWArrayGeneric<u32>;
+    fn struct_w_generic_in_tuple(arg1: StructWTupleGeneric<u32>) -> StructWTupleGeneric<u32>;
+    fn struct_w_diff_generic_in_tuple(arg1: StructWDiffTupleGeneric<u32, bool>) -> StructWDiffTupleGeneric<u32, bool>;
+
+    fn enum_w_generic(arg1: EnumWGeneric<u64>) -> EnumWGeneric<u64>;
+
+    fn complex_test(arg1: MegaExample<str[2], b256>);
+}
+
+impl Hash for str[3] {
+    fn hash(self, ref mut state: Hasher) {
+        state.write_str_array(self);
+    }
+}
+
+impl MyContract for Contract {
+    fn struct_w_generic(arg1: SimpleGeneric<u64>) -> SimpleGeneric<u64> {
+        let expected = SimpleGeneric {
+            single_generic_param: 123u64,
+        };
+
+        assert(arg1.single_generic_param == expected.single_generic_param);
+
+        expected
+    }
+
+    fn struct_delegating_generic(arg1: PassTheGenericOn<str[3]>) -> PassTheGenericOn<str[3]> {
+        let expected = PassTheGenericOn {
+            one: SimpleGeneric {
+                single_generic_param: __to_str_array("abc"),
+            },
+        };
+
+        assert(sha256(expected.one.single_generic_param) == sha256(arg1.one.single_generic_param));
+
+        expected
+    }
+
+    fn struct_w_generic_in_array(arg1: StructWArrayGeneric<u32>) -> StructWArrayGeneric<u32> {
+        let expected = StructWArrayGeneric {
+            a: [1u32, 2u32],
+        };
+
+        assert(expected.a[0] == arg1.a[0]);
+        assert(expected.a[1] == arg1.a[1]);
+
+        expected
+    }
+
+    fn struct_w_generic_in_tuple(arg1: StructWTupleGeneric<u32>) -> StructWTupleGeneric<u32> {
+        let expected = StructWTupleGeneric { a: (1u32, 2u32) };
+        assert(expected.a.0 == arg1.a.0);
+        assert(expected.a.1 == arg1.a.1);
+
+        expected
+    }
+
+    fn struct_w_diff_generic_in_tuple(
+        arg1: StructWDiffTupleGeneric<u32, bool>,
+    ) -> StructWDiffTupleGeneric<u32, bool> {
+        let expected = StructWDiffTupleGeneric { a: (1u32, false) };
+        assert(expected.a.0 == arg1.a.0);
+        assert(expected.a.1 == arg1.a.1);
+
+        expected
+    }
+    fn enum_w_generic(arg1: EnumWGeneric<u64>) -> EnumWGeneric<u64> {
+        match arg1 {
+            EnumWGeneric::b(value) => {
+                assert(value == 10u64);
+            }
+            _ => {
+                assert(false)
+            }
+        }
+        EnumWGeneric::b(10)
+    }
+
+    fn complex_test(arg1: MegaExample<str[2], b256>) {}
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/mega_example/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/mega_example/test.toml
@@ -1,0 +1,3 @@
+category = "compile"
+validate_abi = false
+expected_warnings = 4


### PR DESCRIPTION
## Description

ReplaceDecls for method application was calling replace_decls twice for FunctionDecl. This was visiting function declarations as a binary tree, doing replace decls twice per FunctionDecl.

With these changes, we merge both decl mappings before calling replace_decls once instead of twice.

The performance dropped from over 2min(did not wait for test to finish) to 7 seconds in the mega example. With --experimental-new-encoding and --release.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
