### PR TITLE
feat: add `AbiEncode` implementation for `raw_ptr`

### DIFF
--- a/sway-lib-core/src/codec.sw
+++ b/sway-lib-core/src/codec.sw
@@ -1222,6 +1222,12 @@ impl AbiEncode for raw_slice {
     }
 }
 
+impl AbiEncode for pointer {
+    fn abi_encode(self, ref mut buffer: Buffer) {
+        buffer.push_u64(self);
+    }
+}
+
 // BEGIN ARRAY_ENCODE
 impl<T> AbiEncode for [T; 1]
 where

--- a/sway-lib-core/src/codec.sw
+++ b/sway-lib-core/src/codec.sw
@@ -1222,7 +1222,7 @@ impl AbiEncode for raw_slice {
     }
 }
 
-impl AbiEncode for pointer {
+impl AbiEncode for raw_ptr {
     fn abi_encode(self, ref mut buffer: Buffer) {
         buffer.push_u64(self);
     }

--- a/sway-lib-core/src/codec.sw
+++ b/sway-lib-core/src/codec.sw
@@ -1224,7 +1224,7 @@ impl AbiEncode for raw_slice {
 
 impl AbiEncode for raw_ptr {
     fn abi_encode(self, ref mut buffer: Buffer) {
-        buffer.push_u64(self);
+        buffer.push_u64(self.read::<u64>());
     }
 }
 


### PR DESCRIPTION
## Description

This PR introduces an `AbiEncode` implementation for `raw_ptr`.

Error being thrown in the TS SDK when logging out the value of `vec.ptr()`;

## Checklist

- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
