### PR TITLE
AbiDecode for  Vec using `with_capacity`

### DIFF
--- a/sway-lib-std/src/vec.sw
+++ b/sway-lib-std/src/vec.sw
@@ -669,9 +669,9 @@ where
     T: AbiDecode,
 {
     fn abi_decode(ref mut buffer: BufferReader) -> Vec<T> {
-        let mut v = Vec::new();
-
         let len = u64::abi_decode(buffer);
+
+        let mut v = Vec::with_capacity(len);
 
         let mut i = 0;
         while i < len {

--- a/sway-lib-std/src/vec.sw
+++ b/sway-lib-std/src/vec.sw
@@ -710,3 +710,19 @@ fn test_vec_with_len_1() {
     let _ = ve.remove(0);
     assert(ve.len == 0);
 }
+
+#[test()]
+fn encode_and_decode_vec() {
+    let mut v1: Vec<u64> = Vec::new();
+    v1.push(1);
+    v1.push(2);
+    v1.push(3);
+
+    let v2 = abi_decode::<Vec<u64>>(encode(v1));
+
+    assert(v2.len() == 3);
+    assert(v2.capacity() == 3);
+    assert(v2.get(0) == Some(1));
+    assert(v2.get(1) == Some(2));
+    assert(v2.get(2) == Some(3));
+}


### PR DESCRIPTION
## Description

This PR uses the fact that we know the final length of the `Vec`, and creates it with the correct length, avoiding future allocations.


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
