### PR TITLE
move documents from `Session` to `ServerState`

### DIFF
--- a/sway-lsp/src/capabilities/formatting.rs
+++ b/sway-lsp/src/capabilities/formatting.rs
@@ -1,7 +1,21 @@
-use crate::error::LanguageServerError;
-use lsp_types::{Position, Range, TextEdit};
+use crate::{
+    core::document::Documents,
+    error::{DocumentError, LanguageServerError},
+};
+use lsp_types::{Position, Range, TextEdit, Url};
 use std::sync::Arc;
 use swayfmt::Formatter;
+
+pub fn format_text(documents: &Documents, url: &Url) -> Result<Vec<TextEdit>, LanguageServerError> {
+    let document = documents.try_get(url.path()).try_unwrap().ok_or_else(|| {
+        DocumentError::DocumentNotFound {
+            path: url.path().to_string(),
+        }
+    })?;
+
+    get_page_text_edit(Arc::from(document.get_text()), &mut <_>::default())
+        .map(|page_text_edit| vec![page_text_edit])
+}
 
 pub fn get_page_text_edit(
     text: Arc<str>,

--- a/sway-lsp/src/capabilities/on_enter.rs
+++ b/sway-lsp/src/capabilities/on_enter.rs
@@ -1,9 +1,8 @@
 use crate::{
     config::OnEnterConfig,
-    core::{document::TextDocument, session::Session},
+    core::document::{Documents, TextDocument},
     lsp_ext::OnEnterParams,
 };
-use std::sync::Arc;
 use tower_lsp::lsp_types::{
     DocumentChanges, OneOf, OptionalVersionedTextDocumentIdentifier, Position, Range,
     TextDocumentEdit, TextEdit, Url, WorkspaceEdit,
@@ -17,7 +16,7 @@ const DOC_COMMENT_START: &str = "///";
 /// with the appropriate comment start pattern (// or ///).
 pub fn on_enter(
     config: &OnEnterConfig,
-    session: &Arc<Session>,
+    documents: &Documents,
     temp_uri: &Url,
     params: &OnEnterParams,
 ) -> Option<WorkspaceEdit> {
@@ -26,7 +25,7 @@ pub fn on_enter(
     }
 
     let mut workspace_edit = None;
-    let text_document = session
+    let text_document = documents
         .get_text_document(temp_uri)
         .expect("could not get text document");
 

--- a/sway-lsp/src/core/document.rs
+++ b/sway-lsp/src/core/document.rs
@@ -3,9 +3,11 @@ use crate::{
     error::{DirectoryError, DocumentError, LanguageServerError},
     utils::document,
 };
+use dashmap::DashMap;
 use forc_util::fs_locking::PidFileLocking;
 use lsp_types::{Position, Range, TextDocumentContentChangeEvent, Url};
 use ropey::Rope;
+use tokio::{fs::File, io::AsyncWriteExt};
 
 #[derive(Debug, Clone)]
 pub struct TextDocument {
@@ -139,6 +141,102 @@ struct EditText<'text> {
     change_text: &'text str,
 }
 
+pub struct Documents(DashMap<String, TextDocument>);
+
+impl Documents {
+    pub fn new() -> Self {
+        Documents(DashMap::new())
+    }
+
+    pub async fn handle_open_file(&self, uri: &Url) {
+        if !self.contains_key(uri.path()) {
+            if let Ok(text_document) = TextDocument::build_from_path(uri.path()).await {
+                let _ = self.store_document(text_document);
+            }
+        }
+    }
+
+    /// Asynchronously writes the changes to the file and updates the document.
+    pub async fn write_changes_to_file(
+        &self,
+        uri: &Url,
+        changes: Vec<TextDocumentContentChangeEvent>,
+    ) -> Result<(), LanguageServerError> {
+        let src = self.update_text_document(uri, changes).ok_or_else(|| {
+            DocumentError::DocumentNotFound {
+                path: uri.path().to_string(),
+            }
+        })?;
+
+        let mut file =
+            File::create(uri.path())
+                .await
+                .map_err(|err| DocumentError::UnableToCreateFile {
+                    path: uri.path().to_string(),
+                    err: err.to_string(),
+                })?;
+
+        file.write_all(src.as_bytes())
+            .await
+            .map_err(|err| DocumentError::UnableToWriteFile {
+                path: uri.path().to_string(),
+                err: err.to_string(),
+            })?;
+
+        Ok(())
+    }
+
+    /// Get the document at the given [Url].
+    pub fn get_text_document(&self, url: &Url) -> Result<TextDocument, DocumentError> {
+        self.try_get(url.path())
+            .try_unwrap()
+            .ok_or_else(|| DocumentError::DocumentNotFound {
+                path: url.path().to_string(),
+            })
+            .map(|document| document.clone())
+    }
+
+    /// Update the document at the given [Url] with the Vec of changes returned by the client.
+    pub fn update_text_document(
+        &self,
+        url: &Url,
+        changes: Vec<TextDocumentContentChangeEvent>,
+    ) -> Option<String> {
+        self.try_get_mut(url.path())
+            .try_unwrap()
+            .map(|mut document| {
+                changes.iter().for_each(|change| {
+                    document.apply_change(change);
+                });
+                document.get_text()
+            })
+    }
+
+    /// Remove the text document.
+    pub fn remove_document(&self, url: &Url) -> Result<TextDocument, DocumentError> {
+        self.remove(url.path())
+            .ok_or_else(|| DocumentError::DocumentNotFound {
+                path: url.path().to_string(),
+            })
+            .map(|(_, text_document)| text_document)
+    }
+
+    /// Store the text document.
+    pub fn store_document(&self, text_document: TextDocument) -> Result<(), DocumentError> {
+        let uri = text_document.get_uri().to_string();
+        self.insert(uri.clone(), text_document).map_or(Ok(()), |_| {
+            Err(DocumentError::DocumentAlreadyStored { path: uri })
+        })
+    }
+}
+
+impl std::ops::Deref for Documents {
+    type Target = DashMap<String, TextDocument>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,5 +256,29 @@ mod tests {
             .await
             .expect_err("expected DocumentNotFound");
         assert_eq!(result, DocumentError::DocumentNotFound { path });
+    }
+
+    #[tokio::test]
+    async fn store_document_returns_empty_tuple() {
+        let documents = Documents::new();
+        let path = get_absolute_path("sway-lsp/tests/fixtures/cats.txt");
+        let document = TextDocument::build_from_path(&path).await.unwrap();
+        let result = documents.store_document(document);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn store_document_returns_document_already_stored_error() {
+        let documents = Documents::new();
+        let path = get_absolute_path("sway-lsp/tests/fixtures/cats.txt");
+        let document = TextDocument::build_from_path(&path).await.unwrap();
+        documents
+            .store_document(document)
+            .expect("expected successfully stored");
+        let document = TextDocument::build_from_path(&path).await.unwrap();
+        let result = documents
+            .store_document(document)
+            .expect_err("expected DocumentAlreadyStored");
+        assert_eq!(result, DocumentError::DocumentAlreadyStored { path });
     }
 }


### PR DESCRIPTION
## Description
1st part of a code reorganization. Documents are now stored in ServerState meaning the documents can be shared across workspace members. 

No new code was added.

related to #5856 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
