### PR TITLE
Remove `contract_id()` in favor of `ContractId::this()`

### DIFF
--- a/examples/liquidity_pool/src/main.sw
+++ b/examples/liquidity_pool/src/main.sw
@@ -5,10 +5,7 @@ use std::{
         mint_to_address,
         transfer_to_address,
     },
-    call_frames::{
-        contract_id,
-        msg_asset_id,
-    },
+    call_frames::msg_asset_id,
     constants::DEFAULT_SUB_ID,
     context::msg_amount,
     hash::*,

--- a/sway-lib-std/src/asset.sw
+++ b/sway-lib-std/src/asset.sw
@@ -4,7 +4,6 @@ library;
 use ::address::Address;
 use ::alias::SubId;
 use ::asset_id::AssetId;
-use ::call_frames::contract_id;
 use ::contract_id::ContractId;
 use ::error_signals::FAILED_TRANSFER_TO_ADDRESS_SIGNAL;
 use ::identity::Identity;
@@ -41,7 +40,7 @@ use ::outputs::{Output, output_amount, output_count, output_type};
 /// ```
 pub fn mint_to(to: Identity, sub_id: SubId, amount: u64) {
     mint(sub_id, amount);
-    transfer(to, AssetId::new(contract_id(), sub_id), amount);
+    transfer(to, AssetId::new(ContractId::this(), sub_id), amount);
 }
 
 /// Mint `amount` coins of the current contract's `asset_id` and send them
@@ -71,7 +70,7 @@ pub fn mint_to(to: Identity, sub_id: SubId, amount: u64) {
 /// ```
 pub fn mint_to_contract(to: ContractId, sub_id: SubId, amount: u64) {
     mint(sub_id, amount);
-    force_transfer_to_contract(to, AssetId::new(contract_id(), sub_id), amount);
+    force_transfer_to_contract(to, AssetId::new(ContractId::this(), sub_id), amount);
 }
 
 /// Mint `amount` coins of the current contract's `asset_id` and send them to
@@ -95,7 +94,7 @@ pub fn mint_to_contract(to: ContractId, sub_id: SubId, amount: u64) {
 /// ```
 pub fn mint_to_address(to: Address, sub_id: SubId, amount: u64) {
     mint(sub_id, amount);
-    transfer_to_address(to, AssetId::new(contract_id(), sub_id), amount);
+    transfer_to_address(to, AssetId::new(ContractId::this(), sub_id), amount);
 }
 
 /// Mint `amount` coins of the current contract's `sub_id`. The newly minted assets are owned by the current contract.

--- a/sway-lib-std/src/call_frames.sw
+++ b/sway-lib-std/src/call_frames.sw
@@ -18,36 +18,6 @@ const FIRST_PARAMETER_OFFSET: u64 = 73;
 /// Where 74 (73 + 1) is the current offset in words from the start of the call frame.
 const SECOND_PARAMETER_OFFSET: u64 = 74;
 
-//  Accessing the current call frame
-//
-/// Get the current contract's id when called in an internal context.
-///
-/// # Additional Information
-///
-/// **_Note:_** If called in an external context, this will **not** return a contract ID.
-/// If called externally, will actually return a pointer to the transaction ID.
-///
-/// # Returns
-///
-/// * [ContractId] - The contract id of this contract.
-///
-/// # Examples
-///
-/// ```sway
-/// use std::{call_frames::contract_id, constants::ZERO_B256, asset::mint};
-///
-/// fn foo() {
-///     let this_contract = contract_id();
-///     mint(ZERO_B256, 50);
-///     Address::from(ZERO_B256).transfer(AssetId::default(this_contract), 50);
-/// }
-/// ```
-pub fn contract_id() -> ContractId {
-    ContractId::from(asm() {
-        fp: b256
-    })
-}
-
 /// Get the `asset_id` of coins being sent from the current call frame.
 ///
 /// # Returns

--- a/sway-lib-std/src/context.sw
+++ b/sway-lib-std/src/context.sw
@@ -2,7 +2,6 @@
 library;
 
 use ::asset_id::AssetId;
-use ::call_frames::contract_id;
 use ::contract_id::ContractId;
 use ::registers::balance;
 
@@ -28,7 +27,7 @@ use ::registers::balance;
 /// }
 /// ```
 pub fn this_balance(asset_id: AssetId) -> u64 {
-    balance_of(contract_id(), asset_id)
+    balance_of(ContractId::this(), asset_id)
 }
 
 /// Get the balance of coin `asset_id` for the contract at 'target'.

--- a/sway-lib-std/src/identity.sw
+++ b/sway-lib-std/src/identity.sw
@@ -7,7 +7,6 @@ use ::assert::assert;
 use ::address::Address;
 use ::alias::SubId;
 use ::asset_id::AssetId;
-use ::call_frames::contract_id;
 use ::constants::{BASE_ASSET_ID, ZERO_B256};
 use ::contract_id::ContractId;
 use ::hash::{Hash, Hasher};

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_more_complex_logic/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_more_complex_logic/src/main.sw
@@ -23,7 +23,6 @@ abi NFT {
 use std::{
     block::height,
     call_frames::{
-        contract_id,
         msg_asset_id,
     },
     context::msg_amount,
@@ -79,7 +78,7 @@ impl EnglishAuction for Contract {
 
         match total_bid {
             AuctionAsset::NFTAsset(nft_asset) => {
-                transfer_nft(nft_asset, sender, Identity::ContractId(contract_id()));
+                transfer_nft(nft_asset, sender, Identity::ContractId(ContractId::this()));
             },
             AuctionAsset::TokenAsset(token_asset) => {
                 require(token_asset == 42, 42);
@@ -120,7 +119,7 @@ impl EnglishAuction for Contract {
                 let sender = msg_sender().unwrap();
                 // TODO: Remove this when StorageVec in structs is supported
                 require(initial_price == 1, 42);
-                transfer_nft(asset, sender, Identity::ContractId(contract_id()));
+                transfer_nft(asset, sender, Identity::ContractId(ContractId::this()));
             }
         }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/context_testing_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/context_testing_contract/src/main.sw
@@ -1,11 +1,11 @@
 contract;
 
-use std::{call_frames::{contract_id, msg_asset_id}, context::{balance_of, msg_amount, this_balance}, registers::{global_gas, context_gas}};
+use std::{call_frames::msg_asset_id, context::{balance_of, msg_amount, this_balance}, registers::{global_gas, context_gas}};
 use context_testing_abi::*;
 
 impl ContextTesting for Contract {
     fn get_id() -> ContractId {
-        contract_id()
+        ContractId::this()
     }
 
     fn get_this_balance(asset_id: AssetId) -> u64 {

--- a/test/src/sdk-harness/test_artifacts/call_frames_test_abi/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/call_frames_test_abi/src/main.sw
@@ -10,7 +10,6 @@ pub struct TestStruct2 {
 }
 
 abi CallFramesTest {
-    fn get_id() -> ContractId;
     fn get_id_contract_id_this() -> ContractId;
     fn get_asset_id() -> AssetId;
     fn get_code_size() -> u64;

--- a/test/src/sdk-harness/test_artifacts/context_caller_contract/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/context_caller_contract/src/main.sw
@@ -1,7 +1,7 @@
 contract;
 
 use context_testing_abi::ContextTesting;
-use std::{asset::mint, call_frames::contract_id, constants::ZERO_B256, hash::*};
+use std::{asset::mint, constants::ZERO_B256, hash::*};
 
 abi ContextCaller {
     fn call_get_this_balance_with_coins(send_amount: u64, context_id: ContractId) -> u64;

--- a/test/src/sdk-harness/test_projects/call_frames/mod.rs
+++ b/test/src/sdk-harness/test_projects/call_frames/mod.rs
@@ -23,13 +23,6 @@ async fn get_call_frames_instance() -> (CallFramesTestContract<WalletUnlocked>, 
 }
 
 #[tokio::test]
-async fn can_get_contract_id() {
-    let (instance, id) = get_call_frames_instance().await;
-    let result = instance.methods().get_id().call().await.unwrap();
-    assert_eq!(result.value, id);
-}
-
-#[tokio::test]
 async fn can_get_id_contract_id_this() {
     let (instance, id) = get_call_frames_instance().await;
     let result = instance

--- a/test/src/sdk-harness/test_projects/call_frames/src/main.sw
+++ b/test/src/sdk-harness/test_projects/call_frames/src/main.sw
@@ -4,10 +4,6 @@ use call_frames_test_abi::{CallFramesTest, TestStruct, TestStruct2};
 use std::call_frames::*;
 
 impl CallFramesTest for Contract {
-    fn get_id() -> ContractId {
-        contract_id()
-    }
-
     fn get_id_contract_id_this() -> ContractId {
         ContractId::this()
     }


### PR DESCRIPTION
## Description

We currently support 2 methods of getting the contract id of a contract in an internal context:

- `contract_id()`
- `ContractId::this()`

The `this()` associated function is a constructor that returns `Self` and should be the primary method of getting the contract id. This idiomatically follows Rust's syntax and `contract_id()` has been removed.

The same syntax is followed with `AssetId::base()`.

Closes #5834 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
