### PR TITLE
Use `ModuleId` instead of `SourceId` as the metrics map key

### DIFF
--- a/forc-pkg/src/manifest/mod.rs
+++ b/forc-pkg/src/manifest/mod.rs
@@ -535,7 +535,7 @@ impl PackageManifest {
         })
         .map_err(|e| anyhow!("failed to parse manifest: {}.", e))?;
         for warning in warnings {
-            //println_warning(&warning);
+            println_warning(&warning);
         }
         manifest.implicitly_include_std_if_missing();
         manifest.implicitly_include_default_build_profiles_if_missing();

--- a/forc-pkg/src/manifest/mod.rs
+++ b/forc-pkg/src/manifest/mod.rs
@@ -535,7 +535,7 @@ impl PackageManifest {
         })
         .map_err(|e| anyhow!("failed to parse manifest: {}.", e))?;
         for warning in warnings {
-            println_warning(&warning);
+            //println_warning(&warning);
         }
         manifest.implicitly_include_std_if_missing();
         manifest.implicitly_include_default_build_profiles_if_missing();

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -490,7 +490,7 @@ pub(crate) fn module_id_from_path(
     path: &PathBuf,
     engines: &Engines,
 ) -> Result<ModuleId, DirectoryError> {
-    let module_id = sway_utils::find_parent_manifest_dir(&path)
+    let module_id = sway_utils::find_parent_manifest_dir(path)
         .and_then(|manifest_path| engines.se().get_module_id(&manifest_path))
         .ok_or_else(|| DirectoryError::ModuleIdNotFound {
             path: path.to_string_lossy().to_string(),

--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -40,7 +40,7 @@ use sway_core::{
     BuildTarget, Engines, LspConfig, Namespace, Programs,
 };
 use sway_error::{error::CompileError, handler::Handler, warning::CompileWarning};
-use sway_types::{SourceEngine, SourceId, Spanned};
+use sway_types::{ModuleId, SourceEngine, SourceId, Spanned};
 use sway_utils::{helpers::get_sway_files, PerformanceData};
 
 pub type RunnableMap = DashMap<PathBuf, Vec<Box<dyn Runnable>>>;
@@ -66,7 +66,7 @@ pub struct Session {
     pub sync: SyncWorkspace,
     // Cached diagnostic results that require a lock to access. Readers will wait for writers to complete.
     pub diagnostics: Arc<RwLock<DiagnosticMap>>,
-    pub metrics: DashMap<SourceId, PerformanceData>,
+    pub metrics: DashMap<ModuleId, PerformanceData>,
 }
 
 impl Default for Session {
@@ -276,6 +276,7 @@ pub fn traverse(
     session: Arc<Session>,
 ) -> Result<Option<CompileResults>, LanguageServerError> {
     session.token_map.clear();
+    eprintln!("📖 Metrics | clearing metrics. {:#?}", session.metrics);
     session.metrics.clear();
     let mut diagnostics: CompileResults = (Default::default(), Default::default());
     let results_len = results.len();
@@ -294,11 +295,25 @@ pub fn traverse(
             metrics,
         } = value.unwrap();
 
+        
         let source_id = lexed.root.tree.span().source_id().cloned();
         if let Some(source_id) = source_id {
-            session.metrics.insert(source_id, metrics.clone());
-        }
+            // convert source id to path
+            let path = engines_clone.se().get_path(&source_id);
+            let manifest_path = sway_utils::find_parent_manifest_dir(path.clone()).unwrap_or(path.clone());
+            let manifest_source_id = engines_clone.se().get_source_id(&manifest_path);
 
+            let module_id = engines_clone.se().get_module_id(&path);
+            eprintln!("💁 Path Module ID: {:?}", module_id);
+
+            let module_id = engines_clone.se().get_module_id(&manifest_path).unwrap();
+            eprintln!("💁 Manifest Module ID: {:?}", module_id);
+
+            eprintln!("📖 Metrics | inserting source id {:?} for path: {:?}", &source_id, &path);
+            eprintln!("📖 Metrics | inserting source id {:?} for path: {:?}", &manifest_source_id, &manifest_path);
+            session.metrics.insert(module_id, metrics.clone());
+        }
+        
         let engines_ref = session.engines.read();
         // Check if the cached AST was returned by the compiler for the users workspace.
         // If it was, then we need to use the original engines for traversal.
@@ -306,8 +321,10 @@ pub fn traverse(
         // This is due to the garbage collector removing types from the engines_clone
         // and they have not been re-added due to compilation being skipped.
         let engines = if i == results_len - 1 && metrics.reused_modules > 0 {
+            eprintln!("🚒 Using original engines");
             &*engines_ref
         } else {
+            eprintln!("🚒 Using original clone");
             engines_clone
         };
 

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -72,6 +72,8 @@ pub enum DirectoryError {
     PathFromUrlFailed { url: String },
     #[error("Unable to create span from path {:?}", path)]
     SpanFromPathFailed { path: String },
+    #[error("No module ID found for path {:?}", path)]
+    ModuleIdNotFound { path: String },
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -502,7 +502,8 @@ pub(crate) async fn metrics(
                     .engines
                     .read()
                     .se()
-                    .get_path(kv.key())
+                    .get_path_from_module_id(kv.key())
+                    .unwrap()
                     .to_string_lossy()
                     .to_string();
                 metrics.push((path, kv.value().clone()));

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -178,7 +178,11 @@ impl ServerState {
                                         );
                                     }
                                 } else {
-                                    tracing::error!("Metrics not found for module_id: {:?} | path {:?}", module_id, path);
+                                    tracing::error!(
+                                        "Metrics not found for module_id: {:?} | path {:?}",
+                                        module_id,
+                                        path
+                                    );
                                 }
                                 *last_compilation_state.write() = LastCompilationState::Success;
                             }

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -159,8 +159,10 @@ impl ServerState {
                         ) {
                             Ok(_) => {
                                 let path = uri.to_file_path().unwrap();
+                                // Find the module id from the path
                                 match session::module_id_from_path(&path, &engines_clone) {
                                     Ok(module_id) => {
+                                        // Use the module id to get the metrics for the module
                                         if let Some(metrics) = session.metrics.get(&module_id) {
                                             // It's very important to check if the workspace AST was reused to determine if we need to overwrite the engines.
                                             // Because the engines_clone has garbage collection applied. If the workspace AST was reused, we need to keep the old engines

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -158,68 +158,27 @@ impl ServerState {
                             experimental,
                         ) {
                             Ok(_) => {
-                                let se_clone = engines_clone.se().clone();
                                 let path = uri.to_file_path().unwrap();
-                                let manifest_path = sway_utils::find_parent_manifest_dir(path.clone()).unwrap_or(path.clone());
-                                let module_id = engines_clone.se().get_module_id(&manifest_path).unwrap();
-                                
-                                let source_id = engines_clone.se().get_source_id(&path);
+                                let manifest_path =
+                                    sway_utils::find_parent_manifest_dir(path.clone())
+                                        .unwrap_or(path.clone());
+                                let module_id =
+                                    engines_clone.se().get_module_id(&manifest_path).unwrap();
 
-                                //let module_id = engines_clone.se().get_module_id(&path);
-                                eprintln!("🙆 Module ID: {:?}", module_id);
-
-                                eprintln!("1st get source_id: {:?}", source_id);
-                                match session.metrics.get(&module_id) {
-                                    Some(metrics) => {
-                                        eprintln!("source_id from engines clone found");
+                                if let Some(metrics) = session.metrics.get(&module_id) {
+                                    // It's very important to check if the workspace AST was reused to determine if we need to overwrite the engines.
+                                    // Because the engines_clone has garbage collection applied. If the workspace AST was reused, we need to keep the old engines
+                                    // as the engines_clone might have cleared some types that are still in use.
+                                    if metrics.reused_modules == 0 {
+                                        // The compiler did not reuse the workspace AST.
+                                        // We need to overwrite the old engines with the engines clone.
+                                        mem::swap(
+                                            &mut *session.engines.write(),
+                                            &mut engines_clone,
+                                        );
                                     }
-                                    None => {
-                                        let source_id = session.engines.read().se().get_source_id(&path); 
-                                        eprintln!("2nd get source_id: {:?}", source_id);
-                                        match session.metrics.get(&module_id) {
-                                            Some(metrics) => {
-                                                eprintln!("source_id from original engines found"); 
-                                            }
-                                            None => {
-                                                eprintln!("❌ No source ID found in either engines");
-                                                tracing::error!("Metrics not found for source_id: {:?} | path {:?}", source_id, path);
-                                                for i in session.metrics.iter() {
-                                                    let k = i.key();
-                                                    tracing::error!("Metrics keys: {:?}", k);
-                                                }
-                                                
-                                                eprintln!("SE clone = {:#?}", se_clone);
-                                                eprintln!("");
-                                                eprintln!("SE original = {:#?}", session.engines.read().se());
-                                                panic!();
-                                            }
-                                        }
-                                    }
-                                }
-
-                                if let Ok(path) = uri.to_file_path() {
-                                    let path = Arc::new(path);
-                                    let source_id =
-                                        session.engines.read().se().get_source_id(&path);
-                                    if let Some(metrics) = session.metrics.get(&module_id) {
-                                        // It's very important to check if the workspace AST was reused to determine if we need to overwrite the engines.
-                                        // Because the engines_clone has garbage collection applied. If the workspace AST was reused, we need to keep the old engines
-                                        // as the engines_clone might have cleared some types that are still in use.
-                                        if metrics.reused_modules == 0 {
-                                            // The compiler did not reuse the workspace AST.
-                                            // We need to overwrite the old engines with the engines clone.
-                                            mem::swap(
-                                                &mut *session.engines.write(),
-                                                &mut engines_clone,
-                                            );
-                                        }
-                                    } else {
-                                        // tracing::error!("Metrics not found for source_id: {:?} | path {:?}", source_id, path);
-                                        // for i in session.metrics.iter() {
-                                        //     let k = i.key();
-                                        //     tracing::error!("Metrics keys: {:?}", k);
-                                        // } 
-                                    }
+                                } else {
+                                    tracing::error!("Metrics not found for module_id: {:?} | path {:?}", module_id, path);
                                 }
                                 *last_compilation_state.write() = LastCompilationState::Success;
                             }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -4,7 +4,8 @@ use crate::integration::{code_actions, lsp};
 use lsp_types::*;
 use std::{fs, path::PathBuf};
 use sway_lsp::{
-    core::session, handlers::{notification, request}, server_state::ServerState
+    handlers::{notification, request},
+    server_state::ServerState,
 };
 use sway_lsp_test_utils::{
     assert_server_requests, dir_contains_forc_manifest, doc_comments_dir, e2e_language_dir,

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -4,8 +4,7 @@ use crate::integration::{code_actions, lsp};
 use lsp_types::*;
 use std::{fs, path::PathBuf};
 use sway_lsp::{
-    handlers::{notification, request},
-    server_state::ServerState,
+    core::session, handlers::{notification, request}, server_state::ServerState
 };
 use sway_lsp_test_utils::{
     assert_server_requests, dir_contains_forc_manifest, doc_comments_dir, e2e_language_dir,
@@ -342,6 +341,19 @@ fn lsp_syncs_with_workspace_edits() {
         go_to.def_line = 20;
         lsp::definition_check_with_req_offset(service.inner(), &mut go_to, 45, 24).await;
         shutdown_and_exit(&mut service).await;
+    });
+}
+
+#[test]
+fn compilation_succeeds_when_triggered_from_module() {
+    run_async!({
+        let server = ServerState::default();
+        let _ = open(
+            &server,
+            test_fixtures_dir().join("tokens/modules/src/test_mod.sw"),
+        )
+        .await;
+        let _ = server.shutdown_server().await;
     });
 }
 

--- a/sway-types/src/source_engine.rs
+++ b/sway-types/src/source_engine.rs
@@ -108,6 +108,15 @@ impl SourceEngine {
         self.path_to_module_map.read().unwrap().get(path).cloned()
     }
 
+    /// Returns the [PathBuf] associated with the provided [ModuleId], if it exists in the path_to_module_map.
+    pub fn get_path_from_module_id(&self, module_id: &ModuleId) -> Option<PathBuf> {
+        let path_to_module_map = self.path_to_module_map.read().unwrap();
+        path_to_module_map
+            .iter()
+            .find(|(_, &id)| id == *module_id)
+            .map(|(path, _)| path.clone())
+    }
+
     /// This function provides the file name (with extension) corresponding to a specified source ID.
     pub fn get_file_name(&self, source_id: &SourceId) -> Option<String> {
         self.get_path(source_id)


### PR DESCRIPTION
## Description
Fixes a critical bug where the server would crash if compilation was triggered from anything other than the root `main.sw` file. This was due to the metrics_map using the `SourceId` rather then the `ModuleId` as the key. 

This was introduced last week in #5813 as we now need to metrics to decide if the engines should be mem swapped or discarded. 

closes #5870 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
