### PR TITLE
Simplify Asset Transfer and Mint Functions

### DIFF
--- a/sway-lib-std/src/asset.sw
+++ b/sway-lib-std/src/asset.sw
@@ -10,15 +10,11 @@ use ::identity::Identity;
 use ::revert::revert;
 use ::outputs::{Output, output_amount, output_count, output_type};
 
-/// Mint `amount` coins of the current contract's `asset_id` and transfer them
-/// to `to` by calling either `force_transfer_to_contract` or
-/// `transfer_to_address`, depending on the type of `Identity`.
+/// Mint `amount` coins of the current contract's `asset_id` and transfer them to `to` by calling either `force_transfer_to_contract` or `transfer_to_address`, depending on the type of `Identity`.
 ///
 /// # Additional Information
 ///
-/// If the `to` Identity is a contract, this will transfer coins to the contract even with no way to retrieve them
-/// (i.e: no withdrawal functionality on the receiving contract), possibly leading to
-/// the **_PERMANENT LOSS OF COINS_** if not used with care.
+/// If the `to` Identity is a contract, this will transfer coins to the contract even with no way to retrieve them (i.e: no withdrawal functionality on the receiving contract), possibly leading to the **_PERMANENT LOSS OF COINS_** if not used with care.
 ///
 /// # Arguments
 ///
@@ -43,60 +39,6 @@ pub fn mint_to(to: Identity, sub_id: SubId, amount: u64) {
     transfer(to, AssetId::new(ContractId::this(), sub_id), amount);
 }
 
-/// Mint `amount` coins of the current contract's `asset_id` and send them
-/// UNCONDITIONALLY to the contract at `to`.
-///
-/// # Additional Information
-///
-/// This will transfer coins to a contract even with no way to retrieve them
-/// (i.e: no withdrawal functionality on the receiving contract), possibly leading to
-/// the **_PERMANENT LOSS OF COINS_** if not used with care.
-///
-/// # Arguments
-///
-/// * `to`: [ContractId] - The recipient contract.
-/// * `sub_id`: [SubId] - The sub identifier of the asset which to mint.
-/// * `amount`: [u64] - The amount of coins to mint.
-///
-/// # Examples
-///
-/// ```sway
-/// use std::{constants::ZERO_B256, asset::mint_to_contract};
-///
-/// fn foo() {
-///     let to = ContractId::from(ZERO_B256);
-///     mint_to_contract(to, ZERO_B256, 500);
-/// }
-/// ```
-pub fn mint_to_contract(to: ContractId, sub_id: SubId, amount: u64) {
-    mint(sub_id, amount);
-    force_transfer_to_contract(to, AssetId::new(ContractId::this(), sub_id), amount);
-}
-
-/// Mint `amount` coins of the current contract's `asset_id` and send them to
-/// the Address `to`.
-///
-/// # Arguments
-///
-/// * `to`: [Address] - The recipient address.
-/// * `sub_id`: [SubId] - The sub identifier of the asset which to mint.
-/// * `amount`: [u64] - The amount of coins to mint.
-///
-/// # Examples
-///
-/// ```sway
-/// use std::{constants::ZERO_B256, asset::mint_to_address};
-///
-/// fn foo() {
-///     let to = Address::from(ZERO_B256);
-///     mint_to_address(to, ZERO_B256, 500);
-/// }
-/// ```
-pub fn mint_to_address(to: Address, sub_id: SubId, amount: u64) {
-    mint(sub_id, amount);
-    transfer_to_address(to, AssetId::new(ContractId::this(), sub_id), amount);
-}
-
 /// Mint `amount` coins of the current contract's `sub_id`. The newly minted assets are owned by the current contract.
 ///
 /// # Arguments
@@ -119,7 +61,11 @@ pub fn mint(sub_id: SubId, amount: u64) {
     }
 }
 
-/// Burn `amount` coins of the current contract's `sub_id`. Burns them from the balance of the current contract.
+/// Burn `amount` coins of the current contract's `sub_id`. This function burns them from the balance of the current contract.
+///
+/// # Additional Information
+///
+/// To burn coins, they must be sent or owned by the contract in the transaction this function is called.
 ///
 /// # Arguments
 ///
@@ -145,15 +91,11 @@ pub fn burn(sub_id: SubId, amount: u64) {
     }
 }
 
-/// Transfer `amount` coins of the type `asset_id` and send them
-/// to `to` by calling either `force_transfer_to_contract` or
-/// `transfer_to_address`, depending on the type of `Identity`.
+/// Transfer `amount` coins of the type `asset_id` and send them to `to` by calling either `force_transfer_to_contract` or`transfer_to_address`, depending on the type of `Identity`.
 ///
 /// # Additional Information
 ///
-/// If the `to` Identity is a contract this may transfer coins to the contract even with no way to retrieve them
-/// (i.e. no withdrawal functionality on receiving contract), possibly leading
-/// to the **_PERMANENT LOSS OF COINS_** if not used with care.
+/// If the `to` Identity is a contract this may transfer coins to the contract even with no way to retrieve them (i.e. no withdrawal functionality on receiving contract), possibly leading to the **_PERMANENT LOSS OF COINS_** if not used with care.
 ///
 /// # Arguments
 ///
@@ -186,14 +128,11 @@ pub fn transfer(to: Identity, asset_id: AssetId, amount: u64) {
     };
 }
 
-/// UNCONDITIONAL transfer of `amount` coins of type `asset_id` to
-/// the contract at `to`.
+/// UNCONDITIONAL transfer of `amount` coins of type `asset_id` to the contract at `to`.
 ///
 /// # Additional Information
 ///
-/// This will transfer coins to a contract even with no way to retrieve them
-/// (i.e. no withdrawal functionality on receiving contract), possibly leading
-/// to the **_PERMANENT LOSS OF COINS_** if not used with care.
+/// This will transfer coins to a contract even with no way to retrieve them (i.e. no withdrawal functionality on receiving contract), possibly leading to the **_PERMANENT LOSS OF COINS_** if not used with care.
 ///
 /// # Arguments
 ///
@@ -216,14 +155,13 @@ pub fn transfer(to: Identity, asset_id: AssetId, amount: u64) {
 ///     force_transfer_to_contract(to_contract_id, AssetId::base(), 500);
 /// }
 /// ```
-pub fn force_transfer_to_contract(to: ContractId, asset_id: AssetId, amount: u64) {
+fn force_transfer_to_contract(to: ContractId, asset_id: AssetId, amount: u64) {
     asm(r1: amount, r2: asset_id, r3: to.bits()) {
         tr r3 r1 r2;
     }
 }
 
-/// Transfer `amount` coins of type `asset_id` and send them to
-/// the address `to`.
+/// Transfer `amount` coins of type `asset_id` and send them to the address `to`.
 ///
 /// # Arguments
 ///
@@ -247,7 +185,7 @@ pub fn force_transfer_to_contract(to: ContractId, asset_id: AssetId, amount: u64
 ///     transfer_to_address(to_address, AssetId::base(), 500);
 /// }
 /// ```
-pub fn transfer_to_address(to: Address, asset_id: AssetId, amount: u64) {
+fn transfer_to_address(to: Address, asset_id: AssetId, amount: u64) {
     // maintain a manual index as we only have `while` loops in sway atm:
     let mut index = 0;
 

--- a/test/src/e2e_vm_tests/test_programs/should_fail/non_payable_non_zero_coins_const/src/wallet.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/non_payable_non_zero_coins_const/src/wallet.sw
@@ -6,7 +6,7 @@ use std::{
     auth::AuthError,
     call_frames::msg_asset_id,
     context::msg_amount,
-    asset::transfer_to_address,
+    asset::transfer,
 };
 
 use wallet_abi::Wallet;
@@ -37,6 +37,6 @@ impl Wallet for Contract {
 
         storage.balance = current_balance - amount_to_send;
 
-        transfer_to_address(amount_to_send, AssetId::base(), recipient_address);
+        transfer(Identity::Address(recipient_address), AssetId::base(), amount_to_send);
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/non_payable_non_zero_coins_let_binding/src/wallet.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/non_payable_non_zero_coins_let_binding/src/wallet.sw
@@ -6,7 +6,7 @@ use std::{
     auth::AuthError,
     call_frames::msg_asset_id,
     context::msg_amount,
-    asset::transfer_to_address,
+    asset::transfer,
 };
 
 use wallet_abi::Wallet;
@@ -37,6 +37,6 @@ impl Wallet for Contract {
 
         storage.balance = current_balance - amount_to_send;
 
-        transfer_to_address(amount_to_send, AssetId::base(), recipient_address);
+        transfer(Identity::Address(recipient_address), AssetId::base(), amount_to_send);
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/non_payable_non_zero_coins_literal/src/wallet.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/non_payable_non_zero_coins_literal/src/wallet.sw
@@ -6,7 +6,7 @@ use std::{
     auth::AuthError,
     call_frames::msg_asset_id,
     context::msg_amount,
-    asset::transfer_to_address,
+    asset::transfer,
 };
 
 use wallet_abi::Wallet;
@@ -37,6 +37,6 @@ impl Wallet for Contract {
 
         storage.balance = current_balance - amount_to_send;
 
-        transfer_to_address(amount_to_send, AssetId::base(), recipient_address);
+        transfer(Identity::Address(recipient_address), AssetId::base(), amount_to_send);
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/non_payable_implicit_zero_coins/src/wallet.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/non_payable_implicit_zero_coins/src/wallet.sw
@@ -6,7 +6,7 @@ use std::{
     auth::AuthError,
     call_frames::msg_asset_id,
     context::msg_amount,
-    asset::transfer_to_address,
+    asset::transfer,
 };
 
 use wallet_abi::Wallet;
@@ -37,6 +37,6 @@ impl Wallet for Contract {
 
         storage.balance.write(current_balance - amount_to_send);
 
-        transfer_to_address(amount_to_send, AssetId::base(), recipient_address);
+        transfer(Identity::Address(recipient_address), amount_to_send, AssetId::base());
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/non_payable_zero_coins_let_binding/src/wallet.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/non_payable_zero_coins_let_binding/src/wallet.sw
@@ -6,7 +6,7 @@ use std::{
     auth::AuthError,
     call_frames::msg_asset_id,
     context::msg_amount,
-    asset::transfer_to_address,
+    asset::transfer,
 };
 
 use wallet_abi::Wallet;
@@ -37,6 +37,6 @@ impl Wallet for Contract {
 
         storage.balance.write(current_balance - amount_to_send);
 
-        transfer_to_address(amount_to_send, AssetId::base(), recipient_address);
+        transfer(Identity::Address(recipient_address), AssetId::base(), amount_to_send);
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/payable_non_zero_coins/src/wallet.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/payable_non_zero_coins/src/wallet.sw
@@ -6,7 +6,7 @@ use std::{
     auth::AuthError,
     call_frames::msg_asset_id,
     context::msg_amount,
-    asset::transfer_to_address,
+    asset::transfer,
 };
 
 use wallet_abi::Wallet;
@@ -37,6 +37,6 @@ impl Wallet for Contract {
 
         storage.balance.write(current_balance - amount_to_send);
 
-        transfer_to_address(amount_to_send, AssetId::base(), recipient_address);
+        transfer(Identity::Address(recipient_address), AssetId::base(), amount_to_send);
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_asm_block_tr/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_asm_block_tr/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::asset::force_transfer_to_contract;
+use std::asset::transfer;
 
 abi TestAbi {
     fn deposit();
@@ -17,7 +17,7 @@ impl TestAbi for Contract {
         let address = 0x0000000000000000000000000000000000000000000000000000000000000001;
         let asset = AssetId::from(address);
         let pool = ContractId::from(address);
-        // `force_transfer_to_contract` uses `tr` asm instruction
-        force_transfer_to_contract(pool, asset, amount);
+        // `transfer` uses `tr` asm instruction for ContractId
+        transger(Identity::ContractId(pool), asset, amount);
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_asm_block_tro/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_asm_block_tro/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::asset::transfer_to_address;
+use std::asset::transfer;
 
 abi TestAbi {
     fn deposit();
@@ -17,7 +17,7 @@ impl TestAbi for Contract {
         let address = 0x0000000000000000000000000000000000000000000000000000000000000001;
         let asset = AssetId::from(address);
         let user = Address::from(address);
-        // `transfer_to_address` uses `tro` asm instruction
-        transfer_to_address(user, asset, amount);
+        // `transfer` uses `tro` asm instruction for Address
+        transfer(Identity::Address(user), asset, amount);
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/test_fuel_coin_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/test_fuel_coin_contract/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::{constants::ZERO_B256, asset::{burn, force_transfer_to_contract, mint}};
+use std::{constants::ZERO_B256, asset::{burn, transfer, mint}};
 use test_fuel_coin_abi::*;
 
 impl TestFuelCoin for Contract {
@@ -14,6 +14,6 @@ impl TestFuelCoin for Contract {
     }
 
     fn force_transfer(coins: u64, asset_id: AssetId, c_id: ContractId) {
-        force_transfer_to_contract(c_id, asset_id, coins)
+        transfer(Identity::ContractId(c_id), asset_id, coins)
     }
 }

--- a/test/src/sdk-harness/test_projects/asset_ops/src/main.sw
+++ b/test/src/sdk-harness/test_projects/asset_ops/src/main.sw
@@ -33,12 +33,12 @@ impl TestFuelCoin for Contract {
 
     fn force_transfer_coins(coins: u64, asset_id: b256, target: ContractId) {
         let asset_id = AssetId::from(asset_id);
-        force_transfer_to_contract(target, asset_id, coins);
+        transfer(Identity::ContractId(target), asset_id, coins);
     }
 
     fn transfer_coins_to_address(coins: u64, asset_id: b256, to: Address) {
         let asset_id = AssetId::from(asset_id);
-        transfer_to_address(to, asset_id, coins);
+        transfer(Identity::Address(to), asset_id, coins);
     }
 
     fn get_balance(asset_id: b256, target: ContractId) -> u64 {
@@ -47,11 +47,11 @@ impl TestFuelCoin for Contract {
     }
 
     fn mint_and_send_to_contract(amount: u64, to: ContractId, sub_id: b256) {
-        mint_to_contract(to, sub_id, amount);
+        mint_to(Identity::ContractId(to), sub_id, amount);
     }
 
     fn mint_and_send_to_address(amount: u64, to: Address, sub_id: b256) {
-        mint_to_address(to, sub_id, amount);
+        mint_to(Identity::Address(to), sub_id, amount);
     }
 
     fn generic_mint_to(amount: u64, to: Identity, sub_id: b256) {


### PR DESCRIPTION
## Description

There are currently multiple functions for the same functionality:

Transfer:
- `transfer()`
- `force_transfer_to_contract()`
- `transfer_to_address()`

Mint:
- `mint()`
- `mint_to()`
- `mint_to_contract()`
- `mint_to_address()`

This be reduced to just `transfer()`, `mint()`, `mint_to()`. Specific functions for separately minting and transferring to contracts and addresses are legacy code left over from before the `Identity` type was introduced and now only adds additional complexity. 

## Changes:

- `force_transfer_to_contract()` is now private
- `transfer_to_address()` is now private
- `mint_to_contract()` removed
- `mint_to_address()` removed
- Removed newlines in inline docs for better `forc doc` compatibility
- Updated `burn()` inline docs

## Breaking Changes:

- `force_transfer_to_contract()` is now private
- `transfer_to_address()` is now private
- `mint_to_contract()` removed
- `mint_to_address()` removed

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
