### PR TITLE
ci: add a job for checking fuel-core versions between sdk-harness and test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,45 @@ jobs:
       - name: Run the formatter against all sway projects and fail if any of them panic
         run: scripts/formatter/forc-fmt-check-panic.sh
 
+  check-sdk-harness-test-suite-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install toml-cli
+        run: cargo install toml-cli
+
+      - name: Read and compare versions
+        env:
+          PACKAGE_NAMES: "fuel-core-client, fuel-core"
+          PATH1: "./test/Cargo.toml"
+          PATH2: "./test/src/sdk-harness/Cargo.toml"
+        run: |
+          IFS=',' read -ra PACKAGES <<< "$PACKAGE_NAMES"
+          mismatch=0
+          for PACKAGE in "${PACKAGES[@]}"; do
+            VERSION_FIRST=$(toml get ${{ env.PATH1 }} "dependencies.$PACKAGE.version")
+            VERSION_SECOND=$(toml get ${{ env.PATH2 }} "dependencies.$PACKAGE.version")
+            echo "$PACKAGE Version - First: $VERSION_FIRST, Second: $VERSION_SECOND"
+            if [ "$VERSION_FIRST" != "$VERSION_SECOND" ]; then
+              echo "Version mismatch for $PACKAGE: First: $VERSION_FIRST, Second: $VERSION_SECOND"
+              mismatch=1
+            fi
+          done
+          if [ $mismatch -ne 0 ]; then
+            echo "Version mismatch between fuel-core used in sdk-harness and test suite, this will cause problems if two versions are incompatible or it might simply cause invalid/outdated test suite.
+            If you are bumping fuel-core versions used in sway repo, please also use same version in sdk-harness."
+            exit 1
+          else
+            echo "All specified package versions match."
+
   build-mdbook:
     runs-on: buildjet-8vcpu-ubuntu-2204
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,27 +158,9 @@ jobs:
 
       - name: Read and compare versions
         env:
-          PACKAGE_NAMES: "fuel-core-client, fuel-core"
-          PATH1: "./test/Cargo.toml"
-          PATH2: "./test/src/sdk-harness/Cargo.toml"
+          PACKAGE_NAMES: "fuel-core-client" # multiple packages can be specified delimeted with `,`.
         run: |
-          IFS=',' read -ra PACKAGES <<< "$PACKAGE_NAMES"
-          mismatch=0
-          for PACKAGE in "${PACKAGES[@]}"; do
-            VERSION_FIRST=$(toml get ${{ env.PATH1 }} "dependencies.$PACKAGE.version")
-            VERSION_SECOND=$(toml get ${{ env.PATH2 }} "dependencies.$PACKAGE.version")
-            echo "$PACKAGE Version - First: $VERSION_FIRST, Second: $VERSION_SECOND"
-            if [ "$VERSION_FIRST" != "$VERSION_SECOND" ]; then
-              echo "Version mismatch for $PACKAGE: First: $VERSION_FIRST, Second: $VERSION_SECOND"
-              mismatch=1
-            fi
-          done
-          if [ $mismatch -ne 0 ]; then
-            echo "Version mismatch between fuel-core used in sdk-harness and test suite, this will cause problems if two versions are incompatible or it might simply cause invalid/outdated test suite.
-            If you are bumping fuel-core versions used in sway repo, please also use same version in sdk-harness."
-            exit 1
-          else
-            echo "All specified package versions match."
+          ./scripts/check-sdk-harness-version.sh
 
   build-mdbook:
     runs-on: buildjet-8vcpu-ubuntu-2204

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
         env:
           PACKAGE_NAMES: "fuel-core-client" # multiple packages can be specified delimeted with `,`.
         run: |
-          ./scripts/check-sdk-harness-version.sh
+          .github/workflows/scripts/check-sdk-harness-version.sh
 
   build-mdbook:
     runs-on: buildjet-8vcpu-ubuntu-2204

--- a/.github/workflows/scripts/check-sdk-harness-version.sh
+++ b/.github/workflows/scripts/check-sdk-harness-version.sh
@@ -1,0 +1,19 @@
+IFS=',' read -ra PACKAGES <<< "$PACKAGE_NAMES"
+          mismatch=0
+          for PACKAGE in "${PACKAGES[@]}"; do
+            VERSION_FIRST=$(toml get ./Cargo.toml "workspace.dependencies.$PACKAGE.version")
+            VERSION_SECOND=$(toml get ./test/src/sdk-harness/Cargo.toml "dependencies.$PACKAGE.version")
+            echo "$PACKAGE Version - First: $VERSION_FIRST, Second: $VERSION_SECOND"
+            if [ "$VERSION_FIRST" != "$VERSION_SECOND" ]; then
+              echo "Version mismatch for $PACKAGE: First: $VERSION_FIRST, Second: $VERSION_SECOND"
+              mismatch=1
+            fi
+          done
+          if [ $mismatch -ne 0 ]; then
+            echo "Version mismatch between fuel-core-client used in sdk-harness and rest of sway repo.
+	    This will cause problems if two versions are incompatible or it might simply cause invalid/outdated test suite.
+            If you are bumping fuel-core versions used in sway repo, please also use same version in sdk-harness."
+            exit 1
+          else
+            echo "All specified package versions match."
+	  fi	

--- a/.github/workflows/scripts/check-sdk-harness-version.sh
+++ b/.github/workflows/scripts/check-sdk-harness-version.sh
@@ -1,19 +1,17 @@
 IFS=',' read -ra PACKAGES <<< "$PACKAGE_NAMES"
-          mismatch=0
-          for PACKAGE in "${PACKAGES[@]}"; do
-            VERSION_FIRST=$(toml get ./Cargo.toml "workspace.dependencies.$PACKAGE.version")
-            VERSION_SECOND=$(toml get ./test/src/sdk-harness/Cargo.toml "dependencies.$PACKAGE.version")
-            echo "$PACKAGE Version - First: $VERSION_FIRST, Second: $VERSION_SECOND"
-            if [ "$VERSION_FIRST" != "$VERSION_SECOND" ]; then
-              echo "Version mismatch for $PACKAGE: First: $VERSION_FIRST, Second: $VERSION_SECOND"
-              mismatch=1
-            fi
-          done
-          if [ $mismatch -ne 0 ]; then
-            echo "Version mismatch between fuel-core-client used in sdk-harness and rest of sway repo.
-	    This will cause problems if two versions are incompatible or it might simply cause invalid/outdated test suite.
-            If you are bumping fuel-core versions used in sway repo, please also use same version in sdk-harness."
-            exit 1
-          else
-            echo "All specified package versions match."
-	  fi	
+mismatch=0
+for PACKAGE in "${PACKAGES[@]}"; do
+	VERSION_FIRST=$(toml get ./Cargo.toml "workspace.dependencies.$PACKAGE.version")
+	VERSION_SECOND=$(toml get ./test/src/sdk-harness/Cargo.toml "dependencies.$PACKAGE.version")
+        printf "$PACKAGE Version - First: $VERSION_FIRST, Second: $VERSION_SECOND\n"
+        if [ "$VERSION_FIRST" != "$VERSION_SECOND" ]; then
+        	printf "Version mismatch for $PACKAGE: First: $VERSION_FIRST, Second: $VERSION_SECOND\n"
+        	mismatch=1
+        fi
+done
+if [ $mismatch -ne 0 ]; then
+	printf "Version mismatch between fuel-core-client used in sdk-harness and rest of sway repo.\nThis will cause problems if two versions are incompatible or it might simply cause invalid/outdated test suite.\nIf you are bumping fuel-core versions used in sway repo, please also use same version in sdk-harness.\n"
+	exit 1
+else
+	echo "All specified package versions match."
+fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = [
 
 [workspace.dependencies]
 # Dependencies from the `fuel-core` repository:
-fuel-core-client = { version = "0.24.3", default-features = false }
+fuel-core-client = { version = "0.24.2", default-features = false }
 fuel-core-types = { version = "0.24.3", default-features = false }
 
 # Dependencies from the `fuel-vm` repository:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = [
 
 [workspace.dependencies]
 # Dependencies from the `fuel-core` repository:
-fuel-core-client = { version = "0.24.2", default-features = false }
+fuel-core-client = { version = "0.24.3", default-features = false }
 fuel-core-types = { version = "0.24.3", default-features = false }
 
 # Dependencies from the `fuel-vm` repository:


### PR DESCRIPTION
## Description
We are currently out of sync in between sdk-harness and test suite, this is not ideal due to couple of reasons:

1. It is not nice to have our two test suites, testing with different versions of fuel-core, which means we do not test one version completely in the sense of our e2e and sdk-harness tests.
2. It can create problems in CI if a contract id needs to be updated, when the out-of sync versions are incompatible. (for example: one is using version 0.1.0, one is using 0.2.0)

The added job will fail and inform the dev bumping fuel-core version, to also bump it in sdk-harness or in general make them in sync.

The reason we need this as a CI job is we cannot enforce it via cargo. Since adding sdk-harness to the sway repo workspace, it creates our well known cyclic dependency between sdk and sway. So this should be checked in CI.