### PR TITLE
Fix non idiomatic function names warnings in the std lib.

### DIFF
--- a/sway-lib-std/src/primitive_conversions/u16.sw
+++ b/sway-lib-std/src/primitive_conversions/u16.sw
@@ -155,7 +155,7 @@ fn test_u16_try_from_u256() {
 }
 
 #[test]
-fn test_u16_try_from_U128() {
+fn test_u16_try_from_u128() {
     use ::assert::assert;
 
     let u128_1: U128 = U128::new();

--- a/sway-lib-std/src/primitive_conversions/u32.sw
+++ b/sway-lib-std/src/primitive_conversions/u32.sw
@@ -174,7 +174,7 @@ fn test_u32_try_from_u256() {
 }
 
 #[test]
-fn test_u32_try_from_U128() {
+fn test_u32_try_from_u128() {
     use ::assert::assert;
 
     let u128_1: U128 = U128::new();

--- a/sway-lib-std/src/primitive_conversions/u64.sw
+++ b/sway-lib-std/src/primitive_conversions/u64.sw
@@ -186,7 +186,7 @@ fn test_u64_try_from_u256() {
 }
 
 #[test]
-fn test_u64_try_from_U128() {
+fn test_u64_try_from_u128() {
     use ::assert::assert;
 
     let u128_1: U128 = U128::new();

--- a/sway-lib-std/src/primitive_conversions/u8.sw
+++ b/sway-lib-std/src/primitive_conversions/u8.sw
@@ -135,7 +135,7 @@ fn test_u8_try_from_u256() {
 }
 
 #[test]
-fn test_u8_try_from_U128() {
+fn test_u8_try_from_u128() {
     use ::assert::assert;
 
     let u128_1: U128 = U128::new();


### PR DESCRIPTION
```
warning
   --> sway-lib-std/src/primitive_conversions/u64.sw:189:4
    |
187 |
188 | #[test]
189 | fn test_u64_try_from_U128() {
|    ---------------------- Function name "test_u64_try_from_U128"
is not idiomatic. Function names should be snake_case, like
"test_u64_try_from_u128".
190 |     use ::assert::assert;
    |
```

## Description


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
