### PR TITLE
change submodules to use `im::HashMap` instead of `im::OrdMap`

### DIFF
--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -27,7 +27,7 @@ pub struct Module {
     /// some library dependency that we include as a submodule.
     ///
     /// Note that we *require* this map to be ordered to produce deterministic codegen results.
-    pub(crate) submodules: im::OrdMap<ModuleName, Module>,
+    pub(crate) submodules: im::HashMap<ModuleName, Module>,
     /// Keeps all lexical scopes associated with this module.
     pub lexical_scopes: Vec<LexicalScope>,
     /// Current lexical scope id in the lexical scope hierarchy stack.
@@ -86,7 +86,7 @@ impl Module {
     }
 
     /// Immutable access to this module's submodules.
-    pub fn submodules(&self) -> &im::OrdMap<ModuleName, Module> {
+    pub fn submodules(&self) -> &im::HashMap<ModuleName, Module> {
         &self.submodules
     }
 

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -28,7 +28,7 @@ pub struct Module {
     /// Submodules are normally introduced in Sway code with the `mod foo;` syntax where `foo` is
     /// some library dependency that we include as a submodule.
     ///
-    /// Note that we *require* this map to be ordered to produce deterministic codegen results.
+    /// Note that we *require* this map to produce deterministic codegen results which is why [`FxHasher`] is used.
     pub(crate) submodules: im::HashMap<ModuleName, Module, BuildHasherDefault<FxHasher>>,
     /// Keeps all lexical scopes associated with this module.
     pub lexical_scopes: Vec<LexicalScope>,

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -6,6 +6,8 @@ use super::{
     LexicalScopeId, ModuleName, ModulePath, ModulePathBuf,
 };
 
+use rustc_hash::FxHasher;
+use std::hash::BuildHasherDefault;
 use sway_error::handler::Handler;
 use sway_error::{error::CompileError, handler::ErrorEmitted};
 use sway_types::{span::Span, Spanned};
@@ -27,7 +29,7 @@ pub struct Module {
     /// some library dependency that we include as a submodule.
     ///
     /// Note that we *require* this map to be ordered to produce deterministic codegen results.
-    pub(crate) submodules: im::HashMap<ModuleName, Module>,
+    pub(crate) submodules: im::HashMap<ModuleName, Module, BuildHasherDefault<FxHasher>>,
     /// Keeps all lexical scopes associated with this module.
     pub lexical_scopes: Vec<LexicalScope>,
     /// Current lexical scope id in the lexical scope hierarchy stack.
@@ -86,7 +88,7 @@ impl Module {
     }
 
     /// Immutable access to this module's submodules.
-    pub fn submodules(&self) -> &im::HashMap<ModuleName, Module> {
+    pub fn submodules(&self) -> &im::HashMap<ModuleName, Module, BuildHasherDefault<FxHasher>> {
         &self.submodules
     }
 


### PR DESCRIPTION
## Description

The [`im` docs](https://docs.rs/im/latest/im/) state that the performance of `HashMap` is similar to that found in `std` but the `ImOrd` is between 2-3x slower than `BTreeMap`. Changing submodules from using `im::OrdMap` to using `im::HashMap` is giving us a nice performance win. 

I tried compiling the libraries project from fluid protocol as a test, it has 19 seperate libraries. This change gives us a 21.25% speed increase. 

Before: Elapsed time: `27.968193458s`
After:  Elapsed time: `22.02603425s`

Running the compile benchmark in LSP is showing a 29% improvement. 

Before: Elapsed time: `3.8328s`
After: Elapsed time: `2.7086s`
