### PR TITLE
Wrap `BaseIdent` `name_override_opt` & `TraitName` in an `Arc`

### DIFF
--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -419,7 +419,7 @@ impl TraitMap {
         engines: &Engines,
     ) {
         let key = TraitKey {
-            name: trait_name.into(),
+            name: trait_name,
             type_id,
             trait_decl_span,
         };

--- a/sway-core/src/semantic_analysis/namespace/trait_map.rs
+++ b/sway-core/src/semantic_analysis/namespace/trait_map.rs
@@ -3,6 +3,7 @@ use std::{
     collections::{BTreeSet, HashMap},
     fmt,
     hash::{DefaultHasher, Hash, Hasher},
+    sync::Arc,
 };
 
 use hashbrown::HashSet;
@@ -85,7 +86,7 @@ impl DebugWithEngines for TraitSuffix {
     }
 }
 
-type TraitName = CallPath<TraitSuffix>;
+type TraitName = Arc<CallPath<TraitSuffix>>;
 
 #[derive(Clone, Debug)]
 struct TraitKey {
@@ -235,7 +236,7 @@ impl TraitMap {
                             args: map_trait_type_args,
                         },
                     ..
-                } = map_trait_name;
+                } = &*map_trait_name.clone();
 
                 let unify_checker = UnifyCheck::non_generic_constraint_subset(engines);
 
@@ -385,14 +386,14 @@ impl TraitMap {
                     }
                 }
             }
-            let trait_name: TraitName = CallPath {
+            let trait_name: TraitName = Arc::new(CallPath {
                 prefixes: trait_name.prefixes,
                 suffix: TraitSuffix {
                     name: trait_name.suffix,
                     args: trait_type_args,
                 },
                 is_absolute: trait_name.is_absolute,
-            };
+            });
 
             // even if there is a conflicting definition, add the trait anyway
             self.insert_inner(
@@ -418,7 +419,7 @@ impl TraitMap {
         engines: &Engines,
     ) {
         let key = TraitKey {
-            name: trait_name,
+            name: trait_name.into(),
             type_id,
             trait_decl_span,
         };
@@ -1079,7 +1080,7 @@ impl TraitMap {
                 ResolvedTraitImplItem::Parsed(impl_item) => match impl_item {
                     ImplItem::Fn(fn_ref) => {
                         let decl = engines.pe().get_function(&fn_ref);
-                        let trait_call_path_string = engines.help_out(trait_key.name).to_string();
+                        let trait_call_path_string = engines.help_out(&*trait_key.name).to_string();
                         if decl.name.as_str() == symbol.as_str()
                             && (as_trait.is_none()
                                 || as_trait.clone().unwrap().to_string() == trait_call_path_string)
@@ -1092,7 +1093,7 @@ impl TraitMap {
                     }
                     ImplItem::Constant(const_ref) => {
                         let decl = engines.pe().get_constant(&const_ref);
-                        let trait_call_path_string = engines.help_out(trait_key.name).to_string();
+                        let trait_call_path_string = engines.help_out(&*trait_key.name).to_string();
                         if decl.name.as_str() == symbol.as_str()
                             && (as_trait.is_none()
                                 || as_trait.clone().unwrap().to_string() == trait_call_path_string)
@@ -1105,7 +1106,7 @@ impl TraitMap {
                     }
                     ImplItem::Type(type_ref) => {
                         let decl = engines.pe().get_trait_type(&type_ref);
-                        let trait_call_path_string = engines.help_out(trait_key.name).to_string();
+                        let trait_call_path_string = engines.help_out(&*trait_key.name).to_string();
                         if decl.name.as_str() == symbol.as_str()
                             && (as_trait.is_none()
                                 || as_trait.clone().unwrap().to_string() == trait_call_path_string)
@@ -1120,7 +1121,7 @@ impl TraitMap {
                 ResolvedTraitImplItem::Typed(ty_impl_item) => match ty_impl_item {
                     ty::TyTraitItem::Fn(fn_ref) => {
                         let decl = engines.de().get_function(&fn_ref);
-                        let trait_call_path_string = engines.help_out(trait_key.name).to_string();
+                        let trait_call_path_string = engines.help_out(&*trait_key.name).to_string();
                         if decl.name.as_str() == symbol.as_str()
                             && (as_trait.is_none()
                                 || as_trait.clone().unwrap().to_string() == trait_call_path_string)
@@ -1133,7 +1134,7 @@ impl TraitMap {
                     }
                     ty::TyTraitItem::Constant(const_ref) => {
                         let decl = engines.de().get_constant(&const_ref);
-                        let trait_call_path_string = engines.help_out(trait_key.name).to_string();
+                        let trait_call_path_string = engines.help_out(&*trait_key.name).to_string();
                         if decl.call_path.suffix.as_str() == symbol.as_str()
                             && (as_trait.is_none()
                                 || as_trait.clone().unwrap().to_string() == trait_call_path_string)
@@ -1146,7 +1147,7 @@ impl TraitMap {
                     }
                     ty::TyTraitItem::Type(type_ref) => {
                         let decl = engines.de().get_type(&type_ref);
-                        let trait_call_path_string = engines.help_out(trait_key.name).to_string();
+                        let trait_call_path_string = engines.help_out(&*trait_key.name).to_string();
                         if decl.name.as_str() == symbol.as_str()
                             && (as_trait.is_none()
                                 || as_trait.clone().unwrap().to_string() == trait_call_path_string)

--- a/sway-types/src/ident.rs
+++ b/sway-types/src/ident.rs
@@ -5,7 +5,7 @@ use crate::{span::Span, Spanned};
 use std::{
     cmp::{Ord, Ordering},
     fmt,
-    hash::{Hash, Hasher},
+    hash::{Hash, Hasher}, sync::Arc,
 };
 
 pub trait Named {
@@ -14,7 +14,7 @@ pub trait Named {
 
 #[derive(Clone)]
 pub struct BaseIdent {
-    name_override_opt: Option<String>,
+    name_override_opt: Option<Arc<String>>,
     span: Span,
     is_raw_ident: bool,
 }
@@ -23,6 +23,7 @@ impl BaseIdent {
     pub fn as_str(&self) -> &str {
         self.name_override_opt
             .as_deref()
+            .map(|x| x.as_str())
             .unwrap_or_else(|| self.span.as_str())
     }
 
@@ -31,7 +32,7 @@ impl BaseIdent {
     }
 
     pub fn name_override_opt(&self) -> Option<&str> {
-        self.name_override_opt.as_deref()
+        self.name_override_opt.as_deref().map(|x| x.as_str())
     }
 
     pub fn new(span: Span) -> Ident {
@@ -62,7 +63,7 @@ impl BaseIdent {
 
     pub fn new_with_override(name_override: String, span: Span) -> Ident {
         Ident {
-            name_override_opt: Some(name_override),
+            name_override_opt: Some(Arc::new(name_override)),
             span,
             is_raw_ident: false,
         }
@@ -70,7 +71,7 @@ impl BaseIdent {
 
     pub fn new_no_span(name: String) -> Ident {
         Ident {
-            name_override_opt: Some(name),
+            name_override_opt: Some(Arc::new(name)),
             span: Span::dummy(),
             is_raw_ident: false,
         }
@@ -78,7 +79,7 @@ impl BaseIdent {
 
     pub fn dummy() -> Ident {
         Ident {
-            name_override_opt: Some("foo".into()),
+            name_override_opt: Some(Arc::new("foo".into())),
             span: Span::dummy(),
             is_raw_ident: false,
         }
@@ -168,7 +169,7 @@ impl From<&Ident> for IdentUnique {
 impl From<&IdentUnique> for Ident {
     fn from(item: &IdentUnique) -> Self {
         Ident {
-            name_override_opt: item.0.name_override_opt().map(|s| s.to_string()),
+            name_override_opt: item.0.name_override_opt().map(|s| Arc::new(s.to_string())),
             span: item.0.span(),
             is_raw_ident: item.0.is_raw_ident(),
         }

--- a/sway-types/src/ident.rs
+++ b/sway-types/src/ident.rs
@@ -5,7 +5,8 @@ use crate::{span::Span, Spanned};
 use std::{
     cmp::{Ord, Ordering},
     fmt,
-    hash::{Hash, Hasher}, sync::Arc,
+    hash::{Hash, Hasher},
+    sync::Arc,
 };
 
 pub trait Named {


### PR DESCRIPTION
## Description

I generated a flame graph and saw that we are spending a ton of time cloning `BaseIdent` and `TraitName`. I've wrapped the `name_override_opt` in BaseIdent with an `Arc` and also changed TraitName to: 
```rust
type TraitName = Arc<CallPath<TraitSuffix>>;
``` 

Again running the same test being used in #5976 and also incorporating that PR's optimisations for the benchmark, we are getting a further 33.47% performance increase. 

Before: Elapsed time: `22.02603425s`
After: Elapsed time: `14.653166459s`

In discussions with Jibril today, we should probably look at implementing a String interning system but this can be addressed in a future PR. 

