### PR TITLE
Make ControlFlowGraph store a reference to Engines to remove clones

### DIFF
--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -21,7 +21,7 @@ impl<'cfg> ControlFlowGraph<'cfg> {
     ) -> Result<Self, Vec<CompileError>> {
         let mut errors = vec![];
 
-        let mut graph = ControlFlowGraph::new(engines.clone());
+        let mut graph = ControlFlowGraph::new(engines);
         // do a depth first traversal and cover individual inner ast nodes
         let mut leaves = vec![];
         for ast_entrypoint in module_nodes {

--- a/sway-core/src/control_flow_analysis/flow_graph/mod.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/mod.rs
@@ -33,13 +33,13 @@ pub struct ControlFlowGraph<'cfg> {
     pub(crate) pending_entry_points_edges: Vec<(NodeIndex, ControlFlowGraphEdge)>,
     pub(crate) namespace: ControlFlowNamespace,
     pub(crate) decls: HashMap<IdentUnique, NodeIndex>,
-    pub(crate) engines: Engines,
+    pub(crate) engines: &'cfg Engines,
 }
 
 pub type Graph<'cfg> = petgraph::Graph<ControlFlowGraphNode<'cfg>, ControlFlowGraphEdge>;
 
 impl<'cfg> ControlFlowGraph<'cfg> {
-    pub fn new(engines: Engines) -> Self {
+    pub fn new(engines: &'cfg Engines) -> Self {
         Self {
             graph: Default::default(),
             entry_points: Default::default(),

--- a/sway-core/src/control_flow_analysis/flow_graph/mod.rs
+++ b/sway-core/src/control_flow_analysis/flow_graph/mod.rs
@@ -188,7 +188,7 @@ impl<'cfg> ControlFlowGraph<'cfg> {
         self.pending_entry_points_edges.push((to, label));
     }
     pub(crate) fn add_node<'eng: 'cfg>(&mut self, node: ControlFlowGraphNode<'cfg>) -> NodeIndex {
-        let ident_opt = node.get_decl_ident(&self.engines);
+        let ident_opt = node.get_decl_ident(self.engines);
         let node_index = self.graph.add_node(node);
         if let Some(ident) = ident_opt {
             self.decls.insert(ident.into(), node_index);
@@ -214,7 +214,7 @@ impl<'cfg> ControlFlowGraph<'cfg> {
     }
 
     pub(crate) fn get_node_from_decl(&self, cfg_node: &ControlFlowGraphNode) -> Option<NodeIndex> {
-        if let Some(ident) = cfg_node.get_decl_ident(&self.engines) {
+        if let Some(ident) = cfg_node.get_decl_ident(self.engines) {
             if !ident.span().is_dummy() {
                 self.decls.get(&ident.into()).cloned()
             } else {

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -1008,7 +1008,7 @@ fn dead_code_analysis<'a>(
     program: &ty::TyProgram,
 ) -> Result<ControlFlowGraph<'a>, ErrorEmitted> {
     let decl_engine = engines.de();
-    let mut dead_code_graph = ControlFlowGraph::new(engines.clone());
+    let mut dead_code_graph = ControlFlowGraph::new(engines);
     let tree_type = program.kind.tree_type();
     module_dead_code_analysis(
         handler,


### PR DESCRIPTION
## Description
Using the same performance test as in #5976 and #5978, this change gives a further 21.33% performance improvement. 

Before: Elapsed time: `14.653166459s`
After: Elapsed time: `11.527667375s`
