### PR TITLE
feat: take dynamic asset id into account with `forc-client`

### DIFF
--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -237,7 +237,10 @@ pub async fn deploy_pkg(
         WalletSelectionMode::ForcWallet
     };
 
+    let max_fee = command.gas.max_fee.unwrap_or(0);
+
     let tx = TransactionBuilder::create(bytecode.as_slice().into(), salt, storage_slots.clone())
+        .max_fee_limit(max_fee)
         .maturity(command.maturity.maturity.into())
         .add_output(Output::contract_created(contract_id, state_root))
         .finalize_signed(

--- a/forc-plugins/forc-client/src/util/tx.rs
+++ b/forc-plugins/forc-client/src/util/tx.rs
@@ -4,9 +4,7 @@ use anyhow::{Error, Result};
 use async_trait::async_trait;
 use forc_tracing::println_warning;
 use fuel_crypto::{Message, PublicKey, SecretKey, Signature};
-use fuel_tx::{
-    field, Address, AssetId, Buildable, ContractId, Input, Output, TransactionBuilder, Witness,
-};
+use fuel_tx::{field, Address, Buildable, ContractId, Input, Output, TransactionBuilder, Witness};
 use fuels_accounts::{provider::Provider, wallet::Wallet, ViewOnlyAccount};
 use fuels_core::types::{
     bech32::{Bech32Address, FUEL_BECH32_HRP},
@@ -143,10 +141,10 @@ impl<Tx: Buildable + field::Witnesses + Send> TransactionBuilderExt<Tx> for Tran
         provider: Provider,
         signature_witness_index: u16,
     ) -> Result<&mut Self> {
+        let asset_id = *provider.base_asset_id();
         let wallet = Wallet::from_address(Bech32Address::from(address), Some(provider));
 
         let amount = 1_000_000;
-        let asset_id = AssetId::BASE;
         let inputs: Vec<_> = wallet
             .get_spendable_resources(asset_id, amount)
             .await?
@@ -310,6 +308,8 @@ impl<Tx: Buildable + field::Witnesses + Send> TransactionBuilderExt<Tx> for Tran
             } else {
                 e
             })?;
+
+        // Set max_fee from consensus_parameters.
 
         let mut tx = self.finalize_without_signature_inner();
 

--- a/forc-plugins/forc-client/src/util/tx.rs
+++ b/forc-plugins/forc-client/src/util/tx.rs
@@ -309,7 +309,6 @@ impl<Tx: Buildable + field::Witnesses + Send> TransactionBuilderExt<Tx> for Tran
                 e
             })?;
 
-
         let mut tx = self.finalize_without_signature_inner();
 
         let signature = if let Some(signing_key) = signing_key {

--- a/forc-plugins/forc-client/src/util/tx.rs
+++ b/forc-plugins/forc-client/src/util/tx.rs
@@ -309,7 +309,6 @@ impl<Tx: Buildable + field::Witnesses + Send> TransactionBuilderExt<Tx> for Tran
                 e
             })?;
 
-        // Set max_fee from consensus_parameters.
 
         let mut tx = self.finalize_without_signature_inner();
 

--- a/forc-plugins/forc-tx/src/lib.rs
+++ b/forc-plugins/forc-tx/src/lib.rs
@@ -205,6 +205,9 @@ pub struct Gas {
     /// Gas limit for the transaction.
     #[clap(long = "script-gas-limit")]
     pub script_gas_limit: Option<u64>,
+    /// Max fee for the transaction.
+    #[clap(long)]
+    pub max_fee: Option<u64>,
 }
 
 /// Block until which tx cannot be included.


### PR DESCRIPTION
## Description
Base asset ids are dynamic for the newer fuel-core versions. This PR adds capability to query that and use it for forc-client transactions. Also adds a flag `max-fee` which is required to be set for newer versions of fuel-core.