### PR TITLE
upgrade sdk-harness test to use fuels-rs v0.61

### DIFF
--- a/test/src/sdk-harness/Cargo.lock
+++ b/test/src/sdk-harness/Cargo.lock
@@ -2018,8 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "fuels"
-version = "0.60.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.60.0#b5f563e9051c3cac0edb8f18137069e870f6cb31"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f21be9dc16a233e958c87914f9cbeeb2cdbbd9210093522cd0846783480ee4"
 dependencies = [
  "fuel-core",
  "fuel-core-client",
@@ -2034,8 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-accounts"
-version = "0.60.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.60.0#b5f563e9051c3cac0edb8f18137069e870f6cb31"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e8a8c6a241d49f716313298a17e9da00a1102b3efa26d01cd700a55b3b1710"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2057,8 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
-version = "0.60.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.60.0#b5f563e9051c3cac0edb8f18137069e870f6cb31"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c0a990a3409d91b5e62c542d890c8840edd34e50546c7c7eb347fcbf3711d87"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -2072,8 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-version = "0.60.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.60.0#b5f563e9051c3cac0edb8f18137069e870f6cb31"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f7308bf8b0d11b4acb408bdbcf8a0b98cdd11ea1ffbf6235f5c4a5bee6f5d4"
 dependencies = [
  "async-trait",
  "bech32",
@@ -2097,8 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-macros"
-version = "0.60.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.60.0#b5f563e9051c3cac0edb8f18137069e870f6cb31"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85f319fccc0dcdea878b9aeb8eec9699249d32f9d258fd5abfe9d5c0e92b4b13"
 dependencies = [
  "fuels-code-gen",
  "itertools 0.12.1",
@@ -2110,11 +2115,11 @@ dependencies = [
 
 [[package]]
 name = "fuels-programs"
-version = "0.60.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.60.0#b5f563e9051c3cac0edb8f18137069e870f6cb31"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d2cf1be591ba2589cc9f6d248cabe9186168d5f57f35e381af3b6002dd0eba"
 dependencies = [
  "async-trait",
- "bytes",
  "fuel-abi-types",
  "fuel-asm",
  "fuel-tx",
@@ -2129,8 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.60.0"
-source = "git+https://github.com/FuelLabs/fuels-rs?tag=v0.60.0#b5f563e9051c3cac0edb8f18137069e870f6cb31"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebde4b7d23d0c0a43c235b4ce351643ca0c3e370e1cb4274afd93db3e26c347"
 dependencies = [
  "fuel-core",
  "fuel-core-chain-config",

--- a/test/src/sdk-harness/Cargo.toml
+++ b/test/src/sdk-harness/Cargo.toml
@@ -17,10 +17,7 @@ fuel-core-client = { version = "0.26.0", default-features = false }
 fuel-vm = { version = "0.49.0", features = ["random"] }
 
 # Dependencies from the `fuels-rs` repository:
-# Need to point to master until encoding v1 is default everywhere
-fuels = { git = "https://github.com/FuelLabs/fuels-rs", tag = "v0.60.0", features = [
-    "fuel-core-lib",
-] }
+fuels = { version = "0.61.0", features = ["fuel-core-lib"] }
 
 hex = "0.4.3"
 paste = "1.0.14"

--- a/test/src/sdk-harness/test_projects/low_level_call/mod.rs
+++ b/test/src/sdk-harness/test_projects/low_level_call/mod.rs
@@ -11,11 +11,11 @@ use fuels::{
 macro_rules! fn_selector {
     ( $fn_name: ident ( $($fn_arg: ty),* )  ) => {
         encode_fn_selector(stringify!($fn_name)).to_vec()
-    }
+    };
 }
 macro_rules! calldata {
     ( $($arg: expr),* ) => {
-        ABIEncoder::new(EncoderConfig::default()).encode(&[$(::fuels::core::traits::Tokenizable::into_token($arg)),*]).unwrap().resolve(0)
+        ABIEncoder::new(EncoderConfig::default()).encode(&[$(::fuels::core::traits::Tokenizable::into_token($arg)),*]).unwrap()
     }
 }
 

--- a/test/src/sdk-harness/test_projects/predicate_data_simple/mod.rs
+++ b/test/src/sdk-harness/test_projects/predicate_data_simple/mod.rs
@@ -5,10 +5,7 @@ use fuels::{
     accounts::wallet::{Wallet, WalletUnlocked},
     core::codec::{ABIEncoder, EncoderConfig},
     prelude::*,
-    types::{
-        input::Input, transaction_builders::ScriptTransactionBuilder,
-        unresolved_bytes::UnresolvedBytes, Token,
-    },
+    types::{input::Input, transaction_builders::ScriptTransactionBuilder, Token},
 };
 use std::str::FromStr;
 
@@ -63,7 +60,7 @@ async fn submit_to_predicate(
     amount_to_predicate: u64,
     asset_id: AssetId,
     receiver_address: Address,
-    predicate_data: UnresolvedBytes,
+    predicate_data: Vec<u8>,
 ) -> Result<()> {
     let filter = ResourceFilter {
         from: predicate_address.into(),

--- a/test/src/sdk-harness/test_projects/predicate_data_struct/mod.rs
+++ b/test/src/sdk-harness/test_projects/predicate_data_struct/mod.rs
@@ -5,10 +5,7 @@ use fuels::{
     accounts::wallet::{Wallet, WalletUnlocked},
     core::codec::{ABIEncoder, EncoderConfig},
     prelude::*,
-    types::{
-        input::Input, transaction_builders::ScriptTransactionBuilder,
-        unresolved_bytes::UnresolvedBytes, Token,
-    },
+    types::{input::Input, transaction_builders::ScriptTransactionBuilder, Token},
 };
 use std::str::FromStr;
 
@@ -61,7 +58,7 @@ async fn submit_to_predicate(
     amount_to_predicate: u64,
     asset_id: AssetId,
     receiver_address: Address,
-    predicate_data: UnresolvedBytes,
+    predicate_data: Vec<u8>,
 ) {
     let filter = ResourceFilter {
         from: predicate_address.into(),
@@ -114,7 +111,7 @@ struct Validation {
     total_complete: u64,
 }
 
-fn encode_struct(predicate_struct: Validation) -> UnresolvedBytes {
+fn encode_struct(predicate_struct: Validation) -> Vec<u8> {
     let has_account = Token::Bool(predicate_struct.has_account);
     let total_complete = Token::U64(predicate_struct.total_complete);
     let token_struct: Vec<Token> = vec![has_account, total_complete];

--- a/test/src/sdk-harness/test_projects/tx_fields/mod.rs
+++ b/test/src/sdk-harness/test_projects/tx_fields/mod.rs
@@ -93,7 +93,7 @@ async fn generate_predicate_inputs(
         .unwrap()
         .with_provider(provider.clone());
 
-    let predicate_code = predicate.code().clone();
+    let predicate_code = predicate.code().to_vec();
 
     let predicate_root = predicate.address();
 


### PR DESCRIPTION
## Description

This PR is part of https://github.com/FuelLabs/sway/issues/5727 and it is just doing the minimal changes to update `fuels-rs` to version 0.61, given we don´t need to use `master` anymore.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
