### PR TITLE
feat: point --testnet flag to latest testnet instead of `devnet`

### DIFF
--- a/forc-plugins/forc-client/src/constants.rs
+++ b/forc-plugins/forc-client/src/constants.rs
@@ -10,3 +10,5 @@ pub const BETA_4_FAUCET_URL: &str = "https://faucet-beta-4.fuel.network";
 pub const BETA_5_FAUCET_URL: &str = "https://faucet-beta-5.fuel.network";
 pub const DEVNET_FAUCET_URL: &str = "https://faucet-devnet.fuel.network";
 pub const DEVNET_ENDPOINT_URL: &str = "https://devnet.fuel.network";
+pub const TESTNET_FAUCET_URL: &str = "https://faucet-testnet.fuel.network";
+pub const TESTNET_ENDPOINT_URL: &str = "https://testnet.fuel.network";

--- a/forc-plugins/forc-client/src/util/node_url.rs
+++ b/forc-plugins/forc-client/src/util/node_url.rs
@@ -38,19 +38,30 @@ fn test_get_node_url_testnet() {
     };
 
     let actual = get_node_url(&input, &None).unwrap();
-    assert_eq!("https://devnet.fuel.network", actual);
+    assert_eq!("https://testnet.fuel.network", actual);
 }
 
 #[test]
-fn test_get_node_url_devnet() {
+fn test_get_node_url_target_devnet() {
     let input = NodeTarget {
         target: Some(Target::Devnet),
         node_url: None,
         testnet: false,
     };
-
     let actual = get_node_url(&input, &None).unwrap();
     assert_eq!("https://devnet.fuel.network", actual);
+}
+
+#[test]
+fn test_get_node_url_target_testnet() {
+    let input = NodeTarget {
+        target: Some(Target::Testnet),
+        node_url: None,
+        testnet: false,
+    };
+
+    let actual = get_node_url(&input, &None).unwrap();
+    assert_eq!("https://testnet.fuel.network", actual);
 }
 
 #[test]
@@ -111,17 +122,6 @@ fn test_get_node_url_beta3() {
     };
     let actual = get_node_url(&input, &None).unwrap();
     assert_eq!("https://beta-3.fuel.network", actual);
-}
-
-#[test]
-fn test_get_node_url_devnet() {
-    let input = NodeTarget {
-        target: Some(Target::Devnet),
-        node_url: None,
-        testnet: false,
-    };
-    let actual = get_node_url(&input, &None).unwrap();
-    assert_eq!("https://devnet.fuel.network", actual);
 }
 
 #[test]

--- a/forc-plugins/forc-client/src/util/node_url.rs
+++ b/forc-plugins/forc-client/src/util/node_url.rs
@@ -42,6 +42,18 @@ fn test_get_node_url_testnet() {
 }
 
 #[test]
+fn test_get_node_url_devnet() {
+    let input = NodeTarget {
+        target: Some(Target::Devnet),
+        node_url: None,
+        testnet: false,
+    };
+
+    let actual = get_node_url(&input, &None).unwrap();
+    assert_eq!("https://devnet.fuel.network", actual);
+}
+
+#[test]
 fn test_get_node_url_beta5() {
     let input = NodeTarget {
         target: Some(Target::Beta5),

--- a/forc-plugins/forc-client/src/util/target.rs
+++ b/forc-plugins/forc-client/src/util/target.rs
@@ -82,12 +82,13 @@ impl FromStr for Target {
             "testnet" => Ok(Target::Testnet),
             "local" => Ok(Target::Local),
             _ => bail!(
-                "'{s}' is not a valid target name. Possible values: '{}', '{}', '{}', '{}', '{}', '{}'",
+                "'{s}' is not a valid target name. Possible values: '{}', '{}', '{}', '{}', '{}', '{}', '{}'",
                 Target::Beta2,
                 Target::Beta3,
                 Target::Beta4,
                 Target::Beta5,
                 Target::Devnet,
+                Target::Testnet,
                 Target::Local
             ),
         }

--- a/forc-plugins/forc-client/src/util/target.rs
+++ b/forc-plugins/forc-client/src/util/target.rs
@@ -1,7 +1,7 @@
 use crate::constants::{
     BETA_2_ENDPOINT_URL, BETA_2_FAUCET_URL, BETA_3_ENDPOINT_URL, BETA_3_FAUCET_URL,
     BETA_4_ENDPOINT_URL, BETA_4_FAUCET_URL, BETA_5_ENDPOINT_URL, BETA_5_FAUCET_URL,
-    DEVNET_ENDPOINT_URL, DEVNET_FAUCET_URL, NODE_URL,
+    DEVNET_ENDPOINT_URL, DEVNET_FAUCET_URL, NODE_URL, TESTNET_ENDPOINT_URL, TESTNET_FAUCET_URL,
 };
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
@@ -15,6 +15,7 @@ pub enum Target {
     Beta4,
     Beta5,
     Devnet,
+    Testnet,
     Local,
 }
 
@@ -32,6 +33,7 @@ impl Target {
             Target::Beta4 => BETA_4_ENDPOINT_URL,
             Target::Beta5 => BETA_5_ENDPOINT_URL,
             Target::Devnet => DEVNET_ENDPOINT_URL,
+            Target::Testnet => TESTNET_ENDPOINT_URL,
             Target::Local => NODE_URL,
         };
         url.to_string()
@@ -42,13 +44,16 @@ impl Target {
             BETA_2_ENDPOINT_URL => Some(Target::Beta2),
             BETA_3_ENDPOINT_URL => Some(Target::Beta3),
             BETA_4_ENDPOINT_URL => Some(Target::Beta4),
+            BETA_5_ENDPOINT_URL => Some(Target::Beta5),
+            DEVNET_ENDPOINT_URL => Some(Target::Devnet),
+            TESTNET_ENDPOINT_URL => Some(Target::Testnet),
             NODE_URL => Some(Target::Local),
             _ => None,
         }
     }
 
     pub fn testnet() -> Self {
-        Target::Devnet
+        Target::Testnet
     }
 
     pub fn faucet_url(&self) -> String {
@@ -58,6 +63,7 @@ impl Target {
             Target::Beta4 => BETA_4_FAUCET_URL.to_string(),
             Target::Beta5 => BETA_5_FAUCET_URL.to_string(),
             Target::Devnet => DEVNET_FAUCET_URL.to_string(),
+            Target::Testnet => TESTNET_FAUCET_URL.to_string(),
             Target::Local => "http://localhost:3000".to_string(),
         }
     }
@@ -73,6 +79,7 @@ impl FromStr for Target {
             "beta-4" => Ok(Target::Beta4),
             "beta-5" => Ok(Target::Beta5),
             "devnet" => Ok(Target::Devnet),
+            "testnet" => Ok(Target::Testnet),
             "local" => Ok(Target::Local),
             _ => bail!(
                 "'{s}' is not a valid target name. Possible values: '{}', '{}', '{}', '{}', '{}', '{}'",
@@ -95,6 +102,7 @@ impl std::fmt::Display for Target {
             Target::Beta4 => "beta-4",
             Target::Beta5 => "beta-5",
             Target::Devnet => "devnet",
+            Target::Testnet => "testnet",
             Target::Local => "local",
         };
         write!(f, "{}", s)


### PR DESCRIPTION
## Description

Changes the target of `--testnet` flag to testnet instead of devnet. Also fixes some missing from end point url conversions for target resolving.