### PR TITLE
Improve IR printing CLI in `forc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,6 +2002,7 @@ dependencies = [
  "serde_json",
  "sway-core",
  "sway-error",
+ "sway-ir",
  "sway-types",
  "sway-utils",
  "term-table",

--- a/docs/book/src/forc/manifest_reference.md
+++ b/docs/book/src/forc/manifest_reference.md
@@ -91,12 +91,12 @@ name = "wallet_contract"
 
 [build-profile.debug]
 print-asm = { virtual = false, allocated = false, final = true }
-print-ir = false
+print-ir = { initial = false, final = true, modified = false, passes = []}
 terse = false
 
 [build-profile.release]
 print-asm = { virtual = true, allocated = false, final = true }
-print-ir = false
+print-ir = { initial = true, final = false, modified = true, passes = ["dce", "sroa"]}
 terse = true
 ```
 
@@ -106,7 +106,7 @@ Note that providing the corresponding CLI options (like `--asm`) will override t
 
 ```toml
 print-ast = false
-print-ir = false
+print-ir = { initial = false, final = false, modified = false, passes = []}
 print-asm = { virtual = true, allocated = true, final = true }
 terse = false
 time-phases = false

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -454,17 +454,17 @@ Common optimizations include constant folding, dead code elimination, and loop o
 The optimization passes are organized as different pass groups inside a [`PassManager (sway-ir/src/pass_manager.rs)`](https://github.com/FuelLabs/sway/blob/6c21a39bea6807b30e5c0ffc4aa5b8db5a0b675b/sway-ir/src/pass_manager.rs#L145), and setup in [`compile_ast_to_ir_to_asm (sway-core/src/lib.rs)`](https://github.com/FuelLabs/sway/blob/6c21a39bea6807b30e5c0ffc4aa5b8db5a0b675b/sway-core/src/lib.rs#L902):
 
 ```rust
-        pass_group.append_pass(CONSTDEMOTION_NAME);
-        pass_group.append_pass(ARGDEMOTION_NAME);
-        pass_group.append_pass(RETDEMOTION_NAME);
-        pass_group.append_pass(MISCDEMOTION_NAME);
+        pass_group.append_pass(CONST_DEMOTION_NAME);
+        pass_group.append_pass(ARG_DEMOTION_NAME);
+        pass_group.append_pass(RET_DEMOTION_NAME);
+        pass_group.append_pass(MISC_DEMOTION_NAME);
 
         // Convert loads and stores to mem_copies where possible.
         pass_group.append_pass(MEMCPYOPT_NAME);
 
         // Run a DCE and simplify-cfg to clean up any obsolete instructions.
         pass_group.append_pass(DCE_NAME);
-        pass_group.append_pass(SIMPLIFYCFG_NAME);
+        pass_group.append_pass(SIMPLIFY_CFG_NAME);
 
         match build_config.optimization_level {
             OptLevel::Opt1 => {

--- a/forc-pkg/src/manifest/build_profile.rs
+++ b/forc-pkg/src/manifest/build_profile.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use sway_core::{OptLevel, PrintAsm};
+use sway_core::{OptLevel, PrintAsm, PrintIr};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -18,7 +18,7 @@ pub struct BuildProfile {
     pub print_dca_graph: Option<String>,
     pub print_dca_graph_url_format: Option<String>,
     #[serde(default)]
-    pub print_ir: bool,
+    pub print_ir: PrintIr,
     #[serde(default)]
     pub print_asm: PrintAsm,
     #[serde(default)]
@@ -54,7 +54,7 @@ impl BuildProfile {
             print_ast: false,
             print_dca_graph: None,
             print_dca_graph_url_format: None,
-            print_ir: false,
+            print_ir: PrintIr::default(),
             print_asm: PrintAsm::default(),
             print_bytecode: false,
             terse: false,
@@ -77,7 +77,7 @@ impl BuildProfile {
             print_ast: false,
             print_dca_graph: None,
             print_dca_graph_url_format: None,
-            print_ir: false,
+            print_ir: PrintIr::default(),
             print_asm: PrintAsm::default(),
             print_bytecode: false,
             terse: false,
@@ -103,34 +103,53 @@ impl Default for BuildProfile {
 
 #[cfg(test)]
 mod tests {
-    use sway_core::{OptLevel, PrintAsm};
+    use sway_core::{OptLevel, PrintAsm, PrintIr};
 
     use crate::{manifest::build_profile::ExperimentalFlags, BuildProfile, PackageManifest};
 
     #[test]
-    fn test_build_profile_custom_release_section() {
+    fn test_build_profiles() {
         let manifest = PackageManifest::from_dir("./tests/sections").expect("manifest");
         let build_profiles = manifest.build_profile.expect("build profile");
-        assert_eq!(build_profiles.len(), 3);
+        assert_eq!(build_profiles.len(), 4);
 
+        // Standard debug profile without adaptations.
         let expected = BuildProfile::debug();
         let profile = build_profiles.get("debug").expect("debug profile");
         assert_eq!(*profile, expected);
 
+        // Profile based on debug profile with adjusted ASM printing options.
         let expected = BuildProfile {
             name: "".into(),
             print_asm: PrintAsm::r#final(),
             ..BuildProfile::debug()
         };
-        let profile = build_profiles.get("custom").expect("custom profile");
+        let profile = build_profiles.get("custom_asm").expect("custom profile");
         assert_eq!(*profile, expected);
 
+        // Profile based on debug profile with adjusted IR printing options.
+        let expected = BuildProfile {
+            name: "".into(),
+            print_ir: PrintIr {
+                initial: true,
+                r#final: false,
+                modified_only: true,
+                passes: vec!["dce".to_string(), "sroa".to_string()],
+            },
+            ..BuildProfile::debug()
+        };
+        let profile = build_profiles
+            .get("custom_ir")
+            .expect("custom profile for IR");
+        assert_eq!(*profile, expected);
+
+        // Adapted release profile.
         let expected = BuildProfile {
             name: "".into(),
             print_ast: true,
             print_dca_graph: Some("dca_graph".into()),
             print_dca_graph_url_format: Some("print_dca_graph_url_format".into()),
-            print_ir: true,
+            print_ir: PrintIr::r#final(),
             print_asm: PrintAsm::all(),
             print_bytecode: true,
             terse: true,

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -31,7 +31,6 @@ use std::{
     str::FromStr,
     sync::{atomic::AtomicBool, Arc},
 };
-use sway_core::PrintAsm;
 pub use sway_core::Programs;
 use sway_core::{
     abi_generation::{
@@ -50,6 +49,7 @@ use sway_core::{
     transform::AttributeKind,
     write_dwarf, BuildTarget, Engines, FinalizedEntry, LspConfig,
 };
+use sway_core::{PrintAsm, PrintIr};
 use sway_error::{error::CompileError, handler::Handler, warning::CompileWarning};
 use sway_types::constants::{CORE, PRELUDE, STD};
 use sway_types::{Ident, Span, Spanned};
@@ -263,7 +263,7 @@ pub struct PrintOpts {
     /// Print the bytecode. This is the final output of the compiler.
     pub bytecode: bool,
     /// Print the generated Sway IR (Intermediate Representation).
-    pub ir: bool,
+    pub ir: PrintIr,
     /// Output build errors and warnings in reverse order.
     pub reverse_order: bool,
 }
@@ -1550,7 +1550,7 @@ pub fn sway_build_config(
     .with_print_dca_graph_url_format(build_profile.print_dca_graph_url_format.clone())
     .with_print_asm(build_profile.print_asm)
     .with_print_bytecode(build_profile.print_bytecode)
-    .with_print_ir(build_profile.print_ir)
+    .with_print_ir(build_profile.print_ir.clone())
     .with_include_tests(build_profile.include_tests)
     .with_time_phases(build_profile.time_phases)
     .with_metrics(build_profile.metrics_outfile.clone())
@@ -2070,7 +2070,7 @@ fn build_profile_from_opts(
             .print_dca_graph_url_format
             .clone_from(&print.dca_graph_url_format);
     }
-    profile.print_ir |= print.ir;
+    profile.print_ir |= print.ir.clone();
     profile.print_asm |= print.asm;
     profile.print_bytecode |= print.bytecode;
     profile.terse |= pkg.terse;

--- a/forc-pkg/tests/sections/Forc.toml
+++ b/forc-pkg/tests/sections/Forc.toml
@@ -10,7 +10,7 @@ name = "sections"
 print-ast = true
 print-dca-graph = "dca_graph"
 print-dca-graph-url-format = "print_dca_graph_url_format"
-print-ir = true
+print-ir = { initial = false, final = true, modified = true, passes = []}
 print-asm = { virtual = true, allocated = true, final = true }
 print-bytecode = true
 terse = true
@@ -23,5 +23,8 @@ reverse-results = true
 optimization-level = 0
 experimental = { new-encoding = true }
 
-[build-profile.custom]
+[build-profile.custom_asm]
 print-asm = { virtual = false, allocated = false, final = true }
+
+[build-profile.custom_ir]
+print-ir = { initial = true, final = false, modified = true, passes = ["dce", "sroa"]}

--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -353,7 +353,7 @@ fn build_opts_from_cmd(cmd: &cmd::Deploy) -> pkg::BuildOpts {
             dca_graph_url_format: cmd.print.dca_graph_url_format.clone(),
             asm: cmd.print.asm(),
             bytecode: cmd.print.bytecode,
-            ir: cmd.print.ir,
+            ir: cmd.print.ir(),
             reverse_order: cmd.print.reverse_order,
         },
         time_phases: cmd.print.time_phases,

--- a/forc-plugins/forc-client/src/op/run/mod.rs
+++ b/forc-plugins/forc-client/src/op/run/mod.rs
@@ -222,7 +222,7 @@ fn build_opts_from_cmd(cmd: &cmd::Run) -> pkg::BuildOpts {
             dca_graph_url_format: cmd.print.dca_graph_url_format.clone(),
             asm: cmd.print.asm(),
             bytecode: cmd.print.bytecode,
-            ir: cmd.print.ir,
+            ir: cmd.print.ir(),
             reverse_order: cmd.print.reverse_order,
         },
         minify: pkg::MinifyOpts {

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -34,6 +34,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.73"
 sway-core = { version = "0.58.0", path = "../sway-core" }
 sway-error = { version = "0.58.0", path = "../sway-error" }
+sway-ir = { version = "0.58.0", path = "../sway-ir" }
 sway-types = { version = "0.58.0", path = "../sway-types" }
 sway-utils = { version = "0.58.0", path = "../sway-utils" }
 term-table = "1.3"

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -236,7 +236,7 @@ fn opts_from_cmd(cmd: Command) -> forc_test::TestOpts {
             dca_graph_url_format: cmd.build.print.dca_graph_url_format.clone(),
             asm: cmd.build.print.asm(),
             bytecode: cmd.build.print.bytecode,
-            ir: cmd.build.print.ir,
+            ir: cmd.build.print.ir(),
             reverse_order: cmd.build.print.reverse_order,
         },
         time_phases: cmd.build.print.time_phases,

--- a/forc/src/ops/forc_build.rs
+++ b/forc/src/ops/forc_build.rs
@@ -26,7 +26,7 @@ fn opts_from_cmd(cmd: BuildCommand) -> pkg::BuildOpts {
             dca_graph_url_format: cmd.build.print.dca_graph_url_format.clone(),
             asm: cmd.build.print.asm(),
             bytecode: cmd.build.print.bytecode,
-            ir: cmd.build.print.ir,
+            ir: cmd.build.print.ir(),
             reverse_order: cmd.build.print.reverse_order,
         },
         time_phases: cmd.build.print.time_phases,

--- a/forc/src/ops/forc_contract_id.rs
+++ b/forc/src/ops/forc_contract_id.rs
@@ -61,7 +61,7 @@ fn build_opts_from_cmd(cmd: &ContractIdCommand) -> pkg::BuildOpts {
             dca_graph_url_format: cmd.print.dca_graph_url_format.clone(),
             asm: cmd.print.asm(),
             bytecode: cmd.print.bytecode,
-            ir: cmd.print.ir,
+            ir: cmd.print.ir(),
             reverse_order: cmd.print.reverse_order,
         },
         time_phases: cmd.print.time_phases,

--- a/forc/src/ops/forc_predicate_root.rs
+++ b/forc/src/ops/forc_predicate_root.rs
@@ -30,7 +30,7 @@ fn build_opts_from_cmd(cmd: PredicateRootCommand) -> pkg::BuildOpts {
             dca_graph_url_format: cmd.print.dca_graph_url_format.clone(),
             asm: cmd.print.asm(),
             bytecode: cmd.print.bytecode,
-            ir: cmd.print.ir,
+            ir: cmd.print.ir(),
             reverse_order: cmd.print.reverse_order,
         },
         time_phases: cmd.print.time_phases,

--- a/sway-core/src/lib.rs
+++ b/sway-core/src/lib.rs
@@ -28,7 +28,7 @@ use crate::source_map::SourceMap;
 pub use asm_generation::from_ir::compile_ir_to_asm;
 use asm_generation::FinalizedAsm;
 pub use asm_generation::{CompiledBytecode, FinalizedEntry};
-pub use build_config::{BuildConfig, BuildTarget, LspConfig, OptLevel, PrintAsm};
+pub use build_config::{BuildConfig, BuildTarget, LspConfig, OptLevel, PrintAsm, PrintIr};
 use control_flow_analysis::ControlFlowGraph;
 pub use debug_generation::write_dwarf;
 use indexmap::IndexMap;
@@ -43,9 +43,9 @@ use sway_ast::AttributeDecl;
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_ir::{
     create_o1_pass_group, register_known_passes, Context, Kind, Module, PassGroup, PassManager,
-    ARGDEMOTION_NAME, CONSTDEMOTION_NAME, DCE_NAME, FNDEDUP_DEBUG_PROFILE_NAME, FUNC_DCE_NAME,
-    INLINE_MODULE_NAME, MEM2REG_NAME, MEMCPYOPT_NAME, MISCDEMOTION_NAME, MODULEPRINTER_NAME,
-    RETDEMOTION_NAME, SIMPLIFYCFG_NAME, SROA_NAME,
+    PrintPassesOpts, ARG_DEMOTION_NAME, CONST_DEMOTION_NAME, DCE_NAME, FN_DCE_NAME,
+    FN_DEDUP_DEBUG_PROFILE_NAME, FN_INLINE_NAME, MEM2REG_NAME, MEMCPYOPT_NAME, MISC_DEMOTION_NAME,
+    RET_DEMOTION_NAME, SIMPLIFY_CFG_NAME, SROA_NAME,
 };
 use sway_types::constants::DOC_COMMENT_ATTRIBUTE_NAME;
 use sway_types::SourceEngine;
@@ -881,14 +881,14 @@ pub(crate) fn compile_ast_to_ir_to_asm(
         }
         OptLevel::Opt0 => {
             // Inlining is necessary until #4899 is resolved.
-            pass_group.append_pass(INLINE_MODULE_NAME);
+            pass_group.append_pass(FN_INLINE_NAME);
 
             // We run a function deduplication pass that only removes duplicate
             // functions when everything, including the metadata are identical.
-            pass_group.append_pass(FNDEDUP_DEBUG_PROFILE_NAME);
+            pass_group.append_pass(FN_DEDUP_DEBUG_PROFILE_NAME);
 
             // Do DCE so other optimizations run faster.
-            pass_group.append_pass(FUNC_DCE_NAME);
+            pass_group.append_pass(FN_DCE_NAME);
             pass_group.append_pass(DCE_NAME);
         }
     }
@@ -899,17 +899,17 @@ pub(crate) fn compile_ast_to_ir_to_asm(
         //
         // Demote large by-value constants, arguments and return values to by-reference values
         // using temporaries.
-        pass_group.append_pass(CONSTDEMOTION_NAME);
-        pass_group.append_pass(ARGDEMOTION_NAME);
-        pass_group.append_pass(RETDEMOTION_NAME);
-        pass_group.append_pass(MISCDEMOTION_NAME);
+        pass_group.append_pass(CONST_DEMOTION_NAME);
+        pass_group.append_pass(ARG_DEMOTION_NAME);
+        pass_group.append_pass(RET_DEMOTION_NAME);
+        pass_group.append_pass(MISC_DEMOTION_NAME);
 
         // Convert loads and stores to mem_copies where possible.
         pass_group.append_pass(MEMCPYOPT_NAME);
 
         // Run a DCE and simplify-cfg to clean up any obsolete instructions.
         pass_group.append_pass(DCE_NAME);
-        pass_group.append_pass(SIMPLIFYCFG_NAME);
+        pass_group.append_pass(SIMPLIFY_CFG_NAME);
 
         match build_config.optimization_level {
             OptLevel::Opt1 => {
@@ -921,19 +921,17 @@ pub(crate) fn compile_ast_to_ir_to_asm(
         }
     }
 
-    if build_config.print_ir {
-        pass_group.append_pass(MODULEPRINTER_NAME);
-    }
-
     // Run the passes.
-    let res = if let Err(ir_error) = pass_mgr.run(&mut ir, &pass_group) {
-        Err(handler.emit_err(CompileError::InternalOwned(
-            ir_error.to_string(),
-            span::Span::dummy(),
-        )))
-    } else {
-        Ok(())
-    };
+    let print_passes_opts: PrintPassesOpts = (&build_config.print_ir).into();
+    let res =
+        if let Err(ir_error) = pass_mgr.run_with_print(&mut ir, &pass_group, &print_passes_opts) {
+            Err(handler.emit_err(CompileError::InternalOwned(
+                ir_error.to_string(),
+                span::Span::dummy(),
+            )))
+        } else {
+            Ok(())
+        };
     res?;
 
     let final_asm = compile_ir_to_asm(handler, &ir, Some(build_config))?;

--- a/sway-ir/src/analysis/dominator.rs
+++ b/sway-ir/src/analysis/dominator.rs
@@ -198,12 +198,12 @@ fn compute_dom_tree(
     Ok(Box::new(dom_tree))
 }
 
-pub const DOMFRONTS_NAME: &str = "dominance_frontiers";
+pub const DOM_FRONTS_NAME: &str = "dominance-frontiers";
 
 pub fn create_dom_fronts_pass() -> Pass {
     Pass {
-        name: DOMFRONTS_NAME,
-        descr: "Dominator frontiers computation",
+        name: DOM_FRONTS_NAME,
+        descr: "Dominance frontiers computation",
         deps: vec![DOMINATORS_NAME],
         runner: ScopedPass::FunctionPass(PassMutability::Analysis(compute_dom_fronts)),
     }

--- a/sway-ir/src/analysis/memory_utils.rs
+++ b/sway-ir/src/analysis/memory_utils.rs
@@ -12,12 +12,12 @@ use crate::{
     Value, ValueDatum,
 };
 
-pub const ESCAPED_SYMBOLS_NAME: &str = "escaped_symbols";
+pub const ESCAPED_SYMBOLS_NAME: &str = "escaped-symbols";
 
 pub fn create_escaped_symbols_pass() -> Pass {
     Pass {
         name: ESCAPED_SYMBOLS_NAME,
-        descr: "Symbols that escape / cannot be analysed",
+        descr: "Symbols that escape or cannot be analyzed",
         deps: vec![],
         runner: ScopedPass::FunctionPass(PassMutability::Analysis(compute_escaped_symbols_pass)),
     }

--- a/sway-ir/src/bin/opt.rs
+++ b/sway-ir/src/bin/opt.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::anyhow;
 use sway_ir::{
     insert_after_each, register_known_passes, ExperimentalFlags, PassGroup, PassManager,
-    MODULEPRINTER_NAME, MODULEVERIFIER_NAME,
+    MODULE_PRINTER_NAME, MODULE_VERIFIER_NAME,
 };
 use sway_types::SourceEngine;
 
@@ -40,10 +40,10 @@ fn main() -> Result<(), anyhow::Error> {
         passes.append_pass(pass);
     }
     if config.print_after_each {
-        passes = insert_after_each(passes, MODULEPRINTER_NAME);
+        passes = insert_after_each(passes, MODULE_PRINTER_NAME);
     }
     if config.verify_after_each {
-        passes = insert_after_each(passes, MODULEVERIFIER_NAME);
+        passes = insert_after_each(passes, MODULE_VERIFIER_NAME);
     }
     pass_mgr.run(&mut ir, &passes)?;
 

--- a/sway-ir/src/optimize.rs
+++ b/sway-ir/src/optimize.rs
@@ -54,7 +54,7 @@ pub mod tests {
     ///
     /// ```rust, ignore
     /// assert_optimization(
-    ///     &["constcombine"],
+    ///     &[CONST_FOLDING_NAME],
     ///     "entry fn main() -> u64 {
     ///        entry():
     ///             l = const u64 1

--- a/sway-ir/src/optimize/README.md
+++ b/sway-ir/src/optimize/README.md
@@ -1,0 +1,13 @@
+# IR Optimization Passes
+
+Optimization passes are a part of the compiler interface. They can be specified in build configs via their names and their description can be in the compiler output.
+
+To keep the passes consistent in appearance and simple to use from CLI and in build configs, we follow these conventions:
+- ideally, if there is an equivalent [LLVM transform pass](https://llvm.org/docs/Passes.html) we take that pass name and short description, but considering the below points.
+- use established abbreviations to make pass names short and simple to type. E.g., "fn", "const", "sroa".
+- use kebab-case in pass names. E.g., "const-demotion" and not "constdemotion".
+- explain passes as nouns in descriptions. E.g., "Function inlining" and not "Inline function".
+- the pass description does not end with a dot. E.g., "Constant folding" and not "Constant folding."
+- the pass description does not use abbreviations. E.g., "Constant folding" and not "Const folding."
+
+For the sake of our internal consistency, we apply the same conventions to the utility passes like e.g., module printer, and to analysis passes like e.g., escaped symbols.

--- a/sway-ir/src/optimize/arg_demotion.rs
+++ b/sway-ir/src/optimize/arg_demotion.rs
@@ -9,12 +9,12 @@ use crate::{
 
 use rustc_hash::FxHashMap;
 
-pub const ARGDEMOTION_NAME: &str = "argdemotion";
+pub const ARG_DEMOTION_NAME: &str = "arg-demotion";
 
 pub fn create_arg_demotion_pass() -> Pass {
     Pass {
-        name: ARGDEMOTION_NAME,
-        descr: "By-value function argument demotion to by-reference.",
+        name: ARG_DEMOTION_NAME,
+        descr: "Demotion of by-value function arguments to by-reference",
         deps: Vec::new(),
         runner: ScopedPass::FunctionPass(PassMutability::Transform(arg_demotion)),
     }

--- a/sway-ir/src/optimize/const_demotion.rs
+++ b/sway-ir/src/optimize/const_demotion.rs
@@ -13,12 +13,12 @@ use crate::{
 use rustc_hash::FxHashMap;
 use sway_types::FxIndexMap;
 
-pub const CONSTDEMOTION_NAME: &str = "constdemotion";
+pub const CONST_DEMOTION_NAME: &str = "const-demotion";
 
 pub fn create_const_demotion_pass() -> Pass {
     Pass {
-        name: CONSTDEMOTION_NAME,
-        descr: "By-value constant demotion to by-reference.",
+        name: CONST_DEMOTION_NAME,
+        descr: "Demotion of by-value constants to by-reference",
         deps: Vec::new(),
         runner: ScopedPass::FunctionPass(PassMutability::Transform(const_demotion)),
     }

--- a/sway-ir/src/optimize/constants.rs
+++ b/sway-ir/src/optimize/constants.rs
@@ -1,8 +1,4 @@
 //! Optimization passes for manipulating constant values.
-//!
-//! - combining - compile time evaluation of constant expressions.
-//!   - combine insert_values - reduce expressions which insert a constant value into a constant
-//!     struct.
 
 use crate::{
     constant::{Constant, ConstantValue},
@@ -14,19 +10,19 @@ use crate::{
     AnalysisResults, BranchToWithArgs, Instruction, Pass, PassMutability, Predicate, ScopedPass,
 };
 
-pub const CONSTCOMBINE_NAME: &str = "constcombine";
+pub const CONST_FOLDING_NAME: &str = "const-folding";
 
-pub fn create_const_combine_pass() -> Pass {
+pub fn create_const_folding_pass() -> Pass {
     Pass {
-        name: CONSTCOMBINE_NAME,
-        descr: "constant folding.",
+        name: CONST_FOLDING_NAME,
+        descr: "Constant folding",
         deps: vec![],
-        runner: ScopedPass::FunctionPass(PassMutability::Transform(combine_constants)),
+        runner: ScopedPass::FunctionPass(PassMutability::Transform(fold_constants)),
     }
 }
 
 /// Find constant expressions which can be reduced to fewer operations.
-pub fn combine_constants(
+pub fn fold_constants(
     context: &mut Context,
     _: &AnalysisResults,
     function: Function,
@@ -282,7 +278,7 @@ fn combine_unary_op(context: &mut Context, function: &Function) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::optimize::tests::*;
+    use crate::{optimize::tests::*, CONST_FOLDING_NAME};
 
     fn assert_operator(t: &str, opcode: &str, l: &str, r: Option<&str>, result: Option<&str>) {
         let expected = result.map(|result| format!("v0 = const {t} {result}"));
@@ -300,7 +296,7 @@ mod tests {
             r_inst = r.map_or("".into(), |r| format!("r = const {t} {r}")),
             result_inst = r.map_or("", |_| " r,")
         );
-        assert_optimization(&["constcombine"], &body, expected);
+        assert_optimization(&[CONST_FOLDING_NAME], &body, expected);
     }
 
     #[test]
@@ -360,7 +356,7 @@ mod tests {
 
         // `sub 1` is used to guarantee that the assert string is unique
         assert_optimization(
-            &["constcombine"],
+            &[CONST_FOLDING_NAME],
             "
         entry fn main() -> u64 {
             entry():
@@ -377,7 +373,7 @@ mod tests {
 
         // Binary Operators
         assert_optimization(
-            &["constcombine"],
+            &[CONST_FOLDING_NAME],
             "
         entry fn main() -> u64 {
             entry():

--- a/sway-ir/src/optimize/dce.rs
+++ b/sway-ir/src/optimize/dce.rs
@@ -20,20 +20,20 @@ pub const DCE_NAME: &str = "dce";
 pub fn create_dce_pass() -> Pass {
     Pass {
         name: DCE_NAME,
-        descr: "Dead code elimination.",
+        descr: "Dead code elimination",
         runner: ScopedPass::FunctionPass(PassMutability::Transform(dce)),
         deps: vec![ESCAPED_SYMBOLS_NAME],
     }
 }
 
-pub const FUNC_DCE_NAME: &str = "func_dce";
+pub const FN_DCE_NAME: &str = "fn-dce";
 
-pub fn create_func_dce_pass() -> Pass {
+pub fn create_fn_dce_pass() -> Pass {
     Pass {
-        name: FUNC_DCE_NAME,
-        descr: "Dead function elimination.",
+        name: FN_DCE_NAME,
+        descr: "Dead function elimination",
         deps: vec![],
-        runner: ScopedPass::ModulePass(PassMutability::Transform(func_dce)),
+        runner: ScopedPass::ModulePass(PassMutability::Transform(fn_dce)),
     }
 }
 
@@ -215,11 +215,7 @@ pub fn dce(
 ///
 /// Functions which are `pub` will not be removed and only functions within the passed [`Module`]
 /// are considered for removal.
-pub fn func_dce(
-    context: &mut Context,
-    _: &AnalysisResults,
-    module: Module,
-) -> Result<bool, IrError> {
+pub fn fn_dce(context: &mut Context, _: &AnalysisResults, module: Module) -> Result<bool, IrError> {
     let entry_fns = module
         .function_iter(context)
         .filter(|func| func.is_entry(context) || func.is_fallback(context))

--- a/sway-ir/src/optimize/fn_dedup.rs
+++ b/sway-ir/src/optimize/fn_dedup.rs
@@ -17,24 +17,24 @@ use crate::{
     Value,
 };
 
-pub const FNDEDUP_DEBUG_PROFILE_NAME: &str = "fndedup-debug-profile";
-pub const FNDEDUP_RELEASE_PROFILE_NAME: &str = "fndedup-release-profile";
+pub const FN_DEDUP_DEBUG_PROFILE_NAME: &str = "fn-dedup-debug";
+pub const FN_DEDUP_RELEASE_PROFILE_NAME: &str = "fn-dedup-release";
 
 pub fn create_fn_dedup_release_profile_pass() -> Pass {
     Pass {
-        name: FNDEDUP_RELEASE_PROFILE_NAME,
-        descr: "Deduplicate functions, ignore metadata",
+        name: FN_DEDUP_RELEASE_PROFILE_NAME,
+        descr: "Function deduplication with metadata ignored",
         deps: vec![],
-        runner: ScopedPass::ModulePass(PassMutability::Transform(dedup_fns_release_profile)),
+        runner: ScopedPass::ModulePass(PassMutability::Transform(dedup_fn_release_profile)),
     }
 }
 
 pub fn create_fn_dedup_debug_profile_pass() -> Pass {
     Pass {
-        name: FNDEDUP_DEBUG_PROFILE_NAME,
-        descr: "Deduplicate functions, consider metadata also",
+        name: FN_DEDUP_DEBUG_PROFILE_NAME,
+        descr: "Function deduplication with metadata considered",
         deps: vec![],
-        runner: ScopedPass::ModulePass(PassMutability::Transform(dedup_fns_debug_profile)),
+        runner: ScopedPass::ModulePass(PassMutability::Transform(dedup_fn_debug_profile)),
     }
 }
 
@@ -335,7 +335,7 @@ pub fn dedup_fns(
     Ok(modified)
 }
 
-fn dedup_fns_debug_profile(
+fn dedup_fn_debug_profile(
     context: &mut Context,
     analysis_results: &AnalysisResults,
     module: Module,
@@ -343,7 +343,7 @@ fn dedup_fns_debug_profile(
     dedup_fns(context, analysis_results, module, false)
 }
 
-fn dedup_fns_release_profile(
+fn dedup_fn_release_profile(
     context: &mut Context,
     analysis_results: &AnalysisResults,
     module: Module,

--- a/sway-ir/src/optimize/inline.rs
+++ b/sway-ir/src/optimize/inline.rs
@@ -21,14 +21,14 @@ use crate::{
     AnalysisResults, BlockArgument, Instruction, Module, Pass, PassMutability, ScopedPass,
 };
 
-pub const INLINE_MODULE_NAME: &str = "inline_module";
+pub const FN_INLINE_NAME: &str = "inline";
 
-pub fn create_inline_in_module_pass() -> Pass {
+pub fn create_fn_inline_pass() -> Pass {
     Pass {
-        name: INLINE_MODULE_NAME,
-        descr: "inline function calls in a module.",
+        name: FN_INLINE_NAME,
+        descr: "Function inlining",
         deps: vec![],
-        runner: ScopedPass::ModulePass(PassMutability::Transform(inline_in_module)),
+        runner: ScopedPass::ModulePass(PassMutability::Transform(fn_inline)),
     }
 }
 
@@ -72,7 +72,7 @@ fn metadata_to_inline(context: &Context, md_idx: Option<MetadataIndex>) -> Optio
     })
 }
 
-pub fn inline_in_module(
+pub fn fn_inline(
     context: &mut Context,
     _: &AnalysisResults,
     module: Module,

--- a/sway-ir/src/optimize/mem2reg.rs
+++ b/sway-ir/src/optimize/mem2reg.rs
@@ -11,7 +11,7 @@ use sway_utils::mapped_stack::MappedStack;
 use crate::{
     AnalysisResults, Block, BranchToWithArgs, Context, DomFronts, DomTree, Function, InstOp,
     Instruction, IrError, LocalVar, Pass, PassMutability, PostOrder, ScopedPass, Type, Value,
-    ValueDatum, DOMFRONTS_NAME, DOMINATORS_NAME, POSTORDER_NAME,
+    ValueDatum, DOMINATORS_NAME, DOM_FRONTS_NAME, POSTORDER_NAME,
 };
 
 pub const MEM2REG_NAME: &str = "mem2reg";
@@ -19,8 +19,8 @@ pub const MEM2REG_NAME: &str = "mem2reg";
 pub fn create_mem2reg_pass() -> Pass {
     Pass {
         name: MEM2REG_NAME,
-        descr: "Promote local memory to SSA registers.",
-        deps: vec![POSTORDER_NAME, DOMINATORS_NAME, DOMFRONTS_NAME],
+        descr: "Promotion of local memory to SSA registers",
+        deps: vec![POSTORDER_NAME, DOMINATORS_NAME, DOM_FRONTS_NAME],
         runner: ScopedPass::FunctionPass(PassMutability::Transform(promote_to_registers)),
     }
 }

--- a/sway-ir/src/optimize/memcpyopt.rs
+++ b/sway-ir/src/optimize/memcpyopt.rs
@@ -17,7 +17,7 @@ pub const MEMCPYOPT_NAME: &str = "memcpyopt";
 pub fn create_memcpyopt_pass() -> Pass {
     Pass {
         name: MEMCPYOPT_NAME,
-        descr: "Memcopy optimization.",
+        descr: "Optimizations related to MemCopy instructions",
         deps: vec![ESCAPED_SYMBOLS_NAME],
         runner: ScopedPass::FunctionPass(PassMutability::Transform(mem_copy_opt)),
     }

--- a/sway-ir/src/optimize/misc_demotion.rs
+++ b/sway-ir/src/optimize/misc_demotion.rs
@@ -19,12 +19,12 @@ use crate::{
 
 use rustc_hash::FxHashMap;
 
-pub const MISCDEMOTION_NAME: &str = "miscdemotion";
+pub const MISC_DEMOTION_NAME: &str = "misc-demotion";
 
 pub fn create_misc_demotion_pass() -> Pass {
     Pass {
-        name: MISCDEMOTION_NAME,
-        descr: "By-value miscellaneous demotion to by-reference.",
+        name: MISC_DEMOTION_NAME,
+        descr: "Miscellaneous by-value demotions to by-reference",
         deps: Vec::new(),
         runner: ScopedPass::FunctionPass(PassMutability::Transform(misc_demotion)),
     }

--- a/sway-ir/src/optimize/ret_demotion.rs
+++ b/sway-ir/src/optimize/ret_demotion.rs
@@ -10,12 +10,12 @@ use crate::{
     IrError, Pass, PassMutability, ScopedPass, Type, Value,
 };
 
-pub const RETDEMOTION_NAME: &str = "retdemotion";
+pub const RET_DEMOTION_NAME: &str = "ret-demotion";
 
 pub fn create_ret_demotion_pass() -> Pass {
     Pass {
-        name: RETDEMOTION_NAME,
-        descr: "By-value function return value demotion to by-reference.",
+        name: RET_DEMOTION_NAME,
+        descr: "Demotion of by-value function return values to by-reference",
         deps: Vec::new(),
         runner: ScopedPass::FunctionPass(PassMutability::Transform(ret_val_demotion)),
     }

--- a/sway-ir/src/optimize/simplify_cfg.rs
+++ b/sway-ir/src/optimize/simplify_cfg.rs
@@ -16,12 +16,12 @@ use crate::{
     PassMutability, ScopedPass, Value,
 };
 
-pub const SIMPLIFYCFG_NAME: &str = "simplifycfg";
+pub const SIMPLIFY_CFG_NAME: &str = "simplify-cfg";
 
 pub fn create_simplify_cfg_pass() -> Pass {
     Pass {
-        name: SIMPLIFYCFG_NAME,
-        descr: "merge or remove redundant blocks.",
+        name: SIMPLIFY_CFG_NAME,
+        descr: "Simplify the control flow graph (CFG)",
         deps: vec![],
         runner: ScopedPass::FunctionPass(PassMutability::Transform(simplify_cfg)),
     }

--- a/sway-ir/src/optimize/sroa.rs
+++ b/sway-ir/src/optimize/sroa.rs
@@ -13,7 +13,7 @@ pub const SROA_NAME: &str = "sroa";
 pub fn create_sroa_pass() -> Pass {
     Pass {
         name: SROA_NAME,
-        descr: "Scalar replacement of aggregates.",
+        descr: "Scalar replacement of aggregates",
         deps: vec![],
         runner: ScopedPass::FunctionPass(PassMutability::Transform(sroa)),
     }

--- a/sway-ir/src/pass_manager.rs
+++ b/sway-ir/src/pass_manager.rs
@@ -1,18 +1,20 @@
 use crate::{
-    create_arg_demotion_pass, create_const_combine_pass, create_const_demotion_pass,
+    create_arg_demotion_pass, create_const_demotion_pass, create_const_folding_pass,
     create_dce_pass, create_dom_fronts_pass, create_dominators_pass, create_escaped_symbols_pass,
-    create_fn_dedup_debug_profile_pass, create_fn_dedup_release_profile_pass, create_func_dce_pass,
-    create_inline_in_module_pass, create_mem2reg_pass, create_memcpyopt_pass,
-    create_misc_demotion_pass, create_module_printer_pass, create_module_verifier_pass,
-    create_postorder_pass, create_ret_demotion_pass, create_simplify_cfg_pass, create_sroa_pass,
-    Context, Function, IrError, Module, CONSTCOMBINE_NAME, DCE_NAME, FNDEDUP_RELEASE_PROFILE_NAME,
-    FUNC_DCE_NAME, INLINE_MODULE_NAME, MEM2REG_NAME, SIMPLIFYCFG_NAME,
+    create_fn_dce_pass, create_fn_dedup_debug_profile_pass, create_fn_dedup_release_profile_pass,
+    create_fn_inline_pass, create_mem2reg_pass, create_memcpyopt_pass, create_misc_demotion_pass,
+    create_module_printer_pass, create_module_verifier_pass, create_postorder_pass,
+    create_ret_demotion_pass, create_simplify_cfg_pass, create_sroa_pass, Context, Function,
+    IrError, Module, ARG_DEMOTION_NAME, CONST_DEMOTION_NAME, CONST_FOLDING_NAME, DCE_NAME,
+    FN_DCE_NAME, FN_DEDUP_DEBUG_PROFILE_NAME, FN_DEDUP_RELEASE_PROFILE_NAME, FN_INLINE_NAME,
+    MEM2REG_NAME, MEMCPYOPT_NAME, MISC_DEMOTION_NAME, RET_DEMOTION_NAME, SIMPLIFY_CFG_NAME,
+    SROA_NAME,
 };
 use downcast_rs::{impl_downcast, Downcast};
 use rustc_hash::FxHashMap;
 use std::{
     any::{type_name, TypeId},
-    collections::hash_map,
+    collections::{hash_map, HashSet},
 };
 
 /// Result of an analysis. Specific result must be downcasted to.
@@ -140,6 +142,20 @@ impl AnalysisResults {
     }
 }
 
+/// Options for printing [Pass]es in case of running them with printing requested.
+///
+/// Note that states of IR can always be printed by injecting the module printer pass
+/// and just running the passes. That approach however offers less control over the
+/// printing. E.g., requiring the printing to happen only if the previous passes
+/// modified the IR cannot be done by simply injecting a module printer.
+#[derive(Debug)]
+pub struct PrintPassesOpts {
+    pub initial: bool,
+    pub r#final: bool,
+    pub modified_only: bool,
+    pub passes: HashSet<String>,
+}
+
 #[derive(Default)]
 pub struct PassManager {
     passes: FxHashMap<&'static str, Pass>,
@@ -147,6 +163,23 @@ pub struct PassManager {
 }
 
 impl PassManager {
+    pub const OPTIMIZATION_PASSES: [&'static str; 14] = [
+        FN_INLINE_NAME,
+        SIMPLIFY_CFG_NAME,
+        SROA_NAME,
+        DCE_NAME,
+        FN_DCE_NAME,
+        FN_DEDUP_RELEASE_PROFILE_NAME,
+        FN_DEDUP_DEBUG_PROFILE_NAME,
+        MEM2REG_NAME,
+        MEMCPYOPT_NAME,
+        CONST_FOLDING_NAME,
+        ARG_DEMOTION_NAME,
+        CONST_DEMOTION_NAME,
+        RET_DEMOTION_NAME,
+        MISC_DEMOTION_NAME,
+    ];
+
     /// Register a pass. Should be called only once for each pass.
     pub fn register(&mut self, pass: Pass) -> &'static str {
         for dep in &pass.deps {
@@ -231,12 +264,64 @@ impl PassManager {
         Ok(modified)
     }
 
-    /// Run the passes specified in `config`.
+    /// Run the `passes` and return true if the `passes` modify the initial `ir`.
     pub fn run(&mut self, ir: &mut Context, passes: &PassGroup) -> Result<bool, IrError> {
         let mut modified = false;
         for pass in passes.flatten_pass_group() {
             modified |= self.actually_run(ir, pass)?;
         }
+        Ok(modified)
+    }
+
+    /// Run the `passes` and return true if the `passes` modify the initial `ir`.
+    /// The IR states are printed according to the printing options provided in `print_opts`.
+    pub fn run_with_print(
+        &mut self,
+        ir: &mut Context,
+        passes: &PassGroup,
+        print_opts: &PrintPassesOpts,
+    ) -> Result<bool, IrError> {
+        // Empty IRs are result of compiling dependencies. We don't want to print those.
+        fn ir_is_empty(ir: &Context) -> bool {
+            ir.functions.is_empty()
+                && ir.blocks.is_empty()
+                && ir.values.is_empty()
+                && ir.local_vars.is_empty()
+        }
+
+        fn print_ir_after_pass(ir: &Context, pass: &Pass) {
+            if !ir_is_empty(ir) {
+                println!("// IR: [{}] {}", pass.name, pass.descr);
+                println!("{ir}");
+            }
+        }
+
+        fn print_initial_or_final_ir(ir: &Context, initial_or_final: &'static str) {
+            if !ir_is_empty(ir) {
+                println!("// IR: {initial_or_final}");
+                println!("{ir}");
+            }
+        }
+
+        if print_opts.initial {
+            print_initial_or_final_ir(ir, "Initial");
+        }
+
+        let mut modified = false;
+        for pass in passes.flatten_pass_group() {
+            let modified_in_pass = self.actually_run(ir, pass)?;
+
+            if print_opts.passes.contains(pass) && (!print_opts.modified_only || modified_in_pass) {
+                print_ir_after_pass(ir, self.lookup_registered_pass(pass).unwrap());
+            }
+
+            modified |= modified_in_pass;
+        }
+
+        if print_opts.r#final {
+            print_initial_or_final_ir(ir, "Final");
+        }
+
         Ok(modified)
     }
 
@@ -309,10 +394,10 @@ pub fn register_known_passes(pm: &mut PassManager) {
     pm.register(create_fn_dedup_debug_profile_pass());
     pm.register(create_mem2reg_pass());
     pm.register(create_sroa_pass());
-    pm.register(create_inline_in_module_pass());
-    pm.register(create_const_combine_pass());
+    pm.register(create_fn_inline_pass());
+    pm.register(create_const_folding_pass());
     pm.register(create_simplify_cfg_pass());
-    pm.register(create_func_dce_pass());
+    pm.register(create_fn_dce_pass());
     pm.register(create_dce_pass());
     pm.register(create_arg_demotion_pass());
     pm.register(create_const_demotion_pass());
@@ -326,13 +411,13 @@ pub fn create_o1_pass_group() -> PassGroup {
     let mut o1 = PassGroup::default();
     // Configure to run our passes.
     o1.append_pass(MEM2REG_NAME);
-    o1.append_pass(INLINE_MODULE_NAME);
-    o1.append_pass(FNDEDUP_RELEASE_PROFILE_NAME);
-    o1.append_pass(CONSTCOMBINE_NAME);
-    o1.append_pass(SIMPLIFYCFG_NAME);
-    o1.append_pass(CONSTCOMBINE_NAME);
-    o1.append_pass(SIMPLIFYCFG_NAME);
-    o1.append_pass(FUNC_DCE_NAME);
+    o1.append_pass(FN_INLINE_NAME);
+    o1.append_pass(FN_DEDUP_RELEASE_PROFILE_NAME);
+    o1.append_pass(CONST_FOLDING_NAME);
+    o1.append_pass(SIMPLIFY_CFG_NAME);
+    o1.append_pass(CONST_FOLDING_NAME);
+    o1.append_pass(SIMPLIFY_CFG_NAME);
+    o1.append_pass(FN_DCE_NAME);
     o1.append_pass(DCE_NAME);
 
     o1

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -155,11 +155,11 @@ pub fn function_print(context: &Context, function: Function) {
     );
 }
 
-pub const MODULEPRINTER_NAME: &str = "module_printer";
+pub const MODULE_PRINTER_NAME: &str = "module-printer";
 
 pub fn create_module_printer_pass() -> Pass {
     Pass {
-        name: MODULEPRINTER_NAME,
+        name: MODULE_PRINTER_NAME,
         descr: "Print module to stdout",
         deps: vec![],
         runner: ScopedPass::ModulePass(PassMutability::Analysis(module_printer_pass)),

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -31,11 +31,11 @@ pub fn module_verifier(
     Ok(Box::new(ModuleVerifierResult))
 }
 
-pub const MODULEVERIFIER_NAME: &str = "module_verifier";
+pub const MODULE_VERIFIER_NAME: &str = "module-verifier";
 
 pub fn create_module_verifier_pass() -> Pass {
     Pass {
-        name: MODULEVERIFIER_NAME,
+        name: MODULE_VERIFIER_NAME,
         descr: "Verify module",
         deps: vec![],
         runner: ScopedPass::ModulePass(PassMutability::Analysis(module_verifier)),

--- a/sway-ir/tests/tests.rs
+++ b/sway-ir/tests/tests.rs
@@ -1,12 +1,12 @@
 use std::path::PathBuf;
 
 use sway_ir::{
-    create_arg_demotion_pass, create_const_combine_pass, create_const_demotion_pass,
+    create_arg_demotion_pass, create_const_demotion_pass, create_const_folding_pass,
     create_dce_pass, create_dom_fronts_pass, create_dominators_pass, create_escaped_symbols_pass,
     create_mem2reg_pass, create_memcpyopt_pass, create_misc_demotion_pass, create_postorder_pass,
     create_ret_demotion_pass, create_simplify_cfg_pass, optimize as opt, register_known_passes,
-    Context, ExperimentalFlags, PassGroup, PassManager, DCE_NAME, FNDEDUP_DEBUG_PROFILE_NAME,
-    FNDEDUP_RELEASE_PROFILE_NAME, FUNC_DCE_NAME, MEM2REG_NAME, SROA_NAME,
+    Context, ExperimentalFlags, PassGroup, PassManager, DCE_NAME, FN_DCE_NAME,
+    FN_DEDUP_DEBUG_PROFILE_NAME, FN_DEDUP_RELEASE_PROFILE_NAME, MEM2REG_NAME, SROA_NAME,
 };
 use sway_types::SourceEngine;
 
@@ -135,7 +135,7 @@ fn constants() {
     run_tests("constants", |_first_line, ir: &mut Context| {
         let mut pass_mgr = PassManager::default();
         let mut pass_group = PassGroup::default();
-        let pass = pass_mgr.register(create_const_combine_pass());
+        let pass = pass_mgr.register(create_const_folding_pass());
         pass_group.append_pass(pass);
         pass_mgr.run(ir, &pass_group).unwrap()
     })
@@ -283,8 +283,8 @@ fn fndedup_debug() {
         let mut pass_mgr = PassManager::default();
         let mut pass_group = PassGroup::default();
         register_known_passes(&mut pass_mgr);
-        pass_group.append_pass(FNDEDUP_DEBUG_PROFILE_NAME);
-        pass_group.append_pass(FUNC_DCE_NAME);
+        pass_group.append_pass(FN_DEDUP_DEBUG_PROFILE_NAME);
+        pass_group.append_pass(FN_DCE_NAME);
         pass_mgr.run(ir, &pass_group).unwrap()
     })
 }
@@ -296,8 +296,8 @@ fn fndedup_release() {
         let mut pass_mgr = PassManager::default();
         let mut pass_group = PassGroup::default();
         register_known_passes(&mut pass_mgr);
-        pass_group.append_pass(FNDEDUP_RELEASE_PROFILE_NAME);
-        pass_group.append_pass(FUNC_DCE_NAME);
+        pass_group.append_pass(FN_DEDUP_RELEASE_PROFILE_NAME);
+        pass_group.append_pass(FN_DCE_NAME);
         pass_mgr.run(ir, &pass_group).unwrap()
     })
 }

--- a/test/src/e2e_vm_tests/harness.rs
+++ b/test/src/e2e_vm_tests/harness.rs
@@ -277,7 +277,7 @@ pub(crate) async fn compile_to_bytes(file_name: &str, run_config: &RunConfig) ->
             dca_graph_url_format: None,
             asm: run_config.print_asm,
             bytecode: false,
-            ir: run_config.print_ir,
+            ir: run_config.print_ir.clone(),
             reverse_order: false,
         },
         pkg: forc_pkg::PkgOpts {

--- a/test/src/ir_generation/mod.rs
+++ b/test/src/ir_generation/mod.rs
@@ -14,9 +14,9 @@ use sway_core::{
 use sway_error::handler::Handler;
 
 use sway_ir::{
-    create_inline_in_module_pass, register_known_passes, ExperimentalFlags, PassGroup, PassManager,
-    ARGDEMOTION_NAME, CONSTDEMOTION_NAME, DCE_NAME, MEMCPYOPT_NAME, MISCDEMOTION_NAME,
-    RETDEMOTION_NAME,
+    create_fn_inline_pass, register_known_passes, ExperimentalFlags, PassGroup, PassManager,
+    ARG_DEMOTION_NAME, CONST_DEMOTION_NAME, DCE_NAME, MEMCPYOPT_NAME, MISC_DEMOTION_NAME,
+    RET_DEMOTION_NAME,
 };
 
 enum Checker {
@@ -301,10 +301,10 @@ pub(super) async fn run(
                     let mut pass_mgr = PassManager::default();
                     let mut pass_group = PassGroup::default();
                     register_known_passes(&mut pass_mgr);
-                    pass_group.append_pass(CONSTDEMOTION_NAME);
-                    pass_group.append_pass(ARGDEMOTION_NAME);
-                    pass_group.append_pass(RETDEMOTION_NAME);
-                    pass_group.append_pass(MISCDEMOTION_NAME);
+                    pass_group.append_pass(CONST_DEMOTION_NAME);
+                    pass_group.append_pass(ARG_DEMOTION_NAME);
+                    pass_group.append_pass(RET_DEMOTION_NAME);
+                    pass_group.append_pass(MISC_DEMOTION_NAME);
                     pass_group.append_pass(MEMCPYOPT_NAME);
                     pass_group.append_pass(DCE_NAME);
                     if pass_mgr.run(&mut ir, &pass_group).is_err() {
@@ -402,7 +402,7 @@ pub(super) async fn run(
                             if optimisation_inline {
                                 let mut pass_mgr = PassManager::default();
                                 let mut pmgr_config = PassGroup::default();
-                                let inline = pass_mgr.register(create_inline_in_module_pass());
+                                let inline = pass_mgr.register(create_fn_inline_pass());
                                 pmgr_config.append_pass(inline);
                                 let inline_res = pass_mgr.run(&mut ir, &pmgr_config);
                                 if inline_res.is_err() {


### PR DESCRIPTION
## Description

This PR:
- implements detailed control over printing of IR:
  - initial IR
  - IR after choosen optimization steps, with option to print only the steps that have actually modified the IR
  - final IR
- improves printed IRs by removing the confusing empty modules printed for every external library dependency.
- harmonizes names and descriptions of the optimization passes. The proposed convention is documented in the _sway-ir/src/optimize/README.md_ file.
- harmonizes help comments of the shared compiler options (consistent separation between option title and additional info, wording, etc.)

## Demo

```
'Print initial and final IR together with IR after each optimization step.
--ir all

'Print initial and final IR together with IR after each optimization step that has modified the IR.
--ir all modified

'Print only the final IR.
--ir final

'Print the IR after every "dce", "sroa", and "inline" optimization step.
--ir dce sroa inline

'Print the IR after every "dce", "sroa", and "inline" optimization step that has modified the IR.
--ir dce sroa inline modified
```

## Breaking Changes

### CLI

Instead of the existing `--ir` option without parameters we now have the same CLI option but with parameters. The existing `--ir` is equivalent to the new `--ir final`.

### Build Profile

Instead of the existing `print-ir` of type bool, we now have the same `print-ir` build profile option with parameters. E.g.:

```
print-ir = { initial = true, final = false, modified = true, passes = ["dce", "sroa"]}
```

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.