### PR TITLE
chore: use fuels-rs v0.62.0, fuel-abi-types v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,9 +576,6 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "cast"
@@ -2271,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "forc-wallet"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a20ec61c7c3a3f00e3f0144db7d62d47e928650f2da49648287c65869e9827"
+checksum = "01d7522f7f2cec4cc1748d58ca6a527b4734b79c8c171a506679fb4bb3e0ea3c"
 dependencies = [
  "anyhow",
  "clap 4.5.4",
@@ -2336,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-abi-types"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2351bb0b743c23ac13ac2559756b3929502cd6e29091f2e5302fb9a1bdddaf35"
+checksum = "ee6135cb6e12773a7abf7d6c3a8de6467dee86fcf7293720d33e33feb01dc6d8"
 dependencies = [
  "itertools 0.10.5",
  "lazy_static",
@@ -2690,9 +2687,9 @@ dependencies = [
 
 [[package]]
 name = "fuels"
-version = "0.60.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f6212d1e08a52222b7120d5a11f350720f5564f2dbf3b825619bd497fdf1bd"
+checksum = "8eeb6fa017c6d695cf4468d21c640857ba1c74d31fdac3277ad4414593a14a7b"
 dependencies = [
  "fuel-core-client",
  "fuel-crypto",
@@ -2706,9 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-accounts"
-version = "0.60.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf220a834d5425d3e54fe867035dafa5e5313358a505b04e48ecde460571bc0e"
+checksum = "0a55f3ba7346cb73a5565fd7b6ab2c0016be052863323ca076e6ac9fec719759"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2730,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
-version = "0.60.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0df90f02675a65a015a5c7ed86865acb9376b34cc93b2c58208f21286badb02"
+checksum = "8db288a46989c20bc48dee787008959a2a7c17061fe78cf4ae4c1263c80692e1"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -2746,9 +2743,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-version = "0.60.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be24620ea84d29b56537b21723c4db0853424d3e75599c0ff7f5eaa3ca96143b"
+checksum = "63d0abdc7230e4adb619a3735c237af545dcfdf86f4096b9d1daaf315838987e"
 dependencies = [
  "async-trait",
  "bech32",
@@ -2757,6 +2754,7 @@ dependencies = [
  "fuel-asm",
  "fuel-core-chain-config",
  "fuel-core-client",
+ "fuel-core-types",
  "fuel-crypto",
  "fuel-tx",
  "fuel-types",
@@ -2772,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-macros"
-version = "0.60.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5713fc740bf297647cdfbed4acc65796b2a3a6e7ab28b9498de3fc89d9b824"
+checksum = "9e137a52541dbd0345bf000301091b5266644fd4de04bb8238457c5c70b9ac4e"
 dependencies = [
  "fuels-code-gen",
  "itertools 0.12.1",
@@ -2786,12 +2784,11 @@ dependencies = [
 
 [[package]]
 name = "fuels-programs"
-version = "0.60.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcafe1b5372ed2b97c2550db28262016df80d78286eeb47e999c6bd3fa3a353a"
+checksum = "ada44df4a718da78add027d1204af8154265fc2f64b60cc28b1bba597df7e5d6"
 dependencies = [
  "async-trait",
- "bytes",
  "fuel-abi-types",
  "fuel-asm",
  "fuel-tx",
@@ -2806,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.60.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb2c6749b65cb6a0e6cfd24f140ed4792df0745195c2bceb2033ad5fefc162b"
+checksum = "f46d53ef79da8600d8ef580c0acc859be80b07eef0c9ddc19c61bb04b3cf4c15"
 dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,14 +45,14 @@ fuel-tx = "0.49.0"
 fuel-vm = "0.49.0"
 
 # Dependencies from the `fuels-rs` repository:
-fuels-core = "0.60.0"
-fuels-accounts = "0.60.0"
+fuels-core = "0.62.0"
+fuels-accounts = "0.62.0"
 
 # Dependencies from the `forc-wallet` repository:
-forc-wallet = "0.7.0"
+forc-wallet = "0.7.1"
 
 # Dependencies from the `fuel-abi-types` repository:
-fuel-abi-types = "0.4.0"
+fuel-abi-types = "0.5.0"
 
 [workspace.package]
 edition = "2021"

--- a/forc-plugins/forc-client/src/op/run/encode.rs
+++ b/forc-plugins/forc-client/src/op/run/encode.rs
@@ -1,9 +1,6 @@
 use crate::util::encode::{Token, Type};
 use fuel_abi_types::abi::full_program::FullProgramABI;
-use fuels_core::{
-    codec::{ABIEncoder, EncoderConfig},
-    types::unresolved_bytes::UnresolvedBytes,
-};
+use fuels_core::codec::{ABIEncoder, EncoderConfig};
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct ScriptCallHandler {
@@ -39,7 +36,7 @@ impl ScriptCallHandler {
     /// Encode the provided values with script's main argument types.
     ///
     /// Returns an error if the provided value count does not match the number of arguments.
-    pub(crate) fn encode_arguments(&self, values: &[&str]) -> anyhow::Result<UnresolvedBytes> {
+    pub(crate) fn encode_arguments(&self, values: &[&str]) -> anyhow::Result<Vec<u8>> {
         let main_arg_types = &self.main_arg_types;
         let expected_arg_count = main_arg_types.len();
         let provided_arg_count = values.len();
@@ -99,11 +96,7 @@ mod tests {
         let call_handler = ScriptCallHandler::from_json_abi_str(test_json_abi).unwrap();
         let values = ["2", "true"];
 
-        let test_data_offset = 0;
-        let encoded_bytes = call_handler
-            .encode_arguments(&values)
-            .unwrap()
-            .resolve(test_data_offset);
+        let encoded_bytes = call_handler.encode_arguments(&values).unwrap();
         let expected_bytes = vec![2u8, 1u8];
         assert_eq!(encoded_bytes, expected_bytes);
     }

--- a/forc-plugins/forc-client/src/op/run/mod.rs
+++ b/forc-plugins/forc-client/src/op/run/mod.rs
@@ -79,8 +79,7 @@ pub async fn run_pkg(
                 .ok_or_else(|| anyhow::anyhow!("Missing json abi string"))?;
             let main_arg_handler = ScriptCallHandler::from_json_abi_str(&package_json_abi)?;
             let args = args.iter().map(|arg| arg.as_str()).collect::<Vec<_>>();
-            let unresolved_bytes = main_arg_handler.encode_arguments(args.as_slice())?;
-            unresolved_bytes.resolve(0)
+            main_arg_handler.encode_arguments(args.as_slice())?
         }
         (Some(_), Some(_)) => {
             bail!("Both --args and --data provided, must choose one.")

--- a/forc-test/src/lib.rs
+++ b/forc-test/src/lib.rs
@@ -663,7 +663,7 @@ fn deployment_transaction(
 }
 
 pub fn decode_log_data(
-    log_id: u64,
+    log_id: &str,
     log_data: &[u8],
     program_abi: &ProgramABI,
 ) -> anyhow::Result<DecodedLog> {
@@ -683,7 +683,7 @@ pub fn decode_log_data(
         .logged_types
         .iter()
         .flatten()
-        .map(|logged_type| (logged_type.log_id, logged_type.application.clone()))
+        .map(|logged_type| (logged_type.log_id.as_str(), logged_type.application.clone()))
         .collect();
 
     let type_application = logged_type_lookup

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -155,7 +155,8 @@ fn print_tested_pkg(pkg: &TestedPackage, test_print_opts: &TestPrintOpts) -> For
                         ..
                     } = log
                     {
-                        let decoded_log_data = decode_log_data(*rb, data, &pkg.built.program_abi)?;
+                        let decoded_log_data =
+                            decode_log_data(&rb.to_string(), data, &pkg.built.program_abi)?;
                         let var_value = decoded_log_data.value;
                         info!("Decoded log value: {}, log rb: {}", var_value, rb);
                     }

--- a/sway-core/src/abi_generation/fuel_abi.rs
+++ b/sway-core/src/abi_generation/fuel_abi.rs
@@ -96,7 +96,7 @@ fn generate_logged_types(
         .logged_types
         .iter()
         .map(|(log_id, type_id)| program_abi::LoggedType {
-            log_id: **log_id as u64,
+            log_id: log_id.to_string(),
             application: program_abi::TypeApplication {
                 name: "".to_string(),
                 type_id: type_id.index(),

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -564,9 +564,12 @@ impl TestContext {
                                         ..
                                     } = log
                                     {
-                                        let decoded_log_data =
-                                            decode_log_data(*rb, data, &pkg.built.program_abi)
-                                                .unwrap();
+                                        let decoded_log_data = decode_log_data(
+                                            &rb.to_string(),
+                                            data,
+                                            &pkg.built.program_abi,
+                                        )
+                                        .unwrap();
                                         let var_value = decoded_log_data.value;
                                         if verbose {
                                             println!(

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
@@ -178,7 +178,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 0,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/logging/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/logging/json_abi_oracle_new_encoding.json
@@ -15,7 +15,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 6,
@@ -23,7 +23,7 @@
       }
     },
     {
-      "logId": 1,
+      "logId": "1",
       "loggedType": {
         "name": "",
         "type": 7,
@@ -37,7 +37,7 @@
       }
     },
     {
-      "logId": 2,
+      "logId": "2",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -45,7 +45,7 @@
       }
     },
     {
-      "logId": 3,
+      "logId": "3",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -53,7 +53,7 @@
       }
     },
     {
-      "logId": 4,
+      "logId": "4",
       "loggedType": {
         "name": "",
         "type": 5,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_various_types/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_various_types/json_abi_oracle.json
@@ -20,7 +20,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 1,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_various_types/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_various_types/json_abi_oracle_new_encoding.json
@@ -21,7 +21,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 1,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/smo/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/smo/json_abi_oracle.json
@@ -14,7 +14,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 7,
@@ -22,7 +22,7 @@
       }
     },
     {
-      "logId": 1,
+      "logId": "1",
       "loggedType": {
         "name": "",
         "type": 1,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/smo/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/smo/json_abi_oracle_new_encoding.json
@@ -15,7 +15,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 7,
@@ -23,7 +23,7 @@
       }
     },
     {
-      "logId": 1,
+      "logId": "1",
       "loggedType": {
         "name": "",
         "type": 1,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_abi/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_abi/json_abi_oracle_new_encoding.json
@@ -25,7 +25,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 0,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_eq/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_eq/json_abi_oracle_new_encoding.json
@@ -15,7 +15,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 12,
@@ -23,7 +23,7 @@
       }
     },
     {
-      "logId": 1,
+      "logId": "1",
       "loggedType": {
         "name": "",
         "type": 12,
@@ -31,7 +31,7 @@
       }
     },
     {
-      "logId": 2,
+      "logId": "2",
       "loggedType": {
         "name": "",
         "type": 11,
@@ -39,7 +39,7 @@
       }
     },
     {
-      "logId": 3,
+      "logId": "3",
       "loggedType": {
         "name": "",
         "type": 11,
@@ -47,7 +47,7 @@
       }
     },
     {
-      "logId": 4,
+      "logId": "4",
       "loggedType": {
         "name": "",
         "type": 10,
@@ -55,7 +55,7 @@
       }
     },
     {
-      "logId": 5,
+      "logId": "5",
       "loggedType": {
         "name": "",
         "type": 10,
@@ -63,7 +63,7 @@
       }
     },
     {
-      "logId": 6,
+      "logId": "6",
       "loggedType": {
         "name": "",
         "type": 13,
@@ -71,7 +71,7 @@
       }
     },
     {
-      "logId": 7,
+      "logId": "7",
       "loggedType": {
         "name": "",
         "type": 13,
@@ -79,7 +79,7 @@
       }
     },
     {
-      "logId": 8,
+      "logId": "8",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -87,7 +87,7 @@
       }
     },
     {
-      "logId": 9,
+      "logId": "9",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -95,7 +95,7 @@
       }
     },
     {
-      "logId": 10,
+      "logId": "10",
       "loggedType": {
         "name": "",
         "type": 5,
@@ -103,7 +103,7 @@
       }
     },
     {
-      "logId": 11,
+      "logId": "11",
       "loggedType": {
         "name": "",
         "type": 5,
@@ -111,7 +111,7 @@
       }
     },
     {
-      "logId": 12,
+      "logId": "12",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -119,7 +119,7 @@
       }
     },
     {
-      "logId": 13,
+      "logId": "13",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -127,7 +127,7 @@
       }
     },
     {
-      "logId": 14,
+      "logId": "14",
       "loggedType": {
         "name": "",
         "type": 7,
@@ -135,7 +135,7 @@
       }
     },
     {
-      "logId": 15,
+      "logId": "15",
       "loggedType": {
         "name": "",
         "type": 7,
@@ -143,7 +143,7 @@
       }
     },
     {
-      "logId": 16,
+      "logId": "16",
       "loggedType": {
         "name": "",
         "type": 6,
@@ -151,7 +151,7 @@
       }
     },
     {
-      "logId": 17,
+      "logId": "17",
       "loggedType": {
         "name": "",
         "type": 6,
@@ -159,7 +159,7 @@
       }
     },
     {
-      "logId": 18,
+      "logId": "18",
       "loggedType": {
         "name": "",
         "type": 3,
@@ -167,7 +167,7 @@
       }
     },
     {
-      "logId": 19,
+      "logId": "19",
       "loggedType": {
         "name": "",
         "type": 3,
@@ -175,7 +175,7 @@
       }
     },
     {
-      "logId": 20,
+      "logId": "20",
       "loggedType": {
         "name": "",
         "type": 3,
@@ -183,7 +183,7 @@
       }
     },
     {
-      "logId": 21,
+      "logId": "21",
       "loggedType": {
         "name": "",
         "type": 3,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_eq_revert/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_eq_revert/json_abi_oracle_new_encoding.json
@@ -15,7 +15,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -23,7 +23,7 @@
       }
     },
     {
-      "logId": 1,
+      "logId": "1",
       "loggedType": {
         "name": "",
         "type": 1,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/json_abi_oracle_new_encoding.json
@@ -15,7 +15,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 12,
@@ -23,7 +23,7 @@
       }
     },
     {
-      "logId": 1,
+      "logId": "1",
       "loggedType": {
         "name": "",
         "type": 12,
@@ -31,7 +31,7 @@
       }
     },
     {
-      "logId": 2,
+      "logId": "2",
       "loggedType": {
         "name": "",
         "type": 11,
@@ -39,7 +39,7 @@
       }
     },
     {
-      "logId": 3,
+      "logId": "3",
       "loggedType": {
         "name": "",
         "type": 11,
@@ -47,7 +47,7 @@
       }
     },
     {
-      "logId": 4,
+      "logId": "4",
       "loggedType": {
         "name": "",
         "type": 10,
@@ -55,7 +55,7 @@
       }
     },
     {
-      "logId": 5,
+      "logId": "5",
       "loggedType": {
         "name": "",
         "type": 10,
@@ -63,7 +63,7 @@
       }
     },
     {
-      "logId": 6,
+      "logId": "6",
       "loggedType": {
         "name": "",
         "type": 13,
@@ -71,7 +71,7 @@
       }
     },
     {
-      "logId": 7,
+      "logId": "7",
       "loggedType": {
         "name": "",
         "type": 13,
@@ -79,7 +79,7 @@
       }
     },
     {
-      "logId": 8,
+      "logId": "8",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -87,7 +87,7 @@
       }
     },
     {
-      "logId": 9,
+      "logId": "9",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -95,7 +95,7 @@
       }
     },
     {
-      "logId": 10,
+      "logId": "10",
       "loggedType": {
         "name": "",
         "type": 5,
@@ -103,7 +103,7 @@
       }
     },
     {
-      "logId": 11,
+      "logId": "11",
       "loggedType": {
         "name": "",
         "type": 5,
@@ -111,7 +111,7 @@
       }
     },
     {
-      "logId": 12,
+      "logId": "12",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -119,7 +119,7 @@
       }
     },
     {
-      "logId": 13,
+      "logId": "13",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -127,7 +127,7 @@
       }
     },
     {
-      "logId": 14,
+      "logId": "14",
       "loggedType": {
         "name": "",
         "type": 7,
@@ -135,7 +135,7 @@
       }
     },
     {
-      "logId": 15,
+      "logId": "15",
       "loggedType": {
         "name": "",
         "type": 7,
@@ -143,7 +143,7 @@
       }
     },
     {
-      "logId": 16,
+      "logId": "16",
       "loggedType": {
         "name": "",
         "type": 6,
@@ -151,7 +151,7 @@
       }
     },
     {
-      "logId": 17,
+      "logId": "17",
       "loggedType": {
         "name": "",
         "type": 6,
@@ -159,7 +159,7 @@
       }
     },
     {
-      "logId": 18,
+      "logId": "18",
       "loggedType": {
         "name": "",
         "type": 3,
@@ -167,7 +167,7 @@
       }
     },
     {
-      "logId": 19,
+      "logId": "19",
       "loggedType": {
         "name": "",
         "type": 3,
@@ -175,7 +175,7 @@
       }
     },
     {
-      "logId": 20,
+      "logId": "20",
       "loggedType": {
         "name": "",
         "type": 3,
@@ -183,7 +183,7 @@
       }
     },
     {
-      "logId": 21,
+      "logId": "21",
       "loggedType": {
         "name": "",
         "type": 3,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/json_abi_oracle_new_encoding.json
@@ -15,7 +15,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -23,7 +23,7 @@
       }
     },
     {
-      "logId": 1,
+      "logId": "1",
       "loggedType": {
         "name": "",
         "type": 1,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/require/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/require/json_abi_oracle_new_encoding.json
@@ -15,7 +15,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 3,
@@ -23,7 +23,7 @@
       }
     },
     {
-      "logId": 1,
+      "logId": "1",
       "loggedType": {
         "name": "",
         "type": 3,
@@ -31,7 +31,7 @@
       }
     },
     {
-      "logId": 2,
+      "logId": "2",
       "loggedType": {
         "name": "",
         "type": 3,
@@ -39,7 +39,7 @@
       }
     },
     {
-      "logId": 3,
+      "logId": "3",
       "loggedType": {
         "name": "",
         "type": 3,
@@ -47,7 +47,7 @@
       }
     },
     {
-      "logId": 4,
+      "logId": "4",
       "loggedType": {
         "name": "",
         "type": 3,
@@ -55,7 +55,7 @@
       }
     },
     {
-      "logId": 5,
+      "logId": "5",
       "loggedType": {
         "name": "",
         "type": 2,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/basic_storage/json_abi_oracle_new_encoding.json
@@ -199,7 +199,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -207,7 +207,7 @@
       }
     },
     {
-      "logId": 1,
+      "logId": "1",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -215,7 +215,7 @@
       }
     },
     {
-      "logId": 2,
+      "logId": "2",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -223,7 +223,7 @@
       }
     },
     {
-      "logId": 3,
+      "logId": "3",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -231,7 +231,7 @@
       }
     },
     {
-      "logId": 4,
+      "logId": "4",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -239,7 +239,7 @@
       }
     },
     {
-      "logId": 5,
+      "logId": "5",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -247,7 +247,7 @@
       }
     },
     {
-      "logId": 6,
+      "logId": "6",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -255,7 +255,7 @@
       }
     },
     {
-      "logId": 7,
+      "logId": "7",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -263,7 +263,7 @@
       }
     },
     {
-      "logId": 8,
+      "logId": "8",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -271,7 +271,7 @@
       }
     },
     {
-      "logId": 9,
+      "logId": "9",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -279,7 +279,7 @@
       }
     },
     {
-      "logId": 10,
+      "logId": "10",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -287,7 +287,7 @@
       }
     },
     {
-      "logId": 11,
+      "logId": "11",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -295,7 +295,7 @@
       }
     },
     {
-      "logId": 12,
+      "logId": "12",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -303,7 +303,7 @@
       }
     },
     {
-      "logId": 13,
+      "logId": "13",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -311,7 +311,7 @@
       }
     },
     {
-      "logId": 14,
+      "logId": "14",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -319,7 +319,7 @@
       }
     },
     {
-      "logId": 15,
+      "logId": "15",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -327,7 +327,7 @@
       }
     },
     {
-      "logId": 16,
+      "logId": "16",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -335,7 +335,7 @@
       }
     },
     {
-      "logId": 17,
+      "logId": "17",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -343,7 +343,7 @@
       }
     },
     {
-      "logId": 18,
+      "logId": "18",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -351,7 +351,7 @@
       }
     },
     {
-      "logId": 19,
+      "logId": "19",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -359,7 +359,7 @@
       }
     },
     {
-      "logId": 20,
+      "logId": "20",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -367,7 +367,7 @@
       }
     },
     {
-      "logId": 21,
+      "logId": "21",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -375,7 +375,7 @@
       }
     },
     {
-      "logId": 22,
+      "logId": "22",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -383,7 +383,7 @@
       }
     },
     {
-      "logId": 23,
+      "logId": "23",
       "loggedType": {
         "name": "",
         "type": 1,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/multiple_impl/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/multiple_impl/json_abi_oracle_new_encoding.json
@@ -15,7 +15,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -23,7 +23,7 @@
       }
     },
     {
-      "logId": 1,
+      "logId": "1",
       "loggedType": {
         "name": "",
         "type": 1,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_access_contract/json_abi_oracle_new_encoding.json
@@ -822,7 +822,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 2,
@@ -830,7 +830,7 @@
       }
     },
     {
-      "logId": 1,
+      "logId": "1",
       "loggedType": {
         "name": "",
         "type": 2,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_namespace/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/storage_namespace/json_abi_oracle_new_encoding.json
@@ -199,7 +199,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "0",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -207,7 +207,7 @@
       }
     },
     {
-      "logId": 1,
+      "logId": "1",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -215,7 +215,7 @@
       }
     },
     {
-      "logId": 2,
+      "logId": "2",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -223,7 +223,7 @@
       }
     },
     {
-      "logId": 3,
+      "logId": "3",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -231,7 +231,7 @@
       }
     },
     {
-      "logId": 4,
+      "logId": "4",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -239,7 +239,7 @@
       }
     },
     {
-      "logId": 5,
+      "logId": "5",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -247,7 +247,7 @@
       }
     },
     {
-      "logId": 6,
+      "logId": "6",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -255,7 +255,7 @@
       }
     },
     {
-      "logId": 7,
+      "logId": "7",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -263,7 +263,7 @@
       }
     },
     {
-      "logId": 8,
+      "logId": "8",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -271,7 +271,7 @@
       }
     },
     {
-      "logId": 9,
+      "logId": "9",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -279,7 +279,7 @@
       }
     },
     {
-      "logId": 10,
+      "logId": "10",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -287,7 +287,7 @@
       }
     },
     {
-      "logId": 11,
+      "logId": "11",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -295,7 +295,7 @@
       }
     },
     {
-      "logId": 12,
+      "logId": "12",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -303,7 +303,7 @@
       }
     },
     {
-      "logId": 13,
+      "logId": "13",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -311,7 +311,7 @@
       }
     },
     {
-      "logId": 14,
+      "logId": "14",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -319,7 +319,7 @@
       }
     },
     {
-      "logId": 15,
+      "logId": "15",
       "loggedType": {
         "name": "",
         "type": 9,
@@ -327,7 +327,7 @@
       }
     },
     {
-      "logId": 16,
+      "logId": "16",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -335,7 +335,7 @@
       }
     },
     {
-      "logId": 17,
+      "logId": "17",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -343,7 +343,7 @@
       }
     },
     {
-      "logId": 18,
+      "logId": "18",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -351,7 +351,7 @@
       }
     },
     {
-      "logId": 19,
+      "logId": "19",
       "loggedType": {
         "name": "",
         "type": 8,
@@ -359,7 +359,7 @@
       }
     },
     {
-      "logId": 20,
+      "logId": "20",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -367,7 +367,7 @@
       }
     },
     {
-      "logId": 21,
+      "logId": "21",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -375,7 +375,7 @@
       }
     },
     {
-      "logId": 22,
+      "logId": "22",
       "loggedType": {
         "name": "",
         "type": 1,
@@ -383,7 +383,7 @@
       }
     },
     {
-      "logId": 23,
+      "logId": "23",
       "loggedType": {
         "name": "",
         "type": 1,

--- a/test/src/sdk-harness/Cargo.lock
+++ b/test/src/sdk-harness/Cargo.lock
@@ -1551,9 +1551,9 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fuel-abi-types"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2351bb0b743c23ac13ac2559756b3929502cd6e29091f2e5302fb9a1bdddaf35"
+checksum = "ee6135cb6e12773a7abf7d6c3a8de6467dee86fcf7293720d33e33feb01dc6d8"
 dependencies = [
  "itertools 0.10.5",
  "lazy_static",
@@ -2018,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "fuels"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f21be9dc16a233e958c87914f9cbeeb2cdbbd9210093522cd0846783480ee4"
+checksum = "8eeb6fa017c6d695cf4468d21c640857ba1c74d31fdac3277ad4414593a14a7b"
 dependencies = [
  "fuel-core",
  "fuel-core-client",
@@ -2035,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-accounts"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e8a8c6a241d49f716313298a17e9da00a1102b3efa26d01cd700a55b3b1710"
+checksum = "0a55f3ba7346cb73a5565fd7b6ab2c0016be052863323ca076e6ac9fec719759"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2059,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0a990a3409d91b5e62c542d890c8840edd34e50546c7c7eb347fcbf3711d87"
+checksum = "8db288a46989c20bc48dee787008959a2a7c17061fe78cf4ae4c1263c80692e1"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -2075,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f7308bf8b0d11b4acb408bdbcf8a0b98cdd11ea1ffbf6235f5c4a5bee6f5d4"
+checksum = "63d0abdc7230e4adb619a3735c237af545dcfdf86f4096b9d1daaf315838987e"
 dependencies = [
  "async-trait",
  "bech32",
@@ -2086,6 +2086,7 @@ dependencies = [
  "fuel-asm",
  "fuel-core-chain-config",
  "fuel-core-client",
+ "fuel-core-types",
  "fuel-crypto",
  "fuel-tx",
  "fuel-types",
@@ -2101,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-macros"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f319fccc0dcdea878b9aeb8eec9699249d32f9d258fd5abfe9d5c0e92b4b13"
+checksum = "9e137a52541dbd0345bf000301091b5266644fd4de04bb8238457c5c70b9ac4e"
 dependencies = [
  "fuels-code-gen",
  "itertools 0.12.1",
@@ -2115,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-programs"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d2cf1be591ba2589cc9f6d248cabe9186168d5f57f35e381af3b6002dd0eba"
+checksum = "ada44df4a718da78add027d1204af8154265fc2f64b60cc28b1bba597df7e5d6"
 dependencies = [
  "async-trait",
  "fuel-abi-types",
@@ -2134,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebde4b7d23d0c0a43c235b4ce351643ca0c3e370e1cb4274afd93db3e26c347"
+checksum = "f46d53ef79da8600d8ef580c0acc859be80b07eef0c9ddc19c61bb04b3cf4c15"
 dependencies = [
  "fuel-core",
  "fuel-core-chain-config",

--- a/test/src/sdk-harness/Cargo.toml
+++ b/test/src/sdk-harness/Cargo.toml
@@ -17,7 +17,7 @@ fuel-core-client = { version = "0.26.0", default-features = false }
 fuel-vm = { version = "0.49.0", features = ["random"] }
 
 # Dependencies from the `fuels-rs` repository:
-fuels = { version = "0.61.0", features = ["fuel-core-lib"] }
+fuels = { version = "0.62.0", features = ["fuel-core-lib"] }
 
 hex = "0.4.3"
 paste = "1.0.14"


### PR DESCRIPTION
## Description

Bumps:

1. fuels-rs v0.62.0
2. forc-wallet to v0.7.1
3. fuels-abi-types to v0.5.0

In the process I had to adjust forc-run to use new encoding api from the sdk as well.