### PR TITLE
Fix containing `StorageString`s in `StorageVec`s

### DIFF
--- a/sway-lib-std/src/storage/storage_map.sw
+++ b/sway-lib-std/src/storage/storage_map.sw
@@ -86,11 +86,7 @@ where
         K: Hash,
     {
         let key = sha256((key, self.field_id()));
-        StorageKey::<V>::new(
-            key,
-            0,
-            key,
-        )
+        StorageKey::<V>::new(key, 0, key)
     }
 
     /// Clears a value previously stored using a key

--- a/sway-lib-std/src/storage/storage_map.sw
+++ b/sway-lib-std/src/storage/storage_map.sw
@@ -85,10 +85,11 @@ where
     where
         K: Hash,
     {
+        let key = sha256((key, self.field_id()));
         StorageKey::<V>::new(
-            sha256((key, self.field_id())),
+            key,
             0,
-            sha256((key, self.field_id())),
+            key,
         )
     }
 

--- a/sway-lib-std/src/storage/storage_string.sw
+++ b/sway-lib-std/src/storage/storage_string.sw
@@ -36,7 +36,7 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     /// ```
     #[storage(read, write)]
     fn write_slice(self, string: String) {
-        write_slice(self.slot(), string.as_raw_slice());
+        write_slice(self.field_id(), string.as_raw_slice());
     }
 
     /// Constructs a `String` type from storage.
@@ -69,7 +69,7 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     /// ```
     #[storage(read)]
     fn read_slice(self) -> Option<String> {
-        match read_slice(self.slot()) {
+        match read_slice(self.field_id()) {
             Some(slice) => {
                 Some(String::from(slice))
             },
@@ -111,7 +111,7 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     /// ```
     #[storage(read, write)]
     fn clear(self) -> bool {
-        clear_slice(self.slot())
+        clear_slice(self.field_id())
     }
 
     /// Returns the length of `String` in storage.
@@ -143,6 +143,6 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     /// ```
     #[storage(read)]
     fn len(self) -> u64 {
-        read::<u64>(self.slot(), 0).unwrap_or(0)
+        read::<u64>(self.field_id(), 0).unwrap_or(0)
     }
 }

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -35,7 +35,7 @@ impl<V> StorageKey<StorageVec<V>> {
     /// fn foo() {
     ///     let five = 5_u64;
     ///     storage.vec.push(five);
-    ///     assert(five == storage.vec.get(0).unwrap());
+    ///     assert(five == storage.vec.get(0).unwrap().read());
     /// }
     /// ```
     #[storage(read, write)]
@@ -77,7 +77,7 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     let popped_value = storage.vec.pop().unwrap();
     ///     assert(five == popped_value);
     ///     let none_value = storage.vec.pop();
-    ///     assert(none_value.is_none())
+    ///     assert(none_value.is_none());
     /// }
     /// ```
     #[storage(read, write)]
@@ -124,8 +124,8 @@ impl<V> StorageKey<StorageVec<V>> {
     /// fn foo() {
     ///     let five = 5_u64;
     ///     storage.vec.push(five);
-    ///     assert(five == storage.vec.get(0).unwrap());
-    ///     assert(storage.vec.get(1).is_none())
+    ///     assert(five == storage.vec.get(0).unwrap().read());
+    ///     assert(storage.vec.get(1).is_none());
     /// }
     /// ```
     #[storage(read)]
@@ -253,7 +253,7 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     storage.vec.push(15);
     ///     let removed_value = storage.vec.swap_remove(0);
     ///     assert(5 == removed_value);
-    ///     let swapped_value = storage.vec.get(0).unwrap();
+    ///     let swapped_value = storage.vec.get(0).unwrap().read();
     ///     assert(15 == swapped_value);
     /// }
     /// ```
@@ -311,7 +311,7 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     storage.vec.push(15);
     ///
     ///     storage.vec.set(0, 20);
-    ///     let set_value = storage.vec.get(0).unwrap();
+    ///     let set_value = storage.vec.get(0).unwrap().read();
     ///     assert(20 == set_value);
     /// }
     /// ```
@@ -363,9 +363,9 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     ///     storage.vec.insert(1, 10);
     ///
-    ///     assert(5 == storage.vec.get(0).unwrap());
-    ///     assert(10 == storage.vec.get(1).unwrap());
-    ///     assert(15 == storage.vec.get(2).unwrap());
+    ///     assert(5 == storage.vec.get(0).unwrap().read());
+    ///     assert(10 == storage.vec.get(1).unwrap().read());
+    ///     assert(15 == storage.vec.get(2).unwrap().read());
     /// }
     /// ```
     #[storage(read, write)]
@@ -510,9 +510,9 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     storage.vec.push(15);
     ///
     ///     storage.vec.swap(0, 2);
-    ///     assert(15 == storage.vec.get(0).unwrap());
-    ///     assert(10 == storage.vec.get(1).unwrap());
-    ///     assert(5 == storage.vec.get(2).unwrap());
+    ///     assert(15 == storage.vec.get(0).unwrap().read());
+    ///     assert(10 == storage.vec.get(1).unwrap().read());
+    ///     assert(5 == storage.vec.get(2).unwrap().read());
     /// ```
     #[storage(read, write)]
     pub fn swap(self, element1_index: u64, element2_index: u64) {
@@ -562,7 +562,7 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     ///     storage.vec.push(5);
     ///
-    ///     assert(5 == storage.vec.first().unwrap());
+    ///     assert(5 == storage.vec.first().unwrap().read());
     /// }
     /// ```
     #[storage(read)]
@@ -598,7 +598,7 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     storage.vec.push(5);
     ///     storage.vec.push(10);
     ///
-    ///     assert(10 == storage.vec.last().unwrap());
+    ///     assert(10 == storage.vec.last().unwrap().read());
     /// }
     /// ```
     #[storage(read)]
@@ -633,9 +633,9 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     storage.vec.push(15);
     ///     storage.vec.reverse();
     ///
-    ///     assert(15 == storage.vec.get(0).unwrap());
-    ///     assert(10 == storage.vec.get(1).unwrap());
-    ///     assert(5 == storage.vec.get(2).unwrap());
+    ///     assert(15 == storage.vec.get(0).unwrap().read());
+    ///     assert(10 == storage.vec.get(1).unwrap().read());
+    ///     assert(5 == storage.vec.get(2).unwrap().read());
     /// }
     /// ```
     #[storage(read, write)]
@@ -686,9 +686,9 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     storage.vec.push(15);
     ///     storage.vec.fill(20);
     ///
-    ///     assert(20 == storage.vec.get(0).unwrap());
-    ///     assert(20 == storage.vec.get(1).unwrap());
-    ///     assert(20 == storage.vec.get(2).unwrap());
+    ///     assert(20 == storage.vec.get(0).unwrap().read());
+    ///     assert(20 == storage.vec.get(1).unwrap().read());
+    ///     assert(20 == storage.vec.get(2).unwrap().read());
     /// }
     /// ```
     #[storage(read, write)]
@@ -734,15 +734,15 @@ impl<V> StorageKey<StorageVec<V>> {
     ///     storage.vec.push(10);
     ///     storage.vec.resize(4, 20);
     ///
-    ///     assert(5 == storage.vec.get(0).unwrap());
-    ///     assert(10 == storage.vec.get(1).unwrap());
-    ///     assert(20 == storage.vec.get(2).unwrap());
-    ///     assert(20 == storage.vec.get(3).unwrap());
+    ///     assert(5 == storage.vec.get(0).unwrap().read());
+    ///     assert(10 == storage.vec.get(1).unwrap().read());
+    ///     assert(20 == storage.vec.get(2).unwrap().read());
+    ///     assert(20 == storage.vec.get(3).unwrap().read());
     ///
     ///     storage.vec.resize(2, 0);
     ///
-    ///     assert(5 == storage.vec.get(0).unwrap());
-    ///     assert(10 == storage.vec.get(1).unwrap());
+    ///     assert(5 == storage.vec.get(0).unwrap().read());
+    ///     assert(10 == storage.vec.get(1).unwrap().read());
     ///     assert(None == storage.vec.get(2));
     ///     assert(None == storage.vec.get(3));
     /// }
@@ -802,9 +802,9 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     ///     storage.vec.store_vec(vec);
     ///
-    ///     assert(5 == storage.vec.get(0).unwrap());
-    ///     assert(10 == storage.vec.get(1).unwrap());
-    ///     assert(15 == storage.vec.get(2).unwrap());
+    ///     assert(5 == storage.vec.get(0).unwrap().read());
+    ///     assert(10 == storage.vec.get(1).unwrap().read());
+    ///     assert(15 == storage.vec.get(2).unwrap().read());
     /// }
     /// ```
     #[storage(write)]

--- a/test/src/sdk-harness/Forc.lock
+++ b/test/src/sdk-harness/Forc.lock
@@ -315,6 +315,11 @@ source = "member"
 dependencies = ["std"]
 
 [[package]]
+name = "storage_vec_of_storage_string"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
 name = "storage_vec_to_vec"
 source = "member"
 dependencies = ["std"]

--- a/test/src/sdk-harness/Forc.toml
+++ b/test/src/sdk-harness/Forc.toml
@@ -39,6 +39,7 @@ members = [
   "test_projects/storage_map_nested",
   "test_projects/storage_string",
   "test_projects/storage_vec_nested",
+  "test_projects/storage_vec_of_storage_string",
   "test_projects/storage_vec_to_vec",
   "test_projects/superabi",
   "test_projects/superabi_supertrait",

--- a/test/src/sdk-harness/test_artifacts/auth_testing_contract/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/auth_testing_contract/src/main.sw
@@ -8,7 +8,7 @@ impl AuthTesting for Contract {
         caller_is_external()
     }
 
-    fn returns_msg_sender(expected_id: ContractId) -> bool {
+    fn returns_msg_sender(_expected_id: ContractId) -> bool {
         let result: Result<Identity, AuthError> = msg_sender();
         let mut ret = false;
         if result.is_err() {
@@ -16,7 +16,7 @@ impl AuthTesting for Contract {
         }
         let unwrapped = result.unwrap();
         match unwrapped {
-            Identity::ContractId(v) => {
+            Identity::ContractId(_) => {
                 ret = true
             },
             _ => {
@@ -26,7 +26,7 @@ impl AuthTesting for Contract {
         ret
     }
 
-    fn returns_msg_sender_address(expected_id: Address) -> bool {
+    fn returns_msg_sender_address(_expected_id: Address) -> bool {
         let result: Result<Identity, AuthError> = msg_sender();
         let mut ret = false;
         if result.is_err() {
@@ -34,7 +34,7 @@ impl AuthTesting for Contract {
         }
         let unwrapped = result.unwrap();
         match unwrapped {
-            Identity::Address(v) => {
+            Identity::Address(_) => {
                 ret = true
             },
             _ => {

--- a/test/src/sdk-harness/test_artifacts/methods_contract/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/methods_contract/src/main.sw
@@ -24,8 +24,8 @@ storage {
 impl MethodsContract for Contract {
     #[storage(read, write)]
     fn test_function() -> bool {
-        let identity = bogus();
-        let identity2 = bogus2();
+        let _ = bogus();
+        let _ = bogus2();
         storage
             .stored_struct
             .write(MyStruct {

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_array/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_array/src/main.sw
@@ -104,7 +104,7 @@ impl MyContract for Contract {
 
     #[storage(write)]
     fn clear() {
-        storage.my_vec.clear();
+        let _ = storage.my_vec.clear();
     }
 
     #[storage(read, write)]

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_b256/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_b256/src/main.sw
@@ -104,7 +104,7 @@ impl MyContract for Contract {
 
     #[storage(write)]
     fn clear() {
-        storage.my_vec.clear();
+        let _ = storage.my_vec.clear();
     }
 
     #[storage(read, write)]

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_bool/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_bool/src/main.sw
@@ -104,7 +104,7 @@ impl MyContract for Contract {
 
     #[storage(write)]
     fn clear() {
-        storage.my_vec.clear();
+        let _ = storage.my_vec.clear();
     }
 
     #[storage(read, write)]

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_enum/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_enum/src/main.sw
@@ -109,7 +109,7 @@ impl MyContract for Contract {
 
     #[storage(write)]
     fn clear() {
-        storage.my_vec.clear();
+        let _ = storage.my_vec.clear();
     }
 
     #[storage(read, write)]

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_str/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_str/src/main.sw
@@ -104,7 +104,7 @@ impl MyContract for Contract {
 
     #[storage(write)]
     fn clear() {
-        storage.my_vec.clear();
+        let _ = storage.my_vec.clear();
     }
 
     #[storage(read, write)]

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_struct/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_struct/src/main.sw
@@ -109,7 +109,7 @@ impl MyContract for Contract {
 
     #[storage(write)]
     fn clear() {
-        storage.my_vec.clear();
+        let _ = storage.my_vec.clear();
     }
 
     #[storage(read, write)]

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_tuple/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_tuple/src/main.sw
@@ -104,7 +104,7 @@ impl MyContract for Contract {
 
     #[storage(write)]
     fn clear() {
-        storage.my_vec.clear();
+        let _ = storage.my_vec.clear();
     }
 
     #[storage(read, write)]

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_u16/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_u16/src/main.sw
@@ -104,7 +104,7 @@ impl MyContract for Contract {
 
     #[storage(write)]
     fn clear() {
-        storage.my_vec.clear();
+        let _ = storage.my_vec.clear();
     }
 
     #[storage(read, write)]

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_u32/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_u32/src/main.sw
@@ -104,7 +104,7 @@ impl MyContract for Contract {
 
     #[storage(write)]
     fn clear() {
-        storage.my_vec.clear();
+        let _ = storage.my_vec.clear();
     }
 
     #[storage(read, write)]

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_u64/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_u64/src/main.sw
@@ -104,7 +104,7 @@ impl MyContract for Contract {
 
     #[storage(write)]
     fn clear() {
-        storage.my_vec.clear();
+        let _ = storage.my_vec.clear();
     }
 
     #[storage(read, write)]

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_u8/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_u8/src/main.sw
@@ -104,7 +104,7 @@ impl MyContract for Contract {
 
     #[storage(write)]
     fn clear() {
-        storage.my_vec.clear();
+        let _ = storage.my_vec.clear();
     }
 
     #[storage(read, write)]

--- a/test/src/sdk-harness/test_projects/call_frames/mod.rs
+++ b/test/src/sdk-harness/test_projects/call_frames/mod.rs
@@ -1,8 +1,6 @@
 use fuel_vm::consts::VM_MAX_RAM;
 use fuels::{accounts::wallet::WalletUnlocked, prelude::*, types::ContractId};
 
-use sha2::{Digest, Sha256};
-
 abigen!(Contract(
     name = "CallFramesTestContract",
     abi = "test_projects/call_frames/out/release/call_frames-abi.json"

--- a/test/src/sdk-harness/test_projects/call_frames/src/main.sw
+++ b/test/src/sdk-harness/test_projects/call_frames/src/main.sw
@@ -20,26 +20,26 @@ impl CallFramesTest for Contract {
         first_param()
     }
 
-    fn get_second_param_u64(arg0: u64) -> u64 {
+    fn get_second_param_u64(_arg0: u64) -> u64 {
         second_param()
     }
 
-    fn get_second_param_bool(arg0: bool) -> bool {
+    fn get_second_param_bool(_arg0: bool) -> bool {
         called_args::<bool>()
     }
 
-    fn get_second_param_struct(arg0: TestStruct) -> TestStruct {
+    fn get_second_param_struct(_arg0: TestStruct) -> TestStruct {
         called_args::<TestStruct>()
     }
 
-    fn get_second_param_multiple_params(arg0: bool, arg1: u64) -> (bool, u64) {
+    fn get_second_param_multiple_params(_arg0: bool, _arg1: u64) -> (bool, u64) {
         called_args::<(bool, u64)>()
     }
 
     fn get_second_param_multiple_params2(
-        arg0: u64,
-        arg1: TestStruct,
-        arg2: TestStruct2,
+        _arg0: u64,
+        _arg1: TestStruct,
+        _arg2: TestStruct2,
     ) -> (u64, TestStruct, TestStruct2) {
         called_args::<(u64, TestStruct, TestStruct2)>()
     }

--- a/test/src/sdk-harness/test_projects/generics_in_abi/src/main.sw
+++ b/test/src/sdk-harness/test_projects/generics_in_abi/src/main.sw
@@ -121,5 +121,5 @@ impl MyContract for Contract {
         EnumWGeneric::b(10)
     }
 
-    fn complex_test(arg1: MegaExample<str[2], b256>) {}
+    fn complex_test(_arg1: MegaExample<str[2], b256>) {}
 }

--- a/test/src/sdk-harness/test_projects/harness.rs
+++ b/test/src/sdk-harness/test_projects/harness.rs
@@ -41,6 +41,7 @@ mod storage_map_nested;
 mod storage_string;
 mod storage_vec;
 mod storage_vec_nested;
+mod storage_vec_of_storage_string;
 mod storage_vec_to_vec;
 mod superabi;
 mod superabi_supertrait;

--- a/test/src/sdk-harness/test_projects/result_option_expect/mod.rs
+++ b/test/src/sdk-harness/test_projects/result_option_expect/mod.rs
@@ -22,7 +22,7 @@ async fn setup() -> (ExpectTestingContract<WalletUnlocked>, ContractId) {
 
 #[tokio::test]
 async fn test_expect_option() {
-    let (instance, id) = setup().await;
+    let (instance, _id) = setup().await;
 
     instance
         .methods()
@@ -34,7 +34,7 @@ async fn test_expect_option() {
 
 #[tokio::test]
 async fn test_expect_result() {
-    let (instance, id) = setup().await;
+    let (instance, _id) = setup().await;
 
     instance
         .methods()
@@ -47,7 +47,7 @@ async fn test_expect_result() {
 #[tokio::test]
 #[should_panic]
 async fn test_expect_option_panic() {
-    let (instance, id) = setup().await;
+    let (instance, _id) = setup().await;
 
     instance
         .methods()
@@ -60,7 +60,7 @@ async fn test_expect_option_panic() {
 #[tokio::test]
 #[should_panic]
 async fn test_expect_result_panic() {
-    let (instance, id) = setup().await;
+    let (instance, _id) = setup().await;
 
     instance
         .methods()

--- a/test/src/sdk-harness/test_projects/run_external_proxy/mod.rs
+++ b/test/src/sdk-harness/test_projects/run_external_proxy/mod.rs
@@ -1,6 +1,6 @@
 use fuels::{
     prelude::*,
-    types::{Bits256, ContractId},
+    types::Bits256,
 };
 
 abigen!(Contract(

--- a/test/src/sdk-harness/test_projects/storage_vec_nested/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec_nested/mod.rs
@@ -21,8 +21,15 @@ async fn test_storage_vec_nested_instance() -> TestStorageVecNestedContract<Wall
 }
 
 #[tokio::test]
-async fn nested_vec_access() {
+async fn nested_vec_access_push() {
     let methods = test_storage_vec_nested_instance().await.methods();
 
-    methods.nested_vec_access().call().await.unwrap();
+    methods.nested_vec_access_push().call().await.unwrap();
+}
+
+#[tokio::test]
+async fn nested_vec_access_insert() {
+    let methods = test_storage_vec_nested_instance().await.methods();
+
+    methods.nested_vec_access_insert().call().await.unwrap();
 }

--- a/test/src/sdk-harness/test_projects/storage_vec_nested/src/main.sw
+++ b/test/src/sdk-harness/test_projects/storage_vec_nested/src/main.sw
@@ -8,61 +8,88 @@ storage {
 
 abi ExperimentalStorageTest {
     #[storage(read, write)]
-    fn nested_vec_access();
+    fn nested_vec_access_push();
+
+    #[storage(read, write)]
+    fn nested_vec_access_insert();
 }
 
 impl ExperimentalStorageTest for Contract {
     #[storage(read, write)]
-    fn nested_vec_access() {
+    fn nested_vec_access_push() {
         storage.nested_vec.push(StorageVec {});
         storage.nested_vec.push(StorageVec {});
         storage.nested_vec.push(StorageVec {});
+
         let mut inner_vec0 = storage.nested_vec.get(0).unwrap();
         let mut inner_vec1 = storage.nested_vec.get(1).unwrap();
         let mut inner_vec2 = storage.nested_vec.get(2).unwrap();
+
         assert(storage.nested_vec.len() == 3);
         assert(storage.nested_vec.get(3).is_none());
 
-        inner_vec0.push(0);
-        inner_vec0.push(1);
-
-        inner_vec1.push(2);
-        inner_vec1.push(3);
-        inner_vec1.push(4);
-
-        inner_vec2.push(5);
-        inner_vec2.push(6);
-        inner_vec2.push(7);
-        inner_vec2.push(8);
-
-        inner_vec0.set(0, 0);
-        inner_vec0.set(1, 11);
-
-        inner_vec1.set(0, 22);
-        inner_vec1.set(1, 33);
-        inner_vec1.set(2, 44);
-
-        inner_vec2.set(0, 55);
-        inner_vec2.set(1, 66);
-        inner_vec2.set(2, 77);
-        inner_vec2.set(3, 88);
-
-        assert(inner_vec0.len() == 2);
-        assert(inner_vec0.get(0).unwrap().read() == 0);
-        assert(inner_vec0.get(1).unwrap().read() == 11);
-        assert(inner_vec0.get(2).is_none());
-
-        assert(inner_vec1.len() == 3);
-        assert(inner_vec1.get(0).unwrap().read() == 22);
-        assert(inner_vec1.get(1).unwrap().read() == 33);
-        assert(inner_vec1.get(2).unwrap().read() == 44);
-        assert(inner_vec1.get(3).is_none());
-
-        assert(inner_vec2.len() == 4);
-        assert(inner_vec2.get(0).unwrap().read() == 55);
-        assert(inner_vec2.get(1).unwrap().read() == 66);
-        assert(inner_vec2.get(2).unwrap().read() == 77);
-        assert(inner_vec2.get(3).unwrap().read() == 88);
-        assert(inner_vec2.get(4).is_none());
+        test_access(inner_vec0, inner_vec1, inner_vec2);
     }
+
+    #[storage(read, write)]
+    fn nested_vec_access_insert() {
+        // TODO: Uncomment this test once https://github.com/FuelLabs/sway/issues/6040 is fixed.
+        // storage.nested_vec.insert(0, StorageVec {});
+        // storage.nested_vec.insert(0, StorageVec {});
+        // storage.nested_vec.insert(0, StorageVec {});
+
+        // let mut inner_vec0 = storage.nested_vec.get(0).unwrap();
+        // let mut inner_vec1 = storage.nested_vec.get(1).unwrap();
+        // let mut inner_vec2 = storage.nested_vec.get(2).unwrap();
+
+        // assert(storage.nested_vec.len() == 3);
+        // assert(storage.nested_vec.get(3).is_none());
+
+        // test_access(inner_vec0, inner_vec1, inner_vec2);
+    }
+}
+
+#[storage(read, write)]
+fn test_access(inner_vec0: StorageKey<StorageVec<u64>>, inner_vec1: StorageKey<StorageVec<u64>>, inner_vec2: StorageKey<StorageVec<u64>>) {
+    inner_vec0.push(0);
+    inner_vec0.push(1);
+
+    inner_vec1.push(2);
+    inner_vec1.push(3);
+    inner_vec1.push(4);
+
+    inner_vec2.push(5);
+    inner_vec2.push(6);
+    inner_vec2.push(7);
+    inner_vec2.push(8);
+
+    inner_vec0.set(0, 0);
+    inner_vec0.set(1, 11);
+
+    inner_vec1.set(0, 22);
+    inner_vec1.set(1, 33);
+    inner_vec1.set(2, 44);
+
+    inner_vec2.set(0, 55);
+    inner_vec2.set(1, 66);
+    inner_vec2.set(2, 77);
+    inner_vec2.set(3, 88);
+
+    assert(inner_vec0.len() == 2);
+    assert(inner_vec0.get(0).unwrap().read() == 0);
+    assert(inner_vec0.get(1).unwrap().read() == 11);
+    assert(inner_vec0.get(2).is_none());
+
+    assert(inner_vec1.len() == 3);
+    assert(inner_vec1.get(0).unwrap().read() == 22);
+    assert(inner_vec1.get(1).unwrap().read() == 33);
+    assert(inner_vec1.get(2).unwrap().read() == 44);
+    assert(inner_vec1.get(3).is_none());
+
+    assert(inner_vec2.len() == 4);
+    assert(inner_vec2.get(0).unwrap().read() == 55);
+    assert(inner_vec2.get(1).unwrap().read() == 66);
+    assert(inner_vec2.get(2).unwrap().read() == 77);
+    assert(inner_vec2.get(3).unwrap().read() == 88);
+    assert(inner_vec2.get(4).is_none());
 }

--- a/test/src/sdk-harness/test_projects/storage_vec_of_storage_string/Forc.lock
+++ b/test/src/sdk-harness/test_projects/storage_vec_of_storage_string/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-CF72BC351FBD64D3"
+
+[[package]]
+name = "std"
+source = "path+from-root-CF72BC351FBD64D3"
+dependencies = ["core"]
+
+[[package]]
+name = "storage_vec_of_storage_string"
+source = "member"
+dependencies = ["std"]

--- a/test/src/sdk-harness/test_projects/storage_vec_of_storage_string/Forc.toml
+++ b/test/src/sdk-harness/test_projects/storage_vec_of_storage_string/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "storage_vec_of_storage_string"
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/test/src/sdk-harness/test_projects/storage_vec_of_storage_string/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec_of_storage_string/mod.rs
@@ -1,0 +1,107 @@
+use fuels::accounts::wallet::WalletUnlocked;
+use fuels::prelude::*;
+
+abigen!(Contract(
+    name = "TestStorageVecOfStorageStringContract",
+    abi = "test_projects/storage_vec_of_storage_string/out/release/storage_vec_of_storage_string-abi.json",
+));
+
+async fn test_storage_vec_of_storage_string_instance() -> TestStorageVecOfStorageStringContract<WalletUnlocked> {
+    let wallet = launch_provider_and_get_wallet().await.unwrap();
+    let id = Contract::load_from(
+        "test_projects/storage_vec_of_storage_string/out/release/storage_vec_of_storage_string.bin",
+        LoadConfiguration::default(),
+    )
+    .unwrap()
+    .deploy(&wallet, TxPolicies::default())
+    .await
+    .unwrap();
+
+    TestStorageVecOfStorageStringContract::new(id.clone(), wallet)
+}
+
+// This test proves that https://github.com/FuelLabs/sway/issues/6036 is fixed.
+#[tokio::test]
+async fn test_push_and_get() {
+    let instance = test_storage_vec_of_storage_string_instance().await;
+
+    const NUM_OF_STRINGS: u64 = 10; // Keep it larger then 8, to stress the internal implementation that does % 8.
+    let strings = (0..NUM_OF_STRINGS).map(|i| i.to_string()).collect::<Vec<_>>();
+
+    for string in &strings {
+        let _ = instance
+            .methods()
+            .push(string.to_owned())
+            .call()
+            .await;
+    }
+
+    let returned_count = instance
+        .methods()
+        .count()
+        .call()
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(returned_count, NUM_OF_STRINGS);
+
+    let mut returned_strings = vec![];
+    for i in 0..NUM_OF_STRINGS {
+        let returned_string = instance
+            .methods()
+            .get(i)
+            .call()
+            .await
+            .unwrap()
+            .value;
+
+        returned_strings.push(returned_string);
+    }
+        
+    assert_eq!(returned_strings, strings);
+}
+
+// TODO: Uncomment this test once https://github.com/FuelLabs/sway/issues/6040 is fixed.
+// #[tokio::test]
+// async fn test_push_and_insert() {
+//     let instance = test_storage_vec_of_storage_string_instance().await;
+
+//     const NUM_OF_STRINGS: u64 = 10; // Keep it larger then 8, to stress the internal implementation that does % 8.
+//     let mut strings = (0..NUM_OF_STRINGS).map(|i| i.to_string()).collect::<Vec<_>>();
+
+//     for string in &strings {
+//         let _ = instance
+//             .methods()
+//             .insert(string.to_owned())
+//             .call()
+//             .await;
+//     }
+
+//     let returned_count = instance
+//         .methods()
+//         .count()
+//         .call()
+//         .await
+//         .unwrap()
+//         .value;
+
+//     assert_eq!(returned_count, NUM_OF_STRINGS);
+
+//     let mut returned_strings = vec![];
+//     for i in 0..NUM_OF_STRINGS {
+//         let returned_string = instance
+//             .methods()
+//             .get(i)
+//             .call()
+//             .await
+//             .unwrap()
+//             .value;
+
+//         returned_strings.push(returned_string);
+//     }
+
+//     strings.reverse();
+        
+//     assert_eq!(returned_strings, strings);
+// }

--- a/test/src/sdk-harness/test_projects/storage_vec_of_storage_string/src/main.sw
+++ b/test/src/sdk-harness/test_projects/storage_vec_of_storage_string/src/main.sw
@@ -1,0 +1,55 @@
+contract;
+
+use std::{
+    hash::*, 
+    logging::log,
+    string::String,
+    storage::storage_vec::*,
+    storage::storage_string::*, 
+};
+
+abi StorageVecOfStorageString {
+    #[storage(read)] 
+    fn count() -> u64;
+
+    #[storage(read)] 
+    fn get(index: u64) -> String;
+
+    #[storage(read, write)] 
+    fn push(text: String);
+
+    #[storage(read, write)] 
+    fn insert(text: String);
+}
+
+
+storage {
+    texts: StorageVec<StorageString> = StorageVec {},
+}
+
+impl StorageVecOfStorageString for Contract {
+   
+    #[storage(read)] 
+    fn count() -> u64 {
+        storage.texts.len()
+    }
+
+    #[storage(read)] 
+    fn get(index: u64) -> String
+    {
+        storage.texts.get(index).unwrap().read_slice().unwrap()
+    }
+
+    #[storage(read, write)] 
+    fn push(text: String) {
+        storage.texts.push(StorageString {});
+        let index = storage.texts.len() - 1;
+        storage.texts.get(index).unwrap().write_slice(text);
+    }
+
+    #[storage(read, write)] 
+    fn insert(text: String) {
+        storage.texts.insert(0, StorageString {});
+        storage.texts.get(0).unwrap().write_slice(text);
+    }
+}

--- a/test/src/sdk-harness/test_projects/tx_fields/mod.rs
+++ b/test/src/sdk-harness/test_projects/tx_fields/mod.rs
@@ -7,8 +7,6 @@ use fuels::{
     types::{input::Input as SdkInput, Bits256},
 };
 
-use std::str::FromStr;
-
 const MESSAGE_DATA: [u8; 3] = [1u8, 2u8, 3u8];
 
 abigen!(


### PR DESCRIPTION
## Description

This PR fixes #6036 by using `field_id()` in the `StorageString` instead of `slot()`.

Additionally, the PR:
- fixes documentation glitches in the `StorageVec`.
- optimizes `StorageMap::get` by removing double calculation of the `key`.
- cleans up most of the Sway and all Rust warnings in the SDK harness tests.

The PR is not solving all the issues related to composing dynamic storage types. E.g, #6040 is (very likely just one) of them.

Closes #6036.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.