### PR TITLE
Enable OrdEq on U128

### DIFF
--- a/sway-lib-std/src/u128.sw
+++ b/sway-lib-std/src/u128.sw
@@ -152,9 +152,8 @@ impl core::ops::Ord for U128 {
     }
 }
 
-// TODO this doesn't work?
-// impl core::ops::OrdEq for U128 {
-// }
+impl core::ops::OrdEq for U128 {}
+
 impl u64 {
     /// Performs addition between two `u64` values, returning a `U128`.
     ///
@@ -586,8 +585,7 @@ impl core::ops::Divide for U128 {
             quotient <<= 1;
             remainder <<= 1;
             remainder.lower = remainder.lower | (self >> i).lower & 1;
-            // TODO use >= once OrdEq can be implemented.
-            if remainder > divisor || remainder == divisor {
+            if remainder >= divisor {
                 remainder -= divisor;
                 quotient.lower = quotient.lower | 1;
             }


### PR DESCRIPTION
## Description

OrdEq was disabled there two years ago because it didn't work, it works now.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
