### PR TITLE
Add generated bytecode size to verbose test output

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -497,7 +497,7 @@ impl BuiltPackage {
         let json_abi_path = output_dir.join(program_abi_stem).with_extension("json");
         self.write_json_abi(&json_abi_path, minify)?;
 
-        debug!("      Bytecode size: {} bytes", self.bytecode.bytes.len());
+        info!("      Bytecode size: {} bytes", self.bytecode.bytes.len());
         // Additional ops required depending on the program type
         match self.tree_type {
             TreeType::Contract => {


### PR DESCRIPTION
## Description

This PR adds generated bytecode size to verbose test output:
```
Finished release [optimized + fuel] target(s) in 0.72s
   Bytecode size: 40104 bytes  <<<<---------
   Bytecode hash: 0xc24a3e994874ec26b8698381bb03efc222cfc461a01aeaede8278acaef9524a1
```
This information is useful for ad-hoc visual comparison of bytecode sizes as well as building simple tooling that compares impact of code changes to the bytecode size. 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.