### PR TITLE
Fix code owner precedence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# Everything else
+* @FuelLabs/leads
+
 # Documentation
 /docs/ @FuelLabs/tooling @FuelLabs/sway-compiler @FuelLabs/application-dev @FuelLabs/Devrel
 
@@ -27,8 +30,7 @@
 /templates/ @FuelLabs/sway-compiler
 /test/ @FuelLabs/sway-compiler
 
-# Everything else, including root lockfile and deployment scripts
-Cargo.lock @IGI-111 @JoshuaBatty
-/deployment/ @IGI-111 @JoshuaBatty
-* @IGI-111 @JoshuaBatty
+# Root lockfile and deployment scripts
+Cargo.lock @FuelLabs/leads
+/deployment/ @FuelLabs/leads
 


### PR DESCRIPTION
Put catchall rule at the beginning rather than the end.

This also makes @FuelLabs/leads the code owners of the release infrastructure.