### PR TITLE
Improving binary size for encoding v1

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl.rs
@@ -632,7 +632,7 @@ where
                 }}\n"));
             } else {
                 code.push_str(&format!("if _method_name == \"{method_name}\" {{
-                    let args: {args_types} = decode_second_param::<{args_types}>();
+                    let args: {args_types} = _buffer.decode::<{args_types}>();
                     let result_{method_name}: raw_slice = encode::<{return_type}>(__contract_entry_{method_name}({expanded_args}));
                     __contract_ret(result_{method_name}.ptr(), result_{method_name}.len::<u8>());
                 }}\n"));
@@ -674,6 +674,7 @@ where
 
         let code = format!(
             "{att} pub fn __entry() {{
+            let mut _buffer = BufferReader::from_second_parameter();
             let _method_name = decode_first_param::<str>();
             {code}
             {fallback}

--- a/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl.rs
@@ -38,7 +38,7 @@ where
         T: Parse,
     {
         // Uncomment this to see what is being generated
-        // println!("{}", input);
+        //println!("{}", input);
 
         let handler = <_>::default();
         let source_id =
@@ -333,7 +333,7 @@ where
         });
 
         // Uncomment this to understand why an entry function was not generated
-        // println!("{:#?}", handler);
+        //println!("{:#?}", handler);
 
         let (decl, namespace) = r.map_err(|_| handler.clone())?;
 
@@ -380,7 +380,7 @@ where
         });
 
         // Uncomment this to understand why auto impl failed for a type.
-        // println!("{:#?}", handler);
+        //println!("{:#?}", handler);
 
         let (decl, namespace) = r.map_err(|_| handler.clone())?;
 
@@ -625,18 +625,29 @@ where
 
             let method_name = decl.name.as_str();
 
+            code.push_str(&format!("if _method_name == \"{method_name}\" {{\n"));
+
             if args_types == "()" {
-                code.push_str(&format!("if _method_name == \"{method_name}\" {{
-                    let result_{method_name}: raw_slice = encode::<{return_type}>(__contract_entry_{method_name}());
-                    __contract_ret(result_{method_name}.ptr(), result_{method_name}.len::<u8>());
-                }}\n"));
+                code.push_str(&format!(
+                    "let _result = __contract_entry_{method_name}();\n"
+                ));
             } else {
-                code.push_str(&format!("if _method_name == \"{method_name}\" {{
-                    let args: {args_types} = _buffer.decode::<{args_types}>();
-                    let result_{method_name}: raw_slice = encode::<{return_type}>(__contract_entry_{method_name}({expanded_args}));
-                    __contract_ret(result_{method_name}.ptr(), result_{method_name}.len::<u8>());
-                }}\n"));
+                code.push_str(&format!(
+                    "let args: {args_types} = _buffer.decode::<{args_types}>();
+                    let _result: {return_type} = __contract_entry_{method_name}({expanded_args});\n"
+                ));
             }
+
+            if return_type == "()" {
+                code.push_str("__contract_ret(asm() { zero: raw_ptr }, 0);");
+            } else {
+                code.push_str(&format!(
+                    "let _result: raw_slice = encode::<{return_type}>(_result);
+                    __contract_ret(_result.ptr(), _result.len::<u8>());"
+                ));
+            }
+
+            code.push_str("\n}\n");
         }
 
         let fallback = if let Some(fallback_fn) = fallback_fn {

--- a/sway-ir/src/optimize.rs
+++ b/sway-ir/src/optimize.rs
@@ -128,7 +128,7 @@ pub mod tests {
 
         for (actual, expected) in actual.iter().zip(expected) {
             if !actual.contains(expected) {
-                panic!("error: {actual:?} {expected:?}");
+                panic!("Actual: {actual:?} does not contains expected: {expected:?}. (Run with --nocapture to see a diff)");
             } else {
                 expected_matches -= 1;
             }

--- a/sway-ir/src/optimize/constants.rs
+++ b/sway-ir/src/optimize/constants.rs
@@ -1,5 +1,9 @@
 //! Optimization passes for manipulating constant values.
 
+use std::collections::HashMap;
+
+use rustc_hash::FxHashMap;
+
 use crate::{
     constant::{Constant, ConstantValue},
     context::Context,
@@ -40,6 +44,11 @@ pub fn fold_constants(
         }
 
         if combine_binary_op(context, &function) {
+            modified = true;
+            continue;
+        }
+
+        if remove_useless_binary_op(context, &function) {
             modified = true;
             continue;
         }
@@ -241,6 +250,50 @@ fn combine_binary_op(context: &mut Context, function: &Function) -> bool {
     })
 }
 
+fn remove_useless_binary_op(context: &mut Context, function: &Function) -> bool {
+    let candidate =
+        function
+            .instruction_iter(context)
+            .find_map(
+                |(block, candidate)| match &context.values[candidate.0].value {
+                    ValueDatum::Instruction(Instruction {
+                        op: InstOp::BinaryOp { op, arg1, arg2 },
+                        ..
+                    }) if arg1.is_constant(context) || arg2.is_constant(context) => {
+                        let val1 = arg1.get_constant(context).map(|x| &x.value);
+                        let val2 = arg2.get_constant(context).map(|x| &x.value);
+
+                        use crate::BinaryOpKind::*;
+                        use ConstantValue::*;
+                        match (op, &val1, &val2) {
+                            // 0 + arg2
+                            (Add, Some(Uint(0)), _) => Some((block, candidate, arg2.clone())),
+                            // arg1 + 0
+                            (Add, _, Some(Uint(0))) => Some((block, candidate, arg1.clone())),
+                            // 1 * arg2
+                            (Mul, Some(Uint(1)), _) => Some((block, candidate, arg2.clone())),
+                            // arg1 * 1
+                            (Mul, _, Some(Uint(1))) => Some((block, candidate, arg1.clone())),
+                            // arg1 / 1
+                            (Div, _, Some(Uint(1))) => Some((block, candidate, arg1.clone())),
+                            // arg1 / 1
+                            (Sub, _, Some(Uint(0))) => Some((block, candidate, arg1.clone())),
+                            _ => None,
+                        }
+                    }
+                    _ => None,
+                },
+            );
+
+    candidate.map_or(false, |(block, candidate, new_value)| {
+        block.remove_instruction(context, candidate);
+
+        let replace_map = FxHashMap::from_iter([(candidate, new_value.clone())]);
+        block.replace_values(context, &replace_map);
+        true
+    })
+}
+
 fn combine_unary_op(context: &mut Context, function: &Function) -> bool {
     let candidate = function
         .instruction_iter(context)
@@ -392,6 +445,33 @@ mod tests {
         }
     ",
             Some(["const u64 6"]),
+        );
+    }
+
+    #[test]
+    fn ok_remove_useless_mul() {
+        assert_optimization(
+            &[CONST_FOLDING_NAME],
+            "entry fn main() -> u64 {
+                local u64 LOCAL
+            entry():
+                zero = const u64 0, !0
+                one = const u64 1, !0
+                l_ptr = get_local ptr u64, LOCAL, !0
+                l = load l_ptr, !0
+                result1 = mul l, one, !0
+                result2 = mul one, result1, !0
+                result3 = add result2, zero, !0
+                result4 = add zero, result3, !0
+                result5 = div result4, one, !0
+                result6 = sub result5, zero, !0
+                ret u64 result6, !0
+         }",
+            Some([
+                "v0 = get_local ptr u64, LOCAL",
+                "v1 = load v0",
+                "ret u64 v1",
+            ]),
         );
     }
 }

--- a/sway-ir/src/optimize/constants.rs
+++ b/sway-ir/src/optimize/constants.rs
@@ -264,17 +264,17 @@ fn remove_useless_binary_op(context: &mut Context, function: &Function) -> bool 
                         use ConstantValue::*;
                         match (op, val1, val2) {
                             // 0 + arg2
-                            (Add, Some(Uint(0)), _) => Some((block, candidate, arg2.clone())),
+                            (Add, Some(Uint(0)), _) => Some((block, candidate, *arg2)),
                             // arg1 + 0
-                            (Add, _, Some(Uint(0))) => Some((block, candidate, arg1.clone())),
+                            (Add, _, Some(Uint(0))) => Some((block, candidate, *arg1)),
                             // 1 * arg2
-                            (Mul, Some(Uint(1)), _) => Some((block, candidate, arg2.clone())),
+                            (Mul, Some(Uint(1)), _) => Some((block, candidate, *arg2)),
                             // arg1 * 1
-                            (Mul, _, Some(Uint(1))) => Some((block, candidate, arg1.clone())),
+                            (Mul, _, Some(Uint(1))) => Some((block, candidate, *arg1)),
                             // arg1 / 1
-                            (Div, _, Some(Uint(1))) => Some((block, candidate, arg1.clone())),
+                            (Div, _, Some(Uint(1))) => Some((block, candidate, *arg1)),
                             // arg1 - 0
-                            (Sub, _, Some(Uint(0))) => Some((block, candidate, arg1.clone())),
+                            (Sub, _, Some(Uint(0))) => Some((block, candidate, *arg1)),
                             _ => None,
                         }
                     }

--- a/sway-lib-core/src/codec.sw
+++ b/sway-lib-core/src/codec.sw
@@ -80,7 +80,7 @@ impl BufferReader {
             0u8 => {
                 let ptr = __gtf::<raw_ptr>(predicate_index, 0x20C); // INPUT_COIN_PREDICATE_DATA
                 let _len = __gtf::<u64>(predicate_index, 0x20A); // INPUT_COIN_PREDICATE_DATA_LENGTH
-                BufferReader { ptr}
+                BufferReader { ptr }
             },
             2u8 => {
                 let ptr = __gtf::<raw_ptr>(predicate_index, 0x24A); // INPUT_MESSAGE_PREDICATE_DATA

--- a/sway-lib-core/src/codec.sw
+++ b/sway-lib-core/src/codec.sw
@@ -22,12 +22,11 @@ impl AsRawSlice for Buffer {
 
 pub struct BufferReader {
     ptr: raw_ptr,
-    pos: u64,
 }
 
 impl BufferReader {
     pub fn from_parts(ptr: raw_ptr, _len: u64) -> BufferReader {
-        BufferReader { ptr, pos: 0 }
+        BufferReader { ptr }
     }
 
     pub fn from_first_parameter() -> BufferReader {
@@ -43,7 +42,6 @@ impl BufferReader {
             ptr: asm(ptr: ptr) {
                 ptr: raw_ptr
             },
-            pos: 0,
         }
     }
 
@@ -60,14 +58,13 @@ impl BufferReader {
             ptr: asm(ptr: ptr) {
                 ptr: raw_ptr
             },
-            pos: 0,
         }
     }
 
     pub fn from_script_data() -> BufferReader {
         let ptr = __gtf::<raw_ptr>(0, 0xA); // SCRIPT_DATA
         let _len = __gtf::<u64>(0, 0x4); // SCRIPT_DATA_LEN
-        BufferReader { ptr, pos: 0 }
+        BufferReader { ptr }
     }
 
     pub fn from_predicate_data() -> BufferReader {
@@ -83,55 +80,47 @@ impl BufferReader {
             0u8 => {
                 let ptr = __gtf::<raw_ptr>(predicate_index, 0x20C); // INPUT_COIN_PREDICATE_DATA
                 let _len = __gtf::<u64>(predicate_index, 0x20A); // INPUT_COIN_PREDICATE_DATA_LENGTH
-                BufferReader { ptr, pos: 0 }
+                BufferReader { ptr}
             },
             2u8 => {
                 let ptr = __gtf::<raw_ptr>(predicate_index, 0x24A); // INPUT_MESSAGE_PREDICATE_DATA
                 let _len = __gtf::<u64>(predicate_index, 0x247); // INPUT_MESSAGE_PREDICATE_DATA_LENGTH
-                BufferReader { ptr, pos: 0 }
+                BufferReader { ptr }
             },
             _ => __revert(0),
         }
     }
 
     pub fn read_bytes(ref mut self, count: u64) -> raw_slice {
-        let next_pos = self.pos + count;
-
-        let ptr = self.ptr.add::<u8>(self.pos);
-        let slice = asm(ptr: (ptr, count)) {
+        let slice = asm(ptr: (self.ptr, count)) {
             ptr: raw_slice
         };
-
-        self.pos = next_pos;
-
+        self.ptr = __ptr_add::<u8>(self.ptr, count);
         slice
     }
 
     pub fn read<T>(ref mut self) -> T {
-        let ptr = self.ptr.add::<u8>(self.pos);
-
         let size = __size_of::<T>();
-        let next_pos = self.pos + size;
 
         if __is_reference_type::<T>() {
-            let v = asm(ptr: ptr) {
+            let v = asm(ptr: self.ptr) {
                 ptr: T
             };
-            self.pos = next_pos;
+            self.ptr = __ptr_add::<u8>(self.ptr, size);
             v
         } else if size == 1 {
-            let v = asm(ptr: ptr, val) {
+            let v = asm(ptr: self.ptr, val) {
                 lb val ptr i0;
                 val: T
             };
-            self.pos = next_pos;
+            self.ptr = __ptr_add::<u8>(self.ptr, 1);
             v
         } else {
-            let v = asm(ptr: ptr, val) {
+            let v = asm(ptr: self.ptr, val) {
                 lw val ptr i0;
                 val: T
             };
-            self.pos = next_pos;
+            self.ptr = __ptr_add::<u8>(self.ptr, 8);
             v
         }
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
@@ -6,89 +6,8 @@
         "type": 5,
         "typeArguments": null
       },
-      "name": "C0",
-      "offset": 12496
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 12,
-        "typeArguments": null
-      },
-      "name": "C1",
-      "offset": 12520
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 4,
-        "typeArguments": null
-      },
-      "name": "C2",
-      "offset": 12536
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 8,
-        "typeArguments": []
-      },
-      "name": "C3",
-      "offset": 12568
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 6,
-        "typeArguments": []
-      },
-      "name": "C4",
-      "offset": 12584
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 6,
-        "typeArguments": []
-      },
-      "name": "C5",
-      "offset": 12600
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 7,
-        "typeArguments": null
-      },
-      "name": "C6",
-      "offset": 12616
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 2,
-        "typeArguments": null
-      },
-      "name": "C7",
-      "offset": 12632
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 12,
-        "typeArguments": null
-      },
-      "name": "C9",
-      "offset": 12680
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 5,
-        "typeArguments": null
-      },
       "name": "BOOL",
-      "offset": 12704
+      "offset": 6848
     },
     {
       "configurableType": {
@@ -97,7 +16,7 @@
         "typeArguments": null
       },
       "name": "U8",
-      "offset": 12712
+      "offset": 6984
     },
     {
       "configurableType": {
@@ -105,8 +24,8 @@
         "type": 13,
         "typeArguments": null
       },
-      "name": "ANOTHERU8",
-      "offset": 12728
+      "name": "ANOTHER_U8",
+      "offset": 6776
     },
     {
       "configurableType": {
@@ -115,7 +34,7 @@
         "typeArguments": null
       },
       "name": "U16",
-      "offset": 12736
+      "offset": 6928
     },
     {
       "configurableType": {
@@ -124,7 +43,7 @@
         "typeArguments": null
       },
       "name": "U32",
-      "offset": 12744
+      "offset": 6968
     },
     {
       "configurableType": {
@@ -133,7 +52,7 @@
         "typeArguments": null
       },
       "name": "U64",
-      "offset": 12760
+      "offset": 6976
     },
     {
       "configurableType": {
@@ -142,7 +61,52 @@
         "typeArguments": null
       },
       "name": "U256",
-      "offset": 12776
+      "offset": 6936
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 4,
+        "typeArguments": null
+      },
+      "name": "B256",
+      "offset": 6816
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 8,
+        "typeArguments": []
+      },
+      "name": "CONFIGURABLE_STRUCT",
+      "offset": 6888
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 6,
+        "typeArguments": []
+      },
+      "name": "CONFIGURABLE_ENUM_A",
+      "offset": 6856
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 6,
+        "typeArguments": []
+      },
+      "name": "CONFIGURABLE_ENUM_B",
+      "offset": 6872
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 2,
+        "typeArguments": null
+      },
+      "name": "ARRAY_BOOL",
+      "offset": 6784
     },
     {
       "configurableType": {
@@ -150,8 +114,8 @@
         "type": 3,
         "typeArguments": null
       },
-      "name": "ARRAY_U8",
-      "offset": 12808
+      "name": "ARRAY_U64",
+      "offset": 6792
     },
     {
       "configurableType": {
@@ -159,8 +123,17 @@
         "type": 1,
         "typeArguments": null
       },
-      "name": "ARRAY_U32",
-      "offset": 12840
+      "name": "TUPLE_BOOL_U64",
+      "offset": 6912
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 7,
+        "typeArguments": null
+      },
+      "name": "STR_4",
+      "offset": 6904
     }
   ],
   "encoding": "1",

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
@@ -6,8 +6,89 @@
         "type": 5,
         "typeArguments": null
       },
+      "name": "C0",
+      "offset": 12496
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 12,
+        "typeArguments": null
+      },
+      "name": "C1",
+      "offset": 12520
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 4,
+        "typeArguments": null
+      },
+      "name": "C2",
+      "offset": 12536
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 8,
+        "typeArguments": []
+      },
+      "name": "C3",
+      "offset": 12568
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 6,
+        "typeArguments": []
+      },
+      "name": "C4",
+      "offset": 12584
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 6,
+        "typeArguments": []
+      },
+      "name": "C5",
+      "offset": 12600
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 7,
+        "typeArguments": null
+      },
+      "name": "C6",
+      "offset": 12616
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 2,
+        "typeArguments": null
+      },
+      "name": "C7",
+      "offset": 12632
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 12,
+        "typeArguments": null
+      },
+      "name": "C9",
+      "offset": 12680
+    },
+    {
+      "configurableType": {
+        "name": "",
+        "type": 5,
+        "typeArguments": null
+      },
       "name": "BOOL",
-      "offset": 6928
+      "offset": 12704
     },
     {
       "configurableType": {
@@ -16,7 +97,7 @@
         "typeArguments": null
       },
       "name": "U8",
-      "offset": 7064
+      "offset": 12712
     },
     {
       "configurableType": {
@@ -24,8 +105,8 @@
         "type": 13,
         "typeArguments": null
       },
-      "name": "ANOTHER_U8",
-      "offset": 6856
+      "name": "ANOTHERU8",
+      "offset": 12728
     },
     {
       "configurableType": {
@@ -34,7 +115,7 @@
         "typeArguments": null
       },
       "name": "U16",
-      "offset": 7008
+      "offset": 12736
     },
     {
       "configurableType": {
@@ -43,7 +124,7 @@
         "typeArguments": null
       },
       "name": "U32",
-      "offset": 7048
+      "offset": 12744
     },
     {
       "configurableType": {
@@ -52,7 +133,7 @@
         "typeArguments": null
       },
       "name": "U64",
-      "offset": 7056
+      "offset": 12760
     },
     {
       "configurableType": {
@@ -61,52 +142,7 @@
         "typeArguments": null
       },
       "name": "U256",
-      "offset": 7016
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 4,
-        "typeArguments": null
-      },
-      "name": "B256",
-      "offset": 6896
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 8,
-        "typeArguments": []
-      },
-      "name": "CONFIGURABLE_STRUCT",
-      "offset": 6968
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 6,
-        "typeArguments": []
-      },
-      "name": "CONFIGURABLE_ENUM_A",
-      "offset": 6936
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 6,
-        "typeArguments": []
-      },
-      "name": "CONFIGURABLE_ENUM_B",
-      "offset": 6952
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 2,
-        "typeArguments": null
-      },
-      "name": "ARRAY_BOOL",
-      "offset": 6864
+      "offset": 12776
     },
     {
       "configurableType": {
@@ -114,8 +150,8 @@
         "type": 3,
         "typeArguments": null
       },
-      "name": "ARRAY_U64",
-      "offset": 6872
+      "name": "ARRAY_U8",
+      "offset": 12808
     },
     {
       "configurableType": {
@@ -123,17 +159,8 @@
         "type": 1,
         "typeArguments": null
       },
-      "name": "TUPLE_BOOL_U64",
-      "offset": 6992
-    },
-    {
-      "configurableType": {
-        "name": "",
-        "type": 7,
-        "typeArguments": null
-      },
-      "name": "STR_4",
-      "offset": 6984
+      "name": "ARRAY_U32",
+      "offset": 12840
     }
   ],
   "encoding": "1",

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/slice/slice_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/slice/slice_contract/src/main.sw
@@ -12,7 +12,7 @@ impl MyContract for Contract {
 
 #[test]
 fn test_success() {
-    let contract_id = 0xb144c1847a6403388cfd65eef01c742b24db355a1f12236be682f13aad4fdb3f;
+    let contract_id = 0xe947c4b04b557d746b2f77988a4cd8528f36a71748c9bf830c0a8aad6e03191b;
     let caller = abi(MyContract, contract_id);
 
     let data = 1u64;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/string_slice/string_slice_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/string_slice/string_slice_contract/src/main.sw
@@ -12,7 +12,7 @@ impl MyContract for Contract {
 
 #[test]
 fn test_success() {
-    let contract_id = 0xa2c21e6713a5bd5b44a11b1008bebf35c5498619c545cb37697cd44ddbdb4c73;
+    let contract_id = 0xd2cf22567d02b44ac9f2342b814d9e6502820fec8c37c9b4bc8e15a2821d329e;
     let caller = abi(MyContract, contract_id);
     let result = caller.test_function("a");
     assert(result == "a")

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_abi/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_abi/json_abi_oracle_new_encoding.json
@@ -7,7 +7,7 @@
         "typeArguments": null
       },
       "name": "SOME_U256",
-      "offset": 592
+      "offset": 688
     }
   ],
   "encoding": "1",

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_abi/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_abi/json_abi_oracle_new_encoding.json
@@ -7,7 +7,7 @@
         "typeArguments": null
       },
       "name": "SOME_U256",
-      "offset": 688
+      "offset": 584
     }
   ],
   "encoding": "1",

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
@@ -6,7 +6,7 @@ use std::hash::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x14ed3cd06c2947248f69d54bfa681fe40d26267be84df7e19e253622b7921bbe;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xad5e3937508bd711011c85aaa1e20a7a1051c723174d30139c87978cd24913cd;
+const CONTRACT_ID = 0xcc1468ec267568234fcdb371c6c02ffb778abf67002340d55cbb710b008bb75f;
 
 fn main() -> u64 {
     let addr = abi(TestContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
@@ -6,7 +6,7 @@ use std::hash::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x14ed3cd06c2947248f69d54bfa681fe40d26267be84df7e19e253622b7921bbe;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xcc1468ec267568234fcdb371c6c02ffb778abf67002340d55cbb710b008bb75f;
+const CONTRACT_ID = 0x7c137860c352ba9fbdf1e4a376a335a5b3f71369b8ae35567efc4badfe6fb683;
 
 fn main() -> u64 {
     let addr = abi(TestContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
@@ -6,7 +6,7 @@ use std::hash::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x14ed3cd06c2947248f69d54bfa681fe40d26267be84df7e19e253622b7921bbe;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x7c137860c352ba9fbdf1e4a376a335a5b3f71369b8ae35567efc4badfe6fb683;
+const CONTRACT_ID = 0x0b055b1a6c1c19ceff962224dbb194aefa2e1854948c7510c0c199c5f0d93e9e;
 
 fn main() -> u64 {
     let addr = abi(TestContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
@@ -9,7 +9,7 @@ use test_fuel_coin_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const FUEL_COIN_CONTRACT_ID = 0x4c7b43ef5a097d7cfb87600a4234e33311eeeeb8081e5ea7bb6d9a1f8555c9c4;
 #[cfg(experimental_new_encoding = true)]
-const FUEL_COIN_CONTRACT_ID = 0x99b5be891136039703e20f68f1d290ab944071f2e86b3f6c1ff6b8ffeffed6b4;
+const FUEL_COIN_CONTRACT_ID = 0x08aa952ce1bd827e217c95fcbff17dc680df424e69bf3e912332e5affaa9ef0a;
 
 #[cfg(experimental_new_encoding = false)]
 const BALANCE_CONTRACT_ID = 0x3120fdd1b99c0c611308aff43a99746cc2c661c69c22aa56331d5f3ce5534ee9;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
@@ -9,12 +9,12 @@ use test_fuel_coin_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const FUEL_COIN_CONTRACT_ID = 0x4c7b43ef5a097d7cfb87600a4234e33311eeeeb8081e5ea7bb6d9a1f8555c9c4;
 #[cfg(experimental_new_encoding = true)]
-const FUEL_COIN_CONTRACT_ID = 0x1cca4a529aefcae07be80c5b36c0d0928f936836deb742bebffc041f10fbca1b;
+const FUEL_COIN_CONTRACT_ID = 0x99b5be891136039703e20f68f1d290ab944071f2e86b3f6c1ff6b8ffeffed6b4;
 
 #[cfg(experimental_new_encoding = false)]
 const BALANCE_CONTRACT_ID = 0x3120fdd1b99c0c611308aff43a99746cc2c661c69c22aa56331d5f3ce5534ee9;
 #[cfg(experimental_new_encoding = true)]
-const BALANCE_CONTRACT_ID = 0x9dac51d44d9d053eb2bf1f68bfdbd889ddfdcb470727cda2e1a132f5660f63a6;
+const BALANCE_CONTRACT_ID = 0x2b7c8f397dc8a3d9686865c21043950bfaa31631bf07672b7798d5e4e9ad5603;
 
 fn main() -> bool {
     let default_gas = 1_000_000_000_000;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
@@ -9,12 +9,12 @@ use test_fuel_coin_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const FUEL_COIN_CONTRACT_ID = 0x4c7b43ef5a097d7cfb87600a4234e33311eeeeb8081e5ea7bb6d9a1f8555c9c4;
 #[cfg(experimental_new_encoding = true)]
-const FUEL_COIN_CONTRACT_ID = 0x08aa952ce1bd827e217c95fcbff17dc680df424e69bf3e912332e5affaa9ef0a;
+const FUEL_COIN_CONTRACT_ID = 0x4310867f369075df5771b1d2ac0965d3f28c782afebba2e6f18ebada3a4b367c;
 
 #[cfg(experimental_new_encoding = false)]
 const BALANCE_CONTRACT_ID = 0x3120fdd1b99c0c611308aff43a99746cc2c661c69c22aa56331d5f3ce5534ee9;
 #[cfg(experimental_new_encoding = true)]
-const BALANCE_CONTRACT_ID = 0x2b7c8f397dc8a3d9686865c21043950bfaa31631bf07672b7798d5e4e9ad5603;
+const BALANCE_CONTRACT_ID = 0x766a3ca00db4b974ef2d9bd87ec9a748999ad03eec72d8df26fd326b7c9320c9;
 
 fn main() -> bool {
     let default_gas = 1_000_000_000_000;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/src/main.sw
@@ -5,7 +5,7 @@ use balance_test_abi::BalanceTest;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x3120fdd1b99c0c611308aff43a99746cc2c661c69c22aa56331d5f3ce5534ee9;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x2b7c8f397dc8a3d9686865c21043950bfaa31631bf07672b7798d5e4e9ad5603;
+const CONTRACT_ID = 0x766a3ca00db4b974ef2d9bd87ec9a748999ad03eec72d8df26fd326b7c9320c9;
 
 fn main() -> bool {
     let balance_test_contract = abi(BalanceTest, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/src/main.sw
@@ -5,7 +5,7 @@ use balance_test_abi::BalanceTest;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x3120fdd1b99c0c611308aff43a99746cc2c661c69c22aa56331d5f3ce5534ee9;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x9dac51d44d9d053eb2bf1f68bfdbd889ddfdcb470727cda2e1a132f5660f63a6;
+const CONTRACT_ID = 0x2b7c8f397dc8a3d9686865c21043950bfaa31631bf07672b7798d5e4e9ad5603;
 
 fn main() -> bool {
     let balance_test_contract = abi(BalanceTest, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/src/main.sw
@@ -6,7 +6,7 @@ use abi_with_tuples::{MyContract, Location, Person};
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xb351aff8258ce46d16a71be666dd2b0b09d72243105c51f4423765824e59cac9;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x9f341d1ca758142d81f64f54bddcfd73d836c357a9723dc114fcfd35a21f6b4b;
+const CONTRACT_ID = 0x8d23960fbbac5c6b68b075c4e0e41d96a0633cb5b850620b7b22dcb867d33b08;
 
 fn main() -> bool {
     let the_abi = abi(MyContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/src/main.sw
@@ -6,7 +6,7 @@ use abi_with_tuples::{MyContract, Location, Person};
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xb351aff8258ce46d16a71be666dd2b0b09d72243105c51f4423765824e59cac9;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x8d23960fbbac5c6b68b075c4e0e41d96a0633cb5b850620b7b22dcb867d33b08;
+const CONTRACT_ID = 0x495633977922110c13c86e5637045d6f5ae22779c7a4a52b5d35ec69aad7d0ec;
 
 fn main() -> bool {
     let the_abi = abi(MyContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/src/main.sw
@@ -6,7 +6,7 @@ use abi_with_tuples::{MyContract, Location, Person};
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xb351aff8258ce46d16a71be666dd2b0b09d72243105c51f4423765824e59cac9;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xbc8374cc7bbfa50d3c1f1b6b3a000176272ae875402e6ee55a7ad3bcc3bdde9d;
+const CONTRACT_ID = 0x9f341d1ca758142d81f64f54bddcfd73d836c357a9723dc114fcfd35a21f6b4b;
 
 fn main() -> bool {
     let the_abi = abi(MyContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -4,7 +4,7 @@ use basic_storage_abi::{BasicStorage, Quad};
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x044ab65bcabeebb73c88d8625ce392224c613cb1dae21ebedaa36bf6db1f5f4e;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xc9686da7404bdbd1fd666dd5b9328f0846d22e54765d4c9f49a3fbc6775684f6;
+const CONTRACT_ID = 0x5342d41bd5af94698c162984ba8d470741a4632cbe5d71d3eda49415582653cc;
 
 fn main() -> u64 {
     let addr = abi(BasicStorage, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -4,7 +4,7 @@ use basic_storage_abi::{BasicStorage, Quad};
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x044ab65bcabeebb73c88d8625ce392224c613cb1dae21ebedaa36bf6db1f5f4e;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x0550df4fa340d2bbfe638adc3f078cb522153073466bd246c141866f3a07b6e4;
+const CONTRACT_ID = 0xc9686da7404bdbd1fd666dd5b9328f0846d22e54765d4c9f49a3fbc6775684f6;
 
 fn main() -> u64 {
     let addr = abi(BasicStorage, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -4,7 +4,7 @@ use basic_storage_abi::{BasicStorage, Quad};
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x044ab65bcabeebb73c88d8625ce392224c613cb1dae21ebedaa36bf6db1f5f4e;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x5342d41bd5af94698c162984ba8d470741a4632cbe5d71d3eda49415582653cc;
+const CONTRACT_ID = 0xefdc4aadfe54fe83c0a74b756cc594f096798e299cda748fd63478037a84f8f5;
 
 fn main() -> u64 {
     let addr = abi(BasicStorage, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_contract_with_type_aliases/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_contract_with_type_aliases/src/main.sw
@@ -5,7 +5,7 @@ use contract_with_type_aliases_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x0cbeb6efe3104b460be769bdc4ea101ebf16ccc16f2d7b667ec3e1c7f5ce35b5;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x236840f1de509675db749a31372fb87d45453a99872c0434e74552eea581f22b;
+const CONTRACT_ID = 0x63ce8925d89245252bb2568ea26e9bbde03340634a1553ef05af33d089507d09;
 
 fn main() {
     let caller = abi(MyContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_contract_with_type_aliases/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_contract_with_type_aliases/src/main.sw
@@ -5,7 +5,7 @@ use contract_with_type_aliases_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x0cbeb6efe3104b460be769bdc4ea101ebf16ccc16f2d7b667ec3e1c7f5ce35b5;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x664627a561fd1242cc837616a01ffe4f85a5721012888f7d5c4292708e0c2c77;
+const CONTRACT_ID = 0x236840f1de509675db749a31372fb87d45453a99872c0434e74552eea581f22b;
 
 fn main() {
     let caller = abi(MyContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_contract_with_type_aliases/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_contract_with_type_aliases/src/main.sw
@@ -5,7 +5,7 @@ use contract_with_type_aliases_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x0cbeb6efe3104b460be769bdc4ea101ebf16ccc16f2d7b667ec3e1c7f5ce35b5;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xd5615006ae0854832fa45a8dbbfe716fba427bc3021946fc80817ca62c153850;
+const CONTRACT_ID = 0x664627a561fd1242cc837616a01ffe4f85a5721012888f7d5c4292708e0c2c77;
 
 fn main() {
     let caller = abi(MyContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
@@ -6,7 +6,7 @@ use dynamic_contract_call::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x080ca4b6a4661d3cc2138f733cbe54095ce8b910eee73d913c1f43ecad6bf0d2;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x26900d2bac88ca2f59bf0f73f78d8a862c6e8f0b88c42ca46704a73a35ca4b6d;
+const CONTRACT_ID = 0x3da20813f865a73d19759fe1313070a3d27ef7de3ea8d1eed3e853c7d4f91f23;
 
 fn main() -> bool {
     let the_abi = abi(Incrementor, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
@@ -6,7 +6,7 @@ use dynamic_contract_call::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x080ca4b6a4661d3cc2138f733cbe54095ce8b910eee73d913c1f43ecad6bf0d2;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xe2e720d182b0e443a995ca4bfd1cd44dd5ca8cd4ef393dd2e8f3be509e9f9e34;
+const CONTRACT_ID = 0x26900d2bac88ca2f59bf0f73f78d8a862c6e8f0b88c42ca46704a73a35ca4b6d;
 
 fn main() -> bool {
     let the_abi = abi(Incrementor, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
@@ -6,7 +6,7 @@ use dynamic_contract_call::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x080ca4b6a4661d3cc2138f733cbe54095ce8b910eee73d913c1f43ecad6bf0d2;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x3da20813f865a73d19759fe1313070a3d27ef7de3ea8d1eed3e853c7d4f91f23;
+const CONTRACT_ID = 0x816715b0a467208e131305b645268e1d45ca13a79e01661026ea353e632747c9;
 
 fn main() -> bool {
     let the_abi = abi(Incrementor, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
@@ -5,7 +5,7 @@ use storage_enum_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x0d2d9546e833c166b64a340f5694fa01ca6bb53c3ec681d6c1ade1b9c0a2bf46;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xc49c28329e46bfb7ba3f64a3e931769d1219570a0f40eee78cb4d5540ece1719;
+const CONTRACT_ID = 0xd11aad8da18408a5439db07e26075df0c20b534c30e1c936b2ab566c77e62871;
 
 fn main() -> u64 {
     let caller = abi(StorageEnum, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
@@ -5,7 +5,7 @@ use storage_enum_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x0d2d9546e833c166b64a340f5694fa01ca6bb53c3ec681d6c1ade1b9c0a2bf46;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xc27baae5959faf586dabd2387ff1332b5af71c0c91c62f31bc4f826d61bd6574;
+const CONTRACT_ID = 0xc49c28329e46bfb7ba3f64a3e931769d1219570a0f40eee78cb4d5540ece1719;
 
 fn main() -> u64 {
     let caller = abi(StorageEnum, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
@@ -5,7 +5,7 @@ use storage_enum_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x0d2d9546e833c166b64a340f5694fa01ca6bb53c3ec681d6c1ade1b9c0a2bf46;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xd11aad8da18408a5439db07e26075df0c20b534c30e1c936b2ab566c77e62871;
+const CONTRACT_ID = 0x62253b3aea7ea4986285f38db1f5202d1cf3c8a6684fd4f682370178095f84d0;
 
 fn main() -> u64 {
     let caller = abi(StorageEnum, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/src/main.sw
@@ -5,7 +5,7 @@ use auth_testing_abi::AuthTesting;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xc2eec20491b53aab7232cbd27c31d15417b4e9daf0b89c74cc242ef1295f681f;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x886f83b58dd6af803814b3af3c7f4b2fcdc9b6e99577746996feba8e117fe760;
+const CONTRACT_ID = 0xe0bc2f43777f5eb6d4dfd166ae7466b6b47ec1c4a9441a80d95fcb3d2e8a3e65;
 
 // should be false in the case of a script
 fn main() -> bool {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/src/main.sw
@@ -5,7 +5,7 @@ use auth_testing_abi::AuthTesting;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xc2eec20491b53aab7232cbd27c31d15417b4e9daf0b89c74cc242ef1295f681f;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xe0bc2f43777f5eb6d4dfd166ae7466b6b47ec1c4a9441a80d95fcb3d2e8a3e65;
+const CONTRACT_ID = 0x15d0746653b12e716b17d4443b1fa955a2bf658fe20a7da14e4c9fccd0800761;
 
 // should be false in the case of a script
 fn main() -> bool {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
@@ -6,7 +6,7 @@ use context_testing_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xc2ec2a4a1b20475700e6793c7f20ad8082294894242b17cf08b5fd7c0d3968ad;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x554f1971d3f43aea4a4802bb0d2d11422a9a1bf33c6e347a6a1d188782a78840;
+const CONTRACT_ID = 0x9741593c0898ef633b58d97af2803c1dbaced9f573380ea96e72eaaf629fa32b;
 
 fn main() -> bool {
     let gas: u64 = u64::max();

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
@@ -6,7 +6,7 @@ use context_testing_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xc2ec2a4a1b20475700e6793c7f20ad8082294894242b17cf08b5fd7c0d3968ad;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x9741593c0898ef633b58d97af2803c1dbaced9f573380ea96e72eaaf629fa32b;
+const CONTRACT_ID = 0xbe2bd82457a1a5accf22ffdb26103bb935ae8f0e6d5ddd211c2b7571729362b5;
 
 fn main() -> bool {
     let gas: u64 = u64::max();

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
@@ -6,7 +6,7 @@ use context_testing_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xc2ec2a4a1b20475700e6793c7f20ad8082294894242b17cf08b5fd7c0d3968ad;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xbe2bd82457a1a5accf22ffdb26103bb935ae8f0e6d5ddd211c2b7571729362b5;
+const CONTRACT_ID = 0xcb8c742a94a65c93515aacf26496bdea9b59131a161299d8dad0903c811a60ec;
 
 fn main() -> bool {
     let gas: u64 = u64::max();

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/nested_struct_args_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/nested_struct_args_caller/src/main.sw
@@ -5,7 +5,7 @@ use nested_struct_args_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x64390eb0cac08d41b6476ad57d711b88846ea35ac800d4fc3c95a551e4039432;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x26e66c5eeb71a2d0b8610b6f94ac59922d9b3405de2790bf863a63c46b1b5227;
+const CONTRACT_ID = 0x1b9c368c7192e419e4b27cd8ff0d4231b913a4fe056f080c90a691f5eb53cc63;
 
 fn main() -> bool {
     let caller = abi(NestedStructArgs, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/nested_struct_args_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/nested_struct_args_caller/src/main.sw
@@ -5,7 +5,7 @@ use nested_struct_args_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x64390eb0cac08d41b6476ad57d711b88846ea35ac800d4fc3c95a551e4039432;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x1b9c368c7192e419e4b27cd8ff0d4231b913a4fe056f080c90a691f5eb53cc63;
+const CONTRACT_ID = 0x0728f17e158e716ef954591a1955dd10279e6138196e8e4428b045e735844283;
 
 fn main() -> bool {
     let caller = abi(NestedStructArgs, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/nested_struct_args_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/nested_struct_args_caller/src/main.sw
@@ -5,7 +5,7 @@ use nested_struct_args_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x64390eb0cac08d41b6476ad57d711b88846ea35ac800d4fc3c95a551e4039432;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x0728f17e158e716ef954591a1955dd10279e6138196e8e4428b045e735844283;
+const CONTRACT_ID = 0x8c7a0b9e22605ebe6190880f6344ac85deccdcfcb998fa877adcf9ae52af0f61;
 
 fn main() -> bool {
     let caller = abi(NestedStructArgs, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
@@ -6,7 +6,7 @@ use std::hash::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x88732a14508defea37a44d0b0ae9af5c776253215180a1c3288f8d504ebb84db;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x1c9871685903f7348403dc4bbd4576fbe6803fc6daccf0f016e0c45cb6678368;
+const CONTRACT_ID = 0xc8bba416cbcd180f458ca79d9b700ab4340a41dbe7a2cf9c06b733d878cc137b;
 
 fn main() -> bool {
     let caller = abi(StorageAccess, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
@@ -6,7 +6,7 @@ use std::hash::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x88732a14508defea37a44d0b0ae9af5c776253215180a1c3288f8d504ebb84db;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xc8bba416cbcd180f458ca79d9b700ab4340a41dbe7a2cf9c06b733d878cc137b;
+const CONTRACT_ID = 0x61455db976cc30e0f72b1f6bb12f4e00bb8851b07f57a8272241ffc9bdcdf7de;
 
 fn main() -> bool {
     let caller = abi(StorageAccess, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
@@ -6,7 +6,7 @@ use std::hash::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x88732a14508defea37a44d0b0ae9af5c776253215180a1c3288f8d504ebb84db;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x68d755d3d33d463a1eea52b5a5d38eff4c579f2be440dad02ef6cd8417ce3422;
+const CONTRACT_ID = 0x1c9871685903f7348403dc4bbd4576fbe6803fc6daccf0f016e0c45cb6678368;
 
 fn main() -> bool {
     let caller = abi(StorageAccess, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/test_fuel_coin_abi/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/test_fuel_coin_abi/Forc.lock
@@ -1,11 +1,13 @@
 [[package]]
-name = 'core'
-dependencies = []
+name = "core"
+source = "path+from-root-A7EBB443FC21DBA0"
 
 [[package]]
-name = 'std'
-dependencies = ['core']
+name = "std"
+source = "path+from-root-A7EBB443FC21DBA0"
+dependencies = ["core"]
 
 [[package]]
-name = 'test_fuel_coin_abi'
-dependencies = ['std']
+name = "test_fuel_coin_abi"
+source = "member"
+dependencies = ["std"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/workspace_test/contract_multi_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/workspace_test/contract_multi_test/src/main.sw
@@ -17,7 +17,7 @@ fn test_foo() {
 
 #[test(should_revert)]
 fn test_fail() {
-    let contract_id = 0x348a1d42f7df43a5ba54385c9ed100c309e738916f5104fb149cf96c7cdd0894;
+    let contract_id = 0xaff6151370c3ddd774601146cf743dff5dc0b1bc485a46da875be31f2b3e7493;
     let caller = abi(MyContract, contract_id);
     let result = caller.test_function {}();
     assert(result == false)
@@ -25,7 +25,7 @@ fn test_fail() {
 
 #[test]
 fn test_success() {
-    let contract_id = 0x348a1d42f7df43a5ba54385c9ed100c309e738916f5104fb149cf96c7cdd0894;
+    let contract_id = 0xaff6151370c3ddd774601146cf743dff5dc0b1bc485a46da875be31f2b3e7493;
     let caller = abi(MyContract, contract_id);
     let result = caller.test_function {}();
     assert(result == true)

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/workspace_test/contract_multi_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/workspace_test/contract_multi_test/src/main.sw
@@ -17,7 +17,7 @@ fn test_foo() {
 
 #[test(should_revert)]
 fn test_fail() {
-    let contract_id = 0x0e92e0e9e366124ded23d8c8a9f4dfdc4a966c665387d22b1c977a6a9c3b0653;
+    let contract_id = 0x348a1d42f7df43a5ba54385c9ed100c309e738916f5104fb149cf96c7cdd0894;
     let caller = abi(MyContract, contract_id);
     let result = caller.test_function {}();
     assert(result == false)
@@ -25,7 +25,7 @@ fn test_fail() {
 
 #[test]
 fn test_success() {
-    let contract_id = 0x0e92e0e9e366124ded23d8c8a9f4dfdc4a966c665387d22b1c977a6a9c3b0653;
+    let contract_id = 0x348a1d42f7df43a5ba54385c9ed100c309e738916f5104fb149cf96c7cdd0894;
     let caller = abi(MyContract, contract_id);
     let result = caller.test_function {}();
     assert(result == true)

--- a/test/src/sdk-harness/test_projects/auth/mod.rs
+++ b/test/src/sdk-harness/test_projects/auth/mod.rs
@@ -128,7 +128,7 @@ async fn can_get_predicate_address() {
 
     // Setup Predciate
     let hex_predicate_address: &str =
-        "0x603856cc6c3d2d5f2d7460b2811fe3a3bf1554a4e7e70c411a9da94ea29ad929";
+        "0xe5d0a6dbd36c76a091d21e5281c98a0994f6c6b0bc04793532daf4d5b3594743";
     let predicate_address =
         Address::from_str(hex_predicate_address).expect("failed to create Address from string");
     let predicate_bech32_address = Bech32Address::from(predicate_address);
@@ -143,7 +143,7 @@ async fn can_get_predicate_address() {
 
     // If this test fails, it can be the predicate address
     // Uncomment the next line, get the predicate address and update above.
-    //dbg!(&predicate);
+    // dbg!(&predicate);
 
     // Next, we lock some assets in this predicate using the first wallet:
     // First wallet transfers amount to predicate.
@@ -254,7 +254,7 @@ async fn when_incorrect_predicate_address_passed() {
 async fn can_get_predicate_address_in_message() {
     // Setup Predciate address
     let hex_predicate_address: &str =
-        "0x413c19386a356dc93c35f384cd34efa65f8779d8da3f1bac783bc18edab08a3c";
+        "0xe5d0a6dbd36c76a091d21e5281c98a0994f6c6b0bc04793532daf4d5b3594743";
     let predicate_address =
         Address::from_str(hex_predicate_address).expect("failed to create Address from string");
     let predicate_bech32_address = Bech32Address::from(predicate_address);
@@ -301,6 +301,10 @@ async fn can_get_predicate_address_in_message() {
             .unwrap()
             .with_provider(wallet.try_provider().unwrap().clone())
             .with_data(predicate_data);
+
+    // If this test fails, it can be the predicate address
+    // Uncomment the next line, get the predicate address and update above.
+    // dbg!(&predicate);
 
     // Check predicate balance.
     let balance = predicate

--- a/test/src/sdk-harness/test_projects/auth/mod.rs
+++ b/test/src/sdk-harness/test_projects/auth/mod.rs
@@ -5,7 +5,11 @@ use fuels::{
     },
     prelude::*,
     tx::UtxoId,
-    types::{ContractId, message::{Message, MessageStatus}, coin::{Coin, CoinStatus}, Bytes32},
+    types::{
+        coin::{Coin, CoinStatus},
+        message::{Message, MessageStatus},
+        Bytes32, ContractId,
+    },
 };
 use std::str::FromStr;
 
@@ -124,7 +128,7 @@ async fn can_get_predicate_address() {
 
     // Setup Predciate
     let hex_predicate_address: &str =
-        "0x413c19386a356dc93c35f384cd34efa65f8779d8da3f1bac783bc18edab08a3c";
+        "0x603856cc6c3d2d5f2d7460b2811fe3a3bf1554a4e7e70c411a9da94ea29ad929";
     let predicate_address =
         Address::from_str(hex_predicate_address).expect("failed to create Address from string");
     let predicate_bech32_address = Bech32Address::from(predicate_address);
@@ -136,6 +140,10 @@ async fn can_get_predicate_address() {
             .unwrap()
             .with_provider(first_wallet.try_provider().unwrap().clone())
             .with_data(predicate_data);
+
+    // If this test fails, it can be the predicate address
+    // Uncomment the next line, get the predicate address and update above.
+    //dbg!(&predicate);
 
     // Next, we lock some assets in this predicate using the first wallet:
     // First wallet transfers amount to predicate.
@@ -242,7 +250,6 @@ async fn when_incorrect_predicate_address_passed() {
         .unwrap();
 }
 
-
 #[tokio::test]
 async fn can_get_predicate_address_in_message() {
     // Setup Predciate address
@@ -278,9 +285,11 @@ async fn can_get_predicate_address_in_message() {
     };
     let mut coin_vec: Vec<Coin> = Vec::new();
     coin_vec.push(coin);
-    
+
     let mut wallet = WalletUnlocked::new_random(None);
-    let provider = setup_test_provider(coin_vec, message_vec, None, None).await.unwrap();
+    let provider = setup_test_provider(coin_vec, message_vec, None, None)
+        .await
+        .unwrap();
     wallet.set_provider(provider.clone());
 
     // Setup Predciate
@@ -299,7 +308,7 @@ async fn can_get_predicate_address_in_message() {
         .await
         .unwrap();
     assert_eq!(balance, message_amount);
-    
+
     // Spend the message
     predicate
         .transfer(
@@ -308,7 +317,8 @@ async fn can_get_predicate_address_in_message() {
             AssetId::default(),
             TxPolicies::default(),
         )
-        .await.unwrap();
+        .await
+        .unwrap();
 
     // The predicate has spent the funds
     let predicate_balance = predicate
@@ -318,9 +328,6 @@ async fn can_get_predicate_address_in_message() {
     assert_eq!(predicate_balance, 0);
 
     // Funds were transferred
-    let wallet_balance = wallet
-        .get_asset_balance(&AssetId::default())
-        .await
-        .unwrap();
+    let wallet_balance = wallet.get_asset_balance(&AssetId::default()).await.unwrap();
     assert_eq!(wallet_balance, message_amount);
 }


### PR DESCRIPTION
## Description

This PR implements five optimizations to decrease the binary size of contracts:

1 - create `BufferReader` only once;
2 - `BufferReader` using only one pointer to the current position;
3 - more specialized read fns for `BufferReader`;
4 - remove useless binary operations;
5 - do not encode the result of a contract method, if it is `()`.

Which brings the contract `test_fuel_coin_contract` from 3400 to 2560 bytes. Around 25% improvement. Results will be more timid for bigger contracts.

![image](https://github.com/FuelLabs/sway/assets/83425/b29c1a65-60ff-48c8-91e3-dacf316e1336)

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
