### PR TITLE
Update `Inputs` library return types to match VM specs

### DIFF
--- a/sway-lib-std/src/auth.sw
+++ b/sway-lib-std/src/auth.sw
@@ -134,7 +134,7 @@ pub fn msg_sender() -> Result<Identity, AuthError> {
 pub fn caller_address() -> Result<Address, AuthError> {
     let inputs = input_count();
     let mut candidate = None;
-    let mut i = 0u8;
+    let mut i = 0u16;
 
     // Note: `inputs_count` is guaranteed to be at least 1 for any valid tx.
     while i < inputs {
@@ -144,7 +144,7 @@ pub fn caller_address() -> Result<Address, AuthError> {
             Input::Message => (),
             _ => {
                 // type != InputCoin or InputMessage, continue looping.
-                i += 1u8;
+                i += 1u16;
                 continue;
             }
         }
@@ -154,7 +154,7 @@ pub fn caller_address() -> Result<Address, AuthError> {
         if candidate.is_none() {
             // This is the first input seen of the correct type.
             candidate = owner_of_input;
-            i += 1u8;
+            i += 1u16;
             continue;
         }
 
@@ -163,7 +163,7 @@ pub fn caller_address() -> Result<Address, AuthError> {
         // at this point, so we can unwrap safely.
         if owner_of_input.unwrap() == candidate.unwrap() {
             // Owners are a match, continue looping.
-            i += 1u8;
+            i += 1u16;
             continue;
         }
 

--- a/sway-lib-std/src/inputs.sw
+++ b/sway-lib-std/src/inputs.sw
@@ -108,7 +108,7 @@ pub fn input_type(index: u64) -> Input {
 ///
 /// # Returns
 ///
-/// * [u8] - The number of inputs in the transaction.
+/// * [u16] - The number of inputs in the transaction.
 ///
 /// # Examples
 ///
@@ -117,13 +117,13 @@ pub fn input_type(index: u64) -> Input {
 ///
 /// fn foo() {
 ///     let input_count = input_count();
-///     assert(input_count == 1);
+///     assert(input_count == 1_u16);
 /// }
 /// ```
-pub fn input_count() -> u8 {
+pub fn input_count() -> u16 {
     match tx_type() {
-        Transaction::Script => __gtf::<u8>(0, GTF_SCRIPT_INPUTS_COUNT),
-        Transaction::Create => __gtf::<u8>(0, GTF_CREATE_INPUTS_COUNT),
+        Transaction::Script => __gtf::<u16>(0, GTF_SCRIPT_INPUTS_COUNT),
+        Transaction::Create => __gtf::<u16>(0, GTF_CREATE_INPUTS_COUNT),
     }
 }
 
@@ -299,7 +299,7 @@ pub fn input_asset_id(index: u64) -> Option<AssetId> {
 ///
 /// # Returns
 ///
-/// * [Option<u8>] - The witness index of the input at `index`, if the input's type is `Input::Coin` or `Input::Message`, else `None`.
+/// * [Option<u16>] - The witness index of the input at `index`, if the input's type is `Input::Coin` or `Input::Message`, else `None`.
 ///
 /// # Examples
 ///
@@ -311,10 +311,10 @@ pub fn input_asset_id(index: u64) -> Option<AssetId> {
 ///     assert(input_witness_index.is_some()); // Ensure the input has a witness index.
 /// }
 /// ```
-pub fn input_witness_index(index: u64) -> Option<u8> {
+pub fn input_witness_index(index: u64) -> Option<u16> {
     match input_type(index) {
-        Input::Coin => Some(__gtf::<u8>(index, GTF_INPUT_COIN_WITNESS_INDEX)),
-        Input::Message => Some(__gtf::<u8>(index, GTF_INPUT_MESSAGE_WITNESS_INDEX)),
+        Input::Coin => Some(__gtf::<u16>(index, GTF_INPUT_COIN_WITNESS_INDEX)),
+        Input::Message => Some(__gtf::<u16>(index, GTF_INPUT_MESSAGE_WITNESS_INDEX)),
         Input::Contract => None,
     }
 }
@@ -327,7 +327,7 @@ pub fn input_witness_index(index: u64) -> Option<u8> {
 ///
 /// # Returns
 ///
-/// * [Option<u16>] - The predicate length of the input at `index`, if the input's type is `Input::Coin` or `Input::Message`, else `None`.
+/// * [Option<u64>] - The predicate length of the input at `index`, if the input's type is `Input::Coin` or `Input::Message`, else `None`.
 ///
 /// # Examples
 ///
@@ -336,13 +336,13 @@ pub fn input_witness_index(index: u64) -> Option<u8> {
 ///
 /// fn foo() {
 ///     let input_predicate_length = input_predicate_length(0);
-///     assert(input_predicate_length.unwrap() != 0u16);
+///     assert(input_predicate_length.unwrap() != 0u64);
 /// }
 /// ```
-pub fn input_predicate_length(index: u64) -> Option<u16> {
+pub fn input_predicate_length(index: u64) -> Option<u64> {
     match input_type(index) {
-        Input::Coin => Some(__gtf::<u16>(index, GTF_INPUT_COIN_PREDICATE_LENGTH)),
-        Input::Message => Some(__gtf::<u16>(index, GTF_INPUT_MESSAGE_PREDICATE_LENGTH)),
+        Input::Coin => Some(__gtf::<u64>(index, GTF_INPUT_COIN_PREDICATE_LENGTH)),
+        Input::Message => Some(__gtf::<u64>(index, GTF_INPUT_MESSAGE_PREDICATE_LENGTH)),
         Input::Contract => None,
     }
 }
@@ -404,7 +404,7 @@ pub fn input_predicate(index: u64) -> Bytes {
     if wrapped.is_none() {
         revert(0);
     };
-    let length = wrapped.unwrap().as_u64();
+    let length = wrapped.unwrap();
     let new_ptr = alloc_bytes(length);
     match input_predicate_pointer(index) {
         Some(d) => {
@@ -423,7 +423,7 @@ pub fn input_predicate(index: u64) -> Bytes {
 ///
 /// # Returns
 ///
-/// * [Option<u16>] - The predicate data length of the input at `index`, if the input's type is `Input::Coin` or `Input::Message`, else `None`.
+/// * [Option<u64>] - The predicate data length of the input at `index`, if the input's type is `Input::Coin` or `Input::Message`, else `None`.
 ///
 /// # Examples
 ///
@@ -432,13 +432,13 @@ pub fn input_predicate(index: u64) -> Bytes {
 ///
 /// fn foo() {
 ///     let input_predicate_data_length = input_predicate_data_length(0);
-///     assert(input_predicate_data_length.unwrap() != 0_u16);
+///     assert(input_predicate_data_length.unwrap() != 0_u64);
 /// }
 /// ```
-pub fn input_predicate_data_length(index: u64) -> Option<u16> {
+pub fn input_predicate_data_length(index: u64) -> Option<u64> {
     match input_type(index) {
-        Input::Coin => Some(__gtf::<u16>(index, GTF_INPUT_COIN_PREDICATE_DATA_LENGTH)),
-        Input::Message => Some(__gtf::<u16>(index, GTF_INPUT_MESSAGE_PREDICATE_DATA_LENGTH)),
+        Input::Coin => Some(__gtf::<u64>(index, GTF_INPUT_COIN_PREDICATE_DATA_LENGTH)),
+        Input::Message => Some(__gtf::<u64>(index, GTF_INPUT_MESSAGE_PREDICATE_DATA_LENGTH)),
         Input::Contract => None,
     }
 }
@@ -525,7 +525,7 @@ pub fn input_message_nonce(index: u64) -> b256 {
 ///
 /// # Returns
 ///
-/// * [u16] - The length of the input message at `index`, if the input's type is `Input::Message`.
+/// * [u64] - The length of the input message at `index`, if the input's type is `Input::Message`.
 ///
 /// # Examples
 ///
@@ -534,11 +534,11 @@ pub fn input_message_nonce(index: u64) -> b256 {
 ///
 /// fn foo() {
 ///     let input_message_length = input_message_length(0);
-///     assert(input_message_length != 0_u16);
+///     assert(input_message_length != 0_u64);
 /// }
 /// ```
-pub fn input_message_data_length(index: u64) -> u16 {
-    __gtf::<u16>(index, GTF_INPUT_MESSAGE_DATA_LENGTH)
+pub fn input_message_data_length(index: u64) -> u64 {
+    __gtf::<u64>(index, GTF_INPUT_MESSAGE_DATA_LENGTH)
 }
 
 /// Gets the data of the input message at `index`.
@@ -570,7 +570,7 @@ pub fn input_message_data(index: u64, offset: u64) -> Bytes {
     assert(valid_input_type(index, Input::Message));
     let data = __gtf::<raw_ptr>(index, GTF_INPUT_MESSAGE_DATA);
     let data_with_offset = data.add_uint_offset(offset);
-    let length = input_message_data_length(index).as_u64();
+    let length = input_message_data_length(index);
     let new_ptr = alloc_bytes(length);
 
     data_with_offset.copy_bytes_to(new_ptr, length);

--- a/test/src/sdk-harness/test_artifacts/tx_contract/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/tx_contract/src/main.sw
@@ -42,10 +42,10 @@ abi TxContractTest {
     fn get_input_message_sender(index: u64) -> Address;
     fn get_input_message_recipient(index: u64) -> Address;
     fn get_input_message_nonce(index: u64) -> b256;
-    fn get_input_witness_index(index: u64) -> u8;
-    fn get_input_message_data_length(index: u64) -> u16;
-    fn get_input_predicate_length(index: u64) -> u16;
-    fn get_input_predicate_data_length(index: u64) -> u16;
+    fn get_input_witness_index(index: u64) -> u16;
+    fn get_input_message_data_length(index: u64) -> u64;
+    fn get_input_predicate_length(index: u64) -> u64;
+    fn get_input_predicate_data_length(index: u64) -> u64;
     fn get_input_message_data(index: u64, offset: u64, expected: [u8; 3]) -> bool;
     fn get_input_predicate(index: u64, bytecode: Vec<u8>) -> bool;
 
@@ -139,16 +139,16 @@ impl TxContractTest for Contract {
     fn get_input_message_nonce(index: u64) -> b256 {
         input_message_nonce(index)
     }
-    fn get_input_witness_index(index: u64) -> u8 {
+    fn get_input_witness_index(index: u64) -> u16 {
         input_witness_index(index).unwrap()
     }
-    fn get_input_message_data_length(index: u64) -> u16 {
+    fn get_input_message_data_length(index: u64) -> u64 {
         input_message_data_length(index)
     }
-    fn get_input_predicate_length(index: u64) -> u16 {
+    fn get_input_predicate_length(index: u64) -> u64 {
         input_predicate_length(index).unwrap()
     }
-    fn get_input_predicate_data_length(index: u64) -> u16 {
+    fn get_input_predicate_data_length(index: u64) -> u64 {
         input_predicate_data_length(index).unwrap()
     }
     fn get_input_message_data(index: u64, offset: u64, expected: [u8; 3]) -> bool {
@@ -164,7 +164,7 @@ impl TxContractTest for Contract {
 
     fn get_input_predicate(index: u64, bytecode: Vec<u8>) -> bool {
         let code = input_predicate(index);
-        assert(input_predicate_length(index).unwrap().as_u64() == bytecode.len());
+        assert(input_predicate_length(index).unwrap() == bytecode.len());
         let mut i = 0;
         while i < bytecode.len() {
             assert(bytecode.get(i).unwrap() == code.get(i).unwrap());

--- a/test/src/sdk-harness/test_projects/tx_fields/mod.rs
+++ b/test/src/sdk-harness/test_projects/tx_fields/mod.rs
@@ -742,7 +742,7 @@ mod inputs {
                     .take_receipts_checked(None)
                     .unwrap();
 
-                assert_eq!(receipts[1].data(), Some(&[0, 3][..]));
+                assert_eq!(receipts[1].data(), Some(&[0, 0, 0, 0, 0, 0, 0, 3][..]));
             }
 
             #[tokio::test]
@@ -777,7 +777,7 @@ mod inputs {
                     .take_receipts_checked(None)
                     .unwrap();
 
-                let len = predicate_bytecode.len() as u16;
+                let len = predicate_bytecode.len() as u64;
                 assert_eq!(receipts[1].data(), Some(len.to_be_bytes().as_slice()));
             }
 
@@ -812,7 +812,7 @@ mod inputs {
                     .take_receipts_checked(None)
                     .unwrap();
 
-                assert_eq!(receipts[1].data(), Some(0u16.to_le_bytes().as_slice()));
+                assert_eq!(receipts[1].data(), Some(0u64.to_le_bytes().as_slice()));
             }
 
             #[tokio::test]


### PR DESCRIPTION
## Description

There have been changes to the VM specs where the return type has been updated from `u16` to `u64` or from `u8` to `u16` for inputs. These changes are now reflected in the std-lib's `Inputs` library. Specs: https://github.com/FuelLabs/fuel-specs/blob/master/src/tx-format/input.md

## Breaking

This is a breaking change. Any use of the following will need to be updated:

- `input_count()` now returns a `u16`
- `input_witness_index()` now returns a `u16`
- `input_predicate_length()` now returns a `u64`
- `input_predicate_data_length()` now returns a `u64`
- `input_message_data_length()` now returns a `u64`

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
