### PR TITLE
Change `StorageMap`'s `remove()` to use `sha256(key, self.field_id())` instead of `sha256(key, self.slot())`

### DIFF
--- a/sway-lib-std/src/storage/storage_map.sw
+++ b/sway-lib-std/src/storage/storage_map.sw
@@ -124,7 +124,7 @@ where
     where
         K: Hash,
     {
-        let key = sha256((key, self.slot()));
+        let key = sha256((key, self.field_id()));
         clear::<V>(key, 0)
     }
 

--- a/test/src/sdk-harness/test_projects/storage_map_nested/src/main.sw
+++ b/test/src/sdk-harness/test_projects/storage_map_nested/src/main.sw
@@ -85,6 +85,22 @@ impl ExperimentalStorageTest for Contract {
         assert(storage.nested_map_1.get(2).get(1).get(1).try_read().is_none());
         assert(storage.nested_map_1.get(1).get(2).get(1).try_read().is_none());
         assert(storage.nested_map_1.get(1).get(1).get(2).try_read().is_none());
+
+        let result_1: bool = storage.nested_map_1.get(0).get(0).remove(0);
+        assert(result_1);
+        assert(storage.nested_map_1.get(0).get(0).get(0).try_read().is_none());
+
+        let result_2: bool = storage.nested_map_1.get(0).get(0).remove(1);
+        assert(result_2);
+        assert(storage.nested_map_1.get(0).get(0).get(1).try_read().is_none());
+
+        let result_3: bool = storage.nested_map_1.get(0).get(1).remove(0);
+        assert(result_3);
+        assert(storage.nested_map_1.get(0).get(1).get(0).try_read().is_none());
+
+        let result_4: bool = storage.nested_map_1.get(1).get(1).remove(0);
+        assert(result_4);
+        assert(storage.nested_map_1.get(1).get(1).get(0).try_read().is_none());
     }
 
     #[storage(read, write)]
@@ -118,6 +134,22 @@ impl ExperimentalStorageTest for Contract {
         assert(storage.nested_map_2.get((2, 0)).get(_0001).get(1).try_read().is_none());
         assert(storage.nested_map_2.get((1, 1)).get(_0002).get(0).try_read().is_none());
         assert(storage.nested_map_2.get((1, 1)).get(_0001).get(2).try_read().is_none());
+
+        let result_1: bool = storage.nested_map_2.get((0, 0)).get(_0000).remove(0);
+        assert(result_1);
+        assert(storage.nested_map_2.get((0, 0)).get(_0000).get(0).try_read().is_none());
+
+        let result_2: bool = storage.nested_map_2.get((0, 0)).get(_0001).remove(1);
+        assert(result_2);
+        assert(storage.nested_map_2.get((0, 0)).get(_0001).get(1).try_read().is_none());
+
+        let result_3: bool = storage.nested_map_2.get((0, 1)).get(_0000).remove(0);
+        assert(result_3);
+        assert(storage.nested_map_2.get((0, 1)).get(_0000).get(0).try_read().is_none());
+
+        let result_4: bool = storage.nested_map_2.get((0, 1)).get(_0001).remove(1);
+        assert(result_4);
+        assert(storage.nested_map_2.get((0, 1)).get(_0001).get(1).try_read().is_none());
     }
 
     #[storage(read, write)]
@@ -168,5 +200,21 @@ impl ExperimentalStorageTest for Contract {
                 .is_none(),
         );
         assert(storage.nested_map_3.get(1).get(m2).get(2).try_read().is_none());
+
+        let result_1: bool = storage.nested_map_3.get(0).get(m1).remove(0);
+        assert(result_1);
+        assert(storage.nested_map_3.get(0).get(m1).get(0).try_read().is_none());
+
+        let result_2: bool = storage.nested_map_3.get(0).get(m2).remove(1);
+        assert(result_2);
+        assert(storage.nested_map_3.get(0).get(m2).get(1).try_read().is_none());
+
+        let result_3: bool = storage.nested_map_3.get(1).get(m1).remove(0);
+        assert(result_3);
+        assert(storage.nested_map_3.get(1).get(m1).get(0).try_read().is_none());
+
+        let result_4: bool = storage.nested_map_3.get(1).get(m2).remove(1);
+        assert(result_4);
+        assert(storage.nested_map_3.get(1).get(m2).get(1).try_read().is_none());
     }
 }


### PR DESCRIPTION
## Description

Currently, the `StorageMap` `remove()` function uses the `slot` to compute the key to remove. When inserting, `field_id` is used. This has been updated. Tests that remove from a nested `StorageMap` have also been added.

Closes #6128 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
