### PR TITLE
Make CEI analysis take `burn` and `mint` into account

### DIFF
--- a/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
+++ b/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
@@ -30,8 +30,8 @@ enum Effect {
     BalanceTreeRead,      // balance tree read operation
     BalanceTreeReadWrite, // balance tree read and write operation
     OutputMessage,        // operation creates a new `Output::Message`
-    MintAsset,         // mint operation
-    BurnAsset,         // burn operation
+    MintAsset,            // mint operation
+    BurnAsset,            // burn operation
 }
 
 impl fmt::Display for Effect {
@@ -363,7 +363,6 @@ fn analyze_expression(
                 // TODO: improve locations accuracy
                 warn_after_interaction(&asmblock_effs, &expr.span, &expr.span, block_name, warnings)
             }
-	    // TODO (jjcnn): Add warning?
             set_union(init_effs, asmblock_effs)
         }
     }
@@ -660,8 +659,8 @@ fn effects_of_asm_op(op: &AsmOp) -> HashSet<Effect> {
         "bal" => HashSet::from([Effect::BalanceTreeRead]),
         "smo" => HashSet::from([Effect::OutputMessage]),
         "call" => HashSet::from([Effect::Interaction]),
-	"mint" => HashSet::from([Effect::MintAsset]),
-	"burn" => HashSet::from([Effect::BurnAsset]),
+        "mint" => HashSet::from([Effect::MintAsset]),
+        "burn" => HashSet::from([Effect::BurnAsset]),
         // the rest of the assembly instructions are considered to not have effects
         _ => HashSet::new(),
     }

--- a/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
+++ b/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
@@ -30,6 +30,8 @@ enum Effect {
     BalanceTreeRead,      // balance tree read operation
     BalanceTreeReadWrite, // balance tree read and write operation
     OutputMessage,        // operation creates a new `Output::Message`
+    MintAsset,         // mint operation
+    BurnAsset,         // burn operation
 }
 
 impl fmt::Display for Effect {
@@ -42,6 +44,8 @@ impl fmt::Display for Effect {
             BalanceTreeRead => write!(f, "Balance tree read"),
             BalanceTreeReadWrite => write!(f, "Balance tree update"),
             OutputMessage => write!(f, "Output message sent"),
+            MintAsset => write!(f, "Asset minted"),
+            BurnAsset => write!(f, "Asset burned"),
         }
     }
 }
@@ -56,6 +60,8 @@ impl Effect {
             BalanceTreeRead => "making all balance tree reads",
             BalanceTreeReadWrite => "making all balance tree updates",
             OutputMessage => "sending all output messages",
+            MintAsset => "minting assets",
+            BurnAsset => "burning assets",
         })
     }
 }
@@ -357,6 +363,7 @@ fn analyze_expression(
                 // TODO: improve locations accuracy
                 warn_after_interaction(&asmblock_effs, &expr.span, &expr.span, block_name, warnings)
             }
+	    // TODO (jjcnn): Add warning?
             set_union(init_effs, asmblock_effs)
         }
     }
@@ -653,6 +660,8 @@ fn effects_of_asm_op(op: &AsmOp) -> HashSet<Effect> {
         "bal" => HashSet::from([Effect::BalanceTreeRead]),
         "smo" => HashSet::from([Effect::OutputMessage]),
         "call" => HashSet::from([Effect::Interaction]),
+	"mint" => HashSet::from([Effect::MintAsset]),
+	"burn" => HashSet::from([Effect::BurnAsset]),
         // the rest of the assembly instructions are considered to not have effects
         _ => HashSet::new(),
     }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_asm_block_mint_burn/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_asm_block_mint_burn/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = "cei_pattern_violation_in_asm_block_mint_burn"
+source = "member"
+dependencies = ["core"]
+
+[[package]]
+name = "core"
+source = "path+from-root-61D50B6E7FD9C109"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_asm_block_mint_burn/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_asm_block_mint_burn/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+name = "cei_pattern_violation_in_asm_block_mint_burn"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_asm_block_mint_burn/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_asm_block_mint_burn/src/main.sw
@@ -1,0 +1,33 @@
+contract;
+
+abi TestAbi {
+    fn mint();
+    fn burn();
+}
+
+const AMOUNT_TO_BURN = 100;
+const ASSET_ID = b256::zero();
+
+impl TestAbi for Contract {
+    fn mint() {
+        let other_contract = abi(TestAbi, 0x3dba0a4455b598b7655a7fb430883d96c9527ef275b49739e7b0ad12f8280eae);
+
+        // interaction
+        other_contract.mint();
+        // effect -- therefore violation of CEI where effect should go before interaction
+        asm(r1: AMOUNT_TO_BURN, r2: ASSET_ID) {
+            mint r1 r2;
+        }
+    }
+
+    fn burn() {
+        let other_contract = abi(TestAbi, 0x3dba0a4455b598b7655a7fb430883d96c9527ef275b49739e7b0ad12f8280eae);
+
+        // interaction
+        other_contract.mint();
+        // effect -- therefore violation of CEI where effect should go before interaction
+        asm(r1: AMOUNT_TO_BURN, r2: ASSET_ID) {
+            burn r1 r2;
+        }
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_asm_block_mint_burn/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/static_analysis/cei_pattern_violation_in_asm_block_mint_burn/test.toml
@@ -1,0 +1,5 @@
+category = "compile"
+
+# check: $()Asset burned after external contract interaction in function or method "burn". Consider burning assets before calling another contract
+# check: $()Asset minted after external contract interaction in function or method "mint". Consider minting assets before calling another contract
+expected_warnings = 2


### PR DESCRIPTION
## Description

Fixes #6153. 

The `burn` and `mint` instructions have so far not been taken into account in our CEI analysis, despite them having an effect on the contract state. This PR fixes that issue.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
