### PR TITLE
Update sdk-harness's `configurables_in_contract` test variable name from `CONTRACT_ID` to `MY_CONTRACT_ID`

### DIFF
--- a/test/src/sdk-harness/test_projects/configurables_in_contract/mod.rs
+++ b/test/src/sdk-harness/test_projects/configurables_in_contract/mod.rs
@@ -75,7 +75,7 @@ async fn contract_configurables() -> Result<()> {
         .with_STRUCT(new_struct.clone())?
         .with_ENUM(new_enum.clone())?
         .with_ADDRESS(new_address.clone())?
-        .with_CONTRACT_ID(new_contract_id.clone())?;
+        .with_MY_CONTRACT_ID(new_contract_id.clone())?;
 
     let contract_id = Contract::load_from(
         "test_projects/configurables_in_contract/out/release/configurables_in_contract.bin",

--- a/test/src/sdk-harness/test_projects/configurables_in_contract/src/main.sw
+++ b/test/src/sdk-harness/test_projects/configurables_in_contract/src/main.sw
@@ -21,7 +21,7 @@ configurable {
     },
     ENUM: EnumWithGeneric<bool> = EnumWithGeneric::VariantOne(true),
     ADDRESS: Address = Address::zero(),
-    CONTRACT_ID: ContractId = ContractId::zero(),
+    MY_CONTRACT_ID: ContractId = ContractId::zero(),
 }
 
 abi TestContract {
@@ -30,6 +30,6 @@ abi TestContract {
 
 impl TestContract for Contract {
     fn return_configurables() -> (u8, bool, [u32; 3], str[4], StructWithGeneric<u8>, EnumWithGeneric<bool>, Address, ContractId) {
-        (U8, BOOL, ARRAY, STR_4, STRUCT, ENUM, ADDRESS, CONTRACT_ID)
+        (U8, BOOL, ARRAY, STR_4, STRUCT, ENUM, ADDRESS, MY_CONTRACT_ID)
     }
 }


### PR DESCRIPTION
## Description

As described in https://github.com/FuelLabs/sway/issues/6137, the `configurables_in_contract` test has a `ContractId` defined as `CONTRACT_ID` in the configurable block. If `forc test` were to be run on the sdk-harness, it would fail to compile. 

Until the compiler explicitly disallows `CONTRACT_ID` in a configurable block, this configurable has been changed to `MY_CONTRACT_ID`.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
