### PR TITLE
docs: Fix nightly storage docs

### DIFF
--- a/examples/advanced_storage_variables/src/main.sw
+++ b/examples/advanced_storage_variables/src/main.sw
@@ -14,9 +14,9 @@ use std::storage::storage_vec::*;
 use std::storage::storage_bytes::*;
 // ANCHOR: storage_bytes_import
 
-// ANCHOR: storage_bytes_import
+// ANCHOR: storage_string_import
 use std::storage::storage_string::*;
-// ANCHOR: storage_bytes_import
+// ANCHOR: storage_string_import
 
 // ANCHOR: advanced_storage_declaration
 storage {


### PR DESCRIPTION
## Description
https://vercel.com/fuel-labs/docs-hub/5r9LvMoawPA5PmVPTqX4p4FFcP8Q?filter=errors

This PR https://github.com/FuelLabs/sway/pull/6051/files broke a page in the docs because of a mislabeled anchor tag

`sway
{{#include ../../../../examples/advanced_storage_variables/src/main.sw:storage_string_import}}`
## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
