### PR TITLE
Incomplete escape analysis and referred symbols in IR optimizations

### DIFF
--- a/sway-core/src/asm_generation/fuel/fuel_asm_builder.rs
+++ b/sway-core/src/asm_generation/fuel/fuel_asm_builder.rs
@@ -656,7 +656,7 @@ impl<'ir, 'eng> FuelAsmBuilder<'ir, 'eng> {
                     val_reg,
                     VirtualRegister::Constant(ConstantRegister::Zero),
                 )),
-                comment: "convert to inversed boolean".into(),
+                comment: "convert to inverted boolean".into(),
                 owning_span: self.md_mgr.val_to_span(self.context, *instr_val),
             });
             self.cur_bytecode.push(Op {
@@ -2080,7 +2080,7 @@ impl<'ir, 'eng> FuelAsmBuilder<'ir, 'eng> {
                             let reg = self.reg_seqr.next();
                             self.cur_bytecode.push(Op {
                                 opcode: Either::Left(VirtualOp::MOVI(reg.clone(), imm)),
-                                comment: "initializer constant into register".into(),
+                                comment: "initialize constant into register".into(),
                                 owning_span: None,
                             });
                             reg

--- a/sway-core/src/ir_generation.rs
+++ b/sway-core/src/ir_generation.rs
@@ -100,7 +100,10 @@ impl CompiledFunctionCache {
                     parameters: decl.parameters.clone(),
                     ..decl.clone()
                 };
+                // Entry functions are already compiled at the top level
+                // when compiling scripts, predicates, contracts, and libraries.
                 let is_entry = false;
+                let is_original_entry = callee_fn_decl.is_main() || callee_fn_decl.is_test();
                 let new_func = compile::compile_function(
                     engines,
                     context,
@@ -110,6 +113,7 @@ impl CompiledFunctionCache {
                     logged_types_map,
                     messages_types_map,
                     is_entry,
+                    is_original_entry,
                     None,
                     self,
                 )

--- a/sway-ir/src/function.rs
+++ b/sway-ir/src/function.rs
@@ -38,6 +38,9 @@ pub struct FunctionContent {
     pub module: Module,
     pub is_public: bool,
     pub is_entry: bool,
+    // True if the function was an entry, before getting wrapped
+    // by the `__entry` function. E.g, a script `main` function.
+    pub is_original_entry: bool,
     pub is_fallback: bool,
     pub selector: Option<[u8; 4]>,
     pub metadata: Option<MetadataIndex>,
@@ -65,6 +68,7 @@ impl Function {
         selector: Option<[u8; 4]>,
         is_public: bool,
         is_entry: bool,
+        is_original_entry: bool,
         is_fallback: bool,
         metadata: Option<MetadataIndex>,
     ) -> Function {
@@ -78,6 +82,7 @@ impl Function {
             module,
             is_public,
             is_entry,
+            is_original_entry,
             is_fallback,
             selector,
             metadata,
@@ -283,6 +288,12 @@ impl Function {
     /// methods.
     pub fn is_entry(&self, context: &Context) -> bool {
         context.functions[self.0].is_entry
+    }
+
+    /// Whether or not the function was a program entry point, i.e. `main`, `#[test]` fns or abi
+    /// methods, before it got wrapped within the `__entry` function.
+    pub fn is_original_entry(&self, context: &Context) -> bool {
+        context.functions[self.0].is_original_entry
     }
 
     /// Whether or not this function is a contract fallback function

--- a/sway-ir/src/optimize/dce.rs
+++ b/sway-ir/src/optimize/dce.rs
@@ -40,20 +40,30 @@ pub fn create_fn_dce_pass() -> Pass {
 fn can_eliminate_instruction(
     context: &Context,
     val: Value,
-    num_symbol_uses: &HashMap<Symbol, u32>,
+    num_symbol_loaded: &NumSymbolLoaded,
     escaped_symbols: &EscapedSymbols,
 ) -> bool {
     let inst = val.get_instruction(context).unwrap();
     (!inst.op.is_terminator() && !inst.op.may_have_side_effect())
-        || is_removable_store(context, val, num_symbol_uses, escaped_symbols)
+        || is_removable_store(context, val, num_symbol_loaded, escaped_symbols)
 }
 
 fn is_removable_store(
     context: &Context,
     val: Value,
-    num_symbol_uses: &HashMap<Symbol, u32>,
+    num_symbol_loaded: &NumSymbolLoaded,
     escaped_symbols: &EscapedSymbols,
 ) -> bool {
+    let escaped_symbols = match escaped_symbols {
+        EscapedSymbols::Complete(syms) => syms,
+        EscapedSymbols::Incomplete(_) => return false,
+    };
+
+    let num_symbol_loaded = match num_symbol_loaded {
+        NumSymbolLoaded::Unknown => return false,
+        NumSymbolLoaded::Known(known_num_symbol_loaded) => known_num_symbol_loaded,
+    };
+
     match val.get_instruction(context).unwrap().op {
         InstOp::MemCopyBytes { dst_val_ptr, .. }
         | InstOp::MemCopyVal { dst_val_ptr, .. }
@@ -62,7 +72,7 @@ fn is_removable_store(
             match syms {
                 ReferredSymbols::Complete(syms) => syms.iter().all(|sym| {
                     !escaped_symbols.contains(sym)
-                        && num_symbol_uses.get(sym).map_or(0, |uses| *uses) == 0
+                        && num_symbol_loaded.get(sym).map_or(0, |uses| *uses) == 0
                 }),
                 // We cannot guarantee that the destination is not used.
                 ReferredSymbols::Incomplete(_) => false,
@@ -72,48 +82,94 @@ fn is_removable_store(
     }
 }
 
-/// Perform dead code (if any) elimination and return true if function is modified.
+/// How many times a [Symbol] gets loaded from, directly or indirectly.
+/// This number is either exactly `Known` for all the symbols loaded from, or is
+/// considered to be `Unknown` for all the symbols.
+enum NumSymbolLoaded {
+    Unknown,
+    Known(HashMap<Symbol, u32>),
+}
+
+/// Instructions that store to a [Symbol], directly or indirectly.
+/// These instructions are either exactly `Known` for all the symbols stored to, or is
+/// considered to be `Unknown` for all the symbols.
+enum StoresOfSymbol {
+    Unknown,
+    Known(HashMap<Symbol, Vec<Value>>),
+}
+
+/// Perform dead code (if any) elimination and return true if the `function` is modified.
 pub fn dce(
     context: &mut Context,
     analyses: &AnalysisResults,
     function: Function,
 ) -> Result<bool, IrError> {
+    // For DCE, we need to proceed with the analysis even if we have
+    // incomplete list of escaped symbols, because we could have
+    // unused instructions in code. Removing unused instructions is
+    // independent of having any escaping symbols.
     let escaped_symbols: &EscapedSymbols = analyses.get_analysis_result(function);
 
-    // Number of uses that an instruction has.
-    let mut num_uses: HashMap<Value, u32> = HashMap::new();
+    // Number of uses that an instruction has. This number is always known.
+    let mut num_inst_uses: HashMap<Value, u32> = HashMap::new();
+    // Number of times a local is accessed via `get_local`. This number is always known.
     let mut num_local_uses: HashMap<LocalVar, u32> = HashMap::new();
-    let mut num_symbol_uses: HashMap<Symbol, u32> = HashMap::new();
-    let mut stores_of_sym: HashMap<Symbol, Vec<Value>> = HashMap::new();
+    // Number of times a symbol, local or a function argument, is loaded, directly or indirectly. This number can be unknown.
+    let mut num_symbol_loaded: NumSymbolLoaded = NumSymbolLoaded::Known(HashMap::new());
+    // Instructions that store to a symbol, directly or indirectly. This information can be unknown.
+    let mut stores_of_sym: StoresOfSymbol = StoresOfSymbol::Known(HashMap::new());
 
+    // TODO-IG: Update this logic once `mut arg: T`s are implemented.
+    //          Currently, only `ref mut arg` arguments can be stored to,
+    //          which means they can be loaded from the caller.
+    //          Once we support `mut arg` in general, this will not be
+    //          the case anymore and we will need to distinguish between
+    //          `mut arg: T`, `arg: &mut T`, etc.
     // Every argument is assumed to be loaded from (from the caller),
     // so stores to it shouldn't be eliminated.
-    for sym in function
-        .args_iter(context)
-        .flat_map(|arg| get_gep_referred_symbols(context, arg.1))
-    {
-        num_symbol_uses
-            .entry(sym)
-            .and_modify(|count| *count += 1)
-            .or_insert(1);
-    }
-
-    // Go through each instruction and update use_count.
-    for (_block, inst) in function.instruction_iter(context) {
-        for sym in memory_utils::get_loaded_symbols(context, inst) {
-            num_symbol_uses
+    if let NumSymbolLoaded::Known(known_num_symbol_loaded) = &mut num_symbol_loaded {
+        for sym in function
+            .args_iter(context)
+            .flat_map(|arg| get_gep_referred_symbols(context, arg.1))
+        {
+            known_num_symbol_loaded
                 .entry(sym)
                 .and_modify(|count| *count += 1)
                 .or_insert(1);
         }
+    }
 
-        for stored_sym in memory_utils::get_stored_symbols(context, inst) {
-            stores_of_sym
-                .entry(stored_sym)
-                .and_modify(|stores| stores.push(inst))
-                .or_insert(vec![inst]);
+    // Go through each instruction and update use counters.
+    for (_block, inst) in function.instruction_iter(context) {
+        if let NumSymbolLoaded::Known(known_num_symbol_loaded) = &mut num_symbol_loaded {
+            match memory_utils::get_loaded_symbols(context, inst) {
+                ReferredSymbols::Complete(loaded_symbols) => {
+                    for sym in loaded_symbols {
+                        known_num_symbol_loaded
+                            .entry(sym)
+                            .and_modify(|count| *count += 1)
+                            .or_insert(1);
+                    }
+                }
+                ReferredSymbols::Incomplete(_) => num_symbol_loaded = NumSymbolLoaded::Unknown,
+            }
         }
 
+        if let StoresOfSymbol::Known(known_stores_of_sym) = &mut stores_of_sym {
+            match memory_utils::get_stored_symbols(context, inst) {
+                ReferredSymbols::Complete(stored_symbols) => {
+                    for stored_sym in stored_symbols {
+                        known_stores_of_sym
+                            .entry(stored_sym)
+                            .and_modify(|stores| stores.push(inst))
+                            .or_insert(vec![inst]);
+                    }
+                }
+                ReferredSymbols::Incomplete(_) => stores_of_sym = StoresOfSymbol::Unknown,
+            }
+        }
+
+        // A local is used if it is accessed via `get_local`.
         let inst = inst.get_instruction(context).unwrap();
         if let InstOp::GetLocal(local) = inst.op {
             num_local_uses
@@ -121,12 +177,14 @@ pub fn dce(
                 .and_modify(|count| *count += 1)
                 .or_insert(1);
         }
+
+        // An instruction is used if it is an operand in another instruction.
         let opds = inst.op.get_operands();
-        for v in opds {
-            match context.values[v.0].value {
+        for opd in opds {
+            match context.values[opd.0].value {
                 ValueDatum::Instruction(_) => {
-                    num_uses
-                        .entry(v)
+                    num_inst_uses
+                        .entry(opd)
                         .and_modify(|count| *count += 1)
                         .or_insert(1);
                 }
@@ -135,47 +193,64 @@ pub fn dce(
         }
     }
 
+    // The list of all unused or `Store` instruction. Note that the `Store` instruction does
+    // not result in a value, and will, thus, always be treated as unused and will not
+    // have an entry in `num_inst_uses`. So, to collect unused or `Store` instructions it
+    // is sufficient to filter those that are not used.
     let mut worklist = function
         .instruction_iter(context)
-        .filter_map(|(_block, inst)| {
-            (num_uses.get(&inst).is_none()
-                || is_removable_store(context, inst, &num_symbol_uses, escaped_symbols))
-            .then_some(inst)
-        })
+        .filter_map(|(_, inst)| num_inst_uses.get(&inst).is_none().then_some(inst))
         .collect::<Vec<_>>();
 
     let mut modified = false;
     let mut cemetery = FxHashSet::default();
     while let Some(dead) = worklist.pop() {
-        if !can_eliminate_instruction(context, dead, &num_symbol_uses, escaped_symbols)
+        if !can_eliminate_instruction(context, dead, &num_symbol_loaded, escaped_symbols)
             || cemetery.contains(&dead)
         {
             continue;
         }
         // Process dead's operands.
         let opds = dead.get_instruction(context).unwrap().op.get_operands();
-        for v in opds {
-            // Reduce the use count of v. If it reaches 0, add it to the worklist.
-            match context.values[v.0].value {
+        for opd in opds {
+            // Reduce the use count of the operand used in the dead instruction.
+            // If it reaches 0, add it to the worklist, since it is not used
+            // anywhere else.
+            match context.values[opd.0].value {
                 ValueDatum::Instruction(_) => {
-                    let nu = num_uses.get_mut(&v).unwrap();
+                    let nu = num_inst_uses.get_mut(&opd).unwrap();
                     *nu -= 1;
                     if *nu == 0 {
-                        worklist.push(v);
+                        worklist.push(opd);
                     }
                 }
                 ValueDatum::Constant(_) | ValueDatum::Argument(_) => {}
             }
         }
-        for sym in memory_utils::get_loaded_symbols(context, dead) {
-            let nu = num_symbol_uses.get_mut(&sym).unwrap();
-            *nu -= 1;
-            if *nu == 0 {
-                for store in stores_of_sym.get(&sym).unwrap_or(&vec![]) {
-                    worklist.push(*store);
+
+        // If the `dead` instruction was the only instruction loading from a `sym`bol,
+        // after removing it, there will be no loads anymore, so all the stores to
+        // that `sym`bol can be added to the worklist.
+        if let ReferredSymbols::Complete(loaded_symbols) =
+            memory_utils::get_loaded_symbols(context, dead)
+        {
+            if let (
+                NumSymbolLoaded::Known(known_num_symbol_loaded),
+                StoresOfSymbol::Known(known_stores_of_sym),
+            ) = (&mut num_symbol_loaded, &mut stores_of_sym)
+            {
+                for sym in loaded_symbols {
+                    let nu = known_num_symbol_loaded.get_mut(&sym).unwrap();
+                    *nu -= 1;
+                    if *nu == 0 {
+                        for store in known_stores_of_sym.get(&sym).unwrap_or(&vec![]) {
+                            worklist.push(*store);
+                        }
+                    }
                 }
             }
         }
+
         cemetery.insert(dead);
 
         if let ValueDatum::Instruction(Instruction {
@@ -186,6 +261,7 @@ pub fn dce(
             let count = num_local_uses.get_mut(&local).unwrap();
             *count -= 1;
         }
+
         modified = true;
     }
 

--- a/sway-ir/src/optimize/sroa.rs
+++ b/sway-ir/src/optimize/sroa.rs
@@ -5,7 +5,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::{
     combine_indices, compute_escaped_symbols, get_gep_referred_symbols, get_loaded_ptr_values,
     get_stored_ptr_values, pointee_size, AnalysisResults, Constant, ConstantValue, Context,
-    Function, InstOp, IrError, LocalVar, Pass, PassMutability, ScopedPass, Symbol, Type, Value,
+    EscapedSymbols, Function, InstOp, IrError, LocalVar, Pass, PassMutability, ScopedPass, Symbol,
+    Type, Value,
 };
 
 pub const SROA_NAME: &str = "sroa";
@@ -442,7 +443,11 @@ fn profitability(context: &Context, function: Function, candidates: &mut FxHashS
 /// 3. Never accessed via non-const indexing.
 /// 4. Not aliased via a pointer that may point to more than one symbol.
 fn candidate_symbols(context: &Context, function: Function) -> FxHashSet<Symbol> {
-    let escaped_symbols = compute_escaped_symbols(context, &function);
+    let escaped_symbols = match compute_escaped_symbols(context, &function) {
+        EscapedSymbols::Complete(syms) => syms,
+        EscapedSymbols::Incomplete(_) => return FxHashSet::<_>::default(),
+    };
+
     let mut candidates: FxHashSet<Symbol> = function
         .locals_iter(context)
         .filter_map(|(_, l)| {

--- a/sway-ir/src/printer.rs
+++ b/sway-ir/src/printer.rs
@@ -271,6 +271,25 @@ fn function_to_doc<'a>(
 ) -> Doc {
     let public = if function.is_public { "pub " } else { "" };
     let entry = if function.is_entry { "entry " } else { "" };
+    // TODO: Remove outer `if` once old encoding is fully removed.
+    //       This is an intentional "complication" so that we see
+    //       explicit using of `new_encoding` here.
+    //       For the time being, for the old encoding, we don't want
+    //       to show both `entry` and `entry_orig` although both
+    //       values will be true.
+    // TODO: When removing old encoding, remove also the TODO in the
+    //       `rule fn_decl()` definition of the IR parser.
+    let original_entry = if context.experimental.new_encoding {
+        if function.is_original_entry {
+            "entry_orig "
+        } else {
+            ""
+        }
+    } else if !function.is_entry && function.is_original_entry {
+        "entry_orig "
+    } else {
+        ""
+    };
     let fallback = if function.is_fallback {
         "fallback "
     } else {
@@ -278,8 +297,8 @@ fn function_to_doc<'a>(
     };
     Doc::line(
         Doc::text(format!(
-            "{}{}{}fn {}",
-            public, entry, fallback, function.name
+            "{}{}{}{}fn {}",
+            public, entry, original_entry, fallback, function.name
         ))
         .append(
             function

--- a/sway-ir/tests/dce/dce_cast_ptr.ir
+++ b/sway-ir/tests/dce/dce_cast_ptr.ir
@@ -1,0 +1,37 @@
+// This test proves that the issue given in https://github.com/FuelLabs/sway/issues/6152#issuecomment-2181367848
+// is fixed. The local variable `S` does not get optimized away.
+// The local variable `dummy` is added to introduce a change in the DCE pass to
+// satisfy the testing infrastructure that expect a change after the optimization pass.
+
+script {
+    entry fn main() -> u64 {
+      local u64 S
+      local u64 dummy
+  
+      entry():
+      br block0()
+  
+      block0():
+      c0 = const u64 123
+      p = get_local ptr u64, S
+      store c0 to p
+      p_d = cast_ptr p to ptr u8
+      p_val = ptr_to_int p_d to u64
+      p_val_aug = add p_val, c0
+      p_val_res = sub p_val_aug, c0
+      res = call test(p_val_res)
+      ret u64 res
+    }
+  
+    fn test(arg: u64) -> u64 {
+      entry(arg: u64):
+      br block0(arg)
+  
+      block0(arg: ptr u64):
+      v0 = load arg
+      ret u64 v0
+    }
+}
+
+// check: entry fn main() -> u64 {
+// nextln: local u64 S

--- a/sway-ir/tests/dce/dce_dead_config_assignment.ir
+++ b/sway-ir/tests/dce/dce_dead_config_assignment.ir
@@ -1,0 +1,54 @@
+// The IR code represents the below function.
+// The unused local `x` must be optimized away.
+//
+// abi Abi {
+//     fn assign_config_call_pass_config();
+// }
+// 
+// configurable { CONFIG: u64 = 1234 }
+// 
+// impl Abi for Contract {
+//    fn assign_config_call_pass_config() {
+//        let x = CONFIG;
+//	      poke(CONFIG);
+//    }
+// }
+
+contract {
+    CONFIG = config u64, abi_decode_in_place_0, 0x00000000000004d2
+
+    pub fn abi_decode_in_place_0(ptr: u64, len: u64, target: u64) -> () {
+        entry(ptr: u64, len: u64, target: u64):
+        v0 = const unit ()
+        ret () v0
+    }
+
+    pub entry fn assign_config_call_pass_config<28892dec>() -> () {
+        local u64 x
+
+        entry():
+        v0 = get_config ptr u64, CONFIG
+        v1 = load v0
+        v2 = get_local ptr u64, x
+        store v1 to v2
+        v3 = get_config ptr u64, CONFIG
+        v4 = load v3
+        v5 = call poke_0(v4)
+        v6 = const unit ()
+        ret () v6
+    }
+
+    fn poke_0(_x: u64) -> () {
+        entry(_x: u64):
+        v0 = const unit ()
+        ret () v0
+    }
+}
+
+// check: pub entry fn assign_config_call_pass_config
+// nextln: entry():
+// nextln: v0 = get_config ptr u64, CONFIG
+// nextln: v1 = load v0
+// nextln: v2 = call poke_0(v1)
+// not: store
+// check: ret ()

--- a/sway-ir/tests/dce/dce_dead_constant_assignment.ir
+++ b/sway-ir/tests/dce/dce_dead_constant_assignment.ir
@@ -1,0 +1,39 @@
+// The IR code represents the below function.
+// The unused local `x` must be optimized away.
+//
+// fn main() {
+//    let x = "str";
+// }
+
+script {
+    entry fn main() -> () {
+        local { u64, u64 } __anon_0
+        local slice __anon_1
+        local slice x
+
+        entry():
+        v0 = const string<3> "str"
+        v1 = ptr_to_int v0 to u64
+        v2 = get_local ptr { u64, u64 }, __anon_0
+        v3 = const u64 0
+        v4 = get_elem_ptr v2, ptr u64, v3
+        store v1 to v4
+        v5 = const u64 1
+        v6 = get_elem_ptr v2, ptr u64, v5
+        v7 = const u64 3
+        store v7 to v6
+        v8 = get_local ptr slice, __anon_1
+        mem_copy_bytes v8, v2, 16
+        v9 = load v8
+        v10 = get_local ptr slice, x
+        store v9 to v10
+        v11 = const unit ()
+        ret () v11
+    }
+}
+
+// check: entry fn main() -> () {
+// nextln: entry():
+// nextln: v0 = const unit ()
+// nextln: ret () v0
+// nextln: }

--- a/sway-ir/tests/dce/dce_int_to_ptr.ir
+++ b/sway-ir/tests/dce/dce_int_to_ptr.ir
@@ -1,0 +1,52 @@
+script {
+    entry fn main() -> bool {
+        local mut u64 x
+        local mut u64 y
+        local mut u64 dummy
+
+        entry():
+        v0 = const u64 0
+        v1 = const u64 2
+        v2 = cmp eq v0 v1
+        v3 = const bool false
+        v4 = cmp eq v3 v2
+        cbr v4, block0(), block1()
+
+        block0():
+        v0_0 = get_local ptr u64, x
+        v0_1 = cast_ptr v0_0 to ptr u8
+        v0_2 = cast_ptr v0_1 to ptr u64
+        v0_3 = ptr_to_int v0_2 to u64
+        v0_4 = int_to_ptr v0_3 to ptr u64
+        v0_5 = ptr_to_int v0_4 to u64
+        br block2(v0_5)
+
+        block1():
+        v1_0 = get_local ptr u64, y
+        v1_1 = cast_ptr v1_0 to ptr u8
+        v1_2 = cast_ptr v1_1 to ptr u64
+        v1_3 = ptr_to_int v1_2 to u64
+        v1_4 = int_to_ptr v1_3 to ptr u64
+        v1_5 = ptr_to_int v1_4 to u64
+        br block2(v1_5)
+
+        block2(v2_0: u64):
+        v2_1 = int_to_ptr v2_0 to ptr u64
+        v2_2 = const u64 42
+        store v2_2 to v2_1
+        v2_3 = get_local ptr u64, dummy
+        v2_4 = const u64 42
+        store v2_4 to v2_3
+        v2_5 = const bool true
+        ret bool v2_5
+    }
+}
+
+// check: local mut u64 x
+// check: local mut u64 y
+// not: local mut u64 y
+// check: block2
+// check: store
+// not: get_local ptr u64, dummy
+// not: store
+// check: ret bool

--- a/sway-ir/tests/dce/dce_load_from_b256.ir
+++ b/sway-ir/tests/dce/dce_load_from_b256.ir
@@ -1,0 +1,38 @@
+// The IR code represents the below function.
+// The unused local `x` must be optimized away.
+//
+// fn main() {
+//    let local = 0x1f212e1f2e7b5a8cff18d994b7b7faa61db1a89cbf697facc518f6b6c8430196;
+//    let x = take_b256(local);
+// }
+
+script {
+    entry fn main() -> () {
+        local b256 x
+        local b256 local
+
+        entry():
+        v0 = get_local ptr b256, local
+        v1 = const b256 0x1f212e1f2e7b5a8cff18d994b7b7faa61db1a89cbf697facc518f6b6c8430196
+        store v1 to v0
+        v2 = get_local ptr b256, local
+        v3 = load v2
+        v4 = call take_b256_2(v3)
+        v5 = get_local ptr b256, x
+        store v4 to v5
+        v6 = const unit ()
+        ret () v6
+    }
+
+    fn take_b256_2(_x: b256) -> b256 {
+        entry(_x: b256):
+        v0 = const b256 0x0000000000000000000000000000000000000000000000000000000000000000
+        ret b256 v0
+    }
+}
+
+// check: entry fn main() -> () {
+// not: local b256 x
+// check: entry():
+// not: get_local ptr b256, x
+// check: ret ()

--- a/sway-ir/tests/dce/dce_load_from_struct.ir
+++ b/sway-ir/tests/dce/dce_load_from_struct.ir
@@ -1,0 +1,51 @@
+// The IR code represents the below function.
+// The unused local `x` must be optimized away.
+//
+// fn main() {
+//    let local = S { x: 112233, y: 445566 };
+//    let x = take_struct(local);
+// }
+
+script {
+    entry fn main() -> () {
+        local { u64, u64 } x
+        local { u64, u64 } __anon_0
+        local { u64, u64 } local
+
+        entry():
+        v0 = get_local ptr { u64, u64 }, __anon_0
+        v1 = const u64 0
+        v2 = get_elem_ptr v0, ptr u64, v1
+        v3 = const u64 112233
+        store v3 to v2
+        v4 = const u64 1
+        v5 = get_elem_ptr v0, ptr u64, v4
+        v6 = const u64 445566
+        store v6 to v5
+        v7 = load v0
+        v8 = get_local ptr { u64, u64 }, local
+        store v7 to v8
+        v9 = get_local ptr { u64, u64 }, local
+        v10 = load v9
+        v11 = call take_struct_2(v10)
+        v12 = get_local ptr { u64, u64 }, x
+        store v11 to v12
+        v13 = const unit ()
+        ret () v13
+    }
+
+    fn take_struct_2(_x: { u64, u64 }) -> { u64, u64 } {
+        local { u64, u64 } __anon_0
+
+        entry(_x: { u64, u64 }):
+        v0 = get_local ptr { u64, u64 }, __anon_0
+        v1 = load v0
+        ret { u64, u64 } v1
+    }
+}
+
+// check: entry fn main() -> () {
+// not: local { u64, u64 } x
+// check: entry():
+// not: get_local ptr { u64, u64 }, x
+// check: ret ()

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/abort_control_flow_good/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/abort_control_flow_good/test.toml
@@ -1,4 +1,4 @@
-category = "run"
+category = "disabled" # TODO: Enable once https://github.com/FuelLabs/sway/issues/6174 is fixed.
 expected_result = { action = "revert", value = 42 }
 expected_result_new_encoding = { action = "revert", value = 42 }
 validate_abi = true

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/break_and_continue_block_ret/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/break_and_continue_block_ret/test.toml
@@ -1,3 +1,3 @@
-category = "compile"
+category = "disabled" # TODO: Enable once https://github.com/FuelLabs/sway/issues/6174 is fixed.
 
 # not: $()This returns a value of type unknown, which is not assigned to anything and is ignored.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle.json
@@ -7,7 +7,7 @@
         "typeArguments": null
       },
       "name": "BOOL",
-      "offset": 3560
+      "offset": 3416
     },
     {
       "configurableType": {
@@ -16,7 +16,7 @@
         "typeArguments": null
       },
       "name": "U8",
-      "offset": 3696
+      "offset": 3552
     },
     {
       "configurableType": {
@@ -25,7 +25,7 @@
         "typeArguments": null
       },
       "name": "ANOTHER_U8",
-      "offset": 3488
+      "offset": 3344
     },
     {
       "configurableType": {
@@ -34,7 +34,7 @@
         "typeArguments": null
       },
       "name": "U16",
-      "offset": 3640
+      "offset": 3496
     },
     {
       "configurableType": {
@@ -43,7 +43,7 @@
         "typeArguments": null
       },
       "name": "U32",
-      "offset": 3680
+      "offset": 3536
     },
     {
       "configurableType": {
@@ -52,7 +52,7 @@
         "typeArguments": null
       },
       "name": "U64",
-      "offset": 3688
+      "offset": 3544
     },
     {
       "configurableType": {
@@ -61,7 +61,7 @@
         "typeArguments": null
       },
       "name": "U256",
-      "offset": 3648
+      "offset": 3504
     },
     {
       "configurableType": {
@@ -70,7 +70,7 @@
         "typeArguments": null
       },
       "name": "B256",
-      "offset": 3528
+      "offset": 3384
     },
     {
       "configurableType": {
@@ -79,7 +79,7 @@
         "typeArguments": []
       },
       "name": "CONFIGURABLE_STRUCT",
-      "offset": 3600
+      "offset": 3456
     },
     {
       "configurableType": {
@@ -88,7 +88,7 @@
         "typeArguments": []
       },
       "name": "CONFIGURABLE_ENUM_A",
-      "offset": 3568
+      "offset": 3424
     },
     {
       "configurableType": {
@@ -97,7 +97,7 @@
         "typeArguments": []
       },
       "name": "CONFIGURABLE_ENUM_B",
-      "offset": 3584
+      "offset": 3440
     },
     {
       "configurableType": {
@@ -106,7 +106,7 @@
         "typeArguments": null
       },
       "name": "ARRAY_BOOL",
-      "offset": 3496
+      "offset": 3352
     },
     {
       "configurableType": {
@@ -115,7 +115,7 @@
         "typeArguments": null
       },
       "name": "ARRAY_U64",
-      "offset": 3504
+      "offset": 3360
     },
     {
       "configurableType": {
@@ -124,7 +124,7 @@
         "typeArguments": null
       },
       "name": "TUPLE_BOOL_U64",
-      "offset": 3624
+      "offset": 3480
     },
     {
       "configurableType": {
@@ -133,7 +133,7 @@
         "typeArguments": null
       },
       "name": "STR_4",
-      "offset": 3616
+      "offset": 3472
     }
   ],
   "functions": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
@@ -7,7 +7,7 @@
         "typeArguments": null
       },
       "name": "BOOL",
-      "offset": 6848
+      "offset": 6912
     },
     {
       "configurableType": {
@@ -16,7 +16,7 @@
         "typeArguments": null
       },
       "name": "U8",
-      "offset": 6984
+      "offset": 7048
     },
     {
       "configurableType": {
@@ -25,7 +25,7 @@
         "typeArguments": null
       },
       "name": "ANOTHER_U8",
-      "offset": 6776
+      "offset": 6840
     },
     {
       "configurableType": {
@@ -34,7 +34,7 @@
         "typeArguments": null
       },
       "name": "U16",
-      "offset": 6928
+      "offset": 6992
     },
     {
       "configurableType": {
@@ -43,7 +43,7 @@
         "typeArguments": null
       },
       "name": "U32",
-      "offset": 6968
+      "offset": 7032
     },
     {
       "configurableType": {
@@ -52,7 +52,7 @@
         "typeArguments": null
       },
       "name": "U64",
-      "offset": 6976
+      "offset": 7040
     },
     {
       "configurableType": {
@@ -61,7 +61,7 @@
         "typeArguments": null
       },
       "name": "U256",
-      "offset": 6936
+      "offset": 7000
     },
     {
       "configurableType": {
@@ -70,7 +70,7 @@
         "typeArguments": null
       },
       "name": "B256",
-      "offset": 6816
+      "offset": 6880
     },
     {
       "configurableType": {
@@ -79,7 +79,7 @@
         "typeArguments": []
       },
       "name": "CONFIGURABLE_STRUCT",
-      "offset": 6888
+      "offset": 6952
     },
     {
       "configurableType": {
@@ -88,7 +88,7 @@
         "typeArguments": []
       },
       "name": "CONFIGURABLE_ENUM_A",
-      "offset": 6856
+      "offset": 6920
     },
     {
       "configurableType": {
@@ -97,7 +97,7 @@
         "typeArguments": []
       },
       "name": "CONFIGURABLE_ENUM_B",
-      "offset": 6872
+      "offset": 6936
     },
     {
       "configurableType": {
@@ -106,7 +106,7 @@
         "typeArguments": null
       },
       "name": "ARRAY_BOOL",
-      "offset": 6784
+      "offset": 6848
     },
     {
       "configurableType": {
@@ -115,7 +115,7 @@
         "typeArguments": null
       },
       "name": "ARRAY_U64",
-      "offset": 6792
+      "offset": 6856
     },
     {
       "configurableType": {
@@ -124,7 +124,7 @@
         "typeArguments": null
       },
       "name": "TUPLE_BOOL_U64",
-      "offset": 6912
+      "offset": 6976
     },
     {
       "configurableType": {
@@ -133,7 +133,7 @@
         "typeArguments": null
       },
       "name": "STR_4",
-      "offset": 6904
+      "offset": 6968
     }
   ],
   "encoding": "1",

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/slice/slice_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/slice/slice_contract/src/main.sw
@@ -12,8 +12,7 @@ impl MyContract for Contract {
 
 #[test]
 fn test_success() {
-    let contract_id = 0xe947c4b04b557d746b2f77988a4cd8528f36a71748c9bf830c0a8aad6e03191b;
-    let caller = abi(MyContract, contract_id);
+    let caller = abi(MyContract, CONTRACT_ID);
 
     let data = 1u64;
     let slice = raw_slice::from_parts::<u64>(__addr_of(&data), 1);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/string_slice/string_slice_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/string_slice/string_slice_contract/src/main.sw
@@ -12,8 +12,7 @@ impl MyContract for Contract {
 
 #[test]
 fn test_success() {
-    let contract_id = 0xd2cf22567d02b44ac9f2342b814d9e6502820fec8c37c9b4bc8e15a2821d329e;
-    let caller = abi(MyContract, contract_id);
+    let caller = abi(MyContract, CONTRACT_ID);
     let result = caller.test_function("a");
     assert(result == "a")
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_abi/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_abi/json_abi_oracle.json
@@ -7,7 +7,7 @@
         "typeArguments": null
       },
       "name": "SOME_U256",
-      "offset": 108
+      "offset": 72
     }
   ],
   "functions": [
@@ -24,7 +24,7 @@
   ],
   "loggedTypes": [
     {
-      "logId": 0,
+      "logId": "1970142151624111756",
       "loggedType": {
         "name": "",
         "type": 0,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_abi/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_abi/json_abi_oracle_new_encoding.json
@@ -7,7 +7,7 @@
         "typeArguments": null
       },
       "name": "SOME_U256",
-      "offset": 584
+      "offset": 672
     }
   ],
   "encoding": "1",

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
@@ -6,7 +6,7 @@ use std::hash::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x14ed3cd06c2947248f69d54bfa681fe40d26267be84df7e19e253622b7921bbe;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x0b055b1a6c1c19ceff962224dbb194aefa2e1854948c7510c0c199c5f0d93e9e;
+const CONTRACT_ID = 0xb9c932420d73aedd16ae8942f27d09e469a449797e3f82970e7c8d5cd45fd33f;
 
 fn main() -> u64 {
     let addr = abi(TestContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
@@ -7,14 +7,14 @@ use std::constants::DEFAULT_SUB_ID;
 use test_fuel_coin_abi::*;
 
 #[cfg(experimental_new_encoding = false)]
-const FUEL_COIN_CONTRACT_ID = 0x4c7b43ef5a097d7cfb87600a4234e33311eeeeb8081e5ea7bb6d9a1f8555c9c4;
+const FUEL_COIN_CONTRACT_ID = 0xec2277ebe007ade87e3d797c3b1e070dcd542d5ef8f038b471f262ef9cebc87c;
 #[cfg(experimental_new_encoding = true)]
-const FUEL_COIN_CONTRACT_ID = 0x4310867f369075df5771b1d2ac0965d3f28c782afebba2e6f18ebada3a4b367c;
+const FUEL_COIN_CONTRACT_ID = 0x1a88d0982d216958d18378b6784614b75868a542dc05f8cc85cf3da44268c76c;
 
 #[cfg(experimental_new_encoding = false)]
-const BALANCE_CONTRACT_ID = 0x3120fdd1b99c0c611308aff43a99746cc2c661c69c22aa56331d5f3ce5534ee9;
+const BALANCE_CONTRACT_ID = 0xf6cd545152ac83225e8e7df2efb5c6fa6e37bc9b9e977b5ea8103d28668925df;
 #[cfg(experimental_new_encoding = true)]
-const BALANCE_CONTRACT_ID = 0x766a3ca00db4b974ef2d9bd87ec9a748999ad03eec72d8df26fd326b7c9320c9;
+const BALANCE_CONTRACT_ID = 0x04594851a2bd620dffc360f3976d747598b9184218dc55ff3e839f417ca345ac;
 
 fn main() -> bool {
     let default_gas = 1_000_000_000_000;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/src/main.sw
@@ -3,9 +3,9 @@ script;
 use balance_test_abi::BalanceTest;
 
 #[cfg(experimental_new_encoding = false)]
-const CONTRACT_ID = 0x3120fdd1b99c0c611308aff43a99746cc2c661c69c22aa56331d5f3ce5534ee9;
+const CONTRACT_ID = 0xf6cd545152ac83225e8e7df2efb5c6fa6e37bc9b9e977b5ea8103d28668925df;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x766a3ca00db4b974ef2d9bd87ec9a748999ad03eec72d8df26fd326b7c9320c9;
+const CONTRACT_ID = 0x04594851a2bd620dffc360f3976d747598b9184218dc55ff3e839f417ca345ac;
 
 fn main() -> bool {
     let balance_test_contract = abi(BalanceTest, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/src/main.sw
@@ -4,9 +4,9 @@ use abi_with_tuples::{MyContract, Location, Person};
 
 
 #[cfg(experimental_new_encoding = false)]
-const CONTRACT_ID = 0xb351aff8258ce46d16a71be666dd2b0b09d72243105c51f4423765824e59cac9;
+const CONTRACT_ID = 0x5175a6a984a6d8f92622afd3d987f5b778f5741c56d55ee5993cc368b9afee10;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x495633977922110c13c86e5637045d6f5ae22779c7a4a52b5d35ec69aad7d0ec;
+const CONTRACT_ID = 0x2435d33fbcdcaea63ea81348866a3d565a84cc90f68a18513b0cef78ee3faa03;
 
 fn main() -> bool {
     let the_abi = abi(MyContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -2,9 +2,9 @@ script;
 use basic_storage_abi::{BasicStorage, Quad};
 
 #[cfg(experimental_new_encoding = false)]
-const CONTRACT_ID = 0x044ab65bcabeebb73c88d8625ce392224c613cb1dae21ebedaa36bf6db1f5f4e;
+const CONTRACT_ID = 0x186c989267434c784f7785be57b0db0a490ec382bbf98a6108a840c63b99be99;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xefdc4aadfe54fe83c0a74b756cc594f096798e299cda748fd63478037a84f8f5;
+const CONTRACT_ID = 0x9fd665bb5b0ff768013b7f9b08f76b762bdc7426b11d76bd023c53433e9d21ed;
 
 fn main() -> u64 {
     let addr = abi(BasicStorage, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_contract_with_type_aliases/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_contract_with_type_aliases/src/main.sw
@@ -5,7 +5,7 @@ use contract_with_type_aliases_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x0cbeb6efe3104b460be769bdc4ea101ebf16ccc16f2d7b667ec3e1c7f5ce35b5;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x63ce8925d89245252bb2568ea26e9bbde03340634a1553ef05af33d089507d09;
+const CONTRACT_ID = 0xbcd811d9f9d67f81935a466ccb8b20a1ee505277ccae89ad57b31435e33caa8d;
 
 fn main() {
     let caller = abi(MyContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
@@ -4,9 +4,9 @@ use increment_abi::Incrementor;
 use dynamic_contract_call::*;
 
 #[cfg(experimental_new_encoding = false)]
-const CONTRACT_ID = 0x080ca4b6a4661d3cc2138f733cbe54095ce8b910eee73d913c1f43ecad6bf0d2;
+const CONTRACT_ID = 0xd1b4047af7ef111c023ab71069e01dc2abfde487c0a0ce1268e4f447e6c6e4c2;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x816715b0a467208e131305b645268e1d45ca13a79e01661026ea353e632747c9;
+const CONTRACT_ID = 0xfa28a2cb8354101b787f75b144170dd4373578e342eebe485661b3683427680c;
 
 fn main() -> bool {
     let the_abi = abi(Incrementor, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
@@ -3,9 +3,9 @@ script;
 use storage_enum_abi::*;
 
 #[cfg(experimental_new_encoding = false)]
-const CONTRACT_ID = 0x0d2d9546e833c166b64a340f5694fa01ca6bb53c3ec681d6c1ade1b9c0a2bf46;
+const CONTRACT_ID = 0xb54eb67f943fda15981308ef55b2cb2afe1ed5907c483d2d92d010ab39549644;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x62253b3aea7ea4986285f38db1f5202d1cf3c8a6684fd4f682370178095f84d0;
+const CONTRACT_ID = 0xfd91339494a1600ffb24d90eb7b67582e11fee5936e01704fb17a5445eb3f47e;
 
 fn main() -> u64 {
     let caller = abi(StorageEnum, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/src/main.sw
@@ -5,7 +5,7 @@ use auth_testing_abi::AuthTesting;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xc2eec20491b53aab7232cbd27c31d15417b4e9daf0b89c74cc242ef1295f681f;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x15d0746653b12e716b17d4443b1fa955a2bf658fe20a7da14e4c9fccd0800761;
+const CONTRACT_ID = 0xeb42a6ba3f230441d7ade26f54cfb9f64fe8dd6397cc685fefc7f3d082d4d2ce;
 
 // should be false in the case of a script
 fn main() -> bool {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
@@ -4,9 +4,9 @@ use core::codec::*;
 use context_testing_abi::*;
 
 #[cfg(experimental_new_encoding = false)]
-const CONTRACT_ID = 0xc2ec2a4a1b20475700e6793c7f20ad8082294894242b17cf08b5fd7c0d3968ad;
+const CONTRACT_ID = 0x6054c11cda000f5990373a4d61929396165be4dfdd61d5b7bd26da60ab0d8577;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xcb8c742a94a65c93515aacf26496bdea9b59131a161299d8dad0903c811a60ec;
+const CONTRACT_ID = 0x2d12f460ffd7da3e1281253e4a63f26a5a3cbc8cffd365a4d6fa6444caa7d48f;
 
 fn main() -> bool {
     let gas: u64 = u64::max();

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/nested_struct_args_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/nested_struct_args_caller/src/main.sw
@@ -3,9 +3,9 @@ script;
 use nested_struct_args_abi::*;
 
 #[cfg(experimental_new_encoding = false)]
-const CONTRACT_ID = 0x64390eb0cac08d41b6476ad57d711b88846ea35ac800d4fc3c95a551e4039432;
+const CONTRACT_ID = 0xe63d33a1b3a6903808b379f6a41a72fa8a370e8b76626775e7d9d2f9c4c5da40;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x8c7a0b9e22605ebe6190880f6344ac85deccdcfcb998fa877adcf9ae52af0f61;
+const CONTRACT_ID = 0xbefd6660ae89502652b2ab4e536edf3403208e308a329c06af6017dec242cc37;
 
 fn main() -> bool {
     let caller = abi(NestedStructArgs, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
@@ -4,9 +4,9 @@ use storage_access_abi::*;
 use std::hash::*;
 
 #[cfg(experimental_new_encoding = false)]
-const CONTRACT_ID = 0x88732a14508defea37a44d0b0ae9af5c776253215180a1c3288f8d504ebb84db;
+const CONTRACT_ID = 0x3bc28acd66d327b8c1b9624c1fabfc07e9ffa1b5d71c2832c3bfaaf8f4b805e9;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x61455db976cc30e0f72b1f6bb12f4e00bb8851b07f57a8272241ffc9bdcdf7de;
+const CONTRACT_ID = 0x54f3c43fb35959d0ec76ae22d58811be2a697df1901422dab0e0f9da5887f858;
 
 fn main() -> bool {
     let caller = abi(StorageAccess, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/abi_with_tuples/src/some_module.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_abis/abi_with_tuples/src/some_module.sw
@@ -6,6 +6,5 @@ pub struct SomeStruct {
 
 impl SomeStruct {
     pub fn g(self) {
-        
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/workspace_test/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/workspace_test/Forc.lock
@@ -1,23 +1,23 @@
 [[package]]
-name = 'contract_multi_test'
-source = 'member'
-dependencies = ['std']
+name = "contract_multi_test"
+source = "member"
+dependencies = ["std"]
 
 [[package]]
-name = 'core'
-source = 'path+from-root-28E4A5A6A7E567F7'
+name = "core"
+source = "path+from-root-28E4A5A6A7E567F7"
 
 [[package]]
-name = 'lib_multi_test'
-source = 'member'
-dependencies = ['std']
+name = "lib_multi_test"
+source = "member"
+dependencies = ["std"]
 
 [[package]]
-name = 'script_multi_test'
-source = 'member'
-dependencies = ['std']
+name = "script_multi_test"
+source = "member"
+dependencies = ["std"]
 
 [[package]]
-name = 'std'
-source = 'path+from-root-28E4A5A6A7E567F7'
-dependencies = ['core']
+name = "std"
+source = "path+from-root-28E4A5A6A7E567F7"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/workspace_test/contract_multi_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/workspace_test/contract_multi_test/src/main.sw
@@ -17,16 +17,14 @@ fn test_foo() {
 
 #[test(should_revert)]
 fn test_fail() {
-    let contract_id = 0xaff6151370c3ddd774601146cf743dff5dc0b1bc485a46da875be31f2b3e7493;
-    let caller = abi(MyContract, contract_id);
+    let caller = abi(MyContract, CONTRACT_ID);
     let result = caller.test_function {}();
     assert(result == false)
 }
 
 #[test]
 fn test_success() {
-    let contract_id = 0xaff6151370c3ddd774601146cf743dff5dc0b1bc485a46da875be31f2b3e7493;
-    let caller = abi(MyContract, contract_id);
+    let caller = abi(MyContract, CONTRACT_ID);
     let result = caller.test_function {}();
     assert(result == true)
 }

--- a/test/src/sdk-harness/test_projects/auth/mod.rs
+++ b/test/src/sdk-harness/test_projects/auth/mod.rs
@@ -126,9 +126,9 @@ async fn can_get_predicate_address() {
     let first_wallet = &wallets[0];
     let second_wallet = &wallets[1];
 
-    // Setup Predciate
+    // Setup predicate.
     let hex_predicate_address: &str =
-        "0xe5d0a6dbd36c76a091d21e5281c98a0994f6c6b0bc04793532daf4d5b3594743";
+        "0x96495296fbfc9bb1f8bfb254354a25138cc7331fc5df620b3f4ac5d90f24ff7f";
     let predicate_address =
         Address::from_str(hex_predicate_address).expect("failed to create Address from string");
     let predicate_bech32_address = Bech32Address::from(predicate_address);
@@ -207,7 +207,7 @@ async fn when_incorrect_predicate_address_passed() {
     let first_wallet = &wallets[0];
     let second_wallet = &wallets[1];
 
-    // Setup Predciate with incorrect address
+    // Setup predicate with incorrect address.
     let hex_predicate_address: &str =
         "0x36bf4bd40f2a3b3db595ef8fd8b21dbe9e6c0dd7b419b4413ff6b584ce7da5d7";
     let predicate_address =
@@ -252,9 +252,9 @@ async fn when_incorrect_predicate_address_passed() {
 
 #[tokio::test]
 async fn can_get_predicate_address_in_message() {
-    // Setup Predciate address
+    // Setup predicate address.
     let hex_predicate_address: &str =
-        "0xe5d0a6dbd36c76a091d21e5281c98a0994f6c6b0bc04793532daf4d5b3594743";
+        "0x96495296fbfc9bb1f8bfb254354a25138cc7331fc5df620b3f4ac5d90f24ff7f";
     let predicate_address =
         Address::from_str(hex_predicate_address).expect("failed to create Address from string");
     let predicate_bech32_address = Bech32Address::from(predicate_address);
@@ -292,7 +292,7 @@ async fn can_get_predicate_address_in_message() {
         .unwrap();
     wallet.set_provider(provider.clone());
 
-    // Setup Predciate
+    // Setup predicate.
     let predicate_data = AuthPredicateEncoder::default()
         .encode_data(predicate_bech32_address)
         .unwrap();


### PR DESCRIPTION
## Description

This PR closes #5924 and #6152 by:
- changing the `get_symbols` to:
  - properly cover all possible sources of pointers.
  - properly cover getting pointers over `u64` addresses.
  - not follow `u64` addresses coming over `Load`s.
- adapting all IR optimizations that rely on referred symbols to correctly treat the (unsafe) `Incomplete` capturing of referred symbols.
- propagating the information about `Incomplete` referred symbols to the escape analysis, that now is also `Complete` or `Incomplete`.
- adapting all IR optimizations that rely on escape analysis to correctly treat the (unsafe) `Incomplete` result of escape analysis.

Additionally, the PR marks the functions that were entries before wrapped in `__entry` as so called "original entries". The information about the original entries is now available in the IR. The reason for this change is given in the below chapter on bytcode size changes.

This PR also brought to surface an existing bug independent of this PR that is reported in #6174. This bug makes the following two test failing:
- `should_pass/language/break_and_continue_block_ret`
- `should_pass/language/abort_control_flow_good`

These two tests are temporarily disabled until #6174 is fixed. The reason they fail in this PR is that `main` function is not inlined anymore, as explained in the below chapter on bytcode size changes.

Closes #5924.
Closes #6152.

## Bytecode size changes

Properly treating incomplete escape analysis and referred symbols in IR optimizations was expected to increase bytcode sizes, since we now restrict unsafe optimizations in case of `Incomplete` results.

A special care is given to check those increases, to make sure that they are all justified.

Out of 442 `should_pass` tests, run as `--no-enocoding-v1`, only 41 changed sizes (~10%), and of those only 15 had more then 1% increase in size. All the cases of size increase include code patterns that we now recognize as unsafe. E.g., pointers coming from `asm` blocks or function calls.

Some of the tests actually got decreased in size. The reason is not collecting the symbols that were sources of `Load`s before. Having those symbols wrongly marked as escaping before, has restricted certain optimizations.

When run with the encoding v1, almost all of the tests show a slight, constant increase in size. The reason is the encoding related code in the `__entry` function that contains unsafe patterns, e.g., getting pointers from `asm`. This increase is negligible for contracts, scripts, and predicates of realistic sizes. It can also very likely be mittigated once #6065 and #6173 are implemented.

Since original entries all get inlined in the `__entry` before, those unsafe patterns made the code in the original entries also not being optimized. To overcome this, _we now forbid inlining of original entries_. This restriction might be lifted once the above two improvements are implemented.

Also, we expect some of the tests to again decrese in size once #6065 gets implemented.

<details>
  <summary>Click here for the numbers</summary>

Test | Before | After | Increase %
-- | -- | -- | --
blanket_impl | 40 | 40 | 0
blanket_impl_u16 | 40 | 40 | 0
break_in_strange_positions | 520 | 520 | 0
conditional_compilation/run | 40 | 40 | 0
continue_in_strange_positions | 1072 | 1072 | 0
dca/alias_lib | 80 | 80 | 0
dca/alias_type_ascription | 32 | 32 | 0
dca/alias_type_ascription_generic | 32 | 32 | 0
dca/alias_unused | 32 | 32 | 0
dca/allow_dead_code | 32 | 32 | 0
dca/all_paths_return | 32 | 32 | 0
dca/constant_decl_expr | 40 | 40 | 0
dca/constant_struct | 40 | 40 | 0
dca/constant_while | 32 | 32 | 0
dca/contract/abi_fn_params | 112 | 112 | 0
dca/contract/superabi_contract_calls | 208 | 208 | 0
dca/contract/unused_struct_field | 72 | 72 | 0
dca/contract/unused_struct_field_array | 96 | 96 | 0
dca/contract/unused_struct_field_enum | 96 | 96 | 0
dca/contract/unused_struct_field_tuple | 72 | 72 | 0
dca/func_param | 32 | 32 | 0
dca/generic_fn_trait_constraint | 32 | 32 | 0
dca/impl_self | 32 | 32 | 0
dca/impl_self_alias2 | 32 | 32 | 0
dca/impl_self_alias | 32 | 32 | 0
dca/impl_trait_multiple | 32 | 32 | 0
dca/impl_trait_single | 32 | 32 | 0
dca/impl_unused_fn | 48 | 48 | 0
dca/library/fn_params_free | 24 | 24 | 0
dca/library/fn_params_impl | 24 | 24 | 0
dca/library/fn_params_trait | 24 | 24 | 0
dca/library/unused_priv_free_fn | 24 | 24 | 0
dca/library/unused_pub_free_fn | 24 | 24 | 0
dca/log_intrinsic | 64 | 64 | 0
dca/log_stdlib | 64 | 64 | 0
dca/multiple_enums_same_name | 32 | 32 | 0
dca/multiple_fns_same_name | 32 | 32 | 0
dca/reassignment_lhs | 64 | 64 | 0
dca/revert | 32 | 32 | 0
dca/struct_field_no_warning | 40 | 40 | 0
dca/trait_method | 32 | 32 | 0
dca/trait_method_lib | 24 | 24 | 0
dca/trait_method_neq | 120 | 120 | 0
dca/unused_enum | 32 | 32 | 0
dca/unused_fields | 32 | 32 | 0
dca/unused_free_fn | 32 | 32 | 0
dca/unused_struct | 32 | 32 | 0
dca/unused_trait | 32 | 32 | 0
dca/unused_variable | 32 | 32 | 0
dca/unused_variable_in_free_fn | 32 | 32 | 0
empty_fields_in_storage_struct | 13800 | 13960 | 1.16
evm/evm_basic | 32 | 32 | 0
forc/contract_dependencies/contract_a | 312 | 312 | 0
forc/contract_dependencies/contract_b | 80 | 80 | 0
forc/contract_dependencies/contract_c | 80 | 80 | 0
forc/dependency_package_field | 32 | 32 | 0
forc/dependency_patching | 32 | 32 | 0
forc/workspace_building | 24 | 24 | 0
language/abort_control_flow_good | 40 | 40 | 0
language/aliased_imports | 72 | 72 | 0
language/arg_demotion_inline | 272 | 272 | 0
language/args_on_stack | 1304 | 1304 | 0
language/array_basics | 504 | 504 | 0
language/array_generics | 120 | 120 | 0
language/asm_expr_basic | 144 | 144 | 0
language/asm_without_return | 32 | 32 | 0
language/associated_const_abi | 32 | 32 | 0
language/associated_const_abi_default | 32 | 32 | 0
language/associated_const_abi_multiple | 32 | 32 | 0
language/associated_const_impl | 32 | 32 | 0
language/associated_const_impl_local_same_name | 32 | 32 | 0
language/associated_const_impl_multiple | 32 | 32 | 0
language/associated_const_impl_self | 32 | 32 | 0
language/associated_const_impl_self_order | 32 | 32 | 0
language/associated_const_trait | 32 | 32 | 0
language/associated_const_trait_const | 48 | 48 | 0
language/associated_const_trait_default | 40 | 40 | 0
language/associated_const_trait_impl_method | 32 | 32 | 0
language/associated_const_trait_method | 32 | 32 | 0
language/associated_type_and_associated_const | 32 | 32 | 0
language/associated_type_ascription | 32 | 32 | 0
language/associated_type_container | 1088 | 1088 | 0
language/associated_type_container_in_library | 1088 | 1088 | 0
language/associated_type_fully_qualified | 32 | 32 | 0
language/associated_type_iterator | 1176 | 1176 | 0
language/associated_type_method | 32 | 32 | 0
language/associated_type_parameter | 32 | 32 | 0
language/attributes_warnings | 32 | 32 | 0
language/b256_bad_jumps | 32 | 32 | 0
language/b256_bitwise_ops | 6536 | 6536 | 0
language/b256_ops | 3496 | 3496 | 0
language/basic_func_decl | 48 | 48 | 0
language/basic_predicate | 48 | 48 | 0
language/binary_and_hex_literals | 48 | 48 | 0
language/binop_intrinsics | 40 | 40 | 0
language/bitwise_not | 48 | 48 | 0
language/blanket_trait | 48 | 48 | 0
language/bool_and_or | 64 | 64 | 0
language/break_and_continue | 616 | 616 | 0
language/break_and_continue_block_ret | 40 | 40 | 0
language/builtin_type_method_call | 40 | 40 | 0
language/callpath_local_shadowing | 32 | 32 | 0
language/chained_if_let | 136 | 136 | 0
language/complex_cfg | 384 | 432 | 12.50
language/configurable_consts | 3712 | 3712 | 0
language/const_decl_and_use_in_library | 40 | 40 | 0
language/const_decl_in_library | 64 | 64 | 0
language/const_decl_literal | 40 | 40 | 0
language/const_decl_with_call_path | 240 | 240 | 0
language/const_inits | 1560 | 1560 | 0
language/contract_caller_as_ret | 80 | 80 | 0
language/contract_caller_dynamic_address | 128 | 128 | 0
language/deprecated | 24 | 24 | 0
language/deprecated_attribute | 40 | 40 | 0
language/diagnose_unknown_annotations | 112 | 112 | 0
language/diverging_exprs | 856 | 856 | 0
language/doc_comments | 72 | 72 | 0
language/dummy_method_issue | 152 | 176 | 15.79
language/duplicated_storage_keys | 40 | 40 | 0
language/empty_method_initializer | 712 | 712 | 0
language/enum_destructuring | 96 | 96 | 0
language/enum_if_let | 440 | 440 | 0
language/enum_if_let_large_type | 392 | 392 | 0
language/enum_in_fn_decl | 120 | 120 | 0
language/enum_init_fn_call | 280 | 280 | 0
language/enum_instantiation | 3464 | 3464 | 0
language/enum_padding | 96 | 96 | 0
language/enum_type_inference | 40 | 40 | 0
language/enum_variant_imports | 144 | 144 | 0
language/eq_and_neq | 1784 | 1784 | 0
language/eq_intrinsic | 40 | 40 | 0
language/fallback_only | 816 | 832 | 1.96
language/far_jumps/many_blobs | 11640232 | 11640232 | 0
language/far_jumps/single_blob | 1048640 | 1048640 | 0
language/fix_opcode_bug | 40 | 40 | 0
language/for_loops | 4200 | 4200 | 0
language/fqp_in_lib | 144 | 144 | 0
language/funcs_with_generic_types | 48 | 48 | 0
language/generic_functions | 48 | 48 | 0
language/generic_impl_self | 2312 | 2312 | 0
language/generic_impl_self_where | 2128 | 2072 | -2.63
language/generic_inside_generic | 128 | 128 | 0
language/generic_result_method | 424 | 408 | -3.77
language/generics_in_contract | 2784 | 2784 | 0
language/generic_struct | 56 | 56 | 0
language/generic_struct_instantiation | 32 | 32 | 0
language/generic_structs | 328 | 328 | 0
language/generic_trait_constraints | 320 | 320 | 0
language/generic_traits | 1032 | 1032 | 0
language/generic_transpose | 632 | 632 | 0
language/generic_tuple_trait | 552 | 552 | 0
language/generic_type_inference | 3152 | 3152 | 0
language/generic_where_in_impl_self2 | 224 | 224 | 0
language/generic_where_in_impl_self | 224 | 224 | 0
language/gtf_intrinsic | 352 | 352 | 0
language/if_elseif_enum | 440 | 440 | 0
language/if_implicit_unit | 32 | 32 | 0
language/if_let_no_side_effects | 128 | 128 | 0
language/implicit_casting | 40 | 40 | 0
language/implicit_return | 40 | 40 | 0
language/impl_self_method | 40 | 40 | 0
language/impl_self_method_order | 40 | 40 | 0
language/import_method_from_other_file | 400 | 400 | 0
language/import_star_name_clash | 2096 | 2096 | 0
language/import_trailing_comma | 40 | 40 | 0
language/import_with_different_callpaths | 2536 | 2560 | 0.95
language/impure_ifs | 816 | 816 | 0
language/inline_if_expr_const | 32 | 32 | 0
language/insert_element_reg_reuse | 2208 | 2200 | -0.36
language/integer_type_inference | 1344 | 1344 | 0
language/is_prime | 864 | 864 | 0
language/is_reference_type | 48 | 48 | 0
language/largeint_sroa | 584 | 584 | 0
language/left_to_right_func_args_evaluation | 64 | 64 | 0
language/local_impl_for_ord | 48 | 48 | 0
language/logging | 648 | 648 | 0
language/main_args/main_args_empty | 40 | 40 | 0
language/main_args/main_args_generics | 136 | 136 | 0
language/main_args/main_args_one_u64 | 48 | 48 | 0
language/main_args/main_args_ref | 48 | 48 | 0
language/main_args/main_args_ref_copy | 56 | 56 | 0
language/main_args/main_args_ref_ref | 56 | 56 | 0
language/main_args/main_args_two_u64 | 48 | 48 | 0
language/main_args/main_args_various_types | 560 | 560 | 0
language/main_returns_unit | 32 | 32 | 0
language/many_stack_variables | 656 | 656 | 0
language/match_expressions | 592 | 592 | 0
language/match_expressions_constants | 168 | 168 | 0
language/match_expressions_empty_enums | 40 | 40 | 0
language/match_expressions_enums | 3048 | 3048 | 0
language/match_expressions_explicit_rets | 48 | 48 | 0
language/match_expressions_inside_generic_functions | 232 | 232 | 0
language/match_expressions_mismatched | 88 | 88 | 0
language/match_expressions_nested | 1384 | 1384 | 0
language/match_expressions_or | 8896 | 8896 | 0
language/match_expressions_rest | 1432 | 1432 | 0
language/match_expressions_simple | 128 | 128 | 0
language/match_expressions_structs | 128 | 128 | 0
language/match_expressions_unreachable_catch_all_last_arm | 2016 | 2104 | 4.37
language/match_expressions_unreachable_catch_all_middle_arm | 1664 | 1896 | 13.94
language/match_expressions_unreachable_last_arm | 2808 | 2840 | 1.14
language/match_expressions_unreachable_middle_arm | 3216 | 3248 | 1.00
language/match_expressions_with_self | 176 | 176 | 0
language/mega_example | 2416 | 2416 | 0
language/memcpy | 176 | 176 | 0
language/method_indirect_inference | 304 | 304 | 0
language/method_on_empty_struct | 32 | 32 | 0
language/method_type_args | 32 | 32 | 0
language/method_unambiguous | 264 | 264 | 0
language/module_dep | 24 | 24 | 0
language/module_dep_multiple | 24 | 24 | 0
language/module_dep_self | 24 | 24 | 0
language/modulo_uint_test | 48 | 48 | 0
language/multi_impl_self | 40 | 40 | 0
language/multi_item_import | 32 | 32 | 0
language/mutable_and_initd | 152 | 152 | 0
language/mutable_arrays | 40 | 40 | 0
language/mutable_arrays_enum | 96 | 96 | 0
language/mutable_arrays_multiple_nested | 32 | 32 | 0
language/mutable_arrays_nested | 32 | 32 | 0
language/mutable_arrays_struct | 40 | 40 | 0
language/mutable_arrays_swap | 40 | 40 | 0
language/mut_ref_empty_type | 464 | 464 | 0
language/name_resolution_after_monomorphization | 56 | 56 | 0
language/nested_struct_destructuring | 32 | 32 | 0
language/nested_structs | 824 | 824 | 0
language/nested_while_and_if | 136 | 136 | 0
language/new_allocator_test | 504 | 504 | 0
language/non_literal_const_decl | 40 | 40 | 0
language/numeric_constants | 48 | 48 | 0
language/op_precedence | 32 | 32 | 0
language/ops | 144 | 144 | 0
language/out_of_order_decl | 56 | 56 | 0
language/predicate_while | 72 | 72 | 0
language/predicate_while_dep | 72 | 72 | 0
language/prelude_access2 | 32 | 32 | 0
language/prelude_access | 32 | 32 | 0
language/primitive_type_argument | 40 | 40 | 0
language/raw_identifiers | 160 | 160 | 0
language/raw_ptr/raw_ptr_ret | 48 | 48 | 0
language/raw_ptr/vec_ret | 352 | 352 | 0
language/reassignment_operators | 32 | 32 | 0
language/reassignment_rhs_lhs_evaluation_order | 416 | 416 | 0
language/redundant_return | 32 | 32 | 0
language/references/dereferencing_control_flow_expressions | 712 | 712 | 0
language/references/dereferencing_operator_dot_on_structs | 124712 | 124760 | 0.04
language/references/dereferencing_operator_dot_on_tuples | 124712 | 124760 | 0.04
language/references/dereferencing_operator_index | 92088 | 92088 | 0
language/references/dereferencing_operator_star | 150744 | 150768 | 0.02
language/references/impl_reference_types | 7328 | 7328 | 0
language/references/mutability_of_references | 648 | 648 | 0
language/references/passing_and_returning_references_to_and_from_functions | 15648 | 15648 | 0
language/references/reassigning_via_references_to_values | 13696 | 13696 | 0
language/references/references_and_generics | 3304 | 3304 | 0
language/references/references_in_aggregates | 3616 | 3616 | 0
language/references/references_in_asm_blocks | 1904 | 1904 | 0
language/references/referencing_control_flow_expressions | 536 | 536 | 0
language/references/referencing_function_parameters | 3656 | 3648 | -0.22
language/references/referencing_local_vars_and_values | 36144 | 36144 | 0
language/references/referencing_parts_of_aggregates | 6552 | 6336 | -3.30
language/references/referencing_references | 848 | 848 | 0
language/references/type_unification_of_references | 3168 | 3168 | 0
language/ref_mutable_arrays | 40 | 40 | 0
language/ref_mutable_arrays_inline | 40 | 40 | 0
language/ref_mutable_fn_args_bool | 48 | 48 | 0
language/ref_mutable_fn_args_call | 40 | 40 | 0
language/ref_mutable_fn_args_struct | 40 | 40 | 0
language/ref_mutable_fn_args_struct_assign | 40 | 40 | 0
language/ref_mutable_fn_args_u32 | 40 | 40 | 0
language/retd_b256 | 128 | 128 | 0
language/retd_small_array | 56 | 56 | 0
language/retd_struct | 152 | 152 | 0
language/retd_zero_len_array | 48 | 48 | 0
language/ret_small_string | 64 | 64 | 0
language/ret_string_in_struct | 80 | 80 | 0
language/revert_in_first_if_branch | 40 | 40 | 0
language/same_const_name | 104 | 104 | 0
language/same_const_name_lib | 24 | 24 | 0
language/self_impl_reassignment | 656 | 656 | 0
language/shadowing/shadowed_glob_imports | 32 | 32 | 0
language/size_of | 32 | 32 | 0
language/smo | 880 | 880 | 0
language/smo_opcode | 128 | 128 | 0
language/struct_destructuring | 152 | 152 | 0
language/struct_field_access | 40 | 40 | 0
language/struct_field_reassignment | 32 | 32 | 0
language/struct_init_reorder | 136 | 128 | -5.88
language/struct_instantiation | 2008 | 2008 | 0
language/supertraits | 6936 | 5776 | -16.72
language/supertraits_with_trait_methods | 120 | 120 | 0
language/test_attribute | 24 | 24 | 0
language/test_multiple_attributes | 24 | 24 | 0
language/trait_import_with_star | 32 | 32 | 0
language/trait_method_ascription_disambiguate | 160 | 160 | 0
language/trait_method_generic_qualified | 160 | 160 | 0
language/trait_method_qualified | 48 | 48 | 0
language/trait_nested | 160 | 160 | 0
language/tuple_access | 168 | 168 | 0
language/tuple_desugaring | 64 | 64 | 0
language/tuple_field_reassignment | 144 | 144 | 0
language/tuple_indexing | 32 | 32 | 0
language/tuple_in_struct | 376 | 376 | 0
language/tuple_trait | 120 | 120 | 0
language/tuple_types | 40 | 40 | 0
language/type_alias | 3624 | 3680 | 1.55
language/typeinfo_custom_callpath2 | 80 | 80 | 0
language/typeinfo_custom_callpath | 80 | 80 | 0
language/typeinfo_custom_callpath_with_import | 96 | 96 | 0
language/u256/u256_abi | 152 | 152 | 0
language/u256/u256_operators | 5152 | 5192 | 0.78
language/unary_not_basic_2 | 48 | 48 | 0
language/unary_not_basic | 48 | 48 | 0
language/unit_type_variants | 48 | 48 | 0
language/use_absolute_path | 32 | 32 | 0
language/use_full_path_names | 32 | 32 | 0
language/valid_impurity | 80 | 80 | 0
language/where_clause_enums | 456 | 456 | 0
language/where_clause_functions | 1696 | 1696 | 0
language/where_clause_generic_traits | 200 | 200 | 0
language/where_clause_generic_tuple | 40 | 40 | 0
language/where_clause_impls | 280 | 280 | 0
language/where_clause_methods | 1728 | 1728 | 0
language/where_clause_structs | 304 | 304 | 0
language/where_clause_traits | 32 | 32 | 0
language/while_loops | 304 | 304 | 0
language/zero_field_types | 40 | 40 | 0
multiple_supertraits_for_abis | 96 | 96 | 0
non_payable_implicit_zero_coins | 224 | 224 | 0
non_payable_zero_coins_let_binding | 224 | 224 | 0
resolve_local_items_that_shadow_imports | 176 | 176 | 0
return_in_strange_positions | 40 | 40 | 0
return_into | 640 | 640 | 0
static_analysis/cei_pattern_violation | 568 | 568 | 0
static_analysis/cei_pattern_violation_in_asm_block | 232 | 232 | 0
static_analysis/cei_pattern_violation_in_asm_block_bal | 192 | 192 | 0
static_analysis/cei_pattern_violation_in_asm_block_mint_burn | 360 | 360 | 0
static_analysis/cei_pattern_violation_in_asm_block_read | 224 | 224 | 0
static_analysis/cei_pattern_violation_in_asm_block_smo | 216 | 216 | 0
static_analysis/cei_pattern_violation_in_asm_block_tr | 1328 | 1344 | 1.20
static_analysis/cei_pattern_violation_in_asm_block_tro | 1328 | 1344 | 1.20
static_analysis/cei_pattern_violation_in_codeblocks_other_than_in_functions | 568 | 568 | 0
static_analysis/cei_pattern_violation_in_func_app-1 | 568 | 568 | 0
static_analysis/cei_pattern_violation_in_func_app-2 | 568 | 568 | 0
static_analysis/cei_pattern_violation_in_func_app-3 | 568 | 568 | 0
static_analysis/cei_pattern_violation_in_if_statement-1 | 584 | 584 | 0
static_analysis/cei_pattern_violation_in_if_statement-2 | 568 | 568 | 0
static_analysis/cei_pattern_violation_in_intrinsic_call | 568 | 568 | 0
static_analysis/cei_pattern_violation_in_match_statement-1 | 672 | 672 | 0
static_analysis/cei_pattern_violation_in_standalone_function | 568 | 568 | 0
static_analysis/cei_pattern_violation_in_struct | 568 | 568 | 0
static_analysis/cei_pattern_violation_in_tuple | 568 | 568 | 0
static_analysis/cei_pattern_violation_in_while_loop-1 | 568 | 568 | 0
static_analysis/cei_pattern_violation_in_while_loop-2 | 568 | 568 | 0
static_analysis/cei_pattern_violation_in_while_loop-3 | 568 | 568 | 0
static_analysis/cei_pattern_violation_in_while_loop-4 | 568 | 568 | 0
static_analysis/cei_pattern_violation_more_complex_logic | 11000 | 11144 | 1.31
static_analysis/cei_pattern_violation_smo_intrinsic | 280 | 280 | 0
static_analysis/cei_pattern_violation_storage_map_and_vec | 5640 | 5944 | 5.39
static_analysis/cei_pattern_violation_storage_struct_read | 776 | 792 | 2.06
static_analysis/cei_pattern_violation_storage_var_read | 760 | 760 | 0
static_analysis/cei_pattern_violation_storage_var_update | 688 | 688 | 0
static_analysis/storage_annotations_unused_read | 64 | 64 | 0
static_analysis/storage_annotations_unused_read_and_write | 64 | 64 | 0
static_analysis/storage_annotations_unused_write | 64 | 64 | 0
stdlib/address_test | 3912 | 3912 | 0
stdlib/alloc_test | 576 | 576 | 0
stdlib/assert_eq | 3128 | 3128 | 0
stdlib/assert_eq_revert | 72 | 72 | 0
stdlib/assert_ne | 3072 | 3072 | 0
stdlib/assert_ne_revert | 72 | 72 | 0
stdlib/assert_test | 48 | 48 | 0
stdlib/b512_struct_alignment | 504 | 504 | 0
stdlib/b512_test | 3096 | 3096 | 0
stdlib/block_height | 88 | 88 | 0
stdlib/chess | 1320 | 1320 | 0
stdlib/contract_id_test | 368 | 368 | 0
stdlib/contract_id_type | 368 | 368 | 0
stdlib/eq_custom_type | 448 | 448 | 0
stdlib/eq_generic | 32 | 32 | 0
stdlib/generic_empty_struct_with_constraint | 32 | 32 | 0
stdlib/ge_test | 312 | 312 | 0
stdlib/identity_eq | 2200 | 2200 | 0
stdlib/if_type_revert | 32 | 32 | 0
stdlib/intrinsics | 48 | 48 | 0
stdlib/iterator | 1552 | 1480 | -4.64
stdlib/option | 22456 | 22584 | 0.57
stdlib/option_eq | 11928 | 11952 | 0.20
stdlib/raw_ptr | 4232 | 4232 | 0
stdlib/raw_slice | 688 | 688 | 0
stdlib/require | 288 | 288 | 0
stdlib/result | 8640 | 8664 | 0.28
stdlib/sha256 | 1920 | 1920 | 0
stdlib/storage_vec_insert | 5128 | 5256 | 2.50
stdlib/u128_div_test | 2456 | 2472 | 0.65
stdlib/u128_log_test | 4248 | 4272 | 0.56
stdlib/u128_mul_test | 1208 | 1208 | 0
stdlib/u128_root_test | 4072 | 4072 | 0
stdlib/u128_test | 6208 | 6208 | 0
stdlib/vec | 106224 | 106856 | 0.59
stdlib/vec_swap | 23352 | 23536 | 0.79
storage_into | 616 | 616 | 0
superabi | 96 | 96 | 0
superabi_diamond | 152 | 152 | 0
superabi_diamond_impl | 152 | 152 | 0
superabi_supertrait_same_methods | 432 | 432 | 0
supertraits_for_abis | 96 | 96 | 0
supertraits_for_abis_diamond | 64 | 64 | 0
supertraits_for_abis_ownable | 3200 | 3296 | 3.00
test_abis/abi_impl_methods_in_json_abi | 96 | 96 | 0
test_contracts/abi_with_generic_types | 152 | 152 | 0
test_contracts/abi_with_same_name_types | 96 | 96 | 0
test_contracts/abi_with_tuples_contract | 152 | 152 | 0
test_contracts/array_of_structs_contract | 192 | 192 | 0
test_contracts/auth_testing_contract | 72 | 72 | 0
test_contracts/balance_test_contract | 72 | 72 | 0
test_contracts/basic_storage | 28272 | 28464 | 0.68
test_contracts/context_testing_contract | 800 | 800 | 0
test_contracts/contract_with_type_aliases | 168 | 168 | 0
test_contracts/increment_contract | 1824 | 1824 | 0
test_contracts/issue_1512_repro | 1160 | 1160 | 0
test_contracts/multiple_impl | 80 | 80 | 0
test_contracts/nested_struct_args_contract | 96 | 96 | 0
test_contracts/return_struct | 2168 | 2168 | 0
test_contracts/storage_access_contract | 13768 | 13792 | 0.17
test_contracts/storage_enum_contract | 16768 | 16848 | 0.48
test_contracts/storage_namespace | 26904 | 27096 | 0.71
test_contracts/test_fuel_coin_contract | 1128 | 1136 | 0.71
unit_tests/aggr_indexing | 896 | 896 | 0
unit_tests/contract-multi-contract-calls | 64 | 64 | 0
unit_tests/contract_with_nested_libs | 384 | 384 | 0
unit_tests/lib_multi_test | 352 | 352 | 0
unit_tests/lib_single_test | 88 | 88 | 0
unit_tests/nested_libs | 344 | 344 | 0
unit_tests/predicate_multi_test | 248 | 248 | 0
unit_tests/predicate_with_nested_libs | 296 | 296 | 0
unit_tests/regalloc_spill | 408 | 408 | 0
unit_tests/script-contract-calls | 64 | 64 | 0
unit_tests/script_multi_test | 264 | 264 | 0
unit_tests/script_with_nested_libs | 352 | 352 | 0
unit_tests/should_revert | 160 | 160 | 0
unit_tests/stack_indexing_overflow | 3816 | 3816 | 0
</details>


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.