### PR TITLE
Verify that entry block does not have predecessors

### DIFF
--- a/sway-ir/src/error.rs
+++ b/sway-ir/src/error.rs
@@ -21,6 +21,7 @@ pub enum IrError {
     VerifyBinaryOpIncorrectArgType,
     VerifyBitcastBetweenInvalidTypes(String, String),
     VerifyBitcastUnknownSourceType,
+    VerifyEntryBlockHasPredecessors(String, Vec<String>),
     VerifyBlockArgMalformed,
     VerifyBranchParamsMismatch,
     VerifyBranchToMissingBlock(String),
@@ -71,6 +72,8 @@ pub enum IrError {
 impl std::error::Error for IrError {}
 
 use std::fmt;
+
+use itertools::Itertools;
 
 impl fmt::Display for IrError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
@@ -261,6 +264,31 @@ impl fmt::Display for IrError {
                 "Verification failed: \
                 Function {fn_str} return type must match its RET instructions."
             ),
+            IrError::VerifyEntryBlockHasPredecessors(function_name, predecessors) => {
+                let plural_s = if predecessors.len() == 1 {
+                        ""
+                    } else {
+                        "s"
+                    };
+                write!(
+                    f,
+                    "Verification failed: Entry block of the function \"{function_name}\" has {}predecessor{}. \
+                     The predecessor{} {} {}.",
+                    if predecessors.len() == 1 {
+                        "a "
+                    } else {
+                        ""
+                    },
+                    plural_s,
+                    plural_s,
+                    if predecessors.len() == 1 {
+                        "is"
+                    } else {
+                        "are"
+                    },
+                    predecessors.iter().map(|block_label| format!("\"{block_label}\"")).collect_vec().join(", ")
+                )
+            }
             IrError::VerifyBlockArgMalformed => {
                 write!(f, "Verification failed: Block argument is malformed")
             }

--- a/sway-ir/src/error.rs
+++ b/sway-ir/src/error.rs
@@ -265,11 +265,7 @@ impl fmt::Display for IrError {
                 Function {fn_str} return type must match its RET instructions."
             ),
             IrError::VerifyEntryBlockHasPredecessors(function_name, predecessors) => {
-                let plural_s = if predecessors.len() == 1 {
-                        ""
-                    } else {
-                        "s"
-                    };
+                let plural_s = if predecessors.len() == 1 { "" } else { "s" };
                 write!(
                     f,
                     "Verification failed: Entry block of the function \"{function_name}\" has {}predecessor{}. \

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -73,7 +73,10 @@ impl<'eng> Context<'eng> {
         if entry_block.num_predecessors(self) != 0 {
             return Err(IrError::VerifyEntryBlockHasPredecessors(
                 function.get_name(self).to_string(),
-                entry_block.pred_iter(self).map(|block| block.get_label(self)).collect()
+                entry_block
+                    .pred_iter(self)
+                    .map(|block| block.get_label(self))
+                    .collect(),
             ));
         }
 

--- a/sway-ir/src/verify.rs
+++ b/sway-ir/src/verify.rs
@@ -67,7 +67,16 @@ impl<'eng> Context<'eng> {
                 format!("Module_Index_{:?}", function.get_module(self).0),
             ));
         }
+
         let entry_block = function.get_entry_block(self);
+
+        if entry_block.num_predecessors(self) != 0 {
+            return Err(IrError::VerifyEntryBlockHasPredecessors(
+                function.get_name(self).to_string(),
+                entry_block.pred_iter(self).map(|block| block.get_label(self)).collect()
+            ));
+        }
+
         // Ensure that the entry block arguments are same as function arguments.
         if function.num_args(self) != entry_block.num_args(self) {
             return Err(IrError::VerifyBlockArgMalformed);

--- a/sway-ir/tests/tests.rs
+++ b/sway-ir/tests/tests.rs
@@ -2,7 +2,12 @@ use std::path::PathBuf;
 
 use itertools::Itertools;
 use sway_ir::{
-    create_arg_demotion_pass, create_const_demotion_pass, create_const_folding_pass, create_dce_pass, create_dom_fronts_pass, create_dominators_pass, create_escaped_symbols_pass, create_mem2reg_pass, create_memcpyopt_pass, create_misc_demotion_pass, create_postorder_pass, create_ret_demotion_pass, create_simplify_cfg_pass, optimize as opt, register_known_passes, Context, ExperimentalFlags, IrError, PassGroup, PassManager, DCE_NAME, FN_DCE_NAME, FN_DEDUP_DEBUG_PROFILE_NAME, FN_DEDUP_RELEASE_PROFILE_NAME, MEM2REG_NAME, SROA_NAME
+    create_arg_demotion_pass, create_const_demotion_pass, create_const_folding_pass,
+    create_dce_pass, create_dom_fronts_pass, create_dominators_pass, create_escaped_symbols_pass,
+    create_mem2reg_pass, create_memcpyopt_pass, create_misc_demotion_pass, create_postorder_pass,
+    create_ret_demotion_pass, create_simplify_cfg_pass, optimize as opt, register_known_passes,
+    Context, ExperimentalFlags, IrError, PassGroup, PassManager, DCE_NAME, FN_DCE_NAME,
+    FN_DEDUP_DEBUG_PROFILE_NAME, FN_DEDUP_RELEASE_PROFILE_NAME, MEM2REG_NAME, SROA_NAME,
 };
 use sway_types::SourceEngine;
 
@@ -88,10 +93,13 @@ fn run_ir_verifier_tests(sub_dir: &str) {
             .lines()
             .filter(|line| line.starts_with("// error: "))
             .collect_vec();
-        
+
         let expected_error = match expected_errors[..] {
             [] => {
-                println!("--- IR verifier test does not contain the expected error: {}", path.display());
+                println!(
+                    "--- IR verifier test does not contain the expected error: {}",
+                    path.display()
+                );
                 println!("The expected error must be specified by using the `// error: ` comment.");
                 println!("E.g., `// error: This is the expected error`");
                 println!("There must be exactly one error specified in each IR verifier test.");
@@ -99,8 +107,13 @@ fn run_ir_verifier_tests(sub_dir: &str) {
             }
             [err] => err.replace("// error: ", ""),
             _ => {
-                println!("--- IR verifier test contains more then one expected error: {}", path.display());
-                println!("There must be exactly one expected error specified in each IR verifier test.");
+                println!(
+                    "--- IR verifier test contains more then one expected error: {}",
+                    path.display()
+                );
+                println!(
+                    "There must be exactly one expected error specified in each IR verifier test."
+                );
                 println!("The specified expected errors were:");
                 println!("{}", expected_errors.join("\n"));
                 panic!();
@@ -117,16 +130,24 @@ fn run_ir_verifier_tests(sub_dir: &str) {
 
         match parse_result {
             Ok(_) => {
-                println!("--- Parsing and validating an IR verifier test passed without errors: {}", path.display());
+                println!(
+                    "--- Parsing and validating an IR verifier test passed without errors: {}",
+                    path.display()
+                );
                 println!("The expected IR validation error was: {expected_error}");
                 panic!();
-            },
+            }
             Err(err @ IrError::ParseFailure(_, _)) => {
-                println!("--- Parsing of an IR verifier test failed: {}", path.display());
-                println!("IR verifier test must be parsable and result in an IR verification error.");
+                println!(
+                    "--- Parsing of an IR verifier test failed: {}",
+                    path.display()
+                );
+                println!(
+                    "IR verifier test must be parsable and result in an IR verification error."
+                );
                 println!("The parsing error was: {err}");
                 panic!();
-            },
+            }
             Err(err) => {
                 let err = format!("{err}");
                 if !err.contains(&expected_error) {

--- a/sway-ir/tests/verify/entry_block_dominance_frontier.ir
+++ b/sway-ir/tests/verify/entry_block_dominance_frontier.ir
@@ -1,0 +1,16 @@
+// This test proves that https://github.com/FuelLabs/sway/issues/6148 is fixed.
+
+// error: Entry block of the function "main" has predecessors. The predecessors are "block0", "block1".
+
+script {
+ fn main() -> () {
+    entry():
+    br block0()
+
+    block0():
+    br entry()
+
+    block1():
+    br entry()
+  }
+}

--- a/sway-ir/tests/verify/entry_block_mem2reg.ir
+++ b/sway-ir/tests/verify/entry_block_mem2reg.ir
@@ -1,0 +1,27 @@
+// This test proves that https://github.com/FuelLabs/sway/issues/6148 is fixed.
+
+// error: Entry block of the function "main" has a predecessor. The predecessor is "block1".
+
+script {
+  fn main(x: bool) -> u64 {
+    local u64 S = const u64 3
+
+    entry(x: bool):
+    v0 = get_local ptr u64, S
+    v1 = load v0
+    cbr x, block0(x, v1), block2(x, v1)
+
+    block0(x: bool, y: u64):
+    v0 = get_local ptr u64, S
+    v1 = const u64 1
+    store v1 to v0
+    br block1(x)
+
+    block1(x: bool):
+    z = const bool false
+    br entry(z)
+
+    block2(x: bool, y: u64):
+    ret u64 y
+  }
+}

--- a/sway-ir/tests/verify/entry_block_simplify_cfg.ir
+++ b/sway-ir/tests/verify/entry_block_simplify_cfg.ir
@@ -1,0 +1,10 @@
+// This test proves that https://github.com/FuelLabs/sway/issues/6148 is fixed.
+
+// error: Entry block of the function "main" has a predecessor. The predecessor is "entry".
+
+script {
+  fn main() -> bool {
+    entry():
+    br entry()
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes #6148 by verifying that a function entry block cannot have predecessors.

Additionally, the PR provides a simple testing infrastructure for testing IR verifications.

Closes #6148.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.