### PR TITLE
fix: only support hover links for vscode

### DIFF
--- a/sway-lsp/benches/lsp_benchmarks/requests.rs
+++ b/sway-lsp/benches/lsp_benchmarks/requests.rs
@@ -4,7 +4,7 @@ use lsp_types::{
     TextDocumentIdentifier,
 };
 use sway_lsp::{
-    capabilities, config::LspClientConfig, lsp_ext::OnEnterParams, utils::keyword_docs::KeywordDocs,
+    capabilities, config::LspClient, lsp_ext::OnEnterParams, utils::keyword_docs::KeywordDocs,
 };
 use tokio::runtime::Runtime;
 
@@ -45,7 +45,7 @@ fn benchmarks(c: &mut Criterion) {
                 &keyword_docs,
                 &uri,
                 position,
-                LspClientConfig::default(),
+                LspClient::default(),
             )
         })
     });

--- a/sway-lsp/benches/lsp_benchmarks/requests.rs
+++ b/sway-lsp/benches/lsp_benchmarks/requests.rs
@@ -3,7 +3,9 @@ use lsp_types::{
     CompletionResponse, DocumentSymbolResponse, Position, Range, TextDocumentContentChangeEvent,
     TextDocumentIdentifier,
 };
-use sway_lsp::{capabilities, lsp_ext::OnEnterParams, utils::keyword_docs::KeywordDocs};
+use sway_lsp::{
+    capabilities, config::LspClientConfig, lsp_ext::OnEnterParams, utils::keyword_docs::KeywordDocs,
+};
 use tokio::runtime::Runtime;
 
 fn benchmarks(c: &mut Criterion) {
@@ -37,7 +39,15 @@ fn benchmarks(c: &mut Criterion) {
     });
 
     c.bench_function("hover", |b| {
-        b.iter(|| capabilities::hover::hover_data(session.clone(), &keyword_docs, &uri, position))
+        b.iter(|| {
+            capabilities::hover::hover_data(
+                session.clone(),
+                &keyword_docs,
+                &uri,
+                position,
+                LspClientConfig::default(),
+            )
+        })
     });
 
     c.bench_function("highlight", |b| {

--- a/sway-lsp/src/capabilities/hover/mod.rs
+++ b/sway-lsp/src/capabilities/hover/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod hover_link_contents;
 
 use self::hover_link_contents::HoverLinkContents;
-use crate::config::LspClientConfig;
+use crate::config::LspClient;
 use crate::{
     core::{
         session::Session,
@@ -25,7 +25,7 @@ pub fn hover_data(
     keyword_docs: &KeywordDocs,
     url: &Url,
     position: Position,
-    client_config: LspClientConfig,
+    client_config: LspClient,
 ) -> Option<lsp_types::Hover> {
     let t = session.token_map().token_at_position(url, position)?;
     let (ident, token) = t.pair();
@@ -129,7 +129,7 @@ fn hover_format(
     engines: &Engines,
     token: &Token,
     ident_name: &str,
-    client_config: LspClientConfig,
+    client_config: LspClient,
 ) -> lsp_types::HoverContents {
     let decl_engine = engines.de();
     let doc_comment = format_doc_attributes(engines, token);

--- a/sway-lsp/src/config.rs
+++ b/sway-lsp/src/config.rs
@@ -5,7 +5,7 @@ use tracing::metadata::LevelFilter;
 #[serde(rename_all = "camelCase")]
 pub struct Config {
     #[serde(default)]
-    pub client: LspClientConfig,
+    pub client: LspClient,
     #[serde(default)]
     pub debug: DebugConfig,
     #[serde(default)]
@@ -24,7 +24,7 @@ pub struct Config {
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum LspClientConfig {
+pub enum LspClient {
     VsCode,
     #[serde(other)]
     #[default]

--- a/sway-lsp/src/config.rs
+++ b/sway-lsp/src/config.rs
@@ -5,6 +5,8 @@ use tracing::metadata::LevelFilter;
 #[serde(rename_all = "camelCase")]
 pub struct Config {
     #[serde(default)]
+    pub client: LspClientConfig,
+    #[serde(default)]
     pub debug: DebugConfig,
     #[serde(default)]
     pub logging: LoggingConfig,
@@ -18,6 +20,15 @@ pub struct Config {
     trace: TraceConfig,
     #[serde(default)]
     pub garbage_collection: GarbageCollectionConfig,
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LspClientConfig {
+    VsCode,
+    #[serde(other)]
+    #[default]
+    Other,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Default)]

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -132,6 +132,7 @@ pub async fn handle_hover(
                 &state.keyword_docs,
                 &uri,
                 position,
+                state.config.read().client.clone(),
             ))
         }
         Err(err) => {

--- a/sway-lsp/src/utils/markup.rs
+++ b/sway-lsp/src/utils/markup.rs
@@ -4,8 +4,8 @@
 //! markdown for this purpose.
 //! Modified from rust-analyzer.
 use crate::{
-    capabilities::hover::hover_link_contents::RelatedType, core::token::get_range_from_span,
-    utils::document::get_url_from_span,
+    capabilities::hover::hover_link_contents::RelatedType, config::LspClientConfig,
+    core::token::get_range_from_span, utils::document::get_url_from_span,
 };
 use serde_json::{json, Value};
 use std::fmt::{self};
@@ -56,13 +56,18 @@ impl Markup {
     }
 
     /// Adds go-to links if there are any related types, a link to view implementations if there are any,
-    /// or nothing if there are no related types or implementations.
+    /// or nothing if there are no related types or implementations. Only adds links for VSCode clients.
     pub fn maybe_add_links(
         self,
         source_engine: &SourceEngine,
         related_types: &[RelatedType],
         implementations: &[Span],
+        client_config: LspClientConfig,
     ) -> Self {
+        if client_config != LspClientConfig::VsCode {
+            return self;
+        }
+
         if related_types.is_empty() {
             let locations = implementations
                 .iter()

--- a/sway-lsp/src/utils/markup.rs
+++ b/sway-lsp/src/utils/markup.rs
@@ -4,7 +4,7 @@
 //! markdown for this purpose.
 //! Modified from rust-analyzer.
 use crate::{
-    capabilities::hover::hover_link_contents::RelatedType, config::LspClientConfig,
+    capabilities::hover::hover_link_contents::RelatedType, config::LspClient,
     core::token::get_range_from_span, utils::document::get_url_from_span,
 };
 use serde_json::{json, Value};
@@ -62,9 +62,9 @@ impl Markup {
         source_engine: &SourceEngine,
         related_types: &[RelatedType],
         implementations: &[Span],
-        client_config: LspClientConfig,
+        client_config: LspClient,
     ) -> Self {
-        if client_config != LspClientConfig::VsCode {
+        if client_config != LspClient::VsCode {
             return self;
         }
 

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -4,6 +4,7 @@ use crate::integration::{code_actions, lsp};
 use lsp_types::*;
 use std::{fs, path::PathBuf};
 use sway_lsp::{
+    config::LspClientConfig,
     handlers::{notification, request},
     server_state::ServerState,
 };
@@ -1779,21 +1780,40 @@ fn hover_docs_with_code_examples() {
 }
 
 #[test]
+fn hover_docs_for_self_keywords_vscode() {
+    run_async!({
+        let server = ServerState::default();
+        server.config.write().client = LspClientConfig::VsCode;
+        let uri = open(&server, test_fixtures_dir().join("completion/src/main.sw")).await;
+
+        let mut hover = HoverDocumentation {
+            req_uri: &uri,
+            req_line: 11,
+            req_char: 13,
+            documentation: vec!["\n```sway\nself\n```\n\n---\n\n The receiver of a method, or the current module.\n\n `self` is used in two situations: referencing the current module and marking\n the receiver of a method.\n\n In paths, `self` can be used to refer to the current module, either in a\n [`use`] statement or in a path to access an element:\n\n ```sway\n use std::contract_id::{self, ContractId};\n ```\n\n Is functionally the same as:\n\n ```sway\n use std::contract_id;\n use std::contract_id::ContractId;\n ```\n\n `self` as the current receiver for a method allows to omit the parameter\n type most of the time. With the exception of this particularity, `self` is\n used much like any other parameter:\n\n ```sway\n struct Foo(u32);\n\n impl Foo {\n     // No `self`.\n     fn new() -> Self {\n         Self(0)\n     }\n\n     // Borrowing `self`.\n     fn value(&self) -> u32 {\n         self.0\n     }\n\n     // Updating `self` mutably.\n     fn clear(ref mut self) {\n         self.0 = 0\n     }\n }\n ```"],
+        };
+
+        lsp::hover_request(&server, &hover).await;
+        hover.req_char = 24;
+        hover.documentation = vec!["```sway\nstruct MyStruct\n```\n---\n\n---\n[2 implementations](command:sway.peekLocations?%5B%7B%22locations%22%3A%5B%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A4%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A2%7D%7D%2C%22uri%22%3A%22file","sway%2Fsway-lsp%2Ftests%2Ffixtures%2Fcompletion%2Fsrc%2Fmain.sw%22%7D%2C%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A14%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A6%7D%7D%2C%22uri%22%3A%22file","sway%2Fsway-lsp%2Ftests%2Ffixtures%2Fcompletion%2Fsrc%2Fmain.sw%22%7D%5D%7D%5D \"Go to implementations\")"];
+        lsp::hover_request(&server, &hover).await;
+        let _ = server.shutdown_server();
+    });
+}
+
+#[test]
 fn hover_docs_for_self_keywords() {
     run_async!({
         let server = ServerState::default();
         let uri = open(&server, test_fixtures_dir().join("completion/src/main.sw")).await;
 
-        let mut hover = HoverDocumentation {
-        req_uri: &uri,
-        req_line: 11,
-        req_char: 13,
-        documentation: vec!["\n```sway\nself\n```\n\n---\n\n The receiver of a method, or the current module.\n\n `self` is used in two situations: referencing the current module and marking\n the receiver of a method.\n\n In paths, `self` can be used to refer to the current module, either in a\n [`use`] statement or in a path to access an element:\n\n ```sway\n use std::contract_id::{self, ContractId};\n ```\n\n Is functionally the same as:\n\n ```sway\n use std::contract_id;\n use std::contract_id::ContractId;\n ```\n\n `self` as the current receiver for a method allows to omit the parameter\n type most of the time. With the exception of this particularity, `self` is\n used much like any other parameter:\n\n ```sway\n struct Foo(u32);\n\n impl Foo {\n     // No `self`.\n     fn new() -> Self {\n         Self(0)\n     }\n\n     // Borrowing `self`.\n     fn value(&self) -> u32 {\n         self.0\n     }\n\n     // Updating `self` mutably.\n     fn clear(ref mut self) {\n         self.0 = 0\n     }\n }\n ```"],
-    };
+        let hover = HoverDocumentation {
+            req_uri: &uri,
+            req_line: 11,
+            req_char: 13,
+            documentation: vec!["\n```sway\nself\n```\n\n---\n\n The receiver of a method, or the current module.\n\n `self` is used in two situations: referencing the current module and marking\n the receiver of a method.\n\n In paths, `self` can be used to refer to the current module, either in a\n [`use`] statement or in a path to access an element:\n\n ```sway\n use std::contract_id::{self, ContractId};\n ```\n\n Is functionally the same as:\n\n ```sway\n use std::contract_id;\n use std::contract_id::ContractId;\n ```\n\n `self` as the current receiver for a method allows to omit the parameter\n type most of the time. With the exception of this particularity, `self` is\n used much like any other parameter:\n\n ```sway\n struct Foo(u32);\n\n impl Foo {\n     // No `self`.\n     fn new() -> Self {\n         Self(0)\n     }\n\n     // Borrowing `self`.\n     fn value(&self) -> u32 {\n         self.0\n     }\n\n     // Updating `self` mutably.\n     fn clear(ref mut self) {\n         self.0 = 0\n     }\n }\n ```"],
+        };
 
-        lsp::hover_request(&server, &hover).await;
-        hover.req_char = 24;
-        hover.documentation = vec!["```sway\nstruct MyStruct\n```\n---\n\n---\n[2 implementations](command:sway.peekLocations?%5B%7B%22locations%22%3A%5B%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A4%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A2%7D%7D%2C%22uri%22%3A%22file","sway%2Fsway-lsp%2Ftests%2Ffixtures%2Fcompletion%2Fsrc%2Fmain.sw%22%7D%2C%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A14%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A6%7D%7D%2C%22uri%22%3A%22file","sway%2Fsway-lsp%2Ftests%2Ffixtures%2Fcompletion%2Fsrc%2Fmain.sw%22%7D%5D%7D%5D \"Go to implementations\")"];
         lsp::hover_request(&server, &hover).await;
         let _ = server.shutdown_server();
     });

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -4,7 +4,7 @@ use crate::integration::{code_actions, lsp};
 use lsp_types::*;
 use std::{fs, path::PathBuf};
 use sway_lsp::{
-    config::LspClientConfig,
+    config::LspClient,
     handlers::{notification, request},
     server_state::ServerState,
 };
@@ -1636,9 +1636,10 @@ fn hover_docs_for_consts() {
 }
 
 #[test]
-fn hover_docs_for_functions() {
+fn hover_docs_for_functions_vscode() {
     run_async!({
         let server = ServerState::default();
+        server.config.write().client = LspClient::VsCode;
         let uri = open(
             &server,
             test_fixtures_dir().join("tokens/functions/src/main.sw"),
@@ -1783,7 +1784,7 @@ fn hover_docs_with_code_examples() {
 fn hover_docs_for_self_keywords_vscode() {
     run_async!({
         let server = ServerState::default();
-        server.config.write().client = LspClientConfig::VsCode;
+        server.config.write().client = LspClient::VsCode;
         let uri = open(&server, test_fixtures_dir().join("completion/src/main.sw")).await;
 
         let mut hover = HoverDocumentation {


### PR DESCRIPTION
## Description

Closes https://github.com/FuelLabs/sway/issues/6091

Front end change: https://github.com/FuelLabs/sway-vscode-plugin/pull/187

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
