### PR TITLE
wip: fix configurable block comment formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,6 +3540,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6747,6 +6753,7 @@ dependencies = [
  "anyhow",
  "difference",
  "forc-tracing 0.61.0",
+ "indoc",
  "paste",
  "prettydiff 0.6.4",
  "ropey",

--- a/swayfmt/Cargo.toml
+++ b/swayfmt/Cargo.toml
@@ -25,6 +25,7 @@ toml = { version = "0.7", features = ["parse"] }
 
 [dev-dependencies]
 difference = "2.0.0"
+indoc = "2.0.5"
 paste = "1.0"
 prettydiff = "0.6"
 test-macros = { path = "test_macros" }

--- a/swayfmt/src/items/item_configurable/mod.rs
+++ b/swayfmt/src/items/item_configurable/mod.rs
@@ -1,4 +1,5 @@
 use crate::{
+    comments::rewrite_with_comments,
     config::user_def::FieldAlignment,
     formatter::{
         shape::{ExprKind, LineStyle},
@@ -27,6 +28,9 @@ impl Format for ItemConfigurable {
                 .shape
                 .with_code_line_from(LineStyle::Multiline, ExprKind::default()),
             |formatter| -> Result<(), FormatterError> {
+                // Required for comment formatting
+                let start_len = formatted_code.len();
+
                 // Add configurable token
                 write!(
                     formatted_code,
@@ -116,8 +120,17 @@ impl Format for ItemConfigurable {
                     }
                     FieldAlignment::Off => fields.format(formatted_code, formatter)?,
                 }
+
                 // Handle closing brace
                 Self::close_curly_brace(formatted_code, formatter)?;
+
+                rewrite_with_comments::<ItemConfigurable>(
+                    formatter,
+                    self.span(),
+                    self.leaf_spans(),
+                    formatted_code,
+                    start_len,
+                )?;
 
                 Ok(())
             },

--- a/swayfmt/tests/mod.rs
+++ b/swayfmt/tests/mod.rs
@@ -1,3 +1,4 @@
+use indoc::indoc;
 use std::sync::Arc;
 use swayfmt::{config::user_def::FieldAlignment, Formatter};
 use test_macros::assert_eq_pretty;
@@ -2372,7 +2373,7 @@ fn test_comment_v2() {
     /// This is documentation for a commented out function
     // fn commented_out_function() {
     //}
-        
+
     fn test_function() -> bool {
         true
     }
@@ -2423,7 +2424,7 @@ fn long_doc_break_new_line() {
 /// and the VM Instruction Set for [Memory Allocation](https://docs.fuel.network/docs/specs/fuel-vm/instruction-set#aloc-allocate-memory).
 ///
 /// # Arguments
-/// 
+///
 /// * `count`: [u64] - The number of `size_of<T>` bytes to allocate onto the heap.
 ///
 /// # Returns
@@ -2434,14 +2435,14 @@ fn long_doc_break_new_line() {
 ///
 /// ```sway
 /// use std::alloc::alloc;
-/// 
+///
 /// fn foo() {
 ///     let ptr = alloc::<u64>(2);
 ///     assert(!ptr.is_null());
 /// }
 /// ```
 /// Reallocates the given area of memory.
-/// 
+///
 /// # Arguments
 ///
 /// * `ptr`: [raw_ptr] - The pointer to the area of memory to reallocate.
@@ -2449,7 +2450,7 @@ fn long_doc_break_new_line() {
 /// * `new_count`: [u64] - The number of new `size_of<T>` bytes to allocate. These are set to 0.
 ///
 /// # Returns
-/// 
+///
 /// * [raw_ptr] - The pointer to the newly reallocated memory.
 ///
 /// # Examples
@@ -2611,7 +2612,7 @@ fn test() {}
 fn asm_block_v2() {
     check(
         r#"library;
-    
+
     pub fn transfer(self, asset_id: AssetId, amount: u64) {
         // maintain a manual index as we only have `while` loops in sway atm:
         let mut index = 0;
@@ -2770,7 +2771,7 @@ fn test() {
 fn use_sorting_items() {
     check(
         r#"library;
-    
+
     use ::option::Option::{*, self, z, foo, bar};
 "#,
         r#"library;
@@ -2784,7 +2785,7 @@ use ::option::Option::{self, bar, foo, z, *};
 fn whitespace_after_doccomment() {
     check(
         r#"library;
-    
+
 /// Trait to evaluate if one value is greater than or equal, or less than or equal to another of the same type.
 trait OrdEq: Ord + Eq {
 } {
@@ -2900,7 +2901,7 @@ trait OrdEq: Ord + Eq {
 fn single_argument_method() {
     check(
         r#"library;
-    
+
     pub fn from_be_bytes(bytes: [u8; 32]) -> Self {
         let a = u64::from_be_bytes(
             [
@@ -2950,5 +2951,45 @@ where
     }
 }
 "#,
+    );
+}
+
+#[test]
+fn configurable_block_comments_preserved() {
+    check(
+        indoc! {"
+            script;
+
+            use std::{constants::ZERO_B256, vm::evm::evm_address::EvmAddress};
+
+            configurable { /* multiline */
+                // double slash
+                /// triple slash
+                SIGNER: EvmAddress = EvmAddress {
+                    // double slash
+                    // double slash
+                    value: ZERO_B256, // end of line
+                },
+            }
+
+            fn main() {}
+        "},
+        indoc! {"
+            script;
+
+            use std::{constants::ZERO_B256, vm::evm::evm_address::EvmAddress};
+
+            configurable { /* multiline */
+                // double slash
+                /// triple slash
+                SIGNER: EvmAddress = EvmAddress {
+                    // double slash
+                    // double slash
+                    value: ZERO_B256, // end of line
+                },
+            }
+
+            fn main() {}
+        "},
     );
 }


### PR DESCRIPTION
Once completed this will replace #5297

closes #4966

## Description

comments in configurable blocks are being remove by the formatter

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
