### PR TITLE
Use `$one` for `true` in ASM instead of using data section

### DIFF
--- a/sway-core/src/asm_generation/fuel/fuel_asm_builder.rs
+++ b/sway-core/src/asm_generation/fuel/fuel_asm_builder.rs
@@ -2015,7 +2015,7 @@ impl<'ir, 'eng> FuelAsmBuilder<'ir, 'eng> {
                 (VirtualRegister::Constant(ConstantRegister::Zero), None)
             }
 
-            ConstantValue::Uint(1) if config_name.is_none() => {
+            ConstantValue::Uint(1) | ConstantValue::Bool(true) if config_name.is_none() => {
                 (VirtualRegister::Constant(ConstantRegister::One), None)
             }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle.json
@@ -7,7 +7,7 @@
         "typeArguments": null
       },
       "name": "BOOL",
-      "offset": 3416
+      "offset": 3392
     },
     {
       "configurableType": {
@@ -16,7 +16,7 @@
         "typeArguments": null
       },
       "name": "U8",
-      "offset": 3552
+      "offset": 3528
     },
     {
       "configurableType": {
@@ -25,7 +25,7 @@
         "typeArguments": null
       },
       "name": "ANOTHER_U8",
-      "offset": 3344
+      "offset": 3320
     },
     {
       "configurableType": {
@@ -34,7 +34,7 @@
         "typeArguments": null
       },
       "name": "U16",
-      "offset": 3496
+      "offset": 3472
     },
     {
       "configurableType": {
@@ -43,7 +43,7 @@
         "typeArguments": null
       },
       "name": "U32",
-      "offset": 3536
+      "offset": 3512
     },
     {
       "configurableType": {
@@ -52,7 +52,7 @@
         "typeArguments": null
       },
       "name": "U64",
-      "offset": 3544
+      "offset": 3520
     },
     {
       "configurableType": {
@@ -61,7 +61,7 @@
         "typeArguments": null
       },
       "name": "U256",
-      "offset": 3504
+      "offset": 3480
     },
     {
       "configurableType": {
@@ -70,7 +70,7 @@
         "typeArguments": null
       },
       "name": "B256",
-      "offset": 3384
+      "offset": 3360
     },
     {
       "configurableType": {
@@ -79,7 +79,7 @@
         "typeArguments": []
       },
       "name": "CONFIGURABLE_STRUCT",
-      "offset": 3456
+      "offset": 3432
     },
     {
       "configurableType": {
@@ -88,7 +88,7 @@
         "typeArguments": []
       },
       "name": "CONFIGURABLE_ENUM_A",
-      "offset": 3424
+      "offset": 3400
     },
     {
       "configurableType": {
@@ -97,7 +97,7 @@
         "typeArguments": []
       },
       "name": "CONFIGURABLE_ENUM_B",
-      "offset": 3440
+      "offset": 3416
     },
     {
       "configurableType": {
@@ -106,7 +106,7 @@
         "typeArguments": null
       },
       "name": "ARRAY_BOOL",
-      "offset": 3352
+      "offset": 3328
     },
     {
       "configurableType": {
@@ -115,7 +115,7 @@
         "typeArguments": null
       },
       "name": "ARRAY_U64",
-      "offset": 3360
+      "offset": 3336
     },
     {
       "configurableType": {
@@ -124,7 +124,7 @@
         "typeArguments": null
       },
       "name": "TUPLE_BOOL_U64",
-      "offset": 3480
+      "offset": 3456
     },
     {
       "configurableType": {
@@ -133,7 +133,7 @@
         "typeArguments": null
       },
       "name": "STR_4",
-      "offset": 3472
+      "offset": 3448
     }
   ],
   "functions": [

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/configurable_consts/json_abi_oracle_new_encoding.json
@@ -7,7 +7,7 @@
         "typeArguments": null
       },
       "name": "BOOL",
-      "offset": 6912
+      "offset": 6888
     },
     {
       "configurableType": {
@@ -16,7 +16,7 @@
         "typeArguments": null
       },
       "name": "U8",
-      "offset": 7048
+      "offset": 7024
     },
     {
       "configurableType": {
@@ -25,7 +25,7 @@
         "typeArguments": null
       },
       "name": "ANOTHER_U8",
-      "offset": 6840
+      "offset": 6816
     },
     {
       "configurableType": {
@@ -34,7 +34,7 @@
         "typeArguments": null
       },
       "name": "U16",
-      "offset": 6992
+      "offset": 6968
     },
     {
       "configurableType": {
@@ -43,7 +43,7 @@
         "typeArguments": null
       },
       "name": "U32",
-      "offset": 7032
+      "offset": 7008
     },
     {
       "configurableType": {
@@ -52,7 +52,7 @@
         "typeArguments": null
       },
       "name": "U64",
-      "offset": 7040
+      "offset": 7016
     },
     {
       "configurableType": {
@@ -61,7 +61,7 @@
         "typeArguments": null
       },
       "name": "U256",
-      "offset": 7000
+      "offset": 6976
     },
     {
       "configurableType": {
@@ -70,7 +70,7 @@
         "typeArguments": null
       },
       "name": "B256",
-      "offset": 6880
+      "offset": 6856
     },
     {
       "configurableType": {
@@ -79,7 +79,7 @@
         "typeArguments": []
       },
       "name": "CONFIGURABLE_STRUCT",
-      "offset": 6952
+      "offset": 6928
     },
     {
       "configurableType": {
@@ -88,7 +88,7 @@
         "typeArguments": []
       },
       "name": "CONFIGURABLE_ENUM_A",
-      "offset": 6920
+      "offset": 6896
     },
     {
       "configurableType": {
@@ -97,7 +97,7 @@
         "typeArguments": []
       },
       "name": "CONFIGURABLE_ENUM_B",
-      "offset": 6936
+      "offset": 6912
     },
     {
       "configurableType": {
@@ -106,7 +106,7 @@
         "typeArguments": null
       },
       "name": "ARRAY_BOOL",
-      "offset": 6848
+      "offset": 6824
     },
     {
       "configurableType": {
@@ -115,7 +115,7 @@
         "typeArguments": null
       },
       "name": "ARRAY_U64",
-      "offset": 6856
+      "offset": 6832
     },
     {
       "configurableType": {
@@ -124,7 +124,7 @@
         "typeArguments": null
       },
       "name": "TUPLE_BOOL_U64",
-      "offset": 6976
+      "offset": 6952
     },
     {
       "configurableType": {
@@ -133,7 +133,7 @@
         "typeArguments": null
       },
       "name": "STR_4",
-      "offset": 6968
+      "offset": 6944
     }
   ],
   "encoding": "1",

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_abi_with_tuples/src/main.sw
@@ -4,9 +4,9 @@ use abi_with_tuples::{MyContract, Location, Person};
 
 
 #[cfg(experimental_new_encoding = false)]
-const CONTRACT_ID = 0x5175a6a984a6d8f92622afd3d987f5b778f5741c56d55ee5993cc368b9afee10;
+const CONTRACT_ID = 0xfdc14550c8aee742cd556d0ab7f378b7be0d3b1e6e086c097352e94590d4ed02;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x2435d33fbcdcaea63ea81348866a3d565a84cc90f68a18513b0cef78ee3faa03;
+const CONTRACT_ID = 0xfc32e1cb0635642004594eb3503279b3f4aee3d0b0de0e1aa78dcd7de2389239;
 
 fn main() -> bool {
     let the_abi = abi(MyContract, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -2,9 +2,9 @@ script;
 use basic_storage_abi::{BasicStorage, Quad};
 
 #[cfg(experimental_new_encoding = false)]
-const CONTRACT_ID = 0x186c989267434c784f7785be57b0db0a490ec382bbf98a6108a840c63b99be99;
+const CONTRACT_ID = 0x94db39f409a31b9f2ebcadeea44378e419208c20de90f5d8e1e33dc1523754cb;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x9fd665bb5b0ff768013b7f9b08f76b762bdc7426b11d76bd023c53433e9d21ed;
+const CONTRACT_ID = 0xb6abfeaffedeabec13b886013932f154f50d4d6a2c4cf7bc09dd7fd3063fec3e;
 
 fn main() -> u64 {
     let addr = abi(BasicStorage, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
@@ -3,9 +3,9 @@ script;
 use storage_enum_abi::*;
 
 #[cfg(experimental_new_encoding = false)]
-const CONTRACT_ID = 0xb54eb67f943fda15981308ef55b2cb2afe1ed5907c483d2d92d010ab39549644;
+const CONTRACT_ID = 0xc601d11767195485a6654d566c67774134668863d8c797a8c69e8778fb1f89e9;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xfd91339494a1600ffb24d90eb7b67582e11fee5936e01704fb17a5445eb3f47e;
+const CONTRACT_ID = 0xad38274ba48598272b4e69191748178ac2747fd70d59b4e9d6b9fb6e3599ff07;
 
 fn main() -> u64 {
     let caller = abi(StorageEnum, CONTRACT_ID);


### PR DESCRIPTION
## Description

This PR generates `$one` register access for the boolean constant `true`, instead of placing `1` into the data section.

This removes loading from the data section when using the constant.

E.g., when calling `function(true)`, instead of:

```
.data:
data_0 .byte 1
```
```
load $r30 data_0                        ; literal instantiation
move $$arg0 $r30                        ; pass arg 0
mova $$reta .9                          ; set new return addr
fncall .4                               ; call function_1
```

we now have:

```
move $$arg0 $one                        ; pass arg 0
mova $$reta .9                          ; set new return addr
fncall .4                               ; call function_1
```
Out of 450 `should_pass` tests, 140 got decreased in the bytecode size.

<details>
  <summary>Click here for the numbers</summary>

Test | Before | After | Decrease | Percentage
-- | -- | -- | -- | --
dca/trait_method_neq | 408 | 392 | 16 | 3.92
empty_fields_in_storage_struct | 28920 | 28912 | 8 | 0.03
forc/contract_dependencies/contract_b | 1160 | 1152 | 8 | 0.69
forc/contract_dependencies/contract_c | 1160 | 1152 | 8 | 0.69
language/aliased_imports | 352 | 336 | 16 | 4.55
language/arg_demotion_inline | 1360 | 1344 | 16 | 1.18
language/array_basics | 792 | 784 | 8 | 1.01
language/array_generics | 400 | 384 | 16 | 4.00
language/associated_const_trait_const | 320 | 312 | 8 | 2.50
language/b256_bitwise_ops | 6808 | 6800 | 8 | 0.12
language/basic_func_decl | 320 | 312 | 8 | 2.50
language/basic_predicate | 104 | 88 | 16 | 15.38
language/binary_and_hex_literals | 320 | 312 | 8 | 2.50
language/bitwise_not | 320 | 312 | 8 | 2.50
language/blanket_trait | 320 | 312 | 8 | 2.50
language/bool_and_or | 344 | 336 | 8 | 2.33
language/break_and_continue | 896 | 888 | 8 | 0.89
language/configurable_consts | 7216 | 7184 | 32 | 0.44
language/const_decl_in_library | 344 | 336 | 8 | 2.33
language/contract_caller_as_ret | 1160 | 1152 | 8 | 0.69
language/diagnose_unknown_annotations | 1528 | 1512 | 16 | 1.05
language/diverging_exprs | 1144 | 1112 | 32 | 2.80
language/enum_in_fn_decl | 408 | 392 | 16 | 3.92
language/enum_instantiation | 3752 | 3688 | 64 | 1.71
language/eq_and_neq | 2072 | 2056 | 16 | 0.77
language/for_loops | 4488 | 4472 | 16 | 0.36
language/funcs_with_generic_types | 320 | 312 | 8 | 2.50
language/generic_functions | 320 | 312 | 8 | 2.50
language/generic_impl_self | 2616 | 2584 | 32 | 1.22
language/generic_result_method | 680 | 656 | 24 | 3.53
language/generic_struct | 336 | 328 | 8 | 2.38
language/generic_structs | 608 | 584 | 24 | 3.95
language/generic_trait_constraints | 1048 | 1040 | 8 | 0.76
language/generic_traits | 1312 | 1304 | 8 | 0.61
language/generic_transpose | 912 | 904 | 8 | 0.88
language/generic_tuple_trait | 832 | 824 | 8 | 0.96
language/generic_type_inference | 3352 | 3344 | 8 | 0.24
language/generic_where_in_impl_self2 | 504 | 496 | 8 | 1.59
language/generic_where_in_impl_self | 504 | 496 | 8 | 1.59
language/import_with_different_callpaths | 2752 | 2744 | 8 | 0.29
language/insert_element_reg_reuse | 2488 | 2472 | 16 | 0.64
language/is_prime | 1144 | 1112 | 32 | 2.80
language/is_reference_type | 320 | 312 | 8 | 2.50
language/local_impl_for_ord | 320 | 312 | 8 | 2.50
language/match_expressions_enums | 3336 | 3320 | 16 | 0.48
language/match_expressions_explicit_rets | 320 | 312 | 8 | 2.50
language/match_expressions_inside_generic_functions | 520 | 512 | 8 | 1.54
language/match_expressions_or | 9184 | 9176 | 8 | 0.09
language/match_expressions_simple | 408 | 400 | 8 | 1.96
language/match_expressions_structs | 408 | 400 | 8 | 1.96
language/match_expressions_unreachable_catch_all_last_arm | 2296 | 2232 | 64 | 2.79
language/match_expressions_unreachable_catch_all_middle_arm | 2088 | 2040 | 48 | 2.30
language/match_expressions_unreachable_last_arm | 3032 | 2936 | 96 | 3.17
language/match_expressions_unreachable_middle_arm | 3440 | 3336 | 104 | 3.02
language/match_expressions_with_self | 464 | 456 | 8 | 1.72
language/modulo_uint_test | 320 | 312 | 8 | 2.50
language/mutable_and_initd | 432 | 424 | 8 | 1.85
language/nested_structs | 1104 | 1088 | 16 | 1.45
language/nested_while_and_if | 416 | 408 | 8 | 1.92
language/new_allocator_test | 792 | 776 | 16 | 2.02
language/numeric_constants | 320 | 312 | 8 | 2.50
language/ops | 424 | 408 | 16 | 3.77
language/out_of_order_decl | 328 | 320 | 8 | 2.44
language/predicate_while | 128 | 120 | 8 | 6.25
language/predicate_while_dep | 128 | 120 | 8 | 6.25
language/raw_identifiers | 448 | 432 | 16 | 3.57
language/references/dereferencing_operator_dot_on_structs | 125040 | 124888 | 152 | 0.12
language/references/dereferencing_operator_dot_on_tuples | 125040 | 124888 | 152 | 0.12
language/references/dereferencing_operator_index | 92368 | 92344 | 24 | 0.03
language/references/dereferencing_operator_star | 151248 | 151120 | 128 | 0.08
language/references/passing_and_returning_references_to_and_from_functions | 15928 | 15912 | 16 | 0.10
language/references/reassigning_via_references_passed_and_returned_to_and_from_functions | 38904 | 38832 | 72 | 0.19
language/references/reassigning_via_references_to_expressions | 39368 | 39304 | 64 | 0.16
language/references/reassigning_via_references_to_values | 13976 | 13920 | 56 | 0.40
language/references/referencing_local_vars_and_values | 36424 | 36376 | 48 | 0.13
language/ref_mutable_fn_args_bool | 320 | 312 | 8 | 2.50
language/self_impl_reassignment | 936 | 928 | 8 | 0.85
language/smo | 1936 | 1912 | 24 | 1.24
language/smo_opcode | 408 | 392 | 16 | 3.92
language/struct_destructuring | 432 | 424 | 8 | 1.85
language/struct_instantiation | 2296 | 2184 | 112 | 4.88
language/supertraits | 6056 | 6048 | 8 | 0.13
language/supertraits_with_trait_methods | 400 | 392 | 8 | 2.00
language/trait_method_ascription_disambiguate | 440 | 424 | 16 | 3.64
language/trait_method_generic_qualified | 440 | 424 | 16 | 3.64
language/trait_method_qualified | 320 | 312 | 8 | 2.50
language/trait_nested | 912 | 896 | 16 | 1.75
language/tuple_access | 456 | 440 | 16 | 3.51
language/tuple_in_struct | 656 | 640 | 16 | 2.44
language/tuple_trait | 408 | 392 | 16 | 3.92
language/type_alias | 3880 | 3856 | 24 | 0.62
language/typeinfo_custom_callpath2 | 272 | 264 | 8 | 2.94
language/typeinfo_custom_callpath | 272 | 264 | 8 | 2.94
language/typeinfo_custom_callpath_with_import | 288 | 280 | 8 | 2.78
language/unary_not_basic_2 | 320 | 312 | 8 | 2.50
language/unary_not_basic | 320 | 312 | 8 | 2.50
language/valid_impurity | 1104 | 1096 | 8 | 0.72
language/where_clause_functions | 1984 | 1960 | 24 | 1.21
language/while_loops | 584 | 568 | 16 | 2.74
static_analysis/cei_pattern_violation_more_complex_logic | 16528 | 16520 | 8 | 0.05
static_analysis/cei_pattern_violation_smo_intrinsic | 2248 | 2232 | 16 | 0.71
static_analysis/cei_pattern_violation_storage_map_and_vec | 8000 | 7992 | 8 | 0.10
stdlib/address_test | 4200 | 4184 | 16 | 0.38
stdlib/alloc_test | 856 | 840 | 16 | 1.87
stdlib/assert_eq | 6376 | 6368 | 8 | 0.13
stdlib/assert_ne | 6096 | 6080 | 16 | 0.26
stdlib/assert_test | 320 | 312 | 8 | 2.50
stdlib/b512_test | 3384 | 3368 | 16 | 0.47
stdlib/block_height | 368 | 352 | 16 | 4.35
stdlib/contract_id_test | 656 | 640 | 16 | 2.44
stdlib/contract_id_type | 648 | 640 | 8 | 1.23
stdlib/eq_custom_type | 736 | 720 | 16 | 2.17
stdlib/identity_eq | 2480 | 2472 | 8 | 0.32
stdlib/intrinsics | 320 | 312 | 8 | 2.50
stdlib/iterator | 2528 | 2512 | 16 | 0.63
stdlib/option | 22872 | 22816 | 56 | 0.24
stdlib/option_eq | 12240 | 12216 | 24 | 0.20
stdlib/raw_ptr | 4520 | 4480 | 40 | 0.88
stdlib/raw_slice | 1016 | 1008 | 8 | 0.79
stdlib/require | 1160 | 1128 | 32 | 2.76
stdlib/result | 8944 | 8896 | 48 | 0.54
stdlib/sha256 | 2208 | 2192 | 16 | 0.72
stdlib/storage_vec_insert | 8320 | 8304 | 16 | 0.19
stdlib/u128_div_test | 2752 | 2744 | 8 | 0.29
stdlib/u128_log_test | 4560 | 4544 | 16 | 0.35
stdlib/u128_mul_test | 1488 | 1480 | 8 | 0.54
stdlib/u128_root_test | 4360 | 4344 | 16 | 0.37
stdlib/u128_test | 6488 | 6480 | 8 | 0.12
stdlib/vec | 107152 | 107088 | 64 | 0.06
stdlib/vec_swap | 23824 | 23808 | 16 | 0.07
storage_into | 1784 | 1768 | 16 | 0.90
supertraits_for_abis_ownable | 7336 | 7328 | 8 | 0.11
test_contracts/abi_with_tuples_contract | 2584 | 2568 | 16 | 0.62
test_contracts/basic_storage | 34672 | 34648 | 24 | 0.07
test_contracts/storage_enum_contract | 18312 | 18272 | 40 | 0.22
test_contracts/storage_namespace | 32976 | 32952 | 24 | 0.07
unit_tests/predicate_multi_test | 304 | 288 | 16 | 5.26
unit_tests/predicate_with_nested_libs | 632 | 624 | 8 | 1.27
unit_tests/script_multi_test | 896 | 880 | 16 | 1.79
unit_tests/workspace_test | 896 | 880 | 16 | 1.79

</details>

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.