### PR TITLE
fix: deployment estimation deferred to sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,6 +517,25 @@ jobs:
           mv fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu/fuel-core /usr/local/bin/fuel-core
       - name: Run tests
         run: cargo test --locked --release -p forc-debug
+  cargo-test-forc-client:
+    runs-on: ubuntu-latest
+    needs: get-fuel-core-version
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: "x86_64-unknown-linux-gnu, wasm32-unknown-unknown"
+      - uses: Swatinem/rust-cache@v2
+      - name: Install fuel-core for tests
+        run: |
+          curl -sSLf https://github.com/FuelLabs/fuel-core/releases/download/v${{ needs.get-fuel-core-version.outputs.fuel_core_version }}/fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu.tar.gz -L -o fuel-core.tar.gz
+          tar -xvf fuel-core.tar.gz
+          chmod +x fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu/fuel-core
+          mv fuel-core-${{ needs.get-fuel-core-version.outputs.fuel_core_version }}-x86_64-unknown-linux-gnu/fuel-core /usr/local/bin/fuel-core
+      - name: Run tests
+        run: cargo test --locked --release -p forc-client
   cargo-test-sway-lsp:
     runs-on: ubuntu-latest
     steps:
@@ -538,7 +557,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --locked --release --workspace --exclude forc-debug --exclude sway-lsp
+        run: cargo test --locked --release --workspace --exclude forc-debug --exclude sway-lsp --exlcude forc-client
   cargo-unused-deps-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,7 +557,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --locked --release --workspace --exclude forc-debug --exclude sway-lsp --exlcude forc-client
+        run: cargo test --locked --release --workspace --exclude forc-debug --exclude sway-lsp --exclude forc-client
   cargo-unused-deps-check:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,6 +2012,7 @@ dependencies = [
  "fuels-core",
  "futures",
  "hex",
+ "portpicker",
  "rand",
  "rpassword",
  "serde",
@@ -2019,7 +2020,9 @@ dependencies = [
  "sway-core",
  "sway-types",
  "sway-utils",
+ "tempfile",
  "tokio",
+ "toml_edit 0.21.1",
  "tracing",
 ]
 

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -40,6 +40,11 @@ sway-utils = { version = "0.61.1", path = "../../sway-utils" }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "process"] }
 tracing = "0.1"
 
+[dev-dependencies]
+portpicker = "0.1.1"
+tempfile = "3"
+toml_edit = "0.21.1"
+
 [[bin]]
 name = "forc-deploy"
 path = "src/bin/deploy.rs"

--- a/forc-plugins/forc-client/src/constants.rs
+++ b/forc-plugins/forc-client/src/constants.rs
@@ -12,3 +12,8 @@ pub const DEVNET_FAUCET_URL: &str = "https://faucet-devnet.fuel.network";
 pub const DEVNET_ENDPOINT_URL: &str = "https://devnet.fuel.network";
 pub const TESTNET_FAUCET_URL: &str = "https://faucet-testnet.fuel.network";
 pub const TESTNET_ENDPOINT_URL: &str = "https://testnet.fuel.network";
+/// Default PrivateKey to sign transactions submitted to local node.
+pub const DEFAULT_PRIVATE_KEY: &str =
+    "0xde97d8624a438121b86a1956544bd72ed68cd69f2c99555b08b1e8c51ffd511c";
+/// The maximum time to wait for a transaction to be included in a block by the node
+pub const TX_SUBMIT_TIMEOUT_MS: u64 = 30_000u64;

--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -32,7 +32,7 @@ use sway_core::language::parsed::TreeType;
 use sway_core::BuildTarget;
 use tracing::info;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct DeployedContract {
     pub id: fuel_tx::ContractId,
 }

--- a/forc-plugins/forc-client/src/op/mod.rs
+++ b/forc-plugins/forc-client/src/op/mod.rs
@@ -2,6 +2,6 @@ mod deploy;
 mod run;
 mod submit;
 
-pub use deploy::deploy;
+pub use deploy::{deploy, DeployedContract};
 pub use run::run;
 pub use submit::submit;

--- a/forc-plugins/forc-client/src/util/gas.rs
+++ b/forc-plugins/forc-client/src/util/gas.rs
@@ -1,15 +1,11 @@
 use anyhow::Result;
 
-use fuel_core_client::client::FuelClient;
-use fuel_core_types::services::executor::TransactionExecutionResult;
 use fuel_tx::{
-    field::{Inputs, MaxFeeLimit, Witnesses},
-    Buildable, Chargeable, Create, Input, Script, Transaction, TxPointer,
+    field::{Inputs, Witnesses},
+    Buildable, Chargeable, Input, Script, TxPointer,
 };
 use fuels_accounts::provider::Provider;
-use fuels_core::{
-    constants::DEFAULT_GAS_ESTIMATION_BLOCK_HORIZON, types::transaction::ScriptTransaction,
-};
+use fuels_core::types::transaction::ScriptTransaction;
 
 fn no_spendable_input<'a, I: IntoIterator<Item = &'a Input>>(inputs: I) -> bool {
     !inputs.into_iter().any(|i| {
@@ -54,57 +50,4 @@ pub(crate) async fn get_script_gas_used(mut tx: Script, provider: &Provider) -> 
         .estimate_transaction_cost(script_tx, Some(tolerance), None)
         .await?;
     Ok(estimated_tx_cost.gas_used)
-}
-
-/// Returns an estimation for the max fee of `Create` transactions.
-/// Accepts a `tolerance` which is used to add some safety margin to the estimation.
-/// Resulting estimation is calculated as `(dry_run_estimation * tolerance)/100 + dry_run_estimation)`.
-pub(crate) async fn get_estimated_max_fee(
-    tx: Create,
-    provider: &Provider,
-    client: &FuelClient,
-    tolerance: u64,
-) -> Result<u64> {
-    let mut tx = tx.clone();
-    // Add dummy input to get past validation for dry run.
-    let no_spendable_input = no_spendable_input(tx.inputs());
-    let base_asset_id = provider.base_asset_id();
-    if no_spendable_input {
-        tx.inputs_mut().push(Input::coin_signed(
-            Default::default(),
-            Default::default(),
-            1_000_000_000,
-            *base_asset_id,
-            TxPointer::default(),
-            0,
-        ));
-
-        // Add an empty `Witness` for the `coin_signed` we just added
-        // and increase the witness limit
-        tx.witnesses_mut().push(Default::default());
-    }
-    let consensus_params = provider.consensus_parameters();
-    let gas_price = provider
-        .estimate_gas_price(DEFAULT_GAS_ESTIMATION_BLOCK_HORIZON)
-        .await?
-        .gas_price;
-    let max_fee = tx.max_fee(
-        consensus_params.gas_costs(),
-        consensus_params.fee_params(),
-        gas_price,
-    );
-    tx.set_max_fee_limit(max_fee as u64);
-    let tx = Transaction::from(tx);
-
-    let tx_status = client
-        .dry_run(&[tx])
-        .await
-        .map(|mut status_vec| status_vec.remove(0))?;
-    let total_fee = match tx_status.result {
-        TransactionExecutionResult::Success { total_fee, .. } => total_fee,
-        TransactionExecutionResult::Failed { total_fee, .. } => total_fee,
-    };
-
-    let total_fee_with_tolerance = ((total_fee * tolerance) / 100) + total_fee;
-    Ok(total_fee_with_tolerance)
 }

--- a/forc-plugins/forc-client/src/util/tx.rs
+++ b/forc-plugins/forc-client/src/util/tx.rs
@@ -1,4 +1,4 @@
-use std::{io::Write, str::FromStr};
+use std::{collections::BTreeMap, io::Write, path::Path, str::FromStr};
 
 use anyhow::{Error, Result};
 use async_trait::async_trait;
@@ -23,18 +23,12 @@ use forc_wallet::{
     utils::default_wallet_path,
 };
 
-use crate::util::target::Target;
-
-/// The maximum time to wait for a transaction to be included in a block by the node
-pub const TX_SUBMIT_TIMEOUT_MS: u64 = 30_000u64;
-
-/// Default PrivateKey to sign transactions submitted to local node.
-pub const DEFAULT_PRIVATE_KEY: &str =
-    "0xde97d8624a438121b86a1956544bd72ed68cd69f2c99555b08b1e8c51ffd511c";
+use crate::{constants::DEFAULT_PRIVATE_KEY, util::target::Target};
 
 #[derive(PartialEq, Eq)]
 pub enum WalletSelectionMode {
-    ForcWallet,
+    /// Holds the password of forc-wallet instance.
+    ForcWallet(String),
     Manual,
 }
 
@@ -66,6 +60,89 @@ fn ask_user_yes_no_question(question: &str) -> Result<bool> {
     let ans = ans.trim();
     Ok(ans == "y" || ans == "Y")
 }
+
+fn collect_user_accounts(
+    wallet_path: &Path,
+    password: &str,
+) -> Result<BTreeMap<usize, Bech32Address>> {
+    let verification = AccountVerification::Yes(password.to_string());
+    let accounts = collect_accounts_with_verification(wallet_path, verification).map_err(|e| {
+        if e.to_string().contains("Mac Mismatch") {
+            anyhow::anyhow!("Failed to access forc-wallet vault. Please check your password")
+        } else {
+            e
+        }
+    })?;
+    Ok(accounts)
+}
+
+pub(crate) fn prompt_forc_wallet_password(wallet_path: &Path) -> Result<String> {
+    let prompt = format!(
+        "\nPlease provide the password of your encrypted wallet vault at {wallet_path:?}: "
+    );
+    let password = rpassword::prompt_password(prompt)?;
+    Ok(password)
+}
+
+pub(crate) fn check_and_create_wallet_at_default_path(wallet_path: &Path) -> Result<()> {
+    if !wallet_path.exists() {
+        let question = format!("Could not find a wallet at {wallet_path:?}, would you like to create a new one? [y/N]: ");
+        let accepted = ask_user_yes_no_question(&question)?;
+        let new_options = New {
+            force: false,
+            cache_accounts: None,
+        };
+        if accepted {
+            new_wallet_cli(wallet_path, new_options)?;
+            println!("Wallet created successfully.");
+            // Derive first account for the fresh wallet we created.
+            new_at_index_cli(wallet_path, 0)?;
+            println!("Account derived successfully.");
+        } else {
+            anyhow::bail!("Refused to create a new wallet. If you don't want to use forc-wallet, you can sign this transaction manually with --manual-signing flag.")
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn secret_key_from_forc_wallet(
+    wallet_path: &Path,
+    account_index: usize,
+    password: &str,
+) -> Result<SecretKey> {
+    let secret_key = derive_secret_key(wallet_path, account_index, password).map_err(|e| {
+        if e.to_string().contains("Mac Mismatch") {
+            anyhow::anyhow!("Failed to access forc-wallet vault. Please check your password")
+        } else {
+            e
+        }
+    })?;
+    Ok(secret_key)
+}
+
+pub(crate) fn bech32_from_secret(secret_key: &SecretKey) -> Result<Bech32Address> {
+    let public_key = PublicKey::from(secret_key);
+    let hashed = public_key.hash();
+    let bech32 = Bech32Address::new(FUEL_BECH32_HRP, hashed);
+    Ok(bech32)
+}
+
+pub(crate) fn select_manual_secret_key(
+    default_signer: bool,
+    signing_key: Option<SecretKey>,
+) -> Option<SecretKey> {
+    match (default_signer, signing_key) {
+        // Note: unwrap is safe here as we already know that 'DEFAULT_PRIVATE_KEY' is a valid private key.
+        (true, None) => Some(SecretKey::from_str(DEFAULT_PRIVATE_KEY).unwrap()),
+        (true, Some(signing_key)) => {
+            println_warning("Signing key is provided while requesting to sign with a default signer. Using signing key");
+            Some(signing_key)
+        }
+        (false, None) => None,
+        (false, Some(signing_key)) => Some(signing_key),
+    }
+}
+
 /// Collect and return balances of each account in the accounts map.
 async fn collect_account_balances(
     accounts_map: &AccountsMap,
@@ -79,6 +156,78 @@ async fn collect_account_balances(
     futures::future::try_join_all(accounts.iter().map(|acc| acc.get_balances()))
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+// TODO: Simplify the function signature once https://github.com/FuelLabs/sway/issues/6071 is closed.
+pub(crate) async fn select_secret_key(
+    wallet_mode: &WalletSelectionMode,
+    default_sign: bool,
+    signing_key: Option<SecretKey>,
+    provider: &Provider,
+) -> Result<Option<SecretKey>> {
+    let chain_info = provider.chain_info().await?;
+    let signing_key = match wallet_mode {
+        WalletSelectionMode::ForcWallet(password) => {
+            let wallet_path = default_wallet_path();
+            check_and_create_wallet_at_default_path(&wallet_path)?;
+            // TODO: This is a very simple TUI, we should consider adding a nice TUI
+            // capabilities for selections and answer collection.
+            let accounts = collect_user_accounts(&wallet_path, password)?;
+            let account_balances = collect_account_balances(&accounts, provider).await?;
+
+            let total_balance = account_balances
+                .iter()
+                .flat_map(|account| account.values())
+                .sum::<u64>();
+            if total_balance == 0 {
+                let first_account = accounts
+                    .get(&0)
+                    .ok_or_else(|| anyhow::anyhow!("No account derived for this wallet"))?;
+                let target = Target::from_str(&chain_info.name).unwrap_or(Target::testnet());
+                let faucet_link = format!("{}/?address={first_account}", target.faucet_url());
+                anyhow::bail!("Your wallet does not have any funds to pay for the transaction.\
+                                      \n\nIf you are interacting with a testnet consider using the faucet.\
+                                      \n-> {target} network faucet: {faucet_link}\
+                                      \nIf you are interacting with a local node, consider providing a chainConfig which funds your account.")
+            }
+            print_account_balances(&accounts, &account_balances);
+
+            let mut account_index;
+            loop {
+                print!("\nPlease provide the index of account to use for signing: ");
+                std::io::stdout().flush()?;
+                let mut input_account_index = String::new();
+                std::io::stdin().read_line(&mut input_account_index)?;
+                account_index = input_account_index.trim().parse::<usize>()?;
+                if accounts.contains_key(&account_index) {
+                    break;
+                }
+                let options: Vec<String> = accounts.keys().map(|key| key.to_string()).collect();
+                println_warning(&format!(
+                    "\"{}\" is not a valid account.\nPlease choose a valid option from {}",
+                    account_index,
+                    options.join(","),
+                ));
+            }
+
+            let secret_key = secret_key_from_forc_wallet(&wallet_path, account_index, password)?;
+
+            let bech32 = bech32_from_secret(&secret_key)?;
+            // TODO: Do this via forc-wallet once the functionality is exposed.
+            let question = format!(
+                "Do you agree to sign this transaction with {}? [y/N]: ",
+                bech32
+            );
+            let accepted = ask_user_yes_no_question(&question)?;
+            if !accepted {
+                anyhow::bail!("User refused to sign");
+            }
+
+            Some(secret_key)
+        }
+        WalletSelectionMode::Manual => select_manual_secret_key(default_sign, signing_key),
+    };
+    Ok(signing_key)
 }
 
 #[async_trait]
@@ -95,9 +244,9 @@ pub trait TransactionBuilderExt<Tx> {
     async fn finalize_signed(
         &mut self,
         client: Provider,
-        unsigned: bool,
+        default_signature: bool,
         signing_key: Option<SecretKey>,
-        wallet_mode: WalletSelectionMode,
+        wallet_mode: &WalletSelectionMode,
     ) -> Result<Tx>;
 }
 
@@ -169,131 +318,17 @@ impl<Tx: Buildable + field::Witnesses + Send> TransactionBuilderExt<Tx> for Tran
         provider: Provider,
         default_sign: bool,
         signing_key: Option<SecretKey>,
-        wallet_mode: WalletSelectionMode,
+        wallet_mode: &WalletSelectionMode,
     ) -> Result<Tx> {
         let chain_info = provider.chain_info().await?;
         let params = chain_info.consensus_parameters;
-        let signing_key = match (wallet_mode, signing_key, default_sign) {
-            (WalletSelectionMode::ForcWallet, None, false) => {
-                // TODO: This is a very simple TUI, we should consider adding a nice TUI
-                // capabilities for selections and answer collection.
-                let wallet_path = default_wallet_path();
-                if !wallet_path.exists() {
-                    let question = format!("Could not find a wallet at {wallet_path:?}, would you like to create a new one? [y/N]: ");
-                    let accepted = ask_user_yes_no_question(&question)?;
-                    let new_options = New {
-                        force: false,
-                        cache_accounts: None,
-                    };
-                    if accepted {
-                        new_wallet_cli(&wallet_path, new_options)?;
-                        println!("Wallet created successfully.");
-                        // Derive first account for the fresh wallet we created.
-                        new_at_index_cli(&wallet_path, 0)?;
-                        println!("Account derived successfully.");
-                    } else {
-                        anyhow::bail!("Refused to create a new wallet. If you don't want to use forc-wallet, you can sign this transaction manually with --manual-signing flag.")
-                    }
-                }
-                let prompt = format!(
-                        "\nPlease provide the password of your encrypted wallet vault at {wallet_path:?}: "
-                    );
-                let password = rpassword::prompt_password(prompt)?;
-                let verification = AccountVerification::Yes(password.clone());
-                let accounts = collect_accounts_with_verification(&wallet_path, verification)
-                    .map_err(|e| {
-                        if e.to_string().contains("Mac Mismatch") {
-                            anyhow::anyhow!(
-                                "Failed to access forc-wallet vault. Please check your password"
-                            )
-                        } else {
-                            e
-                        }
-                    })?;
-                let account_balances = collect_account_balances(&accounts, &provider).await?;
-
-                let total_balance = account_balances
-                    .iter()
-                    .flat_map(|account| account.values())
-                    .sum::<u64>();
-                if total_balance == 0 {
-                    let first_account = accounts
-                        .get(&0)
-                        .ok_or_else(|| anyhow::anyhow!("No account derived for this wallet"))?;
-                    let target = Target::from_str(&chain_info.name).unwrap_or(Target::testnet());
-                    let faucet_link = format!("{}/?address={first_account}", target.faucet_url());
-                    anyhow::bail!("Your wallet does not have any funds to pay for the transaction.\
-                                      \n\nIf you are interacting with a testnet consider using the faucet.\
-                                      \n-> {target} network faucet: {faucet_link}\
-                                      \nIf you are interacting with a local node, consider providing a chainConfig which funds your account.")
-                }
-                print_account_balances(&accounts, &account_balances);
-
-                let mut account_index;
-                loop {
-                    print!("\nPlease provide the index of account to use for signing: ");
-                    std::io::stdout().flush()?;
-                    let mut input_account_index = String::new();
-                    std::io::stdin().read_line(&mut input_account_index)?;
-                    account_index = input_account_index.trim().parse::<usize>()?;
-                    if accounts.contains_key(&account_index) {
-                        break;
-                    }
-                    let options: Vec<String> = accounts.keys().map(|key| key.to_string()).collect();
-                    println_warning(&format!(
-                        "\"{}\" is not a valid account.\nPlease choose a valid option from {}",
-                        account_index,
-                        options.join(","),
-                    ));
-                }
-
-                let secret_key = derive_secret_key(&wallet_path, account_index, &password)
-                    .map_err(|e| {
-                        if e.to_string().contains("Mac Mismatch") {
-                            anyhow::anyhow!(
-                                "Failed to access forc-wallet vault. Please check your password"
-                            )
-                        } else {
-                            e
-                        }
-                    })?;
-
-                // TODO: Do this via forc-wallet once the functionality is exposed.
-                let public_key = PublicKey::from(&secret_key);
-                let hashed = public_key.hash();
-                let bech32 = Bech32Address::new(FUEL_BECH32_HRP, hashed);
-                let question = format!(
-                    "Do you agree to sign this transaction with {}? [y/N]: ",
-                    bech32
-                );
-                let accepted = ask_user_yes_no_question(&question)?;
-                if !accepted {
-                    anyhow::bail!("User refused to sign");
-                }
-
-                Some(secret_key)
-            }
-            (WalletSelectionMode::ForcWallet, Some(key), _) => {
-                println_warning("Signing key is provided while requesting to sign with forc-wallet or with default signer. Using signing key");
-                Some(key)
-            }
-            (WalletSelectionMode::Manual, None, false) => None,
-            (WalletSelectionMode::Manual, Some(key), false) => Some(key),
-            (_, None, true) => {
-                // Generate a `SecretKey` to sign this transaction from a default private key used
-                // by fuel-core.
-                let secret_key = SecretKey::from_str(DEFAULT_PRIVATE_KEY)?;
-                Some(secret_key)
-            }
-            (WalletSelectionMode::Manual, Some(key), true) => {
-                println_warning("Signing key is provided while requesting to sign with a default signer. Using signing key");
-                Some(key)
-            }
-        };
+        let signing_key =
+            select_secret_key(wallet_mode, default_sign, signing_key, &provider).await?;
         // Get the address
         let address = if let Some(key) = signing_key {
             Address::from(*key.public_key().hash())
         } else {
+            // TODO: Remove this path https://github.com/FuelLabs/sway/issues/6071
             Address::from(prompt_address()?)
         };
 

--- a/forc-plugins/forc-client/tests/deploy.rs
+++ b/forc-plugins/forc-client/tests/deploy.rs
@@ -1,0 +1,128 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Child, Command},
+    str::FromStr,
+};
+
+use forc::cli::shared::Pkg;
+use forc_client::{
+    cmd,
+    op::{deploy, DeployedContract},
+    NodeTarget,
+};
+use fuel_tx::{ContractId, Salt};
+use portpicker::Port;
+use tempfile::tempdir;
+use toml_edit::{Document, InlineTable, Item, Value};
+
+fn get_workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../")
+        .join("../")
+        .canonicalize()
+        .unwrap()
+}
+
+/// Return the path to the chain config file which is expected to be in
+/// `.github/workflows/local-node` from sway repo root.
+fn chain_config_path() -> PathBuf {
+    get_workspace_root()
+        .join(".github")
+        .join("workflows")
+        .join("local-testnode")
+}
+
+fn test_data_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test")
+        .join("data")
+        .canonicalize()
+        .unwrap()
+}
+
+fn run_node() -> (Child, Port) {
+    let port = portpicker::pick_unused_port().expect("No ports free");
+
+    let chain_config = chain_config_path();
+    let child = Command::new("fuel-core")
+        .arg("run")
+        .arg("--debug")
+        .arg("--db-type")
+        .arg("in-memory")
+        .arg("--port")
+        .arg(port.to_string())
+        .arg("--snapshot")
+        .arg(format!("{}", chain_config.display()))
+        .spawn()
+        .expect("Failed to start fuel-core");
+    (child, port)
+}
+
+/// Copy a directory recursively from `source` to `dest`.
+fn copy_dir(source: &Path, dest: &Path) -> anyhow::Result<()> {
+    fs::create_dir_all(&dest)?;
+    for e in fs::read_dir(source)? {
+        let entry = e?;
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_dir(&entry.path(), &dest.join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), dest.join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
+fn patch_manifest_file_with_path_std(manifest_dir: &Path) -> anyhow::Result<()> {
+    let toml_path = manifest_dir.join(sway_utils::constants::MANIFEST_FILE_NAME);
+    let toml_content = fs::read_to_string(&toml_path).unwrap();
+
+    let mut doc = toml_content.parse::<Document>().unwrap();
+    let new_std_path = get_workspace_root().join("sway-lib-std");
+
+    let mut std_dependency = InlineTable::new();
+    std_dependency.insert("path", Value::from(new_std_path.display().to_string()));
+    doc["dependencies"]["std"] = Item::Value(Value::InlineTable(std_dependency));
+
+    fs::write(&toml_path, doc.to_string()).unwrap();
+    Ok(())
+}
+
+#[tokio::test]
+async fn simple_deploy() {
+    let (mut node, port) = run_node();
+    let tmp_dir = tempdir().unwrap();
+    let project_dir = test_data_path().join("standalone_contract");
+    copy_dir(&project_dir, tmp_dir.path()).unwrap();
+    patch_manifest_file_with_path_std(tmp_dir.path()).unwrap();
+
+    let pkg = Pkg {
+        path: Some(tmp_dir.path().display().to_string()),
+        ..Default::default()
+    };
+
+    let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
+    let target = NodeTarget {
+        node_url: Some(node_url),
+        target: None,
+        testnet: false,
+    };
+    let cmd = cmd::Deploy {
+        pkg,
+        salt: Some(vec![format!("{}", Salt::default())]),
+        node: target,
+        default_signer: true,
+        ..Default::default()
+    };
+    let contract_ids = deploy(cmd).await.unwrap();
+    node.kill().unwrap();
+    let expected = vec![DeployedContract {
+        id: ContractId::from_str(
+            "428896412bda8530282a7b8fca5d20b2a73f30037612ca3a31750cf3bf0e976a",
+        )
+        .unwrap(),
+    }];
+
+    assert_eq!(contract_ids, expected)
+}

--- a/forc-plugins/forc-client/tests/deploy.rs
+++ b/forc-plugins/forc-client/tests/deploy.rs
@@ -61,7 +61,7 @@ fn run_node() -> (Child, Port) {
 
 /// Copy a directory recursively from `source` to `dest`.
 fn copy_dir(source: &Path, dest: &Path) -> anyhow::Result<()> {
-    fs::create_dir_all(&dest)?;
+    fs::create_dir_all(dest)?;
     for e in fs::read_dir(source)? {
         let entry = e?;
         let file_type = entry.file_type()?;


### PR DESCRIPTION
## Description
closes #6211.

Defers the contract deployment estimation to sdk, and refactors signer selection for better testability. Also added an integration test to ensure we are always able to deploy to fuel-core to prevent this happening in the future. Basically some refactoring and a test addition. The diff is because I split finalize signed. I'll be adding unit tests to the split version in a follow up, probably alongside #6069 