### PR TITLE
Add LRU Session Cache to Reduce RAM Usage

### DIFF
--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -364,7 +364,7 @@ impl ServerState {
             .ok_or(DirectoryError::ManifestDirNotFound)?
             .to_path_buf();
 
-        let session = self.sessions.get(&manifest_dir).unwrap_or( {
+        let session = self.sessions.get(&manifest_dir).unwrap_or({
             // If no session can be found, then we need to call init and insert a new session into the map
             self.init_session(uri).await?;
             self.sessions
@@ -434,7 +434,10 @@ impl LruSessionCache {
     fn evict_least_used(&self) {
         let mut order = self.usage_order.lock();
         if let Some(old_path) = order.pop_back() {
-            tracing::trace!("Cache at capacity. Evicting least used session: {:?}", old_path);
+            tracing::trace!(
+                "Cache at capacity. Evicting least used session: {:?}",
+                old_path
+            );
             self.sessions.remove(&old_path);
         }
     }


### PR DESCRIPTION
## Description
This PR introduces an LRU (Least Recently Used) cache mechanism for managing sessions in large workspaces. This change aims to address the issue of high RAM usage reported in workspaces with multiple projects.

closes #6222

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
