### PR TITLE
re-enable LDC test

### DIFF
--- a/test/src/sdk-harness/test_projects/run_external_proxy/mod.rs
+++ b/test/src/sdk-harness/test_projects/run_external_proxy/mod.rs
@@ -6,7 +6,6 @@ abigen!(Contract(
 ));
 
 #[tokio::test]
-#[ignore]
 async fn run_external_can_proxy_call() {
     let wallet = launch_provider_and_get_wallet().await.unwrap();
 


### PR DESCRIPTION
## Description

This test was disabled when we introduced encoding v1. But it has been fixed since and we can enable it again.


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
