### PR TITLE
Add string slices to supported types message in match expressions

### DIFF
--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -1261,11 +1261,12 @@ impl TypeInfo {
         engines: &Engines,
         span: &Span,
     ) -> Result<(), ErrorEmitted> {
-        const CURRENTLY_SUPPORTED_TYPES_MESSAGE: [&str; 8] = [
+        const CURRENTLY_SUPPORTED_TYPES_MESSAGE: [&str; 9] = [
             "Sway currently supports pattern matching on these types:",
             "  - b256",
             "  - boolean",
             "  - enums",
+            "  - string slices",
             "  - structs",
             "  - tuples",
             "  - unsigned integers",


### PR DESCRIPTION
## Description

This PR adds `string slices` to `CURRENTLY_SUPPORTED_TYPES_MESSAGE` in `match` expressions. The support for string slices is added in #6202.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.