### PR TITLE
Unify AST nodes for parsed and typed `impl self` and `impl trait`.

### DIFF
--- a/forc-plugins/forc-doc/src/doc/mod.rs
+++ b/forc-plugins/forc-doc/src/doc/mod.rs
@@ -15,7 +15,7 @@ use std::{
 };
 use sway_core::{
     decl_engine::DeclEngine,
-    language::ty::{TyAstNodeContent, TyDecl, TyImplTrait, TyModule, TyProgram, TySubmodule},
+    language::ty::{TyAstNodeContent, TyDecl, TyImplSelfOrTrait, TyModule, TyProgram, TySubmodule},
     Engines,
 };
 use sway_types::BaseIdent;
@@ -36,7 +36,7 @@ impl Documentation {
     ) -> Result<Documentation> {
         // the first module prefix will always be the project name
         let mut docs = Documentation::default();
-        let mut impl_traits: Vec<(TyImplTrait, ModuleInfo)> = Vec::new();
+        let mut impl_traits: Vec<(TyImplSelfOrTrait, ModuleInfo)> = Vec::new();
         let module_info = ModuleInfo::from_ty_module(vec![project_name.to_owned()], None);
         Documentation::from_ty_module(
             engines.de(),
@@ -144,14 +144,14 @@ impl Documentation {
         module_info: &ModuleInfo,
         ty_module: &TyModule,
         docs: &mut Documentation,
-        impl_traits: &mut Vec<(TyImplTrait, ModuleInfo)>,
+        impl_traits: &mut Vec<(TyImplSelfOrTrait, ModuleInfo)>,
         document_private_items: bool,
     ) -> Result<()> {
         for ast_node in &ty_module.all_nodes {
             if let TyAstNodeContent::Declaration(ref decl) = ast_node.content {
-                if let TyDecl::ImplTrait(impl_trait) = decl {
+                if let TyDecl::ImplSelfOrTrait(impl_trait) = decl {
                     impl_traits.push((
-                        (*decl_engine.get_impl_trait(&impl_trait.decl_id)).clone(),
+                        (*decl_engine.get_impl_self_or_trait(&impl_trait.decl_id)).clone(),
                         module_info.clone(),
                     ));
                 } else {
@@ -175,7 +175,7 @@ impl Documentation {
         decl_engine: &DeclEngine,
         typed_submodule: &TySubmodule,
         docs: &mut Documentation,
-        impl_traits: &mut Vec<(TyImplTrait, ModuleInfo)>,
+        impl_traits: &mut Vec<(TyImplSelfOrTrait, ModuleInfo)>,
         module_info: &ModuleInfo,
         document_private_items: bool,
     ) -> Result<()> {

--- a/forc-plugins/forc-doc/src/render/item/context.rs
+++ b/forc-plugins/forc-doc/src/render/item/context.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 use horrorshow::{box_html, Raw, RenderBox, Template};
 use std::{collections::BTreeMap, fmt::Write};
 use sway_core::language::ty::{
-    TyEnumVariant, TyImplTrait, TyStorageField, TyStructField, TyTraitFn, TyTraitItem,
+    TyEnumVariant, TyImplSelfOrTrait, TyStorageField, TyStructField, TyTraitFn, TyTraitItem,
 };
 
 /// The actual context of the item displayed by [ItemContext].
@@ -268,7 +268,7 @@ impl Renderable for Context {
 #[derive(Debug, Clone)]
 pub struct DocImplTrait {
     pub impl_for_module: ModuleInfo,
-    pub impl_trait: TyImplTrait,
+    pub impl_trait: TyImplSelfOrTrait,
     pub module_info_override: Option<Vec<String>>,
 }
 
@@ -495,7 +495,7 @@ impl Renderable for ItemContext {
 }
 impl Renderable for DocImplTrait {
     fn render(self, render_plan: RenderPlan) -> Result<Box<dyn RenderBox>> {
-        let TyImplTrait {
+        let TyImplSelfOrTrait {
             trait_name,
             items,
             implementing_for,

--- a/forc-plugins/forc-doc/src/render/title.rs
+++ b/forc-plugins/forc-doc/src/render/title.rs
@@ -119,7 +119,7 @@ impl DocBlock for TyDecl {
             TyDecl::TraitDecl(_) => "trait",
             TyDecl::AbiDecl(_) => "abi",
             TyDecl::StorageDecl(_) => "contract_storage",
-            TyDecl::ImplTrait(_) => "impl_trait",
+            TyDecl::ImplSelfOrTrait(_) => "impl_trait",
             TyDecl::FunctionDecl(_) => "fn",
             TyDecl::ConstantDecl(_) => "constant",
             TyDecl::TypeAliasDecl(_) => "type_alias",

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -224,9 +224,9 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             connect_typed_fn_decl(engines, &fn_decl, graph, entry_node)?;
             Ok(leaves.to_vec())
         }
-        ty::TyDecl::ImplTrait(ty::ImplTrait { decl_id, .. }) => {
-            let impl_trait = decl_engine.get_impl_trait(decl_id);
-            let ty::TyImplTrait {
+        ty::TyDecl::ImplSelfOrTrait(ty::ImplSelfOrTrait { decl_id, .. }) => {
+            let impl_trait = decl_engine.get_impl_self_or_trait(decl_id);
+            let ty::TyImplSelfOrTrait {
                 trait_name, items, ..
             } = &*impl_trait;
             let entry_node = graph.add_node(ControlFlowGraphNode::from_node(node));

--- a/sway-core/src/decl_engine/engine.rs
+++ b/sway-core/src/decl_engine/engine.rs
@@ -13,7 +13,7 @@ use crate::{
     engine_threading::*,
     language::ty::{
         self, TyAbiDecl, TyConfigurableDecl, TyConstantDecl, TyEnumDecl, TyFunctionDecl,
-        TyImplTrait, TyStorageDecl, TyStructDecl, TyTraitDecl, TyTraitFn, TyTraitType,
+        TyImplSelfOrTrait, TyStorageDecl, TyStructDecl, TyTraitDecl, TyTraitFn, TyTraitType,
         TyTypeAliasDecl,
     },
 };
@@ -25,7 +25,7 @@ pub struct DeclEngine {
     trait_slab: ConcurrentSlab<TyTraitDecl>,
     trait_fn_slab: ConcurrentSlab<TyTraitFn>,
     trait_type_slab: ConcurrentSlab<TyTraitType>,
-    impl_trait_slab: ConcurrentSlab<TyImplTrait>,
+    impl_self_or_trait_slab: ConcurrentSlab<TyImplSelfOrTrait>,
     struct_slab: ConcurrentSlab<TyStructDecl>,
     storage_slab: ConcurrentSlab<TyStorageDecl>,
     abi_slab: ConcurrentSlab<TyAbiDecl>,
@@ -44,7 +44,7 @@ impl Clone for DeclEngine {
             trait_slab: self.trait_slab.clone(),
             trait_fn_slab: self.trait_fn_slab.clone(),
             trait_type_slab: self.trait_type_slab.clone(),
-            impl_trait_slab: self.impl_trait_slab.clone(),
+            impl_self_or_trait_slab: self.impl_self_or_trait_slab.clone(),
             struct_slab: self.struct_slab.clone(),
             storage_slab: self.storage_slab.clone(),
             abi_slab: self.abi_slab.clone(),
@@ -105,7 +105,7 @@ decl_engine_get!(function_slab, ty::TyFunctionDecl);
 decl_engine_get!(trait_slab, ty::TyTraitDecl);
 decl_engine_get!(trait_fn_slab, ty::TyTraitFn);
 decl_engine_get!(trait_type_slab, ty::TyTraitType);
-decl_engine_get!(impl_trait_slab, ty::TyImplTrait);
+decl_engine_get!(impl_self_or_trait_slab, ty::TyImplSelfOrTrait);
 decl_engine_get!(struct_slab, ty::TyStructDecl);
 decl_engine_get!(storage_slab, ty::TyStorageDecl);
 decl_engine_get!(abi_slab, ty::TyAbiDecl);
@@ -142,7 +142,7 @@ decl_engine_insert!(function_slab, ty::TyFunctionDecl);
 decl_engine_insert!(trait_slab, ty::TyTraitDecl);
 decl_engine_insert!(trait_fn_slab, ty::TyTraitFn);
 decl_engine_insert!(trait_type_slab, ty::TyTraitType);
-decl_engine_insert!(impl_trait_slab, ty::TyImplTrait);
+decl_engine_insert!(impl_self_or_trait_slab, ty::TyImplSelfOrTrait);
 decl_engine_insert!(struct_slab, ty::TyStructDecl);
 decl_engine_insert!(storage_slab, ty::TyStorageDecl);
 decl_engine_insert!(abi_slab, ty::TyAbiDecl);
@@ -164,7 +164,7 @@ decl_engine_replace!(function_slab, ty::TyFunctionDecl);
 decl_engine_replace!(trait_slab, ty::TyTraitDecl);
 decl_engine_replace!(trait_fn_slab, ty::TyTraitFn);
 decl_engine_replace!(trait_type_slab, ty::TyTraitType);
-decl_engine_replace!(impl_trait_slab, ty::TyImplTrait);
+decl_engine_replace!(impl_self_or_trait_slab, ty::TyImplSelfOrTrait);
 decl_engine_replace!(struct_slab, ty::TyStructDecl);
 decl_engine_replace!(storage_slab, ty::TyStorageDecl);
 decl_engine_replace!(abi_slab, ty::TyAbiDecl);
@@ -182,7 +182,7 @@ decl_engine_index!(function_slab, ty::TyFunctionDecl);
 decl_engine_index!(trait_slab, ty::TyTraitDecl);
 decl_engine_index!(trait_fn_slab, ty::TyTraitFn);
 decl_engine_index!(trait_type_slab, ty::TyTraitType);
-decl_engine_index!(impl_trait_slab, ty::TyImplTrait);
+decl_engine_index!(impl_self_or_trait_slab, ty::TyImplSelfOrTrait);
 decl_engine_index!(struct_slab, ty::TyStructDecl);
 decl_engine_index!(storage_slab, ty::TyStorageDecl);
 decl_engine_index!(abi_slab, ty::TyAbiDecl);
@@ -228,7 +228,7 @@ decl_engine_clear_program!(
     trait_slab, ty::TyTraitDecl;
     trait_fn_slab, ty::TyTraitFn;
     trait_type_slab, ty::TyTraitType;
-    impl_trait_slab, ty::TyImplTrait;
+    impl_self_or_trait_slab, ty::TyImplTrait;
     struct_slab, ty::TyStructDecl;
     storage_slab, ty::TyStorageDecl;
     abi_slab, ty::TyAbiDecl;
@@ -360,9 +360,9 @@ impl DeclEngine {
     ///
     /// Calling [DeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_impl_trait<I>(&self, index: &I) -> Arc<ty::TyImplTrait>
+    pub fn get_impl_self_or_trait<I>(&self, index: &I) -> Arc<ty::TyImplSelfOrTrait>
     where
-        DeclEngine: DeclEngineGet<I, ty::TyImplTrait>,
+        DeclEngine: DeclEngineGet<I, ty::TyImplSelfOrTrait>,
     {
         self.get(index)
     }

--- a/sway-core/src/decl_engine/id.rs
+++ b/sway-core/src/decl_engine/id.rs
@@ -10,7 +10,7 @@ use crate::{
     decl_engine::*,
     engine_threading::*,
     language::ty::{
-        TyEnumDecl, TyFunctionDecl, TyImplTrait, TyStructDecl, TyTraitDecl, TyTraitFn,
+        TyEnumDecl, TyFunctionDecl, TyImplSelfOrTrait, TyStructDecl, TyTraitDecl, TyTraitFn,
         TyTypeAliasDecl,
     },
     type_system::*,
@@ -167,7 +167,7 @@ impl SubstTypes for DeclId<TyTraitFn> {
         }
     }
 }
-impl SubstTypes for DeclId<TyImplTrait> {
+impl SubstTypes for DeclId<TyImplSelfOrTrait> {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         let decl_engine = engines.de();
         let mut decl = (*decl_engine.get(self)).clone();

--- a/sway-core/src/decl_engine/parsed_engine.rs
+++ b/sway-core/src/decl_engine/parsed_engine.rs
@@ -3,7 +3,7 @@ use crate::{
     decl_engine::*,
     language::parsed::{
         AbiDeclaration, ConfigurableDeclaration, ConstantDeclaration, EnumDeclaration, EnumVariant,
-        FunctionDeclaration, ImplSelf, ImplTrait, StorageDeclaration, StructDeclaration,
+        FunctionDeclaration, ImplSelfOrTrait, StorageDeclaration, StructDeclaration,
         TraitDeclaration, TraitFn, TraitTypeDeclaration, TypeAliasDeclaration, VariableDeclaration,
     },
 };
@@ -21,8 +21,7 @@ pub struct ParsedDeclEngine {
     trait_slab: ConcurrentSlab<TraitDeclaration>,
     trait_fn_slab: ConcurrentSlab<TraitFn>,
     trait_type_slab: ConcurrentSlab<TraitTypeDeclaration>,
-    impl_trait_slab: ConcurrentSlab<ImplTrait>,
-    impl_self_slab: ConcurrentSlab<ImplSelf>,
+    impl_self_or_trait_slab: ConcurrentSlab<ImplSelfOrTrait>,
     struct_slab: ConcurrentSlab<StructDeclaration>,
     storage_slab: ConcurrentSlab<StorageDeclaration>,
     abi_slab: ConcurrentSlab<AbiDeclaration>,
@@ -66,8 +65,7 @@ decl_engine_get!(function_slab, FunctionDeclaration);
 decl_engine_get!(trait_slab, TraitDeclaration);
 decl_engine_get!(trait_fn_slab, TraitFn);
 decl_engine_get!(trait_type_slab, TraitTypeDeclaration);
-decl_engine_get!(impl_trait_slab, ImplTrait);
-decl_engine_get!(impl_self_slab, ImplSelf);
+decl_engine_get!(impl_self_or_trait_slab, ImplSelfOrTrait);
 decl_engine_get!(struct_slab, StructDeclaration);
 decl_engine_get!(storage_slab, StorageDeclaration);
 decl_engine_get!(abi_slab, AbiDeclaration);
@@ -92,8 +90,7 @@ decl_engine_insert!(function_slab, FunctionDeclaration);
 decl_engine_insert!(trait_slab, TraitDeclaration);
 decl_engine_insert!(trait_fn_slab, TraitFn);
 decl_engine_insert!(trait_type_slab, TraitTypeDeclaration);
-decl_engine_insert!(impl_trait_slab, ImplTrait);
-decl_engine_insert!(impl_self_slab, ImplSelf);
+decl_engine_insert!(impl_self_or_trait_slab, ImplSelfOrTrait);
 decl_engine_insert!(struct_slab, StructDeclaration);
 decl_engine_insert!(storage_slab, StorageDeclaration);
 decl_engine_insert!(abi_slab, AbiDeclaration);
@@ -121,8 +118,7 @@ decl_engine_clear!(
     trait_slab, TraitDeclaration;
     trait_fn_slab, TraitFn;
     trait_type_slab, TraitTypeDeclaration;
-    impl_trait_slab, ImplTrait;
-    impl_self_slab, ImplSelf;
+    impl_self_or_trait_slab, ImplTrait;
     struct_slab, StructDeclaration;
     storage_slab, StorageDeclaration;
     abi_slab, AbiDeclaration;
@@ -158,8 +154,9 @@ decl_engine_clear_program!(
     (trait_type_slab, |item: &TraitTypeDeclaration| item
         .name
         .span()),
-    (impl_trait_slab, |item: &ImplTrait| item.block_span.clone()),
-    (impl_self_slab, |item: &ImplSelf| item.block_span.clone()),
+    (impl_self_or_trait_slab, |item: &ImplSelfOrTrait| item
+        .block_span
+        .clone()),
     (struct_slab, |item: &StructDeclaration| item.name.span()),
     (storage_slab, |item: &StorageDeclaration| item.span.clone()),
     (abi_slab, |item: &AbiDeclaration| item.name.span()),
@@ -212,21 +209,9 @@ impl ParsedDeclEngine {
     ///
     /// Calling [ParsedDeclEngine][get] directly is equivalent to this method, but
     /// this method adds additional syntax that some users may find helpful.
-    pub fn get_impl_trait<I>(&self, index: &I) -> Arc<ImplTrait>
+    pub fn get_impl_self_or_trait<I>(&self, index: &I) -> Arc<ImplSelfOrTrait>
     where
-        ParsedDeclEngine: ParsedDeclEngineGet<I, ImplTrait>,
-    {
-        self.get(index)
-    }
-
-    /// Friendly helper method for calling the `get` method from the
-    /// implementation of [ParsedDeclEngineGet] for [ParsedDeclEngine]
-    ///
-    /// Calling [ParsedDeclEngine][get] directly is equivalent to this method, but
-    /// this method adds additional syntax that some users may find helpful.
-    pub fn get_impl_self<I>(&self, index: &I) -> Arc<ImplSelf>
-    where
-        ParsedDeclEngine: ParsedDeclEngineGet<I, ImplSelf>,
+        ParsedDeclEngine: ParsedDeclEngineGet<I, ImplSelfOrTrait>,
     {
         self.get(index)
     }

--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -29,8 +29,8 @@ use crate::{
     decl_engine::*,
     engine_threading::*,
     language::ty::{
-        self, TyAbiDecl, TyConstantDecl, TyEnumDecl, TyFunctionDecl, TyImplTrait, TyStorageDecl,
-        TyStructDecl, TyTraitDecl, TyTraitFn, TyTraitType,
+        self, TyAbiDecl, TyConstantDecl, TyEnumDecl, TyFunctionDecl, TyImplSelfOrTrait,
+        TyStorageDecl, TyStructDecl, TyTraitDecl, TyTraitFn, TyTraitType,
     },
     semantic_analysis::TypeCheckContext,
     type_system::*,
@@ -40,7 +40,7 @@ pub type DeclRefFunction = DeclRef<DeclId<TyFunctionDecl>>;
 pub type DeclRefTrait = DeclRef<DeclId<TyTraitDecl>>;
 pub type DeclRefTraitFn = DeclRef<DeclId<TyTraitFn>>;
 pub type DeclRefTraitType = DeclRef<DeclId<TyTraitType>>;
-pub type DeclRefImplTrait = DeclRef<DeclId<TyImplTrait>>;
+pub type DeclRefImplTrait = DeclRef<DeclId<TyImplSelfOrTrait>>;
 pub type DeclRefStruct = DeclRef<DeclId<TyStructDecl>>;
 pub type DeclRefStorage = DeclRef<DeclId<TyStorageDecl>>;
 pub type DeclRefAbi = DeclRef<DeclId<TyAbiDecl>>;

--- a/sway-core/src/ir_generation/function.rs
+++ b/sway-core/src/ir_generation/function.rs
@@ -229,7 +229,7 @@ impl<'eng> FnCompiler<'eng> {
                     decl_type: "type alias",
                     span: ast_node.span.clone(),
                 }),
-                ty::TyDecl::ImplTrait { .. } => {
+                ty::TyDecl::ImplSelfOrTrait { .. } => {
                     // XXX What if we ignore the trait implementation???  Potentially since
                     // we currently inline everything and below we 'recreate' the functions
                     // lazily as they are called, nothing needs to be done here.  BUT!

--- a/sway-core/src/language/parsed/declaration.rs
+++ b/sway-core/src/language/parsed/declaration.rs
@@ -46,8 +46,7 @@ pub enum Declaration {
     StructDeclaration(ParsedDeclId<StructDeclaration>),
     EnumDeclaration(ParsedDeclId<EnumDeclaration>),
     EnumVariantDeclaration(EnumVariantDeclaration),
-    ImplTrait(ParsedDeclId<ImplTrait>),
-    ImplSelf(ParsedDeclId<ImplSelf>),
+    ImplSelfOrTrait(ParsedDeclId<ImplSelfOrTrait>),
     AbiDeclaration(ParsedDeclId<AbiDeclaration>),
     ConstantDeclaration(ParsedDeclId<ConstantDeclaration>),
     ConfigurableDeclaration(ParsedDeclId<ConfigurableDeclaration>),
@@ -88,8 +87,7 @@ impl Declaration {
             StructDeclaration(_) => "struct",
             EnumDeclaration(_) => "enum",
             EnumVariantDeclaration(_) => "enum variant",
-            ImplSelf(_) => "impl self",
-            ImplTrait(_) => "impl trait",
+            ImplSelfOrTrait(_) => "impl self/trait",
             AbiDeclaration(_) => "abi",
             StorageDeclaration(_) => "contract storage",
             TypeAliasDeclaration(_) => "type alias",
@@ -106,8 +104,7 @@ impl Declaration {
             StructDeclaration(decl_id) => pe.get_struct(decl_id).span(),
             EnumDeclaration(decl_id) => pe.get_enum(decl_id).span(),
             EnumVariantDeclaration(decl) => decl.variant_decl_span.clone(),
-            ImplTrait(decl_id) => pe.get_impl_trait(decl_id).span(),
-            ImplSelf(decl_id) => pe.get_impl_self(decl_id).span(),
+            ImplSelfOrTrait(decl_id) => pe.get_impl_self_or_trait(decl_id).span(),
             AbiDeclaration(decl_id) => pe.get_abi(decl_id).span(),
             ConstantDeclaration(decl_id) => pe.get_constant(decl_id).span(),
             ConfigurableDeclaration(decl_id) => pe.get_configurable(decl_id).span(),
@@ -138,8 +135,7 @@ impl Declaration {
                 decl_engine.get_type_alias(decl_id).visibility
             }
             Declaration::VariableDeclaration(_decl_id) => Visibility::Private,
-            Declaration::ImplTrait(_)
-            | Declaration::ImplSelf(_)
+            Declaration::ImplSelfOrTrait(_)
             | Declaration::StorageDeclaration(_)
             | Declaration::AbiDeclaration(_)
             | Declaration::TraitTypeDeclaration(_) => Visibility::Public,
@@ -169,7 +165,7 @@ impl DisplayWithEngines for Declaration {
                 Declaration::EnumDeclaration(decl_id) => {
                     engines.pe().get(decl_id).name.as_str().into()
                 }
-                Declaration::ImplTrait(decl_id) => {
+                Declaration::ImplSelfOrTrait(decl_id) => {
                     engines
                         .pe()
                         .get(decl_id)
@@ -213,10 +209,7 @@ impl PartialEqWithEngines for Declaration {
             (Declaration::EnumDeclaration(lid), Declaration::EnumDeclaration(rid)) => {
                 decl_engine.get(lid).eq(&decl_engine.get(rid), ctx)
             }
-            (Declaration::ImplTrait(lid), Declaration::ImplTrait(rid)) => {
-                decl_engine.get(lid).eq(&decl_engine.get(rid), ctx)
-            }
-            (Declaration::ImplSelf(lid), Declaration::ImplSelf(rid)) => {
+            (Declaration::ImplSelfOrTrait(lid), Declaration::ImplSelfOrTrait(rid)) => {
                 decl_engine.get(lid).eq(&decl_engine.get(rid), ctx)
             }
             (Declaration::AbiDeclaration(lid), Declaration::AbiDeclaration(rid)) => {

--- a/sway-core/src/language/ty/ast_node.rs
+++ b/sway-core/src/language/ty/ast_node.rs
@@ -236,7 +236,7 @@ impl TyAstNode {
                     }
                     allow_deprecated.exit(token);
                 }
-                TyDecl::ImplTrait(decl) => {
+                TyDecl::ImplSelfOrTrait(decl) => {
                     let decl = engines.de().get(&decl.decl_id);
                     for item in decl.items.iter() {
                         match item {
@@ -293,7 +293,7 @@ impl TyAstNode {
                         let _ = fn_decl_id.type_check_analyze(handler, &mut ctx);
                         let _ = ctx.check_recursive_calls(handler);
                     }
-                    TyDecl::ImplTrait(decl) => {
+                    TyDecl::ImplSelfOrTrait(decl) => {
                         let decl = engines.de().get(&decl.decl_id);
                         for item in decl.items.iter() {
                             let mut ctx = TypeCheckAnalysisContext::new(engines);
@@ -321,7 +321,7 @@ impl TyAstNode {
     pub fn contract_fns(&self, engines: &Engines) -> Vec<DeclRefFunction> {
         let mut fns = vec![];
 
-        if let TyAstNodeContent::Declaration(TyDecl::ImplTrait(decl)) = &self.content {
+        if let TyAstNodeContent::Declaration(TyDecl::ImplSelfOrTrait(decl)) = &self.content {
             let decl = engines.de().get(&decl.decl_id);
             if decl.is_impl_contract(engines.te()) {
                 for item in &decl.items {

--- a/sway-core/src/language/ty/declaration/function.rs
+++ b/sway-core/src/language/ty/declaration/function.rs
@@ -434,7 +434,7 @@ impl TyFunctionDecl {
         };
 
         match &self.implementing_type {
-            Some(TyDecl::ImplTrait(t)) => {
+            Some(TyDecl::ImplSelfOrTrait(t)) => {
                 let unify_check = UnifyCheck::non_dynamic_equality(engines);
 
                 let implementing_for = engines.de().get(&t.decl_id).implementing_for.type_id;

--- a/sway-core/src/language/ty/declaration/impl_trait.rs
+++ b/sway-core/src/language/ty/declaration/impl_trait.rs
@@ -13,7 +13,7 @@ pub type TyImplItem = TyTraitItem;
 
 // impl <A, B, C> Trait<Arg, Arg> for Type<Arg, Arg>
 #[derive(Clone, Debug)]
-pub struct TyImplTrait {
+pub struct TyImplSelfOrTrait {
     pub impl_type_parameters: Vec<TypeParameter>,
     pub trait_name: CallPath,
     pub trait_type_arguments: Vec<TypeArgument>,
@@ -23,26 +23,26 @@ pub struct TyImplTrait {
     pub span: Span,
 }
 
-impl TyImplTrait {
+impl TyImplSelfOrTrait {
     pub fn is_impl_contract(&self, te: &TypeEngine) -> bool {
         matches!(&*te.get(self.implementing_for.type_id), TypeInfo::Contract)
     }
 }
 
-impl Named for TyImplTrait {
+impl Named for TyImplSelfOrTrait {
     fn name(&self) -> &Ident {
         &self.trait_name.suffix
     }
 }
 
-impl Spanned for TyImplTrait {
+impl Spanned for TyImplSelfOrTrait {
     fn span(&self) -> Span {
         self.span.clone()
     }
 }
 
-impl EqWithEngines for TyImplTrait {}
-impl PartialEqWithEngines for TyImplTrait {
+impl EqWithEngines for TyImplSelfOrTrait {}
+impl PartialEqWithEngines for TyImplSelfOrTrait {
     fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
         self.impl_type_parameters
             .eq(&other.impl_type_parameters, ctx)
@@ -56,9 +56,9 @@ impl PartialEqWithEngines for TyImplTrait {
     }
 }
 
-impl HashWithEngines for TyImplTrait {
+impl HashWithEngines for TyImplSelfOrTrait {
     fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
-        let TyImplTrait {
+        let TyImplSelfOrTrait {
             impl_type_parameters,
             trait_name,
             trait_type_arguments,
@@ -78,7 +78,7 @@ impl HashWithEngines for TyImplTrait {
     }
 }
 
-impl SubstTypes for TyImplTrait {
+impl SubstTypes for TyImplSelfOrTrait {
     fn subst_inner(&mut self, type_mapping: &TypeSubstMap, engines: &Engines) -> HasChanges {
         has_changes! {
             self.impl_type_parameters.subst(type_mapping, engines);

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -404,7 +404,9 @@ impl TyExpression {
             TyExpressionVariant::FunctionApplication {
                 call_path, fn_ref, ..
             } => {
-                if let Some(TyDecl::ImplTrait(t)) = &engines.de().get(fn_ref).implementing_type {
+                if let Some(TyDecl::ImplSelfOrTrait(t)) =
+                    &engines.de().get(fn_ref).implementing_type
+                {
                     let t = &engines.de().get(&t.decl_id).implementing_for;
                     if let TypeInfo::Struct(struct_id) = &*engines.te().get(t.type_id) {
                         let s = engines.de().get(struct_id);

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -1348,8 +1348,8 @@ fn find_const_decl_from_impl(
     const_decl: &TyConstantDecl,
 ) -> Option<TyConstantDecl> {
     match implementing_type {
-        TyDecl::ImplTrait(ImplTrait { decl_id, .. }) => {
-            let impl_trait = decl_engine.get_impl_trait(&decl_id.clone());
+        TyDecl::ImplSelfOrTrait(ImplSelfOrTrait { decl_id, .. }) => {
+            let impl_trait = decl_engine.get_impl_self_or_trait(&decl_id.clone());
             impl_trait
                 .items
                 .iter()

--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -131,9 +131,12 @@ impl TyProgram {
                 // ABI entries are all functions declared in impl_traits on the contract type
                 // itself, except for ABI supertraits, which do not expose their methods to
                 // the user
-                TyAstNodeContent::Declaration(TyDecl::ImplTrait(ImplTrait { decl_id, .. })) => {
-                    let impl_trait_decl = decl_engine.get_impl_trait(decl_id);
-                    let TyImplTrait {
+                TyAstNodeContent::Declaration(TyDecl::ImplSelfOrTrait(ImplSelfOrTrait {
+                    decl_id,
+                    ..
+                })) => {
+                    let impl_trait_decl = decl_engine.get_impl_self_or_trait(decl_id);
+                    let TyImplSelfOrTrait {
                         items,
                         implementing_for,
                         trait_decl_ref,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl.rs
@@ -368,7 +368,7 @@ where
         .unwrap();
 
         let decl = match nodes[0].content {
-            AstNodeContent::Declaration(Declaration::ImplTrait(f)) => f,
+            AstNodeContent::Declaration(Declaration::ImplSelfOrTrait(f)) => f,
             _ => unreachable!("unexpected item"),
         };
 
@@ -376,7 +376,7 @@ where
 
         let ctx = self.ctx.by_ref();
         let r = ctx.scoped_and_namespace(|ctx| {
-            TyDecl::type_check(&handler, ctx, Declaration::ImplTrait(decl))
+            TyDecl::type_check(&handler, ctx, Declaration::ImplSelfOrTrait(decl))
         });
 
         // Uncomment this to understand why auto impl failed for a type.

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -1,5 +1,5 @@
 use sway_error::handler::{ErrorEmitted, Handler};
-use sway_types::{BaseIdent, Ident, Named, Spanned};
+use sway_types::{Ident, Named, Spanned};
 
 use crate::{
     decl_engine::{DeclEngineGet, DeclEngineInsert, DeclRef, ReplaceFunctionImplementingType},
@@ -55,21 +55,16 @@ impl TyDecl {
                 let trait_decl = engines.pe().get_trait(decl_id).as_ref().clone();
                 ctx.insert_parsed_symbol(handler, engines, trait_decl.name.clone(), decl)?;
             }
-            parsed::Declaration::ImplTrait(decl_id) => {
-                let impl_trait = engines.pe().get_impl_trait(decl_id).as_ref().clone();
+            parsed::Declaration::ImplSelfOrTrait(decl_id) => {
+                let impl_trait = engines
+                    .pe()
+                    .get_impl_self_or_trait(decl_id)
+                    .as_ref()
+                    .clone();
                 ctx.insert_parsed_symbol(
                     handler,
                     engines,
                     impl_trait.trait_name.suffix.clone(),
-                    decl,
-                )?;
-            }
-            parsed::Declaration::ImplSelf(decl_id) => {
-                let impl_self = engines.pe().get_impl_self(decl_id).as_ref().clone();
-                ctx.insert_parsed_symbol(
-                    handler,
-                    engines,
-                    BaseIdent::new(impl_self.implementing_for.span),
                     decl,
                 )?;
             }
@@ -285,15 +280,55 @@ impl TyDecl {
                 ctx.insert_symbol(handler, name, decl.clone())?;
                 decl
             }
-            parsed::Declaration::ImplTrait(decl_id) => {
-                let impl_trait = engines.pe().get_impl_trait(&decl_id).as_ref().clone();
-                let span = impl_trait.block_span.clone();
-                let mut impl_trait =
-                    match ty::TyImplTrait::type_check_impl_trait(handler, ctx.by_ref(), impl_trait)
-                    {
-                        Ok(res) => res,
+            parsed::Declaration::ImplSelfOrTrait(decl_id) => {
+                let impl_self_or_trait = engines
+                    .pe()
+                    .get_impl_self_or_trait(&decl_id)
+                    .as_ref()
+                    .clone();
+                let span = impl_self_or_trait.block_span.clone();
+                let mut impl_trait = if impl_self_or_trait.is_self {
+                    let impl_trait_decl = match ty::TyImplSelfOrTrait::type_check_impl_self(
+                        handler,
+                        ctx.by_ref(),
+                        impl_self_or_trait,
+                    ) {
+                        Ok(val) => val,
                         Err(err) => return Ok(ty::TyDecl::ErrorRecovery(span, err)),
                     };
+
+                    let impl_trait =
+                        if let TyDecl::ImplSelfOrTrait(impl_trait_id) = &impl_trait_decl {
+                            decl_engine.get_impl_self_or_trait(&impl_trait_id.decl_id)
+                        } else {
+                            unreachable!();
+                        };
+                    ctx.insert_trait_implementation(
+                        handler,
+                        impl_trait.trait_name.clone(),
+                        impl_trait.trait_type_arguments.clone(),
+                        impl_trait.implementing_for.type_id,
+                        &impl_trait.items,
+                        &impl_trait.span,
+                        impl_trait
+                            .trait_decl_ref
+                            .as_ref()
+                            .map(|decl_ref| decl_ref.decl_span().clone()),
+                        IsImplSelf::Yes,
+                        IsExtendingExistingImpl::No,
+                    )?;
+
+                    return Ok(impl_trait_decl);
+                } else {
+                    match ty::TyImplSelfOrTrait::type_check_impl_trait(
+                        handler,
+                        ctx.by_ref(),
+                        impl_self_or_trait,
+                    ) {
+                        Ok(res) => res,
+                        Err(err) => return Ok(ty::TyDecl::ErrorRecovery(span, err)),
+                    }
+                };
 
                 // Insert prefixed symbols when implementing_for is Contract
                 let is_contract = engines
@@ -355,35 +390,6 @@ impl TyDecl {
                 impl_trait.items.iter_mut().for_each(|item| {
                     item.replace_implementing_type(engines, impl_trait_decl.clone());
                 });
-                impl_trait_decl
-            }
-            parsed::Declaration::ImplSelf(decl_id) => {
-                let impl_self = engines.pe().get_impl_self(&decl_id).as_ref().clone();
-                let span = impl_self.block_span.clone();
-                let impl_trait_decl =
-                    match ty::TyImplTrait::type_check_impl_self(handler, ctx.by_ref(), impl_self) {
-                        Ok(val) => val,
-                        Err(err) => return Ok(ty::TyDecl::ErrorRecovery(span, err)),
-                    };
-                let impl_trait = if let TyDecl::ImplTrait(impl_trait_id) = &impl_trait_decl {
-                    decl_engine.get_impl_trait(&impl_trait_id.decl_id)
-                } else {
-                    unreachable!();
-                };
-                ctx.insert_trait_implementation(
-                    handler,
-                    impl_trait.trait_name.clone(),
-                    impl_trait.trait_type_arguments.clone(),
-                    impl_trait.implementing_for.type_id,
-                    &impl_trait.items,
-                    &impl_trait.span,
-                    impl_trait
-                        .trait_decl_ref
-                        .as_ref()
-                        .map(|decl_ref| decl_ref.decl_span().clone()),
-                    IsImplSelf::Yes,
-                    IsExtendingExistingImpl::No,
-                )?;
                 impl_trait_decl
             }
             parsed::Declaration::StructDeclaration(decl_id) => {
@@ -636,7 +642,7 @@ impl TypeCheckAnalysis for TyDecl {
                 enum_decl.type_check_analyze(handler, ctx)?;
             }
             TyDecl::EnumVariantDecl(_) => {}
-            TyDecl::ImplTrait(node) => {
+            TyDecl::ImplSelfOrTrait(node) => {
                 node.type_check_analyze(handler, ctx)?;
             }
             TyDecl::AbiDecl(node) => {
@@ -693,8 +699,8 @@ impl TypeCheckFinalization for TyDecl {
                 enum_decl.type_check_finalize(handler, ctx)?;
             }
             TyDecl::EnumVariantDecl(_) => {}
-            TyDecl::ImplTrait(node) => {
-                let mut impl_trait = (*decl_engine.get_impl_trait(&node.decl_id)).clone();
+            TyDecl::ImplSelfOrTrait(node) => {
+                let mut impl_trait = (*decl_engine.get_impl_self_or_trait(&node.decl_id)).clone();
                 impl_trait.type_check_finalize(handler, ctx)?;
             }
             TyDecl::AbiDecl(node) => {

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -601,7 +601,7 @@ pub(crate) fn type_check_method_application(
 
     // Unify method type parameters with implementing type type parameters.
     if let Some(implementing_for_typeid) = method.implementing_for_typeid {
-        if let Some(TyDecl::ImplTrait(t)) = method.clone().implementing_type {
+        if let Some(TyDecl::ImplSelfOrTrait(t)) = method.clone().implementing_type {
             let t = &engines.de().get(&t.decl_id).implementing_for;
             if let TypeInfo::Custom {
                 type_arguments: Some(type_arguments),
@@ -665,7 +665,7 @@ pub(crate) fn type_check_method_application(
         fn_ref = cached_fn_ref;
     } else {
         // This handles the case of substituting the generic blanket type by call_path_typeid.
-        if let Some(TyDecl::ImplTrait(t)) = method.clone().implementing_type {
+        if let Some(TyDecl::ImplSelfOrTrait(t)) = method.clone().implementing_type {
             let t = &engines.de().get(&t.decl_id).implementing_for;
             if let TypeInfo::Custom {
                 qualified_call_path,

--- a/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
+++ b/sway-core/src/semantic_analysis/cei_pattern_analysis.rs
@@ -11,7 +11,7 @@
 use crate::{
     decl_engine::*,
     language::{
-        ty::{self, TyFunctionDecl, TyImplTrait},
+        ty::{self, TyFunctionDecl, TyImplSelfOrTrait},
         AsmOp,
     },
     Engines,
@@ -111,7 +111,7 @@ fn contract_entry_points(
             Declaration(ty::TyDecl::FunctionDecl(ty::FunctionDecl { decl_id, .. })) => {
                 decl_id_to_fn_decls(decl_engine, decl_id)
             }
-            Declaration(ty::TyDecl::ImplTrait(ty::ImplTrait { decl_id, .. })) => {
+            Declaration(ty::TyDecl::ImplSelfOrTrait(ty::ImplSelfOrTrait { decl_id, .. })) => {
                 impl_trait_methods(decl_engine, decl_id)
             }
             _ => vec![],
@@ -128,9 +128,9 @@ fn decl_id_to_fn_decls(
 
 fn impl_trait_methods(
     decl_engine: &DeclEngine,
-    impl_trait_decl_id: &DeclId<TyImplTrait>,
+    impl_trait_decl_id: &DeclId<TyImplSelfOrTrait>,
 ) -> Vec<Arc<ty::TyFunctionDecl>> {
-    let impl_trait = decl_engine.get_impl_trait(impl_trait_decl_id);
+    let impl_trait = decl_engine.get_impl_self_or_trait(impl_trait_decl_id);
     impl_trait
         .items
         .iter()

--- a/sway-core/src/semantic_analysis/module.rs
+++ b/sway-core/src/semantic_analysis/module.rs
@@ -387,7 +387,7 @@ impl ty::TyModule {
     fn get_all_impls(
         ctx: TypeCheckContext<'_>,
         nodes: &[AstNode],
-        predicate: fn(&ImplTrait) -> bool,
+        predicate: fn(&ImplSelfOrTrait) -> bool,
     ) -> HashMap<BaseIdent, HashSet<CallPath>> {
         let engines = ctx.engines();
         // Check which structs and enums needs to have auto impl for AbiEncode
@@ -396,8 +396,10 @@ impl ty::TyModule {
         let mut impls = HashMap::<BaseIdent, HashSet<CallPath>>::new();
 
         for node in nodes.iter() {
-            if let AstNodeContent::Declaration(Declaration::ImplTrait(decl_id)) = &node.content {
-                let decl = &*engines.pe().get_impl_trait(decl_id);
+            if let AstNodeContent::Declaration(Declaration::ImplSelfOrTrait(decl_id)) =
+                &node.content
+            {
+                let decl = &*engines.pe().get_impl_self_or_trait(decl_id);
                 let implementing_for = ctx.engines.te().get(decl.implementing_for.type_id);
                 let implementing_for = match &*implementing_for {
                     TypeInfo::Struct(decl_id) => {

--- a/sway-core/src/semantic_analysis/type_check_analysis.rs
+++ b/sway-core/src/semantic_analysis/type_check_analysis.rs
@@ -38,7 +38,7 @@ impl Display for TyNodeDepGraphEdge {
 
 #[derive(Clone, Debug)]
 pub enum TyNodeDepGraphNode {
-    ImplTrait { node: ty::ImplTrait },
+    ImplTrait { node: ty::ImplSelfOrTrait },
     ImplTraitItem { node: ty::TyTraitItem },
     Fn { node: DeclId<TyFunctionDecl> },
 }
@@ -125,7 +125,7 @@ impl TypeCheckAnalysisContext<'_> {
     #[allow(clippy::map_entry)]
     pub(crate) fn push_nodes_for_impl_trait(
         &mut self,
-        impl_trait: &ty::ImplTrait,
+        impl_trait: &ty::ImplSelfOrTrait,
     ) -> TyNodeDepGraphNodeId {
         if self.nodes.contains_key(&impl_trait.decl_id.unique_id()) {
             *self.nodes.get(&impl_trait.decl_id.unique_id()).unwrap()
@@ -136,7 +136,7 @@ impl TypeCheckAnalysisContext<'_> {
             self.nodes.insert(impl_trait.decl_id.unique_id(), node);
 
             let decl_engine = self.engines.de();
-            let impl_trait = decl_engine.get_impl_trait(&impl_trait.decl_id);
+            let impl_trait = decl_engine.get_impl_self_or_trait(&impl_trait.decl_id);
 
             for item in impl_trait.items.iter() {
                 let item_node = self.get_or_create_node_for_impl_item(item);
@@ -372,7 +372,7 @@ impl DebugWithEngines for TyNodeDepGraphNode {
                 format!("{:?}", str)
             }
             TyNodeDepGraphNode::ImplTrait { node } => {
-                let decl = engines.de().get_impl_trait(&node.decl_id);
+                let decl = engines.de().get_impl_self_or_trait(&node.decl_id);
                 format!("{:?}", decl.name().as_str())
             }
             TyNodeDepGraphNode::Fn { node } => {

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -1143,10 +1143,10 @@ impl<'a> TypeCheckContext<'a> {
                 let mut impl_self_method = None;
                 for method_ref in maybe_method_decl_refs.clone() {
                     let method = decl_engine.get_function(&method_ref);
-                    if let Some(ty::TyDecl::ImplTrait(impl_trait)) =
+                    if let Some(ty::TyDecl::ImplSelfOrTrait(impl_trait)) =
                         method.implementing_type.clone()
                     {
-                        let trait_decl = decl_engine.get_impl_trait(&impl_trait.decl_id);
+                        let trait_decl = decl_engine.get_impl_self_or_trait(&impl_trait.decl_id);
                         let mut skip_insert = false;
                         if let Some(as_trait) = as_trait {
                             if let TypeInfo::Custom {

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -39,6 +39,7 @@ use sway_types::{
         TEST_ATTRIBUTE_NAME, VALID_ATTRIBUTE_NAMES,
     },
     integer_bits::IntegerBits,
+    BaseIdent,
 };
 use sway_types::{Ident, Span, Spanned};
 
@@ -767,7 +768,8 @@ pub fn item_impl_to_declaration(
         Some((path_type, _)) => {
             let (trait_name, trait_type_arguments) =
                 path_type_to_call_path_and_type_arguments(context, handler, engines, path_type)?;
-            let impl_trait = ImplTrait {
+            let impl_trait = ImplSelfOrTrait {
+                is_self: false,
                 impl_type_parameters,
                 trait_name: trait_name.to_call_path(handler)?,
                 trait_type_arguments,
@@ -776,20 +778,27 @@ pub fn item_impl_to_declaration(
                 block_span,
             };
             let impl_trait = engines.pe().insert(impl_trait);
-            Ok(Declaration::ImplTrait(impl_trait))
+            Ok(Declaration::ImplSelfOrTrait(impl_trait))
         }
         None => match &*engines.te().get(implementing_for.type_id) {
             TypeInfo::Contract => Err(handler
                 .emit_err(ConvertParseTreeError::SelfImplForContract { span: block_span }.into())),
             _ => {
-                let impl_self = ImplSelf {
+                let impl_self = ImplSelfOrTrait {
+                    is_self: true,
+                    trait_name: CallPath {
+                        is_absolute: false,
+                        prefixes: vec![],
+                        suffix: BaseIdent::dummy(),
+                    },
+                    trait_type_arguments: vec![],
                     implementing_for,
                     impl_type_parameters,
                     items,
                     block_span,
                 };
                 let impl_self = engines.pe().insert(impl_self);
-                Ok(Declaration::ImplSelf(impl_self))
+                Ok(Declaration::ImplSelfOrTrait(impl_self))
             }
         },
     }

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
@@ -6,13 +6,13 @@ use crate::{
     core::{token::TypedAstToken, token_map::TokenMapExt},
 };
 use lsp_types::{CodeActionDisabled, Position, Range, Url};
-use sway_core::language::ty::{self, TyImplTrait, TyStructDecl, TyStructField};
+use sway_core::language::ty::{self, TyImplSelfOrTrait, TyStructDecl, TyStructField};
 use sway_types::{LineCol, Spanned};
 
 pub(crate) struct StructNewCodeAction<'a> {
     decl: &'a TyStructDecl,
     uri: &'a Url,
-    existing_impl_decl: Option<TyImplTrait>,
+    existing_impl_decl: Option<TyImplSelfOrTrait>,
 }
 
 impl<'a> GenerateImplCodeAction<'a, TyStructDecl> for StructNewCodeAction<'a> {
@@ -31,11 +31,11 @@ impl<'a> CodeAction<'a, TyStructDecl> for StructNewCodeAction<'a> {
             .iter()
             .all_references_of_token(ctx.token, ctx.engines)
             .find_map(|item| {
-                if let Some(TypedAstToken::TypedDeclaration(ty::TyDecl::ImplTrait(
-                    ty::ImplTrait { decl_id, .. },
+                if let Some(TypedAstToken::TypedDeclaration(ty::TyDecl::ImplSelfOrTrait(
+                    ty::ImplSelfOrTrait { decl_id, .. },
                 ))) = item.value().typed
                 {
-                    Some((*ctx.engines.de().get_impl_trait(&decl_id)).clone())
+                    Some((*ctx.engines.de().get_impl_self_or_trait(&decl_id)).clone())
                 } else {
                     None
                 }

--- a/sway-lsp/src/capabilities/rename.rs
+++ b/sway-lsp/src/capabilities/rename.rs
@@ -217,8 +217,8 @@ fn find_all_methods_for_decl<'a>(
                             engines.se(),
                         ))
                     }
-                    ty::TyDecl::ImplTrait(ty::ImplTrait { decl_id, .. }) => {
-                        let impl_trait = engines.de().get_impl_trait(decl_id);
+                    ty::TyDecl::ImplSelfOrTrait(ty::ImplSelfOrTrait { decl_id, .. }) => {
+                        let impl_trait = engines.de().get_impl_self_or_trait(decl_id);
                         Some(
                             impl_trait
                                 .items

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -23,15 +23,15 @@ use sway_core::{
             ConstantDeclaration, Declaration, DelineatedPathExpression, EnumDeclaration,
             EnumVariant, Expression, ExpressionKind, ForLoopExpression,
             FunctionApplicationExpression, FunctionDeclaration, FunctionParameter, IfExpression,
-            ImplItem, ImplSelf, ImplTrait, ImportType, IncludeStatement,
-            IntrinsicFunctionExpression, LazyOperatorExpression, MatchExpression,
-            MethodApplicationExpression, MethodName, ParseModule, ParseProgram, ParseSubmodule,
-            QualifiedPathType, ReassignmentExpression, ReassignmentTarget, RefExpression,
-            Scrutinee, StorageAccessExpression, StorageDeclaration, StorageEntry, StorageField,
-            StorageNamespace, StructDeclaration, StructExpression, StructExpressionField,
-            StructField, StructScrutineeField, SubfieldExpression, Supertrait, TraitDeclaration,
-            TraitFn, TraitItem, TraitTypeDeclaration, TupleIndexExpression, TypeAliasDeclaration,
-            UseStatement, VariableDeclaration, WhileLoopExpression,
+            ImplItem, ImplSelfOrTrait, ImportType, IncludeStatement, IntrinsicFunctionExpression,
+            LazyOperatorExpression, MatchExpression, MethodApplicationExpression, MethodName,
+            ParseModule, ParseProgram, ParseSubmodule, QualifiedPathType, ReassignmentExpression,
+            ReassignmentTarget, RefExpression, Scrutinee, StorageAccessExpression,
+            StorageDeclaration, StorageEntry, StorageField, StorageNamespace, StructDeclaration,
+            StructExpression, StructExpressionField, StructField, StructScrutineeField,
+            SubfieldExpression, Supertrait, TraitDeclaration, TraitFn, TraitItem,
+            TraitTypeDeclaration, TupleIndexExpression, TypeAliasDeclaration, UseStatement,
+            VariableDeclaration, WhileLoopExpression,
         },
         CallPathTree, HasSubmodules, Literal,
     },
@@ -126,8 +126,7 @@ impl Parse for Declaration {
             Declaration::StructDeclaration(decl_id) => decl_id.parse(ctx),
             Declaration::EnumDeclaration(decl_id) => decl_id.parse(ctx),
             Declaration::EnumVariantDeclaration(_decl) => unreachable!(),
-            Declaration::ImplTrait(decl_id) => decl_id.parse(ctx),
-            Declaration::ImplSelf(decl_id) => decl_id.parse(ctx),
+            Declaration::ImplSelfOrTrait(decl_id) => decl_id.parse(ctx),
             Declaration::AbiDeclaration(decl_id) => decl_id.parse(ctx),
             Declaration::ConstantDeclaration(decl_id) => decl_id.parse(ctx),
             Declaration::ConfigurableDeclaration(decl_id) => decl_id.parse(ctx),
@@ -779,58 +778,49 @@ impl Parse for ParsedDeclId<EnumDeclaration> {
     }
 }
 
-impl Parse for ParsedDeclId<ImplTrait> {
+impl Parse for ParsedDeclId<ImplSelfOrTrait> {
     fn parse(&self, ctx: &ParseContext) {
-        let impl_trait = ctx.engines.pe().get_impl_trait(self);
-        adaptive_iter(&impl_trait.trait_name.prefixes, |ident| {
+        let impl_self_or_trait = ctx.engines.pe().get_impl_self_or_trait(self);
+        adaptive_iter(&impl_self_or_trait.trait_name.prefixes, |ident| {
             ctx.tokens.insert(
                 ctx.ident(ident),
                 Token::from_parsed(AstToken::Ident(ident.clone()), SymbolKind::Module),
             );
         });
         ctx.tokens.insert(
-            ctx.ident(&impl_trait.trait_name.suffix),
+            ctx.ident(&impl_self_or_trait.trait_name.suffix),
             Token::from_parsed(
-                AstToken::Declaration(Declaration::ImplTrait(*self)),
+                AstToken::Declaration(Declaration::ImplSelfOrTrait(*self)),
                 SymbolKind::Trait,
             ),
         );
-        impl_trait.implementing_for.parse(ctx);
-        adaptive_iter(&impl_trait.impl_type_parameters, |type_param| {
-            type_param.parse(ctx);
-        });
-        adaptive_iter(&impl_trait.items, |item| match item {
-            ImplItem::Fn(fn_decl) => fn_decl.parse(ctx),
-            ImplItem::Constant(const_decl) => const_decl.parse(ctx),
-            ImplItem::Type(type_decl) => type_decl.parse(ctx),
-        });
-    }
-}
-
-impl Parse for ParsedDeclId<ImplSelf> {
-    fn parse(&self, ctx: &ParseContext) {
-        let impl_self = ctx.engines.pe().get_impl_self(self);
         if let TypeInfo::Custom {
             qualified_call_path,
             type_arguments,
             root_type_id: _,
-        } = &&*ctx.engines.te().get(impl_self.implementing_for.type_id)
+        } = &&*ctx
+            .engines
+            .te()
+            .get(impl_self_or_trait.implementing_for.type_id)
         {
             ctx.tokens.insert(
                 ctx.ident(&qualified_call_path.call_path.suffix),
                 Token::from_parsed(
-                    AstToken::Declaration(Declaration::ImplSelf(*self)),
+                    AstToken::Declaration(Declaration::ImplSelfOrTrait(*self)),
                     SymbolKind::Struct,
                 ),
             );
             if let Some(type_arguments) = type_arguments {
                 adaptive_iter(type_arguments, |type_arg| type_arg.parse(ctx));
             }
+        } else {
+            impl_self_or_trait.implementing_for.parse(ctx);
         }
-        adaptive_iter(&impl_self.impl_type_parameters, |type_param| {
+
+        adaptive_iter(&impl_self_or_trait.impl_type_parameters, |type_param| {
             type_param.parse(ctx);
         });
-        adaptive_iter(&impl_self.items, |item| match item {
+        adaptive_iter(&impl_self_or_trait.items, |item| match item {
             ImplItem::Fn(fn_decl) => fn_decl.parse(ctx),
             ImplItem::Constant(const_decl) => const_decl.parse(ctx),
             ImplItem::Type(type_decl) => type_decl.parse(ctx),

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -82,7 +82,7 @@ impl Parse for ty::TyDecl {
             ty::TyDecl::StructDecl(decl) => decl.parse(ctx),
             ty::TyDecl::EnumDecl(decl) => collect_enum(ctx, &decl.decl_id, self),
             ty::TyDecl::EnumVariantDecl(decl) => collect_enum(ctx, decl.enum_ref.id(), self),
-            ty::TyDecl::ImplTrait(decl) => decl.parse(ctx),
+            ty::TyDecl::ImplSelfOrTrait(decl) => decl.parse(ctx),
             ty::TyDecl::AbiDecl(decl) => decl.parse(ctx),
             ty::TyDecl::GenericTypeForFunctionScope(decl) => decl.parse(ctx),
             ty::TyDecl::ErrorRecovery(_, _) => {}
@@ -719,10 +719,10 @@ impl Parse for ty::StructDecl {
     }
 }
 
-impl Parse for ty::ImplTrait {
+impl Parse for ty::ImplSelfOrTrait {
     fn parse(&self, ctx: &ParseContext) {
-        let impl_trait_decl = ctx.engines.de().get_impl_trait(&self.decl_id);
-        let ty::TyImplTrait {
+        let impl_trait_decl = ctx.engines.de().get_impl_self_or_trait(&self.decl_id);
+        let ty::TyImplSelfOrTrait {
             impl_type_parameters,
             trait_name,
             trait_type_arguments,
@@ -754,9 +754,9 @@ impl Parse for ty::ImplTrait {
             .tokens
             .try_get_mut_with_retry(&ctx.ident(&trait_name.suffix))
         {
-            token.typed = Some(TypedAstToken::TypedDeclaration(ty::TyDecl::ImplTrait(
-                self.clone(),
-            )));
+            token.typed = Some(TypedAstToken::TypedDeclaration(
+                ty::TyDecl::ImplSelfOrTrait(self.clone()),
+            ));
             token.type_def = if let Some(decl_ref) = &trait_decl_ref {
                 typed_token = Some(TypedAstToken::TypedArgument(implementing_for.clone()));
                 match &decl_ref.id().clone() {


### PR DESCRIPTION
## Description

This PR unifies the AST representation for the parsed and typed `impl self` and `impl trait` declarations.

Previously we had a parsed node for `impl self`, which was converted into a `impl trait` typed node.
Now we are doing the same for the parsed nodes and using a unified `ImplSelfOrTrait` node.

This will make it possible for https://github.com/FuelLabs/sway/pull/6245 to store the parsed decl id relationship for this node.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
