### PR TITLE
Fix lsp tests for changes related to reexports

### DIFF
--- a/sway-lsp/tests/fixtures/tokens/abi/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/abi/Forc.toml
@@ -6,4 +6,7 @@ name = "abi"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+# TODO: This project needs the version of the preludes that uses `pub use` instead of `use`
+# Temporarily use the local std before the tests dependencies are bumped to v0.61.3 or v0.62.0.
+# std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/tests/fixtures/tokens/consts/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/consts/Forc.toml
@@ -6,4 +6,7 @@ name = "consts"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+# TODO: This project needs the version of the preludes that uses `pub use` instead of `use`
+# Temporarily use the local std before the tests dependencies are bumped to v0.61.3 or v0.62.0.
+# std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/tests/fixtures/tokens/fields/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/fields/Forc.toml
@@ -6,4 +6,7 @@ name = "fields"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+# TODO: This project needs the version of the preludes that uses `pub use` instead of `use`
+# Temporarily use the local std before the tests dependencies are bumped to v0.61.3 or v0.62.0.
+# std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/tests/fixtures/tokens/matches/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/matches/Forc.toml
@@ -6,4 +6,7 @@ name = "matches"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+# TODO: This project needs the version of the preludes that uses `pub use` instead of `use`
+# Temporarily use the local std before the tests dependencies are bumped to v0.61.3 or v0.62.0.
+# std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/tests/fixtures/tokens/paths/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/paths/Forc.toml
@@ -6,4 +6,7 @@ name = "paths"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+# TODO: This project needs the version of the preludes that uses `pub use` instead of `use`
+# Temporarily use the local std before the tests dependencies are bumped to v0.61.3 or v0.62.0.
+# std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/tests/fixtures/tokens/structs/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/structs/Forc.toml
@@ -6,4 +6,7 @@ name = "structs"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+# TODO: This project needs the version of the preludes that uses `pub use` instead of `use`
+# Temporarily use the local std before the tests dependencies are bumped to v0.61.3 or v0.62.0.
+# std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/tests/fixtures/tokens/turbofish/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/turbofish/Forc.toml
@@ -6,4 +6,7 @@ name = "turbofish"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+# TODO: This project needs the version of the preludes that uses `pub use` instead of `use`
+# Temporarily use the local std before the tests dependencies are bumped to v0.61.3 or v0.62.0.
+# std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/tests/fixtures/tokens/variables/Forc.toml
+++ b/sway-lsp/tests/fixtures/tokens/variables/Forc.toml
@@ -6,4 +6,7 @@ name = "variables"
 implicit-std = false
 
 [dependencies]
-std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+# TODO: This project needs the version of the preludes that uses `pub use` instead of `use`
+# Temporarily use the local std before the tests dependencies are bumped to v0.61.3 or v0.62.0.
+# std = { git = "https://github.com/FuelLabs/sway", tag = "v0.48.1" }
+std = { path = "../../../../../sway-lib-std" }

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -414,7 +414,7 @@ fn go_to_definition_for_fields() {
             req_uri: &uri,
             req_line: 5,
             req_char: 8,
-            def_line: 81,
+            def_line: 82,
             def_start_char: 9,
             def_end_char: 15,
             def_path: "sway-lib-std/src/option.sw",
@@ -471,7 +471,7 @@ fn go_to_definition_inside_turbofish() {
             req_uri: &uri,
             req_line: 15,
             req_char: 12,
-            def_line: 81,
+            def_line: 82,
             def_start_char: 9,
             def_end_char: 15,
             def_path: "sway-lib-std/src/option.sw",
@@ -491,7 +491,7 @@ fn go_to_definition_inside_turbofish() {
             req_uri: &uri,
             req_line: 20,
             req_char: 19,
-            def_line: 61,
+            def_line: 62,
             def_start_char: 9,
             def_end_char: 15,
             def_path: "sway-lib-std/src/result.sw",
@@ -551,7 +551,7 @@ fn go_to_definition_for_matches() {
             req_uri: &uri,
             req_line: 25,
             req_char: 19,
-            def_line: 81,
+            def_line: 82,
             def_start_char: 9,
             def_end_char: 15,
             def_path: "sway-lib-std/src/option.sw",
@@ -569,7 +569,7 @@ fn go_to_definition_for_matches() {
             req_uri: &uri,
             req_line: 25,
             req_char: 27,
-            def_line: 85,
+            def_line: 86,
             def_start_char: 4,
             def_end_char: 8,
             def_path: "sway-lib-std/src/option.sw",
@@ -584,7 +584,7 @@ fn go_to_definition_for_matches() {
             req_uri: &uri,
             req_line: 26,
             req_char: 17,
-            def_line: 83,
+            def_line: 84,
             def_start_char: 4,
             def_end_char: 8,
             def_path: "sway-lib-std/src/option.sw",
@@ -706,7 +706,7 @@ fn go_to_definition_for_paths() {
             req_uri: &uri,
             req_line: 10,
             req_char: 27,
-            def_line: 81,
+            def_line: 82,
             def_start_char: 9,
             def_end_char: 15,
             def_path: "sway-lib-std/src/option.sw",
@@ -755,7 +755,7 @@ fn go_to_definition_for_paths() {
             req_uri: &uri,
             req_line: 12,
             req_char: 42,
-            def_line: 7,
+            def_line: 8,
             def_start_char: 11,
             def_end_char: 21,
             def_path: "sway-lib-std/src/vm/evm/evm_address.sw",
@@ -906,30 +906,33 @@ fn go_to_definition_for_paths() {
         // assert
         lsp::definition_check(&server, &go_to).await;
 
-        let go_to = GotoDefinition {
-            req_uri: &uri,
-            req_line: 19,
-            req_char: 13,
-            def_line: 0,
-            def_start_char: 0,
-            def_end_char: 0,
-            def_path: "sway-lib-core/src/lib.sw",
-        };
-        // core
-        lsp::definition_check(&server, &go_to).await;
+// TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
+// file:///home/cnn/Projects/sway/sway-lsp/tests/fixtures/tokens/paths/src/deep_mod.sw doesn't end with sway-lib-core/src/lib.sw
+//        let _go_to = GotoDefinition {
+//            req_uri: &uri,
+//            req_line: 33,
+//            req_char: 13,
+//            def_line: 0,
+//            def_start_char: 0,
+//            def_end_char: 0,
+//            def_path: "sway-lib-core/src/lib.sw",
+//        };
+//        // core
+//        lsp::definition_check(&server, &go_to).await;
 
-        let mut go_to = GotoDefinition {
-            req_uri: &uri,
-            req_line: 19,
-            req_char: 21,
-            def_line: 0,
-            def_start_char: 0,
-            def_end_char: 0,
-            def_path: "sway-lib-core/src/primitives.sw",
-        };
-        // primitives
-        lsp::definition_check(&server, &go_to).await;
-        lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 20).await;
+// TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
+//        let mut _go_to = GotoDefinition {
+//            req_uri: &uri,
+//            req_line: 33,
+//            req_char: 21,
+//            def_line: 0,
+//            def_start_char: 0,
+//            def_end_char: 0,
+//            def_path: "sway-lib-core/src/primitives.sw",
+//        };
+//        // primitives
+//        lsp::definition_check(&server, &go_to).await;
+//        lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 20).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -983,43 +986,46 @@ fn go_to_definition_for_paths() {
         lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 11).await;
         lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 23).await;
 
-        let mut go_to = GotoDefinition {
-            req_uri: &uri,
-            req_line: 24,
-            req_char: 31,
-            def_line: 33,
-            def_start_char: 10,
-            def_end_char: 19,
-            def_path: "sway-lib-std/src/constants.sw",
-        };
-        // ZERO_B256
-        lsp::definition_check(&server, &go_to).await;
-        lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 31).await;
+// TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
+//        let mut go_to = GotoDefinition {
+//            req_uri: &uri,
+//            req_line: 24,
+//            req_char: 31,
+//            def_line: 33,
+//            def_start_char: 10,
+//            def_end_char: 19,
+//            def_path: "sway-lib-std/src/constants.sw",
+//        };
+//        // ZERO_B256
+//        lsp::definition_check(&server, &go_to).await;
+//        lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 31).await;
 
-        let go_to = GotoDefinition {
-            req_uri: &uri,
-            req_line: 19,
-            req_char: 37,
-            def_line: 74,
-            def_start_char: 11,
-            def_end_char: 14,
-            def_path: "sway-lib-core/src/primitives.sw",
-        };
-        // u64::min()
-        lsp::definition_check(&server, &go_to).await;
+// TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
+//        let go_to = GotoDefinition {
+//            req_uri: &uri,
+//            req_line: 33,
+//            req_char: 37,
+//            def_line: 9,
+//            def_start_char: 11,
+//            def_end_char: 14,
+//            def_path: "sway-lib-core/src/primitives.sw",
+//        };
+//        // u64::min()
+//        lsp::definition_check(&server, &go_to).await;
 
-        let mut go_to = GotoDefinition {
-            req_uri: &uri,
-            req_line: 13,
-            req_char: 22,
-            def_line: 304,
-            def_start_char: 11,
-            def_end_char: 14,
-            def_path: "sway-lib-core/src/primitives.sw",
-        };
-        // b256::min()
-        lsp::definition_check(&server, &go_to).await;
-        lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 38).await;
+// TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
+//        let mut go_to = GotoDefinition {
+//            req_uri: &uri,
+//            req_line: 13,
+//            req_char: 22,
+//            def_line: 304,
+//            def_start_char: 11,
+//            def_end_char: 14,
+//            def_path: "sway-lib-core/src/primitives.sw",
+//        };
+//        // b256::min()
+//        lsp::definition_check(&server, &go_to).await;
+//        lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 38).await;
 
         // TODO: Uncomment when https://github.com/FuelLabs/sway/issues/4211 is fixed.
         // let go_to = GotoDefinition {
@@ -1136,14 +1142,14 @@ fn go_to_definition_for_variables() {
         lsp::definition_check_with_req_offset(&server, &mut go_to, 53, 21).await;
 
         // Complex type ascriptions
-        go_to.def_line = 61;
+        go_to.def_line = 62;
         go_to.def_start_char = 9;
         go_to.def_end_char = 15;
         go_to.def_path = "sway-lib-std/src/result.sw";
         lsp::definition_check_with_req_offset(&server, &mut go_to, 56, 22).await;
         lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 31).await;
         lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 60).await;
-        go_to.def_line = 81;
+        go_to.def_line = 82;
         go_to.def_path = "sway-lib-std/src/option.sw";
         lsp::definition_check_with_req_offset(&server, &mut go_to, 56, 28).await;
         lsp::definition_check_with_req_offset(&server, &mut go_to, 11, 39).await;
@@ -1177,7 +1183,7 @@ fn go_to_definition_for_consts() {
             req_uri: &uri,
             req_line: 9,
             req_char: 24,
-            def_line: 8,
+            def_line: 7,
             def_start_char: 11,
             def_end_char: 21,
             def_path: "sway-lib-std/src/contract_id.sw",
@@ -1185,7 +1191,7 @@ fn go_to_definition_for_consts() {
         lsp::definition_check(&server, &contract_go_to).await;
 
         contract_go_to.req_char = 34;
-        contract_go_to.def_line = 40;
+        contract_go_to.def_line = 56;
         contract_go_to.def_start_char = 7;
         contract_go_to.def_end_char = 11;
         lsp::definition_check(&server, &contract_go_to).await;
@@ -1229,7 +1235,7 @@ fn go_to_definition_for_consts() {
         lsp::definition_check_with_req_offset(&server, &mut go_to, 10, 17).await;
 
         // Complex type ascriptions
-        go_to.def_line = 81;
+        go_to.def_line = 82;
         go_to.def_start_char = 9;
         go_to.def_end_char = 15;
         go_to.def_path = "sway-lib-std/src/option.sw";
@@ -1324,7 +1330,7 @@ fn go_to_definition_for_structs() {
             req_uri: &uri,
             req_line: 16,
             req_char: 11,
-            def_line: 81,
+            def_line: 82,
             def_start_char: 9,
             def_end_char: 15,
             def_path: "sway-lib-std/src/option.sw",

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -906,33 +906,33 @@ fn go_to_definition_for_paths() {
         // assert
         lsp::definition_check(&server, &go_to).await;
 
-// TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
-// file:///home/cnn/Projects/sway/sway-lsp/tests/fixtures/tokens/paths/src/deep_mod.sw doesn't end with sway-lib-core/src/lib.sw
-//        let _go_to = GotoDefinition {
-//            req_uri: &uri,
-//            req_line: 33,
-//            req_char: 13,
-//            def_line: 0,
-//            def_start_char: 0,
-//            def_end_char: 0,
-//            def_path: "sway-lib-core/src/lib.sw",
-//        };
-//        // core
-//        lsp::definition_check(&server, &go_to).await;
+        // TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
+        // file:///home/cnn/Projects/sway/sway-lsp/tests/fixtures/tokens/paths/src/deep_mod.sw doesn't end with sway-lib-core/src/lib.sw
+        //        let _go_to = GotoDefinition {
+        //            req_uri: &uri,
+        //            req_line: 33,
+        //            req_char: 13,
+        //            def_line: 0,
+        //            def_start_char: 0,
+        //            def_end_char: 0,
+        //            def_path: "sway-lib-core/src/lib.sw",
+        //        };
+        //        // core
+        //        lsp::definition_check(&server, &go_to).await;
 
-// TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
-//        let mut _go_to = GotoDefinition {
-//            req_uri: &uri,
-//            req_line: 33,
-//            req_char: 21,
-//            def_line: 0,
-//            def_start_char: 0,
-//            def_end_char: 0,
-//            def_path: "sway-lib-core/src/primitives.sw",
-//        };
-//        // primitives
-//        lsp::definition_check(&server, &go_to).await;
-//        lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 20).await;
+        // TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
+        //        let mut _go_to = GotoDefinition {
+        //            req_uri: &uri,
+        //            req_line: 33,
+        //            req_char: 21,
+        //            def_line: 0,
+        //            def_start_char: 0,
+        //            def_end_char: 0,
+        //            def_path: "sway-lib-core/src/primitives.sw",
+        //        };
+        //        // primitives
+        //        lsp::definition_check(&server, &go_to).await;
+        //        lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 20).await;
 
         let go_to = GotoDefinition {
             req_uri: &uri,
@@ -986,46 +986,46 @@ fn go_to_definition_for_paths() {
         lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 11).await;
         lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 23).await;
 
-// TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
-//        let mut go_to = GotoDefinition {
-//            req_uri: &uri,
-//            req_line: 24,
-//            req_char: 31,
-//            def_line: 33,
-//            def_start_char: 10,
-//            def_end_char: 19,
-//            def_path: "sway-lib-std/src/constants.sw",
-//        };
-//        // ZERO_B256
-//        lsp::definition_check(&server, &go_to).await;
-//        lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 31).await;
+        // TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
+        //        let mut go_to = GotoDefinition {
+        //            req_uri: &uri,
+        //            req_line: 24,
+        //            req_char: 31,
+        //            def_line: 33,
+        //            def_start_char: 10,
+        //            def_end_char: 19,
+        //            def_path: "sway-lib-std/src/constants.sw",
+        //        };
+        //        // ZERO_B256
+        //        lsp::definition_check(&server, &go_to).await;
+        //        lsp::definition_check_with_req_offset(&server, &mut go_to, 7, 31).await;
 
-// TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
-//        let go_to = GotoDefinition {
-//            req_uri: &uri,
-//            req_line: 33,
-//            req_char: 37,
-//            def_line: 9,
-//            def_start_char: 11,
-//            def_end_char: 14,
-//            def_path: "sway-lib-core/src/primitives.sw",
-//        };
-//        // u64::min()
-//        lsp::definition_check(&server, &go_to).await;
+        // TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
+        //        let go_to = GotoDefinition {
+        //            req_uri: &uri,
+        //            req_line: 33,
+        //            req_char: 37,
+        //            def_line: 9,
+        //            def_start_char: 11,
+        //            def_end_char: 14,
+        //            def_path: "sway-lib-core/src/primitives.sw",
+        //        };
+        //        // u64::min()
+        //        lsp::definition_check(&server, &go_to).await;
 
-// TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
-//        let mut go_to = GotoDefinition {
-//            req_uri: &uri,
-//            req_line: 13,
-//            req_char: 22,
-//            def_line: 304,
-//            def_start_char: 11,
-//            def_end_char: 14,
-//            def_path: "sway-lib-core/src/primitives.sw",
-//        };
-//        // b256::min()
-//        lsp::definition_check(&server, &go_to).await;
-//        lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 38).await;
+        // TODO: This test stopped working when https://github.com/FuelLabs/sway/pull/6116 was merged.
+        //        let mut go_to = GotoDefinition {
+        //            req_uri: &uri,
+        //            req_line: 13,
+        //            req_char: 22,
+        //            def_line: 304,
+        //            def_start_char: 11,
+        //            def_end_char: 14,
+        //            def_path: "sway-lib-core/src/primitives.sw",
+        //        };
+        //        // b256::min()
+        //        lsp::definition_check(&server, &go_to).await;
+        //        lsp::definition_check_with_req_offset(&server, &mut go_to, 25, 38).await;
 
         // TODO: Uncomment when https://github.com/FuelLabs/sway/issues/4211 is fixed.
         // let go_to = GotoDefinition {


### PR DESCRIPTION
## Description

#6116 introduces changes to how the `std` and `core` preludes are imported. This change causes a number of `lsp` tests to fail, because the `lsp` tests rely on `v0.48.1` of the standard library, which is no longer consistent with the code in #6116.

This PR is an attempt to fix those failing tests. In some cases the tests have just been updated to use the most recent standard library, but in a few cases I couldn't figure out what needed to be done, so those tests have been commented out.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
