### PR TITLE
Cache Build Plans in language server

### DIFF
--- a/sway-lsp/src/core/session.rs
+++ b/sway-lsp/src/core/session.rs
@@ -231,7 +231,7 @@ impl Session {
 }
 
 /// Create a [BuildPlan] from the given [Url] appropriate for the language server.
-pub(crate) fn build_plan(uri: &Url) -> Result<BuildPlan, LanguageServerError> {
+pub fn build_plan(uri: &Url) -> Result<BuildPlan, LanguageServerError> {
     let _p = tracing::trace_span!("build_plan").entered();
     let manifest_dir = PathBuf::from(uri.path());
     let manifest =

--- a/sway-lsp/src/core/sync.rs
+++ b/sway-lsp/src/core/sync.rs
@@ -175,7 +175,7 @@ impl SyncWorkspace {
             .ok()
     }
 
-    pub(crate) fn manifest_path(&self) -> Option<PathBuf> {
+    pub fn manifest_path(&self) -> Option<PathBuf> {
         self.manifest_dir()
             .map(|dir| dir.join(sway_utils::constants::MANIFEST_FILE_NAME))
             .ok()

--- a/sway-lsp/src/error.rs
+++ b/sway-lsp/src/error.rs
@@ -14,6 +14,8 @@ pub enum LanguageServerError {
     // Top level errors
     #[error("Failed to create build plan. {0}")]
     BuildPlanFailed(anyhow::Error),
+    #[error("Build Plan Cache is empty")]
+    BuildPlanCacheIsEmpty,
     #[error("Failed to compile. {0}")]
     FailedToCompile(anyhow::Error),
     #[error("Failed to parse document")]

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -2,7 +2,7 @@
 //! Protocol. This module specifically handles requests.
 
 use crate::{
-    capabilities, core::session::build_plan, lsp_ext, server_state::ServerState, utils::debug,
+    capabilities, core::session::build_plan, lsp_ext, server_state::ServerState, utils::debug
 };
 use forc_tracing::{tracing_subscriber, FmtSpan, StdioTracingWriter, TracingWriterMode};
 use lsp_types::{

--- a/sway-lsp/src/handlers/request.rs
+++ b/sway-lsp/src/handlers/request.rs
@@ -2,7 +2,7 @@
 //! Protocol. This module specifically handles requests.
 
 use crate::{
-    capabilities, core::session::build_plan, lsp_ext, server_state::ServerState, utils::debug
+    capabilities, core::session::build_plan, lsp_ext, server_state::ServerState, utils::debug,
 };
 use forc_tracing::{tracing_subscriber, FmtSpan, StdioTracingWriter, TracingWriterMode};
 use lsp_types::{


### PR DESCRIPTION
## Description
closes #5462
related #5445

before we were recreating the build plan on every keystroke. We now cache the result and reuse on subsequent did change events. We invalidate the cache if there has been any modifications to the `Forc.toml` file since the cache was created.

Here are the timings when triggering this with a did_change event on the FUSD repo.

previous: `80.146ms`
with this change: `56µs`
