### PR TITLE
cache pid lock files to reduce IO operations

### DIFF
--- a/sway-lsp/src/server.rs
+++ b/sway-lsp/src/server.rs
@@ -2,7 +2,6 @@
 //! It provides an interface between the LSP protocol and the sway-lsp internals.
 
 use crate::{
-    core::document,
     handlers::{notification, request},
     lsp_ext::{MetricsParams, OnEnterParams, ShowAstParams, VisualizeParams},
     server_state::ServerState,
@@ -43,7 +42,10 @@ impl LanguageServer for ServerState {
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
-        if let Err(err) = document::remove_dirty_flag(&params.text_document.uri) {
+        if let Err(err) = self
+            .pid_locked_files
+            .remove_dirty_flag(&params.text_document.uri)
+        {
             tracing::error!("{}", err.to_string());
         }
     }

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -3,7 +3,7 @@
 use crate::{
     config::{Config, GarbageCollectionConfig, Warnings},
     core::{
-        document::Documents,
+        document::{Documents, PidLockedFiles},
         session::{self, Session},
     },
     error::{DirectoryError, DocumentError, LanguageServerError},
@@ -49,6 +49,7 @@ pub struct ServerState {
     pub(crate) cb_tx: Sender<TaskMessage>,
     pub(crate) cb_rx: Arc<Receiver<TaskMessage>>,
     pub(crate) finished_compilation: Arc<Notify>,
+    pub(crate) pid_locked_files: PidLockedFiles,
     last_compilation_state: Arc<RwLock<LastCompilationState>>,
 }
 
@@ -66,6 +67,7 @@ impl Default for ServerState {
             cb_tx,
             cb_rx: Arc::new(cb_rx),
             finished_compilation: Arc::new(Notify::new()),
+            pid_locked_files: PidLockedFiles::new(),
             last_compilation_state: Arc::new(RwLock::new(LastCompilationState::Uninitialized)),
         };
         // Spawn a new thread dedicated to handling compilation tasks


### PR DESCRIPTION
## Description
Implements a new `PidLockedFiles` type for efficient file locking. Before this we were doing file IO on every did change key press event. We now cache the results for efficiency. 
