### PR TITLE
chore: correction typos index.md

### DIFF
--- a/docs/book/src/index.md
+++ b/docs/book/src/index.md
@@ -59,11 +59,11 @@ You can find example applications built with Sway in the [Sway Applications repo
 
 **Q: What is the standard library?**
 
-The [standard library](./introduction/standard_library.md), also referred to as `std`, is a library that offers core functions and helpers for developing in Sway. The standard library has it's own [reference documentation](https://fuellabs.github.io/sway/master/std/) that has detailed information about each module in `std`.
+The [standard library](./introduction/standard_library.md), also referred to as `std`, is a library that offers core functions and helpers for developing in Sway. The standard library has its own [reference documentation](https://fuellabs.github.io/sway/master/std/) that has detailed information about each module in `std`.
 
 **Q: What are Sway standards?**
 
-Similar to ERC standards for Ethereum and Solidity, Sway has it's own SRC standards that help enable cross compatibility across different smart contracts. For more information on using a Sway Standard, you can check out the [Sway-Standards Repository](https://github.com/FuelLabs/sway-standards).
+Similar to ERC standards for Ethereum and Solidity, Sway has its own SRC standards that help enable cross compatibility across different smart contracts. For more information on using a Sway Standard, you can check out the [Sway-Standards Repository](https://github.com/FuelLabs/sway-standards).
 
 **Q: How can I make a token?**
 


### PR DESCRIPTION
correction grammar errors

_The standard library has **it's** own reference documentation that has detailed information about each module in std._ => _The standard library has **its** own reference documentation that has detailed information about each module in std._

"it's" should be corrected to "its". "It's" is a contraction for "it is", while "its" is the possessive form.



_Similar to ERC standards for Ethereum and Solidity, Sway has **it's** own SRC standards..._ => _Similar to ERC standards for Ethereum and Solidity, Sway has **its** own SRC standards..._

"it's" should be corrected to "its".

## Description


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
