### PR TITLE
Handle case when `Bytes` appends to `self`

### DIFF
--- a/sway-lib-std/src/bytes.sw
+++ b/sway-lib-std/src/bytes.sw
@@ -700,6 +700,10 @@ impl Bytes {
             return;
         };
 
+        if self.buf.ptr == other.buf.ptr {
+            return
+        };
+
         let both_len = self.len + other_len;
         let other_start = self.len;
 

--- a/test/src/in_language_tests/test_programs/bytes_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/bytes_inline_tests/src/main.sw
@@ -767,6 +767,35 @@ fn bytes_append_to_empty() {
     };
 }
 
+
+#[test()]
+fn bytes_append_self() {
+    let (mut bytes, a, b, c) = setup();
+    assert(bytes.len() == 3);
+    assert(bytes.get(0).unwrap() == a);
+    assert(bytes.get(1).unwrap() == b);
+    assert(bytes.get(2).unwrap() == c);
+
+    let length = bytes.len();
+    let capacity = bytes.capacity();
+
+    bytes.append(bytes);
+
+    assert(bytes.len() == length);
+    assert(bytes.capacity() == capacity);
+    let values = [a, b, c];
+    let mut i = 0;
+    while i < 3 {
+        assert(bytes.get(i).unwrap() == values[i]);
+        i += 1;
+    };
+
+    let mut empty_bytes = Bytes::new();
+    empty_bytes.append(empty_bytes);
+    assert(empty_bytes.len() == 0);
+    assert(empty_bytes.capacity() == 0);
+}
+
 #[test()]
 fn bytes_eq() {
     let (mut bytes, _a, _b, _c) = setup();


### PR DESCRIPTION
## Description

When calling `self.append(self)` for `Bytes`, we experienced undefined behavior as the logic would clear `self`. Now if this case is encountered, nothing is appended or cleared and `self` is returned.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
