### PR TITLE
Fixes overflow in numeric literals.

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u16_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u16_overflow/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = "core"
+source = "path+from-root-F27494A331759FBF"
+
+[[package]]
+name = "numerics_u16_overflow"
+source = "member"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u16_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u16_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "numerics_u16_overflow"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u16_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u16_overflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+fn main() {
+ let mut a0 = 65535; //2^16-1
+ let _x0: u16 = a0;
+
+ let mut a1 = 65536; //2^16
+ let _x1: u16 = a1;
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u16_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u16_overflow/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: $()let mut a1 = 65536; //2^16
+# nextln: $()Literal value is too large for type u16.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u32_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u32_overflow/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = "core"
+source = "path+from-root-1AB6296909947AEE"
+
+[[package]]
+name = "numerics_u32_overflow"
+source = "member"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u32_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u32_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "numerics_u32_overflow"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u32_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u32_overflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+fn main() {
+ let mut a0 = 4294967295; //2^32-1
+ let _x0: u32 = a0;
+
+ let mut a1 = 4294967296; //2^32
+ let _x1: u32 = a1;
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u32_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u32_overflow/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+# check: $()Literal value is too large for type u32.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u8_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u8_overflow/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = "core"
+source = "path+from-root-F921B5701856DAD9"
+
+[[package]]
+name = "numerics_u8_overflow"
+source = "member"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u8_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u8_overflow/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "numerics_u8_overflow"
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u8_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u8_overflow/src/main.sw
@@ -1,0 +1,9 @@
+script;
+
+fn main() {
+ let mut a0 = 255; //2^8-1
+ let _x0: u8 = a0;
+
+ let mut a1 = 256; //2^8
+ let _x1: u8 = a1;
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u8_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/numerics_u8_overflow/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: $()let mut a1 = 256; //2^8
+# nextln: $()Literal value is too large for type u8.


### PR DESCRIPTION
## Description

When we do unification after the variable declaration of numeric, values of u64 were permitted. The compiler allowed those values to be used in u8, u16, and u32, potentially causing overflows.

The solution was to perform a last line of defense check against overflows in the backend where the literals have the return type resolved to the proper uint.

Fixes #6373

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
