### PR TITLE
Reduces memory footprint of collecting unifications.

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -44,6 +44,11 @@ impl ty::TyCodeBlock {
         }
 
         ctx.engines.te().clear_unifications();
+        ctx.namespace()
+            .module(ctx.engines)
+            .current_lexical_scope()
+            .items
+            .clear_symbols_unique_while_collecting_unifications();
 
         // We are typechecking the code block AST nodes twice.
         // The first pass does all the unifications to the variables types.

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -167,7 +167,7 @@ impl TyDecl {
                         .namespace()
                         .module(engines)
                         .current_items()
-                        .check_symbol_unique(&var_decl.name.clone())
+                        .check_symbols_unique_while_collecting_unifications(&var_decl.name.clone())
                         .ok();
 
                     if let Some(ResolvedDeclaration::Typed(ty::TyDecl::VariableDecl(

--- a/sway-core/src/semantic_analysis/namespace/lexical_scope.rs
+++ b/sway-core/src/semantic_analysis/namespace/lexical_scope.rs
@@ -704,7 +704,7 @@ impl Items {
             })
     }
 
-    pub(crate) fn check_symbol_unique(
+    pub(crate) fn check_symbols_unique_while_collecting_unifications(
         &self,
         name: &Ident,
     ) -> Result<ResolvedDeclaration, CompileError> {
@@ -716,6 +716,12 @@ impl Items {
                 name: name.clone(),
                 span: name.span(),
             })
+    }
+
+    pub(crate) fn clear_symbols_unique_while_collecting_unifications(&self) {
+        self.symbols_unique_while_collecting_unifications
+            .write()
+            .clear();
     }
 
     pub fn get_items_for_type(

--- a/sway-core/src/semantic_analysis/namespace/module.rs
+++ b/sway-core/src/semantic_analysis/namespace/module.rs
@@ -194,7 +194,7 @@ impl Module {
     }
 
     /// Returns the current lexical scope associated with this module.
-    fn current_lexical_scope(&self) -> &LexicalScope {
+    pub fn current_lexical_scope(&self) -> &LexicalScope {
         self.lexical_scopes
             .get(self.current_lexical_scope_id)
             .unwrap()


### PR DESCRIPTION
## Description
As shown in https://fuellabs.github.io/sway-performance-dashboard/ #6461 introduced a bigger memory footprint.

Lexical scope has a shared OrdMap called `symbols_unique_while_collecting_unifications` that was never cleared.
With this commit, it is cleared on each code block along with the clear of collected unifications.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
