### PR TITLE
Fixes ABI alias metadata types.

### DIFF
--- a/sway-core/src/abi_generation/abi_str.rs
+++ b/sway-core/src/abi_generation/abi_str.rs
@@ -28,10 +28,12 @@ impl TypeId {
                 &*type_engine.get(resolved_type_id),
             ) {
                 (TypeInfo::Custom { .. }, TypeInfo::Struct { .. })
-                | (TypeInfo::Custom { .. }, TypeInfo::Enum { .. })
-                | (TypeInfo::Custom { .. }, TypeInfo::Alias { .. }) => type_engine
+                | (TypeInfo::Custom { .. }, TypeInfo::Enum { .. }) => type_engine
                     .get(resolved_type_id)
                     .abi_str(ctx, engines, true),
+                (_, TypeInfo::Alias { ty, .. }) => {
+                    ty.type_id.get_abi_type_str(ctx, engines, ty.type_id)
+                }
                 (TypeInfo::Tuple(fields), TypeInfo::Tuple(resolved_fields)) => {
                     assert_eq!(fields.len(), resolved_fields.len());
                     let field_strs = resolved_fields

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_generics/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/main_args/main_args_generics/json_abi_oracle_new_encoding.json
@@ -52,7 +52,7 @@
         }
       ],
       "metadataTypeId": 0,
-      "type": "(struct TwoGenerics<u64,u32>, struct OneGeneric<u8>)"
+      "type": "(_, _)"
     },
     {
       "metadataTypeId": 1,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_alias/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_alias/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = "abi_with_alias"
+source = "member"
+dependencies = ["core"]
+
+[[package]]
+name = "core"
+source = "path+from-root-DE4DCECD674C309C"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_alias/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_alias/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+implicit-std = false
+license = "Apache-2.0"
+name = "abi_with_alias"
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_alias/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_alias/json_abi_oracle.json
@@ -1,0 +1,63 @@
+{
+  "concreteTypes": [
+    {
+      "concreteTypeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
+      "type": "()"
+    },
+    {
+      "concreteTypeId": "41bd1a98f0a59642d8f824c805b798a5f268d1f7d05808eb05c4189c493f1be0",
+      "metadataTypeId": 0,
+      "type": "(u64, u64)"
+    }
+  ],
+  "configurables": [],
+  "encodingVersion": "1",
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [
+        {
+          "concreteTypeId": "41bd1a98f0a59642d8f824c805b798a5f268d1f7d05808eb05c4189c493f1be0",
+          "name": "arg1"
+        }
+      ],
+      "name": "aliased_tuple",
+      "output": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d"
+    },
+    {
+      "attributes": null,
+      "inputs": [
+        {
+          "concreteTypeId": "41bd1a98f0a59642d8f824c805b798a5f268d1f7d05808eb05c4189c493f1be0",
+          "name": "_arg1"
+        }
+      ],
+      "name": "tuple",
+      "output": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d"
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "metadataTypes": [
+    {
+      "components": [
+        {
+          "name": "__tuple_element",
+          "typeId": 1
+        },
+        {
+          "name": "__tuple_element",
+          "typeId": 1
+        }
+      ],
+      "metadataTypeId": 0,
+      "type": "(_, _)"
+    },
+    {
+      "metadataTypeId": 1,
+      "type": "u64"
+    }
+  ],
+  "programType": "contract",
+  "specVersion": "1"
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_alias/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_alias/json_abi_oracle_new_encoding.json
@@ -1,0 +1,63 @@
+{
+  "concreteTypes": [
+    {
+      "concreteTypeId": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d",
+      "type": "()"
+    },
+    {
+      "concreteTypeId": "41bd1a98f0a59642d8f824c805b798a5f268d1f7d05808eb05c4189c493f1be0",
+      "metadataTypeId": 0,
+      "type": "(u64, u64)"
+    }
+  ],
+  "configurables": [],
+  "encodingVersion": "1",
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [
+        {
+          "concreteTypeId": "41bd1a98f0a59642d8f824c805b798a5f268d1f7d05808eb05c4189c493f1be0",
+          "name": "arg1"
+        }
+      ],
+      "name": "aliased_tuple",
+      "output": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d"
+    },
+    {
+      "attributes": null,
+      "inputs": [
+        {
+          "concreteTypeId": "41bd1a98f0a59642d8f824c805b798a5f268d1f7d05808eb05c4189c493f1be0",
+          "name": "_arg1"
+        }
+      ],
+      "name": "tuple",
+      "output": "2e38e77b22c314a449e91fafed92a43826ac6aa403ae6a8acb6cf58239fbaf5d"
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "metadataTypes": [
+    {
+      "components": [
+        {
+          "name": "__tuple_element",
+          "typeId": 1
+        },
+        {
+          "name": "__tuple_element",
+          "typeId": 1
+        }
+      ],
+      "metadataTypeId": 0,
+      "type": "(_, _)"
+    },
+    {
+      "metadataTypeId": 1,
+      "type": "u64"
+    }
+  ],
+  "programType": "contract",
+  "specVersion": "1"
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_alias/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_alias/src/main.sw
@@ -1,0 +1,15 @@
+contract;
+
+type AliasedTuple = (u64, u64);
+
+abi MyContract {
+    fn tuple(arg1: (u64, u64)); // Inline
+    fn aliased_tuple(arg1: AliasedTuple); // Alias
+}
+
+impl MyContract for Contract {
+    fn tuple(_arg1: (u64, u64)) {
+    }
+    fn aliased_tuple(arg1: AliasedTuple) {
+    }
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_alias/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/test_contracts/abi_with_alias/test.toml
@@ -1,0 +1,3 @@
+category = "compile"
+validate_abi = true
+expected_warnings = 1


### PR DESCRIPTION
## Description

Before this push, using an alias in a contract would produce an ABI with two distinct metadata types for tuples: one for `(_,_)` and another for `(u64,u64)`.

With this change, aliases are bypassed and we only produce metadata for the string type of the inner alias type. If alias is `(u64, u64)` we will produce a metadatatype for `(_,_)`.

Fixes #6488

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
