### PR TITLE
Test for contract address being a complex expression

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
@@ -8,8 +8,13 @@ const CONTRACT_ID = 0x14ed3cd06c2947248f69d54bfa681fe40d26267be84df7e19e253622b7
 #[cfg(experimental_new_encoding = true)]
 const CONTRACT_ID = 0xb7fd078d247144fb0b1505caf58ba37e1cb7a44495e135e8626fec02790b0ad4; // AUTO-CONTRACT-ID ../../test_contracts/array_of_structs_contract --release
 
+fn get_address() -> Option<std::address::Address> {
+    Some(CONTRACT_ID.into())
+}
+
 fn main() -> u64 {
-    let addr = abi(TestContract, CONTRACT_ID);
+    // Test address being a complex expression
+    let addr = abi(TestContract, get_address().unwrap().into());
 
     let input = [Wrapper {
         id: Id {


### PR DESCRIPTION
## Description

This PR improves tests for https://github.com/FuelLabs/sway/pull/6490. Now we have one contract test where the contract address comes from a complex expression.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
