### PR TITLE
Change `msg_sender()`'s `Input::Message` from sender to recipient

### DIFF
--- a/sway-lib-std/src/auth.sw
+++ b/sway-lib-std/src/auth.sw
@@ -6,13 +6,7 @@ use ::contract_id::ContractId;
 use ::identity::Identity;
 use ::option::Option::{self, *};
 use ::result::Result::{self, *};
-use ::inputs::{
-    Input,
-    input_coin_owner,
-    input_count,
-    input_message_recipient,
-    input_type,
-};
+use ::inputs::{Input, input_coin_owner, input_count, input_message_recipient, input_type,};
 use ::revert::revert;
 
 /// The error type used when an `Identity` cannot be determined.

--- a/sway-lib-std/src/auth.sw
+++ b/sway-lib-std/src/auth.sw
@@ -11,7 +11,6 @@ use ::inputs::{
     input_coin_owner,
     input_count,
     input_message_recipient,
-    input_message_sender,
     input_type,
 };
 use ::revert::revert;
@@ -163,7 +162,7 @@ pub fn caller_address() -> Result<Address, AuthError> {
                 input_coin_owner(iter)
             },
             Some(Input::Message) => {
-                input_message_sender(iter)
+                input_message_recipient(iter)
             },
             _ => {
                 // type != InputCoin or InputMessage, continue looping.

--- a/test/src/sdk-harness/test_projects/auth/mod.rs
+++ b/test/src/sdk-harness/test_projects/auth/mod.rs
@@ -108,7 +108,7 @@ async fn input_message_msg_sender_from_contract() {
     // Start building transactions
     let call_handler = instance
         .methods()
-        .returns_msg_sender_address(Address::from(*msg.sender.hash()));
+        .returns_msg_sender_address(Address::from(*msg.recipient.hash()));
     let mut tb = call_handler.transaction_builder().await.unwrap();
 
     // Inputs


### PR DESCRIPTION
## Description

The `msg_sender()` function used the `sender` of a `Input::Message` rather than the `recipient`.

Closes #6485 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
