### PR TITLE
Add support for `Transaction::Upload`, `Transaction::Upgrade`, and `Transaction::Blob`

### DIFF
--- a/sway-lib-std/src/inputs.sw
+++ b/sway-lib-std/src/inputs.sw
@@ -18,11 +18,11 @@ use ::tx::{
     tx_type,
 };
 use core::ops::Eq;
+use ::revert::revert;
 
-const GTF_INPUT_TYPE = 0x200;
+pub const GTF_INPUT_TYPE = 0x200;
 
 // GTF Opcode const selectors
-//
 // pub const GTF_INPUT_COIN_TX_ID = 0x201;
 // pub const GTF_INPUT_COIN_OUTPUT_INDEX = 0x202;
 pub const GTF_INPUT_COIN_OWNER = 0x203;
@@ -33,7 +33,7 @@ pub const GTF_INPUT_COIN_PREDICATE_LENGTH = 0x209;
 pub const GTF_INPUT_COIN_PREDICATE_DATA_LENGTH = 0x20A;
 pub const GTF_INPUT_COIN_PREDICATE = 0x20B;
 pub const GTF_INPUT_COIN_PREDICATE_DATA = 0x20C;
-
+// pub const GTF_INPUT_COIN_PREDICATE_GAS_USED = 0x20D;
 // pub const GTF_INPUT_CONTRACT_CONTRACT_ID = 0x225;
 pub const GTF_INPUT_MESSAGE_SENDER = 0x240;
 pub const GTF_INPUT_MESSAGE_RECIPIENT = 0x241;
@@ -46,6 +46,7 @@ pub const GTF_INPUT_MESSAGE_PREDICATE_DATA_LENGTH = 0x247;
 pub const GTF_INPUT_MESSAGE_DATA = 0x248;
 pub const GTF_INPUT_MESSAGE_PREDICATE = 0x249;
 pub const GTF_INPUT_MESSAGE_PREDICATE_DATA = 0x24A;
+// pub const GTF_INPUT_MESSAGE_PREDICATE_GAS_USED = 0x24B;
 
 /// The input type for a transaction.
 pub enum Input {
@@ -127,6 +128,7 @@ pub fn input_count() -> u16 {
     match tx_type() {
         Transaction::Script => __gtf::<u16>(0, GTF_SCRIPT_INPUTS_COUNT),
         Transaction::Create => __gtf::<u16>(0, GTF_CREATE_INPUTS_COUNT),
+        _ => revert(0),
     }
 }
 
@@ -158,6 +160,7 @@ fn input_pointer(index: u64) -> Option<raw_ptr> {
     match tx_type() {
         Transaction::Script => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_INPUT_AT_INDEX)),
         Transaction::Create => Some(__gtf::<raw_ptr>(index, GTF_CREATE_INPUT_AT_INDEX)),
+        _ => None,
     }
 }
 

--- a/sway-lib-std/src/outputs.sw
+++ b/sway-lib-std/src/outputs.sw
@@ -111,6 +111,7 @@ fn output_pointer(index: u64) -> Option<raw_ptr> {
     match tx_type() {
         Transaction::Script => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_OUTPUT_AT_INDEX)),
         Transaction::Create => Some(__gtf::<raw_ptr>(index, GTF_CREATE_OUTPUT_AT_INDEX)),
+        _ => None,
     }
 }
 
@@ -139,6 +140,7 @@ pub fn output_count() -> u16 {
     match tx_type() {
         Transaction::Script => __gtf::<u16>(0, GTF_SCRIPT_OUTPUTS_COUNT),
         Transaction::Create => __gtf::<u16>(0, GTF_CREATE_OUTPUTS_COUNT),
+        _ => revert(0),
     }
 }
 

--- a/test/src/in_language_tests/Forc.toml
+++ b/test/src/in_language_tests/Forc.toml
@@ -21,6 +21,7 @@ members = [
   "test_programs/revert_inline_tests",
   "test_programs/storage_key_inline_tests",
   "test_programs/string_inline_tests",
+  "test_programs/tx_inline_tests",
   "test_programs/u128_inline_tests",
   "test_programs/vec_inline_tests",
   "test_programs/array_conversions_b256_inline_tests",

--- a/test/src/in_language_tests/test_programs/tx_inline_tests/Forc.toml
+++ b/test/src/in_language_tests/test_programs/tx_inline_tests/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "tx_inline_tests"
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/test/src/in_language_tests/test_programs/tx_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/tx_inline_tests/src/main.sw
@@ -1,0 +1,129 @@
+library;
+
+use std::tx::Transaction;
+
+#[test]
+fn tx_transaction_eq() {
+    let transaction_1 = Transaction::Script;
+    let transaction_2 = Transaction::Script;
+    let transaction_3 = Transaction::Create;
+    let transaction_4 = Transaction::Create;
+    let transaction_5 = Transaction::Mint;
+    let transaction_6 = Transaction::Mint;
+    let transaction_7 = Transaction::Upgrade;
+    let transaction_8 = Transaction::Upgrade;
+    let transaction_9 = Transaction::Upload;
+    let transaction_10 = Transaction::Upload;
+    let transaction_11 = Transaction::Blob;
+    let transaction_12 = Transaction::Blob;
+
+    assert(transaction_1 == transaction_1);
+    assert(transaction_1 == transaction_2);
+    assert(transaction_2 == transaction_2);
+
+    assert(transaction_3 == transaction_3);
+    assert(transaction_3 == transaction_4);
+    assert(transaction_4 == transaction_4);
+
+    assert(transaction_5 == transaction_5);
+    assert(transaction_5 == transaction_6);
+    assert(transaction_6 == transaction_6);
+
+    assert(transaction_7 == transaction_7);
+    assert(transaction_7 == transaction_8);
+    assert(transaction_8 == transaction_8);
+
+    assert(transaction_9 == transaction_9);
+    assert(transaction_9 == transaction_10);
+    assert(transaction_10 == transaction_10);
+
+    assert(transaction_11 == transaction_11);
+    assert(transaction_11 == transaction_12);
+    assert(transaction_12 == transaction_12);
+}
+
+#[test]
+fn tx_transaction_ne() {
+    let transaction_1 = Transaction::Script;
+    let transaction_2 = Transaction::Script;
+    let transaction_3 = Transaction::Create;
+    let transaction_4 = Transaction::Create;
+    let transaction_5 = Transaction::Mint;
+    let transaction_6 = Transaction::Mint;
+    let transaction_7 = Transaction::Upgrade;
+    let transaction_8 = Transaction::Upgrade;
+    let transaction_9 = Transaction::Upload;
+    let transaction_10 = Transaction::Upload;
+    let transaction_11 = Transaction::Blob;
+    let transaction_12 = Transaction::Blob;
+
+    assert(transaction_1 != transaction_3);
+    assert(transaction_1 != transaction_4);
+    assert(transaction_1 != transaction_5);
+    assert(transaction_1 != transaction_6);
+    assert(transaction_1 != transaction_7);
+    assert(transaction_1 != transaction_8);
+    assert(transaction_1 != transaction_9);
+    assert(transaction_1 != transaction_10);
+    assert(transaction_1 != transaction_11);
+    assert(transaction_1 != transaction_12);
+
+    assert(transaction_2 != transaction_3);
+    assert(transaction_2 != transaction_4);
+    assert(transaction_2 != transaction_5);
+    assert(transaction_2 != transaction_6);
+    assert(transaction_2 != transaction_7);
+    assert(transaction_2 != transaction_8);
+    assert(transaction_2 != transaction_9);
+    assert(transaction_2 != transaction_10);
+    assert(transaction_2 != transaction_11);
+    assert(transaction_2 != transaction_12);
+
+    assert(transaction_3 != transaction_5);
+    assert(transaction_3 != transaction_6);
+    assert(transaction_3 != transaction_7);
+    assert(transaction_3 != transaction_8);
+    assert(transaction_3 != transaction_9);
+    assert(transaction_3 != transaction_10);
+    assert(transaction_3 != transaction_11);
+    assert(transaction_3 != transaction_12);
+
+    assert(transaction_4 != transaction_5);
+    assert(transaction_4 != transaction_6);
+    assert(transaction_4 != transaction_7);
+    assert(transaction_4 != transaction_8);
+    assert(transaction_4 != transaction_9);
+    assert(transaction_4 != transaction_10);
+    assert(transaction_4 != transaction_11);
+    assert(transaction_4 != transaction_12);
+
+    assert(transaction_5 != transaction_7);
+    assert(transaction_5 != transaction_8);
+    assert(transaction_5 != transaction_9);
+    assert(transaction_5 != transaction_10);
+    assert(transaction_5 != transaction_11);
+    assert(transaction_5 != transaction_12);
+
+    assert(transaction_6 != transaction_7);
+    assert(transaction_6 != transaction_8);
+    assert(transaction_6 != transaction_9);
+    assert(transaction_6 != transaction_10);
+    assert(transaction_6 != transaction_11);
+    assert(transaction_6 != transaction_12);
+
+    assert(transaction_7 != transaction_9);
+    assert(transaction_7 != transaction_10);
+    assert(transaction_7 != transaction_11);
+    assert(transaction_7 != transaction_12);
+
+    assert(transaction_8 != transaction_9);
+    assert(transaction_8 != transaction_10);
+    assert(transaction_8 != transaction_11);
+    assert(transaction_8 != transaction_12);
+
+    assert(transaction_9 != transaction_11);
+    assert(transaction_9 != transaction_12);
+
+    assert(transaction_10 != transaction_11);
+    assert(transaction_10 != transaction_12);
+}

--- a/test/src/sdk-harness/Forc.lock
+++ b/test/src/sdk-harness/Forc.lock
@@ -415,6 +415,11 @@ source = "member"
 dependencies = ["std"]
 
 [[package]]
+name = "tx_type_predicate"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
 name = "type_aliases"
 source = "member"
 dependencies = ["std"]

--- a/test/src/sdk-harness/Forc.toml
+++ b/test/src/sdk-harness/Forc.toml
@@ -75,6 +75,7 @@ members = [
   "test_artifacts/storage_vec/svec_u16",
   "test_artifacts/storage_vec/svec_u64",
   "test_artifacts/tx_contract",
-  "test_artifacts/tx_output_predicate",
   "test_artifacts/tx_output_contract_creation_predicate",
+  "test_artifacts/tx_output_predicate",
+  "test_artifacts/tx_type_predicate",
 ]

--- a/test/src/sdk-harness/test_artifacts/tx_type_predicate/Forc.toml
+++ b/test/src/sdk-harness/test_artifacts/tx_type_predicate/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "tx_type_predicate"
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/test/src/sdk-harness/test_artifacts/tx_type_predicate/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/tx_type_predicate/src/main.sw
@@ -1,0 +1,7 @@
+predicate;
+
+use std::tx::{tx_type, Transaction};
+
+fn main(expected_type: Transaction) -> bool {
+    tx_type() == expected_type
+}

--- a/test/src/sdk-harness/test_projects/auth/mod.rs
+++ b/test/src/sdk-harness/test_projects/auth/mod.rs
@@ -196,7 +196,7 @@ async fn can_get_predicate_address() {
 
     // Setup predicate.
     let hex_predicate_address: &str =
-        "0x188fb1615bacd24d52b1339fcfeed1ecf555d0afde44a087eebf98381c64db1b";
+        "0x8896a8f961e31af598faa2c4041d4d2745b0a11c57f8bb8bae65cff290076a74";
     let predicate_address =
         Address::from_str(hex_predicate_address).expect("failed to create Address from string");
     let predicate_bech32_address = Bech32Address::from(predicate_address);
@@ -322,7 +322,7 @@ async fn when_incorrect_predicate_address_passed() {
 async fn can_get_predicate_address_in_message() {
     // Setup predicate address.
     let hex_predicate_address: &str =
-        "0x188fb1615bacd24d52b1339fcfeed1ecf555d0afde44a087eebf98381c64db1b";
+        "0x8896a8f961e31af598faa2c4041d4d2745b0a11c57f8bb8bae65cff290076a74";
     let predicate_address =
         Address::from_str(hex_predicate_address).expect("failed to create Address from string");
     let predicate_bech32_address = Bech32Address::from(predicate_address);


### PR DESCRIPTION
## Description

The current `Transaction` enum in the `tx` library does not support the new transaction types in the Fuel Specs: https://docs.fuel.network/docs/nightly/specs/tx-format/transaction/

## Changes

- Adds support for `Transaction::Upload`, `Transaction::Upgrade`, and `Transaction::Blob`.
- Implements `Eq` for `Transaction`
- Adds missing GTF opcodes. These will be implemented in another PR.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
