### PR TITLE
Update all Cargo.toml files to use workspace dependency versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,9 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
+      - name: Install clang
+        if: ${{ env.ACT }}
+        run:  dpkg -l clang || apt-get update && apt-get install -y clang
       - name: Install Forc
         run: cargo install --locked --debug --path ./forc
       - name: Initialize test project
@@ -423,32 +426,40 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
-      - name: Install toolchain
+      - name: Install Rust toolchain
+        if: ${{ !env.ACT }}
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
-      - uses: Swatinem/rust-cache@v2
+      - name: Enable Rust caching
+        if: ${{ !env.ACT }}
+        uses: Swatinem/rust-cache@v2
       - name: Install Forc
+        if: ${{ !env.ACT }}
         run: cargo install --locked --debug --path ./forc
       - name: Run benchmarks
+        if: ${{ !env.ACT }}
         run: ./benchmark.sh
       - name: Checkout benchmark data
-        if: github.event_name != 'push'
+        if: ${{ !env.ACT && github.event_name != 'push' }}
         uses: actions/checkout@v3
         with:
           repository: FuelLabs/sway-performance-data
           path: performance-data
+          token: ${{ secrets.CI_ACCOUNT_PAT }}
       - name: Checkout benchmark data
-        if: github.event_name == 'push'
+        if: ${{ !env.ACT && github.event_name == 'push' }}
         uses: actions/checkout@v3
         with:
           repository: FuelLabs/sway-performance-data
           path: performance-data
           token: ${{ secrets.CI_ACCOUNT_PAT }}
       - name: Prepare benchmarks data for commit
-        if: github.event_name == 'push'
+        if: ${{ !env.ACT && github.event_name == 'push' }}
         run: ./benchmark.sh --prepare-for-commit
-      - uses: EndBug/add-and-commit@v9
+      - name: Commit benchmark data
+        if: ${{ !env.ACT }}
+        uses: EndBug/add-and-commit@v9
         with:
           cwd: "./performance-data"
           message: "Updated benchmark data"
@@ -542,7 +553,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Rust and cargo-nextest
-        uses: moonrepo/setup-rust@v0
+        uses: moonrepo/setup-rust@v1
         with:
           channel: stable
           cache-target: release
@@ -588,7 +599,8 @@ jobs:
       - name: Install cargo-udeps
         run: cargo install --locked cargo-udeps
       - name: Check Unused Deps
-        run: cargo udeps --locked --all-targets
+        # cargo udeps will fail if the cache is empty on first go, so try one more time
+        run: cargo udeps --locked --all-targets || cargo udeps --locked --all-targets
 
   notify-slack-on-failure:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.79.0
-  NIGHTLY_RUST_VERSION: nightly-2024-07-16
+  RUST_VERSION: 1.81.0
+  NIGHTLY_RUST_VERSION: nightly-2024-09-11
 
 jobs:
   get-fuel-core-version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,7 +560,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
-      - name: Run forc tests separately 
+      - name: Run forc tests separately
         env:
           RUST_BACKTRACE: full
         run: cargo test --locked --release -p forc -- --nocapture

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,8 @@ forc-plugins/forc-debug/tests/**/Forc.lock
 examples/**/*/Forc.lock
 docs/reference/src/code/examples/**/*/Forc.lock
 
+# `act` for local GitHub Actions
+bin/act
+
 # Insta files
 *.snap.new

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,18 +14,18 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
- "gimli 0.29.0",
+ "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aes"
@@ -33,7 +33,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpufeatures",
 ]
@@ -44,7 +44,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -55,8 +55,8 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "cfg-if 1.0.0",
- "getrandom 0.2.15",
+ "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -76,6 +76,87 @@ name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d319bb544ca6caeab58c39cea8921c55d924d4f68f2c60f24f914673f9a74a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "k256",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f6c5c0a383f14519531cf58d8440e74f10b938e289f803af870be6f79223110"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "alloy-rlp",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411aff151f2a73124ee473708e82ed51b2535f68928b6a1caa8bc1246ae6f7cd"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 1.0.0",
+ "hex-literal",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "proptest",
+ "rand",
+ "ruint",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
+dependencies = [
+ "alloy-rlp-derive",
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "android-tzdata"
@@ -168,27 +249,151 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+]
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii"
@@ -220,13 +425,13 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -256,6 +461,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aurora-engine-modexp"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aef7712851e524f35fbbb74fa6599c5cd8692056a1c36f9ca0d2001b670e7e5"
+dependencies = [
+ "hex",
+ "num",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,7 +478,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -274,18 +489,18 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.36.3",
+ "object",
  "rustc-demangle",
  "serde",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -362,9 +577,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -397,27 +612,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "constant_time_eq 0.1.5",
-]
-
-[[package]]
 name = "blake3"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ec96fe9a81b5e365f9db71fe00edc4fe4ca2cc7dcb7861f0603012a7caa210"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.4",
+ "arrayvec",
  "cc",
- "cfg-if 1.0.0",
- "constant_time_eq 0.3.0",
+ "cfg-if",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -439,6 +643,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "borsh"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,10 +671,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
  "syn_derive",
 ]
 
@@ -547,6 +763,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
+name = "c-kzg"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "caseless"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808dab3318747be122cb31d36de18d4d1c81277a76f8332a02b81a3d73463d7f"
+dependencies = [
+ "regex",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,20 +795,14 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.12"
+version = "1.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68064e60dbf1f17005c2fde4d07c16d8baa506fd7ffed8ccab702d93617975c7"
+checksum = "2d74707dde2ba56f86ae90effb3b43ddd369504387e718014de010cec7959800"
 dependencies = [
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -653,7 +888,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
@@ -662,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -672,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -685,11 +920,11 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.16"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c677cd0126f3026d8b093fa29eae5d812fde5c05bc66dbb29d0374eea95113a"
+checksum = "205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0"
 dependencies = [
- "clap 4.5.16",
+ "clap 4.5.17",
 ]
 
 [[package]]
@@ -698,7 +933,7 @@ version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d494102c8ff3951810c72baf96910b980fb065ca5d3101243e6a8dc19747c86b"
 dependencies = [
- "clap 4.5.16",
+ "clap 4.5.17",
  "clap_complete",
 ]
 
@@ -711,7 +946,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -722,13 +957,11 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clipboard-win"
-version = "4.5.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
 dependencies = [
  "error-code",
- "str-buf",
- "winapi",
 ]
 
 [[package]]
@@ -739,9 +972,9 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "codspeed"
-version = "2.6.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a104ac948e0188b921eb3fcbdd55dcf62e542df4c7ab7e660623f6288302089"
+checksum = "450a0e9df9df1c154156f4344f99d8f6f6e69d0fc4de96ef6e2e68b2ec3bce97"
 dependencies = [
  "colored",
  "libc",
@@ -750,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-criterion-compat"
-version = "2.6.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722c36bdc62d9436d027256ce2627af81ac7a596dfc7d13d849d0d212448d7fe"
+checksum = "8eb1a6cb9c20e177fde58cdef97c1c7c9264eb1424fe45c4fccedc2fb078a569"
 dependencies = [
  "codspeed",
  "colored",
@@ -870,9 +1103,9 @@ checksum = "410de1ffe61368aa040f599747584e9e3d19235cf4045be6159edb167ef45ddb"
 
 [[package]]
 name = "completest-pty"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3635aa91b48c47ea30fe12fe7c04efbbf17dade642d4dbaa1e9cfbf3593eed4a"
+checksum = "fbd2f22a999db122bd2861c504aa363bbacaa32ebea29edf6924ee6cfe044313"
 dependencies = [
  "completest",
  "ptyprocess",
@@ -881,16 +1114,16 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.16.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784836d0812dade01579cc0cc9b1684847044e716fd7aa6bffbc172e42199500"
+checksum = "c93ab3577cca16b4a1d80a88c2e0cd8b6e969e51696f0bbb0d1dcb0157109832"
 dependencies = [
- "clap 4.5.16",
+ "caseless",
+ "clap 4.5.17",
+ "derive_builder",
  "entities",
  "memchr",
  "once_cell",
- "pest",
- "pest_derive",
  "regex",
  "shell-words",
  "slug",
@@ -914,6 +1147,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8a24a26d37e1ffd45343323dc9fe6654ceea44c12f2fcb3d7ac29e610bc6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,15 +1167,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -1001,15 +1241,15 @@ dependencies = [
 
 [[package]]
 name = "countme"
-version = "2.0.4"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328b822bdcba4d4e402be8d9adb6eebf269f969f8eadef977a553ff3c4fbcb58"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -1020,7 +1260,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1032,7 +1272,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.16",
+ "clap 4.5.17",
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
@@ -1061,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1173,12 +1413,12 @@ version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "rustc_version",
+ "rustc_version 0.4.1",
  "subtle",
 ]
 
@@ -1190,7 +1430,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1289,7 +1529,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1311,7 +1551,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1320,7 +1560,21 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.10",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -1396,6 +1650,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,8 +1689,29 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
- "syn 2.0.74",
+ "rustc_version 0.4.1",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1416,9 +1722,9 @@ checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
 
 [[package]]
 name = "devault"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc1d36b1abcd53bf307972de38ed2da0a57ddeb762b141420067149d3952c9a"
+checksum = "b6bd8149b97caf4a72d9dd6b09a4192fcc07c2551ef5c949ea488554a9994649"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1479,31 +1785,20 @@ checksum = "363641827cb8d8387a69364aa2f85433db83b8b00270ed2c786235d83bf0aa0a"
 
 [[package]]
 name = "dirs"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
-dependencies = [
- "libc",
- "redox_users 0.3.5",
- "winapi",
-]
-
-[[package]]
-name = "dirs"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -1512,7 +1807,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -1523,8 +1818,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users 0.4.5",
+ "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1534,7 +1841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users 0.4.5",
+ "redox_users",
  "winapi",
 ]
 
@@ -1561,6 +1868,12 @@ name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ecdsa"
@@ -1641,6 +1954,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1658,7 +1977,7 @@ version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1690,7 +2009,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1703,7 +2022,18 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1746,24 +2076,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "backtrace",
- "version_check",
-]
-
-[[package]]
 name = "error-code"
-version = "2.3.1"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
-]
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "escape8259"
@@ -1872,7 +2188,7 @@ checksum = "dd65f1b59dd22d680c7a626cc4a000c1e03d241c51c3e034d2bc9f1e90734f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1899,18 +2215,19 @@ checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
-name = "fd-lock"
-version = "2.0.0"
+name = "fastrlp"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0010f02effd88c702318c5dde0463206be67495d0b4d906ba7c0a8f166cc7f06"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
 dependencies = [
- "libc",
- "winapi",
+ "arrayvec",
+ "auto_impl",
+ "bytes",
 ]
 
 [[package]]
@@ -1919,7 +2236,7 @@ version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -1963,11 +2280,11 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "libredox 0.1.3",
  "windows-sys 0.59.0",
@@ -1993,9 +2310,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2014,7 +2331,7 @@ dependencies = [
  "annotate-snippets",
  "ansi_term",
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "clap_complete",
  "clap_complete_fig",
  "completest-pty",
@@ -2025,7 +2342,7 @@ dependencies = [
  "fs_extra",
  "fuel-asm",
  "hex",
- "rexpect 0.5.0",
+ "rexpect",
  "serde",
  "serde_json",
  "sway-core",
@@ -2035,8 +2352,8 @@ dependencies = [
  "sway-utils",
  "term-table",
  "tokio",
- "toml 0.7.8",
- "toml_edit 0.19.15",
+ "toml 0.8.19",
+ "toml_edit",
  "tracing",
  "url",
  "uwuify",
@@ -2051,7 +2368,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "clap 4.5.16",
+ "clap 4.5.17",
  "devault",
  "dialoguer",
  "forc",
@@ -2074,7 +2391,7 @@ dependencies = [
  "portpicker",
  "rand",
  "regex",
- "rexpect 0.5.0",
+ "rexpect",
  "rpassword",
  "serde",
  "serde_json",
@@ -2083,7 +2400,7 @@ dependencies = [
  "sway-utils",
  "tempfile",
  "tokio",
- "toml_edit 0.21.1",
+ "toml_edit",
  "tracing",
 ]
 
@@ -2094,7 +2411,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "clap 4.5.16",
+ "clap 4.5.17",
  "forc-tracing 0.63.5",
  "forc-util",
  "fuel-core-types",
@@ -2108,7 +2425,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha3",
- "termion",
+ "termion 4.0.2",
  "tokio",
  "tracing",
 ]
@@ -2118,7 +2435,7 @@ name = "forc-debug"
 version = "0.63.5"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "dap",
  "escargot",
  "forc-pkg",
@@ -2129,7 +2446,7 @@ dependencies = [
  "fuel-vm",
  "portpicker",
  "rayon",
- "rexpect 0.4.0",
+ "rexpect",
  "serde",
  "serde_json",
  "shellfish",
@@ -2144,7 +2461,7 @@ name = "forc-doc"
 version = "0.63.5"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "comrak",
  "dir_indexer",
  "expect-test",
@@ -2154,7 +2471,7 @@ dependencies = [
  "horrorshow",
  "include_dir",
  "minifier",
- "opener 0.5.2",
+ "opener",
  "serde",
  "serde_json",
  "sway-ast",
@@ -2169,11 +2486,11 @@ name = "forc-fmt"
 version = "0.63.5"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "forc-pkg",
  "forc-tracing 0.63.5",
  "forc-util",
- "prettydiff 0.5.1",
+ "prettydiff",
  "sway-core",
  "sway-utils",
  "swayfmt",
@@ -2186,7 +2503,7 @@ name = "forc-lsp"
 version = "0.63.5"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "sway-lsp",
  "tikv-jemallocator",
  "tokio",
@@ -2210,8 +2527,8 @@ dependencies = [
  "ipfs-api-backend-hyper",
  "petgraph",
  "regex",
- "reqwest 0.12.5",
- "semver",
+ "reqwest 0.12.7",
+ "semver 1.0.23",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -2271,7 +2588,7 @@ name = "forc-tx"
 version = "0.63.5"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "devault",
  "forc-util",
  "fuel-tx",
@@ -2288,9 +2605,9 @@ dependencies = [
  "annotate-snippets",
  "ansi_term",
  "anyhow",
- "clap 4.5.16",
- "dirs 3.0.2",
- "fd-lock 4.0.2",
+ "clap 4.5.17",
+ "dirs 5.0.1",
+ "fd-lock",
  "forc-tracing 0.63.5",
  "fuel-tx",
  "hex",
@@ -2315,7 +2632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84fb8dd372e7141efc5a63a1e6036e4ae0789774087ec9936b6cf426ef19bb16"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "eth-keystore",
  "forc-tracing 0.47.0",
  "fuel-crypto",
@@ -2328,7 +2645,7 @@ dependencies = [
  "rand",
  "rpassword",
  "serde_json",
- "termion",
+ "termion 2.0.3",
  "tiny-bip39",
  "tokio",
  "url",
@@ -2386,7 +2703,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "syn 2.0.74",
+ "syn 2.0.77",
  "thiserror",
 ]
 
@@ -2430,7 +2747,7 @@ checksum = "03ad219bde52b072a2d828f27072982047a77cc02c953ea7e83c23de586d466d"
 dependencies = [
  "anyhow",
  "cynic",
- "derive_more",
+ "derive_more 0.99.18",
  "eventsource-client",
  "fuel-core-types",
  "futures",
@@ -2500,7 +2817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f06320744b7d53bc7928d1a40a28fd697191a5b6938a353164231a3423ebdcd9"
 dependencies = [
  "anyhow",
- "derive_more",
+ "derive_more 0.99.18",
  "enum-iterator",
  "fuel-core-types",
  "fuel-vm",
@@ -2524,7 +2841,7 @@ dependencies = [
  "anyhow",
  "bs58",
  "derivative",
- "derive_more",
+ "derive_more 0.99.18",
  "fuel-vm",
  "rand",
  "secrecy",
@@ -2562,7 +2879,7 @@ checksum = "3f49fdbfc1615d88d2849650afc2b0ac2fecd69661ebadd31a073d8416747764"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
  "synstructure 0.13.1",
 ]
 
@@ -2619,7 +2936,7 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf17ce8ee5e8b573ea584c223635ff09f1288ad022bcf662954fdccb907602eb"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "digest 0.10.7",
  "fuel-storage",
  "hashbrown 0.13.2",
@@ -2642,7 +2959,7 @@ checksum = "13aae44611588d199dd119e4a0ebd8eb7ae4cde6bf8b4d12715610b1f5e5b731"
 dependencies = [
  "bitflags 2.6.0",
  "derivative",
- "derive_more",
+ "derive_more 0.99.18",
  "fuel-asm",
  "fuel-crypto",
  "fuel-merkle",
@@ -2680,7 +2997,7 @@ dependencies = [
  "backtrace",
  "bitflags 2.6.0",
  "derivative",
- "derive_more",
+ "derive_more 0.99.18",
  "ethnum",
  "fuel-asm",
  "fuel-crypto",
@@ -2737,7 +3054,7 @@ dependencies = [
  "fuels-core",
  "itertools 0.12.1",
  "rand",
- "semver",
+ "semver 1.0.23",
  "tai64",
  "thiserror",
  "tokio",
@@ -2757,7 +3074,7 @@ dependencies = [
  "quote",
  "regex",
  "serde_json",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2798,7 +3115,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2906,7 +3223,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2950,6 +3267,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb949699c3e4df3a183b1d2142cb24277057055ed23c68ed58894f76c517223"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.58.0",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,42 +3292,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "git2"
@@ -3037,9 +3350,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.9"
+version = "0.10.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d23d5bbda31344d8abc8de7c075b3cf26e5873feba7c4a15d916bce67382bd9"
+checksum = "ebfc4febd088abdcbc9f1246896e57e37b7a34f6909840045a1767c6dafac7af"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -3050,15 +3363,15 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f924267408915fddcd558e3f37295cc7d6a3e50f8bd8b606cee0808c3915157e"
+checksum = "6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b"
 
 [[package]]
 name = "gix-url"
-version = "0.27.4"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2eb9b35bba92ea8f0b5ab406fad3cf6b87f7929aa677ff10aa042c6da621156"
+checksum = "fd280c5e84fb22e128ed2a053a0daeacb6379469be6a85e3d518a0636e160c89"
 dependencies = [
  "bstr",
  "gix-features",
@@ -3074,6 +3387,19 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "globset"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
 
 [[package]]
 name = "graph-cycles"
@@ -3119,7 +3445,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3128,9 +3454,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3138,7 +3464,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3151,7 +3477,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crunchy",
 ]
 
@@ -3177,12 +3503,6 @@ checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hashbrown"
@@ -3221,19 +3541,10 @@ checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
- "rustc_version",
+ "rustc_version 0.4.1",
  "serde",
  "spin",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -3277,6 +3588,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hkdf"
@@ -3439,7 +3756,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -3482,15 +3799,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -3527,9 +3844,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3540,7 +3857,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -3556,7 +3873,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -3644,7 +3961,7 @@ dependencies = [
  "autocfg",
  "impl-tools-lib",
  "proc-macro-error",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3656,7 +3973,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3708,9 +4025,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -3730,7 +4047,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
  "inotify-sys",
  "libc",
 ]
@@ -3755,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.39.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
+checksum = "6593a41c7a73841868772495db7dc1e8ecab43bb5c0b6da2059246c4b506ab60"
 dependencies = [
  "console",
  "lazy_static",
@@ -3773,7 +4090,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -3801,7 +4118,7 @@ checksum = "9b74065805db266ba2c6edbd670b23c4714824a955628472b2e46cc9f3a869cb"
 dependencies = [
  "async-trait",
  "bytes",
- "cfg-if 1.0.0",
+ "cfg-if",
  "common-multipart-rfc7578",
  "dirs 4.0.0",
  "futures",
@@ -3821,9 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "is-terminal"
@@ -3870,6 +4187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,7 +4225,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
@@ -3914,6 +4240,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -3932,7 +4268,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -3947,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.156"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libdbus-sys"
@@ -4018,7 +4354,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.4",
 ]
 
 [[package]]
@@ -4089,7 +4425,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc0bda45ed5b3a2904262c1bb91e526127aa70e7ef3758aba2ef93cf896b9b58"
 dependencies = [
- "clap 4.5.16",
+ "clap 4.5.17",
  "escape8259",
  "termcolor",
  "threadpool",
@@ -4097,9 +4433,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.19"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
 dependencies = [
  "cc",
  "libc",
@@ -4159,12 +4495,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lsp-types"
 version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4188,14 +4537,14 @@ checksum = "b45a38e19bd200220ef07c892b0157ad3d2365e5b5a267ca01ad12182491eea5"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.5.16",
+ "clap 4.5.17",
  "clap_complete",
  "env_logger",
  "handlebars",
  "log",
  "memchr",
  "once_cell",
- "opener 0.7.2",
+ "opener",
  "pulldown-cmark",
  "regex",
  "serde",
@@ -4211,9 +4560,9 @@ name = "mdbook-forc-documenter"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "clap 4.5.16",
+ "clap 4.5.17",
  "mdbook",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_json",
 ]
@@ -4251,7 +4600,7 @@ dependencies = [
  "log",
  "miden-air",
  "miden-assembly",
- "miden-core",
+ "miden-core 0.3.0",
  "miden-processor",
  "miden-prover",
  "miden-stdlib",
@@ -4264,7 +4613,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5046ab97d8c2b7136601e9430fd0a14e7d6c6cdd648c90c1e6b39186a38b9a8b"
 dependencies = [
- "miden-core",
+ "miden-core 0.3.0",
  "winter-air",
 ]
 
@@ -4274,9 +4623,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a04eec160cbd5cf3051ad16a244c3d83e648eddbd3349120dc069f6e309259dc"
 dependencies = [
- "miden-core",
+ "miden-core 0.3.0",
  "num_enum 0.5.11",
- "winter-crypto",
+ "winter-crypto 0.4.2",
 ]
 
 [[package]]
@@ -4285,9 +4634,56 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75a2446684f44e61afb27bbdbf2458e8ec58c5c55d9bd202981d7cd265f7cf4"
 dependencies = [
- "winter-crypto",
- "winter-math",
- "winter-utils",
+ "winter-crypto 0.4.2",
+ "winter-math 0.4.2",
+ "winter-utils 0.4.2",
+]
+
+[[package]]
+name = "miden-core"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3f6db878d6b56c1566cd5b832908675566d3919b9a3523d630dfb5e2f7422d"
+dependencies = [
+ "lock_api",
+ "loom",
+ "memchr",
+ "miden-crypto",
+ "miden-formatting",
+ "miden-thiserror",
+ "num-derive",
+ "num-traits",
+ "parking_lot 0.12.3",
+ "winter-math 0.9.0",
+ "winter-utils 0.9.2",
+]
+
+[[package]]
+name = "miden-crypto"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a69f8362ca496a79c88cf8e5b9b349bf9c6ed49fa867d0548e670afc1f3fca5"
+dependencies = [
+ "blake3",
+ "cc",
+ "glob",
+ "num",
+ "num-complex",
+ "rand",
+ "rand_core",
+ "sha3",
+ "winter-crypto 0.9.0",
+ "winter-math 0.9.0",
+ "winter-utils 0.9.2",
+]
+
+[[package]]
+name = "miden-formatting"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e392e0a8c34b32671012b439de35fa8987bf14f0f8aac279b97f8b8cc6e263b"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -4297,7 +4693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb7a467447a7d6236f3971f91f8c47c8880a01a43c29b0b08285ec50454f02ed"
 dependencies = [
  "log",
- "miden-core",
+ "miden-core 0.3.0",
  "winter-prover",
 ]
 
@@ -4309,7 +4705,7 @@ checksum = "2343eaf338770b78fe421f36a3445bb491123e0787006dfa2b98788cd6440ec6"
 dependencies = [
  "log",
  "miden-air",
- "miden-core",
+ "miden-core 0.3.0",
  "miden-processor",
  "winter-prover",
 ]
@@ -4321,7 +4717,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b2a52fd1a44b136dbce7a513ebe5a407dfebc17160af8a2707383df731fc098"
 dependencies = [
  "miden-assembly",
- "miden-core",
+ "miden-core 0.3.0",
+]
+
+[[package]]
+name = "miden-thiserror"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183ff8de338956ecfde3a38573241eb7a6f3d44d73866c210e5629c07fa00253"
+dependencies = [
+ "miden-thiserror-impl",
+]
+
+[[package]]
+name = "miden-thiserror-impl"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee4176a0f2e7d29d2a8ee7e60b6deb14ce67a20e94c3e2c7275cdb8804e1862"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4332,7 +4748,7 @@ checksum = "d942d5b0bdcad47359d52534ef6fbccebffc0c713d2c7ca65ab603c7965c0a8b"
 dependencies = [
  "miden-air",
  "miden-assembly",
- "miden-core",
+ "miden-core 0.3.0",
  "winter-verifier",
 ]
 
@@ -4354,17 +4770,20 @@ dependencies = [
 
 [[package]]
 name = "minifier"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95bbbf96b9ac3482c2a25450b67a15ed851319bc5fabf3b40742ea9066e84282"
+checksum = "9aa3f302fe0f8de065d4a2d1ed64f60204623cac58b80cd3c2a83a25d5a7d437"
+dependencies = [
+ "clap 4.5.17",
+]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
@@ -4375,7 +4794,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -4387,7 +4806,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -4484,39 +4903,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
-dependencies = [
- "bitflags 1.2.1",
- "cc",
- "cfg-if 0.1.10",
- "libc",
- "void",
-]
-
-[[package]]
-name = "nix"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945"
-dependencies = [
- "bitflags 1.2.1",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
- "bitflags 1.2.1",
- "cfg-if 1.0.0",
+ "bitflags 1.3.2",
+ "cfg-if",
  "libc",
  "memoffset 0.6.5",
  "pin-utils",
@@ -4528,11 +4921,22 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
- "bitflags 1.2.1",
- "cfg-if 1.0.0",
+ "bitflags 1.3.2",
+ "cfg-if",
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -4546,29 +4950,31 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.2.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags 2.6.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
+ "log",
  "mio 0.8.11",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "notify-debouncer-mini"
-version = "0.2.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23e9fa24f094b143c1eb61f90ac6457de87be6987bc70746e0179f7dbc9007b"
+checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
 dependencies = [
  "crossbeam-channel",
+ "log",
  "notify",
 ]
 
@@ -4632,6 +5038,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4669,6 +5086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4717,10 +5135,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4731,42 +5149,33 @@ checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.14.5",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "memchr",
  "ruzstd",
 ]
 
 [[package]]
-name = "object"
-version = "0.36.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
 
 [[package]]
 name = "onig"
-version = "6.3.1"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ddfe2c93bb389eea6e6d713306880c7f6dcc99a75b659ce145d962c861b225"
+checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
 dependencies = [
- "bitflags 1.2.1",
- "lazy_static",
+ "bitflags 1.3.2",
  "libc",
+ "once_cell",
  "onig_sys",
 ]
 
@@ -4794,16 +5203,6 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opener"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c15678e37254c15bd2f092314abb4e51d7fdde05c2021279c12631b54f005"
-dependencies = [
- "bstr",
- "winapi",
-]
-
-[[package]]
-name = "opener"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0812e5e4df08da354c851a3376fead46db31c2214f849d3de356d774d057681"
@@ -4821,7 +5220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.6.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -4837,7 +5236,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4848,9 +5247,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.1+3.3.1"
+version = "300.3.2+3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
 dependencies = [
  "cc",
 ]
@@ -4869,6 +5268,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4879,6 +5284,12 @@ name = "owo-colors"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "p256"
@@ -4907,7 +5318,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
@@ -4921,7 +5332,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4954,7 +5365,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall 0.2.16",
@@ -4968,9 +5379,9 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.4",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -5002,9 +5413,9 @@ dependencies = [
 
 [[package]]
 name = "peg"
-version = "0.7.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c0b841ea54f523f7aa556956fbd293bcbe06f2e67d2eb732b7278aaf1d166a"
+checksum = "295283b02df346d1ef66052a757869b2876ac29a6bb0ac3f5f7cd44aebe40e8f"
 dependencies = [
  "peg-macros",
  "peg-runtime",
@@ -5012,9 +5423,9 @@ dependencies = [
 
 [[package]]
 name = "peg-macros"
-version = "0.7.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aa52829b8decbef693af90202711348ab001456803ba2a98eb4ec8fb70844c"
+checksum = "bdad6a1d9cf116a059582ce415d5f5566aabcd4008646779dab7fdc2a9a9d426"
 dependencies = [
  "peg-runtime",
  "proc-macro2",
@@ -5023,9 +5434,9 @@ dependencies = [
 
 [[package]]
 name = "peg-runtime"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c719dcf55f09a3a7e764c6649ab594c18a177e3599c467983cdf644bfc0a4088"
+checksum = "e3aeb8f54c078314c2065ee649a7241f46b9d8e418e1a9581ba0546657d7aa3a"
 
 [[package]]
 name = "percent-encoding"
@@ -5035,9 +5446,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.11"
+version = "2.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
 dependencies = [
  "memchr",
  "thiserror",
@@ -5046,9 +5457,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.11"
+version = "2.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
+checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5056,22 +5467,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.11"
+version = "2.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
+checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.11"
+version = "2.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
+checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
 dependencies = [
  "once_cell",
  "pest",
@@ -5085,27 +5496,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "serde",
  "serde_derive",
 ]
 
 [[package]]
 name = "phf"
-version = "0.10.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_macros",
  "phf_shared",
- "proc-macro-hack",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
  "rand",
@@ -5113,23 +5523,22 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
 dependencies = [
  "phf_generator",
  "phf_shared",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
@@ -5151,7 +5560,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5189,7 +5598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "quick-xml",
  "serde",
  "time",
@@ -5197,9 +5606,9 @@ dependencies = [
 
 [[package]]
 name = "plotters"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -5210,15 +5619,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
@@ -5234,12 +5643,13 @@ dependencies = [
 
 [[package]]
 name = "postcard"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
 dependencies = [
  "cobs",
- "embedded-io",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
  "heapless",
  "serde",
 ]
@@ -5261,49 +5671,23 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
- "yansi",
+ "yansi 1.0.1",
 ]
 
 [[package]]
 name = "prettydiff"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5671a83709b2755fe5b776d4915701bf36ed2cd9575035502ec12818141d71"
+checksum = "abec3fb083c10660b3854367697da94c674e9e82aa7511014dc958beeb7215e9"
 dependencies = [
- "ansi_term",
- "prettytable-rs 0.8.0",
- "structopt",
-]
-
-[[package]]
-name = "prettydiff"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff1fec61082821f8236cf6c0c14e8172b62ce8a72a0eedc30d3b247bb68dc11"
-dependencies = [
- "ansi_term",
+ "owo-colors 3.5.0",
  "pad",
- "prettytable-rs 0.10.0",
- "structopt",
-]
-
-[[package]]
-name = "prettytable-rs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
-dependencies = [
- "atty",
- "csv",
- "encode_unicode 0.3.6",
- "lazy_static",
- "term 0.5.2",
- "unicode-width",
+ "prettytable-rs",
 ]
 
 [[package]]
@@ -5316,7 +5700,7 @@ dependencies = [
  "encode_unicode 1.0.0",
  "is-terminal",
  "lazy_static",
- "term 0.7.0",
+ "term",
  "unicode-width",
 ]
 
@@ -5354,11 +5738,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5384,12 +5768,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -5420,7 +5798,27 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "proptest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.6.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.8.4",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -5487,6 +5885,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-protobuf"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5506,9 +5910,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -5556,7 +5960,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -5601,17 +6014,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5620,14 +6027,14 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -5640,22 +6047,11 @@ checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "redox_users"
-version = "0.3.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
-dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "libredox 0.1.3",
  "thiserror",
 ]
@@ -5744,7 +6140,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-rustls 0.24.1",
  "tower-service",
@@ -5753,26 +6149,26 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
- "hyper-rustls 0.27.2",
+ "hyper-rustls 0.27.3",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -5788,7 +6184,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -5796,54 +6192,71 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.52.0",
+ "windows-registry",
 ]
 
 [[package]]
 name = "revm"
-version = "2.3.1"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d84c8f9836efb0f5f5f8de4700a953c4e1f3119e5cfcb0aad8e5be73daf991"
+checksum = "1f719e28cc6fdd086f8bc481429e587740d20ad89729cec3f5f5dd7b655474df"
 dependencies = [
- "arrayref",
  "auto_impl",
- "bytes",
- "hashbrown 0.13.2",
- "num_enum 0.5.11",
- "primitive-types",
- "revm_precompiles",
- "rlp",
- "sha3",
+ "cfg-if",
+ "dyn-clone",
+ "revm-interpreter",
+ "revm-precompile",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
-name = "revm_precompiles"
-version = "1.1.2"
+name = "revm-interpreter"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0353d456ef3e989dc9190f42c6020f09bc2025930c37895826029304413204b5"
+checksum = "959ecbc36802de6126852479844737f20194cf8e6718e0c30697d306a2cca916"
 dependencies = [
- "bytes",
- "hashbrown 0.13.2",
- "num",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e25f604cb9db593ca3013be8c00f310d6790ccb1b7d8fbbdd4660ec8888043a"
+dependencies = [
+ "aurora-engine-modexp",
+ "blst",
+ "c-kzg",
+ "cfg-if",
+ "k256",
  "once_cell",
- "primitive-types",
+ "revm-primitives",
  "ripemd",
- "secp256k1 0.24.3",
+ "secp256k1 0.29.1",
  "sha2 0.10.8",
- "sha3",
  "substrate-bn",
 ]
 
 [[package]]
-name = "rexpect"
-version = "0.4.0"
+name = "revm-primitives"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862c0149d91461fab225ddd06a5af919913f5c57405ed4f27d2466d6cc877186"
+checksum = "0ccb981ede47ccf87c68cebf1ba30cdbb7ec935233ea305f3dfff4c1e10ae541"
 dependencies = [
- "error-chain",
- "nix 0.14.1",
- "regex",
- "tempfile",
+ "alloy-eips",
+ "alloy-primitives",
+ "auto_impl",
+ "bitflags 2.6.0",
+ "bitvec",
+ "c-kzg",
+ "cfg-if",
+ "dyn-clone",
+ "enumn",
+ "hashbrown 0.14.5",
+ "hex",
+ "serde",
 ]
 
 [[package]]
@@ -5876,8 +6289,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
- "getrandom 0.2.15",
+ "cfg-if",
+ "getrandom",
  "libc",
  "spin",
  "untrusted",
@@ -5895,9 +6308,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.44"
+version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -5913,9 +6326,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.44"
+version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5939,7 +6352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
  "base64 0.13.1",
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
  "serde",
 ]
 
@@ -5955,14 +6368,13 @@ dependencies = [
 
 [[package]]
 name = "rowan"
-version = "0.14.1"
+version = "0.15.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f77412a3d1f26af0c0783c23b3555a301b1a49805cba7bf9a7827a9e9e285f0"
+checksum = "0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d"
 dependencies = [
  "countme",
- "hashbrown 0.11.2",
- "memoffset 0.6.5",
- "rustc-hash",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
  "text-size",
 ]
 
@@ -5988,24 +6400,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-argon2"
-version = "0.8.3"
+name = "ruint"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
+checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
 dependencies = [
- "base64 0.13.1",
- "blake2b_simd",
- "constant_time_eq 0.1.5",
- "crossbeam-utils",
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes",
+ "fastrlp",
+ "num-bigint",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand",
+ "rlp",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
 ]
 
 [[package]]
-name = "rust_decimal"
-version = "1.35.0"
+name = "ruint-macro"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rust_decimal"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
@@ -6028,6 +6458,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6035,18 +6471,27 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver",
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver 1.0.23",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -6069,13 +6514,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -6129,9 +6574,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -6145,23 +6590,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
-name = "rustyline"
-version = "8.2.0"
+name = "rusty-fork"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd4eaf7a7738f76c98e4f0395253ae853be3eb018f7b0bb57fe1b6c17e31874"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
- "bitflags 1.2.1",
- "cfg-if 1.0.0",
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "rustyline"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a2d683a4ac90aeef5b1013933f6d977bd37d51ff3f4dad829d4931a7e6be86"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
  "clipboard-win",
- "dirs-next",
- "fd-lock 2.0.0",
+ "fd-lock",
+ "home",
  "libc",
  "log",
  "memchr",
- "nix 0.20.2",
+ "nix 0.27.1",
  "radix_trie",
- "scopeguard",
- "smallvec",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
@@ -6170,12 +6625,10 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.5.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
+checksum = "99c3938e133aac070997ddc684d4b393777d293ba170f2988c8fd5ea2ad4ce21"
 dependencies = [
- "byteorder",
- "derive_more",
  "twox-hash",
 ]
 
@@ -6205,20 +6658,20 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.15"
+version = "2.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478f373151538826ed50feaceeef7095ad435065a48153af789005fd5e44c0d"
+checksum = "0c947adb109a8afce5fc9c7bf951f87f146e9147b3a6a58413105628fb1d1e66"
 dependencies = [
  "sdd",
 ]
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6246,6 +6699,12 @@ dependencies = [
  "serde_json",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -6277,9 +6736,9 @@ dependencies = [
 
 [[package]]
 name = "sdd"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0495e4577c672de8254beb68d01a9b62d0e8a13c099edecdbedccce3223cd29f"
+checksum = "60a7b59a5d9b0099720b417b6325d91a52cbf5b3dcb5041d864be53eefa58abc"
 
 [[package]]
 name = "seahash"
@@ -6303,15 +6762,6 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
-dependencies = [
- "secp256k1-sys 0.6.1",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
@@ -6321,12 +6771,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1-sys"
-version = "0.6.1"
+name = "secp256k1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "cc",
+ "rand",
+ "secp256k1-sys 0.10.1",
 ]
 
 [[package]]
@@ -6334,6 +6785,15 @@ name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -6372,6 +6832,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
@@ -6380,23 +6849,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.208"
+name = "semver-parser"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6410,10 +6888,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
+ "indexmap 2.5.0",
  "itoa",
  "memchr",
  "ryu",
@@ -6428,7 +6907,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6462,7 +6941,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6479,7 +6958,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6488,7 +6967,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "itoa",
  "ryu",
  "serde",
@@ -6517,7 +6996,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6527,7 +7006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -6539,7 +7018,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -6552,6 +7031,16 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -6571,15 +7060,17 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shellfish"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c66e6fc7a668d89939ee241fb342f401f8c11a80da8fb72fd14681f8d47440b"
+checksum = "fef42fa3356b28a29aee098d1656681670da7eb15be0e89bba6f05aea540df3d"
 dependencies = [
  "async-trait",
- "cfg-if 1.0.0",
+ "cfg-if",
  "rustyline",
+ "thiserror",
  "tokio",
- "yansi",
+ "version_check",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -6740,12 +7231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
-
-[[package]]
 name = "str_indices"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6770,30 +7255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6807,6 +7268,15 @@ name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
 
 [[package]]
 name = "strum_macros"
@@ -6831,7 +7301,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.74",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6869,34 +7352,34 @@ dependencies = [
 name = "sway-core"
 version = "0.63.5"
 dependencies = [
- "clap 4.5.16",
+ "clap 4.5.17",
  "derivative",
- "dirs 3.0.2",
+ "dirs 5.0.1",
  "either",
  "fuel-abi-types",
  "fuel-ethabi",
  "fuel-etk-asm",
  "fuel-etk-ops",
  "fuel-vm",
- "gimli 0.28.1",
+ "gimli",
  "graph-cycles",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.5",
  "hex",
  "im",
- "indexmap 2.4.0",
- "itertools 0.10.5",
+ "indexmap 2.5.0",
+ "itertools 0.13.0",
  "lazy_static",
- "miden-core",
- "object 0.32.2",
+ "miden-core 0.10.5",
+ "object",
  "parking_lot 0.12.3",
  "pest",
  "pest_derive",
  "petgraph",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "serde",
  "serde_json",
- "sha2 0.9.9",
- "strum 0.24.1",
+ "sha2 0.10.8",
+ "strum 0.26.3",
  "sway-ast",
  "sway-error",
  "sway-ir",
@@ -6931,12 +7414,12 @@ dependencies = [
  "anyhow",
  "downcast-rs",
  "filecheck",
- "indexmap 2.4.0",
- "itertools 0.10.5",
+ "indexmap 2.5.0",
+ "itertools 0.13.0",
  "once_cell",
  "peg",
- "prettydiff 0.6.4",
- "rustc-hash",
+ "prettydiff",
+ "rustc-hash 2.0.0",
  "slotmap",
  "sway-ir-macros",
  "sway-types",
@@ -6947,10 +7430,10 @@ dependencies = [
 name = "sway-ir-macros"
 version = "0.63.5"
 dependencies = [
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6962,14 +7445,14 @@ dependencies = [
  "codspeed-criterion-compat",
  "criterion",
  "crossbeam-channel",
- "dashmap",
- "dirs 4.0.0",
- "fd-lock 4.0.2",
+ "dashmap 6.1.0",
+ "dirs 5.0.1",
+ "fd-lock",
  "forc-pkg",
  "forc-tracing 0.63.5",
  "forc-util",
  "futures",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "lsp-types",
  "notify",
  "notify-debouncer-mini",
@@ -6991,13 +7474,13 @@ dependencies = [
  "sway-types",
  "sway-utils",
  "swayfmt",
- "syn 1.0.109",
+ "syn 2.0.77",
  "tempfile",
  "thiserror",
  "tikv-jemallocator",
  "tokio",
- "toml_edit 0.19.15",
- "tower",
+ "toml_edit",
+ "tower 0.5.1",
  "tower-lsp",
  "tracing",
  "urlencoding",
@@ -7014,7 +7497,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tower",
+ "tower 0.5.1",
  "tower-lsp",
 ]
 
@@ -7044,12 +7527,12 @@ dependencies = [
  "fuel-asm",
  "fuel-crypto",
  "fuel-tx",
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "lazy_static",
  "num-bigint",
  "num-traits",
  "parking_lot 0.12.3",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "serde",
  "sway-utils",
  "thiserror",
@@ -7072,7 +7555,7 @@ dependencies = [
  "forc-tracing 0.63.5",
  "indoc",
  "paste",
- "prettydiff 0.6.4",
+ "prettydiff",
  "ropey",
  "serde",
  "serde_ignored",
@@ -7084,7 +7567,7 @@ dependencies = [
  "sway-utils",
  "test-macros",
  "thiserror",
- "toml 0.7.8",
+ "toml 0.8.19",
 ]
 
 [[package]]
@@ -7100,9 +7583,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.74"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7118,7 +7601,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7132,6 +7615,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -7153,7 +7639,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7163,7 +7649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
 dependencies = [
  "bincode",
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
  "fancy-regex",
  "flate2",
  "fnv",
@@ -7181,17 +7667,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.11"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
+checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
 dependencies = [
- "cfg-if 1.0.0",
  "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
  "rayon",
- "winapi",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -7200,9 +7685,20 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -7210,6 +7706,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7232,19 +7738,23 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "taplo"
-version = "0.7.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d17cb5ff4095af064048f25a0a8df815384f63ce21c7410e96b93016757259"
+checksum = "010941ac4171eaf12f1e26dfc11dadaf78619ea2330940fef01fe6bb0442d14d"
 dependencies = [
- "glob",
- "indexmap 1.9.3",
+ "ahash 0.8.11",
+ "arc-swap",
+ "either",
+ "globset",
+ "itertools 0.10.5",
  "logos",
- "regex",
+ "once_cell",
  "rowan",
- "semver",
- "smallvec",
- "toml 0.5.11",
- "wasm-bindgen",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "tracing",
 ]
 
 [[package]]
@@ -7264,22 +7774,11 @@ version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "term"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
-dependencies = [
- "byteorder",
- "dirs 1.0.5",
- "winapi",
 ]
 
 [[package]]
@@ -7336,12 +7835,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "termion"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccce68e518d1173e80876edd54760b60b792750d0cab6444a79101c6ea03848"
+dependencies = [
+ "libc",
+ "libredox 0.0.2",
+ "numtoa",
+ "redox_termios",
+]
+
+[[package]]
 name = "test"
 version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "clap 4.5.16",
+ "clap 4.5.17",
  "colored",
  "filecheck",
  "forc",
@@ -7357,7 +7868,7 @@ dependencies = [
  "insta",
  "libtest-mimic",
  "miden",
- "prettydiff 0.6.4",
+ "prettydiff",
  "rand",
  "regex",
  "revm",
@@ -7369,7 +7880,7 @@ dependencies = [
  "sway-utils",
  "textwrap 0.16.1",
  "tokio",
- "toml 0.7.8",
+ "toml 0.8.19",
  "tracing",
  "vte 0.13.0",
 ]
@@ -7379,7 +7890,7 @@ name = "test-macros"
 version = "0.0.0"
 dependencies = [
  "paste",
- "prettydiff 0.6.4",
+ "prettydiff",
 ]
 
 [[package]]
@@ -7425,7 +7936,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7434,7 +7945,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -7449,9 +7960,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
 dependencies = [
  "cc",
  "libc",
@@ -7459,9 +7970,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -7509,7 +8020,7 @@ dependencies = [
  "once_cell",
  "pbkdf2 0.11.0",
  "rand",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "sha2 0.10.8",
  "thiserror",
  "unicode-normalization",
@@ -7553,9 +8064,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7587,7 +8098,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7616,16 +8127,16 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -7634,9 +8145,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -7656,18 +8167,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
@@ -7675,7 +8174,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.20",
+ "toml_edit",
 ]
 
 [[package]]
@@ -7689,39 +8188,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.4.0",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap 2.4.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.4.0",
+ "indexmap 2.5.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.18",
+ "winnow",
 ]
 
 [[package]]
@@ -7746,6 +8221,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7760,7 +8249,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "bytes",
- "dashmap",
+ "dashmap 5.5.3",
  "futures",
  "httparse",
  "lsp-types",
@@ -7769,7 +8258,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tower-lsp-macros",
  "tracing",
 ]
@@ -7782,7 +8271,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7810,7 +8299,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7883,7 +8372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7898,7 +8387,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "static_assertions",
 ]
 
@@ -7944,6 +8433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7960,9 +8455,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-linebreak"
@@ -7981,9 +8476,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -7993,9 +8488,9 @@ checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
 
 [[package]]
 name = "unicode_categories"
@@ -8072,7 +8567,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "serde",
 ]
 
@@ -8089,7 +8584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3db6840b7adcfd2e866c79157cc890ecdbbc1f739607134039ae64eaa6c07e24"
 dependencies = [
  "clap 2.34.0",
- "owo-colors",
+ "owo-colors 1.3.0",
  "parking_lot 0.11.2",
  "thiserror",
 ]
@@ -8148,7 +8643,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "utf8parse",
  "vte_generate_state_changes",
 ]
@@ -8159,7 +8654,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40eb22ae96f050e0c0d6f7ce43feeae26c348fc4dea56928ca81537cfaa6188b"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec",
  "utf8parse",
  "vte_generate_state_changes",
 ]
@@ -8172,6 +8667,15 @@ checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -8195,12 +8699,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -8217,10 +8715,8 @@ version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -8235,7 +8731,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -8245,7 +8741,7 @@ version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -8269,7 +8765,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8298,9 +8794,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "which"
-version = "6.0.2"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d9c5ed668ee1f17edb3b627225343d210006a90bb1e3745ce1f30b1fb115075"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
 dependencies = [
  "either",
  "home",
@@ -8310,11 +8806,11 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.4",
  "wasite",
  "web-sys",
 ]
@@ -8351,6 +8847,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8360,12 +8876,111 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.45.0"
+name = "windows-core"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-targets 0.42.2",
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8393,21 +9008,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8443,12 +9043,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -8461,12 +9055,6 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -8476,12 +9064,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8503,12 +9085,6 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -8518,12 +9094,6 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8539,12 +9109,6 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -8557,12 +9121,6 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -8572,15 +9130,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
@@ -8597,17 +9146,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if 1.0.0",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "windows-sys 0.48.0",
 ]
 
@@ -8623,10 +9162,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef91b335c5fefa4e6d3c6274de75a7744b4eecae2d7ee3778c23570f35f83396"
 dependencies = [
- "winter-crypto",
+ "winter-crypto 0.4.2",
  "winter-fri",
- "winter-math",
- "winter-utils",
+ "winter-math 0.4.2",
+ "winter-utils 0.4.2",
 ]
 
 [[package]]
@@ -8637,8 +9176,20 @@ checksum = "3bd17ea728ff42185c54dfbabaafd0b442207df6b2cc60f74c607d8c01e9c4db"
 dependencies = [
  "blake3",
  "sha3",
- "winter-math",
- "winter-utils",
+ "winter-math 0.4.2",
+ "winter-utils 0.4.2",
+]
+
+[[package]]
+name = "winter-crypto"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00fbb724d2d9fbfd3aa16ea27f5e461d4fe1d74b0c9e0ed1bf79e9e2a955f4d5"
+dependencies = [
+ "blake3",
+ "sha3",
+ "winter-math 0.9.0",
+ "winter-utils 0.9.2",
 ]
 
 [[package]]
@@ -8647,9 +9198,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2473f8b2c5c553e9f9d4d94b3b7a1e75806b4cdc964004f9bde4b5fc07c10c87"
 dependencies = [
- "winter-crypto",
- "winter-math",
- "winter-utils",
+ "winter-crypto 0.4.2",
+ "winter-math 0.4.2",
+ "winter-utils 0.4.2",
 ]
 
 [[package]]
@@ -8658,7 +9209,16 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824b459961e5d679a1eb62ec1a71c85ac25c5d3bfd126874fcd32b591202d896"
 dependencies = [
- "winter-utils",
+ "winter-utils 0.4.2",
+]
+
+[[package]]
+name = "winter-math"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004f85bb051ce986ec0b9a2bd90aaf81b83e3c67464becfdf7db31f14c1019ba"
+dependencies = [
+ "winter-utils 0.9.2",
 ]
 
 [[package]]
@@ -8669,10 +9229,10 @@ checksum = "3831583fd662f49f23ea39427aba20a9b5ab6326230f7994e843d2bd34524411"
 dependencies = [
  "log",
  "winter-air",
- "winter-crypto",
+ "winter-crypto 0.4.2",
  "winter-fri",
- "winter-math",
- "winter-utils",
+ "winter-math 0.4.2",
+ "winter-utils 0.4.2",
 ]
 
 [[package]]
@@ -8682,16 +9242,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f0dbf7ca6aa5893b59928718bf1e7dbe7279bb277b5aa4c4898ddf5004f9417"
 
 [[package]]
+name = "winter-utils"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d71ec2c97685c7e7460a30e27f955d26b8426e7c2db0ddb55a6e0537141f53"
+
+[[package]]
 name = "winter-verifier"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "922be4651b76aa80e132386a97d23788e2bc542d37b3c187a39998876a8094b6"
 dependencies = [
  "winter-air",
- "winter-crypto",
+ "winter-crypto 0.4.2",
  "winter-fri",
- "winter-math",
- "winter-utils",
+ "winter-math 0.4.2",
+ "winter-utils 0.4.2",
 ]
 
 [[package]]
@@ -8736,6 +9302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8753,7 +9325,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -8773,5 +9345,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.77",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,63 @@ exclude = [
     "forc-test/test_data"
 ]
 
+[workspace.package]
+edition = "2021"
+version = "0.63.5"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+homepage = "https://fuel.network/"
+license = "Apache-2.0"
+repository = "https://github.com/FuelLabs/sway"
+
 [workspace.dependencies]
+#
+# Internal dependencies in order to propagate `workspace.version`
+#
+
+forc = { path = "forc/" }
+forc-pkg = { path = "forc-pkg/" }
+forc-test = { path = "forc-test/" }
+forc-tracing = { path = "forc-tracing/" }
+forc-util = { path = "forc-util/" }
+
+# Forc plugins
+forc-plugins = { path = "forc-plugins/" }
+forc-client = { path = "forc-plugins/forc-client/" }
+forc-crypto = { path = "forc-plugins/forc-crypto/" }
+forc-debug = { path = "forc-plugins/forc-debug/" }
+forc-doc = { path = "forc-plugins/forc-doc/" }
+forc-fmt = { path = "forc-plugins/forc-fmt/" }
+forc-lsp = { path = "forc-plugins/forc-lsp/" }
+forc-tx = { path = "forc-plugins/forc-tx/" }
+
+sway-ast = { path = "sway-ast/" }
+sway-core = { path = "sway-core/" }
+sway-error = { path = "sway-error/" }
+sway-lsp = { path = "sway-lsp/" }
+sway-parse = { path = "sway-parse/" }
+sway-types = { path = "sway-types/" }
+sway-utils = { path = "sway-utils/" }
+swayfmt = { path = "swayfmt/" }
+
+# Sway IR
+sway-ir = { path = "sway-ir/" }
+sway-ir-macros = { path = "sway-ir/sway-ir-macros" }
+
+#
+# External Fuel dependencies
+#
+
+# Dependencies from the `fuel-abi-types` repository:
+fuel-abi-types = "0.7.0"
+
 # Dependencies from the `fuel-core` repository:
 fuel-core-client = { version = "0.35.0", default-features = false }
 fuel-core-types = { version = "0.35.0", default-features = false }
+
+# Dependencies from the `fuels-rs` repository:
+fuels = "0.66.4"
+fuels-core = "0.66.4"
+fuels-accounts = "0.66.4"
 
 # Dependencies from the `fuel-vm` repository:
 fuel-asm = "0.56.0"
@@ -44,20 +97,137 @@ fuel-types = "0.56.0"
 fuel-tx = "0.56.0"
 fuel-vm = "0.56.0"
 
-# Dependencies from the `fuels-rs` repository:
-fuels-core = "0.66.4"
-fuels-accounts = "0.66.4"
-fuels = "0.66.4"
-
 # Dependencies from the `forc-wallet` repository:
 forc-wallet = "0.9.0"
 
-# Dependencies from the `fuel-abi-types` repository:
-fuel-abi-types = "0.7.0"
+#
+# External dependencies
+#
 
-[workspace.package]
-edition = "2021"
-authors = ["Fuel Labs <contact@fuel.sh>"]
-homepage = "https://fuel.network/"
-license = "Apache-2.0"
-repository = "https://github.com/FuelLabs/sway"
+annotate-snippets = "0.10.1"
+ansi_term = "0.12"
+anyhow = "1.0.75"
+assert_matches = "1.5.0"
+assert-json-diff = "2.0"
+async-trait = "0.1.58"
+atty = "0.2.14"
+byte-unit = "5.1.4"
+bytecount = "0.6"
+bytes = "1.3.0"
+chrono = { version = "0.4", default-features = false }
+cid = "0.11"
+clap = "4.5.4"
+clap_complete = "4.5.2"
+clap_complete_fig = "4.5.0"
+colored = "2.0.0"
+comrak = "0.28.0"
+crossbeam-channel = "0.5"
+dap = "0.4.1-alpha1"
+dashmap = "6.1.0"
+derivative = "2.2.0"
+devault = "0.2.0"
+dialoguer = "0.11"
+dirs = "5.0.1"
+downcast-rs = "1.2.0"
+either = "1.9.0"
+ethabi = { package = "fuel-ethabi", version = "18.0.0" }
+etk-asm = { package = "fuel-etk-asm", version = "0.3.1-dev" }
+etk-ops = { package = "fuel-etk-ops", version = "0.3.1-dev" }
+extension-trait = "1.0.1"
+fd-lock = "4.0"
+filecheck = "0.5"
+fs_extra = "1.2"
+futures = { version = "0.3.24", default-features = false }
+gag = "1.0"
+gimli = "0.31.0"
+git2 = "0.19"
+gix-url = "0.27"
+glob = "0.3.1"
+graph-cycles = "0.1.0"
+hashbrown = "0.14.5"
+hex = "0.4.3"
+horrorshow = "0.8.4"
+im = "15.0"
+in_definite = "1.0.0"
+include_dir = "0.7.3"
+indexmap = "2.0.0"
+indoc = "2.0"
+insta = "1.39.0"
+ipfs-api-backend-hyper = "0.6"
+itertools = "0.13.0"
+lazy_static = "1.4"
+libp2p-identity = "0.2.4"
+libtest-mimic = "0.7.3"
+lsp-types = "0.94"
+mdbook = { version = "0.4", default-features = false }
+miden = "0.3.0"
+miden-core = "0.10.5"
+minifier = "0.3.0"
+notify = "6.1.1"
+notify-debouncer-mini = "0.4.1"
+num-bigint = "0.4.3"
+num-traits = "0.2.16"
+object = "0.36.4"
+once_cell = "1.18.0"
+opener = "0.7.2"
+parking_lot = "0.12.1"
+paste = "1.0.14"
+peg = "0.8.4"
+pest = "2.1.3"
+pest_derive = "2.1"
+petgraph = "0.6"
+phf = "0.11.2"
+pretty_assertions = "1.4.0"
+prettydiff = "0.7.0"
+proc-macro2 = "1.0.5"
+quote = "1.0.21"
+rand = "0.8"
+rayon = "1.7.0"
+rayon-cond = "0.3"
+regex = "1.10.2"
+reqwest = "0.12"
+revm = "14.0.1"
+ropey = "1.5"
+rpassword = "7.2"
+rustc-hash = "2.0.0"
+semver = "1.0"
+serde = "1.0"
+serde_ignored = "0.1.9"
+serde_json = "1.0.91"
+serde_with = "3.3.0"
+serde_yaml = "0.9.27"
+serial_test = "3.0.0"
+sha2 = "0.10"
+sha3 = "0.10.8"
+shellfish = "0.9.0"
+slotmap = "1.0.7"
+smallvec = "1.7"
+strsim = "0.11.1"
+strum = "0.26.3"
+syn = "2.0.77"
+tai64 = "4.0"
+taplo = "0.13.2"
+tar = "0.4.38"
+tempfile = "3"
+term-table = "1.3"
+termion = "4.0.2"
+textwrap = "0.16.0"
+thiserror = "1.0.30"
+tikv-jemallocator = "0.6.0"
+tokio = "1.12"
+toml = "0.8"
+toml_edit = "0.22.20"
+tower = { version = "0.5.1", default-features = false }
+tower-lsp = "0.20"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+uint = "0.9"
+unicode-bidi = "0.3.13"
+unicode-xid = "0.2.2"
+url = "2.2"
+urlencoding = "2.1.2"
+uwuify = "^0.2"
+vec1 = "1.8.0"
+vte = "0.13.0"
+walkdir = "2.3.3"
+whoami = "1.1"

--- a/docs/book/src/reference/contributing_to_sway.md
+++ b/docs/book/src/reference/contributing_to_sway.md
@@ -43,6 +43,32 @@ _n_ tests run (0 skipped)
 
 Congratulations! You've now got everything setup and are ready to start making contributions.
 
+### Running GitHub Actions Workflow Locally
+
+All [GitHub](https://github.com/) pull requests are run through the [GitHub Actions workflow](https://docs.github.com/en/actions) defined in `.github/workflows/ci.yml`. For convenience, these can be run locally in [Docker](https://www.docker.com/) using a 3rd-party tool called [`act`](https://github.com/nektos/act):
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+./bin/act pull_request \
+  -P buildjet-4vcpu-ubuntu-2204=catthehacker/ubuntu:act-latest \
+  -P buildjet-8vcpu-ubuntu-2204=catthehacker/ubuntu:act-latest \
+  -P ubuntu-latest=catthehacker/ubuntu:act-latest \
+  -W .github/workflows/ci.yml \
+  | tee output.txt
+```
+
+By default `act` will run all jobs within `.github/workflows/ci.yml`, but you can narrow down to a single job using the `-j` argument:
+
+```sh
+./bin/act pull_request \
+  -P buildjet-4vcpu-ubuntu-2204=catthehacker/ubuntu:act-latest \
+  -P buildjet-8vcpu-ubuntu-2204=catthehacker/ubuntu:act-latest \
+  -P ubuntu-latest=catthehacker/ubuntu:act-latest \
+  -W .github/workflows/ci.yml \
+  -j cargo-clippy \
+  | tee output.txt
+```
+
 ## Finding something to work on
 
 There are many ways in which you may contribute to the Sway project, some of which involve coding knowledge and some which do not. A few examples include:

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-pkg"
-version = "0.63.5"
+version.workspace = true
 description = "Building, locking, fetching and updating Sway projects as Forc packages."
 authors.workspace = true
 edition.workspace = true
@@ -9,41 +9,41 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-ansi_term = "0.12"
-anyhow = "1"
-byte-unit = "5.1.4"
-cid = "0.11"
-forc-tracing = { version = "0.63.5", path = "../forc-tracing" }
-forc-util = { version = "0.63.5", path = "../forc-util" }
-fuel-abi-types = { workspace = true }
-futures = "0.3"
-git2 = { version = "0.19", features = [
+ansi_term.workspace = true
+anyhow.workspace = true
+byte-unit.workspace = true
+cid.workspace = true
+forc-tracing.workspace = true
+forc-util.workspace = true
+fuel-abi-types.workspace = true
+futures.workspace = true
+git2 = { workspace = true, features = [
     "vendored-libgit2",
     "vendored-openssl",
 ] }
-gix-url = { version = "0.27", features = ["serde"] }
-hex = "0.4.3"
-ipfs-api-backend-hyper = { version = "0.6", features = ["with-builder"] }
-petgraph = { version = "0.6", features = ["serde-1"] }
-reqwest = "0.12"
-semver = { version = "1.0", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_ignored = "0.1.9"
-serde_json = "1.0"
-serde_with = "3.3.0"
-sway-core = { version = "0.63.5", path = "../sway-core" }
-sway-error = { version = "0.63.5", path = "../sway-error" }
-sway-types = { version = "0.63.5", path = "../sway-types" }
-sway-utils = { version = "0.63.5", path = "../sway-utils" }
-tar = "0.4.38"
-toml = { version = "0.8", features = ["parse"] }
-tracing = "0.1"
-url = { version = "2.2", features = ["serde"] }
-vec1 = "1.8.0"
-walkdir = "2"
+gix-url = { workspace = true, features = ["serde"] }
+hex.workspace = true
+ipfs-api-backend-hyper = { workspace = true, features = ["with-builder"] }
+petgraph = { workspace = true, features = ["serde-1"] }
+reqwest.workspace = true
+semver = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+serde_ignored.workspace = true
+serde_json.workspace = true
+serde_with.workspace = true
+sway-core.workspace = true
+sway-error.workspace = true
+sway-types.workspace = true
+sway-utils.workspace = true
+tar.workspace = true
+toml = { workspace = true, features = ["parse"] }
+tracing.workspace = true
+url = { workspace = true, features = ["serde"] }
+vec1.workspace = true
+walkdir.workspace = true
 
 [dev-dependencies]
 regex = "^1.10.2"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-sysinfo = "0.29"
+sysinfo = "0.31.4"

--- a/forc-pkg/src/manifest/mod.rs
+++ b/forc-pkg/src/manifest/mod.rs
@@ -771,7 +771,7 @@ impl std::ops::Deref for PackageManifestFile {
 /// This can be configured using environment variables:
 /// - use `FORC_IMPLICIT_STD_PATH` for the path for the std-lib;
 /// - use `FORC_IMPLICIT_STD_GIT`, `FORC_IMPLICIT_STD_GIT_TAG` and/or `FORC_IMPLICIT_STD_GIT_BRANCH` to configure
-/// the git repo of the std-lib.
+///   the git repo of the std-lib.
 fn implicit_std_dep() -> Dependency {
     if let Ok(path) = std::env::var("FORC_IMPLICIT_STD_PATH") {
         return Dependency::Detailed(DependencyDetails {

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -578,7 +578,7 @@ impl Built {
 impl BuildPlan {
     /// Create a new build plan for the project from the build options provided.
     ///
-    /// To do so, it tries to read the manifet file at the target path and creates the plan with
+    /// To do so, it tries to read the manifest file at the target path and creates the plan with
     /// `BuildPlan::from_lock_and_manifest`.
     pub fn from_pkg_opts(pkg_options: &PkgOpts) -> Result<Self> {
         let path = &pkg_options.path;
@@ -2081,10 +2081,15 @@ fn build_profile_from_opts(
         .get(selected_profile_name)
         .cloned()
         .unwrap_or_else(|| {
-            println_warning(&format!(
-                "The provided profile option {selected_profile_name} is not present in the manifest file. \
-            Using default profile."
-            ));
+            if selected_profile_name.is_empty() {
+                println_warning("No profile provided. Using default profile.");
+            }
+            else {
+                println_warning(&format!(
+                    "The provided profile option '{selected_profile_name}' is not present in the manifest \
+                    file. Using default profile."
+                ));
+            }
             BuildProfile::default()
         });
     profile.name = selected_profile_name.into();

--- a/forc-plugins/forc-client/Cargo.toml
+++ b/forc-plugins/forc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-client"
-version = "0.63.5"
+version.workspace = true
 description = "A `forc` plugin for interacting with a Fuel node."
 authors.workspace = true
 edition.workspace = true
@@ -9,45 +9,45 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = "1"
-async-trait = "0.1.58"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
-clap = { version = "4.5.4", features = ["derive", "env"] }
-devault = "0.1"
-dialoguer = "0.11"
-forc = { version = "0.63.5", path = "../../forc" }
-forc-pkg = { version = "0.63.5", path = "../../forc-pkg" }
-forc-tracing = { version = "0.63.5", path = "../../forc-tracing" }
-forc-tx = { version = "0.63.5", path = "../forc-tx" }
-forc-util = { version = "0.63.5", path = "../../forc-util" }
-forc-wallet = { workspace = true }
-fuel-abi-types = { workspace = true }
+anyhow.workspace = true
+async-trait.workspace = true
+chrono = { workspace = true, features = ["std"] }
+clap = { workspace = true, features = ["derive", "env"] }
+devault.workspace = true
+dialoguer.workspace = true
+forc.workspace = true
+forc-pkg.workspace = true
+forc-tracing.workspace = true
+forc-tx.workspace = true
+forc-util.workspace = true
+forc-wallet.workspace = true
+fuel-abi-types.workspace = true
 fuel-core-client = { workspace = true, features = ["subscriptions"] }
-fuel-core-types = { workspace = true }
-fuel-crypto = { workspace = true }
+fuel-core-types.workspace = true
+fuel-crypto.workspace = true
 fuel-tx = { workspace = true, features = ["test-helpers"] }
-fuel-vm = { workspace = true }
-fuels = { workspace = true }
-fuels-accounts = { workspace = true }
-fuels-core = { workspace = true }
-futures = "0.3"
-hex = "0.4.3"
-rand = "0.8"
-rpassword = "7.2"
-serde = "1.0"
-serde_json = "1"
-sway-core = { version = "0.63.5", path = "../../sway-core" }
-sway-types = { version = "0.63.5", path = "../../sway-types" }
-sway-utils = { version = "0.63.5", path = "../../sway-utils" }
-tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "process"] }
-toml_edit = "0.21.1"
-tracing = "0.1"
+fuel-vm.workspace = true
+fuels.workspace = true
+fuels-accounts.workspace = true
+fuels-core.workspace = true
+futures.workspace = true
+hex.workspace = true
+rand.workspace = true
+rpassword.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sway-core.workspace = true
+sway-types.workspace = true
+sway-utils.workspace = true
+tokio = { workspace = true, features = ["macros", "process", "rt-multi-thread"] }
+toml_edit.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 portpicker = "0.1.1"
 rexpect = "0.5"
 tempfile = "3"
-toml_edit = "0.21.1"
+toml_edit = "0.22.20"
 
 [build-dependencies]
 regex = "1.5.4"

--- a/forc-plugins/forc-client/src/util/pkg.rs
+++ b/forc-plugins/forc-client/src/util/pkg.rs
@@ -26,7 +26,7 @@ pub(crate) fn update_proxy_address_in_manifest(
     let mut toml = String::new();
     let mut file = File::open(manifest.path())?;
     file.read_to_string(&mut toml)?;
-    let mut manifest_toml = toml.parse::<toml_edit::Document>()?;
+    let mut manifest_toml = toml.parse::<toml_edit::DocumentMut>()?;
     if manifest.proxy().is_some() {
         manifest_toml["proxy"]["address"] = toml_edit::value(address);
         let mut file = std::fs::OpenOptions::new()

--- a/forc-plugins/forc-client/tests/deploy.rs
+++ b/forc-plugins/forc-client/tests/deploy.rs
@@ -23,7 +23,7 @@ use std::{
     str::FromStr,
 };
 use tempfile::tempdir;
-use toml_edit::{value, Document, InlineTable, Item, Table, Value};
+use toml_edit::{value, DocumentMut, InlineTable, Item, Table, Value};
 
 fn get_workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -75,7 +75,7 @@ fn patch_manifest_file_with_path_std(manifest_dir: &Path) -> anyhow::Result<()> 
     let toml_path = manifest_dir.join(sway_utils::constants::MANIFEST_FILE_NAME);
     let toml_content = fs::read_to_string(&toml_path).unwrap();
 
-    let mut doc = toml_content.parse::<Document>().unwrap();
+    let mut doc = toml_content.parse::<DocumentMut>().unwrap();
     let new_std_path = get_workspace_root().join("sway-lib-std");
 
     let mut std_dependency = InlineTable::new();
@@ -89,7 +89,7 @@ fn patch_manifest_file_with_path_std(manifest_dir: &Path) -> anyhow::Result<()> 
 fn patch_manifest_file_with_proxy_table(manifest_dir: &Path, proxy: Proxy) -> anyhow::Result<()> {
     let toml_path = manifest_dir.join(sway_utils::constants::MANIFEST_FILE_NAME);
     let toml_content = fs::read_to_string(&toml_path)?;
-    let mut doc = toml_content.parse::<Document>()?;
+    let mut doc = toml_content.parse::<DocumentMut>()?;
 
     let proxy_table = doc.entry("proxy").or_insert(Item::Table(Table::new()));
     let proxy_table = proxy_table.as_table_mut().unwrap();

--- a/forc-plugins/forc-client/tests/deploy.rs
+++ b/forc-plugins/forc-client/tests/deploy.rs
@@ -428,12 +428,12 @@ async fn test_deploy_fresh_proxy() {
     node.kill().unwrap();
     let impl_contract = DeployedContract {
         id: ContractId::from_str(
-            "50fe882cbef5f3da6da82509a66b7e5e0a64a40d70164861c01c908a332198ae",
+            "47fd96252869c61cc26e8274a7991c8d97bf522d4742036ce09699af59524cbb",
         )
         .unwrap(),
         proxy: Some(
             ContractId::from_str(
-                "8eae70214f55d25a65608bd288a5863e7187fcf65705143ee1a45fd228dacc19",
+                "a325d26e72eb664e3d080e547a7cd8824256e37bccad508aedeec5e24fc20cc7",
             )
             .unwrap(),
         ),

--- a/forc-plugins/forc-client/tests/deploy.rs
+++ b/forc-plugins/forc-client/tests/deploy.rs
@@ -341,7 +341,7 @@ async fn test_simple_deploy() {
     node.kill().unwrap();
     let expected = vec![DeployedContract {
         id: ContractId::from_str(
-            "50fe882cbef5f3da6da82509a66b7e5e0a64a40d70164861c01c908a332198ae",
+            "47fd96252869c61cc26e8274a7991c8d97bf522d4742036ce09699af59524cbb",
         )
         .unwrap(),
         proxy: None,
@@ -383,7 +383,7 @@ async fn test_deploy_submit_only() {
     node.kill().unwrap();
     let expected = vec![DeployedContract {
         id: ContractId::from_str(
-            "50fe882cbef5f3da6da82509a66b7e5e0a64a40d70164861c01c908a332198ae",
+            "47fd96252869c61cc26e8274a7991c8d97bf522d4742036ce09699af59524cbb",
         )
         .unwrap(),
         proxy: None,

--- a/forc-plugins/forc-crypto/Cargo.toml
+++ b/forc-plugins/forc-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-crypto"
-version = "0.63.5"
+version.workspace = true
 description = "A `forc` plugin for handling various cryptographic operations and conversions."
 authors.workspace = true
 edition.workspace = true
@@ -9,23 +9,23 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = "1.0.75"
-async-trait = "0.1.58"
-atty = "0.2.14"
-clap = { version = "4.5.4", features = ["derive", "env"] }
-forc-tracing = { version = "0.63.5", path = "../../forc-tracing" }
-forc-util = { version = "0.63.5", path = "../../forc-util" }
-fuel-core-types = { workspace = true }
+anyhow.workspace = true
+async-trait.workspace = true
+atty.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+forc-tracing.workspace = true
+forc-util.workspace = true
+fuel-core-types.workspace = true
 fuel-crypto = { workspace = true, features = ["random"] }
-fuels-core = { workspace = true }
-futures = "0.3"
-hex = "0.4.3"
-libp2p-identity = { version = "0.2.4", features = ["secp256k1", "peerid"] }
-rand = "0.8"
-serde = "1.0"
-serde_json = "1"
-serde_yaml = "0.9.27"
-sha3 = "0.10.8"
-termion = "2.0.1"
-tokio = { version = "1.8", features = ["macros", "rt-multi-thread", "process"] }
-tracing = "0.1"
+fuels-core.workspace = true
+futures.workspace = true
+hex.workspace = true
+libp2p-identity = { workspace = true, features = ["peerid", "secp256k1"] }
+rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+sha3.workspace = true
+termion.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "process"] }
+tracing.workspace = true

--- a/forc-plugins/forc-debug/Cargo.toml
+++ b/forc-plugins/forc-debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-debug"
-version = "0.63.5"
+version.workspace = true
 description = "Supports debugging Sway code via CLI and DAP server."
 authors.workspace = true
 edition.workspace = true
@@ -9,26 +9,26 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = "1.0" # Used by the examples and for conversion only
-clap = { version = "4.5.4", features = ["derive", "env"] }
-dap = "0.4.1-alpha1"
-forc-pkg = { version = "0.63.5", path = "../../forc-pkg" }
-forc-test = { version = "0.63.5", path = "../../forc-test" }
-forc-tracing = { version = "0.63.5", path = "../../forc-tracing" }
-fuel-core-client = { workspace = true }
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+dap.workspace = true
+forc-pkg.workspace = true
+forc-test.workspace = true
+forc-tracing.workspace = true
+fuel-core-client.workspace = true
 fuel-types = { workspace = true, features = ["serde"] }
 fuel-vm = { workspace = true, features = ["serde"] }
-rayon = "1.7.0"
-serde = "1.0"
-serde_json = "1.0"
-shellfish = { version = "0.6.0", features = ["rustyline", "async", "tokio"] }
-sway-core = { version = "0.63.5", path = "../../sway-core" }
-sway-types = { version = "0.63.5", path = "../../sway-types" }
-thiserror = "1.0"
-tokio = { version = "1.8", features = [
-    "net",
+rayon.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+shellfish = { workspace = true, features = ["async", "rustyline", "tokio"] }
+sway-core.workspace = true
+sway-types.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = [
     "io-util",
     "macros",
+    "net",
     "rt-multi-thread",
 ] }
 
@@ -36,4 +36,4 @@ tokio = { version = "1.8", features = [
 dap = { version = "0.4.1-alpha1", features = ["client"] }
 escargot = "0.5.7"
 portpicker = "0.1.1"
-rexpect = "0.4"
+rexpect = "0.5.0"

--- a/forc-plugins/forc-doc/Cargo.toml
+++ b/forc-plugins/forc-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-doc"
-version = "0.63.5"
+version.workspace = true
 description = "Build the documentation for the local package and all dependencies. The output is placed in `out/doc` in the same format as the project."
 authors.workspace = true
 edition.workspace = true
@@ -9,23 +9,23 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = "1.0.65"
-clap = { version = "4.5.4", features = ["derive"] }
-comrak = "0.16"
-forc-pkg = { version = "0.63.5", path = "../../forc-pkg" }
-forc-tracing = { version = "0.63.5", path = "../../forc-tracing" }
-forc-util = { version = "0.63.5", path = "../../forc-util" }
-horrorshow = "0.8.4"
-include_dir = "0.7.3"
-minifier = "0.3.0"
-opener = "0.5.0"
-serde = "1.0"
-serde_json = "1.0"
-sway-ast = { version = "0.63.5", path = "../../sway-ast" }
-sway-core = { version = "0.63.5", path = "../../sway-core" }
-sway-lsp = { version = "0.63.5", path = "../../sway-lsp" }
-sway-types = { version = "0.63.5", path = "../../sway-types" }
-swayfmt = { version = "0.63.5", path = "../../swayfmt" }
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+comrak.workspace = true
+forc-pkg.workspace = true
+forc-tracing.workspace = true
+forc-util.workspace = true
+horrorshow.workspace = true
+include_dir.workspace = true
+minifier.workspace = true
+opener.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sway-ast.workspace = true
+sway-core.workspace = true
+sway-lsp.workspace = true
+sway-types.workspace = true
+swayfmt.workspace = true
 
 [dev-dependencies]
 dir_indexer = "0.0.2"

--- a/forc-plugins/forc-fmt/Cargo.toml
+++ b/forc-plugins/forc-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-fmt"
-version = "0.63.5"
+version.workspace = true
 description = "A `forc` plugin for running the Sway code formatter."
 authors.workspace = true
 edition.workspace = true
@@ -9,14 +9,14 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = "1"
-clap = { version = "4.5.4", features = ["derive"] }
-forc-pkg = { version = "0.63.5", path = "../../forc-pkg" }
-forc-tracing = { version = "0.63.5", path = "../../forc-tracing" }
-forc-util = { version = "0.63.5", path = "../../forc-util" }
-prettydiff = "0.5"
-sway-core = { version = "0.63.5", path = "../../sway-core" }
-sway-utils = { version = "0.63.5", path = "../../sway-utils" }
-swayfmt = { version = "0.63.5", path = "../../swayfmt" }
-taplo = "0.7"
-tracing = "0.1"
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+forc-pkg.workspace = true
+forc-tracing.workspace = true
+forc-util.workspace = true
+prettydiff.workspace = true
+sway-core.workspace = true
+sway-utils.workspace = true
+swayfmt.workspace = true
+taplo.workspace = true
+tracing.workspace = true

--- a/forc-plugins/forc-lsp/Cargo.toml
+++ b/forc-plugins/forc-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-lsp"
-version = "0.63.5"
+version.workspace = true
 description = "A simple `forc` plugin for starting the sway language server."
 authors.workspace = true
 edition.workspace = true
@@ -9,8 +9,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = "1"
-clap = { version = "4.5.4", features = ["derive"] }
-sway-lsp = { version = "0.63.5", path = "../../sway-lsp" }
-tikv-jemallocator = "0.5"
-tokio = { version = "1.8" }
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+sway-lsp.workspace = true
+tikv-jemallocator.workspace = true
+tokio.workspace = true

--- a/forc-plugins/forc-tx/Cargo.toml
+++ b/forc-plugins/forc-tx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-tx"
-version = "0.63.5"
+version.workspace = true
 description = "A `forc` plugin for constructing transactions."
 authors.workspace = true
 edition.workspace = true
@@ -16,12 +16,12 @@ name = "forc-tx"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1"
-clap = { version = "4.5.4", features = ["derive", "env"] }
-devault = "0.1"
-forc-util = { version = "0.63.5", path = "../../forc-util" }
-fuel-tx = { workspace = true, features = ["serde", "test-helpers", "random"] }
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+devault.workspace = true
+forc-util.workspace = true
+fuel-tx = { workspace = true, features = ["random", "serde", "test-helpers"] }
 fuel-types = { workspace = true, features = ["serde"] }
-serde = "1.0"
-serde_json = { version = "1" }
-thiserror = "1"
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true

--- a/forc-test/Cargo.toml
+++ b/forc-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-test"
-version = "0.63.5"
+version.workspace = true
 description = "A library for building and running Sway unit tests within Forc packages."
 authors.workspace = true
 edition.workspace = true
@@ -9,13 +9,13 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = "1"
-forc-pkg = { version = "0.63.5", path = "../forc-pkg" }
-fuel-abi-types = { workspace = true }
+anyhow.workspace = true
+forc-pkg.workspace = true
+fuel-abi-types.workspace = true
 fuel-tx = { workspace = true, features = ["test-helpers"] }
 fuel-vm = { workspace = true, features = ["random", "test-helpers"] }
-fuels-core = { workspace = true }
-rand = "0.8"
-rayon = "1.7.0"
-sway-core = { version = "0.63.5", path = "../sway-core" }
-sway-types = { version = "0.63.5", path = "../sway-types" }
+fuels-core.workspace = true
+rand.workspace = true
+rayon.workspace = true
+sway-core.workspace = true
+sway-types.workspace = true

--- a/forc-tracing/Cargo.toml
+++ b/forc-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-tracing"
-version = "0.63.5"
+version.workspace = true
 description = "Tracing utility shared between forc crates."
 authors.workspace = true
 edition.workspace = true
@@ -9,9 +9,9 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-ansi_term = "0.12"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }
+ansi_term.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "json"] }
 
 [dev-dependencies]
 tracing-test = "0.2"

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-util"
-version = "0.63.5"
+version.workspace = true
 description = "Utility items shared between forc crates."
 authors.workspace = true
 edition.workspace = true
@@ -9,31 +9,31 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-annotate-snippets = { version = "0.10.1" }
-ansi_term = "0.12"
-anyhow = "1"
-clap = { version = "4.5.4", features = ["cargo", "derive", "env"] }
-dirs = "3.0.2"
-fd-lock = "4.0"
-forc-tracing = { version = "0.63.5", path = "../forc-tracing" }
+annotate-snippets.workspace = true
+ansi_term.workspace = true
+anyhow.workspace = true
+clap = { workspace = true, features = ["cargo", "derive", "env"] }
+dirs.workspace = true
+fd-lock.workspace = true
+forc-tracing.workspace = true
 fuel-tx = { workspace = true, features = ["serde"], optional = true }
-hex = "0.4.3"
-paste = "1.0.14"
-regex = "1.10.2"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.73"
-serial_test = "3.0.0"
-sway-core = { version = "0.63.5", path = "../sway-core" }
-sway-error = { version = "0.63.5", path = "../sway-error" }
-sway-types = { version = "0.63.5", path = "../sway-types" }
-sway-utils = { version = "0.63.5", path = "../sway-utils" }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = [
+hex.workspace = true
+paste.workspace = true
+regex.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serial_test.workspace = true
+sway-core.workspace = true
+sway-error.workspace = true
+sway-types.workspace = true
+sway-utils.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = [
     "ansi",
     "env-filter",
     "json",
 ] }
-unicode-xid = "0.2.2"
+unicode-xid.workspace = true
 
 [features]
 default = ["fuel-tx"]

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc"
-version = "0.63.5"
+version.workspace = true
 description = "Fuel Orchestrator."
 authors.workspace = true
 edition.workspace = true
@@ -17,35 +17,35 @@ name = "forc"
 path = "src/main.rs"
 
 [dependencies]
-annotate-snippets = { version = "0.10.1" }
-ansi_term = "0.12"
-anyhow = "1.0.41"
-clap = { version = "4.5.4", features = ["cargo", "derive", "env"] }
-clap_complete = "4.5.2"
-clap_complete_fig = "4.5.0"
-forc-pkg = { version = "0.63.5", path = "../forc-pkg" }
-forc-test = { version = "0.63.5", path = "../forc-test" }
-forc-tracing = { version = "0.63.5", path = "../forc-tracing" }
-forc-util = { version = "0.63.5", path = "../forc-util" }
-fs_extra = "1.2"
-fuel-asm = { workspace = true }
-hex = "0.4.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.73"
-sway-core = { version = "0.63.5", path = "../sway-core" }
-sway-error = { version = "0.63.5", path = "../sway-error" }
-sway-ir = { version = "0.63.5", path = "../sway-ir" }
-sway-types = { version = "0.63.5", path = "../sway-types" }
-sway-utils = { version = "0.63.5", path = "../sway-utils" }
-term-table = "1.3"
-tokio = { version = "1.8.0", features = ["macros", "rt-multi-thread"] }
-toml = { version = "0.7", features = ["parse"] }
-toml_edit = "0.19"
-tracing = "0.1"
-url = "2.2"
-uwuify = { version = "^0.2", optional = true }
-walkdir = "2.3"
-whoami = "1.1"
+annotate-snippets.workspace = true
+ansi_term.workspace = true
+anyhow.workspace = true
+clap = { workspace = true, features = ["cargo", "derive", "env"] }
+clap_complete.workspace = true
+clap_complete_fig.workspace = true
+forc-pkg.workspace = true
+forc-test.workspace = true
+forc-tracing.workspace = true
+forc-util.workspace = true
+fs_extra.workspace = true
+fuel-asm.workspace = true
+hex.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sway-core.workspace = true
+sway-error.workspace = true
+sway-ir.workspace = true
+sway-types.workspace = true
+sway-utils.workspace = true
+term-table.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+toml = { workspace = true, features = ["parse"] }
+toml_edit.workspace = true
+tracing.workspace = true
+url.workspace = true
+uwuify = { workspace = true, optional = true }
+walkdir.workspace = true
+whoami.workspace = true
 
 [features]
 default = []

--- a/forc/src/cli/commands/build.rs
+++ b/forc/src/cli/commands/build.rs
@@ -17,13 +17,13 @@ forc_util::cli_examples! {
 /// - `script`, `predicate` and `contract` projects will produce their bytecode in binary format `<project-name>.bin`.
 ///
 /// - `script` projects will also produce a file containing the hash of the bytecode binary
-/// `<project-name>-bin-hash` (using `fuel_cypto::Hasher`).
+///   `<project-name>-bin-hash` (using `fuel_cypto::Hasher`).
 ///
 /// - `predicate` projects will also produce a file containing the **root** hash of the bytecode binary
-/// `<project-name>-bin-root` (using `fuel_tx::Contract::root_from_code`).
+///   `<project-name>-bin-root` (using `fuel_tx::Contract::root_from_code`).
 ///
 /// - `contract` and `library` projects will also produce the public ABI in JSON format
-/// `<project-name>-abi.json`.
+///   `<project-name>-abi.json`.
 #[derive(Debug, Default, Parser)]
 #[clap(bin_name = "forc build", version, after_help = help())]
 pub struct Command {

--- a/forc/src/ops/forc_template.rs
+++ b/forc/src/ops/forc_template.rs
@@ -84,7 +84,7 @@ fn edit_forc_toml(out_dir: &Path, project_name: &str, real_name: &str) -> Result
     let mut file = File::open(out_dir.join(constants::MANIFEST_FILE_NAME))?;
     let mut toml = String::new();
     file.read_to_string(&mut toml)?;
-    let mut manifest_toml = toml.parse::<toml_edit::Document>()?;
+    let mut manifest_toml = toml.parse::<toml_edit::DocumentMut>()?;
 
     let mut authors = Vec::new();
     let forc_toml: toml::Value = toml::de::from_str(&toml)?;
@@ -144,7 +144,7 @@ fn edit_cargo_toml(out_dir: &Path, project_name: &str, real_name: &str) -> Resul
     }
     updated_authors.push(real_name);
 
-    let mut manifest_toml = toml.parse::<toml_edit::Document>()?;
+    let mut manifest_toml = toml.parse::<toml_edit::DocumentMut>()?;
     manifest_toml["package"]["authors"] = toml_edit::value(updated_authors);
     manifest_toml["package"]["name"] = toml_edit::value(project_name);
 

--- a/forc/tests/cli_integration.rs
+++ b/forc/tests/cli_integration.rs
@@ -49,10 +49,10 @@ fn test_forc_test_raw_logs() -> Result<(), rexpect::error::Error> {
     // Assert that the output is correct
     process.exp_string("      test test_log_4")?;
     process.exp_string("Raw logs:")?;
-    process.exp_string(r#"[{"LogData":{"data":"0000000000000004","digest":"8005f02d43fa06e7d0585fb64c961d57e318b27a145c857bcd3a6bdb413ff7fc","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12652,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
+    process.exp_string(r#"[{"LogData":{"data":"0000000000000004","digest":"8005f02d43fa06e7d0585fb64c961d57e318b27a145c857bcd3a6bdb413ff7fc","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12596,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
     process.exp_string("      test test_log_2")?;
     process.exp_string("Raw logs:")?;
-    process.exp_string(r#"[{"LogData":{"data":"0000000000000002","digest":"cd04a4754498e06db5a13c5f371f1f04ff6d2470f24aa9bd886540e5dce77f70","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12652,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
+    process.exp_string(r#"[{"LogData":{"data":"0000000000000002","digest":"cd04a4754498e06db5a13c5f371f1f04ff6d2470f24aa9bd886540e5dce77f70","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12596,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
 
     process.process.exit()?;
     Ok(())
@@ -74,11 +74,11 @@ fn test_forc_test_both_logs() -> Result<(), rexpect::error::Error> {
     process.exp_string("      test test_log_4")?;
     process.exp_string("Decoded log value: 4, log rb: 1515152261580153489")?;
     process.exp_string("Raw logs:")?;
-    process.exp_string(r#"[{"LogData":{"data":"0000000000000004","digest":"8005f02d43fa06e7d0585fb64c961d57e318b27a145c857bcd3a6bdb413ff7fc","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12652,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
+    process.exp_string(r#"[{"LogData":{"data":"0000000000000004","digest":"8005f02d43fa06e7d0585fb64c961d57e318b27a145c857bcd3a6bdb413ff7fc","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12596,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
     process.exp_string("      test test_log_2")?;
     process.exp_string("Decoded log value: 2, log rb: 1515152261580153489")?;
     process.exp_string("Raw logs:")?;
-    process.exp_string(r#"[{"LogData":{"data":"0000000000000002","digest":"cd04a4754498e06db5a13c5f371f1f04ff6d2470f24aa9bd886540e5dce77f70","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12652,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
+    process.exp_string(r#"[{"LogData":{"data":"0000000000000002","digest":"cd04a4754498e06db5a13c5f371f1f04ff6d2470f24aa9bd886540e5dce77f70","id":"0000000000000000000000000000000000000000000000000000000000000000","is":10368,"len":8,"pc":12596,"ptr":67107840,"ra":0,"rb":1515152261580153489}}]"#)?;
     process.process.exit()?;
     Ok(())
 }

--- a/scripts/mdbook-forc-documenter/Cargo.toml
+++ b/scripts/mdbook-forc-documenter/Cargo.toml
@@ -13,9 +13,9 @@ name = "mdbook_forc_documenter"
 path = "src/lib.rs"
 
 [dependencies]
-anyhow = "1"
-clap = { version = "4.5.4", features = ["derive"] }
-mdbook = { version = "0.4", default-features = false }
-semver = "1.0"
-serde = "1.0"
-serde_json = "1.0"
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+mdbook.workspace = true
+semver.workspace = true
+serde.workspace = true
+serde_json.workspace = true

--- a/sway-ast/Cargo.toml
+++ b/sway-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ast"
-version = "0.63.5"
+version.workspace = true
 description = "Sway's AST"
 authors.workspace = true
 edition.workspace = true
@@ -9,12 +9,12 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-extension-trait = "1.0.1"
-num-bigint = { version = "0.4.3", features = ["serde"] }
-num-traits = "0.2.14"
-serde = { version = "1.0", features = ["derive"] }
-sway-error = { version = "0.63.5", path = "../sway-error" }
-sway-types = { version = "0.63.5", path = "../sway-types" }
+extension-trait.workspace = true
+num-bigint = { workspace = true, features = ["serde"] }
+num-traits.workspace = true
+serde = { workspace = true, features = ["derive"] }
+sway-error.workspace = true
+sway-types.workspace = true
 
 [lints.clippy]
 iter_over_hash_type = "deny"

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-core"
-version = "0.63.5"
+version.workspace = true
 description = "Sway core language."
 authors.workspace = true
 edition.workspace = true
@@ -9,49 +9,47 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-clap = { version = "4.5.4", features = ["derive"] }
-derivative = "2.2.0"
-dirs = "3.0"
-either = "1.9.0"
-ethabi = { package = "fuel-ethabi", version = "18.0.0" }
-etk-asm = { package = "fuel-etk-asm", version = "0.3.1-dev", features = [
-    "backtraces",
-] }
-etk-ops = { package = "fuel-etk-ops", version = "0.3.1-dev" }
-fuel-abi-types = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+derivative.workspace = true
+dirs.workspace = true
+either.workspace = true
+ethabi.workspace = true
+etk-asm = { workspace = true, features = ["backtraces"] }
+etk-ops.workspace = true
+fuel-abi-types.workspace = true
 fuel-vm = { workspace = true, features = ["serde"] }
-gimli = "0.28.1"
-graph-cycles = "0.1.0"
-hashbrown = "0.13.1"
-hex = { version = "0.4", optional = true }
-im = "15.0"
-indexmap = "2.0.0"
-itertools = "0.10"
-lazy_static = "1.4"
-miden-core = "0.3.0"
-object = { version = "0.32.2", features = ["write"] }
-parking_lot = "0.12"
-pest = "2.1.3"
-pest_derive = "2.1"
-petgraph = "0.6"
-rustc-hash = "1.1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.91"
-sha2 = "0.9"
-strum = { version = "0.24.1", features = ["derive"] }
-sway-ast = { version = "0.63.5", path = "../sway-ast" }
-sway-error = { version = "0.63.5", path = "../sway-error" }
-sway-ir = { version = "0.63.5", path = "../sway-ir" }
-sway-parse = { version = "0.63.5", path = "../sway-parse" }
-sway-types = { version = "0.63.5", path = "../sway-types" }
-sway-utils = { version = "0.63.5", path = "../sway-utils" }
-thiserror = "1.0"
-tracing = "0.1"
-uint = "0.9"
-vec1 = "1.8.0"
+gimli.workspace = true
+graph-cycles.workspace = true
+hashbrown.workspace = true
+hex = { workspace = true, optional = true }
+im.workspace = true
+indexmap.workspace = true
+itertools.workspace = true
+lazy_static.workspace = true
+miden-core.workspace = true
+object = { workspace = true, features = ["write"] }
+parking_lot.workspace = true
+pest.workspace = true
+pest_derive.workspace = true
+petgraph.workspace = true
+rustc-hash.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha2.workspace = true
+strum = { workspace = true, features = ["derive"] }
+sway-ast.workspace = true
+sway-error.workspace = true
+sway-ir.workspace = true
+sway-parse.workspace = true
+sway-types.workspace = true
+sway-utils.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+uint.workspace = true
+vec1.workspace = true
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-sysinfo = "0.29.0"
+sysinfo = "0.31.4"
 
 [lints.clippy]
 iter_over_hash_type = "deny"

--- a/sway-core/src/asm_generation/fuel/analyses.rs
+++ b/sway-core/src/asm_generation/fuel/analyses.rs
@@ -17,9 +17,9 @@ use crate::asm_lang::{ControlFlowOp, Label, Op, VirtualRegister};
 /// Two tables are generated: `live_in` and `live_out`. Each row in the tables corresponds to an
 /// instruction in the program.
 /// * A virtual register is in the `live_out` table for a given instruction if it is live on any
-/// of that node's out-edges
+///   of that node's out-edges
 /// * A virtual register is in the `live_in` table for a given instruction if it is live on any
-/// of that node's in-edges
+///   of that node's in-edges
 ///
 ///
 /// Algorithm:

--- a/sway-core/src/asm_generation/fuel/programs/abstract.rs
+++ b/sway-core/src/asm_generation/fuel/programs/abstract.rs
@@ -158,14 +158,12 @@ impl AbstractProgram {
     /// Builds the asm preamble, which includes metadata and a jump past the metadata.
     /// Right now, it looks like this:
     ///
-    /// WORD OP
-    /// 1    MOV $scratch $pc
-    /// -    JMPF $zero i2
-    /// 2    DATA_START (0-32) (in bytes, offset from $is)
-    /// -    DATA_START (32-64)
-    /// 3    LW $ds $scratch 1
-    /// -    ADD $ds $ds $scratch
-    /// 4    .program_start:
+    /// | WORD | OP                                                                      |
+    /// |------|-------------------------------------------------------------------------|
+    /// | 1    | MOV $scratch $pc <br /> JMPF $zero i2                                   |
+    /// | 2    | DATA_START (0-32) (in bytes, offset from $is) <br /> DATA_START (32-64) |
+    /// | 3    | LW $ds $scratch 1 <br /> ADD $ds $ds $scratch                           |
+    /// | 4    | .program_start:                                                         |
     fn build_prologue(&mut self) -> AllocatedAbstractInstructionSet {
         let label = self.reg_seqr.get_label();
         AllocatedAbstractInstructionSet {

--- a/sway-core/src/asm_generation/fuel/register_allocator.rs
+++ b/sway-core/src/asm_generation/fuel/register_allocator.rs
@@ -106,6 +106,7 @@ impl RegisterPool {
     }
 }
 
+#[allow(clippy::doc_lazy_continuation)]
 /// Given a list of instructions `ops` and a `live_out` table computed using the method
 /// `liveness_analysis()`, create an interference graph (aka a "conflict" graph):
 /// * Nodes = virtual registers
@@ -191,8 +192,8 @@ pub(crate) fn create_interference_graph(
 /// * When two registers are coalesced, a new node with a new virtual register (generated using the
 ///   register sequencer) is created in the interference graph.
 /// * When a MOVE instruction is removed, the offset of each subsequent instruction has to be
-/// updated, as well as the immediate values for some or all jump instructions (`ji`, `jnei`, and
-/// `jnzi for now).
+///   updated, as well as the immediate values for some or all jump instructions (`ji`, `jnei`, and
+///   `jnzi for now).
 ///
 pub(crate) fn coalesce_registers(
     ops: &[Op],
@@ -373,6 +374,7 @@ fn compute_def_use_points(ops: &[Op]) -> FxHashMap<VirtualRegister, (Vec<usize>,
     res
 }
 
+#[allow(clippy::doc_lazy_continuation)]
 /// Given an interference graph and a integer k, figure out if the graph k-colorable. Graph
 /// coloring is an NP-complete problem, but the algorithm below is a simple stack based
 /// approximation that relies on the fact that any node n in the graph that has fewer than k

--- a/sway-core/src/language/ty/expression/reassignment.rs
+++ b/sway-core/src/language/ty/expression/reassignment.rs
@@ -47,6 +47,7 @@ pub enum TyReassignmentTarget {
     /// E.g.:
     ///  - *my_ref
     ///  - **if x > 0 { &mut &mut a } else { &mut &mut b }
+    ///
     /// The [TyExpression] is guaranteed to be of [TyExpressionVariant::Deref].
     Deref(Box<TyExpression>),
 }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -1476,6 +1476,7 @@ fn check_for_unconstrained_type_parameters(
 ) -> Result<(), ErrorEmitted> {
     // Create a list of defined generics, with the generic and a span.
     // Purposefully exclude the "self" type parameters.
+    #[allow(clippy::mutable_key_type)]
     let mut defined_generics: HashMap<_, _> = HashMap::from_iter(
         type_parameters
             .iter()
@@ -1484,6 +1485,7 @@ fn check_for_unconstrained_type_parameters(
     );
 
     // create a list of the generics in use in the impl signature
+    #[allow(clippy::mutable_key_type)]
     let mut generics_in_use = HashSet::new();
     for type_arg in trait_type_arguments.iter() {
         generics_in_use.extend(type_arg.type_id.extract_nested_generics(engines));

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/mod.rs
@@ -20,12 +20,12 @@
 //! for a particular match branch (arm):
 //! - branch condition: Overall condition that must be `true` for the branch to match.
 //! - result variable declarations: Variable declarations that needs to be added to the
-//! match branch result, before the actual body. Here we distinguish between the variables
-//! actually declared in the match arm pattern and so called "tuple variables" that are
-//! compiler generated and contain values for variables extracted out of individual OR variants.
+//!   match branch result, before the actual body. Here we distinguish between the variables
+//!   actually declared in the match arm pattern and so called "tuple variables" that are
+//!   compiler generated and contain values for variables extracted out of individual OR variants.
 //! - OR variant index variables: Variable declarations that are generated in case of having
-//! variables in OR patterns. Index variables hold 1-based index of the OR variant being matched
-//! or zero if non of the OR variants has matched.
+//!   variables in OR patterns. Index variables hold 1-based index of the OR variant being matched
+//!   or zero if non of the OR variants has matched.
 //!
 //! Afterwards, these three artifacts coming from every individual branch are glued together in the
 //! [crate::ty::TyMatchExpression] to form the final desugaring.

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
@@ -252,12 +252,12 @@ type CarryOverTupleDeclarations = Vec<VarDecl>;
 /// via [ty::TyMatchBranch]:
 /// - branch condition: Overall condition that must be `true` for the branch to match.
 /// - result variable declarations: Variable declarations that needs to be added to the
-/// match branch result, before the actual body. Here we distinguish between the variables
-/// actually declared in the match arm pattern and so called "tuple variables" that are
-/// compiler generated and contain values for variables extracted out of individual OR variants.
+///   match branch result, before the actual body. Here we distinguish between the variables
+///   actually declared in the match arm pattern and so called "tuple variables" that are
+///   compiler generated and contain values for variables extracted out of individual OR variants.
 /// - OR variant index variables: Variable declarations that are generated in case of having
-/// variables in OR patterns. Index variables hold 1-based index of the OR variant being matched
-/// or zero if non of the OR variants has matched.
+///   variables in OR patterns. Index variables hold 1-based index of the OR variant being matched
+///   or zero if non of the OR variants has matched.
 ///
 /// ## Algorithm Overview
 /// The algorithm traverses the `req_decl_tree` bottom up from left to right and collects the

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -858,7 +858,8 @@ impl ty::TyExpression {
         /// Returns the position of the first match arm that is an "interior" arm, meaning:
         ///  - arm is a catch-all arm
         ///  - arm is not the last match arm
-        /// or `None` if such arm does not exist.
+        ///  - or `None` if such arm does not exist.
+        ///
         /// Note that the arm can be the first arm.
         fn interior_catch_all_arm_position(arms_reachability: &[ReachableReport]) -> Option<usize> {
             arms_reachability

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -1201,6 +1201,7 @@ impl<'a> TypeCheckContext<'a> {
             }
 
             if !maybe_method_decl_refs.is_empty() {
+                #[allow(clippy::mutable_key_type)]
                 let mut trait_methods =
                     HashMap::<(CallPath, Vec<WithEngines<TypeArgument>>), DeclRefFunction>::new();
                 let mut impl_self_method = None;

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -452,6 +452,7 @@ impl TypeId {
         inner_types
     }
 
+    #[allow(clippy::mutable_key_type)]
     pub(crate) fn extract_nested_generics(
         self,
         engines: &Engines,

--- a/sway-core/src/type_system/unify/occurs_check.rs
+++ b/sway-core/src/type_system/unify/occurs_check.rs
@@ -31,6 +31,7 @@ impl<'a> OccursCheck<'a> {
     /// case the occurs check would return `false`, as this is a valid
     /// unification.
     pub(super) fn check(&self, generic: TypeId, other: TypeId) -> bool {
+        #[allow(clippy::mutable_key_type)]
         let other_generics = other.extract_nested_generics(self.engines);
         other_generics.contains(
             &self

--- a/sway-error/Cargo.toml
+++ b/sway-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-error"
-version = "0.63.5"
+version.workspace = true
 description = "Sway's error handling"
 authors.workspace = true
 edition.workspace = true
@@ -9,14 +9,14 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-either = "1.9.0"
-in_definite = "1.0.0"
-num-traits = "0.2.14"
-smallvec = "1.7"
-strsim = "0.11.1"
-sway-types = { version = "0.63.5", path = "../sway-types" }
-thiserror = "1.0"
-uwuify = { version = "^0.2", optional = true }
+either.workspace = true
+in_definite.workspace = true
+num-traits.workspace = true
+smallvec.workspace = true
+strsim.workspace = true
+sway-types.workspace = true
+thiserror.workspace = true
+uwuify = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/sway-ir/Cargo.toml
+++ b/sway-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ir"
-version = "0.63.5"
+version.workspace = true
 description = "Sway intermediate representation."
 authors.workspace = true
 edition.workspace = true
@@ -9,19 +9,19 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = "1.0"
-downcast-rs = "1.2.0"
-filecheck = "0.5"
-indexmap = { version = "2.0.0", features = ["rayon"] }
-itertools = "0.10.3"
-once_cell = "1.18.0"
-peg = "0.7"
-prettydiff = "0.6.4"
-rustc-hash = "1.1.0"
-slotmap = "1.0.7"
-sway-ir-macros = { version = "0.63.5", path = "sway-ir-macros" }
-sway-types = { version = "0.63.5", path = "../sway-types" }
-sway-utils = { version = "0.63.5", path = "../sway-utils" }
+anyhow.workspace = true
+downcast-rs.workspace = true
+filecheck.workspace = true
+indexmap = { workspace = true, features = ["rayon"] }
+itertools.workspace = true
+once_cell.workspace = true
+peg.workspace = true
+prettydiff.workspace = true
+rustc-hash.workspace = true
+slotmap.workspace = true
+sway-ir-macros.workspace = true
+sway-types.workspace = true
+sway-utils.workspace = true
 
 [lints.clippy]
 iter_over_hash_type = "deny"

--- a/sway-ir/sway-ir-macros/Cargo.toml
+++ b/sway-ir/sway-ir-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-ir-macros"
-version = "0.63.5"
+version.workspace = true
 description = "Macros for sway's intermediate representation."
 authors.workspace = true
 edition.workspace = true
@@ -12,10 +12,10 @@ repository.workspace = true
 proc-macro = true
 
 [dependencies]
-itertools = "0.10.3"
-proc-macro2 = "1.0.43"
-quote = "1.0.21"
-syn = { version = "1.0.99", features = ["derive", "extra-traits"] }
+itertools.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+syn = { workspace = true, features = ["derive", "extra-traits", "parsing"] }
 
 [lints.clippy]
 iter_over_hash_type = "deny"

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -8,6 +8,9 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[package.metadata.cargo-udeps.ignore]
+normal = ["tower"]
+
 [dependencies]
 anyhow.workspace = true
 crossbeam-channel.workspace = true

--- a/sway-lsp/Cargo.toml
+++ b/sway-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-lsp"
-version = "0.63.5"
+version.workspace = true
 description = "LSP server for Sway."
 authors.workspace = true
 edition.workspace = true
@@ -9,35 +9,35 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = "1.0.41"
-crossbeam-channel = "0.5"
-dashmap = "5.4"
-fd-lock = "4.0"
-forc-pkg = { version = "0.63.5", path = "../forc-pkg" }
-forc-tracing = { version = "0.63.5", path = "../forc-tracing" }
-forc-util = { version = "0.63.5", path = "../forc-util" }
-indexmap = { version = "2.0.0", features = ["rayon"] }
-lsp-types = { version = "0.94", features = ["proposed"] }
-notify = "5.0.0"
-notify-debouncer-mini = { version = "0.2.0" }
-parking_lot = "0.12.1"
-proc-macro2 = "1.0.5"
-quote = "1.0.9"
-rayon = "1.5.0"
-rayon-cond = "0.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.60"
-sway-ast = { version = "0.63.5", path = "../sway-ast" }
-sway-core = { version = "0.63.5", path = "../sway-core" }
-sway-error = { version = "0.63.5", path = "../sway-error" }
-sway-parse = { version = "0.63.5", path = "../sway-parse" }
-sway-types = { version = "0.63.5", path = "../sway-types" }
-sway-utils = { version = "0.63.5", path = "../sway-utils" }
-swayfmt = { version = "0.63.5", path = "../swayfmt" }
-syn = { version = "1.0.73", features = ["full"] }
-tempfile = "3"
-thiserror = "1.0.30"
-tokio = { version = "1.3", features = [
+anyhow.workspace = true
+crossbeam-channel.workspace = true
+dashmap.workspace = true
+fd-lock.workspace = true
+forc-pkg.workspace = true
+forc-tracing.workspace = true
+forc-util.workspace = true
+indexmap = { workspace = true, features = ["rayon"] }
+lsp-types = { workspace = true, features = ["proposed"] }
+notify.workspace = true
+notify-debouncer-mini.workspace = true
+parking_lot.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+rayon.workspace = true
+rayon-cond.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sway-ast.workspace = true
+sway-core.workspace = true
+sway-error.workspace = true
+sway-parse.workspace = true
+sway-types.workspace = true
+sway-utils.workspace = true
+swayfmt.workspace = true
+syn = { workspace = true, features = ["full"] }
+tempfile.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = [
     "fs",
     "io-std",
     "io-util",
@@ -47,16 +47,16 @@ tokio = { version = "1.3", features = [
     "sync",
     "time",
 ] }
-toml_edit = "0.19"
-tower-lsp = { version = "0.20", features = ["proposed"] }
-tracing = "0.1"
-urlencoding = "2.1.2"
+toml_edit.workspace = true
+tower-lsp = { workspace = true, features = ["proposed"] }
+tracing.workspace = true
+urlencoding.workspace = true
 
 [dev-dependencies]
 assert-json-diff = "2.0"
 codspeed-criterion-compat = "2.6.0"
 criterion = "0.5"
-dirs = "4.0"
+dirs = "5.0.1"
 futures = { version = "0.3", default-features = false, features = [
     "std",
     "async-await",
@@ -65,8 +65,8 @@ pretty_assertions = "1.4.0"
 rand = "0.8"
 regex = "^1.10.2"
 sway-lsp-test-utils = { path = "tests/utils" }
-tikv-jemallocator = "0.5"
-tower = { version = "0.4.12", default-features = false, features = ["util"] }
+tikv-jemallocator = "0.6.0"
+tower = { version = "0.5.1", default-features = false, features = ["util"] }
 
 [[bench]]
 name = "bench_main"

--- a/sway-lsp/src/utils/keyword_docs.rs
+++ b/sway-lsp/src/utils/keyword_docs.rs
@@ -802,7 +802,7 @@ impl KeywordDocs {
             let name = ident.trim_end_matches("_keyword").to_owned();
             let mut documentation = String::new();
             keyword.attrs.iter().for_each(|attr| {
-                let tokens = attr.tokens.to_token_stream();
+                let tokens = attr.to_token_stream();
                 let lit = extract_lit(tokens);
                 writeln!(documentation, "{lit}").unwrap();
             });

--- a/sway-lsp/src/utils/keyword_docs.rs
+++ b/sway-lsp/src/utils/keyword_docs.rs
@@ -802,7 +802,7 @@ impl KeywordDocs {
             let name = ident.trim_end_matches("_keyword").to_owned();
             let mut documentation = String::new();
             keyword.attrs.iter().for_each(|attr| {
-                let tokens = attr.to_token_stream();
+                let tokens = attr.meta.clone().into_token_stream();
                 let lit = extract_lit(tokens);
                 writeln!(documentation, "{lit}").unwrap();
             });

--- a/sway-lsp/src/utils/markdown.rs
+++ b/sway-lsp/src/utils/markdown.rs
@@ -50,13 +50,10 @@ fn is_sway_fence(s: &str) -> bool {
     let mut seen_sway_tags = false;
     let mut seen_other_tags = false;
 
-    let tokens = s
-        .trim()
-        .split(|c| matches!(c, ',' | ' ' | '\t'))
-        .filter_map(|t| {
-            let t = t.trim();
-            (!t.is_empty()).then_some(t)
-        });
+    let tokens = s.trim().split([',', ' ', '\t']).filter_map(|t| {
+        let t = t.trim();
+        (!t.is_empty()).then_some(t)
+    });
 
     for token in tokens {
         match token {

--- a/sway-lsp/tests/lib.rs
+++ b/sway-lsp/tests/lib.rs
@@ -1638,7 +1638,7 @@ fn hover_docs_for_functions_vscode() {
         req_uri: &uri,
         req_line: 20,
         req_char: 14,
-        documentation: vec!["```sway\npub fn bar(p: Point) -> Point\n```\n---\n A function declaration with struct as a function parameter\n\n---\nGo to [Point](command:sway.goToLocation?%5B%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A5%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A2%7D%7D%2C%22uri%22%3A%22file","sway%2Fsway-lsp%2Ftests%2Ffixtures%2Ftokens%2Ffunctions%2Fsrc%2Fmain.sw%22%7D%5D \"functions::Point\")"],
+        documentation: vec!["```sway\npub fn bar(p: Point) -> Point\n```\n---\n A function declaration with struct as a function parameter\n\n---\nGo to [Point](command:sway.goToLocation?%5B%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A5%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A2%7D%7D%2C%22uri%22%3A%22file","sway-lsp%2Ftests%2Ffixtures%2Ftokens%2Ffunctions%2Fsrc%2Fmain.sw%22%7D%5D \"functions::Point\")"],
     };
         lsp::hover_request(&server, &hover).await;
         let _ = server.shutdown_server();
@@ -1784,7 +1784,7 @@ fn hover_docs_for_self_keywords_vscode() {
 
         lsp::hover_request(&server, &hover).await;
         hover.req_char = 24;
-        hover.documentation = vec!["```sway\nstruct MyStruct\n```\n---\n\n---\n[2 implementations](command:sway.peekLocations?%5B%7B%22locations%22%3A%5B%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A4%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A2%7D%7D%2C%22uri%22%3A%22file","sway%2Fsway-lsp%2Ftests%2Ffixtures%2Fcompletion%2Fsrc%2Fmain.sw%22%7D%2C%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A14%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A6%7D%7D%2C%22uri%22%3A%22file","sway%2Fsway-lsp%2Ftests%2Ffixtures%2Fcompletion%2Fsrc%2Fmain.sw%22%7D%5D%7D%5D \"Go to implementations\")"];
+        hover.documentation = vec!["```sway\nstruct MyStruct\n```\n---\n\n---\n[2 implementations](command:sway.peekLocations?%5B%7B%22locations%22%3A%5B%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A4%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A2%7D%7D%2C%22uri%22%3A%22file","sway-lsp%2Ftests%2Ffixtures%2Fcompletion%2Fsrc%2Fmain.sw%22%7D%2C%7B%22range%22%3A%7B%22end%22%3A%7B%22character%22%3A1%2C%22line%22%3A14%7D%2C%22start%22%3A%7B%22character%22%3A0%2C%22line%22%3A6%7D%7D%2C%22uri%22%3A%22file","sway-lsp%2Ftests%2Ffixtures%2Fcompletion%2Fsrc%2Fmain.sw%22%7D%5D%7D%5D \"Go to implementations\")"];
         lsp::hover_request(&server, &hover).await;
         let _ = server.shutdown_server();
     });

--- a/sway-lsp/tests/utils/Cargo.toml
+++ b/sway-lsp/tests/utils/Cargo.toml
@@ -10,12 +10,12 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-assert-json-diff = "2.0"
-futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
-lsp-types = { version = "0.94", features = ["proposed"] }
-rand = "0.8"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.60"
-tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
-tower = { version = "0.4.12", default-features = false, features = ["util"] }
-tower-lsp = { version = "0.20", features = ["proposed"] }
+assert-json-diff.workspace = true
+futures = { workspace = true, features = ["async-await", "std"] }
+lsp-types = { workspace = true, features = ["proposed"] }
+rand.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["io-util", "io-std", "macros", "net", "rt-multi-thread", "sync", "time"] }
+tower = { workspace = true, features = ["util"] }
+tower-lsp = { workspace = true, features = ["proposed"] }

--- a/sway-parse/Cargo.toml
+++ b/sway-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-parse"
-version = "0.63.5"
+version.workspace = true
 description = "Sway's parser"
 authors.workspace = true
 edition.workspace = true
@@ -9,16 +9,16 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-extension-trait = "1.0.1"
-num-bigint = "0.4.3"
-num-traits = "0.2.14"
-phf = { version = "0.10.1", features = ["macros"] }
-sway-ast = { version = "0.63.5", path = "../sway-ast" }
-sway-error = { version = "0.63.5", path = "../sway-error" }
-sway-types = { version = "0.63.5", path = "../sway-types" }
-thiserror = "1.0"
-unicode-bidi = "0.3.13"
-unicode-xid = "0.2.2"
+extension-trait.workspace = true
+num-bigint.workspace = true
+num-traits.workspace = true
+phf = { workspace = true, features = ["macros"] }
+sway-ast.workspace = true
+sway-error.workspace = true
+sway-types.workspace = true
+thiserror.workspace = true
+unicode-bidi.workspace = true
+unicode-xid.workspace = true
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/sway-types/Cargo.toml
+++ b/sway-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-types"
-version = "0.63.5"
+version.workspace = true
 description = "Sway core types."
 authors.workspace = true
 edition.workspace = true
@@ -9,19 +9,19 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-bytecount = "0.6"
-fuel-asm = { workspace = true }
-fuel-crypto = { workspace = true }
-fuel-tx = { workspace = true }
-indexmap = "2.0.0"
-lazy_static = "1.4"
-num-bigint = "0.4.3"
-num-traits = "0.2.16"
-parking_lot = "0.12"
-rustc-hash = "1.1.0"
-serde = { version = "1.0", features = ["derive"] }
-sway-utils = { version = "0.63.5", path = "../sway-utils" }
-thiserror = "1"
+bytecount.workspace = true
+fuel-asm.workspace = true
+fuel-crypto.workspace = true
+fuel-tx.workspace = true
+indexmap.workspace = true
+lazy_static.workspace = true
+num-bigint.workspace = true
+num-traits.workspace = true
+parking_lot.workspace = true
+rustc-hash.workspace = true
+serde = { workspace = true, features = ["derive"] }
+sway-utils.workspace = true
+thiserror.workspace = true
 
 [features]
 no-span-debug = []

--- a/sway-utils/Cargo.toml
+++ b/sway-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sway-utils"
-version = "0.63.5"
+version.workspace = true
 description = "Sway common utils."
 authors.workspace = true
 edition.workspace = true
@@ -9,8 +9,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-walkdir = "2.3.3"
+serde = { workspace = true, features = ["derive"] }
+walkdir.workspace = true
 
 [lints.clippy]
 iter_over_hash_type = "deny"

--- a/sway-utils/src/performance.rs
+++ b/sway-utils/src/performance.rs
@@ -29,9 +29,9 @@ macro_rules! time_expr {
                 if cfg.metrics_outfile.is_some() {
                     #[cfg(not(target_os = "macos"))]
                     let memory_usage = {
-                        use sysinfo::{System, SystemExt};
+                        use sysinfo::{MemoryRefreshKind, System};
                         let mut sys = System::new();
-                        sys.refresh_system();
+                        sys.refresh_memory_specifics(MemoryRefreshKind::new().with_ram());
                         Some(sys.used_memory())
                     };
                     #[cfg(target_os = "macos")]

--- a/swayfmt/Cargo.toml
+++ b/swayfmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swayfmt"
-version = "0.63.5"
+version.workspace = true
 description = "Sway language formatter."
 authors.workspace = true
 edition.workspace = true
@@ -9,23 +9,23 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow = "1"
-forc-tracing = { version = "0.63.5", path = "../forc-tracing" }
-indoc = "2.0"
-ropey = "1.5"
-serde = { version = "1.0", features = ["derive"] }
-serde_ignored = "0.1.9"
-sway-ast = { version = "0.63.5", path = "../sway-ast" }
-sway-core = { version = "0.63.5", path = "../sway-core" }
-sway-error = { version = "0.63.5", path = "../sway-error" }
-sway-parse = { version = "0.63.5", path = "../sway-parse" }
-sway-types = { version = "0.63.5", path = "../sway-types" }
-sway-utils = { version = "0.63.5", path = "../sway-utils" }
-thiserror = "1.0.30"
-toml = { version = "0.7", features = ["parse"] }
+anyhow.workspace = true
+forc-tracing.workspace = true
+indoc.workspace = true
+ropey.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_ignored.workspace = true
+sway-ast.workspace = true
+sway-core.workspace = true
+sway-error.workspace = true
+sway-parse.workspace = true
+sway-types.workspace = true
+sway-utils.workspace = true
+thiserror.workspace = true
+toml = { workspace = true, features = ["parse"] }
 
 [dev-dependencies]
 difference = "2.0.0"
 paste = "1.0"
-prettydiff = "0.6"
+prettydiff = "0.7.0"
 test-macros = { path = "test_macros" }

--- a/swayfmt/test_macros/Cargo.toml
+++ b/swayfmt/test_macros/Cargo.toml
@@ -15,7 +15,7 @@ repository.workspace = true
 
 [dev-dependencies]
 paste = "1.0"
-prettydiff = "0.6"
+prettydiff = "0.7.0"
 
 [package.metadata.cargo-udeps.ignore]
 development = ["paste", "prettydiff"]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -6,39 +6,39 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow = "1.0.41"
-bytes = "1.3.0"
-clap = { version = "4.5.4", features = ["derive", "env"] }
-colored = "2.0.0"
-filecheck = "0.5"
-forc = { path = "../forc", features = ["test"], default-features = false }
-forc-client = { path = "../forc-plugins/forc-client" }
-forc-pkg = { path = "../forc-pkg" }
-forc-test = { path = "../forc-test" }
-forc-tracing = { path = "../forc-tracing" }
+anyhow.workspace = true
+bytes.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+colored.workspace = true
+filecheck.workspace = true
+forc = { workspace = true, features = ["test"] }
+forc-client.workspace = true
+forc-pkg.workspace = true
+forc-test.workspace = true
+forc-tracing.workspace = true
 fuel-vm = { workspace = true, features = ["random"] }
-futures = "0.3.24"
-gag = "1.0"
-glob = "0.3.1"
-hex = "0.4.3"
-insta = "1.39.0"
-libtest-mimic = "0.7.3"
-miden = "0.3.0"
-prettydiff = "0.6"
-rand = "0.8"
-regex = "1.7"
-revm = "2.3.1"
-serde_json = "1.0.73"
-sway-core = { path = "../sway-core" }
-sway-error = { path = "../sway-error" }
-sway-ir = { path = "../sway-ir" }
-sway-types = { path = "../sway-types" }
-sway-utils = { path = "../sway-utils" }
-textwrap = "0.16.0"
-tokio = "1.12"
-toml = { version = "0.7", features = ["parse"] }
-tracing = "0.1"
-vte = "0.13.0"
+futures.workspace = true
+gag.workspace = true
+glob.workspace = true
+hex.workspace = true
+insta.workspace = true
+libtest-mimic.workspace = true
+miden.workspace = true
+prettydiff.workspace = true
+rand.workspace = true
+regex.workspace = true
+revm.workspace = true
+serde_json.workspace = true
+sway-core.workspace = true
+sway-error.workspace = true
+sway-ir.workspace = true
+sway-types.workspace = true
+sway-utils.workspace = true
+textwrap.workspace = true
+tokio.workspace = true
+toml = { workspace = true, features = ["parse"] }
+tracing.workspace = true
+vte.workspace = true
 
 [[test]]
 name = "tests"

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -414,14 +414,16 @@ impl TestContext {
                             }
                         }
                     }
-                    harness::VMExecutionResult::Evm(state) => match state.exit_reason {
-                        revm::Return::Continue => todo!(),
-                        revm::Return::Stop => TestResult::Result(0),
-                        revm::Return::Return => todo!(),
-                        revm::Return::SelfDestruct => todo!(),
-                        revm::Return::Revert => TestResult::Revert(0),
-                        _ => {
-                            panic!("EVM exited with unhandled reason: {:?}", state.exit_reason);
+                    harness::VMExecutionResult::Evm(state) => match state {
+                        revm::primitives::ExecutionResult::Success { reason, .. } => match reason {
+                            revm::primitives::SuccessReason::Stop => TestResult::Result(0),
+                            revm::primitives::SuccessReason::Return => todo!(),
+                            revm::primitives::SuccessReason::SelfDestruct => todo!(),
+                            revm::primitives::SuccessReason::EofReturnContract => todo!(),
+                        },
+                        revm::primitives::ExecutionResult::Revert { .. } => TestResult::Result(0),
+                        revm::primitives::ExecutionResult::Halt { reason, .. } => {
+                            panic!("EVM exited with unhandled reason: {:?}", reason);
                         }
                     },
                     harness::VMExecutionResult::MidenVM(trace) => {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/array_of_structs_caller/src/main.sw
@@ -6,7 +6,7 @@ use std::hash::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x14ed3cd06c2947248f69d54bfa681fe40d26267be84df7e19e253622b7921bbe;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xf9f1fec713b977865880637fc24e58cda9e69f6e711ed8e5efe7de9ce51c88ec; // AUTO-CONTRACT-ID ../../test_contracts/array_of_structs_contract --release
+const CONTRACT_ID = 0x59dd4d4919defc3ca2ab8712550fa9495fee6279cd858c4e635521d05dbcd0c0; // AUTO-CONTRACT-ID ../../test_contracts/array_of_structs_contract --release
 
 fn get_address() -> Option<std::address::Address> {
     Some(CONTRACT_ID.into())

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
@@ -9,12 +9,12 @@ use test_fuel_coin_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const FUEL_COIN_CONTRACT_ID = 0xec2277ebe007ade87e3d797c3b1e070dcd542d5ef8f038b471f262ef9cebc87c;
 #[cfg(experimental_new_encoding = true)]
-const FUEL_COIN_CONTRACT_ID = 0xf2fecff29038dab2ef571397ea5507359265c9154608e7de36ccbea20ed5c8aa;
+const FUEL_COIN_CONTRACT_ID = 0x8ada7184b9acc22a124ff9b836cc7af2b86d872d319aefd0035bc8d5da73515d;
 
 #[cfg(experimental_new_encoding = false)]
 const BALANCE_CONTRACT_ID = 0xf6cd545152ac83225e8e7df2efb5c6fa6e37bc9b9e977b5ea8103d28668925df;
 #[cfg(experimental_new_encoding = true)]
-const BALANCE_CONTRACT_ID = 0xccf637b5b0071861f3074fcf963ef2339dab5d306d919b4c7e65024a7fbc64e6; // AUTO-CONTRACT-ID ../../test_contracts/balance_test_contract --release
+const BALANCE_CONTRACT_ID = 0x5ee90442589b20a58dfd6ff911440ba77709bda043de8b3221d6e0b12b72ec3e; // AUTO-CONTRACT-ID ../../test_contracts/balance_test_contract --release
 
 fn main() -> bool {
     let default_gas = 1_000_000_000_000;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/bal_opcode/src/main.sw
@@ -5,7 +5,7 @@ use balance_test_abi::BalanceTest;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xf6cd545152ac83225e8e7df2efb5c6fa6e37bc9b9e977b5ea8103d28668925df;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xccf637b5b0071861f3074fcf963ef2339dab5d306d919b4c7e65024a7fbc64e6; // AUTO-CONTRACT-ID ../../test_contracts/balance_test_contract --release
+const CONTRACT_ID = 0x5ee90442589b20a58dfd6ff911440ba77709bda043de8b3221d6e0b12b72ec3e; // AUTO-CONTRACT-ID ../../test_contracts/balance_test_contract --release
 
 fn main() -> bool {
     let balance_test_contract = abi(BalanceTest, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_basic_storage/src/main.sw
@@ -4,7 +4,7 @@ use basic_storage_abi::{BasicStorage, Quad};
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x94db39f409a31b9f2ebcadeea44378e419208c20de90f5d8e1e33dc1523754cb;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x23afacfc8eaa13d36c3f2f4d764b66e53d284e4cd31477e8bd72b4ccc411022b; // AUTO-CONTRACT-ID ../../test_contracts/basic_storage --release
+const CONTRACT_ID = 0xecc65bf7cfa323e4863b034efbcb6974ba6f45d795692a88d724a4c8dc833a5b; // AUTO-CONTRACT-ID ../../test_contracts/basic_storage --release
 
 fn main() -> u64 {
     let addr = abi(BasicStorage, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_increment_contract/src/main.sw
@@ -6,7 +6,7 @@ use dynamic_contract_call::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xd1b4047af7ef111c023ab71069e01dc2abfde487c0a0ce1268e4f447e6c6e4c2;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x5229470a8bb907a909aba79325a347bd8849a8aceb9c8116e3d1c73ea4977b6d; // AUTO-CONTRACT-ID ../../test_contracts/increment_contract --release
+const CONTRACT_ID = 0x49b3355ebe3d9148e93e6675a6b82d61bbb1dda21fea0199f2a49b1caf7fe0e9; // AUTO-CONTRACT-ID ../../test_contracts/increment_contract --release
 
 fn main() -> bool {
     let the_abi = abi(Incrementor, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/call_storage_enum/src/main.sw
@@ -5,7 +5,7 @@ use storage_enum_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xc601d11767195485a6654d566c67774134668863d8c797a8c69e8778fb1f89e9;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x4bb9cb0a4b3df7981e702609cbce4b684b3d9c21e474e9988825f48fae81b06d; // AUTO-CONTRACT-ID ../../test_contracts/storage_enum_contract --release
+const CONTRACT_ID = 0xabbd5fe31028e34f224c33cacbeca41de56bbe9eefee4cbe642c93de2e274f47; // AUTO-CONTRACT-ID ../../test_contracts/storage_enum_contract --release
 
 fn main() -> u64 {
     let caller = abi(StorageEnum, CONTRACT_ID);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_auth_test/src/main.sw
@@ -5,7 +5,7 @@ use auth_testing_abi::AuthTesting;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0xc2eec20491b53aab7232cbd27c31d15417b4e9daf0b89c74cc242ef1295f681f;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0xbbd538c6fc4f6a805b4e178529e1460453aee648b5e49949bdfc8a12a585e7d2; // AUTO-CONTRACT-ID ../../test_contracts/auth_testing_contract --release
+const CONTRACT_ID = 0x8422c350d493719dc688581b4666ecdcda39df4105a8d4dfc96f96f3066ca9e8; // AUTO-CONTRACT-ID ../../test_contracts/auth_testing_contract --release
 
 // should be false in the case of a script
 fn main() -> bool {

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/caller_context_test/src/main.sw
@@ -6,7 +6,7 @@ use context_testing_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x6054c11cda000f5990373a4d61929396165be4dfdd61d5b7bd26da60ab0d8577;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x7821bf368390972d4892e1f382fd954fea5b567e533eed6fac0f173800647945; // AUTO-CONTRACT-ID ../../test_contracts/context_testing_contract --release
+const CONTRACT_ID = 0x82d2d8a19e7a3c21eeef5db4e5709000c5803f96d67789576f55c52f4ad447ae; // AUTO-CONTRACT-ID ../../test_contracts/context_testing_contract --release
 
 fn main() -> bool {
     let gas: u64 = u64::max();

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/storage_access_caller/src/main.sw
@@ -6,7 +6,7 @@ use std::hash::*;
 #[cfg(experimental_new_encoding = false)]
 const CONTRACT_ID = 0x3bc28acd66d327b8c1b9624c1fabfc07e9ffa1b5d71c2832c3bfaaf8f4b805e9;
 #[cfg(experimental_new_encoding = true)]
-const CONTRACT_ID = 0x3da675876942326fd4c66b079216742f75e5f15681271a5db54a9cf19a813b22; // AUTO-CONTRACT-ID ../../test_contracts/storage_access_contract --release
+const CONTRACT_ID = 0xf012aa4a68ffac291acd5d8b79b6a76f3e444869cf2302e0b712103b3e5b4ad5; // AUTO-CONTRACT-ID ../../test_contracts/storage_access_contract --release
 
 fn main() -> bool {
     let caller = abi(StorageAccess, CONTRACT_ID);

--- a/test/src/sdk-harness/Cargo.toml
+++ b/test/src/sdk-harness/Cargo.toml
@@ -26,7 +26,7 @@ rand = "0.8"
 sha2 = "0.10"
 sha3 = "0.10.1"
 tai64 = { version = "4.0", features = ["serde"] }
-tokio = { version = "1.12", features = ["rt", "macros"] }
+tokio = { version = "1.12", features = ["macros", "rt"] }
 
 [[test]]
 harness = true


### PR DESCRIPTION
## Description

This PR relates to #6179 which aims to simplify individual workspace member dependency versioning  by deferring upstream to the workspace dependencies itself.

I've also extended #6179 as it currently only relates to external dependencies - I've noticed that whenever Sway has a version bump, the diffs manually update all of the many `Cargo.toml` files to the new globally shared version. We can also use workspaces here to defer each `Cargo.toml` package version to the workspace package version as well.

This PR is in 3 parts:

1. Update all `Cargo.toml` external dependencies to use the shared versions defined in the workspace dependencies
2. Update all `Cargo.toml` package version to defer to the workspace package version.
3. Update all external dependencies to their latest versions

If an individual workspace member needs to break away from the shared workspace package version, we can still do that:

- Update the individual `Cargo.toml` to the new version (as normal)
- Update all references within the whole repository to state this new version

Notes:

- `[dev-dependencies]` was not factored out since `[workspace.dev-dependencies]` is currently not supported by `Cargo.toml`, meaning all dev dependencies would have to be brought into `[workspace.dependencies]` which I assume is not what we would want to do.
- `[target.'cfg(not(target_os = "macos"))'.dependencies]` was not factored out since these crates should only be brought in if the condition is met, but again as the only way to do this would be to move it to `[workspace.dependencies]`, I would advise to keep them separated.

## Checklist

- [✅] I have linked to any relevant issues.
- [✅] I have commented my code, particularly in hard-to-understand areas.
- [␆] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [␆] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [␆] I have added tests that prove my fix is effective or that my feature works.
- [␆] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [✅] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [✅] I have requested a review from the relevant team or maintainers.
