### PR TITLE
Add tests for propagation of type constraints in type inference

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/function_return_type_unification/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/function_return_type_unification/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/function_return_type_unification/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/function_return_type_unification/Forc.lock
@@ -5,9 +5,4 @@ source = "path+from-root-D73E65B1F4E48513"
 [[package]]
 name = "function_return_type_unification"
 source = "member"
-dependencies = ["std"]
-
-[[package]]
-name = "std"
-source = "path+from-root-D73E65B1F4E48513"
 dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/function_return_type_unification/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/function_return_type_unification/src/main.sw
@@ -22,8 +22,7 @@ where T: Build,
     T::build()
 }
 
-fn main() -> bool {
-    let _:u32 = produce();
-
-    true
+fn main() -> u32 {
+    let x: u32 = produce();
+    x
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/function_return_type_unification/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/function_return_type_unification/test.toml
@@ -1,4 +1,4 @@
 category = "run"
-expected_result = { action = "return", value = 1 }
-expected_result_new_encoding = { action = "return_data", value = "01" }
+expected_result = { action = "return", value = 31 }
+expected_result_new_encoding = { action = "return_data", value = "0000001f" }
 validate_abi = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/type_inference_propagation_of_type_constraints/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/type_inference_propagation_of_type_constraints/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = "core"
+source = "path+from-root-9D1294DAC07670CA"
+
+[[package]]
+name = "type_inference_propagation_of_type_constraints"
+source = "member"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/type_inference_propagation_of_type_constraints/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/type_inference_propagation_of_type_constraints/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-name = "function_return_type_unification"
+name = "type_inference_propagation_of_type_constraints"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/type_inference_propagation_of_type_constraints/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/type_inference_propagation_of_type_constraints/src/main.sw
@@ -1,0 +1,64 @@
+// This tests proves that https://github.com/FuelLabs/sway/issues/6379 is fixed.
+
+script;
+
+trait Build {
+    fn build() -> Self;
+}
+
+fn produce<T>() -> T where T: Build {
+    T::build()
+}
+
+impl Build for u8 {
+    fn build() -> Self {
+        7
+    }
+}
+
+impl Build for u32 {
+    fn build() -> Self {
+        31
+    }
+}
+
+impl Build for u64 {
+    fn build() -> Self {
+        63
+    }
+}
+
+fn consume_u8(a: u8) -> u8 {
+    a
+}
+
+fn consume_u32(a: u32) -> u32 {
+    a
+}
+
+fn consume_u64(a: u64) -> u64 {
+    a
+}
+
+fn main() -> (u8, u32, u64) {
+    let a = produce_consume_u8();
+    let b = produce_consume_u32();
+    let c = produce_consume_u64();
+
+    (a, b, c)
+}
+
+fn produce_consume_u8() -> u8 {
+    let x = produce();
+    consume_u8(x)
+}
+
+fn produce_consume_u32() -> u32 {
+    let x = produce();
+    consume_u32(x)
+}
+
+fn produce_consume_u64() -> u64 {
+    let x = produce();
+    consume_u64(x)
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/type_inference_propagation_of_type_constraints/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/type_inference_propagation_of_type_constraints/test.toml
@@ -1,0 +1,4 @@
+category = "run"
+expected_result = { action = "return_data", value = "0700000000000000 000000000000001f 000000000000003f" }
+expected_result_new_encoding = { action = "return_data", value = "07 0000001f 000000000000003f" }
+validate_abi = false


### PR DESCRIPTION
## Description

This PR adds tests that prove that #6379 is fixed. The actual fix happened in #6490.

Closes #6379.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.