### PR TITLE
Replace cargo deps with built-in cargo tree (#6179)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,14 +478,11 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install cargo-deps
-        run: cargo install cargo-deps
-
       # We require this check to avoid cyclic dependencies between 'fuels' and 'forc-pkg'.
       # Detailed explanation is found in the echo below.
       - name: Check 'forc-pkg' dependencies for 'fuels' crates
         run: |
-          deps=$(cargo deps --manifest-path forc-pkg/Cargo.toml)
+          deps=$(cargo tree --manifest-path forc-pkg/Cargo.toml)
 
           case "$deps" in
             *fuels*)


### PR DESCRIPTION
Separating this commit out from the main commit of #6179...

This PR comes in two commits:

1. The changes to CI - replace `cargo-deps` with `cargo tree`
2. A test commit that will create a cyclic dependency which will be reverted once it's tested to be working

The origin commit message:

- cargo-deps is no longer maintained
- cargo-deps doesn't understand workspaces

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.