### PR TITLE
Ensure the return path analysis traverses the entire CFG

### DIFF
--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -83,7 +83,7 @@ impl<'cfg> ControlFlowGraph<'cfg> {
         let mut rovers = vec![entry_point];
         let mut visited = vec![];
         let mut errors = vec![];
-        while !rovers.is_empty() && rovers[0] != exit_point {
+        while !rovers.is_empty() {
             rovers.retain(|idx| *idx != exit_point);
             let mut next_rovers = vec![];
             let mut last_discovered_span;
@@ -122,7 +122,13 @@ impl<'cfg> ControlFlowGraph<'cfg> {
                 }
                 next_rovers.append(&mut neighbors);
             }
-            next_rovers.retain(|idx| !visited.contains(idx));
+            next_rovers.retain(|idx| {
+                !visited.contains(idx)
+                    && !matches!(
+                        self.graph[*idx],
+                        ControlFlowGraphNode::MethodDeclaration { .. }
+                    )
+            });
             rovers = next_rovers;
         }
 


### PR DESCRIPTION
## Description

The return path analysis ensures that if a method must return a value then every path through a method returns a value. The analysis traverses the CFG of each method in a breadth-first manner from the (unique) entry point to the (unique) exit point. If there is ever a node in the graph that does not have outgoing edges, then an error is thrown.

So far the condition in the outer loop has been `!rovers.is_empty() && rovers[0] != exit_point`, where `rovers` is the current set of nodes to be analyzed. The requirement `rovers[0] != exit_point` potentially causes part of the CFG to not be traversed, but appears to have been added because of cases like the following:

```
fn main() -> u64 {
    impl core::ops::Eq for X {
        fn eq(self, other: Self) -> bool {
            asm(r1: self, r2: other, r3) {
                eq r3 r2 r1;
                r3: bool
            }
        }
    }
    if X::Y(true) == X::Y(true) {
        a
    } else {
        a
    }
}
```

The CFG for `main` contains the CFG for `eq` as a subgraph, but since the exit point for `eq` does not have a path leading to the exit point of `main` the analysis throws an error when the condition is removed. (It is not clear to me why this is, but based on my testing it happens consistently).

This is clearly incorrect behavior since the edge leading into the `eq` CFG does not represent control flow.

To solve this problem I have introduced a condition in the inner loop in which a node is ignored if it has been visited before, or if it represents a method declaration that is different from the entry point of the method currently under analysis.

Additionally I have changed the representation of `visited` to be a `HashSet` instead of a vector. This should improve performance slightly.

I have not been able to find a test program that causes the original algorithm to allow illegal programs to pass, but the new algorithm seems more obviously correct.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
