### PR TITLE
Add tests for recursive `const` definitions and associated consts usages

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_fail/const_block_level_no_expr/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/const_block_level_no_expr/src/main.sw
@@ -1,4 +1,4 @@
-script;
+library;
 
 fn main() -> u64 {
     const X;

--- a/test/src/e2e_vm_tests/test_programs/should_fail/const_block_level_no_expr/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/const_block_level_no_expr/test.toml
@@ -2,3 +2,5 @@ category = "fail"
 
 # check: $()const X;
 # nextln: $()Constant requires expression.
+
+# check: $()1 error.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/const_top_level_no_expr/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/const_top_level_no_expr/test.toml
@@ -2,3 +2,5 @@ category = "fail"
 
 # check: $()const X;
 # nextln: $()Constant requires expression.
+
+# check: $()1 error.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_calls/test.toml
@@ -6,3 +6,5 @@ category = "fail"
 # check: $()Function d is recursive via e and f, which is unsupported at this time.
 # check: $()Function e is recursive via f and d, which is unsupported at this time.
 # check: $()Function f is recursive via d and e, which is unsupported at this time.
+
+# check: $()6 errors.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "recursive_const_associated"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "recursive_const_associated"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated/src/main.sw
@@ -1,0 +1,13 @@
+library;
+
+struct S {}
+
+// TODO: Uncomment this code, and enable this test and add checks once https://github.com/FuelLabs/sway/issues/6537 is fixed.
+impl S {
+    // const A: u8 = Self::B;
+    // const B: u8 = Self::A;
+
+    // const X: u8 = Self::Y;
+    // const Y: u8 = Self::Z;
+    // const Z: u8 = Self::X;
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated/test.toml
@@ -1,0 +1,1 @@
+category = "disabled" # TODO: Enable this test and add checks once https://github.com/FuelLabs/sway/issues/6537 is fixed.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_associated_function/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_associated_function/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "recursive_const_associated_over_associated_function"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_associated_function/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_associated_function/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "recursive_const_associated_over_associated_function"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_associated_function/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_associated_function/src/main.sw
@@ -1,0 +1,13 @@
+library;
+
+struct S {}
+
+impl S {
+    fn assoc() -> u8 {
+        Self::S_ASSOC
+    }
+}
+
+impl S {
+    const S_ASSOC: u8 = Self::assoc();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_associated_function/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_associated_function/test.toml
@@ -1,0 +1,9 @@
+category = "fail"
+
+#check: $()Self::S_ASSOC
+#nextln: $()Could not find symbol "S_ASSOC" in this scope.
+
+#check: $()const S_ASSOC: u8 = Self::assoc();
+#nextln: $()No method named "assoc" found for type "S".
+
+#check: $()2 errors.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_module_function/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_module_function/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "recursive_const_associated_over_module_function"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_module_function/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_module_function/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "recursive_const_associated_over_module_function"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_module_function/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_module_function/src/main.sw
@@ -1,0 +1,11 @@
+library;
+
+struct S {}
+
+fn mod_fn() -> u8 {
+    S::S_ASSOC
+}
+
+impl S {
+    const S_ASSOC: u8 = mod_fn();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_module_function/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_associated_over_module_function/test.toml
@@ -1,0 +1,1 @@
+category = "disabled" # TODO: Enable this failing test and write checks once https://github.com/FuelLabs/sway/issues/6539 is fixed. 

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "recursive_const_module"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "recursive_const_module"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module/src/main.sw
@@ -1,0 +1,8 @@
+library;
+
+pub const A: u8 = B;
+pub const B: u8 = A;
+
+pub const X: u8 = Y;
+pub const Y: u8 = Z;
+pub const Z: u8 = X;

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module/test.toml
@@ -1,0 +1,10 @@
+category = "fail" # TODO: Adjust these checks once https://github.com/FuelLabs/sway/issues/6534 is fixed.
+
+# check: $()Type B is recursive via A, which is unsupported at this time.
+# check: $()Type A is recursive via B, which is unsupported at this time.
+
+# check: $()Type Y is recursive via Z and X, which is unsupported at this time.
+# check: $()Type Z is recursive via X and Y, which is unsupported at this time.
+# check: $()Type X is recursive via Y and Z, which is unsupported at this time.
+
+# check: $()5 errors.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_const/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_const/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "recursive_const_module_over_associated_const"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_const/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_const/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "recursive_const_module_over_associated_const"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_const/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_const/src/main.sw
@@ -1,0 +1,9 @@
+library;
+
+struct S {}
+
+impl S {
+    const S_ASSOC: u8 = MOD_CONST;
+}
+
+const MOD_CONST: u8 = S::S_ASSOC;

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_const/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_const/test.toml
@@ -1,0 +1,11 @@
+category = "fail"
+
+#check: $()error
+#check: $()const MOD_CONST: u8 = S::S_ASSOC;
+#nextln: $()Could not find symbol "S_ASSOC" in this scope.
+
+#check: $()error
+#check: $()const MOD_CONST: u8 = S::S_ASSOC;
+#nextln: $()Could not evaluate initializer to a const declaration.
+
+#check: $()2 errors.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_function/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_function/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "recursive_const_module_over_associated_function"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_function/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_function/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "recursive_const_module_over_associated_function"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_function/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_function/src/main.sw
@@ -1,0 +1,11 @@
+library;
+
+struct S {}
+
+impl S {
+    fn assoc() -> u8 {
+        MOD_CONST
+    }
+}
+
+const MOD_CONST: u8 = S::assoc();

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_function/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_associated_function/test.toml
@@ -1,0 +1,9 @@
+category = "fail"
+
+#check: $()const MOD_CONST: u8 = S::assoc();
+#nextln: $()No method named "assoc" found for type "S".
+
+#check: $()const MOD_CONST: u8 = S::assoc();
+#nextln: $()Could not evaluate initializer to a const declaration.
+
+#check: $()2 errors.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_module_function/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_module_function/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "recursive_const_module_over_module_function"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_module_function/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_module_function/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "recursive_const_module_over_module_function"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_module_function/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_module_function/src/main.sw
@@ -1,0 +1,7 @@
+library;
+
+fn mod_fn() -> u8 {
+    MOD_CONST
+}
+
+const MOD_CONST: u8 = mod_fn();

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_module_function/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_module_over_module_function/test.toml
@@ -1,0 +1,11 @@
+category = "fail"
+
+#check: $()error
+#check: $()const MOD_CONST: u8 = mod_fn();
+#nextln: $()Could not find symbol "mod_fn" in this scope.
+
+#check: $()error
+#check: $()const MOD_CONST: u8 = mod_fn();
+#nextln: $()Could not evaluate initializer to a const declaration.
+
+#check: $()2 errors.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_stack_overflow/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_stack_overflow/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "recursive_const_stack_overflow"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_stack_overflow/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_stack_overflow/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "recursive_const_stack_overflow"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_stack_overflow/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_stack_overflow/src/main.sw
@@ -1,0 +1,17 @@
+// This test proves that https://github.com/FuelLabs/sway/issues/6540 is fixed.
+
+library;
+
+pub const MOD_FN: u8 = mod_fn();
+
+fn mod_fn() -> u8 {
+    MOD_FN
+}
+
+struct S {}
+
+impl S {
+    const S_ASSOC: u8 = MOD_CONST;
+}
+
+const MOD_CONST: u8 = S::S_ASSOC;

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_stack_overflow/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_const_stack_overflow/test.toml
@@ -1,0 +1,1 @@
+category = "disabled" # TODO: Enable this failing test and write checks once https://github.com/FuelLabs/sway/issues/6540 is fixed.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_enum/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_enum/src/main.sw
@@ -1,11 +1,7 @@
-script;
+library;
 
 enum E {
     Eins: bool,
     Zwei: u64,
     Drei: E,
-}
-
-fn main() {
-
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_enum/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_enum/test.toml
@@ -1,3 +1,5 @@
 category = "fail"
 
 # check: $()recursive types are not supported
+
+# check: $()1 error.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_struct/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_struct/src/main.sw
@@ -1,11 +1,7 @@
-script;
+library;
 
 struct S {
   Eins: bool,
   Zwei: u64,
   Drei: S,
-}
-
-fn main() {
-
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_struct/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_struct/test.toml
@@ -1,3 +1,5 @@
 category = "fail"
 
 # check: $()recursive types are not supported
+
+# check: $()1 error.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_chain/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_chain/src/main.sw
@@ -1,4 +1,4 @@
-script;
+library;
 
 enum E {
     Eins: F,
@@ -38,8 +38,4 @@ enum Y {
 
 struct Z {
     five: X,
-}
-
-fn main() {
-
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_chain/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_chain/test.toml
@@ -10,3 +10,5 @@ category = "fail"
 # check: $()Type Y is recursive via Z and X, which is unsupported at this time.
 # check: $()Type Z is recursive via X and Y, which is unsupported at this time.
 # check: $()Type X is recursive via Y and Z, which is unsupported at this time.
+
+# check: $()10 errors.

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_unification/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_unification/src/main.sw
@@ -1,4 +1,4 @@
-script;
+library;
 
 enum MyOption<T> {
     Some: T,
@@ -13,5 +13,5 @@ fn bar<V>(value: V) -> MyOption<V> {
 }
 
 fn main() {
-    let x = bar(false);
+    let _ = bar(false);
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_unification/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/recursive_type_unification/test.toml
@@ -13,3 +13,5 @@ category = "fail"
 # nextln: $()expected: V
 # nextln: $()found:    MyOption<V>.
 # nextln: $()Implicit return must match up with block's type.
+
+# check: $()2 errors.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_const_in_decls_of_other_constants/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_const_in_decls_of_other_constants/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "associated_const_in_decls_of_other_constants"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "core"
+source = "path+from-root-8CB91B60FB2568E4"
+
+[[package]]
+name = "std"
+source = "path+from-root-8CB91B60FB2568E4"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_const_in_decls_of_other_constants/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_const_in_decls_of_other_constants/Forc.toml
@@ -1,0 +1,10 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "associated_const_in_decls_of_other_constants"
+implicit-std = false
+
+
+[dependencies]
+std = { path = "../../../../../../../sway-lib-std" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_const_in_decls_of_other_constants/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_const_in_decls_of_other_constants/src/main.sw
@@ -1,0 +1,95 @@
+contract;
+
+struct S {}
+
+impl S {
+    fn bar() -> u8 {
+        11
+    }
+}
+
+impl S {
+    // TODO: Uncomment this once https://github.com/FuelLabs/sway/issues/6538 is fixed.
+    // const S_BAR: u8 = Self::bar();
+    const S_A: u8 = 11;
+    const S_B: u8 = Self::S_A;
+    const S_C: u8 = 22;
+
+    fn assoc_s_b() -> u8 {
+        Self::S_B
+    }
+
+    fn assoc_s_c() -> u8 {
+        Self::S_C
+    }
+
+    fn method_s_c(self) -> u8 {
+        Self::S_C
+    }
+}
+
+storage {
+    // TODO: Uncomment this once https://github.com/FuelLabs/sway/issues/6543 is fixed.
+    // s_a: u8 = S::S_A,
+}
+
+const MOD_S_A: u8 = S::S_A;
+
+fn mod_fn_s_a() -> u8 {
+    S::S_A
+}
+
+abi Abi {
+    fn test_in_contract();
+}
+
+configurable {
+    CONFIG_S_A: u8 = S::S_A,
+}
+
+impl Abi for Contract {
+    fn test_in_contract() {
+        assert_eq(11, S::S_A);
+        assert_eq(22, S::S_C);
+
+        // TODO: Uncomment this once https://github.com/FuelLabs/sway/issues/6544 is fixed.
+        // assert_eq(S::S_B, S::S_A);
+        // assert_eq(S::assoc_s_b(), S::S_B);
+        assert_eq(S::assoc_s_c(), S::S_C);
+        assert_eq(S {}.method_s_c(), S::S_C);
+
+        // TODO: Uncomment this once https://github.com/FuelLabs/sway/issues/6538 is fixed.
+        // assert_eq(S::bar(), S::S_BAR);
+
+        assert_eq(S::S_A, MOD_S_A);
+
+        assert_eq(S::S_A, mod_fn_s_a());
+
+        assert_eq(S::S_A, CONFIG_S_A);
+
+        // TODO: Uncomment this once https://github.com/FuelLabs/sway/issues/6543 is fixed.
+        // assert_eq(S::S_A, storage.s_a.read());
+    }
+}
+
+#[test]
+fn test() {
+    assert_eq(11, S::S_A);
+    assert_eq(22, S::S_C);
+
+    // TODO: Uncomment this once https://github.com/FuelLabs/sway/issues/6544 is fixed.
+    // assert_eq(S::S_B, S::S_A);
+    // assert_eq(S::assoc_s_b(), S::S_B);
+    assert_eq(S::assoc_s_c(), S::S_C);
+    assert_eq(S {}.method_s_c(), S::S_C);
+
+    // TODO: Uncomment this once https://github.com/FuelLabs/sway/issues/6538 is fixed.
+    // assert_eq(S::bar(), S::S_BAR);
+
+    assert_eq(S::S_A, MOD_S_A);
+
+    assert_eq(S::S_A, mod_fn_s_a());
+
+    let caller = abi(Abi, CONTRACT_ID);
+    caller.test_in_contract();
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_const_in_decls_of_other_constants/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/associated_const_in_decls_of_other_constants/test.toml
@@ -1,0 +1,1 @@
+category = "unit_tests_pass"


### PR DESCRIPTION
## Description

This PR adds additional tests for constants. Those test cases are important for the implementation of #6351 which will completely restructure compilation of constants.

Tests for recursive `const` definitions should also be considered before we start implementing `const fn` and `const trait`. In particular, we want to better track and provide precise error messages in case of unintended attempt to recursively define a constant in a complex situation that includes `const fn` and `const trait`.

Related to #6534, #6537, #6538, #6539, #6540, #6543, and #6544.

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.