### PR TITLE
Fixes unreachable on invalid cfg attribute arg.

### DIFF
--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -4943,8 +4943,13 @@ pub fn cfg_eval(
                         }
                     },
                     _ => {
-                        // Already checked with `AttributeKind::expected_args_*`
-                        unreachable!("cfg attribute should only have the `target` or the `program_type` argument");
+                        return Err(handler.emit_err(
+                            ConvertParseTreeError::InvalidCfgArg {
+                                span: arg.span(),
+                                value: arg.name.as_str().to_string(),
+                            }
+                            .into(),
+                        ));
                     }
                 }
             }

--- a/sway-error/src/convert_parse_tree_error.rs
+++ b/sway-error/src/convert_parse_tree_error.rs
@@ -119,6 +119,8 @@ pub enum ConvertParseTreeError {
     ExpectedCfgProgramTypeArgValue { span: Span },
     #[error("Expected \"true\" or \"false\" for experimental_new_encoding")]
     ExpectedExperimentalNewEncodingArgValue { span: Span },
+    #[error("Unexpected attribute value: \"{value}\" for attribute: \"cfg\"")]
+    InvalidCfgArg { span: Span, value: String },
 }
 
 impl Spanned for ConvertParseTreeError {
@@ -182,6 +184,7 @@ impl Spanned for ConvertParseTreeError {
             ConvertParseTreeError::InvalidCfgProgramTypeArgValue { span, .. } => span.clone(),
             ConvertParseTreeError::ExpectedCfgProgramTypeArgValue { span } => span.clone(),
             ConvertParseTreeError::ExpectedExperimentalNewEncodingArgValue { span } => span.clone(),
+            ConvertParseTreeError::InvalidCfgArg { span, .. } => span.clone(),
         }
     }
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/invalid_cfg_arg/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/invalid_cfg_arg/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "invalid_cfg_arg"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/invalid_cfg_arg/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/invalid_cfg_arg/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+name = "invalid_cfg_arg"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/invalid_cfg_arg/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/invalid_cfg_arg/src/main.sw
@@ -1,0 +1,2 @@
+predicate;
+#[cfg(c)] a

--- a/test/src/e2e_vm_tests/test_programs/should_fail/invalid_cfg_arg/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/invalid_cfg_arg/test.toml
@@ -1,0 +1,10 @@
+category = "fail"
+
+# check: $()#[cfg(c)] a
+# nextln: $()Unexpected attribute value: "c" for attribute: "cfg" expected value "target" or "program_type" or "experimental_new_encoding"
+
+# check: $()#[cfg(c)] a
+# nextln: $()Expected an item.
+
+# check: $()#[cfg(c)] a
+# nextln: $()Unexpected attribute value: "c" for attribute: "cfg"


### PR DESCRIPTION
## Description

We now throw an error that enforces cfg arg to be a valid one.

Fixes #6326

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
