### PR TITLE
fix: reapply second pass for metadata types

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -52,7 +52,18 @@ pub(crate) fn type_check_method_application(
         let arg_handler = Handler::default();
         let arg_opt = ty::TyExpression::type_check(&arg_handler, ctx, arg).ok();
 
-        let needs_second_pass = arg_handler.has_errors();
+        // Check this type needs a second pass
+        let has_errors = arg_handler.has_errors();
+        let is_not_concrete = arg_opt
+            .as_ref()
+            .map(|x| {
+                x.return_type
+                    .extract_inner_types(engines, IncludeSelf::Yes)
+                    .iter()
+                    .any(|x| !x.is_concrete(engines, TreatNumericAs::Abstract))
+            })
+            .unwrap_or_default();
+        let needs_second_pass = has_errors || is_not_concrete;
 
         if index == 0 {
             // We want to emit errors in the self parameter and ignore TraitConstraintNotSatisfied with Placeholder

--- a/sway-lib-std/src/bytes.sw
+++ b/sway-lib-std/src/bytes.sw
@@ -927,27 +927,26 @@ impl AbiDecode for Bytes {
     }
 }
 
-// TODO: Uncomment when fixed. https://github.com/FuelLabs/sway/issues/6567
-// #[test]
-// fn ok_bytes_buffer_ownership() {
-//     let mut original_array = [1u8, 2u8, 3u8, 4u8];
-//     let slice = raw_slice::from_parts::<u8>(__addr_of(original_array), 4);
+#[test]
+fn ok_bytes_buffer_ownership() {
+    let mut original_array = [1u8, 2u8, 3u8, 4u8];
+    let slice = raw_slice::from_parts::<u8>(__addr_of(original_array), 4);
 
-//     // Check Bytes duplicates the original slice
-//     let mut bytes = Bytes::from(slice);
-//     bytes.set(0, 5);
-//     assert(original_array[0] == 1);
+    // Check Bytes duplicates the original slice
+    let mut bytes = Bytes::from(slice);
+    bytes.set(0, 5);
+    assert(original_array[0] == 1);
 
-//     // At this point, slice equals [5, 2, 3, 4]
-//     let encoded_slice = encode(bytes);
+    // At this point, slice equals [5, 2, 3, 4]
+    let encoded_slice = encode(bytes);
 
-//     // `Bytes` should duplicate the underlying buffer,
-//     // so when we write to it, it should not change
-//     // `encoded_slice` 
-//     let mut bytes = abi_decode::<Bytes>(encoded_slice);
-//     bytes.set(0, 6);
-//     assert(bytes.get(0) == Some(6));
+    // `Bytes` should duplicate the underlying buffer,
+    // so when we write to it, it should not change
+    // `encoded_slice` 
+    let mut bytes = abi_decode::<Bytes>(encoded_slice);
+    bytes.set(0, 6);
+    assert(bytes.get(0) == Some(6));
 
-//     let mut bytes = abi_decode::<Bytes>(encoded_slice);
-//     assert(bytes.get(0) == Some(5));
-// }
+    let mut bytes = abi_decode::<Bytes>(encoded_slice);
+    assert(bytes.get(0) == Some(5));
+}

--- a/sway-lib-std/src/vec.sw
+++ b/sway-lib-std/src/vec.sw
@@ -705,27 +705,26 @@ impl<T> Iterator for VecIter<T> {
     }
 }
 
-// TODO: Uncomment when fixed. https://github.com/FuelLabs/sway/issues/6567
-// #[test]
-// fn ok_vec_buffer_ownership() {
-//     let mut original_array = [1u8, 2u8, 3u8, 4u8];
-//     let slice = raw_slice::from_parts::<u8>(__addr_of(original_array), 4);
+#[test]
+fn ok_vec_buffer_ownership() {
+    let mut original_array = [1u8, 2u8, 3u8, 4u8];
+    let slice = raw_slice::from_parts::<u8>(__addr_of(original_array), 4);
 
-//     // Check Vec duplicates the original slice
-//     let mut bytes = Vec::<u8>::from(slice);
-//     bytes.set(0, 5);
-//     assert(original_array[0] == 1);
+    // Check Vec duplicates the original slice
+    let mut bytes = Vec::<u8>::from(slice);
+    bytes.set(0, 5);
+    assert(original_array[0] == 1);
 
-//     // At this point, slice equals [5, 2, 3, 4]
-//     let encoded_slice = encode(bytes);
+    // At this point, slice equals [5, 2, 3, 4]
+    let encoded_slice = encode(bytes);
 
-//     // `Vec<u8>` should duplicate the underlying buffer,
-//     // so when we write to it, it should not change
-//     // `encoded_slice` 
-//     let mut bytes = abi_decode::<Vec<u8>>(encoded_slice);
-//     bytes.set(0, 6);
-//     assert(bytes.get(0) == Some(6));
+    // `Vec<u8>` should duplicate the underlying buffer,
+    // so when we write to it, it should not change
+    // `encoded_slice` 
+    let mut bytes = abi_decode::<Vec<u8>>(encoded_slice);
+    bytes.set(0, 6);
+    assert(bytes.get(0) == Some(6));
 
-//     let mut bytes = abi_decode::<Vec<u8>>(encoded_slice);
-//     assert(bytes.get(0) == Some(5));
-// }
+    let mut bytes = abi_decode::<Vec<u8>>(encoded_slice);
+    assert(bytes.get(0) == Some(5));
+}


### PR DESCRIPTION
## Description

Closes https://github.com/FuelLabs/sway/issues/6567

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
