### PR TITLE
fix: forc-deploy block url

### DIFF
--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -1426,14 +1426,8 @@ fn create_deployment_artifact(
     );
 
     let block_height = deployment_artifact.deployed_block_height;
-    if block_height.is_some() {
-        let block_height_formatted =
-            match u32::from_str_radix(&block_height.unwrap().to_string(), 16) {
-                Ok(decimal) => format!("{block_url}{decimal}"),
-                Err(_) => block_height.unwrap().to_string(),
-            };
-
-        println_action_green("Deployed", &format!("in block {block_height_formatted}"));
+    if let Some(block_height) = block_height {
+        println_action_green("Deployed", &format!("in block {block_url}{block_height}"));
     }
 
     let output_dir = cmd


### PR DESCRIPTION
## Description

It looks like there was a change in how fuel core client returns the block height. It used to be a hex number and we had to convert it to decimal, but now it’s returning the number as a decimal so we don't need to convert it.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
