### PR TITLE
ci: add versions to cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,34 +45,34 @@ repository = "https://github.com/FuelLabs/sway"
 # Internal dependencies in order to propagate `workspace.version`
 #
 
-forc = { path = "forc/" }
-forc-pkg = { path = "forc-pkg/" }
-forc-test = { path = "forc-test/" }
-forc-tracing = { path = "forc-tracing/" }
-forc-util = { path = "forc-util/" }
+forc = { path = "forc/", version = "0.64.0" }
+forc-pkg = { path = "forc-pkg/", version = "0.64.0" }
+forc-test = { path = "forc-test/", version = "0.64.0" }
+forc-tracing = { path = "forc-tracing/", version = "0.64.0" }
+forc-util = { path = "forc-util/", version = "0.64.0" }
 
 # Forc plugins
-forc-plugins = { path = "forc-plugins/" }
-forc-client = { path = "forc-plugins/forc-client/" }
-forc-crypto = { path = "forc-plugins/forc-crypto/" }
-forc-debug = { path = "forc-plugins/forc-debug/" }
-forc-doc = { path = "forc-plugins/forc-doc/" }
-forc-fmt = { path = "forc-plugins/forc-fmt/" }
-forc-lsp = { path = "forc-plugins/forc-lsp/" }
-forc-tx = { path = "forc-plugins/forc-tx/" }
+forc-plugins = { path = "forc-plugins/", version = "0.64.0" }
+forc-client = { path = "forc-plugins/forc-client/", version = "0.64.0" }
+forc-crypto = { path = "forc-plugins/forc-crypto/", version = "0.64.0" }
+forc-debug = { path = "forc-plugins/forc-debug/", version = "0.64.0" }
+forc-doc = { path = "forc-plugins/forc-doc/", version = "0.64.0" }
+forc-fmt = { path = "forc-plugins/forc-fmt/", version = "0.64.0" }
+forc-lsp = { path = "forc-plugins/forc-lsp/", version = "0.64.0" }
+forc-tx = { path = "forc-plugins/forc-tx/", version = "0.64.0" }
 
-sway-ast = { path = "sway-ast/" }
-sway-core = { path = "sway-core/" }
-sway-error = { path = "sway-error/" }
-sway-lsp = { path = "sway-lsp/" }
-sway-parse = { path = "sway-parse/" }
-sway-types = { path = "sway-types/" }
-sway-utils = { path = "sway-utils/" }
-swayfmt = { path = "swayfmt/" }
+sway-ast = { path = "sway-ast/", version = "0.64.0" }
+sway-core = { path = "sway-core/", version = "0.64.0" }
+sway-error = { path = "sway-error/", version = "0.64.0" }
+sway-lsp = { path = "sway-lsp/", version = "0.64.0" }
+sway-parse = { path = "sway-parse/", version = "0.64.0" }
+sway-types = { path = "sway-types/", version = "0.64.0" }
+sway-utils = { path = "sway-utils/", version = "0.64.0" }
+swayfmt = { path = "swayfmt/", version = "0.64.0" }
 
 # Sway IR
-sway-ir = { path = "sway-ir/" }
-sway-ir-macros = { path = "sway-ir/sway-ir-macros" }
+sway-ir = { path = "sway-ir/", version = "0.64.0" }
+sway-ir-macros = { path = "sway-ir/sway-ir-macros", version = "0.64.0" }
 
 #
 # External Fuel dependencies


### PR DESCRIPTION
## Description

This should [unblock](https://github.com/FuelLabs/sway/actions/runs/11035362451/job/30652169645#step:4:22) releases. [Cargo doesn't use the workspace version for path dependencies](https://github.com/rust-lang/cargo/issues/11133), so we still have to specify the versions. This is also how it's done in [fuel-core](https://github.com/FuelLabs/fuel-core/blob/master/Cargo.toml).

This is actually nice because it means we could in the future bump the versions of the dependencies separately, all from within the one file.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
