### PR TITLE
fix: Capture more declarations for sway autocomplete

### DIFF
--- a/sway-lsp/src/capabilities/code_actions/diagnostic/auto_import.rs
+++ b/sway-lsp/src/capabilities/code_actions/diagnostic/auto_import.rs
@@ -18,8 +18,7 @@ use std::{
 use sway_core::language::{
     parsed::ImportType,
     ty::{
-        TyConstantDecl, TyDecl, TyEnumDecl, TyFunctionDecl, TyIncludeStatement, TyStructDecl,
-        TyTraitDecl, TyTypeAliasDecl, TyUseStatement,
+        TyConstantDecl, TyDecl, TyFunctionDecl, TyIncludeStatement, TyTypeAliasDecl, TyUseStatement,
     },
     CallPath,
 };
@@ -143,7 +142,7 @@ pub(crate) fn get_call_paths_for_name<'s>(
                         _ => None,
                     };
                 }
-                | Some(TypedAstToken::TypedFunctionDeclaration(TyFunctionDecl {
+                Some(TypedAstToken::TypedFunctionDeclaration(TyFunctionDecl {
                     call_path, ..
                 }))
                 | Some(TypedAstToken::TypedConstantDeclaration(TyConstantDecl {

--- a/sway-lsp/src/capabilities/code_actions/diagnostic/auto_import.rs
+++ b/sway-lsp/src/capabilities/code_actions/diagnostic/auto_import.rs
@@ -18,7 +18,8 @@ use std::{
 use sway_core::language::{
     parsed::ImportType,
     ty::{
-        TyConstantDecl, TyDecl, TyFunctionDecl, TyIncludeStatement, TyTypeAliasDecl, TyUseStatement,
+        TyConstantDecl, TyDecl, TyEnumDecl, TyFunctionDecl, TyIncludeStatement, TyStructDecl,
+        TyTraitDecl, TyTypeAliasDecl, TyUseStatement,
     },
     CallPath,
 };
@@ -118,10 +119,31 @@ pub(crate) fn get_call_paths_for_name<'s>(
                                 trait_decl.call_path.to_import_path(ctx.engines, &namespace);
                             Some(call_path)
                         }
+                        TyDecl::FunctionDecl(decl) => {
+                            let function_decl = ctx.engines.de().get_function(&decl.decl_id);
+                            let call_path = function_decl
+                                .call_path
+                                .to_import_path(ctx.engines, &namespace);
+                            Some(call_path)
+                        }
+                        TyDecl::ConstantDecl(decl) => {
+                            let constant_decl = ctx.engines.de().get_constant(&decl.decl_id);
+                            let call_path = constant_decl
+                                .call_path
+                                .to_import_path(ctx.engines, &namespace);
+                            Some(call_path)
+                        }
+                        TyDecl::TypeAliasDecl(decl) => {
+                            let type_alias_decl = ctx.engines.de().get_type_alias(&decl.decl_id);
+                            let call_path = type_alias_decl
+                                .call_path
+                                .to_import_path(ctx.engines, &namespace);
+                            Some(call_path)
+                        }
                         _ => None,
                     };
                 }
-                Some(TypedAstToken::TypedFunctionDeclaration(TyFunctionDecl {
+                | Some(TypedAstToken::TypedFunctionDeclaration(TyFunctionDecl {
                     call_path, ..
                 }))
                 | Some(TypedAstToken::TypedConstantDeclaration(TyConstantDecl {


### PR DESCRIPTION
## Description

I noticed that autocomplete wasn't working for some function declarations. It was because sometimes function declarations in the token map are stored as `TyDecl::FunctionDecl(decl)` and sometimes as `TypedAstToken::TypedFunctionDeclaration(TyFunctionDecl {..})`

This PR expands the matching for declarations to make autocomplete work in more cases.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
