### PR TITLE
return type checked trait constraints

### DIFF
--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -213,7 +213,7 @@ impl TypeParameter {
             // Type check trait constraints only after type checking all type parameters.
             // This is required because a trait constraint may use other type parameters.
             // Ex: `struct Struct2<A, B> where A : MyAdd<B>`
-            for type_param in &new_type_params {
+            for type_param in new_type_params.iter_mut() {
                 TypeParameter::type_check_trait_constraints(handler, ctx.by_ref(), type_param)?;
             }
 
@@ -327,7 +327,7 @@ impl TypeParameter {
     fn type_check_trait_constraints(
         handler: &Handler,
         mut ctx: TypeCheckContext,
-        type_parameter: &TypeParameter,
+        type_parameter: &mut TypeParameter,
     ) -> Result<(), ErrorEmitted> {
         let type_engine = ctx.engines.te();
 
@@ -371,6 +371,8 @@ impl TypeParameter {
                 source_id: type_parameter.name_ident.span().source_id().copied(),
             },
         );
+
+        type_parameter.trait_constraints = trait_constraints_with_supertraits;
 
         // Insert the trait constraints into the namespace.
         type_parameter.insert_into_namespace_constraints(handler, ctx.by_ref())?;


### PR DESCRIPTION
## Description

This PR fixes https://github.com/FuelLabs/sway/issues/6382.

The issue was that `TypeParameter::type_check_trait_constraints(...)` mutates the type inside the `TypeEngine`, but it was not returning the new typed-checked trait constraints.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
