### PR TITLE
chore: bump to 0.65.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,7 +2678,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "annotate-snippets",
  "ansi_term",
@@ -2689,7 +2689,7 @@ dependencies = [
  "completest-pty",
  "forc-pkg",
  "forc-test",
- "forc-tracing 0.64.0",
+ "forc-tracing 0.65.0",
  "forc-util",
  "fs_extra",
  "fuel-asm",
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "forc-client"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2727,7 +2727,7 @@ dependencies = [
  "dialoguer",
  "forc",
  "forc-pkg",
- "forc-tracing 0.64.0",
+ "forc-tracing 0.65.0",
  "forc-tx",
  "forc-util",
  "forc-wallet",
@@ -2761,13 +2761,13 @@ dependencies = [
 
 [[package]]
 name = "forc-crypto"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "atty",
  "clap 4.5.16",
- "forc-tracing 0.64.0",
+ "forc-tracing 0.65.0",
  "forc-util",
  "fuel-core-types",
  "fuel-crypto",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "forc-debug"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "clap 4.5.16",
@@ -2795,7 +2795,7 @@ dependencies = [
  "escargot",
  "forc-pkg",
  "forc-test",
- "forc-tracing 0.64.0",
+ "forc-tracing 0.65.0",
  "fuel-core-client",
  "fuel-types",
  "fuel-vm",
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "forc-doc"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "clap 4.5.16",
@@ -2821,7 +2821,7 @@ dependencies = [
  "dir_indexer",
  "expect-test",
  "forc-pkg",
- "forc-tracing 0.64.0",
+ "forc-tracing 0.65.0",
  "forc-util",
  "horrorshow",
  "include_dir",
@@ -2838,12 +2838,12 @@ dependencies = [
 
 [[package]]
 name = "forc-fmt"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "clap 4.5.16",
  "forc-pkg",
- "forc-tracing 0.64.0",
+ "forc-tracing 0.65.0",
  "forc-util",
  "prettydiff 0.7.0",
  "sway-core",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "forc-lsp"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "clap 4.5.16",
@@ -2866,13 +2866,13 @@ dependencies = [
 
 [[package]]
 name = "forc-pkg"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "ansi_term",
  "anyhow",
  "byte-unit",
  "cid",
- "forc-tracing 0.64.0",
+ "forc-tracing 0.65.0",
  "forc-util",
  "fuel-abi-types",
  "futures",
@@ -2903,7 +2903,7 @@ dependencies = [
 
 [[package]]
 name = "forc-test"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "forc-pkg",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "forc-tracing"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "ansi_term",
  "tracing",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "forc-tx"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "clap 4.5.16",
@@ -2955,7 +2955,7 @@ dependencies = [
 
 [[package]]
 name = "forc-util"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "annotate-snippets",
  "ansi_term",
@@ -2963,7 +2963,7 @@ dependencies = [
  "clap 4.5.16",
  "dirs 5.0.1",
  "fd-lock",
- "forc-tracing 0.64.0",
+ "forc-tracing 0.65.0",
  "fuel-tx",
  "hex",
  "paste",
@@ -7642,7 +7642,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sway-ast"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "extension-trait",
  "num-bigint",
@@ -7654,7 +7654,7 @@ dependencies = [
 
 [[package]]
 name = "sway-core"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "clap 4.5.16",
  "derivative",
@@ -7699,7 +7699,7 @@ dependencies = [
 
 [[package]]
 name = "sway-error"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "either",
  "in_definite",
@@ -7713,7 +7713,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "downcast-rs",
@@ -7732,7 +7732,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir-macros"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -7742,7 +7742,7 @@ dependencies = [
 
 [[package]]
 name = "sway-lsp"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -7753,7 +7753,7 @@ dependencies = [
  "dirs 4.0.0",
  "fd-lock",
  "forc-pkg",
- "forc-tracing 0.64.0",
+ "forc-tracing 0.65.0",
  "forc-util",
  "futures",
  "indexmap 2.5.0",
@@ -7792,7 +7792,7 @@ dependencies = [
 
 [[package]]
 name = "sway-lsp-test-utils"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "assert-json-diff",
  "futures",
@@ -7807,7 +7807,7 @@ dependencies = [
 
 [[package]]
 name = "sway-parse"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "assert_matches",
  "extension-trait",
@@ -7825,7 +7825,7 @@ dependencies = [
 
 [[package]]
 name = "sway-types"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "bytecount",
  "fuel-asm",
@@ -7844,7 +7844,7 @@ dependencies = [
 
 [[package]]
 name = "sway-utils"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "serde",
  "walkdir",
@@ -7852,11 +7852,11 @@ dependencies = [
 
 [[package]]
 name = "swayfmt"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "anyhow",
  "difference",
- "forc-tracing 0.64.0",
+ "forc-tracing 0.65.0",
  "indoc",
  "paste",
  "prettydiff 0.6.4",
@@ -8140,7 +8140,7 @@ dependencies = [
  "forc-client",
  "forc-pkg",
  "forc-test",
- "forc-tracing 0.64.0",
+ "forc-tracing 0.65.0",
  "fuel-vm",
  "futures",
  "gag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = [
 
 [workspace.package]
 edition = "2021"
-version = "0.64.0"
+version = "0.65.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
@@ -45,34 +45,34 @@ repository = "https://github.com/FuelLabs/sway"
 # Internal dependencies in order to propagate `workspace.version`
 #
 
-forc = { path = "forc/", version = "0.64.0" }
-forc-pkg = { path = "forc-pkg/", version = "0.64.0" }
-forc-test = { path = "forc-test/", version = "0.64.0" }
-forc-tracing = { path = "forc-tracing/", version = "0.64.0" }
-forc-util = { path = "forc-util/", version = "0.64.0" }
+forc = { path = "forc/", version = "0.65.0" }
+forc-pkg = { path = "forc-pkg/", version = "0.65.0" }
+forc-test = { path = "forc-test/", version = "0.65.0" }
+forc-tracing = { path = "forc-tracing/", version = "0.65.0" }
+forc-util = { path = "forc-util/", version = "0.65.0" }
 
 # Forc plugins
-forc-plugins = { path = "forc-plugins/", version = "0.64.0" }
-forc-client = { path = "forc-plugins/forc-client/", version = "0.64.0" }
-forc-crypto = { path = "forc-plugins/forc-crypto/", version = "0.64.0" }
-forc-debug = { path = "forc-plugins/forc-debug/", version = "0.64.0" }
-forc-doc = { path = "forc-plugins/forc-doc/", version = "0.64.0" }
-forc-fmt = { path = "forc-plugins/forc-fmt/", version = "0.64.0" }
-forc-lsp = { path = "forc-plugins/forc-lsp/", version = "0.64.0" }
-forc-tx = { path = "forc-plugins/forc-tx/", version = "0.64.0" }
+forc-plugins = { path = "forc-plugins/", version = "0.65.0" }
+forc-client = { path = "forc-plugins/forc-client/", version = "0.65.0" }
+forc-crypto = { path = "forc-plugins/forc-crypto/", version = "0.65.0" }
+forc-debug = { path = "forc-plugins/forc-debug/", version = "0.65.0" }
+forc-doc = { path = "forc-plugins/forc-doc/", version = "0.65.0" }
+forc-fmt = { path = "forc-plugins/forc-fmt/", version = "0.65.0" }
+forc-lsp = { path = "forc-plugins/forc-lsp/", version = "0.65.0" }
+forc-tx = { path = "forc-plugins/forc-tx/", version = "0.65.0" }
 
-sway-ast = { path = "sway-ast/", version = "0.64.0" }
-sway-core = { path = "sway-core/", version = "0.64.0" }
-sway-error = { path = "sway-error/", version = "0.64.0" }
-sway-lsp = { path = "sway-lsp/", version = "0.64.0" }
-sway-parse = { path = "sway-parse/", version = "0.64.0" }
-sway-types = { path = "sway-types/", version = "0.64.0" }
-sway-utils = { path = "sway-utils/", version = "0.64.0" }
-swayfmt = { path = "swayfmt/", version = "0.64.0" }
+sway-ast = { path = "sway-ast/", version = "0.65.0" }
+sway-core = { path = "sway-core/", version = "0.65.0" }
+sway-error = { path = "sway-error/", version = "0.65.0" }
+sway-lsp = { path = "sway-lsp/", version = "0.65.0" }
+sway-parse = { path = "sway-parse/", version = "0.65.0" }
+sway-types = { path = "sway-types/", version = "0.65.0" }
+sway-utils = { path = "sway-utils/", version = "0.65.0" }
+swayfmt = { path = "swayfmt/", version = "0.65.0" }
 
 # Sway IR
-sway-ir = { path = "sway-ir/", version = "0.64.0" }
-sway-ir-macros = { path = "sway-ir/sway-ir-macros", version = "0.64.0" }
+sway-ir = { path = "sway-ir/", version = "0.65.0" }
+sway-ir-macros = { path = "sway-ir/sway-ir-macros", version = "0.65.0" }
 
 #
 # External Fuel dependencies


### PR DESCRIPTION
## Description
Adds blob deployments for scripts and predicates. Supports fuels 0.66.6 and fuel-core 0.37.0.
