### PR TITLE
Rewrite `TypeEngine` for performance, robustness, and simplicity

### DIFF
--- a/sway-core/src/abi_generation/abi_str.rs
+++ b/sway-core/src/abi_generation/abi_str.rs
@@ -171,7 +171,6 @@ impl TypeInfo {
                     length.val()
                 )
             }
-            Storage { .. } => "contract storage".into(),
             RawUntypedPtr => "raw untyped ptr".into(),
             RawUntypedSlice => "raw untyped slice".into(),
             Ptr(ty) => {

--- a/sway-core/src/abi_generation/evm_abi.rs
+++ b/sway-core/src/abi_generation/evm_abi.rs
@@ -107,7 +107,6 @@ pub fn abi_str(type_info: &TypeInfo, engines: &Engines) -> String {
         Array(elem_ty, length) => {
             format!("{}[{}]", abi_str_type_arg(elem_ty, engines), length.val())
         }
-        Storage { .. } => "contract storage".into(),
         RawUntypedPtr => "raw untyped ptr".into(),
         RawUntypedSlice => "raw untyped slice".into(),
         Ptr(ty) => {

--- a/sway-core/src/concurrent_slab.rs
+++ b/sway-core/src/concurrent_slab.rs
@@ -100,6 +100,13 @@ where
         Arc::into_inner(old)
     }
 
+    pub fn replace_arc(&self, index: usize, new_value: Arc<T>) -> Option<T> {
+        let mut inner = self.inner.write();
+        let item = inner.items.get_mut(index)?;
+        let old = item.replace(new_value)?;
+        Arc::into_inner(old)
+    }
+
     pub fn get(&self, index: usize) -> Arc<T> {
         let inner = self.inner.read();
         inner.items[index]

--- a/sway-core/src/engine_threading.rs
+++ b/sway-core/src/engine_threading.rs
@@ -7,6 +7,7 @@ use std::{
     cmp::Ordering,
     fmt,
     hash::{BuildHasher, Hash, Hasher},
+    sync::Arc,
 };
 use sway_types::{SourceEngine, Span};
 
@@ -40,7 +41,7 @@ impl Engines {
         &self.source_engine
     }
 
-    /// Removes all data associated with `program_id` from the declaration and type engines.
+    /// Removes all data associated with `program_id` from the engines.
     /// It is intended to be used during garbage collection to remove any data that is no longer needed.
     pub fn clear_program(&mut self, program_id: &sway_types::ProgramId) {
         self.type_engine.clear_program(program_id);
@@ -49,7 +50,7 @@ impl Engines {
         self.query_engine.clear_program(program_id);
     }
 
-    /// Removes all data associated with `source_id` from the declaration and type engines.
+    /// Removes all data associated with `source_id` from the engines.
     /// It is intended to be used during garbage collection to remove any data that is no longer needed.
     pub fn clear_module(&mut self, source_id: &sway_types::SourceId) {
         self.type_engine.clear_module(source_id);
@@ -253,6 +254,12 @@ impl<T: HashWithEngines> HashWithEngines for [T] {
 }
 
 impl<T: HashWithEngines> HashWithEngines for Box<T> {
+    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+        (**self).hash(state, engines)
+    }
+}
+
+impl<T: HashWithEngines> HashWithEngines for Arc<T> {
     fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
         (**self).hash(state, engines)
     }

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -221,7 +221,7 @@ pub(crate) fn compile_constant_expression_to_constant(
         // definition, rather than the actual call site.
         ty::TyExpressionVariant::FunctionApplication { call_path, .. } => {
             let span = call_path.span();
-            let span = if span == Span::dummy() {
+            let span = if span.is_dummy() {
                 const_expr.span.clone()
             } else {
                 span

--- a/sway-core/src/ir_generation/convert.rs
+++ b/sway-core/src/ir_generation/convert.rs
@@ -182,7 +182,6 @@ fn convert_resolved_type_info(
         TypeInfo::Placeholder(_) => reject_type!("Placeholder"),
         TypeInfo::TypeParam(_) => reject_type!("TypeParam"),
         TypeInfo::ErrorRecovery(_) => reject_type!("Error recovery"),
-        TypeInfo::Storage { .. } => reject_type!("Storage"),
         TypeInfo::TraitType { .. } => reject_type!("TraitType"),
     })
 }

--- a/sway-core/src/language/parsed/declaration/impl_trait.rs
+++ b/sway-core/src/language/parsed/declaration/impl_trait.rs
@@ -72,7 +72,7 @@ pub struct ImplSelfOrTrait {
     pub trait_decl_ref: Option<ParsedInterfaceDeclId>,
     pub implementing_for: TypeArgument,
     pub items: Vec<ImplItem>,
-    // the span of the whole impl trait and block
+    /// The [Span] of the whole impl trait and block.
     pub(crate) block_span: Span,
 }
 

--- a/sway-core/src/language/ty/declaration/abi.rs
+++ b/sway-core/src/language/ty/declaration/abi.rs
@@ -76,12 +76,9 @@ impl HashWithEngines for TyAbiDecl {
 
 impl CreateTypeId for TyAbiDecl {
     fn create_type_id(&self, engines: &Engines) -> TypeId {
-        let type_engine = engines.te();
-        let ty = TypeInfo::ContractCaller {
-            abi_name: AbiName::Known(self.name.clone().into()),
-            address: None,
-        };
-        type_engine.insert(engines, ty, self.name.span().source_id())
+        engines
+            .te()
+            .new_contract_caller(engines, AbiName::Known(self.name.clone().into()), None)
     }
 }
 

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -740,31 +740,9 @@ impl TyDecl {
                 decl.return_type.type_id
             }
             TyDecl::StructDecl(StructDecl { decl_id }) => {
-                let decl = decl_engine.get_struct(decl_id);
-                type_engine.insert(
-                    engines,
-                    TypeInfo::Struct(*decl_id),
-                    decl.name().span().source_id(),
-                )
+                type_engine.insert_struct(engines, *decl_id)
             }
-            TyDecl::EnumDecl(EnumDecl { decl_id }) => {
-                let decl = decl_engine.get_enum(decl_id);
-                type_engine.insert(
-                    engines,
-                    TypeInfo::Enum(*decl_id),
-                    decl.name().span().source_id(),
-                )
-            }
-            TyDecl::StorageDecl(StorageDecl { decl_id, .. }) => {
-                let storage_decl = decl_engine.get_storage(decl_id);
-                type_engine.insert(
-                    engines,
-                    TypeInfo::Storage {
-                        fields: storage_decl.fields_as_typed_struct_fields(),
-                    },
-                    storage_decl.span().source_id(),
-                )
-            }
+            TyDecl::EnumDecl(EnumDecl { decl_id }) => type_engine.insert_enum(engines, *decl_id),
             TyDecl::TypeAliasDecl(TypeAliasDecl { decl_id, .. }) => {
                 let decl = decl_engine.get_type_alias(decl_id);
                 decl.create_type_id(engines)

--- a/sway-core/src/language/ty/declaration/storage.rs
+++ b/sway-core/src/language/ty/declaration/storage.rs
@@ -8,7 +8,7 @@ use sway_types::{Ident, Named, Span, Spanned};
 
 use crate::{
     engine_threading::*,
-    language::{parsed::StorageDeclaration, ty::*, Visibility},
+    language::{parsed::StorageDeclaration, ty::*},
     transform::{self},
     type_system::*,
     Namespace,
@@ -232,27 +232,6 @@ impl TyStorageDecl {
             },
             return_type,
         ))
-    }
-
-    pub(crate) fn fields_as_typed_struct_fields(&self) -> Vec<TyStructField> {
-        self.fields
-            .iter()
-            .map(
-                |TyStorageField {
-                     ref name,
-                     ref type_argument,
-                     ref span,
-                     ref attributes,
-                     ..
-                 }| TyStructField {
-                    visibility: Visibility::Public,
-                    name: name.clone(),
-                    span: span.clone(),
-                    type_argument: type_argument.clone(),
-                    attributes: attributes.clone(),
-                },
-            )
-            .collect()
     }
 }
 

--- a/sway-core/src/language/ty/declaration/type_alias.rs
+++ b/sway-core/src/language/ty/declaration/type_alias.rs
@@ -64,15 +64,9 @@ impl SubstTypes for TyTypeAliasDecl {
 
 impl CreateTypeId for TyTypeAliasDecl {
     fn create_type_id(&self, engines: &Engines) -> TypeId {
-        let type_engine = engines.te();
-        type_engine.insert(
-            engines,
-            TypeInfo::Alias {
-                name: self.name.clone(),
-                ty: self.ty.clone(),
-            },
-            self.name.span().source_id(),
-        )
+        engines
+            .te()
+            .new_alias(engines, self.name.clone(), self.ty.clone())
     }
 }
 

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -369,7 +369,7 @@ impl TyExpression {
         let type_engine = engines.te();
         TyExpression {
             expression: TyExpressionVariant::Tuple { fields: vec![] },
-            return_type: type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None),
+            return_type: type_engine.id_of_error_recovery(err),
             span,
         }
     }

--- a/sway-core/src/semantic_analysis/ast_node/code_block.rs
+++ b/sway-core/src/semantic_analysis/ast_node/code_block.rs
@@ -91,8 +91,6 @@ impl ty::TyCodeBlock {
         ctx: &TypeCheckContext,
         code_block: &TyCodeBlock,
     ) -> (TypeId, Span) {
-        let engines = ctx.engines();
-
         let implicit_return_span = code_block
             .contents
             .iter()
@@ -122,12 +120,8 @@ impl ty::TyCodeBlock {
                                 ..
                             }),
                         ..
-                    } => Some(
-                        ctx.engines
-                            .te()
-                            .insert(engines, TypeInfo::Never, span.source_id()),
-                    ),
-                    // find the implicit return, if any, and use it as the code block's return type.
+                    } => Some(ctx.engines.te().id_of_never()),
+                    // Find the implicit return, if any, and use it as the code block's return type.
                     // The fact that there is at most one implicit return is an invariant held by the parser.
                     ty::TyAstNode {
                         content:
@@ -153,11 +147,7 @@ impl ty::TyCodeBlock {
                     _ => None,
                 }
             })
-            .unwrap_or_else(|| {
-                ctx.engines
-                    .te()
-                    .insert(engines, TypeInfo::Tuple(Vec::new()), span.source_id())
-            });
+            .unwrap_or_else(|| ctx.engines.te().id_of_unit());
 
         (block_type, span)
     }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -79,6 +79,8 @@ impl ty::TyAbiDecl {
         // so we don't support the case of calling a contract's own interface
         // from itself. This is by design.
 
+        // The span of the `abi_decl` `name` points to the file (use site) in which
+        // the ABI is getting declared, so we can use it as the `use_site_span`.
         let self_type_param = TypeParameter::new_self_type(ctx.engines, name.span());
         let self_type_id = self_type_param.type_id;
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl.rs
@@ -75,11 +75,8 @@ where
         } else {
             format!(
                 "<{}>",
-                itertools::intersperse(
-                    type_parameters.iter().map(|x| { x.name_ident.as_str() }),
-                    ", "
-                )
-                .collect::<String>()
+                itertools::intersperse(type_parameters.iter().map(|x| { x.name.as_str() }), ", ")
+                    .collect::<String>()
             )
         }
     }
@@ -94,7 +91,7 @@ where
         for t in type_parameters.iter() {
             code.push_str(&format!(
                 "{}: {},\n",
-                t.name_ident.as_str(),
+                t.name.as_str(),
                 itertools::intersperse(
                     [extra_constraint].into_iter().chain(
                         t.trait_constraints
@@ -502,7 +499,7 @@ where
     fn generate_type(engines: &Engines, type_id: TypeId) -> Option<String> {
         let name = match &*engines.te().get(type_id) {
             TypeInfo::UnknownGeneric { name, .. } => name.to_string(),
-            TypeInfo::Placeholder(type_param) => type_param.name_ident.to_string(),
+            TypeInfo::Placeholder(type_param) => type_param.name.to_string(),
             TypeInfo::StringSlice => "str".into(),
             TypeInfo::StringArray(x) => format!("str[{}]", x.val()),
             TypeInfo::UnsignedInteger(x) => match x {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/configurable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/configurable.rs
@@ -19,7 +19,6 @@ use crate::{
     },
     semantic_analysis::{type_check_context::EnforceTypeArguments, *},
     Engines, SubstTypes, SubstTypesContext, TypeArgument, TypeBinding, TypeCheckTypeBinding,
-    TypeInfo,
 };
 
 impl ty::TyConfigurableDecl {
@@ -68,7 +67,7 @@ impl ty::TyConfigurableDecl {
                 EnforceTypeArguments::No,
                 None,
             )
-            .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+            .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
         // this subst is required to replace associated types, namely TypeInfo::TraitType.
         type_ascription.type_id.subst(
@@ -87,7 +86,7 @@ impl ty::TyConfigurableDecl {
         let (value, decode_fn) = if ctx.experimental.new_encoding {
             let mut ctx = ctx
                 .by_ref()
-                .with_type_annotation(type_engine.insert(engines, TypeInfo::RawUntypedSlice, None))
+                .with_type_annotation(type_engine.id_of_raw_slice())
                 .with_help_text("Configurables must evaluate to slices.");
 
             let value = value.map(|value| {
@@ -96,21 +95,9 @@ impl ty::TyConfigurableDecl {
             });
 
             let mut arguments = VecDeque::default();
-            arguments.push_back(
-                engines
-                    .te()
-                    .insert(engines, TypeInfo::RawUntypedSlice, None),
-            );
-            arguments.push_back(engines.te().insert(
-                engines,
-                TypeInfo::UnsignedInteger(sway_types::integer_bits::IntegerBits::SixtyFour),
-                None,
-            ));
-            arguments.push_back(
-                engines
-                    .te()
-                    .insert(engines, TypeInfo::RawUntypedSlice, None),
-            );
+            arguments.push_back(engines.te().id_of_raw_slice());
+            arguments.push_back(engines.te().id_of_u64());
+            arguments.push_back(engines.te().id_of_raw_slice());
 
             let value_span = value
                 .as_ref()

--- a/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
@@ -61,7 +61,7 @@ impl ty::TyConstantDecl {
                 EnforceTypeArguments::No,
                 None,
             )
-            .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+            .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
         // this subst is required to replace associated types, namely TypeInfo::TraitType.
         type_ascription.type_id.subst(
@@ -132,7 +132,7 @@ impl ty::TyConstantDecl {
             call_path,
             span,
             attributes: Default::default(),
-            return_type: type_engine.insert(engines, TypeInfo::Unknown, None),
+            return_type: type_engine.new_unknown(),
             type_ascription,
             value: None,
             visibility,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -158,8 +158,7 @@ impl TyDecl {
                 let fn_decl = engines.pe().get_function(&decl_id);
                 let span = fn_decl.span.clone();
 
-                let mut ctx =
-                    ctx.with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+                let mut ctx = ctx.with_type_annotation(type_engine.new_unknown());
                 let fn_decl = match ty::TyFunctionDecl::type_check(
                     handler,
                     ctx.by_ref(),
@@ -445,11 +444,8 @@ impl TyDecl {
 
                             let mut key_ty_expression = None;
                             if let Some(key_expression) = key_expression {
-                                let mut key_ctx = ctx.with_type_annotation(engines.te().insert(
-                                    engines,
-                                    TypeInfo::B256,
-                                    None,
-                                ));
+                                let mut key_ctx =
+                                    ctx.with_type_annotation(engines.te().id_of_b256());
 
                                 key_ty_expression = Some(ty::TyExpression::type_check(
                                     handler,
@@ -523,9 +519,7 @@ impl TyDecl {
                 // Resolve the type that the type alias replaces
                 let new_ty = ctx
                     .resolve_type(handler, ty.type_id, &span, EnforceTypeArguments::Yes, None)
-                    .unwrap_or_else(|err| {
-                        type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None)
-                    });
+                    .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
                 // create the type alias decl using the resolved type above
                 let decl = ty::TyTypeAliasDecl {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -87,7 +87,6 @@ impl ty::TyEnumVariant {
         variant: EnumVariant,
     ) -> Result<Self, ErrorEmitted> {
         let type_engine = ctx.engines.te();
-        let engines = ctx.engines();
         let mut type_argument = variant.type_argument;
         type_argument.type_id = ctx
             .resolve_type(
@@ -97,7 +96,7 @@ impl ty::TyEnumVariant {
                 EnforceTypeArguments::Yes,
                 None,
             )
-            .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+            .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
         Ok(ty::TyEnumVariant {
             name: variant.name.clone(),
             type_argument,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -85,7 +85,6 @@ impl ty::TyFunctionDecl {
         let mut return_type = fn_decl.return_type.clone();
 
         let type_engine = ctx.engines.te();
-        let engines = ctx.engines();
 
         // If functions aren't allowed in this location, return an error.
         if ctx.functions_disallowed() {
@@ -146,9 +145,7 @@ impl ty::TyFunctionDecl {
                         EnforceTypeArguments::Yes,
                         None,
                     )
-                    .unwrap_or_else(|err| {
-                        type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None)
-                    });
+                    .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
                 let (visibility, is_contract_call) = if is_method {
                     if is_in_impl_self {
@@ -325,7 +322,7 @@ impl TypeCheckFinalization for ty::TyFunctionDecl {
 fn test_function_selector_behavior() {
     use crate::language::Visibility;
     use crate::Engines;
-    use sway_types::{integer_bits::IntegerBits, Ident, Span};
+    use sway_types::{Ident, Span};
 
     let engines = Engines::default();
     let handler = Handler::default();
@@ -369,11 +366,7 @@ fn test_function_selector_behavior() {
                 mutability_span: Span::dummy(),
                 type_argument: engines
                     .te()
-                    .insert(
-                        &engines,
-                        TypeInfo::StringArray(Length::new(5, Span::dummy())),
-                        None,
-                    )
+                    .insert_string_array_without_annotations(&engines, 5)
                     .into(),
             },
             ty::TyFunctionParameter {
@@ -382,16 +375,10 @@ fn test_function_selector_behavior() {
                 is_mutable: false,
                 mutability_span: Span::dummy(),
                 type_argument: TypeArgument {
-                    type_id: engines.te().insert(
-                        &engines,
-                        TypeInfo::UnsignedInteger(IntegerBits::ThirtyTwo),
-                        None,
-                    ),
-                    initial_type_id: engines.te().insert(
-                        &engines,
-                        TypeInfo::StringArray(Length::new(5, Span::dummy())),
-                        None,
-                    ),
+                    type_id: engines.te().id_of_u32(),
+                    initial_type_id: engines
+                        .te()
+                        .insert_string_array_without_annotations(&engines, 5),
                     span: Span::dummy(),
                     call_path_tree: None,
                 },

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
@@ -1,7 +1,6 @@
 use crate::{
     language::{parsed::FunctionParameter, ty},
     semantic_analysis::{type_check_context::EnforceTypeArguments, TypeCheckContext},
-    type_system::*,
 };
 
 use sway_error::{
@@ -17,7 +16,6 @@ impl ty::TyFunctionParameter {
         parameter: FunctionParameter,
     ) -> Result<Self, ErrorEmitted> {
         let type_engine = ctx.engines.te();
-        let engines = ctx.engines();
 
         let FunctionParameter {
             name,
@@ -35,7 +33,7 @@ impl ty::TyFunctionParameter {
                 EnforceTypeArguments::Yes,
                 None,
             )
-            .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+            .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
         type_argument.type_id.check_type_parameter_bounds(
             handler,
@@ -71,7 +69,6 @@ impl ty::TyFunctionParameter {
         parameter: &FunctionParameter,
     ) -> Result<Self, ErrorEmitted> {
         let type_engine = ctx.engines.te();
-        let engines = ctx.engines();
 
         let FunctionParameter {
             name,
@@ -90,7 +87,7 @@ impl ty::TyFunctionParameter {
                 EnforceTypeArguments::Yes,
                 None,
             )
-            .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+            .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
         let typed_parameter = ty::TyFunctionParameter {
             name: name.clone(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -83,8 +83,13 @@ impl TyImplSelfOrTrait {
         let decl_engine = ctx.engines.de();
         let engines = ctx.engines();
 
-        // Create a new type parameter for the Self type
-        let self_type_param = TypeParameter::new_self_type(engines, implementing_for.span());
+        // Create a new type parameter for the Self type.
+        // For the `use_site_span` of the self type parameter we take the `bock_span`.
+        // This is the span of the whole impl trait and block and thus, points to
+        // the code in the source file in which the self type is used in the implementation.
+        let self_type_use_site_span = block_span.clone();
+        let self_type_param =
+            TypeParameter::new_self_type(engines, self_type_use_site_span.clone());
         let self_type_id = self_type_param.type_id;
 
         // create a namespace for the impl
@@ -157,7 +162,7 @@ impl TyImplSelfOrTrait {
                 // Update the context
                 let mut ctx = ctx
                     .with_help_text("")
-                    .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None))
+                    .with_type_annotation(type_engine.new_unknown())
                     .with_self_type(Some(implementing_for.type_id));
 
                 let impl_trait = match ctx
@@ -248,7 +253,7 @@ impl TyImplSelfOrTrait {
                         }
 
                         let self_type_param =
-                            TypeParameter::new_self_type(engines, abi.span.clone());
+                            TypeParameter::new_self_type(engines, self_type_use_site_span);
                         // Unify the "self" type param from the abi declaration with
                         // the type that we are implementing for.
                         handler.scope(|h| {
@@ -340,9 +345,11 @@ impl TyImplSelfOrTrait {
         ctx.with_const_shadowing_mode(ConstShadowingMode::ItemStyle)
             .allow_functions()
             .scoped(handler, Some(block_span.clone()), |mut ctx| {
-                // Create a new type parameter for the "self type".
+                // Create a new type parameter for the self type.
                 let self_type_param =
-                    TypeParameter::new_self_type(engines, implementing_for.span());
+                    // Same as with impl trait or ABI, we take the `block_span` as the `use_site_span`
+                    // of the self type.
+                    TypeParameter::new_self_type(engines, block_span.clone());
                 let self_type_id = self_type_param.type_id;
 
                 // create the trait name
@@ -413,7 +420,7 @@ impl TyImplSelfOrTrait {
 
                 let mut ctx = ctx
                     .with_help_text("")
-                    .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+                    .with_type_annotation(type_engine.new_unknown());
 
                 // type check the items inside of the impl block
                 let mut new_items = vec![];
@@ -853,41 +860,27 @@ fn type_check_trait_implementation(
                 let decl_ref = decl_engine.insert(type_decl.clone(), Some(decl_id));
                 impld_item_refs.insert((name, implementing_for), TyTraitItem::Type(decl_ref));
 
-                let old_type_decl_info1 = TypeInfo::TraitType {
-                    name: type_decl.name.clone(),
-                    trait_type_id: implementing_for,
-                };
-                let old_type_decl_info2 = TypeInfo::TraitType {
-                    name: type_decl.name.clone(),
-                    trait_type_id: type_engine.insert(
-                        engines,
-                        TypeInfo::UnknownGeneric {
-                            // Using Span::dummy just to match the type substitution, type is not used anywhere else.
-                            name: Ident::new_with_override("Self".into(), Span::dummy()),
-                            trait_constraints: VecSet(vec![]),
-                            parent: None,
-                            is_from_type_parameter: false,
-                        },
-                        None,
-                    ),
-                };
+                // We want the `Self` type to have the span that points to an arbitrary location withing
+                // the source file in which the trait is implemented for a type. The `trait_name` points
+                // to the name in the `impl <trait_name> for ...` and is thus a good candidate.
+                let self_type_id = type_engine.new_unknown_generic_self(trait_name.span(), false);
                 if let Some(type_arg) = type_decl.ty.clone() {
                     trait_type_mapping.extend(
                         &TypeSubstMap::from_type_parameters_and_type_arguments(
-                            vec![type_engine.insert(
+                            vec![type_engine.insert_trait_type(
                                 engines,
-                                old_type_decl_info1,
-                                type_decl.name.span().source_id(),
+                                type_decl.name.clone(),
+                                implementing_for,
                             )],
                             vec![type_arg.type_id],
                         ),
                     );
                     trait_type_mapping.extend(
                         &TypeSubstMap::from_type_parameters_and_type_arguments(
-                            vec![type_engine.insert(
+                            vec![type_engine.insert_trait_type(
                                 engines,
-                                old_type_decl_info2,
-                                type_decl.name.span().source_id(),
+                                type_decl.name.clone(),
+                                self_type_id,
                             )],
                             vec![type_arg.type_id],
                         ),
@@ -1100,7 +1093,7 @@ fn type_check_impl_method(
     let mut ctx = ctx
         .by_ref()
         .with_help_text("")
-        .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+        .with_type_annotation(type_engine.new_unknown());
 
     let interface_name = || -> InterfaceName {
         if is_contract {
@@ -1341,7 +1334,7 @@ fn type_check_const_decl(
     let mut ctx = ctx
         .by_ref()
         .with_help_text("")
-        .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+        .with_type_annotation(type_engine.new_unknown());
 
     let interface_name = || -> InterfaceName {
         if is_contract {
@@ -1428,7 +1421,7 @@ fn type_check_type_decl(
     let mut ctx = ctx
         .by_ref()
         .with_help_text("")
-        .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+        .with_type_annotation(type_engine.new_unknown());
 
     let interface_name = || -> InterfaceName {
         if is_contract {

--- a/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
@@ -93,9 +93,7 @@ impl ty::TyStructField {
                 EnforceTypeArguments::Yes,
                 None,
             )
-            .unwrap_or_else(|err| {
-                type_engine.insert(ctx.engines(), TypeInfo::ErrorRecovery(err), None)
-            });
+            .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
         let field = ty::TyStructField {
             visibility: field.visibility,
             name: field.name,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -100,7 +100,9 @@ impl TyTraitDecl {
         let decl_engine = ctx.engines.de();
         let engines = ctx.engines();
 
-        // Create a new type parameter for the "self type".
+        // Create a new type parameter for the self type.
+        // The span of the `trait_decl` `name` points to the file (use site) in which
+        // the trait is getting declared, so we can use it as the `use_site_span`.
         let self_type_param = TypeParameter::new_self_type(engines, name.span());
         let self_type = self_type_param.type_id;
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
@@ -52,7 +52,6 @@ impl ty::TyTraitFn {
         } = trait_fn;
 
         let type_engine = ctx.engines.te();
-        let engines = ctx.engines();
 
         // Create a namespace for the trait function.
         ctx.by_ref().scoped(handler, Some(span.clone()), |mut ctx| {
@@ -83,9 +82,7 @@ impl ty::TyTraitFn {
                     EnforceTypeArguments::Yes,
                     None,
                 )
-                .unwrap_or_else(|err| {
-                    type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None)
-                });
+                .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
             let trait_fn = ty::TyTraitFn {
                 name: name.clone(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait_type.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait_type.rs
@@ -15,7 +15,6 @@ use crate::{
         type_check_context::EnforceTypeArguments, TypeCheckAnalysis, TypeCheckAnalysisContext,
         TypeCheckContext,
     },
-    type_system::*,
     Engines,
 };
 
@@ -59,9 +58,7 @@ impl ty::TyTraitType {
                     EnforceTypeArguments::No,
                     None,
                 )
-                .unwrap_or_else(|err| {
-                    type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None)
-                });
+                .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
             Some(ty)
         } else {
             None
@@ -93,11 +90,7 @@ impl ty::TyTraitType {
             name,
             attributes,
             ty: ty_opt,
-            implementing_type: engines.te().insert(
-                engines,
-                TypeInfo::new_self_type(Span::dummy()),
-                None,
-            ),
+            implementing_type: engines.te().new_self_type(engines, Span::dummy()),
             span,
         }
     }

--- a/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
@@ -48,7 +48,7 @@ impl ty::TyVariableDecl {
                 EnforceTypeArguments::Yes,
                 None,
             )
-            .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+            .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
         let mut ctx = ctx
             .with_type_annotation(type_ascription.type_id)
             .with_help_text(

--- a/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
@@ -132,7 +132,7 @@ fn type_check_elem_at(
 
     // check first argument
     let first_argument_span = arguments[0].span.clone();
-    let first_argument_type = type_engine.insert(engines, TypeInfo::Unknown, None);
+    let first_argument_type = type_engine.new_unknown();
     let first_argument_typed_expr = {
         let ctx = ctx
             .by_ref()
@@ -163,32 +163,16 @@ fn type_check_elem_at(
     };
 
     // index argument
-    let index_type = type_engine.insert(
-        engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        None,
-    );
     let index_typed_expr = {
         let ctx = ctx
             .by_ref()
             .with_help_text("")
-            .with_type_annotation(index_type);
+            .with_type_annotation(type_engine.id_of_u64());
         ty::TyExpression::type_check(handler, ctx, &arguments[1])?
     };
 
-    let return_type = type_engine.insert(
-        engines,
-        TypeInfo::Ref {
-            to_mutable_value,
-            referenced_type: TypeArgument {
-                type_id: elem_type_type_id,
-                initial_type_id: elem_type_type_id,
-                span: Span::dummy(),
-                call_path_tree: None,
-            },
-        },
-        None,
-    );
+    let return_type =
+        type_engine.insert_ref_without_annotations(engines, to_mutable_value, elem_type_type_id);
 
     Ok((
         TyIntrinsicFunctionKind {
@@ -221,36 +205,26 @@ fn type_check_slice(
     let engines = ctx.engines();
 
     // start index argument
-    let start_type = type_engine.insert(
-        engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        None,
-    );
     let start_ty_expr = {
         let ctx = ctx
             .by_ref()
             .with_help_text("")
-            .with_type_annotation(start_type);
+            .with_type_annotation(type_engine.id_of_u64());
         ty::TyExpression::type_check(handler, ctx, &arguments[1])?
     };
 
     // end index argument
-    let end_type = type_engine.insert(
-        engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        None,
-    );
     let end_ty_expr = {
         let ctx = ctx
             .by_ref()
             .with_help_text("")
-            .with_type_annotation(end_type);
+            .with_type_annotation(type_engine.id_of_u64());
         ty::TyExpression::type_check(handler, ctx, &arguments[2])?
     };
 
     // check first argument
     let first_argument_span = arguments[0].span.clone();
-    let first_argument_type = type_engine.insert(engines, TypeInfo::Unknown, None);
+    let first_argument_type = type_engine.new_unknown();
     let first_argument_ty_expr = {
         let ctx = ctx
             .by_ref()
@@ -288,18 +262,8 @@ fn type_check_slice(
         elem_type_arg: TypeArgument,
     ) -> TypeId {
         let type_engine = engines.te();
-        let slice_type_id =
-            type_engine.insert(engines, TypeInfo::Slice(elem_type_arg.clone()), None);
-        let ref_to_slice_type = TypeInfo::Ref {
-            to_mutable_value,
-            referenced_type: TypeArgument {
-                type_id: slice_type_id,
-                initial_type_id: slice_type_id,
-                span: Span::dummy(),
-                call_path_tree: None,
-            },
-        };
-        type_engine.insert(engines, ref_to_slice_type, None)
+        let slice_type_id = type_engine.insert_slice(engines, elem_type_arg);
+        type_engine.insert_ref_without_annotations(engines, to_mutable_value, slice_type_id)
     }
 
     // first argument can be ref to array or ref to slice
@@ -375,17 +339,14 @@ fn type_check_encode_as_raw_slice(
     span: Span,
 ) -> Result<(ty::TyIntrinsicFunctionKind, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
-    let engines = ctx.engines();
 
     let buffer_expr = {
         let ctx = ctx
             .by_ref()
             .with_help_text("")
-            .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+            .with_type_annotation(type_engine.new_unknown());
         ty::TyExpression::type_check(handler, ctx, &arguments[0].clone())?
     };
-
-    let return_type = type_engine.insert(engines, TypeInfo::RawUntypedSlice, None);
 
     let kind = ty::TyIntrinsicFunctionKind {
         kind,
@@ -393,27 +354,7 @@ fn type_check_encode_as_raw_slice(
         type_arguments: vec![],
         span,
     };
-    Ok((kind, return_type))
-}
-
-// TODO: Rename to `new_tuple` and move to `TypeInfo` once https://github.com/FuelLabs/sway/issues/5991 is implemented.
-fn new_encoding_buffer_tuple(
-    engines: &Engines,
-    items: impl IntoIterator<Item = TypeInfo>,
-    span: Span,
-) -> TypeInfo {
-    let te = engines.te();
-    let items = items
-        .into_iter()
-        .map(|x| te.insert(engines, x, None))
-        .map(|type_id| TypeArgument {
-            initial_type_id: type_id,
-            type_id,
-            span: span.clone(),
-            call_path_tree: None,
-        })
-        .collect();
-    TypeInfo::Tuple(items)
+    Ok((kind, type_engine.id_of_raw_slice()))
 }
 
 fn type_check_encode_buffer_empty(
@@ -432,56 +373,29 @@ fn type_check_encode_buffer_empty(
         }));
     }
 
-    let type_engine = ctx.engines.te();
-    let engines = ctx.engines();
-
-    let return_type = new_encoding_buffer_tuple(
-        engines,
-        [
-            TypeInfo::RawUntypedPtr,
-            TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-            TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        ],
-        span.clone(),
-    );
-    let return_type = type_engine.insert(engines, return_type, None);
-
     let kind = ty::TyIntrinsicFunctionKind {
         kind,
         arguments: vec![],
         type_arguments: vec![],
         span,
     };
-    Ok((kind, return_type))
+
+    Ok((kind, get_encoding_buffer_type(ctx.engines())))
 }
 
-fn encode_buffer_type(engines: &Engines) -> TypeInfo {
-    let raw_ptr = engines.te().insert(engines, TypeInfo::RawUntypedPtr, None);
-    let uint64 = engines.te().insert(
+/// Returns the [TypeId] of the buffer type used in encoding: `(raw_ptr, u64, u64)`.
+/// The buffer type is a shareable [TypeInfo::Tuple], so it will be inserted into
+/// the [TypeEngine] only once, when this method is called for the first time.
+fn get_encoding_buffer_type(engines: &Engines) -> TypeId {
+    let type_engine = engines.te();
+    type_engine.insert_tuple_without_annotations(
         engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        None,
-    );
-    TypeInfo::Tuple(vec![
-        TypeArgument {
-            type_id: raw_ptr,
-            initial_type_id: raw_ptr,
-            span: Span::dummy(),
-            call_path_tree: None,
-        },
-        TypeArgument {
-            type_id: uint64,
-            initial_type_id: uint64,
-            span: Span::dummy(),
-            call_path_tree: None,
-        },
-        TypeArgument {
-            type_id: uint64,
-            initial_type_id: uint64,
-            span: Span::dummy(),
-            call_path_tree: None,
-        },
-    ])
+        vec![
+            type_engine.id_of_raw_ptr(),
+            type_engine.id_of_u64(),
+            type_engine.id_of_u64(),
+        ],
+    )
 }
 
 fn type_check_encode_append(
@@ -503,7 +417,7 @@ fn type_check_encode_append(
     let type_engine = ctx.engines.te();
     let engines = ctx.engines();
 
-    let buffer_type = type_engine.insert(engines, encode_buffer_type(engines), None);
+    let buffer_type = get_encoding_buffer_type(engines);
     let buffer_expr = {
         let ctx = ctx
             .by_ref()
@@ -513,7 +427,7 @@ fn type_check_encode_append(
     };
 
     let item_span = arguments[1].span.clone();
-    let item_type = type_engine.insert(engines, TypeInfo::Unknown, None);
+    let item_type = type_engine.new_unknown();
     let item_expr = {
         let ctx = ctx
             .by_ref()
@@ -574,7 +488,7 @@ fn type_check_not(
         }));
     }
 
-    let return_type = type_engine.insert(engines, TypeInfo::Unknown, None);
+    let return_type = type_engine.new_unknown();
 
     let mut ctx = ctx.with_help_text("").with_type_annotation(return_type);
 
@@ -616,7 +530,6 @@ fn type_check_size_of_val(
     span: Span,
 ) -> Result<(ty::TyIntrinsicFunctionKind, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
-    let engines = ctx.engines();
 
     if arguments.len() != 1 {
         return Err(handler.emit_err(CompileError::IntrinsicIncorrectNumArgs {
@@ -627,7 +540,7 @@ fn type_check_size_of_val(
     }
     let ctx = ctx
         .with_help_text("")
-        .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+        .with_type_annotation(type_engine.new_unknown());
     let exp = ty::TyExpression::type_check(handler, ctx, &arguments[0])?;
     let intrinsic_function = ty::TyIntrinsicFunctionKind {
         kind,
@@ -635,12 +548,7 @@ fn type_check_size_of_val(
         type_arguments: vec![],
         span: span.clone(),
     };
-    let return_type = type_engine.insert(
-        engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        span.source_id(),
-    );
-    Ok((intrinsic_function, return_type))
+    Ok((intrinsic_function, type_engine.id_of_u64()))
 }
 
 /// Signature: `__size_of<T>() -> u64`
@@ -685,7 +593,7 @@ fn type_check_size_of_type(
             EnforceTypeArguments::Yes,
             None,
         )
-        .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+        .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
     let intrinsic_function = ty::TyIntrinsicFunctionKind {
         kind,
         arguments: vec![],
@@ -697,12 +605,7 @@ fn type_check_size_of_type(
         }],
         span,
     };
-    let return_type = type_engine.insert(
-        engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        None,
-    );
-    Ok((intrinsic_function, return_type))
+    Ok((intrinsic_function, type_engine.id_of_u64()))
 }
 
 /// Signature: `__is_reference_type<T>() -> bool`
@@ -740,7 +643,7 @@ fn type_check_is_reference_type(
             EnforceTypeArguments::Yes,
             None,
         )
-        .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+        .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
     let intrinsic_function = ty::TyIntrinsicFunctionKind {
         kind,
         arguments: vec![],
@@ -752,10 +655,7 @@ fn type_check_is_reference_type(
         }],
         span,
     };
-    Ok((
-        intrinsic_function,
-        type_engine.insert(engines, TypeInfo::Boolean, None),
-    ))
+    Ok((intrinsic_function, type_engine.id_of_bool()))
 }
 
 /// Signature: `__assert_is_str_array<T>()`
@@ -793,7 +693,7 @@ fn type_check_assert_is_str_array(
             EnforceTypeArguments::Yes,
             None,
         )
-        .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+        .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
     let intrinsic_function = ty::TyIntrinsicFunctionKind {
         kind,
         arguments: vec![],
@@ -805,10 +705,7 @@ fn type_check_assert_is_str_array(
         }],
         span,
     };
-    Ok((
-        intrinsic_function,
-        type_engine.insert(engines, TypeInfo::Tuple(vec![]), None),
-    ))
+    Ok((intrinsic_function, type_engine.id_of_unit()))
 }
 
 fn type_check_to_str_array(
@@ -832,17 +729,9 @@ fn type_check_to_str_array(
 
     match &arg.kind {
         ExpressionKind::Literal(Literal::String(s)) => {
-            let literal_length = s.as_str().len();
-            let l = Length::new(literal_length, s.clone());
-            let t = TypeInfo::StringArray(l);
-
             let span = arg.span.clone();
 
-            let mut ctx = ctx.by_ref().with_type_annotation(type_engine.insert(
-                engines,
-                TypeInfo::Unknown,
-                None,
-            ));
+            let mut ctx = ctx.by_ref().with_type_annotation(type_engine.new_unknown());
             let new_type = ty::TyExpression::type_check(handler, ctx.by_ref(), arg)?;
 
             Ok((
@@ -852,7 +741,7 @@ fn type_check_to_str_array(
                     type_arguments: vec![],
                     span,
                 },
-                type_engine.insert(engines, t, None),
+                type_engine.insert_string_array_without_annotations(engines, s.as_str().len()),
             ))
         }
         _ => Err(handler.emit_err(CompileError::ExpectedStringLiteral {
@@ -880,7 +769,6 @@ fn type_check_cmp(
     span: Span,
 ) -> Result<(ty::TyIntrinsicFunctionKind, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
-    let engines = ctx.engines();
 
     if arguments.len() != 2 {
         return Err(handler.emit_err(CompileError::IntrinsicIncorrectNumArgs {
@@ -889,9 +777,7 @@ fn type_check_cmp(
             span,
         }));
     }
-    let mut ctx =
-        ctx.by_ref()
-            .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+    let mut ctx = ctx.by_ref().with_type_annotation(type_engine.new_unknown());
 
     let lhs = &arguments[0];
     let lhs = ty::TyExpression::type_check(handler, ctx.by_ref(), lhs)?;
@@ -926,7 +812,7 @@ fn type_check_cmp(
             type_arguments: vec![],
             span,
         },
-        type_engine.insert(engines, TypeInfo::Boolean, None),
+        type_engine.id_of_bool(),
     ))
 }
 
@@ -964,19 +850,11 @@ fn type_check_gtf(
     }
 
     // Type check the first argument which is the index
-    let mut ctx = ctx.by_ref().with_type_annotation(type_engine.insert(
-        engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        None,
-    ));
+    let mut ctx = ctx.by_ref().with_type_annotation(type_engine.id_of_u64());
     let index = ty::TyExpression::type_check(handler, ctx.by_ref(), &arguments[0])?;
 
     // Type check the second argument which is the tx field ID
-    let mut ctx = ctx.by_ref().with_type_annotation(type_engine.insert(
-        engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        None,
-    ));
+    let mut ctx = ctx.by_ref().with_type_annotation(type_engine.id_of_u64());
     let tx_field_id = ty::TyExpression::type_check(handler, ctx.by_ref(), &arguments[1])?;
 
     let targ = type_arguments[0].clone();
@@ -993,7 +871,7 @@ fn type_check_gtf(
             EnforceTypeArguments::Yes,
             None,
         )
-        .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+        .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
     Ok((
         ty::TyIntrinsicFunctionKind {
@@ -1022,7 +900,6 @@ fn type_check_addr_of(
     span: Span,
 ) -> Result<(ty::TyIntrinsicFunctionKind, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
-    let engines = ctx.engines();
 
     if arguments.len() != 1 {
         return Err(handler.emit_err(CompileError::IntrinsicIncorrectNumArgs {
@@ -1033,7 +910,7 @@ fn type_check_addr_of(
     }
     let ctx = ctx
         .with_help_text("")
-        .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+        .with_type_annotation(type_engine.new_unknown());
     let exp = ty::TyExpression::type_check(handler, ctx, &arguments[0])?;
     let copy_type_info = type_engine
         .to_typeinfo(exp.return_type, &span)
@@ -1053,8 +930,7 @@ fn type_check_addr_of(
         type_arguments: vec![],
         span,
     };
-    let return_type = type_engine.insert(engines, TypeInfo::RawUntypedPtr, None);
-    Ok((intrinsic_function, return_type))
+    Ok((intrinsic_function, type_engine.id_of_raw_ptr()))
 }
 
 /// Signature: `__state_load_clear(key: b256, slots: u64) -> bool`
@@ -1069,7 +945,6 @@ fn type_check_state_clear(
     span: Span,
 ) -> Result<(ty::TyIntrinsicFunctionKind, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
-    let engines = ctx.engines();
 
     if arguments.len() != 2 {
         return Err(handler.emit_err(CompileError::IntrinsicIncorrectNumArgs {
@@ -1082,7 +957,7 @@ fn type_check_state_clear(
     // `key` argument
     let mut ctx = ctx
         .with_help_text("")
-        .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+        .with_type_annotation(type_engine.new_unknown());
     let key_exp = ty::TyExpression::type_check(handler, ctx.by_ref(), &arguments[0])?;
     let key_ty = type_engine
         .to_typeinfo(key_exp.return_type, &span)
@@ -1100,11 +975,7 @@ fn type_check_state_clear(
     }
 
     // `slots` argument
-    let mut ctx = ctx.with_type_annotation(type_engine.insert(
-        engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        None,
-    ));
+    let mut ctx = ctx.with_type_annotation(type_engine.id_of_u64());
     let number_of_slots_exp = ty::TyExpression::type_check(handler, ctx.by_ref(), &arguments[1])?;
 
     // Typed intrinsic
@@ -1114,8 +985,7 @@ fn type_check_state_clear(
         type_arguments: vec![],
         span,
     };
-    let return_type = type_engine.insert(engines, TypeInfo::Boolean, None);
-    Ok((intrinsic_function, return_type))
+    Ok((intrinsic_function, type_engine.id_of_bool()))
 }
 
 /// Signature: `__state_load_word(key: b256) -> u64`
@@ -1140,7 +1010,7 @@ fn type_check_state_load_word(
     }
     let ctx = ctx
         .with_help_text("")
-        .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+        .with_type_annotation(type_engine.new_unknown());
     let exp = ty::TyExpression::type_check(handler, ctx, &arguments[0])?;
     let key_ty = type_engine
         .to_typeinfo(exp.return_type, &span)
@@ -1159,12 +1029,7 @@ fn type_check_state_load_word(
         type_arguments: vec![],
         span,
     };
-    let return_type = type_engine.insert(
-        engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        None,
-    );
-    Ok((intrinsic_function, return_type))
+    Ok((intrinsic_function, type_engine.id_of_u64()))
 }
 
 /// Signature: `__state_store_word(key: b256, val: u64) -> bool`
@@ -1198,7 +1063,7 @@ fn type_check_state_store_word(
     }
     let mut ctx = ctx
         .with_help_text("")
-        .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+        .with_type_annotation(type_engine.new_unknown());
     let key_exp = ty::TyExpression::type_check(handler, ctx.by_ref(), &arguments[0])?;
     let key_ty = type_engine
         .to_typeinfo(key_exp.return_type, &span)
@@ -1214,16 +1079,11 @@ fn type_check_state_store_word(
             hint: "Argument type must be B256, a key into the state storage".to_string(),
         }));
     }
-    let mut ctx = ctx.with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+    let mut ctx = ctx.with_type_annotation(type_engine.new_unknown());
     let val_exp = ty::TyExpression::type_check(handler, ctx.by_ref(), &arguments[1])?;
-    let ctx = ctx.with_type_annotation(type_engine.insert(
-        engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        None,
-    ));
+    let ctx = ctx.with_type_annotation(type_engine.id_of_u64());
     let type_argument = type_arguments.first().map(|targ| {
-        let mut ctx =
-            ctx.with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+        let mut ctx = ctx.with_type_annotation(type_engine.new_unknown());
         let initial_type_info = type_engine
             .to_typeinfo(targ.type_id, &targ.span)
             .map_err(|e| handler.emit_err(e.into()))
@@ -1237,7 +1097,7 @@ fn type_check_state_store_word(
                 EnforceTypeArguments::Yes,
                 None,
             )
-            .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+            .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
         TypeArgument {
             type_id,
             initial_type_id,
@@ -1251,8 +1111,7 @@ fn type_check_state_store_word(
         type_arguments: type_argument.map_or(vec![], |ta| vec![ta]),
         span,
     };
-    let return_type = type_engine.insert(engines, TypeInfo::Boolean, None);
-    Ok((intrinsic_function, return_type))
+    Ok((intrinsic_function, type_engine.id_of_bool()))
 }
 
 /// Signature: `__state_load_quad(key: b256, ptr: raw_ptr, slots: u64)`
@@ -1293,7 +1152,7 @@ fn type_check_state_quad(
     }
     let mut ctx = ctx
         .with_help_text("")
-        .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+        .with_type_annotation(type_engine.new_unknown());
     let key_exp = ty::TyExpression::type_check(handler, ctx.by_ref(), &arguments[0])?;
     let key_ty = type_engine
         .to_typeinfo(key_exp.return_type, &span)
@@ -1309,17 +1168,12 @@ fn type_check_state_quad(
             hint: "Argument type must be B256, a key into the state storage".to_string(),
         }));
     }
-    let mut ctx = ctx.with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+    let mut ctx = ctx.with_type_annotation(type_engine.new_unknown());
     let val_exp = ty::TyExpression::type_check(handler, ctx.by_ref(), &arguments[1])?;
-    let mut ctx = ctx.with_type_annotation(type_engine.insert(
-        engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        None,
-    ));
+    let mut ctx = ctx.with_type_annotation(type_engine.id_of_u64());
     let number_of_slots_exp = ty::TyExpression::type_check(handler, ctx.by_ref(), &arguments[2])?;
     let type_argument = type_arguments.first().map(|targ| {
-        let mut ctx =
-            ctx.with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+        let mut ctx = ctx.with_type_annotation(type_engine.new_unknown());
         let initial_type_info = type_engine
             .to_typeinfo(targ.type_id, &targ.span)
             .map_err(|e| handler.emit_err(e.into()))
@@ -1333,7 +1187,7 @@ fn type_check_state_quad(
                 EnforceTypeArguments::Yes,
                 None,
             )
-            .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+            .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
         TypeArgument {
             type_id,
             initial_type_id,
@@ -1347,8 +1201,7 @@ fn type_check_state_quad(
         type_arguments: type_argument.map_or(vec![], |ta| vec![ta]),
         span,
     };
-    let return_type = type_engine.insert(engines, TypeInfo::Boolean, None);
-    Ok((intrinsic_function, return_type))
+    Ok((intrinsic_function, type_engine.id_of_bool()))
 }
 
 /// Signature: `__log<T>(val: T)`
@@ -1362,7 +1215,6 @@ fn type_check_log(
     span: Span,
 ) -> Result<(ty::TyIntrinsicFunctionKind, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
-    let engines = ctx.engines();
 
     if arguments.len() != 1 {
         return Err(handler.emit_err(CompileError::IntrinsicIncorrectNumArgs {
@@ -1374,7 +1226,7 @@ fn type_check_log(
     let ctx = ctx
         .by_ref()
         .with_help_text("")
-        .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+        .with_type_annotation(type_engine.new_unknown());
     let exp = ty::TyExpression::type_check(handler, ctx, &arguments[0])?;
     let intrinsic_function = ty::TyIntrinsicFunctionKind {
         kind,
@@ -1382,8 +1234,7 @@ fn type_check_log(
         type_arguments: vec![],
         span,
     };
-    let return_type = type_engine.insert(engines, TypeInfo::Tuple(vec![]), None);
-    Ok((intrinsic_function, return_type))
+    Ok((intrinsic_function, type_engine.id_of_unit()))
 }
 
 /// Signature: `__add<T>(lhs: T, rhs: T) -> T`
@@ -1422,7 +1273,6 @@ fn type_check_arith_binary_op(
     span: Span,
 ) -> Result<(ty::TyIntrinsicFunctionKind, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
-    let engines = ctx.engines();
 
     if arguments.len() != 2 {
         return Err(handler.emit_err(CompileError::IntrinsicIncorrectNumArgs {
@@ -1439,7 +1289,7 @@ fn type_check_arith_binary_op(
         }));
     }
 
-    let return_type = type_engine.insert(engines, TypeInfo::Numeric, None);
+    let return_type = type_engine.new_numeric();
     let mut ctx = ctx
         .by_ref()
         .with_type_annotation(return_type)
@@ -1487,7 +1337,7 @@ fn type_check_bitwise_binary_op(
         }));
     }
 
-    let return_type = type_engine.insert(engines, TypeInfo::Unknown, None);
+    let return_type = type_engine.new_unknown();
     let mut ctx = ctx
         .by_ref()
         .with_type_annotation(return_type)
@@ -1553,7 +1403,7 @@ fn type_check_shift_binary_op(
         }));
     }
 
-    let return_type = engines.te().insert(engines, TypeInfo::Unknown, None);
+    let return_type = engines.te().new_unknown();
     let lhs = &arguments[0];
     let lhs = ty::TyExpression::type_check(
         handler,
@@ -1568,7 +1418,7 @@ fn type_check_shift_binary_op(
         handler,
         ctx.by_ref()
             .with_help_text("Incorrect argument type")
-            .with_type_annotation(engines.te().insert(engines, TypeInfo::Numeric, None)),
+            .with_type_annotation(engines.te().new_numeric()),
         rhs,
     )?;
 
@@ -1607,7 +1457,6 @@ fn type_check_revert(
     span: Span,
 ) -> Result<(ty::TyIntrinsicFunctionKind, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
-    let engines = ctx.engines();
 
     if arguments.len() != 1 {
         return Err(handler.emit_err(CompileError::IntrinsicIncorrectNumArgs {
@@ -1626,11 +1475,7 @@ fn type_check_revert(
     }
 
     // Type check the argument which is the revert code
-    let mut ctx = ctx.by_ref().with_type_annotation(type_engine.insert(
-        engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        None,
-    ));
+    let mut ctx = ctx.by_ref().with_type_annotation(type_engine.id_of_u64());
     let revert_code = ty::TyExpression::type_check(handler, ctx.by_ref(), &arguments[0])?;
 
     Ok((
@@ -1640,7 +1485,7 @@ fn type_check_revert(
             type_arguments: vec![],
             span,
         },
-        type_engine.insert(engines, TypeInfo::Never, None),
+        type_engine.id_of_never(),
     ))
 }
 
@@ -1655,7 +1500,6 @@ fn type_check_jmp_mem(
     span: Span,
 ) -> Result<(ty::TyIntrinsicFunctionKind, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
-    let engines = ctx.engines();
 
     if !arguments.is_empty() {
         return Err(handler.emit_err(CompileError::IntrinsicIncorrectNumArgs {
@@ -1680,7 +1524,7 @@ fn type_check_jmp_mem(
             type_arguments: vec![],
             span,
         },
-        type_engine.insert(engines, TypeInfo::Never, None),
+        type_engine.id_of_never(),
     ))
 }
 
@@ -1730,11 +1574,9 @@ fn type_check_ptr_ops(
             EnforceTypeArguments::No,
             None,
         )
-        .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+        .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
-    let mut ctx =
-        ctx.by_ref()
-            .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+    let mut ctx = ctx.by_ref().with_type_annotation(type_engine.new_unknown());
 
     let lhs = &arguments[0];
     let lhs = ty::TyExpression::type_check(handler, ctx.by_ref(), lhs)?;
@@ -1756,11 +1598,7 @@ fn type_check_ptr_ops(
     let ctx = ctx
         .by_ref()
         .with_help_text("Incorrect argument type")
-        .with_type_annotation(type_engine.insert(
-            engines,
-            TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-            None,
-        ));
+        .with_type_annotation(type_engine.id_of_u64());
     let rhs = ty::TyExpression::type_check(handler, ctx, rhs)?;
 
     Ok((
@@ -1815,7 +1653,7 @@ fn type_check_smo(
         let mut ctx = ctx
             .by_ref()
             .with_help_text("")
-            .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+            .with_type_annotation(type_engine.new_unknown());
         let initial_type_info = type_engine
             .to_typeinfo(targ.type_id, &targ.span)
             .map_err(|e| handler.emit_err(e.into()))
@@ -1829,7 +1667,7 @@ fn type_check_smo(
                 EnforceTypeArguments::Yes,
                 None,
             )
-            .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+            .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
         TypeArgument {
             type_id,
             initial_type_id,
@@ -1839,9 +1677,7 @@ fn type_check_smo(
     });
 
     // Type check the first argument which is the recipient address, so it has to be a `b256`.
-    let mut ctx =
-        ctx.by_ref()
-            .with_type_annotation(type_engine.insert(engines, TypeInfo::B256, None));
+    let mut ctx = ctx.by_ref().with_type_annotation(type_engine.id_of_b256());
     let recipient = ty::TyExpression::type_check(handler, ctx.by_ref(), &arguments[0])?;
 
     // Type check the second argument which is the data, which can be anything. If a type
@@ -1849,18 +1685,12 @@ fn type_check_smo(
     let mut ctx = ctx.by_ref().with_type_annotation(
         type_argument
             .clone()
-            .map_or(type_engine.insert(engines, TypeInfo::Unknown, None), |ta| {
-                ta.type_id
-            }),
+            .map_or(type_engine.new_unknown(), |ta| ta.type_id),
     );
     let data = ty::TyExpression::type_check(handler, ctx.by_ref(), &arguments[1])?;
 
     // Type check the third argument which is the amount of coins to send, so it has to be a `u64`.
-    let mut ctx = ctx.by_ref().with_type_annotation(type_engine.insert(
-        engines,
-        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-        None,
-    ));
+    let mut ctx = ctx.by_ref().with_type_annotation(type_engine.id_of_u64());
     let coins = ty::TyExpression::type_check(handler, ctx.by_ref(), &arguments[2])?;
 
     Ok((
@@ -1870,7 +1700,7 @@ fn type_check_smo(
             type_arguments: type_argument.map_or(vec![], |ta| vec![ta]),
             span,
         },
-        type_engine.insert(engines, TypeInfo::Tuple(vec![]), None),
+        type_engine.id_of_unit(),
     ))
 }
 
@@ -1887,7 +1717,6 @@ fn type_check_contract_ret(
     span: Span,
 ) -> Result<(ty::TyIntrinsicFunctionKind, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
-    let engines = ctx.engines();
 
     if arguments.len() != 2 {
         return Err(handler.emit_err(CompileError::IntrinsicIncorrectNumArgs {
@@ -1911,12 +1740,10 @@ fn type_check_contract_ret(
             let ctx = ctx
                 .by_ref()
                 .with_help_text("")
-                .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+                .with_type_annotation(type_engine.new_unknown());
             ty::TyExpression::type_check(handler, ctx, x)
         })
         .collect::<Result<Vec<_>, _>>()?;
-
-    let t = ctx.engines.te().insert(ctx.engines, TypeInfo::Never, None);
 
     Ok((
         ty::TyIntrinsicFunctionKind {
@@ -1925,7 +1752,7 @@ fn type_check_contract_ret(
             type_arguments: vec![],
             span,
         },
-        t,
+        ctx.engines.te().id_of_never(),
     ))
 }
 
@@ -1941,16 +1768,10 @@ fn type_check_contract_call(
     span: Span,
 ) -> Result<(ty::TyIntrinsicFunctionKind, TypeId), ErrorEmitted> {
     let type_engine = ctx.engines.te();
-    let engines = ctx.engines();
 
     if !type_arguments.is_empty() {
         return Err(handler.emit_err(CompileError::TypeArgumentsNotAllowed { span }));
     }
-
-    let return_type_id = ctx
-        .engines
-        .te()
-        .insert(ctx.engines, TypeInfo::Tuple(vec![]), None);
 
     // Arguments
     let arguments: Vec<ty::TyExpression> = arguments
@@ -1959,7 +1780,7 @@ fn type_check_contract_call(
             let ctx = ctx
                 .by_ref()
                 .with_help_text("")
-                .with_type_annotation(type_engine.insert(engines, TypeInfo::Unknown, None));
+                .with_type_annotation(type_engine.new_unknown());
             ty::TyExpression::type_check(handler, ctx, x)
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -1971,5 +1792,5 @@ fn type_check_contract_call(
         span,
     };
 
-    Ok((intrinsic_function, return_type_id))
+    Ok((intrinsic_function, type_engine.id_of_unit()))
 }

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/instantiate.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/instantiate.rs
@@ -1,5 +1,5 @@
 use sway_error::handler::{ErrorEmitted, Handler};
-use sway_types::{integer_bits::IntegerBits, Ident, Span};
+use sway_types::{Ident, Span};
 
 use crate::{
     language::{ty, LazyOp, Literal},
@@ -7,7 +7,7 @@ use crate::{
         typed_expression::{instantiate_lazy_operator, instantiate_tuple_index_access},
         TypeCheckContext,
     },
-    Engines, TypeId, TypeInfo,
+    Engines, TypeId,
 };
 
 /// Simplifies instantiation of desugared code in the match expression and match arms.
@@ -23,19 +23,11 @@ pub(super) struct Instantiate {
 impl Instantiate {
     pub(super) fn new(engines: &Engines, span: Span) -> Self {
         let type_engine = engines.te();
-        let u64_type = type_engine.insert(
-            engines,
-            TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-            None,
-        );
-        let boolean_type = type_engine.insert(engines, TypeInfo::Boolean, None);
-        let revert_type = type_engine.insert(engines, TypeInfo::Never, None);
-
         Self {
             span,
-            u64_type,
-            boolean_type,
-            revert_type,
+            u64_type: type_engine.id_of_u64(),
+            boolean_type: type_engine.id_of_bool(),
+            revert_type: type_engine.id_of_never(),
         }
     }
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
@@ -12,7 +12,7 @@ use crate::{
         },
         TypeCheckContext,
     },
-    Ident, TypeId, TypeInfo, UnifyCheck,
+    Ident, TypeId, UnifyCheck,
 };
 
 use sway_error::{
@@ -20,7 +20,7 @@ use sway_error::{
     handler::{ErrorEmitted, Handler},
 };
 
-use sway_types::{integer_bits::IntegerBits, span::Span, Named, Spanned};
+use sway_types::{span::Span, Named, Spanned};
 
 /// A single requirement in the form `<lhs> == <rhs>` that has to be
 /// fulfilled for the match arm to match.
@@ -492,20 +492,12 @@ fn match_enum(
             expression: ty::TyExpressionVariant::EnumTag {
                 exp: Box::new(exp.clone()),
             },
-            return_type: type_engine.insert(
-                ctx.engines,
-                TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-                None,
-            ),
+            return_type: type_engine.id_of_u64(),
             span: exp.span.clone(),
         },
         ty::TyExpression {
             expression: ty::TyExpressionVariant::Literal(Literal::U64(variant.tag as u64)),
-            return_type: type_engine.insert(
-                ctx.engines,
-                TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-                None,
-            ),
+            return_type: type_engine.id_of_u64(),
             span: exp.span.clone(),
         },
     );

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_match_branch.rs
@@ -17,7 +17,7 @@ use crate::{
         ty::{self, MatchBranchCondition, MatchedOrVariantIndexVars, TyExpression},
     },
     semantic_analysis::*,
-    Engines, TypeArgument, TypeInfo, UnifyCheck,
+    Engines, TypeInfo, UnifyCheck,
 };
 
 use super::{instantiate::Instantiate, matcher::matcher, ReqDeclTree};
@@ -619,7 +619,7 @@ fn instantiate_branch_condition_result_var_declarations_and_matched_or_variant_i
         ) -> Result<(VarDecl, Vec<VarDecl>), ErrorEmitted> {
             let type_engine = ctx.engines.te();
             // At this point we have the guarantee that we have:
-            // - exactly the same variables in each OR variant
+            // - exactly the same variables in each of the OR variants
             // - that variables of the same name are of the same type
             // - that we do not have duplicates in variable names inside of alternatives
 
@@ -645,18 +645,10 @@ fn instantiate_branch_condition_result_var_declarations_and_matched_or_variant_i
             // All variants have same variable types and names, thus we pick them from the first alternative.
             let tuple_field_types = carry_over_vars[0]
                 .iter()
-                .map(|(_, var_body)| TypeArgument {
-                    type_id: var_body.return_type,
-                    initial_type_id: var_body.return_type,
-                    span: var_body.span.clone(), // Although not needed, this span can be mapped to var declaration.
-                    call_path_tree: None,
-                })
+                .map(|(_, var_body)| var_body.return_type)
                 .collect();
-            let tuple_type = type_engine.insert(
-                ctx.engines,
-                TypeInfo::Tuple(tuple_field_types),
-                instantiate.dummy_span().source_id(),
-            );
+            let tuple_type =
+                type_engine.insert_tuple_without_annotations(ctx.engines, tuple_field_types);
             let variable_names = carry_over_vars[0]
                 .iter()
                 .map(|(ident, _)| ident.clone())

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -3,7 +3,7 @@ use sway_error::{
     error::{CompileError, StructFieldUsageContext},
     handler::{ErrorEmitted, Handler},
 };
-use sway_types::{BaseIdent, Ident, Span, Spanned};
+use sway_types::{Ident, Span, Spanned};
 
 use crate::{
     decl_engine::{DeclEngineGetParsedDeclId, DeclEngineInsert},
@@ -29,8 +29,6 @@ impl TyScrutinee {
         let engines = ctx.engines();
         match scrutinee {
             Scrutinee::Or { elems, span } => {
-                let type_id = type_engine.insert(engines, TypeInfo::Unknown, None);
-
                 let mut typed_elems = Vec::with_capacity(elems.len());
                 for scrutinee in elems {
                     typed_elems.push(ty::TyScrutinee::type_check(
@@ -41,27 +39,21 @@ impl TyScrutinee {
                 }
                 let typed_scrutinee = ty::TyScrutinee {
                     variant: ty::TyScrutineeVariant::Or(typed_elems),
-                    type_id,
+                    type_id: type_engine.new_unknown(),
                     span,
                 };
                 Ok(typed_scrutinee)
             }
             Scrutinee::CatchAll { span } => {
-                let type_id = type_engine.insert(engines, TypeInfo::Unknown, None);
-                let dummy_type_param = TypeParameter {
-                    type_id,
-                    initial_type_id: type_id,
-                    name_ident: BaseIdent::new_with_override("_".into(), span.clone()),
-                    trait_constraints: vec![],
-                    trait_constraints_span: Span::dummy(),
-                    is_from_parent: false,
-                };
                 let typed_scrutinee = ty::TyScrutinee {
                     variant: ty::TyScrutineeVariant::CatchAll,
-                    type_id: type_engine.insert(
+                    // The `span` will mostly point to a "_" in code. However, match expressions
+                    // are heavily used in code generation, e.g., to generate code for contract
+                    // function selection in the `__entry` and sometimes the span does not point
+                    // to a "_". But it is always in the code in which the match expression is.
+                    type_id: type_engine.new_placeholder(
                         engines,
-                        TypeInfo::Placeholder(dummy_type_param),
-                        span.source_id(),
+                        TypeParameter::new_placeholder(type_engine.new_unknown(), span.clone()),
                     ),
                     span,
                 };
@@ -210,7 +202,7 @@ fn type_check_variable(
         // appropriate helpful errors, depending on the exact usage of that configurable.
         _ => ty::TyScrutinee {
             variant: ty::TyScrutineeVariant::Variable(name),
-            type_id: type_engine.insert(ctx.engines(), TypeInfo::Unknown, None),
+            type_id: type_engine.new_unknown(),
             span,
         },
     };
@@ -428,11 +420,7 @@ fn type_check_struct(
         decl_engine.get_parsed_decl_id(&struct_id).as_ref(),
     );
     let typed_scrutinee = ty::TyScrutinee {
-        type_id: type_engine.insert(
-            ctx.engines(),
-            TypeInfo::Struct(*struct_ref.id()),
-            struct_ref.span().source_id(),
-        ),
+        type_id: type_engine.insert_struct(engines, *struct_ref.id()),
         span,
         variant: ty::TyScrutineeVariant::StructScrutinee {
             struct_ref,
@@ -555,11 +543,7 @@ fn type_check_enum(
             value: Box::new(typed_value),
             instantiation_call_path: call_path,
         },
-        type_id: type_engine.insert(
-            engines,
-            TypeInfo::Enum(*enum_ref.id()),
-            enum_ref.span().source_id(),
-        ),
+        type_id: type_engine.insert_enum(engines, *enum_ref.id()),
         span,
     };
 
@@ -584,20 +568,17 @@ fn type_check_tuple(
             },
         );
     }
-    let type_id = type_engine.insert(
+    let type_id = type_engine.insert_tuple(
         engines,
-        TypeInfo::Tuple(
-            typed_elems
-                .iter()
-                .map(|x| TypeArgument {
-                    type_id: x.type_id,
-                    initial_type_id: x.type_id,
-                    span: span.clone(),
-                    call_path_tree: None,
-                })
-                .collect(),
-        ),
-        span.source_id(),
+        typed_elems
+            .iter()
+            .map(|elem| TypeArgument {
+                type_id: elem.type_id,
+                initial_type_id: elem.type_id,
+                span: elem.span.clone(),
+                call_path_tree: None,
+            })
+            .collect(),
     );
     let typed_scrutinee = ty::TyScrutinee {
         variant: ty::TyScrutineeVariant::Tuple(typed_elems),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -56,11 +56,7 @@ pub(crate) fn instantiate_enum(
 
     match (&args, &*type_engine.get(enum_variant.type_argument.type_id)) {
         ([], ty) if ty.is_unit() => Ok(ty::TyExpression {
-            return_type: type_engine.insert(
-                engines,
-                TypeInfo::Enum(*enum_ref.id()),
-                enum_ref.span().source_id(),
-            ),
+            return_type: type_engine.insert_enum(engines, *enum_ref.id()),
             expression: ty::TyExpressionVariant::EnumInstantiation {
                 tag: enum_variant.tag,
                 contents: None,
@@ -149,11 +145,7 @@ pub(crate) fn instantiate_enum(
             // Create the resulting enum type based on the enum we have instantiated.
             // Note that we clone the `enum_ref` but the unification we do below will
             // affect the types behind that new enum decl reference.
-            let type_id = type_engine.insert(
-                engines,
-                TypeInfo::Enum(*enum_ref.id()),
-                enum_ref.span().source_id(),
-            );
+            let type_id = type_engine.insert_enum(engines, *enum_ref.id());
 
             // The above type check will unify the type behind the `enum_variant_type_id`
             // and the resulting expression type.

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/if_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/if_expression.rs
@@ -22,7 +22,7 @@ pub(crate) fn instantiate_if_expression(
     let ty_to_check = if r#else.is_some() {
         ctx.type_annotation()
     } else {
-        type_engine.insert(engines, TypeInfo::Tuple(vec![]), then.span.source_id())
+        type_engine.id_of_unit()
     };
 
     // We check then_type_is_never and else_type_is_never before unifying to make sure we don't
@@ -62,9 +62,10 @@ pub(crate) fn instantiate_if_expression(
         Box::new(r#else)
     });
 
-    let r#else_ret_ty = r#else.as_ref().map(|x| x.return_type).unwrap_or_else(|| {
-        type_engine.insert(engines, TypeInfo::Tuple(Vec::new()), span.source_id())
-    });
+    let r#else_ret_ty = r#else
+        .as_ref()
+        .map(|x| x.return_type)
+        .unwrap_or_else(|| type_engine.id_of_unit());
 
     // delay emitting the errors until we decide if this is a missing else branch or some other set of errors
     let h = Handler::default();

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -61,23 +61,18 @@ pub(crate) fn struct_instantiation(
 
     let type_arguments = type_arguments.to_vec();
 
-    let type_info = match (suffix.as_str(), type_arguments.is_empty()) {
-        ("Self", true) => TypeInfo::new_self_type(suffix.span()),
+    // We first create a custom type and then resolve it to the struct type.
+    let custom_type_id = match (suffix.as_str(), type_arguments.is_empty()) {
+        ("Self", true) => type_engine.new_self_type(engines, suffix.span()),
         ("Self", false) => {
             return Err(handler.emit_err(CompileError::TypeArgumentsNotAllowed {
                 span: suffix.span(),
             }));
         }
-        (_, true) => TypeInfo::Custom {
-            qualified_call_path: suffix.clone().into(),
-            type_arguments: None,
-            root_type_id: None,
-        },
-        (_, false) => TypeInfo::Custom {
-            qualified_call_path: suffix.clone().into(),
-            type_arguments: Some(type_arguments),
-            root_type_id: None,
-        },
+        (_, true) => type_engine.new_custom_from_name(engines, suffix.clone()),
+        (_, false) => {
+            type_engine.new_custom(engines, suffix.clone().into(), Some(type_arguments), None)
+        }
     };
 
     // find the module that the struct decl is in
@@ -89,12 +84,12 @@ pub(crate) fn struct_instantiation(
     let type_id = ctx
         .resolve_type(
             handler,
-            type_engine.insert(engines, type_info, suffix.span().source_id()),
+            custom_type_id,
             inner_span,
             EnforceTypeArguments::No,
             Some(&type_info_prefix),
         )
-        .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+        .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
     // extract the struct name and fields from the type info
     let type_info = type_engine.get(type_id);
@@ -393,7 +388,6 @@ fn type_check_field_arguments(
 ) -> Result<Vec<ty::TyStructExpressionField>, ErrorEmitted> {
     handler.scope(|handler| {
         let type_engine = ctx.engines.te();
-        let engines = ctx.engines();
 
         let mut typed_fields = vec![];
         let mut missing_fields = vec![];
@@ -438,11 +432,7 @@ fn type_check_field_arguments(
                         name: struct_field.name.clone(),
                         value: ty::TyExpression {
                             expression: ty::TyExpressionVariant::Tuple { fields: vec![] },
-                            return_type: type_engine.insert(
-                                engines,
-                                TypeInfo::ErrorRecovery(err),
-                                None,
-                            ),
+                            return_type: type_engine.id_of_error_recovery(err),
                             span: span.clone(),
                         },
                     });

--- a/sway-core/src/semantic_analysis/ast_node/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/mod.rs
@@ -91,11 +91,7 @@ impl ty::TyAstNode {
                         _ => {
                             ctx = ctx
                                 .with_help_text("")
-                                .with_type_annotation(type_engine.insert(
-                                    engines,
-                                    TypeInfo::Unknown,
-                                    None,
-                                ));
+                                .with_type_annotation(type_engine.new_unknown());
                         }
                     }
                     let inner = ty::TyExpression::type_check(handler, ctx, &expr)

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -1034,7 +1034,6 @@ fn type_info_name(type_info: &TypeInfo) -> String {
         TypeInfo::Struct { .. } => "struct",
         TypeInfo::Enum { .. } => "enum",
         TypeInfo::Array(..) => "array",
-        TypeInfo::Storage { .. } => "contract storage",
         TypeInfo::RawUntypedPtr => "raw untyped ptr",
         TypeInfo::RawUntypedSlice => "raw untyped slice",
         TypeInfo::Ptr(..) => "__ptr",

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -542,11 +542,7 @@ pub fn item_fn_to_function_declaration(
     let return_type = match item_fn.fn_signature.return_type_opt {
         Some((_right_arrow, ty)) => ty_to_type_argument(context, handler, engines, ty)?,
         None => {
-            let type_id = engines.te().insert(
-                engines,
-                TypeInfo::Tuple(Vec::new()),
-                item_fn.fn_signature.span().source_id(),
-            );
+            let type_id = engines.te().id_of_unit();
             TypeArgument {
                 type_id,
                 initial_type_id: type_id,
@@ -992,7 +988,7 @@ pub(crate) fn item_const_to_constant_declaration(
                     return Err(errors);
                 }
             }
-            engines.te().insert(engines, TypeInfo::Unknown, None).into()
+            engines.te().new_unknown().into()
         }
     };
 
@@ -1255,19 +1251,11 @@ fn generic_params_opt_to_type_parameters_with_parent(
             .into_inner()
             .into_iter()
             .map(|ident| {
-                let custom_type = type_engine.insert(
-                    engines,
-                    TypeInfo::Custom {
-                        qualified_call_path: ident.clone().into(),
-                        type_arguments: None,
-                        root_type_id: None,
-                    },
-                    ident.span().source_id(),
-                );
+                let custom_type = type_engine.new_custom_from_name(engines, ident.clone());
                 TypeParameter {
                     type_id: custom_type,
                     initial_type_id: custom_type,
-                    name_ident: ident,
+                    name: ident,
                     trait_constraints: Vec::new(),
                     trait_constraints_span: Span::dummy(),
                     is_from_parent,
@@ -1287,12 +1275,12 @@ fn generic_params_opt_to_type_parameters_with_parent(
     {
         let param_to_edit = if let Some(o) = params
             .iter_mut()
-            .find(|TypeParameter { name_ident, .. }| name_ident.as_str() == ty_name.as_str())
+            .find(|TypeParameter { name, .. }| name.as_str() == ty_name.as_str())
         {
             o
         } else if let Some(o2) = parent_params
             .iter()
-            .find(|TypeParameter { name_ident, .. }| name_ident.as_str() == ty_name.as_str())
+            .find(|TypeParameter { name, .. }| name.as_str() == ty_name.as_str())
         {
             params.push(o2.clone());
             params.last_mut().unwrap()
@@ -1406,11 +1394,7 @@ fn fn_args_to_function_parameters(
                 (Some(reference), None) => reference.span(),
                 (Some(reference), Some(mutable)) => Span::join(reference.span(), &mutable.span()),
             };
-            let type_id = engines.te().insert(
-                engines,
-                TypeInfo::new_self_type(self_token.span()),
-                self_token.span().source_id(),
-            );
+            let type_id = engines.te().new_self_type(engines, self_token.span());
             let mut function_parameters = vec![FunctionParameter {
                 name: Ident::new(self_token.span()),
                 is_reference: ref_self.is_some(),
@@ -1614,11 +1598,7 @@ fn fn_signature_to_trait_fn(
     let return_type = match &fn_signature.return_type_opt {
         Some((_right_arrow, ty)) => ty_to_type_argument(context, handler, engines, ty.clone())?,
         None => {
-            let type_id = engines.te().insert(
-                engines,
-                TypeInfo::Tuple(Vec::new()),
-                fn_signature.span().source_id(),
-            );
+            let type_id = engines.te().id_of_unit();
             TypeArgument {
                 type_id,
                 initial_type_id: type_id,
@@ -2755,7 +2735,10 @@ fn expr_to_length(
     expr: Expr,
 ) -> Result<Length, ErrorEmitted> {
     let span = expr.span();
-    Ok(Length::new(expr_to_usize(context, handler, expr)?, span))
+    Ok(Length::from_numeric_literal(
+        expr_to_usize(context, handler, expr)?,
+        span,
+    ))
 }
 
 fn expr_to_usize(
@@ -3048,7 +3031,7 @@ fn match_expr_to_expression(
 
     let var_decl = engines.pe().insert(VariableDeclaration {
         type_ascription: {
-            let type_id = engines.te().insert(engines, TypeInfo::Unknown, None);
+            let type_id = engines.te().new_unknown();
             TypeArgument {
                 type_id,
                 initial_type_id: type_id,
@@ -3132,7 +3115,7 @@ fn for_expr_to_expression(
     // Declare iterable with iterator return
     let iterable_decl = engines.pe().insert(VariableDeclaration {
         type_ascription: {
-            let type_id = engines.te().insert(engines, TypeInfo::Unknown, None);
+            let type_id = engines.te().new_unknown();
             TypeArgument {
                 type_id,
                 initial_type_id: type_id,
@@ -3165,7 +3148,7 @@ fn for_expr_to_expression(
     // Declare value_opt = iterable.next()
     let value_opt_to_next_decl = engines.pe().insert(VariableDeclaration {
         type_ascription: {
-            let type_id = engines.te().insert(engines, TypeInfo::Unknown, None);
+            let type_id = engines.te().new_unknown();
             TypeArgument {
                 type_id,
                 initial_type_id: type_id,
@@ -3821,7 +3804,7 @@ fn statement_let_to_ast_nodes_unfold(
             let type_ascription = match ty_opt {
                 Some(ty) => ty_to_type_argument(context, handler, engines, ty)?,
                 None => {
-                    let type_id = engines.te().insert(engines, TypeInfo::Unknown, None);
+                    let type_id = engines.te().new_unknown();
                     TypeArgument {
                         type_id,
                         initial_type_id: type_id,
@@ -3871,7 +3854,7 @@ fn statement_let_to_ast_nodes_unfold(
             let type_ascription = match &ty_opt {
                 Some(ty) => ty_to_type_argument(context, handler, engines, ty.clone())?,
                 None => {
-                    let type_id = engines.te().insert(engines, TypeInfo::Unknown, None);
+                    let type_id = engines.te().new_unknown();
                     TypeArgument {
                         type_id,
                         initial_type_id: type_id,
@@ -3955,52 +3938,41 @@ fn statement_let_to_ast_nodes_unfold(
             let tuple_name =
                 generate_tuple_var_name(context.next_destructured_tuple_unique_suffix());
 
-            let tuple_name = Ident::new_with_override(tuple_name, pat_tuple.span().clone());
+            let tuple_name = Ident::new_with_override(tuple_name, pat_tuple.span());
 
-            // Acript a second declaration to a tuple of placeholders to check that the tuple
-            // is properly sized to the pattern
+            // Ascribe a second declaration to a tuple of placeholders to check that the tuple
+            // is properly sized to the pattern.
             let placeholders_type_ascription = {
-                let type_id = engines.te().insert(
+                let type_id = engines.te().insert_tuple_without_annotations(
                     engines,
-                    TypeInfo::Tuple(
-                        pat_tuple
-                            .clone()
-                            .into_inner()
-                            .into_iter()
-                            .map(|pat| {
-                                let initial_type_id =
-                                    engines.te().insert(engines, TypeInfo::Unknown, None);
-                                let dummy_type_param = TypeParameter {
-                                    type_id: initial_type_id,
-                                    initial_type_id,
-                                    name_ident: Ident::new_with_override(
-                                        "_".into(),
-                                        pat.span().clone(),
-                                    ),
-                                    trait_constraints: vec![],
-                                    trait_constraints_span: Span::dummy(),
-                                    is_from_parent: false,
-                                };
-                                let initial_type_id = engines.te().insert(
-                                    engines,
-                                    TypeInfo::Placeholder(dummy_type_param),
-                                    None,
-                                );
-                                TypeArgument {
-                                    type_id: initial_type_id,
-                                    initial_type_id,
-                                    call_path_tree: None,
-                                    span: Span::dummy(),
-                                }
-                            })
-                            .collect(),
-                    ),
-                    tuple_name.span().source_id(),
+                    pat_tuple
+                        .clone()
+                        .into_inner()
+                        .into_iter()
+                        .map(|pat| {
+                            // Since these placeholders are generated specifically for checks, the `pat.span()` must not
+                            // necessarily point to a "_" string in code. E.g., in this example:
+                            //   let (a, _) = (0, 0);
+                            // The first `pat.span()` will point to "a", while the second one will indeed point to "_".
+                            // However, they `pat.span()` will always be in the source file in which the placeholder
+                            // is logically situated.
+                            engines.te().new_placeholder(
+                                engines,
+                                TypeParameter::new_placeholder(
+                                    engines.te().new_unknown(),
+                                    pat.span(),
+                                ),
+                            )
+                        })
+                        .collect(),
                 );
+
+                // The type argument is a tuple of place holders of unknowns pointing to
+                // the tuple pattern.
                 TypeArgument {
                     type_id,
                     initial_type_id: type_id,
-                    span: tuple_name.span(),
+                    span: pat_tuple.span(),
                     call_path_tree: None,
                 }
             };
@@ -4314,14 +4286,14 @@ fn ty_to_type_parameter(
 ) -> Result<TypeParameter, ErrorEmitted> {
     let type_engine = engines.te();
 
-    let name_ident = match ty {
+    let name = match ty {
         Ty::Path(path_type) => path_type_to_ident(context, handler, path_type)?,
         Ty::Infer { underscore_token } => {
-            let unknown_type = type_engine.insert(engines, TypeInfo::Unknown, None);
+            let unknown_type = type_engine.new_unknown();
             return Ok(TypeParameter {
                 type_id: unknown_type,
                 initial_type_id: unknown_type,
-                name_ident: underscore_token.into(),
+                name: underscore_token.into(),
                 trait_constraints: Vec::default(),
                 trait_constraints_span: Span::dummy(),
                 is_from_parent: false,
@@ -4329,26 +4301,18 @@ fn ty_to_type_parameter(
         }
         Ty::Tuple(..) => panic!("tuple types are not allowed in this position"),
         Ty::Array(..) => panic!("array types are not allowed in this position"),
-        Ty::StringSlice(..) => panic!("str types are not allowed in this position"),
-        Ty::StringArray { .. } => panic!("str types are not allowed in this position"),
+        Ty::StringSlice(..) => panic!("str slice types are not allowed in this position"),
+        Ty::StringArray { .. } => panic!("str array types are not allowed in this position"),
         Ty::Ptr { .. } => panic!("__ptr types are not allowed in this position"),
         Ty::Slice { .. } => panic!("__slice types are not allowed in this position"),
         Ty::Ref { .. } => panic!("ref types are not allowed in this position"),
         Ty::Never { .. } => panic!("never types are not allowed in this position"),
     };
-    let custom_type = type_engine.insert(
-        engines,
-        TypeInfo::Custom {
-            qualified_call_path: name_ident.clone().into(),
-            type_arguments: None,
-            root_type_id: None,
-        },
-        name_ident.span().source_id(),
-    );
+    let custom_type = type_engine.new_custom_from_name(engines, name.clone());
     Ok(TypeParameter {
         type_id: custom_type,
         initial_type_id: custom_type,
-        name_ident,
+        name,
         trait_constraints: Vec::new(),
         trait_constraints_span: Span::dummy(),
         is_from_parent: false,

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -238,7 +238,7 @@ impl TypeBinding<CallPath<(TypeInfo, Ident)>> {
                 EnforceTypeArguments::No,
                 Some(&type_info_prefix),
             )
-            .unwrap_or_else(|err| type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None));
+            .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
         Ok(type_id)
     }
@@ -309,7 +309,7 @@ impl TypeCheckTypeBinding<ty::TyFunctionDecl> for TypeBinding<CallPath> {
     > {
         let type_engine = ctx.engines.te();
         let decl_engine = ctx.engines.de();
-        let engines = ctx.engines();
+
         // Grab the declaration.
         let unknown_decl = ctx.resolve_call_path_with_visibility_check(handler, &self.inner)?;
         // Check to see if this is a fn declaration.
@@ -337,9 +337,7 @@ impl TypeCheckTypeBinding<ty::TyFunctionDecl> for TypeBinding<CallPath> {
                         EnforceTypeArguments::Yes,
                         None,
                     )
-                    .unwrap_or_else(|err| {
-                        type_engine.insert(engines, TypeInfo::ErrorRecovery(err), None)
-                    });
+                    .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
                 }
             }
         }
@@ -407,11 +405,7 @@ impl TypeCheckTypeBinding<ty::TyStructDecl> for TypeBinding<CallPath> {
             new_copy,
             decl_engine.get_parsed_decl_id(&struct_id).as_ref(),
         );
-        let type_id = type_engine.insert(
-            engines,
-            TypeInfo::Struct(*new_struct_ref.id()),
-            new_struct_ref.span().source_id(),
-        );
+        let type_id = type_engine.insert_struct(engines, *new_struct_ref.id());
         Ok((new_struct_ref, Some(type_id), None))
     }
 }
@@ -458,11 +452,7 @@ impl TypeCheckTypeBinding<ty::TyEnumDecl> for TypeBinding<CallPath> {
         // Insert the new copy into the declaration engine.
         let new_enum_ref =
             decl_engine.insert(new_copy, decl_engine.get_parsed_decl_id(&enum_id).as_ref());
-        let type_id = type_engine.insert(
-            engines,
-            TypeInfo::Enum(*new_enum_ref.id()),
-            new_enum_ref.span().source_id(),
-        );
+        let type_id = type_engine.insert_enum(engines, *new_enum_ref.id());
         Ok((new_enum_ref, Some(type_id), Some(unknown_decl)))
     }
 }

--- a/sway-core/src/type_system/ast_elements/length.rs
+++ b/sway-core/src/type_system/ast_elements/length.rs
@@ -1,6 +1,17 @@
 use sway_types::{span::Span, Spanned};
 
-/// Describes a fixed length for types that needs it such as arrays and strings
+/// Describes a fixed length for types that need it, e.g., [crate::TypeInfo::Array].
+///
+/// Optionally, if the length is coming from a literal in code, the [Length]
+/// also keeps the [Span] of that literal. In that case, we say that the length
+/// is annotated.
+///
+/// E.g., in this example, the two lengths coming from the literal `3` will
+/// have two different spans pointing to the two different strings "3":
+///
+/// ```ignore
+/// fn copy(a: [u64;3], b: [u64;3])
+/// ```
 #[derive(Debug, Clone, Hash)]
 pub struct Length {
     val: usize,
@@ -8,12 +19,29 @@ pub struct Length {
 }
 
 impl Length {
-    pub fn new(val: usize, span: Span) -> Self {
-        Length { val, span }
+    /// Creates a new [Length] without span annotation.
+    pub fn new(val: usize) -> Self {
+        Length {
+            val,
+            span: Span::dummy(),
+        }
+    }
+
+    /// Creates a new [Length] from a numeric literal.
+    /// The `span` will be set to the span of the numeric literal.
+    pub fn from_numeric_literal(val: usize, numeric_literal_span: Span) -> Self {
+        Length {
+            val,
+            span: numeric_literal_span,
+        }
     }
 
     pub fn val(&self) -> usize {
         self.val
+    }
+
+    pub fn is_annotated(&self) -> bool {
+        !self.span.is_dummy()
     }
 }
 

--- a/sway-core/src/type_system/ast_elements/trait_constraint.rs
+++ b/sway-core/src/type_system/ast_elements/trait_constraint.rs
@@ -170,11 +170,7 @@ impl TraitConstraint {
                     EnforceTypeArguments::Yes,
                     None,
                 )
-                .unwrap_or_else(|err| {
-                    ctx.engines
-                        .te()
-                        .insert(ctx.engines(), TypeInfo::ErrorRecovery(err), None)
-                });
+                .unwrap_or_else(|err| ctx.engines.te().id_of_error_recovery(err));
         }
 
         Ok(())

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -2,15 +2,60 @@ use crate::{engine_threading::*, language::CallPathTree, type_system::priv_prelu
 use std::{cmp::Ordering, fmt, hash::Hasher};
 use sway_types::{Span, Spanned};
 
+/// [TypeArgument] can be see as an "annotated reference" to a [TypeInfo].
+/// It holds the [TypeArgument::type_id] which is the actual "reference"
+/// to the type, as well as an additional information about that type,
+/// called the annotation.
+///
+/// If a [TypeArgument] only references a [TypeInfo] and is considered as
+/// not being annotated, its `initial_type_id` must be the same as `type_id`,
+/// its `span` must be [Span::dummy] and its `call_path_tree` must be `None`.
+///
+/// The annotations are ignored when calculating the [TypeArgument]'s hash
+/// (with engines) and equality (with engines).
 #[derive(Debug, Clone)]
 pub struct TypeArgument {
+    /// The [TypeId] of the "referenced" [TypeInfo].
     pub type_id: TypeId,
+    /// Denotes the initial type that was referenced before the type
+    /// unification, monomorphization, or replacement of [TypeInfo::Custom]s.
     pub initial_type_id: TypeId,
+    /// The [Span] related in code to the [TypeInfo] represented by this
+    /// [TypeArgument]. This information is mostly used by the LSP and it
+    /// differs from use case to use case.
+    ///
+    /// E.g., in the following example:
+    ///
+    /// ```ignore
+    /// let a: [u64;2] = [0, 0];
+    /// let b: [u64;2] = [1, 1];
+    /// ```
+    ///
+    /// the type arguments if the [TypeInfo::Array]s of `a` and `b` will
+    /// have two different spans pointing to two different strings "u64".
+    /// On the other hand, the two [TypeInfo::Array]s describing the
+    /// two instances `[0, 0]`, and `[1, 1]` will have neither the array
+    /// type span set, nor the length span, which means they will not be
+    /// annotated.
     pub span: Span,
     pub call_path_tree: Option<CallPathTree>,
 }
 
+impl TypeArgument {
+    /// Returns true if `self` is annotated by heaving either
+    /// its [Self::initial_type_id] different from [Self::type_id],
+    /// or [Self::span] different from [Span::dummy]
+    /// or [Self::call_path_tree] different from `None`.
+    pub fn is_annotated(&self) -> bool {
+        self.type_id != self.initial_type_id
+            || self.call_path_tree.is_some()
+            || !self.span.is_dummy()
+    }
+}
+
 impl From<TypeId> for TypeArgument {
+    /// Creates *a non-annotated* [TypeArgument] that points
+    /// to the [TypeInfo] represented by the `type_id`.
     fn from(type_id: TypeId) -> Self {
         TypeArgument {
             type_id,
@@ -102,7 +147,7 @@ impl From<&TypeParameter> for TypeArgument {
         TypeArgument {
             type_id: type_param.type_id,
             initial_type_id: type_param.initial_type_id,
-            span: type_param.name_ident.span(),
+            span: type_param.name.span(),
             call_path_tree: None,
         }
     }

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -12,7 +12,7 @@ use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
 };
-use sway_types::{ident::Ident, span::Span, Spanned};
+use sway_types::{ident::Ident, span::Span, BaseIdent, Spanned};
 
 use std::{
     cmp::Ordering,
@@ -21,21 +21,47 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-#[derive(Clone)]
+/// [TypeParameter] describes a generic type parameter, including its
+/// monomorphized version. It holds the `name` of the parameter, its
+/// `type_id`, and the `initial_type_id`, as well as an additional
+/// information about that type parameter, called the annotation.
+///
+/// If a [TypeParameter] is considered as not being annotated,
+/// its `initial_type_id` must be same as `type_id`, its
+/// `trait_constraints_span` must be [Span::dummy]
+/// and its `is_from_parent` must be false.
+///
+/// The annotations are ignored when calculating the [TypeParameter]'s hash
+/// (with engines) and equality (with engines).
+#[derive(Debug, Clone)]
 pub struct TypeParameter {
     pub type_id: TypeId,
+    /// Denotes the initial type represented by the [TypeParameter], before
+    /// unification, monomorphization, or replacement of [TypeInfo::Custom]s.
     pub(crate) initial_type_id: TypeId,
-    pub name_ident: Ident,
+    pub name: Ident,
     pub(crate) trait_constraints: Vec<TraitConstraint>,
     pub(crate) trait_constraints_span: Span,
     pub(crate) is_from_parent: bool,
+}
+
+impl TypeParameter {
+    /// Returns true if `self` is annotated by heaving either
+    /// its [Self::initial_type_id] different from [Self::type_id],
+    /// or [Self::trait_constraints_span] different from [Span::dummy]
+    /// or [Self::is_from_parent] different from false.
+    pub fn is_annotated(&self) -> bool {
+        self.type_id != self.initial_type_id
+            || self.is_from_parent
+            || !self.trait_constraints_span.is_dummy()
+    }
 }
 
 impl HashWithEngines for TypeParameter {
     fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
         let TypeParameter {
             type_id,
-            name_ident,
+            name,
             trait_constraints,
             // these fields are not hashed because they aren't relevant/a
             // reliable source of obj v. obj distinction
@@ -45,7 +71,7 @@ impl HashWithEngines for TypeParameter {
         } = self;
         let type_engine = engines.te();
         type_engine.get(*type_id).hash(state, engines);
-        name_ident.hash(state);
+        name.hash(state);
         trait_constraints.hash(state, engines);
     }
 }
@@ -57,7 +83,7 @@ impl PartialEqWithEngines for TypeParameter {
         type_engine
             .get(self.type_id)
             .eq(&type_engine.get(other.type_id), ctx)
-            && self.name_ident == other.name_ident
+            && self.name == other.name
             && self.trait_constraints.eq(&other.trait_constraints, ctx)
     }
 }
@@ -66,7 +92,7 @@ impl OrdWithEngines for TypeParameter {
     fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> Ordering {
         let TypeParameter {
             type_id: lti,
-            name_ident: ln,
+            name: ln,
             trait_constraints: ltc,
             // these fields are not compared because they aren't relevant/a
             // reliable source of obj v. obj distinction
@@ -76,7 +102,7 @@ impl OrdWithEngines for TypeParameter {
         } = self;
         let TypeParameter {
             type_id: rti,
-            name_ident: rn,
+            name: rn,
             trait_constraints: rtc,
             // these fields are not compared because they aren't relevant/a
             // reliable source of obj v. obj distinction
@@ -106,7 +132,7 @@ impl SubstTypes for TypeParameter {
 
 impl Spanned for TypeParameter {
     fn span(&self) -> Span {
-        self.name_ident.span()
+        self.name.span()
     }
 }
 
@@ -118,7 +144,7 @@ impl IsConcrete for TypeParameter {
 
 impl DebugWithEngines for TypeParameter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, engines: &Engines) -> fmt::Result {
-        write!(f, "{}", self.name_ident)?;
+        write!(f, "{}", self.name)?;
         if !self.trait_constraints.is_empty() {
             write!(
                 f,
@@ -134,37 +160,56 @@ impl DebugWithEngines for TypeParameter {
     }
 }
 
-impl fmt::Debug for TypeParameter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let _ = write!(f, "{}: {:?}", self.name_ident, self.type_id);
-        for c in &self.trait_constraints {
-            let _ = write!(f, "+ {:?}", c.trait_name);
-        }
-        write!(f, "")
-    }
-}
-
 impl TypeParameter {
-    pub(crate) fn new_self_type(engines: &Engines, span: Span) -> TypeParameter {
+    /// Creates a new [TypeParameter] that represents a `Self` type.
+    /// The returned type parameter will have its [TypeParameter::name]
+    /// set to "Self" with the provided `use_site_span`.
+    ///
+    /// `Self` type is a [TypeInfo::UnknownGeneric] and therefore [TypeParameter::type_id]s
+    /// will be set to newly created unknown generic type.
+    ///
+    /// Note that the span in general does not point to a reserved word "Self" in
+    /// the source code, nor is related to it. The `Self` type represents the type
+    /// in `impl`s and does not necessarily relate to the "Self" keyword in code.
+    ///
+    /// Therefore, *the span must always point to a location in the source file in which
+    /// the particular `Self` type is, e.g., being declared or implemented*.
+    pub(crate) fn new_self_type(engines: &Engines, use_site_span: Span) -> TypeParameter {
         let type_engine = engines.te();
 
-        let name = Ident::new_with_override("Self".into(), span.clone());
-        let type_id = type_engine.insert(
-            engines,
-            TypeInfo::UnknownGeneric {
-                name: name.clone(),
-                trait_constraints: VecSet(vec![]),
-                parent: None,
-                is_from_type_parameter: true,
-            },
-            span.source_id(),
-        );
+        let (type_id, name) = type_engine.new_unknown_generic_self_with_name(use_site_span, true);
         TypeParameter {
             type_id,
             initial_type_id: type_id,
-            name_ident: name,
+            name,
             trait_constraints: vec![],
-            trait_constraints_span: span,
+            trait_constraints_span: Span::dummy(),
+            is_from_parent: false,
+        }
+    }
+
+    /// Creates a new [TypeParameter] specifically to be used as the type parameter
+    /// for a [TypeInfo::Placeholder]. The returned type parameter will have its
+    /// [TypeParameter::name] set to "_" with the provided `placeholder_or_use_site_span`
+    /// and its [TypeParameter::type_id]s set to the `type_id`.
+    ///
+    /// Note that in the user written code, the span will always point to the place in
+    /// the source code where "_" is located. In the compiler generated code that must not
+    /// be the case. For cases when the span does not point to "_" see the comments
+    /// in the usages of this method.
+    ///
+    /// However, *the span must always point to a location in the source file in which
+    /// the particular placeholder is considered to be used*.
+    pub(crate) fn new_placeholder(
+        type_id: TypeId,
+        placeholder_or_use_site_span: Span,
+    ) -> TypeParameter {
+        TypeParameter {
+            type_id,
+            initial_type_id: type_id,
+            name: BaseIdent::new_with_override("_".into(), placeholder_or_use_site_span),
+            trait_constraints: vec![],
+            trait_constraints_span: Span::dummy(),
             is_from_parent: false,
         }
     }
@@ -176,11 +221,11 @@ impl TypeParameter {
     ) {
         let type_parameter_decl =
             ty::TyDecl::GenericTypeForFunctionScope(ty::GenericTypeForFunctionScope {
-                name: self.name_ident.clone(),
+                name: self.name.clone(),
                 type_id: self.type_id,
             });
-        let name_a = Ident::new_with_override("self".into(), self.name_ident.span());
-        let name_b = Ident::new_with_override("Self".into(), self.name_ident.span());
+        let name_a = Ident::new_with_override("self".into(), self.name.span());
+        let name_b = Ident::new_with_override("Self".into(), self.name.span());
         let _ = ctx.insert_symbol(handler, name_a, type_parameter_decl.clone());
         let _ = ctx.insert_symbol(handler, name_b, type_parameter_decl);
     }
@@ -266,11 +311,10 @@ impl TypeParameter {
         type_parameter: TypeParameter,
     ) -> Result<Self, ErrorEmitted> {
         let type_engine = ctx.engines.te();
-        let engines = ctx.engines();
 
         let TypeParameter {
             initial_type_id,
-            name_ident,
+            name,
             trait_constraints,
             trait_constraints_span,
             is_from_parent,
@@ -296,19 +340,15 @@ impl TypeParameter {
 
         // Create type id and type parameter before type checking trait constraints.
         // This order is required because a trait constraint may depend on its own type parameter.
-        let type_id = type_engine.insert(
-            engines,
-            TypeInfo::UnknownGeneric {
-                name: name_ident.clone(),
-                trait_constraints: VecSet(trait_constraints_with_supertraits.clone()),
-                parent,
-                is_from_type_parameter: true,
-            },
-            name_ident.span().source_id(),
+        let type_id = type_engine.new_unknown_generic(
+            name.clone(),
+            VecSet(trait_constraints_with_supertraits.clone()),
+            parent,
+            true,
         );
 
         let type_parameter = TypeParameter {
-            name_ident: name_ident.clone(),
+            name,
             type_id,
             initial_type_id,
             trait_constraints,
@@ -360,15 +400,11 @@ impl TypeParameter {
         type_engine.replace(
             ctx.engines(),
             type_parameter.type_id,
-            TypeSourceInfo {
-                type_info: TypeInfo::UnknownGeneric {
-                    name: type_parameter.name_ident.clone(),
-                    trait_constraints: VecSet(trait_constraints_with_supertraits.clone()),
-                    parent,
-                    is_from_type_parameter: true,
-                }
-                .into(),
-                source_id: type_parameter.name_ident.span().source_id().copied(),
+            TypeInfo::UnknownGeneric {
+                name: type_parameter.name.clone(),
+                trait_constraints: VecSet(trait_constraints_with_supertraits.clone()),
+                parent,
+                is_from_type_parameter: true,
             },
         );
 
@@ -415,7 +451,7 @@ impl TypeParameter {
     ) -> Result<(), ErrorEmitted> {
         let Self {
             is_from_parent,
-            name_ident,
+            name,
             type_id,
             ..
         } = self;
@@ -428,7 +464,7 @@ impl TypeParameter {
                 .module(ctx.engines())
                 .current_items()
                 .symbols
-                .get(name_ident)
+                .get(name)
                 .unwrap();
 
             match sy.expect_typed_ref() {
@@ -450,15 +486,11 @@ impl TypeParameter {
                         ctx.engines.te().replace(
                             ctx.engines(),
                             *type_id,
-                            TypeSourceInfo {
-                                type_info: TypeInfo::UnknownGeneric {
-                                    name: name.clone(),
-                                    trait_constraints: trait_constraints.clone(),
-                                    parent: Some(*parent_type_id),
-                                    is_from_type_parameter: *is_from_type_parameter,
-                                }
-                                .into(),
-                                source_id: name.span().source_id().copied(),
+                            TypeInfo::UnknownGeneric {
+                                name: name.clone(),
+                                trait_constraints: trait_constraints.clone(),
+                                parent: Some(*parent_type_id),
+                                is_from_type_parameter: *is_from_type_parameter,
                             },
                         );
                     }
@@ -466,7 +498,7 @@ impl TypeParameter {
                 _ => {
                     handler.emit_err(CompileError::Internal(
                         "Unexpected TyDeclaration for TypeParameter.",
-                        self.name_ident.span(),
+                        self.name.span(),
                     ));
                 }
             }
@@ -476,10 +508,10 @@ impl TypeParameter {
         // declaration.
         let type_parameter_decl =
             ty::TyDecl::GenericTypeForFunctionScope(ty::GenericTypeForFunctionScope {
-                name: name_ident.clone(),
+                name: name.clone(),
                 type_id: *type_id,
             });
-        ctx.insert_symbol(handler, name_ident.clone(), type_parameter_decl)
+        ctx.insert_symbol(handler, name.clone(), type_parameter_decl)
             .ok();
 
         Ok(())

--- a/sway-core/src/type_system/engine.rs
+++ b/sway-core/src/type_system/engine.rs
@@ -2,25 +2,139 @@ use crate::{
     concurrent_slab::{ConcurrentSlab, ListDisplay},
     decl_engine::*,
     engine_threading::*,
+    language::{
+        ty::{TyEnumDecl, TyExpression, TyStructDecl},
+        QualifiedCallPath,
+    },
     type_system::priv_prelude::*,
 };
 use core::fmt::Write;
 use hashbrown::{hash_map::RawEntryMut, HashMap};
 use parking_lot::RwLock;
-use std::{sync::Arc, time::Instant};
+use std::{
+    hash::{BuildHasher, Hash, Hasher},
+    sync::Arc,
+    time::Instant,
+};
 use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
     type_error::TypeError,
 };
-use sway_types::{integer_bits::IntegerBits, span::Span, ProgramId, SourceId};
+use sway_types::{integer_bits::IntegerBits, span::Span, Ident, ProgramId, SourceId, Spanned};
 
 use super::unify::unifier::UnifyKind;
 
+/// To be able to garbage-collect [TypeInfo]s from the [TypeEngine]
+/// we need to track which types need to be GCed when a particular
+/// module, represented by its source id, is GCed. [TypeSourceInfo]
+/// encapsulates this information.
+///
+/// For types that should never be GCed the `source_id` must be `None`.
+///
+/// The concrete logic of assigning `source_id`s to `type_info`s is
+/// given in the [TypeEngine::get_type_fallback_source_id].
+// TODO: This logic will be further improved when https://github.com/FuelLabs/sway/issues/6603
+//       is implemented (Optimize `TypeEngine` for garbage collection).
+#[derive(Debug, Default, Clone)]
+struct TypeSourceInfo {
+    type_info: Arc<TypeInfo>,
+    source_id: Option<SourceId>,
+}
+
+impl TypeSourceInfo {
+    /// Returns true if the `self` would be equal to another [TypeSourceInfo]
+    /// created from `type_info` and `source_id`.
+    ///
+    /// This method allows us to test equality "upfront", without the need to
+    /// create a new [TypeSourceInfo] which would require a heap allocation
+    /// of a new [TypeInfo].
+    pub(crate) fn equals(
+        &self,
+        type_info: &TypeInfo,
+        source_id: &Option<SourceId>,
+        ctx: &PartialEqWithEnginesContext,
+    ) -> bool {
+        &self.source_id == source_id && self.type_info.eq(type_info, ctx)
+    }
+}
+
+impl HashWithEngines for TypeSourceInfo {
+    fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
+        self.type_info.hash(state, engines);
+        self.source_id.hash(state);
+    }
+}
+
+impl EqWithEngines for TypeSourceInfo {}
+impl PartialEqWithEngines for TypeSourceInfo {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        self.equals(&other.type_info, &other.source_id, ctx)
+    }
+}
+
+/// Holds the singleton instances of [TypeSourceInfo]s of *replaceable types* that,
+/// although being inserted anew into the [TypeEngine], all share the single definition.
+/// This means that, e.g., all the different [TypeEngine::slab] entries representing
+/// the, e.g., [TypeInfo::Unknown] will point to the same singleton instance
+/// of the corresponding [TypeSourceInfo].
+#[derive(Debug, Clone)]
+struct SingletonTypeSourceInfos {
+    /// The single instance of the [TypeSourceInfo]
+    /// representing the [TypeInfo::Unknown] replaceable type.
+    unknown: Arc<TypeSourceInfo>,
+    /// The single instance of the [TypeSourceInfo]
+    /// representing the [TypeInfo::Numeric] replaceable type.
+    numeric: Arc<TypeSourceInfo>,
+}
+
+/// Holds the instances of [TypeInfo]s and allows exchanging them for [TypeId]s.
+/// Supports LSP garbage collection of unused [TypeInfo]s assigned to a particular [SourceId].
+///
+/// ## Intended Usage
+/// Inserting [TypeInfo]s into the type engine returns a [TypeId] that can later be used
+/// to get the same [TypeInfo] by using the [TypeEngine::get] method.
+///
+/// Properly using various inserting methods is crucial for the optimal work of the type engine.
+///
+/// These methods are grouped by the following convention and are intended to be used in the
+/// order of precedence given below:
+/// - `id_of_<type>`: methods that always return the same [TypeId] for a type.
+///   These methods, when inlined, compile to constant [TypeId]s.
+/// - `new_<type>`: methods that always return a new [TypeId] for a type.
+/// - `insert_<type>[_<additional options>]`: methods that might insert a new type into the engine,
+///   and return a new [TypeId], but also reuse an existing [TypeInfo] and return an existing [TypeId].
+/// - `insert`: the fallback method that should be used only in cases when the type is not known
+///   at the call site.
+///
+/// ## Internal Implementation
+/// [TypeInfo]s are stored in a private [TypeSourceInfo] structure that binds them with a [SourceId]
+/// of the module in which they are used. Those [TypeSourceInfo]s are referenced from the `slab`.
+/// The actual [TypeId] of a [TypeInfo] is just an index in the `slab`.
+///
+/// The engine attempts to maximize the reuse of [TypeSourceInfo]s by holding _shareable types_
+/// (see: [Self::is_type_shareable]) in the `shareable_types` hash map.
+///
+/// TODO: Note that the reuse currently happens on the level of [TypeSourceInfo]s, and not [TypeInfo]s.
+///       This is not optimal and will be improved in https://github.com/FuelLabs/sway/issues/6603.
+///       Also note that because of that, having [TypeInfo] stored in `Arc` within the [TypeSourceInfo]
+///       does not bring any real benefits.
+///
+/// The implementation of the type engine is primarily directed with the goal of maximizing the
+/// reuse of the [TypeSourceInfo]s while at the same time having the [TypeInfo]s bound to [SourceId]s
+/// of their use site, so that they can be garbage collected.
+///
+/// TODO: Note that the assignment of [SourceId]s to [TypeInfo]s is currently not as optimal as it
+///       can be. This will be improved in https://github.com/FuelLabs/sway/issues/6603.
 #[derive(Debug)]
 pub struct TypeEngine {
     slab: ConcurrentSlab<TypeSourceInfo>,
-    id_map: RwLock<HashMap<TypeSourceInfo, TypeId>>,
+    /// Holds [TypeId]s of [TypeSourceInfo]s of shareable types (see: [Self::is_type_shareable]).
+    /// [TypeSourceInfo]s of shareable types can be reused if the type is used more
+    /// then once. In that case, for every usage, instead of inserting a new [TypeSourceInfo] instance
+    /// into the [Self::slab], the [TypeId] of an existing instance is returned.
+    shareable_types: RwLock<HashMap<Arc<TypeSourceInfo>, TypeId>>,
+    singleton_types: RwLock<SingletonTypeSourceInfos>,
     unifications: ConcurrentSlab<Unification>,
     last_replace: RwLock<Instant>,
 }
@@ -40,12 +154,28 @@ pub(crate) struct Unification {
 
 impl Default for TypeEngine {
     fn default() -> Self {
-        TypeEngine {
+        let singleton_types = SingletonTypeSourceInfos {
+            unknown: TypeSourceInfo {
+                type_info: TypeInfo::Unknown.into(),
+                source_id: None,
+            }
+            .into(),
+            numeric: TypeSourceInfo {
+                type_info: TypeInfo::Numeric.into(),
+                source_id: None,
+            }
+            .into(),
+        };
+
+        let mut te = TypeEngine {
             slab: Default::default(),
-            id_map: Default::default(),
+            shareable_types: Default::default(),
+            singleton_types: RwLock::new(singleton_types),
             unifications: Default::default(),
             last_replace: RwLock::new(Instant::now()),
-        }
+        };
+        te.insert_shareable_built_in_types();
+        te
     }
 }
 
@@ -53,14 +183,616 @@ impl Clone for TypeEngine {
     fn clone(&self) -> Self {
         TypeEngine {
             slab: self.slab.clone(),
-            id_map: RwLock::new(self.id_map.read().clone()),
+            shareable_types: RwLock::new(self.shareable_types.read().clone()),
+            singleton_types: RwLock::new(self.singleton_types.read().clone()),
             unifications: self.unifications.clone(),
             last_replace: RwLock::new(*self.last_replace.read()),
         }
     }
 }
 
+/// Generates:
+///  - `id_of_<type>` methods for every provided shareable built-in type.
+///  - `insert_shareable_built_in_types` method for initial creation of built-in types within the [TypeEngine].
+///  - `get_shareable_built_in_type_id` method for potential retrieval of built-in types in the [TypeEngine::insert] method.
+///
+/// Note that, when invoking the macro, the `unit` and the [TypeInfo::ErrorRecovery] types *must not be provided in the list*.
+/// The shareable `unit` type requires a special treatment within the macro, because it is modeled
+/// as [TypeInfo::Tuple] with zero elements and not as a separate [TypeInfo] variant.
+/// The [TypeInfo::ErrorRecovery], although being an enum variant with the parameter (the [ErrorEmitted] proof), is
+/// actually a single type because all the [ErrorEmitted] proofs are the same.
+/// This special case is also handled within the macro.
+///
+/// Unfortunately, due to limitations of Rust's macro-by-example, the [TypeInfo] must be
+/// provided twice during the macro invocation, once as an expression `expr` and once as a pattern `pat`.
+///
+/// The macro recursively creates the `id_of_<type>` methods in order to get the proper `usize` value
+/// generated, which corresponds to the index of those types withing the slab.
+macro_rules! type_engine_shareable_built_in_types {
+    // The base recursive case.
+    (@step $_idx:expr,) => {};
+
+    // The actual recursion step that generates the `id_of_<type>` functions.
+    (@step $idx:expr, ($fn_name:ident, $ti:expr, $ti_pat:pat), $(($tail_fn_name:ident, $tail_ti:expr, $tail_ti_pat:pat),)*) => {
+        pub(crate) const fn $fn_name(&self) -> TypeId {
+            TypeId::new($idx)
+        }
+
+        type_engine_shareable_built_in_types!(@step $idx + 1, $(($tail_fn_name, $tail_ti, $tail_ti_pat),)*);
+    };
+
+    // The entry point. Invoking the macro matches this arm.
+    ($(($fn_name:ident, $ti:expr, $ti_pat:pat),)*) => {
+        // The `unit` type is a special case. It will be inserted in the slab as the first type.
+        pub(crate) const fn id_of_unit(&self) -> TypeId {
+            TypeId::new(0)
+        }
+
+        // The error recovery type is a special case. It will be inserted in the slab as the second type.
+        // To preserve the semantics of the `TypeInfo::ErrorRecovery(ErrorEmitted)`, we still insist on
+        // providing the proof of the error being emitted, although that proof is actually
+        // not needed to obtain the type id, nor is used within this method at all.
+        #[allow(unused_variables)]
+        pub(crate) const fn id_of_error_recovery(&self, error_emitted: ErrorEmitted) -> TypeId {
+            TypeId::new(1)
+        }
+
+        // Generate the remaining `id_of_<type>` methods. We start counting the indices from 2.
+        type_engine_shareable_built_in_types!(@step 2, $(($fn_name, $ti, $ti_pat),)*);
+
+        // Generate the method that initially inserts the built-in shareable types into the `slab` in the right order.
+        //
+        // Note that we are inserting the types **only into the `slab`, but not into the `shareable_types`**,
+        // although they should, by definition, be in the `shareable_types` as well.
+        //
+        // What is the reason for not inserting them into the `shareable_types`?
+        //
+        // To insert them into the `shareable_types` we need `Engines` to be able to calculate
+        // the hash and equality with engines, and method is supposed be called internally during the creation
+        // of the `TypeEngine`. At that moment, we are creating a single, isolated engine, and do not
+        // have all the engines available. The only way to have it called with all the engines, is
+        // to do it when `Engines` are created. But this would mean that we cannot have a semantically
+        // valid `TypeEngine` created in isolation, without the `Engines`, which would be a problematic
+        // design that breaks cohesion and creates unexpected dependency.
+        //
+        // Note that having the built-in shareable types initially inserted only in the `slab` does
+        // not cause any issues with type insertion and retrieval. The `id_of_<type>` methods return
+        // indices that are compile-time constants and there is no need for `shareable_types` access.
+        // Also, calling `insert` with built-in shareable types has an optimized path which will redirect
+        // to `id_of_<type>` methods, again bypassing the `shareable_types`.
+        //
+        // The only negligible small "penalty" comes during the `replace()`ment of replaceable types
+        // where a potentially replacement with a built-in shareable type will create a separate instance
+        // of that built-in type and add it to `shareable_types`.
+        fn insert_shareable_built_in_types(&mut self) {
+            use TypeInfo::*;
+
+            let tsi = TypeSourceInfo {
+                type_info: Tuple(vec![]).into(),
+                source_id: None,
+            };
+            self.slab.insert(tsi);
+
+            // For the `ErrorRecovery`, we need an `ErrorEmitted` instance.
+            // All of its instances are the same, so we will (mis)use the `Handler::cancel` method
+            // here to obtain an instance.
+            let tsi = TypeSourceInfo {
+                type_info: ErrorRecovery(crate::Handler::default().cancel()).into(),
+                source_id: None,
+            };
+            self.slab.insert(tsi);
+
+            $(
+                let tsi = TypeSourceInfo {
+                    type_info: $ti.into(),
+                    source_id: None,
+                };
+                self.slab.insert(tsi);
+            )*
+        }
+
+        /// Returns the [TypeId] of the `type_info` only if the type info is
+        /// a shareable built-in type, otherwise `None`.
+        ///
+        /// For a particular shareable built-in type, the method guarantees to always
+        /// return the same, existing [TypeId].
+        fn get_shareable_built_in_type_id(&self, type_info: &TypeInfo) -> Option<TypeId> {
+            use TypeInfo::*;
+            match type_info {
+                Tuple(v) if v.is_empty() => Some(self.id_of_unit()),
+                // Here we also "pass" the dummy value obtained from `Handler::cancel` which will be
+                // optimized away.
+                ErrorRecovery(_) => Some(self.id_of_error_recovery(crate::Handler::default().cancel())),
+                $(
+                    $ti_pat => Some(self.$fn_name()),
+                )*
+                _ => None
+            }
+        }
+    }
+}
+
 impl TypeEngine {
+    type_engine_shareable_built_in_types!(
+        (id_of_never, Never, Never),
+        (id_of_string_slice, StringSlice, StringSlice),
+        (
+            id_of_u8,
+            UnsignedInteger(IntegerBits::Eight),
+            UnsignedInteger(IntegerBits::Eight)
+        ),
+        (
+            id_of_u16,
+            UnsignedInteger(IntegerBits::Sixteen),
+            UnsignedInteger(IntegerBits::Sixteen)
+        ),
+        (
+            id_of_u32,
+            UnsignedInteger(IntegerBits::ThirtyTwo),
+            UnsignedInteger(IntegerBits::ThirtyTwo)
+        ),
+        (
+            id_of_u64,
+            UnsignedInteger(IntegerBits::SixtyFour),
+            UnsignedInteger(IntegerBits::SixtyFour)
+        ),
+        (
+            id_of_u256,
+            UnsignedInteger(IntegerBits::V256),
+            UnsignedInteger(IntegerBits::V256)
+        ),
+        (id_of_bool, Boolean, Boolean),
+        (id_of_b256, B256, B256),
+        (id_of_contract, Contract, Contract),
+        (id_of_raw_ptr, RawUntypedPtr, RawUntypedPtr),
+        (id_of_raw_slice, RawUntypedSlice, RawUntypedSlice),
+    );
+
+    /// Inserts a new [TypeInfo::Unknown] into the [TypeEngine] and returns its [TypeId].
+    ///
+    /// [TypeInfo::Unknown] is an always replaceable type and the method
+    /// guarantees that a new (or unused) [TypeId] will be returned on every
+    /// call.
+    pub(crate) fn new_unknown(&self) -> TypeId {
+        TypeId::new(
+            self.slab
+                .insert_arc(self.singleton_types.read().unknown.clone()),
+        )
+    }
+
+    /// Inserts a new [TypeInfo::Numeric] into the [TypeEngine] and returns its [TypeId].
+    ///
+    /// [TypeInfo::Numeric] is an always replaceable type and the method
+    /// guarantees that a new (or unused) [TypeId] will be returned on every
+    /// call.
+    pub(crate) fn new_numeric(&self) -> TypeId {
+        TypeId::new(
+            self.slab
+                .insert_arc(self.singleton_types.read().numeric.clone()),
+        )
+    }
+
+    /// Inserts a new [TypeInfo::Placeholder] into the [TypeEngine] and returns its [TypeId].
+    ///
+    /// [TypeInfo::Placeholder] is an always replaceable type and the method
+    /// guarantees that a new (or unused) [TypeId] will be returned on every
+    /// call.
+    pub(crate) fn new_placeholder(
+        &self,
+        engines: &Engines,
+        type_parameter: TypeParameter,
+    ) -> TypeId {
+        self.new_placeholder_impl(engines.de(), TypeInfo::Placeholder(type_parameter))
+    }
+
+    fn new_placeholder_impl(&self, decl_engine: &DeclEngine, placeholder: TypeInfo) -> TypeId {
+        let source_id = self.get_placeholder_fallback_source_id(decl_engine, &placeholder);
+        let tsi = TypeSourceInfo {
+            type_info: placeholder.into(),
+            source_id,
+        };
+        TypeId::new(self.slab.insert(tsi))
+    }
+
+    /// Inserts a new [TypeInfo::UnknownGeneric] into the [TypeEngine] and returns its [TypeId].
+    ///
+    /// [TypeInfo::UnknownGeneric] is an always replaceable type and the method
+    /// guarantees that a new (or unused) [TypeId] will be returned on every
+    /// call.
+    pub(crate) fn new_unknown_generic(
+        &self,
+        name: Ident,
+        trait_constraints: VecSet<TraitConstraint>,
+        parent: Option<TypeId>,
+        is_from_type_parameter: bool,
+    ) -> TypeId {
+        self.new_unknown_generic_impl(TypeInfo::UnknownGeneric {
+            name,
+            trait_constraints,
+            parent,
+            is_from_type_parameter,
+        })
+    }
+
+    fn new_unknown_generic_impl(&self, unknown_generic: TypeInfo) -> TypeId {
+        let source_id = Self::get_unknown_generic_fallback_source_id(&unknown_generic);
+        let tsi = TypeSourceInfo {
+            type_info: unknown_generic.into(),
+            source_id,
+        };
+        TypeId::new(self.slab.insert(tsi))
+    }
+
+    /// Inserts a new [TypeInfo::UnknownGeneric] into the [TypeEngine]
+    /// that represents a `Self` type and returns its [TypeId].
+    /// The unknown generic `name` [Ident] will be set to "Self" with the provided `use_site_span`.
+    ///
+    /// Note that the span in general does not point to a reserved word "Self" in
+    /// the source code, nor is related to it. The `Self` type represents the type
+    /// in `impl`s and does not necessarily relate to the "Self" keyword in code.
+    ///
+    /// Therefore, *the span must always point to a location in the source file in which
+    /// the particular `Self` type is, e.g., being declared or implemented*.
+    ///
+    /// `is_from_type_parameter` denotes if the `Self` type is from type parameter or not.
+    pub(crate) fn new_unknown_generic_self(
+        &self,
+        use_site_span: Span,
+        is_from_type_parameter: bool,
+    ) -> TypeId {
+        let name = Ident::new_with_override("Self".into(), use_site_span);
+        self.new_unknown_generic(name.clone(), VecSet(vec![]), None, is_from_type_parameter)
+    }
+
+    /// Same as [Self::new_unknown_generic_self], except that, together with the [TypeId], it also returns the [Ident]
+    /// with the value "Self" and the provided `use_site_span`.
+    pub(crate) fn new_unknown_generic_self_with_name(
+        &self,
+        use_site_span: Span,
+        is_from_type_parameter: bool,
+    ) -> (TypeId, Ident) {
+        let name = Ident::new_with_override("Self".into(), use_site_span);
+        let type_id =
+            self.new_unknown_generic(name.clone(), VecSet(vec![]), None, is_from_type_parameter);
+        (type_id, name)
+    }
+
+    /// Inserts a new [TypeInfo::Enum] into the [TypeEngine] and returns
+    /// its [TypeId], or returns a [TypeId] of an existing shareable enum type
+    /// that corresponds to the enum given by the `decl_id`.
+    pub(crate) fn insert_enum(&self, engines: &Engines, decl_id: DeclId<TyEnumDecl>) -> TypeId {
+        let decl = engines.de().get_enum(&decl_id);
+        let source_id = Self::get_enum_fallback_source_id(&decl);
+        let is_shareable_type = self.is_shareable_enum(engines.de(), &decl);
+        let type_info = TypeInfo::Enum(decl_id);
+        self.insert_or_replace_type_source_info(
+            engines,
+            type_info,
+            source_id,
+            is_shareable_type,
+            None,
+        )
+    }
+
+    /// Inserts a new [TypeInfo::Struct] into the [TypeEngine] and returns
+    /// its [TypeId], or returns a [TypeId] of an existing shareable struct type
+    /// that corresponds to the struct given by the `decl_id`.
+    pub(crate) fn insert_struct(&self, engines: &Engines, decl_id: DeclId<TyStructDecl>) -> TypeId {
+        let decl = engines.de().get_struct(&decl_id);
+        let source_id = Self::get_struct_fallback_source_id(&decl);
+        let is_shareable_type = self.is_shareable_struct(engines.de(), &decl);
+        let type_info = TypeInfo::Struct(decl_id);
+        self.insert_or_replace_type_source_info(
+            engines,
+            type_info,
+            source_id,
+            is_shareable_type,
+            None,
+        )
+    }
+
+    /// Inserts a new [TypeInfo::Tuple] into the [TypeEngine] and returns
+    /// its [TypeId], or returns a [TypeId] of an existing shareable tuple type
+    /// that corresponds to the tuple given by the `elements`.
+    pub(crate) fn insert_tuple(&self, engines: &Engines, elements: Vec<TypeArgument>) -> TypeId {
+        let source_id = self.get_tuple_fallback_source_id(engines.de(), &elements);
+        let is_shareable_type = self.is_shareable_tuple(engines.de(), &elements);
+        let type_info = TypeInfo::Tuple(elements);
+        self.insert_or_replace_type_source_info(
+            engines,
+            type_info,
+            source_id,
+            is_shareable_type,
+            None,
+        )
+    }
+
+    /// Same as [Self::insert_tuple], but intended to be used mostly in the code generation,
+    /// where the tuple elements are non-annotated [TypeArgument]s that contain
+    /// only the [TypeId]s provided in the `elements`.
+    pub(crate) fn insert_tuple_without_annotations(
+        &self,
+        engines: &Engines,
+        elements: Vec<TypeId>,
+    ) -> TypeId {
+        self.insert_tuple(
+            engines,
+            elements.into_iter().map(|type_id| type_id.into()).collect(),
+        )
+    }
+
+    /// Inserts a new [TypeInfo::Array] into the [TypeEngine] and returns
+    /// its [TypeId], or returns a [TypeId] of an existing shareable array type
+    /// that corresponds to the array given by the `elem_type` and the `length`.
+    pub(crate) fn insert_array(
+        &self,
+        engines: &Engines,
+        elem_type: TypeArgument,
+        length: Length,
+    ) -> TypeId {
+        let source_id = self.get_array_fallback_source_id(engines.de(), &elem_type, &length);
+        let is_shareable_type = self.is_shareable_array(engines.de(), &elem_type, &length);
+        let type_info = TypeInfo::Array(elem_type, length);
+        self.insert_or_replace_type_source_info(
+            engines,
+            type_info,
+            source_id,
+            is_shareable_type,
+            None,
+        )
+    }
+
+    /// Same as [Self::insert_array], but intended to insert arrays without annotations.
+    // TODO: Unlike `insert_array`, once the https://github.com/FuelLabs/sway/issues/6603 gets implemented,
+    //       this method will get the additional `use_site_source_id` parameter.
+    pub(crate) fn insert_array_without_annotations(
+        &self,
+        engines: &Engines,
+        elem_type: TypeId,
+        length: usize,
+    ) -> TypeId {
+        self.insert_array(engines, elem_type.into(), Length::new(length))
+    }
+
+    /// Inserts a new [TypeInfo::StringArray] into the [TypeEngine] and returns
+    /// its [TypeId], or returns a [TypeId] of an existing shareable string array type
+    /// that corresponds to the string array given by the `length`.
+    pub(crate) fn insert_string_array(&self, engines: &Engines, length: Length) -> TypeId {
+        let source_id = Self::get_string_array_fallback_source_id(&length);
+        let is_shareable_type = self.is_shareable_string_array(&length);
+        let type_info = TypeInfo::StringArray(length);
+        self.insert_or_replace_type_source_info(
+            engines,
+            type_info,
+            source_id,
+            is_shareable_type,
+            None,
+        )
+    }
+
+    /// Same as [Self::insert_string_array], but intended to insert string arrays without annotations.
+    // TODO: Unlike `insert_string_array`, once the https://github.com/FuelLabs/sway/issues/6603 gets implemented,
+    //       this method will get the additional `use_site_source_id` parameter.
+    pub(crate) fn insert_string_array_without_annotations(
+        &self,
+        engines: &Engines,
+        length: usize,
+    ) -> TypeId {
+        self.insert_string_array(engines, Length::new(length))
+    }
+
+    /// Inserts a new [TypeInfo::ContractCaller] into the [TypeEngine] and returns its [TypeId].
+    ///
+    /// [TypeInfo::ContractCaller] is not a shareable type and the method
+    /// guarantees that a new (or unused) [TypeId] will be returned on every
+    /// call.
+    pub(crate) fn new_contract_caller(
+        &self,
+        engines: &Engines,
+        abi_name: AbiName,
+        address: Option<Box<TyExpression>>,
+    ) -> TypeId {
+        // The contract caller type shareability would be calculated as:
+        //
+        //   !(Self::is_replaceable_contract_caller(abi_name, address)
+        //     ||
+        //     Self::is_contract_caller_distinguishable_by_annotations(abi_name, address))
+        //
+        // If the contract caller is replaceable, either the `abi_name` id `Deferred` or the `address` is `None`.
+        // On the other hand, if the `abi_name` is `Known` or the `address` is `Some`, it will be distinguishable by annotations.
+        // Which means, it will be either replaceable or distinguishable by annotations, which makes the condition always
+        // evaluating to false.
+        //
+        // The fact that we cannot share `ContractCaller`s is not an issue. In any real-life project, the number of contract callers
+        // will be negligible, order of magnitude of ~10.
+        let source_id = Self::get_contract_caller_fallback_source_id(&abi_name, &address);
+        let type_info = TypeInfo::ContractCaller { abi_name, address };
+        self.insert_or_replace_type_source_info(engines, type_info, source_id, false, None)
+    }
+
+    /// Inserts a new [TypeInfo::Alias] into the [TypeEngine] and returns its [TypeId].
+    ///
+    /// [TypeInfo::ContractCaller] is not a shareable type and the method
+    /// guarantees that a new (or unused) [TypeId] will be returned on every
+    /// call.
+    pub(crate) fn new_alias(&self, engines: &Engines, name: Ident, ty: TypeArgument) -> TypeId {
+        // The alias type shareability would be calculated as `!(false || true) ==>> false`.
+        let source_id = self.get_alias_fallback_source_id(engines.de(), &name, &ty);
+        let type_info = TypeInfo::Alias { name, ty };
+        self.insert_or_replace_type_source_info(engines, type_info, source_id, false, None)
+    }
+
+    /// Inserts a new [TypeInfo::Custom] into the [TypeEngine] and returns its [TypeId].
+    ///
+    /// [TypeInfo::Custom] is not a shareable type and the method
+    /// guarantees that a new (or unused) [TypeId] will be returned on every
+    /// call.
+    pub(crate) fn new_custom(
+        &self,
+        engines: &Engines,
+        qualified_call_path: QualifiedCallPath,
+        type_arguments: Option<Vec<TypeArgument>>,
+        root_type_id: Option<TypeId>,
+    ) -> TypeId {
+        let source_id = self.get_custom_fallback_source_id(
+            engines.de(),
+            &qualified_call_path,
+            &type_arguments,
+            &root_type_id,
+        );
+        // The custom type shareability would be calculated as `!(true || true) ==>> false`.
+        // TODO: Improve handling of `TypeInfo::Custom` and `TypeInfo::TraitType`` within the `TypeEngine`:
+        //       https://github.com/FuelLabs/sway/issues/6601
+        let is_shareable_type = false;
+        let type_info = TypeInfo::Custom {
+            qualified_call_path,
+            type_arguments,
+            root_type_id,
+        };
+        self.insert_or_replace_type_source_info(
+            engines,
+            type_info,
+            source_id,
+            is_shareable_type,
+            None,
+        )
+    }
+
+    /// Inserts a new [TypeInfo::Custom] into the [TypeEngine] and returns its [TypeId].
+    /// The custom type is defined only by its `name`. In other words, it does not have
+    /// the qualified call path or type arguments. This is a very common situation in
+    /// the code that just uses the type name, like, e.g., when instantiating structs:
+    ///
+    /// ```ignore
+    /// let _ = Struct { };
+    /// ```
+    ///
+    /// [TypeInfo::Custom] is not a shareable type and the method
+    /// guarantees that a new (or unused) [TypeId] will be returned on every
+    /// call.
+    pub(crate) fn new_custom_from_name(&self, engines: &Engines, name: Ident) -> TypeId {
+        self.new_custom(engines, name.into(), None, None)
+    }
+
+    /// Creates a new [TypeInfo::Custom] that represents a Self type.
+    ///
+    /// The `span` must either be a [Span::dummy] or a span pointing
+    /// to text "Span" or "span", otherwise the method panics.
+    ///
+    /// [TypeInfo::Custom] is not a shareable type and the method
+    /// guarantees that a new (or unused) [TypeId] will be returned on every
+    /// call.
+    pub(crate) fn new_self_type(&self, engines: &Engines, span: Span) -> TypeId {
+        let source_id = span.source_id().copied();
+        // The custom type shareability would be calculated as `!(true || true) ==>> false`.
+        // TODO: Improve handling of `TypeInfo::Custom` and `TypeInfo::TraitType`` within the `TypeEngine`:
+        //       https://github.com/FuelLabs/sway/issues/6601
+        let is_shareable_type = false;
+        let type_info = TypeInfo::new_self_type(span);
+        self.insert_or_replace_type_source_info(
+            engines,
+            type_info,
+            source_id,
+            is_shareable_type,
+            None,
+        )
+    }
+
+    /// Inserts a new [TypeInfo::Slice] into the [TypeEngine] and returns
+    /// its [TypeId], or returns a [TypeId] of an existing shareable slice type
+    /// that corresponds to the slice given by the `elem_type`.
+    pub(crate) fn insert_slice(&self, engines: &Engines, elem_type: TypeArgument) -> TypeId {
+        let source_id = self.get_slice_fallback_source_id(engines.de(), &elem_type);
+        let is_shareable_type = self.is_shareable_slice(engines.de(), &elem_type);
+        let type_info = TypeInfo::Slice(elem_type);
+        self.insert_or_replace_type_source_info(
+            engines,
+            type_info,
+            source_id,
+            is_shareable_type,
+            None,
+        )
+    }
+
+    /// Inserts a new [TypeInfo::Ptr] into the [TypeEngine] and returns
+    /// its [TypeId], or returns a [TypeId] of an existing shareable pointer type
+    /// that corresponds to the pointer given by the `pointee_type`.
+    pub(crate) fn insert_ptr(&self, engines: &Engines, pointee_type: TypeArgument) -> TypeId {
+        let source_id = self.get_ptr_fallback_source_id(engines.de(), &pointee_type);
+        let is_shareable_type = self.is_shareable_ptr(engines.de(), &pointee_type);
+        let type_info = TypeInfo::Ptr(pointee_type);
+        self.insert_or_replace_type_source_info(
+            engines,
+            type_info,
+            source_id,
+            is_shareable_type,
+            None,
+        )
+    }
+
+    /// Inserts a new [TypeInfo::Ref] into the [TypeEngine] and returns
+    /// its [TypeId], or returns a [TypeId] of an existing shareable reference type
+    /// that corresponds to the reference given by the `referenced_type` and `to_mutable_value`.
+    pub(crate) fn insert_ref(
+        &self,
+        engines: &Engines,
+        to_mutable_value: bool,
+        referenced_type: TypeArgument,
+    ) -> TypeId {
+        let source_id = self.get_ref_fallback_source_id(engines.de(), &referenced_type);
+        let is_shareable_type = self.is_shareable_ref(engines.de(), &referenced_type);
+        let type_info = TypeInfo::Ref {
+            to_mutable_value,
+            referenced_type,
+        };
+        self.insert_or_replace_type_source_info(
+            engines,
+            type_info,
+            source_id,
+            is_shareable_type,
+            None,
+        )
+    }
+
+    /// Inserts a new [TypeInfo::TraitType] into the [TypeEngine] and returns
+    /// its [TypeId], or returns a [TypeId] of an existing shareable trait type type
+    /// that corresponds to the trait type given by the `name` and `trait_type_id`.
+    pub(crate) fn insert_trait_type(
+        &self,
+        engines: &Engines,
+        name: Ident,
+        trait_type_id: TypeId,
+    ) -> TypeId {
+        let source_id = self.get_trait_type_fallback_source_id(engines.de(), &name, &trait_type_id);
+        // The trait type type shareability would be calculated as `!(false || false) ==>> true`.
+        // TODO: Improve handling of `TypeInfo::Custom` and `TypeInfo::TraitType`` within the `TypeEngine`:
+        //       https://github.com/FuelLabs/sway/issues/6601
+        let is_shareable_type = true;
+        let type_info = TypeInfo::TraitType {
+            name,
+            trait_type_id,
+        };
+        self.insert_or_replace_type_source_info(
+            engines,
+            type_info,
+            source_id,
+            is_shareable_type,
+            None,
+        )
+    }
+
+    /// Same as [Self::insert_ref], but intended to insert references without annotations.
+    // TODO: Unlike `insert_ref`, once the https://github.com/FuelLabs/sway/issues/6603 gets implemented,
+    //       this method will get the additional `use_site_source_id` parameter.
+    pub(crate) fn insert_ref_without_annotations(
+        &self,
+        engines: &Engines,
+        to_mutable_value: bool,
+        referenced_type: TypeId,
+    ) -> TypeId {
+        self.insert_ref(engines, to_mutable_value, referenced_type.into())
+    }
+
     /// Inserts a [TypeInfo] into the [TypeEngine] and returns a [TypeId]
     /// referring to that [TypeInfo].
     pub(crate) fn insert(
@@ -69,30 +801,855 @@ impl TypeEngine {
         ty: TypeInfo,
         source_id: Option<&SourceId>,
     ) -> TypeId {
-        let source_id = source_id.copied().or_else(|| info_to_source_id(&ty));
-        let tsi = TypeSourceInfo {
-            type_info: ty.clone().into(),
-            source_id,
-        };
-        let mut id_map = self.id_map.write();
+        // Avoid all of the heavy lifting of inserting and replacing logic, if `ty` is a shareable built-in type.
+        //
+        // Note that we are ignoring here the eventual `source_id` that could be provided by the caller.
+        // Ideally, for shareable built-in types that should never be the case, but `insert` is called in
+        // rare cases where the `ty` is not known and not inspected and is usually providing the use site span.
+        //
+        // The reason for ignoring the `source_id` is, because we want these types to be reused and "live forever"
+        // and never be garbage-collected and thus we do not assign any source id to them.
+        if let Some(type_id) = self.get_shareable_built_in_type_id(&ty) {
+            return type_id;
+        }
 
-        let hash_builder = id_map.hasher().clone();
-        let ty_hash = make_hasher(&hash_builder, engines)(&tsi);
+        // Same for the replaceable types, avoid heavy lifting.
+        // Note that we don't want to pack this `match` into a method, because we want to avoid cloning
+        // of `ty` in the case of it being a `Placeholder` or `UnknownGeneric`.
+        //
+        // TODO: Also, note that also here we are ignoring the `source_id` provided by the caller.
+        //       This is only temporary until https://github.com/FuelLabs/sway/issues/6603 gets implemented.
+        //       Until then, this shortcut corresponds to the current `TypeEngine` behavior:
+        //       - `Unknown`s and `Numeric`s never have `source_id` assigned.
+        //       - for `Placeholder`s and `UnknownGeneric`s, the `source_id` is extracted from the call site.
+        match ty {
+            TypeInfo::Unknown => return self.new_unknown(),
+            TypeInfo::Numeric => return self.new_numeric(),
+            TypeInfo::Placeholder(_) => return self.new_placeholder_impl(engines.de(), ty),
+            TypeInfo::UnknownGeneric { .. } => return self.new_unknown_generic_impl(ty),
+            _ => (),
+        }
 
-        let raw_entry = id_map.raw_entry_mut().from_hash(ty_hash, |x| {
-            x.eq(&tsi, &PartialEqWithEnginesContext::new(engines))
-        });
-        match raw_entry {
-            RawEntryMut::Occupied(o) => return *o.get(),
-            RawEntryMut::Vacant(_) if ty.can_change(engines.de()) => {
-                TypeId::new(self.slab.insert(tsi))
+        let is_shareable_type = self.is_type_shareable(engines.de(), &ty);
+        let source_id = source_id
+            .copied()
+            .or_else(|| self.get_type_fallback_source_id(engines.de(), &ty));
+
+        self.insert_or_replace_type_source_info(engines, ty, source_id, is_shareable_type, None)
+    }
+
+    /// This method performs two actions, depending on the `replace_at_type_id`.
+    ///
+    /// If the `replace_at_type_id` is `Some`, this indicates that we want to unconditionally replace the [TypeSourceInfo]
+    /// currently located at `replace_at_type_id` with the one made of the `ty` + `source_id` pair.
+    /// In the case of replacement the method always return the [TypeId] provided in `replace_at_type_id`.
+    ///
+    /// If the `replace_at_type_id` is `None`, this indicates that we want to insert the [TypeSourceInfo], made of the
+    /// `ty` + `source_id` pair, into the `TypeEngine`. The insertion into the engine might require a new insert into
+    /// the `slab` or just returning a [TypeId] of an existing shareable [TypeSourceInfo] that is equal to the one defined by
+    /// the `ty` + `source_id` pair.
+    ///
+    /// If a new insertion is always made, or a reuse is possible, depends on the shareability of `ty` that is given by
+    /// `is_shareable_type`.
+    fn insert_or_replace_type_source_info(
+        &self,
+        engines: &Engines,
+        ty: TypeInfo,
+        source_id: Option<SourceId>,
+        is_shareable_type: bool,
+        replace_at_type_id: Option<TypeId>,
+    ) -> TypeId {
+        if !is_shareable_type {
+            let tsi = TypeSourceInfo {
+                type_info: ty.into(),
+                source_id,
+            };
+            match replace_at_type_id {
+                Some(existing_id) => {
+                    self.slab.replace(existing_id.index(), tsi);
+                    existing_id
+                }
+                None => TypeId::new(self.slab.insert(tsi)),
             }
-            RawEntryMut::Vacant(v) => {
-                let type_id = TypeId::new(self.slab.insert(tsi.clone()));
-                v.insert_with_hasher(ty_hash, tsi, type_id, make_hasher(&hash_builder, engines));
-                type_id
+        } else {
+            let mut shareable_types = self.shareable_types.write();
+
+            let hash_builder = shareable_types.hasher().clone();
+            let ty_hash =
+                self.compute_hash_without_heap_allocation(engines, &hash_builder, &ty, &source_id);
+
+            let raw_entry = shareable_types.raw_entry_mut().from_hash(ty_hash, |x| {
+                // Not that the equality with engines of the types contained in the
+                // `shareable_types` is "strict" in the sense that only one element can equal.
+                // This is because the types that have annotation fields, a.k.a. distinguishable by
+                // annotations types, will never end up in the hash map because they are considered
+                // not to be shareable.
+                x.equals(&ty, &source_id, &PartialEqWithEnginesContext::new(engines))
+            });
+            match raw_entry {
+                RawEntryMut::Occupied(o) => match replace_at_type_id {
+                    Some(existing_id) => {
+                        let existing_type_source_info = o.key();
+                        self.slab
+                            .replace_arc(existing_id.index(), existing_type_source_info.clone());
+                        existing_id
+                    }
+                    None => *o.get(),
+                },
+                RawEntryMut::Vacant(v) => {
+                    let tsi = TypeSourceInfo {
+                        type_info: ty.into(),
+                        source_id,
+                    };
+                    let tsi_arc = Arc::new(tsi);
+                    let type_id = TypeId::new(self.slab.insert_arc(tsi_arc.clone()));
+                    v.insert_with_hasher(
+                        ty_hash,
+                        tsi_arc.clone(),
+                        type_id,
+                        make_hasher(&hash_builder, engines),
+                    );
+                    match replace_at_type_id {
+                        Some(existing_id) => {
+                            self.slab.replace_arc(existing_id.index(), tsi_arc);
+                            existing_id
+                        }
+                        None => type_id,
+                    }
+                }
             }
         }
+    }
+
+    /// Computes the same hash as the [Hasher] returned by [make_hasher] but without
+    /// allocating a new [TypeInfo] on the heap.
+    fn compute_hash_without_heap_allocation(
+        &self,
+        engines: &Engines,
+        hash_builder: &impl BuildHasher,
+        type_info: &TypeInfo,
+        source_id: &Option<SourceId>,
+    ) -> u64 {
+        let mut state = hash_builder.build_hasher();
+        type_info.hash(&mut state, engines);
+        source_id.hash(&mut state);
+        state.finish()
+    }
+
+    /// Returns true if the `ty` is a type that can be replaced by using
+    /// the [Self::replace] method during the type unification.
+    fn is_replaceable_type(ty: &TypeInfo) -> bool {
+        match ty {
+            TypeInfo::Unknown
+            | TypeInfo::Numeric
+            | TypeInfo::Placeholder(_)
+            | TypeInfo::UnknownGeneric { .. } => true,
+            TypeInfo::ContractCaller { abi_name, address } => {
+                Self::is_replaceable_contract_caller(abi_name, address)
+            }
+            _ => false,
+        }
+    }
+
+    fn is_replaceable_contract_caller(
+        abi_name: &AbiName,
+        address: &Option<Box<TyExpression>>,
+    ) -> bool {
+        address.is_none() || matches!(abi_name, AbiName::Deferred)
+    }
+
+    /// Returns true if the `ty` is a shareable type.
+    ///
+    /// A shareable type instance can be reused by the engine and is put into the [Self::shareable_types].
+    fn is_type_shareable(&self, decl_engine: &DeclEngine, ty: &TypeInfo) -> bool {
+        !(self.is_type_changeable(decl_engine, ty)
+            || self.is_type_distinguishable_by_annotations(ty))
+    }
+
+    /// Returns true if the `ty` is a changeable type. A changeable type is either:
+    /// - a type that can be replaced during the type unification (by calling [Self::replace]).
+    ///   We call such types replaceable types. A typical example would be [TypeInfo::UnknownGeneric].
+    /// - or a type that is recursively defined over one or more replaceable types. E.g., a
+    ///   generic enum type `SomeEnum<T>` that is still not monomorphized is a changeable type.
+    ///   Note that a monomorphized version of `SomeEnum`, like e.g., `SomeEnum<u64>` *is not
+    ///   changeable*.
+    ///
+    /// Note that the changeability of a type is tightly related to the unification process
+    /// and the process of handling the types within the [TypeEngine]. As such, it is not
+    /// seen as a property of a type itself, but rather as an information on how the [TypeEngine]
+    /// treats the type. That's why the definition of the changeability of a type resides
+    /// inside of the [TypeEngine].
+    pub(crate) fn is_type_changeable(&self, decl_engine: &DeclEngine, ty: &TypeInfo) -> bool {
+        match ty {
+            // Shareable built-in types are unchangeable by definition.
+            // These type have only one shared `TypeInfo` instance per type
+            // (and one for each unsigned integer).
+            TypeInfo::StringSlice
+            | TypeInfo::UnsignedInteger(_)
+            | TypeInfo::Boolean
+            | TypeInfo::B256
+            | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
+            | TypeInfo::ErrorRecovery(_)
+            | TypeInfo::Contract
+            | TypeInfo::Never => false,
+
+            // Note that `TypeParam` is currently not used at all.
+            TypeInfo::TypeParam(_) => false,
+
+            // `StringArray`s are not changeable. We will have one shared
+            // `TypeInfo` instance for every string size. Note that in case
+            // of explicitly defined string arrays, e.g. in the storage or type ascriptions
+            // like `str[5]`, we can also have different instances for string
+            // arrays of the same size, because the `Length` in that case contains
+            // as well the span of the size (`5` in the example).
+            TypeInfo::StringArray(_) => false,
+
+            // Replaceable types are, by definition, changeable.
+            TypeInfo::Unknown
+            | TypeInfo::Numeric
+            | TypeInfo::Placeholder(_)
+            | TypeInfo::UnknownGeneric { .. } => true,
+
+            // The `ContractCaller` can be replaceable, and thus, sometimes changeable.
+            TypeInfo::ContractCaller { abi_name, address } => {
+                Self::is_replaceable_contract_caller(abi_name, address)
+            }
+
+            // For the types are defined over other types, inspect recursively their constituting types.
+            TypeInfo::Enum(decl_id) => {
+                let decl = decl_engine.get_enum(decl_id);
+                self.is_changeable_enum(decl_engine, &decl)
+            }
+            TypeInfo::Struct(decl_id) => {
+                let decl = decl_engine.get_struct(decl_id);
+                self.is_changeable_struct(decl_engine, &decl)
+            }
+            TypeInfo::Tuple(elements) => self.is_changeable_tuple(decl_engine, elements),
+
+            // Currently, we support only non-generic aliases. Which means the alias
+            // will never be changeable.
+            // TODO: (GENERIC-TYPE-ALIASES) If we ever introduce generic type aliases, update this accordingly.
+            TypeInfo::Alias { name: _, ty: _ } => false,
+
+            // The following types are changeable if their type argument is changeable.
+            TypeInfo::Array(ta, _)
+            | TypeInfo::Slice(ta)
+            | TypeInfo::Ptr(ta)
+            | TypeInfo::Ref {
+                referenced_type: ta,
+                ..
+            } => self.is_changeable_type_argument(decl_engine, ta),
+
+            // TODO: Improve handling of `TypeInfo::Custom` and `TypeInfo::TraitType`` within the `TypeEngine`:
+            //       https://github.com/FuelLabs/sway/issues/6601
+            TypeInfo::Custom { .. } => true,
+            TypeInfo::TraitType { .. } => false,
+        }
+    }
+
+    /// Returns true if two [TypeInfo] instances that are equal (with engines) and have same hashes (with engines)
+    /// should potentially still be treated, within the type engine, as different types.
+    ///
+    /// [TypeParameter]s, [TypeArgument]s, and [Length]s can be "annotated". This means that, aside from the information they
+    /// provide, like, e.g., [TypeArgument::type_id] or [Length::val], they can also, optionally, provide additional information
+    /// most notably various spans.
+    ///
+    /// Same is with [Ident]s. From the hashing and equality (with engines) perspective, only the string value matters,
+    /// but from the strict equality point of view, [Ident]'s span is also relevant.
+    ///
+    /// Thus, from the unification and type equivalence perspective, two [TypeArgument]s with the same `type_id` represent
+    /// the same type. But if those two type arguments differ in their annotations, the [TypeEngine] must be able to distinguish between
+    /// the equal (from the unification perspective) types that use those two different type arguments.
+    ///
+    /// In this example:
+    ///
+    /// ```ignore
+    ///   let a: [u64;3] = (0, 0, 0);
+    ///   let b: [u64;3] = (0, 0, 0);
+    /// ```
+    ///
+    /// `a` and `b` will have the same type, but the span annotations in their [TypeArgument]s and [Length]s will be different
+    /// (different spans pointing to two "u64"s and two "3"s) and thus the [TypeEngine] must treat those two types as two
+    /// different types and when inserting them, assign them two different [TypeId]s, although the types themselves are not
+    /// changeable.
+    ///
+    /// To sum it up:
+    /// - if the `ty` consists of [TypeArgument]s, [TypeParameter]s, or [Length]s, they myst be check for annotations.
+    /// - if the `ty` contains, e.g., [Ident]s, it is considered to be distinguishable by annotations.
+    fn is_type_distinguishable_by_annotations(&self, ty: &TypeInfo) -> bool {
+        match ty {
+            // Types that do not have any annotations.
+            TypeInfo::StringSlice
+            | TypeInfo::UnsignedInteger(_)
+            | TypeInfo::Boolean
+            | TypeInfo::B256
+            | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
+            | TypeInfo::ErrorRecovery(_)
+            | TypeInfo::Never
+            | TypeInfo::Unknown
+            | TypeInfo::Numeric
+            | TypeInfo::Contract
+            | TypeInfo::TypeParam(_) => false,
+
+            // Types that are always distinguishable because they have the `name: Ident`.
+            //
+            // Let's explain this in more detail, taking the `TypeInfo::Alias` as an example.
+            // `TypeInfo::Alias` consists of the `name: Ident` and the `ty: TypeArgument`.
+            //
+            // Consider that we have two aliases with the same name and aliasing the same type but defined in different modules.
+            // Thus, they would be two _different_ alias types. But because the spans in the `name` and `ty` do not count
+            // neither for the equality check nor for the hash calculation, those two types will always be equal (with engines)
+            // and also have the same hashes (with engines).
+            //
+            // This means that the `TypeEngine` would see them as the same type which would be wrong.
+            // The fact that they are always distinguishable by annotations (span in the `name` and spans in the `ty`)
+            // is actually a fortunate fact here, because it will help the `TypeEngine` to distinguish them.
+            //
+            // The consequence of this fact is, that all `TypeInfo::Alias`es are _always distinguishable by annotations_.
+            //
+            // The downside is that repeated usages of an actually *same* alias type will create
+            // unnecessary new instances in the `TypeEngine` for every usage :-(
+            //
+            // Luckily, `TraitType`s and `Alias`es are rarely used and the number of their instances
+            // within the `TypeEngine` will always be negligible, so we don't need to worry about this downside.
+            // (At the time of writing this comment, out of ~200,000 types in the `TypeEngine` in a
+            // realistic real-world project only ~20 were type aliases and only ~5 were trait types.)
+            // And the `UnknownGeneric` is anyhow a changeable type.
+            TypeInfo::UnknownGeneric { .. }
+            // | TypeInfo::TraitType { .. }
+            | TypeInfo::Alias { .. } => true,
+
+            TypeInfo::StringArray(l) => l.is_annotated(),
+
+            // If the contract caller has the `abi_name` defined (AbiName::Know) the span information
+            // that comes with the `Ident`s of the `CallPath` is not relevant for the equality
+            // and hashing (with engines) but makes two same names distinguishable. The same thing is
+            // with the `address` expression. It can be, e.g., the same literal, but it will have different
+            // spans. Moreover, the same `abi_name`, depending on the context, can represent different
+            // ABI declarations, like in the example below:
+            //
+            //   fn a() {
+            //       use ::lib_a::Abi as Abi; // <<<--- `Abi` coming from `lib_**a**`.
+            //       let _ = abi(Abi, 0x1111111111111111111111111111111111111111111111111111111111111111);
+            //   }
+
+            //   fn b() {
+            //       use ::lib_b::Abi as Abi; // <<<--- `Abi` coming from `lib_**b**`.
+            //       let _ = abi(Abi, 0x1111111111111111111111111111111111111111111111111111111111111111);
+            //   }
+            //
+            // This all means, if a `ContractCaller` has either the `abi_name` or the `address` defined,
+            // it is distinguishable by annotations.
+            TypeInfo::ContractCaller { abi_name, address } => Self::is_contract_caller_distinguishable_by_annotations(abi_name, address),
+
+            // Enums `decl`s are either coming from enum declarations,
+            // or from their monomorphizations. If an enum declaration is generic,
+            // its type parameters will always be annotated, having, e.g., spans of
+            // generic parameter names, like, e.g., "T".
+            // Also, all the enum variants have `TypeArguments` that are _always_ annotated
+            // with the type span.
+            //
+            // In other words, all `TyEnumDecl`s are annotated.
+            // The question is, if the monomorphization can produce two same `decl`s that
+            // are differently annotated. E.g., when unifying the generic parameter "T" with "u64",
+            // like in the below example, will the span of the type parameter "T" change
+            // to "u64":
+            //
+            //   let _ = GenericEnum::<u64>::A(42u64);
+            //   let _ = GenericEnum::<u64>::A(42u64);
+            //
+            // In that case, the two equal `decl`s obtained via two monomorphizations above,
+            // would be differently annotated, and thus, distinguishable by annotations.
+            // 
+            // The answer is *no*. The monomorphization changes only the `TypeId`s of the
+            // `TypeParameter`s and `TypeArgument`s but leaves the original spans untouched.
+            // Therefore, we can never end up in a situation that an annotation differs from
+            // the one in the original `TyEnumDecl` coming from the enum declaration.
+            //
+            // Thus, any two equal `TyEnumDecl`s are never distinguishable by annotations.
+            TypeInfo::Enum(_) => false,
+
+            // The same argument as above applies to struct and `TyStructDecl`s.
+            TypeInfo::Struct(_) => false,
+
+            // Equal (with engines) tuple types can have different annotations and are in that case
+            // distinguishable by those annotations. E.g., in the example below, the two
+            // `(u64, u8)` tuples will have different spans for two "u64"s and two "u8"s.
+            //
+            //   let _: (u64, u8) = (64u64, 8u8);
+            //   let _: (u64, u8) = (64u64, 8u8);
+            //
+            // Note that _all the tuples used in code will always be distinguishable by annotations_,
+            // because they will always have spans either pointing to the values like in `(64u64, 8u8)`
+            // or to types like in `(u64, u8)`.
+            //
+            // Only the tuples used in generated code will not be distinguishable by annotations,
+            // as well as tuples representing unit types.
+            TypeInfo::Tuple(elements) => self.is_tuple_distinguishable_by_annotations(elements),
+
+            // The below types are those have `TypeArgument`s (`ta`s) in their definitions.
+            // Note that we are checking only if those `ta`s are annotated, but not
+            // recursively if the types they "reference" are annotated ;-)
+            // We don't need to recursively check if the types behind
+            // the `ta.type_id`s are distinguishable by annotations.
+            // This is because two equal (with engines) parent types
+            // containing `ta`s that pass the above check are also equal in
+            // case when their full type argument content is compared,
+            // because the type arguments will be equal in all their fields.
+
+            TypeInfo::Slice(ta)
+            | TypeInfo::Ptr(ta)
+            | TypeInfo::Ref { referenced_type: ta, .. } => ta.is_annotated(),
+
+            TypeInfo::Array(ta, l) => {
+                ta.is_annotated() || l.is_annotated()
+            }
+
+            // The above reasoning for `TypeArgument`s applies also for the `TypeParameter`s.
+            // We only need to check if the `tp` is annotated.
+            TypeInfo::Placeholder(tp) => tp.is_annotated(),
+
+            // TODO: Improve handling of `TypeInfo::Custom` and `TypeInfo::TraitType`` within the `TypeEngine`:
+            //       https://github.com/FuelLabs/sway/issues/6601
+            TypeInfo::Custom { .. } => true,
+            TypeInfo::TraitType { .. } => false,
+        }
+    }
+
+    fn is_tuple_distinguishable_by_annotations(&self, elements: &[TypeArgument]) -> bool {
+        if elements.is_empty() {
+            false
+        } else {
+            elements.iter().any(|ta| ta.is_annotated())
+        }
+    }
+
+    fn is_contract_caller_distinguishable_by_annotations(
+        abi_name: &AbiName,
+        address: &Option<Box<TyExpression>>,
+    ) -> bool {
+        address.is_some() || matches!(abi_name, AbiName::Known(_))
+    }
+
+    /// Returns true if the `type_id` represents a changeable type.
+    /// For the type changeability see [Self::is_type_changeable].
+    fn is_type_id_of_changeable_type(&self, decl_engine: &DeclEngine, type_id: TypeId) -> bool {
+        self.is_type_changeable(decl_engine, &self.slab.get(type_id.index()).type_info)
+    }
+
+    fn is_changeable_type_argument(&self, decl_engine: &DeclEngine, ta: &TypeArgument) -> bool {
+        self.is_type_id_of_changeable_type(decl_engine, ta.type_id)
+    }
+
+    fn is_changeable_enum(&self, decl_engine: &DeclEngine, decl: &TyEnumDecl) -> bool {
+        if decl.type_parameters.is_empty() {
+            false
+        } else {
+            decl.type_parameters
+                .iter()
+                .any(|tp| self.is_type_id_of_changeable_type(decl_engine, tp.type_id))
+        }
+    }
+
+    fn is_changeable_struct(&self, decl_engine: &DeclEngine, decl: &TyStructDecl) -> bool {
+        if decl.type_parameters.is_empty() {
+            false
+        } else {
+            decl.type_parameters
+                .iter()
+                .any(|tp| self.is_type_id_of_changeable_type(decl_engine, tp.type_id))
+        }
+    }
+
+    fn is_changeable_tuple(&self, decl_engine: &DeclEngine, elements: &[TypeArgument]) -> bool {
+        if elements.is_empty() {
+            false
+        } else {
+            elements
+                .iter()
+                .any(|ta| self.is_type_id_of_changeable_type(decl_engine, ta.type_id))
+        }
+    }
+
+    // In the `is_shareable_<type>` methods we reuse the logic from the
+    // `is_type_changeable` and `is_type_distinguishable_by_annotations`.
+    // This is a very slight and minimal copy of logic, that improves performance
+    // (Inlining, no additional fetching from the `DeclEngine`, no intensive function
+    // calls, etc. Don't forget that this is all on a *very* hot path.)
+
+    fn is_shareable_enum(&self, decl_engine: &DeclEngine, decl: &TyEnumDecl) -> bool {
+        // !(self.is_changeable_enum(decl_engine, decl) || false)
+        !self.is_changeable_enum(decl_engine, decl)
+    }
+
+    fn is_shareable_struct(&self, decl_engine: &DeclEngine, decl: &TyStructDecl) -> bool {
+        // !(self.is_changeable_struct(decl_engine, decl) || false)
+        !self.is_changeable_struct(decl_engine, decl)
+    }
+
+    fn is_shareable_tuple(&self, decl_engine: &DeclEngine, elements: &[TypeArgument]) -> bool {
+        !(self.is_changeable_tuple(decl_engine, elements)
+            || self.is_tuple_distinguishable_by_annotations(elements))
+    }
+
+    fn is_shareable_array(
+        &self,
+        decl_engine: &DeclEngine,
+        elem_type: &TypeArgument,
+        length: &Length,
+    ) -> bool {
+        !(self.is_changeable_type_argument(decl_engine, elem_type)
+            || elem_type.is_annotated()
+            || length.is_annotated())
+    }
+
+    fn is_shareable_string_array(&self, length: &Length) -> bool {
+        // !(false || length.is_annotated())
+        !length.is_annotated()
+    }
+
+    fn is_shareable_slice(&self, decl_engine: &DeclEngine, elem_type: &TypeArgument) -> bool {
+        !(self.is_changeable_type_argument(decl_engine, elem_type) || elem_type.is_annotated())
+    }
+
+    fn is_shareable_ptr(&self, decl_engine: &DeclEngine, pointee_type: &TypeArgument) -> bool {
+        !(self.is_changeable_type_argument(decl_engine, pointee_type)
+            || pointee_type.is_annotated())
+    }
+
+    fn is_shareable_ref(&self, decl_engine: &DeclEngine, referenced_type: &TypeArgument) -> bool {
+        !(self.is_changeable_type_argument(decl_engine, referenced_type)
+            || referenced_type.is_annotated())
+    }
+
+    // TODO: This and other, type-specific, methods that calculate `source_id` have `fallback` in their name.
+    //       They will be called if the `source_id` is not provided in `new` or `insert` methods,
+    //       thus, fallbacks.
+    //       However, some of them actually do calculate the appropriate `source_id` which will for certain
+    //       types and situations always be extracted from the `TypeInfo` and not allowed to be provided
+    //       in `new` or `insert` methods.
+    //       Until https://github.com/FuelLabs/sway/issues/6603 gets implemented, we will call them all
+    //       fallbacks, which corresponds to the current usage, and eventually rename them accordingly
+    //       once we optimize the `TypeEngine` for garbage collection (#6603).
+
+    fn get_type_fallback_source_id(
+        &self,
+        decl_engine: &DeclEngine,
+        ty: &TypeInfo,
+    ) -> Option<SourceId> {
+        match ty {
+            TypeInfo::Unknown
+            | TypeInfo::Never
+            | TypeInfo::TypeParam(_)
+            | TypeInfo::UnsignedInteger(_)
+            | TypeInfo::Boolean
+            | TypeInfo::B256
+            | TypeInfo::Numeric
+            | TypeInfo::ErrorRecovery(_)
+            | TypeInfo::RawUntypedPtr
+            | TypeInfo::RawUntypedSlice
+            | TypeInfo::Contract
+            | TypeInfo::StringSlice => None,
+
+            TypeInfo::UnknownGeneric { .. } => Self::get_unknown_generic_fallback_source_id(ty),
+            TypeInfo::Placeholder(_) => self.get_placeholder_fallback_source_id(decl_engine, ty),
+            TypeInfo::StringArray(length) => Self::get_source_id_from_length(length),
+            TypeInfo::Enum(decl_id) => {
+                let decl = decl_engine.get_enum(decl_id);
+                Self::get_enum_fallback_source_id(&decl)
+            }
+            TypeInfo::Struct(decl_id) => {
+                let decl = decl_engine.get_struct(decl_id);
+                Self::get_struct_fallback_source_id(&decl)
+            }
+            TypeInfo::Tuple(elements) => self.get_tuple_fallback_source_id(decl_engine, elements),
+            TypeInfo::Array(elem_type, length) => {
+                self.get_array_fallback_source_id(decl_engine, elem_type, length)
+            }
+
+            TypeInfo::ContractCaller { abi_name, address } => {
+                Self::get_contract_caller_fallback_source_id(abi_name, address)
+            }
+
+            TypeInfo::Alias { name, ty } => {
+                self.get_alias_fallback_source_id(decl_engine, name, ty)
+            }
+
+            TypeInfo::Ptr(ta)
+            | TypeInfo::Slice(ta)
+            | TypeInfo::Ref {
+                referenced_type: ta,
+                ..
+            } => self.get_source_id_from_type_argument(decl_engine, ta),
+
+            TypeInfo::Custom {
+                qualified_call_path,
+                type_arguments,
+                root_type_id,
+            } => self.get_custom_fallback_source_id(
+                decl_engine,
+                qualified_call_path,
+                type_arguments,
+                root_type_id,
+            ),
+
+            TypeInfo::TraitType {
+                name,
+                trait_type_id,
+            } => self.get_trait_type_fallback_source_id(decl_engine, name, trait_type_id),
+        }
+    }
+
+    fn get_source_id_from_length(length: &Length) -> Option<SourceId> {
+        length.span().source_id().copied()
+    }
+
+    fn get_source_id_from_type_argument(
+        &self,
+        decl_engine: &DeclEngine,
+        ta: &TypeArgument,
+    ) -> Option<SourceId> {
+        // If the `ta` is span-annotated, take the source id from its `span`,
+        // otherwise, take the source id of the type it represents.
+        ta.span.source_id().copied().or_else(|| {
+            self.get_type_fallback_source_id(
+                decl_engine,
+                &self.slab.get(ta.type_id.index()).type_info,
+            )
+        })
+    }
+
+    fn get_source_id_from_type_arguments(
+        &self,
+        decl_engine: &DeclEngine,
+        type_arguments: &[TypeArgument],
+    ) -> Option<SourceId> {
+        // For type arguments, if they are annotated, we take the use site source file.
+        // In semantically valid usages, in a vector of `TypeArgument`s, the use site source file
+        // will be the same for all the elements, so we are taking it from the
+        // first one that is annotated (which will be the first one or none).
+        // E.g., in a `TypeInfo::Tuple`, all the `TypeArgument`s will either not be annotated, or will
+        // all be annotated and situated within the same file.
+        //
+        // If the type arguments are not annotated, we are taking the source file of the first type
+        // pointed by a type argument, that has a source id.
+        if type_arguments.is_empty() {
+            None
+        } else {
+            type_arguments
+                .iter()
+                .find_map(|ta| ta.span.source_id().copied())
+                .or_else(|| {
+                    type_arguments.iter().find_map(|ta| {
+                        self.get_type_fallback_source_id(
+                            decl_engine,
+                            &self.slab.get(ta.type_id.index()).type_info,
+                        )
+                    })
+                })
+        }
+    }
+
+    fn get_source_id_from_type_parameter(
+        &self,
+        decl_engine: &DeclEngine,
+        tp: &TypeParameter,
+    ) -> Option<SourceId> {
+        // If the `ta` is span-annotated, take the source id from its `span`,
+        // otherwise, take the source id of the type it represents.
+        tp.name.span().source_id().copied().or_else(|| {
+            self.get_type_fallback_source_id(
+                decl_engine,
+                &self.slab.get(tp.type_id.index()).type_info,
+            )
+        })
+    }
+
+    fn get_placeholder_fallback_source_id(
+        &self,
+        decl_engine: &DeclEngine,
+        placeholder: &TypeInfo,
+    ) -> Option<SourceId> {
+        // `TypeInfo::Placeholder` is an always replaceable type and we know we will
+        // get a new instance of it in the engine for every "_" occurrence. This means
+        // that it can never happen that instances from different source files point
+        // to the same `TypeSourceInfo`. Therefore, we can safely remove an instance
+        // of a `Placeholder` from the engine if its source file is garbage collected.
+        //
+        // The source file itself is always the one in which the `name`, means "_",
+        // is situated.
+        let TypeInfo::Placeholder(tp) = &placeholder else {
+            unreachable!("The `placeholder` is checked to be of variant `TypeInfo::Placeholder`.");
+        };
+
+        self.get_source_id_from_type_parameter(decl_engine, tp)
+    }
+
+    fn get_unknown_generic_fallback_source_id(unknown_generic: &TypeInfo) -> Option<SourceId> {
+        // `TypeInfo::UnknownGeneric` is an always replaceable type and we know we will
+        // get a new instance of it in the engine for every, e.g., "<T1>", "<T2>", etc. occurrence.
+        // This means that it can never happen that instances from different source files point
+        // to the same `TypeSourceInfo`. Therefore, we can safely remove an instance
+        // of an `UnknownGeneric` from the engine if its source file is garbage collected.
+        //
+        // The source file itself is always the one in which the `name`, means, e.g. "T1", "T2", etc.
+        // is situated.
+        let TypeInfo::UnknownGeneric { name, .. } = &unknown_generic else {
+            unreachable!(
+                "The `unknown_generic` is checked to be of variant `TypeInfo::UnknownGeneric`."
+            );
+        };
+        name.span().source_id().copied()
+    }
+
+    fn get_enum_fallback_source_id(decl: &TyEnumDecl) -> Option<SourceId> {
+        // For `TypeInfo::Enum`, we are taking the source file in which the enum is declared.
+        decl.span.source_id().copied()
+    }
+
+    fn get_struct_fallback_source_id(decl: &TyStructDecl) -> Option<SourceId> {
+        // For `TypeInfo::Struct`, we are taking the source file in which the struct is declared.
+        decl.span.source_id().copied()
+    }
+
+    fn get_tuple_fallback_source_id(
+        &self,
+        decl_engine: &DeclEngine,
+        elements: &[TypeArgument],
+    ) -> Option<SourceId> {
+        self.get_source_id_from_type_arguments(decl_engine, elements)
+    }
+
+    fn get_array_fallback_source_id(
+        &self,
+        decl_engine: &DeclEngine,
+        elem_type: &TypeArgument,
+        length: &Length,
+    ) -> Option<SourceId> {
+        // For `TypeInfo::Array`, if it is annotated, we take the use site source file.
+        // This can be found in the `elem_type` and the `length`.
+        //
+        // If the array type is not annotated, we are taking the source file of the array element.
+        assert_eq!(
+            elem_type.span.source_id(),
+            length.span().source_id(),
+            "If an array is annotated, the type argument and the length spans must have the same source id."
+        );
+
+        self.get_source_id_from_type_argument(decl_engine, elem_type)
+    }
+
+    fn get_string_array_fallback_source_id(length: &Length) -> Option<SourceId> {
+        // For `TypeInfo::StringArray`, if it is annotated, we take the use site source file found in the `length`.
+        Self::get_source_id_from_length(length)
+    }
+
+    fn get_contract_caller_fallback_source_id(
+        abi_name: &AbiName,
+        address: &Option<Box<TyExpression>>,
+    ) -> Option<SourceId> {
+        // For `TypeInfo::ContractCaller`, if it has an `address`, we take the use site source file found in the it.
+        // Otherwise, if it has an `abi_name`, we take the source file of the ABI definition.
+        match address {
+            Some(addr_expr) => addr_expr.span.source_id().copied(),
+            None => {
+                if let AbiName::Known(name) = abi_name {
+                    name.span().source_id().copied()
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn get_alias_fallback_source_id(
+        &self,
+        decl_engine: &DeclEngine,
+        name: &Ident,
+        ty: &TypeArgument,
+    ) -> Option<SourceId> {
+        // For `TypeInfo::Alias`, we take the source file in which the alias is declared, if it exists.
+        // Otherwise, we take the source file of the aliased type `ty`.
+        name.span()
+            .source_id()
+            .copied()
+            .or_else(|| self.get_source_id_from_type_argument(decl_engine, ty))
+    }
+
+    fn get_slice_fallback_source_id(
+        &self,
+        decl_engine: &DeclEngine,
+        elem_type: &TypeArgument,
+    ) -> Option<SourceId> {
+        self.get_source_id_from_type_argument(decl_engine, elem_type)
+    }
+
+    fn get_ptr_fallback_source_id(
+        &self,
+        decl_engine: &DeclEngine,
+        pointee_type: &TypeArgument,
+    ) -> Option<SourceId> {
+        self.get_source_id_from_type_argument(decl_engine, pointee_type)
+    }
+
+    fn get_ref_fallback_source_id(
+        &self,
+        decl_engine: &DeclEngine,
+        referenced_type: &TypeArgument,
+    ) -> Option<SourceId> {
+        self.get_source_id_from_type_argument(decl_engine, referenced_type)
+    }
+
+    fn get_custom_fallback_source_id(
+        &self,
+        decl_engine: &DeclEngine,
+        qualified_call_path: &QualifiedCallPath,
+        type_arguments: &Option<Vec<TypeArgument>>,
+        root_type_id: &Option<TypeId>,
+    ) -> Option<SourceId> {
+        // For `TypeInfo::Custom`, we take the source file in which the custom type is used, extracted from the `qualified_call_path`.
+        // For non-generated source code, this will always exists.
+        // For potential situation of having a `qualified_call_path` without spans in generated code, we do a fallback and
+        // extract the source id from the remaining parameters.
+        qualified_call_path
+            .call_path
+            .suffix
+            .span()
+            .source_id()
+            .copied()
+            .or_else(|| {
+                type_arguments
+                    .as_ref()
+                    .and_then(|tas| self.get_source_id_from_type_arguments(decl_engine, tas))
+            })
+            .or_else(|| {
+                root_type_id.and_then(|root_ty| {
+                    self.get_type_fallback_source_id(
+                        decl_engine,
+                        &self.slab.get(root_ty.index()).type_info,
+                    )
+                })
+            })
+    }
+
+    fn get_trait_type_fallback_source_id(
+        &self,
+        decl_engine: &DeclEngine,
+        name: &Ident,
+        trait_type_id: &TypeId,
+    ) -> Option<SourceId> {
+        // For `TypeInfo::TraitType`, we take the source file in which the trait type is declared, extracted from the `name`.
+        // For non-generated source code, this will always exists.
+        // For potential situation of having a `name` without spans in generated code, we do a fallback and
+        // extract the source id from the `trait_type_id`.
+        name.span().source_id().copied().or_else(|| {
+            self.get_type_fallback_source_id(
+                decl_engine,
+                &self.slab.get(trait_type_id.index()).type_info,
+            )
+        })
     }
 
     fn clear_items<F>(&mut self, keep: F)
@@ -101,7 +1658,7 @@ impl TypeEngine {
     {
         self.slab
             .retain(|_, tsi| tsi.source_id.as_ref().map_or(true, &keep));
-        self.id_map
+        self.shareable_types
             .write()
             .retain(|tsi, _| tsi.source_id.as_ref().map_or(true, &keep));
     }
@@ -116,12 +1673,53 @@ impl TypeEngine {
         self.clear_items(|id| id != source_id);
     }
 
-    pub fn replace(&self, engines: &Engines, id: TypeId, new_value: TypeSourceInfo) {
-        if !(*self.slab.get(id.index())).eq(&new_value, &PartialEqWithEnginesContext::new(engines))
-        {
+    /// Replaces the replaceable type behind the `type_id` with the `new_value`.
+    /// The existing source id will be preserved.
+    ///
+    /// Panics if the type behind the `type_id` is not a replaceable type.
+    pub fn replace(&self, engines: &Engines, type_id: TypeId, new_value: TypeInfo) {
+        // We keep the existing source id. `replace_with_new_source_id` is treated just as a common implementation.
+        let source_id = self.slab.get(type_id.index()).source_id;
+        self.replace_with_new_source_id(engines, type_id, new_value, source_id);
+    }
+
+    /// Replaces the replaceable type behind the `type_id` with the `new_value`.
+    /// The existing source id will also be replaced with the `new_source_id`.
+    ///
+    /// Panics if the type behind the `type_id` is not a replaceable type.
+    // TODO: Once https://github.com/FuelLabs/sway/issues/6603 gets implemented and we further optimize
+    //       the `TypeEngine` for garbage collection, this variant of `replace` will actually not be
+    //       needed any more. The version of `replace` that uses the initially provided `source_id` will
+    //       be sufficient.
+    pub fn replace_with_new_source_id(
+        &self,
+        engines: &Engines,
+        id: TypeId,
+        new_value: TypeInfo,
+        new_source_id: Option<SourceId>,
+    ) {
+        let type_source_info = self.slab.get(id.index());
+        assert!(
+            Self::is_replaceable_type(&type_source_info.type_info),
+            "The type requested to be replaced is not a replaceable type. The type was: {:#?}.",
+            &type_source_info.type_info
+        );
+
+        if !type_source_info.equals(
+            &new_value,
+            &new_source_id,
+            &PartialEqWithEnginesContext::new(engines),
+        ) {
             self.touch_last_replace();
         }
-        self.slab.replace(id.index(), new_value);
+        let is_shareable_type = self.is_type_shareable(engines.de(), &new_value);
+        self.insert_or_replace_type_source_info(
+            engines,
+            new_value,
+            new_source_id,
+            is_shareable_type,
+            Some(id),
+        );
     }
 
     /// Performs a lookup of `id` into the [TypeEngine].
@@ -373,7 +1971,6 @@ impl TypeEngine {
             | TypeInfo::B256
             | TypeInfo::Contract
             | TypeInfo::ErrorRecovery(..)
-            | TypeInfo::Storage { .. }
             | TypeInfo::RawUntypedPtr
             | TypeInfo::RawUntypedSlice
             | TypeInfo::Alias { .. }
@@ -430,25 +2027,12 @@ impl TypeEngine {
             | TypeInfo::B256
             | TypeInfo::Contract
             | TypeInfo::ErrorRecovery(..)
-            | TypeInfo::Storage { .. }
             | TypeInfo::RawUntypedPtr
             | TypeInfo::RawUntypedSlice
             | TypeInfo::Alias { .. }
             | TypeInfo::TraitType { .. } => {}
             TypeInfo::Numeric => {
-                self.unify(
-                    handler,
-                    engines,
-                    type_id,
-                    self.insert(
-                        engines,
-                        TypeInfo::UnsignedInteger(IntegerBits::SixtyFour),
-                        span.source_id(),
-                    ),
-                    span,
-                    "",
-                    None,
-                );
+                self.unify(handler, engines, type_id, self.id_of_u64(), span, "", None);
             }
         }
         Ok(())
@@ -466,25 +2050,5 @@ impl TypeEngine {
         let list = ListDisplay { list };
         write!(builder, "TypeEngine {{\n{list}\n}}").unwrap();
         builder
-    }
-}
-
-/// Maps specific [TypeInfo] variants to a reserved [SourceId], returning `None` for non-mapped types.
-fn info_to_source_id(ty: &TypeInfo) -> Option<SourceId> {
-    match ty {
-        TypeInfo::Unknown
-        | TypeInfo::UnsignedInteger(_)
-        | TypeInfo::Numeric
-        | TypeInfo::Boolean
-        | TypeInfo::B256
-        | TypeInfo::RawUntypedPtr
-        | TypeInfo::RawUntypedSlice
-        | TypeInfo::StringSlice
-        | TypeInfo::Contract
-        | TypeInfo::StringArray(_)
-        | TypeInfo::Array(_, _)
-        | TypeInfo::Ref { .. } => Some(SourceId::reserved()),
-        TypeInfo::Tuple(v) if v.is_empty() => Some(SourceId::reserved()),
-        _ => None,
     }
 }

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -79,7 +79,7 @@ impl CollectTypesMetadata for TypeId {
                 }
                 TypeInfo::Placeholder(type_param) => {
                     res.push(TypeMetadata::UnresolvedType(
-                        type_param.name_ident.clone(),
+                        type_param.name.clone(),
                         ctx.call_site_get(self),
                     ));
                 }
@@ -107,7 +107,7 @@ impl SubstTypes for TypeId {
 }
 
 impl TypeId {
-    pub(super) fn new(index: usize) -> TypeId {
+    pub(super) const fn new(index: usize) -> TypeId {
         TypeId(index)
     }
 
@@ -332,19 +332,6 @@ impl TypeId {
                     ty.type_id
                         .extract_any_including_self(engines, filter_fn, vec![], depth + 1),
                 );
-            }
-            TypeInfo::Storage { fields } => {
-                for field in fields {
-                    extend(
-                        &mut found,
-                        field.type_argument.type_id.extract_any_including_self(
-                            engines,
-                            filter_fn,
-                            vec![],
-                            depth + 1,
-                        ),
-                    );
-                }
             }
             TypeInfo::Alias { name: _, ty } => {
                 extend(
@@ -647,13 +634,7 @@ impl TypeId {
                                         EnforceTypeArguments::No,
                                         None,
                                     )
-                                    .unwrap_or_else(|err| {
-                                        engines.te().insert(
-                                            engines,
-                                            TypeInfo::ErrorRecovery(err),
-                                            None,
-                                        )
-                                    }),
+                                    .unwrap_or_else(|err| engines.te().id_of_error_recovery(err)),
                                     ctx.resolve_type(
                                         handler,
                                         t2.type_id,
@@ -661,13 +642,7 @@ impl TypeId {
                                         EnforceTypeArguments::No,
                                         None,
                                     )
-                                    .unwrap_or_else(|err| {
-                                        engines.te().insert(
-                                            engines,
-                                            TypeInfo::ErrorRecovery(err),
-                                            None,
-                                        )
-                                    }),
+                                    .unwrap_or_else(|err| engines.te().id_of_error_recovery(err)),
                                 )
                             })
                 },

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -39,32 +39,25 @@ fn generic_enum_resolution() {
         a: _
     }
     */
-    let generic_type = engines.te().insert(
+    let generic_type =
+        engines
+            .te()
+            .new_unknown_generic(generic_name.clone(), VecSet(vec![]), None, false);
+    let placeholder_type = engines.te().new_placeholder(
         &engines,
-        TypeInfo::UnknownGeneric {
-            name: generic_name.clone(),
-            trait_constraints: VecSet(Vec::new()),
-            parent: None,
-            is_from_type_parameter: false,
-        },
-        None,
-    );
-    let placeholder_type = engines.te().insert(
-        &engines,
-        TypeInfo::Placeholder(TypeParameter {
+        TypeParameter {
             type_id: generic_type,
             initial_type_id: generic_type,
-            name_ident: generic_name.clone(),
+            name: generic_name.clone(),
             trait_constraints: vec![],
             trait_constraints_span: sp.clone(),
             is_from_parent: false,
-        }),
-        None,
+        },
     );
     let placeholder_type_param = TypeParameter {
         type_id: placeholder_type,
         initial_type_id: placeholder_type,
-        name_ident: generic_name.clone(),
+        name: generic_name.clone(),
         trait_constraints: vec![],
         trait_constraints_span: sp.clone(),
         is_from_parent: false,
@@ -95,16 +88,14 @@ fn generic_enum_resolution() {
         },
         None,
     );
-    let ty_1 = engines
-        .te()
-        .insert(&engines, TypeInfo::Enum(*decl_ref_1.id()), None);
+    let ty_1 = engines.te().insert_enum(&engines, *decl_ref_1.id());
 
     /*
     Result<bool> {
         a: bool
     }
     */
-    let boolean_type = engines.te().insert(&engines, TypeInfo::Boolean, None);
+    let boolean_type = engines.te().id_of_bool();
     let variant_types = vec![ty::TyEnumVariant {
         name: a_name,
         tag: 0,
@@ -120,7 +111,7 @@ fn generic_enum_resolution() {
     let type_param = TypeParameter {
         type_id: boolean_type,
         initial_type_id: boolean_type,
-        name_ident: generic_name,
+        name: generic_name,
         trait_constraints: vec![],
         trait_constraints_span: sp.clone(),
         is_from_parent: false,
@@ -139,9 +130,7 @@ fn generic_enum_resolution() {
         },
         None,
     );
-    let ty_2 = engines
-        .te()
-        .insert(&engines, TypeInfo::Enum(*decl_ref_2.id()), None);
+    let ty_2 = engines.te().insert_enum(&engines, *decl_ref_2.id());
 
     // Unify them together...
     let h = Handler::default();
@@ -168,12 +157,8 @@ fn basic_numeric_unknown() {
 
     let sp = Span::dummy();
     // numerics
-    let id = engines.te().insert(&engines, TypeInfo::Numeric, None);
-    let id2 = engines.te().insert(
-        &engines,
-        TypeInfo::UnsignedInteger(IntegerBits::Eight),
-        None,
-    );
+    let id = engines.te().new_numeric();
+    let id2 = engines.te().id_of_u8();
 
     // Unify them together...
     let h = Handler::default();
@@ -194,12 +179,8 @@ fn unify_numerics() {
     let sp = Span::dummy();
 
     // numerics
-    let id = engines.te().insert(&engines, TypeInfo::Numeric, None);
-    let id2 = engines.te().insert(
-        &engines,
-        TypeInfo::UnsignedInteger(IntegerBits::Eight),
-        None,
-    );
+    let id = engines.te().new_numeric();
+    let id2 = engines.te().id_of_u8();
 
     // Unify them together...
     let h = Handler::default();
@@ -221,12 +202,8 @@ fn unify_numerics_2() {
     let sp = Span::dummy();
 
     // numerics
-    let id = type_engine.insert(&engines, TypeInfo::Numeric, None);
-    let id2 = type_engine.insert(
-        &engines,
-        TypeInfo::UnsignedInteger(IntegerBits::Eight),
-        None,
-    );
+    let id = engines.te().new_numeric();
+    let id2 = engines.te().id_of_u8();
 
     // Unify them together...
     let h = Handler::default();

--- a/sway-core/src/type_system/priv_prelude.rs
+++ b/sway-core/src/type_system/priv_prelude.rs
@@ -22,5 +22,5 @@ pub use super::{
     engine::IsConcrete,
     engine::TypeEngine,
     id::{IncludeSelf, TreatNumericAs, TypeId},
-    info::{AbiEncodeSizeHint, AbiName, TypeInfo, TypeSourceInfo},
+    info::{AbiEncodeSizeHint, AbiName, TypeInfo},
 };

--- a/sway-core/src/type_system/substitute/subst_map.rs
+++ b/sway-core/src/type_system/substitute/subst_map.rs
@@ -6,7 +6,6 @@ use crate::{
     type_system::priv_prelude::*,
 };
 use std::{collections::BTreeMap, fmt};
-use sway_types::Spanned;
 
 type SourceType = TypeId;
 type DestinationType = TypeId;
@@ -92,11 +91,7 @@ impl TypeSubstMap {
             .map(|type_param| {
                 (
                     type_param.type_id,
-                    type_engine.insert(
-                        engines,
-                        TypeInfo::Placeholder(type_param.clone()),
-                        type_param.name_ident.span().source_id(),
-                    ),
+                    type_engine.new_placeholder(engines, type_param.clone()),
                 )
             })
             .collect();
@@ -254,29 +249,6 @@ impl TypeSubstMap {
                     vec![type_argument.type_id],
                 )
             }
-            (
-                TypeInfo::Storage {
-                    fields: type_parameters,
-                },
-                TypeInfo::Storage {
-                    fields: type_arguments,
-                },
-            ) => {
-                let type_parameters = type_parameters
-                    .iter()
-                    .map(|x| x.type_argument.type_id)
-                    .collect::<Vec<_>>();
-                let type_arguments = type_arguments
-                    .iter()
-                    .map(|x| x.type_argument.type_id)
-                    .collect::<Vec<_>>();
-                TypeSubstMap::from_superset_and_subset_helper(
-                    type_engine,
-                    decl_engine,
-                    type_parameters,
-                    type_arguments,
-                )
-            }
             (TypeInfo::Unknown, TypeInfo::Unknown)
             | (TypeInfo::Boolean, TypeInfo::Boolean)
             | (TypeInfo::B256, TypeInfo::B256)
@@ -348,10 +320,10 @@ impl TypeSubstMap {
     /// A match is potentially created (i.e. a new [TypeId] is created) in these
     /// circumstances:
     /// - `type_id` is one of the following: [TypeInfo::Struct], [TypeInfo::Enum],
-    ///    [TypeInfo::Array], [TypeInfo::Tuple], [TypeInfo::Storage], [TypeInfo::Alias],
-    ///    [TypeInfo::Alias], [TypeInfo::Ptr], [TypeInfo::Slice], or [TypeInfo::Ref],
-    ///    and one of the contained types (e.g. a struct field, or a referenced type)
-    ///    finds a match in a recursive call to `find_match`.
+    ///    [TypeInfo::Array], [TypeInfo::Tuple], [TypeInfo::Alias], [TypeInfo::Ptr],
+    ///    [TypeInfo::Slice], or [TypeInfo::Ref],
+    /// - and one of the contained types (e.g. a struct field, or a referenced type)
+    ///   finds a match in a recursive call to `find_match`.
     ///
     /// A match cannot be found in any other circumstance.
     pub(crate) fn find_match(&self, type_id: TypeId, engines: &Engines) -> Option<TypeId> {
@@ -381,11 +353,7 @@ impl TypeSubstMap {
                 if need_to_create_new {
                     let new_decl_ref =
                         decl_engine.insert(decl, decl_engine.get_parsed_decl_id(&decl_id).as_ref());
-                    Some(type_engine.insert(
-                        engines,
-                        TypeInfo::Struct(*new_decl_ref.id()),
-                        new_decl_ref.decl_span().source_id(),
-                    ))
+                    Some(type_engine.insert_struct(engines, *new_decl_ref.id()))
                 } else {
                     None
                 }
@@ -410,75 +378,36 @@ impl TypeSubstMap {
                 if need_to_create_new {
                     let new_decl_ref =
                         decl_engine.insert(decl, decl_engine.get_parsed_decl_id(&decl_id).as_ref());
-                    Some(type_engine.insert(
-                        engines,
-                        TypeInfo::Enum(*new_decl_ref.id()),
-                        new_decl_ref.decl_span().source_id(),
-                    ))
+                    Some(type_engine.insert_enum(engines, *new_decl_ref.id()))
                 } else {
                     None
                 }
             }
-            TypeInfo::Array(mut elem_ty, count) => {
-                self.find_match(elem_ty.type_id, engines).map(|type_id| {
-                    elem_ty.type_id = type_id;
-                    type_engine.insert(
-                        engines,
-                        TypeInfo::Array(elem_ty.clone(), count.clone()),
-                        elem_ty.span.source_id(),
-                    )
+            TypeInfo::Array(mut elem_type, length) => {
+                self.find_match(elem_type.type_id, engines).map(|type_id| {
+                    elem_type.type_id = type_id;
+                    type_engine.insert_array(engines, elem_type, length)
                 })
             }
             TypeInfo::Slice(mut elem_ty) => {
                 let type_id = self.find_match(elem_ty.type_id, engines)?;
                 elem_ty.type_id = type_id;
-                Some(type_engine.insert(
-                    engines,
-                    TypeInfo::Slice(elem_ty.clone()),
-                    elem_ty.span.source_id(),
-                ))
+                Some(type_engine.insert_slice(engines, elem_ty))
             }
             TypeInfo::Tuple(fields) => {
                 let mut need_to_create_new = false;
-                let mut source_id = None;
                 let fields = fields
                     .into_iter()
                     .map(|mut field| {
                         if let Some(type_id) = self.find_match(field.type_id, engines) {
                             need_to_create_new = true;
-                            source_id = field.span.source_id().cloned();
                             field.type_id = type_id;
                         }
                         field.clone()
                     })
                     .collect::<Vec<_>>();
                 if need_to_create_new {
-                    Some(type_engine.insert(engines, TypeInfo::Tuple(fields), source_id.as_ref()))
-                } else {
-                    None
-                }
-            }
-            TypeInfo::Storage { fields } => {
-                let mut need_to_create_new = false;
-                let mut source_id = None;
-                let fields = fields
-                    .into_iter()
-                    .map(|mut field| {
-                        if let Some(type_id) = self.find_match(field.type_argument.type_id, engines)
-                        {
-                            need_to_create_new = true;
-                            source_id = field.span.source_id().copied();
-                            field.type_argument.type_id = type_id;
-                        }
-                        field.clone()
-                    })
-                    .collect::<Vec<_>>();
-                if need_to_create_new {
-                    Some(type_engine.insert(
-                        engines,
-                        TypeInfo::Storage { fields },
-                        source_id.as_ref(),
-                    ))
+                    Some(type_engine.insert_tuple(engines, fields))
                 } else {
                     None
                 }
@@ -486,19 +415,12 @@ impl TypeSubstMap {
             TypeInfo::Alias { name, mut ty } => {
                 self.find_match(ty.type_id, engines).map(|type_id| {
                     ty.type_id = type_id;
-                    type_engine.insert(
-                        engines,
-                        TypeInfo::Alias {
-                            name: name.clone(),
-                            ty: ty.clone(),
-                        },
-                        ty.span.source_id(),
-                    )
+                    type_engine.new_alias(engines, name, ty)
                 })
             }
             TypeInfo::Ptr(mut ty) => self.find_match(ty.type_id, engines).map(|type_id| {
                 ty.type_id = type_id;
-                type_engine.insert(engines, TypeInfo::Ptr(ty.clone()), ty.span.source_id())
+                type_engine.insert_ptr(engines, ty)
             }),
             TypeInfo::TraitType { .. } => iter_for_match(engines, self, &type_info),
             TypeInfo::Ref {
@@ -506,14 +428,7 @@ impl TypeSubstMap {
                 referenced_type: mut ty,
             } => self.find_match(ty.type_id, engines).map(|type_id| {
                 ty.type_id = type_id;
-                type_engine.insert(
-                    engines,
-                    TypeInfo::Ref {
-                        to_mutable_value,
-                        referenced_type: ty.clone(),
-                    },
-                    ty.span.source_id(),
-                )
+                type_engine.insert_ref(engines, to_mutable_value, ty)
             }),
             TypeInfo::Unknown
             | TypeInfo::Never

--- a/sway-core/src/type_system/unify/unifier.rs
+++ b/sway-core/src/type_system/unify/unifier.rs
@@ -61,15 +61,11 @@ impl<'a> Unifier<'a> {
         expected_type_info: &TypeInfo,
         span: &Span,
     ) {
-        let type_engine = self.engines.te();
-        let source_id = span.source_id().copied();
-        type_engine.replace(
+        self.engines.te().replace_with_new_source_id(
             self.engines,
             received,
-            TypeSourceInfo {
-                type_info: expected_type_info.clone().into(),
-                source_id,
-            },
+            expected_type_info.clone(),
+            span.source_id().copied(),
         );
     }
 
@@ -80,15 +76,11 @@ impl<'a> Unifier<'a> {
         received_type_info: &TypeInfo,
         span: &Span,
     ) {
-        let type_engine = self.engines.te();
-        let source_id = span.source_id().copied();
-        type_engine.replace(
+        self.engines.te().replace_with_new_source_id(
             self.engines,
             expected,
-            TypeSourceInfo {
-                type_info: received_type_info.clone().into(),
-                source_id,
-            },
+            received_type_info.clone(),
+            span.source_id().copied(),
         );
     }
 

--- a/sway-core/src/type_system/unify/unify_check.rs
+++ b/sway-core/src/type_system/unify/unify_check.rs
@@ -499,7 +499,6 @@ impl<'a> UnifyCheck<'a> {
                 // engine
                 (TypeInfo::Unknown, TypeInfo::Unknown) => false,
                 (TypeInfo::Numeric, TypeInfo::Numeric) => false,
-                (TypeInfo::Storage { .. }, TypeInfo::Storage { .. }) => false,
 
                 // these cases are able to be directly compared
                 (TypeInfo::Contract, TypeInfo::Contract) => true,

--- a/sway-lsp/src/capabilities/code_actions/common/generate_impl.rs
+++ b/sway-lsp/src/capabilities/code_actions/common/generate_impl.rs
@@ -21,7 +21,7 @@ pub(crate) trait GenerateImplCodeAction<'a, T: Spanned>: CodeAction<'a, T> {
             Some(
                 type_params
                     .iter()
-                    .map(|param| param.name_ident.to_string())
+                    .map(|param| param.name.to_string())
                     .collect::<Vec<_>>()
                     .join(", "),
             )

--- a/sway-lsp/src/server_state.rs
+++ b/sway-lsp/src/server_state.rs
@@ -167,10 +167,10 @@ impl ServerState {
                         ) {
                             Ok(()) => {
                                 let path = uri.to_file_path().unwrap();
-                                // Find the module id from the path
+                                // Find the program id from the path
                                 match session::program_id_from_path(&path, &engines_clone) {
                                     Ok(program_id) => {
-                                        // Use the module id to get the metrics for the module
+                                        // Use the program id to get the metrics for the program
                                         if let Some(metrics) = session.metrics.get(&program_id) {
                                             // It's very important to check if the workspace AST was reused to determine if we need to overwrite the engines.
                                             // Because the engines_clone has garbage collection applied. If the workspace AST was reused, we need to keep the old engines

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -1021,7 +1021,7 @@ impl Parse for EnumVariant {
 impl Parse for TypeParameter {
     fn parse(&self, ctx: &ParseContext) {
         ctx.tokens.insert(
-            ctx.ident(&self.name_ident),
+            ctx.ident(&self.name),
             Token::from_parsed(
                 AstToken::TypeParameter(self.clone()),
                 SymbolKind::TypeParameter,

--- a/sway-lsp/src/traverse/typed_tree.rs
+++ b/sway-lsp/src/traverse/typed_tree.rs
@@ -637,7 +637,7 @@ impl Parse for ty::FunctionDecl {
                 ctx,
                 type_param.type_id,
                 &typed_token,
-                type_param.name_ident.span(),
+                type_param.name.span(),
             );
         });
         collect_type_argument(ctx, &func_decl.return_type);
@@ -650,8 +650,8 @@ impl Parse for ty::FunctionDecl {
                 if let Some(param_decl_ident) = func_decl
                     .type_parameters
                     .par_iter()
-                    .find_any(|type_param| type_param.name_ident.as_str() == ident.as_str())
-                    .map(|type_param| type_param.name_ident.clone())
+                    .find_any(|type_param| type_param.name.as_str() == ident.as_str())
+                    .map(|type_param| type_param.name.clone())
                 {
                     token.type_def = Some(TypeDefinition::Ident(param_decl_ident));
                 }
@@ -710,7 +710,7 @@ impl Parse for ty::StructDecl {
         adaptive_iter(&struct_decl.type_parameters, |type_param| {
             if let Some(mut token) = ctx
                 .tokens
-                .try_get_mut_with_retry(&ctx.ident(&type_param.name_ident))
+                .try_get_mut_with_retry(&ctx.ident(&type_param.name))
             {
                 token.typed = Some(TypedAstToken::TypedParameter(type_param.clone()));
                 token.type_def = Some(TypeDefinition::TypeId(type_param.type_id));
@@ -736,7 +736,7 @@ impl Parse for ty::ImplSelfOrTrait {
                 ctx,
                 param.type_id,
                 &TypedAstToken::TypedParameter(param.clone()),
-                param.name_ident.span(),
+                param.name.span(),
             );
         });
         adaptive_iter(&trait_name.prefixes, |ident| {
@@ -934,7 +934,7 @@ impl Parse for ty::TyFunctionDecl {
                 ctx,
                 type_param.type_id,
                 &typed_token,
-                type_param.name_ident.span(),
+                type_param.name.span(),
             );
         });
         collect_type_argument(ctx, &self.return_type);
@@ -947,8 +947,8 @@ impl Parse for ty::TyFunctionDecl {
                 if let Some(param_decl_ident) = self
                     .type_parameters
                     .par_iter()
-                    .find_any(|type_param| type_param.name_ident.as_str() == ident.as_str())
-                    .map(|type_param| type_param.name_ident.clone())
+                    .find_any(|type_param| type_param.name.as_str() == ident.as_str())
+                    .map(|type_param| type_param.name.clone())
                 {
                     token.type_def = Some(TypeDefinition::Ident(param_decl_ident));
                 }
@@ -1291,7 +1291,7 @@ fn collect_type_id(
                     ctx,
                     param.type_id,
                     &TypedAstToken::TypedParameter(param.clone()),
-                    param.name_ident.span(),
+                    param.name.span(),
                 );
             });
             adaptive_iter(&decl.variants, |variant| {
@@ -1311,7 +1311,7 @@ fn collect_type_id(
                     ctx,
                     param.type_id,
                     &TypedAstToken::TypedParameter(param.clone()),
-                    param.name_ident.span(),
+                    param.name.span(),
                 );
             });
             adaptive_iter(&decl.fields, |field| {
@@ -1335,11 +1335,6 @@ fn collect_type_id(
                     collect_type_argument(ctx, type_arg);
                 });
             }
-        }
-        TypeInfo::Storage { fields } => {
-            adaptive_iter(fields, |field| {
-                field.parse(ctx);
-            });
         }
         _ => {
             if let Some(token) = ctx
@@ -1421,7 +1416,7 @@ fn collect_enum(ctx: &ParseContext, decl_id: &DeclId<ty::TyEnumDecl>, declaratio
     adaptive_iter(&enum_decl.type_parameters, |type_param| {
         if let Some(mut token) = ctx
             .tokens
-            .try_get_mut_with_retry(&ctx.ident(&type_param.name_ident))
+            .try_get_mut_with_retry(&ctx.ident(&type_param.name))
         {
             token.typed = Some(TypedAstToken::TypedParameter(type_param.clone()));
             token.type_def = Some(TypeDefinition::TypeId(type_param.type_id));

--- a/sway-types/src/lib.rs
+++ b/sway-types/src/lib.rs
@@ -88,47 +88,34 @@ impl Instruction {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
-pub struct ProgramId {
-    id: u16,
-}
+pub struct ProgramId(u16);
 
 impl ProgramId {
     pub fn new(id: u16) -> Self {
-        Self { id }
+        Self(id)
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
-pub struct SourceId {
-    id: u32,
-}
+pub struct SourceId(u32);
 
 impl SourceId {
-    const RESERVED: u16 = 0;
     const SOURCE_ID_BITS: u32 = 20;
     const SOURCE_ID_MASK: u32 = (1 << Self::SOURCE_ID_BITS) - 1;
 
-    /// Create a combined ID from module and source IDs.
+    /// Create a combined ID from program and source IDs.
     pub fn new(program_id: u16, source_id: u32) -> Self {
-        SourceId {
-            id: ((program_id as u32) << Self::SOURCE_ID_BITS) | source_id,
-        }
+        SourceId(((program_id as u32) << Self::SOURCE_ID_BITS) | source_id)
     }
 
-    /// Create a reserved source_id. This is assigned to internal types
-    /// that should not be cleared during garbage collection.
-    pub fn reserved() -> Self {
-        Self::new(Self::RESERVED, Self::RESERVED as u32)
-    }
-
-    /// The program_id that this source_id was created from.
+    /// The [ProgramId] that this [SourceId] was created from.
     pub fn program_id(&self) -> ProgramId {
-        ProgramId::new((self.id >> Self::SOURCE_ID_BITS) as u16)
+        ProgramId::new((self.0 >> Self::SOURCE_ID_BITS) as u16)
     }
 
-    /// Id of the source file without the program_id component.
+    /// ID of the source file without the [ProgramId] component.
     pub fn source_id(&self) -> u32 {
-        self.id & Self::SOURCE_ID_MASK
+        self.0 & Self::SOURCE_ID_MASK
     }
 }
 

--- a/sway-types/src/source_engine.rs
+++ b/sway-types/src/source_engine.rs
@@ -81,7 +81,7 @@ impl SourceEngine {
             }
         }
 
-        let source_id = SourceId::new(program_id.id, *self.next_source_id.read());
+        let source_id = SourceId::new(program_id.0, *self.next_source_id.read());
         {
             let mut next_id = self.next_source_id.write();
             *next_id += 1;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_or/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_or/test.toml
@@ -2,4 +2,4 @@ category = "run"
 expected_result = { action = "return", value = 42 }
 expected_result_new_encoding = { action = "return_data", value = "000000000000002A" }
 validate_abi = true
-expected_warnings = 7                                                                 #TODO: Set number of warnings to minimum once TODOs in tests are solved.
+expected_warnings = 7 #TODO: Set number of warnings to minimum once TODOs in tests are solved.


### PR DESCRIPTION
## Description

This PR implements a major rewrite of the `TypeEngine`. The rewrite:
- significantly improves overall compilation performance. The compilation time of the real-world [Spark Orderbook workspace](https://github.com/compolabs/orderbook-contract) got **reduced from 8.99 to 5.94 seconds**, and the memory consumption from **3.32 to 1.78 GB**.
- provides robust API for inserting types, related to the usage of the `source_id` (see: #5991). The new API forbids not providing `source_id`s or providing semantically questionable or non-optimal ones.
- introduces simpler, much less verbose, API for inserting types.

The PR also removes the obsolete and unused `TypeInfo::Storage`.

The PR **does not address** the following:
- The `TypeEngine`'s "garbage-collection-(un)friendlines" (see: #6603).
- The handling of the `TypeInfo::Custom` and `TypeInfo::TraitType` types within the `TypeEngine` (see: #6601).
- The number of interactions with the `TypeEngine`. E.g., removing unnecessary insertions after `resolve()`ing or `monomorphyze()`ing types will be done as a part of `DeclEngine` optimization.

Closes #5991.

## Shareable types

The PR formalizes the notion of a _shareable type_ within the `TypeEngine` (strictly speaking, a shareable `TypeInfo`). A shareable type is a type that is both:
- _unchangeable_: it, or any of its parts, cannot be replaced during the unification or monomorphization.
- and _undistinguishable by annotations_: it doesn't carry any additional information (annotations) that could differ it from another instance of `TypeInfo` that would, purely from the type perspective, be a same type.

E.g., `u64` or `MyStruct<u64, bool>` are unchangeable while `Numeric`, `Unknown` or `MyStruct<T1, T1>` are changeable.

E.g., in this example, `a` and `b` have the same type, `[u64; 2]` but those two types differ in spans assigned to the "u64"s and the "2"s, and are treated as different within the `TypeEngine`, and thus as non-shareable.

```
let a: [u64; 2] = [1, 1];
let b: [u64; 2] = [2, 2];
```

Shareability of a type is crucial for reusing the `TypeSourceInfo` instances within the type engine. Shareable types can be given different `TypeId`s without the need to newly allocate a `TypeSourceInfo`.

## Performance improvements

The cummulative effect of the performance improvements on the compilataion of the real-world [Spark Orderbook workspace](https://github.com/compolabs/orderbook-contract) is given below. The compilation means the frontend compilation, up to the IR generation (`forc check`).

**Compilation time**
```
Before:
  Time (mean ± σ):      8.995 s ±  0.297 s    [User: 7.126 s, System: 1.289 s]
  Range (min … max):    8.675 s …  9.262 s    3 runs

After:
  Time (mean ± σ):      5.945 s ±  0.517 s    [User: 4.749 s, System: 0.768 s]
  Range (min … max):    5.349 s …  6.280 s    3 runs
```

**Memory consumption**
```
---------------------------------------------------------
                total(B)   useful-heap(B)   extra-heap(B)
---------------------------------------------------------
Before:    3,316,786,808    3,237,317,383      79,469,425
After:     1,784,467,376    1,743,772,406      40,694,970
```

### Applied optimizations:

- **Replacement of expensive `insert` calls with compile time constants for built-in types.** Built-in types like `!`, `bool`, `()`, `u8`, etc. are inserted into the engine at its creation at predefined slots within the `slab`. The `id_of_<built-in-type>` methods just return those predefined `TypeId`s, effectively being compiled down to constants. The calls like `type_engine.insert(engines, TypeInfo::Boolean, None)` are replaced with maximally optimized and non-verbose `type_engine.id_of_bool()`.

- **Elimination of extensive creation of `TypeSourceInfo`s for `TypeInfo::Unknown/Numeric`s.** `Unknown` and `Numeric` are inserted into the engine ~50.000 times. Each insert used to create a new instance of `TypeSourceInfo` with the `source_id` set to `None`. The optimization replaces those ~50.000 instances with two predefined singleton instances, one for `Unknown` + `None` and one for `Numeric` + `None`. (Note that when implementing #6603, we will want to bind also `Unknown`s and `Numeric`s to `source_id`s different then `None`, but we will still want to reuse the `TypeInfo` instances.)

- **Elimination of extensive temporary heap-allocations during hash calculation.** The custom hasher obtained by `make_hasher` required a `TypeSourceInfo` to calculate the hash and it was called every time the `insert` was called, ~530.000 times. Getting the `TypeSourceInfo` originally required cloning the `TypeInfo`, which depending on the concrete `TypeInfo` instance could cause heap allocations, and also heap-allocating that copy within an `Arc`. Hash was calculated regardless of the possibility for the type to be stored in the hash map of reusable types. The optimization removed the hashing step if the type is not shareable, removed the cloning of the `TypeInfo` and introduced a custom `compute_hash_without_heap_allocation` method that produced the same hash as the `make_hasher` but without unnecessary temporary heap-allocations of `TypeSourceInfo`s.

- **Replacement of `TypeSourceInfo`s within the hash map with `Arc<TypeSourceInfo>`s.** The hash map unnecessarily required making copies of reused `TypeSourceInfo`s.

- **Introducing the concept of a _shareable type_ and rolling it out for all types.** Previously, the engine checked only for changeability of types by using the `TypeInfo::is_changeable` method. The implementation of that method was extremely simplified, e.g. treating all structs and enums with generic arguments as changeable even if they were fully monomorphized. This resulted in over-bloating the engine with type instances that were actually unchangeable, but considered to be changeable. Also, strictly seen, the unchangeability (during unification and monomorphization) is not the only necessary criteria for reuse (or sharing) a type within the engine. Another important aspect is, as explained above, the _differentiability by annotations_. The PR introduces the notion of a _shareable type_ which is both unchangeable and not differentiable by annotations. The optimization takes advantage of such types by storing them only once per `source_id`.

- **Elimination of extensive unnecessary inserts of new types during `replace()` calls.** When `replace()`ing types during unifications, a new `TypeSourceInfo` instance was created for every replacement, ~46.000 times. This meant a heap-allocation of the `TypeSourceInfo` (16 bytes) and the `Arc`-contained `TypeInfo` (232 bytes), even if the replaced type was shareable and already available in the type engine. The optimization now reuses an already existing shareable type if available.

## Robustness related to `source_id`s

The issues we had with properly providing the `source_id` in the `insert` method are explained in #5991. This PR removes the `source_id` from the new public API and calculates it internally within the engine, based on the type being inserted. This makes inserting of types both more robust and less verbose and eliminates the possibility of providing a semantically wrong `source_id`.

Note that the calculation of an optimal `source_id` done within the engine fully corresponds to the "calculations" we currently have at call sites.

E.g., when inserting enums, previously we always had to write `type_engine.insert(engines, TypeInfo::Enum(decl_id), enum_decl.span.source_id())`. Fetching the `source_id` from the enum declaration is now done within the `insert_enum` method: `type_engine.insert_enum(engines, decl_id)`.

Note that for certain types we will want to change the current behavior and either provide a `source_id` or pick a more suitable one. E.g, even when inserting `Unknown`s, we will want to have `source_id`s, if possible. This will be done in #6603, but again, together with providing a robust API that will be difficult to misuse.

## Simplicity

As already mentioned in some of the examples above, the new `id_of_<type>()` and `insert_<type>` methods provide much simpler and less verbose API to use. Introducing those methods remove a lot of boilerplate code from the callers. Also, the individual `insert_<type>` methods are additionally optimized for inserting the particular type.

The common `insert` method is intended to be used only in cases where the inserted `TypeInfo` is not known at the call site.

Here are some examples of the new API versus the existing one:
|Before|After|
|------|-----|
| `type_engine.insert(engines, TypeInfo::Tuple(vec![]), None)` | `type_engine.id_of_unit()` |
| `type_engine.insert(engines, TypeInfo::Unknown, None)` | `type_engine.new_unknown()` |
| `type_engine.insert(engines, TypeInfo::UnsignedInteger(IntegerBits::SixtyFour), None)` | `type_engine.id_of_u64()` |

For more complex types, like, e.g., `TypeInfo::Tuple`, the difference in inserting is even more prominent, as can be seen from the diffs of numerous code lines deleted in this PR.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.