### PR TITLE
fix: pin forc-deploy to use 100kb blob size by default

### DIFF
--- a/docs/book/src/forc/plugins/forc_client/index.md
+++ b/docs/book/src/forc/plugins/forc_client/index.md
@@ -179,7 +179,7 @@ If an `address` is present, `forc` calls into that contract to update its `targe
 
 ## Large Contracts
 
-For contracts over the maximum contract size limit defined by the network, `forc-deploy` will split the contract into chunks and deploy the contract with multiple transactions using the Rust SDK's [loader contract](https://github.com/FuelLabs/fuels-rs/blob/master/docs/src/deploying/large_contracts.md) functionality. Chunks that have already been deployed will be reused on subsequent deployments.
+For contracts over the maximum contract size limit (currently `100kB`) defined by the network, `forc-deploy` will split the contract into chunks and deploy the contract with multiple transactions using the Rust SDK's [loader contract](https://github.com/FuelLabs/fuels-rs/blob/master/docs/src/deploying/large_contracts.md) functionality. Chunks that have already been deployed will be reused on subsequent deployments.
 
 ## Deploying Scripts and Predicates
 
@@ -200,4 +200,4 @@ The loader files contain the bytecode necessary to load and execute your script 
 
 This new deployment method allows for more efficient storage and execution of scripts and predicates on the Fuel network.
 
-Note: Contracts are still deployed directly, not as blobs given that the contract size is under the maximum contract size limit defined by network.
+Note: Contracts are still deployed directly, not as blobs given that the contract size is under the maximum contract size limit defined by network (currently `100kB`).


### PR DESCRIPTION
## Description

Pins forc-deploy chunk sizes to 100kb to fix errors while deploying chunked contracts. To unblock an ecosystem project, the PR is marked critical.