### PR TITLE
docs: updated docs to add quotes to the URL

### DIFF
--- a/docs/book/src/forc/plugins/forc_client/index.md
+++ b/docs/book/src/forc/plugins/forc_client/index.md
@@ -103,7 +103,7 @@ forc-deploy --testnet
 It is also possible to pass the exact node URL while using `forc-deploy` or `forc-run` which can be done using `--node-url` flag.
 
 ```sh
-forc-deploy --node-url https://beta-3.fuel.network
+forc-deploy --node-url "https://beta-3.fuel.network"
 ```
 
 Another alternative is the `--target` option, which provides useful aliases to all targets. For example if you want to deploy to `beta-5` you can use:


### PR DESCRIPTION
## Description

The following errors were being experienced by some grantees

```
> [1] 60342zsh: no matches found: https://mainnet.fuel.network/v1/graphql?username=blah                 
[1]  + exit 1     forc deploy --node-url https://mainnet.fuel.network/v1/graphql?username=blah
````

Adding quotes resolves this issue, so I have added documentation for this.
