### PR TITLE
Remove redundant `cfe(i)/cfs(i)` instructions from the allocated ASM

### DIFF
--- a/sway-core/src/asm_generation/fuel/abstract_instruction_set.rs
+++ b/sway-core/src/asm_generation/fuel/abstract_instruction_set.rs
@@ -30,7 +30,7 @@ impl AbstractInstructionSet {
             .simplify_cfg()
             .remove_sequential_jumps()
             .remove_redundant_moves()
-            .remove_unused_ops()
+            .remove_redundant_ops()
     }
 
     /// Removes any jumps to the subsequent line.
@@ -114,11 +114,16 @@ impl AbstractInstructionSet {
         self
     }
 
-    fn remove_unused_ops(mut self) -> AbstractInstructionSet {
-        // Just remove NOPs for now.
-        self.ops.retain(|op| match &op.opcode {
-            Either::Left(VirtualOp::NOOP) => false,
-            _otherwise => true,
+    fn remove_redundant_ops(mut self) -> AbstractInstructionSet {
+        self.ops.retain(|op| {
+            // It is easier to think in terms of operations we want to remove
+            // than the operations we want to retain ;-)
+            let remove = match &op.opcode {
+                    Either::Left(VirtualOp::NOOP) => true,
+                    _ => false,
+                };
+            
+            !remove
         });
 
         self

--- a/sway-core/src/asm_generation/fuel/allocated_abstract_instruction_set.rs
+++ b/sway-core/src/asm_generation/fuel/allocated_abstract_instruction_set.rs
@@ -35,6 +35,30 @@ pub struct AllocatedAbstractInstructionSet {
 }
 
 impl AllocatedAbstractInstructionSet {
+    pub(crate) fn optimize(self) -> AllocatedAbstractInstructionSet {
+        self.remove_redundant_ops()
+    }
+
+    fn remove_redundant_ops(mut self) -> AllocatedAbstractInstructionSet {
+        self.ops.retain(|op| {
+            // It is easier to think in terms of operations we want to remove
+            // than the operations we want to retain ;-)
+            let remove = match &op.opcode {
+                    // `cfei i0` and `cfsi i0` pairs.
+                    Either::Left(AllocatedOpcode::CFEI(imm))
+                    | Either::Left(AllocatedOpcode::CFSI(imm)) => imm.value == 0u32,
+                    // `cfe $zero` and `cfs $zero` pairs.
+                    Either::Left(AllocatedOpcode::CFE(reg))
+                    | Either::Left(AllocatedOpcode::CFS(reg)) => reg.is_zero(),
+                    _ => false,
+                };
+            
+            !remove
+        });
+
+        self
+    }
+
     /// Replace each PUSHA instruction with stores of all used registers to the stack, and each
     /// POPA with respective loads from the stack.
     ///

--- a/sway-core/src/asm_generation/fuel/programs/abstract.rs
+++ b/sway-core/src/asm_generation/fuel/programs/abstract.rs
@@ -78,7 +78,7 @@ impl AbstractProgram {
             && self.data_section.value_pairs.is_empty()
     }
 
-    /// Adds prologue, globals allocation, before entries, contract method switch, and allocates virtual register
+    /// Adds prologue, globals allocation, before entries, contract method switch, and allocates virtual register.
     pub(crate) fn into_allocated_program(
         mut self,
         fallback_fn: Option<crate::asm_lang::Label>,
@@ -111,21 +111,21 @@ impl AbstractProgram {
             })
             .collect();
 
-        // Gather all functions
+        // Gather all functions.
         let all_functions = self
             .entries
             .into_iter()
             .map(|entry| entry.ops)
             .chain(self.non_entries);
 
-        // optimise and then verify these functions.
+        // Optimize and then verify abstract functions.
         let abstract_functions = all_functions
             .map(|instruction_set| instruction_set.optimize(&self.data_section))
             .map(AbstractInstructionSet::verify)
             .collect::<Result<Vec<AbstractInstructionSet>, CompileError>>()?;
 
         // Allocate the registers for each function.
-        let functions = abstract_functions
+        let allocated_functions = abstract_functions
             .into_iter()
             .map(|abstract_instruction_set| {
                 let allocated = abstract_instruction_set.allocate_registers()?;
@@ -133,7 +133,12 @@ impl AbstractProgram {
             })
             .collect::<Result<Vec<AllocatedAbstractInstructionSet>, CompileError>>()?;
 
-        // XXX need to verify that the stack use for each function is balanced.
+        // Optimize allocated functions.
+        // TODO: Add verification. E.g., verify that the stack use for each function is balanced.
+        let functions = allocated_functions
+            .into_iter()
+            .map(|instruction_set| instruction_set.optimize())
+            .collect::<Vec<AllocatedAbstractInstructionSet>>();
 
         Ok(AllocatedProgram {
             kind: self.kind,

--- a/sway-core/src/asm_lang/allocated_ops.rs
+++ b/sway-core/src/asm_lang/allocated_ops.rs
@@ -50,6 +50,10 @@ impl AllocatedRegister {
             AllocatedRegister::Constant(constant) => constant.to_reg_id(),
         }
     }
+
+    pub fn is_zero(&self) -> bool {
+        matches!(self, Self::Constant(ConstantRegister::Zero))
+    }
 }
 
 /// This enum is unfortunately a redundancy of the [fuel_asm::Opcode] and [crate::VirtualOp] enums. This variant, however,


### PR DESCRIPTION
## Description

This PR removes redundant `cfei/cfsi` and `cfe/cfs` instructions from the allocated abstract instruction set, if the allocated/dealocated stack size is zero.

Note that, in the case of `cfei/cfsi i0` the removal does not represents a new optimization, because those instructions were anyhow removed at the final bytecode generation step. The PR in this case merely synchronizes the finalized ASM with the generated bytecode, removing potential confusion in existence of redundant zero stack allocations in the printed ASM.

The removal must be done on the allocated instruction set because the register allocation could change the original allocated/dealocated size in case of spilling.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.