### PR TITLE
remove beta and devnet refs

### DIFF
--- a/docs/book/src/forc/plugins/forc_client/index.md
+++ b/docs/book/src/forc/plugins/forc_client/index.md
@@ -109,13 +109,13 @@ forc-deploy --mainnet
 It is also possible to pass the exact node URL while using `forc-deploy` or `forc-run` which can be done using `--node-url` flag:
 
 ```sh
-forc-deploy --node-url https://beta-3.fuel.network
+forc-deploy --node-url https://mainnet.fuel.network
 ```
 
-Another alternative is the `--target` option, which provides useful aliases to all targets. For example if you want to deploy to `beta-5` you can use:
+Another alternative is the `--target` option, which provides useful aliases to all targets. For example if you want to deploy to `testnet` you can use:
 
 ```sh
-forc-deploy --target beta-5
+forc-deploy --target testnet
 ```
 
 Since deploying and running projects on the testnet cost gas, you will need coins to pay for them. You can get some using the [testnet faucet](https://faucet-testnet.fuel.network/).

--- a/forc-plugins/forc-client/src/cmd/deploy.rs
+++ b/forc-plugins/forc-client/src/cmd/deploy.rs
@@ -10,7 +10,7 @@ forc_util::cli_examples! {
    super::Command {
         [ Deploy a single contract => "forc deploy bc09bfa7a11a04ce42b0a5abf04fd437387ee49bf4561d575177e2946468b408" ]
         [ Deploy a single contract from a different path => "forc deploy bc09bfa7a11a04ce42b0a5abf04fd437387ee49bf4561d575177e2946468b408 --path {path}" ]
-        [ Deploy to a custom network => "forc deploy --node-url https://beta-5.fuel.network/graphql" ]
+        [ Deploy to a custom network => "forc deploy --node-url https://testnet.fuel.network/graphql" ]
     }
 }
 

--- a/forc-plugins/forc-client/src/constants.rs
+++ b/forc-plugins/forc-client/src/constants.rs
@@ -1,21 +1,11 @@
 /// Default to localhost to favour the common case of testing.
 pub const NODE_URL: &str = sway_utils::constants::DEFAULT_NODE_URL;
-pub const BETA_2_ENDPOINT_URL: &str = "https://node-beta-2.fuel.network";
-pub const BETA_3_ENDPOINT_URL: &str = "https://beta-3.fuel.network";
-pub const BETA_4_ENDPOINT_URL: &str = "https://beta-4.fuel.network";
-pub const BETA_5_ENDPOINT_URL: &str = "https://beta-5.fuel.network";
-pub const DEVNET_ENDPOINT_URL: &str = "https://devnet.fuel.network";
 pub const TESTNET_ENDPOINT_URL: &str = "https://testnet.fuel.network";
 pub const MAINNET_ENDPOINT_URL: &str = "https://mainnet.fuel.network";
 
-pub const BETA_2_FAUCET_URL: &str = "https://faucet-beta-2.fuel.network";
-pub const BETA_3_FAUCET_URL: &str = "https://faucet-beta-3.fuel.network";
-pub const BETA_4_FAUCET_URL: &str = "https://faucet-beta-4.fuel.network";
-pub const BETA_5_FAUCET_URL: &str = "https://faucet-beta-5.fuel.network";
-pub const DEVNET_FAUCET_URL: &str = "https://faucet-devnet.fuel.network";
 pub const TESTNET_FAUCET_URL: &str = "https://faucet-testnet.fuel.network";
 
-pub const TESTNET_EXPLORER_URL: &str = "https://app.fuel.network";
+pub const TESTNET_EXPLORER_URL: &str = "https://app-testnet.fuel.network";
 pub const MAINNET_EXPLORER_URL: &str = "https://app.fuel.network";
 
 /// Default PrivateKey to sign transactions submitted to local node.

--- a/forc-plugins/forc-client/src/lib.rs
+++ b/forc-plugins/forc-client/src/lib.rs
@@ -22,7 +22,7 @@ pub struct NodeTarget {
     ///
     /// You can also use `--node-url`, `--testnet`, or `--mainnet` to specify the Fuel node.
     ///
-    /// Possible values are: [beta-1, beta-2, beta-3, beta-4, devnet, local, testnet, mainnet]
+    /// Possible values are: [local, testnet, mainnet]
     #[clap(long)]
     pub target: Option<Target>,
 

--- a/forc-plugins/forc-client/src/util/node_url.rs
+++ b/forc-plugins/forc-client/src/util/node_url.rs
@@ -60,18 +60,6 @@ fn test_get_node_url_mainnet() {
 }
 
 #[test]
-fn test_get_node_url_target_devnet() {
-    let input = NodeTarget {
-        target: Some(Target::Devnet),
-        node_url: None,
-        testnet: false,
-        mainnet: false,
-    };
-    let actual = get_node_url(&input, &None).unwrap();
-    assert_eq!("https://devnet.fuel.network", actual);
-}
-
-#[test]
 fn test_get_node_url_target_mainnet() {
     let input = NodeTarget {
         target: Some(Target::Mainnet),
@@ -97,46 +85,6 @@ fn test_get_node_url_target_testnet() {
 }
 
 #[test]
-fn test_get_node_url_beta5() {
-    let input = NodeTarget {
-        target: Some(Target::Beta5),
-        node_url: None,
-        testnet: false,
-        mainnet: false,
-    };
-    let actual = get_node_url(&input, &None).unwrap();
-    assert_eq!("https://beta-5.fuel.network", actual);
-}
-
-#[test]
-fn test_get_node_url_beta4() {
-    let input = NodeTarget {
-        target: None,
-        node_url: Some("https://beta-4.fuel.network".to_string()),
-        testnet: false,
-        mainnet: false,
-    };
-    let actual = get_node_url(&input, &None).unwrap();
-    assert_eq!("https://beta-4.fuel.network", actual);
-}
-
-#[test]
-fn test_get_node_url_url_beta4_manifest() {
-    let network = Network {
-        url: "https://beta-4.fuel.network".to_string(),
-    };
-    let input = NodeTarget {
-        target: None,
-        node_url: None,
-        testnet: false,
-        mainnet: false,
-    };
-
-    let actual = get_node_url(&input, &Some(network)).unwrap();
-    assert_eq!("https://beta-4.fuel.network", actual);
-}
-
-#[test]
 fn test_get_node_url_default() {
     let input = NodeTarget {
         target: None,
@@ -147,18 +95,6 @@ fn test_get_node_url_default() {
 
     let actual = get_node_url(&input, &None).unwrap();
     assert_eq!("http://127.0.0.1:4000", actual);
-}
-
-#[test]
-fn test_get_node_url_beta3() {
-    let input = NodeTarget {
-        target: Some(Target::Beta3),
-        node_url: None,
-        testnet: false,
-        mainnet: false,
-    };
-    let actual = get_node_url(&input, &None).unwrap();
-    assert_eq!("https://beta-3.fuel.network", actual);
 }
 
 #[test]
@@ -193,8 +129,8 @@ fn test_get_node_url_local_testnet() {
 )]
 fn test_get_node_url_same_url() {
     let input = NodeTarget {
-        target: Some(Target::Beta3),
-        node_url: Some("beta-3.fuel.network".to_string()),
+        target: Some(Target::Testnet),
+        node_url: Some("testnet.fuel.network".to_string()),
         testnet: false,
         mainnet: false,
     };

--- a/forc-plugins/forc-client/src/util/target.rs
+++ b/forc-plugins/forc-client/src/util/target.rs
@@ -1,8 +1,6 @@
 use crate::constants::{
-    BETA_2_ENDPOINT_URL, BETA_2_FAUCET_URL, BETA_3_ENDPOINT_URL, BETA_3_FAUCET_URL,
-    BETA_4_ENDPOINT_URL, BETA_4_FAUCET_URL, BETA_5_ENDPOINT_URL, BETA_5_FAUCET_URL,
-    DEVNET_ENDPOINT_URL, DEVNET_FAUCET_URL, MAINNET_ENDPOINT_URL, MAINNET_EXPLORER_URL, NODE_URL,
-    TESTNET_ENDPOINT_URL, TESTNET_EXPLORER_URL, TESTNET_FAUCET_URL,
+    MAINNET_ENDPOINT_URL, MAINNET_EXPLORER_URL, NODE_URL, TESTNET_ENDPOINT_URL,
+    TESTNET_EXPLORER_URL, TESTNET_FAUCET_URL,
 };
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
@@ -11,11 +9,6 @@ use std::str::FromStr;
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 /// Possible target values that forc-client can interact with.
 pub enum Target {
-    Beta2,
-    Beta3,
-    Beta4,
-    Beta5,
-    Devnet,
     Testnet,
     Mainnet,
     Local,
@@ -30,11 +23,6 @@ impl Default for Target {
 impl Target {
     pub fn target_url(&self) -> String {
         let url = match self {
-            Target::Beta2 => BETA_2_ENDPOINT_URL,
-            Target::Beta3 => BETA_3_ENDPOINT_URL,
-            Target::Beta4 => BETA_4_ENDPOINT_URL,
-            Target::Beta5 => BETA_5_ENDPOINT_URL,
-            Target::Devnet => DEVNET_ENDPOINT_URL,
             Target::Testnet => TESTNET_ENDPOINT_URL,
             Target::Mainnet => MAINNET_ENDPOINT_URL,
             Target::Local => NODE_URL,
@@ -44,11 +32,6 @@ impl Target {
 
     pub fn from_target_url(target_url: &str) -> Option<Self> {
         match target_url {
-            BETA_2_ENDPOINT_URL => Some(Target::Beta2),
-            BETA_3_ENDPOINT_URL => Some(Target::Beta3),
-            BETA_4_ENDPOINT_URL => Some(Target::Beta4),
-            BETA_5_ENDPOINT_URL => Some(Target::Beta5),
-            DEVNET_ENDPOINT_URL => Some(Target::Devnet),
             TESTNET_ENDPOINT_URL => Some(Target::Testnet),
             MAINNET_ENDPOINT_URL => Some(Target::Mainnet),
             NODE_URL => Some(Target::Local),
@@ -70,11 +53,6 @@ impl Target {
 
     pub fn faucet_url(&self) -> Option<String> {
         match self {
-            Target::Beta2 => Some(BETA_2_FAUCET_URL.to_string()),
-            Target::Beta3 => Some(BETA_3_FAUCET_URL.to_string()),
-            Target::Beta4 => Some(BETA_4_FAUCET_URL.to_string()),
-            Target::Beta5 => Some(BETA_5_FAUCET_URL.to_string()),
-            Target::Devnet => Some(DEVNET_FAUCET_URL.to_string()),
             Target::Testnet => Some(TESTNET_FAUCET_URL.to_string()),
             Target::Mainnet => None,
             Target::Local => Some("http://localhost:3000".to_string()),
@@ -83,7 +61,7 @@ impl Target {
 
     pub fn explorer_url(&self) -> Option<String> {
         match self {
-            Target::Testnet | Target::Devnet => Some(TESTNET_EXPLORER_URL.to_string()),
+            Target::Testnet => Some(TESTNET_EXPLORER_URL.to_string()),
             Target::Mainnet => Some(MAINNET_EXPLORER_URL.to_string()),
             _ => None,
         }
@@ -95,21 +73,11 @@ impl FromStr for Target {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "beta-2" => Ok(Target::Beta2),
-            "beta-3" => Ok(Target::Beta3),
-            "beta-4" => Ok(Target::Beta4),
-            "beta-5" => Ok(Target::Beta5),
-            "devnet" => Ok(Target::Devnet),
             "testnet" => Ok(Target::Testnet),
             "mainnet" => Ok(Target::Mainnet),
             "local" => Ok(Target::Local),
             _ => bail!(
-                "'{s}' is not a valid target name. Possible values: '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}'",
-                Target::Beta2,
-                Target::Beta3,
-                Target::Beta4,
-                Target::Beta5,
-                Target::Devnet,
+                "'{s}' is not a valid target name. Possible values: '{}', '{}', '{}'",
                 Target::Testnet,
                 Target::Mainnet,
                 Target::Local
@@ -121,11 +89,6 @@ impl FromStr for Target {
 impl std::fmt::Display for Target {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
-            Target::Beta2 => "beta-2",
-            Target::Beta3 => "beta-3",
-            Target::Beta4 => "beta-4",
-            Target::Beta5 => "beta-5",
-            Target::Devnet => "devnet",
             Target::Testnet => "testnet",
             Target::Mainnet => "mainnet",
             Target::Local => "local",


### PR DESCRIPTION
## Description
Removes any references to beta networks and unmaintained devnet channels.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
