### PR TITLE
Properly treat `FuelVMInstruction`s in the `memcpyopt`

### DIFF
--- a/sway-ir/src/optimize/memcpyopt.rs
+++ b/sway-ir/src/optimize/memcpyopt.rs
@@ -655,7 +655,9 @@ fn local_copy_prop(
                                 FuelVmInstruction::WideBinaryOp { result, .. }
                                 | FuelVmInstruction::WideUnaryOp { result, .. }
                                 | FuelVmInstruction::WideModularOp { result, .. }
-                                | FuelVmInstruction::StateLoadQuadWord { load_val: result, ..}
+                                | FuelVmInstruction::StateLoadQuadWord {
+                                    load_val: result, ..
+                                },
                             ),
                         ..
                     } => {

--- a/sway-ir/src/optimize/memcpyopt.rs
+++ b/sway-ir/src/optimize/memcpyopt.rs
@@ -7,9 +7,9 @@ use sway_types::{FxIndexMap, FxIndexSet};
 
 use crate::{
     get_gep_symbol, get_referred_symbol, get_referred_symbols, get_stored_symbols, memory_utils,
-    AnalysisResults, Block, Context, EscapedSymbols, Function, InstOp, Instruction,
-    InstructionInserter, IrError, LocalVar, Pass, PassMutability, ReferredSymbols, ScopedPass,
-    Symbol, Type, Value, ValueDatum, ESCAPED_SYMBOLS_NAME,
+    AnalysisResults, Block, Context, EscapedSymbols, FuelVmInstruction, Function, InstOp,
+    Instruction, InstructionInserter, IrError, LocalVar, Pass, PassMutability, ReferredSymbols,
+    ScopedPass, Symbol, Type, Value, ValueDatum, ESCAPED_SYMBOLS_NAME,
 };
 
 pub const MEMCPYOPT_NAME: &str = "memcpyopt";
@@ -644,6 +644,24 @@ fn local_copy_prop(
                             context,
                             *dst_val_ptr,
                             memory_utils::pointee_size(context, *dst_val_ptr),
+                            &mut available_copies,
+                            &mut src_to_copies,
+                            &mut dest_to_copies,
+                        );
+                    }
+                    Instruction {
+                        op:
+                            InstOp::FuelVm(
+                                FuelVmInstruction::WideBinaryOp { result, .. }
+                                | FuelVmInstruction::WideUnaryOp { result, .. }
+                                | FuelVmInstruction::WideModularOp { result, .. },
+                            ),
+                        ..
+                    } => {
+                        kill_defined_symbol(
+                            context,
+                            *result,
+                            memory_utils::pointee_size(context, *result),
                             &mut available_copies,
                             &mut src_to_copies,
                             &mut dest_to_copies,

--- a/sway-ir/src/optimize/memcpyopt.rs
+++ b/sway-ir/src/optimize/memcpyopt.rs
@@ -654,7 +654,8 @@ fn local_copy_prop(
                             InstOp::FuelVm(
                                 FuelVmInstruction::WideBinaryOp { result, .. }
                                 | FuelVmInstruction::WideUnaryOp { result, .. }
-                                | FuelVmInstruction::WideModularOp { result, .. },
+                                | FuelVmInstruction::WideModularOp { result, .. }
+                                | FuelVmInstruction::StateLoadQuadWord { load_val: result, ..}
                             ),
                         ..
                     } => {

--- a/sway-ir/tests/memcpyopt/no_memcpyopt_wide_binary_operator.ir
+++ b/sway-ir/tests/memcpyopt/no_memcpyopt_wide_binary_operator.ir
@@ -1,0 +1,20 @@
+script {
+    entry fn main() -> u256 {
+        local u256 x
+        local u256 y
+        local u256 z
+
+        entry():
+        v0 = get_local ptr u256, x
+        v1 = get_local ptr u256, y
+        v2 = get_local ptr u256, z
+
+        mem_copy_val v2, v0
+        wide add v0, v1 to v2
+        v3 = load v2
+
+        ret u256 v3
+    }
+}
+
+// check: v3 = load v2

--- a/sway-ir/tests/memcpyopt/no_memcpyopt_wide_unary_operator.ir
+++ b/sway-ir/tests/memcpyopt/no_memcpyopt_wide_unary_operator.ir
@@ -1,0 +1,20 @@
+script {
+    entry fn main() -> u256 {
+        local u256 x
+        local u256 y
+        local u256 z
+
+        entry():
+        v0 = get_local ptr u256, x
+        v1 = get_local ptr u256, y
+        v2 = get_local ptr u256, z
+
+        mem_copy_val v2, v0
+        wide not v1 to v2
+        v3 = load v2
+
+        ret u256 v3
+    }
+}
+
+// check: v3 = load v2


### PR DESCRIPTION
## Description

This PR fixes the issue of  `FuelVMInstruction`s not being considered in the `memcpyopt` as storing into the destination. E.g., in this example:
```
script {
    entry fn main() -> u256 {
        local u256 x
        local u256 y
        local u256 z

        entry():
        v0 = get_local ptr u256, x
        v1 = get_local ptr u256, y
        v2 = get_local ptr u256, z

        mem_copy_val v2, v0
        wide add v0, v1 to v2
        v3 = load v2

        ret u256 v3
    }
}
```
after the `memcpyopt` the `v3 = load v2` got turned into `v3 = load v0` because the `v2` is considered as not being written to.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.