### PR TITLE
Return 0 early if divisor is 0 - U128 div

### DIFF
--- a/sway-lib-std/src/u128.sw
+++ b/sway-lib-std/src/u128.sw
@@ -635,6 +635,10 @@ impl core::ops::Divide for U128 {
 
         if panic_on_unsafe_math_enabled() {
             assert(divisor != zero);
+        } else {
+            if divisor == zero {
+                return zero;
+            }
         }
 
         if self.upper == 0 && divisor.upper == 0 {


### PR DESCRIPTION
## Description
Incase panic on unsafe math is disabled, we return 0 if divisor is 0

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
