### PR TITLE
Forbid `memcpyopt` if the source pointer escapes

### DIFF
--- a/sway-ir/src/instruction.rs
+++ b/sway-ir/src/instruction.rs
@@ -385,10 +385,11 @@ impl InstOp {
                 vals
             }
             InstOp::GetLocal(_local_var) => {
-                // TODO: Not sure.
+                // `GetLocal` returns an SSA `Value` but does not take any as an operand.
                 vec![]
             }
             InstOp::GetConfig(_, _) => {
+                // `GetConfig` returns an SSA `Value` but does not take any as an operand.
                 vec![]
             }
             InstOp::IntToPtr(v, _) => vec![*v],

--- a/sway-ir/src/optimize/cse.rs
+++ b/sway-ir/src/optimize/cse.rs
@@ -220,7 +220,7 @@ pub fn cse(
         }
     }
 
-    // Initialize all instructions and constants. Constants need special treatmemt.
+    // Initialize all instructions and constants. Constants need special treatment.
     // They don't have PartialEq implemented. So we need to value number them manually.
     // This map maps the hash of a constant value to all possible collisions of it.
     let mut const_map = FxHashMap::<u64, Vec<Value>>::default();

--- a/sway-ir/src/optimize/memcpyopt.rs
+++ b/sway-ir/src/optimize/memcpyopt.rs
@@ -166,6 +166,7 @@ fn local_copy_prop_prememcpy(
                         })
                         // We don't deal with symbols that escape.
                         || escaped_symbols.contains(&dst_local)
+                        || escaped_symbols.contains(&src_local)
                         // We don't deal part copies.
                         || dst_local.get_type(context) != src_local.get_type(context)
                         // We don't replace the destination when it's an arg.

--- a/sway-ir/tests/memcpyopt/no_copy_prop_src_ptr_escapes.ir
+++ b/sway-ir/tests/memcpyopt/no_copy_prop_src_ptr_escapes.ir
@@ -1,0 +1,33 @@
+script {
+    entry fn main() -> u64 {
+        local u64 x
+        local u64 y
+
+        entry():
+        v0 = get_local ptr u64, x
+        v1 = get_local ptr u64, y
+	
+        v2 = load v0
+        v3 = call escape(v0) // `v0` escapes here.
+        store v2 to v1
+        v4 = load v1
+
+        ret u64 v4
+    }
+
+    fn escape(a: ptr u64) -> u64 {
+        entry(a: ptr u64):
+        z = const u64 0
+        store z to a
+        ret u64 z
+    }
+}
+
+// The `store` instruction must not be optimized away.
+
+// check: v0 = get_local ptr u64, x
+// check: v1 = get_local ptr u64, y
+// check: v2 = load v0
+// check: v3 = call escape(v0)
+// check: store v2 to v1
+// check: v4 = load v1


### PR DESCRIPTION
## Description

This PR fixes the issue of the source pointer not being checked for escapes in the `memcpyopt::local_copy_prop_prememcpy`. E.g., in this example:
```
script {
    entry fn main() -> u64 {
        local u64 x
        local u64 y

        entry():
        v0 = get_local ptr u64, x
        v1 = get_local ptr u64, y
	
        v2 = load v0
        v3 = call escape(v0) // `v0` escapes here.
        store v2 to v1
        v4 = load v1

        ret u64 v4
    }

    fn escape(a: ptr u64) -> u64 {
        entry(a: ptr u64):
        z = const u64 0
        store z to a
        ret u64 z
    }
}
```
after the `memcpyopt` the `store v2 to v1` got optimized away and the final return was from `v0`. It means the returned value was the one changed in `escape` and not the one taken before the call to `escape`.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.