### PR TITLE
Refactor type resolve to deal with `ResolvedDeclaration`.

### DIFF
--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -679,7 +679,7 @@ impl<'a> TypeCheckContext<'a> {
         &self,
         handler: &Handler,
         call_path: &CallPath,
-    ) -> Result<ty::TyDecl, ErrorEmitted> {
+    ) -> Result<ResolvedDeclaration, ErrorEmitted> {
         resolve_call_path(
             handler,
             self.engines(),
@@ -694,7 +694,7 @@ impl<'a> TypeCheckContext<'a> {
         &mut self,
         handler: &Handler,
         qualified_call_path: &QualifiedCallPath,
-    ) -> Result<ty::TyDecl, ErrorEmitted> {
+    ) -> Result<ResolvedDeclaration, ErrorEmitted> {
         resolve_qualified_call_path(
             handler,
             self.engines(),

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -311,7 +311,9 @@ impl TypeCheckTypeBinding<ty::TyFunctionDecl> for TypeBinding<CallPath> {
         let decl_engine = ctx.engines.de();
         let engines = ctx.engines();
         // Grab the declaration.
-        let unknown_decl = ctx.resolve_call_path_with_visibility_check(handler, &self.inner)?;
+        let unknown_decl = ctx
+            .resolve_call_path_with_visibility_check(handler, &self.inner)?
+            .expect_typed();
         // Check to see if this is a fn declaration.
         let fn_ref = unknown_decl.to_fn_ref(handler, ctx.engines())?;
         // Get a new copy from the declaration engine.
@@ -389,7 +391,9 @@ impl TypeCheckTypeBinding<ty::TyStructDecl> for TypeBinding<CallPath> {
         let decl_engine = ctx.engines.de();
         let engines = ctx.engines();
         // Grab the declaration.
-        let unknown_decl = ctx.resolve_call_path_with_visibility_check(handler, &self.inner)?;
+        let unknown_decl = ctx
+            .resolve_call_path_with_visibility_check(handler, &self.inner)?
+            .expect_typed();
         // Check to see if this is a struct declaration.
         let struct_id = unknown_decl.to_struct_decl(handler, engines)?;
         // Get a new copy from the declaration engine.
@@ -433,7 +437,9 @@ impl TypeCheckTypeBinding<ty::TyEnumDecl> for TypeBinding<CallPath> {
         let decl_engine = ctx.engines.de();
         let engines = ctx.engines();
         // Grab the declaration.
-        let unknown_decl = ctx.resolve_call_path_with_visibility_check(handler, &self.inner)?;
+        let unknown_decl = ctx
+            .resolve_call_path_with_visibility_check(handler, &self.inner)?
+            .expect_typed();
 
         // Get a new copy from the declaration engine.
         let enum_id = if let ty::TyDecl::EnumVariantDecl(ty::EnumVariantDecl { enum_ref, .. }) =
@@ -474,8 +480,9 @@ impl TypeBinding<QualifiedCallPath> {
         ctx: &mut TypeCheckContext,
     ) -> Result<DeclRef<DeclId<ty::TyConstantDecl>>, ErrorEmitted> {
         // Grab the declaration.
-        let unknown_decl =
-            ctx.resolve_qualified_call_path_with_visibility_check(handler, &self.inner)?;
+        let unknown_decl = ctx
+            .resolve_qualified_call_path_with_visibility_check(handler, &self.inner)?
+            .expect_typed();
 
         // Check to see if this is a const declaration.
         let const_ref = unknown_decl.to_const_ref(handler, ctx.engines())?;
@@ -498,7 +505,9 @@ impl TypeCheckTypeBinding<ty::TyConstantDecl> for TypeBinding<CallPath> {
         ErrorEmitted,
     > {
         // Grab the declaration.
-        let unknown_decl = ctx.resolve_call_path_with_visibility_check(handler, &self.inner)?;
+        let unknown_decl = ctx
+            .resolve_call_path_with_visibility_check(handler, &self.inner)?
+            .expect_typed();
 
         // Check to see if this is a const declaration.
         let const_ref = unknown_decl.to_const_ref(handler, ctx.engines())?;


### PR DESCRIPTION
## Description

Refactor type resolving to deal with `ResolvedDeclaration` instead of just `ty::TyDecl`.

Allows further re-use of this code to deal with parsed declarations too.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
