### PR TITLE
improve error messages for array items

### DIFF
--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -2007,7 +2007,7 @@ impl ty::TyExpression {
                     Self::type_check(&handler, ctx, expr)
                         .unwrap_or_else(|err| ty::TyExpression::error(err, span, engines))
                 } else {
-                    Self::type_check(&handler, ctx, expr)
+                    Self::type_check(handler, ctx, expr)
                         .unwrap_or_else(|err| ty::TyExpression::error(err, span, engines))
                 }
             })

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -1946,7 +1946,7 @@ impl ty::TyExpression {
     }
 
     fn type_check_array(
-        _handler: &Handler,
+        handler: &Handler,
         mut ctx: TypeCheckContext,
         contents: &[Expression],
         span: Span,
@@ -2001,10 +2001,15 @@ impl ty::TyExpression {
                     .with_help_text("")
                     .with_type_annotation(type_engine.insert(engines, initial_type.clone(), None));
 
-                // type_check_analyze unification will give the final error
-                let handler = Handler::default();
-                Self::type_check(&handler, ctx, expr)
-                    .unwrap_or_else(|err| ty::TyExpression::error(err, span, engines))
+                if let TypeInfo::Unknown = initial_type {
+                    // type_check_analyze unification will give the final error
+                    let handler = Handler::default();
+                    Self::type_check(&handler, ctx, expr)
+                        .unwrap_or_else(|err| ty::TyExpression::error(err, span, engines))
+                } else {
+                    Self::type_check(&handler, ctx, expr)
+                        .unwrap_or_else(|err| ty::TyExpression::error(err, span, engines))
+                }
             })
             .collect();
 

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -2001,15 +2001,16 @@ impl ty::TyExpression {
                     .with_help_text("")
                     .with_type_annotation(type_engine.insert(engines, initial_type.clone(), None));
 
-                if let TypeInfo::Unknown = initial_type {
-                    // type_check_analyze unification will give the final error
-                    let handler = Handler::default();
-                    Self::type_check(&handler, ctx, expr)
-                        .unwrap_or_else(|err| ty::TyExpression::error(err, span, engines))
-                } else {
-                    Self::type_check(handler, ctx, expr)
-                        .unwrap_or_else(|err| ty::TyExpression::error(err, span, engines))
+                // type_check_analyze unification will give the final error
+                let type_check_handler = Handler::default();
+                let result = Self::type_check(&type_check_handler, ctx, expr)
+                    .unwrap_or_else(|err| ty::TyExpression::error(err, span, engines));
+
+                if let TypeInfo::ErrorRecovery(_) = &*engines.te().get(result.return_type) {
+                    handler.append(type_check_handler);
                 }
+
+                result
             })
             .collect();
 
@@ -2987,7 +2988,7 @@ mod tests {
         let _comp_res = do_type_check_for_boolx2(&handler, &expr);
         let (errors, _warnings) = handler.consume();
 
-        assert!(errors.len() == 1);
+        assert_eq!(errors.len(), 1);
         assert!(matches!(&errors[0],
                          CompileError::TypeError(TypeError::MismatchedType {
                              expected,

--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw
@@ -46,4 +46,7 @@ fn main() {
 
     // Should not warn or error
     let _ : [u8 ; 0] = [];
+
+    // Literal too big
+    let mut a = [8u8, 8, 18446744073709551615];
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/stdout.snap
@@ -10,36 +10,6 @@ stdout:
 
 stderr:
 error
-  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:41:27
-   |
-39 |     // unexpected Option<u8>
-40 |     let a = [None, Some(1), Some(1u8)];
-41 |     let _b: Option<u16> = a[1];
-   |                           ^^^^ Mismatched types.
-expected: Option<u16>
-found:    Option<u8>.
-help: Variable declaration's type annotation does not match up with the assigned expression's type.
-42 | 
-43 |     // unexpected u8
-   |
-____
-
-error
-  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:45:18
-   |
-43 |     // unexpected u8
-44 |     let a = [8, 256u16, 8u8];
-45 |     let b: u32 = a[2];
-   |                  ^^^^ Mismatched types.
-expected: u32
-found:    u16.
-help: Variable declaration's type annotation does not match up with the assigned expression's type.
-46 | 
-47 |     // Should not warn or error
-   |
-____
-
-error
   --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:9:22
    |
  7 | fn main() {
@@ -270,12 +240,42 @@ error
 35 | 
 36 |     // unexpected Vec<u16>
 37 |     let _ = [Vec::new(), vec::<u8>(), vec::<u16>()];
+   |                                       ^^^^^^^^^^ Mismatched types.
+expected: Vec<u8>
+found:    Vec<u16>.
+help: Function return type does not match up with local type annotation.
+38 |     
+39 |     // unexpected Option<u8>
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:37:39
+   |
+35 | 
+36 |     // unexpected Vec<u16>
+37 |     let _ = [Vec::new(), vec::<u8>(), vec::<u16>()];
    |                                       ^^^^^^^^^^^^ Mismatched types.
 expected: Vec<u8>
 found:    Vec<u16>.
 
 38 |     
 39 |     // unexpected Option<u8>
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:41:27
+   |
+39 |     // unexpected Option<u8>
+40 |     let a = [None, Some(1), Some(1u8)];
+41 |     let _b: Option<u16> = a[1];
+   |                           ^^^^ Mismatched types.
+expected: Option<u16>
+found:    Option<u8>.
+help: Variable declaration's type annotation does not match up with the assigned expression's type.
+42 | 
+43 |     // unexpected u8
    |
 ____
 
@@ -294,5 +294,31 @@ found:    u8.
    |
 ____
 
-  Aborting due to 19 errors.
+error
+  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:45:18
+   |
+43 |     // unexpected u8
+44 |     let a = [8, 256u16, 8u8];
+45 |     let b: u32 = a[2];
+   |                  ^^^^ Mismatched types.
+expected: u32
+found:    u16.
+help: Variable declaration's type annotation does not match up with the assigned expression's type.
+46 | 
+47 |     // Should not warn or error
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:51:26
+   |
+49 | 
+50 |     // Literal too big
+51 |     let mut a = [8u8, 8, 18446744073709551615];
+   |                          ^^^^^^^^^^^^^^^^^^^^ Literal value is too large for type u8.
+52 | }
+   |
+____
+
+  Aborting due to 21 errors.
 error: Failed to compile array_wrong_elements_types

--- a/test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/stdout.snap
@@ -10,6 +10,47 @@ stdout:
 
 stderr:
 error
+  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:41:27
+   |
+39 |     // unexpected Option<u8>
+40 |     let a = [None, Some(1), Some(1u8)];
+41 |     let _b: Option<u16> = a[1];
+   |                           ^^^^ Mismatched types.
+expected: Option<u16>
+found:    Option<u8>.
+help: Variable declaration's type annotation does not match up with the assigned expression's type.
+42 | 
+43 |     // unexpected u8
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:45:18
+   |
+43 |     // unexpected u8
+44 |     let a = [8, 256u16, 8u8];
+45 |     let b: u32 = a[2];
+   |                  ^^^^ Mismatched types.
+expected: u32
+found:    u16.
+help: Variable declaration's type annotation does not match up with the assigned expression's type.
+46 | 
+47 |     // Should not warn or error
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:51:26
+   |
+49 | 
+50 |     // Literal too big
+51 |     let mut a = [8u8, 8, 18446744073709551615];
+   |                          ^^^^^^^^^^^^^^^^^^^^ Literal value is too large for type u8.
+52 | }
+   |
+____
+
+error
   --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:9:22
    |
  7 | fn main() {
@@ -240,42 +281,12 @@ error
 35 | 
 36 |     // unexpected Vec<u16>
 37 |     let _ = [Vec::new(), vec::<u8>(), vec::<u16>()];
-   |                                       ^^^^^^^^^^ Mismatched types.
-expected: Vec<u8>
-found:    Vec<u16>.
-help: Function return type does not match up with local type annotation.
-38 |     
-39 |     // unexpected Option<u8>
-   |
-____
-
-error
-  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:37:39
-   |
-35 | 
-36 |     // unexpected Vec<u16>
-37 |     let _ = [Vec::new(), vec::<u8>(), vec::<u16>()];
    |                                       ^^^^^^^^^^^^ Mismatched types.
 expected: Vec<u8>
 found:    Vec<u16>.
 
 38 |     
 39 |     // unexpected Option<u8>
-   |
-____
-
-error
-  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:41:27
-   |
-39 |     // unexpected Option<u8>
-40 |     let a = [None, Some(1), Some(1u8)];
-41 |     let _b: Option<u16> = a[1];
-   |                           ^^^^ Mismatched types.
-expected: Option<u16>
-found:    Option<u8>.
-help: Variable declaration's type annotation does not match up with the assigned expression's type.
-42 | 
-43 |     // unexpected u8
    |
 ____
 
@@ -294,31 +305,5 @@ found:    u8.
    |
 ____
 
-error
-  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:45:18
-   |
-43 |     // unexpected u8
-44 |     let a = [8, 256u16, 8u8];
-45 |     let b: u32 = a[2];
-   |                  ^^^^ Mismatched types.
-expected: u32
-found:    u16.
-help: Variable declaration's type annotation does not match up with the assigned expression's type.
-46 | 
-47 |     // Should not warn or error
-   |
-____
-
-error
-  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:51:26
-   |
-49 | 
-50 |     // Literal too big
-51 |     let mut a = [8u8, 8, 18446744073709551615];
-   |                          ^^^^^^^^^^^^^^^^^^^^ Literal value is too large for type u8.
-52 | }
-   |
-____
-
-  Aborting due to 21 errors.
+  Aborting due to 20 errors.
 error: Failed to compile array_wrong_elements_types

--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_check_analyze_errors/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_check_analyze_errors/stdout.snap
@@ -10,6 +10,21 @@ stdout:
 
 stderr:
 error
+  --> test/src/e2e_vm_tests/test_programs/should_fail/type_check_analyze_errors/src/main.sw:20:22
+   |
+18 | 
+19 | fn insufficient_type_check(arg: u64) -> [u32;2] {
+20 |     let res = [1u32, arg];
+   |                      ^^^ Mismatched types.
+expected: u32
+found:    u64.
+
+21 |     res
+22 | }
+   |
+____
+
+error
  --> test/src/e2e_vm_tests/test_programs/should_fail/type_check_analyze_errors/src/main.sw:5:14
   |
 3 | fn main() {
@@ -42,21 +57,6 @@ error
    |              ^^^^^^^^^^^ Literal would overflow because its value does not fit into "u32"
 14 |     Vec::<u32>::new().push(_a);
 15 | 
-   |
-____
-
-error
-  --> test/src/e2e_vm_tests/test_programs/should_fail/type_check_analyze_errors/src/main.sw:20:22
-   |
-18 | 
-19 | fn insufficient_type_check(arg: u64) -> [u32;2] {
-20 |     let res = [1u32, arg];
-   |                      ^^^ Mismatched types.
-expected: u32
-found:    u64.
-
-21 |     res
-22 | }
    |
 ____
 

--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_check_analyze_errors/stdout.snap
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_check_analyze_errors/stdout.snap
@@ -10,21 +10,6 @@ stdout:
 
 stderr:
 error
-  --> test/src/e2e_vm_tests/test_programs/should_fail/type_check_analyze_errors/src/main.sw:20:22
-   |
-18 | 
-19 | fn insufficient_type_check(arg: u64) -> [u32;2] {
-20 |     let res = [1u32, arg];
-   |                      ^^^ Mismatched types.
-expected: u32
-found:    u64.
-
-21 |     res
-22 | }
-   |
-____
-
-error
  --> test/src/e2e_vm_tests/test_programs/should_fail/type_check_analyze_errors/src/main.sw:5:14
   |
 3 | fn main() {
@@ -57,6 +42,21 @@ error
    |              ^^^^^^^^^^^ Literal would overflow because its value does not fit into "u32"
 14 |     Vec::<u32>::new().push(_a);
 15 | 
+   |
+____
+
+error
+  --> test/src/e2e_vm_tests/test_programs/should_fail/type_check_analyze_errors/src/main.sw:20:22
+   |
+18 | 
+19 | fn insufficient_type_check(arg: u64) -> [u32;2] {
+20 |     let res = [1u32, arg];
+   |                      ^^^ Mismatched types.
+expected: u32
+found:    u64.
+
+21 |     res
+22 | }
    |
 ____
 


### PR DESCRIPTION
## Description

This PR fixes an issue with array items that are typed as `TypeInfo::Error`. These errors were being swallowed and the compiler was failing later with an ICE.

Now we correctly show the more user-friendly error.

```
  --> test/src/e2e_vm_tests/test_programs/should_fail/array_wrong_elements_types/src/main.sw:51:26
   |
49 | 
50 |     // Literal too big
51 |     let mut a = [8u8, 8, 18446744073709551615];
   |                          ^^^^^^^^^^^^^^^^^^^^ Literal value is too large for type u8.
52 | }
```

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
