### PR TITLE
Fix module ancestor check for imports

### DIFF
--- a/sway-core/src/semantic_analysis/namespace/root.rs
+++ b/sway-core/src/semantic_analysis/namespace/root.rs
@@ -181,7 +181,7 @@ impl Root {
         dst: &ModulePath,
         visibility: Visibility,
     ) -> Result<(), ErrorEmitted> {
-        self.check_module_privacy(handler, engines, src)?;
+        self.check_module_privacy(handler, engines, src, dst)?;
 
         let src_mod = self.module.lookup_submodule(handler, engines, src)?;
 
@@ -358,7 +358,7 @@ impl Root {
         alias: Option<Ident>,
         visibility: Visibility,
     ) -> Result<(), ErrorEmitted> {
-        self.check_module_privacy(handler, engines, src)?;
+        self.check_module_privacy(handler, engines, src, dst)?;
         let src_mod = self.module.lookup_submodule(handler, engines, src)?;
 
         let (decl, path) = self.item_lookup(handler, engines, item, src, dst)?;
@@ -445,7 +445,7 @@ impl Root {
         alias: Option<Ident>,
         visibility: Visibility,
     ) -> Result<(), ErrorEmitted> {
-        self.check_module_privacy(handler, engines, src)?;
+        self.check_module_privacy(handler, engines, src, dst)?;
 
         let decl_engine = engines.de();
         let parsed_decl_engine = engines.pe();
@@ -610,7 +610,7 @@ impl Root {
         enum_name: &Ident,
         visibility: Visibility,
     ) -> Result<(), ErrorEmitted> {
-        self.check_module_privacy(handler, engines, src)?;
+        self.check_module_privacy(handler, engines, src, dst)?;
 
         let parsed_decl_engine = engines.pe();
         let decl_engine = engines.de();
@@ -689,8 +689,8 @@ impl Root {
         handler: &Handler,
         engines: &Engines,
         src: &ModulePath,
+        dst: &ModulePath,
     ) -> Result<(), ErrorEmitted> {
-        let dst = self.module.mod_path();
         // you are always allowed to access your ancestor's symbols
         if !is_ancestor(src, dst) {
             // we don't check the first prefix because direct children are always accessible

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "import_from_private_ancestor"
+entry = "main.sw"
+implicit-std = false
+
+[dependencies]
+core = { path = "../../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/json_abi_oracle.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/json_abi_oracle.json
@@ -1,0 +1,25 @@
+{
+  "configurables": [],
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": {
+        "name": "",
+        "type": 0,
+        "typeArguments": null
+      }
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "types": [
+    {
+      "components": null,
+      "type": "bool",
+      "typeId": 0,
+      "typeParameters": null
+    }
+  ]
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/json_abi_oracle_new_encoding.json
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/json_abi_oracle_new_encoding.json
@@ -1,0 +1,23 @@
+{
+  "concreteTypes": [
+    {
+      "concreteTypeId": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903",
+      "type": "bool"
+    }
+  ],
+  "configurables": [],
+  "encodingVersion": "1",
+  "functions": [
+    {
+      "attributes": null,
+      "inputs": [],
+      "name": "main",
+      "output": "b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903"
+    }
+  ],
+  "loggedTypes": [],
+  "messagesTypes": [],
+  "metadataTypes": [],
+  "programType": "script",
+  "specVersion": "1"
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/src/foz.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/src/foz.sw
@@ -1,0 +1,3 @@
+library;
+
+mod foo;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/src/foz/foo.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/src/foz/foo.sw
@@ -1,0 +1,3 @@
+library;
+
+mod bar;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/src/foz/foo/bar.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/src/foz/foo/bar.sw
@@ -1,0 +1,3 @@
+library;
+
+mod baz;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/src/foz/foo/bar/baz.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/src/foz/foo/bar/baz.sw
@@ -1,0 +1,4 @@
+library;
+
+// This is legal even though foo is a private module, because foo is an ancestor of the current module
+use ::foz::foo::*;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/src/main.sw
@@ -1,0 +1,3 @@
+library;
+
+mod foz;

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/import_from_private_ancestor/test.toml
@@ -1,0 +1,2 @@
+category = "compile"
+expected_warnings = 0


### PR DESCRIPTION
## Description

When importing items we allow imports from ancestor modules, even if the ancestor module is declared as private.

The code that performs this check was moved from `module.rs` to `root.rs` as part of #5697. During this move the current module path (i.e., the path of the destination of the import) was mistakenly replaced with the module path of the root module of the destination module. Since root modules do not have ancestors this meant that no source module was ever considered an ancestor of the destination module.

This PR fixes this problem, and adds an abscure test case that shows the issue.


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
