### PR TITLE
Forc-deploy import wallet support if non-existent wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "forc-wallet"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6ad4498ecab72fa7c5e134ade0137279d1b8f4a6df50963bb3803fdeb69dac"
+checksum = "6ed94e0de4d8265fe744704544932bf1285ffa16ee5feb18062194904d299f9f"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "forc-wallet"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed94e0de4d8265fe744704544932bf1285ffa16ee5feb18062194904d299f9f"
+checksum = "4e6ad4498ecab72fa7c5e134ade0137279d1b8f4a6df50963bb3803fdeb69dac"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5270,7 +5270,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -8503,7 +8503,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ fuel-tx = "0.58"
 fuel-vm = "0.58"
 
 # Dependencies from the `forc-wallet` repository:
-forc-wallet = "0.11"
+forc-wallet = "0.11.1"
 
 #
 # External dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ fuel-tx = "0.58"
 fuel-vm = "0.58"
 
 # Dependencies from the `forc-wallet` repository:
-forc-wallet = "0.11.1"
+forc-wallet = "0.11"
 
 #
 # External dependencies

--- a/forc-plugins/forc-client/src/util/tx.rs
+++ b/forc-plugins/forc-client/src/util/tx.rs
@@ -11,6 +11,7 @@ use forc_wallet::{
         collect_accounts_with_verification, AccountBalances, AccountVerification, AccountsMap,
     },
     new::{new_wallet_cli, New},
+    import::{import_wallet_cli, Import},
     utils::default_wallet_path,
 };
 use fuel_crypto::SecretKey;
@@ -45,6 +46,15 @@ fn ask_user_yes_no_question(question: &str) -> Result<bool> {
     Ok(answer)
 }
 
+fn ask_user_with_options(question: &str, options: &[&str], default: usize) -> Result<usize> {
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt(question)
+        .items(options)
+        .default(default)
+        .interact()?;
+    Ok(selection)
+}
+
 fn collect_user_accounts(
     wallet_path: &Path,
     password: &str,
@@ -71,20 +81,24 @@ pub(crate) fn prompt_forc_wallet_password() -> Result<String> {
 
 pub(crate) fn check_and_create_wallet_at_default_path(wallet_path: &Path) -> Result<()> {
     if !wallet_path.exists() {
-        let question = format!("Could not find a wallet at {wallet_path:?}, would you like to create a new one? [y/N]: ");
-        let accepted = ask_user_yes_no_question(&question)?;
-        let new_options = New {
-            force: false,
-            cache_accounts: None,
-        };
-        if accepted {
-            new_wallet_cli(wallet_path, new_options)?;
-            println!("Wallet created successfully.");
-            // Derive first account for the fresh wallet we created.
-            new_at_index_cli(wallet_path, 0)?;
-            println!("Account derived successfully.");
-        } else {
-            anyhow::bail!("Refused to create a new wallet. If you don't want to use forc-wallet, you can sign this transaction manually with --manual-signing flag.")
+        let question = format!("Could not find a wallet at {wallet_path:?}, please select an option: ");
+        let wallet_options = ask_user_with_options(&question, &["Create new wallet", "Import existing wallet"], 0)?;
+        match wallet_options {
+            0 => {
+                new_wallet_cli(wallet_path, New { force: false, cache_accounts: None })?;
+                println!("Wallet created successfully.");
+                // Derive first account for the fresh wallet we created.
+                new_at_index_cli(wallet_path, 0)?;
+                println!("Account derived successfully.");
+            }
+            1 => {
+                import_wallet_cli(wallet_path, Import { force: false, cache_accounts: None })?;
+                println!("Wallet imported successfully.");
+                // Derive first account for the fresh wallet we created.
+                new_at_index_cli(wallet_path, 0)?;
+                println!("Account derived successfully.");
+            },
+            _ => anyhow::bail!("Refused to create or import a new wallet. If you don't want to use forc-wallet, you can sign this transaction manually with --manual-signing flag."),
         }
     }
     Ok(())

--- a/forc-plugins/forc-client/src/util/tx.rs
+++ b/forc-plugins/forc-client/src/util/tx.rs
@@ -92,19 +92,16 @@ pub(crate) fn check_and_create_wallet_at_default_path(wallet_path: &Path) -> Res
             0 => {
                 new_wallet_cli(wallet_path, New { force: false, cache_accounts: None })?;
                 println!("Wallet created successfully.");
-                // Derive first account for the fresh wallet we created.
-                new_at_index_cli(wallet_path, 0)?;
-                println!("Account derived successfully.");
             }
             1 => {
                 import_wallet_cli(wallet_path, Import { force: false, cache_accounts: None })?;
                 println!("Wallet imported successfully.");
-                // Derive first account for the fresh wallet we created.
-                new_at_index_cli(wallet_path, 0)?;
-                println!("Account derived successfully.");
             },
             _ => anyhow::bail!("Refused to create or import a new wallet. If you don't want to use forc-wallet, you can sign this transaction manually with --manual-signing flag."),
         }
+        // Derive first account for the fresh wallet we created.
+        new_at_index_cli(wallet_path, 0)?;
+        println!("Account derived successfully.");
     }
     Ok(())
 }

--- a/forc-plugins/forc-client/src/util/tx.rs
+++ b/forc-plugins/forc-client/src/util/tx.rs
@@ -10,8 +10,8 @@ use forc_wallet::{
     balance::{
         collect_accounts_with_verification, AccountBalances, AccountVerification, AccountsMap,
     },
-    new::{new_wallet_cli, New},
     import::{import_wallet_cli, Import},
+    new::{new_wallet_cli, New},
     utils::default_wallet_path,
 };
 use fuel_crypto::SecretKey;
@@ -81,8 +81,13 @@ pub(crate) fn prompt_forc_wallet_password() -> Result<String> {
 
 pub(crate) fn check_and_create_wallet_at_default_path(wallet_path: &Path) -> Result<()> {
     if !wallet_path.exists() {
-        let question = format!("Could not find a wallet at {wallet_path:?}, please select an option: ");
-        let wallet_options = ask_user_with_options(&question, &["Create new wallet", "Import existing wallet"], 0)?;
+        let question =
+            format!("Could not find a wallet at {wallet_path:?}, please select an option: ");
+        let wallet_options = ask_user_with_options(
+            &question,
+            &["Create new wallet", "Import existing wallet"],
+            0,
+        )?;
         match wallet_options {
             0 => {
                 new_wallet_cli(wallet_path, New { force: false, cache_accounts: None })?;


### PR DESCRIPTION
## Description

- Adds support for importing a wallet on `forc-deploy`
- Resolves https://github.com/FuelLabs/forc-wallet/issues/139

