### PR TITLE
docs: remove dead links to sway-libs/fixed-point

### DIFF
--- a/docs/book/src/reference/sway_libs.md
+++ b/docs/book/src/reference/sway_libs.md
@@ -32,7 +32,6 @@ Cryptography Libraries are any libraries that provided cryptographic functionali
 
 Math Libraries are libraries which provide mathematic functions or number types that are outside of the std-lib's scope.
 
-- [Fixed Point Number Library](https://fuellabs.github.io/sway-libs/book/fixed_point/index.html); an interface to implement fixed-point numbers.
 - [Signed Integers Library](https://fuellabs.github.io/sway-libs/book/signed_integers/index.html); an interface to implement signed integers.
 
 ## Data Structures Libraries

--- a/docs/book/src/sway-program-types/libraries.md
+++ b/docs/book/src/sway-program-types/libraries.md
@@ -192,7 +192,6 @@ Some Sway Libraries to try out:
 
 - [Binary Merkle Proof](https://github.com/FuelLabs/sway-libs/tree/master/libs/src/merkle)
 - [Signed Integers](https://github.com/FuelLabs/sway-libs/tree/master/libs/src/signed_integers)
-- [Unsigned Fixed Point Number](https://github.com/FuelLabs/sway-libs/tree/master/libs/src/fixed_point)
 - [Ownership](https://github.com/FuelLabs/sway-libs/tree/master/libs/src/ownership)
 
 ### Example


### PR DESCRIPTION
## Description
closes #6636.
closes #6631.

As of https://github.com/FuelLabs/sway-libs/pull/278 sway-libs/fixed-point library is deprecated and removed completely from sway-libs repo. We should not link it from our book as well.