### PR TITLE
chore: remove unmaintained `difference` in favor of `similar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,12 +2072,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7807,7 +7801,6 @@ name = "swayfmt"
 version = "0.66.4"
 dependencies = [
  "anyhow",
- "difference",
  "forc-tracing 0.66.4",
  "indoc",
  "paste",
@@ -7815,6 +7808,7 @@ dependencies = [
  "ropey",
  "serde",
  "serde_ignored",
+ "similar",
  "sway-ast",
  "sway-core",
  "sway-error",

--- a/swayfmt/Cargo.toml
+++ b/swayfmt/Cargo.toml
@@ -25,7 +25,7 @@ thiserror.workspace = true
 toml = { workspace = true, features = ["parse"] }
 
 [dev-dependencies]
-difference = "2.0.0"
 paste = "1.0"
 prettydiff = "0.6"
+similar = "2.0"
 test-macros = { path = "test_macros" }


### PR DESCRIPTION
## Description

closes #5421.

Removes unmaintained `difference` create used in swayfmt and uses `similar` instead. Security wise this is not an important problem as the dependency is only used as a dev-dependency. But the pr is a part of an effort cleaning `RUSTSEC` issues mainly for housekeeping reasons of our ever growing repo.
