### PR TITLE
chore: remove unmaintained `ansi_term` in favor of `ansiterm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansiterm"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab587f5395da16dd2e6939adf53dede583221b320cadfb94e02b5b7b9bf24cc"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2672,7 +2681,7 @@ name = "forc"
 version = "0.66.4"
 dependencies = [
  "annotate-snippets",
- "ansi_term",
+ "ansiterm",
  "anyhow",
  "clap 4.5.20",
  "clap_complete",
@@ -2845,7 +2854,7 @@ dependencies = [
  "forc-pkg",
  "forc-tracing 0.66.4",
  "forc-util",
- "prettydiff 0.7.0",
+ "prettydiff",
  "sway-core",
  "sway-utils",
  "swayfmt",
@@ -2868,7 +2877,7 @@ dependencies = [
 name = "forc-pkg"
 version = "0.66.4"
 dependencies = [
- "ansi_term",
+ "ansiterm",
  "anyhow",
  "byte-unit",
  "cid",
@@ -2934,7 +2943,7 @@ dependencies = [
 name = "forc-tracing"
 version = "0.66.4"
 dependencies = [
- "ansi_term",
+ "ansiterm",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -2960,7 +2969,7 @@ name = "forc-util"
 version = "0.66.4"
 dependencies = [
  "annotate-snippets",
- "ansi_term",
+ "ansiterm",
  "anyhow",
  "clap 4.5.20",
  "dirs 5.0.1",
@@ -3904,15 +3913,6 @@ dependencies = [
  "serde",
  "spin",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -5883,18 +5883,6 @@ dependencies = [
 
 [[package]]
 name = "prettydiff"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff1fec61082821f8236cf6c0c14e8172b62ce8a72a0eedc30d3b247bb68dc11"
-dependencies = [
- "ansi_term",
- "pad",
- "prettytable-rs",
- "structopt",
-]
-
-[[package]]
-name = "prettydiff"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abec3fb083c10660b3854367697da94c674e9e82aa7511014dc958beeb7215e9"
@@ -7471,30 +7459,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7666,7 +7630,7 @@ dependencies = [
  "itertools 0.13.0",
  "once_cell",
  "peg",
- "prettydiff 0.7.0",
+ "prettydiff",
  "rustc-hash 1.1.0",
  "slotmap",
  "sway-features",
@@ -7804,7 +7768,7 @@ dependencies = [
  "forc-tracing 0.66.4",
  "indoc",
  "paste",
- "prettydiff 0.6.4",
+ "prettydiff",
  "ropey",
  "serde",
  "serde_ignored",
@@ -8120,7 +8084,7 @@ dependencies = [
  "insta",
  "libtest-mimic",
  "normalize-path",
- "prettydiff 0.7.0",
+ "prettydiff",
  "rand",
  "regex",
  "revm",
@@ -8143,7 +8107,7 @@ name = "test-macros"
 version = "0.0.0"
 dependencies = [
  "paste",
- "prettydiff 0.6.4",
+ "prettydiff",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ forc-wallet = "0.11"
 #
 
 annotate-snippets = "0.10"
-ansi_term = "0.12"
+ansiterm = "0.12"
 anyhow = "1.0"
 assert-json-diff = "2.0"
 async-trait = "0.1"

--- a/forc-pkg/Cargo.toml
+++ b/forc-pkg/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-ansi_term.workspace = true
+ansiterm.workspace = true
 anyhow.workspace = true
 byte-unit.workspace = true
 cid.workspace = true

--- a/forc-pkg/src/lock.rs
+++ b/forc-pkg/src/lock.rs
@@ -354,7 +354,7 @@ where
             };
             println_action_red(
                 "Removing",
-                &format!("{}{src}", ansi_term::Style::new().bold().paint(&pkg.name)),
+                &format!("{}{src}", ansiterm::Style::new().bold().paint(&pkg.name)),
             );
         }
     }
@@ -372,7 +372,7 @@ where
             };
             println_action_green(
                 "Adding",
-                &format!("{}{src}", ansi_term::Style::new().bold().paint(&pkg.name)),
+                &format!("{}{src}", ansiterm::Style::new().bold().paint(&pkg.name)),
             );
         }
     }

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2244,13 +2244,13 @@ pub fn build_with_options(build_options: &BuildOpts) -> Result<Built> {
 
 fn print_pkg_summary_header(built_pkg: &BuiltPackage) {
     let prog_ty_str = forc_util::program_type_str(&built_pkg.tree_type);
-    // The ansi_term formatters ignore the `std::fmt` right-align
+    // The ansiterm formatters ignore the `std::fmt` right-align
     // formatter, so we manually calculate the padding to align the program
     // type and name around the 10th column ourselves.
     let padded_ty_str = format!("{prog_ty_str:>10}");
     let padding = &padded_ty_str[..padded_ty_str.len() - prog_ty_str.len()];
-    let ty_ansi = ansi_term::Colour::Green.bold().paint(prog_ty_str);
-    let name_ansi = ansi_term::Style::new()
+    let ty_ansi = ansiterm::Colour::Green.bold().paint(prog_ty_str);
+    let name_ansi = ansiterm::Style::new()
         .bold()
         .paint(&built_pkg.descriptor.name);
     debug!("{padding}{ty_ansi} {name_ansi}");

--- a/forc-pkg/src/source/git/mod.rs
+++ b/forc-pkg/src/source/git/mod.rs
@@ -206,11 +206,7 @@ impl source::Fetch for Pinned {
             if !repo_path.exists() {
                 println_action_green(
                     "Fetching",
-                    &format!(
-                        "{} {}",
-                        ansi_term::Style::new().bold().paint(ctx.name),
-                        self
-                    ),
+                    &format!("{} {}", ansiterm::Style::new().bold().paint(ctx.name), self),
                 );
                 fetch(ctx.fetch_id(), ctx.name(), self)?;
             }

--- a/forc-pkg/src/source/ipfs.rs
+++ b/forc-pkg/src/source/ipfs.rs
@@ -69,11 +69,7 @@ impl source::Fetch for Pinned {
             if !repo_path.exists() {
                 println_action_green(
                     "Fetching",
-                    &format!(
-                        "{} {}",
-                        ansi_term::Style::new().bold().paint(ctx.name),
-                        self
-                    ),
+                    &format!("{} {}", ansiterm::Style::new().bold().paint(ctx.name), self),
                 );
                 let cid = &self.0;
                 let ipfs_client = ipfs_client();

--- a/forc-tracing/Cargo.toml
+++ b/forc-tracing/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-ansi_term.workspace = true
+ansiterm.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "json"] }
 

--- a/forc-tracing/src/lib.rs
+++ b/forc-tracing/src/lib.rs
@@ -1,6 +1,6 @@
 //! Utility items shared between forc crates.
 
-use ansi_term::Colour;
+use ansiterm::Colour;
 use std::str;
 use std::{env, io};
 use tracing::{Level, Metadata};

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 
 [dependencies]
 annotate-snippets.workspace = true
-ansi_term.workspace = true
+ansiterm.workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = ["cargo", "derive", "env"] }
 dirs.workspace = true

--- a/forc-util/src/cli.rs
+++ b/forc-util/src/cli.rs
@@ -103,7 +103,7 @@ macro_rules! cli_examples {
 
 
         fn help() -> &'static str {
-            Box::leak(format!("{}\n{}", forc_util::ansi_term::Colour::Yellow.paint("EXAMPLES:"), examples()).into_boxed_str())
+            Box::leak(format!("{}\n{}", forc_util::ansiterm::Colour::Yellow.paint("EXAMPLES:"), examples()).into_boxed_str())
         }
 
         pub fn examples() -> &'static str {

--- a/forc-util/src/lib.rs
+++ b/forc-util/src/lib.rs
@@ -29,7 +29,7 @@ pub mod restricted;
 #[macro_use]
 pub mod cli;
 
-pub use ansi_term;
+pub use ansiterm;
 pub use paste;
 pub use regex::Regex;
 pub use serial_test;
@@ -347,7 +347,7 @@ pub fn print_compiling(ty: Option<&TreeType>, name: &str, src: &dyn std::fmt::Di
     };
     println_action_green(
         "Compiling",
-        &format!("{ty}{} ({src})", ansi_term::Style::new().bold().paint(name)),
+        &format!("{ty}{} ({src})", ansiterm::Style::new().bold().paint(name)),
     );
 }
 

--- a/forc/Cargo.toml
+++ b/forc/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 annotate-snippets.workspace = true
-ansi_term.workspace = true
+ansiterm.workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = ["cargo", "derive", "env"] }
 clap_complete.workspace = true

--- a/forc/src/cli/commands/test.rs
+++ b/forc/src/cli/commands/test.rs
@@ -1,5 +1,5 @@
 use crate::cli;
-use ansi_term::Colour;
+use ansiterm::Colour;
 use clap::Parser;
 use forc_pkg as pkg;
 use forc_test::{decode_log_data, TestFilter, TestRunnerCount, TestedPackage};

--- a/swayfmt/Cargo.toml
+++ b/swayfmt/Cargo.toml
@@ -26,6 +26,6 @@ toml = { workspace = true, features = ["parse"] }
 
 [dev-dependencies]
 paste = "1.0"
-prettydiff = "0.6"
+prettydiff = "0.7"
 similar = "2.0"
 test-macros = { path = "test_macros" }

--- a/swayfmt/test_macros/Cargo.toml
+++ b/swayfmt/test_macros/Cargo.toml
@@ -15,7 +15,7 @@ repository.workspace = true
 
 [dev-dependencies]
 paste = "1.0"
-prettydiff = "0.6"
+prettydiff = "0.7"
 
 [package.metadata.cargo-udeps.ignore]
 development = ["paste", "prettydiff"]


### PR DESCRIPTION
## Description

related to #2601.

Removes ansi_term dependency from sway crates. To remove the dependency completely from dep tree we need a release of sway repo to get a new version of forc_util and use it in forc_wallet as forc_wallet is depending on `forc-util v0.47.0` which uses `ansi_term`. Once that is done we can close #2601 