### PR TITLE
fix: forc-deploy asks for password before checking if the wallet exists

### DIFF
--- a/forc-plugins/forc-client/src/op/deploy.rs
+++ b/forc-plugins/forc-client/src/op/deploy.rs
@@ -7,8 +7,8 @@ use crate::{
         pkg::{built_pkgs, create_proxy_contract, update_proxy_address_in_manifest},
         target::Target,
         tx::{
-            prompt_forc_wallet_password, select_account, update_proxy_contract_target,
-            SignerSelectionMode,
+            check_and_create_wallet_at_default_path, prompt_forc_wallet_password, select_account,
+            update_proxy_contract_target, SignerSelectionMode,
         },
     },
 };
@@ -1002,6 +1002,11 @@ async fn setup_deployment_account(
     } else if let Some(arn) = &command.aws_kms_signer {
         SignerSelectionMode::AwsSigner(arn.clone())
     } else {
+        // Check if we have a wallet in the default path
+        // If there is one we will ask for the password
+        // If not we will ask the user to either create a new one or import one
+        let wallet_path = default_wallet_path();
+        check_and_create_wallet_at_default_path(&wallet_path)?;
         println_action_green("", &format!("Wallet: {}", default_wallet_path().display()));
         let password = prompt_forc_wallet_password()?;
         SignerSelectionMode::ForcWallet(password)

--- a/forc-plugins/forc-client/src/util/tx.rs
+++ b/forc-plugins/forc-client/src/util/tx.rs
@@ -170,9 +170,6 @@ pub(crate) async fn select_account(
     match wallet_mode {
         SignerSelectionMode::ForcWallet(password) => {
             let wallet_path = default_wallet_path();
-            check_and_create_wallet_at_default_path(&wallet_path)?;
-            // TODO: This is a very simple TUI, we should consider adding a nice TUI
-            // capabilities for selections and answer collection.
             let accounts = collect_user_accounts(&wallet_path, password)?;
             let account_balances = collect_account_balances(&accounts, provider).await?;
             let base_asset_id = provider.base_asset_id();

--- a/forc-plugins/forc-client/tests/deploy.rs
+++ b/forc-plugins/forc-client/tests/deploy.rs
@@ -693,7 +693,7 @@ async fn test_non_owner_fails_to_set_target() {
 // It would also require overriding `default_wallet_path` function for tests, so as not to interfere with the user's wallet.
 
 #[test]
-fn test_deploy_interactive_wrong_password() -> Result<(), rexpect::error::Error> {
+fn test_deploy_interactive_missing_wallet() -> Result<(), rexpect::error::Error> {
     let (mut node, port) = run_node();
     let node_url = format!("http://127.0.0.1:{}/v1/graphql", port);
 
@@ -711,9 +711,8 @@ fn test_deploy_interactive_wrong_password() -> Result<(), rexpect::error::Error>
     process
         .exp_string("\u{1b}[1;32mConfirming\u{1b}[0m transactions [deploy standalone_contract]")?;
     process.exp_string(&format!("Network: {node_url}"))?;
-    process.exp_string("Wallet: ")?;
-    process.exp_string("Wallet password")?;
-    process.send_line("mock_password")?;
+    process.exp_regex("Could not find a wallet at")?;
+    process.send_line("n")?;
 
     process.process.exit()?;
     node.kill().unwrap();


### PR DESCRIPTION
## Description
closes #6703 and unblocks #6680.

Forc-deploy was asking for a password without checking if a wallet exists or not and the check for existence was happening after the password prompt. This meant we were asking for a password even when the wallet does not exists.

Below examples are taken in a system where the wallet does not exists at the default path (a fresh system):
### Before

```bash
...
  Confirming transactions [deploy final-contract]
             Network: https://testnet.fuel.network
             Wallet: /Users/kayagokalp/.fuel/wallets/.wallet
✔ Wallet password · ****
? Could not find a wallet at "/Users/kayagokalp/.fuel/wallets/.wallet", would you like to create a new one? [y/N]:  (y/n) ›
```

### After

```bash
...
  Confirming transactions [deploy final-contract]
             Network: https://testnet.fuel.network
? Could not find a wallet at "/Users/kayagokalp/.fuel/wallets/.wallet", would you like to create a new one? [y/N]:  (y/n) ›
```