### PR TITLE
`Forc.toml` metadata support

### DIFF
--- a/docs/book/src/forc/manifest_reference.md
+++ b/docs/book/src/forc/manifest_reference.md
@@ -11,6 +11,7 @@ The `Forc.toml` (the _manifest_ file) is a compulsory file for each package and 
     * For the recommended way of selecting an entry point of large libraries please take a look at: [Libraries](./../sway-program-types/libraries.md)
   * `implicit-std` -  Controls whether provided `std` version (with the current `forc` version) will get added as a dependency _implicitly_. _Unless you know what you are doing, leave this as default._
   * `forc-version` - The minimum forc version required for this project to work properly.
+  * `metadata` - Metadata for the project; can be used by tools which would like to store package configuration in `Forc.toml`.
 
 * [`[dependencies]`](#the-dependencies-section) — Defines the dependencies.
 * `[network]` — Defines a network for forc to interact with.
@@ -41,6 +42,9 @@ entry = "main.sw"
 organization = "Fuel_Labs"
 license = "Apache-2.0"
 name = "wallet_contract"
+
+[project.metadata]
+indexing = { namespace = "counter-contract", schema_path = "out/release/counter-contract-abi.json" }
 ```
 
 ## The `[dependencies]` section

--- a/docs/book/src/forc/manifest_reference.md
+++ b/docs/book/src/forc/manifest_reference.md
@@ -55,14 +55,14 @@ The `[project.metadata]` section provides a dedicated space for external tools a
 
 Metadata can be defined at two levels:
 
-Workspace level - defined in the workspace's root `Forc.toml`:
+Workspace level - defined in the workspace\'s root `Forc.toml`:
 
 ```toml
 [workspace.metadata]
 my_tool = { shared_setting = "value" }
 ```
 
-Project level - defined in individual project's `Forc.toml`:
+Project level - defined in individual project\'s `Forc.toml`:
 
 ```toml
 [project.metadata.any_name_here]

--- a/docs/book/src/forc/manifest_reference.md
+++ b/docs/book/src/forc/manifest_reference.md
@@ -66,6 +66,7 @@ setting2 = "value"
 ```
 
 Example from an indexing tool:
+
 ```toml
 [project.metadata.indexing]
 namespace = "counter-contract"
@@ -74,25 +75,28 @@ schema_path = "out/release/counter-contract-abi.json"
 
 #### Guidelines for Plugin Developers
 
-1. Best Practices
-- Choose clear, descriptive metadata key names
-- Document the exact metadata key name your tool expects
-- Don't require `Forc.toml` if tool can function without it
-- Consider using TOML format for dedicated config files
+Best Practices
 
-2. Implementation Notes
-- The metadata section is optional
-- Forc does not parse metadata contents
-- Plugin developers handle their own configuration parsing
-- Choose unique metadata keys to avoid conflicts with other tools
+* Choose clear, descriptive metadata key names
+* Document the exact metadata key name your tool expects
+* Don't require `Forc.toml` if tool can function without it
+* Consider using TOML format for dedicated config files
+
+Implementation Notes
+
+* The metadata section is optional
+* Forc does not parse metadata contents
+* Plugin developers handle their own configuration parsing
+* Choose unique metadata keys to avoid conflicts with other tools
 
 #### Example Use Cases
-- Documentation generation settings
-- Formatter configurations
-- Debugger options
-- Wallet integration
-- Contract indexing
-- Testing frameworks
+
+* Documentation generation settings
+* Formatter configurations
+* Debugger options
+* Wallet integration
+* Contract indexing
+* Testing frameworks
 
 This allows for a streamlined developer experience while maintaining clear separation between core Forc functionality and third-party tools.
 

--- a/docs/book/src/forc/manifest_reference.md
+++ b/docs/book/src/forc/manifest_reference.md
@@ -47,7 +47,7 @@ name = "wallet_contract"
 indexing = { namespace = "counter-contract", schema_path = "out/release/counter-contract-abi.json" }
 ```
 
-### Metadata Section in Forc.toml
+### Metadata Section in `Forc.toml`
 
 The `[project.metadata]` section provides a dedicated space for external tools and plugins to store their configuration in `Forc.toml`. The metadata key names are arbitrary and do not need to match the tool's name.
 

--- a/docs/book/src/forc/manifest_reference.md
+++ b/docs/book/src/forc/manifest_reference.md
@@ -47,6 +47,55 @@ name = "wallet_contract"
 indexing = { namespace = "counter-contract", schema_path = "out/release/counter-contract-abi.json" }
 ```
 
+### Metadata Section in Forc.toml
+
+The `[project.metadata]` section provides a dedicated space for external tools and plugins to store their configuration in `Forc.toml`. The metadata key names are arbitrary and do not need to match the tool's name.
+
+#### Usage
+
+Use any descriptive key name for your metadata table:
+
+```toml
+[project.metadata.any_name_here]
+option1 = "value"
+option2 = "value"
+
+[project.metadata.my_custom_config]
+setting1 = "value"
+setting2 = "value"
+```
+
+Example from an indexing tool:
+```toml
+[project.metadata.indexing]
+namespace = "counter-contract"
+schema_path = "out/release/counter-contract-abi.json"
+```
+
+#### Guidelines for Plugin Developers
+
+1. Best Practices
+- Choose clear, descriptive metadata key names
+- Document the exact metadata key name your tool expects
+- Don't require `Forc.toml` if tool can function without it
+- Consider using TOML format for dedicated config files
+
+2. Implementation Notes
+- The metadata section is optional
+- Forc does not parse metadata contents
+- Plugin developers handle their own configuration parsing
+- Choose unique metadata keys to avoid conflicts with other tools
+
+#### Example Use Cases
+- Documentation generation settings
+- Formatter configurations
+- Debugger options
+- Wallet integration
+- Contract indexing
+- Testing frameworks
+
+This allows for a streamlined developer experience while maintaining clear separation between core Forc functionality and third-party tools.
+
 ## The `[dependencies]` section
 
 The following fields can be provided with a dependency:

--- a/docs/book/src/forc/manifest_reference.md
+++ b/docs/book/src/forc/manifest_reference.md
@@ -51,9 +51,18 @@ indexing = { namespace = "counter-contract", schema_path = "out/release/counter-
 
 The `[project.metadata]` section provides a dedicated space for external tools and plugins to store their configuration in `Forc.toml`. The metadata key names are arbitrary and do not need to match the tool's name.
 
-#### Usage
+#### Workspace vs Project Metadata
 
-Use any descriptive key name for your metadata table:
+Metadata can be defined at two levels:
+
+Workspace level - defined in the workspace's root `Forc.toml`:
+
+```toml
+[workspace.metadata]
+my_tool = { shared_setting = "value" }
+```
+
+Project level - defined in individual project's `Forc.toml`:
 
 ```toml
 [project.metadata.any_name_here]
@@ -65,13 +74,19 @@ setting1 = "value"
 setting2 = "value"
 ```
 
-Example from an indexing tool:
+Example for an indexing tool:
 
 ```toml
 [project.metadata.indexing]
 namespace = "counter-contract"
 schema_path = "out/release/counter-contract-abi.json"
 ```
+
+When both workspace and project metadata exist:
+
+* Project-level metadata should take precedence over workspace metadata
+* Tools can choose to merge workspace and project settings
+* Consider documenting your tool's metadata inheritance behavior
 
 #### Guidelines for Plugin Developers
 
@@ -81,6 +96,7 @@ Best Practices
 * Document the exact metadata key name your tool expects
 * Don't require `Forc.toml` if tool can function without it
 * Consider using TOML format for dedicated config files
+* Specify how your tool handles workspace vs project metadata
 
 Implementation Notes
 

--- a/docs/book/src/forc/manifest_reference.md
+++ b/docs/book/src/forc/manifest_reference.md
@@ -100,6 +100,11 @@ Implementation Notes
 
 This allows for a streamlined developer experience while maintaining clear separation between core Forc functionality and third-party tools.
 
+#### External Tooling Examples
+
+* [forc-index-ts](https://github.com/FuelLabs/example-forc-plugins/tree/master/forc-index-ts): A TypeScript CLI tool for parsing `Forc.toml` metadata to read contract ABI JSON file.
+* [forc-index-rs](https://github.com/FuelLabs/example-forc-plugins/tree/master/forc-index-rs): A Rust CLI tool for parsing `Forc.toml` metadata to read contract ABI JSON file.
+
 ## The `[dependencies]` section
 
 The following fields can be provided with a dependency:

--- a/forc-pkg/src/manifest/mod.rs
+++ b/forc-pkg/src/manifest/mod.rs
@@ -1475,7 +1475,7 @@ mod tests {
             [metadata]
             boolean = true
             integer = 42
-            float = 3.14
+            float = 3.12
             string = "value"
             array = [1, 2, 3]
             mixed_array = [1, "two", true]
@@ -1496,7 +1496,7 @@ mod tests {
         let table = table_val.as_table().unwrap();
         assert!(table.get("boolean").unwrap().as_bool().unwrap());
         assert_eq!(table.get("integer").unwrap().as_integer().unwrap(), 42);
-        assert_eq!(table.get("float").unwrap().as_float().unwrap(), 3.14);
+        assert_eq!(table.get("float").unwrap().as_float().unwrap(), 3.12);
         assert_eq!(table.get("string").unwrap().as_str().unwrap(), "value");
         assert_eq!(table.get("array").unwrap().as_array().unwrap().len(), 3);
         assert!(table.get("nested").unwrap().as_table().is_some());

--- a/forc-pkg/src/manifest/mod.rs
+++ b/forc-pkg/src/manifest/mod.rs
@@ -166,7 +166,7 @@ impl TryInto<WorkspaceManifestFile> for ManifestFile {
 type PatchMap = BTreeMap<String, Dependency>;
 
 /// A [PackageManifest] that was deserialized from a file at a particular path.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PackageManifestFile {
     /// The deserialized `Forc.toml`.
     manifest: PackageManifest,
@@ -175,7 +175,7 @@ pub struct PackageManifestFile {
 }
 
 /// A direct mapping to a `Forc.toml`.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct PackageManifest {
     pub project: Project,
@@ -189,7 +189,7 @@ pub struct PackageManifest {
     pub proxy: Option<Proxy>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct Project {
     pub authors: Option<Vec<String>>,

--- a/forc-pkg/src/manifest/mod.rs
+++ b/forc-pkg/src/manifest/mod.rs
@@ -851,6 +851,7 @@ pub struct WorkspaceManifest {
 #[serde(rename_all = "kebab-case")]
 pub struct Workspace {
     pub members: Vec<PathBuf>,
+    pub metadata: Option<toml::Value>,
 }
 
 impl WorkspaceManifestFile {

--- a/forc-pkg/src/manifest/mod.rs
+++ b/forc-pkg/src/manifest/mod.rs
@@ -202,6 +202,7 @@ pub struct Project {
     pub forc_version: Option<semver::Version>,
     #[serde(default)]
     pub experimental: HashMap<String, bool>,
+    pub metadata: Option<toml::Value>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
# Description
Adds support for `metadata` as `[project.metadata]` or `[workspace.metadata]` in `Forc.toml` of value `toml::Value`

- Addresses: https://github.com/FuelLabs/rfcs/blob/22bf3936a37b60bb496232c1b52bf59e204a0697/text/rfcs/0006-metadata-in-forc-manifest.md#reference-level-explanation
- Resolves: https://github.com/FuelLabs/sway/issues/2180

## Linked examples of usage
- https://github.com/FuelLabs/example-forc-plugins/pull/1
