### PR TITLE
Fix Typographical Errors and Adjust Code Example

### DIFF
--- a/docs/book/src/advanced/generics_and_trait_constraints.md
+++ b/docs/book/src/advanced/generics_and_trait_constraints.md
@@ -1,6 +1,6 @@
 # Generics and Trait Constraints
 
-## Generics as Constraints
+## Generics and Constraints
 
 At a high level, Sway allows you to define constraints, or restrictions, that
 allow you to strike a balance between writing abstract and reusable code and

--- a/docs/book/src/advanced/traits.md
+++ b/docs/book/src/advanced/traits.md
@@ -118,7 +118,7 @@ trait Trait {
 }
 ```
 
-Check the `associated constants` section on [constants](../basics/constants.md) page.
+Check the [associated constants](../basics/constants.md#associated-constants) section on [constants](../basics/constants.md) page.
 
 ### Associated types
 
@@ -132,7 +132,7 @@ trait MyTrait {
 }
 ```
 
-Check the `associated types` section on [associated types](./associated_types.md) page.
+Check the [associated types](./associated_types.md) section on [associated types](./associated_types.md) page.
 
 ## Use Cases
 

--- a/docs/book/src/advanced/traits.md
+++ b/docs/book/src/advanced/traits.md
@@ -9,7 +9,7 @@ Let's take a look at some code:
 ```sway
 trait Compare {
     fn equals(self, b: Self) -> bool;
-} {
+
     fn not_equals(self, b: Self) -> bool {
         !self.equals(b)
     }

--- a/docs/book/src/advanced/traits.md
+++ b/docs/book/src/advanced/traits.md
@@ -118,7 +118,7 @@ trait Trait {
 }
 ```
 
-Check the `associated consts` section on [constants](../basics/constants.md) page.
+Check the `associated constants` section on [constants](../basics/constants.md) page.
 
 ### Associated types
 
@@ -185,7 +185,7 @@ impl Card for MyCard {
 
 fn main() {
     let mut i = 52;
-    let mut deck: Vec<MyCard> = Vec::with_capacity(50);
+    let mut deck: Vec<MyCard> = Vec::with_capacity(52);
     while i > 0 {
         i = i - 1;
         deck.push(MyCard { suit: generate_random_suit(), value: i % 4}


### PR DESCRIPTION

### Description:
This pull request addresses minor typographical issues and makes a small update to the code example in the `generics_and_trait_constraints.md` and `traits.md` documentation.

### Changes:
1. **File:** `docs/book/src/advanced/generics_and_trait_constraints.md`
   - **Change 1**: Changed the section title "Generics as Constraints" to "Generics and Constraints" for clarity.
   
2. **File:** `docs/book/src/advanced/traits.md`
   - **Change 2**: Fixed the typographical error "associated consts" to "associated constants" for consistency with the correct terminology.
   - **Change 3**: Adjusted the deck size in the example code from 50 cards to 52 cards to reflect the standard deck size.

### Affected Files:
- `docs/book/src/advanced/generics_and_trait_constraints.md`
- `docs/book/src/advanced/traits.md`

### Why This Change Is Needed:
- The title and terminology in `generics_and_trait_constraints.md` required clarification to better reflect the content and improve readability.
- The code example in `traits.md` was updated to fix minor typos and ensure the deck size is correct in the card game example.

