### PR TITLE
Error on use of self intead of Self in return type

### DIFF
--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -1446,7 +1446,7 @@ pub(crate) fn type_name_to_type_info_opt(name: &Ident) -> Option<TypeInfo> {
         "str" => Some(TypeInfo::StringSlice),
         "raw_ptr" => Some(TypeInfo::RawUntypedPtr),
         "raw_slice" => Some(TypeInfo::RawUntypedSlice),
-        "Self" | "self" => Some(TypeInfo::new_self_type(name.span())),
+        "Self" => Some(TypeInfo::new_self_type(name.span())),
         "Contract" => Some(TypeInfo::Contract),
         _other => None,
     }
@@ -4598,7 +4598,10 @@ fn path_type_to_type_info(
             }
         }
         None => {
-            if name.as_str() == "ContractCaller" {
+            if name.as_str() == "self" {
+                let error = ConvertParseTreeError::UnknownTypeNameSelf { span };
+                return Err(handler.emit_err(error.into()));
+            } else if name.as_str() == "ContractCaller" {
                 if root_opt.is_some() || !suffix.is_empty() {
                     let error = ConvertParseTreeError::FullySpecifiedTypesNotSupported { span };
                     return Err(handler.emit_err(error.into()));

--- a/sway-error/src/convert_parse_tree_error.rs
+++ b/sway-error/src/convert_parse_tree_error.rs
@@ -121,6 +121,8 @@ pub enum ConvertParseTreeError {
     UnexpectedValueForCfgExperimental { span: Span },
     #[error("Unexpected attribute value: \"{value}\" for attribute: \"cfg\"")]
     InvalidCfgArg { span: Span, value: String },
+    #[error("Unknown type name \"self\". A self type with a similar name exists (notice the capitalization): `Self`")]
+    UnknownTypeNameSelf { span: Span },
 }
 
 impl Spanned for ConvertParseTreeError {
@@ -185,6 +187,7 @@ impl Spanned for ConvertParseTreeError {
             ConvertParseTreeError::ExpectedCfgProgramTypeArgValue { span } => span.clone(),
             ConvertParseTreeError::UnexpectedValueForCfgExperimental { span } => span.clone(),
             ConvertParseTreeError::InvalidCfgArg { span, .. } => span.clone(),
+            ConvertParseTreeError::UnknownTypeNameSelf { span } => span.clone(),
         }
     }
 }

--- a/sway-lib-std/src/bytes.sw
+++ b/sway-lib-std/src/bytes.sw
@@ -692,7 +692,7 @@ impl Bytes {
     ///     assert(bytes.capacity() == first_cap + second_cap);
     /// }
     /// ```
-    pub fn append(ref mut self, ref mut other: self) {
+    pub fn append(ref mut self, ref mut other: Self) {
         let other_len = other.len();
         if other_len == 0 {
             return

--- a/test/src/e2e_vm_tests/test_programs/should_fail/self_return_type/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/self_return_type/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = "core"
+source = "path+from-root-722DFCAB6A209427"
+
+[[package]]
+name = "self_return_type"
+source = "member"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/self_return_type/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/self_return_type/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+name = "self_return_type"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+implicit-std = false
+
+[dependencies]
+core = { path = "../../../../../../sway-lib-core" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/self_return_type/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/self_return_type/src/main.sw
@@ -1,0 +1,13 @@
+script;
+trait MyTrait {
+    fn foo(self, other: Self) -> Self;
+}
+impl MyTrait for u8 {
+    fn foo(self, other: Self) -> self {
+        self
+    }
+}
+fn main() -> () {
+    let a = 1u8;
+    let _ = a.foo(2u8);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/self_return_type/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/self_return_type/test.toml
@@ -1,0 +1,4 @@
+category = "fail"
+
+# check: $()fn foo(self, other: Self) -> self {
+# nextln: $()Unknown type name "self". A self type with a similar name exists (notice the capitalization): `Self`


### PR DESCRIPTION
## Description

With this PR we no longer support using `self` instead of `Self` when referring to the Self Type.

Fixes #6396

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
