### PR TITLE
Correct links and style issues in sway documentation and examples

### DIFF
--- a/docs/book/src/advanced/traits.md
+++ b/docs/book/src/advanced/traits.md
@@ -118,7 +118,7 @@ trait Trait {
 }
 ```
 
-Check the `associated consts` section on [constants](../basics/constants.md) page.
+Check the [associated constants](../basics/constants.md#associated-constants) section on [constants](../basics/constants.md) page.
 
 ### Associated types
 
@@ -132,7 +132,7 @@ trait MyTrait {
 }
 ```
 
-Check the `associated types` section on [associated types](./associated_types.md) page.
+Check the [associated types](./associated_types.md) section on [associated types](./associated_types.md) page.
 
 ## Use Cases
 
@@ -144,10 +144,10 @@ Often, libraries and APIs have interfaces that are abstracted over a type that i
 library;
 
 pub enum Suit {
-    Hearts: (),
-    Diamonds: (),
-    Clubs: (),
-    Spades: (),
+    Hearts,
+    Diamonds,
+    Clubs,
+    Spades,
 }
 
 pub trait Card {
@@ -185,10 +185,10 @@ impl Card for MyCard {
 
 fn main() {
     let mut i = 52;
-    let mut deck: Vec<MyCard> = Vec::with_capacity(50);
+    let mut deck: Vec<MyCard> = Vec::with_capacity(52);
     while i > 0 {
         i = i - 1;
-        deck.push(MyCard { suit: generate_random_suit(), value: i % 4}
+        deck.push(MyCard { suit: generate_random_suit(), value: i % 4});
     }
     play_game_with_deck(deck);
 }

--- a/docs/book/src/basics/index.md
+++ b/docs/book/src/basics/index.md
@@ -1,8 +1,8 @@
-# Sway Language basics
+# Sway Language Basics
 
 Sway is a programming language designed for the FuelVM. It is a statically typed, compiled language with type inference and traits. Sway aims to make smart contract development safer and more efficient through the use of strong static analysis and compiler feedback.
 
-Get started with the basics of Sway:
+## Get started with the basics of Sway:
 
 - [Variables](./variables.md)
 - [Built-in Types](./built_in_types.md)

--- a/docs/book/src/examples/index.md
+++ b/docs/book/src/examples/index.md
@@ -3,8 +3,8 @@
 Some basic example contracts to see how Sway and Forc work.
 
 - [Counter](./counter.md)
-- [`FizzBuzz`](./fizzbuzz.md)
+- [FizzBuzz](./fizzbuzz.md)
 - [Wallet Smart Contract](./wallet_smart_contract.md)
-- [Liquidity Pool](./wallet_smart_contract.md)
+- [Liquidity Pool](./liquidity_pool.md)
 
 Additional examples can be found in the [Sway Applications](https://github.com/FuelLabs/sway-applications/tree/master) repository.

--- a/docs/book/src/forc/workspaces.md
+++ b/docs/book/src/forc/workspaces.md
@@ -12,7 +12,7 @@ Workspace manifests are declared within `Forc.toml` files and support the follow
 * [`members`](#the-members-field) - Packages to include in the workspace.
 * [`[patch]`](#the-patch-section) - Defines the patches.
 
-An empty workspace can be created with `forc new --workspace` or `forc init --workspace`.
+The empty workspace can be created with `forc new --workspace` or `forc init --workspace`.
 
 ## The `members` field
 
@@ -23,14 +23,14 @@ The `members` field defines which packages are members of the workspace:
 members = ["member1", "path/to/member2"]
 ```
 
-The `members` field accepts entries to be given in relative path with respect to the workspace root.
+The `members` field accepts entries to be given in a relative path with respect to the workspace root.
 Packages that are located within a workspace directory but are *not* contained within the `members` set are ignored.
 
 ## The `[patch]` section
 
-The `[patch]` section can be used to override any dependency in the workspace dependency graph. The usage is the same with package level `[patch]` section and details can be seen [here](./manifest_reference.md#the-patch-section).
+The `[patch]` section can be used to override a dependency in the workspace dependency graph. The usage is the same with package level `[patch]` section and details can be seen [here](./manifest_reference.md#the-patch-section).
 
-It is not allowed to declare patch table in member of a workspace if the workspace manifest file contains a patch table.
+It is not allowed to declare a patch table in a member of a workspace if the workspace manifest file already contains a patch table.
 
 Example:
 
@@ -43,14 +43,14 @@ members = ["member1", "path/to/member2"]
 std = { git = "https://github.com/fuellabs/sway", branch = "test" }
 ```
 
-In the above example each occurrence of `std` as a dependency in the workspace will be changed with `std` from `test` branch of sway repo.
+In the above example, each occurrence of `std` as a dependency in the workspace will be changed with `std` from `test` branch of sway repo.
 
-## Some `forc` commands that support workspaces
+## Some `Forc` commands that support workspaces
 
-* `forc build` - Builds an entire workspace.
-* `forc deploy` - Builds and deploys all deployable members (i.e, contracts) of the workspace in the correct order.
-* `forc run` - Builds and runs all scripts of the workspace.
-* `forc check` - Checks all members of the workspace.
-* `forc update` - Checks and updates workspace level `Forc.lock` file that is shared between workspace members.
-* `forc clean` - Cleans all output artifacts for each member of the workspace.
-* `forc fmt` - Formats all members of a workspace.
+* `Forc build` - Builds an entire workspace.
+* `Forc deploy` - Builds and deploys all deployable members (i.e., contracts) of the workspace in the correct order.
+* `Forc run` - Builds and runs all scripts of the workspace.
+* `Forc check` - Checks all members of the workspace.
+* `Forc update` - Checks and updates workspace level `Forc.lock` file that is shared between workspace members.
+* `Forc clean` - Cleans all output artifacts for each member of the workspace.
+* `Forc fmt` - Formats all members of a workspace.


### PR DESCRIPTION
1)
-Sway Language basics	+Sway Language Basics
The section title has been corrected to have the proper capitalization: "Basics" should be capitalized, as it's part of the heading.
2)
The link to the example contract has been corrected. It previously pointed to the wrong file -(wallet_smart_contract.md), and now points to the correct one +(liquidity_pool.md).
- [Liquidity Pool](./wallet_smart_contract.md)	+ [Liquidity Pool](./liquidity_pool.md)
3)
In this change, the section name was corrected from "associated consts" to the correct "associated constants", and the link was updated to point directly to the associated constants section in the documentation.
-  Check the `associated consts` section on [constants](../basics/constants.md) page. 
+ Check the [associated constants](../basics/constants.md#associated-constants) section on [constants](../basics/constants.md) page.
4) 
Code style improvement 
-   Hearts: (), 
-   Diamonds: (), 
-   Clubs: (), 
-   Spades: (), 
- } 
+ pub enum Suit { 
+   Hearts, 
+   Diamonds, 
+   Clubs, 
+   Spades, 
+ }
5)
- let mut deck: Vec<MyCard> = Vec::with_capacity(50); 
+ let mut deck: Vec<MyCard> = Vec::with_capacity(52);
Updated the capacity of the Vec from 50 to 52 to match the number of cards in a standard deck.
6)
Minor logic fix in the main function
- while i > 0 { 
-   i = i - 1; 
-   deck.push(MyCard { suit: generate_random_suit(), value: i % 4});
- } 
+ while i > 0 { 
+   i = i - 1; 
+   deck.push(MyCard { suit: generate_random_suit(), value: i % 4 });
+ }
