### PR TITLE
Change `SubstTypesContext` to contain an optional `TypeSubstMap`.

### DIFF
--- a/sway-core/src/decl_engine/ref.rs
+++ b/sway-core/src/decl_engine/ref.rs
@@ -102,7 +102,7 @@ where
         let decl_engine = ctx.engines.de();
         if ctx
             .type_subst_map
-            .source_ids_contains_concrete_type(ctx.engines)
+            .is_some_and(|tsm| tsm.source_ids_contains_concrete_type(ctx.engines))
             || !decl_engine.get(&self.id).is_concrete(ctx.engines)
         {
             let mut decl = (*decl_engine.get(&self.id)).clone();

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -95,7 +95,10 @@ impl CollectTypesMetadata for TypeId {
 impl SubstTypes for TypeId {
     fn subst_inner(&mut self, ctx: &SubstTypesContext) -> HasChanges {
         let type_engine = ctx.engines.te();
-        if let Some(matching_id) = ctx.type_subst_map.find_match(*self, ctx.engines) {
+        if let Some(matching_id) = ctx
+            .type_subst_map
+            .and_then(|tsm| tsm.find_match(*self, ctx.engines))
+        {
             if !matches!(&*type_engine.get(matching_id), TypeInfo::ErrorRecovery(_)) {
                 *self = matching_id;
                 HasChanges::Yes

--- a/sway-core/src/type_system/substitute/subst_types.rs
+++ b/sway-core/src/type_system/substitute/subst_types.rs
@@ -24,22 +24,30 @@ impl std::ops::BitOr for HasChanges {
     }
 }
 
-pub struct SubstTypesContext<'a, 'b> {
-    pub engines: &'a Engines,
-    pub type_subst_map: &'b TypeSubstMap,
+pub struct SubstTypesContext<'eng, 'tsm> {
+    pub engines: &'eng Engines,
+    pub type_subst_map: Option<&'tsm TypeSubstMap>,
     pub subst_function_body: bool,
 }
 
-impl<'a, 'b> SubstTypesContext<'a, 'b> {
+impl<'eng, 'tsm> SubstTypesContext<'eng, 'tsm> {
     pub fn new(
-        engines: &'a Engines,
-        type_subst_map: &'b TypeSubstMap,
+        engines: &'eng Engines,
+        type_subst_map: &'tsm TypeSubstMap,
         subst_function_body: bool,
-    ) -> SubstTypesContext<'a, 'b> {
+    ) -> SubstTypesContext<'eng, 'tsm> {
         SubstTypesContext {
             engines,
-            type_subst_map,
+            type_subst_map: Some(type_subst_map),
             subst_function_body,
+        }
+    }
+
+    pub fn dummy(engines: &'eng Engines) -> SubstTypesContext<'eng, 'tsm> {
+        SubstTypesContext {
+            engines,
+            type_subst_map: None,
+            subst_function_body: false,
         }
     }
 }
@@ -48,7 +56,7 @@ pub trait SubstTypes {
     fn subst_inner(&mut self, ctx: &SubstTypesContext) -> HasChanges;
 
     fn subst(&mut self, ctx: &SubstTypesContext) -> HasChanges {
-        if ctx.type_subst_map.is_empty() {
+        if ctx.type_subst_map.is_some_and(|tsm| tsm.is_empty()) {
             HasChanges::No
         } else {
             self.subst_inner(ctx)


### PR DESCRIPTION
## Description

Changes `SubstTypesContext` to contain an optional `TypeSubstMap`.

This is to make this usable from collection context where no type substitution needs to be done.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
