### PR TITLE
Add the `StorageIterator` type and implement for `StorageVec`

### DIFF
--- a/sway-lib-std/src/iterator.sw
+++ b/sway-lib-std/src/iterator.sw
@@ -8,6 +8,8 @@ pub trait Iterator {
     type Item;
     /// Advances the iterator and returns the next value.
     ///
+    /// # Additional Information
+    ///
     /// Returns [`None`] when iteration is finished. Individual iterator
     /// implementations may choose to resume iteration, and so calling `next()`
     /// again may or may not eventually start returning [`Some(Item)`] again at some
@@ -15,9 +17,7 @@ pub trait Iterator {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
-    /// ```
+    /// ```sway
     /// let mut a = Vec::new();
     ///
     /// a.push(1);
@@ -38,5 +38,55 @@ pub trait Iterator {
     /// assert_eq!(None, iter.next());
     /// assert_eq!(None, iter.next());
     /// ```
+    fn next(ref mut self) -> Option<Self::Item>;
+}
+
+pub trait StorageIterator {
+    /// The type of the elements being iterated over.
+    type Item
+;
+    /// Advances the iterator and returns the next value for storage types.
+    ///
+    /// # Additional Information
+    ///
+    /// Returns [`None`] when iteration is finished. Individual iterator
+    /// implementations may choose to resume iteration, and so calling `next()`
+    /// again may or may not eventually start returning [`Some(Item)`] again at some
+    /// point.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::storage::storage_vec::*;
+    ///
+    /// abi MyContract {
+    ///     #[storage(read)]
+    ///     fn iter();
+    /// }
+    ///
+    /// storage {
+    ///     my_vec: StorageVec<u64> = StorageVec {},
+    /// }
+    ///
+    /// impl MyContract for Contract {
+    ///     #[storage(read)]
+    ///     fn iter() {
+    ///         storage.my_vec.push(1);
+    ///         storage.my_vec.push(2);
+    ///         storage.my_vec.push(3);
+    ///
+    ///         let mut iter = storage.my_vec.iter();
+    ///
+    ///         // A call to next() returns the next value...
+    ///         assert_eq!(1, iter.next().unwrap().read());
+    ///         assert_eq!(2, iter.next().unwrap().read());
+    ///         assert_eq!(3, iter.next().unwrap().read());
+    ///
+    ///         // ... and then None once it's over.
+    ///         assert_eq!(None, iter.next());
+    ///     }
+    /// }
+    /// ```
+    #[storage(read)]
     fn next(ref mut self) -> Option<Self::Item>;
 }

--- a/sway-lib-std/src/iterator.sw
+++ b/sway-lib-std/src/iterator.sw
@@ -43,8 +43,7 @@ pub trait Iterator {
 
 pub trait StorageIterator {
     /// The type of the elements being iterated over.
-    type Item
-;
+    type Item;
     /// Advances the iterator and returns the next value for storage types.
     ///
     /// # Additional Information

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -7,6 +7,7 @@ use ::option::Option::{self, *};
 use ::storage::storage_api::*;
 use ::storage::storage_key::*;
 use ::vec::Vec;
+use ::iterator::StorageIterator;
 
 /// A persistent vector struct.
 pub struct StorageVec<V> {}
@@ -937,6 +938,61 @@ impl<V> StorageKey<StorageVec<V>> {
                     )
                 }
             }
+        }
+    }
+
+    /// Returns a `StorageVecIter` to iterate over this `StorageVec`.
+    ///
+    /// # Returns
+    ///
+    /// * [StorageVecIter<V>] - The stuct which can be iterated over.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// storage {
+    ///     vec: StorageVec<u64> = StorageVec {},
+    /// }
+    ///
+    /// fn foo() {
+    ///     storage.vec.push(5);
+    ///     storage.vec.push(10);
+    ///     storage.vec..push(15);
+    ///
+    ///     // Get the iterator
+    ///     let iter = storage.vec.iter();
+    ///
+    ///     assert(5 == iter.next().unwrap().read());
+    ///     assert(10 == iter.next().unwrap().read());
+    ///     assert(15 == iter.next().unwrap().read());
+    /// }
+    /// ```
+    pub fn iter(self) -> StorageVecIter<V> {
+        StorageVecIter {
+            values: self,
+            index: 0,
+        }
+    }
+}
+
+pub struct StorageVecIter<V> {
+    values: StorageKey<StorageVec<V>>,
+    index: u64,
+}
+
+impl<V> StorageIterator for StorageVecIter<V> {
+    type Item = StorageKey<V>;
+    #[storage(read)]
+    fn next(ref mut self) -> Option<Self::Item> {
+        if self.index >= self.values.len() {
+            return None
+        }
+
+        self.index += 1;
+        let key = self.values.get(self.index - 1);
+        match key {
+            Some(v) => Some(v),
+            None => None,
         }
     }
 }

--- a/sway-lib-std/src/storage/storage_vec.sw
+++ b/sway-lib-std/src/storage/storage_vec.sw
@@ -945,7 +945,7 @@ impl<V> StorageKey<StorageVec<V>> {
     ///
     /// # Returns
     ///
-    /// * [StorageVecIter<V>] - The stuct which can be iterated over.
+    /// * [StorageVecIter<V>] - The struct which can be iterated over.
     ///
     /// # Examples
     ///

--- a/test/src/sdk-harness/Forc.lock
+++ b/test/src/sdk-harness/Forc.lock
@@ -370,6 +370,11 @@ source = "member"
 dependencies = ["std"]
 
 [[package]]
+name = "svec_iter"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
 name = "svec_str"
 source = "member"
 dependencies = ["std"]

--- a/test/src/sdk-harness/Forc.toml
+++ b/test/src/sdk-harness/Forc.toml
@@ -40,6 +40,7 @@ members = [
   "test_projects/storage_map",
   "test_projects/storage_map_nested",
   "test_projects/storage_string",
+  "test_projects/storage_vec_iter",
   "test_projects/storage_vec_nested",
   "test_projects/storage_vec_of_storage_string",
   "test_projects/storage_vec_to_vec",

--- a/test/src/sdk-harness/test_projects/auth/mod.rs
+++ b/test/src/sdk-harness/test_projects/auth/mod.rs
@@ -207,64 +207,56 @@ async fn caller_addresses_from_messages() {
     .deploy(&wallet4, TxPolicies::default())
     .await
     .unwrap();
-    
+
     let auth_instance = AuthContract::new(id_1.clone(), wallet4.clone());
-    
+
     let result = auth_instance
         .methods()
         .returns_caller_addresses()
         .call()
         .await
         .unwrap();
-    
+
     assert_eq!(result.value, vec![Address::from(*wallet4.address().hash())]);
 
     // Start building transactions
-    let call_handler = auth_instance
-        .methods()
-        .returns_caller_addresses();
+    let call_handler = auth_instance.methods().returns_caller_addresses();
     let mut tb = call_handler.transaction_builder().await.unwrap();
 
     // Inputs
     tb.inputs_mut().push(Input::ResourceSigned {
-        resource: CoinType::Message(
-            setup_single_message(
-                &wallet1.address().clone(),
-                &wallet1.address().clone(),
-                message_amount,
-                0.into(),
-                vec![],
-            )
-        ),
+        resource: CoinType::Message(setup_single_message(
+            &wallet1.address().clone(),
+            &wallet1.address().clone(),
+            message_amount,
+            0.into(),
+            vec![],
+        )),
     });
     tb.inputs_mut().push(Input::ResourceSigned {
-        resource: CoinType::Message(
-            setup_single_message(
-                &wallet2.address().clone(),
-                &wallet2.address().clone(),
-                message_amount,
-                1.into(),
-                vec![],
-            )
-        ),
+        resource: CoinType::Message(setup_single_message(
+            &wallet2.address().clone(),
+            &wallet2.address().clone(),
+            message_amount,
+            1.into(),
+            vec![],
+        )),
     });
     tb.inputs_mut().push(Input::ResourceSigned {
-        resource: CoinType::Message(
-            setup_single_message(
-                &wallet3.address().clone(),
-                &wallet3.address().clone(),
-                message_amount,
-                2.into(),
-                vec![],
-            )
-        ),
+        resource: CoinType::Message(setup_single_message(
+            &wallet3.address().clone(),
+            &wallet3.address().clone(),
+            message_amount,
+            2.into(),
+            vec![],
+        )),
     });
 
     // Build transaction
     tb.add_signer(wallet1.clone()).unwrap();
     tb.add_signer(wallet2.clone()).unwrap();
     tb.add_signer(wallet3.clone()).unwrap();
-    
+
     let provider = wallet1.provider().unwrap();
     let tx = tb.build(provider.clone()).await.unwrap();
 
@@ -273,9 +265,15 @@ async fn caller_addresses_from_messages() {
     let tx_status = provider.tx_status(&tx_id).await.unwrap();
     let result = call_handler.get_response_from(tx_status).unwrap();
 
-    assert!(result.value.contains(&Address::from(wallet1.address().clone())));
-    assert!(result.value.contains(&Address::from(wallet2.address().clone())));
-    assert!(result.value.contains(&Address::from(wallet3.address().clone())));
+    assert!(result
+        .value
+        .contains(&Address::from(wallet1.address().clone())));
+    assert!(result
+        .value
+        .contains(&Address::from(wallet2.address().clone())));
+    assert!(result
+        .value
+        .contains(&Address::from(wallet3.address().clone())));
 }
 
 #[tokio::test]
@@ -346,67 +344,59 @@ async fn caller_addresses_from_coins() {
     .deploy(&wallet4, TxPolicies::default())
     .await
     .unwrap();
-    
+
     let auth_instance = AuthContract::new(id_1.clone(), wallet4.clone());
-    
+
     let result = auth_instance
         .methods()
         .returns_caller_addresses()
         .call()
         .await
         .unwrap();
-    
+
     assert_eq!(result.value, vec![Address::from(*wallet4.address().hash())]);
 
     // Start building transactions
-    let call_handler = auth_instance
-        .methods()
-        .returns_caller_addresses();
+    let call_handler = auth_instance.methods().returns_caller_addresses();
     let mut tb = call_handler.transaction_builder().await.unwrap();
 
     // Inputs
     tb.inputs_mut().push(Input::ResourceSigned {
-        resource: CoinType::Coin(
-            Coin {
-                owner: wallet1.address().clone(),
-                utxo_id: UtxoId::new(Bytes32::zeroed(), 0),
-                amount: coin_amount,
-                asset_id: AssetId::default(),
-                status: CoinStatus::Unspent,
-                block_created: Default::default(),
-            }
-        ),
+        resource: CoinType::Coin(Coin {
+            owner: wallet1.address().clone(),
+            utxo_id: UtxoId::new(Bytes32::zeroed(), 0),
+            amount: coin_amount,
+            asset_id: AssetId::default(),
+            status: CoinStatus::Unspent,
+            block_created: Default::default(),
+        }),
     });
     tb.inputs_mut().push(Input::ResourceSigned {
-        resource: CoinType::Coin(
-            Coin {
-                owner: wallet2.address().clone(),
-                utxo_id: UtxoId::new(Bytes32::zeroed(), 1),
-                amount: coin_amount,
-                asset_id: AssetId::default(),
-                status: CoinStatus::Unspent,
-                block_created: Default::default(),
-            }
-        ),
+        resource: CoinType::Coin(Coin {
+            owner: wallet2.address().clone(),
+            utxo_id: UtxoId::new(Bytes32::zeroed(), 1),
+            amount: coin_amount,
+            asset_id: AssetId::default(),
+            status: CoinStatus::Unspent,
+            block_created: Default::default(),
+        }),
     });
     tb.inputs_mut().push(Input::ResourceSigned {
-        resource: CoinType::Coin(
-            Coin {
-                owner: wallet3.address().clone(),
-                utxo_id: UtxoId::new(Bytes32::zeroed(), 2),
-                amount: coin_amount,
-                asset_id: AssetId::default(),
-                status: CoinStatus::Unspent,
-                block_created: Default::default(),
-            }
-        ),
+        resource: CoinType::Coin(Coin {
+            owner: wallet3.address().clone(),
+            utxo_id: UtxoId::new(Bytes32::zeroed(), 2),
+            amount: coin_amount,
+            asset_id: AssetId::default(),
+            status: CoinStatus::Unspent,
+            block_created: Default::default(),
+        }),
     });
 
     // Build transaction
     tb.add_signer(wallet1.clone()).unwrap();
     tb.add_signer(wallet2.clone()).unwrap();
     tb.add_signer(wallet3.clone()).unwrap();
-    
+
     let provider = wallet1.provider().unwrap();
     let tx = tb.build(provider.clone()).await.unwrap();
 
@@ -415,9 +405,15 @@ async fn caller_addresses_from_coins() {
     let tx_status = provider.tx_status(&tx_id).await.unwrap();
     let result = call_handler.get_response_from(tx_status).unwrap();
 
-    assert!(result.value.contains(&Address::from(wallet1.address().clone())));
-    assert!(result.value.contains(&Address::from(wallet2.address().clone())));
-    assert!(result.value.contains(&Address::from(wallet3.address().clone())));
+    assert!(result
+        .value
+        .contains(&Address::from(wallet1.address().clone())));
+    assert!(result
+        .value
+        .contains(&Address::from(wallet2.address().clone())));
+    assert!(result
+        .value
+        .contains(&Address::from(wallet3.address().clone())));
 }
 
 #[tokio::test]
@@ -490,66 +486,58 @@ async fn caller_addresses_from_coins_and_messages() {
     .deploy(&wallet4, TxPolicies::default())
     .await
     .unwrap();
-    
+
     let auth_instance = AuthContract::new(id_1.clone(), wallet4.clone());
-    
+
     let result = auth_instance
         .methods()
         .returns_caller_addresses()
         .call()
         .await
         .unwrap();
-    
+
     assert_eq!(result.value, vec![Address::from(*wallet4.address().hash())]);
 
     // Start building transactions
-    let call_handler = auth_instance
-        .methods()
-        .returns_caller_addresses();
+    let call_handler = auth_instance.methods().returns_caller_addresses();
     let mut tb = call_handler.transaction_builder().await.unwrap();
 
     // Inputs
     tb.inputs_mut().push(Input::ResourceSigned {
-        resource: CoinType::Message(
-            setup_single_message(
-                &wallet1.address().clone(),
-                &wallet1.address().clone(),
-                message_amount,
-                0.into(),
-                vec![],
-            )
-        ),
+        resource: CoinType::Message(setup_single_message(
+            &wallet1.address().clone(),
+            &wallet1.address().clone(),
+            message_amount,
+            0.into(),
+            vec![],
+        )),
     });
     tb.inputs_mut().push(Input::ResourceSigned {
-        resource: CoinType::Coin(
-            Coin {
-                owner: wallet2.address().clone(),
-                utxo_id: UtxoId::new(Bytes32::zeroed(), 1),
-                amount: coin_amount,
-                asset_id: AssetId::default(),
-                status: CoinStatus::Unspent,
-                block_created: Default::default(),
-            }
-        ),
+        resource: CoinType::Coin(Coin {
+            owner: wallet2.address().clone(),
+            utxo_id: UtxoId::new(Bytes32::zeroed(), 1),
+            amount: coin_amount,
+            asset_id: AssetId::default(),
+            status: CoinStatus::Unspent,
+            block_created: Default::default(),
+        }),
     });
     tb.inputs_mut().push(Input::ResourceSigned {
-        resource: CoinType::Coin(
-            Coin {
-                owner: wallet3.address().clone(),
-                utxo_id: UtxoId::new(Bytes32::zeroed(), 2),
-                amount: coin_amount,
-                asset_id: AssetId::default(),
-                status: CoinStatus::Unspent,
-                block_created: Default::default(),
-            }
-        ),
+        resource: CoinType::Coin(Coin {
+            owner: wallet3.address().clone(),
+            utxo_id: UtxoId::new(Bytes32::zeroed(), 2),
+            amount: coin_amount,
+            asset_id: AssetId::default(),
+            status: CoinStatus::Unspent,
+            block_created: Default::default(),
+        }),
     });
 
     // Build transaction
     tb.add_signer(wallet1.clone()).unwrap();
     tb.add_signer(wallet2.clone()).unwrap();
     tb.add_signer(wallet3.clone()).unwrap();
-    
+
     let provider = wallet1.provider().unwrap();
     let tx = tb.build(provider.clone()).await.unwrap();
 
@@ -558,9 +546,15 @@ async fn caller_addresses_from_coins_and_messages() {
     let tx_status = provider.tx_status(&tx_id).await.unwrap();
     let result = call_handler.get_response_from(tx_status).unwrap();
 
-    assert!(result.value.contains(&Address::from(wallet1.address().clone())));
-    assert!(result.value.contains(&Address::from(wallet2.address().clone())));
-    assert!(result.value.contains(&Address::from(wallet3.address().clone())));
+    assert!(result
+        .value
+        .contains(&Address::from(wallet1.address().clone())));
+    assert!(result
+        .value
+        .contains(&Address::from(wallet2.address().clone())));
+    assert!(result
+        .value
+        .contains(&Address::from(wallet3.address().clone())));
 }
 
 async fn get_contracts() -> (

--- a/test/src/sdk-harness/test_projects/harness.rs
+++ b/test/src/sdk-harness/test_projects/harness.rs
@@ -41,6 +41,7 @@ mod storage_map;
 mod storage_map_nested;
 mod storage_string;
 mod storage_vec;
+mod storage_vec_iter;
 mod storage_vec_nested;
 mod storage_vec_of_storage_string;
 mod storage_vec_to_vec;

--- a/test/src/sdk-harness/test_projects/storage_vec_iter/.gitignore
+++ b/test/src/sdk-harness/test_projects/storage_vec_iter/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/test/src/sdk-harness/test_projects/storage_vec_iter/Forc.lock
+++ b/test/src/sdk-harness/test_projects/storage_vec_iter/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-BE042E6CAC54480A"
+
+[[package]]
+name = "std"
+source = "path+from-root-BE042E6CAC54480A"
+dependencies = ["core"]
+
+[[package]]
+name = "svec_iter"
+source = "member"
+dependencies = ["std"]

--- a/test/src/sdk-harness/test_projects/storage_vec_iter/Forc.toml
+++ b/test/src/sdk-harness/test_projects/storage_vec_iter/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "svec_iter"
+
+[dependencies]
+std = { path = "../../../../../sway-lib-std" }

--- a/test/src/sdk-harness/test_projects/storage_vec_iter/mod.rs
+++ b/test/src/sdk-harness/test_projects/storage_vec_iter/mod.rs
@@ -1,0 +1,74 @@
+use fuels::accounts::wallet::WalletUnlocked;
+use fuels::prelude::*;
+
+abigen!(Contract(
+    name = "TestStorageVecIterContract",
+    abi = "test_projects/storage_vec_iter/out/release/svec_iter-abi.json",
+));
+
+async fn setup() -> TestStorageVecIterContract<WalletUnlocked> {
+    let mut node_config = NodeConfig::default();
+    node_config.starting_gas_price = 0;
+    let mut wallets = launch_custom_provider_and_get_wallets(
+        WalletsConfig::new(Some(1), None, None),
+        Some(node_config),
+        None,
+    )
+    .await
+    .unwrap();
+    let wallet = wallets.pop().unwrap();
+    let id = Contract::load_from(
+        "test_projects/storage_vec_iter/out/release/svec_iter.bin",
+        LoadConfiguration::default(),
+    )
+    .unwrap()
+    .deploy(&wallet, TxPolicies::default())
+    .await
+    .unwrap();
+
+    TestStorageVecIterContract::new(id, wallet)
+}
+
+#[tokio::test]
+async fn for_u64() {
+    let instance = setup().await;
+
+    let mut input = Vec::new();
+    for i in 0..100 {
+        input.push(i);
+    }
+
+    let _ = instance.methods().store(input.clone()).call().await;
+
+    assert!(
+        instance
+            .methods()
+            .for_iter(input)
+            .call()
+            .await
+            .unwrap()
+            .value
+    );
+}
+
+#[tokio::test]
+async fn next_u64() {
+    let instance = setup().await;
+
+    let mut input = Vec::new();
+    for i in 0..100 {
+        input.push(i);
+    }
+
+    let _ = instance.methods().store(input.clone()).call().await;
+
+    assert!(
+        instance
+            .methods()
+            .next_iter(input)
+            .call()
+            .await
+            .unwrap()
+            .value
+    );
+}

--- a/test/src/sdk-harness/test_projects/storage_vec_iter/src/main.sw
+++ b/test/src/sdk-harness/test_projects/storage_vec_iter/src/main.sw
@@ -1,0 +1,65 @@
+contract;
+
+use std::storage::storage_vec::*;
+
+abi MyContract {
+    #[storage(read, write)]
+    fn store(value: Vec<u64>);
+
+    #[storage(read)]
+    fn for_iter(value: Vec<u64>) -> bool;
+
+    #[storage(read)]
+    fn next_iter(value: Vec<u64>) -> bool;
+}
+
+storage {
+    my_vec: StorageVec<u64> = StorageVec {},
+}
+
+impl MyContract for Contract {
+    #[storage(read, write)]
+    fn store(value: Vec<u64>) {
+        let mut iter = 0;
+        while iter < value.len() {
+            storage.my_vec.push(value.get(iter).unwrap());
+            iter += 1;
+        }
+    }
+
+    #[storage(read)]
+    fn for_iter(value: Vec<u64>) -> bool {
+        let mut vec_iter = 0;
+        for element in storage.my_vec.iter() {
+            if element.read() != value.get(vec_iter).unwrap() {
+                return false;
+            }
+
+            vec_iter += 1;
+        }
+
+        true
+    }
+
+    #[storage(read)]
+    fn next_iter(value: Vec<u64>) -> bool {
+        let mut vec_iter = 0;
+        let mut stored_iter = storage.my_vec.iter();
+
+        while vec_iter < value.len() {
+            let result = stored_iter.next();
+            if result.unwrap().read() != value.get(vec_iter).unwrap() {
+                return false;
+            }
+
+            vec_iter += 1;
+        }
+
+        let none_result = stored_iter.next();
+        if none_result.is_some() {
+            return false;
+        }
+
+        true
+    }
+}


### PR DESCRIPTION
## Description

An internal contributor requested we add `Iter` to the `StorageVec` type. 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
