### PR TITLE
Add modulo inline tests

### DIFF
--- a/test/src/in_language_tests/test_programs/math_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/math_inline_tests/src/main.sw
@@ -1,5 +1,7 @@
 library;
 
+mod modulo;
+
 use std::{flags::{disable_panic_on_overflow, disable_panic_on_unsafe_math}, registers::flags};
 
 #[test]

--- a/test/src/in_language_tests/test_programs/math_inline_tests/src/modulo.sw
+++ b/test/src/in_language_tests/test_programs/math_inline_tests/src/modulo.sw
@@ -1,0 +1,147 @@
+library;
+
+use std::flags::disable_panic_on_unsafe_math;
+
+// u8
+#[test]
+pub fn u8_modulo() {
+    let u8_max = u8::max();
+
+    assert(0u8 % 1u8 == 0u8);
+    assert(0u8 % 2u8 == 0u8);
+    assert(1u8 % 1u8 == 0u8);
+    assert(1u8 % 2u8 == 1u8);
+
+    assert(u8_max % 1u8 == 0u8);
+    assert(u8_max % 2u8 == 1u8);
+    assert(u8_max % u8_max == 0u8);
+    assert(254u8 % u8_max == 254u8);
+}
+
+#[test(should_revert)]
+pub fn u8_modulo_panic_on_undefined_math() {
+    log(1u8 % 0u8);
+}
+
+#[test]
+pub fn u8_modulo_unsafe_math() {
+    disable_panic_on_unsafe_math();
+    assert(0u8 % 0u8 == 0u8);
+    assert(1u8 % 0u8 == 0u8);
+    assert(u8::max() % 0u8 == 0u8);
+}
+
+// u16
+#[test]
+pub fn u16_modulo() {
+    let u16_max = u16::max();
+
+    assert(0u16 % 1u16 == 0u16);
+    assert(0u16 % 2u16 == 0u16);
+    assert(1u16 % 1u16 == 0u16);
+    assert(1u16 % 2u16 == 1u16);
+
+    assert(u16_max % 1u16 == 0u16);
+    assert(u16_max % 2u16 == 1u16);
+    assert(u16_max % u16_max == 0u16);
+    assert((u16_max - 1u16) % u16_max == (u16_max - 1u16));
+}
+
+#[test(should_revert)]
+pub fn u16_modulo_panic_on_undefined_math() {
+    log(1u16 % 0u16);
+}
+
+#[test]
+pub fn u16_modulo_unsafe_math() {
+    disable_panic_on_unsafe_math();
+    assert(0u16 % 0u16 == 0u16);
+    assert(1u16 % 0u16 == 0u16);
+    assert(u16::max() % 0u16 == 0u16);
+}
+
+// u32
+#[test]
+pub fn u32_modulo() {
+    let u32_max = u32::max();
+
+    assert(0u32 % 1u32 == 0u32);
+    assert(0u32 % 2u32 == 0u32);
+    assert(1u32 % 1u32 == 0u32);
+    assert(1u32 % 2u32 == 1u32);
+    
+    assert(u32_max % 1u32 == 0u32);
+    assert(u32_max % 2u32 == 1u32);
+    assert(u32_max % u32_max == 0u32);
+    assert((u32_max - 1u32) % u32_max == (u32_max - 1u32));
+}
+
+#[test(should_revert)]
+pub fn u32_modulo_panic_on_undefined_math() {
+    log(1u32 % 0u32);
+}
+
+#[test]
+pub fn u32_modulo_unsafe_math() {
+    disable_panic_on_unsafe_math();
+    assert(0u32 % 0u32 == 0u32);
+    assert(1u32 % 0u32 == 0u32);
+    assert(u32::max() % 0u32 == 0u32);
+}
+
+// u64
+#[test]
+pub fn u64_modulo() {
+    let u64_max = u64::max();
+
+    assert(0u64 % 1u64 == 0u64);
+    assert(0u64 % 2u64 == 0u64);
+    assert(1u64 % 1u64 == 0u64);
+    assert(1u64 % 2u64 == 1u64);
+
+    assert(u64_max % 1u64 == 0u64);
+    assert(u64_max % 2u64 == 1u64);
+    assert(u64_max % u64_max == 0u64);
+    assert((u64_max - 1u64) % u64_max == (u64_max - 1u64));
+}
+
+#[test(should_revert)]
+pub fn u64_modulo_panic_on_undefined_math() {
+    log(1u64 % 0u64);
+}
+
+#[test]
+pub fn u64_modulo_unsafe_math() {
+    disable_panic_on_unsafe_math();
+    assert(0u64 % 0u64 == 0u64);
+    assert(1u64 % 0u64 == 0u64);
+    assert(u64::max() % 0u64 == 0u64);
+}
+
+// u256
+#[test]
+pub fn u256_modulo() {
+    let u256_max = u256::max();
+
+    assert(0x0u256 % 0x1u256 == 0x0u256);
+    assert(0x1u256 % 0x1u256 == 0x0u256);
+    assert(0x1u256 % 0x2u256 == 0x1u256);
+
+    assert(u256_max % 0x1u256 == 0x0u256);
+    assert(u256_max % 0x2u256 == 0x1u256);
+    assert(u256_max % u256_max == 0x0u256);
+    assert((u256_max - 0x1u256) % u256_max == (u256_max - 0x1u256));
+}
+
+#[test(should_revert)]
+pub fn u256_modulo_panic_on_undefined_math() {
+    log(0x1u256 % 0x0u256);
+}
+
+#[test]
+pub fn u256_modulo_unsafe_math() {
+    disable_panic_on_unsafe_math();
+    assert(0x0u256 % 0x0u256 == 0x0u256);
+    assert(0x1u256 % 0x0u256 == 0x0u256);
+    assert(u256::max() % 0x0u256 == 0x0u256);
+}


### PR DESCRIPTION
## Description
Add inline test for modulo operator for primitive types u8 u16 u32 u64 and u256

Closes #6776 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
