### PR TITLE
Remove instances of multiple impl blocks

### DIFF
--- a/sway-lib-core/src/primitive_conversions.sw
+++ b/sway-lib-core/src/primitive_conversions.sw
@@ -45,10 +45,7 @@ impl u32 {
             input: u64
         }
     }
-}
 
-// TODO: This must be in a separate impl block until https://github.com/FuelLabs/sway/issues/1548 is resolved
-impl u32 {
     /// Extends a `u32` to a `u256`.
     ///
     /// # Returns
@@ -114,10 +111,7 @@ impl u16 {
             input: u64
         }
     }
-}
 
-// TODO: This must be in a separate impl block until https://github.com/FuelLabs/sway/issues/1548 is resolved
-impl u16 {
     /// Extends a `u16` to a `u256`.
     ///
     /// # Returns
@@ -204,10 +198,7 @@ impl u8 {
             input: u64
         }
     }
-}
 
-// TODO: This must be in a separate impl block until https://github.com/FuelLabs/sway/issues/1548 is resolved
-impl u8 {
     /// Extends a `u8` to a `u256`.
     ///
     /// # Returns

--- a/sway-lib-std/src/bytes.sw
+++ b/sway-lib-std/src/bytes.sw
@@ -584,10 +584,7 @@ impl Bytes {
     pub fn ptr(self) -> raw_ptr {
         self.buf.ptr()
     }
-}
 
-// Need to use separate impl blocks for now: https://github.com/FuelLabs/sway/issues/1548
-impl Bytes {
     /// Divides one Bytes into two at an index.
     ///
     /// # Additional Information


### PR DESCRIPTION
## Description
Previously due to issue #1548 it was not possible to use a method defined in an impl block in another method defined in the same impl block, that issue is now fixed.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
