### PR TITLE
add erroneously missing #[test()] attribute

### DIFF
--- a/test/src/in_language_tests/test_programs/bytes_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/bytes_inline_tests/src/main.sw
@@ -779,6 +779,7 @@ fn bytes_append_to_empty() {
     };
 }
 
+#[test()]
 fn bytes_append_self() {
     let (mut bytes, a, b, c) = setup();
     assert(bytes.len() == 3);
@@ -797,6 +798,7 @@ fn bytes_append_self() {
     assert(bytes.get(5).unwrap() == c);
 }
 
+#[test()]
 fn bytes_append_empty_self() {
     let mut empty_bytes = Bytes::new();
 


### PR DESCRIPTION
## Description
A few bytes tests are erroneously missing the test attribute, meaning they are not actually run.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
