### PR TITLE
Add tests of visibility of private direct submodules

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_fail/submodule_visibility/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/submodule_visibility/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "submodule_visibility"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_fail/submodule_visibility/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/submodule_visibility/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "submodule_visibility"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_fail/submodule_visibility/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/submodule_visibility/src/main.sw
@@ -1,0 +1,13 @@
+library;
+
+// other is a submodule that declares a private submodule lib
+// lib contains a declaration of the public struct S, but since lib is private it is not visible here.
+// It is visible inside other, though.
+pub mod other;
+
+// lib is private, and not a direct submodule of the current module, so this should fail
+use other::lib::S; 
+
+pub fn foo() {
+    let my_struct = S { val: 0 };
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/submodule_visibility/src/other.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/submodule_visibility/src/other.sw
@@ -1,0 +1,11 @@
+library;
+
+mod lib; // private submodule
+
+// lib is private, but since it is a direct submodule we can access its public items.
+use lib::S;
+
+// Public function
+pub fn foo() {
+    let my_struct = S { val: 0 };
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/submodule_visibility/src/other/lib.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/submodule_visibility/src/other/lib.sw
@@ -1,0 +1,5 @@
+library;
+
+pub struct S {
+    pub val: u64,
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/submodule_visibility/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/submodule_visibility/test.toml
@@ -1,0 +1,6 @@
+category = "fail"
+
+# check: $()error
+# check: $()Module "lib" is private.
+
+# check: $()Aborting due to 1 error.

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/submodule_visibility/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/submodule_visibility/Forc.lock
@@ -1,0 +1,3 @@
+[[package]]
+name = "submodule_visibility"
+source = "member"

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/submodule_visibility/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/submodule_visibility/Forc.toml
@@ -1,0 +1,6 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "submodule_visibility"
+implicit-std = false

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/submodule_visibility/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/submodule_visibility/src/main.sw
@@ -1,0 +1,7 @@
+library;
+
+// other is a submodule that declares a private submodule lib
+// lib contains a declaration of the public struct S, but since lib is private it is not visible here.
+// It is visible inside other, though.
+pub mod other;
+

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/submodule_visibility/src/other.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/submodule_visibility/src/other.sw
@@ -1,0 +1,11 @@
+library;
+
+mod lib; // private submodule
+
+// lib is private, but since it is a direct submodule we can access its public items.
+use lib::S;
+
+// Public function
+pub fn foo() {
+    let my_struct = S { val: 0 };
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/submodule_visibility/src/other/lib.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/submodule_visibility/src/other/lib.sw
@@ -1,0 +1,5 @@
+library;
+
+pub struct S {
+    pub val: u64,
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/submodule_visibility/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/submodule_visibility/test.toml
@@ -1,0 +1,2 @@
+category = "compile"
+expected_warnings = 1


### PR DESCRIPTION
## Description

#5765 was solved by an earlier PR, but we don't seem to have regression tests for that situation. This PR adds those tests.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
