### PR TITLE
fix: gh-pages CI failing due to forc-migrate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -977,13 +977,13 @@ jobs:
       - name: Strip release binaries x86_64-linux-gnu
         if: matrix.job.target == 'x86_64-unknown-linux-gnu'
         run: |
-          for BINARY in forc forc-fmt forc-lsp forc-debug forc-deploy forc-run forc-doc forc-crypto forc-tx forc-submit; do
+          for BINARY in forc forc-fmt forc-lsp forc-debug forc-deploy forc-run forc-doc forc-crypto forc-tx forc-submit forc-migrate; do
             strip "target/${{ matrix.job.target }}/release/$BINARY"
           done
       - name: Strip release binaries aarch64-linux-gnu
         if: matrix.job.target == 'aarch64-unknown-linux-gnu'
         run: |
-          for BINARY in forc forc-fmt forc-lsp forc-debug forc-deploy forc-run forc-doc forc-crypto forc-tx forc-submit; do
+          for BINARY in forc forc-fmt forc-lsp forc-debug forc-deploy forc-run forc-doc forc-crypto forc-tx forc-submit forc-migrate; do
             docker run --rm -v \
             "$PWD/target:/target:Z" \
             ghcr.io/cross-rs/${{ matrix.job.target }}:main \
@@ -993,7 +993,7 @@ jobs:
       - name: Strip release binaries mac
         if: matrix.job.os == 'macos-latest'
         run: |
-          for BINARY in forc forc-fmt forc-lsp forc-debug forc-deploy forc-run forc-doc forc-crypto forc-tx forc-submit; do
+          for BINARY in forc forc-fmt forc-lsp forc-debug forc-deploy forc-run forc-doc forc-crypto forc-tx forc-submit forc-migrate; do
             strip -x "target/${{ matrix.job.target }}/release/$BINARY"
           done
 
@@ -1007,7 +1007,7 @@ jobs:
           ZIP_FILE_NAME=forc-binaries-${{ env.PLATFORM_NAME }}_${{ env.ARCH }}.tar.gz
           echo "ZIP_FILE_NAME=$ZIP_FILE_NAME" >> $GITHUB_ENV
           mkdir -pv ./forc-binaries
-          for BINARY in forc forc-fmt forc-lsp forc-debug forc-deploy forc-run forc-doc forc-crypto forc-tx forc-submit; do
+          for BINARY in forc forc-fmt forc-lsp forc-debug forc-deploy forc-run forc-doc forc-crypto forc-tx forc-submit forc-migrate; do
             cp "target/${{ matrix.job.target }}/release/$BINARY" ./forc-binaries
           done
           tar -czvf $ZIP_FILE_NAME ./forc-binaries

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,6 +31,7 @@ jobs:
           cargo install --locked --debug --path ./forc-plugins/forc-debug
           cargo install --locked --debug --path ./forc-plugins/forc-doc
           cargo install --locked --debug --path ./forc-plugins/forc-crypto
+          cargo install --locked --debug --path ./forc-plugins/forc-migrate
           cargo install --locked --debug forc-explore
       - name: Install mdbook-forc-documenter
         uses: actions-rs/cargo@v1

--- a/.github/workflows/scripts/verify_tag.sh
+++ b/.github/workflows/scripts/verify_tag.sh
@@ -56,6 +56,7 @@ for toml_path in \
     "workspace.dependencies.forc-fmt.version" \
     "workspace.dependencies.forc-lsp.version" \
     "workspace.dependencies.forc-tx.version" \
+    "workspace.dependencies.forc-migrate.version" \
     "workspace.dependencies.sway-ast.version" \
     "workspace.dependencies.sway-core.version" \
     "workspace.dependencies.sway-error.version" \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ forc-doc = { path = "forc-plugins/forc-doc/", version = "0.66.6" }
 forc-fmt = { path = "forc-plugins/forc-fmt/", version = "0.66.6" }
 forc-lsp = { path = "forc-plugins/forc-lsp/", version = "0.66.6" }
 forc-tx = { path = "forc-plugins/forc-tx/", version = "0.66.6" }
+forc-migrate = { path = "forc-plugins/forc-migrate/", version = "0.66.6" }
 
 sway-ast = { path = "sway-ast/", version = "0.66.6" }
 sway-core = { path = "sway-core/", version = "0.66.6" }


### PR DESCRIPTION
## Description

The github-pages CI action has been [failing](https://github.com/FuelLabs/sway/actions/runs/12867769693/job/35873104739) since the forc-migrate PR was merged, because the plugin needs to be installed in that workflow.

It was also missing from forc-binaries which is needed for us to be able to distribute the binary.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
