### PR TITLE
chore: enable serde feature for num_bigint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ minifier = "0.3"
 normalize-path = "0.2"
 notify = "6.1"
 notify-debouncer-mini = "0.4"
-num-bigint = "0.4"
+num-bigint = { version = "0.4", features = ["serde"] }
 num-traits = "0.2"
 object = "0.36"
 once_cell = "1.18"


### PR DESCRIPTION
## Description
The `publish` job [failed](https://github.com/FuelLabs/sway/actions/runs/12918145032/job/3) as the serde feature for the `num_bigint` crate needed to be enabled. 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
