### PR TITLE
Add `Bytes` conversions for `Address`, `ContractId`, `EvmAddress`, `B512` and `AssetId`

### DIFF
--- a/sway-lib-std/src/address.sw
+++ b/sway-lib-std/src/address.sw
@@ -1,8 +1,10 @@
 //! The `Address` type used for interacting with addresses on the fuel network.
 library;
 
-use ::convert::From;
+use ::convert::{From, TryFrom};
 use ::hash::{Hash, Hasher};
+use ::bytes::Bytes;
+use ::option::Option::{self, *};
 
 /// The `Address` type, a struct wrapper around the inner `b256` value.
 pub struct Address {
@@ -116,6 +118,40 @@ impl From<Address> for b256 {
     /// ```
     fn from(address: Address) -> Self {
         address.bits()
+    }
+}
+
+impl TryFrom<Bytes> for Address {
+    /// Casts raw `Bytes` data to an `Address`.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes`: [Bytes] - The raw `Bytes` data to be casted.
+    ///
+    /// # Returns
+    ///
+    /// * [Address] - The newly created `Address` from the raw `Bytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::bytes::Bytes;
+    ///
+    /// fn foo(bytes: Bytes) {
+    ///    let result = Address::try_from(bytes);
+    ///    assert(result.is_some());
+    ///    let address = result.unwrap();
+    /// }
+    /// ```
+    fn try_from(bytes: Bytes) -> Option<Self> {
+        if bytes.len() != 32 {
+            return None;
+        }
+
+
+        Some(Self { 
+            bits: asm(ptr: bytes.ptr()) { ptr: b256 } 
+        })
     }
 }
 

--- a/sway-lib-std/src/address.sw
+++ b/sway-lib-std/src/address.sw
@@ -1,7 +1,7 @@
 //! The `Address` type used for interacting with addresses on the fuel network.
 library;
 
-use ::convert::{From, TryFrom};
+use ::convert::{From, Into, TryFrom};
 use ::hash::{Hash, Hasher};
 use ::bytes::Bytes;
 use ::option::Option::{self, *};
@@ -112,7 +112,7 @@ impl From<Address> for b256 {
     /// ```sway
     /// fn foo() {
     ///     let address = Address::zero();
-    ///     let b256_data: b256 = address.into();
+    ///     let b256_data: b256 = b256::from(address);
     ///     assert(b256_data == b256::zero());
     /// }
     /// ```
@@ -152,6 +152,27 @@ impl TryFrom<Bytes> for Address {
         Some(Self { 
             bits: asm(ptr: bytes.ptr()) { ptr: b256 } 
         })
+    }
+}
+
+impl Into<Bytes> for Address {
+    /// Casts an `Address` to raw `Bytes` data.
+    ///
+    /// # Returns
+    ///
+    /// * [Bytes] - The underlying raw `Bytes` data of the `Address`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// fn foo() {
+    ///     let address = Address::zero();
+    ///     let bytes_data: Bytes = address.into()
+    ///     assert(bytes_data.len() == 32);
+    /// }
+    /// ```
+    fn into(self) -> Bytes {
+        Bytes::from(self.bits())
     }
 }
 

--- a/sway-lib-std/src/asset_id.sw
+++ b/sway-lib-std/src/asset_id.sw
@@ -3,7 +3,7 @@ library;
 
 use ::alias::SubId;
 use ::contract_id::ContractId;
-use ::convert::{From, TryFrom};
+use ::convert::{From, Into, TryFrom};
 use ::hash::{Hash, Hasher};
 use ::bytes::Bytes;
 use ::option::Option::{self, *};
@@ -238,8 +238,8 @@ impl From<AssetId> for b256 {
     ///
     /// ```sway
     /// fn foo() {
-    ///     let asset_id = AssetId::b256::zero();
-    ///     let b256_data: b256 = asset_id.into();
+    ///     let asset_id = AssetId::zero();
+    ///     let b256_data: b256 = b256::from(asset_id);
     ///     assert(b256_data == b256::zero());
     /// }
     /// ```
@@ -278,5 +278,26 @@ impl TryFrom<Bytes> for AssetId {
         Some(Self { 
             bits: asm(ptr: bytes.ptr()) { ptr: b256 } 
         })
+    }
+}
+
+impl Into<Bytes> for AssetId {
+    /// Casts an `AssetId` to raw `Bytes` data.
+    ///
+    /// # Returns
+    ///
+    /// * [Bytes] - The underlying raw `Bytes` data of the `AssetId`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// fn foo() {
+    ///     let asset_id = AssetId::zero();
+    ///     let bytes_data: Bytes = asset_id.into();
+    ///     assert(bytes_data.len() == 32);
+    /// }
+    /// ```
+    fn into(self) -> Bytes {
+        Bytes::from(self.bits())
     }
 }

--- a/sway-lib-std/src/asset_id.sw
+++ b/sway-lib-std/src/asset_id.sw
@@ -3,8 +3,10 @@ library;
 
 use ::alias::SubId;
 use ::contract_id::ContractId;
-use ::convert::From;
+use ::convert::{From, TryFrom};
 use ::hash::{Hash, Hasher};
+use ::bytes::Bytes;
+use ::option::Option::{self, *};
 
 /// An AssetId is used for interacting with an asset on the network.
 ///
@@ -71,7 +73,7 @@ impl AssetId {
     /// # Examples
     ///
     /// ```sway
-    /// use std::callframes::contract_id;
+    /// use std::call_frames::contract_id;
     ///
     /// fn foo() {
     ///     let contract_id = contract_id();
@@ -109,7 +111,7 @@ impl AssetId {
     /// # Examples
     ///
     /// ```sway
-    /// use std::{callframes::contract_id, constants::DEFAULT_SUB_ID};
+    /// use std::{call_frames::contract_id, constants::DEFAULT_SUB_ID};
     ///
     /// fn foo() {
     ///     let asset_id = AssetId::default();
@@ -243,5 +245,38 @@ impl From<AssetId> for b256 {
     /// ```
     fn from(id: AssetId) -> Self {
         id.bits()
+    }
+}
+
+impl TryFrom<Bytes> for AssetId {
+    /// Casts raw `Bytes` data to an `AssetId`.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes`: [Bytes] - The raw `Bytes` data to be casted.
+    ///
+    /// # Returns
+    ///
+    /// * [AssetId] - The newly created `AssetId` from the raw `Bytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::bytes::Bytes;
+    ///
+    /// fn foo(bytes: Bytes) {
+    ///    let result = AssetId::try_from(bytes);
+    ///    assert(result.is_some());
+    ///    let asset_id = result.unwrap();
+    /// }
+    /// ```
+    fn try_from(bytes: Bytes) -> Option<Self> {
+        if bytes.len() != 32 {
+            return None;
+        }
+
+        Some(Self { 
+            bits: asm(ptr: bytes.ptr()) { ptr: b256 } 
+        })
     }
 }

--- a/sway-lib-std/src/b512.sw
+++ b/sway-lib-std/src/b512.sw
@@ -1,7 +1,7 @@
 //! The `B512` type supports the usage of 64-byte values in Sway which are needed when working with public keys and signatures.
 library;
 
-use ::convert::{From, TryFrom};
+use ::convert::{From, Into, TryFrom};
 use ::bytes::Bytes;
 use ::option::Option::{self, *};
 
@@ -192,5 +192,26 @@ impl TryFrom<Bytes> for B512 {
         Some(Self { 
             bits: asm(ptr: bytes.ptr()) { ptr: [b256; 2] } 
         })
+    }
+}
+
+impl Into<Bytes> for B512 {
+    /// Casts an `B512` to raw `Bytes` data.
+    ///
+    /// # Returns
+    ///
+    /// * [Bytes] - The underlying raw `Bytes` data of the `B512`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// fn foo() {
+    ///     let b512 = B512::from((b256::zero(), b256::zero()));
+    ///     let bytes_data: Bytes = b512.into()
+    ///     assert(bytes_data.len() == 64);
+    /// }
+    /// ```
+    fn into(self) -> Bytes {
+        Bytes::from(raw_slice::from_parts::<u8>(__addr_of(self.bits), 64))
     }
 }

--- a/sway-lib-std/src/b512.sw
+++ b/sway-lib-std/src/b512.sw
@@ -1,7 +1,9 @@
 //! The `B512` type supports the usage of 64-byte values in Sway which are needed when working with public keys and signatures.
 library;
 
-use ::convert::From;
+use ::convert::{From, TryFrom};
+use ::bytes::Bytes;
+use ::option::Option::{self, *};
 
 /// Stores two `b256`s in contiguous memory.
 /// Guaranteed to be contiguous for use with ec-recover: `std::ecr::ec_recover`.
@@ -157,5 +159,38 @@ impl B512 {
     /// ```
     pub fn is_zero(self) -> bool {
         (self.bits)[0] == b256::zero() && (self.bits)[1] == b256::zero()
+    }
+}
+
+impl TryFrom<Bytes> for B512 {
+    /// Casts raw `Bytes` data to an `B512`.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes`: [Bytes] - The raw `Bytes` data to be casted.
+    ///
+    /// # Returns
+    ///
+    /// * [B512] - The newly created `B512` from the raw `Bytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::bytes::Bytes;
+    ///
+    /// fn foo(bytes: Bytes) {
+    ///    let result = B512::try_from(bytes);
+    ///    assert(result.is_some());
+    ///    let b512 = result.unwrap();
+    /// }
+    /// ```
+    fn try_from(bytes: Bytes) -> Option<Self> {
+        if bytes.len() != 64 {
+            return None;
+        }
+
+        Some(Self { 
+            bits: asm(ptr: bytes.ptr()) { ptr: [b256; 2] } 
+        })
     }
 }

--- a/sway-lib-std/src/contract_id.sw
+++ b/sway-lib-std/src/contract_id.sw
@@ -1,7 +1,7 @@
 //! The `ContractId` type used for interacting with contracts on the fuel network.
 library;
 
-use ::convert::{From, TryFrom};
+use ::convert::{From, Into, TryFrom};
 use ::hash::{Hash, Hasher};
 use ::bytes::Bytes;
 use ::option::Option::{self, *};
@@ -112,6 +112,27 @@ impl TryFrom<Bytes> for ContractId {
         Some(Self { 
             bits: asm(ptr: bytes.ptr()) { ptr: b256 } 
         })
+    }
+}
+
+impl Into<Bytes> for ContractId {
+    /// Casts an `ContractId` to raw `Bytes` data.
+    ///
+    /// # Returns
+    ///
+    /// * [Bytes] - The underlying raw `Bytes` data of the `ContractId`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// fn foo() {
+    ///     let contract_id = ContractId::zero();
+    ///     let bytes_data: Bytes = contract_id.into()
+    ///     assert(bytes_data.len() == 32);
+    /// }
+    /// ```
+    fn into(self) -> Bytes {
+        Bytes::from(self.bits())
     }
 }
 

--- a/sway-lib-std/src/contract_id.sw
+++ b/sway-lib-std/src/contract_id.sw
@@ -1,8 +1,10 @@
 //! The `ContractId` type used for interacting with contracts on the fuel network.
 library;
 
-use ::convert::From;
+use ::convert::{From, TryFrom};
 use ::hash::{Hash, Hasher};
+use ::bytes::Bytes;
+use ::option::Option::{self, *};
 
 /// The `ContractId` type, a struct wrapper around the inner `b256` value.
 pub struct ContractId {
@@ -77,6 +79,39 @@ impl From<ContractId> for b256 {
     /// ```
     fn from(id: ContractId) -> Self {
         id.bits()
+    }
+}
+
+impl TryFrom<Bytes> for ContractId {
+    /// Casts raw `Bytes` data to an `ContractId`.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes`: [Bytes] - The raw `Bytes` data to be casted.
+    ///
+    /// # Returns
+    ///
+    /// * [ContractId] - The newly created `ContractId` from the raw `Bytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::bytes::Bytes;
+    ///
+    /// fn foo(bytes: Bytes) {
+    ///    let result = ContractId::try_from(bytes);
+    ///    assert(result.is_some());
+    ///    let contract_id = result.unwrap();
+    /// }
+    /// ```
+    fn try_from(bytes: Bytes) -> Option<Self> {
+        if bytes.len() != 32 {
+            return None;
+        }
+
+        Some(Self { 
+            bits: asm(ptr: bytes.ptr()) { ptr: b256 } 
+        })
     }
 }
 

--- a/sway-lib-std/src/vm/evm/evm_address.sw
+++ b/sway-lib-std/src/vm/evm/evm_address.sw
@@ -2,7 +2,7 @@
 library;
 
 use ::intrinsics::size_of_val;
-use ::convert::{From, TryFrom};
+use ::convert::{From, Into, TryFrom};
 use ::hash::*;
 use ::bytes::Bytes;
 use ::option::Option::{self, *};
@@ -172,6 +172,27 @@ impl TryFrom<Bytes> for EvmAddress {
         bytes.ptr().copy_bytes_to(__addr_of(bits).add_uint_offset(12), 20);
 
         Some(Self { bits })
+    }
+}
+
+impl Into<Bytes> for EvmAddress {
+    /// Casts an `EvmAddress` to raw `Bytes` data.
+    ///
+    /// # Returns
+    ///
+    /// * [Bytes] - The underlying raw `Bytes` data of the `EvmAddress`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// fn foo() {
+    ///     let evm_address = EvmAddress::zero();
+    ///     let bytes_data: Bytes = evm_address.into()
+    ///     assert(bytes_data.len() == 32);
+    /// }
+    /// ```
+    fn into(self) -> Bytes {
+        Bytes::from(raw_slice::from_parts::<u8>(__addr_of(self.bits).add_uint_offset(12), 20))
     }
 }
 

--- a/sway-lib-std/src/vm/evm/evm_address.sw
+++ b/sway-lib-std/src/vm/evm/evm_address.sw
@@ -2,8 +2,10 @@
 library;
 
 use ::intrinsics::size_of_val;
-use ::convert::From;
+use ::convert::{From, TryFrom};
 use ::hash::*;
+use ::bytes::Bytes;
+use ::option::Option::{self, *};
 
 /// The `EvmAddress` type, a struct wrapper around the inner `b256` value.
 pub struct EvmAddress {
@@ -136,6 +138,40 @@ impl From<EvmAddress> for b256 {
     /// ```
     fn from(addr: EvmAddress) -> b256 {
         addr.bits
+    }
+}
+
+impl TryFrom<Bytes> for EvmAddress {
+    /// Casts raw `Bytes` data to an `EvmAddress`.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes`: [Bytes] - The raw `Bytes` data to be casted.
+    ///
+    /// # Returns
+    ///
+    /// * [EvmAddress] - The newly created `EvmAddress` from the raw `Bytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::bytes::Bytes;
+    ///
+    /// fn foo(bytes: Bytes) {
+    ///    let result = EvmAddress::try_from(bytes);
+    ///    assert(result.is_some());
+    ///    let evm_address = result.unwrap();
+    /// }
+    /// ```
+    fn try_from(bytes: Bytes) -> Option<Self> {
+        if bytes.len() != 20 {
+            return None;
+        }
+
+        let bits = b256::zero();
+        bytes.ptr().copy_bytes_to(__addr_of(bits).add_uint_offset(12), 20);
+
+        Some(Self { bits })
     }
 }
 

--- a/test/src/in_language_tests/test_programs/address_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/address_inline_tests/src/main.sw
@@ -180,3 +180,44 @@ fn address_is_zero() {
     let address_3 = Address::from(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
     assert(!address_3.is_zero());
 }
+
+#[test]
+fn address_try_from_bytes() {
+    use std::bytes::Bytes;
+
+    // Test empty bytes
+    let bytes_1 = Bytes::new();
+    assert(Address::try_from(bytes_1).is_none());
+
+    // Test not full length but capacity bytes
+    let mut bytes_2 = Bytes::with_capacity(32);
+    bytes_2.push(1u8);
+    bytes_2.push(3u8);
+    bytes_2.push(5u8);
+    assert(Address::try_from(bytes_2).is_none());
+
+    // Test zero bytes
+    let bytes_3 = Bytes::from(b256::zero());
+    let address_3 = Address::try_from(bytes_3);
+    assert(address_3.is_some());
+    assert(address_3.unwrap() == Address::zero());
+
+    // Test max bytes
+    let bytes_4 = Bytes::from(b256::max());
+    let address_4 = Address::try_from(bytes_4);
+    assert(address_4.is_some());
+    assert(address_4.unwrap() == Address::from(b256::max()));
+
+    // Test too many bytes
+    let mut bytes_5 = Bytes::from(b256::max());
+    bytes_5.push(255u8);
+    assert(Address::try_from(bytes_5).is_none());
+
+    // Test modifying bytes after doesn't impact 
+    let mut bytes_6 = Bytes::from(b256::zero());
+    let address_6 = Address::try_from(bytes_6);
+    assert(address_6.is_some());
+    assert(address_6.unwrap() == Address::zero());
+    bytes_6.set(0, 255u8);
+    assert(address_6.unwrap() == Address::zero());
+}

--- a/test/src/in_language_tests/test_programs/address_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/address_inline_tests/src/main.sw
@@ -221,3 +221,39 @@ fn address_try_from_bytes() {
     bytes_6.set(0, 255u8);
     assert(address_6.unwrap() == Address::zero());
 }
+
+#[test]
+fn address_try_into_bytes() {
+    use std::bytes::Bytes;
+
+    let address_1 = Address::zero();
+    let bytes_1: Bytes = <Address as Into<Bytes>>::into(address_1);
+    assert(bytes_1.capacity() == 32);
+    assert(bytes_1.len() == 32);
+    let mut iter_1 = 0;
+    while iter_1 < 32 {
+        assert(bytes_1.get(iter_1).unwrap() == 0u8);
+        iter_1 += 1;
+    }
+
+    let address_2 = Address::from(b256::max());
+    let bytes_2: Bytes = <Address as Into<Bytes>>::into(address_2);
+    assert(bytes_2.capacity() == 32);
+    assert(bytes_2.len() == 32);
+    let mut iter_2 = 0;
+    while iter_2 < 32 {
+        assert(bytes_2.get(iter_2).unwrap() == 255u8);
+        iter_2 += 1;
+    }
+
+    let address_3 = Address::from(0x0000000000000000000000000000000000000000000000000000000000000001);
+    let bytes_3: Bytes = <Address as Into<Bytes>>::into(address_3);
+    assert(bytes_3.capacity() == 32);
+    assert(bytes_3.len() == 32);
+    assert(bytes_3.get(31).unwrap() == 1u8);
+    let mut iter_3 = 0;
+    while iter_3 < 31 {
+        assert(bytes_3.get(iter_3).unwrap() == 0u8);
+        iter_3 += 1;
+    }
+}

--- a/test/src/in_language_tests/test_programs/asset_id_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/asset_id_inline_tests/src/main.sw
@@ -250,3 +250,44 @@ fn asset_id_is_zero() {
     let asset_3 = AssetId::from(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
     assert(!asset_3.is_zero());
 }
+
+#[test]
+fn asset_id_try_from_bytes() {
+    use std::bytes::Bytes;
+
+    // Test empty bytes
+    let bytes_1 = Bytes::new();
+    assert(AssetId::try_from(bytes_1).is_none());
+
+    // Test not full length but capacity bytes
+    let mut bytes_2 = Bytes::with_capacity(32);
+    bytes_2.push(1u8);
+    bytes_2.push(3u8);
+    bytes_2.push(5u8);
+    assert(AssetId::try_from(bytes_2).is_none());
+
+    // Test zero bytes
+    let bytes_3 = Bytes::from(b256::zero());
+    let asset_id_3 = AssetId::try_from(bytes_3);
+    assert(asset_id_3.is_some());
+    assert(asset_id_3.unwrap() == AssetId::zero());
+
+    // Test max bytes
+    let bytes_4 = Bytes::from(b256::max());
+    let asset_id_4 = AssetId::try_from(bytes_4);
+    assert(asset_id_4.is_some());
+    assert(asset_id_4.unwrap() == AssetId::from(b256::max()));
+
+    // Test too many bytes
+    let mut bytes_5 = Bytes::from(b256::max());
+    bytes_5.push(255u8);
+    assert(AssetId::try_from(bytes_5).is_none());
+
+    // Test modifying bytes after doesn't impact 
+    let mut bytes_6 = Bytes::from(b256::zero());
+    let asset_id_6 = AssetId::try_from(bytes_6);
+    assert(asset_id_6.is_some());
+    assert(asset_id_6.unwrap() == AssetId::zero());
+    bytes_6.set(0, 255u8);
+    assert(asset_id_6.unwrap() == AssetId::zero());
+}

--- a/test/src/in_language_tests/test_programs/asset_id_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/asset_id_inline_tests/src/main.sw
@@ -291,3 +291,39 @@ fn asset_id_try_from_bytes() {
     bytes_6.set(0, 255u8);
     assert(asset_id_6.unwrap() == AssetId::zero());
 }
+
+#[test]
+fn asset_id_try_into_bytes() {
+    use std::bytes::Bytes;
+
+    let asset_id_1 = AssetId::zero();
+    let bytes_1: Bytes = <AssetId as Into<Bytes>>::into(asset_id_1);
+    assert(bytes_1.capacity() == 32);
+    assert(bytes_1.len() == 32);
+    let mut iter_1 = 0;
+    while iter_1 < 32 {
+        assert(bytes_1.get(iter_1).unwrap() == 0u8);
+        iter_1 += 1;
+    }
+
+    let asset_id_2 = AssetId::from(b256::max());
+    let bytes_2: Bytes = <AssetId as Into<Bytes>>::into(asset_id_2);
+    assert(bytes_2.capacity() == 32);
+    assert(bytes_2.len() == 32);
+    let mut iter_2 = 0;
+    while iter_2 < 32 {
+        assert(bytes_2.get(iter_2).unwrap() == 255u8);
+        iter_2 += 1;
+    }
+
+    let asset_id_3 = AssetId::from(0x0000000000000000000000000000000000000000000000000000000000000001);
+    let bytes_3: Bytes = <AssetId as Into<Bytes>>::into(asset_id_3);
+    assert(bytes_3.capacity() == 32);
+    assert(bytes_3.len() == 32);
+    assert(bytes_3.get(31).unwrap() == 1u8);
+    let mut iter_3 = 0;
+    while iter_3 < 31 {
+        assert(bytes_3.get(iter_3).unwrap() == 0u8);
+        iter_3 += 1;
+    }
+}

--- a/test/src/in_language_tests/test_programs/b512_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/b512_inline_tests/src/main.sw
@@ -282,3 +282,48 @@ fn b512_is_zero() {
     ));
     assert(!b512_4.is_zero());
 }
+
+#[test]
+fn b512_try_from_bytes() {
+    use std::bytes::Bytes;
+
+    // Test empty bytes
+    let bytes_1 = Bytes::new();
+    assert(B512::try_from(bytes_1).is_none());
+
+    // Test not full length but capacity bytes
+    let mut bytes_2 = Bytes::with_capacity(64);
+    bytes_2.push(1u8);
+    bytes_2.push(3u8);
+    bytes_2.push(5u8);
+    assert(B512::try_from(bytes_2).is_none());
+
+    // Test zero bytes
+    let b256_tuple_3 = (b256::zero(), b256::zero());
+    let bytes_3 = Bytes::from(raw_slice::from_parts::<u8>(__addr_of(b256_tuple_3), 64));
+    let b512_3 = B512::try_from(bytes_3);
+    assert(b512_3.is_some());
+    assert(b512_3.unwrap() == B512::zero());
+
+    // Test max bytes
+    let b256_tuple_4 = (b256::max(), b256::max());
+    let bytes_4 = Bytes::from(raw_slice::from_parts::<u8>(__addr_of(b256_tuple_4), 64));
+    let b512_4 = B512::try_from(bytes_4);
+    assert(b512_4.is_some());
+    assert(b512_4.unwrap() == B512::from((b256::max(), b256::max())));
+
+    // Test too many bytes
+    let b256_tuple_5 = (b256::max(), b256::max());
+    let mut bytes_5 = Bytes::from(raw_slice::from_parts::<u8>(__addr_of(b256_tuple_5), 64));
+    bytes_5.push(255u8);
+    assert(B512::try_from(bytes_5).is_none());
+
+    // Test modifying bytes after doesn't impact 
+    let b256_tuple_6 = (b256::zero(), b256::zero());
+    let mut bytes_6 = Bytes::from(raw_slice::from_parts::<u8>(__addr_of(b256_tuple_6), 64));
+    let b512_6 = B512::try_from(bytes_6);
+    assert(b512_6.is_some());
+    assert(b512_6.unwrap() == B512::zero());
+    bytes_6.set(0, 255u8);
+    assert(b512_6.unwrap() == B512::zero());
+}

--- a/test/src/in_language_tests/test_programs/b512_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/b512_inline_tests/src/main.sw
@@ -327,3 +327,39 @@ fn b512_try_from_bytes() {
     bytes_6.set(0, 255u8);
     assert(b512_6.unwrap() == B512::zero());
 }
+
+#[test]
+fn b512_into_bytes() {
+    use std::bytes::Bytes;
+
+    let b512_1 = B512::zero();
+    let bytes_1: Bytes = <B512 as Into<Bytes>>::into(b512_1);
+    assert(bytes_1.capacity() == 64);
+    assert(bytes_1.len() == 64);
+    let mut iter_1 = 0;
+    while iter_1 < 64 {
+        assert(bytes_1.get(iter_1).unwrap() == 0u8);
+        iter_1 += 1;
+    }
+
+    let b512_2 = B512::from((b256::max(), b256::max()));
+    let bytes_2: Bytes = <B512 as Into<Bytes>>::into(b512_2);
+    assert(bytes_2.capacity() == 64);
+    assert(bytes_2.len() == 64);
+    let mut iter_2 = 0;
+    while iter_2 < 64 {
+        assert(bytes_2.get(iter_2).unwrap() == 255u8);
+        iter_2 += 1;
+    }
+
+    let b512_3 = B512::from((b256::zero() , 0x0000000000000000000000000000000000000000000000000000000000000001));
+    let bytes_3: Bytes = <B512 as Into<Bytes>>::into(b512_3);
+    assert(bytes_3.capacity() == 64);
+    assert(bytes_3.len() == 64);
+    assert(bytes_3.get(63).unwrap() == 1u8);
+    let mut iter_3 = 0;
+    while iter_3 < 63 {
+        assert(bytes_3.get(iter_3).unwrap() == 0u8);
+        iter_3 += 1;
+    }
+}

--- a/test/src/in_language_tests/test_programs/contract_id_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/contract_id_inline_tests/src/main.sw
@@ -221,3 +221,39 @@ fn contract_id_try_from_bytes() {
     bytes_6.set(0, 255u8);
     assert(contract_id_6.unwrap() == ContractId::zero());
 }
+
+#[test]
+fn contract_id_try_into_bytes() {
+    use std::bytes::Bytes;
+
+    let contract_id_1 = ContractId::zero();
+    let bytes_1: Bytes = <ContractId as Into<Bytes>>::into(contract_id_1);
+    assert(bytes_1.capacity() == 32);
+    assert(bytes_1.len() == 32);
+    let mut iter_1 = 0;
+    while iter_1 < 32 {
+        assert(bytes_1.get(iter_1).unwrap() == 0u8);
+        iter_1 += 1;
+    }
+
+    let contract_id_2 = ContractId::from(b256::max());
+    let bytes_2: Bytes = <ContractId as Into<Bytes>>::into(contract_id_2);
+    assert(bytes_2.capacity() == 32);
+    assert(bytes_2.len() == 32);
+    let mut iter_2 = 0;
+    while iter_2 < 32 {
+        assert(bytes_2.get(iter_2).unwrap() == 255u8);
+        iter_2 += 1;
+    }
+
+    let contract_id_3 = ContractId::from(0x0000000000000000000000000000000000000000000000000000000000000001);
+    let bytes_3: Bytes = <ContractId as Into<Bytes>>::into(contract_id_3);
+    assert(bytes_3.capacity() == 32);
+    assert(bytes_3.len() == 32);
+    assert(bytes_3.get(31).unwrap() == 1u8);
+    let mut iter_3 = 0;
+    while iter_3 < 31 {
+        assert(bytes_3.get(iter_3).unwrap() == 0u8);
+        iter_3 += 1;
+    }
+}

--- a/test/src/in_language_tests/test_programs/contract_id_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/contract_id_inline_tests/src/main.sw
@@ -180,3 +180,44 @@ fn contract_id_is_zero() {
     let contract_id_3 = ContractId::from(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
     assert(!contract_id_3.is_zero());
 }
+
+#[test]
+fn contract_id_try_from_bytes() {
+    use std::bytes::Bytes;
+
+    // Test empty bytes
+    let bytes_1 = Bytes::new();
+    assert(ContractId::try_from(bytes_1).is_none());
+
+    // Test not full length but capacity bytes
+    let mut bytes_2 = Bytes::with_capacity(32);
+    bytes_2.push(1u8);
+    bytes_2.push(3u8);
+    bytes_2.push(5u8);
+    assert(ContractId::try_from(bytes_2).is_none());
+
+    // Test zero bytes
+    let bytes_3 = Bytes::from(b256::zero());
+    let contract_id_3 = ContractId::try_from(bytes_3);
+    assert(contract_id_3.is_some());
+    assert(contract_id_3.unwrap() == ContractId::zero());
+
+    // Test max bytes
+    let bytes_4 = Bytes::from(b256::max());
+    let contract_id_4 = ContractId::try_from(bytes_4);
+    assert(contract_id_4.is_some());
+    assert(contract_id_4.unwrap() == ContractId::from(b256::max()));
+
+    // Test too many bytes
+    let mut bytes_5 = Bytes::from(b256::max());
+    bytes_5.push(255u8);
+    assert(ContractId::try_from(bytes_5).is_none());
+
+    // Test modifying bytes after doesn't impact 
+    let mut bytes_6 = Bytes::from(b256::zero());
+    let contract_id_6 = ContractId::try_from(bytes_6);
+    assert(contract_id_6.is_some());
+    assert(contract_id_6.unwrap() == ContractId::zero());
+    bytes_6.set(0, 255u8);
+    assert(contract_id_6.unwrap() == ContractId::zero());
+}

--- a/test/src/in_language_tests/test_programs/vm_evm_evm_address_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/vm_evm_evm_address_inline_tests/src/main.sw
@@ -160,3 +160,48 @@ fn evm_address_hash() {
     let digest_4 = sha256(evm_address_4);
     assert(digest_4 != 0x4eaddc8cfcdd27223821e3e31ab54b2416dd3b0c1a86afd7e8d6538ca1bd0a77);
 }
+
+#[test]
+fn evm_address_try_from_bytes() {
+    use std::bytes::Bytes;
+
+    // Test empty bytes
+    let bytes_1 = Bytes::new();
+    assert(EvmAddress::try_from(bytes_1).is_none());
+
+    // Test not full length but capacity bytes
+    let mut bytes_2 = Bytes::with_capacity(20);
+    bytes_2.push(1u8);
+    bytes_2.push(3u8);
+    bytes_2.push(5u8);
+    assert(EvmAddress::try_from(bytes_2).is_none());
+
+    // Test zero bytes
+    let bytes_3_full = Bytes::from(b256::zero());
+    let (bytes_3, bytes_3_discard) = bytes_3_full.split_at(20);
+    let evm_address_3 = EvmAddress::try_from(bytes_3);
+    assert(evm_address_3.is_some());
+    assert(evm_address_3.unwrap() == EvmAddress::zero());
+
+    // Test max bytes
+    let bytes_4_full = Bytes::from(b256::max());
+    let (bytes_4, bytes_4_discard) = bytes_4_full.split_at(20);
+    let evm_address_4 = EvmAddress::try_from(bytes_4);
+    assert(evm_address_4.is_some());
+    assert(evm_address_4.unwrap() == EvmAddress::from(b256::max()));
+
+    // Test too many bytes
+    let bytes_5_full = Bytes::from(b256::zero());
+    let (mut bytes_5, bytes_5_discard) = bytes_5_full.split_at(20);
+    bytes_5.push(255u8);
+    assert(EvmAddress::try_from(bytes_5).is_none());
+
+    // Test modifying bytes after doesn't impact 
+    let bytes_6_full = Bytes::from(b256::zero());
+    let (mut bytes_6, bytes_6_discard) = bytes_6_full.split_at(20);
+    let evm_address_6 = EvmAddress::try_from(bytes_6);
+    assert(evm_address_6.is_some());
+    assert(evm_address_6.unwrap() == EvmAddress::zero());
+    bytes_6.set(0, 255u8);
+    assert(evm_address_6.unwrap() == EvmAddress::zero());
+}

--- a/test/src/in_language_tests/test_programs/vm_evm_evm_address_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/vm_evm_evm_address_inline_tests/src/main.sw
@@ -205,3 +205,39 @@ fn evm_address_try_from_bytes() {
     bytes_6.set(0, 255u8);
     assert(evm_address_6.unwrap() == EvmAddress::zero());
 }
+
+#[test]
+fn evm_address_into_bytes() {
+    use std::bytes::Bytes;
+
+    let evm_address_1 = EvmAddress::zero();
+    let bytes_1: Bytes = <EvmAddress as Into<Bytes>>::into(evm_address_1);
+    assert(bytes_1.capacity() == 20);
+    assert(bytes_1.len() == 20);
+    let mut iter_1 = 0;
+    while iter_1 < 20 {
+        assert(bytes_1.get(iter_1).unwrap() == 0u8);
+        iter_1 += 1;
+    }
+
+    let evm_address_2 = EvmAddress::from(b256::max());
+    let bytes_2: Bytes = <EvmAddress as Into<Bytes>>::into(evm_address_2);
+    assert(bytes_2.capacity() == 20);
+    assert(bytes_2.len() == 20);
+    let mut iter_2 = 0;
+    while iter_2 < 20 {
+        assert(bytes_2.get(iter_2).unwrap() == 255u8);
+        iter_2 += 1;
+    }
+
+    let evm_address_3 = EvmAddress::from(0x0000000000000000000000000000000000000000000000000000000000000001);
+    let bytes_3: Bytes = <EvmAddress as Into<Bytes>>::into(evm_address_3);
+    assert(bytes_3.capacity() == 20);
+    assert(bytes_3.len() == 20);
+    assert(bytes_3.get(19).unwrap() == 1u8);
+    let mut iter_3 = 0;
+    while iter_3 < 19 {
+        assert(bytes_3.get(iter_3).unwrap() == 0u8);
+        iter_3 += 1;
+    }
+}


### PR DESCRIPTION
## Description

Several stack types did not convert from or into `Bytes`. These have been added in this PR for better interop and devex.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
