### PR TITLE
Auto-generate DWARF debug symbols in debug builds

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2285,7 +2285,6 @@ pub fn build_with_options(build_options: &BuildOpts) -> Result<Built> {
                 .as_ref()
                 .map(|p| output_dir.join(p))
                 .unwrap_or_else(|| output_dir.join("debug_symbols.obj"));
-            println!("Writing debug symbols to {:?}", debug_path);
             built_package.write_debug_info(&debug_path)?;
         }
         built_package.write_output(minify, &pkg_manifest.project.name, &output_dir)?;

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2285,6 +2285,7 @@ pub fn build_with_options(build_options: &BuildOpts) -> Result<Built> {
                 .as_ref()
                 .map(|p| output_dir.join(p))
                 .unwrap_or_else(|| output_dir.join("debug_symbols.obj"));
+            println!("Writing debug symbols to {:?}", debug_path);
             built_package.write_debug_info(&debug_path)?;
         }
         built_package.write_output(minify, &pkg_manifest.project.name, &output_dir)?;

--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2279,8 +2279,13 @@ pub fn build_with_options(build_options: &BuildOpts) -> Result<Built> {
         if let Some(outfile) = &binary_outfile {
             built_package.write_bytecode(outfile.as_ref())?;
         }
-        if let Some(outfile) = &debug_outfile {
-            built_package.write_debug_info(outfile.as_ref())?;
+        // Generate debug symbols if explicitly requested via -g flag or if in debug build
+        if debug_outfile.is_some() || build_profile.name == BuildProfile::DEBUG {
+            let debug_path = debug_outfile
+                .as_ref()
+                .map(|p| output_dir.join(p))
+                .unwrap_or_else(|| output_dir.join("debug_symbols.obj"));
+            built_package.write_debug_info(&debug_path)?;
         }
         built_package.write_output(minify, &pkg_manifest.project.name, &output_dir)?;
         built_workspace.push(Arc::new(built_package));

--- a/sway-core/src/debug_generation/dwarf.rs
+++ b/sway-core/src/debug_generation/dwarf.rs
@@ -47,7 +47,15 @@ pub fn write_dwarf(
         sway_error::error::CompileError::InternalOwned(err.to_string(), Span::dummy())
     })?;
 
-    let file = File::create(out_file).unwrap();
+    // Create parent directories if they don't exist
+    if let Some(parent) = out_file.parent() {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            sway_error::error::CompileError::InternalOwned(err.to_string(), Span::dummy())
+        })?;
+    }
+    let file = File::create(out_file).map_err(|err| {
+        sway_error::error::CompileError::InternalOwned(err.to_string(), Span::dummy())
+    })?;
     let mut obj = Object::new(
         object::BinaryFormat::Elf,
         object::Architecture::X86_64,


### PR DESCRIPTION
## Description
DWARF debug symbols are now automatically generated and saved as `debug_symbols.obj` in the output directory when using debug builds. This enables better debugging support out of the box in development without requiring the `-g` flag. The `-g` flag is still supported for specifying custom debug symbol output paths or generating debug symbols in other build profiles.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
