### PR TITLE
Use compiler source map directly in forc-debug

### DIFF
--- a/forc-plugins/forc-debug/src/server/handlers/handle_stack_trace.rs
+++ b/forc-plugins/forc-debug/src/server/handlers/handle_stack_trace.rs
@@ -46,7 +46,7 @@ impl DapServer {
                     executor.interpreter.registers(),
                 ))
                 .ok()
-                .map(|(source_path, line)| (Some(util::path_into_source(source_path)), line)),
+                .map(|(source_path, line)| (Some(util::path_into_source(&source_path)), line)),
         };
 
         // For now, we only return 1 stack frame.

--- a/forc-plugins/forc-debug/src/server/mod.rs
+++ b/forc-plugins/forc-debug/src/server/mod.rs
@@ -53,7 +53,7 @@ pub struct DapServer {
     /// Used to generate unique breakpoint IDs.
     breakpoint_id_gen: IdGenerator,
     /// The server state.
-    state: ServerState,
+    pub state: ServerState,
 }
 
 impl Default for DapServer {
@@ -261,7 +261,7 @@ impl DapServer {
     }
 
     /// Builds the tests at the given [PathBuf] and stores the source maps.
-    pub(crate) fn build_tests(&mut self) -> Result<(BuiltPackage, TestSetup), AdapterError> {
+    pub fn build_tests(&mut self) -> Result<(BuiltPackage, TestSetup), AdapterError> {
         if let Some(pkg) = &self.state.built_package {
             if let Some(setup) = &self.state.test_setup {
                 return Ok((pkg.clone(), setup.clone()));
@@ -333,6 +333,7 @@ impl DapServer {
             if built_pkg.descriptor.manifest_file == pkg_manifest {
                 pkg_to_debug = Some(built_pkg);
             }
+            self.state.compiler_source_map = Some(built_pkg.source_map.clone());
             let source_map = &built_pkg.source_map;
 
             let paths = &source_map.paths;

--- a/forc-plugins/forc-debug/src/server/state.rs
+++ b/forc-plugins/forc-debug/src/server/state.rs
@@ -100,11 +100,11 @@ impl ServerState {
 
         // Set breakpoints in the VM
         self.executors.iter_mut().for_each(|executor| {
-            // TODO: use `overwrite_breakpoints` when released
-            opcode_indexes.clone().for_each(|&opcode_index| {
-                let bp = fuel_vm::state::Breakpoint::script(opcode_index as u64);
-                executor.interpreter.set_breakpoint(bp);
-            });
+            let bps: Vec<_> = opcode_indexes
+                .clone()
+                .map(|opcode_index| fuel_vm::state::Breakpoint::script(*opcode_index as u64))
+                .collect();
+            executor.interpreter.overwrite_breakpoints(&bps);
         });
 
         self.breakpoints_need_update = false;

--- a/forc-plugins/forc-debug/src/server/state.rs
+++ b/forc-plugins/forc-debug/src/server/state.rs
@@ -6,6 +6,7 @@ use dap::types::StartDebuggingRequestKind;
 use forc_pkg::BuiltPackage;
 use forc_test::{execute::TestExecutor, setup::TestSetup, TestResult};
 use std::path::PathBuf;
+use sway_core::source_map::SourceMap;
 
 #[derive(Default, Debug, Clone)]
 /// The state of the DAP server.
@@ -21,8 +22,7 @@ pub struct ServerState {
     pub breakpoints: Breakpoints,
 
     // Build state
-    pub source_map: crate::types::SourceMap,
-    pub compiler_source_map: Option<sway_core::source_map::SourceMap>,
+    pub source_map: SourceMap,
     pub built_package: Option<BuiltPackage>,
 
     // Test state
@@ -59,24 +59,55 @@ impl ServerState {
     pub fn vm_pc_to_source_location(
         &self,
         pc: Instruction,
-    ) -> Result<(&PathBuf, i64), AdapterError> {
-        // Try to find the source location by looking for the program counter in the source map.
-        self.source_map
+    ) -> Result<(PathBuf, i64), AdapterError> {
+        // Convert PC to instruction index (divide by 4 for byte offset)
+        let instruction_idx = (pc / 4) as usize;
+        if let Some((path, range)) = self.source_map.addr_to_span(instruction_idx) {
+            Ok((path, range.start.line as i64))
+        } else {
+            Err(AdapterError::MissingSourceMap { pc })
+        }
+    }
+
+    /// Updates the breakpoints in the VM for all remaining [TestExecutor]s.
+    pub(crate) fn update_vm_breakpoints(&mut self) {
+        if !self.breakpoints_need_update {
+            return;
+        }
+
+        // Convert breakpoints to instruction offsets using the source map
+        let opcode_indexes = self
+            .breakpoints
             .iter()
-            .find_map(|(source_path, source_map)| {
-                for (&line, instructions) in source_map {
-                    // Divide by 4 to get the opcode offset rather than the program counter offset.
-                    let instruction_offset = pc / 4;
-                    if instructions
-                        .iter()
-                        .any(|instruction| instruction_offset == *instruction)
-                    {
-                        return Some((source_path, line));
-                    }
-                }
-                None
-            })
-            .ok_or(AdapterError::MissingSourceMap { pc })
+            .flat_map(|(source_path, breakpoints)| {
+                breakpoints
+                    .iter()
+                    .filter_map(|bp| {
+                        bp.line.and_then(|line| {
+                            // Find any instruction that maps to this line in the source map
+                            self.source_map.map.iter().find_map(|(pc, _)| {
+                                self.source_map
+                                    .addr_to_span(*pc)
+                                    .filter(|(path, range)| {
+                                        path == source_path && range.start.line as i64 == line
+                                    })
+                                    .map(|_| pc)
+                            })
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            });
+
+        // Set breakpoints in the VM
+        self.executors.iter_mut().for_each(|executor| {
+            // TODO: use `overwrite_breakpoints` when released
+            opcode_indexes.clone().for_each(|&opcode_index| {
+                let bp = fuel_vm::state::Breakpoint::script(opcode_index as u64);
+                executor.interpreter.set_breakpoint(bp);
+            });
+        });
+
+        self.breakpoints_need_update = false;
     }
 
     /// Finds the breakpoint matching a VM program counter.
@@ -86,7 +117,7 @@ impl ServerState {
         // Find the breakpoint ID matching the source location.
         let source_bps = self
             .breakpoints
-            .get(source_path)
+            .get(&source_path)
             .ok_or(AdapterError::UnknownBreakpoint { pc })?;
         let breakpoint_id = source_bps
             .iter()
@@ -100,41 +131,6 @@ impl ServerState {
             .ok_or(AdapterError::UnknownBreakpoint { pc })?;
 
         Ok(breakpoint_id)
-    }
-
-    /// Updates the breakpoints in the VM for all remaining [TestExecutor]s.
-    pub(crate) fn update_vm_breakpoints(&mut self) {
-        if !self.breakpoints_need_update {
-            return;
-        }
-        let opcode_indexes = self
-            .breakpoints
-            .iter()
-            .flat_map(|(source_path, breakpoints)| {
-                if let Some(source_map) = self.source_map.get(&PathBuf::from(source_path)) {
-                    breakpoints
-                        .iter()
-                        .filter_map(|bp| {
-                            bp.line.and_then(|line| {
-                                source_map
-                                    .get(&line)
-                                    .and_then(|instructions| instructions.first())
-                            })
-                        })
-                        .collect::<Vec<_>>()
-                } else {
-                    vec![]
-                }
-            });
-
-        self.executors.iter_mut().for_each(|executor| {
-            // TODO: use `overwrite_breakpoints` when released
-            opcode_indexes.clone().for_each(|opcode_index| {
-                let bp: fuel_vm::prelude::Breakpoint =
-                    fuel_vm::state::Breakpoint::script(*opcode_index);
-                executor.interpreter.set_breakpoint(bp);
-            });
-        });
     }
 
     pub(crate) fn test_complete(&mut self, result: TestResult) {

--- a/forc-plugins/forc-debug/src/server/state.rs
+++ b/forc-plugins/forc-debug/src/server/state.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::AdapterError,
-    types::{Breakpoints, Instruction, SourceMap},
+    types::{Breakpoints, Instruction},
 };
 use dap::types::StartDebuggingRequestKind;
 use forc_pkg::BuiltPackage;
@@ -21,7 +21,8 @@ pub struct ServerState {
     pub breakpoints: Breakpoints,
 
     // Build state
-    pub source_map: SourceMap,
+    pub source_map: crate::types::SourceMap,
+    pub compiler_source_map: Option<sway_core::source_map::SourceMap>,
     pub built_package: Option<BuiltPackage>,
 
     // Test state

--- a/forc-plugins/forc-debug/src/types.rs
+++ b/forc-plugins/forc-debug/src/types.rs
@@ -1,9 +1,6 @@
 use dap::types::Breakpoint;
 use std::{collections::HashMap, path::PathBuf};
 
-pub type Line = i64;
 pub type ExitCode = i64;
 pub type Instruction = u64;
-pub type FileSourceMap = HashMap<Line, Vec<Instruction>>;
-pub type SourceMap = HashMap<PathBuf, FileSourceMap>;
 pub type Breakpoints = HashMap<PathBuf, Vec<Breakpoint>>;

--- a/forc-plugins/forc-debug/tests/server_integration.rs
+++ b/forc-plugins/forc-debug/tests/server_integration.rs
@@ -2,16 +2,14 @@ use dap::{
     events::{Event, OutputEventBody},
     requests::{Command, LaunchRequestArguments, SetBreakpointsArguments, VariablesArguments},
     responses::ResponseBody,
-    types::{OutputEventCategory, Source, SourceBreakpoint, StoppedEventReason, Variable},
+    types::{OutputEventCategory, Source, SourceBreakpoint, StartDebuggingRequestKind, StoppedEventReason, Variable},
 };
 use forc_debug::server::{
     AdditionalData, DapServer, INSTRUCTIONS_VARIABLE_REF, REGISTERS_VARIABLE_REF,
 };
+use itertools::Itertools;
 use std::{
-    env,
-    io::Write,
-    path::PathBuf,
-    sync::{Arc, Mutex},
+    collections::BTreeMap, env, io::Write, path::PathBuf, sync::{Arc, Mutex}
 };
 
 pub fn sway_workspace_dir() -> PathBuf {
@@ -320,5 +318,358 @@ fn assert_variables_eq(expected: Vec<(&str, &str)>, actual: Vec<Variable>) {
     for (i, (name, value)) in expected.iter().enumerate() {
         assert_eq!(actual[i].name, *name);
         assert_eq!(actual[i].value, *value);
+    }
+}
+
+
+#[test]
+fn test_sourcemap_build() {
+    let mut server = DapServer::new(
+        Box::new(std::io::stdin()), 
+        Box::new(std::io::sink())
+    );
+
+    let program_path = test_fixtures_dir().join("simple/src/main.sw");
+    let source_str = program_path.to_string_lossy().to_string();
+
+    // Initialize and set the program path
+    server.handle_command(&Command::Initialize(Default::default()));
+    server.state.program_path = PathBuf::from(&source_str);
+    server.state.mode = Some(StartDebuggingRequestKind::Launch);
+
+    // Explicitly build the tests
+    server.build_tests().expect("Failed to build tests");
+
+    // Now examine what was built
+    let source_map = &server.state.source_map;
+    let file_map = source_map.get(&PathBuf::from(&source_str))
+        .expect("Should have source map for our file");
+    
+    // Print out all line mappings in order
+    let mut lines: Vec<i64> = file_map.keys().cloned().collect();
+    lines.sort();
+    
+    println!("\nComplete source map for {}:", source_str);
+    for line in lines {
+        let instructions = file_map.get(&line).unwrap();
+        println!("Line {:2}: Instructions {:?}", line, instructions);
+    }
+
+    // Also print the source code with line numbers for reference
+    let source_content = std::fs::read_to_string(&program_path).unwrap();
+    println!("\nSource code with line numbers:");
+    for (i, line) in source_content.lines().enumerate() {
+        println!("{:2}: {}", i + 1, line);
+    }
+}
+
+
+#[test]
+fn test_sourcemap_patterns() {
+    let mut server = DapServer::new(
+        Box::new(std::io::stdin()), 
+        Box::new(std::io::sink())
+    );
+
+    let program_path = test_fixtures_dir().join("simple/src/main.sw");
+    let source_str = program_path.to_string_lossy().to_string();
+
+    // Initialize and build
+    server.handle_command(&Command::Initialize(Default::default()));
+    server.state.program_path = PathBuf::from(&source_str);
+    server.state.mode = Some(StartDebuggingRequestKind::Launch);
+    server.build_tests().expect("Failed to build tests");
+
+    let source_map = &server.state.source_map;
+    let file_map = source_map.get(&PathBuf::from(&source_str))
+        .expect("Should have source map for our file");
+
+    // Analyze instruction groupings
+    println!("\nInstruction groupings by function:");
+    
+    // Main function instructions (lines 3-8)
+    println!("\nMain function:");
+    for line in 3..=8 {
+        if let Some(instructions) = file_map.get(&line) {
+            println!("  Line {:2}: Instructions {:?}", line, instructions);
+        }
+    }
+
+    // Helper function instructions (lines 11-16)
+    println!("\nHelper function:");
+    for line in 11..=16 {
+        if let Some(instructions) = file_map.get(&line) {
+            println!("  Line {:2}: Instructions {:?}", line, instructions);
+        }
+    }
+
+    // Test function instructions
+    let test_ranges = [(20..=24, "test_1"), (28..=32, "test_2"), (36..=40, "test_3")];
+    
+    for (range, name) in test_ranges.clone() {
+        println!("\n{}:", name);
+        for line in range {
+            if let Some(instructions) = file_map.get(&line) {
+                println!("  Line {:2}: Instructions {:?}", line, instructions);
+            }
+        }
+    }
+
+    // Verify consistent patterns within each group
+    
+    // 1. Main and helper functions should have similar instruction patterns
+    let main_params = file_map.get(&3).expect("main params");
+    let helper_params = file_map.get(&11).expect("helper params");
+    assert_eq!(main_params.len(), helper_params.len(), 
+               "Main and helper should have same number of param instructions");
+
+    // 2. Test functions should have identical instruction patterns
+    let test1_instructions: Vec<_> = (21..=24)
+        .filter_map(|line| file_map.get(&line))
+        .collect();
+    let test2_instructions: Vec<_> = (29..=32)
+        .filter_map(|line| file_map.get(&line))
+        .collect();
+    let test3_instructions: Vec<_> = (37..=40)
+        .filter_map(|line| file_map.get(&line))
+        .collect();
+
+    // Each corresponding instruction set in the test functions should have the same size
+    for i in 0..test1_instructions.len() {
+        assert_eq!(
+            test1_instructions[i].len(),
+            test2_instructions[i].len(),
+            "Test 1 and 2 instruction counts should match at step {}", i
+        );
+        assert_eq!(
+            test2_instructions[i].len(),
+            test3_instructions[i].len(),
+            "Test 2 and 3 instruction counts should match at step {}", i
+        );
+    }
+
+    // 3. Instructions within each function should be sequential
+    let verify_sequential_range = |range: std::ops::RangeInclusive<i64>, name: &str| {
+        let mut last_instr = None;
+        for line in range {
+            if let Some(instructions) = file_map.get(&line) {
+                for &instr in instructions {
+                    if let Some(last) = last_instr {
+                        if instr < last {
+                            println!("Warning: Non-sequential instruction in {}: {} -> {}", 
+                                   name, last, instr);
+                        }
+                    }
+                    last_instr = Some(instr);
+                }
+            }
+        }
+    };
+
+    verify_sequential_range(3..=8, "main");
+    verify_sequential_range(11..=16, "helper");
+    for (range, name) in test_ranges {
+        verify_sequential_range(range, name);
+    }
+}
+
+#[test]
+fn test_sourcemap_instruction_patterns() {
+    let mut server = DapServer::new(
+        Box::new(std::io::stdin()), 
+        Box::new(std::io::sink())
+    );
+
+    let program_path = test_fixtures_dir().join("simple/src/main.sw");
+    let source_str = program_path.to_string_lossy().to_string();
+
+    // Initialize and build
+    server.handle_command(&Command::Initialize(Default::default()));
+    server.state.program_path = PathBuf::from(&source_str);
+    server.state.mode = Some(StartDebuggingRequestKind::Launch);
+    server.build_tests().expect("Failed to build tests");
+
+    let source_map = &server.state.source_map;
+    let file_map = source_map.get(&PathBuf::from(&source_str))
+        .expect("Should have source map for our file");
+
+    // 1. Verify main function instruction patterns
+    let main_params = file_map.get(&3).expect("main params");
+    assert_eq!(main_params.len(), 4, "Main function parameter setup uses 4 instructions");
+    assert_eq!(main_params, &vec![159, 160, 163, 164]);
+
+    let main_add = file_map.get(&4).expect("main addition");
+    assert_eq!(main_add.len(), 2, "Addition operation uses 2 instructions");
+    assert_eq!(main_add, &vec![166, 167]);
+
+    // 2. Verify helper function has same pattern as main
+    let helper_params = file_map.get(&11).expect("helper params");
+    assert_eq!(helper_params.len(), 4, "Helper function parameter setup uses 4 instructions");
+    assert_eq!(helper_params, &vec![262, 263, 266, 267]);
+
+    let helper_add = file_map.get(&12).expect("helper addition");
+    assert_eq!(helper_add.len(), 2, "Addition operation uses 2 instructions");
+    assert_eq!(helper_add, &vec![269, 270]);
+
+    // 3. Verify test function patterns
+    struct TestPattern {
+        let_hi: u64,
+        let_hey: u64,
+        helper_call: u64,
+        assert: u64,
+    }
+
+    let test_patterns = [
+        TestPattern { 
+            let_hi: 68,      // test_1
+            let_hey: 70,
+            helper_call: 80,
+            assert: 84,
+        },
+        TestPattern { 
+            let_hi: 92,      // test_2
+            let_hey: 94,
+            helper_call: 104,
+            assert: 108,
+        },
+        TestPattern { 
+            let_hi: 116,     // test_3
+            let_hey: 118,
+            helper_call: 128,
+            assert: 132,
+        },
+    ];
+
+    // Verify each test function follows the pattern
+    for (i, pattern) in test_patterns.iter().enumerate() {
+        let test_num = i + 1;
+        let base_line = 19 + (i as i64 * 8); // Tests are 8 lines apart
+
+        assert_eq!(
+            file_map.get(&(base_line + 2)).expect(&format!("test_{} let_hi", test_num)),
+            &vec![pattern.let_hi]
+        );
+        assert_eq!(
+            file_map.get(&(base_line + 3)).expect(&format!("test_{} let_hey", test_num)),
+            &vec![pattern.let_hey]
+        );
+        assert_eq!(
+            file_map.get(&(base_line + 4)).expect(&format!("test_{} helper_call", test_num)),
+            &vec![pattern.helper_call]
+        );
+        assert_eq!(
+            file_map.get(&(base_line + 5)).expect(&format!("test_{} assert", test_num)),
+            &vec![pattern.assert]
+        );
+
+        // Verify instruction spacing pattern within each test
+        if i < test_patterns.len() - 1 {
+            let curr = pattern;
+            let next = &test_patterns[i + 1];
+            
+            // Each test starts 24 instructions after the previous one
+            assert_eq!(
+                next.let_hi - curr.let_hi, 
+                24, 
+                "Tests should be 24 instructions apart"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_compiler_sourcemap() {
+    let mut server = DapServer::new(
+        Box::new(std::io::stdin()), 
+        Box::new(std::io::sink())
+    );
+
+    let program_path = test_fixtures_dir().join("simple/src/main.sw");
+    let source_str = program_path.to_string_lossy().to_string();
+
+    // Initialize and build
+    server.handle_command(&Command::Initialize(Default::default()));
+    server.state.program_path = PathBuf::from(&source_str);
+    server.state.mode = Some(StartDebuggingRequestKind::Launch);
+    server.build_tests().expect("Failed to build tests");
+
+    // Examine the source map
+    let source_map = &server.state.compiler_source_map.unwrap();
+    
+    println!("\nSource map contents:");
+    println!("Paths:");
+    for path in &source_map.paths {
+        println!("  {}", path.display());
+    }
+    
+    println!("\nDependency paths:");
+    for path in &source_map.dependency_paths {
+        println!("  {}", path.display());
+    }
+    
+    println!("\nMapping entries:");
+    for (pc, span) in &source_map.map {
+        if let Some((path, range)) = source_map.addr_to_span(*pc) {
+            println!("  Instruction {}: {}:{}:{}-{}:{}", 
+                    pc,
+                    path.display(),
+                    range.start.line,
+                    range.start.col,
+                    range.end.line,
+                    range.end.col);
+        }
+    }
+}
+
+#[test]
+fn compare_original_sourcemap() {
+    let mut server = DapServer::new(
+        Box::new(std::io::stdin()), 
+        Box::new(std::io::sink())
+    );
+
+    let program_path = test_fixtures_dir().join("simple/src/main.sw");
+    let source_str = program_path.to_string_lossy().to_string();
+
+    // Initialize and build
+    server.handle_command(&Command::Initialize(Default::default()));
+    server.state.program_path = PathBuf::from(&source_str);
+    server.state.mode = Some(StartDebuggingRequestKind::Launch);
+    server.build_tests().expect("Failed to build tests");
+
+    // Looking at what we had in our original output:
+    println!("\nOriginal source map output showed:");
+    println!("Line  3: Instructions [159, 160, 163, 164]");
+    println!("Line  4: Instructions [166, 167]");
+    println!("Line  5: Instructions [170]");
+    println!("Line  6: Instructions [175]");
+    println!("Line 11: Instructions [262, 263, 266, 267]");
+    println!("Line 12: Instructions [269, 270]");
+    println!("Line 13: Instructions [273]");
+    println!("Line 14: Instructions [278]");
+    println!("Line 21: Instructions [68]");
+    println!("Line 22: Instructions [70]");
+    println!("Line 23: Instructions [80]");
+    println!("Line 24: Instructions [84]");
+
+    println!("\nNew compiler source map shows:");
+    // Group instructions by line number for comparison
+    let mut line_to_instructions: BTreeMap<i64, Vec<usize>> = BTreeMap::new();
+    
+    let source_map = &server.state.compiler_source_map.unwrap();
+    for (pc, span) in source_map.clone().map {
+        if let Some((path, range)) = source_map.addr_to_span(pc) {
+            if path == program_path {
+                line_to_instructions
+                    .entry(range.start.line as i64)
+                    .or_default()
+                    .push(pc);
+            }
+        }
+    }
+
+    // Print in same format as original for comparison
+    for (line, instructions) in &line_to_instructions {
+        println!("Line {:2}: Instructions {:?}", line, instructions);
     }
 }

--- a/forc-plugins/forc-debug/tests/server_integration.rs
+++ b/forc-plugins/forc-debug/tests/server_integration.rs
@@ -2,14 +2,20 @@ use dap::{
     events::{Event, OutputEventBody},
     requests::{Command, LaunchRequestArguments, SetBreakpointsArguments, VariablesArguments},
     responses::ResponseBody,
-    types::{OutputEventCategory, Source, SourceBreakpoint, StartDebuggingRequestKind, StoppedEventReason, Variable},
+    types::{
+        OutputEventCategory, Source, SourceBreakpoint, StartDebuggingRequestKind,
+        StoppedEventReason, Variable,
+    },
 };
 use forc_debug::server::{
     AdditionalData, DapServer, INSTRUCTIONS_VARIABLE_REF, REGISTERS_VARIABLE_REF,
 };
-use itertools::Itertools;
 use std::{
-    collections::BTreeMap, env, io::Write, path::PathBuf, sync::{Arc, Mutex}
+    collections::BTreeMap,
+    env,
+    io::Write,
+    path::PathBuf,
+    sync::{Arc, Mutex},
 };
 
 pub fn sway_workspace_dir() -> PathBuf {
@@ -277,6 +283,66 @@ fn test_server_launch_mode() {
     assert!(body.output.contains("Result: OK. 3 passed. 0 failed"));
 }
 
+#[test]
+fn test_sourcemap_build() {
+    let mut server = DapServer::new(Box::new(std::io::stdin()), Box::new(std::io::sink()));
+
+    let program_path = test_fixtures_dir().join("simple/src/main.sw");
+
+    // Initialize and set the program path
+    server.handle_command(&Command::Initialize(Default::default()));
+    server.state.program_path = program_path.clone();
+    server.state.mode = Some(StartDebuggingRequestKind::Launch);
+
+    // Explicitly build the tests
+    server.build_tests().expect("Failed to build tests");
+
+    // Group instructions by line number
+    let mut line_to_instructions: BTreeMap<i64, Vec<usize>> = BTreeMap::new();
+    let source_map = &server.state.source_map;
+
+    for (pc, _span) in &source_map.map {
+        if let Some((path, range)) = source_map.addr_to_span(*pc) {
+            if path == program_path {
+                line_to_instructions
+                    .entry(range.start.line as i64)
+                    .or_default()
+                    .push(*pc);
+            }
+        }
+    }
+
+    // Verify essential source locations are mapped correctly
+    let key_locations = [
+        // Main function and its contents
+        (3, 4, "main function parameters"), // Should have 4 instructions
+        (4, 2, "addition operation"),       // Should have 2 instructions (add operation)
+        // Helper function and its contents
+        (11, 4, "helper function parameters"), // Should have 4 instructions
+        (12, 2, "helper addition operation"),  // Should have 2 instructions
+        // Test functions (identical patterns)
+        (21, 1, "test_1 first line"),  // Each test line should have
+        (22, 1, "test_1 second line"), // exactly one instruction
+        (23, 1, "test_1 helper call"),
+        (24, 1, "test_1 assertion"),
+    ];
+
+    for (line, expected_count, description) in key_locations {
+        let instructions = line_to_instructions
+            .get(&line)
+            .unwrap_or_else(|| panic!("Missing mapping for line {}: {}", line, description));
+        assert_eq!(
+            instructions.len(),
+            expected_count,
+            "Line {} ({}): Expected {} instructions, found {:?}",
+            line,
+            description,
+            expected_count,
+            instructions
+        );
+    }
+}
+
 /// Asserts that the given event is a Stopped event with a breakpoint reason and the given breakpoint ID.
 fn assert_stopped_breakpoint_event(event: Option<Event>, breakpoint_id: i64) {
     match event.expect("received event") {
@@ -318,358 +384,5 @@ fn assert_variables_eq(expected: Vec<(&str, &str)>, actual: Vec<Variable>) {
     for (i, (name, value)) in expected.iter().enumerate() {
         assert_eq!(actual[i].name, *name);
         assert_eq!(actual[i].value, *value);
-    }
-}
-
-
-#[test]
-fn test_sourcemap_build() {
-    let mut server = DapServer::new(
-        Box::new(std::io::stdin()), 
-        Box::new(std::io::sink())
-    );
-
-    let program_path = test_fixtures_dir().join("simple/src/main.sw");
-    let source_str = program_path.to_string_lossy().to_string();
-
-    // Initialize and set the program path
-    server.handle_command(&Command::Initialize(Default::default()));
-    server.state.program_path = PathBuf::from(&source_str);
-    server.state.mode = Some(StartDebuggingRequestKind::Launch);
-
-    // Explicitly build the tests
-    server.build_tests().expect("Failed to build tests");
-
-    // Now examine what was built
-    let source_map = &server.state.source_map;
-    let file_map = source_map.get(&PathBuf::from(&source_str))
-        .expect("Should have source map for our file");
-    
-    // Print out all line mappings in order
-    let mut lines: Vec<i64> = file_map.keys().cloned().collect();
-    lines.sort();
-    
-    println!("\nComplete source map for {}:", source_str);
-    for line in lines {
-        let instructions = file_map.get(&line).unwrap();
-        println!("Line {:2}: Instructions {:?}", line, instructions);
-    }
-
-    // Also print the source code with line numbers for reference
-    let source_content = std::fs::read_to_string(&program_path).unwrap();
-    println!("\nSource code with line numbers:");
-    for (i, line) in source_content.lines().enumerate() {
-        println!("{:2}: {}", i + 1, line);
-    }
-}
-
-
-#[test]
-fn test_sourcemap_patterns() {
-    let mut server = DapServer::new(
-        Box::new(std::io::stdin()), 
-        Box::new(std::io::sink())
-    );
-
-    let program_path = test_fixtures_dir().join("simple/src/main.sw");
-    let source_str = program_path.to_string_lossy().to_string();
-
-    // Initialize and build
-    server.handle_command(&Command::Initialize(Default::default()));
-    server.state.program_path = PathBuf::from(&source_str);
-    server.state.mode = Some(StartDebuggingRequestKind::Launch);
-    server.build_tests().expect("Failed to build tests");
-
-    let source_map = &server.state.source_map;
-    let file_map = source_map.get(&PathBuf::from(&source_str))
-        .expect("Should have source map for our file");
-
-    // Analyze instruction groupings
-    println!("\nInstruction groupings by function:");
-    
-    // Main function instructions (lines 3-8)
-    println!("\nMain function:");
-    for line in 3..=8 {
-        if let Some(instructions) = file_map.get(&line) {
-            println!("  Line {:2}: Instructions {:?}", line, instructions);
-        }
-    }
-
-    // Helper function instructions (lines 11-16)
-    println!("\nHelper function:");
-    for line in 11..=16 {
-        if let Some(instructions) = file_map.get(&line) {
-            println!("  Line {:2}: Instructions {:?}", line, instructions);
-        }
-    }
-
-    // Test function instructions
-    let test_ranges = [(20..=24, "test_1"), (28..=32, "test_2"), (36..=40, "test_3")];
-    
-    for (range, name) in test_ranges.clone() {
-        println!("\n{}:", name);
-        for line in range {
-            if let Some(instructions) = file_map.get(&line) {
-                println!("  Line {:2}: Instructions {:?}", line, instructions);
-            }
-        }
-    }
-
-    // Verify consistent patterns within each group
-    
-    // 1. Main and helper functions should have similar instruction patterns
-    let main_params = file_map.get(&3).expect("main params");
-    let helper_params = file_map.get(&11).expect("helper params");
-    assert_eq!(main_params.len(), helper_params.len(), 
-               "Main and helper should have same number of param instructions");
-
-    // 2. Test functions should have identical instruction patterns
-    let test1_instructions: Vec<_> = (21..=24)
-        .filter_map(|line| file_map.get(&line))
-        .collect();
-    let test2_instructions: Vec<_> = (29..=32)
-        .filter_map(|line| file_map.get(&line))
-        .collect();
-    let test3_instructions: Vec<_> = (37..=40)
-        .filter_map(|line| file_map.get(&line))
-        .collect();
-
-    // Each corresponding instruction set in the test functions should have the same size
-    for i in 0..test1_instructions.len() {
-        assert_eq!(
-            test1_instructions[i].len(),
-            test2_instructions[i].len(),
-            "Test 1 and 2 instruction counts should match at step {}", i
-        );
-        assert_eq!(
-            test2_instructions[i].len(),
-            test3_instructions[i].len(),
-            "Test 2 and 3 instruction counts should match at step {}", i
-        );
-    }
-
-    // 3. Instructions within each function should be sequential
-    let verify_sequential_range = |range: std::ops::RangeInclusive<i64>, name: &str| {
-        let mut last_instr = None;
-        for line in range {
-            if let Some(instructions) = file_map.get(&line) {
-                for &instr in instructions {
-                    if let Some(last) = last_instr {
-                        if instr < last {
-                            println!("Warning: Non-sequential instruction in {}: {} -> {}", 
-                                   name, last, instr);
-                        }
-                    }
-                    last_instr = Some(instr);
-                }
-            }
-        }
-    };
-
-    verify_sequential_range(3..=8, "main");
-    verify_sequential_range(11..=16, "helper");
-    for (range, name) in test_ranges {
-        verify_sequential_range(range, name);
-    }
-}
-
-#[test]
-fn test_sourcemap_instruction_patterns() {
-    let mut server = DapServer::new(
-        Box::new(std::io::stdin()), 
-        Box::new(std::io::sink())
-    );
-
-    let program_path = test_fixtures_dir().join("simple/src/main.sw");
-    let source_str = program_path.to_string_lossy().to_string();
-
-    // Initialize and build
-    server.handle_command(&Command::Initialize(Default::default()));
-    server.state.program_path = PathBuf::from(&source_str);
-    server.state.mode = Some(StartDebuggingRequestKind::Launch);
-    server.build_tests().expect("Failed to build tests");
-
-    let source_map = &server.state.source_map;
-    let file_map = source_map.get(&PathBuf::from(&source_str))
-        .expect("Should have source map for our file");
-
-    // 1. Verify main function instruction patterns
-    let main_params = file_map.get(&3).expect("main params");
-    assert_eq!(main_params.len(), 4, "Main function parameter setup uses 4 instructions");
-    assert_eq!(main_params, &vec![159, 160, 163, 164]);
-
-    let main_add = file_map.get(&4).expect("main addition");
-    assert_eq!(main_add.len(), 2, "Addition operation uses 2 instructions");
-    assert_eq!(main_add, &vec![166, 167]);
-
-    // 2. Verify helper function has same pattern as main
-    let helper_params = file_map.get(&11).expect("helper params");
-    assert_eq!(helper_params.len(), 4, "Helper function parameter setup uses 4 instructions");
-    assert_eq!(helper_params, &vec![262, 263, 266, 267]);
-
-    let helper_add = file_map.get(&12).expect("helper addition");
-    assert_eq!(helper_add.len(), 2, "Addition operation uses 2 instructions");
-    assert_eq!(helper_add, &vec![269, 270]);
-
-    // 3. Verify test function patterns
-    struct TestPattern {
-        let_hi: u64,
-        let_hey: u64,
-        helper_call: u64,
-        assert: u64,
-    }
-
-    let test_patterns = [
-        TestPattern { 
-            let_hi: 68,      // test_1
-            let_hey: 70,
-            helper_call: 80,
-            assert: 84,
-        },
-        TestPattern { 
-            let_hi: 92,      // test_2
-            let_hey: 94,
-            helper_call: 104,
-            assert: 108,
-        },
-        TestPattern { 
-            let_hi: 116,     // test_3
-            let_hey: 118,
-            helper_call: 128,
-            assert: 132,
-        },
-    ];
-
-    // Verify each test function follows the pattern
-    for (i, pattern) in test_patterns.iter().enumerate() {
-        let test_num = i + 1;
-        let base_line = 19 + (i as i64 * 8); // Tests are 8 lines apart
-
-        assert_eq!(
-            file_map.get(&(base_line + 2)).expect(&format!("test_{} let_hi", test_num)),
-            &vec![pattern.let_hi]
-        );
-        assert_eq!(
-            file_map.get(&(base_line + 3)).expect(&format!("test_{} let_hey", test_num)),
-            &vec![pattern.let_hey]
-        );
-        assert_eq!(
-            file_map.get(&(base_line + 4)).expect(&format!("test_{} helper_call", test_num)),
-            &vec![pattern.helper_call]
-        );
-        assert_eq!(
-            file_map.get(&(base_line + 5)).expect(&format!("test_{} assert", test_num)),
-            &vec![pattern.assert]
-        );
-
-        // Verify instruction spacing pattern within each test
-        if i < test_patterns.len() - 1 {
-            let curr = pattern;
-            let next = &test_patterns[i + 1];
-            
-            // Each test starts 24 instructions after the previous one
-            assert_eq!(
-                next.let_hi - curr.let_hi, 
-                24, 
-                "Tests should be 24 instructions apart"
-            );
-        }
-    }
-}
-
-#[test]
-fn test_compiler_sourcemap() {
-    let mut server = DapServer::new(
-        Box::new(std::io::stdin()), 
-        Box::new(std::io::sink())
-    );
-
-    let program_path = test_fixtures_dir().join("simple/src/main.sw");
-    let source_str = program_path.to_string_lossy().to_string();
-
-    // Initialize and build
-    server.handle_command(&Command::Initialize(Default::default()));
-    server.state.program_path = PathBuf::from(&source_str);
-    server.state.mode = Some(StartDebuggingRequestKind::Launch);
-    server.build_tests().expect("Failed to build tests");
-
-    // Examine the source map
-    let source_map = &server.state.compiler_source_map.unwrap();
-    
-    println!("\nSource map contents:");
-    println!("Paths:");
-    for path in &source_map.paths {
-        println!("  {}", path.display());
-    }
-    
-    println!("\nDependency paths:");
-    for path in &source_map.dependency_paths {
-        println!("  {}", path.display());
-    }
-    
-    println!("\nMapping entries:");
-    for (pc, span) in &source_map.map {
-        if let Some((path, range)) = source_map.addr_to_span(*pc) {
-            println!("  Instruction {}: {}:{}:{}-{}:{}", 
-                    pc,
-                    path.display(),
-                    range.start.line,
-                    range.start.col,
-                    range.end.line,
-                    range.end.col);
-        }
-    }
-}
-
-#[test]
-fn compare_original_sourcemap() {
-    let mut server = DapServer::new(
-        Box::new(std::io::stdin()), 
-        Box::new(std::io::sink())
-    );
-
-    let program_path = test_fixtures_dir().join("simple/src/main.sw");
-    let source_str = program_path.to_string_lossy().to_string();
-
-    // Initialize and build
-    server.handle_command(&Command::Initialize(Default::default()));
-    server.state.program_path = PathBuf::from(&source_str);
-    server.state.mode = Some(StartDebuggingRequestKind::Launch);
-    server.build_tests().expect("Failed to build tests");
-
-    // Looking at what we had in our original output:
-    println!("\nOriginal source map output showed:");
-    println!("Line  3: Instructions [159, 160, 163, 164]");
-    println!("Line  4: Instructions [166, 167]");
-    println!("Line  5: Instructions [170]");
-    println!("Line  6: Instructions [175]");
-    println!("Line 11: Instructions [262, 263, 266, 267]");
-    println!("Line 12: Instructions [269, 270]");
-    println!("Line 13: Instructions [273]");
-    println!("Line 14: Instructions [278]");
-    println!("Line 21: Instructions [68]");
-    println!("Line 22: Instructions [70]");
-    println!("Line 23: Instructions [80]");
-    println!("Line 24: Instructions [84]");
-
-    println!("\nNew compiler source map shows:");
-    // Group instructions by line number for comparison
-    let mut line_to_instructions: BTreeMap<i64, Vec<usize>> = BTreeMap::new();
-    
-    let source_map = &server.state.compiler_source_map.unwrap();
-    for (pc, span) in source_map.clone().map {
-        if let Some((path, range)) = source_map.addr_to_span(pc) {
-            if path == program_path {
-                line_to_instructions
-                    .entry(range.start.line as i64)
-                    .or_default()
-                    .push(pc);
-            }
-        }
-    }
-
-    // Print in same format as original for comparison
-    for (line, instructions) in &line_to_instructions {
-        println!("Line {:2}: Instructions {:?}", line, instructions);
     }
 }

--- a/forc-plugins/forc-debug/tests/server_integration.rs
+++ b/forc-plugins/forc-debug/tests/server_integration.rs
@@ -301,7 +301,7 @@ fn test_sourcemap_build() {
     let mut line_to_instructions: BTreeMap<i64, Vec<usize>> = BTreeMap::new();
     let source_map = &server.state.source_map;
 
-    for (pc, _span) in &source_map.map {
+    for pc in source_map.map.keys() {
         if let Some((path, range)) = source_map.addr_to_span(*pc) {
             if path == program_path {
                 line_to_instructions


### PR DESCRIPTION
## Description
Replace the custom HashMap-based source map implementation in `forc-debug` with the compiler's source map format directly. This simplifies our source mapping logic and maintains better consistency with the compiler's source location tracking, while preserving all existing functionality.

Key changes:
- Remove custom source map types and use compiler's SourceMap
- Simplify breakpoint verification using compiler spans
- Add test to verify source map instruction-to-line mappings

closes #6733

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
