### PR TITLE
Check for type aliases when implementing traits

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_alias_unification/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_alias_unification/Forc.lock
@@ -1,0 +1,13 @@
+[[package]]
+name = "core"
+source = "path+from-root-6E306998EEBF0DBD"
+
+[[package]]
+name = "std"
+source = "path+from-root-6E306998EEBF0DBD"
+dependencies = ["core"]
+
+[[package]]
+name = "type_alias_unification"
+source = "member"
+dependencies = ["std"]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_alias_unification/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_alias_unification/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "type_alias_unification"
+
+[dependencies]
+std = { path = "../../../reduced_std_libs/sway-lib-std-assert" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_alias_unification/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_alias_unification/src/main.sw
@@ -1,0 +1,33 @@
+script;
+
+trait MyTrait {
+    fn extract_a(self) -> u64;
+}
+
+struct A {
+    a: u64,
+}
+
+impl MyTrait for A {
+    fn extract_a(self) -> u64 {
+        self.a
+    }
+}
+
+type B = A;
+
+// B is an alias for A, and A already has an implementation of MyTrait,
+// so this should cause a compilation error.
+impl MyTrait for B {
+    fn extract_a(self) -> u64 {
+	self.a + 1
+    }
+}
+
+fn main() {
+    let struct_a = A { a: 1 }; 
+    let struct_b = B { a: 42 };
+    // TODO: This results in disambiguation error, which is unhelpful since it doesn't get to the root of the problem - needs to recongnize that A == B
+    assert(struct_a.extract_a() == 1);
+    assert(struct_b.extract_a() == 42);
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/type_alias_unification/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/type_alias_unification/test.toml
@@ -1,0 +1,3 @@
+category = "fail"
+
+#not: $()error


### PR DESCRIPTION
## Description

Fixes #6329 .

#6867 makes a lot of changes to `TraitMap::insert` and the unification that happens inside the trait map, so I'm postponing this issue until that PR is in a stable state.

Status:
- Testcase added. The compiler correctly rejects the program, but the error message is unhelpful. The error message suggests that the alias still is treated as different type from the aliased type, which ought to be fixed.


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
