### PR TITLE
feat: disallow dependency package name collision in forc-pkg

### DIFF
--- a/forc-pkg/src/manifest/mod.rs
+++ b/forc-pkg/src/manifest/mod.rs
@@ -654,6 +654,11 @@ impl PackageManifest {
             {
                 bail!(format!("Dependency \"{dep_name}\" declares an alias (\"package\" field) that is the same as project name"))
             }
+            if dep_name == &self.project.name {
+                bail!(format!(
+                    "Dependency \"{dep_name}\" collides with project name."
+                ))
+            }
         }
         Ok(())
     }
@@ -1708,6 +1713,10 @@ mod tests {
         "#;
 
         let project = PackageManifest::from_string(original_toml.to_string());
-        assert!(project.is_ok())
+        let err = project.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            format!("Dependency \"lib_contract\" collides with project name.")
+        )
     }
 }


### PR DESCRIPTION
## Description

closes #6861 

`forc` was allowing dependency name being the same (through the use of `package` alias and the declaration itself) as the project name.

The following two cases are now invalid and produces an error on the forc-pkg side before going to the compiler.

```TOML
[project]
authors = ["Fuel Labs <contact@fuel.sh>"]
entry = "main.sw"
license = "Apache-2.0"
name = "lib_contract"

[dependencies]
lib_contract = { path = "../lib_contract_abi/", package = "lib_contract_abi" }
```


and

```TOML
[project]
authors = ["Fuel Labs <contact@fuel.sh>"]
entry = "main.sw"
license = "Apache-2.0"
name = "lib_contract_abi"

[dependencies]
lib_contract = { path = "../lib_contract_abi/", package = "lib_contract_abi" }

```