### PR TITLE
Add support for fetching verfied ABI from registry for forc call

### DIFF
--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -184,7 +184,7 @@ pub struct Command {
     pub contract_id: ContractId,
 
     /// Path or URI to a JSON ABI file.
-    #[clap(long, value_parser = parse_abi_path)]
+    #[clap(long, value_parser = parse_abi_path, default_value = "registry")]
     pub abi: Either<PathBuf, Url>,
 
     /// The function selector to call.
@@ -226,6 +226,9 @@ pub struct Command {
 }
 
 fn parse_abi_path(s: &str) -> Result<Either<PathBuf, Url>, String> {
+    if s == "registry" {
+        return Ok(Either::Right(Url::parse("registry://default").unwrap()));
+    }
     if let Ok(url) = Url::parse(s) {
         match url.scheme() {
             "http" | "https" | "ipfs" => Ok(Either::Right(url)),


### PR DESCRIPTION
## Description
Issue: Closes #6893
Add support for fetching ABI from registry in forc call

##Changes:

Modified call.rs to default to "registry" if no ABI is provided.
Updated mod.rs to fetch the ABI from https://registry.fuel.network/abi/{contract_id}.
Added error handling for failed fetch requests.

Behavior:

If ABI is explicitly provided via path or URL, it will be used.
If no ABI is provided, forc call will attempt to fetch from the registry.
If fetching fails, an error message is returned.