### PR TITLE
Fix issue with `__transmute` type checking

### DIFF
--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -1431,6 +1431,14 @@ fn const_eval_intrinsic(
                 value: &ConstantValue,
             ) -> Result<(), ConstEvalError> {
                 match t.get_content(ctx) {
+                    TypeContent::Struct(fields) => match value {
+                        ConstantValue::Struct(constants) => {
+                            for (field_type, field) in fields.iter().zip(constants.iter()) {
+                                append_bytes(ctx, bytes, field_type, &field.value)?;
+                            }
+                        }
+                        _ => unreachable!(),
+                    },
                     TypeContent::Array(item_type, size) => match value {
                         ConstantValue::Array(items) => {
                             assert!(*size as usize == items.len());

--- a/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/intrinsic_function.rs
@@ -215,20 +215,14 @@ fn type_check_transmute(
         None,
     );
 
+    let mut final_type_arguments = type_arguments.to_vec();
+    final_type_arguments[0].type_id = src_type;
+    final_type_arguments[1].type_id = return_type;
     Ok((
         TyIntrinsicFunctionKind {
             kind,
             arguments: vec![first_argument_typed_expr],
-            type_arguments: vec![
-                TypeArgument {
-                    type_id: src_type,
-                    ..type_arguments[0].clone()
-                },
-                TypeArgument {
-                    type_id: return_type,
-                    ..type_arguments[1].clone()
-                },
-            ],
+            type_arguments: final_type_arguments,
             span,
         },
         return_type,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_inits/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_inits/src/main.sw
@@ -95,6 +95,15 @@ const CARR1 = [X_SIZE - Y_SIZE + 1; 4];
 // and the type checker needs to know the size of the array.
 // const CARR2 = [1; X_SIZE - Y_SIZE + 1];
 
+// Const init with Self
+struct WithSelf { value: u64 }
+impl WithSelf {
+    pub fn size() -> u64 {
+        __transmute::<Self, u64>(Self { value: 1u64 })
+    }
+}
+const WithSelfValue: u64 =  WithSelf::size();
+
 fn main() -> u64 {
     const int1 = 1;
     assert(int1 == INT1 && ZERO_B256 == KEY);

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_inits/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_inits/src/main.sw
@@ -167,6 +167,8 @@ fn main() -> u64 {
 
     test_not();
 
+    assert(WithSelfValue == 1);
+
     1
 }
 


### PR DESCRIPTION
## Description

This PR solves an issue with `__transmute` in "const contexts". In these cases, the "source" and "return" types were not being correctly solved.

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
