### PR TITLE
Add test of never type in arrays

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_fail/unify_never/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unify_never/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+license = "Apache-2.0"
+name = "unify_never"
+entry = "main.sw"
+
+[dependencies]
+std = { path = "../../../reduced_std_libs/sway-lib-std-assert" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unify_never/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unify_never/src/main.sw
@@ -1,0 +1,22 @@
+script;
+
+// Test of unification of the Never type
+
+impl [u32;0] {
+    fn foo(self){
+        log("32");
+    }
+}
+
+impl [!;0] {
+    fn foo(self){
+        log("never");
+    }
+}
+
+fn main() {
+    let z:[u32;0] = [];
+
+    // Should fail because z gets the type of its type ascription
+    let y: [!;0] = z;
+}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/unify_never/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/unify_never/test.toml
@@ -1,0 +1,9 @@
+category = "fail"
+
+#check: $()error
+#check: $()Mismatched types
+#nextln: $()expected: [!; 0]
+#nextln: $()found:    [u32; 0].
+#nextln: $()help: Variable declaration's type annotation does not match up with the assigned expression's type
+
+#check: $()Aborting due to 1 error

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/unify_never/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/unify_never/src/main.sw
@@ -13,7 +13,22 @@ fn test_2(){
 }
 
 
-fn main() {
+impl [u32;0] {
+    fn foo(self) -> u64 {
+        32
+    }
+}
+
+impl [!;0] {
+    fn foo(self) -> u64{
+        64
+    }
+}
+
+fn main() -> u64 {
     test_1();
     test_2();
+
+    let x:[u32;0] = [];
+    x.foo() // should return 32
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/unify_never/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/unify_never/test.toml
@@ -1,2 +1,5 @@
-category = "compile"
+category = "run"
 expected_warnings = 1
+expected_result = { action = "return", value = 32 }
+expected_result_new_encoding = { action = "return_data", value = "0000000000000020" }
+validate_abi = false


### PR DESCRIPTION
## Description

Shows that #6387 has been fixed.

This PR adds a few tests of variable initializers that involve type Never. In this case the variable's type ascription should be used instead of the initializer's type.

No changes have been made to the compiler, since the problem that was originally reported was fixed by #6911.


## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
