### PR TITLE
Extend `#[deprecated]` support

### DIFF
--- a/sway-core/src/language/ty/code_block.rs
+++ b/sway-core/src/language/ty/code_block.rs
@@ -1,6 +1,6 @@
 use crate::{
     decl_engine::*, engine_threading::*, language::ty::*, semantic_analysis::TypeCheckContext,
-    type_system::*,
+    transform::AllowDeprecatedState, type_system::*,
 };
 use serde::{Deserialize, Serialize};
 use std::hash::Hasher;
@@ -11,6 +11,19 @@ use sway_types::Span;
 pub struct TyCodeBlock {
     pub contents: Vec<TyAstNode>,
     pub(crate) whole_block_span: Span,
+}
+
+impl TyCodeBlock {
+    pub(crate) fn check_deprecated(
+        &self,
+        engines: &Engines,
+        handler: &Handler,
+        allow_deprecated: &mut AllowDeprecatedState,
+    ) {
+        for n in self.contents.iter() {
+            n.check_deprecated(engines, handler, allow_deprecated);
+        }
+    }
 }
 
 impl Default for TyCodeBlock {

--- a/sway-lib-std/src/ecr.sw
+++ b/sway-lib-std/src/ecr.sw
@@ -217,6 +217,7 @@ pub fn ed_verify(public_key: b256, signature: B512, msg: Bytes) -> Result<bool, 
 /// }
 /// ```
 #[deprecated(note = "std::ecr has been replaced by std::crypto, and is no longer maintained")]
+#[allow(deprecated)]
 pub fn ec_recover_address(signature: B512, msg_hash: b256) -> Result<Address, EcRecoverError> {
     let pub_key_result = ec_recover(signature, msg_hash);
 
@@ -263,6 +264,7 @@ pub fn ec_recover_address(signature: B512, msg_hash: b256) -> Result<Address, Ec
 /// }
 /// ```
 #[deprecated(note = "std::ecr has been replaced by std::crypto, and is no longer maintained")]
+#[allow(deprecated)]
 pub fn ec_recover_address_r1(signature: B512, msg_hash: b256) -> Result<Address, EcRecoverError> {
     let pub_key_result = ec_recover_r1(signature, msg_hash);
 

--- a/sway-lib-std/src/vm/evm/ecr.sw
+++ b/sway-lib-std/src/vm/evm/ecr.sw
@@ -36,6 +36,7 @@ use ::vm::evm::evm_address::EvmAddress;
 /// }
 /// ```
 #[deprecated(note = "std:vm::evm:ecr has been replaced by std::crypto, and is no longer maintained")]
+#[allow(deprecated)]
 pub fn ec_recover_evm_address(
     signature: B512,
     msg_hash: b256,

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/deprecated/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/deprecated/src/main.sw
@@ -1,15 +1,46 @@
-library;
+script;
 
 #[deprecated]
 struct A {
+    #[deprecated]
+    a: u64,
+    b: u64,
+}
+
+impl A {
+    #[deprecated]
+    fn fun(self) {}
 }
 
 #[deprecated]
 enum B {
-    A: ()
+    A: (),
+    #[deprecated]
+    B: (),
 }
 
-pub fn f() {
-    let _ = A {};
+
+#[deprecated]
+fn depr(_a: A) {}
+
+fn fun(_a: A) {}
+
+#[deprecated]
+fn depr_b(_b: B) {}
+
+// TODO: support for traits, abis and their methods
+pub fn main() {
+    let a = A { a: 0, b: 0 };
+    let b = B::A;
+    depr(a);
+    depr(A { a: 0, b: 0  });
+    depr_b(b);
+    depr_b(B::A);
+    fun(a);
+    fun(A { a: 0, b: 0 });
+    let _ = a.a;
+    let _ = a.b;
     let _ = B::A;
+    let _ = B::B;
+    a.fun();
 }

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/deprecated/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/deprecated/test.toml
@@ -1,4 +1,23 @@
 category = "compile"
-expected_warnings = 1
+expected_warnings = 20
 
+# check: $()deprecated struct field
 # check: $()deprecated struct
+# check: $()deprecated enum
+# check: $()deprecated enum
+# check: $()deprecated enum variant
+# check: $()deprecated struct
+# check: $()deprecated enum
+# check: $()deprecated function
+# check: $()deprecated struct
+# check: $()deprecated function
+# check: $()deprecated function
+# check: $()deprecated enum
+# check: $()deprecated function
+# check: $()deprecated struct
+# check: $()deprecated struct field
+# check: $()deprecated enum
+# check: $()deprecated enum
+# check: $()deprecated enum variant
+# check: $()deprecated struct
+# check: $()deprecated function


### PR DESCRIPTION
## Description

Add support for the `#[deprecated]` attribute to functions, enums, struct items, enum variants and propagate deprecation check exhaustively throughout expressions variants.

Partially addresses #6942.

Support for deprecating traits, abis and the methods thereof in their definitions is still missing, as well as scrutinees and storage fields.


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
