### PR TITLE
Add len function for String

### DIFF
--- a/sway-lib-std/src/string.sw
+++ b/sway-lib-std/src/string.sw
@@ -235,6 +235,28 @@ impl String {
     pub fn ptr(self) -> raw_ptr {
         self.bytes.ptr()
     }
+
+    /// Gets the length of the `String`.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The length of the `String`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use std::string::String;
+    ///
+    /// fn foo() {
+    ///     let string = String::new();
+    ///     assrt(string.len() == 0);
+    ///     let string = String::from_ascii_str("ABCDEF");
+    ///     assert(string.len() == 6);
+    /// }
+    /// ```
+    pub fn len(self) -> u64 {
+        self.bytes.len
+    }
 }
 
 impl From<Bytes> for String {

--- a/sway-lib-std/src/string.sw
+++ b/sway-lib-std/src/string.sw
@@ -255,7 +255,7 @@ impl String {
     /// }
     /// ```
     pub fn len(self) -> u64 {
-        self.bytes.len
+        self.bytes.len()
     }
 }
 

--- a/test/src/in_language_tests/test_programs/string_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/string_inline_tests/src/main.sw
@@ -393,3 +393,21 @@ fn string_clone() {
     assert(cloned_string.as_bytes().get(1).unwrap() == string.as_bytes().get(1).unwrap());
     assert(cloned_string.as_bytes().get(2).unwrap() == string.as_bytes().get(2).unwrap());
 }
+
+#[test]
+fn test_string_len() {
+    let string = String::from_ascii_str("fuel");
+    assert(string.len() == 4);
+
+    let string = String::new();
+    assert(string.len() == 0);
+
+    let string = String::from_ascii_str("ABCDEF");
+    assert(string.len() == 6);
+
+    let string = String::from_ascii_str("1234");
+    assert(string.len() == 4);
+
+    let string = String::from_ascii_str("");
+    assert(string.len() == 0);
+}


### PR DESCRIPTION
## Description
Adds the len helper function to get the length of the String

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
