### PR TITLE
Allow `ldc` opcode in predicates

### DIFF
--- a/sway-core/src/asm_generation/fuel/checks.rs
+++ b/sway-core/src/asm_generation/fuel/checks.rs
@@ -104,7 +104,6 @@ pub(crate) fn check_predicate_opcodes(
                         span: get_op_span(op),
                     });
                 }
-                LDC(..) => invalid_opcode("LDC"),
                 LOG(..) => invalid_opcode("LOG"),
                 LOGD(..) => invalid_opcode("LOGD"),
                 MINT(..) => invalid_opcode("MINT"),

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_invalid_opcodes/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_invalid_opcodes/src/main.sw
@@ -56,10 +56,6 @@ fn main() -> bool {
     r1: u64
   };
 
-  asm(r1: 0, r2: 0, r3: 0) {
-    ldc r1 r2 r3 i0;
-  }
-
   asm(r1: 0, r2: 0, r3: 0, r4: 0) {
     log r1 r2 r3 r4;
   }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_invalid_opcodes/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_invalid_opcodes/test.toml
@@ -35,9 +35,6 @@ category = "fail"
 
 # not: $()The GM (get-metadata) opcode, when called from an external context, will cause the VM to panic.
 
-# check: ldc r1 r2 r3 i0;
-# nextln: $()The LDC opcode cannot be used in a predicate.
-
 # check: log r1 r2 r3 r4;
 # nextln: $()The LOG opcode cannot be used in a predicate.
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/asm/instructions/ldc/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/asm/instructions/ldc/Forc.lock
@@ -1,0 +1,8 @@
+[[package]]
+name = "core"
+source = "path+from-root-441B0FE8436A0A54"
+
+[[package]]
+name = "ldc"
+source = "member"
+dependencies = ["core"]

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/asm/instructions/ldc/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/asm/instructions/ldc/Forc.toml
@@ -1,0 +1,10 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "ldc"
+
+[dependencies]
+core = { path = "../../../../../../../../../sway-lib-core" }
+
+

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/asm/instructions/ldc/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/asm/instructions/ldc/src/main.sw
@@ -1,0 +1,8 @@
+predicate;
+
+fn main() -> bool {
+    asm(r1: 0, r2: 0, r3: 0) {
+        ldc r1 r2 r3 i0;
+    }
+    true
+}

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/asm/instructions/ldc/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/asm/instructions/ldc/test.toml
@@ -1,0 +1,1 @@
+category = "compile"


### PR DESCRIPTION
## Description

This PR allows `LDC` opcode in predicates. Historically, it was not allowed in the FuelVM, but this restriction is removed and we are removing it now from Sway as well.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.