### PR TITLE
fix fallback compilation on new encoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Build All Tests
         run: cargo run --locked --release -p forc -- build --release --locked --path ./test/src/sdk-harness
+      - name: Test All Tests
+        run: cargo run --locked --release -p forc -- test --release --locked --path ./test/src/sdk-harness
       - name: Cargo Test sway-lib-std
         run: cargo test --locked --release --manifest-path ./test/src/sdk-harness/Cargo.toml -- --nocapture
       - name: Build All Tests - Experimental Feature 'storage_domains'

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -186,22 +186,24 @@ pub(super) fn compile_contract(
         )?;
     }
 
-    // Fallback function needs to be compiled
-    for decl in declarations {
-        if let ty::TyDecl::FunctionDecl(decl) = decl {
-            let decl_id = decl.decl_id;
-            let decl = engines.de().get(&decl_id);
-            if decl.is_fallback() {
-                compile_abi_method(
-                    context,
-                    &mut md_mgr,
-                    module,
-                    &decl_id,
-                    logged_types_map,
-                    messages_types_map,
-                    engines,
-                    cache,
-                )?;
+    if !context.experimental.new_encoding {
+        // Fallback function needs to be compiled
+        for decl in declarations {
+            if let ty::TyDecl::FunctionDecl(decl) = decl {
+                let decl_id = decl.decl_id;
+                let decl = engines.de().get(&decl_id);
+                if decl.is_fallback() {
+                    compile_abi_method(
+                        context,
+                        &mut md_mgr,
+                        module,
+                        &decl_id,
+                        logged_types_map,
+                        messages_types_map,
+                        engines,
+                        cache,
+                    )?;
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

When running testing in contracts with the fallback function, we get an error with the `__log` intrinsic. The issue is that we needlessly compiled the fallback function twice. And in some cases (numeric decay), the `__log` argument would return a `TypeId` that was not collected in the `collect_metadata` phase.

This was never caught because we only compile `sdk-harness` tests, we never run their unit tests in the CI. Which this PR is also doing.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
