### PR TITLE
NOT TO BE MERGED: Add fuel-telemetry to forc-tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,6 +3511,7 @@ checksum = "ada067d4aaff1acf1175a00edb1c3efbeccf7e2fb414270a2d29eedb2f207c97"
 [[package]]
 name = "fuel-telemetry"
 version = "0.1.0"
+source = "git+https://github.com/FuelLabs/fuel-telemetry.git?branch=fuel-telemetry#5941f3331dcbb1a956fe45871cb543a7d93f1a7e"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3521,7 +3522,7 @@ dependencies = [
  "regex",
  "reqwest",
  "sysinfo 0.33.1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -5256,10 +5257,11 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.0.0"
+source = "git+https://github.com/FuelLabs/fuel-telemetry.git?branch=fuel-telemetry#5941f3331dcbb1a956fe45871cb543a7d93f1a7e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6732,7 +6734,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox 0.1.3",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9582,7 +9584,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -9593,7 +9595,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.99",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,6 +2147,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,7 +2172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -2175,8 +2184,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2186,7 +2207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -3036,7 +3057,7 @@ dependencies = [
  "sway-features",
  "sway-types",
  "sway-utils",
- "sysinfo",
+ "sysinfo 0.29.11",
  "tar",
  "tempfile",
  "toml 0.8.20",
@@ -3102,6 +3123,7 @@ name = "forc-tracing"
 version = "0.66.8"
 dependencies = [
  "ansiterm",
+ "fuel-telemetry",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -3485,6 +3507,26 @@ name = "fuel-storage"
 version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ada067d4aaff1acf1175a00edb1c3efbeccf7e2fb414270a2d29eedb2f207c97"
+
+[[package]]
+name = "fuel-telemetry"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "dirs 6.0.0",
+ "influxdb-line-protocol",
+ "macros",
+ "nix 0.29.0",
+ "regex",
+ "reqwest",
+ "sysinfo 0.33.1",
+ "thiserror 2.0.11",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "uuid 1.15.1",
+]
 
 [[package]]
 name = "fuel-tx"
@@ -4398,7 +4440,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -4684,6 +4726,19 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "influxdb-line-protocol"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fa7ee6be451ea0b1912b962c91c8380835e97cf1584a77e18264e908448dcb"
+dependencies = [
+ "bytes",
+ "log",
+ "nom",
+ "smallvec",
+ "snafu",
+]
 
 [[package]]
 name = "inotify"
@@ -5199,6 +5254,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "macros"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5284,6 +5348,12 @@ checksum = "9bfdc64e2f805f3d12965f10522000bae36e88d2cfea44112331f467d4f4bf68"
 dependencies = [
  "clap",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -5442,6 +5512,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -6645,6 +6725,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox 0.1.3",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6734,6 +6825,7 @@ dependencies = [
  "cookie",
  "cookie_store",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.8",
@@ -7944,7 +8036,7 @@ dependencies = [
  "sway-parse",
  "sway-types",
  "sway-utils",
- "sysinfo",
+ "sysinfo 0.29.11",
  "thiserror 1.0.69",
  "tracing",
  "uint",
@@ -8229,6 +8321,20 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
 ]
 
 [[package]]
@@ -8847,6 +8953,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9426,12 +9544,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -9446,8 +9608,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -9466,7 +9637,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ fuel-tx = "0.59"
 fuel-vm = "0.59"
 
 # Dependencies for Fuel Telemetry
-fuel-telemetry = { path = "../fuel-telemetry", version = "0.1" }
+fuel-telemetry = { git = "https://github.com/FuelLabs/fuel-telemetry.git", branch = "fuel-telemetry" }
 
 # Dependencies from the `forc-wallet` repository:
 forc-wallet = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,9 @@ fuel-types = "0.59"
 fuel-tx = "0.59"
 fuel-vm = "0.59"
 
+# Dependencies for Fuel Telemetry
+fuel-telemetry = { path = "../fuel-telemetry", version = "0.1" }
+
 # Dependencies from the `forc-wallet` repository:
 forc-wallet = "0.12"
 

--- a/forc-tracing/Cargo.toml
+++ b/forc-tracing/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 ansiterm.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "json"] }
+fuel-telemetry.workspace = true
 
 [dev-dependencies]
 tracing-test.workspace = true

--- a/forc-tracing/Cargo.toml
+++ b/forc-tracing/Cargo.toml
@@ -8,6 +8,10 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+telemetry = []
+
 [dependencies]
 ansiterm.workspace = true
 tracing.workspace = true

--- a/forc-tracing/src/lib.rs
+++ b/forc-tracing/src/lib.rs
@@ -15,10 +15,16 @@ pub use tracing_subscriber::{
     Layer,
 };
 
-pub use fuel_telemetry::{
-    debug_telemetry, error_telemetry, info_telemetry, span_telemetry, trace_telemetry,
-    warn_telemetry,
-};
+pub mod telemetry {
+    pub use fuel_telemetry::{
+        error_telemetry,
+        info_telemetry,
+        warn_telemetry,
+        debug_telemetry,
+        trace_telemetry,
+        span_telemetry,
+    };
+}
 
 const ACTION_COLUMN_WIDTH: usize = 12;
 


### PR DESCRIPTION
## Description

This adds `fuel-telemetry` to `forc-tracing` (not quite - dependency is currently pointing to Github).

First, add it to the `forc-tracing` dependency:

```toml
[dependencies]
forc-tracing = { version = "0.47", features = ["telemetry"] }
```

Then use the `telemetry::*` glob, followed by the usual `tracing` macros, but with a `_telemetry` postfix:

```rust
use forc_tracing::{
    init_tracing_subscriber, println_green, println_red, println_yellow, telemetry::*,
};

fn main() {
    init_tracing_subscriber(Default::default());

    println_red("Stop");
    println_yellow("Slow down");
    println_green("Go");

    error_telemetry!("Error message for InfluxDB");
    warn_telemetry!("Warn message for InfluxDB");
    info_telemetry!("Info message for InfluxDB");
    debug_telemetry!("Debug message for InfluxDB");
    trace_telemetry!("Trace message for InfluxDB");
}
```

This will output the following (note `DEBUG` and `TRACE` messages are filtered out because of `RUST_LOG=info`):

```bash
> RUST_LOG=info ./target/debug/example
Stop
Slow down
Go
```

We can then peek into telemetry files like the following:

```bash
> cat ~/.fuelup/tmp/*.telemetry.* | while read line; do echo "$line" | base64 -d; echo; done
2025-03-06T19:53:24.923452000Z ERROR aarch64-apple-darwin:Darwin:23.6.0 forc-tracing:0.66.8:src/main.rs 0e3480f5-faab-48b8-a935-21ce90a6f028 auto: Error message for InfluxDB
2025-03-06T19:53:24.925348000Z  WARN aarch64-apple-darwin:Darwin:23.6.0 forc-tracing:0.66.8:src/main.rs 0e3480f5-faab-48b8-a935-21ce90a6f028 auto: Warn message for InfluxDB
2025-03-06T19:53:24.925434000Z  INFO aarch64-apple-darwin:Darwin:23.6.0 forc-tracing:0.66.8:src/main.rs 0e3480f5-faab-48b8-a935-21ce90a6f028 auto: Info message for InfluxDB
2025-03-06T19:53:31.335690000Z  INFO aarch64-apple-darwin:Darwin:23.6.0 systeminfo_watcher:0.1.0:src/systeminfo_watcher.rs ec63b355-7862-47db-9ae3-de0cfcc094c8 poll_systeminfo: cpu_arch="arm64" cpu_brand="Apple M2 Pro" cpu_count=10 global_cpu_usage=15.85 total_memory=34359738368 free_memory=23388143616 free_memory_percentage=0.68 os_long_name="macOS 14.6.1 Sonoma" kernel_version="23.6.0" uptime=2482559 vm="" ci="" load_average_1m=4.52 load_average_5m=4.17 load_average_15m=3.86
```

All 4 rows appear in InfluxDB.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
