### PR TITLE
Refactor CONTRACT_ID injection logic to only occur in LSP mode 

### DIFF
--- a/forc-pkg/src/pkg.rs
+++ b/forc-pkg/src/pkg.rs
@@ -2620,17 +2620,22 @@ pub fn check(
         )
         .map_err(|err| anyhow!("{err}"))?;
 
-        // This is necessary because `CONTRACT_ID` is a special constant that's injected into the
-        // compiler's namespace. Although we only know the contract id during building, we are
-        // inserting a dummy value here to avoid false error signals being reported in LSP.
-        // We only do this for the last node in the compilation order because previous nodes
-        // are dependencies.
-        //
-        // See this github issue for more context: https://github.com/FuelLabs/sway-vscode-plugin/issues/154
-        const DUMMY_CONTRACT_ID: &str =
-            "0x0000000000000000000000000000000000000000000000000000000000000000";
-        let contract_id_value =
-            (idx == plan.compilation_order.len() - 1).then(|| DUMMY_CONTRACT_ID.to_string());
+        // Only inject a dummy CONTRACT_ID in LSP mode, not when check() is called from tests or other non-LSP contexts,
+        // to avoid polluting namespaces unnecessarily.
+        let contract_id_value = if lsp_mode.is_some() && (idx == plan.compilation_order.len() - 1) {
+            // This is necessary because `CONTRACT_ID` is a special constant that's injected into the
+            // compiler's namespace. Although we only know the contract id during building, we are
+            // inserting a dummy value here to avoid false error signals being reported in LSP.
+            // We only do this for the last node in the compilation order because previous nodes
+            // are dependencies.
+            //
+            // See this github issue for more context: https://github.com/FuelLabs/sway-vscode-plugin/issues/154
+            const DUMMY_CONTRACT_ID: &str =
+                "0x0000000000000000000000000000000000000000000000000000000000000000";
+            Some(DUMMY_CONTRACT_ID.to_string())
+        } else {
+            None
+        };
 
         let program_id = engines
             .se()


### PR DESCRIPTION
## Description
This PR modifies `CONTRACT_ID` injection to only occur in LSP mode, preventing unnecessary dummy values from being added when `check()` is called outside LSP contexts. Fixes issues with IR test suite where `core` was incorrectly receiving a `CONTRACT_ID` definition.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
