### PR TITLE
Add migration for `Bytes::into(self) -> b256` to `Bytes::try_into`

### DIFF
--- a/forc-plugins/forc-migrate/src/migrations/mod.rs
+++ b/forc-plugins/forc-migrate/src/migrations/mod.rs
@@ -501,6 +501,9 @@ const MIGRATION_STEPS: MigrationSteps = &[
     ),
     (
         Feature::TryFromBytesForB256,
-        &[self::try_from_bytes_for_b256::REPLACE_B256_FROM_BYTES_TO_TRY_FROM_BYTES_STEP],
+        &[
+            self::try_from_bytes_for_b256::REPLACE_B256_FROM_BYTES_WITH_TRY_FROM_BYTES_STEP,
+            self::try_from_bytes_for_b256::REPLACE_BYTES_INTO_B256_WITH_TRY_INTO_B256_STEP,
+        ],
     ),
 ];

--- a/forc-plugins/forc-migrate/src/migrations/try_from_bytes_for_b256.rs
+++ b/forc-plugins/forc-migrate/src/migrations/try_from_bytes_for_b256.rs
@@ -2,12 +2,16 @@ use crate::{
     migrations::MutProgramInfo,
     modifying::*,
     visiting::{
-        InvalidateTypedElement, LexedFnCallInfoMut, LexedMethodCallInfoMut, ProgramVisitorMut, TreesVisitorMut, TyFnCallInfo, TyMethodCallInfo, VisitingContext
+        InvalidateTypedElement, LexedFnCallInfoMut, LexedMethodCallInfoMut, ProgramVisitorMut,
+        TreesVisitorMut, TyFnCallInfo, TyMethodCallInfo, VisitingContext,
     },
 };
 use anyhow::{bail, Ok, Result};
 use sway_ast::Expr;
-use sway_core::{language::{ty::TyExpression, CallPath}, TypeInfo};
+use sway_core::{
+    language::{ty::TyExpression, CallPath},
+    TypeInfo,
+};
 use sway_types::{Span, Spanned};
 
 use super::{ContinueMigrationProcess, DryRun, MigrationStep, MigrationStepKind};
@@ -156,8 +160,16 @@ fn replace_bytes_into_b256_with_try_into_b256_step(
                 return Ok(InvalidateTypedElement::No);
             };
 
-            let method_return_type = ctx.engines.te().get(ty_method_call_info.fn_decl.return_type.type_id);
-            let method_target_is_bytes_struct = match ctx.engines.te().get(ty_method_call_info.parent_type_id).as_ref() {
+            let method_return_type = ctx
+                .engines
+                .te()
+                .get(ty_method_call_info.fn_decl.return_type.type_id);
+            let method_target_is_bytes_struct = match ctx
+                .engines
+                .te()
+                .get(ty_method_call_info.parent_type_id)
+                .as_ref()
+            {
                 TypeInfo::Struct(decl_id) => {
                     let struct_decl = ctx.engines.de().get_struct(decl_id);
                     struct_decl.call_path == CallPath::fullpath(&["std", "bytes", "Bytes"])

--- a/forc-plugins/forc-migrate/src/migrations/try_from_bytes_for_b256.rs
+++ b/forc-plugins/forc-migrate/src/migrations/try_from_bytes_for_b256.rs
@@ -2,13 +2,12 @@ use crate::{
     migrations::MutProgramInfo,
     modifying::*,
     visiting::{
-        InvalidateTypedElement, LexedFnCallInfoMut, ProgramVisitorMut, TreesVisitorMut,
-        TyFnCallInfo, VisitingContext,
+        InvalidateTypedElement, LexedFnCallInfoMut, LexedMethodCallInfoMut, ProgramVisitorMut, TreesVisitorMut, TyFnCallInfo, TyMethodCallInfo, VisitingContext
     },
 };
 use anyhow::{bail, Ok, Result};
 use sway_ast::Expr;
-use sway_core::language::{ty::TyExpression, CallPath};
+use sway_core::{language::{ty::TyExpression, CallPath}, TypeInfo};
 use sway_types::{Span, Spanned};
 
 use super::{ContinueMigrationProcess, DryRun, MigrationStep, MigrationStepKind};
@@ -16,20 +15,20 @@ use super::{ContinueMigrationProcess, DryRun, MigrationStep, MigrationStepKind};
 // NOTE: We do not fully support cases when `b256::from` is nested within another `b256::from`.
 //       E.g.: `b256::from(Bytes::from(b256::from(nested_bytes)))`.
 //       In such cases, only the outermost `b256::from` will be migrated.
+//       The same is with `Bytes::into`.
 //       In practice, this does not happen.
 
-#[allow(dead_code)]
-pub(super) const REPLACE_B256_FROM_BYTES_TO_TRY_FROM_BYTES_STEP: MigrationStep = MigrationStep {
-    title: "Replace calls to `b256::from(<bytes>)` with `b256::try_from(<bytes>).unwrap()`",
+pub(super) const REPLACE_B256_FROM_BYTES_WITH_TRY_FROM_BYTES_STEP: MigrationStep = MigrationStep {
+    title: "Replace `b256::from(<bytes>)` calls with `b256::try_from(<bytes>).unwrap()`",
     duration: 0,
     kind: MigrationStepKind::CodeModification(
-        replace_b256_from_bytes_to_try_from_bytes_step,
+        replace_b256_from_bytes_with_try_from_bytes_step,
         &[],
         ContinueMigrationProcess::IfNoManualMigrationActionsNeeded,
     ),
     help: &[
-        "Migration will replace all the calls to `b256::from(<bytes>)` with",
-        "`b256::try_from(<bytes>).unwrap()`.",
+        "Migration will replace all the `b256::from(<bytes>)` calls",
+        "with `b256::try_from(<bytes>).unwrap()`.",
         " ",
         "E.g.:",
         "  let result = b256::from(some_bytes);",
@@ -38,7 +37,26 @@ pub(super) const REPLACE_B256_FROM_BYTES_TO_TRY_FROM_BYTES_STEP: MigrationStep =
     ],
 };
 
-fn replace_b256_from_bytes_to_try_from_bytes_step(
+pub(super) const REPLACE_BYTES_INTO_B256_WITH_TRY_INTO_B256_STEP: MigrationStep = MigrationStep {
+    title: "Replace `<bytes>.into()` calls with `<bytes>.try_into().unwrap()`",
+    duration: 0,
+    kind: MigrationStepKind::CodeModification(
+        replace_bytes_into_b256_with_try_into_b256_step,
+        &[],
+        ContinueMigrationProcess::IfNoManualMigrationActionsNeeded,
+    ),
+    help: &[
+        "Migration will replace all the `<bytes>.into()` calls resulting in \"b256\"",
+        "with `<bytes>.try_into().unwrap()`.",
+        " ",
+        "E.g.:",
+        "  let result: b256 = some_bytes.into();",
+        "will become:",
+        "  let result: b256 = some_bytes.try_into().unwrap();",
+    ],
+};
+
+fn replace_b256_from_bytes_with_try_from_bytes_step(
     program_info: &mut MutProgramInfo,
     dry_run: DryRun,
 ) -> Result<Vec<Span>> {
@@ -106,6 +124,73 @@ fn replace_b256_from_bytes_to_try_from_bytes_step(
             let target = lexed_fn_call.clone();
             let insert_span = Span::empty_at_end(&target.span());
             *lexed_fn_call = New::method_call(insert_span, target, "unwrap");
+
+            Ok(InvalidateTypedElement::Yes)
+        }
+    }
+
+    ProgramVisitorMut::visit_program(program_info, dry_run, &mut Visitor {})
+}
+
+fn replace_bytes_into_b256_with_try_into_b256_step(
+    program_info: &mut MutProgramInfo,
+    dry_run: DryRun,
+) -> Result<Vec<Span>> {
+    struct Visitor;
+    impl TreesVisitorMut<Span> for Visitor {
+        fn visit_method_call(
+            &mut self,
+            ctx: &VisitingContext,
+            lexed_method_call: &mut Expr,
+            ty_method_call: Option<&TyExpression>,
+            output: &mut Vec<Span>,
+        ) -> Result<InvalidateTypedElement> {
+            let lexed_method_call_info = LexedMethodCallInfoMut::new(lexed_method_call)?;
+            let ty_method_call_info = ty_method_call
+                .map(|ty_method_call| TyMethodCallInfo::new(ctx.engines.de(), ty_method_call))
+                .transpose()?;
+
+            // We need the typed info in order to ensure that the `into` function
+            // is really the `Bytes::into(self) -> b256` function.
+            let Some(ty_method_call_info) = ty_method_call_info else {
+                return Ok(InvalidateTypedElement::No);
+            };
+
+            let method_return_type = ctx.engines.te().get(ty_method_call_info.fn_decl.return_type.type_id);
+            let method_target_is_bytes_struct = match ctx.engines.te().get(ty_method_call_info.parent_type_id).as_ref() {
+                TypeInfo::Struct(decl_id) => {
+                    let struct_decl = ctx.engines.de().get_struct(decl_id);
+                    struct_decl.call_path == CallPath::fullpath(&["std", "bytes", "Bytes"])
+                }
+                _ => false,
+            };
+
+            if !(ty_method_call_info.fn_decl.name.as_str() == "into"
+                && matches!(method_return_type.as_ref(), TypeInfo::B256)
+                && method_target_is_bytes_struct)
+            {
+                return Ok(InvalidateTypedElement::No);
+            }
+
+            // We have found a `Bytes::into(self) -> b256` call.
+            output.push(lexed_method_call_info.path_seg.span());
+
+            if ctx.dry_run == DryRun::Yes {
+                return Ok(InvalidateTypedElement::No);
+            }
+
+            let lexed_into_path = match lexed_method_call {
+                Expr::MethodCall { path_seg, .. } => path_seg,
+                _ => bail!("`lexed_method_call` must be of the variant `Expr::MethodCall`."),
+            };
+
+            // Rename the call to `into` to `try_into`.
+            modify(lexed_into_path).set_name("try_into");
+
+            // The call to `try_into` becomes the target of the `unwrap` method call.
+            let target = lexed_method_call.clone();
+            let insert_span = Span::empty_at_end(&target.span());
+            *lexed_method_call = New::method_call(insert_span, target, "unwrap");
 
             Ok(InvalidateTypedElement::Yes)
         }


### PR DESCRIPTION
## Description

This PR adds migration step for migrating `<bytes>.into()` calls to `<bytes>.try_into().unwrap`, as explained in the Breaking Changes chapter of #6994.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.