### PR TITLE
Add migration for merging `core` and `std` libraries

### DIFF
--- a/forc-plugins/forc-migrate/src/migrations/merge_core_std.rs
+++ b/forc-plugins/forc-migrate/src/migrations/merge_core_std.rs
@@ -1,0 +1,223 @@
+#![allow(deprecated)]
+
+use std::{sync::Arc, vec};
+
+use crate::{
+    migrations::{InteractionResponse, MutProgramInfo},
+    print_single_choice_menu,
+    visiting::{
+        InvalidateTypedElement, LexedFnCallInfo, LexedFnCallInfoMut, ProgramVisitor,
+        ProgramVisitorMut, TreesVisitor, TreesVisitorMut, VisitingContext,
+    },
+};
+use anyhow::{Ok, Result};
+use sway_ast::{Expr, ItemImpl, ItemUse, UseTree};
+use sway_core::language::ty::{TyExpression, TyImplSelfOrTrait, TyUseStatement};
+use sway_types::{Ident, Span, Spanned};
+
+use super::{ContinueMigrationProcess, DryRun, MigrationStep, MigrationStepKind, ProgramInfo};
+
+pub(super) const REPLACE_CORE_WITH_STD_IN_PATHS: MigrationStep = MigrationStep {
+    title: "Replace `core` with `std` in paths",
+    duration: 1,
+    kind: MigrationStepKind::Interaction(
+        replace_core_with_std_in_paths_instruction,
+        replace_core_with_std_in_paths_interaction,
+        &[],
+        ContinueMigrationProcess::IfNoManualMigrationActionsNeeded,
+    ),
+    help: &[
+        "Migration will replace all occurrences of `core` with `std` in paths.",
+        " ",
+        "E.g.:",
+        "  use core::ops::*;",
+        "will become:",
+        "  use std::ops::*;",
+        " ",
+        "Run this migration only if you are switching fully to the `merge_core_std` feature,",
+        "and do not plan to use the old, separated, standard libraries anymore.",
+    ],
+};
+
+fn replace_core_with_std_in_paths_instruction(program_info: &ProgramInfo) -> Result<Vec<Span>> {
+    struct Visitor;
+    impl TreesVisitor<Span> for Visitor {
+        fn visit_use(
+            &mut self,
+            _ctx: &VisitingContext,
+            lexed_use: &ItemUse,
+            _ty_use: Option<&TyUseStatement>,
+            output: &mut Vec<Span>,
+        ) -> Result<InvalidateTypedElement> {
+            let path_prefix = match &lexed_use.tree {
+                UseTree::Path { prefix, .. } => Some(prefix),
+                _ => None,
+            };
+
+            if lexed_use.root_import.is_none()
+                && path_prefix.is_some()
+                && path_prefix.map_or("", |path_prefix| path_prefix.as_str()) == "core"
+            {
+                output.push(
+                    path_prefix
+                        .expect("`path_prefix` is checked to be `Some`")
+                        .span(),
+                );
+            }
+
+            Ok(InvalidateTypedElement::No)
+        }
+
+        fn visit_impl(
+            &mut self,
+            _ctx: &VisitingContext,
+            lexed_impl: &ItemImpl,
+            _ty_impl: Option<Arc<TyImplSelfOrTrait>>,
+            output: &mut Vec<Span>,
+        ) -> Result<InvalidateTypedElement> {
+            let Some((trait_path, _for_token)) = &lexed_impl.trait_opt else {
+                return Ok(InvalidateTypedElement::No);
+            };
+
+            if trait_path.root_opt.is_none() && trait_path.prefix.name.as_str() == "core" {
+                output.push(trait_path.prefix.span());
+            }
+
+            Ok(InvalidateTypedElement::No)
+        }
+
+        fn visit_fn_call(
+            &mut self,
+            _ctx: &VisitingContext,
+            lexed_fn_call: &Expr,
+            _ty_fn_call: Option<&TyExpression>,
+            output: &mut Vec<Span>,
+        ) -> Result<InvalidateTypedElement> {
+            let lexed_fn_call_info = LexedFnCallInfo::new(lexed_fn_call)?;
+            let fn_path = match lexed_fn_call_info.func {
+                Expr::Path(path) => Some(path),
+                _ => None,
+            };
+
+            let Some(fn_path) = fn_path else {
+                return Ok(InvalidateTypedElement::No);
+            };
+
+            if fn_path.root_opt.is_none()
+                && !fn_path.suffix.is_empty()
+                && fn_path.prefix.name.as_str() == "core"
+            {
+                output.push(fn_path.prefix.span());
+            }
+
+            Ok(InvalidateTypedElement::No)
+        }
+    }
+
+    ProgramVisitor::visit_program(program_info, DryRun::Yes, &mut Visitor {})
+}
+
+fn replace_core_with_std_in_paths_interaction(
+    program_info: &mut MutProgramInfo,
+) -> Result<(InteractionResponse, Vec<Span>)> {
+    println!("All the occurrences of `core` shown above will be replaced with `std`.");
+    println!();
+    println!("Do you want to replace those occurrences and switch fully to the `merge_core_std` feature?");
+    println!();
+
+    if print_single_choice_menu(&[
+        "Yes, replace `core` with `std` and switch fully to the `merge_core_std` feature.",
+        "No, continue using `core` and `std` as separated libraries.",
+    ]) != 0
+    {
+        return Ok((InteractionResponse::PostponeStep, vec![]));
+    }
+
+    // Execute the migration step.
+    struct Visitor;
+    impl TreesVisitorMut<Span> for Visitor {
+        // In all of the cases, we keep the old span and just override the name.
+        fn visit_use(
+            &mut self,
+            _ctx: &VisitingContext,
+            lexed_use: &mut ItemUse,
+            _ty_use: Option<&TyUseStatement>,
+            output: &mut Vec<Span>,
+        ) -> Result<InvalidateTypedElement> {
+            let path_prefix = match &mut lexed_use.tree {
+                UseTree::Path { prefix, .. } => Some(prefix),
+                _ => None,
+            };
+
+            if lexed_use.root_import.is_none()
+                && path_prefix.is_some()
+                && path_prefix
+                    .as_ref()
+                    .map_or("", |path_prefix| path_prefix.as_str())
+                    == "core"
+            {
+                let path_prefix = path_prefix.expect("`path_prefix` is checked to be `Some`");
+
+                output.push(path_prefix.span());
+
+                *path_prefix = Ident::new_with_override("std".to_string(), path_prefix.span());
+            }
+
+            Ok(InvalidateTypedElement::Yes)
+        }
+
+        fn visit_impl(
+            &mut self,
+            _ctx: &VisitingContext,
+            lexed_impl: &mut ItemImpl,
+            _ty_impl: Option<Arc<TyImplSelfOrTrait>>,
+            output: &mut Vec<Span>,
+        ) -> Result<InvalidateTypedElement> {
+            let Some((trait_path, _for_token)) = &mut lexed_impl.trait_opt else {
+                return Ok(InvalidateTypedElement::No);
+            };
+
+            if trait_path.root_opt.is_none() && trait_path.prefix.name.as_str() == "core" {
+                output.push(trait_path.prefix.span());
+
+                trait_path.prefix.name =
+                    Ident::new_with_override("std".to_string(), trait_path.prefix.span());
+            }
+
+            Ok(InvalidateTypedElement::Yes)
+        }
+
+        fn visit_fn_call(
+            &mut self,
+            _ctx: &VisitingContext,
+            lexed_fn_call: &mut Expr,
+            _ty_fn_call: Option<&TyExpression>,
+            output: &mut Vec<Span>,
+        ) -> Result<InvalidateTypedElement> {
+            let lexed_fn_call_info = LexedFnCallInfoMut::new(lexed_fn_call)?;
+            let fn_path = match lexed_fn_call_info.func {
+                Expr::Path(path) => Some(path),
+                _ => None,
+            };
+
+            let Some(fn_path) = fn_path else {
+                return Ok(InvalidateTypedElement::No);
+            };
+
+            if fn_path.root_opt.is_none()
+                && !fn_path.suffix.is_empty()
+                && fn_path.prefix.name.as_str() == "core"
+            {
+                output.push(fn_path.prefix.span());
+
+                fn_path.prefix.name =
+                    Ident::new_with_override("std".to_string(), fn_path.prefix.span());
+            }
+
+            Ok(InvalidateTypedElement::Yes)
+        }
+    }
+
+    ProgramVisitorMut::visit_program(program_info, DryRun::No, &mut Visitor {})
+        .map(|result| (InteractionResponse::ExecuteStep, result))
+}

--- a/forc-plugins/forc-migrate/src/migrations/mod.rs
+++ b/forc-plugins/forc-migrate/src/migrations/mod.rs
@@ -9,6 +9,7 @@
 //! the migration tool.
 
 mod demo;
+mod merge_core_std;
 mod partial_eq;
 mod references;
 mod storage_domains;
@@ -502,5 +503,9 @@ const MIGRATION_STEPS: MigrationSteps = &[
     (
         Feature::TryFromBytesForB256,
         &[self::try_from_bytes_for_b256::REPLACE_B256_FROM_BYTES_TO_TRY_FROM_BYTES_STEP],
+    ),
+    (
+        Feature::MergeCoreStd,
+        &[self::merge_core_std::REPLACE_CORE_WITH_STD_IN_PATHS],
     ),
 ];

--- a/sway-features/src/lib.rs
+++ b/sway-features/src/lib.rs
@@ -179,6 +179,8 @@ features! {
     "https://github.com/FuelLabs/sway/issues/6860",
     try_from_bytes_for_b256 = false,
     "https://github.com/FuelLabs/sway/issues/6994",
+    merge_core_std = false,
+    "https://github.com/FuelLabs/sway/issues/7006",
 }
 
 #[derive(Clone, Debug, Default, Parser)]


### PR DESCRIPTION
## Description

This PR adds migration step for merging `core` and `std` libraries, as explained in the Breaking Changes chapter of #7006.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.