### PR TITLE
Fix source dependencies preventing release

### DIFF
--- a/sway-features/Cargo.toml
+++ b/sway-features/Cargo.toml
@@ -11,5 +11,5 @@ repository.workspace = true
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 paste.workspace = true
-sway-error = { path = "../sway-error" }
-sway-types = { path = "../sway-types" }
+sway-error.workspace = true
+sway-types.workspace = true


### PR DESCRIPTION
## Description

The sway-features Cargo.toml had dependencies not aligned with the
workspace which prevented the publish action to run properly.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
