### PR TITLE
forc-call list functions support with example call usage

### DIFF
--- a/docs/book/src/forc/plugins/forc_client/forc_call.md
+++ b/docs/book/src/forc/plugins/forc_client/forc_call.md
@@ -22,7 +22,7 @@ impl ContractABI for Contract {
 }
 ```
 
-### List callable functions of a contract given it's ABI file:
+### List callable functions of a contract given it's ABI file
 
 ```bash
 forc call 0xe18de7c7c8c61a1c706dccb3533caa00ba5c11b5230da4428582abf1b6831b4d \
@@ -42,7 +42,7 @@ add(a: u64, b: u64) -> u64
     add "0, 0"
 ```
 
-### Call a simple addition function on a deployed contract (in dry-run mode):
+### Call a simple addition function on a deployed contract (in dry-run mode)
 
 ```bash
 forc call 0xe18de7c7c8c61a1c706dccb3533caa00ba5c11b5230da4428582abf1b6831b4d \
@@ -50,7 +50,7 @@ forc call 0xe18de7c7c8c61a1c706dccb3533caa00ba5c11b5230da4428582abf1b6831b4d \
   add 1 2
 ```
 
-### Query the owner of a deployed [DEX contract](https://github.com/mira-amm/mira-v1-core) on testnet:
+### Query the owner of a deployed [DEX contract](https://github.com/mira-amm/mira-v1-core) on testnet
 
 ```bash
 forc call \

--- a/docs/book/src/forc/plugins/forc_client/forc_call.md
+++ b/docs/book/src/forc/plugins/forc_client/forc_call.md
@@ -39,7 +39,7 @@ add(a: u64, b: u64) -> u64
   forc call \
     --abi ./out/debug/counter-contract-abi.json \
     0xe18de7c7c8c61a1c706dccb3533caa00ba5c11b5230da4428582abf1b6831b4d \
-    add "0, 0"
+    add "0" "0"
 ```
 
 ### Call a simple addition function on a deployed contract (in dry-run mode)

--- a/docs/book/src/forc/plugins/forc_client/forc_call.md
+++ b/docs/book/src/forc/plugins/forc_client/forc_call.md
@@ -8,8 +8,6 @@ The `forc call` command is part of the Forc toolchain and is installed alongside
 
 Here are a few examples of what you can do with `forc call`:
 
-Call a simple addition function on a deployed contract (in dry-run mode):
-
 ```sway
 contract;
 
@@ -24,13 +22,35 @@ impl ContractABI for Contract {
 }
 ```
 
+### List callable functions of a contract given it's ABI file:
+
+```bash
+forc call 0xe18de7c7c8c61a1c706dccb3533caa00ba5c11b5230da4428582abf1b6831b4d \
+  --abi ./out/debug/counter-contract-abi.json \
+  --list-functions
+```
+
+Output:
+
+```log
+Available functions in contract: 0xe18de7c7c8c61a1c706dccb3533caa00ba5c11b5230da4428582abf1b6831b4d
+
+add(a: u64, b: u64) -> u64
+  forc call \
+    --abi ./out/debug/counter-contract-abi.json \
+    0xe18de7c7c8c61a1c706dccb3533caa00ba5c11b5230da4428582abf1b6831b4d \
+    add "0, 0"
+```
+
+### Call a simple addition function on a deployed contract (in dry-run mode):
+
 ```bash
 forc call 0xe18de7c7c8c61a1c706dccb3533caa00ba5c11b5230da4428582abf1b6831b4d \
   --abi ./out/debug/counter-contract-abi.json \
   add 1 2
 ```
 
-Query the owner of a deployed [DEX contract](https://github.com/mira-amm/mira-v1-core) on testnet:
+### Query the owner of a deployed [DEX contract](https://github.com/mira-amm/mira-v1-core) on testnet:
 
 ```bash
 forc call \

--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -178,6 +178,11 @@ impl FromStr for OutputFormat {
     --amount 100 \
     --asset-id 0x0087675439e10a8351b1d5e4cf9d0ea6da77675623ff6b16470b5e3c58998423 \
     --live
+
+# List all available functions in a contract
+» forc call 0x0dcba78d7b09a1f77353f51367afd8b8ab94b5b2bb6c9437d9ba9eea47dede97 \
+    --abi ./contract-abi.json \
+    --list-functions
 "#)]
 pub struct Command {
     /// The contract ID to call.
@@ -190,7 +195,9 @@ pub struct Command {
     /// The function selector to call.
     /// The function selector is the name of the function to call (e.g. "transfer").
     /// It must be a valid selector present in the ABI file.
-    pub function: FuncType,
+    /// Not required when --list-functions is specified.
+    #[clap(required_unless_present = "list_functions")]
+    pub function: Option<FuncType>,
 
     /// Arguments to pass into the function to be called.
     pub function_args: Vec<String>,
@@ -209,6 +216,11 @@ pub struct Command {
     /// The execution mode to use for the call; defaults to dry-run; possible values: dry-run, simulate, live
     #[clap(long, default_value = "dry-run")]
     pub mode: ExecutionMode,
+
+    /// List all available functions in the contract
+    /// Requires ABI and contract ID to be provided
+    #[clap(long, alias = "list-functions")]
+    pub list_functions: bool,
 
     /// The gas price to use for the call; defaults to 0
     #[clap(flatten)]

--- a/forc-plugins/forc-client/src/op/call/list_functions.rs
+++ b/forc-plugins/forc-client/src/op/call/list_functions.rs
@@ -100,10 +100,11 @@ pub fn list_contract_functions<W: Write>(
                 Either::Right(url) => url.to_string(),
             };
 
+            let painted_name = forc_util::ansiterm::Colour::Blue.paint(func.name.clone());
             writeln!(
                 writer,
                 "{}({}) -> {}",
-                func.name, func_args_types, return_type
+                painted_name, func_args_types, return_type
             )?;
             writeln!(
                 writer,
@@ -151,15 +152,16 @@ mod tests {
         // Verify the output contains expected function names and formatting
         assert!(output_string.contains("Callable functions for contract:"));
 
-        assert!(
-            output_string.contains("test_struct_with_generic(a: GenericStruct) -> GenericStruct")
-        );
+        assert!(output_string.contains(
+            "\u{1b}[34mtest_struct_with_generic\u{1b}[0m(a: GenericStruct) -> GenericStruct"
+        ));
         assert!(output_string.contains("forc call \\"));
         assert!(output_string.contains(format!("--abi {abi_path_str} \\").as_str()));
         assert!(output_string.contains(format!("{id} \\").as_str()));
         assert!(output_string.contains("test_struct_with_generic \"{0, aaaa}\""));
 
-        assert!(output_string.contains("test_complex_struct(a: ComplexStruct) -> ComplexStruct"));
+        assert!(output_string
+            .contains("\u{1b}[34mtest_complex_struct\u{1b}[0m(a: ComplexStruct) -> ComplexStruct"));
         assert!(output_string.contains("forc call \\"));
         assert!(output_string.contains(format!("--abi {abi_path_str} \\").as_str()));
         assert!(output_string.contains(format!("{id} \\").as_str()));

--- a/forc-plugins/forc-client/src/op/call/list_functions.rs
+++ b/forc-plugins/forc-client/src/op/call/list_functions.rs
@@ -59,19 +59,28 @@ pub fn list_contract_functions<W: Write>(
                             )
                         })?
                     };
-                    Ok((func_args, func_args_input))
+                    Ok((func_args, func_args_input, param_type))
                 })
                 .collect::<Result<Vec<_>>>()?;
 
             let func_args_types = func_args
                 .iter()
-                .map(|(func_args, _)| func_args.to_owned())
+                .map(|(func_args, _, _)| func_args.to_owned())
                 .collect::<Vec<String>>()
                 .join(", ");
 
             let func_args_inputs = func_args
                 .iter()
-                .map(|(_, func_args_input)| format!("\"{}\"", func_args_input))
+                .map(|(_, func_args_input, param_type)| match param_type {
+                    ParamType::Array(_, _)
+                    | ParamType::Unit
+                    | ParamType::Tuple(_)
+                    | ParamType::Struct { .. }
+                    | ParamType::Enum { .. }
+                    | ParamType::RawSlice
+                    | ParamType::Vector(_) => format!("\"{}\"", func_args_input),
+                    _ => func_args_input.to_owned(),
+                })
                 .collect::<Vec<String>>()
                 .join(" ");
 

--- a/forc-plugins/forc-client/src/op/call/list_functions.rs
+++ b/forc-plugins/forc-client/src/op/call/list_functions.rs
@@ -17,7 +17,7 @@ pub fn list_contract_functions<W: Write>(
 ) -> Result<()> {
     writeln!(
         writer,
-        "\nAvailable functions in contract: {}\n",
+        "\nCallable functions for contract: {}\n",
         contract_id
     )?;
 
@@ -140,7 +140,7 @@ mod tests {
         let output_string = String::from_utf8(output_bytes).expect("Output was not valid UTF-8");
 
         // Verify the output contains expected function names and formatting
-        assert!(output_string.contains("Available functions in contract:"));
+        assert!(output_string.contains("Callable functions for contract:"));
 
         assert!(
             output_string.contains("test_struct_with_generic(a: GenericStruct) -> GenericStruct")

--- a/forc-plugins/forc-client/src/op/call/list_functions.rs
+++ b/forc-plugins/forc-client/src/op/call/list_functions.rs
@@ -1,0 +1,111 @@
+use crate::op::call::parser::{
+    get_default_value, param_to_function_arg, param_type_val_to_token, token_to_string,
+};
+use anyhow::{anyhow, bail, Result};
+use either::Either;
+use fuel_abi_types::abi::unified_program::UnifiedProgramABI;
+use fuels_core::types::{param_types::ParamType, ContractId};
+use std::collections::HashMap;
+use std::io::Write;
+
+/// List all functions in a contract's ABI along with examples of how to call them.
+pub fn list_contract_functions<W: Write>(
+    contract_id: &ContractId,
+    abi: &Either<std::path::PathBuf, reqwest::Url>,
+    unified_program_abi: &UnifiedProgramABI,
+    writer: &mut W,
+) -> Result<()> {
+    writeln!(
+        writer,
+        "\nAvailable functions in contract: {}\n",
+        contract_id
+    )?;
+
+    if unified_program_abi.functions.is_empty() {
+        writeln!(writer, "No functions found in the contract ABI.")?;
+    } else {
+        let type_lookup = unified_program_abi
+            .types
+            .iter()
+            .map(|decl| (decl.type_id, decl.clone()))
+            .collect::<HashMap<_, _>>();
+
+        for func in &unified_program_abi.functions {
+            let func_args = func
+                .inputs
+                .iter()
+                .map(|input| {
+                    let Ok(param_type) = ParamType::try_from_type_application(input, &type_lookup)
+                    else {
+                        return Err(anyhow!("Failed to convert input type application"));
+                    };
+                    let func_args =
+                        format!("{}: {}", input.name, param_to_function_arg(&param_type));
+                    let func_args_input = {
+                        let token =
+                            param_type_val_to_token(&param_type, &get_default_value(&param_type))
+                                .map_err(|err| {
+                                anyhow!(
+                                    "Failed to generate example call for {}: {}",
+                                    func.name,
+                                    err
+                                )
+                            })?;
+                        token_to_string(&token).map_err(|err| {
+                            anyhow!(
+                                "Failed to convert token to string for {}: {}",
+                                func.name,
+                                err
+                            )
+                        })?
+                    };
+                    Ok((func_args, func_args_input))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let func_args_types = func_args
+                .iter()
+                .map(|(func_args, _)| func_args.to_owned())
+                .collect::<Vec<String>>()
+                .join(", ");
+            let func_args_inputs = func_args
+                .iter()
+                .map(|(_, func_args_input)| func_args_input.to_owned())
+                .collect::<Vec<String>>()
+                .join(", ");
+
+            let return_type = match ParamType::try_from_type_application(&func.output, &type_lookup)
+            {
+                Ok(param_type) => param_to_function_arg(&param_type),
+                Err(err) => bail!(
+                    "Failed to convert output type application for {}: {}",
+                    func.name,
+                    err
+                ),
+            };
+
+            // Get the ABI path or URL as a string
+            let raw_abi_input = match abi {
+                Either::Left(path) => path.to_str().unwrap_or("").to_owned(),
+                Either::Right(url) => url.to_string(),
+            };
+
+            writeln!(
+                writer,
+                "{}({}) -> {}",
+                func.name, func_args_types, return_type
+            )?;
+            let args_part = if func_args_inputs.is_empty() {
+                String::new()
+            } else {
+                format!("\"{}\"", func_args_inputs)
+            };
+            writeln!(
+                writer,
+                "  forc call \\\n      --abi {} \\\n      {} \\\n      {} {}\n",
+                raw_abi_input, contract_id, func.name, args_part,
+            )?;
+        }
+    }
+
+    Ok(())
+}

--- a/forc-plugins/forc-client/src/op/call/mod.rs
+++ b/forc-plugins/forc-client/src/op/call/mod.rs
@@ -336,7 +336,7 @@ async fn get_wallet(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use fuels::accounts::wallet::Wallet;
     use fuels::prelude::*;
@@ -346,7 +346,8 @@ mod tests {
         abi = "forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json"
     ));
 
-    async fn get_contract_instance() -> (TestContract<WalletUnlocked>, ContractId, WalletUnlocked) {
+    pub async fn get_contract_instance(
+    ) -> (TestContract<WalletUnlocked>, ContractId, WalletUnlocked) {
         // Launch a local network and deploy the contract
         let mut wallets = launch_custom_provider_and_get_wallets(
             WalletsConfig::new(
@@ -390,7 +391,7 @@ mod tests {
             abi: Either::Left(std::path::PathBuf::from(
                 "../../forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json",
             )),
-            function: cmd::call::FuncType::Selector(selector.into()),
+            function: Some(cmd::call::FuncType::Selector(selector.into())),
             function_args: args.into_iter().map(String::from).collect(),
             node: crate::NodeTarget {
                 node_url: Some(wallet.provider().unwrap().url().to_owned()),
@@ -406,6 +407,7 @@ mod tests {
             external_contracts: None,
             output: cmd::call::OutputFormat::Raw,
             show_receipts: false,
+            list_functions: false,
         }
     }
 

--- a/forc-plugins/forc-client/src/op/call/parser.rs
+++ b/forc-plugins/forc-client/src/op/call/parser.rs
@@ -434,6 +434,65 @@ fn parse_delimited_string(param_type: &ParamType, input: &str) -> Result<Vec<Str
     Ok(parts)
 }
 
+pub fn get_default_value(param_type: &ParamType) -> String {
+    match param_type {
+        ParamType::Unit => "()".to_string(),
+        ParamType::Bool => "false".to_string(),
+        ParamType::U8 => "0".to_string(),
+        ParamType::U16 => "0".to_string(),
+        ParamType::U32 => "0".to_string(),
+        ParamType::U64 => "0".to_string(),
+        ParamType::U128 => "0".to_string(),
+        ParamType::U256 => "0".to_string(),
+        ParamType::B256 => {
+            "0x0000000000000000000000000000000000000000000000000000000000000000".to_string()
+        }
+        ParamType::Bytes => "0x".to_string(),
+        ParamType::String => "hello".to_string(),
+        ParamType::RawSlice => "0x".to_string(),
+        ParamType::StringArray(size) => "a".repeat(*size),
+        ParamType::StringSlice => "hello".to_string(),
+        ParamType::Tuple(types) => {
+            let inner = types
+                .iter()
+                .map(get_default_value)
+                .collect::<Vec<String>>()
+                .join(", ");
+            format!("({inner})")
+        }
+        ParamType::Array(ty, size) => {
+            let inner = (0..*size)
+                .map(|_| get_default_value(ty))
+                .collect::<Vec<String>>()
+                .join(", ");
+            format!("[{inner}]")
+        }
+        ParamType::Vector(ty) => {
+            let inner = (0..2)
+                .map(|_| get_default_value(ty))
+                .collect::<Vec<String>>()
+                .join(", ");
+            format!("[{inner}]")
+        }
+        ParamType::Struct { fields, .. } => {
+            let inner = fields
+                .iter()
+                .map(|(_, ty)| get_default_value(ty))
+                .collect::<Vec<String>>()
+                .join(", ");
+            format!("{{{inner}}}")
+        }
+        ParamType::Enum { enum_variants, .. } => {
+            let (variant_key, variant_val_type) = enum_variants
+                .variants()
+                .first()
+                .expect("Enum must have at least one variant");
+            let variant_val_str = get_default_value(variant_val_type);
+            format!("({variant_key}: {variant_val_str})")
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1553,5 +1612,83 @@ mod tests {
         );
         let output = token_to_string(&token).unwrap();
         assert_eq!(output, "(container:{{42, fuel}, fuel})");
+    }
+
+    #[test]
+    fn get_default_value_for_param_type() {
+        let param_type = ParamType::Unit;
+        assert_eq!(get_default_value(&param_type), "()");
+
+        let param_type = ParamType::Bool;
+        assert_eq!(get_default_value(&param_type), "false");
+
+        let param_type = ParamType::U8;
+        assert_eq!(get_default_value(&param_type), "0");
+
+        let param_type = ParamType::U16;
+        assert_eq!(get_default_value(&param_type), "0");
+
+        let param_type = ParamType::U32;
+        assert_eq!(get_default_value(&param_type), "0");
+
+        let param_type = ParamType::U64;
+        assert_eq!(get_default_value(&param_type), "0");
+
+        let param_type = ParamType::U128;
+        assert_eq!(get_default_value(&param_type), "0");
+
+        let param_type = ParamType::U256;
+        assert_eq!(get_default_value(&param_type), "0");
+
+        let param_type = ParamType::B256;
+        assert_eq!(
+            get_default_value(&param_type),
+            "0x0000000000000000000000000000000000000000000000000000000000000000"
+        );
+
+        let param_type = ParamType::Bytes;
+        assert_eq!(get_default_value(&param_type), "0x");
+
+        let param_type = ParamType::String;
+        assert_eq!(get_default_value(&param_type), "hello");
+
+        let param_type = ParamType::RawSlice;
+        assert_eq!(get_default_value(&param_type), "0x");
+
+        let param_type = ParamType::StringArray(4);
+        assert_eq!(get_default_value(&param_type), "aaaa");
+
+        let param_type = ParamType::StringSlice;
+        assert_eq!(get_default_value(&param_type), "hello");
+
+        let param_type = ParamType::Tuple(vec![ParamType::U32, ParamType::StringArray(4)]);
+        assert_eq!(get_default_value(&param_type), "(0, aaaa)");
+
+        let param_type = ParamType::Array(Box::new(ParamType::U32), 4);
+        assert_eq!(get_default_value(&param_type), "[0, 0, 0, 0]");
+
+        let param_type = ParamType::Vector(Box::new(ParamType::U32));
+        assert_eq!(get_default_value(&param_type), "[0, 0]");
+
+        let param_type = ParamType::Struct {
+            generics: vec![],
+            name: "GenericStruct".to_string(),
+            fields: vec![
+                ("value".to_string(), ParamType::U32),
+                ("description".to_string(), ParamType::StringArray(4)),
+            ],
+        };
+        assert_eq!(get_default_value(&param_type), "{0, aaaa}");
+
+        let param_type = ParamType::Enum {
+            generics: vec![],
+            name: "GenericEnum".to_string(),
+            enum_variants: EnumVariants::new(vec![
+                ("Active".to_string(), ParamType::Bool),
+                ("Pending".to_string(), ParamType::U64),
+            ])
+            .unwrap(),
+        };
+        assert_eq!(get_default_value(&param_type), "(Active: false)");
     }
 }

--- a/forc-plugins/forc-client/src/op/call/parser.rs
+++ b/forc-plugins/forc-client/src/op/call/parser.rs
@@ -1701,9 +1701,6 @@ mod tests {
         let param_type = ParamType::StringSlice;
         assert_eq!(param_to_function_arg(&param_type), "str");
 
-        let param_type = ParamType::StringArray(4);
-        assert_eq!(param_to_function_arg(&param_type), "str[4]");
-
         let param_type = ParamType::Tuple(vec![ParamType::U32, ParamType::StringArray(4)]);
         assert_eq!(param_to_function_arg(&param_type), "(u32, str[4])");
 


### PR DESCRIPTION
## Description
Adds optional `--list-functions` CLI arg to `forc call`.

With provided ABI and a contract address; calling `forc-call` with `--list-functions` will list all available functions in the contract and additionally display example CLI usage to call the respective functions with default/basic parameters.

## Example output
```sh
> forc call -- \               
  --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
  23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 --list-functions

Available functions in contract: 23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4

test_array(a: [u64; 10]) -> [u64; 10]
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_array "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"

test_b256(a: b256) -> b256
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_b256 "0x0000000000000000000000000000000000000000000000000000000000000000"

test_bytes(a: Bytes) -> Bytes
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_bytes "0x"

test_complex_struct(a: ComplexStruct) -> ComplexStruct
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_complex_struct "{({aa, 0}, 0), (Active:false), 0, {{0, aaaa}, aaaa}}"

test_empty() -> ()
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_empty 

test_empty_no_return() -> ()
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_empty_no_return 

test_enum(a: Status) -> Status
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_enum "(Active:false)"

test_enum_with_complex_generic(a: GenericEnum) -> GenericEnum
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_enum_with_complex_generic "(container:{{0, aaaa}, aaaa})"

test_enum_with_generic(a: GenericEnum) -> GenericEnum
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_enum_with_generic "(container:{0, aaaa})"

test_option(a: Option) -> Option
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_option "(None:())"

test_str(a: str) -> str
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_str "hello"

test_str_array(a: str[10]) -> str[10]
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_str_array "aaaaaaaaaa"

test_str_slice(a: str) -> str
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_str_slice "hello"

test_struct(a: User) -> User
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_struct "{aa, 0}"

test_struct_with_generic(a: GenericStruct) -> GenericStruct
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_struct_with_generic "{0, aaaa}"

test_tuple(a: (u64, bool)) -> (u64, bool)
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_tuple "(0, false)"

test_u128(a: U128) -> U128
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_u128 "0"

test_u16(a: u16) -> u16
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_u16 "0"

test_u256(a: U256) -> U256
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_u256 "0"

test_u32(a: u32) -> u32
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_u32 "0"

test_u64(a: u64) -> u64
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_u64 "0"

test_u8(a: u8) -> u8
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_u8 "0"

test_unit(a: ()) -> ()
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_unit "()"

test_vector(a: Vec<u64>) -> Vec<u64>
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      test_vector "[0, 0]"

transfer(amount_to_transfer: u64, asset_id: AssetId, recipient: Identity) -> ()
  forc call \
      --abi ./forc-plugins/forc-client/test/data/contract_with_types/contract_with_types-abi.json \
      23190a0648a92ac42f58dc2f4159ee28cdd1448bbcaabd272ec42a00e8e4aed4 \
      transfer "0" "{0x0000000000000000000000000000000000000000000000000000000000000000}" "(Address:{0x0000000000000000000000000000000000000000000000000000000000000000})"
```

Addresses https://github.com/FuelLabs/sway/issues/6935

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
