### PR TITLE
Improve snapshot testing

### DIFF
--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -42,8 +42,3 @@ tokio.workspace = true
 toml = { workspace = true, features = ["parse"] }
 tracing.workspace = true
 vte.workspace = true
-
-[[test]]
-name = "tests"
-path = "tests/tests.rs"
-harness = false

--- a/test/src/e2e_vm_tests/mod.rs
+++ b/test/src/e2e_vm_tests/mod.rs
@@ -752,9 +752,6 @@ pub async fn run(filter_config: &FilterConfig, run_config: &RunConfig) -> Result
         .map(|exclude| tests.retained(|t| !exclude.is_match(&t.name)))
         .unwrap_or_default();
 
-    if filter_config.exclude_core {
-        tests.retain(|t| exclude_tests_dependency(t, "core"));
-    }
     if filter_config.exclude_std {
         tests.retain(|t| exclude_tests_dependency(t, "std"));
     }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -106,12 +106,7 @@ impl TestKindOpt {
     const IR: &'static str = "ir";
     const SNAPSHOT: &'static str = "snapshot";
     const ALL: &'static str = "all";
-    pub const CLI_OPTIONS: [&'static str; 4] = [
-        Self::E2E,
-        Self::IR,
-        Self::SNAPSHOT,
-        Self::ALL,
-    ];
+    pub const CLI_OPTIONS: [&'static str; 4] = [Self::E2E, Self::IR, Self::SNAPSHOT, Self::ALL];
 }
 
 impl From<&Vec<String>> for TestKindOpt {

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -1,6 +1,7 @@
 mod e2e_vm_tests;
 mod ir_generation;
 mod reduced_std_libs;
+mod snapshot;
 mod test_consistency;
 
 use anyhow::Result;
@@ -29,11 +30,7 @@ struct Cli {
     #[arg(long, visible_alias = "abi")]
     abi_only: bool,
 
-    /// Only run tests with no core dependencies
-    #[arg(long, visible_alias = "exclude_core")]
-    exclude_core: bool,
-
-    /// Only run tests with no std dependencies
+    /// Only run tests with no `std` dependencies
     #[arg(long, visible_alias = "exclude_std")]
     exclude_std: bool,
 
@@ -49,11 +46,11 @@ struct Cli {
     #[arg(long, env = "SWAY_TEST_VERBOSE")]
     verbose: bool,
 
-    /// Compile sway code in release mode
+    /// Compile Sway code in release mode
     #[arg(long)]
     release: bool,
 
-    /// Intended for use in `CI` to ensure test lock files are up to date
+    /// Intended for use in CI to ensure test lock files are up to date
     #[arg(long)]
     locked: bool,
 
@@ -79,6 +76,60 @@ struct Cli {
 
     #[command(flatten)]
     experimental: sway_features::CliFields,
+
+    /// Only run tests of a particular kind
+    #[arg(long, short, num_args(1..=4), value_parser = clap::builder::PossibleValuesParser::new(&TestKindOpt::CLI_OPTIONS))]
+    kind: Option<Vec<String>>,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct TestKind {
+    pub e2e: bool,
+    pub ir: bool,
+    pub snapshot: bool,
+}
+
+impl TestKind {
+    fn all() -> Self {
+        Self {
+            e2e: true,
+            ir: true,
+            snapshot: true,
+        }
+    }
+}
+
+pub struct TestKindOpt(pub TestKind);
+
+impl TestKindOpt {
+    const E2E: &'static str = "e2e";
+    const IR: &'static str = "ir";
+    const SNAPSHOT: &'static str = "snapshot";
+    const ALL: &'static str = "all";
+    pub const CLI_OPTIONS: [&'static str; 4] = [
+        Self::E2E,
+        Self::IR,
+        Self::SNAPSHOT,
+        Self::ALL,
+    ];
+}
+
+impl From<&Vec<String>> for TestKindOpt {
+    fn from(value: &Vec<String>) -> Self {
+        let contains_opt = |opt: &str| value.iter().any(|val| *val == opt);
+
+        let test_kind = if contains_opt(Self::ALL) {
+            TestKind::all()
+        } else {
+            TestKind {
+                e2e: contains_opt(Self::E2E),
+                ir: contains_opt(Self::IR),
+                snapshot: contains_opt(Self::SNAPSHOT),
+            }
+        };
+
+        Self(test_kind)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -87,7 +138,6 @@ pub struct FilterConfig {
     pub exclude: Option<regex::Regex>,
     pub skip_until: Option<regex::Regex>,
     pub abi_only: bool,
-    pub exclude_core: bool,
     pub exclude_std: bool,
     pub contract_only: bool,
     pub first_only: bool,
@@ -104,6 +154,7 @@ pub struct RunConfig {
     pub print_asm: PrintAsm,
     pub print_bytecode: bool,
     pub experimental: sway_features::CliFields,
+    pub kind: TestKind,
 }
 
 #[tokio::main]
@@ -117,7 +168,6 @@ async fn main() -> Result<()> {
         exclude: cli.exclude,
         skip_until: cli.skip_until,
         abi_only: cli.abi_only,
-        exclude_core: cli.exclude_core,
         exclude_std: cli.exclude_std,
         contract_only: cli.contract_only,
         first_only: cli.first_only,
@@ -145,21 +195,27 @@ async fn main() -> Result<()> {
             .as_ref()
             .map_or(PrintAsm::default(), |opts| PrintAsmCliOpt::from(opts).0),
         print_bytecode: cli.print_bytecode,
+        kind: cli
+            .kind
+            .as_ref()
+            .map_or(TestKind::all(), |opts| TestKindOpt::from(opts).0),
     };
 
     // Check that the tests are consistent
     test_consistency::check()?;
 
-    // Create reduced versions of the `std` library.
+    // Create reduced versions of the `std` library
     reduced_std_libs::create()?;
 
     // Run E2E tests
-    e2e_vm_tests::run(&filter_config, &run_config)
-        .instrument(tracing::trace_span!("E2E"))
-        .await?;
+    if run_config.kind.e2e {
+        e2e_vm_tests::run(&filter_config, &run_config)
+            .instrument(tracing::trace_span!("E2E"))
+            .await?;
+    }
 
     // Run IR tests
-    if !filter_config.first_only {
+    if run_config.kind.ir && !filter_config.first_only {
         println!("\n");
         ir_generation::run(filter_config.include.as_ref(), cli.verbose, &run_config)
             .instrument(tracing::trace_span!("IR"))
@@ -167,16 +223,12 @@ async fn main() -> Result<()> {
     }
 
     // Run snapshot tests
-    let mut args = vec!["t", "--release", "-p", "test", "--"];
-    if let Some(include) = cli.include.as_ref().map(|x| x.as_str()) {
-        args.push(include);
+    if run_config.kind.snapshot && !filter_config.first_only {
+        println!("\n");
+        snapshot::run(filter_config.include.as_ref())
+            .instrument(tracing::trace_span!("SNAPSHOT"))
+            .await?;
     }
-
-    let mut t = std::process::Command::new("cargo")
-        .args(args)
-        .spawn()
-        .unwrap();
-    assert!(t.wait().unwrap().success());
 
     Ok(())
 }

--- a/test/src/snapshot/mod.rs
+++ b/test/src/snapshot/mod.rs
@@ -30,9 +30,11 @@ pub(super) async fn run(filter_regex: Option<&regex::Regex>) -> Result<()> {
         PathBuf::from_str(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).unwrap();
     let repo_root = repo_root.parent().unwrap().to_path_buf();
 
-    let mut args = Arguments::default();
-    args.filter = filter_regex.as_ref().map(|filter| filter.to_string());
-    args.nocapture = true;
+    let args = Arguments {
+        filter: filter_regex.as_ref().map(|filter| filter.to_string()),
+        nocapture: true,
+        ..Default::default()
+    };
 
     let tests = discover_test()
         .into_iter()

--- a/test/src/snapshot/mod.rs
+++ b/test/src/snapshot/mod.rs
@@ -1,8 +1,8 @@
+use anyhow::Result;
 use libtest_mimic::{Arguments, Trial};
 use normalize_path::NormalizePath;
 use regex::Regex;
 use std::{path::PathBuf, str::FromStr, sync::Once};
-use anyhow::Result;
 
 static FORC_COMPILATION: Once = Once::new();
 static FORC_DOC_COMPILATION: Once = Once::new();


### PR DESCRIPTION
## Description

This PR improves snapshot testing by moving the snapshot testing infrastructure from the separate `tests` project inside of the `e2e_vm_tests`.

This solves the following issues:
- double test execution on CI. Snapshot tests were executed twice on the CI, once as as part of `cargo_run_e2e_tests` and once as a part of `cargo_test_workspace`.
- double compilation. When running `e2e_vm_tests`, snapshot tests were executed as a separate process. In the recent issue with recompiling crates, this has caused the crates to be recompiled twice, starting from the `ring` crate.
- access to `reduced_std_libs`. Snapshot tests also need access to `reduced_std_libs`. Until now, they dependent only on `core` and full-blown `std`, but now they also depend on `sway-lib-std-core` which is generated when `e2e_vm_tests` are executed, but not when only snapshot tests were executed without the `e2e_vm_tests`.

Additionally, the PR:
- adds the `--kind/-k` CLI parameter to the `e2e_vm_tests` allowing to filter out which tests should be run. E.g.:
```
--kind e2e
--kind ir e2e snapshot
```
Not specifying `--kind` runs all the tests.
- removes the obsolete `exclude_core` CLI parameter from the `e2e_vm_tests`.


## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.