### PR TITLE
Fix #6727

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7926,6 +7926,7 @@ dependencies = [
  "indexmap 2.7.1",
  "itertools 0.13.0",
  "lazy_static",
+ "num-bigint",
  "object",
  "parking_lot",
  "paste",

--- a/sway-core/Cargo.toml
+++ b/sway-core/Cargo.toml
@@ -25,6 +25,7 @@ im.workspace = true
 indexmap = { workspace = true, features = ["serde"] }
 itertools.workspace = true
 lazy_static.workspace = true
+num-bigint.workspace = true
 object = { workspace = true, features = ["write"] }
 parking_lot.workspace = true
 paste.workspace = true

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use either::Either;
 use itertools::Itertools;
+use num_bigint::BigUint;
 use sway_ast::{
     assignable::ElementAccess,
     expr::{LoopControlFlow, ReassignmentOp, ReassignmentOpVariant},
@@ -3528,12 +3529,27 @@ fn literal_to_literal(
             } = lit_int;
             match ty_opt {
                 None => {
-                    let orig_str = span.as_str();
-                    if let Some(hex_digits) = orig_str.strip_prefix("0x") {
-                        let num_digits = hex_digits.chars().filter(|c| *c != '_').count();
+                    let mut stripped_str = span.as_str();
+                    if let Some(stripped) = stripped_str.strip_suffix("b256") {
+                        for (prefix, required_digits) in [("0x", 64), ("0b", 256)] {
+                            if let Some(digits) = stripped.strip_prefix(prefix) {
+                                let num_digits = digits.chars().filter(|c| *c != '_').count();
+                                if num_digits == required_digits {
+                                    stripped_str = stripped;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if let Some(hex_digits) = stripped_str.strip_prefix("0x") {
+                        let hex_digits_filtered = hex_digits.replace("_", "");
+                        let num_digits = hex_digits_filtered.len();
                         match num_digits {
                             1..=16 => Literal::Numeric(u64::try_from(parsed).unwrap()),
                             64 => {
+                                let parsed =
+                                    BigUint::parse_bytes(hex_digits_filtered.as_bytes(), 16)
+                                        .unwrap();
                                 let bytes = parsed.to_bytes_be();
                                 let mut full_bytes = [0u8; 32];
                                 full_bytes[(32 - bytes.len())..].copy_from_slice(&bytes);
@@ -3544,11 +3560,15 @@ fn literal_to_literal(
                                 return Err(handler.emit_err(error.into()));
                             }
                         }
-                    } else if let Some(bin_digits) = orig_str.strip_prefix("0b") {
-                        let num_digits = bin_digits.chars().filter(|c| *c != '_').count();
+                    } else if let Some(bin_digits) = stripped_str.strip_prefix("0b") {
+                        let bin_digits_filtered = bin_digits.replace("_", "");
+                        let num_digits = bin_digits_filtered.len();
                         match num_digits {
                             1..=64 => Literal::Numeric(u64::try_from(parsed).unwrap()),
                             256 => {
+                                let parsed =
+                                    BigUint::parse_bytes(bin_digits_filtered.as_bytes(), 2)
+                                        .unwrap();
                                 let bytes = parsed.to_bytes_be();
                                 let mut full_bytes = [0u8; 32];
                                 full_bytes[(32 - bytes.len())..].copy_from_slice(&bytes);


### PR DESCRIPTION
## Description

This PR fixes a bug where hex literals have their optional suffix counted as part of their digits.
The root cause of the bug it that the lexer wrongfully interpret the suffix as additional hex digits as "0xb256" happens to be a valid hex string.
This won't occur with other numeric literal constants such as "0x0u256" as the lexer will stop upon encountering "u" which is not a valid hex digit, the lexer will then extract the type suffix to help decoding the numeric literal which the suffix is stripped from before being further processed.
As far as binary b256 literals are concerned, the suffixed version will correctly stop interpreting characters as bits until the suffix is found, but it will fail with a lexer "InvalidIntSuffix" error because b256 is an unknown suffix in the first place (see https://github.com/FuelLabs/sway/blob/master/sway-parse/src/token.rs#L750-L764).
The suffix-free version is not impacted and correctly compiles (already was before this fix).

The initial proposed fix is to patch the literal_to_literal function which is responsible for transforming a sway_ast literal into a sway language literal: the suffix is removed from the hex literal only if it's preceded by 64 hex digits to form a correct b256 literal. The hex digits are parsed again because we can't use the parsed BigUint provided by the lexer as it may include the optional suffix wrongfully interpreted as "0xb256".

This fix feels like a band-aid and a deeper fix should be implemented at the lexer level to properly parse b256 literals.

Here's a test summarizing the bug and validating the fix:

```sway
#[test]
fn test_b256_literal_suffix() {
    // 64 zeros followed by the b256 suffix
    // the lexer will wrongfully interpret this as a 68 long hex string with the suffix adding 2 extra bytes
    // in the literal_to_literal function we have to strip the suffix and reparse it to get the correct b256
    let foo = 0x0000000000000000000000000000000000000000000000000000000000000000b256;
    assert(foo == b256::zero());
    // 60 zeroes followed by 4 hex digits "b256"
    // the trailing b256 is not a suffix but the last 2 bytes of an hex literal ending with "0xb256": it must be 
    // preserved
    let bar = 0x000000000000000000000000000000000000000000000000000000000000b256;
    assert(bar.as_u256() == 0xb256);
    // this will not compile at the moment because the lexer will thow an InvalidIntSuffix error as b256 is not a
    // known suffix
    // let foo_bin = 0b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b256;
    // assert(foo_bin == b256::zero());
    // this is parsed correctly
    let bar_bin = 0b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001011001001010110;
    assert(bar_bin.as_u256() == 0xb256);
}
```

Closes #6727 

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
