### PR TITLE
Allow decimal/binary/octal u256 literals

### DIFF
--- a/sway-error/src/lex_error.rs
+++ b/sway-error/src/lex_error.rs
@@ -59,8 +59,6 @@ pub enum LexErrorKind {
     UnicodeTextDirInLiteral { position: usize, character: char },
     #[error("invalid escape code")]
     InvalidEscapeCode { position: usize },
-    #[error("invalid u256. Only hex literals are supported")]
-    U256NotInHex,
 }
 
 impl Spanned for LexError {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/u256/u256_only_hex_literal/Forc.lock
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/u256/u256_only_hex_literal/Forc.lock
@@ -1,8 +1,0 @@
-[[package]]
-name = "std"
-source = "path+from-root-C960D6DF73DB999C"
-
-[[package]]
-name = "u256_only_hex_literal"
-source = "member"
-dependencies = ["std"]

--- a/test/src/e2e_vm_tests/test_programs/should_fail/u256/u256_only_hex_literal/Forc.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/u256/u256_only_hex_literal/Forc.toml
@@ -1,8 +1,0 @@
-[project]
-authors = ["Fuel Labs <contact@fuel.sh>"]
-entry = "main.sw"
-license = "Apache-2.0"
-name = "u256_only_hex_literal"
-
-[dependencies]
-std = { path = "../../../../reduced_std_libs/sway-lib-std-assert" }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/u256/u256_only_hex_literal/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/u256/u256_only_hex_literal/src/main.sw
@@ -1,5 +1,0 @@
-script; 
-
-fn main() -> u256 {
-    1u256
-}

--- a/test/src/e2e_vm_tests/test_programs/should_fail/u256/u256_only_hex_literal/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/u256/u256_only_hex_literal/test.toml
@@ -1,4 +1,0 @@
-category = "fail"
-
-# check: $()error
-# check: $()invalid u256. Only hex literals are supported

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_operators/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_operators/src/main.sw
@@ -1,8 +1,23 @@
 library; 
 
 // returns 3
-fn literals() -> u256 {
+fn hex_literals() -> u256 {
     0x0000000000000000000000000000000000000000000000000000000000000001u256 + 0x0000000000000000000000000000000000000000000000000000000000000002u256
+}
+
+// returns 3
+fn oct_literals() -> u256 {
+    0o1u256 + 0o2u256
+}
+
+// returns 3
+fn bin_literals() -> u256 {
+    0b1u256 + 0b10u256
+}
+
+// returns 3
+fn literals() -> u256 {
+    1u256 + 2u256
 }
 
 // returns 1
@@ -118,6 +133,9 @@ fn comparison_operators() -> u256 {
 #[test]
 fn should_be_able_to_use_literals() {
     let result = 0x0000000000000000000000000000000000000000000000000000000000000003u256;
+    assert_eq(hex_literals(), result);
+    assert_eq(oct_literals(), result);
+    assert_eq(bin_literals(), result);
     assert_eq(literals(), result);
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_operators/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/u256/u256_operators/src/main.sw
@@ -1,23 +1,23 @@
 library; 
 
-// returns 3
+// returns 32
 fn hex_literals() -> u256 {
-    0x0000000000000000000000000000000000000000000000000000000000000001u256 + 0x0000000000000000000000000000000000000000000000000000000000000002u256
+    0x10u256 + 0x10u256
 }
 
-// returns 3
+// returns 32
 fn oct_literals() -> u256 {
-    0o1u256 + 0o2u256
+    0o20u256 + 0o20u256
 }
 
-// returns 3
+// returns 32
 fn bin_literals() -> u256 {
-    0b1u256 + 0b10u256
+    0b0001_0000u256 + 0b0001_0000u256
 }
 
-// returns 3
+// returns 32
 fn literals() -> u256 {
-    1u256 + 2u256
+    16u256 + 16u256
 }
 
 // returns 1
@@ -132,10 +132,13 @@ fn comparison_operators() -> u256 {
 
 #[test]
 fn should_be_able_to_use_literals() {
-    let result = 0x0000000000000000000000000000000000000000000000000000000000000003u256;
-    assert_eq(hex_literals(), result);
-    assert_eq(oct_literals(), result);
-    assert_eq(bin_literals(), result);
+    let hex_result = 0x20u256;
+    assert_eq(hex_literals(), hex_result);
+    let oct_result = 0o40u256;
+    assert_eq(oct_literals(), oct_result);
+    let bin_result = 0b0010_0000u256;
+    assert_eq(bin_literals(), bin_result);
+    let result = 32u256;
     assert_eq(literals(), result);
 }
 


### PR DESCRIPTION
## Description

This PR removes the constraint on `u256` literals being only expressed in hexadecimal.
The constraint has been removed and the code slightly refactored to remove the unnecessary `radix` variable in the `lex_int_lit` function in `token.rs`.
The corresponding error `LexErrorKind::U256NotInHex` has been removed from the codebasen as well as the `should_fail` test looking to raise this error.

The u256 testing suite has been augmented with additional tests to make sure we can express u256 literals in decimal, binary and octal.

Closes #5456 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
