### PR TITLE
Merge type and const generics

### DIFF
--- a/sway-core/src/abi_generation/abi_str.rs
+++ b/sway-core/src/abi_generation/abi_str.rs
@@ -1,4 +1,4 @@
-use sway_types::integer_bits::IntegerBits;
+use sway_types::{integer_bits::IntegerBits, Named};
 
 use crate::{language::CallPath, Engines, TypeArgument, TypeId, TypeInfo};
 
@@ -87,13 +87,12 @@ impl TypeInfo {
     pub fn abi_str(&self, ctx: &AbiStrContext, engines: &Engines, is_root: bool) -> String {
         use TypeInfo::*;
         let decl_engine = engines.de();
-        let type_engine = engines.te();
         match self {
             Unknown => "unknown".into(),
             Never => "never".into(),
             UnknownGeneric { name, .. } => name.to_string(),
             Placeholder(_) => "_".to_string(),
-            TypeParam(param) => format!("typeparam({})", param.name),
+            TypeParam(param) => format!("typeparam({})", param.name()),
             StringSlice => "str".into(),
             StringArray(length) => format!("str[{}]", length.val()),
             UnsignedInteger(x) => match x {
@@ -139,7 +138,7 @@ impl TypeInfo {
                         "<{}>",
                         decl.type_parameters
                             .iter()
-                            .map(|p| type_engine.get(p.type_id).abi_str(ctx, engines, false))
+                            .map(|p| p.abi_str(engines, ctx, false))
                             .collect::<Vec<_>>()
                             .join(",")
                     )
@@ -161,7 +160,7 @@ impl TypeInfo {
                         "<{}>",
                         decl.type_parameters
                             .iter()
-                            .map(|p| type_engine.get(p.type_id).abi_str(ctx, engines, false))
+                            .map(|p| p.abi_str(engines, ctx, false))
                             .collect::<Vec<_>>()
                             .join(",")
                     )

--- a/sway-core/src/abi_generation/evm_abi.rs
+++ b/sway-core/src/abi_generation/evm_abi.rs
@@ -1,4 +1,4 @@
-use sway_types::integer_bits::IntegerBits;
+use sway_types::{integer_bits::IntegerBits, Named};
 
 use crate::{
     asm_generation::EvmAbiResult,
@@ -69,7 +69,7 @@ pub fn abi_str(type_info: &TypeInfo, engines: &Engines) -> String {
         Never => "never".into(),
         UnknownGeneric { name, .. } => name.to_string(),
         Placeholder(_) => "_".to_string(),
-        TypeParam(param) => format!("typeparam({})", param.name),
+        TypeParam(param) => format!("typeparam({})", param.name()),
         StringSlice => "str".into(),
         StringArray(x) => format!("str[{}]", x.val()),
         UnsignedInteger(x) => match x {

--- a/sway-core/src/abi_generation/fuel_abi.rs
+++ b/sway-core/src/abi_generation/fuel_abi.rs
@@ -7,9 +7,10 @@ use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::Span;
 
 use crate::{
+    ast_elements::type_parameter::GenericTypeParameter,
     language::ty::{TyFunctionDecl, TyProgram, TyProgramKind},
     transform::Attributes,
-    Engines, TypeId, TypeInfo, TypeParameter,
+    Engines, TypeId, TypeInfo,
 };
 
 use super::abi_str::AbiStrContext;
@@ -591,8 +592,11 @@ impl TypeId {
                 .get_type_parameters(engines)
                 .map(|v| {
                     v.iter()
-                        .map(|v| {
-                            v.get_abi_type_parameter(
+                        .map(|p| {
+                            let p = p
+                                .as_type_parameter()
+                                .expect("only works with type parameters");
+                            p.get_abi_type_parameter(
                                 handler,
                                 ctx,
                                 engines,
@@ -854,6 +858,9 @@ impl TypeId {
                             .unwrap_or_default()
                             .iter(),
                     ) {
+                        let p = p
+                            .as_type_parameter()
+                            .expect("only works with type parameters");
                         generate_type_metadata_declaration(
                             handler,
                             ctx,
@@ -939,6 +946,9 @@ impl TypeId {
                 let resolved_params = resolved_params.unwrap_or_default();
 
                 for (v, p) in type_arguments.iter().zip(resolved_params.iter()) {
+                    let p = p
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
                     generate_type_metadata_declaration(
                         handler,
                         ctx,
@@ -955,6 +965,9 @@ impl TypeId {
                     .iter()
                     .zip(resolved_params.iter())
                     .map(|(arg, p)| {
+                        let p = p
+                            .as_type_parameter()
+                            .expect("only works with type parameters");
                         Ok(program_abi::TypeApplication {
                             name: "".to_string(),
                             type_id: program_abi::TypeId::Metadata(MetadataTypeId(
@@ -978,15 +991,18 @@ impl TypeId {
 
                 let mut new_metadata_types_to_add =
                     Vec::<program_abi::TypeMetadataDeclaration>::new();
-                for v in decl.type_parameters.iter() {
+                for p in decl.type_parameters.iter() {
+                    let p = p
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
                     generate_type_metadata_declaration(
                         handler,
                         ctx,
                         engines,
                         metadata_types,
                         concrete_types,
-                        v.type_id,
-                        v.type_id,
+                        p.type_id,
+                        p.type_id,
                         &mut new_metadata_types_to_add,
                     )?;
                 }
@@ -994,19 +1010,22 @@ impl TypeId {
                 let type_arguments = decl
                     .type_parameters
                     .iter()
-                    .map(|arg| {
+                    .map(|p| {
+                        let p = p
+                            .as_type_parameter()
+                            .expect("only works with type parameters");
                         Ok(program_abi::TypeApplication {
                             name: "".to_string(),
                             type_id: program_abi::TypeId::Metadata(MetadataTypeId(
-                                arg.type_id.index(),
+                                p.type_id.index(),
                             )),
-                            type_arguments: arg.type_id.get_abi_type_arguments(
+                            type_arguments: p.type_id.get_abi_type_arguments(
                                 handler,
                                 ctx,
                                 engines,
                                 metadata_types,
                                 concrete_types,
-                                arg.type_id,
+                                p.type_id,
                                 &mut new_metadata_types_to_add,
                             )?,
                         })
@@ -1026,15 +1045,18 @@ impl TypeId {
 
                 let mut new_metadata_types_to_add =
                     Vec::<program_abi::TypeMetadataDeclaration>::new();
-                for v in decl.type_parameters.iter() {
+                for p in decl.type_parameters.iter() {
+                    let p = p
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
                     generate_type_metadata_declaration(
                         handler,
                         ctx,
                         engines,
                         metadata_types,
                         concrete_types,
-                        v.type_id,
-                        v.type_id,
+                        p.type_id,
+                        p.type_id,
                         &mut new_metadata_types_to_add,
                     )?;
                 }
@@ -1042,19 +1064,22 @@ impl TypeId {
                 let type_arguments = decl
                     .type_parameters
                     .iter()
-                    .map(|arg| {
+                    .map(|p| {
+                        let p = p
+                            .as_type_parameter()
+                            .expect("only works with type parameters");
                         Ok(program_abi::TypeApplication {
                             name: "".to_string(),
                             type_id: program_abi::TypeId::Metadata(MetadataTypeId(
-                                arg.type_id.index(),
+                                p.type_id.index(),
                             )),
-                            type_arguments: arg.type_id.get_abi_type_arguments(
+                            type_arguments: p.type_id.get_abi_type_arguments(
                                 handler,
                                 ctx,
                                 engines,
                                 metadata_types,
                                 concrete_types,
-                                arg.type_id,
+                                p.type_id,
                                 &mut new_metadata_types_to_add,
                             )?,
                         })
@@ -1098,6 +1123,9 @@ impl TypeId {
                     .iter()
                     .zip(resolved_params.iter())
                     .map(|(arg, p)| {
+                        let p = p
+                            .as_type_parameter()
+                            .expect("only works with type parameters");
                         generate_concrete_type_declaration(
                             handler,
                             ctx,
@@ -1115,15 +1143,18 @@ impl TypeId {
                 Some(
                     decl.type_parameters
                         .iter()
-                        .map(|arg| {
+                        .map(|p| {
+                            let p = p
+                                .as_type_parameter()
+                                .expect("only works with type parameters");
                             generate_concrete_type_declaration(
                                 handler,
                                 ctx,
                                 engines,
                                 metadata_types,
                                 concrete_types,
-                                arg.type_id,
-                                arg.type_id,
+                                p.type_id,
+                                p.type_id,
                             )
                         })
                         .collect::<Result<Vec<_>, _>>()?,
@@ -1134,15 +1165,18 @@ impl TypeId {
                 Some(
                     decl.type_parameters
                         .iter()
-                        .map(|arg| {
+                        .map(|p| {
+                            let p = p
+                                .as_type_parameter()
+                                .expect("only works with type parameters");
                             generate_concrete_type_declaration(
                                 handler,
                                 ctx,
                                 engines,
                                 metadata_types,
                                 concrete_types,
-                                arg.type_id,
-                                arg.type_id,
+                                p.type_id,
+                                p.type_id,
                             )
                         })
                         .collect::<Result<Vec<_>, _>>()?,
@@ -1213,7 +1247,7 @@ fn generate_attributes(attributes: &Attributes) -> Option<Vec<program_abi::Attri
     }
 }
 
-impl TypeParameter {
+impl GenericTypeParameter {
     /// Returns the initial type ID of a TypeParameter. Also updates the provided list of types to
     /// append the current TypeParameter as a `program_abi::TypeMetadataDeclaration`.
     pub(self) fn get_abi_type_parameter(

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -925,9 +925,12 @@ fn get_struct_type_info_from_type_id(
     match type_info {
         TypeInfo::Enum(decl_ref) => {
             let decl = decl_engine.get_enum(&decl_ref);
-            for param in decl.type_parameters.iter() {
+            for p in decl.type_parameters.iter() {
+                let p = p
+                    .as_type_parameter()
+                    .expect("only works with type parameters");
                 if let Ok(Some(type_info)) =
-                    get_struct_type_info_from_type_id(type_engine, decl_engine, param.type_id)
+                    get_struct_type_info_from_type_id(type_engine, decl_engine, p.type_id)
                 {
                     return Ok(Some(type_info));
                 }
@@ -2501,8 +2504,11 @@ fn connect_type_id<'eng: 'cfg, 'cfg>(
             if let Some(enum_idx) = enum_idx.cloned() {
                 graph.add_edge(entry_node, enum_idx, "".into());
             }
-            for type_param in &decl.type_parameters {
-                connect_type_id(engines, type_param.type_id, graph, entry_node)?;
+            for p in &decl.type_parameters {
+                let p = p
+                    .as_type_parameter()
+                    .expect("only works with type parameters");
+                connect_type_id(engines, p.type_id, graph, entry_node)?;
             }
         }
         TypeInfo::Struct(decl_ref) => {
@@ -2511,8 +2517,11 @@ fn connect_type_id<'eng: 'cfg, 'cfg>(
             if let Some(struct_idx) = struct_idx.cloned() {
                 graph.add_edge(entry_node, struct_idx, "".into());
             }
-            for type_param in &decl.type_parameters {
-                connect_type_id(engines, type_param.type_id, graph, entry_node)?;
+            for p in &decl.type_parameters {
+                let p = p
+                    .as_type_parameter()
+                    .expect("only works with type parameters");
+                connect_type_id(engines, p.type_id, graph, entry_node)?;
             }
         }
         TypeInfo::Alias { name, .. } => {

--- a/sway-core/src/language/parsed/declaration/function.rs
+++ b/sway-core/src/language/parsed/declaration/function.rs
@@ -1,5 +1,4 @@
 use crate::{
-    ast_elements::type_parameter::ConstGenericParameter,
     engine_threading::*,
     language::{parsed::*, *},
     transform::{self, AttributeKind},
@@ -26,7 +25,6 @@ pub struct FunctionDeclaration {
     pub span: Span,
     pub return_type: TypeArgument,
     pub type_parameters: Vec<TypeParameter>,
-    pub const_generic_parameters: Vec<ConstGenericParameter>,
     pub where_clause: Vec<(Ident, Vec<TraitConstraint>)>,
     pub kind: FunctionDeclarationKind,
     pub implementing_type: Option<Declaration>,

--- a/sway-core/src/language/parsed/declaration/impl_trait.rs
+++ b/sway-core/src/language/parsed/declaration/impl_trait.rs
@@ -1,6 +1,4 @@
-use super::{
-    ConstGenericDeclaration, ConstantDeclaration, FunctionDeclaration, TraitTypeDeclaration,
-};
+use super::{ConstantDeclaration, FunctionDeclaration, TraitTypeDeclaration};
 use crate::{
     decl_engine::{parsed_id::ParsedDeclId, ParsedInterfaceDeclId},
     engine_threading::{
@@ -69,7 +67,6 @@ impl DebugWithEngines for ImplItem {
 pub struct ImplSelfOrTrait {
     pub is_self: bool,
     pub impl_type_parameters: Vec<TypeParameter>,
-    pub impl_const_generics_parameters: Vec<ParsedDeclId<ConstGenericDeclaration>>,
     pub trait_name: CallPath,
     pub trait_type_arguments: Vec<TypeArgument>,
     pub trait_decl_ref: Option<ParsedInterfaceDeclId>,

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     type_system::*,
 };
+use ast_elements::type_parameter::GenericTypeParameter;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -875,7 +876,7 @@ impl ReplaceDecls for TyExpressionVariant {
                     // Handle the trait constraints. This includes checking to see if the trait
                     // constraints are satisfied and replacing old decl ids based on the
                     let mut inner_decl_mapping =
-                        TypeParameter::gather_decl_mapping_from_trait_constraints(
+                        GenericTypeParameter::gather_decl_mapping_from_trait_constraints(
                             handler,
                             ctx.by_ref(),
                             &method.type_parameters,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/abi.rs
@@ -4,6 +4,7 @@ use sway_error::error::CompileError;
 use sway_types::{Ident, Named, Span, Spanned};
 
 use crate::{
+    ast_elements::type_parameter::GenericTypeParameter,
     decl_engine::{
         parsed_id::ParsedDeclId, DeclEngineGetParsedDeclId, DeclEngineInsert, DeclEngineInsertArc,
         DeclId,
@@ -14,7 +15,7 @@ use crate::{
         symbol_collection_context::SymbolCollectionContext, TypeCheckAnalysis,
         TypeCheckAnalysisContext, TypeCheckFinalization, TypeCheckFinalizationContext,
     },
-    Engines, TypeParameter,
+    Engines,
 };
 use sway_error::handler::{ErrorEmitted, Handler};
 
@@ -77,7 +78,7 @@ impl ty::TyAbiDecl {
 
         // The span of the `abi_decl` `name` points to the file (use site) in which
         // the ABI is getting declared, so we can use it as the `use_site_span`.
-        let self_type_param = TypeParameter::new_self_type(ctx.engines, name.span());
+        let self_type_param = GenericTypeParameter::new_self_type(ctx.engines, name.span());
         let self_type_id = self_type_param.type_id;
 
         let mod_path = ctx.namespace().current_mod_path().clone();

--- a/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use sway_error::handler::Handler;
 use sway_parse::Parse;
-use sway_types::{ProgramId, Spanned};
+use sway_types::{Named, ProgramId, Spanned};
 
 /// Contains all information needed to auto-implement code for a certain feature.
 pub struct AutoImplContext<'a, 'b, I>
@@ -86,7 +86,7 @@ where
         } else {
             format!(
                 "<{}>",
-                itertools::intersperse(type_parameters.iter().map(|x| { x.name.as_str() }), ", ")
+                itertools::intersperse(type_parameters.iter().map(|p| { p.name().as_str() }), ", ")
                     .collect::<String>()
             )
         }
@@ -100,13 +100,16 @@ where
     ) -> String {
         let mut code = String::new();
 
-        for t in type_parameters.iter() {
+        for p in type_parameters.iter() {
+            let p = p
+                .as_type_parameter()
+                .expect("only works with type parameters");
             code.push_str(&format!(
                 "{}: {},\n",
-                t.name.as_str(),
+                p.name.as_str(),
                 itertools::intersperse(
                     [extra_constraint].into_iter().chain(
-                        t.trait_constraints
+                        p.trait_constraints
                             .iter()
                             .map(|x| x.trait_name.suffix.as_str())
                     ),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/configurable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/configurable.rs
@@ -9,6 +9,7 @@ use sway_types::{style::is_screaming_snake_case, Spanned};
 use symbol_collection_context::SymbolCollectionContext;
 
 use crate::{
+    ast_elements::type_parameter::GenericTypeParameter,
     decl_engine::{
         parsed_id::ParsedDeclId, DeclEngineGetParsedDeclId, DeclEngineInsert, ReplaceDecls,
     },
@@ -136,7 +137,7 @@ impl ty::TyConfigurableDecl {
 
             let decode_fn_id = *decode_fn_ref.id();
             let mut decode_fn_decl = (*engines.de().get_function(&decode_fn_id)).clone();
-            let decl_mapping = crate::TypeParameter::gather_decl_mapping_from_trait_constraints(
+            let decl_mapping = GenericTypeParameter::gather_decl_mapping_from_trait_constraints(
                 handler,
                 ctx.by_ref(),
                 &decode_fn_decl.type_parameters,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -5,6 +5,7 @@ use crate::{
     type_system::*,
     Engines,
 };
+use ast_elements::type_parameter::GenericTypeParameter;
 use sway_error::handler::{ErrorEmitted, Handler};
 use symbol_collection_context::SymbolCollectionContext;
 
@@ -44,7 +45,7 @@ impl ty::TyEnumDecl {
         // create a namespace for the decl, used to create a scope for generics
         ctx.scoped(handler, Some(span.clone()), |ctx| {
             // Type check the type parameters.
-            let new_type_parameters = TypeParameter::type_check_type_params(
+            let new_type_parameters = GenericTypeParameter::type_check_type_params(
                 handler,
                 ctx.by_ref(),
                 type_parameters,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -215,7 +215,7 @@ impl ty::TyFunctionDecl {
                 for p in type_parameters.iter().filter_map(|x| x.as_type_parameter()) {
                     p.insert_into_namespace_self(handler, ctx.by_ref())?;
                 }
-                for p in type_parameters.into_iter().filter_map(|x| x.as_type_parameter()) {
+                for p in type_parameters.iter().filter_map(|x| x.as_type_parameter()) {
                     p.insert_into_namespace_constraints(handler, ctx.by_ref())?;
                 }
 
@@ -340,7 +340,6 @@ fn test_function_selector_behavior() {
         attributes: Default::default(),
         return_type: TypeId::from(0).into(),
         type_parameters: vec![],
-        const_generic_parameters: vec![],
         visibility: Visibility::Public,
         is_contract_call: false,
         where_clause: vec![],
@@ -392,7 +391,6 @@ fn test_function_selector_behavior() {
         attributes: Default::default(),
         return_type: TypeId::from(0).into(),
         type_parameters: vec![],
-        const_generic_parameters: vec![],
         visibility: Visibility::Public,
         is_contract_call: false,
         where_clause: vec![],

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -1,5 +1,6 @@
 mod function_parameter;
 
+use ast_elements::type_parameter::GenericTypeParameter;
 use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
@@ -106,13 +107,12 @@ impl ty::TyFunctionDecl {
             .disallow_functions()
             .scoped(handler, Some(span.clone()), |ctx| {
                 // Type check the type parameters.
-                let new_type_parameters = TypeParameter::type_check_type_params(
+                let new_type_parameters = GenericTypeParameter::type_check_type_params(
                     handler,
                     ctx.by_ref(),
                     type_parameters.clone(),
                     None,
                 )?;
-                let new_const_generic_parameters = fn_decl.const_generic_parameters.clone();
 
                 // type check the function parameters, which will also insert them into the namespace
                 let mut new_parameters = vec![];
@@ -172,7 +172,6 @@ impl ty::TyFunctionDecl {
                     attributes: attributes.clone(),
                     return_type,
                     type_parameters: new_type_parameters,
-                    const_generic_parameters: new_const_generic_parameters,
                     visibility,
                     is_contract_call,
                     purity: *purity,
@@ -213,10 +212,10 @@ impl ty::TyFunctionDecl {
 
                 // Insert the previously type checked type parameters into the current namespace.
                 // We insert all type parameter before the constraints because some constraints may depend on the parameters.
-                for p in type_parameters.iter() {
+                for p in type_parameters.iter().filter_map(|x| x.as_type_parameter()) {
                     p.insert_into_namespace_self(handler, ctx.by_ref())?;
                 }
-                for p in type_parameters {
+                for p in type_parameters.into_iter().filter_map(|x| x.as_type_parameter()) {
                     p.insert_into_namespace_constraints(handler, ctx.by_ref())?;
                 }
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -174,7 +174,7 @@ impl TyImplSelfOrTrait {
                             return_type: const_generic_decl.ty,
                             value: None,
                         },
-                        Some(&const_generic_decl_id),
+                        Some(const_generic_decl_id),
                     );
 
                     ctx.insert_symbol(

--- a/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
@@ -5,6 +5,7 @@ use crate::{
     type_system::*,
     Engines,
 };
+use ast_elements::type_parameter::GenericTypeParameter;
 use sway_error::handler::{ErrorEmitted, Handler};
 use symbol_collection_context::SymbolCollectionContext;
 
@@ -47,7 +48,7 @@ impl ty::TyStructDecl {
         // create a namespace for the decl, used to create a scope for generics
         ctx.scoped(handler, Some(span.clone()), |ctx| {
             // Type check the type parameters.
-            let new_type_parameters = TypeParameter::type_check_type_params(
+            let new_type_parameters = GenericTypeParameter::type_check_type_params(
                 handler,
                 ctx.by_ref(),
                 type_parameters,

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+use ast_elements::type_parameter::GenericTypeParameter;
 use parsed_id::ParsedDeclId;
 use sway_error::{
     error::CompileError,
@@ -99,14 +100,14 @@ impl TyTraitDecl {
         // Create a new type parameter for the self type.
         // The span of the `trait_decl` `name` points to the file (use site) in which
         // the trait is getting declared, so we can use it as the `use_site_span`.
-        let self_type_param = TypeParameter::new_self_type(engines, name.span());
+        let self_type_param = GenericTypeParameter::new_self_type(engines, name.span());
         let self_type = self_type_param.type_id;
 
         // A temporary namespace for checking within the trait's scope.
         ctx.with_self_type(Some(self_type))
             .scoped(handler, Some(span.clone()), |ctx| {
                 // Type check the type parameters.
-                let new_type_parameters = TypeParameter::type_check_type_params(
+                let new_type_parameters = GenericTypeParameter::type_check_type_params(
                     handler,
                     ctx.by_ref(),
                     type_parameters,
@@ -265,7 +266,7 @@ impl TyTraitDecl {
                 let typed_trait_decl = ty::TyTraitDecl {
                     name: name.clone(),
                     type_parameters: new_type_parameters,
-                    self_type: self_type_param,
+                    self_type: TypeParameter::Type(self_type_param),
                     interface_surface: new_interface_surface,
                     items: new_items,
                     supertraits,
@@ -391,12 +392,14 @@ impl TyTraitDecl {
         let type_mapping = TypeSubstMap::from_type_parameters_and_type_arguments(
             type_parameters
                 .iter()
-                .map(|type_param| type_param.type_id)
+                .map(|t| {
+                    let t = t
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
+                    t.type_id
+                })
                 .collect(),
-            type_arguments
-                .iter()
-                .map(|type_arg| type_arg.type_id)
-                .collect(),
+            type_arguments.iter().map(|t| t.type_id).collect(),
         );
 
         for item in ctx
@@ -501,12 +504,14 @@ impl TyTraitDecl {
         let type_mapping = TypeSubstMap::from_type_parameters_and_type_arguments(
             type_parameters
                 .iter()
-                .map(|type_param| type_param.type_id)
+                .map(|t| {
+                    let t = t
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
+                    t.type_id
+                })
                 .collect(),
-            type_arguments
-                .iter()
-                .map(|type_arg| type_arg.type_id)
-                .collect(),
+            type_arguments.iter().map(|t| t.type_id).collect(),
         );
 
         let mut const_symbols = HashMap::<Ident, ty::TyDecl>::new();

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
@@ -124,7 +124,6 @@ impl ty::TyTraitFn {
             return_type: self.return_type.clone(),
             visibility: Visibility::Public,
             type_parameters: vec![],
-            const_generic_parameters: vec![],
             is_contract_call: matches!(abi_mode, AbiMode::ImplAbiFn(..)),
             where_clause: vec![],
             is_trait_method_dummy: true,

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use ast_elements::type_parameter::GenericTypeParameter;
 use itertools::Itertools;
 use sway_error::{
     error::{CompileError, StructFieldUsageContext},
@@ -50,9 +51,11 @@ impl TyScrutinee {
                     // are heavily used in code generation, e.g., to generate code for contract
                     // function selection in the `__entry` and sometimes the span does not point
                     // to a "_". But it is always in the code in which the match expression is.
-                    type_id: type_engine.new_placeholder(TypeParameter::new_placeholder(
-                        type_engine.new_unknown(),
-                        span.clone(),
+                    type_id: type_engine.new_placeholder(TypeParameter::Type(
+                        GenericTypeParameter::new_placeholder(
+                            type_engine.new_unknown(),
+                            span.clone(),
+                        ),
                     )),
                     span,
                 };

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     semantic_analysis::{ast_node::*, TypeCheckContext},
 };
+use ast_elements::type_parameter::GenericTypeParameter;
 use indexmap::IndexMap;
 use sway_error::error::CompileError;
 use sway_types::{IdentUnique, Spanned};
@@ -88,7 +89,7 @@ pub(crate) fn instantiate_function_application(
             // Handle the trait constraints. This includes checking to see if the trait
             // constraints are satisfied and replacing old decl ids based on the
             // constraint with new decl ids based on the new type.
-            let decl_mapping = TypeParameter::gather_decl_mapping_from_trait_constraints(
+            let decl_mapping = GenericTypeParameter::gather_decl_mapping_from_trait_constraints(
                 handler,
                 ctx.by_ref(),
                 &function_decl.type_parameters,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/method_application.rs
@@ -734,7 +734,7 @@ pub(crate) fn type_check_method_application(
                 // This will subst inner method_application placeholders with the already resolved
                 // current method application type parameter
                 for p in method.type_parameters.clone() {
-                    if names_type_ids.contains_key(&p.name()) {
+                    if names_type_ids.contains_key(p.name()) {
                         let type_id = p
                             .as_type_parameter()
                             .expect("only works with type parameters")

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -300,8 +300,11 @@ pub(crate) fn struct_instantiation(
         .scoped(handler, None, |scoped_ctx| {
             // Insert struct type parameter into namespace.
             // This is required so check_type_parameter_bounds can resolve generic trait type parameters.
-            for type_parameter in struct_decl.type_parameters.iter() {
-                type_parameter.insert_into_namespace_self(handler, scoped_ctx.by_ref())?;
+            for p in struct_decl.type_parameters.iter() {
+                let p = p
+                    .as_type_parameter()
+                    .expect("only works with type parameters");
+                p.insert_into_namespace_self(handler, scoped_ctx.by_ref())?;
             }
 
             type_id.check_type_parameter_bounds(handler, scoped_ctx.by_ref(), &span, None)?;

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -763,11 +763,12 @@ impl Dependencies {
     }
 
     fn gather_from_type_parameters(self, type_parameters: &[TypeParameter]) -> Self {
-        self.gather_from_iter(type_parameters.iter(), |deps, type_parameter| {
-            deps.gather_from_iter(
-                type_parameter.trait_constraints.iter(),
-                |deps, constraint| deps.gather_from_call_path(&constraint.trait_name, false, false),
-            )
+        self.gather_from_iter(type_parameters.iter(), |deps, p| match p {
+            TypeParameter::Type(p) => deps
+                .gather_from_iter(p.trait_constraints.iter(), |deps, constraint| {
+                    deps.gather_from_call_path(&constraint.trait_name, false, false)
+                }),
+            TypeParameter::Const(_) => deps,
         })
     }
 

--- a/sway-core/src/semantic_analysis/symbol_resolve.rs
+++ b/sway-core/src/semantic_analysis/symbol_resolve.rs
@@ -402,9 +402,13 @@ impl ResolveSymbols for TypeArgument {
 
 impl ResolveSymbols for TypeParameter {
     fn resolve_symbols(&mut self, handler: &Handler, mut ctx: SymbolResolveContext) {
-        self.trait_constraints
-            .iter_mut()
-            .for_each(|tc| tc.resolve_symbols(handler, ctx.by_ref()));
+        match self {
+            TypeParameter::Type(p) => p
+                .trait_constraints
+                .iter_mut()
+                .for_each(|tc| tc.resolve_symbols(handler, ctx.by_ref())),
+            TypeParameter::Const(_) => todo!(),
+        }
     }
 }
 

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -1303,11 +1303,13 @@ impl<'a> TypeCheckContext<'a> {
 
         // Use trait name with full path, improves consistency between
         // this inserting and getting in `get_methods_for_type_and_trait_name`.
-        impl_type_parameters.iter_mut().for_each(|tp| {
-            tp.trait_constraints.iter_mut().for_each(|tc| {
-                tc.trait_name = tc.trait_name.to_fullpath(self.engines(), self.namespace())
-            })
-        });
+        for tc in impl_type_parameters
+            .iter_mut()
+            .filter_map(|x| x.as_type_parameter_mut())
+            .flat_map(|x| x.trait_constraints.iter_mut())
+        {
+            tc.trait_name = tc.trait_name.to_fullpath(self.engines(), self.namespace())
+        }
 
         let impl_type_parameters_ids = impl_type_parameters
             .iter()

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -11,7 +11,7 @@ use crate::{
     type_system::*,
     BuildTarget, Engines,
 };
-use either::Either;
+use ast_elements::type_parameter::GenericTypeParameter;
 use itertools::Itertools;
 use sway_ast::{
     assignable::ElementAccess,
@@ -417,7 +417,7 @@ fn item_struct_to_struct_declaration(
         Ok(())
     })?;
 
-    let (type_parameters, _) = generic_params_opt_to_type_parameters(
+    let generic_parameters = generic_params_opt_to_type_parameters(
         context,
         handler,
         engines,
@@ -428,7 +428,7 @@ fn item_struct_to_struct_declaration(
         name: item_struct.name,
         attributes,
         fields,
-        type_parameters,
+        type_parameters: generic_parameters,
         visibility: pub_token_opt_to_visibility(item_struct.visibility),
         span,
     });
@@ -500,7 +500,7 @@ fn item_enum_to_enum_declaration(
         Ok(())
     })?;
 
-    let (type_parameters, _) = generic_params_opt_to_type_parameters(
+    let type_parameters = generic_params_opt_to_type_parameters(
         context,
         handler,
         engines,
@@ -552,16 +552,15 @@ pub fn item_fn_to_function_declaration(
     let kind = override_kind.unwrap_or(kind);
     let implementing_type = context.implementing_type.clone();
 
-    let (type_parameters, const_generic_parameters) =
-        generic_params_opt_to_type_parameters_with_parent(
-            context,
-            handler,
-            engines,
-            item_fn.fn_signature.generics,
-            parent_generic_params_opt,
-            item_fn.fn_signature.where_clause_opt.clone(),
-            parent_where_clause_opt,
-        )?;
+    let generic_parameters = generic_params_opt_to_type_parameters_with_parent(
+        context,
+        handler,
+        engines,
+        item_fn.fn_signature.generics,
+        parent_generic_params_opt,
+        item_fn.fn_signature.where_clause_opt.clone(),
+        parent_where_clause_opt,
+    )?;
 
     let fn_decl = FunctionDeclaration {
         purity: attributes.purity(),
@@ -577,8 +576,7 @@ pub fn item_fn_to_function_declaration(
         )?,
         span,
         return_type,
-        type_parameters,
-        const_generic_parameters,
+        type_parameters: generic_parameters,
         where_clause: item_fn
             .fn_signature
             .where_clause_opt
@@ -620,7 +618,7 @@ fn item_trait_to_trait_declaration(
     attributes: Attributes,
 ) -> Result<ParsedDeclId<TraitDeclaration>, ErrorEmitted> {
     let span = item_trait.span();
-    let (type_parameters, _) = generic_params_opt_to_type_parameters(
+    let type_parameters = generic_params_opt_to_type_parameters(
         context,
         handler,
         engines,
@@ -782,25 +780,26 @@ pub fn item_impl_to_declaration(
         .filter_map_ok(|item| item)
         .collect::<Result<_, _>>()?;
 
-    let (impl_type_parameters, impl_const_generics_parameters) =
-        generic_params_opt_to_type_parameters(
-            context,
-            handler,
-            engines,
-            item_impl.generic_params_opt,
-            item_impl.where_clause_opt,
-        )?;
+    let mut impl_type_parameters = generic_params_opt_to_type_parameters(
+        context,
+        handler,
+        engines,
+        item_impl.generic_params_opt,
+        item_impl.where_clause_opt,
+    )?;
 
-    let impl_const_generics_parameters = impl_const_generics_parameters
-        .iter()
-        .map(|param| {
-            engines.pe().insert(ConstGenericDeclaration {
-                name: param.name.clone(),
-                ty: param.ty,
-                span: param.span.clone(),
-            })
-        })
-        .collect::<Vec<_>>();
+    for p in impl_type_parameters.iter_mut() {
+        match p {
+            TypeParameter::Type(_) => {}
+            TypeParameter::Const(p) => {
+                p.id = Some(engines.pe().insert(ConstGenericDeclaration {
+                    name: p.name.clone(),
+                    ty: p.ty,
+                    span: p.span.clone(),
+                }));
+            }
+        }
+    }
 
     match item_impl.trait_opt {
         Some((path_type, _)) => {
@@ -809,7 +808,6 @@ pub fn item_impl_to_declaration(
             let impl_trait = ImplSelfOrTrait {
                 is_self: false,
                 impl_type_parameters,
-                impl_const_generics_parameters,
                 trait_name: trait_name.to_call_path(handler)?,
                 trait_type_arguments,
                 trait_decl_ref: None,
@@ -835,7 +833,6 @@ pub fn item_impl_to_declaration(
                     trait_type_arguments: vec![],
                     implementing_for,
                     impl_type_parameters,
-                    impl_const_generics_parameters,
                     items,
                     block_span,
                 };
@@ -1283,7 +1280,7 @@ fn generic_params_opt_to_type_parameters(
     engines: &Engines,
     generic_params_opt: Option<GenericParams>,
     where_clause_opt: Option<WhereClause>,
-) -> Result<(Vec<TypeParameter>, Vec<ConstGenericParameter>), ErrorEmitted> {
+) -> Result<Vec<TypeParameter>, ErrorEmitted> {
     generic_params_opt_to_type_parameters_with_parent(
         context,
         handler,
@@ -1303,7 +1300,7 @@ fn generic_params_opt_to_type_parameters_with_parent(
     parent_generic_params_opt: Option<GenericParams>,
     where_clause_opt: Option<WhereClause>,
     parent_where_clause_opt: Option<WhereClause>,
-) -> Result<(Vec<TypeParameter>, Vec<ConstGenericParameter>), ErrorEmitted> {
+) -> Result<Vec<TypeParameter>, ErrorEmitted> {
     let type_engine = engines.te();
 
     let trait_constraints = match where_clause_opt {
@@ -1330,11 +1327,11 @@ fn generic_params_opt_to_type_parameters_with_parent(
             .parameters
             .into_inner()
             .into_iter()
-            .partition_map(|param| {
+            .map(|param| {
                 match param {
                     GenericParam::Trait { ident } => {
                         let custom_type = type_engine.new_custom_from_name(engines, ident.clone());
-                        Either::Left(TypeParameter {
+                        TypeParameter::Type(GenericTypeParameter {
                             type_id: custom_type,
                             initial_type_id: custom_type,
                             name: ident,
@@ -1353,41 +1350,50 @@ fn generic_params_opt_to_type_parameters_with_parent(
                                     .error_because_is_disabled(&ident.span()),
                             );
                         }
-                        Either::Right(ConstGenericParameter {
+                        TypeParameter::Const(ConstGenericParameter {
                             span: ident.span().clone(),
                             name: ident,
                             ty: type_engine.id_of_u64(),
                             is_from_parent,
+                            id: None,
                         })
                     }
                 }
-            }),
-        None => (vec![], vec![]),
+            })
+            .collect(),
+        None => vec![],
     };
 
-    let (mut trait_params, mut const_generic_params) =
-        generics_to_params(generic_params_opt, false);
-    let (trait_parent_params, mut const_generic_parent_params) =
-        generics_to_params(parent_generic_params_opt, true);
-
-    const_generic_params.append(&mut const_generic_parent_params);
+    let mut params = generics_to_params(generic_params_opt, false);
+    let parent_params = generics_to_params(parent_generic_params_opt, true);
+    params.extend(
+        parent_params
+            .iter()
+            .filter(|x| x.as_const_parameter().is_some())
+            .cloned(),
+    );
 
     let mut errors = Vec::new();
     for (ty_name, bounds) in trait_constraints
         .into_iter()
         .chain(parent_trait_constraints)
     {
-        let param_to_edit = if let Some(o) = trait_params
+        let param_to_edit = if let Some(o) = params
             .iter_mut()
-            .find(|TypeParameter { name, .. }| name.as_str() == ty_name.as_str())
+            .filter_map(|x| x.as_type_parameter_mut())
+            .find(|GenericTypeParameter { name, .. }| name.as_str() == ty_name.as_str())
         {
             o
-        } else if let Some(o2) = trait_parent_params
-            .iter()
-            .find(|TypeParameter { name, .. }| name.as_str() == ty_name.as_str())
-        {
-            trait_params.push(o2.clone());
-            trait_params.last_mut().unwrap()
+        } else if let Some(o2) = parent_params.iter().find(|t| match t {
+            TypeParameter::Type(p) => p.name.as_str() == ty_name.as_str(),
+            TypeParameter::Const(_) => false,
+        }) {
+            params.push(o2.clone());
+            params
+                .last_mut()
+                .unwrap()
+                .as_type_parameter_mut()
+                .expect("must be type parameter")
         } else {
             errors.push(ConvertParseTreeError::ConstrainedNonExistentType {
                 ty_name: ty_name.clone(),
@@ -1397,7 +1403,6 @@ fn generic_params_opt_to_type_parameters_with_parent(
         };
 
         param_to_edit.trait_constraints_span = Span::join(ty_name.span(), &bounds.span());
-
         param_to_edit
             .trait_constraints
             .extend(traits_to_trait_constraints(
@@ -1408,7 +1413,7 @@ fn generic_params_opt_to_type_parameters_with_parent(
         return Err(errors);
     }
 
-    Ok((trait_params, const_generic_params))
+    Ok(params)
 }
 
 fn pub_token_opt_to_visibility(pub_token_opt: Option<PubToken>) -> Visibility {
@@ -4110,9 +4115,11 @@ fn statement_let_to_ast_nodes_unfold(
                             // The first `pat.span()` will point to "a", while the second one will indeed point to "_".
                             // However, their `pat.span()`s will always be in the source file in which the placeholder
                             // is logically situated.
-                            engines.te().new_placeholder(TypeParameter::new_placeholder(
-                                engines.te().new_unknown(),
-                                pat.span(),
+                            engines.te().new_placeholder(TypeParameter::Type(
+                                GenericTypeParameter::new_placeholder(
+                                    engines.te().new_unknown(),
+                                    pat.span(),
+                                ),
                             ))
                         })
                         .collect(),
@@ -4441,14 +4448,14 @@ fn ty_to_type_parameter(
         Ty::Path(path_type) => path_type_to_ident(context, handler, path_type)?,
         Ty::Infer { underscore_token } => {
             let unknown_type = type_engine.new_unknown();
-            return Ok(TypeParameter {
+            return Ok(TypeParameter::Type(GenericTypeParameter {
                 type_id: unknown_type,
                 initial_type_id: unknown_type,
                 name: underscore_token.into(),
                 trait_constraints: Vec::default(),
                 trait_constraints_span: Span::dummy(),
                 is_from_parent: false,
-            });
+            }));
         }
         Ty::Tuple(..) => panic!("tuple types are not allowed in this position"),
         Ty::Array(..) => panic!("array types are not allowed in this position"),
@@ -4460,14 +4467,14 @@ fn ty_to_type_parameter(
         Ty::Never { .. } => panic!("never types are not allowed in this position"),
     };
     let custom_type = type_engine.new_custom_from_name(engines, name.clone());
-    Ok(TypeParameter {
+    Ok(TypeParameter::Type(GenericTypeParameter {
         type_id: custom_type,
         initial_type_id: custom_type,
         name,
         trait_constraints: Vec::new(),
         trait_constraints_span: Span::dummy(),
         is_from_parent: false,
-    })
+    }))
 }
 
 fn path_type_to_ident(

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -144,12 +144,15 @@ impl DebugWithEngines for TypeArgument {
 }
 
 impl From<&TypeParameter> for TypeArgument {
-    fn from(type_param: &TypeParameter) -> Self {
-        TypeArgument {
-            type_id: type_param.type_id,
-            initial_type_id: type_param.initial_type_id,
-            span: type_param.name.span(),
-            call_path_tree: None,
+    fn from(p: &TypeParameter) -> Self {
+        match p {
+            TypeParameter::Type(p) => TypeArgument {
+                type_id: p.type_id,
+                initial_type_id: p.initial_type_id,
+                span: p.name.span(),
+                call_path_tree: None,
+            },
+            TypeParameter::Const(_) => todo!(),
         }
     }
 }

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -94,14 +94,14 @@ impl DebugWithEngines for TypeParameter {
 }
 
 impl TypeParameter {
-    pub(crate) fn as_type_parameter(&self) -> Option<&GenericTypeParameter> {
+    pub fn as_type_parameter(&self) -> Option<&GenericTypeParameter> {
         match self {
             TypeParameter::Type(p) => Some(p),
             TypeParameter::Const(_) => None,
         }
     }
 
-    pub(crate) fn as_type_parameter_mut(&mut self) -> Option<&mut GenericTypeParameter> {
+    pub fn as_type_parameter_mut(&mut self) -> Option<&mut GenericTypeParameter> {
         match self {
             TypeParameter::Type(p) => Some(p),
             TypeParameter::Const(_) => None,
@@ -115,7 +115,7 @@ impl TypeParameter {
         }
     }
 
-    pub(crate) fn as_const_parameter(&self) -> Option<&ConstGenericParameter> {
+    pub fn as_const_parameter(&self) -> Option<&ConstGenericParameter> {
         match self {
             TypeParameter::Type(_) => None,
             TypeParameter::Const(p) => Some(p),

--- a/sway-core/src/type_system/id.rs
+++ b/sway-core/src/type_system/id.rs
@@ -5,7 +5,7 @@ use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
 };
-use sway_types::{BaseIdent, Span};
+use sway_types::{BaseIdent, Named, Span};
 
 use crate::{
     decl_engine::{DeclEngineGet, MaterializeConstGenerics},
@@ -82,7 +82,7 @@ impl CollectTypesMetadata for TypeId {
                 }
                 TypeInfo::Placeholder(type_param) => {
                     res.push(TypeMetadata::UnresolvedType(
-                        type_param.name.clone(),
+                        type_param.name().clone(),
                         ctx.call_site_get(self),
                     ));
                 }
@@ -273,6 +273,12 @@ impl TypeId {
                     .iter()
                     .zip(orig_enum_decl.type_parameters.iter())
                 {
+                    let orig_type_param = orig_type_param
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
+                    let type_param = type_param
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
                     type_parameters.push((type_param.type_id, orig_type_param.type_id));
                     type_param.type_id.extract_type_parameters(
                         engines,
@@ -294,6 +300,12 @@ impl TypeId {
                     .iter()
                     .zip(orig_struct_decl.type_parameters.iter())
                 {
+                    let orig_type_param = orig_type_param
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
+                    let type_param = type_param
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
                     type_parameters.push((type_param.type_id, orig_type_param.type_id));
                     type_param.type_id.extract_type_parameters(
                         engines,
@@ -315,6 +327,12 @@ impl TypeId {
                     .iter()
                     .zip(orig_enum_decl.type_parameters.iter())
                 {
+                    let orig_type_param = orig_type_param
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
+                    let type_param = type_param
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
                     type_parameters.push((type_param.type_id, orig_type_param.type_id));
                     type_param.type_id.extract_type_parameters(
                         engines,
@@ -336,6 +354,12 @@ impl TypeId {
                     .iter()
                     .zip(orig_struct_decl.type_parameters.iter())
                 {
+                    let orig_type_param = orig_type_param
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
+                    let type_param = type_param
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
                     type_parameters.push((type_param.type_id, orig_type_param.type_id));
                     type_param.type_id.extract_type_parameters(
                         engines,
@@ -513,6 +537,9 @@ impl TypeId {
             TypeInfo::UntypedEnum(decl_id) => {
                 let enum_decl = engines.pe().get_enum(decl_id);
                 for type_param in &enum_decl.type_parameters {
+                    let type_param = type_param
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
                     extend(
                         &mut found,
                         type_param.type_id.extract_any_including_self(
@@ -538,6 +565,9 @@ impl TypeId {
             TypeInfo::UntypedStruct(decl_id) => {
                 let struct_decl = engines.pe().get_struct(decl_id);
                 for type_param in &struct_decl.type_parameters {
+                    let type_param = type_param
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
                     extend(
                         &mut found,
                         type_param.type_id.extract_any_including_self(
@@ -563,6 +593,9 @@ impl TypeId {
             TypeInfo::Enum(enum_ref) => {
                 let enum_decl = decl_engine.get_enum(enum_ref);
                 for type_param in &enum_decl.type_parameters {
+                    let type_param = type_param
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
                     extend(
                         &mut found,
                         type_param.type_id.extract_any_including_self(
@@ -588,6 +621,9 @@ impl TypeId {
             TypeInfo::Struct(struct_id) => {
                 let struct_decl = decl_engine.get_struct(struct_id);
                 for type_param in &struct_decl.type_parameters {
+                    let type_param = type_param
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
                     extend(
                         &mut found,
                         type_param.type_id.extract_any_including_self(
@@ -840,8 +876,11 @@ impl TypeId {
         let mut structure_generics = self.extract_inner_types_with_trait_constraints(engines);
 
         if let Some(type_param) = type_param {
-            if !type_param.trait_constraints.is_empty() {
-                structure_generics.insert(self, type_param.trait_constraints);
+            match type_param {
+                TypeParameter::Type(p) => {
+                    structure_generics.insert(self, p.trait_constraints);
+                }
+                TypeParameter::Const(_) => todo!(),
             }
         }
 

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -23,7 +23,7 @@ use sway_error::{
     error::{CompileError, InvalidImplementingForType},
     handler::{ErrorEmitted, Handler},
 };
-use sway_types::{integer_bits::IntegerBits, span::Span};
+use sway_types::{integer_bits::IntegerBits, span::Span, Named};
 
 use super::ast_elements::length::NumericLength;
 
@@ -544,8 +544,8 @@ impl DisplayWithEngines for TypeInfo {
             Unknown => "{unknown}".into(),
             Never => "!".into(),
             UnknownGeneric { name, .. } => name.to_string(),
-            Placeholder(type_param) => type_param.name.to_string(),
-            TypeParam(param) => format!("{}", param.name),
+            Placeholder(type_param) => type_param.name().to_string(),
+            TypeParam(param) => format!("{}", param.name()),
             StringSlice => "str".into(),
             StringArray(x) => format!("str[{}]", x.val()),
             UnsignedInteger(x) => match x {
@@ -577,7 +577,12 @@ impl DisplayWithEngines for TypeInfo {
                 print_inner_types(
                     engines,
                     decl.name.as_str(),
-                    decl.type_parameters.iter().map(|x| x.type_id),
+                    decl.type_parameters.iter().map(|x| {
+                        let x = x
+                            .as_type_parameter()
+                            .expect("only works with type parameters");
+                        x.type_id
+                    }),
                 )
             }
             UntypedStruct(decl_id) => {
@@ -585,7 +590,12 @@ impl DisplayWithEngines for TypeInfo {
                 print_inner_types(
                     engines,
                     decl.name.as_str(),
-                    decl.type_parameters.iter().map(|x| x.type_id),
+                    decl.type_parameters.iter().map(|x| {
+                        let x = x
+                            .as_type_parameter()
+                            .expect("only works with type parameters");
+                        x.type_id
+                    }),
                 )
             }
             Enum(decl_ref) => {
@@ -593,7 +603,12 @@ impl DisplayWithEngines for TypeInfo {
                 print_inner_types(
                     engines,
                     decl.call_path.suffix.as_str(),
-                    decl.type_parameters.iter().map(|x| x.type_id),
+                    decl.type_parameters.iter().map(|x| {
+                        let x = x
+                            .as_type_parameter()
+                            .expect("only works with type parameters");
+                        x.type_id
+                    }),
                 )
             }
             Struct(decl_ref) => {
@@ -601,7 +616,12 @@ impl DisplayWithEngines for TypeInfo {
                 print_inner_types(
                     engines,
                     decl.call_path.suffix.as_str(),
-                    decl.type_parameters.iter().map(|x| x.type_id),
+                    decl.type_parameters.iter().map(|x| {
+                        let x = x
+                            .as_type_parameter()
+                            .expect("only works with type parameters");
+                        x.type_id
+                    }),
                 )
             }
             ContractCaller { abi_name, .. } => format!("ContractCaller<{abi_name}>"),
@@ -663,7 +683,7 @@ impl DebugWithEngines for TypeInfo {
                 }
             }
             Placeholder(t) => format!("placeholder({:?})", engines.help_out(t)),
-            TypeParam(param) => format!("typeparam({})", param.name),
+            TypeParam(param) => format!("typeparam({})", param.name()),
             StringSlice => "str".into(),
             StringArray(x) => format!("str[{}]", x.val()),
             UnsignedInteger(x) => match x {
@@ -711,7 +731,12 @@ impl DebugWithEngines for TypeInfo {
                 print_inner_types_debug(
                     engines,
                     decl.name.as_str(),
-                    decl.type_parameters.iter().map(|x| x.type_id),
+                    decl.type_parameters.iter().map(|x| {
+                        let x = x
+                            .as_type_parameter()
+                            .expect("only works with type parameter");
+                        x.type_id
+                    }),
                 )
             }
             UntypedStruct(decl_id) => {
@@ -719,7 +744,12 @@ impl DebugWithEngines for TypeInfo {
                 print_inner_types_debug(
                     engines,
                     decl.name.as_str(),
-                    decl.type_parameters.iter().map(|x| x.type_id),
+                    decl.type_parameters.iter().map(|x| {
+                        let x = x
+                            .as_type_parameter()
+                            .expect("only works with type parameter");
+                        x.type_id
+                    }),
                 )
             }
             Enum(decl_ref) => {
@@ -727,7 +757,12 @@ impl DebugWithEngines for TypeInfo {
                 print_inner_types_debug(
                     engines,
                     decl.call_path.suffix.as_str(),
-                    decl.type_parameters.iter().map(|x| x.type_id),
+                    decl.type_parameters.iter().map(|x| {
+                        let x = x
+                            .as_type_parameter()
+                            .expect("only works with type parameter");
+                        x.type_id
+                    }),
                 )
             }
             Struct(decl_ref) => {
@@ -735,7 +770,12 @@ impl DebugWithEngines for TypeInfo {
                 print_inner_types_debug(
                     engines,
                     decl.call_path.suffix.as_str(),
-                    decl.type_parameters.iter().map(|x| x.type_id),
+                    decl.type_parameters.iter().map(|x| {
+                        let x = x
+                            .as_type_parameter()
+                            .expect("only works with type parameter");
+                        x.type_id
+                    }),
                 )
             }
             ContractCaller { abi_name, address } => {
@@ -946,6 +986,9 @@ impl TypeInfo {
                         .type_parameters
                         .iter()
                         .map(|ty| {
+                            let ty = ty
+                                .as_type_parameter()
+                                .expect("only works with type parameters");
                             let ty = match type_engine.to_typeinfo(ty.type_id, error_msg_span) {
                                 Err(e) => return Err(handler.emit_err(e.into())),
                                 Ok(ty) => ty,
@@ -997,6 +1040,9 @@ impl TypeInfo {
                         .type_parameters
                         .iter()
                         .map(|ty| {
+                            let ty = ty
+                                .as_type_parameter()
+                                .expect("only works with type parameters");
                             let ty = match type_engine.to_typeinfo(ty.type_id, error_msg_span) {
                                 Err(e) => return Err(handler.emit_err(e.into())),
                                 Ok(ty) => ty,
@@ -1651,7 +1697,7 @@ impl TypeInfo {
             Never => "never".into(),
             UnknownGeneric { name, .. } => name.to_string(),
             Placeholder(_) => "_".to_string(),
-            TypeParam(param) => format!("typeparam({})", param.name),
+            TypeParam(param) => format!("typeparam({})", param.name()),
             StringSlice => "str".into(),
             StringArray(x) => format!("str[{}]", x.val()),
             UnsignedInteger(x) => match x {
@@ -1687,7 +1733,12 @@ impl TypeInfo {
                         "<{}>",
                         decl.type_parameters
                             .iter()
-                            .map(|p| p.type_id.get_type_str(engines))
+                            .map(|p| {
+                                let p = p
+                                    .as_type_parameter()
+                                    .expect("only works with type parameters");
+                                p.type_id.get_type_str(engines)
+                            })
                             .collect::<Vec<_>>()
                             .join(",")
                     )
@@ -1703,7 +1754,12 @@ impl TypeInfo {
                         "<{}>",
                         decl.type_parameters
                             .iter()
-                            .map(|p| p.type_id.get_type_str(engines))
+                            .map(|p| {
+                                let p = p
+                                    .as_type_parameter()
+                                    .expect("only works with type parameters");
+                                p.type_id.get_type_str(engines)
+                            })
                             .collect::<Vec<_>>()
                             .join(",")
                     )
@@ -1719,7 +1775,12 @@ impl TypeInfo {
                         "<{}>",
                         decl.type_parameters
                             .iter()
-                            .map(|p| p.type_id.get_type_str(engines))
+                            .map(|p| {
+                                let p = p
+                                    .as_type_parameter()
+                                    .expect("only works with type parameters");
+                                p.type_id.get_type_str(engines)
+                            })
                             .collect::<Vec<_>>()
                             .join(",")
                     )
@@ -1735,7 +1796,12 @@ impl TypeInfo {
                         "<{}>",
                         decl.type_parameters
                             .iter()
-                            .map(|p| p.type_id.get_type_str(engines))
+                            .map(|p| {
+                                let p = p
+                                    .as_type_parameter()
+                                    .expect("will only work with type parameters");
+                                p.type_id.get_type_str(engines)
+                            })
                             .collect::<Vec<_>>()
                             .join(",")
                     )

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -64,6 +64,7 @@ fn generic_enum_resolution() {
     use crate::{
         decl_engine::DeclEngineInsert, language::ty, span::Span, transform, Engines, Ident,
     };
+    use ast_elements::type_parameter::GenericTypeParameter;
 
     let engines = Engines::default();
 
@@ -81,22 +82,25 @@ fn generic_enum_resolution() {
         engines
             .te()
             .new_unknown_generic(generic_name.clone(), VecSet(vec![]), None, false);
-    let placeholder_type = engines.te().new_placeholder(TypeParameter {
-        type_id: generic_type,
-        initial_type_id: generic_type,
-        name: generic_name.clone(),
-        trait_constraints: vec![],
-        trait_constraints_span: sp.clone(),
-        is_from_parent: false,
-    });
-    let placeholder_type_param = TypeParameter {
+    let placeholder_type =
+        engines
+            .te()
+            .new_placeholder(TypeParameter::Type(GenericTypeParameter {
+                type_id: generic_type,
+                initial_type_id: generic_type,
+                name: generic_name.clone(),
+                trait_constraints: vec![],
+                trait_constraints_span: sp.clone(),
+                is_from_parent: false,
+            }));
+    let placeholder_type_param = TypeParameter::Type(GenericTypeParameter {
         type_id: placeholder_type,
         initial_type_id: placeholder_type,
         name: generic_name.clone(),
         trait_constraints: vec![],
         trait_constraints_span: sp.clone(),
         is_from_parent: false,
-    };
+    });
     let variant_types = vec![ty::TyEnumVariant {
         name: a_name.clone(),
         tag: 0,
@@ -143,14 +147,14 @@ fn generic_enum_resolution() {
         span: sp.clone(),
         attributes: transform::Attributes::default(),
     }];
-    let type_param = TypeParameter {
+    let type_param = TypeParameter::Type(GenericTypeParameter {
         type_id: boolean_type,
         initial_type_id: boolean_type,
         name: generic_name,
         trait_constraints: vec![],
         trait_constraints_span: sp.clone(),
         is_from_parent: false,
-    };
+    });
 
     let mut call_path: CallPath<BaseIdent> = result_name.into();
     call_path.callpath_type = CallPathType::Full;

--- a/sway-core/src/type_system/monomorphization.rs
+++ b/sway-core/src/type_system/monomorphization.rs
@@ -99,7 +99,12 @@ where
             let non_parent_type_params = value
                 .type_parameters()
                 .iter()
-                .filter(|x| !x.is_from_parent)
+                .filter(|x| {
+                    let x = x
+                        .as_type_parameter()
+                        .expect("only works with type parameters");
+                    !x.is_from_parent
+                })
                 .count()
                 - adjust_for_trait_decl;
 
@@ -139,7 +144,12 @@ where
                 value
                     .type_parameters()
                     .iter()
-                    .map(|type_param| type_param.type_id)
+                    .map(|type_param| {
+                        let type_param = type_param
+                            .as_type_parameter()
+                            .expect("only works with type parameters");
+                        type_param.type_id
+                    })
                     .collect(),
                 type_arguments
                     .iter()

--- a/sway-core/src/type_system/substitute/subst_map.rs
+++ b/sway-core/src/type_system/substitute/subst_map.rs
@@ -86,14 +86,15 @@ impl TypeSubstMap {
         let type_engine = engines.te();
         let mapping = type_parameters
             .iter()
-            .filter(|type_param| {
-                let type_info = type_engine.get(type_param.type_id);
+            .filter_map(|p| p.as_type_parameter())
+            .filter(|p| {
+                let type_info = type_engine.get(p.type_id);
                 !matches!(*type_info, TypeInfo::Placeholder(_))
             })
-            .map(|type_param| {
+            .map(|p| {
                 (
-                    type_param.type_id,
-                    type_engine.new_placeholder(type_param.clone()),
+                    p.type_id,
+                    type_engine.new_placeholder(TypeParameter::Type(p.clone())),
                 )
             })
             .collect();
@@ -194,12 +195,22 @@ impl TypeSubstMap {
                 let type_parameters = decl_params
                     .type_parameters
                     .iter()
-                    .map(|x| x.type_id)
+                    .map(|x| {
+                        let x = x
+                            .as_type_parameter()
+                            .expect("will only work with type parameters");
+                        x.type_id
+                    })
                     .collect::<Vec<_>>();
                 let type_arguments = decl_args
                     .type_parameters
                     .iter()
-                    .map(|x| x.type_id)
+                    .map(|x| {
+                        let x = x
+                            .as_type_parameter()
+                            .expect("will only work with type parameters");
+                        x.type_id
+                    })
                     .collect::<Vec<_>>();
                 TypeSubstMap::from_superset_and_subset_helper(
                     engines,
@@ -214,12 +225,22 @@ impl TypeSubstMap {
                 let type_parameters = decl_params
                     .type_parameters
                     .iter()
-                    .map(|x| x.type_id)
+                    .map(|x| {
+                        let x = x
+                            .as_type_parameter()
+                            .expect("only works with type parameters");
+                        x.type_id
+                    })
                     .collect::<Vec<_>>();
                 let type_arguments = decl_args
                     .type_parameters
                     .iter()
-                    .map(|x| x.type_id)
+                    .map(|x| {
+                        let x = x
+                            .as_type_parameter()
+                            .expect("only works with type parameters");
+                        x.type_id
+                    })
                     .collect::<Vec<_>>();
                 TypeSubstMap::from_superset_and_subset_helper(
                     engines,
@@ -377,6 +398,9 @@ impl TypeSubstMap {
                 }
 
                 for type_param in &mut decl.type_parameters {
+                    let type_param = type_param
+                        .as_type_parameter_mut()
+                        .expect("only works with type parameters");
                     if let Some(type_id) = self.find_match(type_param.type_id, engines) {
                         need_to_create_new = true;
                         type_param.type_id = type_id;
@@ -404,6 +428,9 @@ impl TypeSubstMap {
                     }
                 }
                 for type_param in &mut decl.type_parameters {
+                    let type_param = type_param
+                        .as_type_parameter_mut()
+                        .expect("only works with type parameters");
                     if let Some(type_id) = self.find_match(type_param.type_id, engines) {
                         need_to_create_new = true;
                         type_param.type_id = type_id;
@@ -431,6 +458,9 @@ impl TypeSubstMap {
                     }
                 }
                 for type_param in &mut decl.type_parameters {
+                    let type_param = type_param
+                        .as_type_parameter_mut()
+                        .expect("only works with type parameters");
                     if let Some(type_id) = self.find_match(type_param.type_id, engines) {
                         need_to_create_new = true;
                         type_param.type_id = type_id;
@@ -456,6 +486,9 @@ impl TypeSubstMap {
                 }
 
                 for type_param in &mut decl.type_parameters {
+                    let type_param = type_param
+                        .as_type_parameter_mut()
+                        .expect("only works with type parameters");
                     if let Some(type_id) = self.find_match(type_param.type_id, engines) {
                         need_to_create_new = true;
                         type_param.type_id = type_id;
@@ -550,6 +583,12 @@ fn iter_for_match(
             TypeInfo::Placeholder(current_type_param),
         ) = ((*source_type_info).clone(), type_info)
         {
+            let source_type_param = source_type_param
+                .as_type_parameter()
+                .expect("only works with type parameters");
+            let current_type_param = current_type_param
+                .as_type_parameter()
+                .expect("only works with type parameters");
             if source_type_param.name.as_str() == current_type_param.name.as_str()
                 && current_type_param
                     .trait_constraints

--- a/sway-core/src/type_system/unify/unifier.rs
+++ b/sway-core/src/type_system/unify/unifier.rs
@@ -396,6 +396,12 @@ impl<'a> Unifier<'a> {
         let (en, etps) = e;
         if rn == en && rtps.len() == etps.len() {
             rtps.iter().zip(etps.iter()).for_each(|(rtp, etp)| {
+                let rtp = rtp
+                    .as_type_parameter()
+                    .expect("will only work with type parameters");
+                let etp = etp
+                    .as_type_parameter()
+                    .expect("will only work with type parameters");
                 self.unify(handler, rtp.type_id, etp.type_id, span, false);
             });
         } else {
@@ -425,6 +431,12 @@ impl<'a> Unifier<'a> {
         let (en, etps) = e;
         if rn == en && rtps.len() == etps.len() {
             rtps.iter().zip(etps.iter()).for_each(|(rtp, etp)| {
+                let rtp = rtp
+                    .as_type_parameter()
+                    .expect("will only work with type parameters");
+                let etp = etp
+                    .as_type_parameter()
+                    .expect("will only work with type parameters");
                 self.unify(handler, rtp.type_id, etp.type_id, span, false);
             });
         } else {

--- a/sway-core/src/type_system/unify/unify_check.rs
+++ b/sway-core/src/type_system/unify/unify_check.rs
@@ -794,13 +794,23 @@ impl<'a> UnifyCheck<'a> {
         let l_types = left
             .type_parameters
             .iter()
-            .map(|x| x.type_id)
+            .map(|x| {
+                let x = x
+                    .as_type_parameter()
+                    .expect("will only work with type parameters");
+                x.type_id
+            })
             .collect::<Vec<_>>();
 
         let r_types = right
             .type_parameters
             .iter()
-            .map(|x| x.type_id)
+            .map(|x| {
+                let x = x
+                    .as_type_parameter()
+                    .expect("will only work with type parameters");
+                x.type_id
+            })
             .collect::<Vec<_>>();
 
         self.check_multiple(&l_types, &r_types)
@@ -855,13 +865,23 @@ impl<'a> UnifyCheck<'a> {
         let l_types = left
             .type_parameters
             .iter()
-            .map(|x| x.type_id)
+            .map(|x| {
+                let x = x
+                    .as_type_parameter()
+                    .expect("will only work with type parameters");
+                x.type_id
+            })
             .collect::<Vec<_>>();
 
         let r_types = right
             .type_parameters
             .iter()
-            .map(|x| x.type_id)
+            .map(|x| {
+                let x = x
+                    .as_type_parameter()
+                    .expect("will only work with type parameters");
+                x.type_id
+            })
             .collect::<Vec<_>>();
 
         self.check_multiple(&l_types, &r_types)

--- a/sway-lsp/src/capabilities/code_actions/common/generate_impl.rs
+++ b/sway-lsp/src/capabilities/code_actions/common/generate_impl.rs
@@ -2,7 +2,7 @@ use sway_core::{
     transform::{AttributeKind, Attributes},
     TypeParameter,
 };
-use sway_types::Spanned;
+use sway_types::{Named, Spanned};
 
 use crate::capabilities::code_actions::CodeAction;
 
@@ -21,7 +21,7 @@ pub(crate) trait GenerateImplCodeAction<'a, T: Spanned>: CodeAction<'a, T> {
             Some(
                 type_params
                     .iter()
-                    .map(|param| param.name.to_string())
+                    .map(|param| param.name().to_string())
                     .collect::<Vec<_>>()
                     .join(", "),
             )

--- a/sway-lsp/src/capabilities/hover/hover_link_contents.rs
+++ b/sway-lsp/src/capabilities/hover/hover_link_contents.rs
@@ -55,6 +55,7 @@ impl<'a> HoverLinkContents<'a> {
                 );
                 decl.type_parameters
                     .iter()
+                    .filter_map(|x| x.as_type_parameter())
                     .for_each(|type_param| self.add_related_types(&type_param.type_id));
             }
             TypeInfo::Struct(decl_id) => {
@@ -66,6 +67,7 @@ impl<'a> HoverLinkContents<'a> {
                 );
                 decl.type_parameters
                     .iter()
+                    .filter_map(|x| x.as_type_parameter())
                     .for_each(|type_param| self.add_related_types(&type_param.type_id));
             }
             _ => {}

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -1083,13 +1083,18 @@ impl Parse for EnumVariant {
 
 impl Parse for TypeParameter {
     fn parse(&self, ctx: &ParseContext) {
-        ctx.tokens.insert(
-            ctx.ident(&self.name),
-            Token::from_parsed(
-                ParsedAstToken::TypeParameter(self.clone()),
-                SymbolKind::TypeParameter,
-            ),
-        );
+        match self {
+            TypeParameter::Type(p) => {
+                ctx.tokens.insert(
+                    ctx.ident(&p.name),
+                    Token::from_parsed(
+                        ParsedAstToken::TypeParameter(self.clone()),
+                        SymbolKind::TypeParameter,
+                    ),
+                );
+            }
+            TypeParameter::Const(_) => todo!(),
+        }
     }
 }
 


### PR DESCRIPTION
## Description

This PR only brings type and const generic arguments to the same `Vec`. It is being done separately because it changes a lot of files.

No change in behaviour is expected.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
