### PR TITLE
fix: prevent RVRT opcode for predicates

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_fail/predicate_invalid_opcodes/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/predicate_invalid_opcodes/src/main.sw
@@ -75,6 +75,9 @@ fn main() -> bool {
     smo r1 r2 r3 r4;
   }
 
+  // cannot test rvrt op code because control flow instructions
+  // are not allowed in assembly blocks
+
   // cannot test storage opcodes due to needing to annotate main
   // with #[storage(read, write)] which is not allowed for predicates
   /*


### PR DESCRIPTION
## Description

Closes #5986 

## Checklist

- [x] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
