### PR TITLE
Feat/rust enum diagnostics

### DIFF
--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -2690,6 +2690,25 @@ impl ToDiagnostic for CompileError {
             },
             Parse { error } => {
                 match &error.kind {
+                    ParseErrorKind::MissingColonInEnumTypeField { variant_name, tuple_contents } => Diagnostic {
+                        reason: Some(Reason::new(code(1), "Enum variant declaration is not valid".to_string())),
+                        issue: Issue::error(
+                            source_engine,
+                            error.span.clone(),
+                            format!("`{}` is not a valid enum variant declaration.", error.span.as_str()),
+                        ),
+                        hints: vec![
+                            Hint::help(
+                                source_engine,
+                                error.span.clone(),
+                                format!("Did you mean `{}: ({})`?", variant_name, tuple_contents.as_str())
+                            )
+                        ],
+                        help: vec![
+                            "In Sway, enum variants are in the form `Variant: ()`, `Variant: <type>`, or `Variant: (<type1>, ..., <typeN>)`.".to_string(),
+                            format!("E.g., `Foo: (), `Bar: u64`, or `Bar: (bool, u32)`."),
+                        ],
+                    },
                     ParseErrorKind::UnassignableExpression { erroneous_expression_kind, erroneous_expression_span } => Diagnostic {
                         reason: Some(Reason::new(code(1), "Expression cannot be assigned to".to_string())),
                         // A bit of a special handling for parentheses, because they are the only

--- a/sway-error/src/error.rs
+++ b/sway-error/src/error.rs
@@ -2698,11 +2698,15 @@ impl ToDiagnostic for CompileError {
                             format!("`{}` is not a valid enum variant declaration.", error.span.as_str()),
                         ),
                         hints: vec![
-                            Hint::help(
-                                source_engine,
-                                error.span.clone(),
-                                format!("Did you mean `{}: ({})`?", variant_name, tuple_contents.as_str())
-                            )
+                            if let Some(tuple_contents) = tuple_contents {
+                                Hint::help(
+                                    source_engine,
+                                    error.span.clone(),
+                                    format!("Did you mean `{}: ({})`?", variant_name, tuple_contents.as_str())
+                                )
+                            } else {
+                                Hint::none()
+                            }
                         ],
                         help: vec![
                             "In Sway, enum variants are in the form `Variant: ()`, `Variant: <type>`, or `Variant: (<type1>, ..., <typeN>)`.".to_string(),

--- a/sway-error/src/parser_error.rs
+++ b/sway-error/src/parser_error.rs
@@ -120,7 +120,7 @@ pub enum ParseErrorKind {
     #[error("Expected ':'. Enum variants must be in the form `Variant: ()`, `Variant: <type>`, or `Variant: (<type1>, ..., <typeN>)`. E.g., `Foo: (), or `Bar: (bool, u32)`.")]
     MissingColonInEnumTypeField {
         variant_name: Ident,
-        tuple_contents: Span,
+        tuple_contents: Option<Span>,
     },
     #[error("Expected storage key of type U256.")]
     ExpectedStorageKeyU256,

--- a/sway-error/src/parser_error.rs
+++ b/sway-error/src/parser_error.rs
@@ -118,7 +118,10 @@ pub enum ParseErrorKind {
     #[error("Expected a path type.")]
     ExpectedPathType,
     #[error("Expected ':'. Enum variants must be in the form `Variant: ()`, `Variant: <type>`, or `Variant: (<type1>, ..., <typeN>)`. E.g., `Foo: (), or `Bar: (bool, u32)`.")]
-    MissingColonInEnumTypeField,
+    MissingColonInEnumTypeField {
+        variant_name: Ident,
+        tuple_contents: Span,
+    },
     #[error("Expected storage key of type U256.")]
     ExpectedStorageKeyU256,
 }

--- a/test/src/e2e_vm_tests/test_programs/should_fail/enum_rust_like/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/enum_rust_like/src/main.sw
@@ -13,13 +13,9 @@ enum Enum2 {
   G(u32, u32),   // Also illegal, but shadowed by previous error
 }
 
-// enum Enum3 {
-//  Complex(bool, u32, str[4]),  // Illegal
-//  Another(u64, bool),          // Also illegal, but shadowed by previous error
-// }
-
-enum Enum4 {
-  Struct {foo: u32, bar: u32}
+enum Enum3 {
+  Complex(bool, u32, str[4]),  // Illegal
+  Another(u64, bool),          // Also illegal, but shadowed by previous error
 }
 
 fn main() {

--- a/test/src/e2e_vm_tests/test_programs/should_fail/enum_rust_like/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/enum_rust_like/src/main.sw
@@ -13,6 +13,15 @@ enum Enum2 {
   G(u32, u32),   // Also illegal, but shadowed by previous error
 }
 
+// enum Enum3 {
+//  Complex(bool, u32, str[4]),  // Illegal
+//  Another(u64, bool),          // Also illegal, but shadowed by previous error
+// }
+
+enum Enum4 {
+  Struct {foo: u32, bar: u32}
+}
+
 fn main() {
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_fail/enum_rust_like/test.toml
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/enum_rust_like/test.toml
@@ -1,11 +1,25 @@
 category = "fail"
 
 # check: $()error
-# check: enum_rust_like/src/main.sw:7:5
+# check: enum_rust_like/src/main.sw:7:3
 # check: $()Ok,    // Illegal
-# nextln: $()Expected ':'. Enum variants must be in the form `Variant: ()`, `Variant: <type>`, or `Variant: (<type1>, ..., <typeN>)`. E.g., `Foo: (), or `Bar: (bool, u32)`.
+# nextln: $()`Ok` is not a valid enum variant declaration.
+# nextln: $()Did you mean `Ok: ()`?
+# check: $()In Sway, enum variants are in the form `Variant: ()`, `Variant: <type>`, or `Variant: (<type1>, ..., <typeN>)`.
+# nextln: $()E.g., `Foo: (), `Bar: u64`, or `Bar: (bool, u32)`.
 
 # check: $()error
-# check: enum_rust_like/src/main.sw:12:4
+# check: enum_rust_like/src/main.sw:12:3
 # check: $()F(u32),        // Illegal
-# nextln: $()Expected ':'. Enum variants must be in the form `Variant: ()`, `Variant: <type>`, or `Variant: (<type1>, ..., <typeN>)`. E.g., `Foo: (), or `Bar: (bool, u32)`.
+# nextln: $()`F(u32)` is not a valid enum variant declaration.
+# nextln: $()Did you mean `F: (u32)`?
+# check: $()In Sway, enum variants are in the form `Variant: ()`, `Variant: <type>`, or `Variant: (<type1>, ..., <typeN>)`.
+# nextln: $()E.g., `Foo: (), `Bar: u64`, or `Bar: (bool, u32)`.
+
+# check: $()error
+# check: enum_rust_like/src/main.sw:17:3
+# check: $()Complex(bool, u32, str[4]),  // Illegal
+# nextln: $()`Complex(bool, u32, str[4])` is not a valid enum variant declaration.
+# nextln: $()Did you mean `Complex: (bool, u32, str[4])`?
+# check: $()In Sway, enum variants are in the form `Variant: ()`, `Variant: <type>`, or `Variant: (<type1>, ..., <typeN>)`.
+# nextln: $()E.g., `Foo: (), `Bar: u64`, or `Bar: (bool, u32)`.


### PR DESCRIPTION
## Description
Adds detailed error messages when detected Rust-style enums

Fixes #5403

Most error messages match ones in the issue description, but I failed to make errors for structs look like described.
My progress so far:
```
          error: Enum variant declaration is not valid
            --> /path_to/enum_rust_like/src/main.sw:22:3
             |
          ...
          22 |   Struct {foo: u32, bar: u32},
             |   ^^^^^^ `Struct` is not a valid enum variant declaration.
             |
             = help: In Sway, enum variants are in the form `Variant: ()`, `Variant: <type>`, or `Variant: (<type1>, ..., <typeN>)`.
             = help: E.g., `Foo: (), `Bar: u64`, or `Bar: (bool, u32)`.
```
## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
