### PR TITLE
TypeArgument as enum to support const generics

### DIFF
--- a/forc-plugins/forc-doc/src/doc/mod.rs
+++ b/forc-plugins/forc-doc/src/doc/mod.rs
@@ -22,6 +22,7 @@ use sway_core::{
     Engines,
 };
 use sway_types::BaseIdent;
+use sway_types::Spanned;
 
 mod descriptor;
 pub mod module;
@@ -77,7 +78,7 @@ impl Documentation {
 
         // Add one documentation page for each primitive type that has an implementation.
         for (impl_trait, module_info) in impl_traits.iter() {
-            let impl_for_type = engines.te().get(impl_trait.implementing_for.type_id);
+            let impl_for_type = engines.te().get(impl_trait.implementing_for.type_id());
             if let Ok(Descriptor::Documentable(doc)) =
                 Descriptor::from_type_info(impl_for_type.as_ref(), engines, module_info.clone())
             {
@@ -103,7 +104,7 @@ impl Documentation {
                     for (impl_trait, _) in impl_traits.iter_mut() {
                         // Check if this implementation is for this struct/enum.
                         if item_name.as_str()
-                            == strip_generic_suffix(impl_trait.implementing_for.span.as_str())
+                            == strip_generic_suffix(impl_trait.implementing_for.span().as_str())
                         {
                             let module_info_override = if let Some(decl_module_info) =
                                 trait_decls.get(&impl_trait.trait_name.suffix)

--- a/forc-plugins/forc-doc/src/render/item/context.rs
+++ b/forc-plugins/forc-doc/src/render/item/context.rs
@@ -19,6 +19,7 @@ use sway_core::language::ty::{
     TyConstantDecl, TyEnumVariant, TyFunctionDecl, TyImplSelfOrTrait, TyStorageField,
     TyStructField, TyTraitFn, TyTraitItem, TyTraitType,
 };
+use sway_types::Spanned;
 
 /// The actual context of the item displayed by [ItemContext].
 /// This uses [ContextType] to determine how to represent the context of an item.
@@ -59,7 +60,7 @@ impl Renderable for Context {
                 for field in fields {
                     let struct_field_id = format!("structfield.{}", field.name.as_str());
                     let type_anchor = render_type_anchor(
-                        (*render_plan.engines.te().get(field.type_argument.type_id)).clone(),
+                        (*render_plan.engines.te().get(field.type_argument.type_id())).clone(),
                         &render_plan,
                         &self.module_info,
                     );
@@ -71,7 +72,7 @@ impl Renderable for Context {
                                 @ if let Ok(type_anchor) = type_anchor {
                                     : type_anchor;
                                 } else {
-                                    : field.type_argument.span.as_str();
+                                    : field.type_argument.span().as_str();
                                 }
                             }
                         }
@@ -87,7 +88,7 @@ impl Renderable for Context {
                 for field in fields {
                     let storage_field_id = format!("storagefield.{}", field.name.as_str());
                     let type_anchor = render_type_anchor(
-                        (*render_plan.engines.te().get(field.type_argument.type_id)).clone(),
+                        (*render_plan.engines.te().get(field.type_argument.type_id())).clone(),
                         &render_plan,
                         &self.module_info,
                     );
@@ -99,7 +100,7 @@ impl Renderable for Context {
                                 @ if let Ok(type_anchor) = type_anchor {
                                     : type_anchor;
                                 } else {
-                                    : field.type_argument.span.as_str();
+                                    : field.type_argument.span().as_str();
                                 }
                             }
                         }
@@ -115,7 +116,11 @@ impl Renderable for Context {
                 for variant in variants {
                     let enum_variant_id = format!("variant.{}", variant.name.as_str());
                     let type_anchor = render_type_anchor(
-                        (*render_plan.engines.te().get(variant.type_argument.type_id)).clone(),
+                        (*render_plan
+                            .engines
+                            .te()
+                            .get(variant.type_argument.type_id()))
+                        .clone(),
                         &render_plan,
                         &self.module_info,
                     );
@@ -127,7 +132,7 @@ impl Renderable for Context {
                                 @ if let Ok(type_anchor) = type_anchor {
                                     : type_anchor;
                                 } else {
-                                    : variant.type_argument.span.as_str();
+                                    : variant.type_argument.span().as_str();
                                 }
                             }
                         }
@@ -158,11 +163,11 @@ impl Renderable for Context {
                                 fn_sig,
                                 "{} {},",
                                 param.name.as_str(),
-                                param.type_argument.span.as_str()
+                                param.type_argument.span().as_str()
                             )?;
                         }
                     }
-                    write!(fn_sig, ") -> {}", method.return_type.span.as_str())?;
+                    write!(fn_sig, ") -> {}", method.return_type.span().as_str())?;
                     let multiline = fn_sig.chars().count() >= 60;
                     let fn_sig = format!("fn {}(", method.name);
                     let method_id = format!("tymethod.{}", method.name.as_str());
@@ -192,7 +197,7 @@ impl Renderable for Context {
                                         } else {
                                             : param.name.as_str();
                                             : ": ";
-                                            : param.type_argument.span.as_str();
+                                            : param.type_argument.span().as_str();
                                             : ","
                                         }
                                     }
@@ -211,7 +216,7 @@ impl Renderable for Context {
                                         } else {
                                             : param.name.as_str();
                                             : ": ";
-                                            : param.type_argument.span.as_str();
+                                            : param.type_argument.span().as_str();
                                         }
                                         @ if param.name.as_str()
                                             != method.parameters.last()
@@ -222,9 +227,9 @@ impl Renderable for Context {
                                     }
                                     : ")";
                                 }
-                                @ if !method.return_type.span.as_str().contains(&fn_sig) {
+                                @ if !method.return_type.span().as_str().contains(&fn_sig) {
                                     : " -> ";
-                                    : method.return_type.span.as_str();
+                                    : method.return_type.span().as_str();
                                 }
                             }
                         }
@@ -282,7 +287,7 @@ impl DocImplTrait {
         self.impl_trait
             .trait_type_arguments
             .iter()
-            .map(|arg| arg.span.as_str().to_string())
+            .map(|arg| arg.span().as_str().to_string())
             .collect()
     }
 
@@ -298,7 +303,7 @@ impl DocImplTrait {
     // If the trait name is the same as the declaration's name, it's an inherent implementation.
     // Otherwise, it's a trait implementation.
     pub fn is_inherent(&self) -> bool {
-        self.short_name() == self.impl_trait.implementing_for.span.as_str()
+        self.short_name() == self.impl_trait.implementing_for.span().as_str()
             || self.short_name() == "r#Self"
     }
 }
@@ -560,7 +565,7 @@ impl Renderable for DocImplTrait {
                         }
                         : " for ";
                     }
-                    : implementing_for.span.as_str();
+                    : implementing_for.span().as_str();
                 }
             }
         }
@@ -624,11 +629,11 @@ impl Renderable for TyFunctionDecl {
                     fn_sig,
                     "{} {},",
                     param.name.as_str(),
-                    param.type_argument.span.as_str()
+                    param.type_argument.span().as_str()
                 )?;
             }
         }
-        write!(fn_sig, ") -> {}", self.return_type.span.as_str())?;
+        write!(fn_sig, ") -> {}", self.return_type.span().as_str())?;
         let multiline = fn_sig.chars().count() >= 60;
 
         let method_id = format!("method.{}", self.name.as_str());
@@ -660,7 +665,7 @@ impl Renderable for TyFunctionDecl {
                                     } else {
                                         : param.name.as_str();
                                         : ": ";
-                                        : param.type_argument.span.as_str();
+                                        : param.type_argument.span().as_str();
                                         : ","
                                     }
                                 }
@@ -679,7 +684,7 @@ impl Renderable for TyFunctionDecl {
                                     } else {
                                         : param.name.as_str();
                                         : ": ";
-                                        : param.type_argument.span.as_str();
+                                        : param.type_argument.span().as_str();
                                     }
                                     @ if param.name.as_str()
                                         != self.parameters.last()
@@ -692,7 +697,7 @@ impl Renderable for TyFunctionDecl {
                             }
                             @ if self.span.as_str().contains("->") {
                                 : " -> ";
-                                : self.return_type.span.as_str();
+                                : self.return_type.span().as_str();
                             }
                         }
                     }

--- a/forc-plugins/forc-doc/src/render/item/type_anchor.rs
+++ b/forc-plugins/forc-doc/src/render/item/type_anchor.rs
@@ -23,7 +23,7 @@ pub(crate) fn render_type_anchor(
     match type_info {
         TypeInfo::Array(ty_arg, len) => {
             let inner = render_type_anchor(
-                (*render_plan.engines.te().get(ty_arg.type_id)).clone(),
+                (*render_plan.engines.te().get(ty_arg.type_id())).clone(),
                 render_plan,
                 current_module_info,
             )?;
@@ -36,7 +36,7 @@ pub(crate) fn render_type_anchor(
         }
         TypeInfo::Slice(ty_arg) => {
             let inner = render_type_anchor(
-                (*render_plan.engines.te().get(ty_arg.type_id)).clone(),
+                (*render_plan.engines.te().get(ty_arg.type_id())).clone(),
                 render_plan,
                 current_module_info,
             )?;
@@ -50,7 +50,7 @@ pub(crate) fn render_type_anchor(
             let mut rendered_args: Vec<_> = Vec::new();
             for ty_arg in ty_args {
                 rendered_args.push(render_type_anchor(
-                    (*render_plan.engines.te().get(ty_arg.type_id)).clone(),
+                    (*render_plan.engines.te().get(ty_arg.type_id())).clone(),
                     render_plan,
                     current_module_info,
                 )?);

--- a/forc-plugins/forc-migrate/src/migrations/try_from_bytes_for_b256.rs
+++ b/forc-plugins/forc-migrate/src/migrations/try_from_bytes_for_b256.rs
@@ -165,7 +165,7 @@ fn replace_bytes_into_b256_with_try_into_b256_step(
             let method_return_type = ctx
                 .engines
                 .te()
-                .get(ty_method_call_info.fn_decl.return_type.type_id);
+                .get(ty_method_call_info.fn_decl.return_type.type_id());
             let method_target_is_bytes_struct = match ctx
                 .engines
                 .te()

--- a/sway-core/src/abi_generation/abi_str.rs
+++ b/sway-core/src/abi_generation/abi_str.rs
@@ -1,6 +1,6 @@
 use sway_types::{integer_bits::IntegerBits, Named};
 
-use crate::{language::CallPath, Engines, TypeArgument, TypeId, TypeInfo};
+use crate::{language::CallPath, Engines, GenericArgument, TypeId, TypeInfo};
 
 #[derive(Clone)]
 pub struct AbiStrContext {
@@ -32,7 +32,7 @@ impl TypeId {
                     .get(resolved_type_id)
                     .abi_str(ctx, engines, true),
                 (_, TypeInfo::Alias { ty, .. }) => {
-                    ty.type_id.get_abi_type_str(ctx, engines, ty.type_id)
+                    ty.type_id().get_abi_type_str(ctx, engines, ty.type_id())
                 }
                 (TypeInfo::Tuple(fields), TypeInfo::Tuple(resolved_fields)) => {
                     assert_eq!(fields.len(), resolved_fields.len());
@@ -40,7 +40,7 @@ impl TypeId {
                         .iter()
                         .map(|f| {
                             if ctx.abi_with_fully_specified_types {
-                                type_engine.get(f.type_id).abi_str(ctx, engines, false)
+                                type_engine.get(f.type_id()).abi_str(ctx, engines, false)
                             } else {
                                 "_".to_string()
                             }
@@ -55,7 +55,7 @@ impl TypeId {
                     );
                     let inner_type = if ctx.abi_with_fully_specified_types {
                         type_engine
-                            .get(type_arg.type_id)
+                            .get(type_arg.type_id())
                             .abi_str(ctx, engines, false)
                     } else {
                         "_".to_string()
@@ -65,7 +65,7 @@ impl TypeId {
                 (TypeInfo::Slice(type_arg), TypeInfo::Slice(_)) => {
                     let inner_type = if ctx.abi_with_fully_specified_types {
                         type_engine
-                            .get(type_arg.type_id)
+                            .get(type_arg.type_id())
                             .abi_str(ctx, engines, false)
                     } else {
                         "_".to_string()
@@ -227,11 +227,11 @@ fn call_path_display(ctx: &AbiStrContext, call_path: &CallPath) -> String {
     buf
 }
 
-impl TypeArgument {
+impl GenericArgument {
     pub(self) fn abi_str(&self, ctx: &AbiStrContext, engines: &Engines, is_root: bool) -> String {
         engines
             .te()
-            .get(self.type_id)
+            .get(self.type_id())
             .abi_str(ctx, engines, is_root)
     }
 }

--- a/sway-core/src/abi_generation/evm_abi.rs
+++ b/sway-core/src/abi_generation/evm_abi.rs
@@ -4,7 +4,7 @@ use crate::{
     asm_generation::EvmAbiResult,
     decl_engine::DeclId,
     language::ty::{TyFunctionDecl, TyProgram, TyProgramKind},
-    Engines, TypeArgument, TypeId, TypeInfo,
+    Engines, GenericArgument, TypeId, TypeInfo,
 };
 
 pub fn generate_abi_program(program: &TyProgram, engines: &Engines) -> EvmAbiResult {
@@ -170,7 +170,7 @@ pub fn abi_param_type(type_info: &TypeInfo, engines: &Engines) -> ethabi::ParamT
         Tuple(fields) => ethabi::ParamType::Tuple(
             fields
                 .iter()
-                .map(|f| abi_param_type(&type_engine.get(f.type_id), engines))
+                .map(|f| abi_param_type(&type_engine.get(f.type_id()), engines))
                 .collect::<Vec<ethabi::ParamType>>(),
         ),
         Struct(decl_ref) => {
@@ -178,12 +178,12 @@ pub fn abi_param_type(type_info: &TypeInfo, engines: &Engines) -> ethabi::ParamT
             ethabi::ParamType::Tuple(
                 decl.fields
                     .iter()
-                    .map(|f| abi_param_type(&type_engine.get(f.type_argument.type_id), engines))
+                    .map(|f| abi_param_type(&type_engine.get(f.type_argument.type_id()), engines))
                     .collect::<Vec<ethabi::ParamType>>(),
             )
         }
         Array(elem_ty, ..) => ethabi::ParamType::Array(Box::new(abi_param_type(
-            &type_engine.get(elem_ty.type_id),
+            &type_engine.get(elem_ty.type_id()),
             engines,
         ))),
         _ => panic!("cannot convert type to Solidity ABI param type: {type_info:?}",),
@@ -204,9 +204,9 @@ fn generate_abi_function(
             name: x.name.to_string(),
             kind: ethabi::ParamType::Address,
             internal_type: Some(get_type_str(
-                &x.type_argument.type_id,
+                &x.type_argument.type_id(),
                 engines,
-                x.type_argument.type_id,
+                x.type_argument.type_id(),
             )),
         })
         .collect::<Vec<_>>();
@@ -216,9 +216,9 @@ fn generate_abi_function(
         name: String::default(),
         kind: ethabi::ParamType::Address,
         internal_type: Some(get_type_str(
-            &fn_decl.return_type.type_id,
+            &fn_decl.return_type.type_id(),
             engines,
-            fn_decl.return_type.type_id,
+            fn_decl.return_type.type_id(),
         )),
     };
 
@@ -233,6 +233,6 @@ fn generate_abi_function(
     })
 }
 
-fn abi_str_type_arg(type_arg: &TypeArgument, engines: &Engines) -> String {
-    abi_str(&engines.te().get(type_arg.type_id), engines)
+fn abi_str_type_arg(type_arg: &GenericArgument, engines: &Engines) -> String {
+    abi_str(&engines.te().get(type_arg.type_id()), engines)
 }

--- a/sway-core/src/abi_generation/fuel_abi.rs
+++ b/sway-core/src/abi_generation/fuel_abi.rs
@@ -560,8 +560,8 @@ fn generate_configurables(
                     engines,
                     metadata_types,
                     concrete_types,
-                    decl.type_ascription.type_id,
-                    decl.type_ascription.type_id,
+                    decl.type_ascription.type_id(),
+                    decl.type_ascription.type_id(),
                 )?,
                 offset: 0,
             })
@@ -641,8 +641,8 @@ impl TypeId {
                         engines,
                         metadata_types,
                         concrete_types,
-                        x.type_argument.initial_type_id,
-                        x.type_argument.type_id,
+                        x.type_argument.initial_type_id(),
+                        x.type_argument.type_id(),
                         &mut new_metadata_types_to_add,
                     )?;
                 }
@@ -656,18 +656,18 @@ impl TypeId {
                         Ok(program_abi::TypeApplication {
                             name: x.name.to_string(),
                             type_id: program_abi::TypeId::Metadata(MetadataTypeId(
-                                x.type_argument.initial_type_id.index(),
+                                x.type_argument.initial_type_id().index(),
                             )),
                             type_arguments: x
                                 .type_argument
-                                .initial_type_id
+                                .initial_type_id()
                                 .get_abi_type_arguments(
                                     handler,
                                     ctx,
                                     engines,
                                     metadata_types,
                                     concrete_types,
-                                    x.type_argument.type_id,
+                                    x.type_argument.type_id(),
                                     &mut new_metadata_types_to_add,
                                 )?,
                         })
@@ -693,8 +693,8 @@ impl TypeId {
                         engines,
                         metadata_types,
                         concrete_types,
-                        x.type_argument.initial_type_id,
-                        x.type_argument.type_id,
+                        x.type_argument.initial_type_id(),
+                        x.type_argument.type_id(),
                         &mut new_metadata_types_to_add,
                     )?;
                 }
@@ -708,18 +708,18 @@ impl TypeId {
                         Ok(program_abi::TypeApplication {
                             name: x.name.to_string(),
                             type_id: program_abi::TypeId::Metadata(MetadataTypeId(
-                                x.type_argument.initial_type_id.index(),
+                                x.type_argument.initial_type_id().index(),
                             )),
                             type_arguments: x
                                 .type_argument
-                                .initial_type_id
+                                .initial_type_id()
                                 .get_abi_type_arguments(
                                     handler,
                                     ctx,
                                     engines,
                                     metadata_types,
                                     concrete_types,
-                                    x.type_argument.type_id,
+                                    x.type_argument.type_id(),
                                     &mut new_metadata_types_to_add,
                                 )?,
                         })
@@ -741,8 +741,8 @@ impl TypeId {
                         engines,
                         metadata_types,
                         concrete_types,
-                        elem_ty.initial_type_id,
-                        elem_ty.type_id,
+                        elem_ty.initial_type_id(),
+                        elem_ty.type_id(),
                         metadata_types_to_add,
                     )?;
 
@@ -751,15 +751,15 @@ impl TypeId {
                     Some(vec![program_abi::TypeApplication {
                         name: "__array_element".to_string(),
                         type_id: program_abi::TypeId::Metadata(MetadataTypeId(
-                            elem_ty.initial_type_id.index(),
+                            elem_ty.initial_type_id().index(),
                         )),
-                        type_arguments: elem_ty.initial_type_id.get_abi_type_arguments(
+                        type_arguments: elem_ty.initial_type_id().get_abi_type_arguments(
                             handler,
                             ctx,
                             engines,
                             metadata_types,
                             concrete_types,
-                            elem_ty.type_id,
+                            elem_ty.type_id(),
                             metadata_types_to_add,
                         )?,
                     }])
@@ -775,8 +775,8 @@ impl TypeId {
                         engines,
                         metadata_types,
                         concrete_types,
-                        elem_ty.initial_type_id,
-                        elem_ty.type_id,
+                        elem_ty.initial_type_id(),
+                        elem_ty.type_id(),
                         metadata_types_to_add,
                     )?;
 
@@ -785,15 +785,15 @@ impl TypeId {
                     Some(vec![program_abi::TypeApplication {
                         name: "__slice_element".to_string(),
                         type_id: program_abi::TypeId::Metadata(MetadataTypeId(
-                            elem_ty.initial_type_id.index(),
+                            elem_ty.initial_type_id().index(),
                         )),
-                        type_arguments: elem_ty.initial_type_id.get_abi_type_arguments(
+                        type_arguments: elem_ty.initial_type_id().get_abi_type_arguments(
                             handler,
                             ctx,
                             engines,
                             metadata_types,
                             concrete_types,
-                            elem_ty.type_id,
+                            elem_ty.type_id(),
                             metadata_types_to_add,
                         )?,
                     }])
@@ -812,8 +812,8 @@ impl TypeId {
                             engines,
                             metadata_types,
                             concrete_types,
-                            x.initial_type_id,
-                            x.type_id,
+                            x.initial_type_id(),
+                            x.type_id(),
                             &mut new_metadata_types_to_add,
                         )?;
                     }
@@ -826,15 +826,15 @@ impl TypeId {
                             Ok(program_abi::TypeApplication {
                                 name: "__tuple_element".to_string(),
                                 type_id: program_abi::TypeId::Metadata(MetadataTypeId(
-                                    x.initial_type_id.index(),
+                                    x.initial_type_id().index(),
                                 )),
-                                type_arguments: x.initial_type_id.get_abi_type_arguments(
+                                type_arguments: x.initial_type_id().get_abi_type_arguments(
                                     handler,
                                     ctx,
                                     engines,
                                     metadata_types,
                                     concrete_types,
-                                    x.type_id,
+                                    x.type_id(),
                                     metadata_types_to_add,
                                 )?,
                             })
@@ -867,7 +867,7 @@ impl TypeId {
                             engines,
                             metadata_types,
                             concrete_types,
-                            v.initial_type_id,
+                            v.initial_type_id(),
                             p.type_id,
                             metadata_types_to_add,
                         )?;
@@ -887,13 +887,13 @@ impl TypeId {
             }
             TypeInfo::Alias { .. } => {
                 if let TypeInfo::Alias { ty, .. } = &*type_engine.get(resolved_type_id) {
-                    ty.initial_type_id.get_abi_type_components(
+                    ty.initial_type_id().get_abi_type_components(
                         handler,
                         ctx,
                         engines,
                         metadata_types,
                         concrete_types,
-                        ty.type_id,
+                        ty.type_id(),
                         metadata_types_to_add,
                     )?
                 } else {
@@ -955,7 +955,7 @@ impl TypeId {
                         engines,
                         metadata_types,
                         concrete_types,
-                        v.type_id,
+                        v.type_id(),
                         p.type_id,
                         metadata_types_to_add,
                     )?;
@@ -971,9 +971,9 @@ impl TypeId {
                         Ok(program_abi::TypeApplication {
                             name: "".to_string(),
                             type_id: program_abi::TypeId::Metadata(MetadataTypeId(
-                                arg.initial_type_id.index(),
+                                arg.initial_type_id().index(),
                             )),
-                            type_arguments: arg.initial_type_id.get_abi_type_arguments(
+                            type_arguments: arg.initial_type_id().get_abi_type_arguments(
                                 handler,
                                 ctx,
                                 engines,
@@ -1132,7 +1132,7 @@ impl TypeId {
                             engines,
                             metadata_types,
                             concrete_types,
-                            arg.initial_type_id,
+                            arg.initial_type_id(),
                             p.type_id,
                         )
                     })
@@ -1211,8 +1211,8 @@ impl TyFunctionDecl {
                             engines,
                             metadata_types,
                             concrete_types,
-                            x.type_argument.initial_type_id,
-                            x.type_argument.type_id,
+                            x.type_argument.initial_type_id(),
+                            x.type_argument.type_id(),
                         )?,
                     })
                 })
@@ -1223,8 +1223,8 @@ impl TyFunctionDecl {
                 engines,
                 metadata_types,
                 concrete_types,
-                self.return_type.initial_type_id,
-                self.return_type.type_id,
+                self.return_type.initial_type_id(),
+                self.return_type.type_id(),
             )?,
             attributes: generate_attributes(&self.attributes),
         })

--- a/sway-core/src/control_flow_analysis/analyze_return_paths.rs
+++ b/sway-core/src/control_flow_analysis/analyze_return_paths.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use petgraph::prelude::NodeIndex;
 use sway_error::error::CompileError;
-use sway_types::{ident::Ident, span::Span, IdentUnique};
+use sway_types::{ident::Ident, span::Span, IdentUnique, Spanned};
 
 impl<'cfg> ControlFlowGraph<'cfg> {
     pub(crate) fn construct_return_path_graph<'eng: 'cfg>(
@@ -312,7 +312,7 @@ fn connect_typed_fn_decl<'eng: 'cfg, 'cfg>(
         entry_point: entry_node,
         exit_point: fn_exit_node,
         return_type: type_engine
-            .to_typeinfo(fn_decl.return_type.type_id, &fn_decl.return_type.span)
+            .to_typeinfo(fn_decl.return_type.type_id(), &fn_decl.return_type.span())
             .unwrap_or_else(|_| TypeInfo::Tuple(Vec::new())),
     };
     graph.namespace.insert_function(fn_decl, namespace_entry);

--- a/sway-core/src/control_flow_analysis/dead_code_analysis.rs
+++ b/sway-core/src/control_flow_analysis/dead_code_analysis.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     transform::Attributes,
     type_system::TypeInfo,
-    Engines, TypeArgument, TypeEngine, TypeId,
+    Engines, GenericArgument, TypeEngine, TypeId,
 };
 use petgraph::{prelude::NodeIndex, visit::Dfs};
 use std::collections::{BTreeSet, HashMap};
@@ -527,7 +527,7 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
             if let Ok(ref vec) = result {
                 if !vec.is_empty() {
                     // Connect variable declaration node to its type ascription.
-                    connect_type_id(engines, type_ascription.type_id, graph, entry_node)?;
+                    connect_type_id(engines, type_ascription.type_id(), graph, entry_node)?;
                 }
             }
 
@@ -581,7 +581,7 @@ fn connect_declaration<'eng: 'cfg, 'cfg>(
                 .namespace
                 .insert_configurable(call_path.suffix.clone(), entry_node);
 
-            connect_type_id(engines, type_ascription.type_id, graph, entry_node)?;
+            connect_type_id(engines, type_ascription.type_id(), graph, entry_node)?;
 
             if let Some(value) = &value {
                 connect_expression(
@@ -738,7 +738,7 @@ fn connect_impl_trait<'eng: 'cfg, 'cfg>(
     entry_node: NodeIndex,
     tree_type: &TreeType,
     trait_decl_ref: &Option<DeclRef<InterfaceDeclId>>,
-    implementing_for: &TypeArgument,
+    implementing_for: &GenericArgument,
     options: NodeConnectionOptions,
 ) -> Result<(), CompileError> {
     let decl_engine = engines.de();
@@ -758,7 +758,7 @@ fn connect_impl_trait<'eng: 'cfg, 'cfg>(
         };
     }
 
-    connect_type_id(engines, implementing_for.type_id, graph, entry_node)?;
+    connect_type_id(engines, implementing_for.type_id(), graph, entry_node)?;
 
     let trait_entry = graph.namespace.find_trait(trait_name).cloned();
     // Collect the methods that are directly implemented in the trait.
@@ -898,7 +898,7 @@ fn connect_abi_declaration(
                 if let Some(TypeInfo::Struct(decl_ref)) = get_struct_type_info_from_type_id(
                     type_engine,
                     decl_engine,
-                    fn_decl.return_type.type_id,
+                    fn_decl.return_type.type_id(),
                 )? {
                     let decl = decl_engine.get_struct(&decl_ref);
                     if let Some(ns) = graph.namespace.get_struct(&decl.call_path.suffix).cloned() {
@@ -939,7 +939,7 @@ fn get_struct_type_info_from_type_id(
                 if let Ok(Some(type_info)) = get_struct_type_info_from_type_id(
                     type_engine,
                     decl_engine,
-                    var.type_argument.type_id,
+                    var.type_argument.type_id(),
                 ) {
                     return Ok(Some(type_info));
                 }
@@ -949,7 +949,7 @@ fn get_struct_type_info_from_type_id(
         TypeInfo::Tuple(type_args) => {
             for arg in type_args.iter() {
                 if let Ok(Some(type_info)) =
-                    get_struct_type_info_from_type_id(type_engine, decl_engine, arg.type_id)
+                    get_struct_type_info_from_type_id(type_engine, decl_engine, arg.type_id())
                 {
                     return Ok(Some(type_info));
                 }
@@ -960,7 +960,7 @@ fn get_struct_type_info_from_type_id(
             if let Some(type_arguments) = type_arguments {
                 for arg in type_arguments.iter() {
                     if let Ok(Some(type_info)) =
-                        get_struct_type_info_from_type_id(type_engine, decl_engine, arg.type_id)
+                        get_struct_type_info_from_type_id(type_engine, decl_engine, arg.type_id())
                     {
                         return Ok(Some(type_info));
                     }
@@ -970,10 +970,10 @@ fn get_struct_type_info_from_type_id(
         }
         TypeInfo::Struct { .. } => Ok(Some(type_info)),
         TypeInfo::Array(type_arg, _) => {
-            get_struct_type_info_from_type_id(type_engine, decl_engine, type_arg.type_id)
+            get_struct_type_info_from_type_id(type_engine, decl_engine, type_arg.type_id())
         }
         TypeInfo::Slice(type_arg) => {
-            get_struct_type_info_from_type_id(type_engine, decl_engine, type_arg.type_id)
+            get_struct_type_info_from_type_id(type_engine, decl_engine, type_arg.type_id())
         }
         _ => Ok(None),
     }
@@ -1031,7 +1031,7 @@ fn connect_typed_fn_decl<'eng: 'cfg, 'cfg>(
             param_name: fn_param.name.clone(),
             is_self: engines
                 .te()
-                .get(fn_param.type_argument.initial_type_id)
+                .get(fn_param.type_argument.initial_type_id())
                 .is_self_type(),
         });
         graph.add_edge(entry_node, fn_param_node, "".into());
@@ -1045,7 +1045,7 @@ fn connect_typed_fn_decl<'eng: 'cfg, 'cfg>(
 
         connect_type_id(
             engines,
-            fn_param.type_argument.type_id,
+            fn_param.type_argument.type_id(),
             graph,
             fn_param_node,
         )?;
@@ -1073,7 +1073,7 @@ fn connect_typed_fn_decl<'eng: 'cfg, 'cfg>(
     // not sure how correct it is to default to Unit here...
     // I think types should all be resolved by now.
     let ty = type_engine
-        .to_typeinfo(fn_decl.return_type.type_id, &span)
+        .to_typeinfo(fn_decl.return_type.type_id(), &span)
         .unwrap_or_else(|_| TypeInfo::Tuple(Vec::new()));
 
     let namespace_entry = FunctionNamespaceEntry {
@@ -1100,8 +1100,10 @@ fn connect_fn_params_struct_enums<'eng: 'cfg, 'cfg>(
 ) -> Result<(), CompileError> {
     let type_engine = engines.te();
     for fn_param in &fn_decl.parameters {
-        let ty = type_engine
-            .to_typeinfo(fn_param.type_argument.type_id, &fn_param.type_argument.span)?;
+        let ty = type_engine.to_typeinfo(
+            fn_param.type_argument.type_id(),
+            &fn_param.type_argument.span(),
+        )?;
         match ty {
             TypeInfo::Enum(decl_ref) => {
                 let decl = engines.de().get_enum(&decl_ref);
@@ -2483,7 +2485,7 @@ fn connect_type_alias_declaration<'eng: 'cfg, 'cfg>(
         .insert_alias(decl.name().clone(), entry_node);
 
     let ty::TyTypeAliasDecl { ty, .. } = decl;
-    connect_type_id(engines, ty.type_id, graph, entry_node)?;
+    connect_type_id(engines, ty.type_id(), graph, entry_node)?;
 
     Ok(())
 }

--- a/sway-core/src/ir_generation/compile.rs
+++ b/sway-core/src/ir_generation/compile.rs
@@ -342,8 +342,8 @@ pub(crate) fn compile_configurables(
                 engines.te(),
                 engines.de(),
                 context,
-                decl.type_ascription.type_id,
-                &decl.type_ascription.span,
+                decl.type_ascription.type_id(),
+                &decl.type_ascription.span(),
             )
             .unwrap();
             let ptr_ty = Type::new_ptr(context, ty);
@@ -367,7 +367,7 @@ pub(crate) fn compile_configurables(
                     _ => unreachable!(),
                 };
 
-                let config_type_info = engines.te().get(decl.type_ascription.type_id);
+                let config_type_info = engines.te().get(decl.type_ascription.type_id());
                 let buffer_size = match config_type_info.abi_encode_size_hint(engines) {
                     crate::AbiEncodeSizeHint::Exact(len) => len,
                     crate::AbiEncodeSizeHint::Range(_, len) => len,
@@ -584,8 +584,8 @@ fn compile_fn(
                 type_engine,
                 decl_engine,
                 context,
-                param.type_argument.type_id,
-                &param.type_argument.span,
+                param.type_argument.type_id(),
+                &param.type_argument.span(),
             )
             .map(|ty| {
                 (
@@ -608,8 +608,8 @@ fn compile_fn(
         type_engine,
         decl_engine,
         context,
-        return_type.type_id,
-        &return_type.span,
+        return_type.type_id(),
+        &return_type.span(),
     )
     .map_err(|err| vec![err])?;
 

--- a/sway-core/src/ir_generation/const_eval.rs
+++ b/sway-core/src/ir_generation/const_eval.rs
@@ -1175,8 +1175,8 @@ fn const_eval_intrinsic(
                 lookup.engines.te(),
                 lookup.engines.de(),
                 lookup.context,
-                targ.type_id,
-                &targ.span,
+                targ.type_id(),
+                &targ.span(),
             )
             .map_err(|_| ConstEvalError::CompileError)?;
             let c = ConstantContent {
@@ -1209,8 +1209,8 @@ fn const_eval_intrinsic(
                 lookup.engines.te(),
                 lookup.engines.de(),
                 lookup.context,
-                targ.type_id,
-                &targ.span,
+                targ.type_id(),
+                &targ.span(),
             )
             .map_err(|_| ConstEvalError::CompileError)?;
             let c = ConstantContent {
@@ -1227,8 +1227,8 @@ fn const_eval_intrinsic(
                 lookup.engines.te(),
                 lookup.engines.de(),
                 lookup.context,
-                targ.type_id,
-                &targ.span,
+                targ.type_id(),
+                &targ.span(),
             )
             .map_err(|_| ConstEvalError::CompileError)?;
             match ir_type.get_content(lookup.context) {
@@ -1545,8 +1545,8 @@ fn const_eval_intrinsic(
                 lookup.engines.te(),
                 lookup.engines.de(),
                 lookup.context,
-                src_type.type_id,
-                &src_type.span,
+                src_type.type_id(),
+                &src_type.span(),
             )
             .unwrap();
 
@@ -1555,8 +1555,8 @@ fn const_eval_intrinsic(
                 lookup.engines.te(),
                 lookup.engines.de(),
                 lookup.context,
-                dst_type.type_id,
-                &dst_type.span,
+                dst_type.type_id(),
+                &dst_type.span(),
             )
             .unwrap();
 

--- a/sway-core/src/ir_generation/convert.rs
+++ b/sway-core/src/ir_generation/convert.rs
@@ -112,7 +112,7 @@ fn convert_resolved_type_info(
                 .get_struct(decl_ref)
                 .fields
                 .iter()
-                .map(|field| field.type_argument.type_id)
+                .map(|field| field.type_argument.type_id())
                 .collect::<Vec<_>>()
                 .as_slice(),
         )?,
@@ -132,7 +132,7 @@ fn convert_resolved_type_info(
                 type_engine,
                 decl_engine,
                 context,
-                elem_type.type_id,
+                elem_type.type_id(),
                 span,
             )?;
             Type::new_array(context, elem_type, len as u64)
@@ -145,7 +145,7 @@ fn convert_resolved_type_info(
                 // aggregate which might not make as much sense as a dedicated Unit type.
                 Type::get_unit(context)
             } else {
-                let new_fields: Vec<_> = fields.iter().map(|x| x.type_id).collect();
+                let new_fields: Vec<_> = fields.iter().map(|x| x.type_id()).collect();
                 create_tuple_aggregate(type_engine, decl_engine, context, &new_fields)?
             }
         }
@@ -153,19 +153,19 @@ fn convert_resolved_type_info(
         TypeInfo::RawUntypedSlice => Type::get_slice(context),
         TypeInfo::Ptr(_) => Type::get_uint64(context),
         TypeInfo::Alias { ty, .. } => {
-            convert_resolved_type_id(type_engine, decl_engine, context, ty.type_id, span)?
+            convert_resolved_type_id(type_engine, decl_engine, context, ty.type_id(), span)?
         }
         // refs to slice are actually fat pointers,
         // all others refs are thin pointers.
         TypeInfo::Ref {
             referenced_type, ..
         } => {
-            if let Some(slice_elem) = type_engine.get(referenced_type.type_id).as_slice() {
+            if let Some(slice_elem) = type_engine.get(referenced_type.type_id()).as_slice() {
                 let elem_ir_type = convert_resolved_type_id(
                     type_engine,
                     decl_engine,
                     context,
-                    slice_elem.type_id,
+                    slice_elem.type_id(),
                     span,
                 )?;
                 Type::get_typed_slice(context, elem_ir_type)

--- a/sway-core/src/ir_generation/types.rs
+++ b/sway-core/src/ir_generation/types.rs
@@ -1,8 +1,9 @@
 use crate::{
+    ast_elements::type_argument::GenericTypeArgument,
     decl_engine::DeclEngine,
     language::ty,
     type_system::{TypeId, TypeInfo},
-    TypeArgument, TypeEngine,
+    GenericArgument, TypeEngine,
 };
 
 use super::convert::convert_resolved_typeid_no_span;
@@ -26,7 +27,7 @@ pub(super) fn create_tagged_union_type(
                 type_engine,
                 decl_engine,
                 context,
-                tev.type_argument.type_id,
+                tev.type_argument.type_id(),
             )
         })
         .collect::<Result<Vec<_>, CompileError>>()?;
@@ -115,12 +116,12 @@ pub(super) fn get_struct_name_field_index_and_type(
                     .iter()
                     .enumerate()
                     .find(|(_, field)| field.name == *field_name)
-                    .map(|(idx, field)| (idx as u64, field.type_argument.type_id)),
+                    .map(|(idx, field)| (idx as u64, field.type_argument.type_id())),
             ))
         }
         (
             TypeInfo::Alias {
-                ty: TypeArgument { type_id, .. },
+                ty: GenericArgument::Type(GenericTypeArgument { type_id, .. }),
                 ..
             },
             _,
@@ -198,7 +199,7 @@ pub(super) fn get_indices_for_struct_access(
                             .enumerate()
                             .find(|(_, field)| field.name == *field_name);
                         let (field_idx, field_type) = match field_idx_and_type_opt {
-                            Some((idx, field)) => (idx as u64, field.type_argument.type_id),
+                            Some((idx, field)) => (idx as u64, field.type_argument.type_id()),
                             None => {
                                 return Err(CompileError::InternalOwned(
                                     format!(
@@ -216,7 +217,7 @@ pub(super) fn get_indices_for_struct_access(
                     }
                     (TypeInfo::Tuple(fields), ty::ProjectionKind::TupleField { index, .. }) => {
                         let field_type = match fields.get(*index) {
-                            Some(field_type_argument) => field_type_argument.type_id,
+                            Some(field_type_argument) => field_type_argument.type_id(),
                             None => {
                                 return Err(CompileError::InternalOwned(
                                     format!(

--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -4,7 +4,7 @@ use crate::{
         OrdWithEnginesContext, PartialEqWithEngines, PartialEqWithEnginesContext,
     },
     parsed::QualifiedPathType,
-    Engines, Ident, Namespace, GenericArgument,
+    Engines, GenericArgument, Ident, Namespace,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -434,7 +434,11 @@ impl CallPath {
     /// - `some::module::SomeGenericType<T, u64>`
     ///
     /// Note that the trailing arguments are never separated by `::` from the suffix.
-    pub(crate) fn to_string_with_args(&self, engines: &Engines, args: &[GenericArgument]) -> String {
+    pub(crate) fn to_string_with_args(
+        &self,
+        engines: &Engines,
+        args: &[GenericArgument],
+    ) -> String {
         let args = args
             .iter()
             .map(|type_arg| engines.help_out(type_arg).to_string())

--- a/sway-core/src/language/call_path.rs
+++ b/sway-core/src/language/call_path.rs
@@ -4,7 +4,7 @@ use crate::{
         OrdWithEnginesContext, PartialEqWithEngines, PartialEqWithEnginesContext,
     },
     parsed::QualifiedPathType,
-    Engines, Ident, Namespace, TypeArgument,
+    Engines, Ident, Namespace, GenericArgument,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -434,7 +434,7 @@ impl CallPath {
     /// - `some::module::SomeGenericType<T, u64>`
     ///
     /// Note that the trailing arguments are never separated by `::` from the suffix.
-    pub(crate) fn to_string_with_args(&self, engines: &Engines, args: &[TypeArgument]) -> String {
+    pub(crate) fn to_string_with_args(&self, engines: &Engines, args: &[GenericArgument]) -> String {
         let args = args
             .iter()
             .map(|type_arg| engines.help_out(type_arg).to_string())

--- a/sway-core/src/language/parsed/declaration.rs
+++ b/sway-core/src/language/parsed/declaration.rs
@@ -152,7 +152,7 @@ impl Declaration {
             Declaration::StructDeclaration(decl_id) => Ok(*decl_id),
             Declaration::TypeAliasDeclaration(decl_id) => {
                 let alias = engines.pe().get_type_alias(decl_id);
-                let struct_decl_id = engines.te().get(alias.ty.type_id).expect_struct(
+                let struct_decl_id = engines.te().get(alias.ty.type_id()).expect_struct(
                     handler,
                     engines,
                     &self.span(engines),

--- a/sway-core/src/language/parsed/declaration/configurable.rs
+++ b/sway-core/src/language/parsed/declaration/configurable.rs
@@ -1,7 +1,7 @@
 use crate::{
     engine_threading::DebugWithEngines,
     language::{parsed::Expression, Visibility},
-    transform, Engines, TypeArgument,
+    transform, Engines, GenericArgument,
 };
 use sway_types::{Ident, Named, Span, Spanned};
 
@@ -9,7 +9,7 @@ use sway_types::{Ident, Named, Span, Spanned};
 pub struct ConfigurableDeclaration {
     pub name: Ident,
     pub attributes: transform::Attributes,
-    pub type_ascription: TypeArgument,
+    pub type_ascription: GenericArgument,
     pub value: Option<Expression>,
     pub visibility: Visibility,
     pub span: Span,

--- a/sway-core/src/language/parsed/declaration/constant.rs
+++ b/sway-core/src/language/parsed/declaration/constant.rs
@@ -3,7 +3,7 @@ use crate::{
         DebugWithEngines, EqWithEngines, PartialEqWithEngines, PartialEqWithEnginesContext,
     },
     language::{parsed::Expression, Visibility},
-    transform, Engines, TypeArgument,
+    transform, Engines, GenericArgument,
 };
 use sway_types::{Ident, Named, Span, Spanned};
 
@@ -11,7 +11,7 @@ use sway_types::{Ident, Named, Span, Spanned};
 pub struct ConstantDeclaration {
     pub name: Ident,
     pub attributes: transform::Attributes,
-    pub type_ascription: TypeArgument,
+    pub type_ascription: GenericArgument,
     pub value: Option<Expression>,
     pub visibility: Visibility,
     pub span: Span,

--- a/sway-core/src/language/parsed/declaration/enum.rs
+++ b/sway-core/src/language/parsed/declaration/enum.rs
@@ -44,7 +44,7 @@ impl Spanned for EnumDeclaration {
 pub struct EnumVariant {
     pub name: Ident,
     pub attributes: transform::Attributes,
-    pub type_argument: TypeArgument,
+    pub type_argument: GenericArgument,
     pub(crate) tag: usize,
     pub(crate) span: Span,
 }

--- a/sway-core/src/language/parsed/declaration/function.rs
+++ b/sway-core/src/language/parsed/declaration/function.rs
@@ -23,7 +23,7 @@ pub struct FunctionDeclaration {
     pub body: CodeBlock,
     pub parameters: Vec<FunctionParameter>,
     pub span: Span,
-    pub return_type: TypeArgument,
+    pub return_type: GenericArgument,
     pub type_parameters: Vec<TypeParameter>,
     pub where_clause: Vec<(Ident, Vec<TraitConstraint>)>,
     pub kind: FunctionDeclarationKind,
@@ -68,7 +68,7 @@ pub struct FunctionParameter {
     pub is_reference: bool,
     pub is_mutable: bool,
     pub mutability_span: Span,
-    pub type_argument: TypeArgument,
+    pub type_argument: GenericArgument,
 }
 
 impl EqWithEngines for FunctionParameter {}

--- a/sway-core/src/language/parsed/declaration/impl_trait.rs
+++ b/sway-core/src/language/parsed/declaration/impl_trait.rs
@@ -5,7 +5,7 @@ use crate::{
         DebugWithEngines, EqWithEngines, PartialEqWithEngines, PartialEqWithEnginesContext,
     },
     language::CallPath,
-    type_system::TypeArgument,
+    type_system::GenericArgument,
     Engines, TypeParameter,
 };
 
@@ -68,9 +68,9 @@ pub struct ImplSelfOrTrait {
     pub is_self: bool,
     pub impl_type_parameters: Vec<TypeParameter>,
     pub trait_name: CallPath,
-    pub trait_type_arguments: Vec<TypeArgument>,
+    pub trait_type_arguments: Vec<GenericArgument>,
     pub trait_decl_ref: Option<ParsedInterfaceDeclId>,
-    pub implementing_for: TypeArgument,
+    pub implementing_for: GenericArgument,
     pub items: Vec<ImplItem>,
     /// The [Span] of the whole impl trait and block.
     pub(crate) block_span: Span,

--- a/sway-core/src/language/parsed/declaration/storage.rs
+++ b/sway-core/src/language/parsed/declaration/storage.rs
@@ -80,7 +80,7 @@ pub struct StorageField {
     pub name: Ident,
     pub key_expression: Option<Expression>,
     pub attributes: transform::Attributes,
-    pub type_argument: TypeArgument,
+    pub type_argument: GenericArgument,
     pub span: Span,
     pub initializer: Expression,
 }

--- a/sway-core/src/language/parsed/declaration/struct.rs
+++ b/sway-core/src/language/parsed/declaration/struct.rs
@@ -3,7 +3,7 @@ use crate::{
     language::Visibility,
     transform,
     type_system::TypeParameter,
-    TypeArgument,
+    GenericArgument,
 };
 use sway_types::{ident::Ident, span::Span, Named, Spanned};
 
@@ -48,7 +48,7 @@ pub struct StructField {
     pub name: Ident,
     pub attributes: transform::Attributes,
     pub(crate) span: Span,
-    pub type_argument: TypeArgument,
+    pub type_argument: GenericArgument,
 }
 
 impl EqWithEngines for StructField {}

--- a/sway-core/src/language/parsed/declaration/trait.rs
+++ b/sway-core/src/language/parsed/declaration/trait.rs
@@ -116,7 +116,7 @@ pub struct TraitFn {
     pub attributes: transform::Attributes,
     pub purity: Purity,
     pub parameters: Vec<FunctionParameter>,
-    pub return_type: TypeArgument,
+    pub return_type: GenericArgument,
 }
 
 impl Spanned for TraitFn {
@@ -129,7 +129,7 @@ impl Spanned for TraitFn {
 pub struct TraitTypeDeclaration {
     pub name: Ident,
     pub attributes: transform::Attributes,
-    pub ty_opt: Option<TypeArgument>,
+    pub ty_opt: Option<GenericArgument>,
     pub span: Span,
 }
 

--- a/sway-core/src/language/parsed/declaration/type_alias.rs
+++ b/sway-core/src/language/parsed/declaration/type_alias.rs
@@ -11,7 +11,7 @@ use sway_types::{ident::Ident, span::Span, Named, Spanned};
 pub struct TypeAliasDeclaration {
     pub name: Ident,
     pub attributes: transform::Attributes,
-    pub ty: TypeArgument,
+    pub ty: GenericArgument,
     pub visibility: Visibility,
     pub span: Span,
 }

--- a/sway-core/src/language/parsed/declaration/variable.rs
+++ b/sway-core/src/language/parsed/declaration/variable.rs
@@ -3,13 +3,13 @@ use sway_types::{Named, Spanned};
 use crate::{
     engine_threading::{EqWithEngines, PartialEqWithEngines, PartialEqWithEnginesContext},
     language::parsed::Expression,
-    Ident, TypeArgument,
+    Ident, GenericArgument,
 };
 
 #[derive(Debug, Clone)]
 pub struct VariableDeclaration {
     pub name: Ident,
-    pub type_ascription: TypeArgument,
+    pub type_ascription: GenericArgument,
     pub body: Expression, // will be codeblock variant
     pub is_mutable: bool,
 }

--- a/sway-core/src/language/parsed/declaration/variable.rs
+++ b/sway-core/src/language/parsed/declaration/variable.rs
@@ -3,7 +3,7 @@ use sway_types::{Named, Spanned};
 use crate::{
     engine_threading::{EqWithEngines, PartialEqWithEngines, PartialEqWithEnginesContext},
     language::parsed::Expression,
-    Ident, GenericArgument,
+    GenericArgument, Ident,
 };
 
 #[derive(Debug, Clone)]

--- a/sway-core/src/language/parsed/expression/method_name.rs
+++ b/sway-core/src/language/parsed/expression/method_name.rs
@@ -1,7 +1,7 @@
 use crate::engine_threading::{EqWithEngines, PartialEqWithEngines, PartialEqWithEnginesContext};
 use crate::language::CallPath;
 use crate::type_system::TypeBinding;
-use crate::{Ident, GenericArgument, TypeId, TypeInfo};
+use crate::{GenericArgument, Ident, TypeId, TypeInfo};
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]

--- a/sway-core/src/language/parsed/expression/method_name.rs
+++ b/sway-core/src/language/parsed/expression/method_name.rs
@@ -1,7 +1,7 @@
 use crate::engine_threading::{EqWithEngines, PartialEqWithEngines, PartialEqWithEnginesContext};
 use crate::language::CallPath;
 use crate::type_system::TypeBinding;
-use crate::{Ident, TypeArgument, TypeId, TypeInfo};
+use crate::{Ident, GenericArgument, TypeId, TypeInfo};
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
@@ -24,7 +24,7 @@ pub enum MethodName {
     /// Represents a method lookup with a fully qualified path.
     /// like <S as Trait>::method()
     FromQualifiedPathRoot {
-        ty: TypeArgument,
+        ty: GenericArgument,
         as_trait: TypeId,
         method_name: Ident,
     },

--- a/sway-core/src/language/parsed/expression/mod.rs
+++ b/sway-core/src/language/parsed/expression/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     language::{parsed::CodeBlock, *},
     type_system::TypeBinding,
-    Engines, TypeArgument, TypeId,
+    Engines, GenericArgument, TypeId,
 };
 use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, fmt, hash::Hasher};
@@ -228,7 +228,7 @@ impl Spanned for AmbiguousSuffix {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QualifiedPathType {
-    pub ty: TypeArgument,
+    pub ty: GenericArgument,
     pub as_trait: TypeId,
     pub as_trait_span: Span,
 }

--- a/sway-core/src/language/ty/declaration/configurable.rs
+++ b/sway-core/src/language/ty/declaration/configurable.rs
@@ -22,7 +22,7 @@ pub struct TyConfigurableDecl {
     pub visibility: Visibility,
     pub attributes: transform::Attributes,
     pub return_type: TypeId,
-    pub type_ascription: TypeArgument,
+    pub type_ascription: GenericArgument,
     pub span: Span,
     // Only encoding v1 has a decode_fn
     pub decode_fn: Option<DeclRef<DeclId<TyFunctionDecl>>>,

--- a/sway-core/src/language/ty/declaration/constant.rs
+++ b/sway-core/src/language/ty/declaration/constant.rs
@@ -22,7 +22,7 @@ pub struct TyConstantDecl {
     pub visibility: Visibility,
     pub attributes: transform::Attributes,
     pub return_type: TypeId,
-    pub type_ascription: TypeArgument,
+    pub type_ascription: GenericArgument,
     pub span: Span,
 }
 

--- a/sway-core/src/language/ty/declaration/declaration.rs
+++ b/sway-core/src/language/ty/declaration/declaration.rs
@@ -373,7 +373,7 @@ impl DisplayWithEngines for TyDecl {
                     builder.push_str(": ");
                     builder.push_str(
                         &engines
-                            .help_out(&*type_engine.get(type_ascription.type_id))
+                            .help_out(&*type_engine.get(type_ascription.type_id()))
                             .to_string(),
                     );
                     builder.push_str(" = ");
@@ -423,7 +423,7 @@ impl CollectTypesMetadata for TyDecl {
                 body.append(
                     &mut decl
                         .type_ascription
-                        .type_id
+                        .type_id()
                         .collect_types_metadata(handler, ctx)?,
                 );
                 body
@@ -555,7 +555,7 @@ impl TyDecl {
                 let TyTypeAliasDecl { ty, span, .. } = &*alias_decl;
                 engines
                     .te()
-                    .get(ty.type_id)
+                    .get(ty.type_id())
                     .expect_enum(handler, engines, "", span)
             }
             // `Self` type parameter might resolve to an Enum
@@ -591,7 +591,7 @@ impl TyDecl {
                 let TyTypeAliasDecl { ty, span, .. } = &*alias_decl;
                 engines
                     .te()
-                    .get(ty.type_id)
+                    .get(ty.type_id())
                     .expect_struct(handler, engines, span)
             }
             TyDecl::ErrorRecovery(_, err) => Err(*err),
@@ -765,7 +765,7 @@ impl TyDecl {
         match self {
             TyDecl::ImplSelfOrTrait(ImplSelfOrTrait { decl_id, .. }) => {
                 let decl = decl_engine.get_impl_self_or_trait(decl_id);
-                let implementing_for_type_id_arc = type_engine.get(decl.implementing_for.type_id);
+                let implementing_for_type_id_arc = type_engine.get(decl.implementing_for.type_id());
                 let implementing_for_type_id = &*implementing_for_type_id_arc;
                 format!(
                     "{} for {:?}",
@@ -828,7 +828,7 @@ impl TyDecl {
             TyDecl::VariableDecl(decl) => decl.return_type,
             TyDecl::FunctionDecl(FunctionDecl { decl_id, .. }) => {
                 let decl = decl_engine.get_function(decl_id);
-                decl.return_type.type_id
+                decl.return_type.type_id()
             }
             TyDecl::StructDecl(StructDecl { decl_id }) => {
                 type_engine.insert_struct(engines, *decl_id)

--- a/sway-core/src/language/ty/declaration/enum.rs
+++ b/sway-core/src/language/ty/declaration/enum.rs
@@ -146,7 +146,7 @@ impl Spanned for TyEnumVariant {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TyEnumVariant {
     pub name: Ident,
-    pub type_argument: TypeArgument,
+    pub type_argument: GenericArgument,
     pub(crate) tag: usize,
     pub span: Span,
     pub attributes: transform::Attributes,

--- a/sway-core/src/language/ty/declaration/impl_trait.rs
+++ b/sway-core/src/language/ty/declaration/impl_trait.rs
@@ -17,17 +17,20 @@ pub type TyImplItem = TyTraitItem;
 pub struct TyImplSelfOrTrait {
     pub impl_type_parameters: Vec<TypeParameter>,
     pub trait_name: CallPath,
-    pub trait_type_arguments: Vec<TypeArgument>,
+    pub trait_type_arguments: Vec<GenericArgument>,
     pub items: Vec<TyImplItem>,
     pub supertrait_items: Vec<TyImplItem>,
     pub trait_decl_ref: Option<DeclRefMixedInterface>,
-    pub implementing_for: TypeArgument,
+    pub implementing_for: GenericArgument,
     pub span: Span,
 }
 
 impl TyImplSelfOrTrait {
     pub fn is_impl_contract(&self, te: &TypeEngine) -> bool {
-        matches!(&*te.get(self.implementing_for.type_id), TypeInfo::Contract)
+        matches!(
+            &*te.get(self.implementing_for.type_id()),
+            TypeInfo::Contract
+        )
     }
 
     pub fn is_impl_self(&self) -> bool {

--- a/sway-core/src/language/ty/declaration/mod.rs
+++ b/sway-core/src/language/ty/declaration/mod.rs
@@ -31,9 +31,9 @@ pub use trait_type::*;
 pub use type_alias::*;
 pub use variable::*;
 
-use crate::TypeArgument;
+use crate::GenericArgument;
 
 pub trait FunctionSignature {
     fn parameters(&self) -> &Vec<TyFunctionParameter>;
-    fn return_type(&self) -> &TypeArgument;
+    fn return_type(&self) -> &GenericArgument;
 }

--- a/sway-core/src/language/ty/declaration/storage.rs
+++ b/sway-core/src/language/ty/declaration/storage.rs
@@ -109,7 +109,7 @@ impl TyStorageDecl {
                     key_expression,
                     name,
                     ..
-                }) => (type_argument.type_id, key_expression, name),
+                }) => (type_argument.type_id(), key_expression, name),
                 None => {
                     return Err(handler.emit_err(CompileError::StorageFieldDoesNotExist {
                         field_name: first_field.into(),
@@ -165,7 +165,7 @@ impl TyStorageDecl {
 
                             // Everything is fine. Push the storage access descriptor and move to the next field.
 
-                            let current_field_type_id = struct_field.type_argument.type_id;
+                            let current_field_type_id = struct_field.type_argument.type_id();
 
                             access_descriptors.push(TyStorageAccessDescriptor {
                                 name: field.clone(),
@@ -247,7 +247,7 @@ pub struct TyStorageField {
     pub name: Ident,
     pub namespace_names: Vec<Ident>,
     pub key_expression: Option<TyExpression>,
-    pub type_argument: TypeArgument,
+    pub type_argument: GenericArgument,
     pub initializer: TyExpression,
     pub(crate) span: Span,
     pub attributes: transform::Attributes,

--- a/sway-core/src/language/ty/declaration/struct.rs
+++ b/sway-core/src/language/ty/declaration/struct.rs
@@ -135,7 +135,7 @@ impl TyStructDecl {
             .iter()
             .enumerate()
             .find(|(_, field)| field.name == *field_name)
-            .map(|(idx, field)| (idx as u64, field.type_argument.type_id))
+            .map(|(idx, field)| (idx as u64, field.type_argument.type_id()))
     }
 
     /// Returns true if the struct `self` has at least one private field.
@@ -200,7 +200,7 @@ pub struct TyStructField {
     pub visibility: Visibility,
     pub name: Ident,
     pub span: Span,
-    pub type_argument: TypeArgument,
+    pub type_argument: GenericArgument,
     pub attributes: transform::Attributes,
 }
 

--- a/sway-core/src/language/ty/declaration/trait_fn.rs
+++ b/sway-core/src/language/ty/declaration/trait_fn.rs
@@ -20,7 +20,7 @@ pub struct TyTraitFn {
     pub(crate) span: Span,
     pub(crate) purity: Purity,
     pub parameters: Vec<TyFunctionParameter>,
-    pub return_type: TypeArgument,
+    pub return_type: GenericArgument,
     pub attributes: transform::Attributes,
 }
 
@@ -39,11 +39,11 @@ impl DebugWithEngines for TyTraitFn {
                 .map(|p| format!(
                     "{}:{}",
                     p.name.as_str(),
-                    engines.help_out(p.type_argument.initial_type_id)
+                    engines.help_out(p.type_argument.initial_type_id())
                 ))
                 .collect::<Vec<_>>()
                 .join(", "),
-            engines.help_out(self.return_type.initial_type_id),
+            engines.help_out(self.return_type.initial_type_id()),
         )
     }
 }
@@ -67,11 +67,11 @@ impl IsConcrete for TyTraitFn {
             .all(|tp| tp.is_concrete(engines))
             && self
                 .return_type
-                .type_id
+                .type_id()
                 .is_concrete(engines, TreatNumericAs::Concrete)
             && self.parameters().iter().all(|t| {
                 t.type_argument
-                    .type_id
+                    .type_id()
                     .is_concrete(engines, TreatNumericAs::Concrete)
             })
     }
@@ -82,7 +82,7 @@ impl declaration::FunctionSignature for TyTraitFn {
         &self.parameters
     }
 
-    fn return_type(&self) -> &TypeArgument {
+    fn return_type(&self) -> &GenericArgument {
         &self.return_type
     }
 }
@@ -95,8 +95,8 @@ impl PartialEqWithEngines for TyTraitFn {
             && self.purity == other.purity
             && self.parameters.eq(&other.parameters, ctx)
             && type_engine
-                .get(self.return_type.type_id)
-                .eq(&type_engine.get(other.return_type.type_id), ctx)
+                .get(self.return_type.type_id())
+                .eq(&type_engine.get(other.return_type.type_id()), ctx)
             && self.attributes == other.attributes
     }
 }
@@ -116,7 +116,7 @@ impl HashWithEngines for TyTraitFn {
         let type_engine = engines.te();
         name.hash(state);
         parameters.hash(state, engines);
-        type_engine.get(return_type.type_id).hash(state, engines);
+        type_engine.get(return_type.type_id()).hash(state, engines);
         purity.hash(state);
     }
 }

--- a/sway-core/src/language/ty/declaration/trait_type.rs
+++ b/sway-core/src/language/ty/declaration/trait_type.rs
@@ -13,7 +13,7 @@ use sway_types::{Ident, Named, Span, Spanned};
 pub struct TyTraitType {
     pub name: Ident,
     pub attributes: transform::Attributes,
-    pub ty: Option<TypeArgument>,
+    pub ty: Option<GenericArgument>,
     pub implementing_type: TypeId,
     pub span: Span,
 }
@@ -37,7 +37,7 @@ impl Named for TyTraitType {
 impl IsConcrete for TyTraitType {
     fn is_concrete(&self, engines: &Engines) -> bool {
         if let Some(ty) = &self.ty {
-            ty.type_id.is_concrete(engines, TreatNumericAs::Concrete)
+            ty.type_id().is_concrete(engines, TreatNumericAs::Concrete)
         } else {
             false
         }

--- a/sway-core/src/language/ty/declaration/type_alias.rs
+++ b/sway-core/src/language/ty/declaration/type_alias.rs
@@ -13,7 +13,7 @@ pub struct TyTypeAliasDecl {
     pub name: Ident,
     pub call_path: CallPath,
     pub attributes: transform::Attributes,
-    pub ty: TypeArgument,
+    pub ty: GenericArgument,
     pub visibility: Visibility,
     pub span: Span,
 }

--- a/sway-core/src/language/ty/declaration/variable.rs
+++ b/sway-core/src/language/ty/declaration/variable.rs
@@ -13,7 +13,7 @@ pub struct TyVariableDecl {
     pub body: TyExpression,
     pub mutability: VariableMutability,
     pub return_type: TypeId,
-    pub type_ascription: TypeArgument,
+    pub type_ascription: GenericArgument,
 }
 
 impl TyDeclParsedType for TyVariableDecl {

--- a/sway-core/src/language/ty/expression/expression.rs
+++ b/sway-core/src/language/ty/expression/expression.rs
@@ -140,7 +140,7 @@ impl TypeCheckFinalization for TyExpression {
         let res = self.expression.type_check_finalize(handler, ctx);
         if let TyExpressionVariant::FunctionApplication { fn_ref, .. } = &self.expression {
             let method = ctx.engines.de().get_function(fn_ref);
-            self.return_type = method.return_type.type_id;
+            self.return_type = method.return_type.type_id();
         }
         res
     }
@@ -190,7 +190,7 @@ impl CollectTypesMetadata for TyExpression {
                                         .and_then(|type_binding| {
                                             type_binding.type_arguments.as_slice().get(idx)
                                         })
-                                        .map(|type_argument| Some(type_argument.span.clone()))
+                                        .map(|type_argument| Some(type_argument.span()))
                                         .unwrap_or(original_span);
                                     TypeMetadata::UnresolvedType(ident, span)
                                 }
@@ -321,7 +321,7 @@ impl CollectTypesMetadata for TyExpression {
                     res.append(
                         &mut variant
                             .type_argument
-                            .type_id
+                            .type_id()
                             .collect_types_metadata(handler, ctx)?,
                     );
                 }
@@ -350,7 +350,7 @@ impl CollectTypesMetadata for TyExpression {
                 res.append(
                     &mut variant
                         .type_argument
-                        .type_id
+                        .type_id()
                         .collect_types_metadata(handler, ctx)?,
                 );
             }
@@ -563,7 +563,7 @@ impl TyExpression {
                 let fn_ty = engines.de().get(fn_ref);
                 if let Some(TyDecl::ImplSelfOrTrait(t)) = &fn_ty.implementing_type {
                     let t = &engines.de().get(&t.decl_id).implementing_for;
-                    if let TypeInfo::Struct(struct_id) = &*engines.te().get(t.type_id) {
+                    if let TypeInfo::Struct(struct_id) = &*engines.te().get(t.type_id()) {
                         let s = engines.de().get(struct_id);
                         emit_warning_if_deprecated(
                             &s.attributes,

--- a/sway-core/src/language/ty/expression/expression_variant.rs
+++ b/sway-core/src/language/ty/expression/expression_variant.rs
@@ -862,7 +862,7 @@ impl ReplaceDecls for TyExpressionVariant {
                                 implementing_for_typeid,
                                 &[ctx.namespace().current_package_name().clone()],
                                 &call_path.suffix,
-                                method.return_type.type_id,
+                                method.return_type.type_id(),
                                 &arguments
                                     .iter()
                                     .map(|a| a.1.return_type)
@@ -1078,7 +1078,7 @@ impl TypeCheckAnalysis for TyExpressionVariant {
                     unifier.unify(
                         handler,
                         arg.1.return_type,
-                        decl_param.type_argument.type_id,
+                        decl_param.type_argument.type_id(),
                         &Span::dummy(),
                         false,
                     );

--- a/sway-core/src/language/ty/expression/intrinsic_function.rs
+++ b/sway-core/src/language/ty/expression/intrinsic_function.rs
@@ -16,7 +16,7 @@ use sway_types::Span;
 pub struct TyIntrinsicFunctionKind {
     pub kind: Intrinsic,
     pub arguments: Vec<TyExpression>,
-    pub type_arguments: Vec<TypeArgument>,
+    pub type_arguments: Vec<GenericArgument>,
     pub span: Span,
 }
 
@@ -86,7 +86,7 @@ impl DebugWithEngines for TyIntrinsicFunctionKind {
         let targs = self
             .type_arguments
             .iter()
-            .map(|targ| format!("{:?}", engines.help_out(targ.type_id)))
+            .map(|targ| format!("{:?}", engines.help_out(targ.type_id())))
             .join(", ");
         let args = self
             .arguments
@@ -106,7 +106,7 @@ impl CollectTypesMetadata for TyIntrinsicFunctionKind {
     ) -> Result<Vec<TypeMetadata>, ErrorEmitted> {
         let mut types_metadata = vec![];
         for type_arg in self.type_arguments.iter() {
-            types_metadata.append(&mut type_arg.type_id.collect_types_metadata(handler, ctx)?);
+            types_metadata.append(&mut type_arg.type_id().collect_types_metadata(handler, ctx)?);
         }
         for arg in self.arguments.iter() {
             types_metadata.append(&mut arg.collect_types_metadata(handler, ctx)?);

--- a/sway-core/src/language/ty/program.rs
+++ b/sway-core/src/language/ty/program.rs
@@ -138,7 +138,7 @@ impl TyProgram {
                         ..
                     } = &*impl_trait_decl;
                     if matches!(
-                        &*ty_engine.get(implementing_for.type_id),
+                        &*ty_engine.get(implementing_for.type_id()),
                         TypeInfo::Contract
                     ) {
                         // add methods to the ABI only if they come from an ABI implementation
@@ -208,7 +208,7 @@ impl TyProgram {
                         for field in storage_decl.fields.iter() {
                             if let Some(error) = get_type_not_allowed_error(
                                 engines,
-                                field.type_argument.type_id,
+                                field.type_argument.type_id(),
                                 &field.type_argument,
                                 |t| match t {
                                     TypeInfo::StringSlice => {
@@ -289,7 +289,7 @@ impl TyProgram {
                 };
 
                 let main_fn = decl_engine.get(&main_fn_id);
-                if !ty_engine.get(main_fn.return_type.type_id).is_bool() {
+                if !ty_engine.get(main_fn.return_type.type_id()).is_bool() {
                     handler.emit_err(CompileError::PredicateMainDoesNotReturnBool(
                         main_fn.span.clone(),
                     ));
@@ -343,7 +343,7 @@ impl TyProgram {
                     for p in main_fn.parameters() {
                         if let Some(error) = get_type_not_allowed_error(
                             engines,
-                            p.type_argument.type_id,
+                            p.type_argument.type_id(),
                             &p.type_argument,
                             |t| match t {
                                 TypeInfo::StringSlice => {
@@ -362,7 +362,7 @@ impl TyProgram {
                     // Check main return type is valid
                     if let Some(error) = get_type_not_allowed_error(
                         engines,
-                        main_fn.return_type.type_id,
+                        main_fn.return_type.type_id(),
                         &main_fn.return_type,
                         |t| match t {
                             TypeInfo::StringSlice => {
@@ -376,7 +376,7 @@ impl TyProgram {
                     ) {
                         // Let main return `raw_slice` directly
                         if !matches!(
-                            &*engines.te().get(main_fn.return_type.type_id),
+                            &*engines.te().get(main_fn.return_type.type_id()),
                             TypeInfo::RawUntypedSlice
                         ) {
                             handler.emit_err(error);

--- a/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/abi_encoding.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/abi_encoding.rs
@@ -125,7 +125,7 @@ where
         let arms = decl.variants.iter()
             .map(|x| {
                 let name = x.name.as_str();
-                Some(match &*engines.te().get(x.type_argument.type_id) {
+                Some(match &*engines.te().get(x.type_argument.type_id()) {
                     // unit
                     TypeInfo::Tuple(fields) if fields.is_empty() => {
                         format!("{} => {}::{}, \n", x.tag, enum_name, name)
@@ -162,7 +162,7 @@ where
             .iter()
             .map(|x| {
                 let name = x.name.as_str();
-                if engines.te().get(x.type_argument.type_id).is_unit() {
+                if engines.te().get(x.type_argument.type_id()).is_unit() {
                     format!(
                         "{enum_name}::{variant_name} => {{
                         {tag_value}u64.abi_encode(buffer)

--- a/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/mod.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/auto_impl/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         ty::{self, TyAstNode, TyDecl},
     },
     semantic_analysis::TypeCheckContext,
-    Engines, TypeArgument, TypeInfo, TypeParameter,
+    Engines, GenericArgument, TypeInfo, TypeParameter,
 };
 use sway_error::handler::Handler;
 use sway_parse::Parse;
@@ -268,7 +268,7 @@ where
                 &handler,
                 impl_trait.trait_name.clone(),
                 impl_trait.trait_type_arguments.clone(),
-                impl_trait.implementing_for.type_id,
+                impl_trait.implementing_for.type_id(),
                 impl_trait.impl_type_parameters.clone(),
                 &impl_trait.items,
                 &impl_trait.span,
@@ -294,8 +294,8 @@ where
     /// The safest way would be to return a canonical fully qualified type path.
     /// We do not have a way to do this at the moment, so the best way is to use
     /// exactly what was typed by the user, to accommodate aliased imports.
-    fn generate_type(engines: &Engines, ta: &TypeArgument) -> Option<String> {
-        match &*engines.te().get(ta.type_id) {
+    fn generate_type(engines: &Engines, ta: &GenericArgument) -> Option<String> {
+        match &*engines.te().get(ta.type_id()) {
             // A special case for function return type.
             // When a function does not define a return type, the span points to the whole signature.
             TypeInfo::Tuple(v) if v.is_empty() => Some("()".into()),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/constant.rs
@@ -53,18 +53,18 @@ impl ty::TyConstantDecl {
             visibility,
         } = decl;
 
-        type_ascription.type_id = ctx
+        *type_ascription.type_id_mut() = ctx
             .resolve_type(
                 handler,
-                type_ascription.type_id,
-                &type_ascription.span,
+                type_ascription.type_id(),
+                &type_ascription.span(),
                 EnforceTypeArguments::No,
                 None,
             )
             .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
         // this subst is required to replace associated types, namely TypeInfo::TraitType.
-        type_ascription.type_id.subst(&ctx.subst_ctx());
+        type_ascription.type_id_mut().subst(&ctx.subst_ctx());
 
         if !is_screaming_snake_case(name.as_str()) {
             handler.emit_warn(CompileWarning {
@@ -75,7 +75,7 @@ impl ty::TyConstantDecl {
 
         let mut ctx = ctx
             .by_ref()
-            .with_type_annotation(type_ascription.type_id)
+            .with_type_annotation(type_ascription.type_id())
             .with_help_text(
                 "This declaration's type annotation does not match up with the assigned \
         expression's type.",
@@ -89,11 +89,11 @@ impl ty::TyConstantDecl {
         // to get the type of the variable. The type of the variable *has* to follow
         // `type_ascription` if `type_ascription` is a concrete integer type that does not
         // conflict with the type of `expression` (i.e. passes the type checking above).
-        let return_type = match &*type_engine.get(type_ascription.type_id) {
-            TypeInfo::UnsignedInteger(_) => type_ascription.type_id,
+        let return_type = match &*type_engine.get(type_ascription.type_id()) {
+            TypeInfo::UnsignedInteger(_) => type_ascription.type_id(),
             _ => match &value {
                 Some(value) => value.return_type,
-                None => type_ascription.type_id,
+                None => type_ascription.type_id(),
             },
         };
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/declaration.rs
@@ -1,3 +1,4 @@
+use ast_elements::type_argument::GenericTypeArgument;
 use sway_error::handler::{ErrorEmitted, Handler};
 use sway_types::{Ident, Named, Spanned};
 
@@ -245,7 +246,7 @@ impl TyDecl {
                         handler,
                         impl_trait.trait_name.clone(),
                         impl_trait.trait_type_arguments.clone(),
-                        impl_trait.implementing_for.type_id,
+                        impl_trait.implementing_for.type_id(),
                         impl_trait.impl_type_parameters.clone(),
                         &impl_trait.items,
                         &impl_trait.span,
@@ -272,7 +273,7 @@ impl TyDecl {
                 // Insert prefixed symbols when implementing_for is Contract
                 let is_contract = engines
                     .te()
-                    .get(impl_trait.implementing_for.type_id)
+                    .get(impl_trait.implementing_for.type_id())
                     .is_contract();
                 if is_contract {
                     for i in &impl_trait.items {
@@ -313,7 +314,7 @@ impl TyDecl {
                     handler,
                     impl_trait.trait_name.clone(),
                     impl_trait.trait_type_arguments.clone(),
-                    impl_trait.implementing_for.type_id,
+                    impl_trait.implementing_for.type_id(),
                     impl_trait.impl_type_parameters.clone(),
                     impl_trait_items,
                     &impl_trait.span,
@@ -415,9 +416,9 @@ impl TyDecl {
                             ..
                         }) = entry
                         {
-                            type_argument.type_id = ctx.by_ref().resolve_type(
+                            *type_argument.type_id_mut() = ctx.by_ref().resolve_type(
                                 handler,
-                                type_argument.type_id,
+                                type_argument.type_id(),
                                 &name.span(),
                                 EnforceTypeArguments::Yes,
                                 None,
@@ -425,7 +426,7 @@ impl TyDecl {
 
                             let mut ctx = ctx
                                 .by_ref()
-                                .with_type_annotation(type_argument.type_id)
+                                .with_type_annotation(type_argument.type_id())
                                 .with_storage_declaration();
                             let initializer =
                                 ty::TyExpression::type_check(handler, ctx.by_ref(), &initializer)?;
@@ -516,7 +517,13 @@ impl TyDecl {
 
                 // Resolve the type that the type alias replaces
                 let new_ty = ctx
-                    .resolve_type(handler, ty.type_id, &span, EnforceTypeArguments::Yes, None)
+                    .resolve_type(
+                        handler,
+                        ty.type_id(),
+                        &span,
+                        EnforceTypeArguments::Yes,
+                        None,
+                    )
                     .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
                 // create the type alias decl using the resolved type above
@@ -524,12 +531,12 @@ impl TyDecl {
                     name: name.clone(),
                     call_path: CallPath::from(name.clone()).to_fullpath(engines, ctx.namespace()),
                     attributes: decl.attributes.clone(),
-                    ty: TypeArgument {
-                        initial_type_id: ty.initial_type_id,
+                    ty: GenericArgument::Type(GenericTypeArgument {
+                        initial_type_id: ty.initial_type_id(),
                         type_id: new_ty,
-                        call_path_tree: ty.call_path_tree.clone(),
-                        span: ty.span.clone(),
-                    },
+                        call_path_tree: ty.call_path_tree().cloned(),
+                        span: ty.span(),
+                    }),
                     visibility: decl.visibility,
                     span,
                 };

--- a/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/enum.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use ast_elements::type_parameter::GenericTypeParameter;
 use sway_error::handler::{ErrorEmitted, Handler};
+use sway_types::Spanned;
 use symbol_collection_context::SymbolCollectionContext;
 
 impl ty::TyEnumDecl {
@@ -87,11 +88,11 @@ impl ty::TyEnumVariant {
     ) -> Result<Self, ErrorEmitted> {
         let type_engine = ctx.engines.te();
         let mut type_argument = variant.type_argument;
-        type_argument.type_id = ctx
+        *type_argument.type_id_mut() = ctx
             .resolve_type(
                 handler,
-                type_argument.type_id,
-                &type_argument.span,
+                type_argument.type_id(),
+                &type_argument.span(),
                 EnforceTypeArguments::Yes,
                 None,
             )

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function.rs
@@ -135,11 +135,11 @@ impl ty::TyFunctionDecl {
                 })?;
 
                 // type check the return type
-                return_type.type_id = ctx
+                *return_type.type_id_mut() = ctx
                     .resolve_type(
                         handler,
-                        return_type.type_id,
-                        &return_type.span,
+                        return_type.type_id(),
+                        &return_type.span(),
                         EnforceTypeArguments::Yes,
                         None,
                     )
@@ -234,8 +234,8 @@ impl ty::TyFunctionDecl {
                     .with_help_text(
                         "Function body's return type does not match up with its return type annotation.",
                     )
-                    .with_type_annotation(return_type.type_id)
-                    .with_function_type_annotation(return_type.type_id);
+                    .with_type_annotation(return_type.type_id())
+                    .with_function_type_annotation(return_type.type_id());
 
                 let body = ty::TyCodeBlock::type_check(handler, ctx.by_ref(), body, true)
                     .unwrap_or_else(|_err| ty::TyCodeBlock::default());
@@ -243,10 +243,10 @@ impl ty::TyFunctionDecl {
                 ty_fn_decl.body = body;
                 ty_fn_decl.is_type_check_finalized = true;
 
-                return_type.type_id.check_type_parameter_bounds(
+                return_type.type_id().check_type_parameter_bounds(
                     handler,
                     ctx.by_ref(),
-                    &return_type.span,
+                    &return_type.span(),
                     None,
                 )?;
 
@@ -376,14 +376,16 @@ fn test_function_selector_behavior() {
                 is_reference: false,
                 is_mutable: false,
                 mutability_span: Span::dummy(),
-                type_argument: TypeArgument {
-                    type_id: engines.te().id_of_u32(),
-                    initial_type_id: engines
-                        .te()
-                        .insert_string_array_without_annotations(&engines, 5),
-                    span: Span::dummy(),
-                    call_path_tree: None,
-                },
+                type_argument: GenericArgument::Type(
+                    ast_elements::type_argument::GenericTypeArgument {
+                        type_id: engines.te().id_of_u32(),
+                        initial_type_id: engines
+                            .te()
+                            .insert_string_array_without_annotations(&engines, 5),
+                        span: Span::dummy(),
+                        call_path_tree: None,
+                    },
+                ),
             },
         ],
         span: Span::dummy(),

--- a/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/function/function_parameter.rs
@@ -26,20 +26,20 @@ impl ty::TyFunctionParameter {
             mut type_argument,
         } = parameter;
 
-        type_argument.type_id = ctx
+        *type_argument.type_id_mut() = ctx
             .resolve_type(
                 handler,
-                type_argument.type_id,
-                &type_argument.span,
+                type_argument.type_id(),
+                &type_argument.span(),
                 EnforceTypeArguments::Yes,
                 None,
             )
             .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
-        type_argument.type_id.check_type_parameter_bounds(
+        type_argument.type_id().check_type_parameter_bounds(
             handler,
             ctx,
-            &type_argument.span,
+            &type_argument.span(),
             None,
         )?;
 
@@ -80,11 +80,11 @@ impl ty::TyFunctionParameter {
         } = parameter;
 
         let mut new_type_argument = type_argument.clone();
-        new_type_argument.type_id = ctx
+        *new_type_argument.type_id_mut() = ctx
             .resolve_type(
                 handler,
-                type_argument.type_id,
-                &type_argument.span,
+                type_argument.type_id(),
+                &type_argument.span(),
                 EnforceTypeArguments::Yes,
                 None,
             )
@@ -109,14 +109,14 @@ impl ty::TyFunctionParameter {
                 name: self.name.clone(),
                 body: ty::TyExpression {
                     expression: ty::TyExpressionVariant::FunctionParameter,
-                    return_type: self.type_argument.type_id,
+                    return_type: self.type_argument.type_id(),
                     span: self.name.span(),
                 },
                 mutability: ty::VariableMutability::new_from_ref_mut(
                     self.is_reference,
                     self.is_mutable,
                 ),
-                return_type: self.type_argument.type_id,
+                return_type: self.type_argument.type_id(),
                 type_ascription: self.type_argument.clone(),
             })),
         );

--- a/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/impl_trait.rs
@@ -196,10 +196,10 @@ impl TyImplSelfOrTrait {
 
                 // resolve the types of the trait type arguments
                 for type_arg in trait_type_arguments.iter_mut() {
-                    type_arg.type_id = ctx.resolve_type(
+                    *type_arg.type_id_mut() = ctx.resolve_type(
                         handler,
-                        type_arg.type_id,
-                        &type_arg.span,
+                        type_arg.type_id(),
+                        &type_arg.span(),
                         EnforceTypeArguments::Yes,
                         None,
                     )?;
@@ -207,21 +207,21 @@ impl TyImplSelfOrTrait {
 
                 // type check the type that we are implementing for
 
-                implementing_for.type_id = ctx.resolve_type(
+                *implementing_for.type_id_mut() = ctx.resolve_type(
                     handler,
-                    implementing_for.type_id,
-                    &implementing_for.span,
+                    implementing_for.type_id(),
+                    &implementing_for.span(),
                     EnforceTypeArguments::Yes,
                     None,
                 )?;
 
                 // check to see if this type is supported in impl blocks
                 type_engine
-                    .get(implementing_for.type_id)
+                    .get(implementing_for.type_id())
                     .expect_is_supported_in_impl_blocks_self(
                         handler,
                         Some(&trait_name.suffix),
-                        &implementing_for.span,
+                        &implementing_for.span(),
                     )?;
 
                 // check for unconstrained type parameters
@@ -230,7 +230,7 @@ impl TyImplSelfOrTrait {
                     engines,
                     &new_impl_type_parameters,
                     &trait_type_arguments,
-                    implementing_for.type_id,
+                    implementing_for.type_id(),
                 )?;
 
                 // Unify the "self" type param and the type that we are implementing for
@@ -238,9 +238,9 @@ impl TyImplSelfOrTrait {
                     type_engine.unify_with_self(
                         h,
                         engines,
-                        implementing_for.type_id,
+                        implementing_for.type_id(),
                         self_type_id,
-                        &implementing_for.span,
+                        &implementing_for.span(),
                         "",
                         None,
                     );
@@ -252,7 +252,7 @@ impl TyImplSelfOrTrait {
                     .by_ref()
                     .with_help_text("")
                     .with_type_annotation(type_engine.new_unknown())
-                    .with_self_type(Some(implementing_for.type_id));
+                    .with_self_type(Some(implementing_for.type_id()));
 
                 let impl_trait = match ctx.resolve_call_path(handler, &trait_name).ok() {
                     Some(ty::TyDecl::TraitDecl(ty::TraitDecl { decl_id, .. })) => {
@@ -286,13 +286,13 @@ impl TyImplSelfOrTrait {
                             ctx.by_ref(),
                             &trait_name,
                             &trait_type_arguments,
-                            implementing_for.type_id,
+                            implementing_for.type_id(),
                         );
 
                         let (new_items, supertrait_items) = type_check_trait_implementation(
                             handler,
                             ctx.by_ref(),
-                            implementing_for.type_id,
+                            implementing_for.type_id(),
                             &new_impl_type_parameters,
                             &trait_decl.type_parameters,
                             &trait_type_arguments,
@@ -328,13 +328,13 @@ impl TyImplSelfOrTrait {
 
                         let abi = decl_engine.get_abi(&decl_id);
 
-                        if !type_engine.get(implementing_for.type_id).eq(
+                        if !type_engine.get(implementing_for.type_id()).eq(
                             &TypeInfo::Contract,
                             &PartialEqWithEnginesContext::new(engines),
                         ) {
                             handler.emit_err(CompileError::ImplAbiForNonContract {
                                 span: implementing_for.span(),
-                                ty: engines.help_out(implementing_for.type_id).to_string(),
+                                ty: engines.help_out(implementing_for.type_id()).to_string(),
                             });
                         }
 
@@ -346,9 +346,9 @@ impl TyImplSelfOrTrait {
                             type_engine.unify_with_self(
                                 h,
                                 engines,
-                                implementing_for.type_id,
+                                implementing_for.type_id(),
                                 self_type_param.type_id,
-                                &implementing_for.span,
+                                &implementing_for.span(),
                                 "",
                                 None,
                             );
@@ -363,14 +363,14 @@ impl TyImplSelfOrTrait {
                             handler,
                             decl_id,
                             ctx.by_ref(),
-                            implementing_for.type_id,
+                            implementing_for.type_id(),
                             None,
                         );
 
                         let (new_items, supertrait_items) = type_check_trait_implementation(
                             handler,
                             ctx.by_ref(),
-                            implementing_for.type_id,
+                            implementing_for.type_id(),
                             &[], // this is empty because abi definitions don't support generics,
                             &[], // this is empty because abi definitions don't support generics,
                             &[], // this is empty because abi definitions don't support generics,
@@ -453,7 +453,7 @@ impl TyImplSelfOrTrait {
                 let self_type_id = self_type_param.type_id;
 
                 // create the trait name
-                let suffix = match &&*type_engine.get(implementing_for.type_id) {
+                let suffix = match &&*type_engine.get(implementing_for.type_id()) {
                     TypeInfo::Custom {
                         qualified_call_path: call_path,
                         ..
@@ -470,21 +470,21 @@ impl TyImplSelfOrTrait {
                 )?;
 
                 // type check the type that we are implementing for
-                implementing_for.type_id = ctx.resolve_type(
+                *implementing_for.type_id_mut() = ctx.resolve_type(
                     handler,
-                    implementing_for.type_id,
-                    &implementing_for.span,
+                    implementing_for.type_id(),
+                    &implementing_for.span(),
                     EnforceTypeArguments::Yes,
                     None,
                 )?;
 
                 // check to see if this type is supported in impl blocks
                 type_engine
-                    .get(implementing_for.type_id)
+                    .get(implementing_for.type_id())
                     .expect_is_supported_in_impl_blocks_self(
                         handler,
                         None,
-                        &implementing_for.span,
+                        &implementing_for.span(),
                     )?;
 
                 // check for unconstrained type parameters
@@ -493,13 +493,13 @@ impl TyImplSelfOrTrait {
                     engines,
                     &new_impl_type_parameters,
                     &[],
-                    implementing_for.type_id,
+                    implementing_for.type_id(),
                 )?;
 
-                implementing_for.type_id.check_type_parameter_bounds(
+                implementing_for.type_id().check_type_parameter_bounds(
                     handler,
                     ctx.by_ref(),
-                    &implementing_for.span,
+                    &implementing_for.span(),
                     None,
                 )?;
 
@@ -508,9 +508,9 @@ impl TyImplSelfOrTrait {
                     type_engine.unify_with_self(
                         h,
                         engines,
-                        implementing_for.type_id,
+                        implementing_for.type_id(),
                         self_type_id,
-                        &implementing_for.span,
+                        &implementing_for.span(),
                         "",
                         None,
                     );
@@ -536,7 +536,7 @@ impl TyImplSelfOrTrait {
                                     &fn_decl,
                                     true,
                                     true,
-                                    Some(implementing_for.type_id),
+                                    Some(implementing_for.type_id()),
                                 ) {
                                     Ok(res) => res,
                                     Err(_) => continue,
@@ -599,7 +599,7 @@ impl TyImplSelfOrTrait {
                         handler,
                         impl_trait.trait_name.clone(),
                         impl_trait.trait_type_arguments.clone(),
-                        impl_trait.implementing_for.type_id,
+                        impl_trait.implementing_for.type_id(),
                         impl_trait.impl_type_parameters.clone(),
                         &impl_trait.items,
                         &impl_trait.span,
@@ -776,7 +776,7 @@ fn type_check_trait_implementation(
     implementing_for: TypeId,
     impl_type_parameters: &[TypeParameter],
     trait_type_parameters: &[TypeParameter],
-    trait_type_arguments: &[TypeArgument],
+    trait_type_arguments: &[GenericArgument],
     trait_supertraits: &[Supertrait],
     trait_interface_surface: &[TyTraitInterfaceItem],
     trait_items: &[TyImplItem],
@@ -809,7 +809,7 @@ fn type_check_trait_implementation(
         })?;
 
     for (type_arg, type_param) in trait_type_arguments.iter().zip(trait_type_parameters) {
-        type_arg.type_id.check_type_parameter_bounds(
+        type_arg.type_id().check_type_parameter_bounds(
             handler,
             ctx.by_ref(),
             &type_arg.span(),
@@ -973,7 +973,7 @@ fn type_check_trait_implementation(
                                 type_decl.name.clone(),
                                 implementing_for,
                             )],
-                            vec![type_arg.type_id],
+                            vec![type_arg.type_id()],
                         ),
                     );
                     trait_type_mapping.extend(
@@ -983,7 +983,7 @@ fn type_check_trait_implementation(
                                 type_decl.name.clone(),
                                 self_type_id,
                             )],
-                            vec![type_arg.type_id],
+                            vec![type_arg.type_id()],
                         ),
                     );
                 }
@@ -1095,7 +1095,7 @@ fn type_check_trait_implementation(
             .collect(),
         trait_type_arguments
             .iter()
-            .map(|type_arg| type_arg.type_id)
+            .map(|type_arg| type_arg.type_id())
             .collect(),
     );
     type_mapping.extend(&trait_type_mapping);
@@ -1340,11 +1340,11 @@ fn type_check_impl_method(
             }
 
             // this subst is required to replace associated types, namely TypeInfo::TraitType.
-            let mut impl_method_param_type_id = impl_method_param.type_argument.type_id;
+            let mut impl_method_param_type_id = impl_method_param.type_argument.type_id();
             impl_method_param_type_id.subst(&ctx.subst_ctx());
 
             let mut impl_method_signature_param_type_id =
-                impl_method_signature_param.type_argument.type_id;
+                impl_method_signature_param.type_argument.type_id();
             impl_method_signature_param_type_id.subst(&ctx.subst_ctx());
 
             if !UnifyCheck::non_dynamic_equality(engines).check(
@@ -1353,7 +1353,7 @@ fn type_check_impl_method(
             ) {
                 handler.emit_err(CompileError::MismatchedTypeInInterfaceSurface {
                     interface_name: interface_name(),
-                    span: impl_method_param.type_argument.span.clone(),
+                    span: impl_method_param.type_argument.span(),
                     decl_type: "function".to_string(),
                     given: engines.help_out(impl_method_param_type_id).to_string(),
                     expected: engines
@@ -1415,11 +1415,11 @@ fn type_check_impl_method(
         }
 
         // this subst is required to replace associated types, namely TypeInfo::TraitType.
-        let mut impl_method_return_type_id = impl_method.return_type.type_id;
+        let mut impl_method_return_type_id = impl_method.return_type.type_id();
         impl_method_return_type_id.subst(&ctx.subst_ctx());
 
         let mut impl_method_signature_return_type_type_id =
-            impl_method_signature.return_type.type_id;
+            impl_method_signature.return_type.type_id();
         impl_method_signature_return_type_type_id.subst(&ctx.subst_ctx());
 
         if !UnifyCheck::non_dynamic_equality(engines).check(
@@ -1429,7 +1429,7 @@ fn type_check_impl_method(
             return Err(
                 handler.emit_err(CompileError::MismatchedTypeInInterfaceSurface {
                     interface_name: interface_name(),
-                    span: impl_method.return_type.span.clone(),
+                    span: impl_method.return_type.span(),
                     decl_type: "function".to_string(),
                     expected: engines
                         .help_out(impl_method_signature_return_type_type_id)
@@ -1581,10 +1581,10 @@ fn type_check_const_decl(
     };
 
     // this subst is required to replace associated types, namely TypeInfo::TraitType.
-    let mut const_decl_type_id = const_decl.type_ascription.type_id;
+    let mut const_decl_type_id = const_decl.type_ascription.type_id();
     const_decl_type_id.subst(&ctx.subst_ctx());
 
-    let mut const_decl_signature_type_id = const_decl_signature.type_ascription.type_id;
+    let mut const_decl_signature_type_id = const_decl_signature.type_ascription.type_id();
     const_decl_signature_type_id.subst(&ctx.subst_ctx());
 
     // unify the types from the constant with the constant signature
@@ -1700,7 +1700,7 @@ fn check_for_unconstrained_type_parameters(
     handler: &Handler,
     engines: &Engines,
     type_parameters: &[TypeParameter],
-    trait_type_arguments: &[TypeArgument],
+    trait_type_arguments: &[GenericArgument],
     self_type: TypeId,
 ) -> Result<(), ErrorEmitted> {
     // Create a list of defined generics, with the generic and a span.
@@ -1716,7 +1716,7 @@ fn check_for_unconstrained_type_parameters(
     // create a list of the generics in use in the impl signature
     let mut generics_in_use = HashSet::new();
     for type_arg in trait_type_arguments.iter() {
-        generics_in_use.extend(type_arg.type_id.extract_nested_generics(engines));
+        generics_in_use.extend(type_arg.type_id().extract_nested_generics(engines));
     }
     generics_in_use.extend(self_type.extract_nested_generics(engines));
 

--- a/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/struct.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use ast_elements::type_parameter::GenericTypeParameter;
 use sway_error::handler::{ErrorEmitted, Handler};
+use sway_types::Spanned;
 use symbol_collection_context::SymbolCollectionContext;
 
 impl ty::TyStructDecl {
@@ -87,11 +88,11 @@ impl ty::TyStructField {
         let type_engine = ctx.engines.te();
 
         let mut type_argument = field.type_argument;
-        type_argument.type_id = ctx
+        *type_argument.type_id_mut() = ctx
             .resolve_type(
                 handler,
-                type_argument.type_id,
-                &type_argument.span,
+                type_argument.type_id(),
+                &type_argument.span(),
                 EnforceTypeArguments::Yes,
                 None,
             )

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait.rs
@@ -339,7 +339,7 @@ impl TyTraitDecl {
         ctx: &TypeCheckContext,
         type_id: TypeId,
         call_path: &CallPath,
-        type_arguments: &[TypeArgument],
+        type_arguments: &[GenericArgument],
     ) -> (InterfaceItemMap, ItemMap, ItemMap) {
         let mut interface_surface_item_refs: InterfaceItemMap = BTreeMap::new();
         let mut item_refs: ItemMap = BTreeMap::new();
@@ -399,7 +399,7 @@ impl TyTraitDecl {
                     t.type_id
                 })
                 .collect(),
-            type_arguments.iter().map(|t| t.type_id).collect(),
+            type_arguments.iter().map(|t| t.type_id()).collect(),
         );
 
         for item in ctx
@@ -483,7 +483,7 @@ impl TyTraitDecl {
         handler: &Handler,
         mut ctx: TypeCheckContext,
         trait_name: &CallPath,
-        type_arguments: &[TypeArgument],
+        type_arguments: &[GenericArgument],
         type_id: TypeId,
     ) {
         let decl_engine = ctx.engines.de();
@@ -511,7 +511,7 @@ impl TyTraitDecl {
                     t.type_id
                 })
                 .collect(),
-            type_arguments.iter().map(|t| t.type_id).collect(),
+            type_arguments.iter().map(|t| t.type_id()).collect(),
         );
 
         let mut const_symbols = HashMap::<Ident, ty::TyDecl>::new();

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait_fn.rs
@@ -69,11 +69,11 @@ impl ty::TyTraitFn {
 
             // Type check the return type.
             let mut new_return_type = return_type.clone();
-            new_return_type.type_id = ctx
+            *new_return_type.type_id_mut() = ctx
                 .resolve_type(
                     handler,
-                    return_type.type_id,
-                    &return_type.span,
+                    return_type.type_id(),
+                    &return_type.span(),
                     EnforceTypeArguments::Yes,
                     None,
                 )

--- a/sway-core/src/semantic_analysis/ast_node/declaration/trait_type.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/trait_type.rs
@@ -2,7 +2,7 @@ use sway_error::{
     error::CompileError,
     handler::{ErrorEmitted, Handler},
 };
-use sway_types::Span;
+use sway_types::{Span, Spanned};
 
 use crate::{
     decl_engine::parsed_id::ParsedDeclId,
@@ -49,11 +49,11 @@ impl ty::TyTraitType {
         let type_engine = engines.te();
 
         let ty = if let Some(mut ty) = ty_opt {
-            ty.type_id = ctx
+            *ty.type_id_mut() = ctx
                 .resolve_type(
                     handler,
-                    ty.type_id,
-                    &ty.span,
+                    ty.type_id(),
+                    &ty.span(),
                     EnforceTypeArguments::No,
                     None,
                 )

--- a/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
+++ b/sway-core/src/semantic_analysis/ast_node/declaration/variable.rs
@@ -40,18 +40,18 @@ impl ty::TyVariableDecl {
 
         let mut type_ascription = var_decl.type_ascription.clone();
 
-        type_ascription.type_id = ctx
+        *type_ascription.type_id_mut() = ctx
             .resolve_type(
                 handler,
-                type_ascription.type_id,
-                &type_ascription.span,
+                type_ascription.type_id(),
+                &type_ascription.span(),
                 EnforceTypeArguments::Yes,
                 None,
             )
             .unwrap_or_else(|err| type_engine.id_of_error_recovery(err));
 
         let mut ctx = ctx
-            .with_type_annotation(type_ascription.type_id)
+            .with_type_annotation(type_ascription.type_id())
             .with_help_text(
                 "Variable declaration's type annotation does not match up \
                  with the assigned expression's type.",
@@ -67,7 +67,7 @@ impl ty::TyVariableDecl {
         // in a way to always use the context provided by the LHS, and use the unified type of LHS
         // and RHS as the return type of the RHS.  Remove this special case as a part of the
         // initiative of improving type inference.
-        let return_type = match (&*type_engine.get(type_ascription.type_id), &*type_engine.get(body.return_type)) {
+        let return_type = match (&*type_engine.get(type_ascription.type_id()), &*type_engine.get(body.return_type)) {
             // Integers: We can't rely on the type of the RHS to give us the correct integer
             // type, so the type of the variable *has* to follow `type_ascription` if
             // `type_ascription` is a concrete integer type that does not conflict with the type
@@ -84,7 +84,7 @@ impl ty::TyVariableDecl {
             //   let v = <some error>; // `v` will remain "{unknown}".
             // TODO: Refine and improve this further. E.g.,
             //   let v: Struct { /* MISSING FIELDS */ }; // Despite the error, `v` should be of type "Struct".
-            (_, TypeInfo::ErrorRecovery(_)) => type_ascription.type_id,
+            (_, TypeInfo::ErrorRecovery(_)) => type_ascription.type_id(),
             // In all other cases we use the type of the RHS.
             _ => body.return_type,
         };

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/matcher.rs
@@ -155,10 +155,10 @@ impl ReqDeclNode {
 /// };
 ///
 /// match p {
-///     Point { x, y: 5 } => { x },                        // 1.                 
+///     Point { x, y: 5 } => { x },                        // 1.
 ///     Point { x, y: 5 } | Point { x, y: 10 } => { x },   // 2.
-///     Point { x: 10, y: 24 } => { 1 },                   // 3.    
-///     Point { x: 22, .. } => { 2 },                      // 4.          
+///     Point { x: 10, y: 24 } => { 1 },                   // 3.
+///     Point { x: 22, .. } => { 2 },                      // 4.
 ///     Point { .. } => { 3 },                             // 5.
 ///     _ => 0                                             // 6.
 /// }
@@ -169,19 +169,19 @@ impl ReqDeclNode {
 ///
 /// ```ignore
 /// 1.
-///               &&  
+///               &&
 ///              /  \
 /// [let x = p.x]    [p.y == 5]
 ///
 /// 2.
-///                             ||       
+///                             ||
 ///                 ___________/  \____________
-///               &&                           &&    
-///              /  \                         /  \  
+///               &&                           &&
+///              /  \                         /  \
 /// [let x = p.x]    [p.y == 5]  [let x = p.x]    [p.y == 10]
 ///
 /// 3.
-///             &&  
+///             &&
 ///            /  \
 /// [p.x == 10]    [p.y == 24]
 ///
@@ -401,7 +401,7 @@ fn match_constant(
     span: Span,
 ) -> ReqDeclTree {
     let name = const_decl.name().clone();
-    let return_type = const_decl.type_ascription.type_id;
+    let return_type = const_decl.type_ascription.type_id();
 
     let req = (
         exp.to_owned(),

--- a/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/match_expression/typed/typed_scrutinee.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use ast_elements::type_parameter::GenericTypeParameter;
+use ast_elements::{type_argument::GenericTypeArgument, type_parameter::GenericTypeParameter};
 use itertools::Itertools;
 use sway_error::{
     error::{CompileError, StructFieldUsageContext},
@@ -560,11 +560,13 @@ fn type_check_tuple(
         engines,
         typed_elems
             .iter()
-            .map(|elem| TypeArgument {
-                type_id: elem.type_id,
-                initial_type_id: elem.type_id,
-                span: elem.span.clone(),
-                call_path_tree: None,
+            .map(|elem| {
+                GenericArgument::Type(GenericTypeArgument {
+                    type_id: elem.type_id,
+                    initial_type_id: elem.type_id,
+                    span: elem.span.clone(),
+                    call_path_tree: None,
+                })
             })
             .collect(),
     );

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression.rs
@@ -35,6 +35,7 @@ use crate::{
     Engines,
 };
 
+use ast_elements::type_argument::GenericTypeArgument;
 use ast_node::declaration::{insert_supertraits_into_namespace, SupertraitOf};
 use either::Either;
 use indexmap::IndexMap;
@@ -139,7 +140,7 @@ impl ty::TyExpression {
                 contract_call_params: IndexMap::new(),
                 contract_caller: None,
             },
-            return_type: return_type.type_id,
+            return_type: return_type.type_id(),
             span,
         };
         Ok(exp)
@@ -1181,26 +1182,26 @@ impl ty::TyExpression {
                 .map(|field_type_ids| field_type_ids[i].clone())
                 .unwrap_or_else(|| {
                     let initial_type_id = type_engine.new_unknown();
-                    TypeArgument {
+                    GenericArgument::Type(GenericTypeArgument {
                         type_id: initial_type_id,
                         initial_type_id,
                         span: Span::dummy(),
                         call_path_tree: None,
-                    }
+                    })
                 });
             let field_span = field.span();
             let ctx = ctx
                 .by_ref()
                 .with_help_text("tuple field type does not match the expected type")
-                .with_type_annotation(field_type.type_id);
+                .with_type_annotation(field_type.type_id());
             let typed_field = ty::TyExpression::type_check(handler, ctx, field)
                 .unwrap_or_else(|err| ty::TyExpression::error(err, field_span, engines));
-            typed_field_types.push(TypeArgument {
+            typed_field_types.push(GenericArgument::Type(GenericTypeArgument {
                 type_id: typed_field.return_type,
-                initial_type_id: field_type.type_id,
+                initial_type_id: field_type.type_id(),
                 span: typed_field.span.clone(),
                 call_path_tree: None,
-            });
+            }));
             typed_fields.push(typed_field);
         }
         let exp = ty::TyExpression {
@@ -1283,12 +1284,12 @@ impl ty::TyExpression {
 
         // Set the type arguments to `StorageKey` to the `access_type`, which is represents the
         // type of the data that the `StorageKey` "points" to.
-        let mut type_arguments = vec![TypeArgument {
+        let mut type_arguments = vec![GenericArgument::Type(GenericTypeArgument {
             initial_type_id: access_type,
             type_id: access_type,
             span: span.clone(),
             call_path_tree: None,
-        }];
+        })];
 
         // Monomorphize the generic `StorageKey` type given the type argument specified above
         let mut ctx = ctx;
@@ -2036,7 +2037,7 @@ impl ty::TyExpression {
         // otherwise, fallback to Unknown.
         let elem_type = match &*ctx.engines().te().get(ctx.type_annotation()) {
             TypeInfo::Array(element_type, _) => {
-                let element_type = (*ctx.engines().te().get(element_type.type_id)).clone();
+                let element_type = (*ctx.engines().te().get(element_type.type_id())).clone();
                 if matches!(element_type, TypeInfo::Never) {
                     TypeInfo::Unknown //Even if array element type is Never other elements may not be of type Never.
                 } else {
@@ -2046,12 +2047,12 @@ impl ty::TyExpression {
             _ => TypeInfo::Unknown,
         };
         let elem_type = type_engine.insert(engines, elem_type, None);
-        let elem_type_arg = TypeArgument {
+        let elem_type_arg = GenericArgument::Type(GenericTypeArgument {
             type_id: elem_type,
             initial_type_id: elem_type,
             span: span.clone(),
             call_path_tree: None,
-        };
+        });
 
         let value_ctx = ctx
             .by_ref()
@@ -2116,7 +2117,7 @@ impl ty::TyExpression {
         // otherwise, fallback to Unknown.
         let initial_type = match &*ctx.engines().te().get(ctx.type_annotation()) {
             TypeInfo::Array(element_type, _) => {
-                let element_type = (*ctx.engines().te().get(element_type.type_id)).clone();
+                let element_type = (*ctx.engines().te().get(element_type.type_id())).clone();
                 if matches!(element_type, TypeInfo::Never) {
                     TypeInfo::Unknown //Even if array element type is Never other elements may not be of type Never.
                 } else {
@@ -2217,7 +2218,7 @@ impl ty::TyExpression {
                 TypeInfo::Ref {
                     referenced_type, ..
                 } => {
-                    let referenced_type_id = referenced_type.type_id;
+                    let referenced_type_id = referenced_type.type_id();
 
                     current_prefix_te = Box::new(ty::TyExpression {
                         expression: ty::TyExpressionVariant::Deref(current_prefix_te),
@@ -2254,7 +2255,7 @@ impl ty::TyExpression {
                 prefix: current_prefix_te,
                 index: Box::new(index_te),
             },
-            return_type: array_type_argument.type_id,
+            return_type: array_type_argument.type_id(),
             span,
         })
     }
@@ -2727,7 +2728,7 @@ impl ty::TyExpression {
                                 }));
                             }
 
-                            struct_field.type_argument.type_id
+                            struct_field.type_argument.type_id()
                         }
                         None => {
                             return Err(handler.emit_err(CompileError::StructFieldDoesNotExist {
@@ -2749,9 +2750,9 @@ impl ty::TyExpression {
                 }
                 (TypeInfo::Tuple(fields), ty::ProjectionKind::TupleField { index, index_span }) => {
                     let field_type_opt = {
-                        fields
-                            .get(*index)
-                            .map(|TypeArgument { type_id, .. }| type_id)
+                        fields.get(*index).map(
+                            |GenericArgument::Type(GenericTypeArgument { type_id, .. })| type_id,
+                        )
                     };
                     let field_type = match field_type_opt {
                         Some(field_type) => field_type,
@@ -2775,14 +2776,14 @@ impl ty::TyExpression {
                         referenced_type, ..
                     } = actually
                     {
-                        actually = (*engines.te().get(referenced_type.type_id)).clone();
+                        actually = (*engines.te().get(referenced_type.type_id())).clone();
                     }
                     match actually {
                         TypeInfo::Array(elem_ty, array_length)
                             if array_length.as_literal_val().is_some() =>
                         {
                             parent_rover = symbol;
-                            symbol = elem_ty.type_id;
+                            symbol = elem_ty.type_id();
                             symbol_span = index_span.clone();
 
                             if let Some(index_literal) = index
@@ -2876,7 +2877,7 @@ impl ty::TyExpression {
         let type_annotation = match &*type_engine.get(ctx.type_annotation()) {
             TypeInfo::Ref {
                 referenced_type, ..
-            } => referenced_type.type_id,
+            } => referenced_type.type_id(),
             _ => type_engine.new_unknown(),
         };
 
@@ -2998,7 +2999,7 @@ impl ty::TyExpression {
             TypeInfo::Ref {
                 referenced_type: ref exp,
                 ..
-            } => Ok(exp.type_id), // Get the referenced type.
+            } => Ok(exp.type_id()), // Get the referenced type.
             _ => Err(
                 handler.emit_err(CompileError::ExpressionCannotBeDereferenced {
                     expression_type: engines.help_out(expr.return_type).to_string(),

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/enum_instantiation.rs
@@ -38,7 +38,7 @@ pub(crate) fn instantiate_enum(
     // Return an error if enum variant is of type unit and it is called with parenthesis.
     // `args_opt.is_some()` returns true when this variant was called with parenthesis.
     if type_engine
-        .get(enum_variant.type_argument.initial_type_id)
+        .get(enum_variant.type_argument.initial_type_id())
         .is_unit()
         && args_opt.is_some()
     {
@@ -54,7 +54,10 @@ pub(crate) fn instantiate_enum(
     // If there is an instantiator, it must match up with the type. If there is not an
     // instantiator, then the type of the enum is necessarily the unit type.
 
-    match (&args, &*type_engine.get(enum_variant.type_argument.type_id)) {
+    match (
+        &args,
+        &*type_engine.get(enum_variant.type_argument.type_id()),
+    ) {
         ([], ty) if ty.is_unit() => Ok(ty::TyExpression {
             return_type: type_engine.insert_enum(engines, *enum_ref.id()),
             expression: ty::TyExpressionVariant::EnumInstantiation {
@@ -113,20 +116,20 @@ pub(crate) fn instantiate_enum(
                                 .cloned()?;
                             (
                                 true,
-                                context_expected_enum_variant.type_argument.type_id,
+                                context_expected_enum_variant.type_argument.type_id(),
                                 ctx.help_text(),
                             )
                         } else {
                             (
                                 false,
-                                enum_variant.type_argument.type_id,
+                                enum_variant.type_argument.type_id(),
                                 UNIFY_ENUM_VARIANT_HELP_TEXT,
                             )
                         }
                     }
                     _ => (
                         false,
-                        enum_variant.type_argument.type_id,
+                        enum_variant.type_argument.type_id(),
                         UNIFY_ENUM_VARIANT_HELP_TEXT,
                     ),
                 };
@@ -161,7 +164,7 @@ pub(crate) fn instantiate_enum(
                         handler,
                         engines,
                         typed_expr.return_type,
-                        enum_variant.type_argument.type_id,
+                        enum_variant.type_argument.type_id(),
                         &single_expr.span, // Use the span of the instantiator expression.
                         help_text,
                         None,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/function_application.rs
@@ -66,14 +66,14 @@ pub(crate) fn instantiate_function_application(
     engines.te().unify_with_generic(
         handler,
         engines,
-        function_decl.return_type.type_id,
+        function_decl.return_type.type_id(),
         ctx.type_annotation(),
         &call_path_binding.span(),
         "Function return type does not match up with local type annotation.",
         None,
     );
 
-    let mut function_return_type_id = function_decl.return_type.type_id;
+    let mut function_return_type_id = function_decl.return_type.type_id();
 
     let function_ident: IdentUnique = function_decl.name.clone().into();
     let function_sig = TyFunctionSig::from_fn_decl(&function_decl);
@@ -102,7 +102,7 @@ pub(crate) fn instantiate_function_application(
 
         let method_sig = TyFunctionSig::from_fn_decl(&function_decl);
 
-        function_return_type_id = function_decl.return_type.type_id;
+        function_return_type_id = function_decl.return_type.type_id();
         let function_is_type_check_finalized = function_decl.is_type_check_finalized;
         let function_is_trait_method_dummy = function_decl.is_trait_method_dummy;
         let new_decl_ref = decl_engine
@@ -173,7 +173,7 @@ fn type_check_arguments(
                 let ctx = ctx
                     .by_ref()
                     .with_help_text(UNIFY_ARGS_HELP_TEXT)
-                    .with_type_annotation(param.type_argument.type_id);
+                    .with_type_annotation(param.type_argument.type_id());
                 ty::TyExpression::type_check(handler, ctx, arg)
                     .unwrap_or_else(|err| ty::TyExpression::error(err, arg.span(), engines))
             })
@@ -204,7 +204,7 @@ fn unify_arguments_and_parameters(
                     unify_handler,
                     engines,
                     arg.return_type,
-                    param.type_argument.type_id,
+                    param.type_argument.type_id(),
                     &arg.span,
                     UNIFY_ARGS_HELP_TEXT,
                     None,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_field_access.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_field_access.rs
@@ -37,7 +37,7 @@ pub(crate) fn instantiate_struct_field_access(
             TypeInfo::Ref {
                 referenced_type, ..
             } => {
-                let referenced_type_id = referenced_type.type_id;
+                let referenced_type_id = referenced_type.type_id();
 
                 current_prefix_te = Box::new(ty::TyExpression {
                     expression: ty::TyExpressionVariant::Deref(current_prefix_te),
@@ -94,7 +94,7 @@ pub(crate) fn instantiate_struct_field_access(
         }
     };
 
-    let return_type = field.type_argument.type_id;
+    let return_type = field.type_argument.type_id();
     Ok(ty::TyExpression {
         expression: ty::TyExpressionVariant::StructFieldAccess {
             resolved_type_of_parent: current_prefix_te.return_type,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/struct_instantiation.rs
@@ -399,7 +399,7 @@ fn type_check_field_arguments(
                     let ctx = ctx
                         .by_ref()
                         .with_help_text(help_text)
-                        .with_type_annotation(struct_field.type_argument.type_id)
+                        .with_type_annotation(struct_field.type_argument.type_id())
                         .with_unify_generic(true);
 
                     // TODO: Remove the `handler.scope` once https://github.com/FuelLabs/sway/issues/5606 gets solved.
@@ -473,7 +473,7 @@ fn unify_field_arguments_and_struct_fields(
                     handler,
                     engines,
                     typed_field.value.return_type,
-                    struct_field.type_argument.type_id,
+                    struct_field.type_argument.type_id(),
                     &typed_field.value.span, // Use the span of the initialization value.
                     help_text,
                     None,

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/tuple_index_access.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/tuple_index_access.rs
@@ -31,7 +31,7 @@ pub(crate) fn instantiate_tuple_index_access(
             TypeInfo::Ref {
                 referenced_type, ..
             } => {
-                let referenced_type_id = referenced_type.type_id;
+                let referenced_type_id = referenced_type.type_id();
 
                 current_prefix_te = Box::new(ty::TyExpression {
                     expression: ty::TyExpressionVariant::Deref(current_prefix_te),
@@ -76,7 +76,7 @@ pub(crate) fn instantiate_tuple_index_access(
             elem_to_access_num: index,
             elem_to_access_span: index_span,
         },
-        return_type: type_args[index].type_id,
+        return_type: type_args[index].type_id(),
         span,
     })
 }

--- a/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/unsafe_downcast.rs
+++ b/sway-core/src/semantic_analysis/ast_node/expression/typed_expression/unsafe_downcast.rs
@@ -20,7 +20,7 @@ pub(crate) fn instantiate_enum_unsafe_downcast(
             variant: variant.clone(),
             call_path_decl,
         },
-        return_type: variant.type_argument.type_id,
+        return_type: variant.type_argument.type_id(),
         span,
     }
 }

--- a/sway-core/src/semantic_analysis/module.rs
+++ b/sway-core/src/semantic_analysis/module.rs
@@ -502,7 +502,7 @@ impl ty::TyModule {
                 &node.content
             {
                 let decl = &*engines.pe().get_impl_self_or_trait(decl_id);
-                let implementing_for = ctx.engines.te().get(decl.implementing_for.type_id);
+                let implementing_for = ctx.engines.te().get(decl.implementing_for.type_id());
                 let implementing_for = match &*implementing_for {
                     TypeInfo::Struct(decl_id) => {
                         Some(ctx.engines().de().get(decl_id).name().clone())

--- a/sway-core/src/semantic_analysis/node_dependencies.rs
+++ b/sway-core/src/semantic_analysis/node_dependencies.rs
@@ -775,16 +775,16 @@ impl Dependencies {
     fn gather_from_type_arguments(
         self,
         engines: &Engines,
-        type_arguments: &[TypeArgument],
+        type_arguments: &[GenericArgument],
     ) -> Self {
         self.gather_from_iter(type_arguments.iter(), |deps, type_argument| {
             deps.gather_from_type_argument(engines, type_argument)
         })
     }
 
-    fn gather_from_type_argument(self, engines: &Engines, type_argument: &TypeArgument) -> Self {
+    fn gather_from_type_argument(self, engines: &Engines, type_argument: &GenericArgument) -> Self {
         let type_engine = engines.te();
-        self.gather_from_typeinfo(engines, &type_engine.get(type_argument.type_id))
+        self.gather_from_typeinfo(engines, &type_engine.get(type_argument.type_id()))
     }
 
     fn gather_from_typeinfo(mut self, engines: &Engines, type_info: &TypeInfo) -> Self {
@@ -944,7 +944,7 @@ fn decl_name(engines: &Engines, decl: &Declaration) -> Option<DependentSymbol> {
                     Ident::new_with_override("self".into(), decl.implementing_for.span());
                 impl_sym(
                     trait_name,
-                    &type_engine.get(decl.implementing_for.type_id),
+                    &type_engine.get(decl.implementing_for.type_id()),
                     decl.items
                         .iter()
                         .map(|item| match item {
@@ -967,7 +967,7 @@ fn decl_name(engines: &Engines, decl: &Declaration) -> Option<DependentSymbol> {
             } else if decl.trait_name.prefixes.is_empty() {
                 impl_sym(
                     decl.trait_name.suffix.clone(),
-                    &type_engine.get(decl.implementing_for.type_id),
+                    &type_engine.get(decl.implementing_for.type_id()),
                     decl.items
                         .iter()
                         .map(|item| match item {

--- a/sway-core/src/semantic_analysis/symbol_resolve.rs
+++ b/sway-core/src/semantic_analysis/symbol_resolve.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         CallPath, CallPathTree, ResolvedCallPath,
     },
-    TraitConstraint, TypeArgument, TypeBinding, TypeParameter,
+    GenericArgument, TraitConstraint, TypeBinding, TypeParameter,
 };
 
 use super::symbol_resolve_context::SymbolResolveContext;
@@ -392,9 +392,9 @@ impl ResolveSymbols for TypeAliasDeclaration {
     }
 }
 
-impl ResolveSymbols for TypeArgument {
+impl ResolveSymbols for GenericArgument {
     fn resolve_symbols(&mut self, handler: &Handler, ctx: SymbolResolveContext) {
-        if let Some(call_path) = self.call_path_tree.as_mut() {
+        if let Some(call_path) = self.call_path_tree_mut() {
             call_path.resolve_symbols(handler, ctx);
         }
     }

--- a/sway-core/src/semantic_analysis/type_check_context.rs
+++ b/sway-core/src/semantic_analysis/type_check_context.rs
@@ -18,7 +18,7 @@ use crate::{
         ast_node::{AbiMode, ConstShadowingMode},
         Namespace,
     },
-    type_system::{SubstTypes, TypeArgument, TypeId, TypeInfo},
+    type_system::{GenericArgument, SubstTypes, TypeId, TypeInfo},
     EnforceTypeArguments, SubstTypesContext, TraitConstraint, TypeParameter, TypeSubstMap,
     UnifyCheck,
 };
@@ -531,7 +531,7 @@ impl<'a> TypeCheckContext<'a> {
         &mut self,
         handler: &Handler,
         value: &mut T,
-        type_arguments: &mut [TypeArgument],
+        type_arguments: &mut [GenericArgument],
         const_generics: BTreeMap<String, TyExpression>,
         enforce_type_arguments: EnforceTypeArguments,
         call_site_span: &Span,
@@ -879,13 +879,13 @@ impl<'a> TypeCheckContext<'a> {
                         .parameters
                         .iter()
                         .zip(arguments_types.iter().skip(args_len_diff))
-                        .all(|(p, a)| coercion_check.check(*a, p.type_argument.type_id))
+                        .all(|(p, a)| coercion_check.check(*a, p.type_argument.type_id()))
                     && (matches!(&*type_engine.get(annotation_type), TypeInfo::Unknown)
                         || matches!(
-                            &*type_engine.get(method.return_type.type_id),
+                            &*type_engine.get(method.return_type.type_id()),
                             TypeInfo::Never
                         )
-                        || coercion_check.check(annotation_type, method.return_type.type_id))
+                        || coercion_check.check(annotation_type, method.return_type.type_id()))
                 {
                     maybe_method_decl_refs.push(decl_ref);
                 }
@@ -895,7 +895,7 @@ impl<'a> TypeCheckContext<'a> {
                 let mut trait_methods = HashMap::<
                     (
                         CallPath,
-                        Vec<WithEngines<TypeArgument>>,
+                        Vec<WithEngines<GenericArgument>>,
                         Option<WithEngines<TypeInfo>>,
                     ),
                     DeclRefFunction,
@@ -945,15 +945,15 @@ impl<'a> TypeCheckContext<'a> {
                                             {
                                                 let p1_type_id = self.resolve_type(
                                                     handler,
-                                                    p1.type_id,
-                                                    &p1.span,
+                                                    p1.type_id(),
+                                                    &p1.span(),
                                                     EnforceTypeArguments::Yes,
                                                     None,
                                                 )?;
                                                 let p2_type_id = self.resolve_type(
                                                     handler,
-                                                    p2.type_id,
-                                                    &p2.span,
+                                                    p2.type_id(),
+                                                    &p2.span(),
                                                     EnforceTypeArguments::Yes,
                                                     None,
                                                 )?;
@@ -1042,7 +1042,7 @@ impl<'a> TypeCheckContext<'a> {
                         } else {
                             fn to_string(
                                 trait_name: CallPath,
-                                trait_type_args: Vec<WithEngines<TypeArgument>>,
+                                trait_type_args: Vec<WithEngines<GenericArgument>>,
                             ) -> String {
                                 format!(
                                     "{}{}",
@@ -1102,10 +1102,10 @@ impl<'a> TypeCheckContext<'a> {
                         method
                             .parameters
                             .iter()
-                            .map(|p| self.engines.help_out(p.type_argument.type_id).to_string())
+                            .map(|p| self.engines.help_out(p.type_argument.type_id()).to_string())
                             .collect::<Vec<_>>()
                             .join(", "),
-                        self.engines.help_out(method.return_type.type_id),
+                        self.engines.help_out(method.return_type.type_id()),
                         if let Some(implementing_for_type_id) = method.implementing_for_typeid {
                             format!(" in {}", self.engines.help_out(implementing_for_type_id))
                         } else {
@@ -1290,7 +1290,7 @@ impl<'a> TypeCheckContext<'a> {
         &mut self,
         handler: &Handler,
         trait_name: CallPath,
-        trait_type_args: Vec<TypeArgument>,
+        trait_type_args: Vec<GenericArgument>,
         type_id: TypeId,
         mut impl_type_parameters: Vec<TypeParameter>,
         items: &[ty::TyImplItem],
@@ -1356,7 +1356,7 @@ impl<'a> TypeCheckContext<'a> {
         &self,
         type_id: TypeId,
         trait_name: &CallPath,
-        trait_type_args: &[TypeArgument],
+        trait_type_args: &[GenericArgument],
     ) -> Vec<ty::TyTraitItem> {
         // CallPath::to_fullpath gives a resolvable path, but is not guaranteed to provide the path
         // to the actual trait declaration. Since the path of the trait declaration is used as a key

--- a/sway-core/src/semantic_analysis/type_resolve.rs
+++ b/sway-core/src/semantic_analysis/type_resolve.rs
@@ -74,12 +74,12 @@ pub fn resolve_type(
             )?
         }
         TypeInfo::Array(mut elem_ty, length) => {
-            elem_ty.type_id = resolve_type(
+            *elem_ty.type_id_mut() = resolve_type(
                 handler,
                 engines,
                 namespace,
                 mod_path,
-                elem_ty.type_id,
+                elem_ty.type_id(),
                 span,
                 enforce_type_arguments,
                 None,
@@ -92,12 +92,12 @@ pub fn resolve_type(
             engines.te().insert_array(engines, elem_ty, length)
         }
         TypeInfo::Slice(mut elem_ty) => {
-            elem_ty.type_id = resolve_type(
+            *elem_ty.type_id_mut() = resolve_type(
                 handler,
                 engines,
                 namespace,
                 mod_path,
-                elem_ty.type_id,
+                elem_ty.type_id(),
                 span,
                 enforce_type_arguments,
                 None,
@@ -111,12 +111,12 @@ pub fn resolve_type(
         }
         TypeInfo::Tuple(mut type_arguments) => {
             for type_argument in type_arguments.iter_mut() {
-                type_argument.type_id = resolve_type(
+                *type_argument.type_id_mut() = resolve_type(
                     handler,
                     engines,
                     namespace,
                     mod_path,
-                    type_argument.type_id,
+                    type_argument.type_id(),
                     span,
                     enforce_type_arguments,
                     None,
@@ -145,7 +145,7 @@ pub fn resolve_type(
             if let ResolvedTraitImplItem::Typed(TyTraitItem::Type(type_ref)) = trait_item_ref {
                 let type_decl = engines.de().get_type(type_ref.id());
                 if let Some(ty) = &type_decl.ty {
-                    ty.type_id
+                    ty.type_id()
                 } else {
                     type_id
                 }
@@ -160,12 +160,12 @@ pub fn resolve_type(
             referenced_type: mut ty,
             to_mutable_value,
         } => {
-            ty.type_id = resolve_type(
+            *ty.type_id_mut() = resolve_type(
                 handler,
                 engines,
                 namespace,
                 mod_path,
-                ty.type_id,
+                ty.type_id(),
                 span,
                 enforce_type_arguments,
                 None,
@@ -199,7 +199,7 @@ pub fn resolve_qualified_call_path(
 ) -> Result<ResolvedDeclaration, ErrorEmitted> {
     let type_engine = engines.te();
     if let Some(qualified_path_root) = qualified_call_path.clone().qualified_path_root {
-        let root_type_id = match &&*type_engine.get(qualified_path_root.ty.type_id) {
+        let root_type_id = match &&*type_engine.get(qualified_path_root.ty.type_id()) {
             TypeInfo::Custom {
                 qualified_call_path,
                 type_arguments,
@@ -228,7 +228,7 @@ pub fn resolve_qualified_call_path(
                     subst_ctx,
                 )?
             }
-            _ => qualified_path_root.ty.type_id,
+            _ => qualified_path_root.ty.type_id(),
         };
 
         let as_trait_opt = match &&*type_engine.get(qualified_path_root.as_trait) {
@@ -450,7 +450,7 @@ fn decl_to_type_info(
                         symbol.span(),
                     )));
                 }
-                (*engines.te().get(type_decl.ty.clone().unwrap().type_id)).clone()
+                (*engines.te().get(type_decl.ty.clone().unwrap().type_id())).clone()
             }
             ty::TyDecl::GenericTypeForFunctionScope(decl) => {
                 (*engines.te().get(decl.type_id)).clone()

--- a/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
+++ b/sway-core/src/transform/to_parsed_lang/convert_parse_tree.rs
@@ -11,7 +11,7 @@ use crate::{
     type_system::*,
     BuildTarget, Engines,
 };
-use ast_elements::type_parameter::GenericTypeParameter;
+use ast_elements::{type_argument::GenericTypeArgument, type_parameter::GenericTypeParameter};
 use itertools::Itertools;
 use sway_ast::{
     assignable::ElementAccess,
@@ -398,7 +398,7 @@ fn item_struct_to_struct_declaration(
 
     handler.scope(|handler| {
         if fields.iter().any(
-            |field| matches!(&&*engines.te().get(field.type_argument.type_id), TypeInfo::Custom { qualified_call_path, ..} if qualified_call_path.call_path.suffix == item_struct.name),
+            |field| matches!(&&*engines.te().get(field.type_argument.type_id()), TypeInfo::Custom { qualified_call_path, ..} if qualified_call_path.call_path.suffix == item_struct.name),
         ) {
             handler.emit_err(ConvertParseTreeError::RecursiveType { span: span.clone() }.into());
         }
@@ -481,7 +481,7 @@ fn item_enum_to_enum_declaration(
 
     handler.scope(|handler| {
         if variants.iter().any(|variant| {
-        matches!(&&*engines.te().get(variant.type_argument.type_id), TypeInfo::Custom { qualified_call_path, ..} if qualified_call_path.call_path.suffix == item_enum.name)
+        matches!(&&*engines.te().get(variant.type_argument.type_id()), TypeInfo::Custom { qualified_call_path, ..} if qualified_call_path.call_path.suffix == item_enum.name)
         }) {
             handler.emit_err(ConvertParseTreeError::RecursiveType { span: span.clone() }.into());
         }
@@ -534,12 +534,12 @@ pub fn item_fn_to_function_declaration(
         Some((_right_arrow, ty)) => ty_to_type_argument(context, handler, engines, ty)?,
         None => {
             let type_id = engines.te().id_of_unit();
-            TypeArgument {
+            GenericArgument::Type(GenericTypeArgument {
                 type_id,
                 initial_type_id: type_id,
                 span: item_fn.fn_signature.span(),
                 call_path_tree: None,
-            }
+            })
         }
     };
 
@@ -731,7 +731,7 @@ pub fn item_impl_to_declaration(
 ) -> Result<Declaration, ErrorEmitted> {
     let block_span = item_impl.span();
     let implementing_for = ty_to_type_argument(context, handler, engines, item_impl.ty)?;
-    let impl_item_parent = (&*engines.te().get(implementing_for.type_id)).into();
+    let impl_item_parent = (&*engines.te().get(implementing_for.type_id())).into();
 
     let items = item_impl
         .contents
@@ -818,7 +818,7 @@ pub fn item_impl_to_declaration(
             let impl_trait = engines.pe().insert(impl_trait);
             Ok(Declaration::ImplSelfOrTrait(impl_trait))
         }
-        None => match &*engines.te().get(implementing_for.type_id) {
+        None => match &*engines.te().get(implementing_for.type_id()) {
             TypeInfo::Contract => Err(handler
                 .emit_err(ConvertParseTreeError::SelfImplForContract { span: block_span }.into())),
             _ => {
@@ -848,7 +848,7 @@ fn path_type_to_call_path_and_type_arguments(
     handler: &Handler,
     engines: &Engines,
     path_type: PathType,
-) -> Result<(QualifiedCallPath, Vec<TypeArgument>), ErrorEmitted> {
+) -> Result<(QualifiedCallPath, Vec<GenericArgument>), ErrorEmitted> {
     let root_opt = path_type.root_opt.clone();
     let (prefixes, suffix) = path_type_to_prefixes_and_suffix(context, handler, path_type.clone())?;
 
@@ -1509,12 +1509,12 @@ fn fn_args_to_function_parameters(
                 is_reference: ref_self.is_some(),
                 is_mutable: mutable_self.is_some(),
                 mutability_span,
-                type_argument: TypeArgument {
+                type_argument: GenericArgument::Type(GenericTypeArgument {
                     type_id,
                     initial_type_id: type_id,
                     span: self_token.span(),
                     call_path_tree: None,
-                },
+                }),
             }];
             if let Some((_comma_token, args)) = args_opt {
                 for arg in args {
@@ -1687,7 +1687,7 @@ fn ty_to_type_argument(
     handler: &Handler,
     engines: &Engines,
     ty: Ty,
-) -> Result<TypeArgument, ErrorEmitted> {
+) -> Result<GenericArgument, ErrorEmitted> {
     let type_engine = engines.te();
     let span = ty.span();
     let call_path_tree = ty_to_call_path_tree(context, handler, engines, ty.clone())?;
@@ -1697,12 +1697,12 @@ fn ty_to_type_argument(
         ty.span().source_id(),
     );
 
-    let type_argument = TypeArgument {
+    let type_argument = GenericArgument::Type(GenericTypeArgument {
         type_id: initial_type_id,
         initial_type_id,
         call_path_tree,
         span,
-    };
+    });
     Ok(type_argument)
 }
 
@@ -1717,13 +1717,13 @@ fn fn_signature_to_trait_fn(
         Some((_right_arrow, ty)) => ty_to_type_argument(context, handler, engines, ty.clone())?,
         None => {
             let type_id = engines.te().id_of_unit();
-            TypeArgument {
+            GenericArgument::Type(GenericTypeArgument {
                 type_id,
                 initial_type_id: type_id,
                 // TODO: Fix as part of https://github.com/FuelLabs/sway/issues/3635
                 span: fn_signature.span(),
                 call_path_tree: None,
-            }
+            })
         }
     };
 
@@ -1905,7 +1905,7 @@ fn method_call_fields_to_method_application_expression(
 
     let span = match &*type_arguments {
         [] => method_name.span(),
-        [.., last] => Span::join(method_name.span(), &last.span),
+        [.., last] => Span::join(method_name.span(), &last.span()),
     };
 
     let method_name_binding = TypeBinding {
@@ -2991,7 +2991,7 @@ fn path_expr_segment_to_ident_or_type_argument(
     handler: &Handler,
     engines: &Engines,
     PathExprSegment { name, generics_opt }: PathExprSegment,
-) -> Result<(Ident, Vec<TypeArgument>), ErrorEmitted> {
+) -> Result<(Ident, Vec<GenericArgument>), ErrorEmitted> {
     let type_args = match generics_opt {
         Some((_, x)) => generic_args_to_type_arguments(context, handler, engines, x)?,
         None => Vec::default(),
@@ -3183,12 +3183,12 @@ fn match_expr_to_expression(
     let var_decl = engines.pe().insert(VariableDeclaration {
         type_ascription: {
             let type_id = engines.te().new_unknown();
-            TypeArgument {
+            GenericArgument::Type(GenericTypeArgument {
                 type_id,
                 initial_type_id: type_id,
                 span: var_decl_name.span(),
                 call_path_tree: None,
-            }
+            })
         },
         name: var_decl_name,
         is_mutable: false,
@@ -3267,12 +3267,12 @@ fn for_expr_to_expression(
     let iterable_decl = engines.pe().insert(VariableDeclaration {
         type_ascription: {
             let type_id = engines.te().new_unknown();
-            TypeArgument {
+            GenericArgument::Type(GenericTypeArgument {
                 type_id,
                 initial_type_id: type_id,
                 span: iterable_ident.clone().span(),
                 call_path_tree: None,
-            }
+            })
         },
         name: iterable_ident,
         is_mutable: true,
@@ -3300,12 +3300,12 @@ fn for_expr_to_expression(
     let value_opt_to_next_decl = engines.pe().insert(VariableDeclaration {
         type_ascription: {
             let type_id = engines.te().new_unknown();
-            TypeArgument {
+            GenericArgument::Type(GenericTypeArgument {
                 type_id,
                 initial_type_id: type_id,
                 span: value_opt_ident.clone().span(),
                 call_path_tree: None,
-            }
+            })
         },
         name: value_opt_ident,
         is_mutable: true,
@@ -3964,12 +3964,12 @@ fn statement_let_to_ast_nodes_unfold(
                 Some(ty) => ty_to_type_argument(context, handler, engines, ty)?,
                 None => {
                     let type_id = engines.te().new_unknown();
-                    TypeArgument {
+                    GenericArgument::Type(GenericTypeArgument {
                         type_id,
                         initial_type_id: type_id,
                         span: name.span(),
                         call_path_tree: None,
-                    }
+                    })
                 }
             };
             let var_decl = engines.pe().insert(VariableDeclaration {
@@ -4014,12 +4014,12 @@ fn statement_let_to_ast_nodes_unfold(
                 Some(ty) => ty_to_type_argument(context, handler, engines, ty.clone())?,
                 None => {
                     let type_id = engines.te().new_unknown();
-                    TypeArgument {
+                    GenericArgument::Type(GenericTypeArgument {
                         type_id,
                         initial_type_id: type_id,
                         span: destructured_struct_name.span(),
                         call_path_tree: None,
-                    }
+                    })
                 }
             };
 
@@ -4127,12 +4127,12 @@ fn statement_let_to_ast_nodes_unfold(
 
                 // The type argument is a tuple of place holders of unknowns pointing to
                 // the tuple pattern.
-                TypeArgument {
+                GenericArgument::Type(GenericTypeArgument {
                     type_id,
                     initial_type_id: type_id,
                     span: pat_tuple.span(),
                     call_path_tree: None,
-                }
+                })
             };
 
             // Parse the type ascription and the type ascription span.
@@ -4701,7 +4701,7 @@ fn generic_args_to_type_arguments(
     handler: &Handler,
     engines: &Engines,
     generic_args: GenericArgs,
-) -> Result<Vec<TypeArgument>, ErrorEmitted> {
+) -> Result<Vec<GenericArgument>, ErrorEmitted> {
     generic_args
         .parameters
         .into_inner()
@@ -4715,7 +4715,7 @@ fn ty_tuple_descriptor_to_type_arguments(
     handler: &Handler,
     engines: &Engines,
     ty_tuple_descriptor: TyTupleDescriptor,
-) -> Result<Vec<TypeArgument>, ErrorEmitted> {
+) -> Result<Vec<GenericArgument>, ErrorEmitted> {
     let type_arguments = match ty_tuple_descriptor {
         TyTupleDescriptor::Nil => vec![],
         TyTupleDescriptor::Cons { head, tail, .. } => {
@@ -4858,10 +4858,14 @@ fn error_if_self_param_is_not_allowed(
     fn_kind: &str,
 ) -> Result<(), ErrorEmitted> {
     for param in parameters {
-        if engines.te().get(param.type_argument.type_id).is_self_type() {
+        if engines
+            .te()
+            .get(param.type_argument.type_id())
+            .is_self_type()
+        {
             let error = ConvertParseTreeError::SelfParameterNotAllowedForFn {
                 fn_kind: fn_kind.to_owned(),
-                span: param.type_argument.span.clone(),
+                span: param.type_argument.span(),
             };
             return Err(handler.emit_err(error.into()));
         }

--- a/sway-core/src/type_system/ast_elements/binding.rs
+++ b/sway-core/src/type_system/ast_elements/binding.rs
@@ -108,27 +108,27 @@ pub struct TypeBinding<T> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TypeArgs {
     /// `Regular` variant indicates the type arguments are located after the suffix.
-    Regular(Vec<TypeArgument>),
+    Regular(Vec<GenericArgument>),
     /// `Prefix` variant indicates the type arguments are located between the last
     /// prefix and the suffix.
-    Prefix(Vec<TypeArgument>),
+    Prefix(Vec<GenericArgument>),
 }
 
 impl TypeArgs {
-    pub fn to_vec(&self) -> Vec<TypeArgument> {
+    pub fn to_vec(&self) -> Vec<GenericArgument> {
         match self {
             TypeArgs::Regular(vec) => vec.to_vec(),
             TypeArgs::Prefix(vec) => vec.to_vec(),
         }
     }
 
-    pub fn as_slice(&self) -> &[TypeArgument] {
+    pub fn as_slice(&self) -> &[GenericArgument] {
         match self {
             TypeArgs::Regular(vec) | TypeArgs::Prefix(vec) => vec,
         }
     }
 
-    pub(crate) fn to_vec_mut(&mut self) -> &mut Vec<TypeArgument> {
+    pub(crate) fn to_vec_mut(&mut self) -> &mut Vec<GenericArgument> {
         match self {
             TypeArgs::Regular(vec) => vec,
             TypeArgs::Prefix(vec) => vec,
@@ -336,8 +336,8 @@ impl TypeCheckTypeBinding<ty::TyFunctionDecl> for TypeBinding<CallPath> {
                 for type_argument in self.type_arguments.to_vec_mut().iter_mut() {
                     ctx.resolve_type(
                         handler,
-                        type_argument.type_id,
-                        &type_argument.span,
+                        type_argument.type_id(),
+                        &type_argument.span(),
                         EnforceTypeArguments::Yes,
                         None,
                     )

--- a/sway-core/src/type_system/ast_elements/type_argument.rs
+++ b/sway-core/src/type_system/ast_elements/type_argument.rs
@@ -3,19 +3,8 @@ use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, fmt, hash::Hasher};
 use sway_types::{Span, Spanned};
 
-/// [TypeArgument] can be seen as an "annotated reference" to a [TypeInfo].
-/// It holds the [TypeArgument::type_id] which is the actual "reference"
-/// to the type, as well as an additional information about that type,
-/// called the annotation.
-///
-/// If a [TypeArgument] only references a [TypeInfo] and is considered as
-/// not being annotated, its `initial_type_id` must be the same as `type_id`,
-/// its `span` must be [Span::dummy] and its `call_path_tree` must be `None`.
-///
-/// The annotations are ignored when calculating the [TypeArgument]'s hash
-/// (with engines) and equality (with engines).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TypeArgument {
+pub struct GenericTypeArgument {
     /// The [TypeId] of the "referenced" [TypeInfo].
     pub type_id: TypeId,
     /// Denotes the initial type that was referenced before the type
@@ -42,123 +31,204 @@ pub struct TypeArgument {
     pub call_path_tree: Option<CallPathTree>,
 }
 
-impl TypeArgument {
+/// [TypeArgument] can be seen as an "annotated reference" to a [TypeInfo].
+/// It holds the [TypeArgument::type_id] which is the actual "reference"
+/// to the type, as well as an additional information about that type,
+/// called the annotation.
+///
+/// If a [TypeArgument] only references a [TypeInfo] and is considered as
+/// not being annotated, its `initial_type_id` must be the same as `type_id`,
+/// its `span` must be [Span::dummy] and its `call_path_tree` must be `None`.
+///
+/// The annotations are ignored when calculating the [TypeArgument]'s hash
+/// (with engines) and equality (with engines).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum GenericArgument {
+    Type(GenericTypeArgument),
+}
+
+impl GenericArgument {
+    pub fn as_type_argument(&self) -> Option<&GenericTypeArgument> {
+        match self {
+            GenericArgument::Type(a) => Some(a),
+        }
+    }
+
+    pub fn as_type_argument_mut(&mut self) -> Option<&mut GenericTypeArgument> {
+        match self {
+            GenericArgument::Type(a) => Some(a),
+        }
+    }
+
+    pub fn type_id(&self) -> TypeId {
+        self.as_type_argument()
+            .expect("only works with type arguments")
+            .type_id
+    }
+
+    pub fn initial_type_id(&self) -> TypeId {
+        self.as_type_argument()
+            .expect("only works with type arguments")
+            .initial_type_id
+    }
+
+    pub fn call_path_tree(&self) -> Option<&CallPathTree> {
+        match self {
+            GenericArgument::Type(a) => a.call_path_tree.as_ref(),
+        }
+    }
+
+    pub fn call_path_tree_mut(&mut self) -> Option<&mut CallPathTree> {
+        match self {
+            GenericArgument::Type(a) => a.call_path_tree.as_mut(),
+        }
+    }
+
+    pub fn type_id_mut(&mut self) -> &mut TypeId {
+        &mut self
+            .as_type_argument_mut()
+            .expect("only works with type arguments")
+            .type_id
+    }
+
     /// Returns true if `self` is annotated by having either
     /// its [Self::initial_type_id] different from [Self::type_id],
     /// or [Self::span] different from [Span::dummy]
     /// or [Self::call_path_tree] different from `None`.
     pub fn is_annotated(&self) -> bool {
-        self.type_id != self.initial_type_id
-            || self.call_path_tree.is_some()
-            || !self.span.is_dummy()
+        match self {
+            GenericArgument::Type(a) => {
+                a.type_id != a.initial_type_id || a.call_path_tree.is_some() || !a.span.is_dummy()
+            }
+        }
     }
 }
 
-impl From<TypeId> for TypeArgument {
+impl Spanned for GenericArgument {
+    fn span(&self) -> Span {
+        match self {
+            GenericArgument::Type(a) => a.span.clone(),
+        }
+    }
+}
+
+impl From<TypeId> for GenericArgument {
     /// Creates *a non-annotated* [TypeArgument] that points
     /// to the [TypeInfo] represented by the `type_id`.
     fn from(type_id: TypeId) -> Self {
-        TypeArgument {
+        GenericArgument::Type(GenericTypeArgument {
             type_id,
             initial_type_id: type_id,
             span: Span::dummy(),
             call_path_tree: None,
-        }
+        })
     }
 }
 
-impl Spanned for TypeArgument {
-    fn span(&self) -> Span {
-        self.span.clone()
-    }
-}
-
-impl HashWithEngines for TypeArgument {
+impl HashWithEngines for GenericArgument {
     fn hash<H: Hasher>(&self, state: &mut H, engines: &Engines) {
-        let TypeArgument {
-            type_id,
-            // these fields are not hashed because they aren't relevant/a
-            // reliable source of obj v. obj distinction
-            initial_type_id: _,
-            span: _,
-            call_path_tree: _,
-        } = self;
-        let type_engine = engines.te();
-        type_engine.get(*type_id).hash(state, engines);
-    }
-}
-
-impl EqWithEngines for TypeArgument {}
-impl PartialEqWithEngines for TypeArgument {
-    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
-        let type_engine = ctx.engines().te();
-        self.type_id == other.type_id
-            || type_engine
-                .get(self.type_id)
-                .eq(&type_engine.get(other.type_id), ctx)
-    }
-}
-
-impl OrdWithEngines for TypeArgument {
-    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> Ordering {
-        let TypeArgument {
-            type_id: lti,
-            // these fields are not compared because they aren't relevant/a
-            // reliable source of obj v. obj distinction
-            initial_type_id: _,
-            span: _,
-            call_path_tree: _,
-        } = self;
-        let TypeArgument {
-            type_id: rti,
-            // these fields are not compared because they aren't relevant/a
-            // reliable source of obj v. obj distinction
-            initial_type_id: _,
-            span: _,
-            call_path_tree: _,
-        } = other;
-        if lti == rti {
-            return Ordering::Equal;
+        match self {
+            GenericArgument::Type(GenericTypeArgument {
+                type_id,
+                // these fields are not hashed because they aren't relevant/a
+                // reliable source of obj v. obj distinction
+                initial_type_id: _,
+                span: _,
+                call_path_tree: _,
+            }) => {
+                let type_engine = engines.te();
+                type_engine.get(*type_id).hash(state, engines);
+            }
         }
-        ctx.engines()
-            .te()
-            .get(*lti)
-            .cmp(&ctx.engines().te().get(*rti), ctx)
     }
 }
 
-impl DisplayWithEngines for TypeArgument {
+impl EqWithEngines for GenericArgument {}
+impl PartialEqWithEngines for GenericArgument {
+    fn eq(&self, other: &Self, ctx: &PartialEqWithEnginesContext) -> bool {
+        match (self, other) {
+            (GenericArgument::Type(l), GenericArgument::Type(r)) => {
+                let type_engine = ctx.engines().te();
+                l.type_id == r.type_id
+                    || type_engine
+                        .get(l.type_id)
+                        .eq(&type_engine.get(r.type_id), ctx)
+            }
+        }
+    }
+}
+
+impl OrdWithEngines for GenericArgument {
+    fn cmp(&self, other: &Self, ctx: &OrdWithEnginesContext) -> Ordering {
+        match (self, other) {
+            (
+                GenericArgument::Type(GenericTypeArgument {
+                    type_id: lti,
+                    // these fields are not compared because they aren't relevant/a
+                    // reliable source of obj v. obj distinction
+                    initial_type_id: _,
+                    span: _,
+                    call_path_tree: _,
+                }),
+                GenericArgument::Type(GenericTypeArgument {
+                    type_id: rti,
+                    // these fields are not compared because they aren't relevant/a
+                    // reliable source of obj v. obj distinction
+                    initial_type_id: _,
+                    span: _,
+                    call_path_tree: _,
+                }),
+            ) => {
+                if lti == rti {
+                    return Ordering::Equal;
+                }
+                ctx.engines()
+                    .te()
+                    .get(*lti)
+                    .cmp(&ctx.engines().te().get(*rti), ctx)
+            }
+        }
+    }
+}
+
+impl DisplayWithEngines for GenericArgument {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, engines: &Engines) -> fmt::Result {
-        write!(f, "{}", engines.help_out(&*engines.te().get(self.type_id)))
+        match self {
+            GenericArgument::Type(a) => {
+                write!(f, "{}", engines.help_out(&*engines.te().get(a.type_id)))
+            }
+        }
     }
 }
 
-impl DebugWithEngines for TypeArgument {
+impl DebugWithEngines for GenericArgument {
     fn fmt(&self, f: &mut fmt::Formatter<'_>, engines: &Engines) -> fmt::Result {
-        write!(
-            f,
-            "{:?}",
-            engines.help_out(&*engines.te().get(self.type_id))
-        )
+        match self {
+            GenericArgument::Type(a) => {
+                write!(f, "{:?}", engines.help_out(&*engines.te().get(a.type_id)))
+            }
+        }
     }
 }
 
-impl From<&TypeParameter> for TypeArgument {
+impl From<&TypeParameter> for GenericArgument {
     fn from(p: &TypeParameter) -> Self {
         match p {
-            TypeParameter::Type(p) => TypeArgument {
+            TypeParameter::Type(p) => GenericArgument::Type(GenericTypeArgument {
                 type_id: p.type_id,
                 initial_type_id: p.initial_type_id,
                 span: p.name.span(),
                 call_path_tree: None,
-            },
+            }),
             TypeParameter::Const(_) => todo!(),
         }
     }
 }
 
-impl SubstTypes for TypeArgument {
+impl SubstTypes for GenericArgument {
     fn subst_inner(&mut self, ctx: &SubstTypesContext) -> HasChanges {
-        self.type_id.subst(ctx)
+        match self {
+            GenericArgument::Type(a) => a.type_id.subst(ctx),
+        }
     }
 }

--- a/sway-core/src/type_system/ast_elements/type_parameter.rs
+++ b/sway-core/src/type_system/ast_elements/type_parameter.rs
@@ -761,7 +761,7 @@ fn handle_trait(
     ctx: &TypeCheckContext,
     type_id: TypeId,
     trait_name: &CallPath,
-    type_arguments: &[TypeArgument],
+    type_arguments: &[GenericArgument],
     function_name: &str,
     access_span: Span,
 ) -> Result<(InterfaceItemMap, ItemMap, ItemMap), ErrorEmitted> {

--- a/sway-core/src/type_system/info.rs
+++ b/sway-core/src/type_system/info.rs
@@ -25,7 +25,7 @@ use sway_error::{
 };
 use sway_types::{integer_bits::IntegerBits, span::Span, Named};
 
-use super::ast_elements::length::NumericLength;
+use super::ast_elements::{length::NumericLength, type_argument::GenericTypeArgument};
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum AbiName {
@@ -117,7 +117,7 @@ pub enum TypeInfo {
     Enum(DeclId<TyEnumDecl>),
     Struct(DeclId<TyStructDecl>),
     Boolean,
-    Tuple(Vec<TypeArgument>),
+    Tuple(Vec<GenericArgument>),
     /// Represents a type which contains methods to issue a contract call.
     /// The specific contract is identified via the `Ident` within.
     ContractCaller {
@@ -131,7 +131,7 @@ pub enum TypeInfo {
     /// until the semantic analysis stage.
     Custom {
         qualified_call_path: QualifiedCallPath,
-        type_arguments: Option<Vec<TypeArgument>>,
+        type_arguments: Option<Vec<GenericArgument>>,
     },
     B256,
     /// This means that specific type of a number is not yet known. It will be
@@ -141,7 +141,7 @@ pub enum TypeInfo {
     // used for recovering from errors in the ast
     ErrorRecovery(ErrorEmitted),
     // Static, constant size arrays.
-    Array(TypeArgument, Length),
+    Array(GenericArgument, Length),
     /// Pointers.
     /// These are represented in memory as u64 but are a different type since pointers only make
     /// sense in the context they were created in. Users can obtain pointers via standard library
@@ -150,8 +150,8 @@ pub enum TypeInfo {
     /// gtf instruction, or manipulating u64s.
     RawUntypedPtr,
     RawUntypedSlice,
-    Ptr(TypeArgument),
-    Slice(TypeArgument),
+    Ptr(GenericArgument),
+    Slice(GenericArgument),
     /// Type aliases.
     /// This type and the type `ty` it encapsulates always coerce. They are effectively
     /// interchangeable.
@@ -160,7 +160,7 @@ pub enum TypeInfo {
     //       in the `TypeEngine` accordingly, e.g., the `is_type_changeable`.
     Alias {
         name: Ident,
-        ty: TypeArgument,
+        ty: GenericArgument,
     },
     TraitType {
         name: Ident,
@@ -168,7 +168,7 @@ pub enum TypeInfo {
     },
     Ref {
         to_mutable_value: bool,
-        referenced_type: TypeArgument,
+        referenced_type: GenericArgument,
     },
 }
 
@@ -348,10 +348,10 @@ impl PartialEqWithEngines for TypeInfo {
                 l_abi_name == r_abi_name && l_address_span == r_address_span
             }
             (Self::Array(l0, l1), Self::Array(r0, r1)) => {
-                ((l0.type_id == r0.type_id)
+                ((l0.type_id() == r0.type_id())
                     || type_engine
-                        .get(l0.type_id)
-                        .eq(&type_engine.get(r0.type_id), ctx))
+                        .get(l0.type_id())
+                        .eq(&type_engine.get(r0.type_id()), ctx))
                     && l1 == r1
             }
             (
@@ -365,10 +365,10 @@ impl PartialEqWithEngines for TypeInfo {
                 },
             ) => {
                 l_name == r_name
-                    && ((l_ty.type_id == r_ty.type_id)
+                    && ((l_ty.type_id() == r_ty.type_id())
                         || type_engine
-                            .get(l_ty.type_id)
-                            .eq(&type_engine.get(r_ty.type_id), ctx))
+                            .get(l_ty.type_id())
+                            .eq(&type_engine.get(r_ty.type_id()), ctx))
             }
             (
                 Self::TraitType {
@@ -397,10 +397,10 @@ impl PartialEqWithEngines for TypeInfo {
                 },
             ) => {
                 (l_to_mut == r_to_mut)
-                    && ((l_ty.type_id == r_ty.type_id)
+                    && ((l_ty.type_id() == r_ty.type_id())
                         || type_engine
-                            .get(l_ty.type_id)
-                            .eq(&type_engine.get(r_ty.type_id), ctx))
+                            .get(l_ty.type_id())
+                            .eq(&type_engine.get(r_ty.type_id()), ctx))
             }
 
             (l, r) => l.discriminant_value() == r.discriminant_value(),
@@ -484,8 +484,8 @@ impl OrdWithEngines for TypeInfo {
                 l_abi_name.cmp(r_abi_name)
             }
             (Self::Array(l0, l1), Self::Array(r0, r1)) => type_engine
-                .get(l0.type_id)
-                .cmp(&type_engine.get(r0.type_id), ctx)
+                .get(l0.type_id())
+                .cmp(&type_engine.get(r0.type_id()), ctx)
                 .then_with(|| {
                     if let Some(ord) = l1.partial_cmp(r1) {
                         ord
@@ -503,8 +503,8 @@ impl OrdWithEngines for TypeInfo {
                     ty: r_ty,
                 },
             ) => type_engine
-                .get(l_ty.type_id)
-                .cmp(&type_engine.get(r_ty.type_id), ctx)
+                .get(l_ty.type_id())
+                .cmp(&type_engine.get(r_ty.type_id()), ctx)
                 .then_with(|| l_name.cmp(r_name)),
             (
                 Self::TraitType {
@@ -529,8 +529,8 @@ impl OrdWithEngines for TypeInfo {
                 },
             ) => l_to_mut.cmp(r_to_mut).then_with(|| {
                 type_engine
-                    .get(l_ty.type_id)
-                    .cmp(&type_engine.get(r_ty.type_id), ctx)
+                    .get(l_ty.type_id())
+                    .cmp(&type_engine.get(r_ty.type_id()), ctx)
             }),
             (l, r) => l.discriminant_value().cmp(&r.discriminant_value()),
         }
@@ -940,7 +940,7 @@ impl TypeInfo {
                         .iter()
                         .map(|field_type| {
                             type_engine
-                                .to_typeinfo(field_type.type_id, error_msg_span)
+                                .to_typeinfo(field_type.type_id(), error_msg_span)
                                 .expect("unreachable?")
                                 .to_selector_name(handler, engines, error_msg_span)
                         })
@@ -963,7 +963,7 @@ impl TypeInfo {
                         .iter()
                         .map(|ty| {
                             let ty = match type_engine
-                                .to_typeinfo(ty.type_argument.type_id, error_msg_span)
+                                .to_typeinfo(ty.type_argument.type_id(), error_msg_span)
                             {
                                 Err(e) => return Err(handler.emit_err(e.into())),
                                 Ok(ty) => ty,
@@ -1020,7 +1020,7 @@ impl TypeInfo {
                         .iter()
                         .map(|ty| {
                             let ty = match type_engine
-                                .to_typeinfo(ty.type_argument.type_id, error_msg_span)
+                                .to_typeinfo(ty.type_argument.type_id(), error_msg_span)
                             {
                                 Err(e) => return Err(handler.emit_err(e.into())),
                                 Ok(ty) => ty,
@@ -1071,7 +1071,7 @@ impl TypeInfo {
                 let len = length
                     .as_literal_val()
                     .expect("unexpected non literal length");
-                let name = type_engine.get(elem_ty.type_id).to_selector_name(
+                let name = type_engine.get(elem_ty.type_id()).to_selector_name(
                     handler,
                     engines,
                     error_msg_span,
@@ -1082,10 +1082,11 @@ impl TypeInfo {
             RawUntypedPtr => "rawptr".to_string(),
             RawUntypedSlice => "rawslice".to_string(),
             Alias { ty, .. } => {
-                let name =
-                    type_engine
-                        .get(ty.type_id)
-                        .to_selector_name(handler, engines, error_msg_span);
+                let name = type_engine.get(ty.type_id()).to_selector_name(
+                    handler,
+                    engines,
+                    error_msg_span,
+                );
                 name?
             }
             // TODO-IG: No references in ABIs according to the RFC. Or we want to have them?
@@ -1108,23 +1109,23 @@ impl TypeInfo {
                 .get_enum(decl_ref)
                 .variants
                 .iter()
-                .all(|variant_type| id_uninhabited(variant_type.type_argument.type_id)),
+                .all(|variant_type| id_uninhabited(variant_type.type_argument.type_id())),
             TypeInfo::Struct(decl_ref) => decl_engine
                 .get_struct(decl_ref)
                 .fields
                 .iter()
-                .any(|field| id_uninhabited(field.type_argument.type_id)),
+                .any(|field| id_uninhabited(field.type_argument.type_id())),
             TypeInfo::Tuple(fields) => fields
                 .iter()
-                .any(|field_type| id_uninhabited(field_type.type_id)),
-            TypeInfo::Array(elem_ty, _) => id_uninhabited(elem_ty.type_id),
-            TypeInfo::Ptr(ty) => id_uninhabited(ty.type_id),
-            TypeInfo::Alias { name: _, ty } => id_uninhabited(ty.type_id),
-            TypeInfo::Slice(ty) => id_uninhabited(ty.type_id),
+                .any(|field_type| id_uninhabited(field_type.type_id())),
+            TypeInfo::Array(elem_ty, _) => id_uninhabited(elem_ty.type_id()),
+            TypeInfo::Ptr(ty) => id_uninhabited(ty.type_id()),
+            TypeInfo::Alias { name: _, ty } => id_uninhabited(ty.type_id()),
+            TypeInfo::Slice(ty) => id_uninhabited(ty.type_id()),
             TypeInfo::Ref {
                 to_mutable_value: _,
                 referenced_type,
-            } => id_uninhabited(referenced_type.type_id),
+            } => id_uninhabited(referenced_type.type_id()),
             _ => false,
         }
     }
@@ -1135,7 +1136,7 @@ impl TypeInfo {
                 let decl = decl_engine.get_enum(decl_ref);
                 let mut found_unit_variant = false;
                 for variant_type in &decl.variants {
-                    let type_info = type_engine.get(variant_type.type_argument.type_id);
+                    let type_info = type_engine.get(variant_type.type_argument.type_id());
                     if type_info.is_uninhabited(type_engine, decl_engine) {
                         continue;
                     }
@@ -1151,7 +1152,7 @@ impl TypeInfo {
                 let decl = decl_engine.get_struct(decl_ref);
                 let mut all_zero_sized = true;
                 for field in &decl.fields {
-                    let type_info = type_engine.get(field.type_argument.type_id);
+                    let type_info = type_engine.get(field.type_argument.type_id());
                     if type_info.is_uninhabited(type_engine, decl_engine) {
                         return true;
                     }
@@ -1164,7 +1165,7 @@ impl TypeInfo {
             TypeInfo::Tuple(fields) => {
                 let mut all_zero_sized = true;
                 for field in fields {
-                    let field_type = type_engine.get(field.type_id);
+                    let field_type = type_engine.get(field.type_id());
                     if field_type.is_uninhabited(type_engine, decl_engine) {
                         return true;
                     }
@@ -1181,7 +1182,7 @@ impl TypeInfo {
                     .expect("unexpected non literal length");
                 len == 0
                     || type_engine
-                        .get(elem_ty.type_id)
+                        .get(elem_ty.type_id())
                         .is_zero_sized(type_engine, decl_engine)
             }
             _ => false,
@@ -1195,7 +1196,7 @@ impl TypeInfo {
         match self {
             TypeInfo::Tuple(fields) => fields.iter().all(|type_argument| {
                 type_engine
-                    .get(type_argument.type_id)
+                    .get(type_argument.type_id())
                     .can_safely_ignore(type_engine, decl_engine)
             }),
             TypeInfo::Array(elem_ty, length) if length.as_literal_val().is_some() => {
@@ -1205,7 +1206,7 @@ impl TypeInfo {
                     .expect("unexpected non literal length");
                 len == 0
                     || type_engine
-                        .get(elem_ty.type_id)
+                        .get(elem_ty.type_id())
                         .can_safely_ignore(type_engine, decl_engine)
             }
             TypeInfo::ErrorRecovery(_) => true,
@@ -1251,7 +1252,7 @@ impl TypeInfo {
         matches!(self, TypeInfo::Ref { .. })
     }
 
-    pub fn as_reference(&self) -> Option<(&bool, &TypeArgument)> {
+    pub fn as_reference(&self) -> Option<(&bool, &GenericArgument)> {
         match self {
             TypeInfo::Ref {
                 to_mutable_value,
@@ -1281,7 +1282,7 @@ impl TypeInfo {
         matches!(self, TypeInfo::Slice(_))
     }
 
-    pub fn as_slice(&self) -> Option<&TypeArgument> {
+    pub fn as_slice(&self) -> Option<&GenericArgument> {
         if let TypeInfo::Slice(t) = self {
             Some(t)
         } else {
@@ -1292,7 +1293,7 @@ impl TypeInfo {
     pub(crate) fn apply_type_arguments(
         self,
         handler: &Handler,
-        type_arguments: Vec<TypeArgument>,
+        type_arguments: Vec<GenericArgument>,
         span: &Span,
     ) -> Result<TypeInfo, ErrorEmitted> {
         if type_arguments.is_empty() {
@@ -1383,7 +1384,7 @@ impl TypeInfo {
             | TypeInfo::Never
             | TypeInfo::StringSlice => Ok(()),
             TypeInfo::Alias { ty, .. } => {
-                let ty = engines.te().get(ty.type_id);
+                let ty = engines.te().get(ty.type_id());
                 ty.expect_is_supported_in_match_expressions(handler, engines, span)
             }
             TypeInfo::RawUntypedPtr
@@ -1530,7 +1531,7 @@ impl TypeInfo {
         match self {
             TypeInfo::Enum(decl_ref) => Ok(*decl_ref),
             TypeInfo::Alias {
-                ty: TypeArgument { type_id, .. },
+                ty: GenericArgument::Type(GenericTypeArgument { type_id, .. }),
                 ..
             } => engines
                 .te()
@@ -1571,7 +1572,7 @@ impl TypeInfo {
         match self {
             TypeInfo::Struct(decl_id) => Ok(*decl_id),
             TypeInfo::Alias {
-                ty: TypeArgument { type_id, .. },
+                ty: GenericArgument::Type(GenericTypeArgument { type_id, .. }),
                 ..
             } => engines
                 .te()
@@ -1618,12 +1619,12 @@ impl TypeInfo {
             TypeInfo::Ptr(_) => AbiEncodeSizeHint::PotentiallyInfinite,
 
             TypeInfo::Alias { ty, .. } => {
-                let elem_type = engines.te().get(ty.type_id);
+                let elem_type = engines.te().get(ty.type_id());
                 elem_type.abi_encode_size_hint(engines)
             }
 
             TypeInfo::Array(elem, len) => {
-                let elem_type = engines.te().get(elem.type_id);
+                let elem_type = engines.te().get(elem.type_id());
                 let size_hint = elem_type.abi_encode_size_hint(engines);
                 match &len {
                     Length::Literal { val, .. } => size_hint * *val,
@@ -1639,7 +1640,7 @@ impl TypeInfo {
                 items
                     .iter()
                     .fold(AbiEncodeSizeHint::Exact(0), |old_size_hint, t| {
-                        let field_type = engines.te().get(t.type_id);
+                        let field_type = engines.te().get(t.type_id());
                         let field_size_hint = field_type.abi_encode_size_hint(engines);
                         old_size_hint + field_size_hint
                     })
@@ -1650,7 +1651,7 @@ impl TypeInfo {
                 decl.fields
                     .iter()
                     .fold(AbiEncodeSizeHint::Exact(0), |old_size_hint, f| {
-                        let field_type = engines.te().get(f.type_argument.type_id);
+                        let field_type = engines.te().get(f.type_argument.type_id());
                         let field_size_hint = field_type.abi_encode_size_hint(engines);
                         old_size_hint + field_size_hint
                     })
@@ -1662,7 +1663,7 @@ impl TypeInfo {
                     .variants
                     .iter()
                     .fold(None, |old_size_hint: Option<AbiEncodeSizeHint>, v| {
-                        let variant_type = engines.te().get(v.type_argument.type_id);
+                        let variant_type = engines.te().get(v.type_argument.type_id());
                         let current_size_hint = variant_type.abi_encode_size_hint(engines);
                         match old_size_hint {
                             Some(old_size_hint) => Some(old_size_hint.min(current_size_hint)),
@@ -1675,7 +1676,7 @@ impl TypeInfo {
                     decl.variants
                         .iter()
                         .fold(AbiEncodeSizeHint::Exact(0), |old_size_hint, v| {
-                            let variant_type = engines.te().get(v.type_argument.type_id);
+                            let variant_type = engines.te().get(v.type_argument.type_id());
                             let current_size_hint = variant_type.abi_encode_size_hint(engines);
                             old_size_hint.max(current_size_hint)
                         });
@@ -1716,7 +1717,7 @@ impl TypeInfo {
             Tuple(fields) => {
                 let field_strs = fields
                     .iter()
-                    .map(|field| field.type_id.get_type_str(engines))
+                    .map(|field| field.type_id().get_type_str(engines))
                     .collect::<Vec<String>>();
                 format!("({})", field_strs.join(", "))
             }
@@ -1814,19 +1815,19 @@ impl TypeInfo {
             Array(elem_ty, length) => {
                 format!(
                     "[{}; {:?}]",
-                    elem_ty.type_id.get_type_str(engines),
+                    elem_ty.type_id().get_type_str(engines),
                     engines.help_out(length)
                 )
             }
             RawUntypedPtr => "raw untyped ptr".into(),
             RawUntypedSlice => "raw untyped slice".into(),
             Ptr(ty) => {
-                format!("__ptr {}", ty.type_id.get_type_str(engines))
+                format!("__ptr {}", ty.type_id().get_type_str(engines))
             }
             Slice(ty) => {
-                format!("__slice {}", ty.type_id.get_type_str(engines))
+                format!("__slice {}", ty.type_id().get_type_str(engines))
             }
-            Alias { ty, .. } => ty.type_id.get_type_str(engines),
+            Alias { ty, .. } => ty.type_id().get_type_str(engines),
             TraitType {
                 name,
                 trait_type_id: _,
@@ -1838,7 +1839,7 @@ impl TypeInfo {
                 format!(
                     "__ref {}{}",
                     if *to_mutable_value { "mut " } else { "" },
-                    referenced_type.type_id.get_type_str(engines)
+                    referenced_type.type_id().get_type_str(engines)
                 )
             }
         }

--- a/sway-core/src/type_system/mod.rs
+++ b/sway-core/src/type_system/mod.rs
@@ -104,12 +104,12 @@ fn generic_enum_resolution() {
     let variant_types = vec![ty::TyEnumVariant {
         name: a_name.clone(),
         tag: 0,
-        type_argument: TypeArgument {
+        type_argument: GenericArgument::Type(ast_elements::type_argument::GenericTypeArgument {
             type_id: placeholder_type,
             initial_type_id: placeholder_type,
             span: sp.clone(),
             call_path_tree: None,
-        },
+        }),
         span: sp.clone(),
         attributes: transform::Attributes::default(),
     }];
@@ -138,12 +138,12 @@ fn generic_enum_resolution() {
     let variant_types = vec![ty::TyEnumVariant {
         name: a_name,
         tag: 0,
-        type_argument: TypeArgument {
+        type_argument: GenericArgument::Type(ast_elements::type_argument::GenericTypeArgument {
             type_id: boolean_type,
             initial_type_id: boolean_type,
             span: sp.clone(),
             call_path_tree: None,
-        },
+        }),
         span: sp.clone(),
         attributes: transform::Attributes::default(),
     }];
@@ -181,7 +181,7 @@ fn generic_enum_resolution() {
         let decl = engines.de().get_enum(decl_ref_1);
         assert_eq!(decl.call_path.suffix.as_str(), "Result");
         assert!(matches!(
-            &*engines.te().get(variant_types[0].type_argument.type_id),
+            &*engines.te().get(variant_types[0].type_argument.type_id()),
             TypeInfo::Boolean
         ));
     } else {

--- a/sway-core/src/type_system/priv_prelude.rs
+++ b/sway-core/src/type_system/priv_prelude.rs
@@ -16,7 +16,7 @@ pub(crate) use super::{
 
 pub use super::{
     ast_elements::{
-        length::Length, trait_constraint::TraitConstraint, type_argument::TypeArgument,
+        length::Length, trait_constraint::TraitConstraint, type_argument::GenericArgument,
         type_parameter::TypeParameter,
     },
     engine::IsConcrete,

--- a/sway-core/src/type_system/substitute/subst_map.rs
+++ b/sway-core/src/type_system/substitute/subst_map.rs
@@ -175,13 +175,13 @@ impl TypeSubstMap {
                     .clone()
                     .unwrap_or_default()
                     .iter()
-                    .map(|x| x.type_id)
+                    .map(|x| x.type_id())
                     .collect::<Vec<_>>();
                 let type_arguments = type_arguments
                     .clone()
                     .unwrap_or_default()
                     .iter()
-                    .map(|x| x.type_id)
+                    .map(|x| x.type_id())
                     .collect::<Vec<_>>();
                 TypeSubstMap::from_superset_and_subset_helper(
                     engines,
@@ -253,16 +253,19 @@ impl TypeSubstMap {
                     engines,
                     type_parameters
                         .iter()
-                        .map(|x| x.type_id)
+                        .map(|x| x.type_id())
                         .collect::<Vec<_>>(),
-                    type_arguments.iter().map(|x| x.type_id).collect::<Vec<_>>(),
+                    type_arguments
+                        .iter()
+                        .map(|x| x.type_id())
+                        .collect::<Vec<_>>(),
                 )
             }
             (TypeInfo::Array(type_parameter, l), TypeInfo::Array(type_argument, r)) => {
                 let mut map = TypeSubstMap::from_superset_and_subset_helper(
                     engines,
-                    vec![type_parameter.type_id],
-                    vec![type_argument.type_id],
+                    vec![type_parameter.type_id()],
+                    vec![type_argument.type_id()],
                 );
                 match (&l, &r) {
                     (
@@ -287,8 +290,8 @@ impl TypeSubstMap {
             (TypeInfo::Slice(type_parameter), TypeInfo::Slice(type_argument)) => {
                 TypeSubstMap::from_superset_and_subset_helper(
                     engines,
-                    vec![type_parameter.type_id],
-                    vec![type_argument.type_id],
+                    vec![type_parameter.type_id()],
+                    vec![type_argument.type_id()],
                 )
             }
             (TypeInfo::Unknown, TypeInfo::Unknown)
@@ -391,9 +394,10 @@ impl TypeSubstMap {
                 let mut need_to_create_new = false;
 
                 for variant in &mut decl.variants {
-                    if let Some(type_id) = self.find_match(variant.type_argument.type_id, engines) {
+                    if let Some(type_id) = self.find_match(variant.type_argument.type_id(), engines)
+                    {
                         need_to_create_new = true;
-                        variant.type_argument.type_id = type_id;
+                        *variant.type_argument.type_id_mut() = type_id;
                     }
                 }
 
@@ -422,9 +426,9 @@ impl TypeSubstMap {
                 let mut decl = (*parsed_decl_engine.get_struct(&decl_id)).clone();
                 let mut need_to_create_new = false;
                 for field in &mut decl.fields {
-                    if let Some(type_id) = self.find_match(field.type_argument.type_id, engines) {
+                    if let Some(type_id) = self.find_match(field.type_argument.type_id(), engines) {
                         need_to_create_new = true;
-                        field.type_argument.type_id = type_id;
+                        *field.type_argument.type_id_mut() = type_id;
                     }
                 }
                 for type_param in &mut decl.type_parameters {
@@ -452,9 +456,9 @@ impl TypeSubstMap {
                 let mut decl = (*decl_engine.get_struct(&decl_id)).clone();
                 let mut need_to_create_new = false;
                 for field in &mut decl.fields {
-                    if let Some(type_id) = self.find_match(field.type_argument.type_id, engines) {
+                    if let Some(type_id) = self.find_match(field.type_argument.type_id(), engines) {
                         need_to_create_new = true;
-                        field.type_argument.type_id = type_id;
+                        *field.type_argument.type_id_mut() = type_id;
                     }
                 }
                 for type_param in &mut decl.type_parameters {
@@ -479,9 +483,10 @@ impl TypeSubstMap {
                 let mut need_to_create_new = false;
 
                 for variant in &mut decl.variants {
-                    if let Some(type_id) = self.find_match(variant.type_argument.type_id, engines) {
+                    if let Some(type_id) = self.find_match(variant.type_argument.type_id(), engines)
+                    {
                         need_to_create_new = true;
-                        variant.type_argument.type_id = type_id;
+                        *variant.type_argument.type_id_mut() = type_id;
                     }
                 }
 
@@ -502,26 +507,27 @@ impl TypeSubstMap {
                     None
                 }
             }
-            TypeInfo::Array(mut elem_type, length) => {
-                self.find_match(elem_type.type_id, engines).map(|type_id| {
-                    elem_type.type_id = type_id;
+            TypeInfo::Array(mut elem_type, length) => self
+                .find_match(elem_type.type_id(), engines)
+                .map(|type_id| {
+                    *elem_type.type_id_mut() = type_id;
                     type_engine.insert_array(engines, elem_type, length)
-                })
-            }
+                }),
             TypeInfo::Slice(mut elem_type) => {
-                self.find_match(elem_type.type_id, engines).map(|type_id| {
-                    elem_type.type_id = type_id;
-                    type_engine.insert_slice(engines, elem_type)
-                })
+                self.find_match(elem_type.type_id(), engines)
+                    .map(|type_id| {
+                        *elem_type.type_id_mut() = type_id;
+                        type_engine.insert_slice(engines, elem_type)
+                    })
             }
             TypeInfo::Tuple(fields) => {
                 let mut need_to_create_new = false;
                 let fields = fields
                     .into_iter()
                     .map(|mut field| {
-                        if let Some(type_id) = self.find_match(field.type_id, engines) {
+                        if let Some(type_id) = self.find_match(field.type_id(), engines) {
                             need_to_create_new = true;
-                            field.type_id = type_id;
+                            *field.type_id_mut() = type_id;
                         }
                         field.clone()
                     })
@@ -533,21 +539,21 @@ impl TypeSubstMap {
                 }
             }
             TypeInfo::Alias { name, mut ty } => {
-                self.find_match(ty.type_id, engines).map(|type_id| {
-                    ty.type_id = type_id;
+                self.find_match(ty.type_id(), engines).map(|type_id| {
+                    *ty.type_id_mut() = type_id;
                     type_engine.new_alias(engines, name, ty)
                 })
             }
-            TypeInfo::Ptr(mut ty) => self.find_match(ty.type_id, engines).map(|type_id| {
-                ty.type_id = type_id;
+            TypeInfo::Ptr(mut ty) => self.find_match(ty.type_id(), engines).map(|type_id| {
+                *ty.type_id_mut() = type_id;
                 type_engine.insert_ptr(engines, ty)
             }),
             TypeInfo::TraitType { .. } => iter_for_match(engines, self, &type_info),
             TypeInfo::Ref {
                 to_mutable_value,
                 referenced_type: mut ty,
-            } => self.find_match(ty.type_id, engines).map(|type_id| {
-                ty.type_id = type_id;
+            } => self.find_match(ty.type_id(), engines).map(|type_id| {
+                *ty.type_id_mut() = type_id;
                 type_engine.insert_ref(engines, to_mutable_value, ty)
             }),
             TypeInfo::Unknown

--- a/sway-core/src/type_system/unify/unifier.rs
+++ b/sway-core/src/type_system/unify/unifier.rs
@@ -4,7 +4,7 @@ use sway_error::{
     handler::{ErrorEmitted, Handler},
     type_error::TypeError,
 };
-use sway_types::Span;
+use sway_types::{Span, Spanned};
 
 use crate::{
     engine_threading::{Engines, PartialEqWithEngines, PartialEqWithEnginesContext, WithEngines},
@@ -247,8 +247,8 @@ impl<'a> Unifier<'a> {
             (Never, _) => {}
 
             // Type aliases and the types they encapsulate coerce to each other.
-            (Alias { ty, .. }, _) => self.unify(handler, ty.type_id, expected, span, false),
-            (_, Alias { ty, .. }) => self.unify(handler, received, ty.type_id, span, false),
+            (Alias { ty, .. }, _) => self.unify(handler, ty.type_id(), expected, span, false),
+            (_, Alias { ty, .. }) => self.unify(handler, received, ty.type_id(), span, false),
 
             (Enum(r_decl_ref), Enum(e_decl_ref)) => {
                 let r_decl = self.engines.de().get_enum(r_decl_ref);
@@ -377,9 +377,9 @@ impl<'a> Unifier<'a> {
         }
     }
 
-    fn unify_tuples(&self, handler: &Handler, rfs: &[TypeArgument], efs: &[TypeArgument]) {
+    fn unify_tuples(&self, handler: &Handler, rfs: &[GenericArgument], efs: &[GenericArgument]) {
         for (rf, ef) in rfs.iter().zip(efs.iter()) {
-            self.unify(handler, rf.type_id, ef.type_id, &rf.span, false);
+            self.unify(handler, rf.type_id(), ef.type_id(), &rf.span(), false);
         }
     }
 
@@ -463,14 +463,14 @@ impl<'a> Unifier<'a> {
         received_parent: TypeId,
         expected_parent: TypeId,
         span: &Span,
-        received_type_argument: &TypeArgument,
-        expected_type_argument: &TypeArgument,
+        received_type_argument: &GenericArgument,
+        expected_type_argument: &GenericArgument,
     ) -> Result<(), ErrorEmitted> {
         let h = Handler::default();
         self.unify(
             &h,
-            received_type_argument.type_id,
-            expected_type_argument.type_id,
+            received_type_argument.type_id(),
+            expected_type_argument.type_id(),
             span,
             false,
         );

--- a/sway-core/src/type_system/unify/unify_check.rs
+++ b/sway-core/src/type_system/unify/unify_check.rs
@@ -274,15 +274,15 @@ impl<'a> UnifyCheck<'a> {
         match (&*left_info, &*right_info) {
             // when a type alias is encountered, defer the decision to the type it contains (i.e. the
             // type it aliases with)
-            (Alias { ty, .. }, _) => return self.check_inner(ty.type_id, right),
-            (_, Alias { ty, .. }) => return self.check_inner(left, ty.type_id),
+            (Alias { ty, .. }, _) => return self.check_inner(ty.type_id(), right),
+            (_, Alias { ty, .. }) => return self.check_inner(left, ty.type_id()),
 
             (Never, Never) => {
                 return true;
             }
 
             (Array(l0, l1), Array(r0, r1)) => {
-                let elem_types_unify = self.check_inner(l0.type_id, r0.type_id);
+                let elem_types_unify = self.check_inner(l0.type_id(), r0.type_id());
                 return if !elem_types_unify {
                     false
                 } else {
@@ -301,12 +301,12 @@ impl<'a> UnifyCheck<'a> {
             }
 
             (Slice(l0), Slice(r0)) => {
-                return self.check_inner(l0.type_id, r0.type_id);
+                return self.check_inner(l0.type_id(), r0.type_id());
             }
 
             (Tuple(l_types), Tuple(r_types)) => {
-                let l_types = l_types.iter().map(|x| x.type_id).collect::<Vec<_>>();
-                let r_types = r_types.iter().map(|x| x.type_id).collect::<Vec<_>>();
+                let l_types = l_types.iter().map(|x| x.type_id()).collect::<Vec<_>>();
+                let r_types = r_types.iter().map(|x| x.type_id()).collect::<Vec<_>>();
                 return self.check_multiple(&l_types, &r_types);
             }
 
@@ -331,13 +331,13 @@ impl<'a> UnifyCheck<'a> {
                     .as_ref()
                     .unwrap_or(&vec![])
                     .iter()
-                    .map(|x| x.type_id)
+                    .map(|x| x.type_id())
                     .collect::<Vec<_>>();
                 let r_types = r_type_args
                     .as_ref()
                     .unwrap_or(&vec![])
                     .iter()
-                    .map(|x| x.type_id)
+                    .map(|x| x.type_id())
                     .collect::<Vec<_>>();
                 let same_qualified_path_root = match (
                     l_name.qualified_path_root.clone(),
@@ -345,8 +345,8 @@ impl<'a> UnifyCheck<'a> {
                 ) {
                     (Some(l_qualified_path_root), Some(r_qualified_path_root)) => {
                         self.check_inner(
-                            l_qualified_path_root.ty.type_id,
-                            r_qualified_path_root.ty.type_id,
+                            l_qualified_path_root.ty.type_id(),
+                            r_qualified_path_root.ty.type_id(),
                         ) && self.check_inner(
                             l_qualified_path_root.as_trait,
                             r_qualified_path_root.as_trait,
@@ -383,7 +383,8 @@ impl<'a> UnifyCheck<'a> {
                 //  - `&` -> `&`
                 //  - `&mut` -> `&`
                 //  - `&mut` -> `&mut`
-                return (*l_to_mut || !*r_to_mut) && self.check_inner(l_ty.type_id, r_ty.type_id);
+                return (*l_to_mut || !*r_to_mut)
+                    && self.check_inner(l_ty.type_id(), r_ty.type_id());
             }
 
             (
@@ -396,7 +397,7 @@ impl<'a> UnifyCheck<'a> {
                     referenced_type: r_ty,
                 },
             ) => {
-                return *l_to_mut == *r_to_mut && self.check_inner(l_ty.type_id, r_ty.type_id);
+                return *l_to_mut == *r_to_mut && self.check_inner(l_ty.type_id(), r_ty.type_id());
             }
 
             (UnknownGeneric { parent: lp, .. }, r)
@@ -782,7 +783,7 @@ impl<'a> UnifyCheck<'a> {
             .variants
             .iter()
             .zip(right.variants.iter())
-            .any(|(l, r)| !self.check_inner(l.type_argument.type_id, r.type_argument.type_id))
+            .any(|(l, r)| !self.check_inner(l.type_argument.type_id(), r.type_argument.type_id()))
         {
             return false;
         }
@@ -853,7 +854,7 @@ impl<'a> UnifyCheck<'a> {
             .fields
             .iter()
             .zip(right.fields.iter())
-            .any(|(l, r)| !self.check_inner(l.type_argument.type_id, r.type_argument.type_id))
+            .any(|(l, r)| !self.check_inner(l.type_argument.type_id(), r.type_argument.type_id()))
         {
             return false;
         }
@@ -893,12 +894,12 @@ pub fn array_constraint_subset() {
     let engines = Engines::default();
     let array_u64_1 = engines.te().insert_array(
         &engines,
-        TypeArgument {
+        GenericArgument::Type(crate::ast_elements::type_argument::GenericTypeArgument {
             type_id: engines.te().id_of_u64(),
             initial_type_id: engines.te().id_of_u64(),
             span: sway_types::Span::dummy(),
             call_path_tree: None,
-        },
+        }),
         Length::Literal {
             val: 1,
             span: sway_types::Span::dummy(),
@@ -906,12 +907,12 @@ pub fn array_constraint_subset() {
     );
     let array_u64_n = engines.te().insert_array(
         &engines,
-        TypeArgument {
+        GenericArgument::Type(crate::ast_elements::type_argument::GenericTypeArgument {
             type_id: engines.te().id_of_u64(),
             initial_type_id: engines.te().id_of_u64(),
             span: sway_types::Span::dummy(),
             call_path_tree: None,
-        },
+        }),
         Length::AmbiguousVariableExpression {
             ident: sway_types::BaseIdent::new_no_span("N".into()),
         },

--- a/sway-lsp/src/capabilities/code_actions/abi_decl/abi_impl.rs
+++ b/sway-lsp/src/capabilities/code_actions/abi_decl/abi_impl.rs
@@ -59,10 +59,13 @@ impl AbiImplCodeAction<'_> {
     fn return_type_string(&self, function_decl: &TyTraitFn) -> String {
         let type_engine = self.engines.te();
         // Unit is the implicit return type for ABI functions.
-        if type_engine.get(function_decl.return_type.type_id).is_unit() {
+        if type_engine
+            .get(function_decl.return_type.type_id())
+            .is_unit()
+        {
             String::new()
         } else {
-            format!(" -> {}", function_decl.return_type.span.as_str())
+            format!(" -> {}", function_decl.return_type.span().as_str())
         }
     }
 
@@ -98,7 +101,7 @@ impl AbiImplCodeAction<'_> {
 fn params_string(params: &[TyFunctionParameter]) -> String {
     params
         .iter()
-        .map(|param| format!("{}: {}", param.name, param.type_argument.span.as_str()))
+        .map(|param| format!("{}: {}", param.name, param.type_argument.span().as_str()))
         .collect::<Vec<String>>()
         .join(", ")
 }

--- a/sway-lsp/src/capabilities/code_actions/abi_decl/abi_impl.rs
+++ b/sway-lsp/src/capabilities/code_actions/abi_decl/abi_impl.rs
@@ -1,13 +1,13 @@
+use crate::capabilities::code_actions::{
+    common::generate_impl::{GenerateImplCodeAction, CONTRACT},
+    CodeAction, CodeActionContext, CODE_ACTION_IMPL_TITLE,
+};
 use lsp_types::{Range, Url};
 use sway_core::{
     language::ty::{self, TyAbiDecl, TyFunctionParameter, TyTraitFn},
     Engines,
 };
-
-use crate::capabilities::code_actions::{
-    common::generate_impl::{GenerateImplCodeAction, CONTRACT},
-    CodeAction, CodeActionContext, CODE_ACTION_IMPL_TITLE,
-};
+use sway_types::Spanned;
 
 pub(crate) struct AbiImplCodeAction<'a> {
     engines: &'a Engines,

--- a/sway-lsp/src/capabilities/code_actions/common/fn_doc_comment.rs
+++ b/sway-lsp/src/capabilities/code_actions/common/fn_doc_comment.rs
@@ -93,7 +93,7 @@ impl<T: Spanned + Named + FunctionSignature> FnDocCommentCodeAction<'_, T> {
             lines.push(self.formatted_list_item(
                 self.engines,
                 Some(param.name.to_string()),
-                param.type_argument.type_id,
+                param.type_argument.type_id(),
             ));
         });
         lines
@@ -104,7 +104,7 @@ impl<T: Spanned + Named + FunctionSignature> FnDocCommentCodeAction<'_, T> {
         if self
             .engines
             .te()
-            .get(self.decl.return_type().type_id)
+            .get(self.decl.return_type().type_id())
             .is_unit()
         {
             return vec![];
@@ -113,7 +113,7 @@ impl<T: Spanned + Named + FunctionSignature> FnDocCommentCodeAction<'_, T> {
             String::new(),
             "### Returns".to_string(),
             String::new(),
-            self.formatted_list_item(self.engines, None, self.decl.return_type().type_id),
+            self.formatted_list_item(self.engines, None, self.decl.return_type().type_id()),
         ]
     }
 

--- a/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
+++ b/sway-lsp/src/capabilities/code_actions/struct_decl/struct_new.rs
@@ -143,7 +143,7 @@ impl StructNewCodeAction<'_> {
     fn params_string(params: &[TyStructField]) -> String {
         params
             .iter()
-            .map(|field| format!("{}: {}", field.name, field.type_argument.span.as_str()))
+            .map(|field| format!("{}: {}", field.name, field.type_argument.span().as_str()))
             .collect::<Vec<String>>()
             .join(", ")
     }

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -7,6 +7,7 @@ use sway_core::{
     language::ty::{TyAstNodeContent, TyDecl, TyFunctionDecl, TyFunctionParameter},
     Engines, Namespace, TypeId, TypeInfo,
 };
+use sway_types::Spanned;
 
 pub(crate) fn to_completion_items(
     namespace: &Namespace,

--- a/sway-lsp/src/capabilities/completion.rs
+++ b/sway-lsp/src/capabilities/completion.rs
@@ -36,7 +36,7 @@ fn completion_items_for_type_id(
                 kind: Some(CompletionItemKind::FIELD),
                 label: field.name.as_str().to_string(),
                 label_details: Some(CompletionItemLabelDetails {
-                    description: Some(field.type_argument.span.clone().str()),
+                    description: Some(field.type_argument.span().clone().str()),
                     detail: None,
                 }),
                 ..Default::default()
@@ -103,7 +103,11 @@ fn fn_signature_string(
         .parameters
         .iter()
         .map(|p| {
-            replace_self_with_type_str(engines, p.type_argument.clone().span.str(), parent_type_id)
+            replace_self_with_type_str(
+                engines,
+                p.type_argument.clone().span().str(),
+                parent_type_id,
+            )
         })
         .collect::<Vec<String>>()
         .join(", ");
@@ -112,7 +116,7 @@ fn fn_signature_string(
         params_str,
         replace_self_with_type_str(
             engines,
-            fn_decl.return_type.clone().span.str(),
+            fn_decl.return_type.clone().span().str(),
             parent_type_id
         )
     )
@@ -165,7 +169,7 @@ fn type_id_of_raw_ident(
                                 .de()
                                 .get_function(&method.id().clone())
                                 .return_type
-                                .type_id,
+                                .type_id(),
                         );
                     }
                     None
@@ -176,7 +180,7 @@ fn type_id_of_raw_ident(
                 .fields
                 .iter()
                 .find(|field| field.name.as_str() == parts[i])
-                .map(|field| field.type_argument.type_id);
+                .map(|field| field.type_argument.type_id());
         }
         i += 1;
     }
@@ -192,7 +196,7 @@ fn type_id_of_local_ident(ident_name: &str, fn_decl: &TyFunctionDecl) -> Option<
         .find_map(|param| {
             // Check if this ident is a function parameter
             if param.name.as_str() == ident_name {
-                return Some(param.type_argument.type_id);
+                return Some(param.type_argument.type_id());
             }
             None
         })

--- a/sway-lsp/src/capabilities/hover/mod.rs
+++ b/sway-lsp/src/capabilities/hover/mod.rs
@@ -150,8 +150,8 @@ fn hover_format(
             TypedAstToken::TypedDeclaration(decl) => match decl {
                 ty::TyDecl::VariableDecl(var_decl) => {
                     let type_name =
-                        format!("{}", engines.help_out(var_decl.type_ascription.type_id));
-                    hover_link_contents.add_related_types(&var_decl.type_ascription.type_id);
+                        format!("{}", engines.help_out(var_decl.type_ascription.type_id()));
+                    hover_link_contents.add_related_types(&var_decl.type_ascription.type_id());
                     Some(format_variable_hover(
                         var_decl.mutability.is_mutable(),
                         &type_name,
@@ -192,24 +192,24 @@ fn hover_format(
                 _ => None,
             },
             TypedAstToken::TypedFunctionDeclaration(func) => {
-                hover_link_contents.add_related_types(&func.return_type.type_id);
+                hover_link_contents.add_related_types(&func.return_type.type_id());
                 Some(extract_fn_signature(&func.span()))
             }
             TypedAstToken::TypedFunctionParameter(param) => {
-                hover_link_contents.add_related_types(&param.type_argument.type_id);
+                hover_link_contents.add_related_types(&param.type_argument.type_id());
                 Some(format_name_with_type(
                     param.name.as_str(),
-                    &param.type_argument.type_id,
+                    &param.type_argument.type_id(),
                 ))
             }
             TypedAstToken::TypedStructField(field) => {
                 hover_link_contents.add_implementations_for_type(
                     &field.type_argument.span(),
-                    field.type_argument.type_id,
+                    field.type_argument.type_id(),
                 );
                 Some(format_name_with_type(
                     field.name.as_str(),
-                    &field.type_argument.type_id,
+                    &field.type_argument.type_id(),
                 ))
             }
             TypedAstToken::TypedExpression(expr) => match expr.expression {

--- a/sway-lsp/src/capabilities/inlay_hints.rs
+++ b/sway-lsp/src/capabilities/inlay_hints.rs
@@ -74,8 +74,12 @@ pub fn inlay_hints(
             }
 
             // Variable declaration hints
-            if var.type_ascription.call_path_tree.is_none() {
-                let type_info = session.engines.read().te().get(var.type_ascription.type_id);
+            if var.type_ascription.call_path_tree().is_none() {
+                let type_info = session
+                    .engines
+                    .read()
+                    .te()
+                    .get(var.type_ascription.type_id());
                 if !matches!(
                     *type_info,
                     TypeInfo::Unknown | TypeInfo::UnknownGeneric { .. }

--- a/sway-lsp/src/core/token.rs
+++ b/sway-lsp/src/core/token.rs
@@ -15,7 +15,7 @@ use sway_core::{
     },
     transform::Attribute,
     type_system::{TypeId, TypeInfo, TypeParameter},
-    Engines, TraitConstraint, TypeArgument, TypeEngine,
+    Engines, GenericArgument, TraitConstraint, TypeEngine,
 };
 use sway_types::{Ident, SourceEngine, Span, Spanned};
 
@@ -52,7 +52,7 @@ pub enum ParsedAstToken {
     Supertrait(Supertrait),
     TraitConstraint(TraitConstraint),
     TraitFn(ParsedDeclId<TraitFn>),
-    TypeArgument(TypeArgument),
+    TypeArgument(GenericArgument),
     TypeParameter(TypeParameter),
     UseStatement(UseStatement),
 }
@@ -79,7 +79,7 @@ pub enum TypedAstToken {
     TypedStorageAccess(ty::TyStorageAccess),
     TypedStorageAccessDescriptor(ty::TyStorageAccessDescriptor),
     TypedReassignment(ty::TyReassignment),
-    TypedArgument(TypeArgument),
+    TypedArgument(GenericArgument),
     TypedParameter(TypeParameter),
     TypedTraitConstraint(TraitConstraint),
     TypedModuleName,
@@ -303,11 +303,11 @@ pub fn type_info_to_symbol_kind(
         }
         TypeInfo::Enum { .. } => SymbolKind::Enum,
         TypeInfo::Array(elem_ty, ..) => {
-            let type_info = type_engine.get(elem_ty.type_id);
+            let type_info = type_engine.get(elem_ty.type_id());
             type_info_to_symbol_kind(type_engine, &type_info, Some(&elem_ty.span()))
         }
         TypeInfo::Slice(elem_ty) => {
-            let type_info = type_engine.get(elem_ty.type_id);
+            let type_info = type_engine.get(elem_ty.type_id());
             type_info_to_symbol_kind(type_engine, &type_info, Some(&elem_ty.span()))
         }
         _ => SymbolKind::Unknown,

--- a/sway-lsp/src/traverse/parsed_tree.rs
+++ b/sway-lsp/src/traverse/parsed_tree.rs
@@ -37,7 +37,7 @@ use sway_core::{
         CallPathTree, HasSubmodules, Literal,
     },
     transform::Attributes,
-    type_system::{TypeArgument, TypeParameter},
+    type_system::{GenericArgument, TypeParameter},
     TraitConstraint, TypeInfo,
 };
 use sway_types::{Ident, Span, Spanned};
@@ -843,7 +843,7 @@ impl Parse for ParsedDeclId<ImplSelfOrTrait> {
         } = &&*ctx
             .engines
             .te()
-            .get(impl_self_or_trait.implementing_for.type_id)
+            .get(impl_self_or_trait.implementing_for.type_id())
         {
             ctx.tokens.insert(
                 ctx.ident(&qualified_call_path.call_path.suffix),
@@ -1098,9 +1098,9 @@ impl Parse for TypeParameter {
     }
 }
 
-impl Parse for TypeArgument {
+impl Parse for GenericArgument {
     fn parse(&self, ctx: &ParseContext) {
-        let type_info = ctx.engines.te().get(self.type_id);
+        let type_info = ctx.engines.te().get(self.type_id());
         match &*type_info {
             TypeInfo::Array(type_arg, length) => {
                 let ident = Ident::new(length.span());
@@ -1121,7 +1121,7 @@ impl Parse for TypeArgument {
             }
             _ => {
                 let symbol_kind = type_info_to_symbol_kind(ctx.engines.te(), &type_info, None);
-                if let Some(tree) = &self.call_path_tree {
+                if let Some(tree) = &self.call_path_tree() {
                     let token =
                         Token::from_parsed(ParsedAstToken::TypeArgument(self.clone()), symbol_kind);
                     collect_call_path_tree(ctx, tree, &token, ctx.tokens);


### PR DESCRIPTION
## Description

Continuation of https://github.com/FuelLabs/sway/pull/7044.
This PR converts `TypeArgument` to an enum to support "const generic" in the future. It is being done separately because it changes a lot of files.

No change in behaviour is expected.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
