### PR TITLE
chore: improve `test_cleanup_stale_files` test & add `mark-flaky-tests` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,6 +3139,7 @@ dependencies = [
  "fuel-tx",
  "fuels-core",
  "hex",
+ "mark-flaky-tests",
  "paste",
  "regex",
  "serde",
@@ -5196,6 +5197,28 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "mark-flaky-tests"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "586c4a7c95a05351b04ebbe4f60edc53c3bb611651b1bf0be54a9575a95b4930"
+dependencies = [
+ "mark-flaky-tests-macro",
+]
+
+[[package]]
+name = "mark-flaky-tests-macro"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078b1ffd16b299642ebc515a520c3793f6fe0db38c2e6a2abf686db22e58ab84"
+dependencies = [
+ "proc-macro-crate 1.1.3",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ lazy_static = "1.4"
 libp2p-identity = "0.2"
 libtest-mimic = "0.7"
 lsp-types = "0.94"
+mark-flaky-tests = "1.0"
 mdbook = { version = "0.4", default-features = false }
 minifier = "0.3"
 normalize-path = "0.2"

--- a/forc-util/Cargo.toml
+++ b/forc-util/Cargo.toml
@@ -21,6 +21,7 @@ fuel-asm.workspace = true
 fuel-tx = { workspace = true, optional = true }
 fuels-core = { workspace = true, optional = true }
 hex.workspace = true
+mark-flaky-tests.workspace = true
 paste.workspace = true
 regex.workspace = true
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
## Description
adds the mark-flaky-tests crate so we can use `#[flaky]` above tests that might fail. Also improves the `test_cleanup_stale_files` test which was added in #6816

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
