### PR TITLE
Check for redundant `.gitignore` files in tests

### DIFF
--- a/test/src/e2e_vm_tests/test_programs/should_fail/abort_control_flow_bad/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/abort_control_flow_bad/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/chained_if_let_missing_branch/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/different_contract_caller_types/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/different_contract_caller_types/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_enum/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_enum/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_fn/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_fn/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_impl_self_fn/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_impl_self_fn/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_struct/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_struct/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_trait_fn/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_trait_fn/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_var/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/double_underscore_var/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/forc/nested_package/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/forc/nested_package/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/forc/nested_package/src/sub_package/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/forc/nested_package/src/sub_package/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/forc/unexpected_nested_workspace/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/forc/unexpected_nested_workspace/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/forc/unexpected_nested_workspace/test_workspace/test_contract/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/forc/unexpected_nested_workspace/test_workspace/test_contract/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/forc/unexpected_nested_workspace/test_workspace/test_lib/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/forc/unexpected_nested_workspace/test_workspace/test_lib/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/forc/unexpected_nested_workspace/test_workspace/test_script/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/forc/unexpected_nested_workspace/test_workspace/test_script/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/generic_empty_struct_with_constraint/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/generic_empty_struct_with_constraint/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/impl_with_bad_generic/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/impl_with_bad_generic/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/impl_with_semantic_type_constraints/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/impl_with_semantic_type_constraints/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/insufficient_type_info/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/language/intrinsics/transmute/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/language/intrinsics/transmute/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/lexer_errors/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/lexer_errors/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/primitive_type_argument/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/primitive_type_argument/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/same_named_fn_params/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/same_named_fn_params/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/vec/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/vec/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_fail/wrongly_sized_tuple_destructuring/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_fail/wrongly_sized_tuple_destructuring/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/contract_dependencies/contract_a/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/contract_dependencies/contract_a/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/contract_dependencies/contract_b/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/contract_dependencies/contract_b/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/contract_dependencies/contract_c/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/contract_dependencies/contract_c/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/dependency_package_field/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/dependency_package_field/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/contract_a/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/parent_pkg_manifest/contract_a/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/workspace_building/test_contract/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/workspace_building/test_contract/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/workspace_building/test_lib/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/workspace_building/test_lib/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/forc/workspace_building/test_script/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/forc/workspace_building/test_script/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/impl_self_dependency_order_conflict/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/impl_self_dependency_order_conflict/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/bitwise_not/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/bitwise_not/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/chained_if_let/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/chained_if_let/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/const_generics/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_dynamic_address/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/contract_caller_dynamic_address/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/for_loops/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/for_loops/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_type_inference/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/generic_type_inference/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/if_let_no_side_effects/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/if_let_no_side_effects/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/impl_self_method/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/impl_self_method/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/impl_self_method_multiple/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/impl_self_method_multiple/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/impl_self_method_order/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/impl_self_method_order/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/transmute/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/intrinsics/transmute/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_explicit_rets/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/match_expressions_explicit_rets/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/multi_impl_self/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/numeric_constants/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/ops/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/ops/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/primitive_type_argument/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/primitive_type_argument/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/totalord/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/totalord/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_constraint_param_order/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/trait_constraint_param_order/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/language/while_loops/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/language/while_loops/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_eq/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_eq/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_eq_revert/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_eq_revert/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne/.gitignore
@@ -1,4 +1,0 @@
-out
-target
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/assert_ne_revert/.gitignore
@@ -1,8 +1,0 @@
-out
-target
-out
-target
-out
-target
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ge_test/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/ge_test/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/identity_eq/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/identity_eq/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_log_test/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_log_test/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_pow_test/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_pow_test/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_root_test/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/stdlib/u128_root_test/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/aggr_indexing/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/aggr_indexing/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/lib_log_decode/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/lib_log_decode/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/memcpyopt/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/memcpyopt/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/regalloc_spill/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/regalloc_spill/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_log_decode/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/script_log_decode/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/should_revert/.gitignore
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/unit_tests/should_revert/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/e2e_vm_tests/utils/.gitignore
+++ b/test/src/e2e_vm_tests/utils/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/auth_caller_contract/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/auth_caller_contract/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/auth_caller_script/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/auth_caller_script/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/auth_predicate/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/auth_predicate/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/auth_testing_abi/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/auth_testing_abi/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/auth_testing_contract/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/auth_testing_contract/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/block_test_abi/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/block_test_abi/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/call_frames_test_abi/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/call_frames_test_abi/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/context_caller_contract/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/context_caller_contract/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/context_testing_abi/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/context_testing_abi/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/evm_test_abi/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/evm_test_abi/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/low_level_callee_contract/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/low_level_callee_contract/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/parsing_logs_test_abi/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/parsing_logs_test_abi/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/pow/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/pow/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_array/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_array/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_b256/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_b256/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_bool/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_bool/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_enum/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_enum/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_str/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_str/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_struct/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_struct/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_tuple/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_tuple/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_u16/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_u16/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_u32/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_u32/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_u64/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_u64/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_artifacts/storage_vec/svec_u8/.gitignore
+++ b/test/src/sdk-harness/test_artifacts/storage_vec/svec_u8/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/auth/.gitignore
+++ b/test/src/sdk-harness/test_projects/auth/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/block/.gitignore
+++ b/test/src/sdk-harness/test_projects/block/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/call_frames/.gitignore
+++ b/test/src/sdk-harness/test_projects/call_frames/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/configurables_in_contract/.gitignore
+++ b/test/src/sdk-harness/test_projects/configurables_in_contract/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/configurables_in_script/.gitignore
+++ b/test/src/sdk-harness/test_projects/configurables_in_script/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/context/.gitignore
+++ b/test/src/sdk-harness/test_projects/context/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/contract_bytecode/.gitignore
+++ b/test/src/sdk-harness/test_projects/contract_bytecode/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/ec_recover/.gitignore
+++ b/test/src/sdk-harness/test_projects/ec_recover/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/evm/.gitignore
+++ b/test/src/sdk-harness/test_projects/evm/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/evm_ec_recover/.gitignore
+++ b/test/src/sdk-harness/test_projects/evm_ec_recover/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/hashing/.gitignore
+++ b/test/src/sdk-harness/test_projects/hashing/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/parsing_logs/.gitignore
+++ b/test/src/sdk-harness/test_projects/parsing_logs/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/result_option_expect/.gitignore
+++ b/test/src/sdk-harness/test_projects/result_option_expect/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/storage/.gitignore
+++ b/test/src/sdk-harness/test_projects/storage/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/storage_bytes/.gitignore
+++ b/test/src/sdk-harness/test_projects/storage_bytes/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/sdk-harness/test_projects/storage_string/.gitignore
+++ b/test/src/sdk-harness/test_projects/storage_string/.gitignore
@@ -1,2 +1,0 @@
-out
-target

--- a/test/src/test_consistency.rs
+++ b/test/src/test_consistency.rs
@@ -24,7 +24,10 @@ fn check_redundant_gitignore_files(all_tests_dir: &Path) -> Result<()> {
     return if gitignores.is_empty() {
         Ok(())
     } else {
-        let mut gitignores = gitignores.iter().map(|file| file.to_string_lossy().to_string()).collect::<Vec<_>>();
+        let mut gitignores = gitignores
+            .iter()
+            .map(|file| file.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
         gitignores.sort();
 
         Err(anyhow!("Redundant .gitignore files.\nTo fix the error, delete these redundant .gitignore files:\n{}", gitignores.join("\n")))

--- a/test/src/test_consistency.rs
+++ b/test/src/test_consistency.rs
@@ -8,11 +8,51 @@ use crate::reduced_std_libs::REDUCED_STD_LIBS_DIR_NAME;
 
 pub(crate) fn check() -> Result<()> {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let all_tests_dir = format!("{manifest_dir}/src");
+    let all_tests_dir = PathBuf::from(format!("{manifest_dir}/src"));
 
-    check_test_forc_tomls(&PathBuf::from(all_tests_dir))?;
+    check_test_forc_tomls(&all_tests_dir)?;
+
+    check_redundant_gitignore_files(&all_tests_dir)?;
 
     Ok(())
+}
+
+fn check_redundant_gitignore_files(all_tests_dir: &Path) -> Result<()> {
+    let mut gitignores = vec![];
+    find_gitignores(&PathBuf::from(all_tests_dir), &mut gitignores);
+
+    return if gitignores.is_empty() {
+        Ok(())
+    } else {
+        let mut gitignores = gitignores.iter().map(|file| file.to_string_lossy().to_string()).collect::<Vec<_>>();
+        gitignores.sort();
+
+        Err(anyhow!("Redundant .gitignore files.\nTo fix the error, delete these redundant .gitignore files:\n{}", gitignores.join("\n")))
+    };
+
+    fn find_gitignores(path: &Path, gitignores: &mut Vec<PathBuf>) {
+        const IN_LANGUAGE_TESTS_GITIGNORE: &str = "in_language_tests/.gitignore";
+
+        if path.is_dir() {
+            for entry in std::fs::read_dir(path).unwrap() {
+                let entry = entry.unwrap().path();
+                let entry_name = entry.to_str().unwrap();
+                if entry_name.contains(REDUCED_STD_LIBS_DIR_NAME)
+                    || entry_name.contains(IN_LANGUAGE_TESTS_GITIGNORE)
+                {
+                    continue;
+                }
+                find_gitignores(&entry, gitignores);
+            }
+        } else if path.is_file()
+            && path
+                .file_name()
+                .map(|f| f.eq_ignore_ascii_case(".gitignore"))
+                .unwrap_or(false)
+        {
+            gitignores.push(path.to_path_buf());
+        }
+    }
 }
 
 /// Checks that every Forc.toml file has the authors, license,


### PR DESCRIPTION
## Description

This PR adds a test consistency check that searches for redundant `.gitignore` files in tests. They were spotted several times in code reviews and removed. It was mentioned that having a lint for them would spare us of these kind of findings in reviews.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.