### PR TITLE
move codspeed benchmarks to buildjet

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,7 +35,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-binstall
+          tool: cargo-codspeed
 
       - name: Build the benchmark target(s)
         run: cargo codspeed build

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,7 +32,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ matrix.command }}-${{ matrix.args }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-binstall

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,16 +20,22 @@ concurrency:
 
 jobs:
   benchmarks:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup rust toolchain, cache and cargo-codspeed binary
-        uses: moonrepo/setup-rust@v0
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: buildjet/cache@v3
         with:
-          channel: stable
-          cache-target: release
-          bins: cargo-codspeed
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.command }}-${{ matrix.args }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binstall
 
       - name: Build the benchmark target(s)
         run: cargo codspeed build

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - "master"
   pull_request:
-#    paths:
-#       - forc-plugins/forc-lsp/**
-#       - sway-lsp/**
-#       - forc-pkg/**
-#       - sway-core/**
-#       -
+    paths:
+       - forc-plugins/forc-lsp/**
+       - sway-lsp/**
+       - forc-pkg/**
+       - sway-core/**
+
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,11 +5,12 @@ on:
     branches:
       - "master"
   pull_request:
-    paths: 
-       - forc-plugins/forc-lsp/** 
-       - sway-lsp/** 
-       - forc-pkg/** 
-       - sway-core/**
+#    paths:
+#       - forc-plugins/forc-lsp/**
+#       - sway-lsp/**
+#       - forc-pkg/**
+#       - sway-core/**
+#       -
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:


### PR DESCRIPTION
## Description
The default ubuntu runners are too limited to run the codspeed benchmarks, this PR moves the benchmarks over to buildjet
