### PR TITLE
fix: run forc-publish tarball tests sequentially to remove flakiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,6 +3051,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
+ "serial_test",
  "tar",
  "tempfile",
  "thiserror 1.0.69",

--- a/forc-plugins/forc-publish/Cargo.toml
+++ b/forc-plugins/forc-publish/Cargo.toml
@@ -17,6 +17,7 @@ reqwest = { workspace = true, features = ["json"] }
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+serial_test.workspace = true
 tar.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true

--- a/forc-plugins/forc-publish/src/tarball.rs
+++ b/forc-plugins/forc-publish/src/tarball.rs
@@ -68,11 +68,13 @@ fn copy_project_excluding_out(temp_project_dir: &Path) -> Result<()> {
 mod test {
     use super::*;
     use flate2::read::GzDecoder;
+    use serial_test::serial;
     use std::{env, fs};
     use tar::Archive;
     use tempfile::tempdir;
 
     #[test]
+    #[serial]
     fn test_create_tarball_success() {
         // Create a temporary directory
         let temp_project_dir = tempdir().unwrap();
@@ -112,6 +114,7 @@ mod test {
     }
 
     #[test]
+    #[serial]
     fn test_create_tarball_fails_without_forc_toml() {
         // Create a temporary directory that DOES NOT contain Forc.toml
         let temp_project_dir = tempdir().unwrap();
@@ -127,6 +130,7 @@ mod test {
     }
 
     #[test]
+    #[serial]
     fn test_create_tarball_excludes_out_dir() {
         let temp_project_dir = tempdir().unwrap();
 


### PR DESCRIPTION
## Description

close #7063.

`forc-publish` tarball tests are setting the current working director with `env::set_current_dir`. One thing to note here is `env` module is changing things for the whole process. Here is the [docs](https://doc.rust-lang.org/std/env/index.html):

> Inspection and manipulation of the process’s environment.

So setting `env::set_current_dir` changes the current dir on all threads. By default cargo runs tests in parallel using multiple threads in a single process. This means, tarball tests are racing with each other and changing each other's working directory making the tests flaky.