### PR TITLE
forc call verbosity levels

### DIFF
--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -57,6 +57,37 @@ pub enum OutputFormat {
     Default,
     /// Raw unformatted output
     Raw,
+    /// JSON formatted output
+    Json,
+}
+
+/// Verbosity level for log output
+#[derive(Debug, Clone, PartialEq, Default)]
+#[repr(transparent)]
+pub struct Verbosity(pub u8);
+
+impl Verbosity {
+    /// Verbose mode (-v)
+    pub(crate) fn v1(&self) -> bool {
+        self.0 >= 1
+    }
+
+    /// Very Verbose mode (-vv)
+    pub(crate) fn v2(&self) -> bool {
+        self.0 >= 2
+    }
+}
+
+impl From<u8> for Verbosity {
+    fn from(level: u8) -> Self {
+        Verbosity(level)
+    }
+}
+
+impl From<Verbosity> for u8 {
+    fn from(verbosity: Verbosity) -> Self {
+        verbosity.0
+    }
 }
 
 /// Flags for specifying the caller account
@@ -260,10 +291,10 @@ pub struct Command {
     /// Output format for the call result
     #[clap(long, default_value = "default", help_heading = "OUTPUT")]
     pub output: OutputFormat,
-
-    /// Show transaction receipts in the output
-    #[clap(long, short = 'r', alias = "receipts", help_heading = "OUTPUT")]
-    pub show_receipts: bool,
+    
+    /// Set verbosity levels; currently only supports max 2 levels
+    #[clap(short = 'v', action = clap::ArgAction::Count, help_heading = "OUTPUT")]
+    pub verbosity: u8,
 }
 
 impl Command {

--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -57,8 +57,6 @@ pub enum OutputFormat {
     Default,
     /// Raw unformatted output
     Raw,
-    /// JSON formatted output
-    Json,
 }
 
 /// Verbosity level for log output

--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -297,6 +297,8 @@ pub struct Command {
     pub output: OutputFormat,
 
     /// Set verbosity levels; currently only supports max 2 levels
+    /// - `-v=1`: Print decoded logs
+    /// - `-v=2`: Additionally print receipts and script json
     #[clap(short = 'v', action = clap::ArgAction::Count, help_heading = "OUTPUT")]
     pub verbosity: u8,
 }

--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -289,7 +289,7 @@ pub struct Command {
     /// Output format for the call result
     #[clap(long, default_value = "default", help_heading = "OUTPUT")]
     pub output: OutputFormat,
-    
+
     /// Set verbosity levels; currently only supports max 2 levels
     #[clap(short = 'v', action = clap::ArgAction::Count, help_heading = "OUTPUT")]
     pub verbosity: u8,

--- a/forc-plugins/forc-client/src/cmd/call.rs
+++ b/forc-plugins/forc-client/src/cmd/call.rs
@@ -170,6 +170,12 @@ pub enum Operation {
     --abi ./contract-abi.json \
     get_balance 0x0087675439e10a8351b1d5e4cf9d0ea6da77675623ff6b16470b5e3c58998423
 
+# Call a contract with function parameters; additionally print logs, receipts and script json
+» forc call 0x0dcba78d7b09a1f77353f51367afd8b8ab94b5b2bb6c9437d9ba9eea47dede97 \
+    --abi ./contract-abi.json \
+    get_balance 0x0087675439e10a8351b1d5e4cf9d0ea6da77675623ff6b16470b5e3c58998423 \
+    -vv
+
 # Call a contract without function parameters
 » forc call 0x0dcba78d7b09a1f77353f51367afd8b8ab94b5b2bb6c9437d9ba9eea47dede97 \
     --abi ./contract-abi.json \

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -126,19 +126,18 @@ pub async fn call_function(
         .transaction_builder(tx_policies, variable_output_policy, &wallet)
         .await
         .map_err(|e| anyhow!("Failed to initialize transaction builder: {e}"))?;
-    let (tx_status, tx_hash) = match mode {
+    let (tx, tx_status) = match mode {
         cmd::call::ExecutionMode::DryRun => {
             let tx = call
                 .build_tx(tb, &wallet)
                 .await
                 .map_err(|e| anyhow!("Failed to build transaction: {e}"))?;
-            let tx_hash = tx.id(chain_id);
             let tx_status = wallet
                 .provider()
-                .dry_run(tx)
+                .dry_run(tx.clone())
                 .await
                 .map_err(|e| anyhow!("Failed to dry run transaction: {e}"))?;
-            (tx_status, tx_hash)
+            (tx, tx_status)
         }
         cmd::call::ExecutionMode::Simulate => {
             let tb = tb.with_build_strategy(ScriptBuildStrategy::StateReadOnly);
@@ -146,14 +145,13 @@ pub async fn call_function(
                 .build_tx(tb, &wallet)
                 .await
                 .map_err(|e| anyhow!("Failed to build transaction: {e}"))?;
-            let tx_hash = tx.id(chain_id);
             let gas_price = gas.map(|g| g.price).unwrap_or(Some(0));
             let tx_status = wallet
                 .provider()
-                .dry_run_opt(tx, false, gas_price)
+                .dry_run_opt(tx.clone(), false, gas_price)
                 .await
                 .map_err(|e| anyhow!("Failed to simulate transaction: {e}"))?;
-            (tx_status, tx_hash)
+            (tx, tx_status)
         }
         cmd::call::ExecutionMode::Live => {
             forc_tracing::println_action_green(
@@ -164,15 +162,24 @@ pub async fn call_function(
                 .build_tx(tb, &wallet)
                 .await
                 .map_err(|e| anyhow!("Failed to build transaction: {e}"))?;
-            let tx_hash = tx.id(chain_id);
             let tx_status = wallet
                 .provider()
-                .send_transaction_and_await_commit(tx)
+                .send_transaction_and_await_commit(tx.clone())
                 .await
                 .map_err(|e| anyhow!("Failed to send transaction: {e}"))?;
-            (tx_status, tx_hash)
+            (tx, tx_status)
         }
     };
+    let tx_hash = tx.id(chain_id);
+    let fuel_tx::Transaction::Script(script) = tx.into() else {
+        return Err(anyhow!("Transaction is not a script"));
+    };
+    
+    // Display the script JSON when verbosity level is 2 or higher (vv)
+    if verbosity.v2() {
+        let script_json = serde_json::json!({ "Script": script });
+        forc_tracing::println_label_green("transaction script:\n", &serde_json::to_string_pretty(&script_json).unwrap());
+    }
 
     // Process transaction results
     let receipts = tx_status

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -1,5 +1,8 @@
 use crate::{
-    cmd::{self, call::{FuncType, Verbosity}},
+    cmd::{
+        self,
+        call::{FuncType, Verbosity},
+    },
     op::call::{
         missing_contracts::get_missing_contracts,
         parser::{param_type_val_to_token, token_to_string},
@@ -174,11 +177,14 @@ pub async fn call_function(
     let fuel_tx::Transaction::Script(script) = tx.into() else {
         return Err(anyhow!("Transaction is not a script"));
     };
-    
+
     // Display the script JSON when verbosity level is 2 or higher (vv)
     if verbosity.v2() {
         let script_json = serde_json::json!({ "Script": script });
-        forc_tracing::println_label_green("transaction script:\n", &serde_json::to_string_pretty(&script_json).unwrap());
+        forc_tracing::println_label_green(
+            "transaction script:\n",
+            &serde_json::to_string_pretty(&script_json).unwrap(),
+        );
     }
 
     // Process transaction results

--- a/forc-plugins/forc-client/src/op/call/call_function.rs
+++ b/forc-plugins/forc-client/src/op/call/call_function.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cmd::{self, call::FuncType},
+    cmd::{self, call::{FuncType, Verbosity}},
     op::call::{
         missing_contracts::get_missing_contracts,
         parser::{param_type_val_to_token, token_to_string},
@@ -46,11 +46,12 @@ pub async fn call_function(
         caller,
         call_parameters,
         gas,
-        show_receipts,
         output,
         external_contracts,
+        verbosity,
         ..
     } = cmd;
+    let verbosity: Verbosity = verbosity.into();
 
     // Load ABI (already provided in the operation)
     let abi_str = super::load_abi(&abi).await?;
@@ -207,7 +208,7 @@ pub async fn call_function(
         result,
         &mode,
         &node,
-        show_receipts,
+        &verbosity,
     )
 }
 
@@ -295,8 +296,8 @@ pub mod tests {
             gas: None,
             external_contracts: None,
             output: cmd::call::OutputFormat::Raw,
-            show_receipts: false,
             list_functions: false,
+            verbosity: 0,
         }
     }
 

--- a/forc-plugins/forc-client/src/op/call/transfer.rs
+++ b/forc-plugins/forc-client/src/op/call/transfer.rs
@@ -13,8 +13,8 @@ pub async fn transfer(
     amount: u64,
     asset_id: AssetId,
     tx_policies: TxPolicies,
-    show_receipts: bool,
     node: &crate::NodeTarget,
+    verbosity: &crate::cmd::call::Verbosity,
 ) -> anyhow::Result<super::CallResponse> {
     let provider = wallet.provider();
 
@@ -53,7 +53,7 @@ pub async fn transfer(
         "".to_string(),
         &crate::cmd::call::ExecutionMode::Live,
         node,
-        show_receipts,
+        verbosity,
     )
 }
 
@@ -112,8 +112,8 @@ mod tests {
             amount,
             *base_asset_id,
             tx_policies,
-            false, // show_receipts
             &node,
+            &(0u8.into()),
         )
         .await
         .unwrap();
@@ -163,8 +163,8 @@ mod tests {
             amount,
             *base_asset_id,
             tx_policies,
-            false, // show_receipts
             &node,
+            &(0u8.into()),
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Description

- Introduces verbosity levels for the `forc-call` command, replacing the `show-receipts` flag
  - Inspired by [`forge test` verbosity levels](https://book.getfoundry.sh/reference/forge/forge-test#evm-options); i.e. can specify `-v=1` or `-vv`, etc.
- Verbosity `v1` prints the following additional info:
  - logs
- Verbosity `v2` prints the following additional info:
  - receipts
  - script json (`tx.json`)

Note: The `tx.json` printed in the response can be used by `forc-debug` to debug the transaction
^ Addresses: https://github.com/FuelLabs/sway/issues/7019

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
