### PR TITLE
Implement `Eq` for `Signature` and add missing `codec` tests

### DIFF
--- a/sway-lib-std/src/crypto/signature.sw
+++ b/sway-lib-std/src/crypto/signature.sw
@@ -13,6 +13,7 @@ use ::option::Option::{self, *};
 use ::result::Result::{self, *};
 use ::vm::evm::evm_address::EvmAddress;
 use ::codec::*;
+use ::ops::*;
 
 /// An ECDSA signature.
 pub enum Signature {
@@ -485,3 +486,21 @@ impl Signature {
         }
     }
 }
+
+impl PartialEq for Signature {
+    fn eq(self, other: Self) -> bool {
+        match (self, other) {
+            (Self::Secp256k1(sig_1), Self::Secp256k1(sig_2)) => {
+                sig_1 == sig_2
+            },
+            (Self::Secp256r1(sig_1), Self::Secp256r1(sig_2)) => {
+                sig_1 == sig_2
+            },
+            (Self::Ed25519(sig_1), Self::Ed25519(sig_2)) => {
+                sig_1 == sig_2
+            },
+            _ => false,
+        }
+    }
+}
+impl Eq for Signature {}

--- a/test/src/in_language_tests/test_programs/crypto_ed25519_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/crypto_ed25519_inline_tests/src/main.sw
@@ -331,3 +331,9 @@ fn ed25519_hash() {
     let hash = sha256(ed25519);
     assert(hash == 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b);
 }
+
+#[test]
+fn ed25519_codec() {
+    let ed25519 = Ed25519::from((b256::zero(), b256::zero()));
+    log(ed25519);
+}

--- a/test/src/in_language_tests/test_programs/crypto_message_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/crypto_message_inline_tests/src/main.sw
@@ -208,3 +208,9 @@ fn message_hash() {
     let result_2 = sha256(one_message);
     assert(result_2 == 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
 }
+
+#[test]
+fn message_codec() {
+    let message = Message::new();
+    log(message);
+}

--- a/test/src/in_language_tests/test_programs/crypto_point2d_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/crypto_point2d_inline_tests/src/main.sw
@@ -287,3 +287,9 @@ fn point2d_b256_array_try_from() {
     assert(array[0] == 0x0000000000000000000000000000000000000000000000000000000000000000);
     assert(array[1] == 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
 }
+
+#[test]
+fn point2d_codec() {
+    let point = Point2D::new();
+    log(point);
+}

--- a/test/src/in_language_tests/test_programs/crypto_public_key_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/crypto_public_key_inline_tests/src/main.sw
@@ -333,3 +333,9 @@ fn public_key_hash() {
     let result_2 = sha256(one_public_key);
     assert(result_2 == 0xec4916dd28fc4c10d78e287ca5d9cc51ee1ae73cbfde08c6b37324cbfaac8bc5);
 }
+
+#[test]
+fn public_key_codec() {
+    let public_key = PublicKey::new();
+    log(public_key);
+}

--- a/test/src/in_language_tests/test_programs/crypto_scalar_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/crypto_scalar_inline_tests/src/main.sw
@@ -141,3 +141,9 @@ fn scalar_b256_try_from() {
     let other_u256 = b256::try_from(other).unwrap();
     assert(other_u256 == 0x1000000000000000000000000000000000000000000000000000000000000001);
 }
+
+#[test]
+fn scalar_codec() {
+    let scalar = Scalar::new();
+    log(scalar);
+}

--- a/test/src/in_language_tests/test_programs/crypto_secp256k1_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/crypto_secp256k1_inline_tests/src/main.sw
@@ -452,3 +452,9 @@ fn secp256k1_hash() {
     let hash = sha256(secp256k1);
     assert(hash == 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b);
 }
+
+#[test]
+fn secp256k1_codec() {
+    let secp256k1 = Secp256k1::from((b256::zero(), b256::zero()));
+    log(secp256k1);
+}

--- a/test/src/in_language_tests/test_programs/crypto_secp256r1_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/crypto_secp256r1_inline_tests/src/main.sw
@@ -452,3 +452,9 @@ fn secp256r1_hash() {
     let hash = sha256(secp256r1);
     assert(hash == 0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b);
 }
+
+#[test]
+fn secp256r1_codec() {
+    let secp256r1 = Secp256r1::from((b256::zero(), b256::zero()));
+    log(secp256r1);
+}

--- a/test/src/in_language_tests/test_programs/crypto_signature_inline_tests/src/main.sw
+++ b/test/src/in_language_tests/test_programs/crypto_signature_inline_tests/src/main.sw
@@ -362,3 +362,91 @@ fn signature_bits() {
         iter += 1;
     }
 }
+
+#[test]
+fn signature_eq() {
+    let secp256r1_1 = Signature::Secp256r1(Secp256r1::from((b256::zero(), b256::zero())));
+    let secp256r1_2 = Signature::Secp256r1(Secp256r1::from((b256::zero(), b256::zero())));
+    let secp256r1_3 = Signature::Secp256r1(Secp256r1::from((
+        b256::zero(),
+        0x0000000000000000000000000000000000000000000000000000000000000001,
+    )));
+    let secp256r1_4 = Signature::Secp256r1(Secp256r1::from((
+        b256::zero(),
+        0x0000000000000000000000000000000000000000000000000000000000000001,
+    )));
+    let secp256r1_5 = Signature::Secp256r1(Secp256r1::from((b256::max(), b256::max())));
+    let secp256r1_6 = Signature::Secp256r1(Secp256r1::from((b256::max(), b256::max())));
+
+    let secp256k1_1 = Signature::Secp256k1(Secp256k1::from((b256::zero(), b256::zero())));
+    let secp256k1_2 = Signature::Secp256k1(Secp256k1::from((b256::zero(), b256::zero())));
+    let secp256k1_3 = Signature::Secp256k1(Secp256k1::from((
+        b256::zero(),
+        0x0000000000000000000000000000000000000000000000000000000000000001,
+    )));
+    let secp256k1_4 = Signature::Secp256k1(Secp256k1::from((
+        b256::zero(),
+        0x0000000000000000000000000000000000000000000000000000000000000001,
+    )));
+    let secp256k1_5 = Signature::Secp256k1(Secp256k1::from((b256::max(), b256::max())));
+    let secp256k1_6 = Signature::Secp256k1(Secp256k1::from((b256::max(), b256::max())));
+
+    let ed25519_1 = Signature::Ed25519(Ed25519::from((b256::zero(), b256::zero())));
+    let ed25519_2 = Signature::Ed25519(Ed25519::from((b256::zero(), b256::zero())));
+    let ed25519_3 = Signature::Ed25519(Ed25519::from((
+        b256::zero(),
+        0x0000000000000000000000000000000000000000000000000000000000000001,
+    )));
+    let ed25519_4 = Signature::Ed25519(Ed25519::from((
+        b256::zero(),
+        0x0000000000000000000000000000000000000000000000000000000000000001,
+    )));
+    let ed25519_5 = Signature::Ed25519(Ed25519::from((b256::max(), b256::max())));
+    let ed25519_6 = Signature::Ed25519(Ed25519::from((b256::max(), b256::max())));
+
+    assert(secp256r1_1 == secp256r1_2);
+    assert(secp256r1_3 == secp256r1_4);
+    assert(secp256r1_5 == secp256r1_6);
+    assert(secp256r1_1 != secp256r1_3);
+    assert(secp256r1_1 != secp256r1_5);
+    assert(secp256r1_3 != secp256r1_5);
+
+    assert(secp256k1_1 == secp256k1_2);
+    assert(secp256k1_3 == secp256k1_4);
+    assert(secp256k1_5 == secp256k1_6);
+    assert(secp256k1_1 != secp256k1_3);
+    assert(secp256k1_1 != secp256k1_5);
+    assert(secp256k1_3 != secp256k1_5);
+
+    assert(ed25519_1 == ed25519_2);
+    assert(ed25519_3 == ed25519_4);
+    assert(ed25519_5 == ed25519_6);
+    assert(ed25519_1 != ed25519_3);
+    assert(ed25519_1 != ed25519_5);
+    assert(ed25519_3 != ed25519_5);
+
+    assert(secp256r1_1 != secp256k1_1);
+    assert(secp256r1_1 != ed25519_1);
+    assert(secp256r1_3 != secp256k1_3);
+    assert(secp256r1_3 != ed25519_3);
+    assert(secp256r1_5 != secp256k1_5);
+    assert(secp256r1_5 != ed25519_5);
+
+    assert(secp256r1_1 != ed25519_3);
+    assert(secp256r1_1 != secp256k1_3);
+    assert(secp256r1_1 != ed25519_5);
+    assert(secp256r1_1 != secp256k1_5);
+
+    assert(secp256k1_1 != ed25519_1);
+    assert(secp256k1_3 != ed25519_3);
+    assert(secp256k1_5 != ed25519_5);
+
+    assert(secp256k1_1 != ed25519_3);
+    assert(secp256k1_1 != ed25519_5);
+}
+
+#[test]
+fn signature_codec() {
+    let signature = Signature::Secp256r1(Secp256r1::from((b256::zero(), b256::zero())));
+    log(signature);
+}


### PR DESCRIPTION
## Description

This PR implement `Eq` and `PartialEq` for `Signature` and adds missing `AbiEncode` and `AbiDecode` tests for the crypto module.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
