### PR TITLE
Optimize `tx` module for bytecode size and gas usage

### DIFF
--- a/sway-lib-std/src/tx.sw
+++ b/sway-lib-std/src/tx.sw
@@ -79,6 +79,14 @@ impl PartialEq for Transaction {
 }
 impl Eq for Transaction {}
 
+const TX_TYPE_SCRIPT: u8 = 0u8;
+const TX_TYPE_CREATE: u8 = 1u8;
+#[allow(dead_code)]
+const TX_TYPE_MINT: u8 = 2u8;
+const TX_TYPE_UPGRADE: u8 = 3u8;
+const TX_TYPE_UPLOAD: u8 = 4u8;
+const TX_TYPE_BLOB: u8 = 5u8;
+
 /// Get the type of the current transaction.
 ///
 /// # Returns
@@ -120,11 +128,11 @@ impl Eq for Transaction {}
 /// ```
 pub fn tx_type() -> Transaction {
     match __gtf::<u8>(0, GTF_TYPE) {
-        0u8 => Transaction::Script,
-        1u8 => Transaction::Create,
-        3u8 => Transaction::Upgrade,
-        4u8 => Transaction::Upload,
-        5u8 => Transaction::Blob,
+        TX_TYPE_SCRIPT => Transaction::Script,
+        TX_TYPE_CREATE => Transaction::Create,
+        TX_TYPE_UPGRADE => Transaction::Upgrade,
+        TX_TYPE_UPLOAD => Transaction::Upload,
+        TX_TYPE_BLOB => Transaction::Blob,
         _ => revert(0),
     }
 }
@@ -276,9 +284,10 @@ pub fn tx_max_fee() -> Option<u64> {
 /// }
 /// ```
 pub fn tx_script_length() -> Option<u64> {
-    match tx_type() {
-        Transaction::Script => Some(__gtf::<u64>(0, GTF_SCRIPT_SCRIPT_LENGTH)),
-        _ => None,
+    if __gtf::<u8>(0, GTF_TYPE) == TX_TYPE_SCRIPT {
+        Some(__gtf::<u64>(0, GTF_SCRIPT_SCRIPT_LENGTH))
+    } else {
+        None
     }
 }
 
@@ -299,9 +308,10 @@ pub fn tx_script_length() -> Option<u64> {
 /// }
 /// ```
 pub fn tx_script_data_length() -> Option<u64> {
-    match tx_type() {
-        Transaction::Script => Some(__gtf::<u64>(0, GTF_SCRIPT_SCRIPT_DATA_LENGTH)),
-        _ => None,
+    if __gtf::<u8>(0, GTF_TYPE) == TX_TYPE_SCRIPT {
+        Some(__gtf::<u64>(0, GTF_SCRIPT_SCRIPT_DATA_LENGTH))
+    } else {
+        None
     }
 }
 
@@ -327,11 +337,11 @@ pub fn tx_script_data_length() -> Option<u64> {
 /// ```
 pub fn tx_witnesses_count() -> u64 {
     match tx_type() {
-        Transaction::Script => __gtf::<u64>(0, GTF_SCRIPT_WITNESSES_COUNT),
+        Transaction::Script
+        | Transaction::Upgrade
+        | Transaction::Upload
+        | Transaction::Blob => __gtf::<u64>(0, GTF_SCRIPT_WITNESSES_COUNT),
         Transaction::Create => __gtf::<u64>(0, GTF_CREATE_WITNESSES_COUNT),
-        Transaction::Upgrade => __gtf::<u64>(0, GTF_SCRIPT_WITNESSES_COUNT),
-        Transaction::Upload => __gtf::<u64>(0, GTF_SCRIPT_WITNESSES_COUNT),
-        Transaction::Blob => __gtf::<u64>(0, GTF_SCRIPT_WITNESSES_COUNT),
         _ => revert(0),
     }
 }
@@ -362,11 +372,11 @@ fn tx_witness_pointer(index: u64) -> Option<raw_ptr> {
     }
 
     match tx_type() {
-        Transaction::Script => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_WITNESS_AT_INDEX)),
+        Transaction::Script
+        | Transaction::Upgrade
+        | Transaction::Upload
+        | Transaction::Blob => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_WITNESS_AT_INDEX)),
         Transaction::Create => Some(__gtf::<raw_ptr>(index, GTF_CREATE_WITNESS_AT_INDEX)),
-        Transaction::Upgrade => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_WITNESS_AT_INDEX)),
-        Transaction::Upload => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_WITNESS_AT_INDEX)),
-        Transaction::Blob => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_WITNESS_AT_INDEX)),
         _ => None,
     }
 }
@@ -429,13 +439,9 @@ pub fn tx_witness_data<T>(index: u64) -> Option<T> {
         return None
     }
 
-    let length = match tx_witness_data_length(index) {
-        Some(len) => len,
-        None => return None,
-    };
-
+    let witness_data_ptr = __gtf::<raw_ptr>(index, GTF_WITNESS_DATA);
     if __is_reference_type::<T>() {
-        let witness_data_ptr = __gtf::<raw_ptr>(index, GTF_WITNESS_DATA);
+        let length = __gtf::<u64>(index, GTF_WITNESS_DATA_LENGTH);
         let new_ptr = alloc_bytes(length);
         witness_data_ptr.copy_bytes_to(new_ptr, length);
 
@@ -445,56 +451,10 @@ pub fn tx_witness_data<T>(index: u64) -> Option<T> {
     } else {
         // u8 is the only value type that is less than 8 bytes and should be handled separately
         if __size_of::<T>() == 1 {
-            Some(__gtf::<raw_ptr>(index, GTF_WITNESS_DATA).add::<u8>(7).read::<T>())
+            Some(witness_data_ptr.add::<u8>(7).read::<T>())
         } else {
-            Some(__gtf::<raw_ptr>(index, GTF_WITNESS_DATA).read::<T>())
+            Some(witness_data_ptr.read::<T>())
         }
-    }
-}
-
-/// Get the transaction script start pointer.
-///
-/// # Returns
-///
-/// * [Option<raw_ptr>] - The transaction script start pointer.
-///
-/// # Examples
-///
-/// ```sway
-/// use std::tx::tx_script_start_pointer;
-///
-/// fn foo() {
-///     let script_start_pointer = tx_script_start_pointer().unwrap();
-///     log(script_start_pointer);
-/// }
-/// ```
-fn tx_script_start_pointer() -> Option<raw_ptr> {
-    match tx_type() {
-        Transaction::Script => Some(__gtf::<raw_ptr>(0, GTF_SCRIPT_SCRIPT)),
-        _ => None,
-    }
-}
-
-/// Get the transaction script data start pointer.
-///
-/// # Returns
-///
-/// * [Option<raw_ptr>] - The transaction script data start pointer.
-///
-/// # Examples
-///
-/// ```sway
-/// use std::tx::tx_script_data_start_pointer;
-///
-/// fn foo() {
-///     let script_data_start_pointer = tx_script_data_start_pointer().unwrap();
-///     log(script_data_start_pointer);
-/// }
-/// ```
-fn tx_script_data_start_pointer() -> Option<raw_ptr> {
-    match tx_type() {
-        Transaction::Script => Some(__gtf::<raw_ptr>(0, GTF_SCRIPT_SCRIPT_DATA)),
-        _ => None,
     }
 }
 
@@ -520,13 +480,12 @@ fn tx_script_data_start_pointer() -> Option<raw_ptr> {
 /// }
 /// ```
 pub fn tx_script_data<T>() -> Option<T> {
-    let ptr = tx_script_data_start_pointer();
-    if ptr.is_none() {
-        return None
+    if __gtf::<u8>(0, GTF_TYPE) == TX_TYPE_SCRIPT {
+        // TODO some safety checks on the input data? We are going to assume it is the right type for now.
+        Some(__gtf::<raw_ptr>(0, GTF_SCRIPT_SCRIPT_DATA).read::<T>())
+    } else {
+        None
     }
-
-    // TODO some safety checks on the input data? We are going to assume it is the right type for now.
-    Some(ptr.unwrap().read::<T>())
 }
 
 /// Get the script bytecode.
@@ -551,9 +510,10 @@ pub fn tx_script_data<T>() -> Option<T> {
 /// }
 /// ```
 pub fn tx_script_bytecode<T>() -> Option<T> {
-    match tx_type() {
-        Transaction::Script => Some(tx_script_start_pointer().unwrap().read::<T>()),
-        _ => None,
+    if __gtf::<u8>(0, GTF_TYPE) == TX_TYPE_SCRIPT {
+        Some(__gtf::<raw_ptr>(0, GTF_SCRIPT_SCRIPT).read::<T>())
+    } else {
+        None
     }
 }
 
@@ -574,12 +534,11 @@ pub fn tx_script_bytecode<T>() -> Option<T> {
 /// }
 /// ```
 pub fn tx_script_bytecode_hash() -> Option<b256> {
-    match tx_type() {
-        Transaction::Script => {
+    if __gtf::<u8>(0, GTF_TYPE) == TX_TYPE_SCRIPT {
             // Get the script memory details
             let mut result_buffer = b256::zero();
-            let script_length = tx_script_length().unwrap();
-            let script_ptr = tx_script_start_pointer().unwrap();
+            let script_length = __gtf::<u64>(0, GTF_SCRIPT_SCRIPT_LENGTH);
+            let script_ptr = __gtf::<raw_ptr>(0, GTF_SCRIPT_SCRIPT);
 
             // Run the hash opcode for the script in memory
             Some(
@@ -588,8 +547,8 @@ pub fn tx_script_bytecode_hash() -> Option<b256> {
                     hash: b256
                 },
             )
-        },
-        _ => None,
+    } else {
+        None
     }
 }
 

--- a/sway-lib-std/src/tx.sw
+++ b/sway-lib-std/src/tx.sw
@@ -337,10 +337,7 @@ pub fn tx_script_data_length() -> Option<u64> {
 /// ```
 pub fn tx_witnesses_count() -> u64 {
     match tx_type() {
-        Transaction::Script
-        | Transaction::Upgrade
-        | Transaction::Upload
-        | Transaction::Blob => __gtf::<u64>(0, GTF_SCRIPT_WITNESSES_COUNT),
+        Transaction::Script | Transaction::Upgrade | Transaction::Upload | Transaction::Blob => __gtf::<u64>(0, GTF_SCRIPT_WITNESSES_COUNT),
         Transaction::Create => __gtf::<u64>(0, GTF_CREATE_WITNESSES_COUNT),
         _ => revert(0),
     }
@@ -372,10 +369,7 @@ fn tx_witness_pointer(index: u64) -> Option<raw_ptr> {
     }
 
     match tx_type() {
-        Transaction::Script
-        | Transaction::Upgrade
-        | Transaction::Upload
-        | Transaction::Blob => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_WITNESS_AT_INDEX)),
+        Transaction::Script | Transaction::Upgrade | Transaction::Upload | Transaction::Blob => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_WITNESS_AT_INDEX)),
         Transaction::Create => Some(__gtf::<raw_ptr>(index, GTF_CREATE_WITNESS_AT_INDEX)),
         _ => None,
     }
@@ -535,18 +529,18 @@ pub fn tx_script_bytecode<T>() -> Option<T> {
 /// ```
 pub fn tx_script_bytecode_hash() -> Option<b256> {
     if __gtf::<u8>(0, GTF_TYPE) == TX_TYPE_SCRIPT {
-            // Get the script memory details
-            let mut result_buffer = b256::zero();
-            let script_length = __gtf::<u64>(0, GTF_SCRIPT_SCRIPT_LENGTH);
-            let script_ptr = __gtf::<raw_ptr>(0, GTF_SCRIPT_SCRIPT);
+        // Get the script memory details
+        let mut result_buffer = b256::zero();
+        let script_length = __gtf::<u64>(0, GTF_SCRIPT_SCRIPT_LENGTH);
+        let script_ptr = __gtf::<raw_ptr>(0, GTF_SCRIPT_SCRIPT);
 
-            // Run the hash opcode for the script in memory
-            Some(
-                asm(hash: result_buffer, ptr: script_ptr, len: script_length) {
-                    s256 hash ptr len;
-                    hash: b256
-                },
-            )
+        // Run the hash opcode for the script in memory
+        Some(
+            asm(hash: result_buffer, ptr: script_ptr, len: script_length) {
+                s256 hash ptr len;
+                hash: b256
+            },
+        )
     } else {
         None
     }

--- a/sway-lib-std/src/tx.sw
+++ b/sway-lib-std/src/tx.sw
@@ -336,9 +336,9 @@ pub fn tx_script_data_length() -> Option<u64> {
 /// }
 /// ```
 pub fn tx_witnesses_count() -> u64 {
-    match tx_type() {
-        Transaction::Script | Transaction::Upgrade | Transaction::Upload | Transaction::Blob => __gtf::<u64>(0, GTF_SCRIPT_WITNESSES_COUNT),
-        Transaction::Create => __gtf::<u64>(0, GTF_CREATE_WITNESSES_COUNT),
+    match __gtf::<u8>(0, GTF_TYPE) {
+        TX_TYPE_SCRIPT | TX_TYPE_UPGRADE | TX_TYPE_UPLOAD | TX_TYPE_BLOB => __gtf::<u64>(0, GTF_SCRIPT_WITNESSES_COUNT),
+        TX_TYPE_CREATE => __gtf::<u64>(0, GTF_CREATE_WITNESSES_COUNT),
         _ => revert(0),
     }
 }
@@ -368,9 +368,9 @@ fn tx_witness_pointer(index: u64) -> Option<raw_ptr> {
         return None
     }
 
-    match tx_type() {
-        Transaction::Script | Transaction::Upgrade | Transaction::Upload | Transaction::Blob => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_WITNESS_AT_INDEX)),
-        Transaction::Create => Some(__gtf::<raw_ptr>(index, GTF_CREATE_WITNESS_AT_INDEX)),
+    match __gtf::<u8>(0, GTF_TYPE) {
+        TX_TYPE_SCRIPT | TX_TYPE_UPGRADE | TX_TYPE_UPLOAD | TX_TYPE_BLOB => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_WITNESS_AT_INDEX)),
+        TX_TYPE_CREATE => Some(__gtf::<raw_ptr>(index, GTF_CREATE_WITNESS_AT_INDEX)),
         _ => None,
     }
 }


### PR DESCRIPTION
## Description

This PR optimizes functions in the `tx` module for bytecode size and gas usage. E.g., the bytecode size of the following script that calls all of the optimized functions got **reduced from 1792 bytes to 648 bytes**:

```sway
fn main() {
    let _ = std::tx::tx_script_length();
    let _ = std::tx::tx_script_data_length();
    let _ = std::tx::tx_script_data::<u64>();
    let _ = std::tx::tx_script_bytecode::<u64>();
    let _ = std::tx::tx_script_bytecode_hash();
    let _ = std::tx::tx_witnesses_count();
    let _ = std::tx::tx_witness_data::<u64>(0);
}
```

The optimization:
- mostly removes the duplicated checks for `tx_type()` and where necessary, replaces calls to `tx_type()` to a single `if`.
- removes the private helper function `tx_script_start_pointer`. The function was re-checking the `tx_type()` to be a script, although always being called only if the `tx_type` was already checked for being a script. Additionally, it was wrapping the result in `Option` requiring an additional unnecessary indirection.
- removes the private helper function `tx_script_data_start_pointer` for similar reasons.
- rewrites `tx_witness_data` by removing unnecessary length calculation and duplicated code.
- simplifies `match` expressions by replacing duplicated match arms with a single arm.

The PR introduces a slight change in the semantics of functions like, e.g., `tx_script_length` that return `Option`. Before, if the `tx_type` was `Mint` they would panic instead of returning `None`. Now they return `None`. The new behavior actually looks like the proper one to me. A function returning `Option` shouldn't panic.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
