### PR TITLE
Optimize `inputs` and `outputs` modules for bytecode size and gas usage

### DIFF
--- a/sway-lib-std/src/inputs.sw
+++ b/sway-lib-std/src/inputs.sw
@@ -1,5 +1,5 @@
 //! Getters for fields on transaction inputs.
-//! This includes `Input::Coins`, `Input::Messages` and `Input::Contracts`.
+//! This includes `Input::Coin`, `Input::Message` and `Input::Contract`.
 library;
 
 use ::address::Address;
@@ -14,8 +14,11 @@ use ::tx::{
     GTF_CREATE_INPUTS_COUNT,
     GTF_SCRIPT_INPUT_AT_INDEX,
     GTF_SCRIPT_INPUTS_COUNT,
+    GTF_TYPE,
     Transaction,
     tx_type,
+    TX_TYPE_CREATE,
+    TX_TYPE_MINT,
 };
 use ::ops::*;
 use ::revert::revert;
@@ -72,13 +75,28 @@ impl PartialEq for Input {
 }
 impl Eq for Input {}
 
-// General Inputs
+const INPUT_TYPE_COIN: u8 = 0;
+const INPUT_TYPE_CONTRACT: u8 = 1;
+const INPUT_TYPE_MESSAGE: u8 = 2;
+
+// Returns the `u8` type id of the input at `index` if such input exists,
+// or a non-existing type id if the `index` is out of input bounds.
+//
+// This private function is used to avoid the overhead of creating and
+// inspecting `Option`s for the input type.
+fn input_type_id(index: u64) -> u8 {
+    if index < input_count().as_u64() {
+        __gtf::<u8>(index, GTF_INPUT_TYPE)
+    } else {
+        u8::max()
+    }
+}
 
 /// Gets the type of the input at `index`.
 ///
 /// # Additional Information
 ///
-/// The Input can be of 3 variants, `Input::Coin`, `Input::Contract` or `Input::Message`.
+/// The `Input` can be of three variants, `Input::Coin`, `Input::Contract`, or `Input::Message`.
 ///
 /// # Arguments
 ///
@@ -99,14 +117,10 @@ impl Eq for Input {}
 /// }
 /// ```
 pub fn input_type(index: u64) -> Option<Input> {
-    if index >= input_count().as_u64() {
-        return None
-    }
-
-    match __gtf::<u8>(index, GTF_INPUT_TYPE) {
-        0u8 => Some(Input::Coin),
-        1u8 => Some(Input::Contract),
-        2u8 => Some(Input::Message),
+    match input_type_id(index) {
+        INPUT_TYPE_COIN => Some(Input::Coin),
+        INPUT_TYPE_CONTRACT => Some(Input::Contract),
+        INPUT_TYPE_MESSAGE => Some(Input::Message),
         _ => None,
     }
 }
@@ -132,13 +146,10 @@ pub fn input_type(index: u64) -> Option<Input> {
 /// }
 /// ```
 pub fn input_count() -> u16 {
-    match tx_type() {
-        Transaction::Script => __gtf::<u16>(0, GTF_SCRIPT_INPUTS_COUNT),
-        Transaction::Create => __gtf::<u16>(0, GTF_CREATE_INPUTS_COUNT),
-        Transaction::Upgrade => __gtf::<u16>(0, GTF_SCRIPT_INPUTS_COUNT),
-        Transaction::Upload => __gtf::<u16>(0, GTF_SCRIPT_INPUTS_COUNT),
-        Transaction::Blob => __gtf::<u16>(0, GTF_SCRIPT_INPUTS_COUNT),
-        _ => revert(0),
+    match __gtf::<u8>(0, GTF_TYPE) {
+        TX_TYPE_CREATE => __gtf::<u16>(0, GTF_CREATE_INPUTS_COUNT),
+        TX_TYPE_MINT => revert(0),
+        _ => __gtf::<u16>(0, GTF_SCRIPT_INPUTS_COUNT),
     }
 }
 
@@ -167,17 +178,14 @@ fn input_pointer(index: u64) -> Option<raw_ptr> {
         return None
     }
 
-    match tx_type() {
-        Transaction::Script => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_INPUT_AT_INDEX)),
-        Transaction::Create => Some(__gtf::<raw_ptr>(index, GTF_CREATE_INPUT_AT_INDEX)),
-        Transaction::Upgrade => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_INPUT_AT_INDEX)),
-        Transaction::Upload => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_INPUT_AT_INDEX)),
-        Transaction::Blob => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_INPUT_AT_INDEX)),
-        _ => None,
+    match __gtf::<u8>(0, GTF_TYPE) {
+        TX_TYPE_CREATE => Some(__gtf::<raw_ptr>(index, GTF_CREATE_INPUT_AT_INDEX)),
+        TX_TYPE_MINT => None,
+        _ => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_INPUT_AT_INDEX)),
     }
 }
 
-/// Gets amount field from input at `index`.
+/// Gets the amount field from the input at `index`.
 ///
 /// # Arguments
 ///
@@ -198,14 +206,14 @@ fn input_pointer(index: u64) -> Option<raw_ptr> {
 /// }
 /// ```
 pub fn input_amount(index: u64) -> Option<u64> {
-    match input_type(index) {
-        Some(Input::Coin) => Some(__gtf::<u64>(index, GTF_INPUT_COIN_AMOUNT)),
-        Some(Input::Message) => Some(__gtf::<u64>(index, GTF_INPUT_MESSAGE_AMOUNT)),
+    match input_type_id(index) {
+        INPUT_TYPE_COIN => Some(__gtf::<u64>(index, GTF_INPUT_COIN_AMOUNT)),
+        INPUT_TYPE_MESSAGE => Some(__gtf::<u64>(index, GTF_INPUT_MESSAGE_AMOUNT)),
         _ => None,
     }
 }
 
-/// Gets owner field from input at `index` if it's a coin.
+/// Gets the owner field from the input at `index` if it's a coin.
 ///
 /// # Arguments
 ///
@@ -226,8 +234,8 @@ pub fn input_amount(index: u64) -> Option<u64> {
 /// }
 /// ```
 pub fn input_coin_owner(index: u64) -> Option<Address> {
-    match input_type(index) {
-        Some(Input::Coin) => Some(Address::from(__gtf::<b256>(index, GTF_INPUT_COIN_OWNER))),
+    match input_type_id(index) {
+        INPUT_TYPE_COIN => Some(Address::from(__gtf::<b256>(index, GTF_INPUT_COIN_OWNER))),
         _ => None,
     }
 }
@@ -253,9 +261,9 @@ pub fn input_coin_owner(index: u64) -> Option<Address> {
 /// }
 #[allow(dead_code)]
 fn input_predicate_data_pointer(index: u64) -> Option<raw_ptr> {
-    match input_type(index) {
-        Some(Input::Coin) => Some(__gtf::<raw_ptr>(index, GTF_INPUT_COIN_PREDICATE_DATA)),
-        Some(Input::Message) => Some(__gtf::<raw_ptr>(index, GTF_INPUT_MESSAGE_PREDICATE_DATA)),
+    match input_type_id(index) {
+        INPUT_TYPE_COIN => Some(__gtf::<raw_ptr>(index, GTF_INPUT_COIN_PREDICATE_DATA)),
+        INPUT_TYPE_MESSAGE => Some(__gtf::<raw_ptr>(index, GTF_INPUT_MESSAGE_PREDICATE_DATA)),
         _ => None,
     }
 }
@@ -284,14 +292,13 @@ pub fn input_predicate_data<T>(index: u64) -> Option<T>
 where
     T: AbiDecode,
 {
-    match input_type(index) {
-        Some(Input::Coin) => Some(decode_predicate_data_by_index::<T>(index)),
-        Some(Input::Message) => Some(decode_predicate_data_by_index::<T>(index)),
+    match input_type_id(index) {
+        INPUT_TYPE_COIN | INPUT_TYPE_MESSAGE => Some(decode_predicate_data_by_index::<T>(index)),
         _ => None,
     }
 }
 
-/// Gets the AssetId of the input at `index`.
+/// Gets the asset id of the input at `index`.
 ///
 /// # Arguments
 ///
@@ -299,7 +306,7 @@ where
 ///
 /// # Returns
 ///
-/// * [Option<AssetId>] - The asset_id of the input at `index`, if the input's type is `Input::Coin` or `Input::Message`, else `None`.
+/// * [Option<AssetId>] - The asset id of the input at `index`, if the input's type is `Input::Coin` or `Input::Message`, else `None`.
 ///
 /// # Examples
 ///
@@ -312,9 +319,9 @@ where
 /// }
 /// ```
 pub fn input_asset_id(index: u64) -> Option<AssetId> {
-    match input_type(index) {
-        Some(Input::Coin) => Some(AssetId::from(__gtf::<b256>(index, GTF_INPUT_COIN_ASSET_ID))),
-        Some(Input::Message) => Some(AssetId::base()),
+    match input_type_id(index) {
+        INPUT_TYPE_COIN => Some(AssetId::from(__gtf::<b256>(index, GTF_INPUT_COIN_ASSET_ID))),
+        INPUT_TYPE_MESSAGE => Some(AssetId::base()),
         _ => None,
     }
 }
@@ -340,9 +347,9 @@ pub fn input_asset_id(index: u64) -> Option<AssetId> {
 /// }
 /// ```
 pub fn input_witness_index(index: u64) -> Option<u16> {
-    match input_type(index) {
-        Some(Input::Coin) => Some(__gtf::<u16>(index, GTF_INPUT_COIN_WITNESS_INDEX)),
-        Some(Input::Message) => Some(__gtf::<u16>(index, GTF_INPUT_MESSAGE_WITNESS_INDEX)),
+    match input_type_id(index) {
+        INPUT_TYPE_COIN => Some(__gtf::<u16>(index, GTF_INPUT_COIN_WITNESS_INDEX)),
+        INPUT_TYPE_MESSAGE => Some(__gtf::<u16>(index, GTF_INPUT_MESSAGE_WITNESS_INDEX)),
         _ => None,
     }
 }
@@ -368,9 +375,9 @@ pub fn input_witness_index(index: u64) -> Option<u16> {
 /// }
 /// ```
 pub fn input_predicate_length(index: u64) -> Option<u64> {
-    match input_type(index) {
-        Some(Input::Coin) => Some(__gtf::<u64>(index, GTF_INPUT_COIN_PREDICATE_LENGTH)),
-        Some(Input::Message) => Some(__gtf::<u64>(index, GTF_INPUT_MESSAGE_PREDICATE_LENGTH)),
+    match input_type_id(index) {
+        INPUT_TYPE_COIN => Some(__gtf::<u64>(index, GTF_INPUT_COIN_PREDICATE_LENGTH)),
+        INPUT_TYPE_MESSAGE => Some(__gtf::<u64>(index, GTF_INPUT_MESSAGE_PREDICATE_LENGTH)),
         _ => None,
     }
 }
@@ -395,15 +402,15 @@ pub fn input_predicate_length(index: u64) -> Option<u64> {
 ///     assert(input_predicate_pointer.is_some());
 /// }
 /// ```
-fn input_predicate_pointer(index: u64) -> Option<raw_ptr> {
-    match input_type(index) {
-        Some(Input::Coin) => Some(__gtf::<raw_ptr>(index, GTF_INPUT_COIN_PREDICATE)),
-        Some(Input::Message) => Some(__gtf::<raw_ptr>(index, GTF_INPUT_MESSAGE_PREDICATE)),
+pub fn input_predicate_pointer(index: u64) -> Option<raw_ptr> {
+    match input_type_id(index) {
+        INPUT_TYPE_COIN => Some(__gtf::<raw_ptr>(index, GTF_INPUT_COIN_PREDICATE)),
+        INPUT_TYPE_MESSAGE => Some(__gtf::<raw_ptr>(index, GTF_INPUT_MESSAGE_PREDICATE)),
         _ => None,
     }
 }
 
-/// Gets the predicate from the input at `index`.
+/// Gets the predicate bytecode from the input at `index`.
 ///
 /// # Arguments
 ///
@@ -411,7 +418,7 @@ fn input_predicate_pointer(index: u64) -> Option<raw_ptr> {
 ///
 /// # Returns
 ///
-/// * [Option<Bytes>] - The predicate bytecode of the input at `index`, if the input's type is `Input::Coin` or `Input::Message`.
+/// * [Option<Bytes>] - The predicate bytecode of the input at `index`, if the input's type is `Input::Coin` or `Input::Message`, else `None`.
 ///
 /// # Examples
 ///
@@ -424,20 +431,21 @@ fn input_predicate_pointer(index: u64) -> Option<raw_ptr> {
 /// }
 /// ```
 pub fn input_predicate(index: u64) -> Option<Bytes> {
-    let wrapped = input_predicate_length(index);
-    if wrapped.is_none() {
-        return None
-    }
+    let (length, ptr) = match input_type_id(index) {
+        INPUT_TYPE_COIN => (
+            __gtf::<u64>(index, GTF_INPUT_COIN_PREDICATE_LENGTH),
+            __gtf::<raw_ptr>(index, GTF_INPUT_COIN_PREDICATE),
+        ),
+        INPUT_TYPE_MESSAGE => (
+            __gtf::<u64>(index, GTF_INPUT_MESSAGE_PREDICATE_LENGTH),
+            __gtf::<raw_ptr>(index, GTF_INPUT_MESSAGE_PREDICATE),
+        ),
+        _ => return None,
+    };
 
-    let length = wrapped.unwrap();
-    match input_predicate_pointer(index) {
-        Some(d) => {
-            let new_ptr = alloc_bytes(length);
-            d.copy_bytes_to(new_ptr, length);
-            Some(Bytes::from(raw_slice::from_parts::<u8>(new_ptr, length)))
-        },
-        None => None,
-    }
+    let new_ptr = alloc_bytes(length);
+    ptr.copy_bytes_to(new_ptr, length);
+    Some(Bytes::from(raw_slice::from_parts::<u8>(new_ptr, length)))
 }
 
 /// Gets the predicate data length from the input at `index`.
@@ -461,9 +469,9 @@ pub fn input_predicate(index: u64) -> Option<Bytes> {
 /// }
 /// ```
 pub fn input_predicate_data_length(index: u64) -> Option<u64> {
-    match input_type(index) {
-        Some(Input::Coin) => Some(__gtf::<u64>(index, GTF_INPUT_COIN_PREDICATE_DATA_LENGTH)),
-        Some(Input::Message) => Some(__gtf::<u64>(index, GTF_INPUT_MESSAGE_PREDICATE_DATA_LENGTH)),
+    match input_type_id(index) {
+        INPUT_TYPE_COIN => Some(__gtf::<u64>(index, GTF_INPUT_COIN_PREDICATE_DATA_LENGTH)),
+        INPUT_TYPE_MESSAGE => Some(__gtf::<u64>(index, GTF_INPUT_MESSAGE_PREDICATE_DATA_LENGTH)),
         _ => None,
     }
 }
@@ -476,7 +484,7 @@ pub fn input_predicate_data_length(index: u64) -> Option<u64> {
 ///
 /// # Returns
 ///
-/// * [Option<Address>] - The sender of the input message at `index`, if the input's type is `Input::Message`.
+/// * [Option<Address>] - The sender of the input message at `index`, if the input's type is `Input::Message`, else `None`.
 ///
 /// # Examples
 ///
@@ -489,8 +497,8 @@ pub fn input_predicate_data_length(index: u64) -> Option<u64> {
 /// }
 /// ```
 pub fn input_message_sender(index: u64) -> Option<Address> {
-    match input_type(index) {
-        Some(Input::Message) => Some(Address::from(__gtf::<b256>(index, GTF_INPUT_MESSAGE_SENDER))),
+    match input_type_id(index) {
+        INPUT_TYPE_MESSAGE => Some(Address::from(__gtf::<b256>(index, GTF_INPUT_MESSAGE_SENDER))),
         _ => None,
     }
 }
@@ -503,7 +511,7 @@ pub fn input_message_sender(index: u64) -> Option<Address> {
 ///
 /// # Returns
 ///
-/// * [Option<Address>] - The recipient of the input message at `index`, if the input's type is `Input::Message`.
+/// * [Option<Address>] - The recipient of the input message at `index`, if the input's type is `Input::Message`, else `None`.
 ///
 /// # Examples
 ///
@@ -516,13 +524,13 @@ pub fn input_message_sender(index: u64) -> Option<Address> {
 /// }
 /// ```
 pub fn input_message_recipient(index: u64) -> Option<Address> {
-    match input_type(index) {
-        Some(Input::Message) => Some(Address::from(__gtf::<b256>(index, GTF_INPUT_MESSAGE_RECIPIENT))),
+    match input_type_id(index) {
+        INPUT_TYPE_MESSAGE => Some(Address::from(__gtf::<b256>(index, GTF_INPUT_MESSAGE_RECIPIENT))),
         _ => None,
     }
 }
 
-/// Gets the nonce of input message at `index`.
+/// Gets the nonce of the input message at `index`.
 ///
 /// # Arguments
 ///
@@ -530,7 +538,7 @@ pub fn input_message_recipient(index: u64) -> Option<Address> {
 ///
 /// # Returns
 ///
-/// * [b256] - The nonce of the input message at `index`, if the input's type is `Input::Message`.
+/// * [b256] - The nonce of the input message at `index`, if the input's type is `Input::Message`, else `None`.
 ///
 /// # Examples
 ///
@@ -543,8 +551,8 @@ pub fn input_message_recipient(index: u64) -> Option<Address> {
 /// }
 /// ```
 pub fn input_message_nonce(index: u64) -> Option<b256> {
-    match input_type(index) {
-        Some(Input::Message) => Some(__gtf::<b256>(index, GTF_INPUT_MESSAGE_NONCE)),
+    match input_type_id(index) {
+        INPUT_TYPE_MESSAGE => Some(__gtf::<b256>(index, GTF_INPUT_MESSAGE_NONCE)),
         _ => None,
     }
 }
@@ -557,7 +565,7 @@ pub fn input_message_nonce(index: u64) -> Option<b256> {
 ///
 /// # Returns
 ///
-/// * [Option<u64>] - The length of the input message at `index`, if the input's type is `Input::Message`.
+/// * [Option<u64>] - The length of the input message at `index`, if the input's type is `Input::Message`, else `None`.
 ///
 /// # Examples
 ///
@@ -570,8 +578,8 @@ pub fn input_message_nonce(index: u64) -> Option<b256> {
 /// }
 /// ```
 pub fn input_message_data_length(index: u64) -> Option<u64> {
-    match input_type(index) {
-        Some(Input::Message) => Some(__gtf::<u64>(index, GTF_INPUT_MESSAGE_DATA_LENGTH)),
+    match input_type_id(index) {
+        INPUT_TYPE_MESSAGE => Some(__gtf::<u64>(index, GTF_INPUT_MESSAGE_DATA_LENGTH)),
         _ => None,
     }
 }
@@ -585,7 +593,7 @@ pub fn input_message_data_length(index: u64) -> Option<u64> {
 ///
 /// # Returns
 ///
-/// * [Option<Bytes>] - The data of the input message at `index`, if the input's type is `Input::Message`.
+/// * [Option<Bytes>] - The data of the input message at `index`, if the input's type is `Input::Message`, else `None`.
 ///
 /// # Examples
 ///
@@ -598,20 +606,22 @@ pub fn input_message_data_length(index: u64) -> Option<u64> {
 /// }
 /// ```
 pub fn input_message_data(index: u64, offset: u64) -> Option<Bytes> {
-    match input_type(index) {
-        Some(Input::Message) => {
-            let data = __gtf::<raw_ptr>(index, GTF_INPUT_MESSAGE_DATA);
-            let data_with_offset = data.add_uint_offset(offset);
-            let total_length = input_message_data_length(index).unwrap();
+    match input_type_id(index) {
+        INPUT_TYPE_MESSAGE => {
+            let total_length = __gtf::<u64>(index, GTF_INPUT_MESSAGE_DATA_LENGTH);
+
             if offset > total_length {
-                return None
+                None
+            } else {
+                let offset_length = total_length - offset;
+                let new_ptr = alloc_bytes(offset_length);
+
+                let data = __gtf::<raw_ptr>(index, GTF_INPUT_MESSAGE_DATA);
+                let data_with_offset = data.add_uint_offset(offset);
+
+                data_with_offset.copy_bytes_to(new_ptr, offset_length);
+                Some(Bytes::from(raw_slice::from_parts::<u8>(new_ptr, offset_length)))
             }
-            let offset_length = total_length - offset;
-
-            let new_ptr = alloc_bytes(offset_length);
-
-            data_with_offset.copy_bytes_to(new_ptr, offset_length);
-            Some(Bytes::from(raw_slice::from_parts::<u8>(new_ptr, offset_length)))
         },
         _ => None,
     }

--- a/sway-lib-std/src/outputs.sw
+++ b/sway-lib-std/src/outputs.sw
@@ -1,5 +1,5 @@
 //! Getters for fields on transaction outputs.
-//! This includes `Output::Coins`, `Input::Messages` and `Input::Contracts`.
+//! This includes `Output::Coin`, `Output::Contract`, `Output::Change`, `Output::Variable`, and `Output::ContractCreated`.
 library;
 
 use ::address::Address;
@@ -11,8 +11,11 @@ use ::tx::{
     GTF_CREATE_OUTPUTS_COUNT,
     GTF_SCRIPT_OUTPUT_AT_INDEX,
     GTF_SCRIPT_OUTPUTS_COUNT,
+    GTF_TYPE,
     Transaction,
     tx_type,
+    TX_TYPE_CREATE,
+    TX_TYPE_MINT,
 };
 use ::option::Option::{self, *};
 use ::ops::*;
@@ -49,7 +52,40 @@ pub enum Output {
     ContractCreated: (),
 }
 
-/// Get the type of an output at `index`.
+impl PartialEq for Output {
+    fn eq(self, other: Self) -> bool {
+        match (self, other) {
+            (Output::Coin, Output::Coin) => true,
+            (Output::Contract, Output::Contract) => true,
+            (Output::Change, Output::Change) => true,
+            (Output::Variable, Output::Variable) => true,
+            (Output::ContractCreated, Output::ContractCreated) => true,
+            _ => false,
+        }
+    }
+}
+impl Eq for Output {}
+
+const OUTPUT_TYPE_COIN: u8 = 0;
+const OUTPUT_TYPE_CONTRACT: u8 = 1;
+const OUTPUT_TYPE_CHANGE: u8 = 2;
+const OUTPUT_TYPE_VARIABLE: u8 = 3;
+const OUTPUT_TYPE_CONTRACT_CREATED: u8 = 4;
+
+/// Returns the `u8` type id of the output at `index` if such output exists,
+/// or a non-existing type id if the `index` is out of output bounds.
+///
+/// This private function is used to avoid the overhead of creating and
+/// inspecting `Option`s for the output type.
+fn output_type_id(index: u64) -> u8 {
+    if index < output_count().as_u64() {
+        __gtf::<u8>(index, GTF_OUTPUT_TYPE)
+    } else {
+        u8::max()
+    }
+}
+
+/// Get the type of the output at `index`.
 ///
 /// # Arguments
 ///
@@ -76,57 +112,29 @@ pub enum Output {
 /// }
 /// ```
 pub fn output_type(index: u64) -> Option<Output> {
-    if index >= output_count().as_u64() {
-        return None
-    }
-
-    match __gtf::<u8>(index, GTF_OUTPUT_TYPE) {
-        0u8 => Some(Output::Coin),
-        1u8 => Some(Output::Contract),
-        2u8 => Some(Output::Change),
-        3u8 => Some(Output::Variable),
-        4u8 => Some(Output::ContractCreated),
+    match output_type_id(index) {
+        OUTPUT_TYPE_COIN => Some(Output::Coin),
+        OUTPUT_TYPE_CONTRACT => Some(Output::Contract),
+        OUTPUT_TYPE_CHANGE => Some(Output::Change),
+        OUTPUT_TYPE_VARIABLE => Some(Output::Variable),
+        OUTPUT_TYPE_CONTRACT_CREATED => Some(Output::ContractCreated),
         _ => None,
     }
 }
 
-/// Get a pointer to the output at `index`
-/// for either `tx_type` (transaction-script or transaction-create).
+/// Returns the pointer to the output at `index`.
 ///
-/// # Arguments
-///
-/// * `index`: [u64] - The index of the output to get the pointer to.
-///
-/// # Returns
-///
-/// * [Option<raw_ptr>] - A pointer to the output at `index`.
-///
-/// # Examples
-///
-/// ```sway
-/// use std::outputs::output_pointer;
-///
-/// fn foo() {
-///     let output_pointer = output_pointer(0).unwrap();
-/// }
-/// ```
-fn output_pointer(index: u64) -> Option<raw_ptr> {
-    if output_type(index).is_none() {
-        return None
-    }
-
-    match tx_type() {
-        Transaction::Script => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_OUTPUT_AT_INDEX)),
-        Transaction::Create => Some(__gtf::<raw_ptr>(index, GTF_CREATE_OUTPUT_AT_INDEX)),
-        Transaction::Upgrade => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_OUTPUT_AT_INDEX)),
-        Transaction::Upload => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_OUTPUT_AT_INDEX)),
-        Transaction::Blob => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_OUTPUT_AT_INDEX)),
-        _ => None,
+/// This private function **does not check if the `index` is out of bounds**.
+/// It assumes that the caller has already checked the output count.
+fn output_pointer(index: u64) -> raw_ptr {
+    match __gtf::<u8>(0, GTF_TYPE) {
+        TX_TYPE_CREATE => __gtf::<raw_ptr>(index, GTF_CREATE_OUTPUT_AT_INDEX),
+        TX_TYPE_MINT => revert(0),
+        _ => __gtf::<raw_ptr>(index, GTF_SCRIPT_OUTPUT_AT_INDEX),
     }
 }
 
-/// Get the transaction outputs count for either `tx_type`
-/// (transaction-script or transaction-create).
+/// Gets the transaction outputs count.
 ///
 /// # Returns
 ///
@@ -147,13 +155,10 @@ fn output_pointer(index: u64) -> Option<raw_ptr> {
 /// }
 /// ```
 pub fn output_count() -> u16 {
-    match tx_type() {
-        Transaction::Script => __gtf::<u16>(0, GTF_SCRIPT_OUTPUTS_COUNT),
-        Transaction::Create => __gtf::<u16>(0, GTF_CREATE_OUTPUTS_COUNT),
-        Transaction::Upgrade => __gtf::<u16>(0, GTF_SCRIPT_OUTPUTS_COUNT),
-        Transaction::Upload => __gtf::<u16>(0, GTF_SCRIPT_OUTPUTS_COUNT),
-        Transaction::Blob => __gtf::<u16>(0, GTF_SCRIPT_OUTPUTS_COUNT),
-        _ => revert(0),
+    match __gtf::<u8>(0, GTF_TYPE) {
+        TX_TYPE_CREATE => __gtf::<u16>(0, GTF_CREATE_OUTPUTS_COUNT),
+        TX_TYPE_MINT => revert(0),
+        _ => __gtf::<u16>(0, GTF_SCRIPT_OUTPUTS_COUNT),
     }
 }
 
@@ -162,7 +167,7 @@ pub fn output_count() -> u16 {
 /// # Additional Information
 ///
 /// This method is only meaningful if the `Output` type has the `amount` field,
-/// specifically: `Output::Coin`, `Output::Change` & `Output::Variable`.
+/// specifically: `Output::Coin`, `Output::Change`, and `Output::Variable`.
 ///
 /// For now, output changes are always guaranteed to have an amount of
 /// zero since they're only set after execution terminates.
@@ -186,14 +191,11 @@ pub fn output_count() -> u16 {
 /// }
 /// ```
 pub fn output_amount(index: u64) -> Option<u64> {
-    match output_type(index) {
-        Some(Output::Coin) => Some(__gtf::<u64>(index, GTF_OUTPUT_COIN_AMOUNT)),
-        Some(Output::Contract) => None,
-        // For now, output changes are always guaranteed to have an amount of
-        // zero since they're only set after execution terminates.
-        Some(Output::Change) => Some(0),
-        Some(Output::Variable) => {
-            let ptr = output_pointer(index).unwrap();
+    match output_type_id(index) {
+        OUTPUT_TYPE_COIN => Some(__gtf::<u64>(index, GTF_OUTPUT_COIN_AMOUNT)),
+        OUTPUT_TYPE_CHANGE => Some(0),
+        OUTPUT_TYPE_VARIABLE => {
+            let ptr = output_pointer(index);
             Some(
                 asm(r1, r2, r3: ptr) {
                     addi r2 r3 i40;
@@ -202,24 +204,22 @@ pub fn output_amount(index: u64) -> Option<u64> {
                 },
             )
         },
-        Some(Output::ContractCreated) => None,
-        None => None,
+        _ => None,
     }
 }
 
-/// Gets the AssetId of the output.
+/// Gets the asset id of the output at `index`.
+///
+/// If you want to get the asset id and the receiver of the output,
+/// use `output_asset_id_and_to` instead.
 ///
 /// # Arguments
 ///
-/// * `index`: [u64] - The index of the output to get the AssetId of.
+/// * `index`: [u64] - The index of the output to get the asset id of.
 ///
 /// # Returns
 ///
-/// * [Option<AssetId>] - The AssetId of the output. None otherwise.
-///
-/// # Reverts
-///
-/// * When the output type is unrecognized. This should never happen.
+/// * [Option<AssetId>] - The asset id of the output.
 ///
 /// # Examples
 ///
@@ -232,18 +232,20 @@ pub fn output_amount(index: u64) -> Option<u64> {
 /// }
 /// ```
 pub fn output_asset_id(index: u64) -> Option<AssetId> {
-    match output_type(index) {
-        Some(Output::Coin) => Some(AssetId::from(__gtf::<b256>(index, GTF_OUTPUT_COIN_ASSET_ID))),
-        Some(Output::Change) => Some(AssetId::from(__gtf::<b256>(index, GTF_OUTPUT_COIN_ASSET_ID))),
-        Some(Output::Variable) => {
-            let ptr = output_pointer(index).unwrap();
+    match output_type_id(index) {
+        OUTPUT_TYPE_COIN | OUTPUT_TYPE_CHANGE => Some(AssetId::from(__gtf::<b256>(index, GTF_OUTPUT_COIN_ASSET_ID))),
+        OUTPUT_TYPE_VARIABLE => {
+            let ptr = output_pointer(index);
             Some(AssetId::from(ptr.add_uint_offset(OUTPUT_VARIABLE_ASSET_ID_OFFSET).read::<b256>()))
         },
         _ => None,
     }
 }
 
-/// Returns the receiver of the output.
+/// Returns the receiver of the output at `index`.
+///
+/// If you want to get the asset id and the receiver of the output,
+/// use `output_asset_id_and_to` instead.
 ///
 /// # Arguments
 ///
@@ -251,11 +253,7 @@ pub fn output_asset_id(index: u64) -> Option<AssetId> {
 ///
 /// # Returns
 ///
-/// * [Option<Address>] - The receiver of the output. None otherwise.
-///
-/// # Reverts
-///
-/// * When the output type is unrecognized. This should never happen.
+/// * [Option<Address>] - The receiver of the output.
 ///
 /// # Examples
 ///
@@ -268,27 +266,50 @@ pub fn output_asset_id(index: u64) -> Option<AssetId> {
 /// }
 /// ```
 pub fn output_asset_to(index: u64) -> Option<Address> {
-    match output_type(index) {
-        Some(Output::Coin) => Some(__gtf::<Address>(index, GTF_OUTPUT_COIN_TO)),
-        Some(Output::Change) => Some(__gtf::<Address>(index, GTF_OUTPUT_COIN_TO)),
-        Some(Output::Variable) => {
-            let ptr = output_pointer(index).unwrap();
+    match output_type_id(index) {
+        OUTPUT_TYPE_COIN | OUTPUT_TYPE_CHANGE => Some(__gtf::<Address>(index, GTF_OUTPUT_COIN_TO)),
+        OUTPUT_TYPE_VARIABLE => {
+            let ptr = output_pointer(index);
             Some(Address::from(ptr.add_uint_offset(OUTPUT_VARIABLE_TO_OFFSET).read::<b256>()))
         },
         _ => None,
     }
 }
 
-impl PartialEq for Output {
-    fn eq(self, other: Self) -> bool {
-        match (self, other) {
-            (Output::Coin, Output::Coin) => true,
-            (Output::Contract, Output::Contract) => true,
-            (Output::Change, Output::Change) => true,
-            (Output::Variable, Output::Variable) => true,
-            (Output::ContractCreated, Output::ContractCreated) => true,
-            _ => false,
-        }
+/// Gets the asset id and the receiver of the output at `index`.
+///
+/// # Arguments
+///
+/// * `index`: [u64] - The index of the output to get the asset id and the receiver of.
+///
+/// # Returns
+///
+/// * [Option<Address>] - The asset id and the receiver of the output.
+///
+/// # Examples
+///
+/// ```sway
+/// use std::outputs::output_asset_id_and_to;
+///
+/// fn foo() {
+///     let (output_asset_id, output_receiver) = output_asset_id_and_to(0);
+///     log(output_asset_id);
+///     log(output_receiver);
+/// }
+/// ```
+pub fn output_asset_id_and_to(index: u64) -> Option<(AssetId, Address)> {
+    match output_type_id(index) {
+        OUTPUT_TYPE_COIN | OUTPUT_TYPE_CHANGE => Some((
+            AssetId::from(__gtf::<b256>(index, GTF_OUTPUT_COIN_ASSET_ID)),
+            __gtf::<Address>(index, GTF_OUTPUT_COIN_TO),
+        )),
+        OUTPUT_TYPE_VARIABLE => {
+            let ptr = output_pointer(index);
+            Some((
+                AssetId::from(ptr.add_uint_offset(OUTPUT_VARIABLE_ASSET_ID_OFFSET).read::<b256>()),
+                Address::from(ptr.add_uint_offset(OUTPUT_VARIABLE_TO_OFFSET).read::<b256>()),
+            ))
+        },
+        _ => None,
     }
 }
-impl Eq for Output {}

--- a/sway-lib-std/src/tx.sw
+++ b/sway-lib-std/src/tx.sw
@@ -79,13 +79,12 @@ impl PartialEq for Transaction {
 }
 impl Eq for Transaction {}
 
-const TX_TYPE_SCRIPT: u8 = 0u8;
-const TX_TYPE_CREATE: u8 = 1u8;
-#[allow(dead_code)]
-const TX_TYPE_MINT: u8 = 2u8;
-const TX_TYPE_UPGRADE: u8 = 3u8;
-const TX_TYPE_UPLOAD: u8 = 4u8;
-const TX_TYPE_BLOB: u8 = 5u8;
+pub const TX_TYPE_SCRIPT: u8 = 0u8;
+pub const TX_TYPE_CREATE: u8 = 1u8;
+pub const TX_TYPE_MINT: u8 = 2u8;
+pub const TX_TYPE_UPGRADE: u8 = 3u8;
+pub const TX_TYPE_UPLOAD: u8 = 4u8;
+pub const TX_TYPE_BLOB: u8 = 5u8;
 
 /// Get the type of the current transaction.
 ///
@@ -337,9 +336,9 @@ pub fn tx_script_data_length() -> Option<u64> {
 /// ```
 pub fn tx_witnesses_count() -> u64 {
     match __gtf::<u8>(0, GTF_TYPE) {
-        TX_TYPE_SCRIPT | TX_TYPE_UPGRADE | TX_TYPE_UPLOAD | TX_TYPE_BLOB => __gtf::<u64>(0, GTF_SCRIPT_WITNESSES_COUNT),
         TX_TYPE_CREATE => __gtf::<u64>(0, GTF_CREATE_WITNESSES_COUNT),
-        _ => revert(0),
+        TX_TYPE_MINT => revert(0),
+        _ => __gtf::<u64>(0, GTF_SCRIPT_WITNESSES_COUNT),
     }
 }
 
@@ -369,9 +368,9 @@ fn tx_witness_pointer(index: u64) -> Option<raw_ptr> {
     }
 
     match __gtf::<u8>(0, GTF_TYPE) {
-        TX_TYPE_SCRIPT | TX_TYPE_UPGRADE | TX_TYPE_UPLOAD | TX_TYPE_BLOB => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_WITNESS_AT_INDEX)),
         TX_TYPE_CREATE => Some(__gtf::<raw_ptr>(index, GTF_CREATE_WITNESS_AT_INDEX)),
-        _ => None,
+        TX_TYPE_MINT => None,
+        _ => Some(__gtf::<raw_ptr>(index, GTF_SCRIPT_WITNESS_AT_INDEX)),
     }
 }
 

--- a/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
+++ b/test/src/e2e_vm_tests/test_programs/should_pass/require_contract_deployment/asset_ops_test/src/main.sw
@@ -9,7 +9,7 @@ use test_fuel_coin_abi::*;
 #[cfg(experimental_new_encoding = false)]
 const FUEL_COIN_CONTRACT_ID = 0xec2277ebe007ade87e3d797c3b1e070dcd542d5ef8f038b471f262ef9cebc87c;
 #[cfg(experimental_new_encoding = true)]
-const FUEL_COIN_CONTRACT_ID = 0xd8ca4eaa438f31a1c0e0ec2e74b75b27d97df77714b3fb0b789d22d6b57d459f; // AUTO-CONTRACT-ID ../../test_contracts/test_fuel_coin_contract --release
+const FUEL_COIN_CONTRACT_ID = 0x6e8bc09f34b7eccea8cf518a38754669515084377ec13d8fd73f83da519816ad; // AUTO-CONTRACT-ID ../../test_contracts/test_fuel_coin_contract --release
 
 #[cfg(experimental_new_encoding = false)]
 const BALANCE_CONTRACT_ID = 0xf6cd545152ac83225e8e7df2efb5c6fa6e37bc9b9e977b5ea8103d28668925df;

--- a/test/src/sdk-harness/test_artifacts/tx_output_contract/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/tx_output_contract/src/main.sw
@@ -24,9 +24,21 @@ fn get_variable_tx_params(index: u64) -> (Address, AssetId, u64) {
     let tx_asset_id = output_asset_id(index);
     let tx_to = output_asset_to(index);
     let tx_amount = output_amount(index);
+    let tx_asset_id_and_to = output_asset_id_and_to(index);
 
     let tx_output_type = output_type(index);
     assert(tx_output_type.is_some() && tx_output_type.unwrap() == Output::Variable);
+    assert(
+        (tx_asset_id.is_some() && tx_asset_id_and_to.is_some() && tx_asset_id.unwrap() == tx_asset_id_and_to.unwrap().0)
+        ||
+        (tx_asset_id.is_none() && tx_asset_id_and_to.is_none())
+    );
+    assert(
+        (tx_to.is_some() && tx_asset_id_and_to.is_some() && tx_to.unwrap() == tx_asset_id_and_to.unwrap().1)
+        ||
+        (tx_to.is_none() && tx_asset_id_and_to.is_none())
+    );
+
     (
         tx_to.unwrap_or(Address::zero()),
         tx_asset_id.unwrap_or(AssetId::zero()),

--- a/test/src/sdk-harness/test_artifacts/tx_output_predicate/src/main.sw
+++ b/test/src/sdk-harness/test_artifacts/tx_output_predicate/src/main.sw
@@ -1,15 +1,18 @@
 predicate;
 
-use std::outputs::{Output, output_asset_id, output_asset_to, output_type};
+use std::outputs::{Output, output_asset_id, output_asset_to, output_asset_id_and_to, output_type};
 
 fn main(index: u64, asset_id: b256, to: b256, expected_type: Output) -> bool {
     let tx_asset_id = output_asset_id(index);
     let tx_to = output_asset_to(index);
     let tx_output_type = output_type(index);
+    let tx_asset_id_and_to = output_asset_id_and_to(index);
 
     assert(tx_asset_id.is_some() && tx_asset_id.unwrap().bits() == asset_id);
     assert(tx_to.is_some() && tx_to.unwrap().bits() == to);
     assert(tx_output_type.is_some() && tx_output_type.unwrap() == expected_type);
+    assert(tx_asset_id_and_to.is_some() && tx_asset_id.unwrap() == tx_asset_id_and_to.unwrap().0);
+    assert(tx_to.unwrap() == tx_asset_id_and_to.unwrap().1);
 
     true
 }

--- a/test/src/sdk-harness/test_projects/auth/mod.rs
+++ b/test/src/sdk-harness/test_projects/auth/mod.rs
@@ -618,7 +618,7 @@ async fn can_get_predicate_address() {
 
     // Setup predicate.
     let hex_predicate_address: &str =
-        "0x599331f8a4696d67739a28360222f1a671e349ad51ccd0682be19a683b058d84";
+        "0xb2618f228760d4845f904fde8f732bafdbc50bdc6fe30870b72e2778ae4e06aa";
     let predicate_address =
         Address::from_str(hex_predicate_address).expect("failed to create Address from string");
     let predicate_bech32_address = Bech32Address::from(predicate_address);
@@ -631,8 +631,8 @@ async fn can_get_predicate_address() {
             .with_provider(first_wallet.try_provider().unwrap().clone())
             .with_data(predicate_data);
 
-    // If this test fails, it can be the predicate address
-    // Uncomment the next line, get the predicate address and update above.
+    // If this test fails, it can be that the predicate address got changed.
+    // Uncomment the next line, get the predicate address, and update it above.
     // dbg!(&predicate);
 
     // Next, we lock some assets in this predicate using the first wallet:
@@ -744,7 +744,7 @@ async fn when_incorrect_predicate_address_passed() {
 async fn can_get_predicate_address_in_message() {
     // Setup predicate address.
     let hex_predicate_address: &str =
-        "0x599331f8a4696d67739a28360222f1a671e349ad51ccd0682be19a683b058d84";
+        "0xb2618f228760d4845f904fde8f732bafdbc50bdc6fe30870b72e2778ae4e06aa";
     let predicate_address =
         Address::from_str(hex_predicate_address).expect("failed to create Address from string");
     let predicate_bech32_address = Bech32Address::from(predicate_address);
@@ -793,8 +793,8 @@ async fn can_get_predicate_address_in_message() {
             .with_provider(wallet.try_provider().unwrap().clone())
             .with_data(predicate_data);
 
-    // If this test fails, it can be the predicate address
-    // Uncomment the next line, get the predicate address and update above.
+    // If this test fails, it can be that the predicate address got changed.
+    // Uncomment the next line, get the predicate address, and update it above.
     // dbg!(&predicate);
 
     // Check predicate balance.


### PR DESCRIPTION
## Description

This PR optimizes the `std::inputs` and `std::outputs` modules for bytcode size and gas cost using the same optimization techinques like in #7087.

The optimized public functions are listed in the below code snippet. **The bytcode size of that code got reduced from 5688 bytes to 2544 bytes.**

```sway
fn main() {
    let _ = std::tx::tx_witnesses_count();

    let _ = std::inputs::input_count();
    let _ = std::inputs::input_amount(0);
    let _ = std::inputs::input_coin_owner(0);
    let _ = std::inputs::input_predicate_data::<u64>(0);
    let _ = std::inputs::input_asset_id(0);
    let _ = std::inputs::input_witness_index(0);
    let _ = std::inputs::input_predicate_length(0);
    let _ = std::inputs::input_predicate(0);
    let _ = std::inputs::input_predicate_data_length(0);
    let _ = std::inputs::input_message_sender(0);
    let _ = std::inputs::input_message_recipient(0);
    let _ = std::inputs::input_message_nonce(0);
    let _ = std::inputs::input_message_data_length(0);
    let _ = std::inputs::input_message_data(0, 0);

    let _ = std::outputs::output_count();
    let _ = std::outputs::output_amount(0);
    let _ = std::outputs::output_asset_id(0);
    let _ = std::outputs::output_asset_to(0);
}
```

Additionally, the PR adds a new function `std::outputs::output_asset_id_and_to` to efficiently retrieve the id and the receiver of the output asset in a single call. Calling this function is more performant that calling `output_asset_id` and `output_asset_to` separately.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.