### PR TITLE
feat: limit registry nesting to 2 levels for registry sources

### DIFF
--- a/forc-pkg/src/source/reg/file_location.rs
+++ b/forc-pkg/src/source/reg/file_location.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, path::PathBuf};
 
+/// Number of levels of nesting to use for file locations.
+const NESTING_LEVELS: usize = 2;
+
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub enum Namespace {
     /// Flat namespace means no sub-namespace with different domains.
@@ -44,7 +47,15 @@ pub fn location_from_root(chunk_size: usize, namespace: &Namespace, package_name
         return path;
     }
 
-    let chars: Vec<char> = package_name.chars().collect();
+    let char_count = chunk_size * NESTING_LEVELS;
+    // do not panic.
+    let to_be_chunked_section = package_name
+        .chars()
+        .enumerate()
+        .take_while(|(index, _)| *index < char_count)
+        .map(|(_, ch)| ch);
+
+    let chars: Vec<char> = to_be_chunked_section.collect();
     for chunk in chars.chunks(chunk_size) {
         let chunk_str: String = chunk.iter().collect();
         path.push(chunk_str);
@@ -90,8 +101,8 @@ mod tests {
 
         let path = location_from_root(chunk_size, &namespace, entry.name());
 
-        // Should produce: fo/ob/ar/foobar
-        assert_eq!(path, Path::new("fo").join("ob").join("ar").join("foobar"));
+        // Should produce: fo/ob/foobar
+        assert_eq!(path, Path::new("fo").join("ob").join("foobar"));
     }
 
     #[test]
@@ -102,14 +113,10 @@ mod tests {
 
         let path = location_from_root(chunk_size, &namespace, entry.name());
 
-        // Should produce: example/fo/ob/ar/foobar
+        // Should produce: example/fo/ob/foobar
         assert_eq!(
             path,
-            Path::new("example")
-                .join("fo")
-                .join("ob")
-                .join("ar")
-                .join("foobar")
+            Path::new("example").join("fo").join("ob").join("foobar")
         );
     }
 
@@ -121,8 +128,8 @@ mod tests {
 
         let path = location_from_root(chunk_size, &namespace, entry.name());
 
-        // Should produce: he/ll/o/hello
-        assert_eq!(path, Path::new("he").join("ll").join("o").join("hello"));
+        // Should produce: he/ll/hello
+        assert_eq!(path, Path::new("he").join("ll").join("hello"));
     }
 
     #[test]
@@ -133,11 +140,8 @@ mod tests {
 
         let path = location_from_root(chunk_size, &namespace, entry.name());
 
-        // Should produce: fib/ona/cci/fibonacci
-        assert_eq!(
-            path,
-            Path::new("fib").join("ona").join("cci").join("fibonacci")
-        );
+        // Should produce: fib/ona/fibonacci
+        assert_eq!(path, Path::new("fib").join("ona").join("fibonacci"));
     }
 
     #[test]
@@ -160,8 +164,8 @@ mod tests {
 
         let path = location_from_root(chunk_size, &namespace, entry.name());
 
-        // Should produce: hé/ll/o/héllo
-        assert_eq!(path, Path::new("hé").join("ll").join("o").join("héllo"));
+        // Should produce: hé/ll/héllo
+        assert_eq!(path, Path::new("hé").join("ll").join("héllo"));
     }
 
     #[test]

--- a/forc-pkg/src/source/reg/file_location.rs
+++ b/forc-pkg/src/source/reg/file_location.rs
@@ -48,7 +48,6 @@ pub fn location_from_root(chunk_size: usize, namespace: &Namespace, package_name
     }
 
     let char_count = chunk_size * NESTING_LEVELS;
-    // do not panic.
     let to_be_chunked_section = package_name
         .chars()
         .enumerate()


### PR DESCRIPTION
## Description


Limits the levels of nesting to 2 for registry sources. Changes the naming convention for the index files from unlimited amount of nesting by `chunk_size` to only 2 levels of nesting with `chunk_size`.

So `foobar` was split as `fo/ob/ar/foobar` with `chunk_size` 2 but with this PR it is split as `fo/ob/foobar`.