### PR TITLE
ci: move build binaries step to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -944,12 +944,12 @@ jobs:
     strategy:
       matrix:
         job:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             platform: linux
             target: x86_64-unknown-linux-gnu
             arch: amd64
             svm_target_platform: linux-amd64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             platform: linux
             target: aarch64-unknown-linux-gnu
             arch: arm64


### PR DESCRIPTION
## Description

`build-and-release-forc-binaries` step failed in the last release because it was using an old OS version (20.04). The details can be seen [here](https://github.com/FuelLabs/sway/actions/runs/14605196507/job/40975381937) and [here](https://github.com/actions/runner-images/issues/11101).