### PR TITLE
chore: bump to 0.67.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "forc"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "annotate-snippets",
  "ansiterm",
@@ -2755,7 +2755,7 @@ dependencies = [
  "completest-pty",
  "forc-pkg",
  "forc-test",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "forc-util",
  "fs_extra",
  "fuel-asm",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "forc-client"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2794,7 +2794,7 @@ dependencies = [
  "either",
  "forc",
  "forc-pkg",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "forc-tx",
  "forc-util",
  "forc-wallet",
@@ -2834,13 +2834,13 @@ dependencies = [
 
 [[package]]
 name = "forc-crypto"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "anyhow",
  "async-trait",
  "clap",
  "criterion",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "forc-util",
  "fuel-core-types",
  "fuel-crypto",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "forc-debug"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2873,7 +2873,7 @@ dependencies = [
  "escargot",
  "forc-pkg",
  "forc-test",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "forc-util",
  "fuel-abi-types",
  "fuel-core-client",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "forc-doc"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2905,7 +2905,7 @@ dependencies = [
  "dir_indexer",
  "expect-test",
  "forc-pkg",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "forc-util",
  "horrorshow",
  "include_dir",
@@ -2923,12 +2923,12 @@ dependencies = [
 
 [[package]]
 name = "forc-fmt"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "anyhow",
  "clap",
  "forc-pkg",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "forc-util",
  "prettydiff",
  "sway-core",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "forc-lsp"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2951,13 +2951,13 @@ dependencies = [
 
 [[package]]
 name = "forc-migrate"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "anyhow",
  "clap",
  "duplicate",
  "forc-pkg",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "forc-util",
  "itertools 0.13.0",
  "num-bigint",
@@ -2972,12 +2972,12 @@ dependencies = [
 
 [[package]]
 name = "forc-node"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "anyhow",
  "clap",
  "dialoguer",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "forc-util",
  "fuel-crypto",
  "libp2p-identity",
@@ -2995,14 +2995,14 @@ dependencies = [
 
 [[package]]
 name = "forc-pkg"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "ansiterm",
  "anyhow",
  "byte-unit",
  "cid",
  "flate2",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "forc-util",
  "fuel-abi-types",
  "futures",
@@ -3036,11 +3036,11 @@ dependencies = [
 
 [[package]]
 name = "forc-publish"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "clap",
  "flate2",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "forc-util",
  "reqwest",
  "semver 1.0.26",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "forc-test"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "anyhow",
  "forc-pkg",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "forc-tracing"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "ansiterm",
  "tracing",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "forc-tx"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "forc-util"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "annotate-snippets",
  "ansiterm",
@@ -3122,7 +3122,7 @@ dependencies = [
  "clap",
  "dirs 5.0.1",
  "fd-lock",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "fuel-abi-types",
  "fuel-asm",
  "fuel-tx",
@@ -7888,7 +7888,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sway-ast"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "extension-trait",
  "num-bigint",
@@ -7900,7 +7900,7 @@ dependencies = [
 
 [[package]]
 name = "sway-core"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -7945,7 +7945,7 @@ dependencies = [
 
 [[package]]
 name = "sway-error"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "either",
  "in_definite",
@@ -7958,7 +7958,7 @@ dependencies = [
 
 [[package]]
 name = "sway-features"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "clap",
  "paste",
@@ -7968,7 +7968,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "anyhow",
  "downcast-rs",
@@ -7989,7 +7989,7 @@ dependencies = [
 
 [[package]]
 name = "sway-ir-macros"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "sway-lsp"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -8010,7 +8010,7 @@ dependencies = [
  "dirs 5.0.1",
  "fd-lock",
  "forc-pkg",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "forc-util",
  "futures",
  "indexmap 2.7.1",
@@ -8050,7 +8050,7 @@ dependencies = [
 
 [[package]]
 name = "sway-lsp-test-utils"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "assert-json-diff",
  "futures",
@@ -8065,7 +8065,7 @@ dependencies = [
 
 [[package]]
 name = "sway-parse"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "assert_matches",
  "extension-trait",
@@ -8083,7 +8083,7 @@ dependencies = [
 
 [[package]]
 name = "sway-types"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "fuel-asm",
  "fuel-crypto",
@@ -8101,7 +8101,7 @@ dependencies = [
 
 [[package]]
 name = "sway-utils"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "serde",
  "walkdir",
@@ -8109,10 +8109,10 @@ dependencies = [
 
 [[package]]
 name = "swayfmt"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "anyhow",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "indoc",
  "paste",
  "prettydiff",
@@ -8371,7 +8371,7 @@ dependencies = [
  "forc-client",
  "forc-pkg",
  "forc-test",
- "forc-tracing 0.67.1",
+ "forc-tracing 0.67.2",
  "forc-util",
  "fuel-vm",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = ["examples/*", "swayfmt/test_macros", "forc-test/test_data"]
 
 [workspace.package]
 edition = "2021"
-version = "0.67.1"
+version = "0.67.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
@@ -45,37 +45,37 @@ repository = "https://github.com/FuelLabs/sway"
 # Internal dependencies in order to propagate `workspace.version`
 #
 
-forc = { path = "forc/", version = "0.67.1" }
-forc-pkg = { path = "forc-pkg/", version = "0.67.1" }
-forc-test = { path = "forc-test/", version = "0.67.1" }
-forc-tracing = { path = "forc-tracing/", version = "0.67.1" }
-forc-util = { path = "forc-util/", version = "0.67.1" }
+forc = { path = "forc/", version = "0.67.2" }
+forc-pkg = { path = "forc-pkg/", version = "0.67.2" }
+forc-test = { path = "forc-test/", version = "0.67.2" }
+forc-tracing = { path = "forc-tracing/", version = "0.67.2" }
+forc-util = { path = "forc-util/", version = "0.67.2" }
 
 # Forc plugins
-forc-plugins = { path = "forc-plugins/", version = "0.67.1" }
-forc-client = { path = "forc-plugins/forc-client/", version = "0.67.1" }
-forc-crypto = { path = "forc-plugins/forc-crypto/", version = "0.67.1" }
-forc-debug = { path = "forc-plugins/forc-debug/", version = "0.67.1" }
-forc-doc = { path = "forc-plugins/forc-doc/", version = "0.67.1" }
-forc-fmt = { path = "forc-plugins/forc-fmt/", version = "0.67.1" }
-forc-lsp = { path = "forc-plugins/forc-lsp/", version = "0.67.1" }
-forc-migrate = { path = "forc-plugins/forc-migrate/", version = "0.67.1" }
-forc-publish = { path = "forc-plugins/forc-publish/", version = "0.67.1" }
-forc-tx = { path = "forc-plugins/forc-tx/", version = "0.67.1" }
+forc-plugins = { path = "forc-plugins/", version = "0.67.2" }
+forc-client = { path = "forc-plugins/forc-client/", version = "0.67.2" }
+forc-crypto = { path = "forc-plugins/forc-crypto/", version = "0.67.2" }
+forc-debug = { path = "forc-plugins/forc-debug/", version = "0.67.2" }
+forc-doc = { path = "forc-plugins/forc-doc/", version = "0.67.2" }
+forc-fmt = { path = "forc-plugins/forc-fmt/", version = "0.67.2" }
+forc-lsp = { path = "forc-plugins/forc-lsp/", version = "0.67.2" }
+forc-migrate = { path = "forc-plugins/forc-migrate/", version = "0.67.2" }
+forc-publish = { path = "forc-plugins/forc-publish/", version = "0.67.2" }
+forc-tx = { path = "forc-plugins/forc-tx/", version = "0.67.2" }
 
-sway-ast = { path = "sway-ast/", version = "0.67.1" }
-sway-core = { path = "sway-core/", version = "0.67.1" }
-sway-error = { path = "sway-error/", version = "0.67.1" }
-sway-features = { path = "sway-features/", version = "0.67.1" }
-sway-lsp = { path = "sway-lsp/", version = "0.67.1" }
-sway-parse = { path = "sway-parse/", version = "0.67.1" }
-sway-types = { path = "sway-types/", version = "0.67.1" }
-sway-utils = { path = "sway-utils/", version = "0.67.1" }
-swayfmt = { path = "swayfmt/", version = "0.67.1" }
+sway-ast = { path = "sway-ast/", version = "0.67.2" }
+sway-core = { path = "sway-core/", version = "0.67.2" }
+sway-error = { path = "sway-error/", version = "0.67.2" }
+sway-features = { path = "sway-features/", version = "0.67.2" }
+sway-lsp = { path = "sway-lsp/", version = "0.67.2" }
+sway-parse = { path = "sway-parse/", version = "0.67.2" }
+sway-types = { path = "sway-types/", version = "0.67.2" }
+sway-utils = { path = "sway-utils/", version = "0.67.2" }
+swayfmt = { path = "swayfmt/", version = "0.67.2" }
 
 # Sway IR
-sway-ir = { path = "sway-ir/", version = "0.67.1" }
-sway-ir-macros = { path = "sway-ir/sway-ir-macros", version = "0.67.1" }
+sway-ir = { path = "sway-ir/", version = "0.67.2" }
+sway-ir-macros = { path = "sway-ir/sway-ir-macros", version = "0.67.2" }
 
 #
 # External Fuel dependencies


### PR DESCRIPTION
## Description

Release of 0.67.2 failed due to a CI issue fixed in #7099. This release of 0.67.2 is to replace invalid release of 0.67.1